### PR TITLE
fix(sdk): resolve packed artifacts under strict Node ESM

### DIFF
--- a/packages/client/script/build.ts
+++ b/packages/client/script/build.ts
@@ -95,7 +95,7 @@ await Effect.runPromise(
       ),
       write(
         emitEffectImported(effectContract, {
-          module: "../../contract",
+          module: "../../contract.js",
           api: "ClientApi",
           shapeModule: "../api/api.js",
         }),

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -3,7 +3,7 @@ import { Effect, Stream, Schema } from "effect"
 import { Sse } from "effect/unstable/encoding"
 import { HttpClientError } from "effect/unstable/http"
 import { HttpApiClient } from "effect/unstable/httpapi"
-import { ClientApi } from "../../contract"
+import { ClientApi } from "../../contract.js"
 import type {
   HealthGetOutput,
   ServerGetOutput,

--- a/packages/client/src/effect/index.ts
+++ b/packages/client/src/effect/index.ts
@@ -2,7 +2,7 @@
 // Core or Server. Preserve these datatype exports so internal model reorganizations do not require caller migrations.
 import type { Effect } from "effect"
 
-export * from "./generated/index"
+export * from "./generated/index.js"
 export type {
   AgentApi,
   AppApi,
@@ -47,4 +47,4 @@ export { Skill } from "@opencode-ai/schema/skill"
 export { Prompt } from "@opencode-ai/schema/prompt"
 export { PromptInput } from "@opencode-ai/schema/prompt-input"
 export type { OpenCodeEvent } from "@opencode-ai/protocol/groups/event"
-export type OpenCodeClient = Effect.Success<ReturnType<typeof import("./generated/client").make>>
+export type OpenCodeClient = Effect.Success<ReturnType<typeof import("./generated/client.js").make>>

--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -1,7 +1,7 @@
 export * as Watcher from "./watcher.js"
 
 // @ts-ignore
-import { createWrapper } from "@parcel/watcher/wrapper"
+import { createWrapper } from "@parcel/watcher/wrapper.js"
 import type ParcelWatcher from "@parcel/watcher"
 import { FileSystem } from "@opencode-ai/schema/filesystem"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"

--- a/packages/sdk/script/verify-package.ts
+++ b/packages/sdk/script/verify-package.ts
@@ -72,6 +72,34 @@ try {
   )
   await Promise.all([
     Bun.write(
+      join(consumer, "node-import.mjs"),
+      'await import("@opencode-ai/sdk")\nawait import("@opencode-ai/simulation/backend")\n',
+    ),
+    Bun.write(
+      join(consumer, "consumer.ts"),
+      `import { OpenCode, Tool } from "@opencode-ai/sdk"
+import { OpenCodeWorkerd } from "@opencode-ai/sdk/workerd"
+
+OpenCode.create satisfies Function
+OpenCodeWorkerd.create satisfies Function
+Tool.Error satisfies Function
+`,
+    ),
+    Bun.write(
+      join(consumer, "tsconfig.json"),
+      JSON.stringify({
+        compilerOptions: {
+          target: "ES2022",
+          module: "NodeNext",
+          moduleResolution: "NodeNext",
+          strict: true,
+          noEmit: true,
+          lib: ["ES2022", "DOM", "ESNext.Disposable"],
+        },
+        include: ["consumer.ts"],
+      }),
+    ),
+    Bun.write(
       join(consumer, "wrangler.jsonc"),
       JSON.stringify({
         name: "opencode-sdk-packed-consumer",
@@ -148,7 +176,10 @@ try {
 
   const sdk = archives.get("@opencode-ai/sdk")
   if (!sdk) throw new Error("Packed SDK archive was not created")
-  await $`npm install --ignore-scripts --no-audit --no-fund --package-lock=false ${sdk} wrangler@4.110.0`.cwd(consumer)
+  await $`npm install --ignore-scripts --no-audit --no-fund --package-lock=false ${sdk} @types/json-schema@7.0.15 typescript@5.8.2 wrangler@4.110.0`.cwd(consumer)
+  await $`node node-import.mjs`.cwd(consumer)
+  await $`node_modules/.bin/tsc --noEmit`.cwd(consumer)
+
   await $`node_modules/.bin/wrangler deploy --dry-run --config wrangler.jsonc --outdir dist`.cwd(consumer)
 
   const transpiler = new Bun.Transpiler({ loader: "js" })

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,5 +1,5 @@
-export * as OpenCode from "./opencode"
-export * as Tool from "./tool"
+export * as OpenCode from "./opencode.js"
+export * as Tool from "./tool.js"
 
 export { ClientError } from "@opencode-ai/client/effect"
 export type { OpenCodeEvent } from "@opencode-ai/client/effect"

--- a/packages/sdk/src/opencode.ts
+++ b/packages/sdk/src/opencode.ts
@@ -9,10 +9,10 @@ import { createEmbeddedRoutes } from "@opencode-ai/server/routes"
 import type { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Config, Context, Effect, Layer, ManagedRuntime, Scope } from "effect"
 import { FetchHttpClient, HttpEffect, HttpRouter, HttpServer, HttpServerRequest } from "effect/unstable/http"
-import * as Logging from "./logging"
+import * as Logging from "./logging.js"
 
-export type { LogEntry, LogLevel, LogOptions, LogWriter } from "./logging"
-import type { LogOptions } from "./logging"
+export type { LogEntry, LogLevel, LogOptions, LogWriter } from "./logging.js"
+import type { LogOptions } from "./logging.js"
 
 export interface CreateOptions {
   readonly app?: {

--- a/packages/sdk/src/workerd.ts
+++ b/packages/sdk/src/workerd.ts
@@ -1,9 +1,9 @@
-export * as OpenCodeWorkerd from "./workerd"
+export * as OpenCodeWorkerd from "./workerd.js"
 
 import type { DurableObjectStorage } from "@opencode-ai/core/database/sqlite.workerd"
 import { ServerWorkerd } from "@opencode-ai/server/workerd"
 import { Config, Effect, Layer, Scope } from "effect"
-import * as OpenCode from "./opencode"
+import * as OpenCode from "./opencode.js"
 
 export interface CreateOptions extends Pick<OpenCode.CreateOptions, "log" | "workspaceProviders"> {
   readonly storage: DurableObjectStorage

--- a/packages/server/script/build.ts
+++ b/packages/server/script/build.ts
@@ -2,6 +2,7 @@
 
 import { $ } from "bun"
 import { rm } from "node:fs/promises"
+import { extname } from "node:path"
 import { fileURLToPath } from "node:url"
 
 process.chdir(fileURLToPath(new URL("..", import.meta.url)))
@@ -13,10 +14,26 @@ const files = await Array.fromAsync(new Bun.Glob("**/*.ts").scan({ cwd: "src" })
 )
 const transpiler = new Bun.Transpiler({ loader: "ts", target: "bun" })
 await Promise.all(
-  files.map(async (file) =>
-    Bun.write(
-      file.replace(/^src\//, "dist/").replace(/\.ts$/, ".js"),
-      await transpiler.transform(await Bun.file(file).text()),
+  files
+    .map(async (file) =>
+      Bun.write(
+        file.replace(/^src\//, "dist/").replace(/\.ts$/, ".js"),
+        withRelativeExtensions(await transpiler.transform(await Bun.file(file).text())),
+      ),
+    )
+    .concat(
+      await Array.fromAsync(new Bun.Glob("**/*.d.ts").scan({ cwd: "dist" })).then((declarations) =>
+        declarations.map(async (file) =>
+          Bun.write(`dist/${file}`, withRelativeExtensions(await Bun.file(`dist/${file}`).text())),
+        ),
+      ),
     ),
-  ),
 )
+
+function withRelativeExtensions(source: string) {
+  return source.replaceAll(
+    /((?:from\s*|import\s*(?:\(\s*)?)["'])(\.{1,2}\/[^"']+)(["'])/g,
+    (match, prefix: string, specifier: string, suffix: string) =>
+      extname(specifier) ? match : `${prefix}${specifier}.js${suffix}`,
+  )
+}

--- a/packages/simulation/src/backend/index.ts
+++ b/packages/simulation/src/backend/index.ts
@@ -4,10 +4,10 @@ import { httpClient } from "@opencode-ai/util/effect/app-node-platform"
 import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { Config, Effect, FileSystem, Layer } from "effect"
 import { HttpClient } from "effect/unstable/http"
-import { DriveManifest } from "../manifest"
-import { SimulationNetwork } from "./network"
-import { SimulationOpenAI } from "./openai"
-import { SimulatedProvider } from "./simulated-provider"
+import { DriveManifest } from "../manifest.js"
+import { SimulationNetwork } from "./network.js"
+import { SimulationOpenAI } from "./openai.js"
+import { SimulatedProvider } from "./simulated-provider.js"
 
 /**
  * Layer replacements applied when the server is built in simulation mode.
@@ -56,4 +56,4 @@ export const simulationReplacements: (app: {
   return [[httpClient, networkNode]] satisfies LayerNode.Replacements
 })
 
-export * as Simulation from "./index"
+export * as Simulation from "./index.js"

--- a/packages/simulation/src/backend/network.ts
+++ b/packages/simulation/src/backend/network.ts
@@ -2,7 +2,7 @@ import { Clock, Effect, Layer, Ref } from "effect"
 import { HttpClient, HttpClientResponse, type HttpMethod } from "effect/unstable/http"
 import { HttpClientError, TransportError } from "effect/unstable/http/HttpClientError"
 import type { HttpClientRequest } from "effect/unstable/http"
-import { SimulationProtocol } from "../protocol"
+import { SimulationProtocol } from "../protocol/index.js"
 
 /**
  * Simulated network.
@@ -82,4 +82,4 @@ export const make = Effect.fn("SimulationNetwork.make")(function* (routes: reado
 export const layer = (routes: readonly Route[] = []) =>
   Layer.effect(HttpClient.HttpClient, make(routes).pipe(Effect.map((run) => run.client)))
 
-export * as SimulationNetwork from "./network"
+export * as SimulationNetwork from "./network.js"

--- a/packages/simulation/src/backend/openai.ts
+++ b/packages/simulation/src/backend/openai.ts
@@ -2,8 +2,8 @@ import { Effect, Schema, Stream } from "effect"
 import { HttpClientResponse } from "effect/unstable/http"
 import { HttpClientError, TransportError } from "effect/unstable/http/HttpClientError"
 import { OpenAIChatEvent, DEFAULT_BASE_URL, PATH } from "@opencode-ai/ai/protocols/openai-chat"
-import { SimulationNetwork } from "./network"
-import { SimulatedProvider } from "./simulated-provider"
+import { SimulationNetwork } from "./network.js"
+import { SimulatedProvider } from "./simulated-provider.js"
 
 /**
  * Driver-answered OpenAI endpoint for the simulated network.
@@ -130,4 +130,4 @@ export const route = (provider: SimulatedProvider.Interface): SimulationNetwork.
   },
 })
 
-export * as SimulationOpenAI from "./openai"
+export * as SimulationOpenAI from "./openai.js"

--- a/packages/simulation/src/backend/simulated-provider.ts
+++ b/packages/simulation/src/backend/simulated-provider.ts
@@ -20,8 +20,8 @@ import {
   Semaphore,
   Stream,
 } from "effect"
-import { SimulationControlServer } from "../control-server"
-import { SimulationProtocol } from "../protocol"
+import { SimulationControlServer } from "../control-server.js"
+import { SimulationProtocol } from "../protocol/index.js"
 
 export interface ProviderRequest {
   readonly url: string
@@ -916,4 +916,4 @@ function releaseController(
   )
 }
 
-export * as SimulatedProvider from "./simulated-provider"
+export * as SimulatedProvider from "./simulated-provider.js"

--- a/packages/simulation/src/control-server.ts
+++ b/packages/simulation/src/control-server.ts
@@ -1,5 +1,5 @@
 import { Effect, Fiber, FiberSet, Queue, Stream } from "effect"
-import { SimulationProtocol } from "./protocol"
+import { SimulationProtocol } from "./protocol/index.js"
 
 export interface Server {
   readonly url: string
@@ -181,4 +181,4 @@ function send(socket: Socket, response: SimulationProtocol.JsonRpc.Response | un
   return socket.send(JSON.stringify(response))
 }
 
-export * as SimulationControlServer from "./control-server"
+export * as SimulationControlServer from "./control-server.js"

--- a/packages/simulation/src/manifest.ts
+++ b/packages/simulation/src/manifest.ts
@@ -107,4 +107,4 @@ export const resolve = Effect.fn("DriveManifest.resolve")(function* () {
   )
 })
 
-export * as DriveManifest from "./manifest"
+export * as DriveManifest from "./manifest.js"


### PR DESCRIPTION
## What

Make the packed npm artifacts resolvable under strict Node ESM and fully type-checkable under NodeNext. This is the follow-up leg of the split started in #44703: that PR made the packed SDK boot on Cloudflare workerd; this one makes it a legitimate npm citizen for consumers with no bundler in the loop.

## The problem

Node's ESM loader requires exact file paths for relative imports; it never guesses extensions. Bundlers (wrangler/esbuild, Vite, Bun) all guess, which is why everything worked in the workspace and on workerd, while the most vanilla possible consumer failed on its first import:

```ts
// $ npm install @opencode-ai/sdk && node index.mjs
import { OpenCode } from "@opencode-ai/sdk"
// Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../dist/opencode'
```

SDK, Client, Server, and Simulation ship per-file transpiled output where extensionless source imports like `./opencode` survive verbatim into `dist`. The same defect breaks TypeScript consumers under `moduleResolution: "NodeNext"`, whose `tsc` walks the published `.d.ts` chain and hits the same extensionless specifiers. Simulation is included because it is a runtime dependency of Server, so the sdk → server → simulation chain must resolve end to end.

```mermaid
flowchart LR
    spec["import './opencode'<br/>in published dist"] --> bundlers["wrangler / Vite / Bun:<br/>guess extensions — works"]
    spec --> node["plain Node ESM:<br/>exact paths only — fails"]
    spec --> tsc["tsc under NodeNext:<br/>exact paths only — fails"]
```

## The fix

- **Explicit `.js` relative specifiers** in `packages/sdk/src`, `packages/client/src` (including the generated Effect client; the generator in `client/script/build.ts` owns its generated specifier), and `packages/simulation/src`. TypeScript resolves `.js` back to `.ts` while checking, so development is unaffected.
- **Mechanical rewriting for Server** (`packages/server/script/build.ts`): appends `.js` to extensionless relative specifiers in both the transpiled JavaScript and the tsc-emitted declarations, so Server sources stay extensionless.
- **Watcher subpath** (`packages/core/src/filesystem/watcher.ts`): `@parcel/watcher/wrapper` → `@parcel/watcher/wrapper.js`, the same exactness rule for a package subpath with no exports-map entry.
- **Verifier grows its Node legs** (`packages/sdk/script/verify-package.ts`): the packed consumer from #44703 now also runs `node node-import.mjs` (imports the packed SDK and Simulation under real Node ESM) and `tsc --noEmit` under NodeNext without `skipLibCheck` (the published declaration chain must fully typecheck), alongside the existing wrangler bundle scans and Miniflare boot.

## Before / After

**Before:** `node` could not import the packed SDK (`ERR_MODULE_NOT_FOUND` on the first extensionless relative specifier), and NodeNext consumers could not typecheck against the published declarations. Only bundler-mediated consumers worked.

**After:** the packed cohort installs and imports cleanly under plain Node ESM, fully typechecks from a strict NodeNext consumer, and the same verifier run still proves the workerd boot from #44703 — one gate, both runtimes.

## Scope

- Builds on #44703; contains no workerd-runtime changes of its own.
- This PR does not publish a beta cohort.
- Core's bundled dist is unaffected (bundling resolves relative specifiers; only transpiled packages need exact ones).

## Testing

- `packages/sdk`: `bun run verify:package` (pack eleven-package cohort, clean npm install, Node ESM import of SDK and Simulation, full NodeNext declaration check without `skipLibCheck`, wrangler dry-run bundle and scans, Miniflare SQLite Durable Object boot).
- `packages/client`, `packages/sdk`, `packages/server`, `packages/simulation`, `packages/core`: `bun typecheck`.
