### PR TITLE
fix(ai): support disable_parallel_tool_use and send beta query

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -205,8 +205,11 @@ const AnthropicTool = Schema.Struct({
 type AnthropicTool = Schema.Schema.Type<typeof AnthropicTool>
 
 const AnthropicToolChoice = Schema.Union([
-  Schema.Struct({ type: Schema.Literals(["auto", "any", "none"]) }),
-  Schema.Struct({ type: Schema.tag("tool"), name: Schema.String }),
+  Schema.Struct({
+    type: Schema.Literals(["auto", "any", "none"]),
+    disable_parallel_tool_use: Schema.optional(Schema.Boolean),
+  }),
+  Schema.Struct({ type: Schema.tag("tool"), name: Schema.String, disable_parallel_tool_use: Schema.optional(Schema.Boolean) }),
 ])
 
 const AnthropicThinking = Schema.Union([
@@ -370,10 +373,26 @@ const lowerTool = (breakpoints: Cache.Breakpoints, tool: ToolDefinition, inputSc
 
 const lowerToolChoice = (toolChoice: NonNullable<LLMRequest["toolChoice"]>) =>
   ProviderShared.matchToolChoice("Anthropic Messages", toolChoice, {
-    auto: () => ({ type: "auto" as const }),
+    auto: () => ({
+      type: "auto" as const,
+      ...(toolChoice.disableParallelToolUse === undefined
+        ? {}
+        : { disable_parallel_tool_use: toolChoice.disableParallelToolUse }),
+    }),
     none: () => ({ type: "none" as const }),
-    required: () => ({ type: "any" as const }),
-    tool: (name) => ({ type: "tool" as const, name }),
+    required: () => ({
+      type: "any" as const,
+      ...(toolChoice.disableParallelToolUse === undefined
+        ? {}
+        : { disable_parallel_tool_use: toolChoice.disableParallelToolUse }),
+    }),
+    tool: (name) => ({
+      type: "tool" as const,
+      name,
+      ...(toolChoice.disableParallelToolUse === undefined
+        ? {}
+        : { disable_parallel_tool_use: toolChoice.disableParallelToolUse }),
+    }),
   })
 
 const scrubToolCallID = (id: string) => id.replace(/[^a-zA-Z0-9_-]/g, "_")
@@ -1064,7 +1083,10 @@ export const route = Route.make({
   provider: "anthropic",
   providerMetadataKey: "anthropic",
   protocol,
-  endpoint: Endpoint.path(PATH, { baseURL: DEFAULT_BASE_URL }),
+  endpoint: Endpoint.path(
+    (input) => (input.request.model.provider === "anthropic" ? `${PATH}?beta=true` : PATH),
+    { baseURL: DEFAULT_BASE_URL },
+  ),
   auth: Auth.none,
   framing,
   headers: () => ({ "anthropic-version": "2023-06-01" }),

--- a/packages/ai/src/schema/messages.ts
+++ b/packages/ai/src/schema/messages.ts
@@ -255,6 +255,7 @@ export namespace ToolDefinition {
 export class ToolChoice extends Schema.Class<ToolChoice>("LLM.ToolChoice")({
   type: Schema.Literals(["auto", "none", "required", "tool"]),
   name: Schema.optional(Schema.String),
+  disableParallelToolUse: Schema.optional(Schema.Boolean),
 }) {}
 
 export namespace ToolChoice {


### PR DESCRIPTION
Adds `disable_parallel_tool_use` passthrough for Anthropic Messages and ensures `/v1/messages?beta=true` is sent.

- `ToolChoice` now has `disableParallelToolUse?: boolean` (`packages/ai/src/schema/messages.ts:258`) and wire `AnthropicToolChoice:205` carries `disable_parallel_tool_use`. `lowerToolChoice:373` spreads it for `auto`/`any`/`tool` (SDK: `messages.ts:3429` only those three support it; `none` intentionally omitted). Defaults remain parallel enabled when not set.

- Keeps existing defaults (`interleaved-thinking` + `fine-grained-tool-streaming` betas via `core/plugin/provider/anthropic.ts:15`) but now sends `?beta=true` via `Endpoint.query:1083` to match SDK beta path `client.beta.messages.create → /v1/messages?beta=true:122` (`messages.ts:97` vs `beta/messages.ts:122`). No toggling logic changed — just makes the query consistent with the headers we already send.