### PR TITLE
fix(tui): skip malformed custom themes

### DIFF
--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -54,7 +54,12 @@ export async function discoverThemes(directories: string[]) {
   for (const directory of directories) {
     const files = await Glob.scan("themes/*.json", { cwd: directory, absolute: true, dot: true, symlink: true })
     for (const file of files) {
-      result[path.basename(file, ".json")] = JSON.parse(await readFile(file, "utf8")) as unknown
+      await readFile(file, "utf8")
+        .then((content) => JSON.parse(content) as unknown)
+        .then((theme) => {
+          result[path.basename(file, ".json")] = theme
+        })
+        .catch((error) => console.warn("[tui.theme] failed to load custom theme", { file, error }))
     }
   }
   return result

--- a/packages/tui/test/theme.test.ts
+++ b/packages/tui/test/theme.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test"
+import { expect, spyOn, test } from "bun:test"
 import { mkdir, writeFile } from "node:fs/promises"
 import path from "node:path"
 import type { TerminalColors } from "@opentui/core"
@@ -68,14 +68,24 @@ test("terminalMode does not derive mode from ANSI slot zero", () => {
   expect(terminalMode(terminalColors(null, ["#000000"]))).toBeUndefined()
 })
 
-test("custom theme precedence follows directory order", async () => {
+test("custom theme discovery follows directory order and skips malformed files", async () => {
   await using tmp = await tmpdir()
   const global = path.join(tmp.path, "global")
   const project = path.join(tmp.path, "project")
-  await mkdir(path.join(global, "themes"), { recursive: true })
-  await mkdir(path.join(project, "themes"), { recursive: true })
-  await writeFile(path.join(global, "themes", "custom.json"), JSON.stringify({ source: "global" }))
-  await writeFile(path.join(project, "themes", "custom.json"), JSON.stringify({ source: "project" }))
+  const globalTheme = path.join(global, "themes", "custom.json")
+  const projectTheme = path.join(project, "themes", "custom.json")
+  await mkdir(path.dirname(globalTheme), { recursive: true })
+  await mkdir(path.dirname(projectTheme), { recursive: true })
+  await writeFile(globalTheme, JSON.stringify({ source: "global" }))
+  await writeFile(projectTheme, JSON.stringify({ source: "project" }))
+  expect(await discoverThemes([global, project])).toEqual({ custom: { source: "project" } })
 
-  await expect(discoverThemes([global, project])).resolves.toEqual({ custom: { source: "project" } })
+  await writeFile(projectTheme, "{")
+  const warn = spyOn(console, "warn").mockImplementation(() => {})
+  try {
+    expect(await discoverThemes([global, project])).toEqual({ custom: { source: "global" } })
+    expect(warn.mock.calls[0]?.[1]).toMatchObject({ file: projectTheme, error: expect.any(SyntaxError) })
+  } finally {
+    warn.mockRestore()
+  }
 })


### PR DESCRIPTION
### Issue for this PR

Closes #44263

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Handles custom theme read and parse failures per file. A malformed theme is now skipped with a warning instead of rejecting the entire discovery pass, so valid themes remain available and directory precedence still applies.

### How did you verify your code works?

- `bun test test/theme.test.ts` in `packages/tui`: 8 pass
- `bun run test` in `packages/tui`: 193 pass, 1 skip
- `bun run typecheck` in `packages/tui`
- Repository pre-push typecheck: 30/30 packages passed
- `git diff --check`

### Screenshots / recordings

Not applicable; this changes theme discovery error handling without changing UI layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR