### PR TITLE
fix(ai): drop invalid item ids when replaying responses history

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -313,6 +313,9 @@ export const Event = Schema.StructWithRest(
 )
 export type Event = Schema.Schema.Type<typeof Event>
 
+// Which lowered input item a persisted item id is about to be attached to.
+export type ItemKind = "message" | "reasoning" | "function-call" | "reference"
+
 export interface Extension {
   readonly id: string
   readonly name: string
@@ -321,6 +324,10 @@ export interface Extension {
     readonly media: ProviderShared.NormalizedMedia
     readonly request: LLMRequest
   }) => MediaInput | undefined
+  // Optional grammar check applied before a persisted item id is resent as
+  // part of replayed history. Returning false drops the id; every lowered
+  // item treats a dropped id the same as an absent one.
+  readonly acceptsItemID?: (kind: ItemKind, id: string) => boolean
 }
 
 const BASE: Extension = { id: ADAPTER, name: NAME }
@@ -376,28 +383,46 @@ export const lowerToolChoice = (protocolName: string, toolChoice: NonNullable<LL
     tool: (toolName) => ({ type: "function" as const, name: toolName }),
   })
 
+// Servers validate item ids on replayed history, and a malformed or oversized
+// id can fail an otherwise valid request. Only server-issued tokens are worth
+// resending; anything else is treated as absent so the item is resent without
+// an id (or skipped, for items that cannot be expressed without one).
+const ITEM_ID_PATTERN = /^[A-Za-z0-9_-]{1,64}$/
 const itemID = (providerMetadata: ProviderMetadata | undefined, providerMetadataKey: string) => {
   const metadata = providerMetadata?.[providerMetadataKey]
-  return ProviderShared.isRecord(metadata) && typeof metadata.itemId === "string" && metadata.itemId.length > 0
+  return ProviderShared.isRecord(metadata) &&
+    typeof metadata.itemId === "string" &&
+    ITEM_ID_PATTERN.test(metadata.itemId)
     ? metadata.itemId
     : undefined
 }
 
-const lowerToolCall = (part: ToolCallPart, providerMetadataKey: string): OpenResponsesInputItem => {
+const acceptsItemID = (extension: Extension, kind: ItemKind, id: string | undefined): id is string =>
+  id !== undefined && (extension.acceptsItemID?.(kind, id) ?? true)
+
+const lowerToolCall = (
+  part: ToolCallPart,
+  providerMetadataKey: string,
+  extension: Extension,
+): OpenResponsesInputItem => {
   const id = itemID(part.providerMetadata, providerMetadataKey)
   return {
     type: "function_call",
-    ...(id ? { id } : {}),
+    ...(acceptsItemID(extension, "function-call", id) ? { id } : {}),
     call_id: part.id,
     name: part.name,
     arguments: ProviderShared.encodeJson(part.input),
   }
 }
 
-const lowerReasoning = (part: ReasoningPart, providerMetadataKey: string): OpenResponsesReasoningInput | undefined => {
+const lowerReasoning = (
+  part: ReasoningPart,
+  providerMetadataKey: string,
+  extension: Extension,
+): OpenResponsesReasoningInput | undefined => {
   const metadata = part.providerMetadata?.[providerMetadataKey]
   const id = itemID(part.providerMetadata, providerMetadataKey)
-  if (!ProviderShared.isRecord(metadata) || !id) return undefined
+  if (!ProviderShared.isRecord(metadata) || !acceptsItemID(extension, "reasoning", id)) return undefined
   const encryptedContent =
     typeof metadata.reasoningEncryptedContent === "string" || metadata.reasoningEncryptedContent === null
       ? metadata.reasoningEncryptedContent
@@ -529,7 +554,8 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
           Array<{ id: string | undefined; phase: MessagePhase | null | undefined; parts: TextPart[] }>
         >((groups, part) => {
           const metadata = part.providerMetadata?.[providerMetadataKey]
-          const id = itemID(part.providerMetadata, providerMetadataKey)
+          const rawID = itemID(part.providerMetadata, providerMetadataKey)
+          const id = acceptsItemID(extension, "message", rawID) ? rawID : undefined
           const phase = ProviderShared.isRecord(metadata) ? messagePhase(metadata.phase) : undefined
           const group = groups.at(-1)
           if (group && group.id === id && group.phase === phase) group.parts.push(part)
@@ -554,7 +580,7 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
         }
         if (part.type === "reasoning") {
           flushText()
-          const reasoning = lowerReasoning(part, providerMetadataKey)
+          const reasoning = lowerReasoning(part, providerMetadataKey, extension)
           if (!reasoning) continue
           if (store !== false) {
             if (!reasoningReferences.has(reasoning.id)) input.push({ type: "item_reference", id: reasoning.id })
@@ -575,13 +601,15 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
         if (part.type === "tool-call") {
           flushText()
           if (part.providerExecuted === true) continue
-          input.push(lowerToolCall(part, providerMetadataKey))
+          input.push(lowerToolCall(part, providerMetadataKey, extension))
           continue
         }
         if (part.type === "tool-result" && part.providerExecuted === true) {
           flushText()
           const id = itemID(part.providerMetadata, providerMetadataKey)
-          if (store !== false && id && !hostedToolReferences.has(id)) input.push({ type: "item_reference", id })
+          const reference = acceptsItemID(extension, "reference", id) ? id : undefined
+          if (store !== false && reference && !hostedToolReferences.has(reference))
+            input.push({ type: "item_reference", id: reference })
           if (store === false) {
             // The server is not storing this exchange, so the tool outcome has to
             // travel in the input. Non-content results degrade to their text form.
@@ -596,7 +624,7 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
               ),
             })
           }
-          if (id) hostedToolReferences.add(id)
+          if (reference) hostedToolReferences.add(reference)
           continue
         }
         return yield* ProviderShared.unsupportedContent(extension.name, "assistant", [

--- a/packages/ai/src/protocols/openai-responses.ts
+++ b/packages/ai/src/protocols/openai-responses.ts
@@ -51,9 +51,28 @@ const OpenAIResponsesBody = Schema.Struct({
 })
 export type OpenAIResponsesBody = Schema.Schema.Type<typeof OpenAIResponsesBody>
 
+// Replayed items are paired with stored server state by id, so a foreign or
+// synthetic token can fail request validation even when `call_id` pairing is
+// intact. Only resend ids in each item kind's own grammar; hosted tool
+// references keep generic validation because every hosted tool mints its own
+// prefix. The same allowlist approach codex uses before resending history
+// (codex-rs core/src/client.rs, `prepare_response_items_for_request`).
+const ITEM_ID_PREFIXES: Record<OpenResponses.ItemKind, ReadonlyArray<string>> = {
+  message: ["msg_"],
+  reasoning: ["rs_"],
+  "function-call": ["fc_"],
+  // Every hosted tool mints its own id prefix, so references keep generic
+  // validation only.
+  reference: [],
+}
+
 const extension = {
   id: ADAPTER,
   name: NAME,
+  acceptsItemID: (kind: OpenResponses.ItemKind, id: string) => {
+    const prefixes = ITEM_ID_PREFIXES[kind]
+    return prefixes.length === 0 || prefixes.some((prefix) => id.startsWith(prefix))
+  },
 } satisfies OpenResponses.Extension
 
 const nativeImageToolInput = (tool: ToolDefinition) => {

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -132,6 +132,47 @@ describe("Open Responses-compatible route", () => {
     }),
   )
 
+  it.effect("keeps foreign item id grammars but drops malformed ids", () =>
+    Effect.gen(function* () {
+      const model = configure({
+        apiKey: "test-key",
+        baseURL: "https://responses.example.test/v1",
+      }).model("example-model")
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.assistant([
+              // The baseline does not enforce a provider id grammar, so a
+              // non-OpenAI but well-formed token is resent as-is.
+              { type: "text", text: "Kept.", providerMetadata: { openresponses: { itemId: "history_1" } } },
+              // Shape violations are dropped even without a grammar policy.
+              {
+                type: "text",
+                text: "Dropped.",
+                providerMetadata: { openresponses: { itemId: `m${"a".repeat(64)}` } },
+              },
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
+        {
+          type: "message",
+          id: "history_1",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Kept." }],
+        },
+        {
+          type: "message",
+          role: "assistant",
+          content: [{ type: "output_text", text: "Dropped." }],
+        },
+      ])
+    }),
+  )
+
   it.effect("preserves nullable phases in the forgiving Open Responses baseline", () =>
     Effect.gen(function* () {
       const model = configure({

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -2343,9 +2343,99 @@ describe("OpenAI Responses route", () => {
 
       expect(prepared.body.input).toEqual([
         { role: "user", content: [{ type: "input_text", text: "Search." }] },
-        { role: "user", content: [{ type: "input_text", text: '{"type":"web_search_call","id":"ws_1","status":"completed"}' }] },
+        {
+          role: "user",
+          content: [{ type: "input_text", text: '{"type":"web_search_call","id":"ws_1","status":"completed"}' }],
+        },
         { role: "user", content: [{ type: "input_text", text: "Continue." }] },
       ])
+    }),
+  )
+
+  it.effect("drops replayed item ids outside the server's grammar", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.assistant([
+              // Fails the message id prefix.
+              {
+                type: "text",
+                text: "Hello",
+                providerMetadata: { openai: { itemId: "history_1" } },
+              },
+              // Oversized for the Responses item id limit.
+              {
+                type: "text",
+                text: "World",
+                providerMetadata: { openai: { itemId: `m${"a".repeat(64)}` } },
+              },
+              // Fails the reasoning id prefix, so the whole item is unreplayable
+              // statelessly and is skipped rather than sent malformed.
+              {
+                type: "reasoning",
+                text: "Checked the diff.",
+                providerMetadata: { openai: { itemId: "thinking_1", reasoningEncryptedContent: "encrypted-state" } },
+              },
+              ToolCallPart.make({
+                id: "call_1",
+                name: "lookup",
+                input: { query: "weather" },
+                providerMetadata: { openai: { itemId: "toolu_01A" } },
+              }),
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
+        {
+          type: "message",
+          role: "assistant",
+          content: [
+            { type: "output_text", text: "Hello" },
+            { type: "output_text", text: "World" },
+          ],
+        },
+        {
+          type: "function_call",
+          call_id: "call_1",
+          name: "lookup",
+          arguments: '{"query":"weather"}',
+        },
+      ])
+    }),
+  )
+
+  it.effect("keeps well-formed hosted references and drops malformed ones under storage", () =>
+    Effect.gen(function* () {
+      const hostedResult = (itemId: string) => [
+        ToolCallPart.make({
+          id: itemId,
+          name: "web_search",
+          input: { query: "effect 4" },
+          providerExecuted: true,
+          providerMetadata: { openai: { itemId } },
+        }),
+        {
+          type: "tool-result" as const,
+          id: itemId,
+          name: "web_search",
+          result: { type: "json" as const, value: { status: "completed" } },
+          providerExecuted: true as const,
+          providerMetadata: { openai: { itemId } },
+        },
+      ]
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [Message.assistant(hostedResult("ws_1")), Message.assistant(hostedResult("bad ref"))],
+          providerOptions: { store: true },
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([{ type: "item_reference", id: "ws_1" }])
     }),
   )
 
@@ -2472,15 +2562,15 @@ describe("OpenAI Responses route", () => {
       const body = sseEvents(
         {
           type: "response.output_item.added",
-          item: { type: "function_call", id: "item_1", call_id: "call_1", name: "lookup", arguments: "" },
+          item: { type: "function_call", id: "fc_item_1", call_id: "call_1", name: "lookup", arguments: "" },
         },
-        { type: "response.function_call_arguments.delta", item_id: "item_1", delta: '{"query"' },
-        { type: "response.function_call_arguments.delta", item_id: "item_1", delta: ':"weather"}' },
+        { type: "response.function_call_arguments.delta", item_id: "fc_item_1", delta: '{"query"' },
+        { type: "response.function_call_arguments.delta", item_id: "fc_item_1", delta: ':"weather"}' },
         {
           type: "response.output_item.done",
           item: {
             type: "function_call",
-            id: "item_1",
+            id: "fc_item_1",
             call_id: "call_1",
             name: "lookup",
             arguments: '{"query":"weather"}',
@@ -2509,7 +2599,7 @@ describe("OpenAI Responses route", () => {
           type: "tool-input-start",
           id: "call_1",
           name: "lookup",
-          providerMetadata: { openai: { itemId: "item_1" } },
+          providerMetadata: { openai: { itemId: "fc_item_1" } },
         },
         {
           type: "tool-input-delta",
@@ -2527,7 +2617,7 @@ describe("OpenAI Responses route", () => {
           type: "tool-input-end",
           id: "call_1",
           name: "lookup",
-          providerMetadata: { openai: { itemId: "item_1" } },
+          providerMetadata: { openai: { itemId: "fc_item_1" } },
         },
         {
           type: "tool-call",
@@ -2535,7 +2625,7 @@ describe("OpenAI Responses route", () => {
           name: "lookup",
           input: { query: "weather" },
           providerExecuted: undefined,
-          providerMetadata: { openai: { itemId: "item_1" } },
+          providerMetadata: { openai: { itemId: "fc_item_1" } },
         },
         {
           type: "step-finish",
@@ -2556,7 +2646,7 @@ describe("OpenAI Responses route", () => {
       expect(prepared.body.input).toEqual([
         {
           type: "function_call",
-          id: "item_1",
+          id: "fc_item_1",
           call_id: "call_1",
           name: "lookup",
           arguments: '{"query":"weather"}',
@@ -2570,7 +2660,7 @@ describe("OpenAI Responses route", () => {
       const body = sseEvents(
         {
           type: "response.output_item.added",
-          item: { type: "function_call", id: "item_1", call_id: "call_1", name: "lookup", arguments: "" },
+          item: { type: "function_call", id: "fc_item_1", call_id: "call_1", name: "lookup", arguments: "" },
         },
         { type: "response.completed", response: { usage: { input_tokens: 5, output_tokens: 1 } } },
       )
@@ -2582,7 +2672,7 @@ describe("OpenAI Responses route", () => {
             type: "tool-input-end",
             id: "call_1",
             name: "lookup",
-            providerMetadata: { openai: { itemId: "item_1" } },
+            providerMetadata: { openai: { itemId: "fc_item_1" } },
           },
           {
             type: "tool-call",
@@ -2590,7 +2680,7 @@ describe("OpenAI Responses route", () => {
             name: "lookup",
             input: {},
             providerExecuted: undefined,
-            providerMetadata: { openai: { itemId: "item_1" } },
+            providerMetadata: { openai: { itemId: "fc_item_1" } },
           },
         ],
       )
@@ -2603,14 +2693,14 @@ describe("OpenAI Responses route", () => {
       const body = sseEvents(
         {
           type: "response.output_item.added",
-          item: { type: "function_call", id: "item_1", call_id: "call_1", name: "lookup", arguments: "" },
+          item: { type: "function_call", id: "fc_item_1", call_id: "call_1", name: "lookup", arguments: "" },
         },
-        { type: "response.function_call_arguments.delta", item_id: "item_1", delta: '{"query":"streamed"}' },
+        { type: "response.function_call_arguments.delta", item_id: "fc_item_1", delta: '{"query":"streamed"}' },
         {
           type: "response.output_item.done",
           item: {
             type: "function_call",
-            id: "item_1",
+            id: "fc_item_1",
             call_id: "call_1",
             name: "lookup",
             arguments: '{"query":"partial',
@@ -2642,7 +2732,7 @@ describe("OpenAI Responses route", () => {
           type: "response.output_item.done",
           item: {
             type: "function_call",
-            id: "item_1",
+            id: "fc_item_1",
             call_id: "call_1",
             name: "lookup",
             arguments: '{"query":"partial',
@@ -2671,7 +2761,7 @@ describe("OpenAI Responses route", () => {
                 type: "response.output_item.done",
                 item: {
                   type: "function_call",
-                  id: "item_1",
+                  id: "fc_item_1",
                   call_id: "call_1",
                   name: "lookup",
                   arguments: '{"query":"weather"}',
@@ -2685,7 +2775,7 @@ describe("OpenAI Responses route", () => {
 
       expect(response.events.find(LLMEvent.is.toolCall)).toMatchObject({
         id: "call_1",
-        providerMetadata: { openai: { itemId: "item_1" } },
+        providerMetadata: { openai: { itemId: "fc_item_1" } },
       })
     }),
   )


### PR DESCRIPTION
## Summary

When replaying conversation history to a Responses API, persisted item ids (`msg_`, `rs_`, `fc_`, hosted tool ids) were resent verbatim from provider metadata. A malformed, oversized, or foreign id can fail request validation server-side even when `call_id` pairing is intact — for example after switching models mid-session or when synthetic ids end up in history.

## Changes

- **Baseline shape validation** (`open-responses.ts`): `itemID()` now only accepts ids matching `/^[A-Za-z0-9_-]{1,64}$/`. Dropped ids are treated exactly like absent ones at every lowering site:
  - `function_call` items are resent without an `id`
  - assistant message groups lose their `id` (grouping splits so distinct original items stay distinct)
  - hosted tool results skip the `item_reference` synthesis
  - reasoning items, which cannot be expressed without an id, are skipped entirely
- **Per-provider grammar hook**: new optional `Extension.acceptsItemID(kind, id)` lets provider routes enforce their own id grammar. The OpenAI route uses it to resend only `msg_`/`rs_`/`fc_`-prefixed ids for messages/reasoning/function calls; hosted tool references keep shape-only validation since every hosted tool mints its own prefix.
- The provider-neutral baseline (used by compatible deployments) enforces shape only, never a specific grammar.

This mirrors the allowlist approach codex uses before resending history (codex-rs `core/src/client.rs`, `prepare_response_items_for_request` strips ids without a recognized prefix).

## Tests

- New: drops ids failing the OpenAI per-kind grammar (prefix + length) and skips unreplayable reasoning items
- New: keeps well-formed hosted references while dropping malformed ones under storage
- New: baseline keeps well-formed foreign grammars but drops shape violations
- Updated: function-call stream fixtures now use realistic `fc_`-prefixed item ids

Full `packages/ai` suite passes; the six OpenRouter failures are pre-existing on `v2`.