### PR TITLE
fix(app): use a deletable cursor for draft blob cleanup

### DIFF
--- a/packages/app/src/runtime/persistence/drafts.ts
+++ b/packages/app/src/runtime/persistence/drafts.ts
@@ -114,7 +114,7 @@ export function createBrowserDraftStore(): DraftStore {
           if (item?.blob && typeof item.blob.id === "string") used.add(item.blob.id)
           return item
         })
-        const blobs = transaction.objectStore("blobs").openKeyCursor()
+        const blobs = transaction.objectStore("blobs").openCursor()
         blobs.addEventListener("success", () => {
           const cursor = blobs.result
           if (!cursor) return

--- a/packages/app/src/runtime/persistence/drafts.ts
+++ b/packages/app/src/runtime/persistence/drafts.ts
@@ -114,11 +114,12 @@ export function createBrowserDraftStore(): DraftStore {
           if (item?.blob && typeof item.blob.id === "string") used.add(item.blob.id)
           return item
         })
-        const blobs = transaction.objectStore("blobs").openCursor()
+        const store = transaction.objectStore("blobs")
+        const blobs = store.openKeyCursor()
         blobs.addEventListener("success", () => {
           const cursor = blobs.result
           if (!cursor) return
-          if (!used.has(String(cursor.key))) cursor.delete()
+          if (!used.has(String(cursor.key))) store.delete(cursor.key)
           cursor.continue()
         })
       })


### PR DESCRIPTION
The browser draft store opened the blobs object store with openKeyCursor() while reclaiming unreferenced image blobs. IDBCursor.delete() is invalid for key cursors and raised an uncaught InvalidStateError during IndexedDB cleanup. Use openCursor() so stale blob records can be deleted safely while iterating.

(apparently) fixes this error I got in the browser console:

```
index-DswqPbRa.js:94 Uncaught InvalidStateError: Failed to execute 'delete' on 'IDBCursor': The cursor is a key cursor.    at IDBRequest.<anonymous> (index-DswqPbRa.js:94:145245)
(anonymous)	@	index-DswqPbRa.js:94
IndexedDB		
(anonymous)	@	index-DswqPbRa.js:94
IndexedDB		
(anonymous)	@	index-DswqPbRa.js:94
IndexedDB		
cO	@	index-DswqPbRa.js:94
fO	@	index-DswqPbRa.js:94
(anonymous)	@	index-DswqPbRa.js:100
```