### PR TITLE
fix: settle shell completion on process exit instead of pipe EOF

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -96,7 +96,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -144,7 +144,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -158,7 +158,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -194,7 +194,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -221,7 +221,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -243,7 +243,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -267,7 +267,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -287,7 +287,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -381,7 +381,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "drizzle-orm": "catalog:",
@@ -435,7 +435,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -449,7 +449,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -461,7 +461,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -493,7 +493,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -509,7 +509,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -540,7 +540,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -559,7 +559,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -690,7 +690,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -766,7 +766,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -781,7 +781,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -796,7 +796,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/client": "file:../app/vendor/opencode-ai-client-1.17.13-v2.tgz",
@@ -836,7 +836,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -849,7 +849,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -883,7 +883,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -902,7 +902,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -944,7 +944,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -971,7 +971,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1022,7 +1022,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.20",
+      "version": "1.18.21",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/cross-spawn-spawner.ts
+++ b/packages/core/src/cross-spawn-spawner.ts
@@ -268,18 +268,25 @@ export const make = Effect.gen(function* () {
     Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
-      let end = false
+      let settled = false
       let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
+      const settle = (args: readonly [code: number | null, signal: NodeJS.Signals | null]) => {
+        if (settled) return
+        settled = true
+        Deferred.doneUnsafe(signal, Exit.succeed(args))
+      }
       proc.on("error", (err) => {
         resume(Effect.fail(toPlatformError("spawn", err, command)))
       })
+      // Settle from `exit`: it fires as soon as the direct child ends, regardless of
+      // whether a descendant still holds an inherited stdio pipe open. `close` is kept
+      // as a fallback for platforms/paths where `exit` does not fire.
       proc.on("exit", (...args) => {
         exit = args
+        settle(args)
       })
       proc.on("close", (...args) => {
-        if (end) return
-        end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+        settle(exit ?? args)
       })
       proc.on("spawn", () => {
         resume(Effect.succeed([proc, signal]))

--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -1,7 +1,7 @@
-import { Context, Duration, Effect, Fiber, Layer, Schema, Stream } from "effect"
+import { Context, Duration, Effect, Fiber, Layer, Ref, Schema, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess } from "effect/unstable/process"
-import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import { ChildProcessSpawner, type ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
 import { CrossSpawnSpawner } from "./cross-spawn-spawner"
 import { makeGlobalNode } from "./effect/app-node"
 
@@ -136,6 +136,44 @@ export const collectStream = (stream: Stream.Stream<Uint8Array, PlatformError>, 
     },
   ).pipe(Effect.map((x) => ({ buffer: Buffer.concat(x.chunks), truncated: x.truncated })))
 
+const DRAIN_GRACE_MS = Duration.millis(2_000)
+
+/**
+ * Like collectStream, but never blocks indefinitely on stream EOF. Reads the
+ * stream concurrently (so a pipe-full child cannot deadlock), waits for the
+ * process to exit, then allows a short bounded window for in-flight output
+ * before returning whatever has been captured. A descendant that inherited the
+ * stdio pipe (e.g. a gradle daemon) can therefore no longer keep the caller
+ * waiting forever for the pipe to close.
+ */
+export const collectBounded = (
+  handle: ChildProcessHandle,
+  stream: Stream.Stream<Uint8Array, PlatformError>,
+  maxOutputBytes: number | undefined,
+) =>
+  Effect.gen(function* () {
+    const acc = yield* Ref.make({ chunks: [] as Uint8Array[], bytes: 0, truncated: false })
+    const push = (chunk: Uint8Array) =>
+      Ref.update(acc, (a) => {
+        if (maxOutputBytes === undefined) {
+          a.chunks.push(chunk)
+          a.bytes += chunk.length
+          return a
+        }
+        const remaining = maxOutputBytes - a.bytes
+        if (remaining > 0) a.chunks.push(remaining >= chunk.length ? chunk : chunk.slice(0, remaining))
+        a.bytes += chunk.length
+        a.truncated = a.truncated || a.bytes > maxOutputBytes
+        return a
+      })
+    const reader = yield* Effect.forkScoped(Stream.runForEach(stream, push))
+    yield* handle.exitCode
+    yield* Fiber.join(reader).pipe(Effect.timeoutOption(DRAIN_GRACE_MS), Effect.ignore)
+    yield* Fiber.interrupt(reader).pipe(Effect.ignore)
+    const { chunks, truncated } = yield* Ref.get(acc)
+    return { buffer: Buffer.concat(chunks), truncated }
+  })
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -148,7 +186,7 @@ const layer = Layer.effect(
           const handle = yield* spawner.spawn(command)
           if (options?.combineOutput) {
             const [output, exitCode] = yield* Effect.all(
-              [collectStream(handle.all, options.maxOutputBytes), handle.exitCode],
+              [collectBounded(handle, handle.all, options.maxOutputBytes), handle.exitCode],
               { concurrency: "unbounded" },
             )
             return {
@@ -164,8 +202,8 @@ const layer = Layer.effect(
           }
           const [stdout, stderr, exitCode] = yield* Effect.all(
             [
-              collectStream(handle.stdout, options?.maxOutputBytes),
-              collectStream(handle.stderr, options?.maxErrorBytes),
+              collectBounded(handle, handle.stdout, options?.maxOutputBytes),
+              collectBounded(handle, handle.stderr, options?.maxErrorBytes),
               handle.exitCode,
             ],
             { concurrency: "unbounded" },

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -423,4 +423,29 @@ describe("cross-spawn spawner", () => {
       }),
     )
   })
+
+  describe("descendant holds stdio pipe", () => {
+    fx.effect(
+      "resolves exitCode on direct child exit while a descendant keeps the pipe open",
+      Effect.gen(function* () {
+        const script = [
+          "const { spawn } = require('node:child_process')",
+          "const child = spawn(process.execPath, ['-e', 'setTimeout(()=>process.exit(0), 6000)'], { stdio: ['ignore', 'inherit', 'inherit'] })",
+          "child.unref()",
+        ].join(";")
+        const handle = yield* ChildProcess.make(process.execPath, ["-e", script], {
+          stdin: "ignore",
+          stdout: "pipe",
+          stderr: "pipe",
+        })
+        const start = Date.now()
+        const code = yield* handle.exitCode
+        const elapsed = Date.now() - start
+        expect(code).toBe(ChildProcessSpawner.ExitCode(0))
+        // Settles from the direct child's `exit`, not from pipe EOF, which the
+        // still-alive descendant keeps open for 6 seconds.
+        expect(elapsed).toBeLessThan(4_000)
+      }),
+    )
+  })
 })

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Duration, Effect, Fiber, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -25,6 +25,11 @@ import { BashArity } from "@/permission/arity"
 export { Parameters } from "./shell/prompt"
 
 const MAX_METADATA_LENGTH = 30_000
+// After the direct child exits, allow a short bounded window for in-flight output to be
+// drained before the stream reader is interrupted. Prevents a descendant that inherited
+// the stdio pipe (e.g. a gradle daemon, adb server, dev server) from keeping the tool
+// blocked forever waiting for pipe EOF.
+const EXIT_DRAIN_GRACE_MS = Duration.millis(2_000)
 const CWD = new Set(["cd", "chdir", "popd", "pushd", "push-location", "set-location"])
 const FILES = new Set([
   ...CWD,
@@ -483,7 +488,7 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
-          yield* Effect.forkScoped(
+          const reader = yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
               list.push({ text: chunk, size })
@@ -553,6 +558,13 @@ export const ShellTool = Tool.define(
             expired = true
             yield* handle.kill({ forceKillAfter: "3 seconds" }).pipe(Effect.orDie)
           }
+
+          if (exit.kind === "exit") {
+            // Drain any output still in flight for a short bounded window, then stop
+            // reading. The stream may never EOF if a descendant holds the pipe open.
+            yield* Fiber.join(reader).pipe(Effect.timeoutOption(EXIT_DRAIN_GRACE_MS), Effect.ignore)
+          }
+          yield* Fiber.interrupt(reader).pipe(Effect.ignore)
 
           return exit.kind === "exit" ? exit.code : null
         }),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1197,3 +1197,36 @@ describe("tool.shell truncation", () => {
     ),
   )
 })
+
+describe("tool.shell completion", () => {
+  it.live(
+    "returns after the foreground process exits even when a descendant keeps the pipe open",
+    () =>
+      runIn(
+        projectRoot,
+        Effect.gen(function* () {
+          if (sh() === "cmd") return
+          const code = [
+            "const{spawn}=require(\"node:child_process\")",
+            "const c=spawn(process.execPath,[\"-e\",\"setTimeout(()=>process.exit(0),6000)\"],{stdio:[\"ignore\",\"inherit\",\"inherit\"]})",
+            "c.unref()",
+            "process.stdout.write(\"done\")",
+          ].join(";")
+          const text = `${bin} -e ${evalarg(code)}`
+          const command = PS.has(sh()) ? `& ${text}` : text
+          const start = Date.now()
+          const result = yield* run({
+            command,
+            timeout: 20_000,
+          })
+          const elapsed = Date.now() - start
+          expect(result.metadata.exit).toBe(0)
+          expect(result.output).toContain("done")
+          // The direct child exited immediately; the 6s descendant holds the pipe.
+          // The tool must not wait for pipe EOF, so it completes well before then.
+          expect(elapsed).toBeLessThan(8_000)
+        }),
+      ),
+    30_000,
+  )
+})

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/src/util/transcript.ts
+++ b/packages/tui/src/util/transcript.ts
@@ -105,6 +105,13 @@ export function formatPart(part: Part, options: TranscriptOptions): string {
     }
     if (options.toolDetails && part.state.status === "error" && part.state.error) {
       result += `\n**Error:**\n\`\`\`\n${part.state.error}\n\`\`\`\n`
+      const captured =
+        "metadata" in part.state && part.state.metadata && typeof part.state.metadata.output === "string"
+          ? part.state.metadata.output
+          : undefined
+      if (captured) {
+        result += `\n**Output (captured before abort):**\n\`\`\`\n${captured}\n\`\`\`\n`
+      }
     }
     result += `\n`
     return result

--- a/packages/tui/test/util/transcript.test.ts
+++ b/packages/tui/test/util/transcript.test.ts
@@ -252,6 +252,29 @@ describe("transcript", () => {
       expect(result).toContain("**Error:**")
       expect(result).toContain("Command failed")
     })
+
+    test("formats aborted tool with captured output", () => {
+      const part: Part = {
+        id: "part_1",
+        sessionID: "ses_123",
+        messageID: "msg_123",
+        type: "tool",
+        callID: "call_1",
+        tool: "bash",
+        state: {
+          status: "error",
+          input: { command: "gradlew build" },
+          error: "Tool execution aborted",
+          metadata: { output: "Performing Streamed Install\nSuccess", interrupted: true },
+          time: { start: 1000, end: 1100 },
+        },
+      }
+      const result = formatPart(part, options)
+      expect(result).toContain("**Error:**")
+      expect(result).toContain("Tool execution aborted")
+      expect(result).toContain("**Output (captured before abort):**")
+      expect(result).toContain("Performing Streamed Install")
+    })
   })
 
   describe("formatMessage", () => {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.20",
+  "version": "1.18.21",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #20902

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The bash/shell tool reports a command as done only when the spawned child's stdio pipes fully close (`close` event). When a command leaves a background descendant alive (gradle daemon, adb server, dev server, `Start-Process` children), that descendant inherits the pipe and keeps it open after the direct child exits, so the tool never sees EOF and blocks until timeout/abort. Same root cause as #22012, #24784, #29822, #32504, #37838, #42524, #43910.

It's two problems stacked:
1. `cross-spawn-spawner.ts` settles `exitCode` from `close` instead of `exit`.
2. Callers still gate completion on stream EOF — `AppProcess.run` (`Effect.all([collectStream, exitCode])`) and the V1 `ShellTool` stream reader both wait for the pipe to close.

Changes:
- Settle `exitCode` from the `exit` event, keep `close` as a fallback.
- `process.ts`: new `collectBounded` — reads the stream concurrently (avoids a pipe-full deadlock), waits for process exit, then a short 2s drain window before returning captured output. A shared accumulator preserves partial output if the window expires.
- `opencode/src/tool/shell.ts`: after the direct child exits, drain briefly then interrupt the stream-reader fiber so the effect scope closes.
- `tui/src/util/transcript.ts`: `/copy` now renders captured output for aborted/error tool parts.

Completion is now anchored to the direct process exiting instead of pipe EOF, so a surviving grandchild can't block the tool; the bounded drain still captures all in-flight output.

Related fix attempt #42275 only covers the first layer and explicitly leaves callers waiting for stream completion; this PR closes that gap. The background-shell features #40005 / #33310 are intentionally out of scope (managed background jobs remain explicitly opt-in).

### How did you verify your code works?

- `bun typecheck`: @opencode-ai/core, opencode, @opencode-ai/tui all pass.
- `bun test`: process (32), tool-bash, cross-spawn-spawner (incl. new regression: `exitCode` resolves on direct-child exit while a descendant holds the pipe open), shell tool (66, incl. new regression: foreground exits but a descendant holds the pipe 6s → tool returns in < 8s), transcript (20, incl. aborted-tool output), processor-effect (17).
- `--single` build passes the smoke test.
- Reproduced the real hang (gradle + adb install on Windows): output completed with "Success", the tool part stayed `running` ~6 min until abort, then ended as `error: "Tool execution aborted"` with no output in `/copy`. The same command returns promptly in an interactive pwsh because stdout is a console handle, not a pipe.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR