### PR TITLE
fix(core): recover context-limited length completions

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -236,15 +236,35 @@ const layer = Layer.effect(
       const publish = (event: LLMEvent, outputPaths: ReadonlyArray<string> = []) =>
         withPublication(publisher.publish(event, outputPaths))
       let overflowFailure: ProviderErrorEvent | undefined
+      let recoverableLength = false
+      const isContextLimitedLength = (event: LLMEvent) => {
+        if (!LLMEvent.is.stepFinish(event) || event.reason !== "length") return false
+        const context = model.route.defaults.limits?.context
+        const output = request.generation?.maxTokens ?? model.route.defaults.limits?.output
+        const inputTokens = event.usage?.inputTokens
+        const outputTokens = event.usage?.outputTokens
+        return (
+          context !== undefined &&
+          output !== undefined &&
+          inputTokens !== undefined &&
+          outputTokens !== undefined &&
+          inputTokens + output > context &&
+          outputTokens < output
+        )
+      }
       const providerStream = llm.stream(request).pipe(
         Stream.runForEach((event) =>
           Effect.gen(function* () {
-            if (overflowFailure || publisher.hasProviderError()) return
+            if (overflowFailure || recoverableLength || publisher.hasProviderError()) return
             if (LLMEvent.is.providerError(event)) {
               if (isContextOverflowFailure(event) && !publisher.hasAssistantStarted()) {
                 overflowFailure = event
                 return
               }
+            }
+            if (isContextLimitedLength(event) && !publisher.hasAssistantStarted()) {
+              recoverableLength = true
+              return
             }
             yield* publish(event)
             if (event.type !== "tool-call" || event.providerExecuted) return
@@ -289,7 +309,7 @@ const layer = Layer.effect(
           if (
             recoverOverflow &&
             !publisher.hasAssistantStarted() &&
-            isContextOverflowFailure(overflowFailure ?? failure) &&
+            (isContextOverflowFailure(overflowFailure ?? failure) || recoverableLength) &&
             (yield* restore(recoverOverflow({ sessionID: session.id, entries, model, request })))
           )
             return yield* Effect.die(continueAfterOverflowCompaction(currentStep))

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1238,6 +1238,64 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("recovers a context-limited length stop before durable output", () =>
+    Effect.gen(function* () {
+      const session = yield* setupOverflowRecovery
+      responses = [
+        [
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.stepFinish({
+            index: 0,
+            reason: "length",
+            usage: { inputTokens: 19_900, outputTokens: 40, totalTokens: 19_940 },
+          }),
+          LLMEvent.finish({
+            reason: "length",
+            usage: { inputTokens: 19_900, outputTokens: 40, totalTokens: 19_940 },
+          }),
+        ],
+        fragmentFixture("text", "text-summary", ["## Objective\n- Recover length stop"]).completeEvents,
+        fragmentFixture("text", "text-final", ["Recovered"]).completeEvents,
+      ]
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Continue" }), resume: false })
+      yield* session.resume(sessionID)
+
+      expect(requests).toHaveLength(3)
+      expect(userTexts(requests[1])[0]).toContain("## Objective")
+      expect(userTexts(requests[2])[0]).toContain("<summary>\n## Objective\n- Recover length stop\n</summary>")
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "compaction", summary: "## Objective\n- Recover length stop" },
+        { type: "assistant", finish: "stop" },
+      ])
+    }),
+  )
+
+  it.effect("does not recover a length stop when output limit was reached", () =>
+    Effect.gen(function* () {
+      const session = yield* setupOverflowRecovery
+      responses = [
+        [
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.stepFinish({
+            index: 0,
+            reason: "length",
+            usage: { inputTokens: 19_900, outputTokens: 1_000, totalTokens: 20_900 },
+          }),
+          LLMEvent.finish({
+            reason: "length",
+            usage: { inputTokens: 19_900, outputTokens: 1_000, totalTokens: 20_900 },
+          }),
+        ],
+      ]
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Continue" }), resume: false })
+      yield* session.resume(sessionID)
+
+      expect(requests).toHaveLength(1)
+      const context = yield* session.context(sessionID)
+      expect(context.at(-1)).toMatchObject({ type: "assistant", finish: "length" })
+    }),
+  )
+
   it.effect("persists a second context overflow after one recovery", () =>
     Effect.gen(function* () {
       const session = yield* setupOverflowRecovery


### PR DESCRIPTION
### Issue for this PR

Closes #44609

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a provider returns `reason: "length"` before any durable assistant output, OpenCode currently persists the finish and stops. This can happen when the input plus the configured output budget exceeds the model context window, even though the model has not actually used the output budget.

This change treats only that narrow case as recoverable and reuses the existing overflow-compaction/retry path. It does not retry normal output-limit stops or responses where assistant output has already started.

Related issue scope:

- #42900 covers the broader zero-output `length` exit problem.
- #18108 focuses on truncated tool calls and repair/doom-loop behavior.
- #17471 requests general auto-continue for output-token-limit stops.
- This PR specifically handles context-window exhaustion before durable assistant output.

### How did you verify your code works?

Added failing-first regression coverage for:

- recovering a context-limited `length` stop through compaction and retry;
- preserving a normal output-limit `length` stop without retrying.

The unmodified source reproduces the bug: 1 request instead of 3. The post-fix local run is blocked before test setup by an existing Windows Bun dependency-link `EPERM` error while resolving `ioredis -> debug`. No dependency or lockfile changes were made.

### Screenshots / recordings

Not applicable; this is a core runtime change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR