### PR TITLE
fix(llm): read pending tool calls with an own-property check

### DIFF
--- a/packages/llm/src/protocols/utils/tool-stream.ts
+++ b/packages/llm/src/protocols/utils/tool-stream.ts
@@ -39,6 +39,14 @@ export interface AppendOutcome<K extends StreamKey> {
 /** Create empty accumulator state for one provider stream. */
 export const empty = <K extends StreamKey>(): State<K> => ({})
 
+/**
+ * Read one pending call. The stream key is provider-supplied, so an
+ * `Object.prototype` member name (`toString`, `constructor`, ...) must not
+ * resolve to an inherited value and be mistaken for a started tool call.
+ */
+const read = <K extends StreamKey>(tools: State<K>, key: K): PendingTool | undefined =>
+  Object.hasOwn(tools, key) ? tools[key] : undefined
+
 const withTool = <K extends StreamKey>(tools: State<K>, key: K, tool: PendingTool): State<K> => {
   return { ...tools, [key]: tool }
 }
@@ -85,7 +93,7 @@ const appendTool = <K extends StreamKey>(
   text: string,
 ): AppendOutcome<K> => {
   const events: LLMEvent[] = []
-  if (!tools[key]) events.push(inputStart(tool))
+  if (!read(tools, key)) events.push(inputStart(tool))
   if (text.length > 0) events.push(inputDelta(tool, text))
   return {
     tools: withTool(tools, key, tool),
@@ -121,7 +129,7 @@ export const appendOrStart = <K extends StreamKey>(
   delta: { readonly id?: string; readonly name?: string; readonly text: string },
   missingToolMessage: string,
 ): AppendOutcome<K> | LLMError => {
-  const current = tools[key]
+  const current = read(tools, key)
   const id = delta.id ?? current?.id
   const name = delta.name ?? current?.name
   if (!id || !name) return eventError(route, missingToolMessage)
@@ -150,7 +158,7 @@ export const appendExisting = <K extends StreamKey>(
   text: string,
   missingToolMessage: string,
 ): AppendOutcome<K> | LLMError => {
-  const current = tools[key]
+  const current = read(tools, key)
   if (!current) return eventError(route, missingToolMessage)
   if (text.length === 0) return { tools, tool: current, events: [] }
   return appendTool(tools, key, { ...current, input: `${current.input}${text}` }, text)
@@ -163,7 +171,7 @@ export const appendExisting = <K extends StreamKey>(
  */
 export const finish = <K extends StreamKey>(route: string, tools: State<K>, key: K) =>
   Effect.gen(function* () {
-    const tool = tools[key]
+    const tool = read(tools, key)
     if (!tool) return { tools }
     return {
       tools: withoutTool(tools, key),
@@ -181,7 +189,7 @@ export const finish = <K extends StreamKey>(route: string, tools: State<K>, key:
  */
 export const finishWithInput = <K extends StreamKey>(route: string, tools: State<K>, key: K, input: string) =>
   Effect.gen(function* () {
-    const tool = tools[key]
+    const tool = read(tools, key)
     if (!tool) return { tools }
     return {
       tools: withoutTool(tools, key),

--- a/packages/llm/test/tool-stream.test.ts
+++ b/packages/llm/test/tool-stream.test.ts
@@ -96,4 +96,27 @@ describe("ToolStream", () => {
       })
     }),
   )
+
+  it.effect("treats an Object.prototype stream key as an unstarted tool call", () =>
+    Effect.gen(function* () {
+      const error = ToolStream.appendExisting(
+        ADAPTER,
+        ToolStream.empty<string>(),
+        "toString",
+        '{"query":"weather"}',
+        "missing tool",
+      )
+
+      expect(error).toBeInstanceOf(LLMError)
+      if (ToolStream.isError(error)) expect(error.reason.message).toBe("missing tool")
+    }),
+  )
+
+  it.effect("ignores a stop event for an Object.prototype stream key", () =>
+    Effect.gen(function* () {
+      const finished = yield* ToolStream.finish(ADAPTER, ToolStream.empty<string>(), "constructor")
+
+      expect(finished).toEqual({ tools: {} })
+    }),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #44625

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ToolStream` keeps pending tool calls in a plain object keyed by the provider's stream id. On the OpenAI Responses protocol that key is `event.item_id`, a free-form string from the server.

If that string is an `Object.prototype` member name (`toString`, `constructor`, `valueOf`, ...), `tools[key]` returns the inherited function rather than `undefined`. That value is truthy, so `appendExisting`, `finish` and `finishWithInput` skip their `if (!tool) return ...` guards and build an event out of it with `id`/`name` undefined. The schema constructor then throws `Expected string, got undefined` synchronously — outside the Effect error channel — so the stream dies with a defect instead of yielding a typed provider-output error.

The fix reads pending calls through an own-property check (`Object.hasOwn`) in the five places that look one up, so an inherited member can never be mistaken for a started tool call. The state shape and semantics are unchanged.

### How did you verify your code works?

Added two cases to `packages/llm/test/tool-stream.test.ts` covering `appendExisting` and `finish` with a prototype key. Both throw on `dev` (`Expected string, got undefined`) and pass with the fix.

```
bun test test/tool-stream.test.ts   # 6 pass / 0 fail (4 pass / 2 fail without the fix)
bun test                            # packages/llm: 300 pass, 30 skip, 0 fail
bun run typecheck                   # clean
```

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
