### PR TITLE
fix(app): reference ui custom element declarations

### DIFF
--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />


### PR DESCRIPTION
### Issue for this PR

No tracking issue - found while auditing why the root `bun typecheck` (and therefore the pre-push hook) fails on every clean v2 checkout.

### Type of change

- [x] Bug fix

### What does this PR do?

`packages/app/src/custom-elements.d.ts` has contained a bare relative path line since the desktop->app rename, so tsgo fails with TS1128 the moment anyone typechecks `packages/app`, which in turn blocks the root monorepo typecheck and the pre-push hook for every contributor. This restores what the file obviously intended: a triple-slash reference pulling in the ui package'"'"'s `<diffs-container>` JSX declarations.

After this one line, `bun run typecheck` passes cleanly for packages/app on an otherwise unmodified checkout.

### How did you verify your code works?

- before: `bun run typecheck` (packages/app) -> TS1128 x2 at src/custom-elements.d.ts(1,1)/(1,2)
- after: same command exits 0
- root effect: with this file fixed, the full-monorepo pre-push typecheck can pass again (verified locally alongside our other branches)

### Screenshots / recordings

Not a UI change.

Closes #44674

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
