### PR TITLE
fix(llm): reject Bedrock event-stream frames above the 16 MiB maximum

### DIFF
--- a/packages/llm/src/protocols/bedrock-event-stream.ts
+++ b/packages/llm/src/protocols/bedrock-event-stream.ts
@@ -11,6 +11,13 @@ import { ProviderShared } from "./shared"
 const eventCodec = new EventStreamCodec(toUtf8, fromUtf8)
 const utf8 = new TextDecoder()
 
+// AWS caps a single event-stream message at 16 MiB, but the prelude carries
+// `total_length` as a 32-bit field, so a malformed or truncated response can
+// announce a frame of up to 4 GiB. Nothing else bounds the buffer: every byte
+// that arrives after such a prelude is appended (and the whole accumulated
+// window re-copied) while waiting for a frame that never completes.
+const MAX_FRAME_BYTES = 16 * 1024 * 1024
+
 // Cursor-tracking buffer state. Bytes accumulate in `buffer`; `offset` is the
 // read position. Reading by `subarray` is zero-copy. We only allocate a fresh
 // buffer when a new network chunk arrives and we need to append.
@@ -39,6 +46,11 @@ const consumeFrames = (route: string) => (state: FrameBufferState, chunk: Uint8A
     while (cursor.buffer.length - cursor.offset >= 4) {
       const view = cursor.buffer.subarray(cursor.offset)
       const totalLength = new DataView(view.buffer, view.byteOffset, view.byteLength).getUint32(0, false)
+      if (totalLength > MAX_FRAME_BYTES)
+        return yield* ProviderShared.eventError(
+          route,
+          `Bedrock Converse event-stream frame declares ${totalLength} bytes, above the ${MAX_FRAME_BYTES} byte maximum`,
+        )
       if (view.length < totalLength) break
 
       const decoded = yield* Effect.try({

--- a/packages/llm/test/provider/bedrock-converse.test.ts
+++ b/packages/llm/test/provider/bedrock-converse.test.ts
@@ -388,6 +388,22 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
+  it.effect("rejects an event-stream frame that declares more than the 16 MiB maximum", () =>
+    Effect.gen(function* () {
+      // A truncated or malformed prelude can announce a frame far larger than
+      // the AWS maximum. Framing must reject it instead of buffering (and
+      // re-copying) every byte that follows a frame that never completes.
+      const prelude = new Uint8Array(8)
+      new DataView(prelude.buffer).setUint32(0, 0xffffffff, false)
+      const error = yield* LLMClient.generate(baseRequest).pipe(
+        Effect.provide(fixedBytes(concat([prelude, new Uint8Array(64)]))),
+        Effect.flip,
+      )
+
+      expect(error.message).toContain("above the 16777216 byte maximum")
+    }),
+  )
+
   it.effect("rejects requests with no auth path", () =>
     Effect.gen(function* () {
       const unsignedModel = AmazonBedrock.configure({


### PR DESCRIPTION
### Issue for this PR

Closes #44630

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`bedrock-event-stream.ts` reads `total_length` from the frame prelude and waits for that many bytes. It's a 32-bit field, so a malformed response can declare up to 4 GiB. Nothing bounds the wait, and since the buffer is only compacted once a frame completes, `appendChunk` re-copies the whole accumulated window on every network chunk — cost is quadratic in bytes received. Measured with 16 KiB chunks after a `0xFFFFFFFF` prelude: 16 MiB sent → 4.1 s / 166 MiB RSS; 64 MiB sent → 47.2 s / 650 MiB RSS. The stream then fails with the generic `ended without a terminal finish event`, so there's no diagnostic either.

AWS caps an event-stream message at 16 MiB. `@smithy/eventstream-codec` doesn't enforce it. This adds that check before the length gate, so an oversized prelude fails fast with the declared size in the message instead of buffering toward a frame that can never complete. Well-formed frames are unaffected — the check only fires above 16 MiB, which no valid Converse frame reaches.

### How did you verify your code works?

Added a test to `packages/llm/test/provider/bedrock-converse.test.ts` that feeds a prelude declaring `0xFFFFFFFF` through `LLMClient.generate` and asserts the framing error. Without the fix it fails with `Provider stream ended without a terminal finish event`; with it, it passes.

`bun test` in `packages/llm`: 298 pass on `dev`, 299 pass with this change, 0 fail. `bun run typecheck` clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
