### PR TITLE
fix(session-ui): show tool errors inline

### DIFF
--- a/packages/session-ui/src/components/tool-error-card.css
+++ b/packages/session-ui/src/components/tool-error-card.css
@@ -36,8 +36,7 @@
     color: var(--v2-text-text-muted);
   }
 
-  [data-slot="tool-error-card-summary"],
-  [data-slot="tool-error-card-message"] {
+  [data-slot="tool-error-card-summary"] {
     font-family: var(--v2-font-family-sans);
     font-size: 13px;
     font-weight: 440;
@@ -52,11 +51,6 @@
   [data-slot="tool-error-card-summary"] {
     flex-shrink: 1;
     min-width: 0;
-  }
-
-  [data-slot="tool-error-card-message"] {
-    /* Text column indent: 16px icon + 8px gap. */
-    padding-inline-start: 24px;
   }
 
   [data-slot="basic-tool-tool-info-main"] {
@@ -83,8 +77,7 @@
   }
 
   > [data-component="collapsible"].tool-collapsible {
-    /* Figma's 4px gap minus the 1.5px the compact line box adds above the summary em. */
-    gap: 2.5px;
+    gap: 0px;
 
     > [data-slot="collapsible-trigger"] {
       height: 24px;
@@ -100,11 +93,6 @@
         display: none;
       }
     }
-  }
-
-  > [data-component="collapsible"].tool-collapsible[data-open="true"] {
-    /* The compact line box alone yields Figma's spacing under the header. */
-    gap: 0px;
   }
 
   [data-component="tool-error-card-icon"] [data-slot="icon-svg"] {

--- a/packages/session-ui/src/components/tool-error-card.tsx
+++ b/packages/session-ui/src/components/tool-error-card.tsx
@@ -122,12 +122,10 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
                         </a>
                       </Show>
                     </Show>
-                    <Show when={open()}>
-                      <span data-slot="tool-error-card-dot" aria-hidden="true">
-                        ·
-                      </span>
-                      <span data-slot="tool-error-card-summary">{summary()}</span>
-                    </Show>
+                    <span data-slot="tool-error-card-dot" aria-hidden="true">
+                      ·
+                    </span>
+                    <span data-slot="tool-error-card-summary">{summary()}</span>
                   </div>
                 </div>
               </div>
@@ -135,9 +133,6 @@ export function ToolErrorCard(props: ToolErrorCardProps) {
             <Collapsible.Arrow />
           </div>
         </Collapsible.Trigger>
-        <Show when={!open()}>
-          <div data-slot="tool-error-card-message">{summary()}</div>
-        </Show>
         <Show when={detail()}>
           <Collapsible.Content>
             <div data-slot="tool-error-card-content">


### PR DESCRIPTION
### Issue for this PR

No tracking issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps failed tool summaries in the tool header while collapsed instead of rendering them on a second line. The summary continues to truncate within the available width, leaving room for the disclosure arrow.

### How did you verify your code works?

- `bun typecheck` in `packages/session-ui`
- `bun test src --only-failures` in `packages/session-ui` (101 pass)
- Full repository typecheck via the pre-push hook
- Storybook at 420x480 in dark mode

### Screenshots / recordings

| Before | After |
| --- | --- |
| ![Before: failed tool summaries on a second line](https://github.com/user-attachments/assets/1b41f01f-7be8-4fae-aec8-4cc02e945f58) | ![After: failed tool summaries inline with tool names](https://github.com/user-attachments/assets/ee2caa0a-f57f-4b23-bd82-bb3ffc4994ce) |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
