### PR TITLE
docs(go): clarify DeepSeek weekend pricing

### DIFF
--- a/packages/web/src/content/docs/ar/go.mdx
+++ b/packages/web/src/content/docs/ar/go.mdx
@@ -168,7 +168,7 @@ OpenCode Go هو اشتراك منخفض التكلفة بقيمة **$10/شهر�
 | Hy3                                     | $0.14   | $0.58   | $0.035          | -               | $60       |
 | Ox Alpha Free                           | -       | -       | -               | -               | -         |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** ساعات Peak هي 01:00-04:00 و06:00-10:00 UTC؛ وجميع الساعات الأخرى Off-Peak. [اعرف المزيد](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** ساعات Peak هي 01:00-04:00 و06:00-10:00 UTC من الاثنين إلى الجمعة؛ وجميع الساعات الأخرى، بما في ذلك عطلات نهاية الأسبوع، Off-Peak. [اعرف المزيد](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** يتم تحويل الصور إلى رموز بناءً على أبعادها، وتُحتسب كرموز إدخال إلى جانب رموز النص. [اعرف المزيد](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/bs/go.mdx
+++ b/packages/web/src/content/docs/bs/go.mdx
@@ -178,7 +178,7 @@ Procjene se također zasnivaju na sljedećim cijenama po 1M tokena i mjesečnoj 
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60       |
 | Ox Alpha Free                           | -      | -      | -           | -            | -         |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak sati su 01:00-04:00 i 06:00-10:00 UTC; svi ostali sati su Off-Peak. [Saznajte više](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak sati su 01:00-04:00 i 06:00-10:00 UTC od ponedjeljka do petka; svi ostali sati, uključujući vikende, su Off-Peak. [Saznajte više](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Slike se pretvaraju u tokene na osnovu svojih dimenzija i naplaćuju kao ulazni tokeni zajedno s tekstualnim tokenima. [Saznajte više](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/da/go.mdx
+++ b/packages/web/src/content/docs/da/go.mdx
@@ -178,7 +178,7 @@ Estimaterne er også baseret på følgende priser pr. 1M tokens og det månedlig
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60     |
 | Ox Alpha Free                           | -      | -      | -           | -            | -       |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak-tiderne er 01:00-04:00 og 06:00-10:00 UTC; alle andre tider er Off-Peak. [Læs mere](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak-tiderne er 01:00-04:00 og 06:00-10:00 UTC fra mandag til fredag; alle andre tider, herunder weekender, er Off-Peak. [Læs mere](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Billeder konverteres til tokens baseret på deres dimensioner og afregnes som inputtokens sammen med teksttokens. [Læs mere](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/de/go.mdx
+++ b/packages/web/src/content/docs/de/go.mdx
@@ -170,7 +170,7 @@ Die Schätzungen basieren außerdem auf den folgenden Preisen pro 1M Tokens und 
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60     |
 | Ox Alpha Free                           | -      | -      | -           | -            | -       |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Die Peak-Zeiten sind 01:00-04:00 und 06:00-10:00 UTC; alle anderen Zeiten sind Off-Peak. [Mehr erfahren](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Die Peak-Zeiten sind montags bis freitags von 01:00-04:00 und 06:00-10:00 UTC; alle anderen Zeiten, einschließlich der Wochenenden, sind Off-Peak. [Mehr erfahren](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Bilder werden anhand ihrer Abmessungen in Tokens umgewandelt und zusammen mit Text-Tokens als Input-Tokens abgerechnet. [Mehr erfahren](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/es/go.mdx
+++ b/packages/web/src/content/docs/es/go.mdx
@@ -178,7 +178,7 @@ Las estimaciones también se basan en los siguientes precios por 1M tokens y en 
 | Hy3                                     | $0.14   | $0.58  | $0.035           | -                  | $60 |
 | Ox Alpha Free                           | -       | -      | -                | -                  | -   |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Las horas Peak son 01:00-04:00 y 06:00-10:00 UTC; todas las demás horas son Off-Peak. [Más información](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Las horas Peak son 01:00-04:00 y 06:00-10:00 UTC, de lunes a viernes; todas las demás horas, incluidos los fines de semana, son Off-Peak. [Más información](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Las imágenes se convierten en tokens según sus dimensiones y se facturan como tokens de entrada junto con los tokens de texto. [Más información](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/fr/go.mdx
+++ b/packages/web/src/content/docs/fr/go.mdx
@@ -168,7 +168,7 @@ Les estimations sont également basées sur les prix suivants par 1M tokens et s
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60         |
 | Ox Alpha Free                           | -      | -      | -           | -            | -           |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Les heures Peak sont 01:00-04:00 et 06:00-10:00 UTC ; toutes les autres heures sont Off-Peak. [En savoir plus](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Les heures Peak sont 01:00-04:00 et 06:00-10:00 UTC, du lundi au vendredi ; toutes les autres heures, y compris le week-end, sont Off-Peak. [En savoir plus](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Les images sont converties en tokens selon leurs dimensions et facturées comme tokens d’entrée avec les tokens de texte. [En savoir plus](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -178,7 +178,7 @@ The estimates are also based on the following prices per 1M tokens and the month
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60   |
 | Ox Alpha Free                           | -      | -      | -           | -            | -     |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak hours are 01:00-04:00 and 06:00-10:00 UTC; all other hours are Off-Peak. [Learn more](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak hours are 01:00-04:00 and 06:00-10:00 UTC, Monday through Friday; all other hours, including weekends, are Off-Peak. [Learn more](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Images are converted into tokens based on their dimensions and billed as input tokens alongside text tokens. [Learn more](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/it/go.mdx
+++ b/packages/web/src/content/docs/it/go.mdx
@@ -176,7 +176,7 @@ Le stime si basano anche sui seguenti prezzi per 1M token e sull'utilizzo mensil
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60      |
 | Ox Alpha Free                           | -      | -      | -           | -            | -        |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Gli orari Peak sono 01:00-04:00 e 06:00-10:00 UTC; tutti gli altri orari sono Off-Peak. [Scopri di più](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Gli orari Peak sono 01:00-04:00 e 06:00-10:00 UTC, dal lunedì al venerdì; tutti gli altri orari, inclusi i fine settimana, sono Off-Peak. [Scopri di più](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Le immagini vengono convertite in token in base alle loro dimensioni e fatturate come token di input insieme ai token di testo. [Scopri di più](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/ja/go.mdx
+++ b/packages/web/src/content/docs/ja/go.mdx
@@ -168,7 +168,7 @@ OpenCode Goには以下の制限が含まれています：
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60   |
 | Ox Alpha Free                           | -      | -      | -           | -            | -     |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak時間は01:00-04:00と06:00-10:00 UTCで、それ以外の時間はすべてOff-Peakです。[詳しく見る](https://api-docs.deepseek.com/quick_start/pricing/)。
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak時間は月曜日から金曜日の01:00-04:00と06:00-10:00 UTCで、週末を含むそれ以外の時間はすべてOff-Peakです。[詳しく見る](https://api-docs.deepseek.com/quick_start/pricing/)。
 
 **DeepSeek V4 Flash Vision Exp:** 画像はサイズに基づいてトークンに変換され、テキストトークンと合わせて入力トークンとして課金されます。 [詳しく見る](https://api-docs.deepseek.com/quick_start/pricing/)。
 

--- a/packages/web/src/content/docs/ko/go.mdx
+++ b/packages/web/src/content/docs/ko/go.mdx
@@ -168,7 +168,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60   |
 | Ox Alpha Free                           | -      | -      | -           | -            | -     |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 시간은 01:00-04:00 및 06:00-10:00 UTC이며, 그 외 모든 시간은 Off-Peak입니다. [자세히 알아보기](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 시간은 월요일부터 금요일까지 01:00-04:00 및 06:00-10:00 UTC이며, 주말을 포함한 그 외 모든 시간은 Off-Peak입니다. [자세히 알아보기](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** 이미지는 크기에 따라 토큰으로 변환되며 텍스트 토큰과 함께 입력 토큰으로 청구됩니다. [자세히 알아보기](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/nb/go.mdx
+++ b/packages/web/src/content/docs/nb/go.mdx
@@ -178,7 +178,7 @@ Estimatene er også basert på følgende priser per 1M tokens og den månedlige 
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60  |
 | Ox Alpha Free                           | -      | -      | -           | -            | -    |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak-tidene er 01:00-04:00 og 06:00-10:00 UTC; alle andre tider er Off-Peak. [Les mer](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak-tidene er 01:00-04:00 og 06:00-10:00 UTC fra mandag til fredag; alle andre tider, inkludert helger, er Off-Peak. [Les mer](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Bilder konverteres til tokens basert på dimensjonene og faktureres som input-tokens sammen med tekst-tokens. [Les mer](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/pl/go.mdx
+++ b/packages/web/src/content/docs/pl/go.mdx
@@ -172,7 +172,7 @@ Szacunki opierają się również na następujących cenach za 1M tokenów oraz 
 | Hy3                                     | $0.14   | $0.58   | $0.035         | -              | $60    |
 | Ox Alpha Free                           | -       | -       | -              | -              | -      |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Godziny Peak to 01:00-04:00 i 06:00-10:00 UTC; wszystkie pozostałe godziny to Off-Peak. [Dowiedz się więcej](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Godziny Peak to 01:00-04:00 i 06:00-10:00 UTC od poniedziałku do piątku; wszystkie pozostałe godziny, w tym weekendy, to Off-Peak. [Dowiedz się więcej](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Obrazy są przeliczane na tokeny na podstawie ich wymiarów i rozliczane jako tokeny wejściowe razem z tokenami tekstowymi. [Dowiedz się więcej](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/pt-br/go.mdx
+++ b/packages/web/src/content/docs/pt-br/go.mdx
@@ -178,7 +178,7 @@ As estimativas também se baseiam nos seguintes preços por 1M tokens e no uso m
 | Hy3                                     | $0.14   | $0.58  | $0.035           | -                | $60 |
 | Ox Alpha Free                           | -       | -      | -                | -                | -   |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Os horários Peak são 01:00-04:00 e 06:00-10:00 UTC; todos os demais horários são Off-Peak. [Saiba mais](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Os horários Peak são 01:00-04:00 e 06:00-10:00 UTC, de segunda a sexta-feira; todos os demais horários, incluindo os fins de semana, são Off-Peak. [Saiba mais](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** As imagens são convertidas em tokens com base em suas dimensões e cobradas como tokens de entrada junto com os tokens de texto. [Saiba mais](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/ru/go.mdx
+++ b/packages/web/src/content/docs/ru/go.mdx
@@ -178,7 +178,7 @@ OpenCode Go включает следующие лимиты:
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60           |
 | Ox Alpha Free                           | -      | -      | -           | -            | -             |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Часы Peak: 01:00-04:00 и 06:00-10:00 UTC; все остальные часы относятся к Off-Peak. [Подробнее](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Часы Peak с понедельника по пятницу: 01:00-04:00 и 06:00-10:00 UTC; все остальные часы, включая выходные, относятся к Off-Peak. [Подробнее](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Изображения преобразуются в токены с учётом их размеров и оплачиваются как входные токены вместе с текстовыми токенами. [Подробнее](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/th/go.mdx
+++ b/packages/web/src/content/docs/th/go.mdx
@@ -168,7 +168,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60   |
 | Ox Alpha Free                           | -      | -      | -           | -            | -     |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** ช่วงเวลา Peak คือ 01:00-04:00 และ 06:00-10:00 UTC ส่วนเวลาอื่นทั้งหมดเป็น Off-Peak [ดูข้อมูลเพิ่มเติม](https://api-docs.deepseek.com/quick_start/pricing/)
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** ช่วงเวลา Peak คือ 01:00-04:00 และ 06:00-10:00 UTC ตั้งแต่วันจันทร์ถึงวันศุกร์ ส่วนเวลาอื่นทั้งหมด รวมถึงวันหยุดสุดสัปดาห์ เป็น Off-Peak [ดูข้อมูลเพิ่มเติม](https://api-docs.deepseek.com/quick_start/pricing/)
 
 **DeepSeek V4 Flash Vision Exp:** รูปภาพจะถูกแปลงเป็น token ตามขนาด และคิดค่าบริการเป็น input token รวมกับ text token [ดูข้อมูลเพิ่มเติม](https://api-docs.deepseek.com/quick_start/pricing/)
 

--- a/packages/web/src/content/docs/tr/go.mdx
+++ b/packages/web/src/content/docs/tr/go.mdx
@@ -168,7 +168,7 @@ Tahminler ayrıca 1M token başına aşağıdaki fiyatlara ve her modelle birlik
 | Hy3                                     | $0.14  | $0.58  | $0.035      | -            | $60      |
 | Ox Alpha Free                           | -      | -      | -           | -            | -        |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak saatleri 01:00-04:00 ve 06:00-10:00 UTC'dir; diğer tüm saatler Off-Peak'tir. [Daha fazla bilgi](https://api-docs.deepseek.com/quick_start/pricing/).
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak saatleri pazartesiden cumaya 01:00-04:00 ve 06:00-10:00 UTC'dir; hafta sonları dahil diğer tüm saatler Off-Peak'tir. [Daha fazla bilgi](https://api-docs.deepseek.com/quick_start/pricing/).
 
 **DeepSeek V4 Flash Vision Exp:** Görseller boyutlarına göre token'lara dönüştürülür ve metin token'larıyla birlikte girdi token'ları olarak ücretlendirilir. [Daha fazla bilgi](https://api-docs.deepseek.com/quick_start/pricing/).
 

--- a/packages/web/src/content/docs/zh-cn/go.mdx
+++ b/packages/web/src/content/docs/zh-cn/go.mdx
@@ -168,7 +168,7 @@ OpenCode Go 包含以下限制：
 | Hy3                                     | $0.14  | $0.58  | $0.035    | -        | $60      |
 | Ox Alpha Free                           | -      | -      | -         | -        | -        |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 时段为 01:00-04:00 和 06:00-10:00 UTC；其他所有时段均为 Off-Peak。[了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 时段为周一至周五的 01:00-04:00 和 06:00-10:00 UTC；其他所有时段（包括周末）均为 Off-Peak。[了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
 
 **DeepSeek V4 Flash Vision Exp:** 图片会根据尺寸转换为 token，并与文本 token 一起按输入 token 计费。 [了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
 

--- a/packages/web/src/content/docs/zh-tw/go.mdx
+++ b/packages/web/src/content/docs/zh-tw/go.mdx
@@ -168,7 +168,7 @@ OpenCode Go 包含以下限制：
 | Hy3                                     | $0.14  | $0.58  | $0.035    | -        | $60    |
 | Ox Alpha Free                           | -      | -      | -         | -        | -      |
 
-**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 時段為 01:00-04:00 和 06:00-10:00 UTC；其他所有時段均為 Off-Peak。[了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
+**DeepSeek V4 Flash / V4 Flash Vision Exp / V4 Pro:** Peak 時段為週一至週五的 01:00-04:00 和 06:00-10:00 UTC；其他所有時段（包括週末）均為 Off-Peak。[了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
 
 **DeepSeek V4 Flash Vision Exp:** 圖片會根據尺寸轉換為 token，並與文字 token 一起按輸入 token 計費。 [了解更多](https://api-docs.deepseek.com/quick_start/pricing/)。
 


### PR DESCRIPTION
Clarifies the DeepSeek peak and off-peak schedule across localized Go documentation.