### PR TITLE
fix(llm): guard Object.prototype keys in tool-stream state

### DIFF
--- a/packages/llm/src/protocols/utils/tool-stream.ts
+++ b/packages/llm/src/protocols/utils/tool-stream.ts
@@ -150,7 +150,7 @@ export const appendExisting = <K extends StreamKey>(
   text: string,
   missingToolMessage: string,
 ): AppendOutcome<K> | LLMError => {
-  const current = tools[key]
+  const current = Object.hasOwn(tools, key) ? tools[key] : undefined
   if (!current) return eventError(route, missingToolMessage)
   if (text.length === 0) return { tools, tool: current, events: [] }
   return appendTool(tools, key, { ...current, input: `${current.input}${text}` }, text)
@@ -163,7 +163,7 @@ export const appendExisting = <K extends StreamKey>(
  */
 export const finish = <K extends StreamKey>(route: string, tools: State<K>, key: K) =>
   Effect.gen(function* () {
-    const tool = tools[key]
+    const tool = Object.hasOwn(tools, key) ? tools[key] : undefined
     if (!tool) return { tools }
     return {
       tools: withoutTool(tools, key),
@@ -181,7 +181,7 @@ export const finish = <K extends StreamKey>(route: string, tools: State<K>, key:
  */
 export const finishWithInput = <K extends StreamKey>(route: string, tools: State<K>, key: K, input: string) =>
   Effect.gen(function* () {
-    const tool = tools[key]
+    const tool = Object.hasOwn(tools, key) ? tools[key] : undefined
     if (!tool) return { tools }
     return {
       tools: withoutTool(tools, key),


### PR DESCRIPTION
### Issue for this PR

Closes #44625

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Provider-supplied tool stream keys can match `Object.prototype` names such as `toString` or `constructor`. The accumulator now uses an own-property check for every pending-tool lookup, so inherited values are never treated as started tool calls.

### How did you verify your code works?

From `packages/llm`:

- `bun test test/tool-stream.test.ts --timeout 30000` (6 passed)
- `bun typecheck`

The focused tests cover starting a `toString` key, rejecting an unstarted inherited key, and ignoring a `constructor` stop event.

### Screenshots / recordings

Not applicable (non-UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR