### PR TITLE
fix(llm): reject oversized Bedrock event-stream frames

### DIFF
--- a/packages/llm/src/protocols/bedrock-event-stream.ts
+++ b/packages/llm/src/protocols/bedrock-event-stream.ts
@@ -11,6 +11,11 @@ import { ProviderShared } from "./shared"
 const eventCodec = new EventStreamCodec(toUtf8, fromUtf8)
 const utf8 = new TextDecoder()
 
+// AWS documents a 16 MiB maximum event-stream message. Reject frames that
+// declare a larger length to prevent unbounded buffer growth from malformed
+// or truncated responses.
+const MAX_EVENT_STREAM_MESSAGE_LENGTH = 16 * 1024 * 1024
+
 // Cursor-tracking buffer state. Bytes accumulate in `buffer`; `offset` is the
 // read position. Reading by `subarray` is zero-copy. We only allocate a fresh
 // buffer when a new network chunk arrives and we need to append.
@@ -39,6 +44,13 @@ const consumeFrames = (route: string) => (state: FrameBufferState, chunk: Uint8A
     while (cursor.buffer.length - cursor.offset >= 4) {
       const view = cursor.buffer.subarray(cursor.offset)
       const totalLength = new DataView(view.buffer, view.byteOffset, view.byteLength).getUint32(0, false)
+      if (totalLength > MAX_EVENT_STREAM_MESSAGE_LENGTH) {
+        yield* ProviderShared.eventError(
+          route,
+          `Bedrock event-stream frame declares ${totalLength} bytes, exceeding the 16 MiB protocol maximum`,
+        )
+        break
+      }
       if (view.length < totalLength) break
 
       const decoded = yield* Effect.try({


### PR DESCRIPTION
## Summary

AWS documents a 16 MiB maximum event-stream message. The frame prelude declares a 32-bit length, so a malformed response can declare up to 4 GiB. Nothing bounded the wait before this change, causing `appendChunk` to keep allocating and copying the accumulated buffer.

## Problem

In `packages/llm/src/protocols/bedrock-event-stream.ts`, `consumeFrames` reads `totalLength` from the 4-byte frame prelude and loops until that many bytes have arrived. A malformed response can declare `0xFFFFFFFF` (4 GiB). Because the buffer is only compacted once a frame completes, `appendChunk` re-copies the whole accumulated window on every network chunk. Cost is quadratic in bytes received.

AWS documents a 16 MiB maximum event-stream message; `@smithy/eventstream-codec` does not enforce it, and neither did we.

## Fix

Add `MAX_EVENT_STREAM_MESSAGE_LENGTH = 16 * 1024 * 1024` and reject frames that declare a larger length with a typed `InvalidProviderOutput` error instead of buffering toward a frame that can never complete.

## Testing

| sent | wall (before) | RSS (before) |
|------|---------------|--------------|
| 8 MiB | 1.2 s | 134 MiB |
| 16 MiB | 4.1 s | 166 MiB |
| 32 MiB | 10.9 s | 262 MiB |
| 64 MiB | 47.2 s | 650 MiB |

After the fix, a frame declaring > 16 MiB immediately emits an error and stops buffering.

Fixes #44630