### PR TITLE
fix(ci): fall back to body scan for closing keywords on non-default branches

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -119,6 +119,7 @@ jobs:
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
+                    baseRefName
                     closingIssuesReferences(first: 1) {
                       totalCount
                     }
@@ -133,9 +134,18 @@ jobs:
               number: pr.number
             });
 
+            const baseRef = result.repository.pullRequest.baseRefName;
             const linkedIssues = result.repository.pullRequest.closingIssuesReferences.totalCount;
 
-            if (linkedIssues === 0) {
+            // When targeting a non-default branch, GitHub does not build closing
+            // references, so fall back to scanning the PR body for a keyword.
+            const closingKeywordPattern = /(fixes|closes|resolves)\s+#(\d+)/i;
+            const hasClosingKeyword = closingKeywordPattern.test(pr.body || '');
+            const hasLinkedIssues = baseRef === context.repo.default_branch
+              ? linkedIssues > 0
+              : hasClosingKeyword;
+
+            if (!hasLinkedIssues) {
               await addLabel('needs:issue');
               await comment('issue', `Thanks for your contribution!
 


### PR DESCRIPTION
## Summary

When PRs target a non-default branch (e.g. `v2`), GitHub's `closingIssuesReferences` GraphQL field always returns 0 even if the PR body contains `Closes #N`. This caused the `pr-standards` workflow to add a false-positive `needs:issue` label to all v2 PRs.

## Problem

The `pr-standards` workflow checks `closingIssuesReferences.totalCount === 0` to detect missing issue links. However, GitHub only creates closing references when a PR targets the repository's **default branch** (`dev`). Since the contribution guidelines ask for PRs against `v2`, the GraphQL check always returns 0 for v2-targeted PRs — even when the body contains a perfectly valid `Closes #N`.

This affects many open PRs: #44501 (`Closes #36892`), #44422 (`Closes #43945`), #44418 (`Closes #42790`), and at least 10 others all carry the false-positive label.

## Fix

In `.github/workflows/pr-standards.yml`, when `baseRefName !== context.repo.default_branch`, fall back to checking the PR body for `(Fixes|Closes|Resolves)\s+#(\d+)` instead of relying on `closingIssuesReferences`.

## Testing

- `#44501` (base: `v2`, body: `Closes #36892`) — no longer flagged after fix
- `#44422` (base: `v2`, body: `Closes #43945`) — no longer flagged after fix
- PRs targeting `dev` with no issue link — still correctly flagged

Fixes #44629