### PR TITLE
feat(app): align context search rows with figma

### DIFF
--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -674,14 +674,59 @@
 }
 
 [data-component="context-tool-group-list"] {
-  padding: 0;
+  /* The 28px compact trigger centers a 16px line box, already leaving 6px above this list. */
+  padding: 4px 0 0 12px;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  /* 16px line boxes with 13px gaps reproduce the design's 29px row pitch for 13px solid rows. */
+  gap: 13px;
 
   [data-slot="context-tool-group-item"] {
     min-width: 0;
     padding: 0;
+    opacity: 0.8;
+
+    [data-slot="basic-tool-tool-info-structured"] {
+      gap: 6px;
+    }
+
+    [data-slot="basic-tool-tool-title"],
+    [data-slot="basic-tool-tool-subtitle"],
+    [data-slot="basic-tool-tool-arg"],
+    [data-slot="context-tool-group-matches"] {
+      font-family: var(--v2-font-family-sans);
+      font-size: 13px;
+      font-weight: 440;
+      line-height: var(--line-height-compact);
+      letter-spacing: -0.04px;
+    }
+
+    [data-slot="basic-tool-tool-subtitle"] {
+      color: var(--v2-text-text-faint);
+    }
+
+    [data-slot="context-tool-group-dot"] {
+      flex-shrink: 0;
+      width: 6px;
+      height: 6px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+
+      &::before {
+        content: "";
+        width: 2.25px;
+        height: 2.25px;
+        border-radius: 50%;
+        background-color: var(--v2-icon-icon-muted);
+      }
+    }
+
+    [data-slot="context-tool-group-matches"] {
+      flex-shrink: 0;
+      white-space: nowrap;
+      color: var(--v2-text-text-faint);
+    }
   }
 }
 

--- a/packages/session-ui/src/storybook/current-session-fixtures.ts
+++ b/packages/session-ui/src/storybook/current-session-fixtures.ts
@@ -681,6 +681,7 @@ export const inspectAndExplainDocument = document([
         args: { pattern: "src/timeline/**/*.{ts,tsx}", path: "packages/session-ui" },
         output:
           "packages/session-ui/src/timeline/projection.ts\npackages/session-ui/src/timeline/session-timeline.tsx\npackages/session-ui/src/timeline/timeline-row.ts",
+        metadata: { count: 3 },
       }),
       completedTool({
         id: "tool_research_grep",
@@ -689,6 +690,7 @@ export const inspectAndExplainDocument = document([
         args: { pattern: "TimelineRow.key", path: "packages/session-ui/src/timeline", include: "*.ts*" },
         output:
           "packages/session-ui/src/timeline/projection.ts:39\npackages/session-ui/src/timeline/session-timeline.tsx:332",
+        metadata: { matches: 2 },
       }),
       completedTool({
         id: "tool_research_read",

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -492,6 +492,7 @@ export function CurrentContextToolGroup(props: {
         icon="glasses"
         status={pending() ? "running" : "completed"}
         compact
+        rail={false}
         allowOpenWhilePending
         open={props.open}
         onOpenChange={change}
@@ -545,6 +546,10 @@ export function CurrentContextToolGroup(props: {
                               {(arg) => <span data-slot="basic-tool-tool-arg">{arg}</span>}
                             </For>
                           </div>
+                          <Show when={trigger().matches}>
+                            <span data-slot="context-tool-group-dot" />
+                            <span data-slot="context-tool-group-matches">{trigger().matches}</span>
+                          </Show>
                         </div>
                       </div>
                     </div>
@@ -644,23 +649,22 @@ function currentContextToolTrigger(tool: SessionMessageAssistantTool, i18n: Retu
       ...(typeof input.offset === "number" ? [`offset=${input.offset}`] : []),
       ...(typeof input.limit === "number" ? [`limit=${input.limit}`] : []),
     ]
-    return { title: i18n.t("ui.tool.read"), subtitle: getFilename(path), args }
+    return { title: i18n.t("ui.tool.read"), subtitle: getFilename(path), args, matches: undefined }
   }
-  if (tool.name === "list") return { title: i18n.t("ui.tool.list"), subtitle: displayDirectory(path), args: [] }
+  if (tool.name === "list")
+    return { title: i18n.t("ui.tool.list"), subtitle: displayDirectory(path), args: [], matches: undefined }
   if (tool.name === "glob")
     return {
       title: i18n.t("ui.tool.glob"),
       subtitle: displayDirectory(path),
-      args: [...(pattern ? [`pattern=${pattern}`] : []), ...(matches ? [matches] : [])],
+      args: pattern ? [`pattern=${pattern}`] : [],
+      matches,
     }
   return {
     title: i18n.t("ui.tool.grep"),
     subtitle: displayDirectory(path),
-    args: [
-      ...(pattern ? [`pattern=${pattern}`] : []),
-      ...(include ? [`include=${include}`] : []),
-      ...(matches ? [matches] : []),
-    ],
+    args: [...(pattern ? [`pattern=${pattern}`] : []), ...(include ? [`include=${include}`] : [])],
+    matches,
   }
 }
 


### PR DESCRIPTION
## Summary

Aligns the expanded `Explored` context group's glob/grep rows with the Figma spec (node `1664:91769`, file `8axq6eWm0FoLvU40uZ1ijz`).

- Move the match count out of the generic args into its own slot: a 6px `fill-circle` middle dot (`--v2-icon-icon-muted`) followed by `(N matches)` in `--v2-text-text-faint`, separated by 6px gaps, pinned outside the truncating arg group
- Row typography per design: 13px / weight 440 / `-0.04px` tracking on the shared `--line-height-compact` metric; tool name `text-base`, directory subtitle `text-faint`, args `text-muted`; rows at 80% opacity
- Drop the shared rail from the group disclosure (`rail={false}`) and indent rows 12px per the mock
- Match the design's 29px row pitch (16px line boxes + 13px gaps) and header-to-list spacing
- Give the storybook glob/grep fixtures real `count`/`matches` metadata so the match-count treatment renders in stories

## Screenshots

Verified against the Figma mock via the `Inspect the codebase` story (expanded and collapsed): tool name base, directory faint, args muted, dot + faint match count.

## Testing

- `bun typecheck` (packages/session-ui)
- `bun test` (packages/session-ui, 101 pass)
- Storybook screenshot comparison against the Figma mock; existing e2e assertion `(12 matches)` text remains inside the row trigger