### PR TITLE
fix(install): support windows-arm64

### DIFF
--- a/install
+++ b/install
@@ -101,7 +101,7 @@ else
 
     combo="$os-$arch"
     case "$combo" in
-      linux-x64|linux-arm64|darwin-x64|darwin-arm64|windows-x64)
+      linux-x64|linux-arm64|darwin-x64|darwin-arm64|windows-x64|windows-arm64)
         ;;
       *)
         echo -e "${RED}Unsupported OS/Arch: $os/$arch${NC}"


### PR DESCRIPTION
### Issue for this PR

Closes #44664

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`install` works out the platform correctly on Windows ARM64 — `uname -s` gives `MINGW*`, which maps to `windows`, and `uname -m` gives `aarch64`, which maps to `arm64`. So `combo` ends up as `windows-arm64`. The problem is the next `case` statement, which lists the supported combos and never included `windows-arm64`, so the script fell through to the `*)` branch and exited with `Unsupported OS/Arch: windows/arm64`.

That binary does exist. `packages/opencode/script/build.ts` declares `{ os: "win32", arch: "arm64" }`, and `publish.yml` signs it, verifies the signature, repacks it and uploads `opencode-windows-arm64.zip` on every release. Nothing else in the script needed changing: `archive_ext` is already `.zip` for windows, and `needs_baseline` only applies to x64, so the filename it builds is `opencode-windows-arm64.zip`, which is exactly the published asset name.

Adding the combo to the allowlist is the whole fix. This also unblocks `opencode upgrade` for curl installs, since that path re-runs this same script (`packages/opencode/src/installation/index.ts` fetches `https://opencode.ai/install`).

### How did you verify your code works?

I don't have a Windows ARM64 machine, so I want to be upfront that I did not run the installer end to end on one.

What I did check:

- Ran the old and new `case` statements directly against sample combos. Before: `windows-arm64` hits the reject branch. After: it is accepted, and unsupported combos like `freebsd-x64` still get rejected, so the allowlist hasn't been loosened beyond the one target.
- Confirmed the asset the script would request actually exists — `https://github.com/anomalyco/opencode/releases/latest/download/opencode-windows-arm64.zip` returns HTTP 200.
- Confirmed the filename the script builds for this target matches that asset name.

A reviewer can confirm the same by running the installer on Windows ARM64, or by checking the release assets against the allowlist.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
