### PR TITLE
docs(github): correct GitHub Action inputs

### DIFF
--- a/packages/web/src/content/docs/github.mdx
+++ b/packages/web/src/content/docs/github.mdx
@@ -70,7 +70,7 @@ Or you can set it up manually.
            with:
              model: anthropic/claude-sonnet-4-20250514
              # share: true
-             # github_token: xxxx
+             # use_github_token: true
    ```
 
 3. **Store the API keys in secrets**
@@ -85,9 +85,12 @@ Or you can set it up manually.
 - `agent`: The agent to use. Must be a primary agent. Falls back to `default_agent` from config or `"build"` if not found.
 - `share`: Whether to share the OpenCode session. Defaults to **true** for public repositories.
 - `prompt`: Optional custom prompt to override the default behavior. Use this to customize how OpenCode processes requests.
-- `token`: Optional GitHub access token for performing operations such as creating comments, committing changes, and opening pull requests. By default, OpenCode uses the installation access token from the OpenCode GitHub App, so commits, comments, and pull requests appear as coming from the app.
+- `mentions`: Comma-separated list of trigger phrases, case-insensitive. Defaults to `/opencode,/oc`.
+- `variant`: Model variant for provider-specific reasoning effort, for example `high`, `max`, or `minimal`.
+- `oidc_base_url`: Base URL for the OIDC token exchange API. Only needed when running a custom GitHub App install. Defaults to `https://api.opencode.ai`.
+- `use_github_token`: Set to `true` to use the workflow's `GITHUB_TOKEN` instead of the OpenCode App token exchange. Defaults to `false`. By default, OpenCode uses the installation access token from the OpenCode GitHub App, so commits, comments, and pull requests appear as coming from the app.
 
-  Alternatively, you can use the GitHub Action runner's [built-in `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token) without installing the OpenCode GitHub App. Just make sure to grant the required permissions in your workflow:
+  This lets you use the GitHub Action runner's [built-in `GITHUB_TOKEN`](https://docs.github.com/en/actions/tutorials/authenticate-with-github_token) without installing the OpenCode GitHub App. Pass the token through `env` as `GITHUB_TOKEN` (it is required when `use_github_token` is enabled) and grant the required permissions in your workflow:
 
   ```yaml
   permissions:


### PR DESCRIPTION
### Issue for this PR

Closes #44667

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The Configuration list on the GitHub Action docs page didn't match `github/action.yml`.

It documented a `token` input, which the action doesn't define — so anyone following the docs and setting `with: token: ...` gets it silently ignored, because composite actions just drop unknown inputs. The setup example had the same problem with a commented-out `# github_token: xxxx`. At the same time, four inputs that do exist (`use_github_token`, `mentions`, `variant`, `oidc_base_url`) weren't documented at all.

So this replaces the `token` bullet with `use_github_token` and adds the three missing ones, and changes the example's commented line to `# use_github_token: true`.

I also reworded the paragraph under it. It previously read as "alternatively you can use the built-in GITHUB_TOKEN", which suggested that using the runner token was a separate path from the input. It isn't — `use_github_token: true` is what selects it, and the token still has to be passed in `env`. `github.handler.ts` reads `USE_GITHUB_TOKEN` and then requires `GITHUB_TOKEN`, throwing `GITHUB_TOKEN environment variable is not set. When using use_github_token, you must provide GITHUB_TOKEN.` if it's absent. The PR example further down the same page already passes it that way, so this makes the Configuration section agree with the example.

Descriptions for the new bullets are taken from the `description` fields in `action.yml` and the defaults in the handler (`mentions` defaults to `/opencode,/oc`, `oidc_base_url` defaults to `https://api.opencode.ai`, `use_github_token` defaults to `false`).

### How did you verify your code works?

Docs-only change, so there's nothing to run. I checked it by diffing the documented inputs against the `inputs:` block in `github/action.yml`, and by tracing each one to where it's consumed: `USE_GITHUB_TOKEN` and `OIDC_BASE_URL` in `github.handler.ts`, `MENTIONS` in the same file with the `/opencode,/oc` fallback, and `VARIANT`/`AGENT`/`SHARE`/`PROMPT` passed through the action's `env` block.

A reviewer can confirm by comparing the bullet list against `github/action.yml`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
