### PR TITLE
chore: set explicit permissions on workflows missing them

### DIFF
--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released] # fires when a draft release is published
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -25,6 +25,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: storybook build

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -7,6 +7,9 @@ on:
     branches: [dev]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
### Issue for this PR

Closes #44669

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `permissions: contents: read` to the three workflows that didn't declare one: `typecheck.yml`, `storybook.yml` and `notify-discord.yml`.

When a workflow omits `permissions:`, the `GITHUB_TOKEN` it gets is whatever the repository or org default is, instead of being scoped to what the workflow actually needs. Every other workflow here already pins its scopes — `deploy.yml` at the top level, `review.yml`, `pr-management.yml` and `pr-standards.yml` per job — so these three looked like they were just missed.

I checked what each one needs before picking the scope. `typecheck` checks out and runs `bun typecheck`. `storybook` checks out and runs a build. `notify-discord` doesn't touch the repo at all — it hands the release payload to a Discord webhook via `secrets.DISCORD_WEBHOOK`. None of them write anything, so `contents: read` is enough for all three, which is also what the checkout step needs.

I put the block at the top level rather than per job, matching `deploy.yml`, since each of these has a single job.

To be clear about the scope of this: it's hardening, not a live bug. If the repo default is already read-only then nothing changes at runtime. The point is that these three stop depending on that default.

I deliberately left the `types: [released]` comment in `notify-discord.yml` alone even though I think it's inaccurate, since that's unrelated to this change.

### How did you verify your code works?

- Parsed all three files with a YAML parser after the change to confirm they're still valid and that `permissions` resolves to `{'contents': 'read'}` with the job list unchanged.
- Read each workflow's steps to confirm none of them write to the repo, create releases, or comment — so nothing needed a wider scope than `contents: read`.
- The diff is additive only: three files, three lines each, no existing lines touched.

A reviewer can confirm by re-running these workflows; they should behave identically.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
