### PR TITLE
chore: add concurrency group to typecheck workflow

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -7,6 +7,12 @@ on:
     branches: [dev]
   workflow_dispatch:
 
+concurrency:
+  # Keep every run on dev so cancelled checks do not pollute the default branch
+  # commit history. PRs and other branches still share a group and cancel stale runs.
+  group: ${{ case(github.ref == 'refs/heads/dev', format('{0}-{1}', github.workflow, github.run_id), format('{0}-{1}', github.workflow, github.event.pull_request.number || github.ref)) }}
+  cancel-in-progress: true
+
 jobs:
   typecheck:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
### Issue for this PR

Closes #44671

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Gives `typecheck.yml` a concurrency group so a new push to a PR cancels the previous typecheck instead of letting it run to completion.

Right now it has no `concurrency` block at all, so every push starts another run on a `blacksmith-4vcpu-ubuntu-2404` runner while the earlier one keeps going, and only the last result matters.

I copied the group expression from `test.yml` rather than writing a new one, because the naive `${{ github.workflow }}-${{ github.ref }}` version would also cancel runs on `dev`, and the comment in `test.yml` explains why they didn't want that — cancelled checks on the default branch pollute its commit history. The expression keys on `github.run_id` when the ref is `dev`, which makes each dev run its own group so nothing cancels it, and falls back to the PR number or ref otherwise so PR runs do share a group. Using the same expression keeps the two workflows consistent.

Note: this touches the same region of `typecheck.yml` as #44670, which adds a `permissions:` block between `on:` and `jobs:`. They're separate concerns so I kept them as separate PRs, but whichever lands second will need a trivial rebase. Happy to combine them if you'd rather.

### How did you verify your code works?

The behaviour this fixes is visible in the existing run history. For a single push to the `zed-acp-docs` PR:

- `test` run `32718073842` was cancelled after 9m37s when the next push landed — its concurrency group doing its job.
- `typecheck` run `32718073884`, from that same push, ran to completion in 1m9s and was never cancelled, then `32718860388` started on top of it.

That's the same push producing a cancelled `test` and an uncancelled `typecheck`, which isolates the missing block as the cause.

I also parsed the file with a YAML parser after the change to confirm it still loads and the `typecheck` job is unchanged. I can't fully exercise cancellation from a fork, so the real confirmation is that after merging, two quick pushes to a PR should leave only one running typecheck.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
