### PR TITLE
fix(app): reference ui custom element declarations

### DIFF
--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />


### PR DESCRIPTION
### Issue for this PR

Closes #44674

### Type of change

- [x] Bug fix

### What does this PR do?

`packages/app/src/custom-elements.d.ts` has contained a bare relative path line since the desktop->app rename, so tsgo fails on every clean checkout with TS1128 and the root monorepo typecheck / pre-push hook blocks all contributors. This restores what the file obviously intended: a triple-slash reference pulling in the ui package'"'"'s `<diffs-container>` JSX declarations.

(Supersedes #44628, which was auto-closed before a tracking issue existed - #44674 is that issue.)

### How did you verify your code works?

- before: bun run typecheck (packages/app) -> TS1128 x2 at src/custom-elements.d.ts
- after: same command exits 0 on an otherwise unmodified checkout

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR