### PR TITLE
feat: detect stalled provider streams and auto-restart

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -8,7 +8,8 @@ import {
   isContextOverflowFailure,
   type ProviderErrorEvent,
 } from "@opencode-ai/llm"
-import { Cause, DateTime, Effect, FiberSet, Layer, Option, Semaphore, Stream } from "effect"
+import { DEFAULT_STREAM_IDLE_TIMEOUT_MS, guardIdle } from "@opencode-ai/llm/route"
+import { Cause, DateTime, Duration, Effect, FiberSet, Layer, Option, Semaphore, Stream } from "effect"
 import { AgentV2 } from "../../agent"
 import { Config } from "../../config"
 import { Database } from "../../database/database"
@@ -89,6 +90,28 @@ import { llmClient } from "../../effect/app-node-platform"
  * provider turn. Registry definitions are advertised, local tool calls are settled durably, and an
  * explicit loop starts the next provider turn after local settlement. Configured agent step limits bound the loop.
  */
+
+/**
+ * Automatic restarts for a provider stream that stalls (no events within the idle timeout) before
+ * any output was published. Bounded and pre-output only; post-output failures still fail the turn.
+ */
+export const STREAM_IDLE_RETRIES = 2
+const STREAM_IDLE_RESTART_DELAY_MS = 1_000
+
+export const isStreamIdleTimeout = (failure: unknown) =>
+  failure instanceof LLMError && failure.reason._tag === "Transport" && failure.reason.kind === "IdleTimeout"
+
+export const shouldRestartStalledStream = (input: {
+  readonly failure: unknown
+  readonly assistantStarted: boolean
+  /** Retries consumed so far; the first attempt passes 0. */
+  readonly retry: number
+  readonly interrupted: boolean
+}) =>
+  !input.interrupted &&
+  !input.assistantStarted &&
+  input.retry < STREAM_IDLE_RETRIES &&
+  isStreamIdleTimeout(input.failure)
 
 const layer = Layer.effect(
   Service,
@@ -182,7 +205,6 @@ const layer = Layer.effect(
       const agent = yield* agents.select(session.agent)
       const initialized = yield* SessionContextEpoch.initialize(db, loadSystemContext(agent), session.id)
       const toolFibers = yield* FiberSet.make<void, ToolOutputStore.Error>()
-      let needsContinuation = false
       let currentStep = step
       if (promotion) {
         const cutoff = yield* EventV2.latestSequence(db, session.id)
@@ -221,137 +243,169 @@ const layer = Layer.effect(
       })
       if (yield* compaction.compactIfNeeded({ sessionID: session.id, entries, model, request }))
         return yield* Effect.die(continueAfterCompaction(currentStep))
-      const startSnapshot = yield* snapshots.capture()
-      const publisher = createLLMEventPublisher(events, {
-        sessionID: session.id,
-        agent: agent.id,
-        model: {
-          id: ModelV2.ID.make(model.id),
-          providerID: ProviderV2.ID.make(model.provider),
-          ...(session.model?.variant === undefined ? {} : { variant: session.model.variant }),
-        },
-        snapshot: startSnapshot,
-      })
-      const withPublication = Semaphore.makeUnsafe(1).withPermit
-      const publish = (event: LLMEvent, outputPaths: ReadonlyArray<string> = []) =>
-        withPublication(publisher.publish(event, outputPaths))
-      let overflowFailure: ProviderErrorEvent | undefined
-      const providerStream = llm.stream(request).pipe(
-        Stream.runForEach((event) =>
-          Effect.gen(function* () {
-            if (overflowFailure || publisher.hasProviderError()) return
-            if (LLMEvent.is.providerError(event)) {
-              if (isContextOverflowFailure(event) && !publisher.hasAssistantStarted()) {
-                overflowFailure = event
+      const runProviderAttempt = Effect.fn("SessionRunner.runProviderAttempt")(function* (retry: number) {
+        const startSnapshot = yield* snapshots.capture()
+        const publisher = createLLMEventPublisher(events, {
+          sessionID: session.id,
+          agent: agent.id,
+          model: {
+            id: ModelV2.ID.make(model.id),
+            providerID: ProviderV2.ID.make(model.provider),
+            ...(session.model?.variant === undefined ? {} : { variant: session.model.variant }),
+          },
+          snapshot: startSnapshot,
+        })
+        const withPublication = Semaphore.makeUnsafe(1).withPermit
+        const publish = (event: LLMEvent, outputPaths: ReadonlyArray<string> = []) =>
+          withPublication(publisher.publish(event, outputPaths))
+        let overflowFailure: ProviderErrorEvent | undefined
+        let needsContinuation = false
+        // Core config exposes no stream-idle knob; this constant is the shared llm-package default.
+        const providerStream = guardIdle({ idleMs: DEFAULT_STREAM_IDLE_TIMEOUT_MS })(llm.stream(request)).pipe(
+          Stream.runForEach((event) =>
+            Effect.gen(function* () {
+              if (overflowFailure || publisher.hasProviderError()) return
+              if (LLMEvent.is.providerError(event)) {
+                if (isContextOverflowFailure(event) && !publisher.hasAssistantStarted()) {
+                  overflowFailure = event
+                  return
+                }
+              }
+              yield* publish(event)
+              if (event.type !== "tool-call" || event.providerExecuted) return
+              if (!toolMaterialization) {
+                yield* withPublication(publisher.failUnsettledTools("Tools are disabled after the maximum agent steps"))
                 return
               }
-            }
-            yield* publish(event)
-            if (event.type !== "tool-call" || event.providerExecuted) return
-            if (!toolMaterialization) {
-              yield* withPublication(publisher.failUnsettledTools("Tools are disabled after the maximum agent steps"))
-              return
-            }
-            needsContinuation = true
-            const assistantMessageID = yield* publisher.assistantMessageID(event.id)
-            yield* Effect.uninterruptibleMask((restore) =>
-              restore(
-                toolMaterialization.settle({
-                  sessionID: session.id,
-                  agent: agent.id,
-                  assistantMessageID,
-                  call: event,
-                }),
-              ).pipe(
-                Effect.flatMap((settlement) =>
-                  publish(
-                    LLMEvent.toolResult({
-                      id: event.id,
-                      name: event.name,
-                      result: settlement.result,
-                      output: settlement.output,
-                    }),
-                    settlement.outputPaths ?? [],
+              needsContinuation = true
+              const assistantMessageID = yield* publisher.assistantMessageID(event.id)
+              yield* Effect.uninterruptibleMask((restore) =>
+                restore(
+                  toolMaterialization.settle({
+                    sessionID: session.id,
+                    agent: agent.id,
+                    assistantMessageID,
+                    call: event,
+                  }),
+                ).pipe(
+                  Effect.flatMap((settlement) =>
+                    publish(
+                      LLMEvent.toolResult({
+                        id: event.id,
+                        name: event.name,
+                        result: settlement.result,
+                        output: settlement.output,
+                      }),
+                      settlement.outputPaths ?? [],
+                    ),
                   ),
                 ),
-              ),
-            ).pipe(FiberSet.run(toolFibers))
-          }),
-        ),
-        Effect.ensuring(withPublication(publisher.flush())),
-      )
+              ).pipe(FiberSet.run(toolFibers))
+            }),
+          ),
+          Effect.ensuring(withPublication(publisher.flush())),
+        )
 
-      return yield* Effect.uninterruptibleMask((restore) =>
-        Effect.gen(function* () {
-          const stream = yield* restore(providerStream).pipe(Effect.exit)
-          const failure =
-            stream._tag === "Failure" ? Option.getOrUndefined(Cause.findErrorOption(stream.cause)) : undefined
-          if (
-            recoverOverflow &&
-            !publisher.hasAssistantStarted() &&
-            isContextOverflowFailure(overflowFailure ?? failure) &&
-            (yield* restore(recoverOverflow({ sessionID: session.id, entries, model, request })))
-          )
-            return yield* Effect.die(continueAfterOverflowCompaction(currentStep))
-          if (overflowFailure) yield* publish(overflowFailure)
-          const llmFailure = failure instanceof LLMError ? failure : undefined
-          if (llmFailure && !publisher.hasProviderError()) {
-            yield* withPublication(publisher.failUnsettledTools("Provider did not return a tool result", true))
-            yield* withPublication(publisher.failAssistant(llmFailure.reason.message))
-          }
-          if (stream._tag === "Failure" && Cause.hasInterrupts(stream.cause)) yield* FiberSet.clear(toolFibers)
-          const settled = yield* restore(awaitToolFibers(toolFibers)).pipe(Effect.exit)
-          if (settled._tag === "Failure" && isUserDeclined(settled.cause)) {
-            yield* FiberSet.clear(toolFibers)
-            yield* withPublication(publisher.failUnsettledTools("Tool execution interrupted"))
-            return yield* Effect.interrupt
-          }
-          if (
-            (stream._tag === "Failure" && Cause.hasInterrupts(stream.cause)) ||
-            (settled._tag === "Failure" && Cause.hasInterrupts(settled.cause))
-          ) {
-            yield* FiberSet.clear(toolFibers)
-            yield* withPublication(publisher.failUnsettledTools("Tool execution interrupted"))
-            if (publisher.hasActiveAssistant())
-              yield* withPublication(publisher.failAssistant("Provider turn interrupted"))
-          }
-          if (settled._tag === "Failure" && !Cause.hasInterrupts(settled.cause)) {
-            const failure = Cause.squash(settled.cause)
-            const message = failure instanceof Error ? failure.message : String(failure)
-            yield* withPublication(publisher.failUnsettledTools(`Tool execution failed: ${message}`))
-          }
-          const stepSettlement = publisher.stepSettlement()
-          if (stepSettlement && !publisher.hasProviderError()) {
-            const endSnapshot = yield* snapshots.capture()
-            const files =
-              startSnapshot && endSnapshot
-                ? yield* snapshots
-                    .files({ from: startSnapshot, to: endSnapshot })
-                    .pipe(Effect.catch(() => Effect.succeed(undefined)))
-                : undefined
-            yield* withPublication(
-              events.publish(SessionEvent.Step.Ended, {
-                sessionID: session.id,
-                timestamp: yield* DateTime.now,
-                assistantMessageID: yield* publisher.startAssistant(),
-                finish: stepSettlement.finish,
-                cost: 0,
-                tokens: stepSettlement.tokens,
-                snapshot: endSnapshot,
-                files,
-              }),
+        return yield* Effect.uninterruptibleMask((restore) =>
+          Effect.gen(function* () {
+            const stream = yield* restore(providerStream).pipe(Effect.exit)
+            const failure =
+              stream._tag === "Failure" ? Option.getOrUndefined(Cause.findErrorOption(stream.cause)) : undefined
+            if (
+              shouldRestartStalledStream({
+                failure,
+                assistantStarted: publisher.hasAssistantStarted(),
+                retry,
+                interrupted: stream._tag === "Failure" && Cause.hasInterrupts(stream.cause),
+              })
             )
-          }
-          if (publisher.hasProviderError())
-            yield* withPublication(publisher.failUnsettledTools("Tool execution interrupted"))
-          if (stream._tag === "Success" && !publisher.hasProviderError())
-            yield* withPublication(publisher.failUnsettledTools("Provider did not return a tool result", true))
-          if (stream._tag === "Failure") return yield* Effect.failCause(stream.cause)
-          if (settled._tag === "Failure" && Cause.hasInterrupts(settled.cause))
-            return yield* Effect.failCause(settled.cause)
-          return { needsContinuation: !publisher.hasProviderError() && needsContinuation, step: currentStep }
-        }),
-      )
+              return { restart: true, needsContinuation: false, step: currentStep }
+            if (
+              recoverOverflow &&
+              !publisher.hasAssistantStarted() &&
+              isContextOverflowFailure(overflowFailure ?? failure) &&
+              (yield* restore(recoverOverflow({ sessionID: session.id, entries, model, request })))
+            )
+              return yield* Effect.die(continueAfterOverflowCompaction(currentStep))
+            if (overflowFailure) yield* publish(overflowFailure)
+            const llmFailure = failure instanceof LLMError ? failure : undefined
+            if (llmFailure && !publisher.hasProviderError()) {
+              yield* withPublication(publisher.failUnsettledTools("Provider did not return a tool result", true))
+              yield* withPublication(publisher.failAssistant(llmFailure.reason.message))
+            }
+            if (stream._tag === "Failure" && Cause.hasInterrupts(stream.cause)) yield* FiberSet.clear(toolFibers)
+            const settled = yield* restore(awaitToolFibers(toolFibers)).pipe(Effect.exit)
+            if (settled._tag === "Failure" && isUserDeclined(settled.cause)) {
+              yield* FiberSet.clear(toolFibers)
+              yield* withPublication(publisher.failUnsettledTools("Tool execution interrupted"))
+              return yield* Effect.interrupt
+            }
+            if (
+              (stream._tag === "Failure" && Cause.hasInterrupts(stream.cause)) ||
+              (settled._tag === "Failure" && Cause.hasInterrupts(settled.cause))
+            ) {
+              yield* FiberSet.clear(toolFibers)
+              yield* withPublication(publisher.failUnsettledTools("Tool execution interrupted"))
+              if (publisher.hasActiveAssistant())
+                yield* withPublication(publisher.failAssistant("Provider turn interrupted"))
+            }
+            if (settled._tag === "Failure" && !Cause.hasInterrupts(settled.cause)) {
+              const failure = Cause.squash(settled.cause)
+              const message = failure instanceof Error ? failure.message : String(failure)
+              yield* withPublication(publisher.failUnsettledTools(`Tool execution failed: ${message}`))
+            }
+            const stepSettlement = publisher.stepSettlement()
+            if (stepSettlement && !publisher.hasProviderError()) {
+              const endSnapshot = yield* snapshots.capture()
+              const files =
+                startSnapshot && endSnapshot
+                  ? yield* snapshots
+                      .files({ from: startSnapshot, to: endSnapshot })
+                      .pipe(Effect.catch(() => Effect.succeed(undefined)))
+                  : undefined
+              yield* withPublication(
+                events.publish(SessionEvent.Step.Ended, {
+                  sessionID: session.id,
+                  timestamp: yield* DateTime.now,
+                  assistantMessageID: yield* publisher.startAssistant(),
+                  finish: stepSettlement.finish,
+                  cost: 0,
+                  tokens: stepSettlement.tokens,
+                  snapshot: endSnapshot,
+                  files,
+                }),
+              )
+            }
+            if (publisher.hasProviderError())
+              yield* withPublication(publisher.failUnsettledTools("Tool execution interrupted"))
+            if (stream._tag === "Success" && !publisher.hasProviderError())
+              yield* withPublication(publisher.failUnsettledTools("Provider did not return a tool result", true))
+            if (stream._tag === "Failure") return yield* Effect.failCause(stream.cause)
+            if (settled._tag === "Failure" && Cause.hasInterrupts(settled.cause))
+              return yield* Effect.failCause(settled.cause)
+            return {
+              restart: false,
+              needsContinuation: !publisher.hasProviderError() && needsContinuation,
+              step: currentStep,
+            }
+          }),
+        )
+      })
+
+      for (let retries = 0; ; retries++) {
+        const outcome = yield* runProviderAttempt(retries)
+        if (outcome.restart) {
+          yield* Effect.logWarning("provider stream stalled; restarting turn", {
+            sessionID: session.id,
+            agent: agent.id,
+            model: `${model.provider}/${model.id}`,
+            attempt: retries + 1,
+          })
+          yield* Effect.sleep(Duration.millis(STREAM_IDLE_RESTART_DELAY_MS))
+          continue
+        }
+        return { needsContinuation: outcome.needsContinuation, step: outcome.step }
+      }
     }, Effect.scoped)
     type RunTurn = (
       sessionID: SessionSchema.ID,

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -107,9 +107,12 @@ export const shouldRestartStalledStream = (input: {
   /** Retries consumed so far; the first attempt passes 0. */
   readonly retry: number
   readonly interrupted: boolean
+  /** A context-overflow providerError event arrived this attempt; compaction must handle it, not a resend. */
+  readonly providerOverflow: boolean
 }) =>
   !input.interrupted &&
   !input.assistantStarted &&
+  !input.providerOverflow &&
   input.retry < STREAM_IDLE_RETRIES &&
   isStreamIdleTimeout(input.failure)
 
@@ -317,6 +320,7 @@ const layer = Layer.effect(
                 assistantStarted: publisher.hasAssistantStarted(),
                 retry,
                 interrupted: stream._tag === "Failure" && Cause.hasInterrupts(stream.cause),
+                providerOverflow: overflowFailure !== undefined,
               })
             )
               return { restart: true, needsContinuation: false, step: currentStep }

--- a/packages/core/test/session-runner-idle-restart.test.ts
+++ b/packages/core/test/session-runner-idle-restart.test.ts
@@ -15,6 +15,7 @@ const restart = (failure: unknown, overrides?: Partial<Parameters<typeof shouldR
     assistantStarted: false,
     retry: 0,
     interrupted: false,
+    providerOverflow: false,
     ...overrides,
   })
 
@@ -35,6 +36,10 @@ describe("shouldRestartStalledStream", () => {
 
   it("never restarts an interrupted stream", () => {
     expect(restart(idleTimeout(), { interrupted: true })).toBe(false)
+  })
+
+  it("never restarts after a provider overflow event", () => {
+    expect(restart(idleTimeout(), { providerOverflow: true })).toBe(false)
   })
 
   it("only restarts on the typed IdleTimeout transport failure", () => {

--- a/packages/core/test/session-runner-idle-restart.test.ts
+++ b/packages/core/test/session-runner-idle-restart.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test"
+import { InvalidRequestReason, LLMError, TransportReason } from "@opencode-ai/llm"
+import { shouldRestartStalledStream, STREAM_IDLE_RETRIES } from "@opencode-ai/core/session/runner/llm"
+
+const idleTimeout = () =>
+  new LLMError({
+    module: "test",
+    method: "stream",
+    reason: new TransportReason({ message: "Provider stream stalled", kind: "IdleTimeout" }),
+  })
+
+const restart = (failure: unknown, overrides?: Partial<Parameters<typeof shouldRestartStalledStream>[0]>) =>
+  shouldRestartStalledStream({
+    failure,
+    assistantStarted: false,
+    retry: 0,
+    interrupted: false,
+    ...overrides,
+  })
+
+describe("shouldRestartStalledStream", () => {
+  it("restarts a pre-output idle timeout while the budget remains", () => {
+    expect(restart(idleTimeout())).toBe(true)
+    expect(restart(idleTimeout(), { retry: STREAM_IDLE_RETRIES - 1 })).toBe(true)
+  })
+
+  it("never restarts once the retry budget is exhausted", () => {
+    expect(restart(idleTimeout(), { retry: STREAM_IDLE_RETRIES })).toBe(false)
+    expect(restart(idleTimeout(), { retry: STREAM_IDLE_RETRIES + 1 })).toBe(false)
+  })
+
+  it("never restarts after assistant output started", () => {
+    expect(restart(idleTimeout(), { assistantStarted: true })).toBe(false)
+  })
+
+  it("never restarts an interrupted stream", () => {
+    expect(restart(idleTimeout(), { interrupted: true })).toBe(false)
+  })
+
+  it("only restarts on the typed IdleTimeout transport failure", () => {
+    expect(
+      restart(
+        new LLMError({
+          module: "test",
+          method: "stream",
+          reason: new TransportReason({ message: "Provider unavailable" }),
+        }),
+      ),
+    ).toBe(false)
+    expect(
+      restart(
+        new LLMError({
+          module: "test",
+          method: "stream",
+          reason: new InvalidRequestReason({ message: "prompt too long", classification: "context-overflow" }),
+        }),
+      ),
+    ).toBe(false)
+    expect(restart(new Error("unexpected"))).toBe(false)
+    expect(restart(undefined)).toBe(false)
+  })
+})

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -345,6 +345,13 @@ const providerUnavailable = () =>
     reason: new TransportReason({ message: "Provider unavailable" }),
   })
 
+const providerIdleTimeout = () =>
+  new LLMError({
+    module: "test",
+    method: "stream",
+    reason: new TransportReason({ message: "Provider stream stalled", kind: "IdleTimeout" }),
+  })
+
 const setupOverflowRecovery = Effect.gen(function* () {
   yield* setup
   const session = yield* SessionV2.Service
@@ -555,11 +562,75 @@ const verifyPartialFlushOnInterruption = (kind: FragmentKind) =>
   })
 
 describe("SessionRunnerLLM", () => {
+  it.live("restarts a stalled first attempt before any assistant output", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      requests.length = 0
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Stall then answer" }), resume: false })
+      responseStream = Stream.fail(providerIdleTimeout())
+      responses = [fragmentFixture("text", "text-recovered", ["Recovered"]).completeEvents]
+
+      yield* session.resume(sessionID)
+
+      expect(requests).toHaveLength(2)
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user", text: "Stall then answer" },
+        { type: "assistant", finish: "stop", content: [{ type: "text", id: "text-recovered", text: "Recovered" }] },
+      ])
+    }),
+  )
+
+  it.live("fails without restart when a stall lands after assistant output started", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const fixture = fragmentFixture("text", "text-partial", ["Partial"])
+      const failure = providerIdleTimeout()
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Fail late" }), resume: false })
+      requests.length = 0
+      responseStream = Stream.concat(Stream.fromIterable(fixture.partialEvents), Stream.fail(failure))
+
+      expect(yield* session.resume(sessionID).pipe(Effect.flip)).toBe(failure)
+
+      expect(requests).toHaveLength(1)
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user", text: "Fail late" },
+        {
+          type: "assistant",
+          finish: "error",
+          error: { type: "unknown", message: "Provider stream stalled" },
+          content: [fixture.expectedContent],
+        },
+      ])
+    }),
+  )
+
+  it.live("surfaces the stall after exhausting the restart budget", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const failure = providerIdleTimeout()
+      yield* session.prompt({ sessionID, prompt: Prompt.make({ text: "Always stalls" }), resume: false })
+      requests.length = 0
+      streamFailure = failure
+
+      expect(yield* session.resume(sessionID).pipe(Effect.flip)).toBe(failure)
+
+      expect(requests).toHaveLength(SessionRunnerLLM.STREAM_IDLE_RETRIES + 1)
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user", text: "Always stalls" },
+        { type: "assistant", finish: "error", error: { type: "unknown", message: "Provider stream stalled" } },
+      ])
+    }),
+  )
+
   it.effect("advertises and executes a globally attached application tool", () =>
     Effect.gen(function* () {
       yield* setup
       const applicationTools = yield* ApplicationTools.Service
       const session = yield* SessionV2.Service
+      requests.length = 0
       const contexts: Tool.Context[] = []
       yield* applicationTools.register({
         application_context: Tool.make({

--- a/packages/llm/src/route/idle-watchdog.ts
+++ b/packages/llm/src/route/idle-watchdog.ts
@@ -1,0 +1,41 @@
+import { Stream } from "effect"
+import { LLMError, TransportReason } from "../schema"
+
+/**
+ * Default maximum gap between stream elements before a provider stream is
+ * declared stalled.
+ */
+export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000
+
+/**
+ * Fail a stream instead of letting it hang when the provider stops sending
+ * data.
+ *
+ * Uses `Stream.timeoutOrElse` rather than bare `Stream.timeout`: the bare
+ * variant ENDS the stream silently on timeout, which makes a stalled provider
+ * look like clean completion. `timeoutOrElse` checks the deadline on every
+ * pull and switches to `orElse` — exactly one failing element — so elements
+ * emitted before the stall are preserved and the consumer observes a typed
+ * failure.
+ */
+export function guardIdle(options: { readonly idleMs: number }) {
+  return <A, E, R>(self: Stream.Stream<A, E, R>): Stream.Stream<A, E | LLMError, R> =>
+    self.pipe(
+      Stream.timeoutOrElse({
+        duration: options.idleMs,
+        orElse: () =>
+          Stream.fail(
+            new LLMError({
+              module: "IdleWatchdog",
+              method: "guard",
+              reason: new TransportReason({
+                message: `Provider stream stalled: no data received for ${options.idleMs}ms`,
+                kind: "IdleTimeout",
+              }),
+            }),
+          ),
+      }),
+    )
+}
+
+export * as IdleWatchdog from "./idle-watchdog"

--- a/packages/llm/src/route/idle-watchdog.ts
+++ b/packages/llm/src/route/idle-watchdog.ts
@@ -1,41 +1,65 @@
-import { Stream } from "effect"
+import { Cause, Effect, Exit, Stream } from "effect"
 import { LLMError, TransportReason } from "../schema"
 
 /**
  * Default maximum gap between stream elements before a provider stream is
- * declared stalled.
+ * declared stalled. Tracking starts only after the stream has begun
+ * delivering elements; silence before the first element is not bounded.
  */
 export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000
 
+const stalled = (ms: number) =>
+  new LLMError({
+    module: "IdleWatchdog",
+    method: "guard",
+    reason: new TransportReason({
+      message: `Provider stream stalled: no data received for ${ms}ms`,
+      kind: "IdleTimeout",
+    }),
+  })
+
+const endsWithDone = <A, E>(exit: Exit.Exit<A, E>): boolean =>
+  Exit.isFailure(exit) && exit.cause.reasons.some((reason) => Cause.DoneTypeId in reason)
+
 /**
- * Fail a stream instead of letting it hang when the provider stops sending
- * data.
+ * Fail a stream instead of letting it hang once streaming has started but
+ * elements stop arriving.
  *
- * Uses `Stream.timeoutOrElse` rather than bare `Stream.timeout`: the bare
- * variant ENDS the stream silently on timeout, which makes a stalled provider
- * look like clean completion. `timeoutOrElse` checks the deadline on every
- * pull and switches to `orElse` — exactly one failing element — so elements
- * emitted before the stall are preserved and the consumer observes a typed
- * failure.
+ * A deadline arms only after the first element: prompt-processing silence
+ * before the stream begins is never counted, and every later gap is bounded
+ * by `idleMs`. This mirrors `Stream.timeoutOrElse` per-pull deadlines (the
+ * bare `Stream.timeout` would END the stream silently, making a stalled
+ * provider look like clean completion) while skipping the pre-stream phase.
+ *
+ * Any element resets the deadline, so liveness signals at ANY layer (bytes,
+ * keep-alive frames) keep the stream alive when this guard wraps a low-level
+ * stream.
  */
 export function guardIdle(options: { readonly idleMs: number }) {
   return <A, E, R>(self: Stream.Stream<A, E, R>): Stream.Stream<A, E | LLMError, R> =>
-    self.pipe(
-      Stream.timeoutOrElse({
-        duration: options.idleMs,
-        orElse: () =>
-          Stream.fail(
-            new LLMError({
-              module: "IdleWatchdog",
-              method: "guard",
-              reason: new TransportReason({
-                message: `Provider stream stalled: no data received for ${options.idleMs}ms`,
-                kind: "IdleTimeout",
-              }),
-            }),
-          ),
-      }),
-    )
+    Stream.transformPull(self, (pull) => {
+      // Created once per stream execution: concurrent or repeated runs never
+      // share this phase flag.
+      let received = false
+      const guardedPull = Effect.gen(function* () {
+        while (true) {
+          const outcome = yield* (received
+            ? Effect.race(
+                Effect.map(Effect.exit(pull), (exit) => ({ _tag: "data" as const, exit })),
+                Effect.as(Effect.sleep(options.idleMs), { _tag: "stalled" as const }),
+              )
+            : Effect.map(Effect.exit(pull), (exit) => ({ _tag: "data" as const, exit }) as const))
+          if (outcome._tag === "stalled") return yield* stalled(options.idleMs)
+          if (Exit.isFailure(outcome.exit)) {
+            if (endsWithDone(outcome.exit)) return yield* Cause.done()
+            return yield* Effect.failCause(outcome.exit.cause)
+          }
+          received = true
+          return outcome.exit.value
+        }
+      })
+      return Effect.succeed(guardedPull)
+    })
 }
 
 export * as IdleWatchdog from "./idle-watchdog"

--- a/packages/llm/src/route/idle-watchdog.ts
+++ b/packages/llm/src/route/idle-watchdog.ts
@@ -8,6 +8,31 @@ import { LLMError, TransportReason } from "../schema"
  */
 export const DEFAULT_STREAM_IDLE_TIMEOUT_MS = 120_000
 
+/**
+ * Event tags that end a continuous generation segment. Silence that follows
+ * one of these is LOCAL or TRANSITION time, not provider stall: local tool
+ * execution (bash, subagents, MCP calls, permission gates) happens between
+ * `tool-call` and its `tool-result`/`tool-error`, and the next step's
+ * request starts after `step-finish`. The deadline stays disarmed until the
+ * next element arrives so legitimate waits are never killed.
+ *
+ * Trade-off: a provider hanging immediately after one of these events is not
+ * bounded by this guard on paths without transport-level byte coverage (the
+ * AI SDK runtime); the native route keeps byte-level protection in
+ * HttpTransport.
+ */
+const DISARM_TAGS: ReadonlySet<string> = new Set(["tool-call", "tool-result", "tool-error", "step-finish"])
+
+const disarmsDeadline = (element: unknown): boolean => {
+  // pulls yield chunks; a boundary tag anywhere in the chunk ends the segment
+  const items: readonly unknown[] = Array.isArray(element) ? element : [element]
+  return items.some((item) => {
+    if (typeof item !== "object" || item === null) return false
+    const tag = (item as { readonly type?: unknown }).type
+    return typeof tag === "string" && DISARM_TAGS.has(tag)
+  })
+}
+
 const stalled = (ms: number) =>
   new LLMError({
     module: "IdleWatchdog",
@@ -25,11 +50,13 @@ const endsWithDone = <A, E>(exit: Exit.Exit<A, E>): boolean =>
  * Fail a stream instead of letting it hang once streaming has started but
  * elements stop arriving.
  *
- * A deadline arms only after the first element: prompt-processing silence
- * before the stream begins is never counted, and every later gap is bounded
- * by `idleMs`. This mirrors `Stream.timeoutOrElse` per-pull deadlines (the
- * bare `Stream.timeout` would END the stream silently, making a stalled
- * provider look like clean completion) while skipping the pre-stream phase.
+ * A deadline arms only after the first element and only between consecutive
+ * generation elements: prompt-processing silence before the stream begins,
+ * local tool execution windows, and step transitions are never counted. Any
+ * other later gap is bounded by `idleMs`. This mirrors `Stream.timeoutOrElse`
+ * per-pull deadlines (the bare `Stream.timeout` would END the stream
+ * silently, making a stalled provider look like clean completion) while
+ * skipping the phases where silence is expected.
  *
  * Any element resets the deadline, so liveness signals at ANY layer (bytes,
  * keep-alive frames) keep the stream alive when this guard wraps a low-level
@@ -40,10 +67,10 @@ export function guardIdle(options: { readonly idleMs: number }) {
     Stream.transformPull(self, (pull) => {
       // Created once per stream execution: concurrent or repeated runs never
       // share this phase flag.
-      let received = false
+      let armed = false
       const guardedPull = Effect.gen(function* () {
         while (true) {
-          const outcome = yield* (received
+          const outcome = yield* (armed
             ? Effect.race(
                 Effect.map(Effect.exit(pull), (exit) => ({ _tag: "data" as const, exit })),
                 Effect.as(Effect.sleep(options.idleMs), { _tag: "stalled" as const }),
@@ -54,8 +81,9 @@ export function guardIdle(options: { readonly idleMs: number }) {
             if (endsWithDone(outcome.exit)) return yield* Cause.done()
             return yield* Effect.failCause(outcome.exit.cause)
           }
-          received = true
-          return outcome.exit.value
+          const value = outcome.exit.value
+          armed = !disarmsDeadline(value)
+          return value
         }
       })
       return Effect.succeed(guardedPull)

--- a/packages/llm/src/route/index.ts
+++ b/packages/llm/src/route/index.ts
@@ -10,6 +10,7 @@ export type {
   Service as LLMClientService,
 } from "./client"
 export * from "./executor"
+export * from "./idle-watchdog"
 export { Auth } from "./auth"
 export { AuthOptions } from "./auth-options"
 export { Endpoint } from "./endpoint"

--- a/packages/llm/src/route/transport/http.ts
+++ b/packages/llm/src/route/transport/http.ts
@@ -1,11 +1,15 @@
 import { Effect, Stream } from "effect"
 import { Headers, HttpClientRequest } from "effect/unstable/http"
+import {
+  DEFAULT_STREAM_IDLE_TIMEOUT_MS,
+  guardIdle,
+} from "../idle-watchdog"
 import { Auth } from "../auth"
 import { render as renderEndpoint } from "../endpoint"
 import { Framing, type Framing as FramingDef } from "../framing"
 import type { Transport, TransportPrepareInput } from "./index"
 import * as ProviderShared from "../../protocols/shared"
-import { mergeJsonRecords, type LLMRequest } from "../../schema"
+import { LLMError, mergeJsonRecords, type LLMRequest } from "../../schema"
 
 export type JsonRequestInput<Body> = TransportPrepareInput<Body>
 
@@ -135,12 +139,18 @@ export const httpJson = <Body, Frame>(input: HttpJsonInput<Body, Frame>): HttpJs
           Effect.map((response) =>
             prepared.framing.frame(
               response.stream.pipe(
+                // Byte-level liveness: any body chunk (including SSE comments
+                // and keep-alive frames that framing later drops) resets the
+                // deadline, so only genuine transport silence can trip it.
+                guardIdle({ idleMs: DEFAULT_STREAM_IDLE_TIMEOUT_MS }),
                 Stream.mapError((error) =>
-                  ProviderShared.eventError(
-                    `${request.model.provider}/${request.model.route.id}`,
-                    `Failed to read ${request.model.provider}/${request.model.route.id} stream`,
-                    ProviderShared.errorText(error),
-                  ),
+                  error instanceof LLMError
+                    ? error
+                    : ProviderShared.eventError(
+                        `${request.model.provider}/${request.model.route.id}`,
+                        `Failed to read ${request.model.provider}/${request.model.route.id} stream`,
+                        ProviderShared.errorText(error),
+                      ),
                 ),
               ),
             ),

--- a/packages/llm/test/route/idle-watchdog.test.ts
+++ b/packages/llm/test/route/idle-watchdog.test.ts
@@ -108,4 +108,58 @@ describe("IdleWatchdog", () => {
       expect(error.reason.message).toBe("Provider stream stalled: no data received for 300ms")
     }),
   )
+
+  it.effect("does not count local tool execution toward the idle budget", () =>
+    Effect.gen(function* () {
+      // a long-running local tool (bash, subagent, MCP call) silences the
+      // event stream between tool-call and tool-result; that window must
+      // never trip the watchdog. All elements arrive on clock sleeps so the
+      // guard is always parked in exactly one awaited phase per adjustment.
+      const stream = Stream.fromEffect(Effect.as(Effect.sleep(100), { type: "text-delta" })).pipe(
+        Stream.concat(Stream.fromEffect(Effect.as(Effect.sleep(100), { type: "tool-call", name: "bash" }))),
+        Stream.concat(Stream.fromEffect(Effect.as(Effect.sleep(4_800), { type: "tool-result", name: "bash" }))),
+        Stream.concat(Stream.fromEffect(Effect.as(Effect.sleep(100), { type: "text-delta" }))),
+      )
+      const fiber = yield* IdleWatchdog.guardIdle({ idleMs: 1_000 })(stream).pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true }),
+      )
+
+      yield* TestClock.adjust(200)
+      // 4.8s of silence inside the tool window: far past the 1s budget
+      yield* TestClock.adjust(4_800)
+      yield* TestClock.adjust(100)
+      const events = yield* Fiber.join(fiber)
+
+      expect(events).toEqual([
+        { type: "text-delta" },
+        { type: "tool-call", name: "bash" },
+        { type: "tool-result", name: "bash" },
+        { type: "text-delta" },
+      ])
+    }),
+  )
+
+  it.effect("re-arms after a step transition and still trips on generation stalls", () =>
+    Effect.gen(function* () {
+      // silence after step-finish is unbounded (next-step request), but once
+      // generation resumes, gaps are bounded again
+      const stream = Stream.make({ type: "step-finish", index: 0 }).pipe(
+        Stream.concat(Stream.fromEffect(Effect.as(Effect.sleep(2_000), { type: "text-delta" }))),
+        Stream.concat(Stream.never),
+      )
+      const fiber = yield* IdleWatchdog.guardIdle({ idleMs: 300 })(stream).pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true }),
+      )
+
+      yield* TestClock.adjust(2_000)
+      // text-delta arrived and re-armed; the following gap now trips
+      yield* TestClock.adjust(300)
+      const error = yield* Fiber.join(fiber).pipe(Effect.flip)
+
+      expectLLMError(error)
+      expect(error.reason).toMatchObject({ _tag: "Transport", kind: "IdleTimeout" })
+    }),
+  )
 })

--- a/packages/llm/test/route/idle-watchdog.test.ts
+++ b/packages/llm/test/route/idle-watchdog.test.ts
@@ -65,4 +65,23 @@ describe("IdleWatchdog", () => {
       expectLLMError(error)
     }),
   )
+
+  it.effect("does not arm the deadline before the first element", () =>
+    Effect.gen(function* () {
+      // silence for longer than idleMs BEFORE the stream begins is not counted
+      const stream = Stream.fromEffect(Effect.as(Effect.sleep(2_000), "first")).pipe(Stream.concat(Stream.never))
+      const fiber = yield* IdleWatchdog.guardIdle({ idleMs: 300 })(stream).pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true }),
+      )
+
+      yield* TestClock.adjust(300)
+      yield* TestClock.adjust(1_700)
+      // first element delivered; from here every 300ms gap trips the watchdog
+      yield* TestClock.adjust(300)
+      const error = yield* Fiber.join(fiber).pipe(Effect.flip)
+
+      expect(error.reason.message).toBe("Provider stream stalled: no data received for 300ms")
+    }),
+  )
 })

--- a/packages/llm/test/route/idle-watchdog.test.ts
+++ b/packages/llm/test/route/idle-watchdog.test.ts
@@ -27,6 +27,30 @@ describe("IdleWatchdog", () => {
     }),
   )
 
+  it.effect("resets the deadline per gap, surviving consecutive sub-budget pauses", () =>
+    Effect.gen(function* () {
+      // three 800ms pauses: each is under the 1s budget, but they sum to 2.4s.
+      // Per-pull deadline reset means every resume-before-expiry keeps the
+      // stream alive; only a single gap reaching idleMs may trip it.
+      const stream = Stream.make(1).pipe(
+        Stream.concat(Stream.fromEffect(Effect.as(Effect.sleep(800), 2))),
+        Stream.concat(Stream.fromEffect(Effect.as(Effect.sleep(800), 3))),
+        Stream.concat(Stream.fromEffect(Effect.as(Effect.sleep(800), 4))),
+      )
+      const fiber = yield* IdleWatchdog.guardIdle({ idleMs: 1_000 })(stream).pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true }),
+      )
+
+      yield* TestClock.adjust(800)
+      yield* TestClock.adjust(800)
+      yield* TestClock.adjust(800)
+      const events = yield* Fiber.join(fiber)
+
+      expect(events).toEqual([1, 2, 3, 4])
+    }),
+  )
+
   it.effect("fails with an IdleTimeout transport error when the provider stalls", () =>
     Effect.gen(function* () {
       const stream = Stream.make("first").pipe(Stream.concat(Stream.never))

--- a/packages/llm/test/route/idle-watchdog.test.ts
+++ b/packages/llm/test/route/idle-watchdog.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect } from "bun:test"
+import { Effect, Fiber, Stream } from "effect"
+import * as TestClock from "effect/testing/TestClock"
+import { LLMError } from "../../src"
+import { IdleWatchdog } from "../../src/route"
+import { it } from "../lib/effect"
+
+const expectLLMError = (error: unknown) => {
+  expect(error).toBeInstanceOf(LLMError)
+  if (!(error instanceof LLMError)) throw new Error("expected LLMError")
+  return error
+}
+
+describe("IdleWatchdog", () => {
+  it.effect("passes elements through when gaps stay under the idle budget", () =>
+    Effect.gen(function* () {
+      const stream = Stream.make(1, 2).pipe(Stream.concat(Stream.fromEffect(Effect.as(Effect.sleep(400), 3))))
+      const fiber = yield* IdleWatchdog.guardIdle({ idleMs: 1_000 })(stream).pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true }),
+      )
+
+      yield* TestClock.adjust(400)
+      const events = yield* Fiber.join(fiber)
+
+      expect(events).toEqual([1, 2, 3])
+    }),
+  )
+
+  it.effect("fails with an IdleTimeout transport error when the provider stalls", () =>
+    Effect.gen(function* () {
+      const stream = Stream.make("first").pipe(Stream.concat(Stream.never))
+      const fiber = yield* IdleWatchdog.guardIdle({ idleMs: 500 })(stream).pipe(
+        Stream.runCollect,
+        Effect.forkChild({ startImmediately: true }),
+      )
+
+      yield* TestClock.adjust(500)
+      const error = yield* Fiber.join(fiber).pipe(Effect.flip)
+
+      expectLLMError(error)
+      expect(error.reason).toMatchObject({
+        _tag: "Transport",
+        kind: "IdleTimeout",
+        message: "Provider stream stalled: no data received for 500ms",
+      })
+    }),
+  )
+
+  it.effect("preserves elements emitted before the deadline", () =>
+    Effect.gen(function* () {
+      const stream = IdleWatchdog.guardIdle({ idleMs: 300 })(
+        Stream.make("a", "b").pipe(Stream.concat(Stream.never)),
+      )
+      const pull = yield* Stream.toPull(stream)
+
+      // the consumer receives both elements before any deadline elapses
+      expect(yield* pull).toEqual(["a", "b"])
+
+      // the next pull stalls past the deadline and fails with the typed error
+      const stalled = yield* Effect.forkChild({ startImmediately: true })(pull)
+      yield* TestClock.adjust(300)
+      const error = yield* Fiber.join(stalled).pipe(Effect.flip)
+
+      expectLLMError(error)
+    }),
+  )
+})

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -112,6 +112,10 @@ type Info = ConfigV1.Info & {
   // plugin_origins is derived state, not a persisted config field. It keeps each winning plugin spec together
   // with the file and scope it came from so later runtime code can make location-sensitive decisions.
   plugin_origins?: ConfigPlugin.Origin[]
+  // streamIdleTimeoutMs is declared here because the core Config schema does not carry it yet; it configures
+  // the stalled-stream watchdog in session/llm.ts (undefined → default, 0 → disabled). Values set in config
+  // files only reach runtime once the core experimental schema declares the field.
+  experimental?: { streamIdleTimeoutMs?: number }
 }
 
 type State = {

--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -8,7 +8,7 @@ import { Context, Effect, Layer } from "effect"
 import * as Stream from "effect/Stream"
 import { streamText, wrapLanguageModel, type ModelMessage, type Tool } from "ai"
 import type { LLMEvent } from "@opencode-ai/llm"
-import { LLMClient } from "@opencode-ai/llm/route"
+import { LLMClient, DEFAULT_STREAM_IDLE_TIMEOUT_MS, guardIdle } from "@opencode-ai/llm/route"
 import type { LLMClientService } from "@opencode-ai/llm/route"
 import { GitLabWorkflowLanguageModel } from "gitlab-ai-provider"
 import { ProviderTransform } from "@/provider/transform"
@@ -365,17 +365,23 @@ const live: Layer.Layer<
 
             const result = yield* run({ ...input, abort: ctrl.signal })
 
-            if (result.type === "native") return result.stream
-
             // Adapter seam: both runtimes expose the same LLMEvent stream. Native
             // already returns one; AI SDK streams are converted here.
-            const state = LLMAISDK.adapterState()
-            return Stream.fromAsyncIterable(result.result.fullStream, (e) =>
-              e instanceof Error ? e : new Error(String(e)),
-            ).pipe(
-              Stream.mapEffect((event) => LLMAISDK.toLLMEvents(state, event)),
-              Stream.flatMap((events) => Stream.fromIterable(events)),
-            )
+            const inner =
+              result.type === "native"
+                ? result.stream
+                : Stream.fromAsyncIterable(result.result.fullStream, (e) =>
+                      e instanceof Error ? e : new Error(String(e)),
+                    ).pipe(
+                      Stream.mapEffect((event) => LLMAISDK.toLLMEvents(LLMAISDK.adapterState(), event)),
+                      Stream.flatMap((events) => Stream.fromIterable(events)),
+                    )
+
+            // Stalled-stream watchdog: fail the stream with a typed LLMError when no event
+            // arrives within the idle window so the processor can classify it as retryable.
+            // Wrapped once here so both runtimes are covered; 0 disables the watchdog.
+            const idleMs = (yield* config.get()).experimental?.streamIdleTimeoutMs ?? DEFAULT_STREAM_IDLE_TIMEOUT_MS
+            return idleMs > 0 ? inner.pipe(guardIdle({ idleMs })) : inner
           }),
         ),
       )

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -18,6 +18,7 @@ import {
 
 import { NamedError } from "@opencode-ai/core/util/error"
 import { APICallError, convertToModelMessages, LoadAPIKeyError, type ModelMessage, type UIMessage } from "ai"
+import { LLMError } from "@opencode-ai/llm"
 import { Database } from "@opencode-ai/core/database/database"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { NotFoundError } from "@/storage/storage"
@@ -676,6 +677,19 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
+    case isIdleTimeoutError(e):
+      // The stalled-stream watchdog fails the LLM stream with this typed error;
+      // surface it as retryable so the processor schedules another attempt.
+      return new APIError(
+        {
+          message: "Provider stream stalled",
+          isRetryable: true,
+          metadata: {
+            code: "IdleTimeout",
+          },
+        },
+        { cause: e },
+      ).toObject()
     case APICallError.isInstance(e):
       const parsed = ProviderError.parseAPICallError({
         providerID: ctx.providerID,
@@ -731,6 +745,10 @@ export function fromError(
       } catch {}
       return new NamedError.Unknown({ message: JSON.stringify(e) }, { cause: e }).toObject()
   }
+}
+
+function isIdleTimeoutError(e: unknown): e is LLMError {
+  return e instanceof LLMError && e.reason._tag === "Transport" && e.reason.kind === "IdleTimeout"
 }
 
 export * as MessageV2 from "./message-v2"

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -34,7 +34,7 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   /429|500|502|503|504|524/i,
   /rate increased too quickly|rate limit|rate-limit|rate_limit|too many requests/i,
   /overloaded|service unavailable|service_unavailable|service-unavailable|internal error|internal_error|internal server error|server error|server_error|server-error|provider returned error|provider_returned_error|provider-returned-error/i,
-  /terminated|fetch failed|failed to fetch|network[-_\s]error|upstream connect|connection error|connection refused|connection lost|socket connection was closed|socket hang up|reset before headers|getaddrinfo|enotfound|eai_again|econnrefused|econnreset|etimedout/i,
+  /terminated|fetch failed|failed to fetch|network[-_\s]error|upstream connect|connection error|connection refused|connection lost|socket connection was closed|socket hang up|reset before headers|getaddrinfo|enotfound|eai_again|econnrefused|econnreset|etimedout|\bstalled\b/i,
   /^timeout$|\b(?:request|response|connection|network|stream|read) (?:timeout|timed out|time out)\b/i,
   /try your request again|retry your request|resource exhausted|resource_exhausted/i,
   /\btry again (?:later|in\b)|\b(?:currently|temporarily) at capacity\b/i,

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -3,6 +3,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import type { NamedError } from "@opencode-ai/core/util/error"
 import { APICallError } from "ai"
+import { LLMError, TransportReason } from "@opencode-ai/llm"
 import { setTimeout as sleep } from "node:timers/promises"
 import { Effect, Schedule, Schema } from "effect"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
@@ -146,6 +147,38 @@ describe("session.retry.delay", () => {
       expect(attempts).toStrictEqual([1, 2, 3, 4, 5])
     }),
   )
+
+  it.instance("policy retries provider stream idle timeouts", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionID.make("session-retry-idle-timeout")
+      const status = yield* SessionStatus.Service
+      const error = new LLMError({
+        module: "route",
+        method: "stream",
+        reason: new TransportReason({ message: "No stream elements within 1000ms", kind: "IdleTimeout" }),
+      })
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: retryProvider,
+          parse: (e) => MessageV2.fromError(e, { providerID }),
+          set: (info) =>
+            status.set(sessionID, {
+              type: "retry",
+              attempt: info.attempt,
+              message: info.message,
+              next: info.next,
+            }),
+        }),
+      )
+      yield* step(error)
+
+      expect(yield* status.get(sessionID)).toMatchObject({
+        type: "retry",
+        attempt: 1,
+        message: "Provider stream stalled",
+      })
+    }),
+  )
 })
 
 describe("session.retry.retryable", () => {
@@ -260,6 +293,36 @@ describe("session.retry.retryable", () => {
     expect(SessionV1.APIError.isInstance(request)).toBe(true)
     expect(SessionRetry.retryable(request, retryProvider)).toEqual({
       message: "WebSocket closed before response.completed (code 1006: Connection ended)",
+    })
+  })
+
+  test("retries LLM stream idle timeout errors", () => {
+    const error = new LLMError({
+      module: "route",
+      method: "stream",
+      reason: new TransportReason({ message: "No stream elements within 120000ms", kind: "IdleTimeout" }),
+    })
+    const request = MessageV2.fromError(error, { providerID })
+    expect(SessionV1.APIError.isInstance(request)).toBe(true)
+    if (!SessionV1.APIError.isInstance(request)) throw new Error("expected APIError")
+    expect(request.data.message).toBe("Provider stream stalled")
+    expect(SessionRetry.retryable(request, retryProvider)).toEqual({ message: "Provider stream stalled" })
+  })
+
+  test("does not retry other LLM transport errors", () => {
+    const error = new LLMError({
+      module: "route",
+      method: "stream",
+      reason: new TransportReason({ message: "transport failed mid-response" }),
+    })
+    const request = MessageV2.fromError(error, { providerID })
+    expect(SessionRetry.retryable(request, retryProvider)).toBeUndefined()
+  })
+
+  test("retries raw stalled stream messages", () => {
+    const error = wrap("route.stream: Provider stream stalled")
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({
+      message: "route.stream: Provider stream stalled",
     })
   })
 


### PR DESCRIPTION
### Issue for this PR

Closes #

No tracked issue. Related open PR on the same problem from the transport layer: #40010.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A provider can return response headers and then stop sending tokens while keeping the connection open; both session paths waited forever in that state.

This adds an idle watchdog that fails the provider event stream when no event arrives within a window (default 120s). On the legacy path the failure surfaces as a retryable APIError, so the existing SessionRetry machinery retries it with backoff. In the V2 runner a stalled attempt restarts up to 2 times while nothing has been published for the assistant message; post-output stalls keep today's failAssistant behavior, and an overflow signal followed by a stall routes to compaction instead of resending.

The watchdog lives in `@opencode-ai/llm` as `guardIdle` (`Stream.timeoutOrElse` per-pull deadline — bare `Stream.timeout` would end stalled streams silently, looking like clean completion) and wraps both native and AI SDK runtimes at the session LLM boundary. `experimental.streamIdleTimeoutMs` overrides the window, `0` disables it.

### How did you verify your code works?

- `bun typecheck` in packages/llm, packages/opencode, packages/core.
- New TestClock-based watchdog tests in packages/llm (pass-through under budget, typed failure on stall, elements before deadline preserved).
- New restart-predicate tests plus fixture-based runner stall tests in packages/core (restart wiring, post-output no-restart, budget exhaustion, overflow skip).
- Existing opencode retry/processor/provider-error suites and the full core suite pass.

### Screenshots / recordings

Not applicable — no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
