### PR TITLE
refactor(core): optimize stats tool summary

### DIFF
--- a/packages/core/src/session/stats.ts
+++ b/packages/core/src/session/stats.ts
@@ -49,7 +49,12 @@ type ToolRow = {
   duration: number | null
 }
 
-type ToolSummaryRow = { status: string | null; count: number }
+type ToolSummaryRow = {
+  calls: number
+  succeeded: number
+  failed: number
+  unfinished: number
+}
 
 type ModelAggregate = {
   model: Model.Ref
@@ -188,25 +193,38 @@ export const get = Effect.fn("SessionStats.get")(function* (input: Input = {}) {
       (range) => {
         if (toolMode === "summary")
           return db
-            .all<ToolSummaryRow>(
+            .get<ToolSummaryRow>(
               sql`
-            SELECT json_extract(content.value, '$.state.status') AS status, count(*) AS count
-            FROM ${SessionMessageTable} AS message
-            JOIN ${SessionTable} AS session ON session.id = message.session_id,
-              json_each(message.data, '$.content') AS content
-            WHERE message.type = 'assistant'
-              AND message.time_created >= ${range.from}
-              AND message.time_created < ${range.to}
-              AND (session.fork_session_id IS NULL OR message.time_created >= session.time_created)
-              AND json_extract(content.value, '$.type') = 'tool'
-              ${project}
-            GROUP BY status
+            WITH calls AS MATERIALIZED (
+              SELECT json_extract(content.value, '$.state.status') AS status
+              FROM ${SessionMessageTable} AS message
+              JOIN ${SessionTable} AS session ON session.id = message.session_id,
+                json_each(message.data, '$.content') AS content
+              WHERE message.type = 'assistant'
+                AND message.time_created >= ${range.from}
+                AND message.time_created < ${range.to}
+                AND (session.fork_session_id IS NULL OR message.time_created >= session.time_created)
+                AND json_extract(content.value, '$.type') = 'tool'
+                ${project}
+            )
+            SELECT
+              count(*) AS calls,
+              count(*) FILTER (WHERE status = 'completed') AS succeeded,
+              count(*) FILTER (WHERE status = 'error') AS failed,
+              count(*) FILTER (WHERE status IS NULL OR status NOT IN ('completed', 'error')) AS unfinished
+            FROM calls
           `,
             )
             .pipe(
               Effect.orDie,
-              Effect.tap((rows) =>
-                Effect.sync(() => rows.forEach((row) => addToolStatus(toolTotals, row.status, row.count))),
+              Effect.tap((row) =>
+                Effect.sync(() => {
+                  if (!row) return
+                  toolTotals.calls += row.calls
+                  toolTotals.succeeded += row.succeeded
+                  toolTotals.failed += row.failed
+                  toolTotals.unfinished += row.unfinished
+                }),
               ),
               Effect.asVoid,
             )

--- a/packages/core/test/session-stats.test.ts
+++ b/packages/core/test/session-stats.test.ts
@@ -113,6 +113,13 @@ describe("SessionStats", () => {
                   completed: DateTime.makeUnsafe(Date.UTC(2026, 0, 2, 10, 0, 2)),
                 },
               }),
+              SessionMessage.AssistantTool.make({
+                type: "tool",
+                id: "call_pending",
+                name: "pending",
+                state: SessionMessage.ToolStateRunning.make({ status: "running", input: {}, metadata: {} }),
+                time: { created: DateTime.makeUnsafe(Date.UTC(2026, 0, 2, 10)) },
+              }),
             ]),
           ),
           messageRow(childID, 1, assistant("msg_stats_child", Date.UTC(2026, 0, 3, 10), [], "large", 2)),
@@ -210,7 +217,7 @@ describe("SessionStats", () => {
       expect(stats.cost).toBe(Money.USD.make(6.25))
       expect(stats.tools).toMatchObject({
         mode: "detail",
-        totals: { calls: 2, succeeded: 1, failed: 1, unfinished: 0 },
+        totals: { calls: 3, succeeded: 1, failed: 1, unfinished: 1 },
       })
       expect(stats.activity).toEqual([
         { date: "2026-01-02", steps: 1 },
@@ -224,6 +231,7 @@ describe("SessionStats", () => {
       expect(stats.tools.usage).toMatchObject([
         { name: "read", calls: 1, succeeded: 1, failed: 0, durationP50: 250 },
         { name: "edit", calls: 1, succeeded: 0, failed: 1, durationP50: 2_000 },
+        { name: "pending", calls: 1, succeeded: 0, failed: 0, unfinished: 1 },
       ])
 
       const summary = yield* SessionStats.get({
@@ -234,7 +242,7 @@ describe("SessionStats", () => {
       expect(summary.models.map((model) => String(model.model.id))).toEqual(["large", "sonnet", "fork-new"])
       expect(summary.tools).toEqual({
         mode: "summary",
-        totals: { calls: 2, succeeded: 1, failed: 1, unfinished: 0 },
+        totals: { calls: 3, succeeded: 1, failed: 1, unfinished: 1 },
       })
 
       const withoutTools = yield* SessionStats.get({


### PR DESCRIPTION
## Summary
- replace per-status grouping with one materialized status projection and filtered aggregates
- preserve 31-day query windows and existing range/project indexes
- cover completed, failed, and unfinished tool statuses
- leave base and detailed p50 queries unchanged because candidate rewrites did not benchmark faster

## Benchmark
Warm five-run median against the live 18 GB SQLite database:

| Range | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| 30 days | 260.8 ms | 150.4 ms | 42% |
| All time | 2685.9 ms | 1424.0 ms | 47% |

Plans retain `session_message_time_created_idx` for all-project ranges and `session_v2_project_idx` plus `session_message_session_time_created_id_idx` for project ranges. No index or migration is added.

## Testing
- `bun typecheck` in `packages/core`
- `bun test test/session-stats.test.ts` in `packages/core`
- `bunx bun@1.3.14 test test/session-stats.test.ts` in `packages/core`
- targeted Oxlint
- full pre-push workspace typecheck