### PR TITLE
fix(core): make packed SDK boot on workerd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,6 +89,12 @@ jobs:
         working-directory: packages/codemode
         run: bun run script/publish.ts --dry-run
 
+      - name: Verify packed workerd SDK
+        if: runner.os == 'Linux'
+        timeout-minutes: 15
+        working-directory: packages/sdk
+        run: bun run verify:package
+
       - name: Verify compiled service lifecycle
         if: always()
         timeout-minutes: 10

--- a/packages/core/script/build.ts
+++ b/packages/core/script/build.ts
@@ -32,3 +32,38 @@ const result = await Bun.build({
   },
 })
 if (!result.success) throw new AggregateError(result.logs, "Failed to build Core")
+
+// Bun's Node target eagerly creates its shared require helper, so every split
+// entry evaluates import.meta.url even when it never requires a module. Keep
+// the helper lazy until Bun stops hoisting it into workerd-reachable chunks.
+// https://github.com/oven-sh/bun/issues/12615
+const eagerRequire = "var __require = /* @__PURE__ */ createRequire(import.meta.url);"
+const lazyRequire = `var __require = (specifier) => createRequire(import.meta.url ?? "file:///worker.js")(specifier);
+__require.resolve = (specifier, options) => createRequire(import.meta.url ?? "file:///worker.js").resolve(specifier, options);`
+const rewritten = await Promise.all(
+  result.outputs.map(async (output) => {
+    if (!output.path.endsWith(".js")) return false
+    const source = await output.text()
+
+    const generatedUses = source
+      .replace(/import\s*\{[^}]*\b__require\b[^}]*\}\s*from\s*["'][^"']+["'];/g, "")
+      .replace(/export\s*\{[^}]*\b__require\b[^}]*\};/g, "")
+      .replace(eagerRequire, "")
+    if (/\bnew\s+__require\s*\(/.test(generatedUses))
+      throw new Error(`Unsupported generated require constructor in ${output.path}`)
+    const unsupported = generatedUses
+      .replace(/\b__require\.resolve\s*\(/g, "")
+      .replace(/\b__require\s*\(/g, "")
+    if (/\b__require\b/.test(unsupported)) throw new Error(`Unsupported generated require usage in ${output.path}`)
+
+    if (!source.includes(eagerRequire)) return false
+    if (source.indexOf(eagerRequire) !== source.lastIndexOf(eagerRequire))
+      throw new Error(`Multiple eager require helpers in ${output.path}`)
+    const rewrittenSource = source.replace(eagerRequire, lazyRequire)
+    if (rewrittenSource.includes(eagerRequire)) throw new Error(`Failed to rewrite eager require helper in ${output.path}`)
+    await Bun.write(output.path, rewrittenSource)
+    return true
+  }),
+)
+if (rewritten.filter(Boolean).length !== 1)
+  throw new Error("Expected exactly one eager require helper; Bun may have fixed #12615 and made this shim removable")

--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -572,7 +572,7 @@ function cacheKey(source: string) {
 }
 
 export function bodyDigest(text: string) {
-  return new Bun.CryptoHasher("sha256").update(text).digest("hex")
+  return Hash.sha256(text)
 }
 
 export const layer = (options?: Options) =>

--- a/packages/core/src/session/message.ts
+++ b/packages/core/src/session/message.ts
@@ -1,2 +1,2 @@
-export * as SessionMessage from "./message.js"
+export * as SessionMessage from "@opencode-ai/schema/session-message"
 export * from "@opencode-ai/schema/session-message"

--- a/packages/core/src/session/schema.ts
+++ b/packages/core/src/session/schema.ts
@@ -1,4 +1,4 @@
-export * as SessionSchema from "./schema.js"
+export * as SessionSchema from "@opencode-ai/schema/session"
 
 import { Session } from "@opencode-ai/schema/session"
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build": "bun run script/build.ts",
     "test": "bun test --timeout 5000",
-    "typecheck": "tsgo -b"
+    "typecheck": "tsgo -b",
+    "verify:package": "bun run script/verify-package.ts"
   },
   "dependencies": {
     "@opencode-ai/client": "workspace:*",

--- a/packages/sdk/script/verify-package.ts
+++ b/packages/sdk/script/verify-package.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env bun
+
+import { $ } from "bun"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = fileURLToPath(new URL("../../..", import.meta.url))
+const names = ["schema", "codemode", "ai", "util", "protocol", "client", "plugin", "core", "simulation", "server", "sdk"]
+const temporary = await mkdtemp(join(tmpdir(), "opencode-sdk-package-"))
+const archives = new Map<string, string>()
+
+try {
+  for (const name of names) {
+    const directory = join(root, "packages", name)
+    await $`bun run build`.cwd(directory)
+    const original = await Bun.file(join(directory, "package.json")).text()
+    // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- package manifests are validated by their package builds.
+    const pkg = JSON.parse(original) as {
+      name: string
+      dependencies?: Record<string, string>
+      exports?: Record<string, string | { import: string; types: string }>
+      imports?: Record<string, Record<string, string>>
+    }
+    const archive = join(temporary, `${name}.tgz`)
+
+    if (pkg.dependencies) {
+      const unpacked = Object.keys(pkg.dependencies).filter(
+        (dependency) => dependency.startsWith("@opencode-ai/") && !archives.has(dependency),
+      )
+      if (unpacked.length > 0) throw new Error(`${pkg.name} has unpacked workspace dependencies: ${unpacked.join(", ")}`)
+      pkg.dependencies = Object.fromEntries(
+        Object.entries(pkg.dependencies).map(([dependency, version]) => {
+          const local = archives.get(dependency)
+          return [dependency, local ? `file:${local}` : version]
+        }),
+      )
+    }
+    if (pkg.exports) {
+      pkg.exports = Object.fromEntries(
+        Object.entries(pkg.exports).map(([key, value]) => {
+          if (typeof value !== "string") return [key, value]
+          return [key, { import: output(name, value), types: output(name, value, true) }]
+        }),
+      )
+    }
+    if (pkg.imports) {
+      pkg.imports = Object.fromEntries(
+        Object.entries(pkg.imports).map(([key, conditions]) => [
+          key,
+          Object.fromEntries(
+            Object.entries(conditions).map(([condition, value]) => [condition, output(name, value, condition === "types")]),
+          ),
+        ]),
+      )
+    }
+
+    await Bun.write(join(directory, "package.json"), JSON.stringify(pkg, null, 2) + "\n")
+    try {
+      await $`bun pm pack --filename ${archive} --ignore-scripts --quiet`.cwd(directory)
+    } finally {
+      await Bun.write(join(directory, "package.json"), original)
+    }
+    archives.set(pkg.name, archive)
+  }
+
+  const consumer = join(temporary, "consumer")
+  await Bun.write(
+    join(consumer, "package.json"),
+    JSON.stringify({ name: "opencode-sdk-consumer", private: true, type: "module" }),
+  )
+  await Promise.all([
+    Bun.write(
+      join(consumer, "wrangler.jsonc"),
+      JSON.stringify({
+        name: "opencode-sdk-packed-consumer",
+        main: "worker.js",
+        compatibility_date: "2026-07-15",
+        compatibility_flags: ["nodejs_compat"],
+        durable_objects: { bindings: [{ name: "OPENCODE", class_name: "OpenCodeDO" }] },
+        migrations: [{ tag: "v1", new_sqlite_classes: ["OpenCodeDO"] }],
+      }),
+    ),
+    Bun.write(
+      join(consumer, "worker.js"),
+      `import { bodyDigest } from "@opencode-ai/core/models-dev"
+import { OpenCodeWorkerd } from "@opencode-ai/sdk/workerd"
+import { Effect } from "effect"
+
+export class OpenCodeDO {
+  constructor(state) {
+    this.state = state
+  }
+
+  fetch() {
+    if (bodyDigest("packed-workerd") !== "5fc174bf63e8dd108ebb6c53d85e7bbc4525b2f4c1c43280364cdbfd9b37aaf5") {
+      throw new Error("Packed workerd SHA-256 mismatch")
+    }
+    const storage = this.state.storage
+    return Effect.runPromise(
+      Effect.gen(function* () {
+        const sdk = yield* OpenCodeWorkerd.create({
+          storage,
+          app: { version: "packed-workerd" },
+          config: { content: "{}" },
+        })
+        return Response.json(yield* sdk.health.get())
+      }).pipe(Effect.scoped),
+    )
+  }
+}
+
+export default {
+  fetch(request, env) {
+    return env.OPENCODE.get(env.OPENCODE.idFromName("packed-consumer")).fetch(request)
+  },
+}
+`,
+    ),
+    Bun.write(
+      join(consumer, "boot.mjs"),
+      `import { Miniflare } from "miniflare"
+
+const miniflare = new Miniflare({
+  compatibilityDate: "2026-07-15",
+  compatibilityFlags: ["nodejs_compat"],
+  modules: true,
+  scriptPath: new URL("./dist/worker.js", import.meta.url).pathname,
+  durableObjects: { OPENCODE: { className: "OpenCodeDO", useSQLite: true } },
+})
+
+try {
+  const response = await miniflare.dispatchFetch("http://opencode.local/health")
+  if (response.status !== 200) throw new Error(
+    "Packed workerd health returned " + response.status + ": " + await response.text(),
+  )
+  const body = await response.json()
+  if (body.healthy !== true || body.version !== "packed-workerd") {
+    throw new Error("Unexpected packed workerd health: " + JSON.stringify(body))
+  }
+} finally {
+  await miniflare.dispose()
+}
+`,
+    ),
+  ])
+
+  const sdk = archives.get("@opencode-ai/sdk")
+  if (!sdk) throw new Error("Packed SDK archive was not created")
+  await $`npm install --ignore-scripts --no-audit --no-fund --package-lock=false ${sdk} wrangler@4.110.0`.cwd(consumer)
+  await $`node_modules/.bin/wrangler deploy --dry-run --config wrangler.jsonc --outdir dist`.cwd(consumer)
+
+  const transpiler = new Bun.Transpiler({ loader: "js" })
+  const bundled = await Bun.file(join(consumer, "dist/worker.js")).text()
+  if (/createRequire\s*\(\s*import\.meta\.url\s*\)/.test(bundled)) {
+    throw new Error("Packed workerd bundle contains Bun's eager Node require initializer")
+  }
+  const bunGlobals = Array.from(new Set(bundled.match(/\bBun\.[A-Za-z_$][\w$]*/g) ?? []))
+  if (bunGlobals.length > 0) throw new Error(`Packed workerd bundle references Bun globals: ${bunGlobals.join(", ")}`)
+  const leaked = [
+    ...transpiler.scanImports(bundled)
+      .filter((imported) => imported.kind !== "dynamic-import")
+      .map((imported) => imported.path),
+    ...Array.from(bundled.matchAll(/\brequire\(\s*["']([^"']+)["']\s*\)/g), (match) => match[1]),
+  ]
+    .filter((specifier) => specifier === "bun" || specifier.startsWith("bun:"))
+  if (leaked.length > 0) throw new Error(`Packed workerd bundle statically imports Bun builtins: ${leaked.join(", ")}`)
+
+  await $`node boot.mjs`.cwd(consumer)
+  console.log("packed SDK consumer OK")
+} finally {
+  await rm(temporary, { recursive: true, force: true })
+}
+
+function output(name: string, value: string, types = false) {
+  const root = name === "core" && types ? "./dist/types/" : "./dist/"
+  return value.replace("./src/", root).replace(/\.ts$/, types ? ".d.ts" : ".js")
+}

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -25,7 +25,7 @@
       "default": "./src/global-roots.ts"
     },
     "#runtime-import": {
-      "workerd": "./src/runtime/import.bun.ts",
+      "workerd": "./src/runtime/import.workerd.ts",
       "bun": "./src/runtime/import.bun.ts",
       "node": "./src/runtime/import.node.ts",
       "default": "./src/runtime/import.bun.ts"

--- a/packages/util/src/runtime/import.workerd.ts
+++ b/packages/util/src/runtime/import.workerd.ts
@@ -1,0 +1,9 @@
+const unavailable = () => new Error("Dynamic module loading is unavailable on workerd")
+
+export function importModule(_specifier: string): Promise<unknown> {
+  return Promise.reject(unavailable())
+}
+
+export function resolveModule(_specifier: string, _directory: string): string {
+  throw unavailable()
+}


### PR DESCRIPTION
## What

Make the packed `@opencode-ai/sdk/workerd` entrypoint boot on Cloudflare workerd from a clean npm install. This is the minimal Cloudflare-only slice of #44582: Core's dist stops crashing Workers at module initialization, and a new CI gate boots the real packed artifact on workerd. The strict-Node ESM resolution work (`.js` specifiers, server build rewriter, Node consumer legs of the verifier) stays in #44582 as the follow-up.

## The problem

Two independent defects killed every Worker at module initialization, before any user code ran.

### 1. Bun's dead, eager `createRequire` helper

Bun's bundler has a known bug ([oven-sh/bun#12615](https://github.com/oven-sh/bun/issues/12615), fix PR [#12760](https://github.com/oven-sh/bun/pull/12760) closed unmerged): any dynamic `import()` of a builtin or external package makes it emit an eager CJS-interop helper that nothing ever uses. We verified zero `__require(...)` call sites across all ~750 output files. With `splitting: true` the helper lands in the shared chunk that also holds `__export`, which every module needs, so every entrypoint evaluates it at load:

```mermaid
flowchart LR
    src["source:<br/>await import('node:http')<br/>(35 deliberate lazy imports)"] --> scan["Bun scan phase:<br/>'might need require interop'"]
    scan --> helper["emits eager helper:<br/>createRequire(import.meta.url)"]
    helper --> chunk["shared chunk<br/>(splitting hoists helpers together)"]
    exp["__export helper<br/>(needed by every module)"] --> chunk
    chunk --> everyone["every entrypoint<br/>loads the shared chunk"]
    everyone --> node["Node: import.meta.url is a file URL<br/>harmless no-op"]
    everyone --> wd["workerd: import.meta.url is undefined<br/>createRequire throws at boot"]
```

The same bug class is currently biting published SDKs on Workers across bundlers: [e2b-dev/E2B#1579](https://github.com/e2b-dev/E2B/issues/1579), [runpod/js-sdk#20](https://github.com/runpod/js-sdk/issues/20), [zenstackhq/zenstack#2610](https://github.com/zenstackhq/zenstack/issues/2610), [sveltejs/kit#15960](https://github.com/sveltejs/kit/issues/15960) (Rolldown).

### 2. Recursive self-namespace chunk ordering

With the helper defused, workerd still failed to start: `TypeError: Cannot read properties of undefined (reading 'ast')` inside `decodeUnknownEffect` during module evaluation. The `export * as SessionSchema from "./schema.js"` self-namespace pattern in `session/schema.ts` and `session/message.ts` produces a recursive split-chunk namespace object whose evaluation order workerd's flattened bundle resolves differently, reading a schema before it is initialized. This was verified by A/B: the packed Miniflare boot fails with exactly this error when only the helper fix is applied, and passes with the facades projected directly onto the canonical `@opencode-ai/schema` namespaces.

### Smaller leaks

`models-dev` hashing reached the `Bun.CryptoHasher` global on workerd's catalog-refresh path, and workerd resolved `#runtime-import` to the Bun implementation it can never support.

## The fix

1. **Keep `target: "node"`, defuse the helper at the build boundary.** After `Bun.build`, Core's build script rewrites the one eager line to defer `createRequire` until an actual call (which today is never). The rewrite fails closed:

```mermaid
flowchart TD
    build["Bun.build target: node"] --> audit["audit all outputs for __require forms"]
    audit --> forms{"only supported forms?<br/>call and .resolve"}
    forms -- no --> f1["build fails:<br/>unsupported generated usage"]
    forms -- yes --> count{"exactly one<br/>eager helper?"}
    count -- "zero" --> f2["build fails:<br/>Bun may have fixed #12615,<br/>shim may be removable"]
    count -- "more than one" --> f3["build fails: re-audit"]
    count -- one --> rewrite["rewrite helper to lazy"]
    rewrite --> gate["verify:package boots the<br/>packed artifact on Miniflare"]
```

   The workaround carries its own expiration: the day Bun fixes #12615, the zero-count assertion fails the build and points at the issue.

2. **Project the Session facades onto canonical Schema namespaces** (`session/message.ts`, `session/schema.ts`), removing the recursive split-chunk self-namespace object while preserving exact schema identity. Proven load-bearing by the A/B failure above.

3. **Runtime-neutral hashing**: `models-dev` uses the `node:crypto`-backed `Hash.sha256` (identical digests) instead of the Bun global.

4. **workerd gets an explicit answer instead of an accident**: `#runtime-import` maps to an implementation reporting dynamic module loading as unavailable.

5. **A CI gate for the whole bug class**: `verify:package` builds and packs the eleven-package cohort, installs the SDK tarball in a clean npm consumer, bundles a Durable Object worker with a plain wrangler config, scans the bundle, and boots it on Miniflare:

```mermaid
sequenceDiagram
    participant Repo
    participant Pack as exact local tarballs
    participant npm as clean npm consumer
    participant Wrangler
    participant DO as Miniflare SQLite DO

    Repo->>Pack: build and pack 11-package cohort
    Pack->>npm: install SDK plus local dependency closure
    npm->>Wrangler: bundle SDK/workerd (dry run)
    Wrangler->>Wrangler: scan bundle: no eager helper, no Bun globals or builtins
    Wrangler->>DO: boot bundled Worker with SQLite storage
    DO->>DO: run real SHA-256 through models-dev path
    DO-->>npm: healthy packed-workerd response
```

## Before / After

**Before:** wrangler bundled the packed SDK, but workerd threw during module initialization, first `createRequire` receiving an undefined `import.meta.url`, then, with that fixed, the `'ast'` TypeError from the recursive schema namespace. No Durable Object could ever construct.

**After:** a clean SQLite Durable Object boots the packed SDK with a plain consumer config (no `define` shims, no aliases), executes the models-dev SHA-256 path, and returns a healthy response. Node consumers are untouched: the rewritten helper was dead code, the hash swap produces identical digests, and the `#runtime-import` change only affects the previously-broken workerd condition.

## Scope

- The `.js` relative-specifier work, server build rewriter, watcher subpath, simulation fixes, and the Node-import and NodeNext type-check legs of the verifier remain in #44582, which becomes the follow-up on top of this.
- This PR does not publish a beta cohort.
- Explicit `createRequire` calls in guarded Node-only bindings remain unchanged.
- This does not add dynamic provider or plugin loading to workerd; that capability is deliberately unavailable.
- This does not add a second Core build, disable splitting, or broaden Core's runtime target.

## Testing

- `packages/sdk`: `bun run verify:package` (pack eleven-package cohort, clean npm install, wrangler dry-run bundle, eager-helper and Bun-global and bun-builtin scans, workerd SHA-256 assertion, Miniflare SQLite Durable Object boot).
- A/B verification of the facade changes: helper fix alone fails the Miniflare boot with the `'ast'` TypeError; with the facades the boot passes.
- `packages/core`, `packages/util`, `packages/sdk`: `bun typecheck`.
- `packages/core`: `bun run build` (shim assertions pass; lazy helper confirmed in the shared chunk).
