### PR TITLE
fix(app): correct project rename persistence

### DIFF
--- a/packages/app/src/components/edit-project.ts
+++ b/packages/app/src/components/edit-project.ts
@@ -7,10 +7,14 @@ import { createStore } from "solid-js/store"
 import { useGlobal } from "@/context/global"
 import { type LocalProject } from "@/context/layout"
 import { ServerConnection } from "@/context/server"
+import { useLanguage } from "@/context/language"
+import { showToast } from "@/utils/toast"
+import { formatServerError } from "@/utils/server-errors"
 
 export function createEditProjectModel(props: { project: LocalProject; server: ServerConnection.Any }) {
   const dialog = useDialog()
   const global = useGlobal()
+  const language = useLanguage()
   const serverCtx = createMemo(() => global.ensureServerCtx(props.server))
   const folderName = createMemo(() => getFilename(props.project.worktree))
   const defaultName = createMemo(() => props.project.name || folderName())
@@ -71,23 +75,25 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
       const start = store.startup.trim()
 
       if (props.project.id && props.project.id !== "global") {
-        if ((await serverCtx().sdk.protocol) !== "v1") return
+        if ((await serverCtx().sdk.protocol) === "v1") {
+          serverCtx().sync.project.meta(props.project.worktree, {
+            name,
+            icon: { color: store.color || undefined, override: store.iconOverride || undefined },
+            commands: { start: start || undefined },
+          })
+          dialog.close()
+          return
+        }
         const project = await serverCtx()
           .sdk.client.project.update({
             projectID: props.project.id,
             directory: props.project.worktree,
             name,
-            icon: { color: store.color || "", override: store.iconOverride || "" },
-            commands: { start },
+            icon: { color: store.color || undefined, override: store.iconOverride || undefined },
+            commands: { start: start || undefined },
           })
           .then((result) => result.data)
-        if (!project) return
-        // const project = await serverCtx().sdk.api.project.update({
-        //   projectID: props.project.id,
-        //   name,
-        //   icon: { color: store.color || "", override: store.iconOverride || "" },
-        //   commands: { start },
-        // })
+        if (!project) throw new Error(`Project not found: ${props.project.id}`)
         serverCtx().sync.set("project", (items) =>
           items.map((item) => (item.id === project.id ? normalizeProjectInfo(project) : item)),
         )
@@ -102,6 +108,13 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
         commands: { start: start || undefined },
       })
       dialog.close()
+    },
+    onError: (error) => {
+      showToast({
+        title: language.t("common.requestFailed"),
+        description: formatServerError(error, language.t, language.t("common.requestFailed")),
+        variant: "error",
+      })
     },
   }))
 

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -117,10 +117,23 @@ function createServerCtx(
       ? sync.data.project.find((x) => x.id === projectID)
       : sync.data.project.find((x) => x.worktree === project.worktree)
 
+    // Local metadata: v1 servers persist name/icon/commands client-side via projectMeta.
+    // A stored empty-string name means "reset to folder name" and must still override.
+    const meta = childStore.projectMeta
+    const base = {
+      ...metadata,
+      ...project,
+      ...(meta?.name === undefined ? {} : { name: meta.name }),
+      ...(meta?.icon || meta?.commands
+        ? {
+            icon: { ...metadata?.icon, ...meta.icon },
+            commands: { ...metadata?.commands, ...meta.commands },
+          }
+        : {}),
+    }
     // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
     // Without this, different subdirectories of the same git repo would share the same
     // icon from the database instead of using their individual overrides.
-    const base = { ...metadata, ...project }
     if (childStore.icon) {
       return { ...base, icon: { ...base.icon, override: childStore.icon } }
     }

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -449,10 +449,23 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         ? serverSync().data.project.find((x) => x.id === projectID)
         : serverSync().data.project.find((x) => x.worktree === project.worktree)
 
+      // Local metadata: v1 servers persist name/icon/commands client-side via projectMeta.
+      // A stored empty-string name means "reset to folder name" and must still override.
+      const meta = childStore.projectMeta
+      const base = {
+        ...metadata,
+        ...project,
+        ...(meta?.name === undefined ? {} : { name: meta.name }),
+        ...(meta?.icon || meta?.commands
+          ? {
+              icon: { ...metadata?.icon, ...meta.icon },
+              commands: { ...metadata?.commands, ...meta.commands },
+            }
+          : {}),
+      }
       // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
       // Without this, different subdirectories of the same git repo would share the same
       // icon from the database instead of using their individual overrides.
-      const base = { ...metadata, ...project }
       if (childStore.icon) {
         return { ...base, icon: { ...base.icon, override: childStore.icon } }
       }

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -573,7 +573,10 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         const projectID = project.id
         void (async () => {
           const sdk = serverSdk()
-          if ((await sdk.protocol) !== "v1") return
+          if ((await sdk.protocol) === "v1") {
+            serverSync().project.meta(worktree, { icon: { color } })
+            return
+          }
           return sdk.client.project
             .update({ projectID, directory: worktree, icon: { color } })
             .then((response) => response.data)

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -34,6 +34,7 @@ import { DragDropProvider, DragDropSensors, DragOverlay, SortableProvider, close
 import type { DragEvent } from "@thisbeyond/solid-dnd"
 import { useProviders } from "@/hooks/use-providers"
 import { dismissToast, setV2Toast, showToast, ToastRegion } from "@/utils/toast"
+import { formatServerError } from "@/utils/server-errors"
 import { useServerSDK } from "@/context/server-sdk"
 import { normalizeProjectInfo } from "@/context/global-sync/utils"
 import { clearWorkspaceTerminals } from "@/context/terminal"
@@ -1288,15 +1289,25 @@ export default function LegacyLayout(props: ParentProps) {
 
     if (project.id && project.id !== "global") {
       const sdk = serverSDK()
-      if ((await sdk.protocol) !== "v1") return
-      const result = await sdk.client.project
-        .update({ projectID: project.id, directory: project.worktree, name })
-        .then((response) => response.data)
-      if (!result) return
-      // const result = await serverSDK().api.project.update({ projectID: project.id, name })
-      serverSync().set("project", (items) =>
-        items.map((item) => (item.id === result.id ? normalizeProjectInfo(result) : item)),
-      )
+      if ((await sdk.protocol) === "v1") {
+        serverSync().project.meta(project.worktree, { name })
+        return
+      }
+      try {
+        const result = await sdk.client.project
+          .update({ projectID: project.id, directory: project.worktree, name })
+          .then((response) => response.data)
+        if (!result) throw new Error(`Project not found: ${project.id}`)
+        serverSync().set("project", (items) =>
+          items.map((item) => (item.id === result.id ? normalizeProjectInfo(result) : item)),
+        )
+      } catch (error) {
+        showToast({
+          title: language.t("common.requestFailed"),
+          description: formatServerError(error, language.t, language.t("common.requestFailed")),
+          variant: "error",
+        })
+      }
       return
     }
 


### PR DESCRIPTION
Fixes #43989

**Root cause v2 : garde inversée**
- `edit-project.ts:78`, `context/layout.tsx:576`, `pages/layout.tsx:1292` faisaient `if (protocol !== "v1") return` → early-return silencieux sur serveurs v2 (aucune requête, aucun toast). Corrigé en `=== "v1"` avec fallback `sync.project.meta` pour v1 et `client.project.update` pour v2. Reproduit sur `opencode web` 1.18.21 (`PATCH /project/{id}` jamais envoyé, DB intacte) — conforme à #43928.

**Payload & erreurs**
- `icon/color|override` et `commands.start` : `"" -> undefined` (évite `icon_url_override=''\'') et gère le clear (`""\'\' via ``|| undefined``).
- `if (!project) return` silencieux → `throw` + `onError` / `try/catch` → `showToast(formatServerError)` avec `variant: error`.

**Affichage v1**
- `enrich()` dans `global.tsx:113` et `layout.tsx:445` ne lisait jamais `childStore.projectMeta` → nom/icon sauvegardés en localStorage mais jamais affichés ("modifié dans local storage mais pas dans le front"). Merge maintenant `projectMeta` par-dessus les métadonnées serveur (empty-string `""` = reset vers folder name).

**Tests**
- `bun typecheck` OK (packages/app + opencode, 30 tasks).
- Manuel v1 (`bun run serve` 4096 + `vite 4444`) : rename persiste et s'affiche instantanément via meta.
- Refs #43928, #32691 (duplicates).

Refs #43928, #32691