### PR TITLE
feat(plugin): add session.stopping hook for loop continuation

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -288,6 +288,50 @@ const layer = Layer.effect(
     >(name: Name, input: Input, output: Output) {
       if (!name) return output
       const s = yield* InstanceState.get(state)
+
+      // `session.stopping` runs every listener sequentially in registration
+      // order over one shared output, with fail-closed merge semantics:
+      //
+      // - A listener opts the loop into continuing by setting `stop = false`
+      //   plus a non-empty `message`. The default `stop` is `true` (stop).
+      // - `stop` is sticky-true: once a listener vetoes (`stop` moves from
+      //   false -> true), a later `stop = false` cannot override it.
+      // - Listener errors are isolated: one listener throwing or rejecting
+      //   does not prevent the remaining listeners from running, and any
+      //   error forces the final output to `stop: true, message: undefined`.
+      if (name === "session.stopping") {
+        let failed = false
+        let vetoed = false
+        const stoppingInput = input as { sessionID: string }
+        const stoppingOutput = output as { stop: boolean; message?: string }
+        for (const [index, hook] of s.hooks.entries()) {
+          const fn = hook["session.stopping"]
+          if (!fn) continue
+          const before = stoppingOutput.stop
+          yield* Effect.tryPromise(() => fn(stoppingInput, stoppingOutput)).pipe(
+            Effect.catch((error) => {
+              failed = true
+              return Effect.logError("session.stopping hook error; failing closed", {
+                "session.id": stoppingInput.sessionID,
+                hook: name,
+                listener: index,
+                error: errorMessage(error),
+              })
+            }),
+          )
+          if (!before && stoppingOutput.stop) {
+            vetoed = true
+          }
+        }
+        // stop is sticky-true: once vetoed (or on any error) neither `stop`
+        // nor `message` written by a later listener can stay set.
+        if (failed || vetoed) {
+          stoppingOutput.stop = true
+          stoppingOutput.message = undefined
+        }
+        return output
+      }
+
       for (const hook of s.hooks) {
         const fn = hook[name] as any
         if (!fn) continue

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -81,6 +81,22 @@ IMPORTANT:
 
 const STRUCTURED_OUTPUT_SYSTEM_PROMPT = `IMPORTANT: The user has requested structured output. You MUST use the StructuredOutput tool to provide your final response. Do NOT respond with plain text - you MUST call the StructuredOutput tool with your answer formatted according to the schema.`
 
+/**
+ * Conservative core-side re-entry cap for `session.stopping` continuations.
+ * Defense-in-depth only: client plugin policy is authoritative. On exhaustion the
+ * hook fails closed (`stop: true`, no continuation) with telemetry, so the
+ * fork can never loop unboundedly.
+ */
+const SESSION_STOPPING_REENTRY_CAP = 3
+
+interface SessionStoppingState {
+  /** Continuations consumed on this session since the last clean stop. */
+  continuations: number
+  /** Set while a continuation is being evaluated; prevents double-consume. */
+  inFlight: boolean
+}
+const sessionStopping = new Map<SessionID, SessionStoppingState>()
+
 function mcpResourceBase64Size(value: string) {
   const trimmed = value.replace(/\s/g, "")
   const padding = trimmed.endsWith("==") ? 2 : trimmed.endsWith("=") ? 1 : 0
@@ -1078,6 +1094,83 @@ const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
+    const stoppingStateFor = (sessionID: SessionID): SessionStoppingState => {
+      let state = sessionStopping.get(sessionID)
+      if (!state) {
+        state = { continuations: 0, inFlight: false }
+        sessionStopping.set(sessionID, state)
+      }
+      return state
+    }
+
+    const maybeContinueStopping = (sessionID: SessionID) =>
+    Effect.gen(function* () {
+      const state = stoppingStateFor(sessionID)
+      // Serialize per-session: a concurrent continuation evaluation for the
+      // same session must never double-consume or double-persist.
+      if (state.inFlight) {
+        yield* Effect.logWarning("session.stopping re-entry already in flight; skipping", {
+          "session.id": sessionID,
+        })
+        return false
+      }
+      state.inFlight = true
+      try {
+        const stoppingOutput = yield* plugin
+          .trigger("session.stopping", { sessionID }, { stop: true, message: undefined as string | undefined })
+          .pipe(
+            Effect.catchCause((cause) =>
+              Effect.logError("session.stopping hook failed; stopping", { "session.id": sessionID, cause })
+                .pipe(Effect.as({ stop: true, message: undefined as string | undefined })),
+            ),
+          )
+        const message = stoppingOutput.message
+        const ok = !stoppingOutput.stop && typeof message === "string" && message.trim().length > 0
+        if (!ok) {
+          // Clean stop: the hook (or an empty/whitespace message) decided to
+          // stop. Reset the per-session counter so a future engagement starts
+          // with a full budget again.
+          state.continuations = 0
+          return false
+        }
+        if (state.continuations >= SESSION_STOPPING_REENTRY_CAP) {
+          // Cap exhausted: the 4th continuation request stops WITHOUT
+          // persisting and does NOT reset the counter, so a repeated
+          // `prompt.loop`/`prompt` invocation on the same session cannot
+          // restart the budget.
+          yield* Effect.logWarning("session.stopping re-entry cap exceeded; stopping", {
+            "session.id": sessionID,
+            continuations: state.continuations,
+          })
+          return false
+        }
+        const persisted = yield* createUserMessage({
+          sessionID,
+          parts: [{ type: "text", text: message }],
+        }).pipe(Effect.as(true), Effect.catchCause(() => Effect.succeed(false)))
+        if (!persisted) return false
+        state.continuations += 1
+        yield* Effect.logInfo("session.stopping hook prevented stop", {
+          "session.id": sessionID,
+          continuations: state.continuations,
+        })
+        return true
+      } finally {
+        state.inFlight = false
+      }
+    })
+
+    // Clean up per-session stopping state when a session is deleted.
+    // This is NOT triggered by natural completion — only by explicit session
+    // deletion — because a session may be deleted while a continuation budget
+    // is partially consumed, and the Map must not leak.
+    yield* events.listen((event) => {
+      if (event.type !== "session.deleted") return Effect.void
+      const sid = (event.data as any)?.id as SessionID | undefined
+      if (sid) sessionStopping.delete(sid)
+      return Effect.void
+    }).pipe(Effect.flatMap((unsub) => Effect.addFinalizer(() => unsub)))
+
     const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
@@ -1126,6 +1219,8 @@ const layer = Layer.effect(
               })
             }
             yield* Effect.logInfo("exiting loop", { "session.id": sessionID })
+
+            if (yield* maybeContinueStopping(sessionID)) continue
             break
           }
 
@@ -1316,7 +1411,13 @@ const layer = Layer.effect(
               }
             }
 
-            if (result === "stop") return "break" as const
+            if (result === "stop") {
+              // Non-natural exit (provider error, tool error, blocked, retry
+              // exhausted). The `session.stopping` hook applies only to a
+              // genuine natural completion (detected at the loop top), so an
+              // errored/blocked stop must never invoke a stopping callback.
+              return "break" as const
+            }
             if (result === "compact") {
               yield* compaction.create({
                 sessionID,

--- a/packages/opencode/test/plugin/session-stopping-exit-matrix.test.ts
+++ b/packages/opencode/test/plugin/session-stopping-exit-matrix.test.ts
@@ -1,0 +1,1057 @@
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+import { Database } from "@opencode-ai/core/database/database"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { describe, expect } from "bun:test"
+import { Effect, Fiber, Layer } from "effect"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Agent as AgentSvc } from "../../src/agent/agent"
+import { BackgroundJob } from "@/background/job"
+import { Command } from "../../src/command"
+import { Config } from "@/config/config"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { LSP } from "@/lsp/lsp"
+import { MCP } from "../../src/mcp"
+import { Permission } from "../../src/permission"
+import { Plugin } from "../../src/plugin"
+import { Provider as ProviderSvc } from "@/provider/provider"
+import { Env } from "../../src/env"
+import { Git } from "../../src/git"
+import { Image } from "../../src/image/image"
+import { Question } from "../../src/question"
+import { Todo } from "../../src/session/todo"
+import { Session } from "@/session/session"
+import { LLM } from "../../src/session/llm"
+import { MessageV2 } from "../../src/session/message-v2"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { SessionCompaction } from "../../src/session/compaction"
+import { SessionSummary } from "../../src/session/summary"
+import { Instruction } from "../../src/session/instruction"
+import { SessionProcessor } from "../../src/session/processor"
+import { SessionPrompt } from "../../src/session/prompt"
+import { SessionRevert } from "../../src/session/revert"
+import { SessionRunState } from "../../src/session/run-state"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { SessionStatus } from "../../src/session/status"
+import { Skill } from "../../src/skill"
+import { SystemPrompt } from "../../src/session/system"
+import { Shell } from "@opencode-ai/core/shell"
+import { Snapshot } from "../../src/snapshot"
+import { ToolRegistry } from "@/tool/registry"
+import { Truncate } from "@/tool/truncate"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { Format } from "../../src/format"
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { TestLLMServer, raw } from "../lib/llm-server"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+
+const summary = Layer.succeed(
+  SessionSummary.Service,
+  SessionSummary.Service.of({
+    summarize: () => Effect.void,
+    diff: () => Effect.succeed([]),
+    computeDiff: () => Effect.succeed([]),
+  }),
+)
+
+const ref = {
+  providerID: ProviderV2.ID.make("test"),
+  modelID: ModelV2.ID.make("test-model"),
+}
+
+function makeMcp() {
+  return Layer.succeed(MCP.Service, MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    instructions: () => Effect.succeed([]),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    resourceTemplates: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: (_name: string) => Effect.succeed({ status: "connected" as const }),
+    disconnect: (_name: string) => Effect.void,
+    getPrompt: (_name: string, _promptName: string) => Effect.succeed(undefined),
+    readResource: (_uri: string) => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth in session-stopping tests"),
+    authenticate: () => Effect.die("unexpected MCP auth in session-stopping tests"),
+    finishAuth: () => Effect.die("unexpected MCP auth in session-stopping tests") as any,
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }))
+}
+
+const lsp = Layer.succeed(LSP.Service, LSP.Service.of({
+  init: () => Effect.void,
+  status: () => Effect.succeed([]),
+  hasClients: () => Effect.succeed(false),
+  touchFile: () => Effect.void,
+  diagnostics: () => Effect.succeed({}),
+  hover: () => Effect.succeed(undefined),
+  definition: () => Effect.succeed([]),
+  references: () => Effect.succeed([]),
+  implementation: () => Effect.succeed([]),
+  documentSymbol: () => Effect.succeed([]),
+  workspaceSymbol: () => Effect.succeed([]),
+  prepareCallHierarchy: () => Effect.succeed([]),
+  incomingCalls: () => Effect.succeed([]),
+  outgoingCalls: () => Effect.succeed([]),
+}))
+
+const runtimeFlags = RuntimeFlags.layer({ experimentalEventSystem: true })
+const testLLMServerNode = LayerNode.make({ service: TestLLMServer, layer: TestLLMServer.layer, deps: [] })
+
+const promptRoot = LayerNode.group([
+  SessionPrompt.node,
+  Session.node,
+  SessionProjector.node,
+  MessageV2.node,
+  Snapshot.node,
+  LLM.node,
+  Env.node,
+  AgentSvc.node,
+  Command.node,
+  Permission.node,
+  Plugin.node,
+  Config.node,
+  ProviderSvc.node,
+  LSP.node,
+  MCP.node,
+  FSUtil.node,
+  BackgroundJob.node,
+  SessionStatus.node,
+  SessionRunState.node,
+  Database.node,
+  EventV2Bridge.node,
+  Question.node,
+  Todo.node,
+  ToolRegistry.node,
+  Skill.node,
+  Git.node,
+  Ripgrep.node,
+  Format.node,
+  Truncate.node,
+  SessionProcessor.node,
+  Image.node,
+  SessionCompaction.node,
+  SessionRevert.node,
+  Instruction.node,
+  SystemPrompt.node,
+  CrossSpawnSpawner.node,
+  RuntimeFlags.node,
+])
+
+function makeHttp() {
+  const root = LayerNode.group([promptRoot, testLLMServerNode])
+  const replacements = [
+    [SessionSummary.node, summary],
+    [LSP.node, lsp],
+    [MCP.node, makeMcp()],
+    [RuntimeFlags.node, runtimeFlags],
+  ] as const
+  return LayerNode.compile(root, replacements)
+}
+
+const it = testEffect(makeHttp())
+
+const writeText = Effect.fn("test.writeText")(function* (file: string, text: string) {
+  const fs = yield* FSUtil.Service
+  yield* fs.writeWithDirs(file, text)
+})
+
+const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string) {
+  const session = yield* Session.Service
+  const msg = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: msg.id,
+    sessionID,
+    type: "text",
+    text,
+  })
+  return msg
+})
+
+const seed = Effect.fn("test.seed")(function* (sessionID: SessionID, opts?: { finish?: string }) {
+  const session = yield* Session.Service
+  const msg = yield* user(sessionID, "hello")
+  const assistant: SessionV1.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: msg.id,
+    sessionID,
+    mode: "build",
+    agent: "build",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    time: { created: Date.now() },
+    ...(opts?.finish ? { finish: opts.finish } : {}),
+  }
+  yield* session.updateMessage(assistant)
+  yield* session.updatePart({
+    id: PartID.ascending(),
+    messageID: assistant.id,
+    sessionID,
+    type: "text",
+    text: "hi there",
+  })
+  return { user: msg, assistant }
+})
+
+const BASE_CFG: ConfigV1.Info = {
+  provider: {
+    test: {
+      name: "Test",
+      id: "test",
+      env: [],
+      npm: "@ai-sdk/openai-compatible",
+      models: {
+        "test-model": {
+          id: "test-model",
+          name: "Test Model",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 100000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+      },
+      options: {
+        apiKey: "test-key",
+        baseURL: "http://localhost:1/v1",
+      },
+    },
+  },
+}
+
+function providerCfg(url: string): ConfigV1.Info {
+  return {
+    ...BASE_CFG,
+    provider: {
+      test: {
+        ...BASE_CFG.provider!.test,
+        options: {
+          ...BASE_CFG.provider!.test.options,
+          baseURL: url,
+        },
+      },
+    },
+  }
+}
+
+const waitForBusy = (sessionID: SessionID) =>
+  Effect.gen(function* () {
+    const status = yield* SessionStatus.Service
+    while (true) {
+      const s = yield* status.get(sessionID)
+      if (s.type === "busy") return true as const
+      yield* Effect.sleep("20 millis")
+    }
+  }).pipe(Effect.timeoutOrElse({ duration: "2 seconds", orElse: () => Effect.die("session never became busy") }))
+
+describe("session.stopping exit-matrix", () => {
+  it.instance("natural-exit seeded assistant fires hook — loop exits normally",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const chat = yield* sessions.create({ title: "Pooled exit test" })
+        const marker = path.join(dir, "stopping-count")
+
+        yield* seed(chat.id, { finish: "stop" })
+        const result = yield* prompt.loop({ sessionID: chat.id })
+        expect(result.info.role).toBe("assistant")
+
+        const countText = yield* Effect.promise(() => Bun.file(marker).text())
+        expect(countText).toBe("fire")
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const marker = path.join(dir, "stopping-count")
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input, output) => {`,
+              `    await Bun.write(${JSON.stringify(marker)}, 'fire')`,
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...BASE_CFG,
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("cancel (non-natural) does NOT fire stopping hook",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const marker = path.join(dir, "stopping-fired")
+
+        const chat = yield* sessions.create({})
+        yield* user(chat.id, "hello")
+        const fiber = yield* prompt.loop({ sessionID: chat.id }).pipe(Effect.forkChild)
+        yield* waitForBusy(chat.id) as Effect.Effect<true, never, never>
+        yield* prompt.cancel(chat.id)
+        yield* Fiber.await(fiber).pipe(
+          Effect.timeoutOrElse({ duration: "5 seconds", orElse: () => Effect.die("cancelled loop never exited") }),
+        )
+
+        const exists = yield* Effect.promise(async () => Bun.file(marker).exists())
+        expect(exists).toBe(false)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const marker = path.join(dir, "stopping-fired")
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input) => {`,
+              `    await Bun.write(${JSON.stringify(marker)}, 'fired')`,
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...BASE_CFG,
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("continuation message persists and re-entry is bounded by the cap",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+
+        const chat = yield* sessions.create({
+          title: "cap test",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        yield* llm.text("one")
+        yield* llm.text("two")
+        yield* llm.text("three")
+        yield* llm.text("four")
+
+        // Loop must terminate (bounded re-entry) rather than run forever.
+        const result = yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({
+            duration: "20 seconds",
+            orElse: () => Effect.die("loop did not terminate; re-entry cap failed"),
+          }),
+        )
+        expect(result.info.role).toBe("assistant")
+
+        // Boundedness: exactly 4 LLM turns (1 initial + 3 continuations), not infinite.
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        const assistants = msgs.filter((m) => m.info.role === "assistant")
+        expect(assistants).toHaveLength(4)
+
+        // Hook fired on every natural completion: initial + 3 continuations + 1 cap stop.
+        const countText = yield* Effect.promise(() => Bun.file(path.join(dir, "stopping-count")).text())
+        expect(Number(countText)).toBe(4)
+
+        // SH-4 persistence contract: exactly 3 continuation messages survive,
+        // each an ordinary user message with a single text part.
+        const injected = msgs.filter(
+          (m) => m.info.role === "user" && m.parts.some((p) => p.type === "text" && p.text === "keep going"),
+        )
+        expect(injected).toHaveLength(3)
+        for (const msg of injected) {
+          expect(msg.info.role).toBe("user")
+          expect(msg.info.sessionID).toBe(chat.id)
+          expect(msg.info.agent).toBe("build")
+          expect(msg.parts).toHaveLength(1)
+          expect(msg.parts[0].type).toBe("text")
+          expect((msg.parts[0] as SessionV1.TextPart).text).toBe("keep going")
+        }
+        // No duplicate ids; the three injected messages are distinct records.
+        expect(new Set(injected.map((m) => m.info.id)).size).toBe(3)
+
+        // ── SH-4 ordering + metadata + attribution ────────────────────────
+        // The injected continuation is an ordinary user message created through
+        // the same store path as a real prompt; its metadata must be populated
+        // consistently with the session's other user messages.
+        const ordinary = msgs.filter((m) => m.info.role === "user" && m.info.id !== injected[0]!.info.id)
+        expect(ordinary.length).toBeGreaterThan(0)
+        const injectedIds = new Set(injected.map((m) => m.info.id))
+        for (const msg of injected) {
+          expect(msg.info.role).toBe("user")
+          expect(msg.info.sessionID).toBe(chat.id)
+          const injectedInfo = msg.info as SessionV1.User
+          expect(injectedInfo.model).toBeDefined()
+          if (injectedInfo.model) {
+            expect(injectedInfo.model.providerID).toBe(ref.providerID)
+            expect(injectedInfo.model.modelID).toBe(ref.modelID)
+          }
+          expect(typeof msg.info.time.created).toBe("number")
+          // Attribution: the part is bound to the injected message, like any
+          // other persisted user part.
+          expect(msg.parts[0].messageID).toBe(msg.info.id)
+        }
+        // Ordering + attribution: each injected message must be positioned
+        // strictly between the assistant turn that triggered the stop and the
+        // next assistant turn, and the following assistant must be parented to
+        // the injected message (the loop continued FROM that message).
+        const withIndex = msgs.map((m) => m.info).map((info) => info.id)
+        for (const msg of injected) {
+          const idx = withIndex.indexOf(msg.info.id)
+          expect(idx).toBeGreaterThan(0)
+          expect(idx).toBeLessThan(withIndex.length - 1)
+          const prev = msgs[idx - 1]!
+          const next = msgs[idx + 1]!
+          if (next.info.role === "assistant") {
+            expect(next.info.parentID).toBe(msg.info.id)
+          }
+          // metadata consistency with the triggering/following assistant too
+          expect(prev.info.sessionID).toBe(chat.id)
+          expect(next.info.sessionID).toBe(chat.id)
+          expect(next.info.role).toBe("assistant")
+        }
+        expect(injectedIds.size).toBe(3)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-count")
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input, output) => {`,
+              "    const n = await Bun.file(" + JSON.stringify(marker) + ").text().catch(() => '0')",
+              "    await Bun.write(" + JSON.stringify(marker) + ", String(Number(n) + 1))",
+              "    output.stop = false",
+              '    output.message = "keep going"',
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...providerCfg(llm.url),
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("repeated loop invocation cannot reset the per-session cap",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+
+        const chat = yield* sessions.create({
+          title: "repeated cap",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        yield* llm.text("one")
+        yield* llm.text("two")
+        yield* llm.text("three")
+        yield* llm.text("four")
+
+        yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({
+            duration: "20 seconds",
+            orElse: () => Effect.die("first loop did not terminate"),
+          }),
+        )
+        // Cap exhausted: 3 continuations consumed.
+        const before = yield* sessions.messages({ sessionID: chat.id })
+        const injectedBefore = before.filter(
+          (m) => m.info.role === "user" && m.parts.some((p) => p.type === "text" && p.text === "keep going"),
+        )
+        expect(injectedBefore).toHaveLength(3)
+
+        // A second loop invocation on the SAME session must NOT reset the
+        // counter: the 4th natural completion is still refused (no persist,
+        // no new continuation message). The loop surfaces the finished
+        // assistant and stops.
+        yield* llm.text("five")
+        yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({
+            duration: "20 seconds",
+            orElse: () => Effect.die("second loop did not terminate"),
+          }),
+        )
+        const after = yield* sessions.messages({ sessionID: chat.id })
+        const injectedAfter = after.filter(
+          (m) => m.info.role === "user" && m.parts.some((p) => p.type === "text" && p.text === "keep going"),
+        )
+        expect(injectedAfter).toHaveLength(3)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-count")
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input, output) => {`,
+              "    const n = await Bun.file(" + JSON.stringify(marker) + ").text().catch(() => '0')",
+              "    await Bun.write(" + JSON.stringify(marker) + ", String(Number(n) + 1))",
+              "    output.stop = false",
+              '    output.message = "keep going"',
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...providerCfg(llm.url),
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("provider error (non-natural) does NOT fire stopping hook",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+        const marker = path.join(dir, "stopping-fired")
+
+        const chat = yield* sessions.create({
+          title: "provider error",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        yield* llm.error(400, { error: { message: "contradiction", type: "invalid_request" } })
+
+        const exit = yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "20 seconds", orElse: () => Effect.die("loop did not terminate") }),
+          Effect.exit,
+        )
+        void exit
+        const exists = yield* Effect.promise(async () => Bun.file(marker).exists())
+        expect(exists).toBe(false)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-fired")
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input) => {`,
+              `    await Bun.write(${JSON.stringify(marker)}, 'fired')`,
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...providerCfg(llm.url),
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("retry (transient error then success) fires the hook exactly once",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+        const marker = path.join(dir, "stopping-count")
+
+        const chat = yield* sessions.create({
+          title: "retry",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        // First attempt raises a retryable server error; SessionRetry retries and
+        // the second attempt succeeds with a natural completion.
+        yield* llm.error(500, { error: { message: "server error", type: "server" } })
+        yield* llm.text("ok")
+
+        const result = yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "30 seconds", orElse: () => Effect.die("retry loop did not terminate") }),
+        )
+        expect(result.info.role).toBe("assistant")
+        // Exactly one hook fire at the final natural completion — the transient
+        // provider error during the retry never invoked a stopping callback.
+        const countText = yield* Effect.promise(() => Bun.file(marker).text())
+        expect(Number(countText)).toBe(1)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-count")
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input, output) => {`,
+              "    const n = await Bun.file(" + JSON.stringify(marker) + ").text().catch(() => '0')",
+              "    await Bun.write(" + JSON.stringify(marker) + ", String(Number(n) + 1))",
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...providerCfg(llm.url),
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("clean stop resets the per-session continuation budget",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+        const decide = path.join(dir, "decide")
+        const marker = path.join(dir, "stopping-count")
+
+        yield* writeText(decide, "stop")
+        const chat = yield* sessions.create({
+          title: "clean stop reset",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        yield* llm.text("done")
+
+        // First loop: the hook reads decide=stop and cleanly stops — no
+        // continuation message is injected.
+        yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "20 seconds", orElse: () => Effect.die("clean loop did not terminate") }),
+        )
+        let injected = (yield* sessions.messages({ sessionID: chat.id })).filter(
+          (m) => m.info.role === "user" && m.parts.some((p) => p.type === "text" && p.text === "keep going"),
+        )
+        expect(injected).toHaveLength(0)
+
+        // Flip the decision to continue: a subsequent cleanly-stopped session
+        // gets a FRESH budget (the counter was reset), so up to cap continuations
+        // are allowed again.
+        yield* writeText(decide, "continue")
+        yield* llm.text("one")
+        yield* llm.text("two")
+        yield* llm.text("three")
+        yield* llm.text("four")
+        yield* llm.text("five")
+        yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "20 seconds", orElse: () => Effect.die("re-entry loop did not terminate") }),
+        )
+        const after = (yield* sessions.messages({ sessionID: chat.id })).filter(
+          (m) => m.info.role === "user" && m.parts.some((p) => p.type === "text" && p.text === "keep going"),
+        )
+        expect(after).toHaveLength(3)
+        void marker
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const decide = path.join(dir, "decide")
+          const marker = path.join(dir, "stopping-count")
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input, output) => {`,
+              "    const n = await Bun.file(" + JSON.stringify(marker) + ").text().catch(() => '0')",
+              "    await Bun.write(" + JSON.stringify(marker) + ", String(Number(n) + 1))",
+              '    const decide2 = await Bun.file(' + JSON.stringify(decide) + ').text().catch(() => "stop")',
+              '    if (decide2.trim() === "continue") {',
+              "      output.stop = false",
+              '      output.message = "keep going"',
+              "    }",
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...providerCfg(llm.url),
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("empty/whitespace continuation message treated as clean stop (no persist)",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+
+        const chat = yield* sessions.create({
+          title: "whitespace policy",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        yield* llm.text("one")
+        const result = yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "20 seconds", orElse: () => Effect.die("loop did not terminate") }),
+        )
+        expect(result.info.role).toBe("assistant")
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        // No continuation persisted: an empty / whitespace-only message is not a
+        // real continuation, so the session stops cleanly.
+        const injected = msgs.filter((m) => m.info.role === "user" && m.parts.some((p) => p.type === "text"))
+        expect(injected).toHaveLength(1) // original "hello" only
+        expect(msgs.filter((m) => m.info.role === "assistant")).toHaveLength(1)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input, output) => {`,
+              "    output.stop = false",
+              '    output.message = "   "',
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...providerCfg(llm.url),
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("two concurrent loop callers for one session consume a single continuation budget",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+
+        const chat = yield* sessions.create({
+          title: "concurrent callers",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        // Enough replies for one bounded cap journey (initial + 3 continuations).
+        yield* llm.text("one")
+        yield* llm.text("two")
+        yield* llm.text("three")
+        yield* llm.text("four")
+
+        const [a, b] = yield* Effect.all([prompt.loop({ sessionID: chat.id }), prompt.loop({ sessionID: chat.id })], {
+          concurrency: "unbounded",
+        })
+        expect(a.info.id).toBe(b.info.id)
+        expect(a.info.role).toBe("assistant")
+
+        // The continuation budget is per-session, so the two concurrent callers
+        // together must not exceed a single cap's worth of continuations, and no
+        // continuation is ever persisted twice.
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        const injected = msgs.filter(
+          (m) => m.info.role === "user" && m.parts.some((p) => p.type === "text" && p.text === "keep going"),
+        )
+        expect(injected).toHaveLength(3)
+        expect(new Set(injected.map((m) => m.info.id)).size).toBe(3)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-count")
+          yield* writeText(
+            path.join(dir, "plugin.ts"),
+            [
+              "export default async () => ({",
+              `  "session.stopping": async (_input, output) => {`,
+              "    const n = await Bun.file(" + JSON.stringify(marker) + ").text().catch(() => '0')",
+              "    await Bun.write(" + JSON.stringify(marker) + ", String(Number(n) + 1))",
+              "    output.stop = false",
+              '    output.message = "keep going"',
+              "  },",
+              "})",
+              "",
+            ].join("\n"),
+          )
+          yield* writeText(
+            path.join(dir, "opencode.json"),
+            JSON.stringify({
+              $schema: "https://opencode.ai/config.json",
+              ...providerCfg(llm.url),
+              plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href],
+            }),
+          )
+        }),
+    },
+  )
+
+  it.instance("SH-5 tool error exit (non-natural) does NOT fire stopping hook",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+        const marker = path.join(dir, "stopping-fired")
+
+        const chat = yield* sessions.create({
+          title: "tool error",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        // The model calls a tool that errors, then the provider call fails.
+        yield* llm.tool("read", { filePath: "/tmp/does-not-exist-xyz" })
+        yield* llm.error(400, { error: { message: "boom", type: "invalid_request" } })
+
+        const exit = yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "20 seconds", orElse: () => Effect.die("loop did not terminate") }),
+          Effect.exit,
+        )
+        const exists = yield* Effect.promise(async () => Bun.file(marker).exists())
+        expect(exists).toBe(false)
+        // The tool error exit is non-natural: the run ends on an errored turn,
+        // never via a natural completion where the hook could fire.
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        const last = msgs.at(-1)?.info
+        if (!last) throw new Error("expected a persisted message")
+        expect((last as any).error).toBeDefined()
+        void exit
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-fired")
+          yield* writeText(path.join(dir, "plugin.ts"), `export default async () => ({ "session.stopping": async (_i) => { await Bun.write(${JSON.stringify(marker)}, 'fired') },})`)
+          yield* writeText(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json", ...providerCfg(llm.url), plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href] }))
+        }),
+    },
+  )
+
+  it.instance("SH-5 compaction stop (non-natural) does NOT fire stopping hook",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const compact = yield* SessionCompaction.Service
+        const llm = yield* TestLLMServer
+        const marker = path.join(dir, "stopping-fired")
+
+        const chat = yield* sessions.create({
+          title: "compact stop",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        yield* compact.create({ sessionID: chat.id, agent: "build", model: ref, auto: false })
+        // The compaction summarizer errors, so the loop breaks at the compaction
+        // stop without ever consulting the stopping hook.
+        yield* llm.error(400, { error: { message: "compaction failed", type: "invalid_request" } })
+
+        yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "20 seconds", orElse: () => Effect.die("loop did not terminate") }),
+          Effect.exit,
+        )
+        const exists = yield* Effect.promise(async () => Bun.file(marker).exists())
+        expect(exists).toBe(false)
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        expect(msgs.flatMap((m) => m.parts).some((p) => p.type === "compaction")).toBe(true)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-fired")
+          yield* writeText(path.join(dir, "plugin.ts"), `export default async () => ({ "session.stopping": async (_i) => { await Bun.write(${JSON.stringify(marker)}, 'fired') },})`)
+          yield* writeText(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json", ...providerCfg(llm.url), plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href] }))
+        }),
+    },
+  )
+
+  it.instance("SH-5 malformed provider response (non-natural) does NOT fire stopping hook",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+        const marker = path.join(dir, "stopping-fired")
+
+        const chat = yield* sessions.create({
+          title: "malformed response",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        // The SDK cannot parse this chunk (content is a number), so the whole
+        // turn errors out — a non-natural exit that must not consult the hook.
+        yield* llm.push(raw({ chunks: [{ id: "x", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: 123 } }] }] }))
+
+        yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "20 seconds", orElse: () => Effect.die("loop did not terminate") }),
+          Effect.exit,
+        )
+        const exists = yield* Effect.promise(async () => Bun.file(marker).exists())
+        expect(exists).toBe(false)
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        const last = msgs.at(-1)?.info
+        expect((last as any).error).toBeDefined()
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-fired")
+          yield* writeText(path.join(dir, "plugin.ts"), `export default async () => ({ "session.stopping": async (_i) => { await Bun.write(${JSON.stringify(marker)}, 'fired') },})`)
+          yield* writeText(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json", ...providerCfg(llm.url), plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href] }))
+        }),
+    },
+  )
+
+  it.instance("SH-5 nested session path attributes the stopping hook to the nested session, not the parent",
+    () =>
+      Effect.gen(function* () {
+        const { directory: dir } = yield* TestInstance
+        const prompt = yield* SessionPrompt.Service
+        const sessions = yield* Session.Service
+        const llm = yield* TestLLMServer
+        const marker = path.join(dir, "stopping-fired")
+
+        const parent = yield* sessions.create({
+          title: "parent",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        const chat = yield* sessions.create({
+          parentID: parent.id,
+          title: "nested",
+          permission: [{ permission: "*", pattern: "*", action: "allow" }],
+        })
+        yield* user(chat.id, "hello")
+        yield* llm.text("one")
+
+        // Running the nested (parentID-carrying) session completes naturally and
+        // fires the stopping hook exactly once, for the nested session's own id
+        // — the parent session must never observe a stopping callback.
+        const result = yield* prompt.loop({ sessionID: chat.id }).pipe(
+          Effect.timeoutOrElse({ duration: "20 seconds", orElse: () => Effect.die("loop did not terminate") }),
+        )
+        expect(result.info.role).toBe("assistant")
+        const seen = yield* Effect.promise(async () => Bun.file(marker).text().catch(() => ""))
+        expect(seen).toBe(chat.id)
+        expect(seen).not.toBe(parent.id)
+        const msgs = yield* sessions.messages({ sessionID: chat.id })
+        expect(msgs.filter((m) => m.info.role === "assistant")).toHaveLength(1)
+      }),
+    {
+      git: true,
+      init: (dir) =>
+        Effect.gen(function* () {
+          const llm = yield* TestLLMServer
+          const marker = path.join(dir, "stopping-fired")
+          yield* writeText(path.join(dir, "plugin.ts"), `export default async () => ({ "session.stopping": async (input) => { await Bun.write(${JSON.stringify(marker)}, input.sessionID) },})`)
+          yield* writeText(path.join(dir, "opencode.json"), JSON.stringify({ $schema: "https://opencode.ai/config.json", ...providerCfg(llm.url), plugin: [pathToFileURL(path.join(dir, "plugin.ts")).href] }))
+        }),
+    },
+  )
+})

--- a/packages/opencode/test/plugin/session-stopping.test.ts
+++ b/packages/opencode/test/plugin/session-stopping.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect } from "bun:test"
+import { Effect, Logger, LogLevel } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Npm } from "@opencode-ai/core/npm"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Account } from "../../src/account/account"
+import { Auth } from "../../src/auth"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { Plugin } from "../../src/plugin/index"
+
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { AccountTest } from "../fake/account"
+import { AuthTest } from "../fake/auth"
+import { NpmTest } from "../fake/npm"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Plugin.node, CrossSpawnSpawner.node]), [
+    [Auth.node, AuthTest.empty],
+    [Account.node, AccountTest.empty],
+    [Npm.node, NpmTest.noop],
+    [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
+  ]),
+)
+
+const stoppingHook = "session.stopping"
+
+function pluginSource(body: string) {
+  return ["export default async () => ({", body, "})", ""].join("\n")
+}
+
+function stoppingPlugin(listenerBody: string) {
+  return pluginSource(`  ${JSON.stringify(stoppingHook)}: async (_input, output) => { ${listenerBody} },`)
+}
+
+function withPlugins<A, E, R>(sources: string[], self: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const test = yield* TestInstance
+    const files = sources.map((source, index) => ({
+      name: path.join(test.directory, `plugin-${index}.ts`),
+      source,
+    }))
+    yield* Effect.all(
+      [
+        ...files.map((file) => Effect.promise(() => Bun.write(file.name, file.source))),
+        Effect.promise(() =>
+          Bun.write(
+            path.join(test.directory, "opencode.json"),
+            JSON.stringify(
+              {
+                $schema: "https://opencode.ai/config.json",
+                plugin: files.map((file) => pathToFileURL(file.name).href),
+              },
+              null,
+              2,
+            ),
+          ),
+        ),
+      ],
+      { discard: true, concurrency: 2 },
+    )
+    return yield* self
+  })
+}
+
+function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+  return withPlugins([source], self)
+}
+
+const triggerStopping = Effect.fn("StopHookTest.triggerStopping")(function* () {
+  const plugin = yield* Plugin.Service
+  const out = { stop: true, message: undefined as string | undefined }
+  yield* plugin.trigger(stoppingHook, { sessionID: "test-session" }, out)
+  return out
+})
+
+// Captures Effect log output (the same lines the runtime would write to stderr)
+// so tests can assert the user-visible diagnostic + its structured payload.
+function capturedLogs<R>(effect: Effect.Effect<unknown, never, R>) {
+  const logs: Array<unknown> = []
+  const capture = Logger.make<unknown, void>((options) =>
+    logs.push({
+      level: String(options.logLevel) as string,
+      message: options.message,
+    }),
+  )
+  return effect
+    .pipe(Effect.provide(Logger.layer([capture])))
+    .pipe(Effect.as(logs))
+}
+
+describe("session.stopping hook", () => {
+  it.instance("plugin with session.stopping hook loads and trigger returns mutated output", () =>
+    withProject(
+      pluginSource(`  ${JSON.stringify(stoppingHook)}: async (_input, output) => {\n    output.stop = false\n    output.message = "workflow gate"\n  },`),
+      Effect.gen(function* () {
+        const out = yield* triggerStopping()
+        expect(out.stop).toBe(false)
+        expect(out.message).toBe("workflow gate")
+      }),
+    ),
+  )
+
+  it.instance("no plugin installed — stop stays true", () =>
+    withProject(
+      pluginSource(""),
+      Effect.gen(function* () {
+        const out = yield* triggerStopping()
+        expect(out.stop).toBe(true)
+        expect(out.message).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.instance("stop=false without message does not satisfy continuation condition", () =>
+    withProject(
+      stoppingPlugin(`output.stop = false`),
+      Effect.gen(function* () {
+        const out = yield* triggerStopping()
+        expect(out.stop).toBe(false)
+        expect(out.message).toBeUndefined()
+        expect(!out.stop && !!out.message).toBe(false)
+      }),
+    ),
+  )
+
+  it.instance("two listeners run sequentially in registration order over one shared output", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const marker = path.join(test.directory, "stopping-order")
+      yield* withPlugins(
+        [
+          stoppingPlugin(`await Bun.write(${JSON.stringify(marker)}, "first"); output.stop = false; output.message = "one"`),
+          stoppingPlugin(`await Bun.write(${JSON.stringify(marker)}, "second"); output.stop = false; output.message = "two"`),
+        ],
+        Effect.gen(function* () {
+          const out = yield* triggerStopping()
+          expect(out.stop).toBe(false)
+          expect(out.message).toBe("two")
+        }),
+      )
+      const text = yield* Effect.promise(() => Bun.file(marker).text())
+      expect(text).toBe("second")
+    }),
+  )
+
+  it.instance("replacement: later listener's message replaces the earlier one", () =>
+    withPlugins(
+      [
+        stoppingPlugin(`output.stop = false; output.message = "first"`),
+        stoppingPlugin(`output.stop = false; output.message = "second"`),
+      ],
+      Effect.gen(function* () {
+        const out = yield* triggerStopping()
+        expect(out.stop).toBe(false)
+        expect(out.message).toBe("second")
+      }),
+    ),
+  )
+
+  it.instance("precedence: later stop=false cannot override a prior stop=true", () =>
+    withPlugins(
+      [
+        pluginSource(
+          `  ${JSON.stringify(stoppingHook)}: async (_input, output) => {\n    output.stop = false\n    output.message = "continue"\n  },`,
+        ),
+        pluginSource(
+          `  ${JSON.stringify(stoppingHook)}: (_input, output) => {\n    output.stop = true\n  },`,
+        ),
+        stoppingPlugin(`output.stop = false; output.message = "override"`),
+      ],
+      Effect.gen(function* () {
+        const out = yield* triggerStopping()
+        expect(out.stop).toBe(true)
+        expect(out.message).toBeUndefined()
+      }),
+    ),
+  )
+
+  it.instance("sync throw isolates the failing listener; later listeners still run and hook fails closed", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const later = path.join(test.directory, "stopping-later-ran")
+      const captured = yield* capturedLogs(
+        withPlugins(
+          [
+            pluginSource(
+              `  ${JSON.stringify(stoppingHook)}: () => {\n    throw new Error("simulated hook failure")\n  },`,
+            ),
+            stoppingPlugin(`await Bun.write(${JSON.stringify(later)}, "later"); output.stop = false; output.message = "still-ran"`),
+          ],
+          Effect.gen(function* () {
+            const out = yield* triggerStopping()
+            expect(out.stop).toBe(true)
+            expect(out.message).toBeUndefined()
+          }),
+        ),
+      )
+      const text = yield* Effect.promise(() => Bun.file(later).text())
+      expect(text).toBe("later")
+
+      // SH-2: a throwing listener produces a user-visible diagnostic (what the
+      // runtime logs to stderr) whose structured payload carries the sessionID,
+      // hook key, and the failing listener's index.
+      const failure = (captured as Array<{ level: string; message: unknown }>).find(
+        (entry) => Array.isArray(entry.message) && entry.message[0] === "session.stopping hook error; failing closed",
+      )
+      expect(failure).toBeDefined()
+      if (failure && Array.isArray(failure.message)) {
+        expect(failure.level).toBe("Error")
+        const payload = failure.message[1] as Record<string, unknown>
+        expect(payload["session.id"]).toBe("test-session")
+        expect(payload["hook"]).toBe("session.stopping")
+        expect(typeof payload["listener"]).toBe("number")
+        expect(typeof payload["error"]).toBe("string")
+      }
+    }),
+  )
+
+  it.instance("async rejection isolates the failing listener; later listeners still run and hook fails closed", () =>
+    withPlugins(
+      [
+        pluginSource(
+          `  ${JSON.stringify(stoppingHook)}: async () => {\n    throw new Error("simulated async failure")\n  },`,
+        ),
+        pluginSource(
+          `  ${JSON.stringify(stoppingHook)}: async (_input, output) => {\n    output.stop = false\n    output.message = "still-ran"\n  },`,
+        ),
+      ],
+      Effect.gen(function* () {
+        const captured = yield* capturedLogs(triggerStopping())
+        // SH-2: a rejecting listener emits the same user-visible diagnostic
+        // (Error level) whose structured payload carries the sessionID, hook
+        // key, and the failing listener's index.
+        const failure = (captured as Array<{ level: string; message: unknown }>).find(
+          (entry) => Array.isArray(entry.message) && entry.message[0] === "session.stopping hook error; failing closed",
+        )
+        expect(failure).toBeDefined()
+        if (failure && Array.isArray(failure.message)) {
+          expect(failure.level).toBe("Error")
+          const payload = failure.message[1] as Record<string, unknown>
+          expect(payload["session.id"]).toBe("test-session")
+          expect(payload["hook"]).toBe("session.stopping")
+          expect(typeof payload["listener"]).toBe("number")
+          expect(typeof payload["error"]).toBe("string")
+        }
+      }),
+    ),
+  )
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -223,6 +223,10 @@ export interface Hooks {
   dispose?: () => Promise<void>
   event?: (input: { event: Event }) => Promise<void>
   config?: (input: Config) => Promise<void>
+  "session.stopping"?: (
+    input: { sessionID: string },
+    output: { stop: boolean; message?: string },
+  ) => Promise<void>
   tool?: {
     [key: string]: ToolDefinition
   }


### PR DESCRIPTION
### Issue for this PR

Closes #16626

### Type of change

- [x] New feature

### What does this PR do?

Adds an awaited `session.stopping` plugin hook in the `Hooks` interface to allow external plugins to evaluate session state and optionally inject a continuation message before the prompt loop breaks.

Key semantics:
- **Awaited Lifecycle**: Dispatched in `SessionPrompt.run` immediately prior to natural loop exit.
- **Fail-Closed Default**: Output defaults to `stop: true`. If a plugin listener throws or rejects, execution stops cleanly (`stop: true`, `message: undefined`).
- **Sticky Veto**: Multiple listeners run in registration order. If any listener sets `stop: true`, subsequent listeners cannot force continuation.
- **Defense-in-Depth Cap**: Core enforces `SESSION_STOPPING_REENTRY_CAP = 3` to prevent runaway infinite loops from misconfigured plugins.
- **Cleanup**: In-memory continuation state is pruned on `session.deleted`.

### How did you verify your code works?

- `bun test packages/opencode/test/plugin/session-stopping.test.ts` (listener ordering, error isolation, fail-closed behavior)
- `bun test --timeout 30000 packages/opencode/test/plugin/session-stopping-exit-matrix.test.ts` (compaction stops, provider/tool error non-natural exits, nested sessions, concurrent loop callers)
- `bun turbo typecheck` across all workspace packages

### Screenshots / recordings

_N/A — backend lifecycle hook change without UI modifications._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
