### PR TITLE
fix(tui): keep remotely closed tabs closed

### DIFF
--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -1,4 +1,4 @@
-import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
+import { createEffect, createMemo, createSignal, on, onCleanup } from "solid-js"
 import { useKeyboard, useRenderer } from "@opentui/solid"
 import { isDeepEqual } from "remeda"
 import { createSimpleContext } from "./helper"
@@ -156,24 +156,47 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
       }
     }
 
+    // Shared storage updates must not re-admit a tab unless this client changes route or scope.
+    createEffect(
+      on(
+        [
+          () => (enabled() && route.data.type === "session" ? route.data.sessionID : undefined),
+          () => config.tabs.scope,
+          () => paths.cwd,
+        ],
+        ([routed]) => {
+          if (!routed || routed === "dummy") return
+          const sessionID = root(routed)
+          cancelledTabs.delete(sessionID)
+          history = recordSessionTabHistory(history, sessionID)
+          const fallback = newTab() ? NEW_SESSION_TAB_TITLE : undefined
+          const tabs = openSessionTab(state().tabs, {
+            sessionID,
+            title: title(sessionID, state().tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
+          })
+          if (tabs === state().tabs) return
+          update((draft) => {
+            if (cancelledTabs.has(sessionID)) return
+            draft.tabs = openSessionTab(draft.tabs, {
+              sessionID,
+              title: title(sessionID, draft.tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
+            })
+          })
+        },
+      ),
+    )
+
     createEffect(() => {
-      if (!enabled()) return
-      if (route.data.type !== "session" || route.data.sessionID === "dummy") return
+      if (!enabled() || route.data.type !== "session" || route.data.sessionID === "dummy") return
       const sessionID = root(route.data.sessionID)
-      cancelledTabs.delete(sessionID)
-      history = recordSessionTabHistory(history, sessionID)
-      const fallback = newTab() ? NEW_SESSION_TAB_TITLE : undefined
-      const tabs = openSessionTab(state().tabs, {
-        sessionID,
-        title: title(sessionID, state().tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
-      })
-      if (tabs === state().tabs) return
+      const tab = state().tabs.find((tab) => tab.sessionID === sessionID)
+      if (!tab) return
+      const nextTitle = title(sessionID, tab.title)
+      if (!nextTitle || nextTitle === tab.title) return
       update((draft) => {
-        if (cancelledTabs.has(sessionID)) return
-        draft.tabs = openSessionTab(draft.tabs, {
-          sessionID,
-          title: title(sessionID, draft.tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
-        })
+        const tab = draft.tabs.find((tab) => tab.sessionID === sessionID)
+        if (!tab) return
+        draft.tabs = openSessionTab(draft.tabs, { sessionID, title: title(sessionID, tab.title) })
       })
     })
 

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -162,19 +162,14 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
         [
           () => (enabled() && route.data.type === "session" ? route.data.sessionID : undefined),
           () => config.tabs.scope,
-          () => paths.cwd,
         ],
         ([routed]) => {
           if (!routed || routed === "dummy") return
           const sessionID = root(routed)
           cancelledTabs.delete(sessionID)
           history = recordSessionTabHistory(history, sessionID)
+          if (state().tabs.some((tab) => tab.sessionID === sessionID)) return
           const fallback = newTab() ? NEW_SESSION_TAB_TITLE : undefined
-          const tabs = openSessionTab(state().tabs, {
-            sessionID,
-            title: title(sessionID, state().tabs.find((tab) => tab.sessionID === sessionID)?.title, fallback),
-          })
-          if (tabs === state().tabs) return
           update((draft) => {
             if (cancelledTabs.has(sessionID)) return
             draft.tabs = openSessionTab(draft.tabs, {
@@ -185,20 +180,6 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
         },
       ),
     )
-
-    createEffect(() => {
-      if (!enabled() || route.data.type !== "session" || route.data.sessionID === "dummy") return
-      const sessionID = root(route.data.sessionID)
-      const tab = state().tabs.find((tab) => tab.sessionID === sessionID)
-      if (!tab) return
-      const nextTitle = title(sessionID, tab.title)
-      if (!nextTitle || nextTitle === tab.title) return
-      update((draft) => {
-        const tab = draft.tabs.find((tab) => tab.sessionID === sessionID)
-        if (!tab) return
-        draft.tabs = openSessionTab(draft.tabs, { sessionID, title: title(sessionID, tab.title) })
-      })
-    })
 
     // Viewed state is server-global, so acknowledgement runs even with tabs disabled: other
     // clients rely on this client reporting what its user has seen.

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -505,6 +505,31 @@ test("concurrent TUIs do not alternate shared tab titles from divergent session 
   }
 })
 
+test("closing a tab is not undone by another TUI viewing the same session", async () => {
+  await using temporary = await tmpdir()
+  const first = await renderSessionTabs("shared", { state: temporary.path })
+  const second = await renderSessionTabs("shared", { state: temporary.path })
+
+  try {
+    await wait(() => first.tabs.tabs().some((tab) => tab.sessionID === "shared"))
+    await wait(() => second.tabs.tabs().some((tab) => tab.sessionID === "shared"))
+    first.tabs.close()
+    await wait(() => first.route.data.type === "home")
+    await wait(() => !second.tabs.tabs().some((tab) => tab.sessionID === "shared"))
+    await Bun.sleep(50)
+
+    expect(first.tabs.tabs().some((tab) => tab.sessionID === "shared")).toBe(false)
+
+    second.route.navigate({ type: "home" })
+    await wait(() => second.route.data.type === "home")
+    second.route.navigate({ type: "session", sessionID: "shared" })
+    await wait(() => first.tabs.tabs().some((tab) => tab.sessionID === "shared"))
+  } finally {
+    await first.destroy()
+    await second.destroy()
+  }
+})
+
 test("user prompt admissions pulse an already-busy background tab", async () => {
   const setup = await renderSessionTabs("background")
   const admitted = (sessionID: string, inboxID: string): OpenCodeEvent => ({

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -507,26 +507,29 @@ test("concurrent TUIs do not alternate shared tab titles from divergent session 
 
 test("closing a tab is not undone by another TUI viewing the same session", async () => {
   await using temporary = await tmpdir()
-  const first = await renderSessionTabs("shared", { state: temporary.path })
-  const second = await renderSessionTabs("shared", { state: temporary.path })
+  const clients: Awaited<ReturnType<typeof renderSessionTabs>>[] = []
 
   try {
+    const first = await renderSessionTabs("shared", { state: temporary.path })
+    clients.push(first)
+    const second = await renderSessionTabs("shared", { state: temporary.path })
+    clients.push(second)
     await wait(() => first.tabs.tabs().some((tab) => tab.sessionID === "shared"))
     await wait(() => second.tabs.tabs().some((tab) => tab.sessionID === "shared"))
     first.tabs.close()
     await wait(() => first.route.data.type === "home")
     await wait(() => !second.tabs.tabs().some((tab) => tab.sessionID === "shared"))
-    await Bun.sleep(50)
+    await Promise.all([first.flush(), second.flush()])
 
-    expect(first.tabs.tabs().some((tab) => tab.sessionID === "shared")).toBe(false)
+    const stored = await Bun.file(path.join(temporary.path, "test", "tui", "tabs.json")).json()
+    expect(stored.cwd[directory].tabs).toEqual([])
 
     second.route.navigate({ type: "home" })
     await wait(() => second.route.data.type === "home")
     second.route.navigate({ type: "session", sessionID: "shared" })
     await wait(() => first.tabs.tabs().some((tab) => tab.sessionID === "shared"))
   } finally {
-    await first.destroy()
-    await second.destroy()
+    await Promise.allSettled(clients.map((client) => client.destroy()))
   }
 })
 


### PR DESCRIPTION
## What

Keep a session tab closed when another TUI connected to the same service is still viewing that session.

Fixes #41394. Related to #43553.

## Before / After

**Before:** Closing a tab removed it from shared persistence, but another TUI whose route still pointed at that session reacted to the storage update as if it had navigated. It immediately admitted the session again, so the tab flashed closed and reappeared.

**After:** Only an actual route or tab-scope change may admit a missing tab. Session metadata can still refresh an existing tab, but storage updates cannot resurrect a removed one. Navigating away and back explicitly reopens the session as expected.

## How

- `packages/tui/src/context/session-tabs.tsx` separates route admission from the existing title and root normalization.
- Route admission tracks only the raw route and tab scope, preventing shared storage and root-session hydration from masquerading as navigation.
- Normalization reduces over existing tabs, so metadata changes can reconcile a tab but cannot create a missing one.
- `packages/tui/test/context/session-tabs.test.tsx` runs two TUI providers against the same persisted state and verifies close, durable non-resurrection, and explicit reopen behavior.

## Scope

- Preserves shared global and cwd-scoped tab persistence across TUI clients.
- Does not change tab keybindings, close animations, session deletion, or browser/desktop tabs.

## Testing

- `bun run test test/context/session-tabs.test.tsx --test-name-pattern 'closing a tab is not undone' --rerun-each 10` from `packages/tui` (10 passed)
- `bun run test test/context/session-tabs.test.tsx test/context/session-tabs-model.test.ts` from `packages/tui` (52 passed)
- `bun run test` from `packages/tui` (759 passed, 5 skipped)
- `bun typecheck` from `packages/tui`
- Push-hook workspace typecheck (32 tasks passed)
- `git diff --check`

## Demo

Matched OpenCode Drive recording. Left runs the PR merge base (`50a8539e4b`); right runs this branch (`f39ba45603`). Both use the same two-TUI script, viewport, timing, prompts, and simulated model. The controller closes tab 2 while the recorded observer remains on that session.

https://github.com/user-attachments/assets/eb01c8bf-9a37-4316-8e5a-4b2469a3bc78

## Flow

```mermaid
sequenceDiagram
  participant A as TUI A
  participant S as Shared tab state
  participant B as TUI B
  A->>S: Close session tab
  S-->>B: Persisted tab removed
  Note over B: Route is unchanged
  B->>B: Normalize existing tabs only
  Note over S: Tab remains closed
  B->>B: Navigate away and back
  B->>S: Admit session tab
```
