### PR TITLE
fix(core): resolve npm provider entrypoint to a file on Node

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -1,6 +1,9 @@
 export * as Npm from "./npm"
 
+import fs from "fs"
 import path from "path"
+import { createRequire } from "module"
+import { pathToFileURL } from "url"
 import npa from "npm-package-arg"
 import { Effect, Schema, Context, Layer, Option, FileSystem } from "effect"
 import { NodeFileSystem } from "@effect/platform-node"
@@ -47,10 +50,84 @@ export function sanitize(pkg: string) {
   return Array.from(pkg, (char) => (illegal.has(char) || char.charCodeAt(0) < 32 ? "_" : char)).join("")
 }
 
+// Conditions enabled for a dynamic import() from ESM, in the spirit of Node's own
+// resolver. The fallback set additionally allows "require" targets — importing a CJS
+// file via import() is fine, and it beats failing to load the provider at all.
+const IMPORT_CONDITIONS = new Set(["node", "import", "module-sync", "default"])
+const IMPORT_CONDITIONS_WITH_REQUIRE = new Set(["node", "import", "module-sync", "require", "default"])
+
+const resolveExportsTarget = (value: unknown, conditions: ReadonlySet<string>): string | undefined => {
+  if (typeof value === "string") return value
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const target = resolveExportsTarget(entry, conditions)
+      if (target) return target
+    }
+    return undefined
+  }
+  if (value && typeof value === "object") {
+    // Condition objects are matched in key order, per the package exports spec.
+    for (const [key, entry] of Object.entries(value)) {
+      if (!conditions.has(key)) continue
+      const target = resolveExportsTarget(entry, conditions)
+      if (target) return target
+    }
+  }
+  return undefined
+}
+
+const resolveRootExports = (exportsField: unknown, conditions: ReadonlySet<string>): string | undefined => {
+  if (exportsField && typeof exportsField === "object" && !Array.isArray(exportsField)) {
+    const keys = Object.keys(exportsField)
+    // Keys starting with "." are subpaths; the package root is the "." entry.
+    if (keys.some((key) => key.startsWith("."))) {
+      return resolveExportsTarget((exportsField as Record<string, unknown>)["."], conditions)
+    }
+  }
+  return resolveExportsTarget(exportsField, conditions)
+}
+
+// Node's ESM loader cannot import a directory (ERR_UNSUPPORTED_DIR_IMPORT), and
+// import.meta.resolve in Node only accepts a parent URL argument behind
+// --experimental-import-meta-resolve, so resolve the entry file manually from the
+// installed package's manifest: exports ("." entry) -> module -> main -> index.js,
+// with a createRequire fallback for anything exotic.
+export const resolveNodeEntryPoint = (name: string, dir: string): string | undefined => {
+  const manifestPath = path.join(dir, "package.json")
+  let manifest: Record<string, unknown> | undefined
+  try {
+    manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"))
+  } catch {
+    manifest = undefined
+  }
+  const candidates: (string | undefined)[] = []
+  if (manifest?.exports != null) {
+    candidates.push(resolveRootExports(manifest.exports, IMPORT_CONDITIONS))
+    candidates.push(resolveRootExports(manifest.exports, IMPORT_CONDITIONS_WITH_REQUIRE))
+  }
+  if (typeof manifest?.module === "string") candidates.push(manifest.module)
+  if (typeof manifest?.main === "string") candidates.push(manifest.main)
+  candidates.push("./index.js")
+  for (const candidate of candidates) {
+    if (!candidate) continue
+    const resolved = path.resolve(dir, candidate)
+    // Reject targets that escape the package directory.
+    const relative = path.relative(dir, resolved)
+    if (relative.startsWith("..") || path.isAbsolute(relative)) continue
+    if (!fs.existsSync(resolved) || fs.statSync(resolved).isDirectory()) continue
+    return pathToFileURL(resolved).href
+  }
+  try {
+    return pathToFileURL(createRequire(manifestPath).resolve(name)).href
+  } catch {
+    return undefined
+  }
+}
+
 const resolveEntryPoint = (name: string, dir: string): EntryPoint => {
   let entrypoint: string | undefined
   try {
-    entrypoint = typeof Bun !== "undefined" ? import.meta.resolve(name, dir) : import.meta.resolve(dir)
+    entrypoint = typeof Bun !== "undefined" ? import.meta.resolve(name, dir) : resolveNodeEntryPoint(name, dir)
   } catch {
     entrypoint = undefined
   }

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -1,5 +1,6 @@
 import fs from "fs/promises"
 import path from "path"
+import { pathToFileURL } from "url"
 import { describe, expect, test } from "bun:test"
 import { Effect, Option } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -80,5 +81,117 @@ describe("Npm.install", () => {
 
     await expect(fs.stat(path.join(tmp.path, "node_modules", "prod-pkg"))).resolves.toBeDefined()
     await expect(fs.stat(path.join(tmp.path, "node_modules", "dev-pkg"))).rejects.toThrow()
+  })
+})
+
+describe("Npm.resolveNodeEntryPoint", () => {
+  const makeEntry = async (root: string, manifest: Record<string, unknown> | string | undefined, files: string[]) => {
+    const dir = path.join(root, "pkg")
+    await fs.mkdir(dir, { recursive: true })
+    if (manifest !== undefined)
+      await Bun.write(
+        path.join(dir, "package.json"),
+        typeof manifest === "string" ? manifest : JSON.stringify(manifest),
+      )
+    for (const file of files) await Bun.write(path.join(dir, file), "export {}\n")
+    return dir
+  }
+
+  const fileURL = (dir: string, file: string) => pathToFileURL(path.join(dir, file)).href
+
+  test("resolves conditional exports to the import target", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(
+      tmp.path,
+      {
+        name: "esm-provider",
+        exports: {
+          "./package.json": "./package.json",
+          ".": {
+            types: "./dist/index.d.ts",
+            import: "./dist/index.mjs",
+            require: "./dist/index.js",
+          },
+        },
+      },
+      ["dist/index.mjs", "dist/index.js"],
+    )
+    expect(Npm.resolveNodeEntryPoint("esm-provider", dir)).toBe(fileURL(dir, "dist/index.mjs"))
+  })
+
+  test("resolved entrypoint is a file URL, never the package directory", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(tmp.path, { name: "p", exports: "./dist/index.mjs" }, ["dist/index.mjs"])
+    const entrypoint = Npm.resolveNodeEntryPoint("p", dir)!
+    expect(entrypoint.startsWith("file://")).toBe(true)
+    expect(entrypoint).not.toBe(pathToFileURL(dir).href)
+  })
+
+  test("resolves array export targets to the first usable entry", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(
+      tmp.path,
+      { name: "p", exports: { ".": [{ import: "./dist/a.mjs" }, "./dist/b.js"] } },
+      ["dist/a.mjs", "dist/b.js"],
+    )
+    expect(Npm.resolveNodeEntryPoint("p", dir)).toBe(fileURL(dir, "dist/a.mjs"))
+  })
+
+  test("falls back to require condition when no import target exists", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(tmp.path, { name: "p", exports: { ".": { require: "./dist/index.cjs" } } }, [
+      "dist/index.cjs",
+    ])
+    expect(Npm.resolveNodeEntryPoint("p", dir)).toBe(fileURL(dir, "dist/index.cjs"))
+  })
+
+  test("falls back to module then main without exports", async () => {
+    await using tmp = await tmpdir()
+    const withModule = await makeEntry(tmp.path, { name: "p", module: "./dist/index.mjs", main: "./dist/index.js" }, [
+      "dist/index.mjs",
+      "dist/index.js",
+    ])
+    expect(Npm.resolveNodeEntryPoint("p", withModule)).toBe(fileURL(withModule, "dist/index.mjs"))
+  })
+
+  test("falls back to main and then index.js", async () => {
+    await using tmp = await tmpdir()
+    const withMain = await makeEntry(tmp.path, { name: "p", main: "./dist/index.js" }, ["dist/index.js"])
+    expect(Npm.resolveNodeEntryPoint("p", withMain)).toBe(fileURL(withMain, "dist/index.js"))
+  })
+
+  test("falls back to index.js when the manifest names no entry", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(tmp.path, { name: "p" }, ["index.js"])
+    expect(Npm.resolveNodeEntryPoint("p", dir)).toBe(fileURL(dir, "index.js"))
+  })
+
+  test("skips export targets pointing at missing files", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(
+      tmp.path,
+      { name: "p", exports: { ".": { import: "./dist/missing.mjs" } }, main: "./dist/real.js" },
+      ["dist/real.js"],
+    )
+    expect(Npm.resolveNodeEntryPoint("p", dir)).toBe(fileURL(dir, "dist/real.js"))
+  })
+
+  test("rejects targets that escape the package directory", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(tmp.path, { name: "p", exports: "../outside.js" }, [])
+    await Bun.write(path.join(tmp.path, "outside.js"), "export {}\n")
+    expect(Npm.resolveNodeEntryPoint("p", dir)).toBeUndefined()
+  })
+
+  test("returns undefined for an empty directory", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(tmp.path, undefined, [])
+    expect(Npm.resolveNodeEntryPoint("does-not-exist-anywhere", dir)).toBeUndefined()
+  })
+
+  test("returns undefined for a malformed manifest with no entry files", async () => {
+    await using tmp = await tmpdir()
+    const dir = await makeEntry(tmp.path, "{ not json", [])
+    expect(Npm.resolveNodeEntryPoint("does-not-exist-anywhere", dir)).toBeUndefined()
   })
 })


### PR DESCRIPTION
<!-- Branch: fix/npm-provider-entrypoint-node -->
<!-- Title: fix(core): resolve npm provider entrypoint to a file on Node -->

### Issue for this PR

Closes #31909

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom npm providers configured via the `npm` field currently fail to initialize in **Desktop** (and any Node/Electron runtime) with `ERR_UNSUPPORTED_DIR_IMPORT`, while the same configuration works in the CLI (Bun).

Root cause, in `packages/core/src/npm.ts` (`resolveEntryPoint`):

- **Bun path** calls `import.meta.resolve(name, dir)` and gets the real entry file.
- **Node path** calls `import.meta.resolve(dir)`, which merely converts the installed package **directory** to a `file://` URL. `resolveSDK` then does `await import(<directory URL>)`, and Node's ESM loader refuses to import directories — every non-bundled provider fails, regardless of what the provider's `package.json` declares.

Node's `import.meta.resolve` only accepts a parent-URL second argument behind `--experimental-import-meta-resolve`, so this PR resolves the entry manually from the installed package's manifest instead (`resolveNodeEntryPoint`):

1. `exports` — root (`"."`) entry, matched in key order; import-suitable conditions (`node`, `import`, `module-sync`, `default`) first, with a second pass allowing `require` (importing a CJS file via `import()` is fine, and beats failing to load entirely)
2. `module`, then `main`, then `index.js`
3. `createRequire(...).resolve(name)` as a last resort

Targets that escape the package directory or don't exist on disk are rejected. The Bun path is unchanged.

Note: this is essentially a revival of #32060, which was auto-closed by the stale-PR cleanup before review; the code has since moved from `provider.ts` into `packages/core/src/npm.ts`, so this is a fresh implementation against the current layout.

### How did you verify your code works?

- `packages/core`: `bun test test/npm.test.ts` — 15 pass (4 existing + 11 new covering conditional/string/array exports, condition fallback order, `module`/`main`/`index.js` fallbacks, missing-file skip, directory-escape rejection, malformed manifest)
- `packages/core`: `bun run typecheck` — clean
- Verified in plain Node 22 that a `file://` URL to a real entry file (as now produced) dynamic-imports successfully, while the previous directory URL reproduces `ERR_UNSUPPORTED_DIR_IMPORT`

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes
