### PR TITLE
feat(core): [v2] restore OPENCODE_DISABLE_CLAUDE_CODE

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -50,6 +50,7 @@ export const Options = Schema.Struct({
   global: Schema.optional(Schema.Boolean),
   file: Schema.optional(Schema.String),
   content: Schema.optional(Schema.String),
+  disableClaudeCode: Schema.optional(Schema.Boolean),
 })
 export type Options = typeof Options.Type
 

--- a/packages/core/src/config/discovery.ts
+++ b/packages/core/src/config/discovery.ts
@@ -1,7 +1,7 @@
 export * as ConfigDiscovery from "./discovery.js"
 
 import path from "path"
-import { Effect } from "effect"
+import { Config, Effect } from "effect"
 import { FSUtil } from "@opencode/util/fs-util"
 import { Global } from "@opencode/util/global"
 import { Location } from "../location.js"
@@ -50,6 +50,8 @@ export const discover = Effect.fn("ConfigDiscovery.discover")(function* (options
   )
 
   const globalEnabled = options?.global !== false
+  const disableClaudeCode =
+    options?.disableClaudeCode ?? (yield* Config.boolean("OPENCODE_DISABLE_CLAUDE_CODE").pipe(Config.withDefault(false)))
   const globalFiles = yield* Effect.forEach(names, (name) => fs.resolve(path.join(globalDirectory, name)))
   // Global sources must not re-enter through the project walk.
   const visible = discovered
@@ -68,12 +70,14 @@ export const discover = Effect.fn("ConfigDiscovery.discover")(function* (options
       visible.filter((item) => path.basename(item) === ".opencode").toReversed(),
       (directory) => fs.isDir(directory).pipe(Effect.map((present) => ({ path: directory, present }))),
     ),
-    claude: [
-      ...new Set([
-        ...(globalEnabled ? [globalClaudeDirectory] : []),
-        ...visible.filter((item) => path.basename(item) === ".claude").toReversed(),
-      ]),
-    ],
+    claude: disableClaudeCode
+      ? []
+      : [
+          ...new Set([
+            ...(globalEnabled ? [globalClaudeDirectory] : []),
+            ...visible.filter((item) => path.basename(item) === ".claude").toReversed(),
+          ]),
+        ],
     agents: [
       ...new Set([
         ...(globalEnabled ? [globalAgentsDirectory] : []),

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -1615,4 +1615,45 @@ describe("Config", () => {
       }),
     ),
   )
+
+  it.live("excludes claude sources when disableClaudeCode option is set", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) => {
+        const global = path.join(tmp.path, "global")
+        const directory = path.join(tmp.path, "repo")
+        const globalAgents = path.join(global, "home", ".agents")
+        const globalClaude = path.join(global, "home", ".claude")
+        return Effect.gen(function* () {
+          yield* Effect.promise(async () => {
+            await fs.mkdir(global, { recursive: true })
+            await fs.mkdir(globalAgents, { recursive: true })
+            await fs.mkdir(globalClaude, { recursive: true })
+            await fs.mkdir(directory, { recursive: true })
+            await fs.mkdir(path.join(directory, ".agents"), { recursive: true })
+          })
+
+          return yield* Effect.gen(function* () {
+            const config = yield* Config.Service
+            const entries = (yield* config.entries()).filter(
+              (entry) => !entry.path || inFixture(tmp.path, entry.path),
+            )
+            expect(entries.filter((entry) => entry.type === "claude").map((entry) => entry.path)).toEqual([])
+            expect(entries.filter((entry) => entry.type === "agents").map((entry) => entry.path)).toEqual([
+              AbsolutePath.make(globalAgents),
+              AbsolutePath.make(path.join(directory, ".agents")),
+            ])
+          }).pipe(
+            Effect.provide(
+              testLayer(directory, global, directory, undefined, Watcher.testLayer, emptyCredentialNode, emptyWellknownNode, {
+                disableClaudeCode: true,
+              }),
+            ),
+          )
+        })
+      }),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Part of #36990

### Type of change

- [x] New feature

### What does this PR do?

Brings back `OPENCODE_DISABLE_CLAUDE_CODE` support on the `v2` branch.

V1 honored this flag to keep OpenCode from reading `~/.claude` (the prompt and skills). On v2 the env var was declared in the flag module but never wired into config discovery, so the flag had no effect: config kept pulling in the global `~/.claude` directory plus any `.claude` dirs found walking up from the project.

The change gates the `claude` source in `Config.discover()` on the flag. The global `~/.claude` directory and project `.claude` dirs are both skipped when `OPENCODE_DISABLE_CLAUDE_CODE` is set, matching V1 behavior. Setting it stops `.claude` skills and the `CLAUDE.md` prompt from loading, which is useful when you don't use Claude Code and don't want its content appearing in OpenCode.

I also added `disableClaudeCode` to `Config.Options` so callers can control this at the API level as well, not just through the env var. A test covers the discovery behavior (claude sources dropped, `.agents` untouched).

### How did you verify your code works?

- Ran the config test suite for the core package: all 36 tests pass, including the new one.
- The new test sets up a global `~/.claude` + `.agents` and a project `.agents`, then asserts that with the flag on, no `claude` entries are discovered while `agents` still are.
- Lint (oxlint) is clean on the touched files.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
