### PR TITLE
fix(opencode): skip snapshot restore checkout when worktree already matches

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -383,6 +383,17 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
           return yield* locked(
             Effect.gen(function* () {
               yield* Effect.logInfo("restore", { commit: snapshot })
+              // Compare the worktree against the snapshot content-wise first. If
+              // they already match, skip the checkout entirely: `checkout-index
+              // -a -f` force-rewrites every indexed file, which bumps mtimes on
+              // byte-identical files and breaks mtime-based sync tools.
+              const changed = yield* git([...quote, ...args(["diff", "--name-only", "-z", snapshot, "--", "."])], {
+                cwd: state.worktree,
+              })
+              if (changed.code === 0 && !changed.text) {
+                yield* Effect.logInfo("restore skipped, worktree already matches snapshot", { snapshot })
+                return
+              }
               const result = yield* git([...core, ...args(["read-tree", snapshot])], { cwd: state.worktree })
               if (result.code === 0) {
                 const checkout = yield* git([...core, ...args(["checkout-index", "-a", "-f"])], {


### PR DESCRIPTION
### Issue for this PR

Closes #44724

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`snapshot.restore()` runs `read-tree` + `checkout-index -a -f`, which force-rewrites every indexed file even when the worktree is already byte-identical to the snapshot. All mtimes get bumped with zero content change (`git status` stays clean), so mtime-based tools misfire — in my case the Obsidian Remotely Save plugin saw 657/945 vault files as changed after every session and tripped its own ">=50% changed" safety abort (details in #44724).

This adds a content-level `git diff <snapshot>` check before the checkout and returns early when the worktree already matches. Real restores (actual content differences) keep the original `read-tree` + full checkout path, so rollback behavior is unchanged.

### How did you verify your code works?

- Reproduced the churn with plain git: after `read-tree`, `checkout-index -a -f` rewrites all files byte-identically (mtimes bump, content unchanged, `git status` clean)
- With the fix: identical content → restore is a no-op and mtimes are preserved; a real modification → restore rewrites that file back to the snapshot content; a deleted file → recreated
- Note: plumbing `diff-files` can't be used for this check after `read-tree` (the index has no stat cache, so it reports every file) — the porcelain `git diff <tree>` is content-aware, which is why the fix uses it

### Screenshots / recordings

Not a UI change — log and mtime evidence is in #44724.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR