### PR TITLE
fix(ai): remove obsolete reasoning summary aliases

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -1186,7 +1186,6 @@ export const step = (state: ParserState, event: Event) => {
   if (
     event.type === "response.reasoning.done" ||
     event.type === "response.reasoning_summary_text.done" ||
-    event.type === "response.reasoning_summary.done" ||
     event.type === "response.reasoning_text.done"
   ) {
     if (!event.item_id) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)

--- a/packages/ai/src/protocols/openai-responses.ts
+++ b/packages/ai/src/protocols/openai-responses.ts
@@ -162,7 +162,7 @@ const HOSTED_TOOLS = {
 } as const satisfies ResponsesHostedTools.Definitions
 
 const step = (state: OpenResponses.ParserState, event: OpenResponses.Event) => {
-  if (event.type === "response.reasoning_text.delta" || event.type === "response.reasoning_summary.delta")
+  if (event.type === "response.reasoning_text.delta")
     return event.item_id
       ? Effect.succeed(OpenResponses.onReasoningDelta(state, event, event.item_id))
       : ProviderShared.eventError(ADAPTER, `${event.type} is missing item_id`)


### PR DESCRIPTION
## Summary

Remove the obsolete short reasoning-summary stream names:

- `response.reasoning_summary.delta`
- `response.reasoning_summary.done`

Current OpenAI and Open Responses discriminators use `response.reasoning_summary_text.delta/.done`. The short names survive only in historical generated contracts and inconsistent schema prose; no checked-in provider recording emits them.

The provider-neutral Open Responses raw-reasoning events (`response.reasoning.delta/.done`) remain supported, as do current OpenAI raw-reasoning events (`response.reasoning_text.delta/.done`).

## Verification

- `bun run typecheck`
- 123 focused OpenAI, Open Responses-compatible, xAI, and Bedrock Mantle tests pass
- Full package suite is unchanged from clean `v2`: 569 pass, same 14 unrelated baseline failures