### PR TITLE
fix(app): support attachments in insecure contexts

### DIFF
--- a/packages/app/src/utils/draft-store.ts
+++ b/packages/app/src/utils/draft-store.ts
@@ -22,7 +22,10 @@ function blobUrl(id: string, blob: Blob) {
 }
 
 async function blobID(blob: Blob) {
-  const id = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", await blob.arrayBuffer())))
+  const bytes = crypto.subtle
+    ? new Uint8Array(await crypto.subtle.digest("SHA-256", await blob.arrayBuffer()))
+    : crypto.getRandomValues(new Uint8Array(16))
+  const id = Array.from(bytes)
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("")
   return id

--- a/packages/app/test-browser/prompt-attachments.test.ts
+++ b/packages/app/test-browser/prompt-attachments.test.ts
@@ -3,6 +3,7 @@ import { createRoot } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createPromptAttachmentsCore } from "@/components/prompt-input/attachments"
 import { createPromptState } from "@/context/prompt"
+import { createBlobReference } from "@/utils/draft-store"
 import { createPromptInputV2Attachments } from "../../session-ui/src/v2/components/prompt-input/attachments"
 import type { PromptInputV2Prompt } from "../../session-ui/src/v2/components/prompt-input/types"
 
@@ -170,6 +171,55 @@ test("rejects desktop duplicates and keeps changed files in the V2 prompt store"
   })
 })
 
+describe.serial("prompt attachments in insecure contexts", () => {
+  test("creates a blob reference without Web Crypto", async () => {
+    await withoutWebCrypto(async () => {
+      const reference = await createBlobReference(new Blob(["hello"]))
+      expect(reference.id).toHaveLength(32)
+      expect(reference.url).toStartWith("blob:")
+    })
+  })
+
+  test("adds a V2 attachment without Web Crypto", async () => {
+    await withoutWebCrypto(async () => {
+      await createRoot(async (dispose) => {
+        const [state, setState] = createStore({ prompt: [] as PromptInputV2Prompt })
+        const attachments = createPromptInputV2Attachments({
+          capture: () => ({
+            current: () => state.prompt,
+            cursor: () => 0,
+            set: (prompt) => setState("prompt", prompt),
+          }),
+          editor: () => document.createElement("div"),
+          focusEditor: () => undefined,
+          addPart: () => false,
+          setDraggingType: () => undefined,
+          directory: () => "/",
+          isDialogActive: () => false,
+          warn: () => undefined,
+          duplicate: () => undefined,
+          onError: () => undefined,
+        })
+
+        await attachments.addAttachments([new File(["hello"], "hello.txt", { type: "text/plain" })])
+
+        expect(state.prompt).toHaveLength(1)
+        expect(state.prompt[0]?.type === "image" && state.prompt[0].blob.id).toHaveLength(32)
+        dispose()
+      })
+    })
+  })
+})
+
 function images(prompt: ReturnType<typeof createPromptState>) {
   return prompt.current().filter((part) => part.type === "image")
+}
+
+async function withoutWebCrypto(run: () => Promise<void>) {
+  const crypto = globalThis.crypto
+  Object.defineProperty(globalThis, "crypto", {
+    configurable: true,
+    value: { getRandomValues: crypto.getRandomValues.bind(crypto) },
+  })
+  await run().finally(() => Object.defineProperty(globalThis, "crypto", { configurable: true, value: crypto }))
 }

--- a/packages/session-ui/src/v2/components/prompt-input/attachments.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/attachments.ts
@@ -222,7 +222,10 @@ export function createPromptInputV2Attachments(
 const imageMimes = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"])
 
 async function blobReference(file: File) {
-  const id = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", await file.arrayBuffer())))
+  const bytes = crypto.subtle
+    ? new Uint8Array(await crypto.subtle.digest("SHA-256", await file.arrayBuffer()))
+    : crypto.getRandomValues(new Uint8Array(16))
+  const id = Array.from(bytes)
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("")
   return { id, url: URL.createObjectURL(file) }


### PR DESCRIPTION
### Issue for this PR

Closes #41706

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This fixes attachment blob-ID generation when the app is served over an insecure HTTP origin, where `crypto.subtle` is unavailable. It keeps the existing SHA-256 IDs when `crypto.subtle` is available and otherwise generates a 128-bit ID with `crypto.getRandomValues`. The fallback is applied to both draft storage and the active V2 attachment path, so previews can be created without relying on the secure-context-only API.

This ports the fallback accepted in #42706 to `dev` and adds V2-path regression coverage.

### How did you verify your code works?

- `bun run test:browser` in `packages/app` — 43 passed
- `bun run typecheck` in `packages/app`
- `bun run typecheck` in `packages/session-ui`
- Firefox against a LAN HTTP origin with `isSecureContext === false` and no `crypto.subtle`: image preview appeared without a page error.

### Screenshots / recordings

Manual browser verification was performed in Firefox over LAN HTTP; no screenshot or recording was captured.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
