### PR TITLE
fix(ai): ignore unknown Gemini response parts

### DIFF
--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -134,7 +134,7 @@ const GeminiContent = Schema.Struct({
 type GeminiContent = Schema.Schema.Type<typeof GeminiContent>
 
 const GeminiResponseContent = Schema.Struct({
-  role: Schema.optional(Schema.String),
+  role: optionalNull(Schema.Literals(["user", "model"])),
   parts: optionalNull(Schema.Array(Schema.Unknown)),
 })
 

--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
 import { Tool } from "@opencode-ai/schema/tool"
 import { Route } from "../route/client.js"
 import { Auth } from "../route/auth.js"
@@ -125,12 +125,27 @@ const GeminiContentPart = Schema.Union([
   GeminiFunctionCallPart,
   GeminiFunctionResponsePart,
 ])
+const decodeGeminiContentPart = Schema.decodeUnknownOption(GeminiContentPart)
+
+const GeminiUnknownResponsePart = Schema.declare(
+  (input): input is Record<string, unknown> =>
+    ProviderShared.isRecord(input) &&
+    !("text" in input) &&
+    !("inlineData" in input) &&
+    !("functionCall" in input) &&
+    !("functionResponse" in input),
+)
 
 const GeminiContent = Schema.Struct({
   role: optionalNull(Schema.Literals(["user", "model"])),
   parts: optionalNull(Schema.Array(GeminiContentPart)),
 })
 type GeminiContent = Schema.Schema.Type<typeof GeminiContent>
+
+const GeminiResponseContent = Schema.Struct({
+  role: optionalNull(Schema.Literals(["user", "model"])),
+  parts: optionalNull(Schema.Array(Schema.Union([GeminiContentPart, GeminiUnknownResponsePart]))),
+})
 
 const GeminiSystemInstruction = Schema.Struct({
   parts: Schema.Array(Schema.Struct({ text: Schema.String })),
@@ -200,7 +215,7 @@ const GeminiUsage = Schema.Struct({
 type GeminiUsage = Schema.Schema.Type<typeof GeminiUsage>
 
 const GeminiCandidate = Schema.Struct({
-  content: optionalNull(GeminiContent),
+  content: optionalNull(GeminiResponseContent),
   finishReason: optionalNull(Schema.String),
 })
 
@@ -598,7 +613,10 @@ const step = (state: ParserState, event: GeminiEvent) => {
   // Supplier ids must be tracked across chunks of the same response, not just within one event's parts.
   const seenCallIds = new Set(nextState.seenCallIds)
 
-  for (const part of candidate.content.parts ?? []) {
+  for (const input of candidate.content.parts ?? []) {
+    const decoded = decodeGeminiContentPart(input)
+    if (Option.isNone(decoded)) continue
+    const part = decoded.value
     const signature = "thoughtSignature" in part && part.thoughtSignature ? part.thoughtSignature : undefined
     // Gemini attaches replay signatures to thought parts, visible text, or function calls;
     // each block kind must retain the signature attached to its own parts.

--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -134,7 +134,7 @@ const GeminiContent = Schema.Struct({
 type GeminiContent = Schema.Schema.Type<typeof GeminiContent>
 
 const GeminiResponseContent = Schema.Struct({
-  role: optionalNull(Schema.Literals(["user", "model"])),
+  role: Schema.optional(Schema.String),
   parts: optionalNull(Schema.Array(Schema.Unknown)),
 })
 

--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -127,15 +127,6 @@ const GeminiContentPart = Schema.Union([
 ])
 const decodeGeminiContentPart = Schema.decodeUnknownOption(GeminiContentPart)
 
-const GeminiUnknownResponsePart = Schema.declare(
-  (input): input is Record<string, unknown> =>
-    ProviderShared.isRecord(input) &&
-    !("text" in input) &&
-    !("inlineData" in input) &&
-    !("functionCall" in input) &&
-    !("functionResponse" in input),
-)
-
 const GeminiContent = Schema.Struct({
   role: optionalNull(Schema.Literals(["user", "model"])),
   parts: optionalNull(Schema.Array(GeminiContentPart)),
@@ -144,7 +135,7 @@ type GeminiContent = Schema.Schema.Type<typeof GeminiContent>
 
 const GeminiResponseContent = Schema.Struct({
   role: optionalNull(Schema.Literals(["user", "model"])),
-  parts: optionalNull(Schema.Array(Schema.Union([GeminiContentPart, GeminiUnknownResponsePart]))),
+  parts: optionalNull(Schema.Array(Schema.Unknown)),
 })
 
 const GeminiSystemInstruction = Schema.Struct({
@@ -237,6 +228,7 @@ const GeminiEvent = Schema.Struct({
 type GeminiEvent = Schema.Schema.Type<typeof GeminiEvent>
 
 interface ParserState {
+  readonly route: string
   readonly finishReason?: string
   readonly hasToolCalls: boolean
   readonly promptFeedback?: GeminiPromptFeedback
@@ -614,8 +606,19 @@ const step = (state: ParserState, event: GeminiEvent) => {
   const seenCallIds = new Set(nextState.seenCallIds)
 
   for (const input of candidate.content.parts ?? []) {
+    if (
+      ProviderShared.isRecord(input) &&
+      !("text" in input) &&
+      !("inlineData" in input) &&
+      !("functionCall" in input) &&
+      !("functionResponse" in input)
+    )
+      continue
     const decoded = decodeGeminiContentPart(input)
-    if (Option.isNone(decoded)) continue
+    if (Option.isNone(decoded))
+      return Effect.fail(
+        ProviderShared.eventError(ADAPTER, `Invalid ${state.route} stream event`, ProviderShared.encodeJson(event)),
+      )
     const part = decoded.value
     const signature = "thoughtSignature" in part && part.thoughtSignature ? part.thoughtSignature : undefined
     // Gemini attaches replay signatures to thought parts, visible text, or function calls;
@@ -709,7 +712,11 @@ export const protocol = Protocol.make({
   },
   stream: {
     event: Protocol.jsonEvent(GeminiEvent),
-    initial: () => ({ hasToolCalls: false, lifecycle: Lifecycle.initial() }),
+    initial: (request) => ({
+      route: `${request.model.provider}/${request.model.route.id}`,
+      hasToolCalls: false,
+      lifecycle: Lifecycle.initial(),
+    }),
     step,
     onHalt: finish,
   },

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -906,6 +906,35 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("ignores unknown response parts", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              candidates: [
+                {
+                  content: {
+                    role: "model",
+                    parts: [
+                      { text: "Hello " },
+                      { executableCode: { language: "PYTHON", code: "print('ignored')" } },
+                      { text: "world" },
+                    ],
+                  },
+                  finishReason: "STOP",
+                },
+              ],
+            }),
+          ),
+        ),
+      )
+
+      expect(response.text).toBe("Hello world")
+      expect(response.finishReason).toEqual({ normalized: "stop", raw: "STOP" })
+    }),
+  )
+
   it.effect("preserves thoughtSignature for reasoning and tool-call continuation", () =>
     Effect.gen(function* () {
       const body = sseEvents({

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -906,7 +906,7 @@ describe("Gemini route", () => {
     }),
   )
 
-  it.effect("ignores unknown response parts", () =>
+  it.effect("ignores unknown response parts with an arbitrary string role", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(
         Effect.provide(
@@ -915,7 +915,7 @@ describe("Gemini route", () => {
               candidates: [
                 {
                   content: {
-                    role: "model",
+                    role: "future-role",
                     parts: [
                       { text: "Hello " },
                       { executableCode: { language: "PYTHON", code: "print('ignored')" } },
@@ -951,6 +951,24 @@ describe("Gemini route", () => {
       expect(error).toBeInstanceOf(AIError)
       expect(error.reason).toMatchObject({ _tag: "InvalidProviderOutput" })
       expect(error.message).toContain("Invalid google/gemini stream event")
+    }),
+  )
+
+  it.effect("rejects null response roles", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              candidates: [{ content: { role: null, parts: [{ text: "Hello" }] } }],
+            }),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expect(error).toBeInstanceOf(AIError)
+      expect(error.reason).toMatchObject({ _tag: "InvalidProviderOutput" })
     }),
   )
 

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -906,7 +906,7 @@ describe("Gemini route", () => {
     }),
   )
 
-  it.effect("ignores unknown response parts with an arbitrary string role", () =>
+  it.effect("ignores unknown response parts", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(
         Effect.provide(
@@ -915,7 +915,7 @@ describe("Gemini route", () => {
               candidates: [
                 {
                   content: {
-                    role: "future-role",
+                    role: "model",
                     parts: [
                       { text: "Hello " },
                       { executableCode: { language: "PYTHON", code: "print('ignored')" } },
@@ -951,24 +951,6 @@ describe("Gemini route", () => {
       expect(error).toBeInstanceOf(AIError)
       expect(error.reason).toMatchObject({ _tag: "InvalidProviderOutput" })
       expect(error.message).toContain("Invalid google/gemini stream event")
-    }),
-  )
-
-  it.effect("rejects null response roles", () =>
-    Effect.gen(function* () {
-      const error = yield* LLMClient.generate(request).pipe(
-        Effect.provide(
-          fixedResponse(
-            sseEvents({
-              candidates: [{ content: { role: null, parts: [{ text: "Hello" }] } }],
-            }),
-          ),
-        ),
-        Effect.flip,
-      )
-
-      expect(error).toBeInstanceOf(AIError)
-      expect(error.reason).toMatchObject({ _tag: "InvalidProviderOutput" })
     }),
   )
 

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -935,6 +935,25 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("rejects malformed recognized response parts", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents({
+              candidates: [{ content: { role: "model", parts: [{ text: 42 }] } }],
+            }),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expect(error).toBeInstanceOf(AIError)
+      expect(error.reason).toMatchObject({ _tag: "InvalidProviderOutput" })
+      expect(error.message).toContain("Invalid google/gemini stream event")
+    }),
+  )
+
   it.effect("preserves thoughtSignature for reasoning and tool-call continuation", () =>
     Effect.gen(function* () {
       const body = sseEvents({


### PR DESCRIPTION
## Summary

- keep inbound Gemini response parts opaque until parser dispatch
- ignore object parts that match no recognized handler
- strict-decode every recognized part before processing it
- preserve existing null-tolerant response fields and strict outbound request validation

## Testing

- `bun run typecheck`
- `bun test test/provider/gemini.test.ts`
- 44 pass, 0 fail
- scoped audit: no findings
- `git diff --check`