### PR TITLE
fix(www): update docs section navigation

### DIFF
--- a/packages/www/src/docs/components/DocsHeader.astro
+++ b/packages/www/src/docs/components/DocsHeader.astro
@@ -1,11 +1,12 @@
 ---
-import { docsHref, docsSections } from "../lib/navigation"
+import { docsHref, docsSections, getDocsSection } from "../lib/navigation"
 
 interface Props {
   currentSlug: string
 }
 
 const currentSlug = Astro.props.currentSlug
+const currentSection = getDocsSection(currentSlug)
 const searchEnabled = import.meta.env.PROD
 ---
 
@@ -17,7 +18,7 @@ const searchEnabled = import.meta.env.PROD
     <nav aria-label="Documentation sections">
       {
         docsSections.map((section) => (
-          <a href={docsHref(section.landingSlug)} aria-current={currentSlug === section.key || currentSlug.startsWith(`${section.key}/`) || (section.key === "docs" && !currentSlug.includes("/") && currentSlug !== "api") ? "page" : undefined}>
+          <a href={docsHref(section.landingSlug)} aria-current={currentSection.key === section.key ? "page" : undefined}>
             {section.title}
           </a>
         ))

--- a/packages/www/src/docs/lib/navigation.ts
+++ b/packages/www/src/docs/lib/navigation.ts
@@ -60,12 +60,12 @@ export const docsSections: DocsSection[] = [
   {
     key: "cli",
     title: "CLI",
-    landingSlug: "cli/index",
+    landingSlug: "cli",
     groups: [
       {
         title: "Intro",
         items: [
-          { title: "Intro", slug: "cli/index" },
+          { title: "Intro", slug: "cli" },
           { title: "Config", slug: "cli/config" },
         ],
       },
@@ -85,13 +85,13 @@ export const docsSections: DocsSection[] = [
   {
     key: "build",
     title: "Build",
-    landingSlug: "build/index",
+    landingSlug: "build",
     groups: [
       {
         title: "Build",
         items: [
           { title: "SDK", slug: "build/sdk" },
-          { title: "Build", slug: "build/index" },
+          { title: "Build", slug: "build" },
           { title: "Client", slug: "build/client" },
           { title: "Plugins", slug: "build/plugins" },
         ],


### PR DESCRIPTION
## Summary
- align CLI and Build landing slugs with Astro collection IDs
- resolve the active header section through the shared navigation model
- render the correct desktop and mobile sidebars for section landing pages

## Validation
- `bun typecheck`
- `bun run check:generated`
- `bun run build`