### PR TITLE
fix(tui): preserve dialog size on replace

### DIFF
--- a/packages/tui/src/ui/dialog.tsx
+++ b/packages/tui/src/ui/dialog.tsx
@@ -155,7 +155,6 @@ function init() {
       for (const item of store.stack) {
         if (item.onClose) item.onClose()
       }
-      setStore("size", "medium")
       setStore("stack", [
         {
           element: input,

--- a/packages/tui/test/cli/tui/dialog.test.tsx
+++ b/packages/tui/test/cli/tui/dialog.test.tsx
@@ -1,0 +1,87 @@
+/** @jsxImportSource @opentui/solid */
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { mkdir } from "node:fs/promises"
+import path from "node:path"
+import { onCleanup, onMount } from "solid-js"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+import { TestTuiContexts } from "../../fixture/tui-environment"
+import { tmpdir } from "../../fixture/fixture"
+
+async function wait(fn: () => boolean, timeout = 2000) {
+  const start = Date.now()
+  while (!fn()) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for condition")
+    await Bun.sleep(10)
+  }
+}
+
+test("dialog replacement preserves the requested size", async () => {
+  await using tmp = await tmpdir()
+  const state = path.join(tmp.path, "state")
+  await mkdir(state, { recursive: true })
+  await Bun.write(path.join(state, "kv.json"), "{}")
+  const [
+    { DialogProvider, useDialog },
+    { KVProvider },
+    { ThemeProvider },
+    { TuiConfigProvider },
+    { ToastProvider },
+    { OpencodeKeymapProvider, registerOpencodeKeymap },
+  ] = await Promise.all([
+    import("../../../src/ui/dialog"),
+    import("../../../src/context/kv"),
+    import("../../../src/context/theme"),
+    import("../../../src/config"),
+    import("../../../src/ui/toast"),
+    import("../../../src/keymap"),
+  ])
+
+  let size: DialogContext["size"]
+  type DialogContext = ReturnType<typeof useDialog>
+
+  function ReplaceDialog() {
+    const dialog = useDialog()
+    onMount(() => {
+      dialog.setSize("xlarge")
+      dialog.replace(<box />)
+      size = dialog.size
+    })
+    return null
+  }
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const config = createTuiResolvedConfig()
+    const off = registerOpencodeKeymap(keymap, renderer, config)
+    onCleanup(off)
+
+    return (
+      <TestTuiContexts directory={tmp.path} paths={{ home: tmp.path, state, worktree: tmp.path }}>
+        <OpencodeKeymapProvider keymap={keymap}>
+          <TuiConfigProvider config={config}>
+            <KVProvider>
+              <ThemeProvider mode="dark">
+                <ToastProvider>
+                  <DialogProvider>
+                    <ReplaceDialog />
+                  </DialogProvider>
+                </ToastProvider>
+              </ThemeProvider>
+            </KVProvider>
+          </TuiConfigProvider>
+        </OpencodeKeymapProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  const app = await testRender(() => <Harness />)
+  try {
+    await wait(() => size !== undefined)
+    expect(size!).toBe("xlarge")
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #44754

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`DialogProvider.replace()` no longer overwrites a size selected with `api.ui.dialog.setSize()`. Clearing the dialog still restores the default medium size, so a later independent dialog keeps the existing default behavior.

A renderer-level regression calls the public `useDialog()` API in the same order used by plugins: `setSize("xlarge")`, then `replace()`.

### Evidence

Base: `7cde8329bc33801248d6aafa2a4dd46dc86e5683`
Head: `cd54506d963de577f78de3db57a7d60aaf4767aa`

On the unchanged base, the new regression receives `medium` and fails. On this head, it receives `xlarge` and passes.

### How did you verify your code works?

- `cd packages/tui && bun test`: 194 passed, 1 skipped, 0 failed
- `cd packages/tui && bun typecheck`: passed
- pre-push repository typecheck: 30/30 tasks passed
- Prettier check: passed
- `git diff --check`: passed
- Publication-time searches for #44754, `dialog replace size`, and `setSize` found no same-root open PR; #43728 changes built-in informational dialog alignment instead.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR