### PR TITLE
fix(sdk): gate recovery on host startup

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -69,4 +69,21 @@ const opencode = yield * OpenCode.create()
 const session = yield * opencode.sessions.get({ sessionID })
 ```
 
-The Effect Workerd entrypoint is `@opencode-ai/sdk/workerd/effect`.
+`OpenCode.create()` starts recovery automatically. When composing an application from Layers, apply `OpenCode.start` to the complete application Layer so registration Layers finish before suspended Sessions resume:
+
+```ts
+import { OpenCode } from "@opencode-ai/sdk/effect"
+import { Effect, Layer } from "effect"
+import myPlugin from "./my-plugin"
+
+const PluginLive = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const opencode = yield* OpenCode.Service
+    yield* opencode.plugin(myPlugin)
+  }),
+)
+
+const ApplicationLive = PluginLive.pipe(Layer.provideMerge(OpenCode.layerDeferred()), OpenCode.start)
+```
+
+Use `OpenCode.layer()` when there are no registration layers; it starts recovery automatically. The Effect Workerd entrypoint is `@opencode-ai/sdk/workerd/effect`, with matching `layerDeferred` and `start` exports.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -69,7 +69,7 @@ const opencode = yield * OpenCode.create()
 const session = yield * opencode.sessions.get({ sessionID })
 ```
 
-`OpenCode.create()` starts recovery automatically. When composing an application from Layers, apply `OpenCode.start` to the complete application Layer so registration Layers finish before suspended Sessions resume:
+`OpenCode.create()` and `OpenCode.layer()` start recovery automatically. Use `OpenCode.layerWith()` when plugins come from registration Layers so recovery starts only after those Layers succeed:
 
 ```ts
 import { OpenCode } from "@opencode-ai/sdk/effect"
@@ -83,7 +83,7 @@ const PluginLive = Layer.effectDiscard(
   }),
 )
 
-const ApplicationLive = PluginLive.pipe(Layer.provideMerge(OpenCode.layerDeferred()), OpenCode.start)
+const OpenCodeLive = OpenCode.layerWith(PluginLive)
 ```
 
-Use `OpenCode.layer()` when there are no registration layers; it starts recovery automatically. The Effect Workerd entrypoint is `@opencode-ai/sdk/workerd/effect`, with matching `layerDeferred` and `start` exports.
+The Effect Workerd entrypoint is `@opencode-ai/sdk/workerd/effect`, with a matching `layerWith` export.

--- a/packages/sdk/script/verify-package.ts
+++ b/packages/sdk/script/verify-package.ts
@@ -103,20 +103,11 @@ try {
       `import { bodyDigest } from "@opencode-ai/core/models-dev"
 import { OpenCodeWorkerd } from "@opencode-ai/sdk/workerd"
 
-const pluginReady = Promise.withResolvers()
-const packedPlugin = {
-  id: "packed-workerd-plugin",
-  setup() {
-    pluginReady.resolve()
-  },
-}
-
 export class OpenCodeDO {
   constructor(state) {
     this.opencode = state.blockConcurrencyWhile(() => OpenCodeWorkerd.create({
       storage: state.storage,
       app: { version: "packed-workerd" },
-      plugins: [packedPlugin],
     }))
   }
 
@@ -125,11 +116,6 @@ export class OpenCodeDO {
       throw new Error("Packed workerd SHA-256 mismatch")
     }
     const opencode = await this.opencode
-    await opencode.plugin.list({ location: { directory: "/" } })
-    await Promise.race([
-      pluginReady.promise,
-      new Promise((_, reject) => setTimeout(() => reject(new Error("Packed workerd Promise plugin did not activate")), 2_000)),
-    ])
     return Response.json(await opencode.health.get())
   }
 }

--- a/packages/sdk/script/verify-package.ts
+++ b/packages/sdk/script/verify-package.ts
@@ -103,11 +103,20 @@ try {
       `import { bodyDigest } from "@opencode-ai/core/models-dev"
 import { OpenCodeWorkerd } from "@opencode-ai/sdk/workerd"
 
+const pluginReady = Promise.withResolvers()
+const packedPlugin = {
+  id: "packed-workerd-plugin",
+  setup() {
+    pluginReady.resolve()
+  },
+}
+
 export class OpenCodeDO {
   constructor(state) {
     this.opencode = state.blockConcurrencyWhile(() => OpenCodeWorkerd.create({
       storage: state.storage,
       app: { version: "packed-workerd" },
+      plugins: [packedPlugin],
     }))
   }
 
@@ -116,6 +125,11 @@ export class OpenCodeDO {
       throw new Error("Packed workerd SHA-256 mismatch")
     }
     const opencode = await this.opencode
+    await opencode.plugin.list({ location: { directory: "/" } })
+    await Promise.race([
+      pluginReady.promise,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("Packed workerd Promise plugin did not activate")), 2_000)),
+    ])
     return Response.json(await opencode.health.get())
   }
 }

--- a/packages/sdk/src/effect/opencode.ts
+++ b/packages/sdk/src/effect/opencode.ts
@@ -64,7 +64,7 @@ export const create: (
 export class Service extends Context.Service<Service, Interface>()("@opencode-ai/sdk/OpenCode") {}
 
 export const layer = (options: CreateOptions = {}): Layer.Layer<Service, Config.ConfigError | Error> =>
-  layerWith(Layer.empty, options)
+  Layer.effect(Service, create(options))
 
 /** Builds a registration layer before starting suspended-session recovery. */
 export const layerWith = <E, R>(

--- a/packages/sdk/src/effect/opencode.ts
+++ b/packages/sdk/src/effect/opencode.ts
@@ -25,10 +25,12 @@ export type Interface = Omit<OpenCodeClient, "plugin" | "workspace"> & {
   readonly plugin: EmbeddedHost.Interface["plugins"]["register"] & OpenCodeClient["plugin"]
 }
 
-export const create: (
+const starts = new WeakMap<Interface, Effect.Effect<void>>()
+
+const make: (
   options?: CreateOptions,
   embed?: EmbedOptions,
-) => Effect.Effect<Interface, Config.ConfigError | Error, Scope.Scope> = Effect.fn("OpenCode.create")(function* (
+) => Effect.Effect<Interface, Config.ConfigError | Error, Scope.Scope> = Effect.fn("OpenCode.make")(function* (
   options: CreateOptions = {},
   embed: EmbedOptions = {},
 ) {
@@ -39,7 +41,7 @@ export const create: (
     ),
   )
 
-  return {
+  const opencode: Interface = {
     ...client,
     sessions: client.session,
     events: client.event,
@@ -50,9 +52,39 @@ export const create: (
     },
     plugin: Object.assign(host.plugins.register, client.plugin),
   }
+  starts.set(opencode, host.start)
+  return opencode
+})
+
+export const create: (
+  options?: CreateOptions,
+  embed?: EmbedOptions,
+) => Effect.Effect<Interface, Config.ConfigError | Error, Scope.Scope> = Effect.fn("OpenCode.create")(function* (
+  options: CreateOptions = {},
+  embed: EmbedOptions = {},
+) {
+  const opencode = yield* make(options, embed)
+  yield* recovery(opencode)
+  return opencode
 })
 
 export class Service extends Context.Service<Service, Interface>()("@opencode-ai/sdk/OpenCode") {}
 
-export const layer = (options: CreateOptions = {}): Layer.Layer<Service, Config.ConfigError | Error> =>
-  Layer.effect(Service, create(options))
+export const layer = (
+  options: CreateOptions = {},
+  embed: EmbedOptions = {},
+): Layer.Layer<Service, Config.ConfigError | Error> => Layer.effect(Service, create(options, embed))
+
+/** Builds a host whose recovery is deferred until `OpenCode.start`. */
+export const layerDeferred = (
+  options: CreateOptions = {},
+  embed: EmbedOptions = {},
+): Layer.Layer<Service, Config.ConfigError | Error> => Layer.effect(Service, make(options, embed))
+
+/** Starts suspended-session recovery after the complete application layer has built. */
+export const start = <A, E, R>(self: Layer.Layer<Service | A, E, R>): Layer.Layer<Service | A, E, R> =>
+  self.pipe(Layer.tap((services: Context.Context<Service>) => recovery(Context.get(services, Service))))
+
+function recovery(opencode: Interface) {
+  return starts.get(opencode) ?? Effect.die(new Error("OpenCode.start requires OpenCode.layerDeferred"))
+}

--- a/packages/sdk/src/effect/opencode.ts
+++ b/packages/sdk/src/effect/opencode.ts
@@ -25,15 +25,7 @@ export type Interface = Omit<OpenCodeClient, "plugin" | "workspace"> & {
   readonly plugin: EmbeddedHost.Interface["plugins"]["register"] & OpenCodeClient["plugin"]
 }
 
-const starts = new WeakMap<Interface, Effect.Effect<void>>()
-
-const make: (
-  options?: CreateOptions,
-  embed?: EmbedOptions,
-) => Effect.Effect<Interface, Config.ConfigError | Error, Scope.Scope> = Effect.fn("OpenCode.make")(function* (
-  options: CreateOptions = {},
-  embed: EmbedOptions = {},
-) {
+const make = Effect.fn("OpenCode.make")(function* (options: CreateOptions = {}, embed: EmbedOptions = {}) {
   const host = yield* Effect.acquireRelease(EmbeddedHost.create(options, embed), (host) => Effect.promise(host.close))
   const client = yield* OpenCode.make({ baseUrl: "http://opencode.local" }).pipe(
     Effect.provide(
@@ -41,19 +33,20 @@ const make: (
     ),
   )
 
-  const opencode: Interface = {
-    ...client,
-    sessions: client.session,
-    events: client.event,
-    workspace: {
-      create: ({ provider }: { readonly provider: string }) => host.workspace.create(provider),
-      provision: ({ workspaceID }: { readonly workspaceID: Workspace.ID }) => host.workspace.provision(workspaceID),
-      destroy: ({ workspaceID }: { readonly workspaceID: Workspace.ID }) => host.workspace.destroy(workspaceID),
+  return {
+    opencode: {
+      ...client,
+      sessions: client.session,
+      events: client.event,
+      workspace: {
+        create: ({ provider }: { readonly provider: string }) => host.workspace.create(provider),
+        provision: ({ workspaceID }: { readonly workspaceID: Workspace.ID }) => host.workspace.provision(workspaceID),
+        destroy: ({ workspaceID }: { readonly workspaceID: Workspace.ID }) => host.workspace.destroy(workspaceID),
+      },
+      plugin: Object.assign(host.plugins.register, client.plugin),
     },
-    plugin: Object.assign(host.plugins.register, client.plugin),
+    start: host.start,
   }
-  starts.set(opencode, host.start)
-  return opencode
 })
 
 export const create: (
@@ -63,28 +56,29 @@ export const create: (
   options: CreateOptions = {},
   embed: EmbedOptions = {},
 ) {
-  const opencode = yield* make(options, embed)
-  yield* recovery(opencode)
-  return opencode
+  const host = yield* make(options, embed)
+  yield* host.start
+  return host.opencode
 })
 
 export class Service extends Context.Service<Service, Interface>()("@opencode-ai/sdk/OpenCode") {}
 
-export const layer = (
+export const layer = (options: CreateOptions = {}): Layer.Layer<Service, Config.ConfigError | Error> =>
+  layerWith(Layer.empty, options)
+
+/** Builds a registration layer before starting suspended-session recovery. */
+export const layerWith = <E, R>(
+  registration: Layer.Layer<never, E, R>,
   options: CreateOptions = {},
   embed: EmbedOptions = {},
-): Layer.Layer<Service, Config.ConfigError | Error> => Layer.effect(Service, create(options, embed))
-
-/** Builds a host whose recovery is deferred until `OpenCode.start`. */
-export const layerDeferred = (
-  options: CreateOptions = {},
-  embed: EmbedOptions = {},
-): Layer.Layer<Service, Config.ConfigError | Error> => Layer.effect(Service, make(options, embed))
-
-/** Starts suspended-session recovery after the complete application layer has built. */
-export const start = <A, E, R>(self: Layer.Layer<Service | A, E, R>): Layer.Layer<Service | A, E, R> =>
-  self.pipe(Layer.tap((services: Context.Context<Service>) => recovery(Context.get(services, Service))))
-
-function recovery(opencode: Interface) {
-  return starts.get(opencode) ?? Effect.die(new Error("OpenCode.start requires OpenCode.layerDeferred"))
-}
+): Layer.Layer<Service, Config.ConfigError | Error | E, Exclude<R, Service>> =>
+  Layer.unwrap(
+    make(options, embed).pipe(
+      Effect.map((host) =>
+        registration.pipe(
+          Layer.provideMerge(Layer.succeed(Service, host.opencode)),
+          Layer.tap(() => host.start),
+        ),
+      ),
+    ),
+  )

--- a/packages/sdk/src/effect/workerd.ts
+++ b/packages/sdk/src/effect/workerd.ts
@@ -5,6 +5,8 @@ import type { Config, Scope } from "effect"
 import { WorkerdProfile } from "../internal/workerd"
 import { OpenCode } from "./opencode"
 
+export { Service } from "./opencode"
+
 export type Configuration = WorkerdProfile.Configuration
 
 export interface CreateOptions extends WorkerdProfile.Options {
@@ -12,13 +14,30 @@ export interface CreateOptions extends WorkerdProfile.Options {
   readonly workspaceProviders?: OpenCode.CreateOptions["workspaceProviders"]
 }
 
-export const create = ({ log, workspaceProviders, ...options }: CreateOptions) => {
-  const profile = WorkerdProfile.make(options)
-  return OpenCode.create({ ...profile.options, log, workspaceProviders }, { overrides: profile.replacements })
+export const create = (options: CreateOptions) => {
+  const host = make(options)
+  return OpenCode.create(host.options, host.embed)
 }
 
-export const layer = (options: CreateOptions): Layer.Layer<OpenCode.Service, Config.ConfigError | Error> =>
-  Layer.effect(OpenCode.Service, create(options))
+export const layer = (options: CreateOptions): Layer.Layer<OpenCode.Service, Config.ConfigError | Error> => {
+  const host = make(options)
+  return OpenCode.layer(host.options, host.embed)
+}
+
+export const layerDeferred = (options: CreateOptions): Layer.Layer<OpenCode.Service, Config.ConfigError | Error> => {
+  const host = make(options)
+  return OpenCode.layerDeferred(host.options, host.embed)
+}
+
+export const start = OpenCode.start
 
 export type Interface = OpenCode.Interface
 export type Requirements = Scope.Scope
+
+function make({ log, workspaceProviders, ...options }: CreateOptions) {
+  const profile = WorkerdProfile.make(options)
+  return {
+    options: { ...profile.options, log, workspaceProviders },
+    embed: { overrides: profile.replacements },
+  }
+}

--- a/packages/sdk/src/effect/workerd.ts
+++ b/packages/sdk/src/effect/workerd.ts
@@ -20,7 +20,7 @@ export const create = (options: CreateOptions) => {
 }
 
 export const layer = (options: CreateOptions): Layer.Layer<OpenCode.Service, Config.ConfigError | Error> =>
-  layerWith(Layer.empty, options)
+  Layer.effect(OpenCode.Service, create(options))
 
 export const layerWith = <E, R>(
   registration: Layer.Layer<never, E, R>,

--- a/packages/sdk/src/effect/workerd.ts
+++ b/packages/sdk/src/effect/workerd.ts
@@ -19,17 +19,16 @@ export const create = (options: CreateOptions) => {
   return OpenCode.create(host.options, host.embed)
 }
 
-export const layer = (options: CreateOptions): Layer.Layer<OpenCode.Service, Config.ConfigError | Error> => {
-  const host = make(options)
-  return OpenCode.layer(host.options, host.embed)
-}
+export const layer = (options: CreateOptions): Layer.Layer<OpenCode.Service, Config.ConfigError | Error> =>
+  layerWith(Layer.empty, options)
 
-export const layerDeferred = (options: CreateOptions): Layer.Layer<OpenCode.Service, Config.ConfigError | Error> => {
+export const layerWith = <E, R>(
+  registration: Layer.Layer<never, E, R>,
+  options: CreateOptions,
+): Layer.Layer<OpenCode.Service, Config.ConfigError | Error | E, Exclude<R, OpenCode.Service>> => {
   const host = make(options)
-  return OpenCode.layerDeferred(host.options, host.embed)
+  return OpenCode.layerWith(registration, host.options, host.embed)
 }
-
-export const start = OpenCode.start
 
 export type Interface = OpenCode.Interface
 export type Requirements = Scope.Scope

--- a/packages/sdk/src/internal/host.ts
+++ b/packages/sdk/src/internal/host.ts
@@ -46,11 +46,6 @@ export const create = Effect.fn("EmbeddedHost.create")(function* (
     const services = yield* runtime.contextEffect
     const plugins = Context.get(services, SdkPlugins.Service)
     yield* Effect.forEach(initialPlugins, (plugin) => plugins.register(plugin), { discard: true })
-    const start = yield* Effect.cached(
-      Effect.sync(() => {
-        runtime.runFork(Context.get(services, SessionRestart.Service).resumeSuspendedSessions)
-      }),
-    )
     const handler = HttpEffect.toWebHandlerWith<never, HttpServerRequest.HttpServerRequest | Scope.Scope>(
       context(services),
     )(Context.get(services, HttpRouter.HttpRouter).asHttpEffect())
@@ -63,7 +58,9 @@ export const create = Effect.fn("EmbeddedHost.create")(function* (
       workspace: Context.get(services, Workspace.Service),
       // The sweep is a no-op when nothing is suspended. ManagedRuntime owns
       // the fiber so recovery never delays startup but still stops with the host.
-      start,
+      start: Effect.sync(() => {
+        runtime.runFork(Context.get(services, SessionRestart.Service).resumeSuspendedSessions)
+      }),
       close: transport.close,
     }
   }).pipe(Effect.onError(() => runtime.disposeEffect))

--- a/packages/sdk/src/internal/host.ts
+++ b/packages/sdk/src/internal/host.ts
@@ -46,6 +46,11 @@ export const create = Effect.fn("EmbeddedHost.create")(function* (
     const services = yield* runtime.contextEffect
     const plugins = Context.get(services, SdkPlugins.Service)
     yield* Effect.forEach(initialPlugins, (plugin) => plugins.register(plugin), { discard: true })
+    const start = yield* Effect.cached(
+      Effect.sync(() => {
+        runtime.runFork(Context.get(services, SessionRestart.Service).resumeSuspendedSessions)
+      }),
+    )
     const handler = HttpEffect.toWebHandlerWith<never, HttpServerRequest.HttpServerRequest | Scope.Scope>(
       context(services),
     )(Context.get(services, HttpRouter.HttpRouter).asHttpEffect())
@@ -58,9 +63,7 @@ export const create = Effect.fn("EmbeddedHost.create")(function* (
       workspace: Context.get(services, Workspace.Service),
       // The sweep is a no-op when nothing is suspended. ManagedRuntime owns
       // the fiber so recovery never delays startup but still stops with the host.
-      start: Effect.sync(() => {
-        runtime.runFork(Context.get(services, SessionRestart.Service).resumeSuspendedSessions)
-      }),
+      start,
       close: transport.close,
     }
   }).pipe(Effect.onError(() => runtime.disposeEffect))

--- a/packages/sdk/src/internal/host.ts
+++ b/packages/sdk/src/internal/host.ts
@@ -4,6 +4,7 @@ import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
 import { Workspace } from "@opencode-ai/core/workspace"
 import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
+import type { Plugin } from "@opencode-ai/plugin/effect/plugin"
 import { createEmbeddedRoutes } from "@opencode-ai/server/routes"
 import type { ServerOptions } from "@opencode-ai/server/options"
 import type { LayerNode } from "@opencode-ai/util/effect/layer-node"
@@ -25,6 +26,7 @@ export interface EmbedOptions {
 export const create = Effect.fn("EmbeddedHost.create")(function* (
   options: CreateOptions = {},
   embed: EmbedOptions = {},
+  initialPlugins: ReadonlyArray<Plugin> = [],
 ) {
   const { log, workspaceProviders, ...server } = options
   const runtime = ManagedRuntime.make(
@@ -42,9 +44,13 @@ export const create = Effect.fn("EmbeddedHost.create")(function* (
 
   return yield* Effect.gen(function* () {
     const services = yield* runtime.contextEffect
-    // The sweep is a no-op when nothing is suspended. ManagedRuntime owns the
-    // fiber so recovery never delays startup but still stops with the host.
-    runtime.runFork(Context.get(services, SessionRestart.Service).resumeSuspendedSessions)
+    const plugins = Context.get(services, SdkPlugins.Service)
+    yield* Effect.forEach(initialPlugins, (plugin) => plugins.register(plugin), { discard: true })
+    const start = yield* Effect.cached(
+      Effect.sync(() => {
+        runtime.runFork(Context.get(services, SessionRestart.Service).resumeSuspendedSessions)
+      }),
+    )
     const handler = HttpEffect.toWebHandlerWith<never, HttpServerRequest.HttpServerRequest | Scope.Scope>(
       context(services),
     )(Context.get(services, HttpRouter.HttpRouter).asHttpEffect())
@@ -53,8 +59,11 @@ export const create = Effect.fn("EmbeddedHost.create")(function* (
     return {
       runtime,
       fetch: transport.fetch,
-      plugins: Context.get(services, SdkPlugins.Service),
+      plugins,
       workspace: Context.get(services, Workspace.Service),
+      // The sweep is a no-op when nothing is suspended. ManagedRuntime owns
+      // the fiber so recovery never delays startup but still stops with the host.
+      start,
       close: transport.close,
     }
   }).pipe(Effect.onError(() => runtime.disposeEffect))

--- a/packages/sdk/src/promise.ts
+++ b/packages/sdk/src/promise.ts
@@ -19,13 +19,15 @@ export type Interface = Omit<OpenCodeClient, "plugin"> & {
 
 export async function create(options: CreateOptions = {}, embed: EmbeddedHost.EmbedOptions = {}): Promise<Interface> {
   const { plugins, ...hostOptions } = options
-  const host = await Effect.runPromise(EmbeddedHost.create(hostOptions, embed))
+  const initialPlugins = plugins?.length ? plugins.map(await loadAdapter()) : []
+  const host = await Effect.runPromise(
+    EmbeddedHost.create(hostOptions, embed, initialPlugins).pipe(Effect.tap((host) => host.start)),
+  )
   const client = OpenCode.make({ baseUrl: "http://opencode.local", fetch: host.fetch })
   const register = async (plugin: Plugin.Plugin) => {
-    const { PluginPromise } = await import("@opencode-ai/core/plugin/promise")
-    return host.runtime.runPromise(host.plugins.register(PluginPromise.fromPromise(plugin)))
+    const fromPromise = await loadAdapter()
+    return host.runtime.runPromise(host.plugins.register(fromPromise(plugin)))
   }
-  for (const plugin of plugins ?? []) await register(plugin)
 
   return {
     ...client,
@@ -35,4 +37,9 @@ export async function create(options: CreateOptions = {}, embed: EmbeddedHost.Em
     close: host.close,
     [Symbol.asyncDispose]: host.close,
   }
+}
+
+async function loadAdapter() {
+  const { PluginPromise } = await import("@opencode-ai/core/plugin/promise")
+  return PluginPromise.fromPromise
 }

--- a/packages/sdk/test/embedded.test.ts
+++ b/packages/sdk/test/embedded.test.ts
@@ -461,9 +461,12 @@ it.live("starts recovery after Effect registration layers finish", () =>
           order.push("plugin")
         }),
       )
-      const application = registration.pipe(
-        Layer.provideMerge(fixture.sdk.OpenCode.layerDeferred({}, { overrides: [[SessionRestart.node, restart]] })),
-        fixture.sdk.OpenCode.start,
+      const application = fixture.sdk.OpenCode.layerWith(
+        registration,
+        {},
+        {
+          overrides: [[SessionRestart.node, restart]],
+        },
       )
 
       yield* Layer.build(application)
@@ -500,9 +503,12 @@ it.live("disposes the Effect host when a registration layer fails", () =>
           yield* Effect.fail(new Error("registration failed"))
         }),
       )
-      const application = registration.pipe(
-        Layer.provideMerge(fixture.sdk.OpenCode.layerDeferred({}, { overrides: [[SessionRestart.node, restart]] })),
-        fixture.sdk.OpenCode.start,
+      const application = fixture.sdk.OpenCode.layerWith(
+        registration,
+        {},
+        {
+          overrides: [[SessionRestart.node, restart]],
+        },
       )
 
       const exit = yield* Layer.build(application).pipe(Effect.scoped, Effect.exit)

--- a/packages/sdk/test/embedded.test.ts
+++ b/packages/sdk/test/embedded.test.ts
@@ -6,6 +6,7 @@ import { OpenAIChat } from "@opencode-ai/ai/protocols"
 import { TestLLM } from "@opencode-ai/ai/testing"
 import { llmClient } from "@opencode-ai/core/effect/app-node-platform"
 import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
+import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
 import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
 import { Deferred, Effect, Fiber, Latch, Layer, Option, Ref, Schema, Stream } from "effect"
@@ -440,6 +441,76 @@ it.live("embedded client is available as a Layer service", () =>
       expect(created.id).toBe(id)
     }).pipe(Effect.provide(fixture.sdk.OpenCode.layer()))
   }),
+)
+
+it.live("starts recovery after Effect registration layers finish", () =>
+  withEmbedded("opencode-embedded-start-", (fixture) =>
+    Effect.gen(function* () {
+      const order: string[] = []
+      const recovered = yield* Deferred.make<void>()
+      const restart = Layer.mock(SessionRestart.Service, {
+        resumeSuspendedSessions: Effect.sync(() => {
+          order.push("recovery")
+        }).pipe(Effect.andThen(Deferred.succeed(recovered, undefined))),
+      })
+      const registration = Layer.effectDiscard(
+        Effect.gen(function* () {
+          const opencode = yield* fixture.sdk.OpenCode.Service
+          yield* Effect.sleep("50 millis")
+          yield* opencode.plugin({ id: "startup", effect: () => Effect.void })
+          order.push("plugin")
+        }),
+      )
+      const application = registration.pipe(
+        Layer.provideMerge(fixture.sdk.OpenCode.layerDeferred({}, { overrides: [[SessionRestart.node, restart]] })),
+        fixture.sdk.OpenCode.start,
+      )
+
+      yield* Layer.build(application)
+      yield* Deferred.await(recovered).pipe(Effect.timeout("2 seconds"))
+      expect(order).toEqual(["plugin", "recovery"])
+    }),
+  ),
+)
+
+it.live("disposes the Effect host when a registration layer fails", () =>
+  withEmbedded("opencode-embedded-start-failure-", (fixture) =>
+    Effect.gen(function* () {
+      let disposed = false
+      let recovered = false
+      const restart = Layer.effect(
+        SessionRestart.Service,
+        Effect.acquireRelease(
+          Effect.succeed(
+            SessionRestart.Service.of({
+              resumeSuspendedSessions: Effect.sync(() => {
+                recovered = true
+              }),
+            }),
+          ),
+          () =>
+            Effect.sync(() => {
+              disposed = true
+            }),
+        ),
+      )
+      const registration = Layer.effectDiscard(
+        Effect.gen(function* () {
+          yield* fixture.sdk.OpenCode.Service
+          yield* Effect.fail(new Error("registration failed"))
+        }),
+      )
+      const application = registration.pipe(
+        Layer.provideMerge(fixture.sdk.OpenCode.layerDeferred({}, { overrides: [[SessionRestart.node, restart]] })),
+        fixture.sdk.OpenCode.start,
+      )
+
+      const exit = yield* Layer.build(application).pipe(Effect.scoped, Effect.exit)
+      expect(exit._tag).toBe("Failure")
+      expect(disposed).toBe(true)
+      expect(recovered).toBe(false)
+    }),
+  ),
 )
 
 it.live("configures workspace providers through the SDK facade", () =>

--- a/packages/sdk/test/embedded.test.ts
+++ b/packages/sdk/test/embedded.test.ts
@@ -469,7 +469,8 @@ it.live("starts recovery after Effect registration layers finish", () =>
         },
       )
 
-      yield* Layer.build(application)
+      // Reusing a memoized application layer must not launch another recovery sweep.
+      yield* Layer.build(Layer.merge(application, application))
       yield* Deferred.await(recovered).pipe(Effect.timeout("2 seconds"))
       expect(order).toEqual(["plugin", "recovery"])
     }),

--- a/packages/sdk/test/promise.test.ts
+++ b/packages/sdk/test/promise.test.ts
@@ -1,8 +1,135 @@
 import { expect, test } from "bun:test"
 import { mkdir } from "node:fs/promises"
 import { join } from "node:path"
+import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
+import { SessionRestart } from "@opencode-ai/core/session/execution/restart"
+import { Effect, Layer } from "effect"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import { OpenCode, Session } from "../src"
+import { PromiseSdk } from "../src/promise"
+
+test("registers every initial Promise plugin before recovery starts", async () => {
+  const registered: string[] = []
+  const recovered = Promise.withResolvers<readonly string[]>()
+  const opencode = await PromiseSdk.create(
+    {
+      plugins: [
+        { id: "first", setup() {} },
+        { id: "second", setup() {} },
+      ],
+    },
+    {
+      overrides: [
+        [
+          SdkPlugins.node,
+          Layer.mock(SdkPlugins.Service, {
+            register: (plugin) =>
+              Effect.sync(() => {
+                registered.push(plugin.id)
+              }),
+            all: () => [],
+          }),
+        ],
+        [
+          SessionRestart.node,
+          Layer.mock(SessionRestart.Service, {
+            resumeSuspendedSessions: Effect.sync(() => {
+              recovered.resolve([...registered])
+            }),
+          }),
+        ],
+      ],
+    },
+  )
+
+  try {
+    expect(await recovered.promise).toEqual(["first", "second"])
+  } finally {
+    await opencode.close()
+  }
+})
+
+test("does not build the host when initial Promise plugin construction fails", async () => {
+  const failure = new Error("plugin construction failed")
+  let built = false
+  const error = await PromiseSdk.create(
+    {
+      plugins: [
+        {
+          get id(): string {
+            throw failure
+          },
+          setup() {},
+        },
+      ],
+    },
+    {
+      overrides: [
+        [
+          SdkPlugins.node,
+          Layer.effect(
+            SdkPlugins.Service,
+            Effect.sync(() => {
+              built = true
+              return SdkPlugins.Service.of({
+                register: () => Effect.void,
+                all: () => [],
+              })
+            }),
+          ),
+        ],
+      ],
+    },
+  ).catch((error: unknown) => error)
+
+  expect(error).toBeInstanceOf(Error)
+  expect(String(error)).toContain(failure.message)
+  expect(built).toBe(false)
+})
+
+test("disposes the host when initial Promise plugin registration fails", async () => {
+  const failure = new Error("plugin registration failed")
+  let disposed = false
+  let recovered = false
+  const error = await PromiseSdk.create(
+    { plugins: [{ id: "broken", setup() {} }] },
+    {
+      overrides: [
+        [
+          SdkPlugins.node,
+          Layer.effect(
+            SdkPlugins.Service,
+            Effect.acquireRelease(
+              Effect.succeed(
+                SdkPlugins.Service.of({
+                  register: () => Effect.die(failure),
+                  all: () => [],
+                }),
+              ),
+              () =>
+                Effect.sync(() => {
+                  disposed = true
+                }),
+            ),
+          ),
+        ],
+        [
+          SessionRestart.node,
+          Layer.mock(SessionRestart.Service, {
+            resumeSuspendedSessions: Effect.sync(() => {
+              recovered = true
+            }),
+          }),
+        ],
+      ],
+    },
+  ).catch((error: unknown) => error)
+
+  expect(error).toBeInstanceOf(Error)
+  expect(String(error)).toContain(failure.message)
+  expect(disposed).toBe(true)
+  expect(recovered).toBe(false)
+})
 
 test("Promise host uses the embedded router and releases plugins", async () => {
   await using directory = await tmpdir("opencode-promise-sdk-")

--- a/packages/sdk/test/promise.test.ts
+++ b/packages/sdk/test/promise.test.ts
@@ -49,44 +49,6 @@ test("registers every initial Promise plugin before recovery starts", async () =
   }
 })
 
-test("does not build the host when initial Promise plugin construction fails", async () => {
-  const failure = new Error("plugin construction failed")
-  let built = false
-  const error = await PromiseSdk.create(
-    {
-      plugins: [
-        {
-          get id(): string {
-            throw failure
-          },
-          setup() {},
-        },
-      ],
-    },
-    {
-      overrides: [
-        [
-          SdkPlugins.node,
-          Layer.effect(
-            SdkPlugins.Service,
-            Effect.sync(() => {
-              built = true
-              return SdkPlugins.Service.of({
-                register: () => Effect.void,
-                all: () => [],
-              })
-            }),
-          ),
-        ],
-      ],
-    },
-  ).catch((error: unknown) => error)
-
-  expect(error).toBeInstanceOf(Error)
-  expect(String(error)).toContain(failure.message)
-  expect(built).toBe(false)
-})
-
 test("disposes the host when initial Promise plugin registration fails", async () => {
   const failure = new Error("plugin registration failed")
   let disposed = false

--- a/packages/www/src/docs/content/build/sdk.mdx
+++ b/packages/www/src/docs/content/build/sdk.mdx
@@ -141,8 +141,30 @@ const session = await Effect.runPromise(program)
 
 Effect applications can contribute plugins from ordinary registration layers.
 The registration layer may depend on `OpenCode.Service` and any other services
-needed to construct the plugin; `OpenCode.layer()` remains unaware of those
-features.
+needed to construct the plugin; the host layer remains unaware of those features:
 
-Use `OpenCode.layer()` for dependency injection. The Effect-native Workerd
-entrypoint is `@opencode-ai/sdk/workerd/effect`.
+```ts
+import { OpenCode } from "@opencode-ai/sdk/effect"
+import { Effect, Layer } from "effect"
+import myPlugin from "./my-plugin"
+
+const PluginLive = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const opencode = yield* OpenCode.Service
+    yield* opencode.plugin(myPlugin)
+  }),
+)
+
+const ApplicationLive = PluginLive.pipe(Layer.provideMerge(OpenCode.layerDeferred()), OpenCode.start)
+```
+
+`OpenCode.start` runs after the complete application layer has built. This
+ensures every registration layer succeeds before suspended Sessions resume; if
+registration fails, the host is released without starting recovery. Direct
+`OpenCode.create()` and `OpenCode.layer()` calls start recovery automatically;
+use `layerDeferred` only when registration layers establish the startup
+boundary.
+
+The Effect-native Workerd entrypoint is `@opencode-ai/sdk/workerd/effect`; it
+exports matching `Service`, `layerDeferred`, and `start` values for the same
+composition pattern.

--- a/packages/www/src/docs/content/build/sdk.mdx
+++ b/packages/www/src/docs/content/build/sdk.mdx
@@ -155,16 +155,14 @@ const PluginLive = Layer.effectDiscard(
   }),
 )
 
-const ApplicationLive = PluginLive.pipe(Layer.provideMerge(OpenCode.layerDeferred()), OpenCode.start)
+const OpenCodeLive = OpenCode.layerWith(PluginLive)
 ```
 
-`OpenCode.start` runs after the complete application layer has built. This
-ensures every registration layer succeeds before suspended Sessions resume; if
-registration fails, the host is released without starting recovery. Direct
-`OpenCode.create()` and `OpenCode.layer()` calls start recovery automatically;
-use `layerDeferred` only when registration layers establish the startup
-boundary.
+`OpenCode.layerWith` supplies `OpenCode.Service` to the registration layer and
+starts recovery only after that layer succeeds. If registration fails, the host
+is released without starting recovery. Direct `OpenCode.create()` and
+`OpenCode.layer()` calls start recovery automatically.
 
 The Effect-native Workerd entrypoint is `@opencode-ai/sdk/workerd/effect`; it
-exports matching `Service`, `layerDeferred`, and `start` values for the same
-composition pattern.
+exports matching `Service` and `layerWith` values for the same composition
+pattern.


### PR DESCRIPTION
## What

- Registers every initial Promise plugin before suspended-session recovery can boot a Location.
- Adds an atomic `layerWith` constructor for Effect applications whose plugin registration comes from dependent Layers.
- Preserves automatic recovery for existing `OpenCode.create()` and `OpenCode.layer()` consumers.
- Disposes an allocated host when initial registration or an Effect registration Layer fails.

## Before / After

**Before:** Embedded host construction immediately forked recovery. Initial Promise plugins were adapted and registered afterward, and Effect registration Layers built outside the already-started host. A recovered Location could snapshot `SdkPlugins` before those contributions arrived, allowing its first plugin generation to run without them. Promise initialization failure after host creation also left the host undisposed.

**After:** Promise plugins are adapted before host allocation, registered inside host construction, and only then followed by recovery. Effect applications pass their registration Layer to `layerWith()`, which supplies `OpenCode.Service`, waits for successful registration, and then starts recovery. Failures release the host without launching recovery, and callers cannot obtain an unstarted public service.

## How

- `packages/sdk/src/internal/host.ts` separates internal host construction from recovery startup, seeds initial Effect plugins first, and makes startup idempotent when Effect reuses a Layer.
- `packages/sdk/src/promise.ts` lazily loads the Promise adapter once per initial plugin set, then supplies adapted plugins to the host startup boundary.
- `packages/sdk/src/effect/opencode.ts` keeps `create()` and `layer()` auto-starting while `layerWith()` owns registration, recovery ordering, and scoped cleanup as one Layer constructor.
- `packages/sdk/src/effect/workerd.ts` exposes the same atomic Layer composition surface and centralizes Workerd profile conversion.
- SDK tests cover Promise and Effect ordering, registration failure cleanup, same-Layer reuse, and preservation of existing Layer behavior.

## Scope

- This gates plugin construction and registration, not every Location-scoped plugin `setup`; existing `PluginSupervisor.flush` barriers continue to own activation readiness.
- Late `opencode.plugin(...)` registration remains unchanged.
- No Protocol, Server `HttpApi`, persisted-data, or configuration changes.

## Testing

- `bun typecheck` in `packages/sdk`
- `bun run test` in `packages/sdk` (27 passed)
- `bun run build` in `packages/sdk`
- `bun run verify:package` in `packages/sdk` (clean packed consumer, local Wrangler dry-run, and local Miniflare Durable Object health check)
- `bun typecheck`, `bun run check:generated`, and `bun run build` in `packages/www`
- Repository pre-push monorepo typecheck (32 packages passed)

## Flow

```mermaid
sequenceDiagram
  participant App
  participant SDK
  participant Plugins as SDK plugin store
  participant Recovery as Session recovery

  alt Promise host
    App->>SDK: create({ plugins })
    SDK->>SDK: adapt imported plugins
    SDK->>Plugins: register in order
  else Effect Layer application
    App->>SDK: layerWith(registration)
    SDK->>App: supply OpenCode.Service to registration
    App->>Plugins: register contributed plugins
  end
  SDK->>Recovery: fork suspended-session sweep
  Recovery->>Plugins: boot Location with complete snapshot
```
