### PR TITLE
feat(command): execute plugin callbacks

### DIFF
--- a/packages/app/src/composer/submit.ts
+++ b/packages/app/src/composer/submit.ts
@@ -274,15 +274,8 @@ async function sendCommand(
   const request = await buildSubmissionRequest(session, value)
   await session.api.command({
     sessionID: session.id,
-    id: value.id,
     command: command.command,
-    arguments: command.arguments,
-    agent: value.selection.agent,
-    model: {
-      id: value.selection.model.modelID,
-      providerID: value.selection.model.providerID,
-      variant: value.selection.variant,
-    },
+    text: command.arguments,
     files: request.files.map((file) => ({ uri: file.uri, name: file.name, mention: file.mention })),
     agents: request.agents,
     skills: request.skills,

--- a/packages/cli/src/acp/event.ts
+++ b/packages/cli/src/acp/event.ts
@@ -76,6 +76,7 @@ export async function streamTurn(input: {
   readonly cwd: string
   readonly start: TurnStart
   readonly writeTextFile: boolean
+  readonly action?: boolean
   readonly submit: (signal: AbortSignal) => Promise<unknown>
   readonly control: TurnControl
   readonly childSessionUpdate?: (update: ChildSessionUpdate) => Promise<void>
@@ -345,6 +346,11 @@ export async function streamTurn(input: {
     await input.submit(control.admission.signal).catch((error) => {
       if (!control.cancelled) throw error
     })
+    if (input.action) {
+      streamController.abort()
+      await completed.catch(() => {})
+      return response(undefined, undefined, "succeeded", control.cancelled, undefined)
+    }
     if (control.cancelled) {
       await input.client.session.interrupt({ sessionID: input.sessionID }).catch(() => {})
       if (!started) {

--- a/packages/cli/src/acp/service.ts
+++ b/packages/cli/src/acp/service.ts
@@ -326,6 +326,7 @@ export function make(input: { readonly client: OpenCodeClient; readonly connecti
         cwd: state.cwd,
         start: prepared.start,
         writeTextFile: capabilities.writeTextFile,
+        action: prepared.command !== undefined,
         control,
         connectionSignal: input.connection.signal,
         sessionSignal: state.abort.signal,
@@ -377,9 +378,8 @@ async function submitPrompt(client: OpenCodeClient, session: Attached, prompt: P
     return client.session.command(
       {
         sessionID: session.id,
-        id: prompt.start.id,
         command: prompt.command.name,
-        arguments: prompt.slash?.args,
+        text: prompt.slash?.args ?? "",
         files: prompt.files,
         delivery: "steer",
       },

--- a/packages/cli/test/acp/event.test.ts
+++ b/packages/cli/test/acp/event.test.ts
@@ -121,3 +121,42 @@ test("acp prompt resolves after ordered turn updates", async () => {
     controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`))
   }
 })
+
+test("acp action resolves without prompt lifecycle events", async () => {
+  const encoder = new TextEncoder()
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      if (new URL(request.url).pathname !== "/api/event") return new Response(null, { status: 404 })
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ type: "server.connected", data: {} })}\n\n`))
+          },
+        }),
+        { headers: { "content-type": "text/event-stream" } },
+      )
+    },
+  })
+
+  try {
+    const response = await streamTurn({
+      client: OpenCode.make({ baseUrl: server.url.toString() }),
+      connection: {
+        sessionUpdate: async () => {},
+        requestPermission: async () => ({ outcome: { outcome: "cancelled" } }),
+      },
+      sessionID: "ses_test",
+      cwd: "/workspace",
+      start: { type: "input", id: "msg_action" },
+      writeTextFile: false,
+      action: true,
+      control: { cancelled: false, admission: new AbortController() },
+      submit: async () => {},
+    })
+
+    expect(response).toMatchObject({ stopReason: "end_turn" })
+  } finally {
+    await server.stop(true)
+  }
+})

--- a/packages/cli/test/acp/service-fixture.ts
+++ b/packages/cli/test/acp/service-fixture.ts
@@ -87,7 +87,6 @@ export const planAgent = {
 export const reviewCommand = {
   name: "review",
   description: "Review changes",
-  template: "",
 } satisfies CommandInfo
 
 export const verifySkill = {

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -255,18 +255,14 @@ export type SessionPromptOperation<E = never> = (input: SessionPromptInput) => E
 
 export type SessionCommandInput = {
   readonly sessionID: Session.ID
-  readonly id?: SessionMessage.ID | undefined
   readonly command: string
-  readonly arguments?: string | undefined
-  readonly agent?: Agent.ID | undefined
-  readonly model?: Model.Ref | undefined
+  readonly text: string
   readonly files?: ReadonlyArray<PromptInput.FileAttachment> | undefined
   readonly agents?: ReadonlyArray<AgentAttachment> | undefined
   readonly skills?: ReadonlyArray<PromptInput.SkillAttachment> | undefined
   readonly delivery?: SessionInbox.Delivery | undefined
-  readonly resume?: boolean | undefined
 }
-export type SessionCommandOutput = SessionInbox.User
+export type SessionCommandOutput = void
 export type SessionCommandOperation<E = never> = (input: SessionCommandInput) => Effect.Effect<SessionCommandOutput, E>
 
 export type SessionSkillInput = {

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -440,21 +440,14 @@ const EndpointSessionCommand = (raw: RawClient["server.session"]) => (input: Ses
     raw["session.command"]({
       params: { sessionID: input["sessionID"] },
       payload: {
-        id: input["id"],
         command: input["command"],
-        arguments: input["arguments"],
-        agent: input["agent"],
-        model: input["model"],
+        text: input["text"],
         files: input["files"],
         agents: input["agents"],
         skills: input["skills"],
         delivery: input["delivery"],
-        resume: input["resume"],
       },
-    }).pipe(
-      Effect.mapError(mapClientError),
-      Effect.map((value) => value.data),
-    ),
+    }).pipe(Effect.mapError(mapClientError)),
   )
 
 const EndpointSessionSkill = (raw: RawClient["server.session"]) => (input: SessionSkillInput) =>

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -631,28 +631,24 @@ export function make(options: ClientOptions) {
           requestOptions,
         ).then((value) => value.data),
       command: (input: SessionCommandInput, requestOptions?: RequestOptions) =>
-        request<{ readonly data: SessionCommandOutput }>(
+        request<SessionCommandOutput>(
           {
             method: "POST",
             path: `/api/session/${encodeURIComponent(input.sessionID)}/command`,
             body: {
-              id: input["id"],
               command: input["command"],
-              arguments: input["arguments"],
-              agent: input["agent"],
-              model: input["model"],
+              text: input["text"],
               files: input["files"],
               agents: input["agents"],
               skills: input["skills"],
               delivery: input["delivery"],
-              resume: input["resume"],
             },
-            successStatus: 200,
-            declaredStatuses: [409, 400, 404, 500, 401],
-            empty: false,
+            successStatus: 204,
+            declaredStatuses: [404, 500, 400, 401],
+            empty: true,
           },
           requestOptions,
-        ).then((value) => value.data),
+        ),
       skill: (input: SessionSkillInput, requestOptions?: RequestOptions) =>
         request<SessionSkillOutput>(
           {

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -20,13 +20,6 @@ export type SessionForkBoundary = { type: "before"; messageID: string } | { type
 
 export type MoneyUSD = number
 
-export type TokenUsageInfo = {
-  input: number
-  output: number
-  reasoning: number
-  cache: { read: number; write: number }
-}
-
 export type LocationRef = { directory: string; workspaceID?: string }
 
 export type FileDiffInfo = {
@@ -50,104 +43,21 @@ export type SessionStatsToolUsage = {
 
 export type SessionStatsActivity = { date: string; steps: number }
 
-export type SessionMessageAgentSelected = {
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  type: "agent-switched"
-  agent: string
-  previous?: string
-}
-
 export type PromptBase64 = string
 
 export type PromptFileSource = { type: "inline" } | { type: "uri"; uri: string }
 
 export type PromptMention = { start: number; end: number; text: string }
 
-export type SessionMessageSynthetic = {
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  text: string
-  description?: string
-  type: "synthetic"
-}
-
-export type SessionMessageSystem = {
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  type: "system"
-  text: string
-  description?: string
-}
-
-export type SessionMessageSkill = {
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  type: "skill"
-  skill: string
-  name: string
-  text: string
-}
-
-export type SessionMessageShell = {
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number; completed?: number }
-  type: "shell"
-  shellID: string
-  command: string
-  status: "running" | "exited" | "timeout" | "killed"
-  exit?: number | "Infinity" | "-Infinity" | "NaN"
-  output?: { output: string; cursor: number; size: number; truncated: boolean }
-}
-
-export type SessionMessageProviderState = { [x: string]: JsonValue }
-
 export type SessionMessageToolStateStreaming = { status: "streaming"; input: string }
-
-export type SessionMessageToolStateRunning = {
-  status: "running"
-  input: { [x: string]: JsonValue }
-  metadata: { [x: string]: JsonValue }
-}
 
 export type ToolTextContent = { type: "text"; text: string }
 
-export type ToolFileContent = { type: "file"; uri: string; mime: string; name?: string | null }
-
 export type SessionStructuredError = { type: string; message: string; status?: number }
-
-export type SessionMessageCompactionRunning = {
-  type: "compaction"
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  status: "running"
-  reason: "auto" | "manual"
-  summary: string
-  recent: string
-}
-
-export type SessionMessageCompactionCompleted = {
-  type: "compaction"
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  status: "completed"
-  reason: "auto" | "manual"
-  summary: string
-  recent: string
-}
 
 export type SessionActive = { type: "running" }
 
 export type SessionInboxDelivery = "steer" | "queue"
-
-export type SessionInboxSyntheticPayload = { text: string; description?: string; metadata?: { [x: string]: JsonValue } }
 
 export type SessionInboxCompactionPayload = {}
 
@@ -156,19 +66,6 @@ export type InstructionEntryKey = string
 export type SessionGenerateResponse = { data: { text: string } }
 
 export type SessionInboxSyntheticPayload1 = { text: string; description?: string; metadata?: { [x: string]: any } }
-
-export type ShellInfo = {
-  id: string
-  status: "running" | "exited" | "timeout" | "killed"
-  command: string
-  cwd: string
-  shell: string
-  file: string
-  pid?: number
-  exit?: number
-  metadata: { [x: string]: any }
-  time: { started: number; completed?: number }
-}
 
 export type SessionMessageProviderState1 = { [x: string]: any }
 
@@ -180,40 +77,9 @@ export type ModelReasoningField = "reasoning" | "reasoning_content" | "reasoning
 
 export type ModelMaxTokensField = "max_completion_tokens" | "max_tokens"
 
-export type ModelCapabilities = {
-  tools: boolean
-  input: Array<string>
-  output: Array<string>
-  responsesWebsockets?: boolean
-}
-
-export type ModelVariant = {
-  id: string
-  settings?: { [x: string]: any }
-  headers?: { [x: string]: string }
-  body?: { [x: string]: any }
-}
-
 export type MoneyUSDPerMillionTokens = number
 
 export type GenerateTextResponse = { data: { text: string } }
-
-export type ProviderInfo = {
-  id: string
-  integrationID?: string
-  name: string
-  activation: "auto" | "enabled" | "disabled"
-  package: string
-  settings?: { [x: string]: any }
-  headers?: { [x: string]: string }
-  body?: { [x: string]: any }
-}
-
-export type FormWhen = {
-  key: string
-  op: "eq" | "neq"
-  value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
-}
 
 export type FormOption = { value: string; label: string; description?: string }
 
@@ -226,50 +92,6 @@ export type IntegrationEnvMethod = { type: "env"; names: Array<string> }
 export type ConnectionCredentialInfo = { type: "credential"; id: string; label: string }
 
 export type ConnectionEnvInfo = { type: "env"; name: string }
-
-export type IntegrationAttemptStatus =
-  | {
-      status: "pending"
-      time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-    }
-  | {
-      status: "complete"
-      time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-    }
-  | {
-      status: "failed"
-      message: string
-      time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-    }
-  | {
-      status: "expired"
-      time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-    }
-
-export type IntegrationCommandAttempt = {
-  attemptID: string
-  time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-}
-
-export type IntegrationCommandAttemptStatus =
-  | {
-      status: "pending"
-      message?: string
-      time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-    }
-  | {
-      status: "complete"
-      time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-    }
-  | {
-      status: "failed"
-      message: string
-      time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-    }
-  | {
-      status: "expired"
-      time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
-    }
 
 export type McpStatusConnected = { status: "connected" }
 
@@ -301,8 +123,6 @@ export type ProjectTime = { created: number; updated: number; initialized?: numb
 
 export type ProjectCurrent = { id: string; directory: string; canonical: string }
 
-export type FormMetadata = { [x: string]: JsonValue }
-
 export type FormValue = string | number | boolean | Array<string>
 
 export type PermissionSource = { type: "tool"; messageID: string; id: string }
@@ -310,6 +130,8 @@ export type PermissionSource = { type: "tool"; messageID: string; id: string }
 export type PermissionSavedInfo = { id: string; projectID: string; action: string; resource: string }
 
 export type FileSystemEntry = { path: string; type: "file" | "directory" }
+
+export type CommandInfo = { name: string; description?: string }
 
 export type SkillInfo = {
   id: string
@@ -351,19 +173,6 @@ export type SessionStatus =
 
 export type PtyTicketConnectToken = { ticket: string; expires_in: number }
 
-export type ShellInfo1 = {
-  id: string
-  status: "running" | "exited" | "timeout" | "killed"
-  command: string
-  cwd: string
-  shell: string
-  file: string
-  pid?: number
-  exit?: number
-  metadata: { [x: string]: JsonValue }
-  time: { started: number; completed?: number }
-}
-
 export type ReferenceLocalSource = { type: "local"; path: string; description?: string; hidden?: boolean }
 
 export type ReferenceGitSource = {
@@ -391,15 +200,6 @@ export type WebSearchProvider = { id: string; name: string }
 
 export type WebSearchResult = { url: string; title?: string; content?: string; time: { published?: number } }
 
-export type CommandInfo = {
-  name: string
-  template: string
-  description?: string
-  agent?: string
-  model?: ModelRef
-  subtask?: boolean
-}
-
 export type ProviderRequest = {
   settings: ProviderSettings
   headers: { [x: string]: string }
@@ -412,15 +212,11 @@ export type PluginInfo =
   | { id: string; source: PluginSource; status: "active"; tui: boolean }
   | { id?: string; source: PluginSource; status: "failed"; error: string; tui: boolean }
 
-export type SessionMessageLocationSwitched = {
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  type: "location-switched"
-  location: LocationRef
-  projectID?: string
-  subpath?: string
-  previous?: { location: LocationRef; projectID?: string; subpath?: string }
+export type TokenUsageInfo = {
+  input: number
+  output: number
+  reasoning: number
+  cache: { read: number; write: number }
 }
 
 export type SessionInboxMovePayload = { location: LocationRef; projectID: string; subpath?: string }
@@ -433,23 +229,22 @@ export type V2EventServerConnected = {
   data: {}
 }
 
-export type SessionRevert = { messageID: string; partID?: string; snapshot?: string; files?: Array<FileDiffInfo> }
-
 export type SessionStatsTools =
   | { mode: "none" }
   | { mode: "summary"; totals: SessionStatsToolTotals }
   | { mode: "detail"; totals: SessionStatsToolTotals; usage: Array<SessionStatsToolUsage> }
 
-export type SessionStatsModelUsage = { model: ModelRef; steps: number; tokens: TokenUsageInfo; cost: MoneyUSD }
+export type SessionMessageProviderState = { [x: string]: JsonValue }
 
-export type SessionMessageModelSelected = {
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  type: "model-switched"
-  model: ModelRef
-  previous?: ModelRef
+export type SessionMessageToolStateRunning = {
+  status: "running"
+  input: { [x: string]: JsonValue }
+  metadata: { [x: string]: JsonValue }
 }
+
+export type SessionInboxSyntheticPayload = { text: string; description?: string; metadata?: { [x: string]: JsonValue } }
+
+export type FormMetadata = { [x: string]: JsonValue }
 
 export type PromptFileAttachment = {
   data: PromptBase64
@@ -464,37 +259,9 @@ export type PromptAgentAttachment = { name: string; mention?: PromptMention }
 
 export type PromptSkillAttachment = { id: string; name: string; mention?: PromptMention }
 
-export type SessionMessageAssistantText = { type: "text"; text: string; state?: SessionMessageProviderState }
-
-export type SessionMessageAssistantReasoning = {
-  type: "reasoning"
-  text: string
-  state?: SessionMessageProviderState
-  time?: { created: number; completed?: number }
-}
-
-export type ToolContent = ToolTextContent | ToolFileContent
+export type ToolFileContent = { type: "file"; uri: string; mime: string; name?: string | null }
 
 export type SessionMessageAssistantRetry = { attempt: number; at: number; error: SessionStructuredError }
-
-export type SessionMessageCompactionFailed = {
-  type: "compaction"
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  status: "failed"
-  reason: "auto" | "manual"
-  error: SessionStructuredError
-}
-
-export type SessionInboxSynthetic = {
-  id: string
-  sessionID: string
-  timeCreated: number
-  type: "synthetic"
-  payload: SessionInboxSyntheticPayload
-  delivery: SessionInboxDelivery
-}
 
 export type SessionInboxCompaction = {
   id: string
@@ -740,36 +507,6 @@ export type SessionRetryScheduled = {
   data: { sessionID: string; assistantMessageID: string; attempt: number; at: number; error: SessionStructuredError }
 }
 
-export type SessionCompactionStarted = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.compaction.started"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: { sessionID: string; reason: "auto" | "manual"; recent: string; inputID?: string }
-}
-
-export type SessionCompactionEnded = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.compaction.ended"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: { sessionID: string; reason: "auto" | "manual"; text: string; recent: string }
-}
-
-export type SessionCompactionFailed = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.compaction.failed"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: { sessionID: string; reason: "auto" | "manual"; error: SessionStructuredError; inputID?: string }
-}
-
 export type SessionRevertCleared = {
   id: string
   created: number
@@ -788,16 +525,6 @@ export type SessionRevertCommitted = {
   durable: { aggregateID: string; seq: number; version: 1 }
   location?: LocationRef
   data: { sessionID: string; to: string }
-}
-
-export type SessionUsageRecorded = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.usage.recorded"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: { sessionID: string; source: "title" | "compaction"; cost: MoneyUSD; tokens: TokenUsageInfo }
 }
 
 export type ModelsDevRefreshed = {
@@ -843,15 +570,6 @@ export type AgentUpdated = {
   type: "agent.updated"
   location?: LocationRef
   data: {}
-}
-
-export type SessionUsageUpdated = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.usage.updated"
-  location?: LocationRef
-  data: { sessionID: string; cost: MoneyUSD; tokens: TokenUsageInfo }
 }
 
 export type SessionTextDelta = {
@@ -1150,78 +868,30 @@ export type McpResourcesChanged = {
   data: { server: string }
 }
 
-export type SessionShellStarted = {
+export type ShellInfo = {
   id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.shell.started"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: { sessionID: string; shell: ShellInfo }
+  status: "running" | "exited" | "timeout" | "killed"
+  command: string
+  cwd: string
+  shell: string
+  file: string
+  pid?: number
+  exit?: number
+  metadata: { [x: string]: any }
+  time: { started: number; completed?: number }
 }
 
-export type SessionShellEnded = {
+export type ShellInfo1 = {
   id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.shell.ended"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: {
-    sessionID: string
-    shell: ShellInfo
-    output: { output: string; cursor: number; size: number; truncated: boolean }
-  }
-}
-
-export type ShellCreated = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "shell.created"
-  location?: LocationRef
-  data: { info: ShellInfo }
-}
-
-export type SessionStepEnded = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.step.ended"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: {
-    sessionID: string
-    assistantMessageID: string
-    finish: "stop" | "length" | "tool-calls" | "content-filter" | "error" | "unknown"
-    rawFinish?: string
-    providerState?: SessionMessageProviderState1
-    cost: MoneyUSD
-    tokens: TokenUsageInfo
-    snapshot?: string
-    files?: Array<string>
-  }
-}
-
-export type SessionStepFailed = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.step.failed"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: {
-    sessionID: string
-    assistantMessageID: string
-    error: SessionStructuredError
-    finish?: "content-filter"
-    rawFinish?: string
-    providerState?: SessionMessageProviderState1
-    cost?: MoneyUSD
-    tokens?: TokenUsageInfo
-    snapshot?: string
-    files?: Array<string>
-  }
+  status: "running" | "exited" | "timeout" | "killed"
+  command: string
+  cwd: string
+  shell: string
+  file: string
+  pid?: number
+  exit?: number
+  metadata: { [x: string]: JsonValue }
+  time: { started: number; completed?: number }
 }
 
 export type SessionTextEnded = {
@@ -1285,10 +955,65 @@ export type SessionToolCalled = {
 
 export type ToolContent1 = ToolTextContent | ToolFileContent1
 
+export type SessionCompactionStarted = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.compaction.started"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: { sessionID: string; reason: "auto" | "manual"; recent: string; inputID?: string }
+}
+
+export type SessionCompactionEnded = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.compaction.ended"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: { sessionID: string; reason: "auto" | "manual"; text: string; recent: string }
+}
+
+export type SessionCompactionFailed = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.compaction.failed"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: { sessionID: string; reason: "auto" | "manual"; error: SessionStructuredError; inputID?: string }
+}
+
 export type ModelCompatibility = {
   reasoningField?: ModelReasoningField
   maxTokensField?: ModelMaxTokensField
   requireFinishReason?: boolean
+}
+
+export type ModelVariant = {
+  id: string
+  settings?: { [x: string]: any }
+  headers?: { [x: string]: string }
+  body?: { [x: string]: any }
+}
+
+export type ProviderInfo = {
+  id: string
+  integrationID?: string
+  name: string
+  activation: "auto" | "enabled" | "disabled"
+  package: string
+  settings?: { [x: string]: any }
+  headers?: { [x: string]: string }
+  body?: { [x: string]: any }
+}
+
+export type ModelCapabilities = {
+  tools: boolean
+  input: Array<string>
+  output: Array<string>
+  responsesWebsockets?: boolean
 }
 
 export type ModelCost = {
@@ -1296,71 +1021,6 @@ export type ModelCost = {
   input: MoneyUSDPerMillionTokens
   output: MoneyUSDPerMillionTokens
   cache: { read: MoneyUSDPerMillionTokens; write: MoneyUSDPerMillionTokens }
-}
-
-export type FormNumberField = {
-  key: string
-  title?: string
-  description?: string
-  required?: boolean
-  when?: Array<FormWhen>
-  type: "number"
-  minimum?: number | "Infinity" | "-Infinity" | "NaN"
-  maximum?: number | "Infinity" | "-Infinity" | "NaN"
-  default?: number | "Infinity" | "-Infinity" | "NaN"
-}
-
-export type FormIntegerField = {
-  key: string
-  title?: string
-  description?: string
-  required?: boolean
-  when?: Array<FormWhen>
-  type: "integer"
-  minimum?: number | "Infinity" | "-Infinity" | "NaN"
-  maximum?: number | "Infinity" | "-Infinity" | "NaN"
-  default?: number | "Infinity" | "-Infinity" | "NaN"
-}
-
-export type FormBooleanField = {
-  key: string
-  title?: string
-  description?: string
-  required?: boolean
-  when?: Array<FormWhen>
-  type: "boolean"
-  default?: boolean
-}
-
-export type FormStringField = {
-  key: string
-  title?: string
-  description?: string
-  required?: boolean
-  when?: Array<FormWhen>
-  type: "string"
-  format?: "email" | "uri" | "date" | "date-time"
-  minLength?: number
-  maxLength?: number
-  pattern?: string
-  placeholder?: string
-  default?: string
-  options?: Array<FormOption>
-  custom?: boolean
-}
-
-export type FormMultiselectField = {
-  key: string
-  title?: string
-  description?: string
-  required?: boolean
-  when?: Array<FormWhen>
-  type: "multiselect"
-  options: Array<FormOption>
-  minItems?: number
-  maxItems?: number
-  custom?: boolean
-  default?: Array<string>
 }
 
 export type ConnectionInfo = ConnectionCredentialInfo | ConnectionEnvInfo
@@ -1440,6 +1100,340 @@ export type PtyUpdated = {
   data: { info: Pty }
 }
 
+export type SessionStatusUpdated = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.status"
+  location?: LocationRef
+  data: { sessionID: string; status: SessionStatus }
+}
+
+export type ReferenceSource = ReferenceLocalSource | ReferenceGitSource
+
+export type WorktreeList = Array<WorktreeDirectory>
+
+export type VcsInfo = { branch: VcsBranch }
+
+export type PermissionRuleset = Array<PermissionRule>
+
+export type SessionStatsModelUsage = { model: ModelRef; steps: number; tokens: TokenUsageInfo; cost: MoneyUSD }
+
+export type SessionStepEnded = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.step.ended"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: {
+    sessionID: string
+    assistantMessageID: string
+    finish: "stop" | "length" | "tool-calls" | "content-filter" | "error" | "unknown"
+    rawFinish?: string
+    providerState?: SessionMessageProviderState1
+    cost: MoneyUSD
+    tokens: TokenUsageInfo
+    snapshot?: string
+    files?: Array<string>
+  }
+}
+
+export type SessionUsageRecorded = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.usage.recorded"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: { sessionID: string; source: "title" | "compaction"; cost: MoneyUSD; tokens: TokenUsageInfo }
+}
+
+export type SessionUsageUpdated = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.usage.updated"
+  location?: LocationRef
+  data: { sessionID: string; cost: MoneyUSD; tokens: TokenUsageInfo }
+}
+
+export type SessionStepFailed = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.step.failed"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: {
+    sessionID: string
+    assistantMessageID: string
+    error: SessionStructuredError
+    finish?: "content-filter"
+    rawFinish?: string
+    providerState?: SessionMessageProviderState1
+    cost?: MoneyUSD
+    tokens?: TokenUsageInfo
+    snapshot?: string
+    files?: Array<string>
+  }
+}
+
+export type SessionInboxMove = {
+  id: string
+  sessionID: string
+  timeCreated: number
+  type: "move"
+  payload: SessionInboxMovePayload
+  delivery: SessionInboxDelivery
+}
+
+export type SessionRevert = { messageID: string; partID?: string; snapshot?: string; files?: Array<FileDiffInfo> }
+
+export type SessionMessageAgentSelected = {
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  type: "agent-switched"
+  agent: string
+  previous?: string
+}
+
+export type SessionMessageModelSelected = {
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  type: "model-switched"
+  model: ModelRef
+  previous?: ModelRef
+}
+
+export type SessionMessageLocationSwitched = {
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  type: "location-switched"
+  location: LocationRef
+  projectID?: string
+  subpath?: string
+  previous?: { location: LocationRef; projectID?: string; subpath?: string }
+}
+
+export type SessionMessageSynthetic = {
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  text: string
+  description?: string
+  type: "synthetic"
+}
+
+export type SessionMessageSystem = {
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  type: "system"
+  text: string
+  description?: string
+}
+
+export type SessionMessageSkill = {
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  type: "skill"
+  skill: string
+  name: string
+  text: string
+}
+
+export type SessionMessageShell = {
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number; completed?: number }
+  type: "shell"
+  shellID: string
+  command: string
+  status: "running" | "exited" | "timeout" | "killed"
+  exit?: number | ("Infinity" | "-Infinity" | "NaN")
+  output?: { output: string; cursor: number; size: number; truncated: boolean }
+}
+
+export type SessionMessageCompactionRunning = {
+  type: "compaction"
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  status: "running"
+  reason: "auto" | "manual"
+  summary: string
+  recent: string
+}
+
+export type SessionMessageCompactionCompleted = {
+  type: "compaction"
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  status: "completed"
+  reason: "auto" | "manual"
+  summary: string
+  recent: string
+}
+
+export type SessionMessageCompactionFailed = {
+  type: "compaction"
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  status: "failed"
+  reason: "auto" | "manual"
+  error: SessionStructuredError
+}
+
+export type SessionMessageAssistantText = { type: "text"; text: string; state?: SessionMessageProviderState }
+
+export type SessionMessageAssistantReasoning = {
+  type: "reasoning"
+  text: string
+  state?: SessionMessageProviderState
+  time?: { created: number; completed?: number }
+}
+
+export type SessionInboxSynthetic = {
+  id: string
+  sessionID: string
+  timeCreated: number
+  type: "synthetic"
+  payload: SessionInboxSyntheticPayload
+  delivery: SessionInboxDelivery
+}
+
+export type FormWhen = {
+  key: string
+  op: "eq" | "neq"
+  value: string | (number | ("Infinity" | "-Infinity" | "NaN")) | boolean
+}
+
+export type ToolContent = ToolTextContent | ToolFileContent
+
+export type SessionForked = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.forked"
+  durable: { aggregateID: string; seq: number; version: 2 }
+  location?: LocationRef
+  data: {
+    sessionID: string
+    parentID: string
+    boundary: SessionForkBoundary
+    instructions?: { [x: string]: string }
+    instructionEntries?: InstructionEntrySnapshot
+  }
+}
+
+export type SessionShellStarted = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.shell.started"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: { sessionID: string; shell: ShellInfo }
+}
+
+export type SessionShellEnded = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.shell.ended"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: {
+    sessionID: string
+    shell: ShellInfo
+    output: { output: string; cursor: number; size: number; truncated: boolean }
+  }
+}
+
+export type ShellCreated = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "shell.created"
+  location?: LocationRef
+  data: { info: ShellInfo }
+}
+
+export type SessionToolSuccess = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.tool.success"
+  durable: { aggregateID: string; seq: number; version: 2 }
+  location?: LocationRef
+  data: {
+    sessionID: string
+    assistantMessageID: string
+    id: string
+    content: [ToolContent1, ...Array<ToolContent1>]
+    metadata?: { [x: string]: JsonValue }
+    executed: boolean
+    resultState?: SessionMessageProviderState1
+  }
+}
+
+export type SessionToolFailed = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.tool.failed"
+  durable: { aggregateID: string; seq: number; version: 2 }
+  location?: LocationRef
+  data: {
+    sessionID: string
+    assistantMessageID: string
+    id: string
+    error: SessionStructuredError
+    content?: [ToolContent1, ...Array<ToolContent1>]
+    metadata?: { [x: string]: JsonValue }
+    executed: boolean
+    resultState?: SessionMessageProviderState1
+  }
+}
+
+export type ModelInfo = {
+  id: string
+  modelID: string
+  providerID: string
+  family?: string
+  name: string
+  compatibility?: ModelCompatibility
+  package?: string
+  settings?: { [x: string]: any }
+  headers?: { [x: string]: string }
+  body?: { [x: string]: any }
+  capabilities: ModelCapabilities
+  variants: Array<ModelVariant>
+  time: { released: number }
+  cost: Array<ModelCost>
+  status: "alpha" | "beta" | "deprecated" | "active"
+  enabled: boolean
+  limit: { context: number; input?: number; output: number }
+}
+
+export type FormState = { status: "pending" } | { status: "answered"; answer: FormAnswer } | { status: "cancelled" }
+
+export type FormReplied = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "form.replied"
+  location?: LocationRef
+  data: { id: string; sessionID: string; answer: FormAnswer }
+}
+
 export type FormStringField1 = {
   key: string
   title?: string
@@ -1504,221 +1498,6 @@ export type FormMultiselectField1 = {
   custom?: boolean
   default?: Array<string>
 }
-
-export type SessionStatusUpdated = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.status"
-  location?: LocationRef
-  data: { sessionID: string; status: SessionStatus }
-}
-
-export type ReferenceSource = ReferenceLocalSource | ReferenceGitSource
-
-export type WorktreeList = Array<WorktreeDirectory>
-
-export type VcsInfo = { branch: VcsBranch }
-
-export type PermissionRuleset = Array<PermissionRule>
-
-export type SessionInboxMove = {
-  id: string
-  sessionID: string
-  timeCreated: number
-  type: "move"
-  payload: SessionInboxMovePayload
-  delivery: SessionInboxDelivery
-}
-
-export type SessionInfo = {
-  id: string
-  parentID?: string
-  fork?: { sessionID: string; boundary: SessionForkBoundary }
-  projectID: string
-  agent?: string
-  model?: ModelRef
-  cost: MoneyUSD
-  tokens: TokenUsageInfo
-  outcome?: "succeeded" | "failed" | "interrupted"
-  time: { created: number; updated: number; idle?: number; viewed?: number; archived?: number }
-  title?: string
-  location: LocationRef
-  subpath?: string
-  revert?: SessionRevert
-}
-
-export type SessionRevertStaged = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.revert.staged"
-  durable: { aggregateID: string; seq: number; version: 1 }
-  location?: LocationRef
-  data: { sessionID: string; revert: SessionRevert }
-}
-
-export type SessionStatsInfo = {
-  range: { from: number; to: number }
-  sessions: number
-  subagents: number
-  prompts: number
-  steps: number
-  tokens: TokenUsageInfo
-  cost: MoneyUSD
-  tools: SessionStatsTools
-  activeDays: number
-  streak: number
-  activity: Array<SessionStatsActivity>
-  models: Array<SessionStatsModelUsage>
-}
-
-export type SessionMessageUser = {
-  id: string
-  metadata?: { [x: string]: JsonValue }
-  time: { created: number }
-  text: string
-  files?: Array<PromptFileAttachment>
-  agents?: Array<PromptAgentAttachment>
-  skills?: Array<PromptSkillAttachment>
-  type: "user"
-}
-
-export type SessionInboxUserPayload = {
-  text: string
-  files?: Array<PromptFileAttachment>
-  agents?: Array<PromptAgentAttachment>
-  skills?: Array<PromptSkillAttachment>
-  metadata?: { [x: string]: JsonValue }
-}
-
-export type SessionInboxUserPayload1 = {
-  text: string
-  files?: Array<PromptFileAttachment>
-  agents?: Array<PromptAgentAttachment>
-  skills?: Array<PromptSkillAttachment>
-  metadata?: { [x: string]: any }
-}
-
-export type SessionMessageToolStateCompleted = {
-  status: "completed"
-  input: { [x: string]: JsonValue }
-  content: [ToolContent, ...Array<ToolContent>]
-  metadata?: { [x: string]: JsonValue }
-}
-
-export type SessionMessageToolStateError = {
-  status: "error"
-  input: { [x: string]: JsonValue }
-  error: SessionStructuredError
-  content?: [ToolContent, ...Array<ToolContent>]
-  metadata?: { [x: string]: JsonValue }
-}
-
-export type SessionMessageCompaction =
-  | SessionMessageCompactionRunning
-  | SessionMessageCompactionCompleted
-  | SessionMessageCompactionFailed
-
-export type SessionForked = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.forked"
-  durable: { aggregateID: string; seq: number; version: 2 }
-  location?: LocationRef
-  data: {
-    sessionID: string
-    parentID: string
-    boundary: SessionForkBoundary
-    instructions?: { [x: string]: string }
-    instructionEntries?: InstructionEntrySnapshot
-  }
-}
-
-export type SessionToolSuccess = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.tool.success"
-  durable: { aggregateID: string; seq: number; version: 2 }
-  location?: LocationRef
-  data: {
-    sessionID: string
-    assistantMessageID: string
-    id: string
-    content: [ToolContent1, ...Array<ToolContent1>]
-    metadata?: { [x: string]: JsonValue }
-    executed: boolean
-    resultState?: SessionMessageProviderState1
-  }
-}
-
-export type SessionToolFailed = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "session.tool.failed"
-  durable: { aggregateID: string; seq: number; version: 2 }
-  location?: LocationRef
-  data: {
-    sessionID: string
-    assistantMessageID: string
-    id: string
-    error: SessionStructuredError
-    content?: [ToolContent1, ...Array<ToolContent1>]
-    metadata?: { [x: string]: JsonValue }
-    executed: boolean
-    resultState?: SessionMessageProviderState1
-  }
-}
-
-export type ModelInfo = {
-  id: string
-  modelID: string
-  providerID: string
-  family?: string
-  name: string
-  compatibility?: ModelCompatibility
-  package?: string
-  settings?: { [x: string]: any }
-  headers?: { [x: string]: string }
-  body?: { [x: string]: any }
-  capabilities: ModelCapabilities
-  variants: Array<ModelVariant>
-  time: { released: number }
-  cost: Array<ModelCost>
-  status: "alpha" | "beta" | "deprecated" | "active"
-  enabled: boolean
-  limit: { context: number; input?: number; output: number }
-}
-
-export type FormField =
-  | FormStringField
-  | FormNumberField
-  | FormIntegerField
-  | FormBooleanField
-  | FormMultiselectField
-  | FormExternalField
-
-export type FormState = { status: "pending" } | { status: "answered"; answer: FormAnswer } | { status: "cancelled" }
-
-export type FormReplied = {
-  id: string
-  created: number
-  metadata?: { [x: string]: any }
-  type: "form.replied"
-  location?: LocationRef
-  data: { id: string; sessionID: string; answer: FormAnswer }
-}
-
-export type FormField1 =
-  | FormStringField1
-  | FormNumberField1
-  | FormIntegerField1
-  | FormBooleanField1
-  | FormMultiselectField1
-  | FormExternalField
 
 export type ReferenceInfo = {
   name: string
@@ -1907,6 +1686,171 @@ export type ConfigEntry =
   | { type: "agents"; path: string }
   | { type: "claude"; path: string }
 
+export type SessionStatsInfo = {
+  range: { from: number; to: number }
+  sessions: number
+  subagents: number
+  prompts: number
+  steps: number
+  tokens: TokenUsageInfo
+  cost: MoneyUSD
+  tools: SessionStatsTools
+  activeDays: number
+  streak: number
+  activity: Array<SessionStatsActivity>
+  models: Array<SessionStatsModelUsage>
+}
+
+export type SessionInfo = {
+  id: string
+  parentID?: string
+  fork?: { sessionID: string; boundary: SessionForkBoundary }
+  projectID: string
+  agent?: string
+  model?: ModelRef
+  cost: MoneyUSD
+  tokens: TokenUsageInfo
+  outcome?: "succeeded" | "failed" | "interrupted"
+  time: { created: number; updated: number; idle?: number; viewed?: number; archived?: number }
+  title?: string
+  location: LocationRef
+  subpath?: string
+  revert?: SessionRevert
+}
+
+export type SessionRevertStaged = {
+  id: string
+  created: number
+  metadata?: { [x: string]: any }
+  type: "session.revert.staged"
+  durable: { aggregateID: string; seq: number; version: 1 }
+  location?: LocationRef
+  data: { sessionID: string; revert: SessionRevert }
+}
+
+export type SessionMessageCompaction =
+  | SessionMessageCompactionRunning
+  | SessionMessageCompactionCompleted
+  | SessionMessageCompactionFailed
+
+export type SessionMessageUser = {
+  id: string
+  metadata?: { [x: string]: JsonValue }
+  time: { created: number }
+  text: string
+  files?: Array<PromptFileAttachment>
+  agents?: Array<PromptAgentAttachment>
+  skills?: Array<PromptSkillAttachment>
+  type: "user"
+}
+
+export type SessionInboxUserPayload = {
+  text: string
+  files?: Array<PromptFileAttachment>
+  agents?: Array<PromptAgentAttachment>
+  skills?: Array<PromptSkillAttachment>
+  metadata?: { [x: string]: JsonValue }
+}
+
+export type SessionInboxUserPayload1 = {
+  text: string
+  files?: Array<PromptFileAttachment>
+  agents?: Array<PromptAgentAttachment>
+  skills?: Array<PromptSkillAttachment>
+  metadata?: { [x: string]: any }
+}
+
+export type IntegrationAttemptStatus =
+  | {
+      status: "pending"
+      time: {
+        created: number | ("Infinity" | "-Infinity" | "NaN")
+        expires: number | ("Infinity" | "-Infinity" | "NaN")
+      }
+    }
+  | {
+      status: "complete"
+      time: {
+        created: number | ("Infinity" | "-Infinity" | "NaN")
+        expires: number | ("Infinity" | "-Infinity" | "NaN")
+      }
+    }
+  | {
+      status: "failed"
+      message: string
+      time: {
+        created: number | ("Infinity" | "-Infinity" | "NaN")
+        expires: number | ("Infinity" | "-Infinity" | "NaN")
+      }
+    }
+  | {
+      status: "expired"
+      time: {
+        created: number | ("Infinity" | "-Infinity" | "NaN")
+        expires: number | ("Infinity" | "-Infinity" | "NaN")
+      }
+    }
+
+export type IntegrationCommandAttempt = {
+  attemptID: string
+  time: { created: number | ("Infinity" | "-Infinity" | "NaN"); expires: number | ("Infinity" | "-Infinity" | "NaN") }
+}
+
+export type IntegrationCommandAttemptStatus =
+  | {
+      status: "pending"
+      message?: string
+      time: {
+        created: number | ("Infinity" | "-Infinity" | "NaN")
+        expires: number | ("Infinity" | "-Infinity" | "NaN")
+      }
+    }
+  | {
+      status: "complete"
+      time: {
+        created: number | ("Infinity" | "-Infinity" | "NaN")
+        expires: number | ("Infinity" | "-Infinity" | "NaN")
+      }
+    }
+  | {
+      status: "failed"
+      message: string
+      time: {
+        created: number | ("Infinity" | "-Infinity" | "NaN")
+        expires: number | ("Infinity" | "-Infinity" | "NaN")
+      }
+    }
+  | {
+      status: "expired"
+      time: {
+        created: number | ("Infinity" | "-Infinity" | "NaN")
+        expires: number | ("Infinity" | "-Infinity" | "NaN")
+      }
+    }
+
+export type SessionMessageToolStateCompleted = {
+  status: "completed"
+  input: { [x: string]: JsonValue }
+  content: [ToolContent, ...Array<ToolContent>]
+  metadata?: { [x: string]: JsonValue }
+}
+
+export type SessionMessageToolStateError = {
+  status: "error"
+  input: { [x: string]: JsonValue }
+  error: SessionStructuredError
+  content?: [ToolContent, ...Array<ToolContent>]
+  metadata?: { [x: string]: JsonValue }
+}
+
+export type FormField1 =
+  | FormStringField1
+  | FormNumberField1
+  | FormIntegerField1
+  | FormBooleanField1
+  | FormMultiselectField1
+  | FormExternalField
+
 export type SessionsResponse = { data: Array<SessionInfo>; cursor: { previous?: string | null; next?: string | null } }
 
 export type SessionInboxUser = {
@@ -1924,6 +1868,71 @@ export type SessionInboxItem =
   | { type: "compaction"; payload: SessionInboxCompactionPayload; delivery: SessionInboxDelivery }
   | { type: "move"; payload: SessionInboxMovePayload; delivery: SessionInboxDelivery }
 
+export type FormStringField = {
+  key: string
+  title?: string
+  description?: string
+  required?: boolean
+  when?: Array<FormWhen>
+  type: "string"
+  format?: "email" | "uri" | "date" | "date-time"
+  minLength?: number
+  maxLength?: number
+  pattern?: string
+  placeholder?: string
+  default?: string
+  options?: Array<FormOption>
+  custom?: boolean
+}
+
+export type FormNumberField = {
+  key: string
+  title?: string
+  description?: string
+  required?: boolean
+  when?: Array<FormWhen>
+  type: "number"
+  minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+  maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+  default?: number | ("Infinity" | "-Infinity" | "NaN")
+}
+
+export type FormIntegerField = {
+  key: string
+  title?: string
+  description?: string
+  required?: boolean
+  when?: Array<FormWhen>
+  type: "integer"
+  minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+  maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+  default?: number | ("Infinity" | "-Infinity" | "NaN")
+}
+
+export type FormBooleanField = {
+  key: string
+  title?: string
+  description?: string
+  required?: boolean
+  when?: Array<FormWhen>
+  type: "boolean"
+  default?: boolean
+}
+
+export type FormMultiselectField = {
+  key: string
+  title?: string
+  description?: string
+  required?: boolean
+  when?: Array<FormWhen>
+  type: "multiselect"
+  options: Array<FormOption>
+  minItems?: number
+  maxItems?: number
+  custom?: boolean
+  default?: Array<string>
+}
+
 export type SessionMessageAssistantTool = {
   type: "tool"
   id: string
@@ -1939,8 +1948,6 @@ export type SessionMessageAssistantTool = {
   time: { created: number; ran?: number; completed?: number }
 }
 
-export type FormFields = [FormField, ...Array<FormField>]
-
 export type FormFields2 = [FormField1, ...Array<FormField1>]
 
 export type SessionInboxInfo = SessionInboxUser | SessionInboxSynthetic | SessionInboxCompaction | SessionInboxMove
@@ -1954,6 +1961,14 @@ export type SessionInboxEnqueued = {
   location?: LocationRef
   data: { sessionID: string; inboxID: string; item: SessionInboxItem }
 }
+
+export type FormField =
+  | FormStringField
+  | FormNumberField
+  | FormIntegerField
+  | FormBooleanField
+  | FormMultiselectField
+  | FormExternalField
 
 export type SessionMessageAssistant = {
   id: string
@@ -1972,12 +1987,6 @@ export type SessionMessageAssistant = {
   error?: SessionStructuredError
   retry?: SessionMessageAssistantRetry
 }
-
-export type IntegrationOAuthMethod = { id: string; type: "oauth"; label: string; form?: FormFields }
-
-export type IntegrationKeyMethod = { type: "key"; label?: string; form?: FormFields }
-
-export type FormInfo = { id: string; sessionID: string; title: string; metadata?: FormMetadata; fields: FormFields }
 
 export type FormInfo1 = { id: string; sessionID: string; title: string; metadata?: FormMetadata1; fields: FormFields2 }
 
@@ -2024,6 +2033,8 @@ export type SessionEventDurable =
   | SessionRevertCommitted
   | SessionUsageRecorded
 
+export type FormFields = [FormField, ...Array<FormField>]
+
 export type SessionMessageInfo =
   | SessionMessageAgentSelected
   | SessionMessageModelSelected
@@ -2036,12 +2047,6 @@ export type SessionMessageInfo =
   | SessionMessageAssistant
   | SessionMessageCompaction
 
-export type IntegrationMethod =
-  | IntegrationOAuthMethod
-  | IntegrationCommandMethod
-  | IntegrationKeyMethod
-  | IntegrationEnvMethod
-
 export type FormCreated = {
   id: string
   created: number
@@ -2053,18 +2058,17 @@ export type FormCreated = {
 
 export type SessionLogItem = SessionEventDurable | EventLogSynced
 
+export type IntegrationOAuthMethod = { id: string; type: "oauth"; label: string; form?: FormFields }
+
+export type IntegrationKeyMethod = { type: "key"; label?: string; form?: FormFields }
+
+export type FormInfo = { id: string; sessionID: string; title: string; metadata?: FormMetadata; fields: FormFields }
+
 export type SessionTransferData = { info: SessionInfo; messages: Array<SessionMessageInfo> }
 
 export type SessionMessagesResponse = {
   data: Array<SessionMessageInfo>
   cursor: { previous?: string | null; next?: string | null }
-}
-
-export type IntegrationInfo = {
-  id: string
-  name: string
-  methods: Array<IntegrationMethod>
-  connections: Array<ConnectionInfo>
 }
 
 export type V2Event =
@@ -2154,6 +2158,19 @@ export type V2Event =
   | McpResourcesChanged
   | V2EventServerConnected
 
+export type IntegrationMethod =
+  | IntegrationOAuthMethod
+  | IntegrationCommandMethod
+  | IntegrationKeyMethod
+  | IntegrationEnvMethod
+
+export type IntegrationInfo = {
+  id: string
+  name: string
+  methods: Array<IntegrationMethod>
+  connections: Array<ConnectionInfo>
+}
+
 export type UnauthorizedError = { readonly _tag: "UnauthorizedError"; readonly message: string }
 export const isUnauthorizedError = (value: unknown): value is UnauthorizedError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "UnauthorizedError"
@@ -2220,13 +2237,13 @@ export type CommandNotFoundError = {
 export const isCommandNotFoundError = (value: unknown): value is CommandNotFoundError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "CommandNotFoundError"
 
-export type CommandEvaluationError = {
-  readonly _tag: "CommandEvaluationError"
+export type CommandExecutionError = {
+  readonly _tag: "CommandExecutionError"
   readonly command: string
   readonly message: string
 }
-export const isCommandEvaluationError = (value: unknown): value is CommandEvaluationError =>
-  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "CommandEvaluationError"
+export const isCommandExecutionError = (value: unknown): value is CommandExecutionError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "CommandExecutionError"
 
 export type SkillNotFoundError = {
   readonly _tag: "SkillNotFoundError"
@@ -3637,35 +3654,9 @@ export type SessionPromptOutput = { data: SessionInboxUser }["data"]
 
 export type SessionCommandInput = {
   readonly sessionID: { readonly sessionID: string }["sessionID"]
-  readonly id?: {
-    readonly id?: string | null
-    readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
-    readonly files?: ReadonlyArray<{
-      readonly uri: string
-      readonly name?: string
-      readonly description?: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly agents?: ReadonlyArray<{
-      readonly name: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly skills?: ReadonlyArray<{
-      readonly id: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
-  }["id"]
   readonly command: {
-    readonly id?: string | null
     readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly text: string
     readonly files?: ReadonlyArray<{
       readonly uri: string
       readonly name?: string
@@ -3681,14 +3672,10 @@ export type SessionCommandInput = {
       readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
     }>
     readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
   }["command"]
-  readonly arguments?: {
-    readonly id?: string | null
+  readonly text: {
     readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly text: string
     readonly files?: ReadonlyArray<{
       readonly uri: string
       readonly name?: string
@@ -3704,60 +3691,10 @@ export type SessionCommandInput = {
       readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
     }>
     readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
-  }["arguments"]
-  readonly agent?: {
-    readonly id?: string | null
-    readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
-    readonly files?: ReadonlyArray<{
-      readonly uri: string
-      readonly name?: string
-      readonly description?: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly agents?: ReadonlyArray<{
-      readonly name: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly skills?: ReadonlyArray<{
-      readonly id: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
-  }["agent"]
-  readonly model?: {
-    readonly id?: string | null
-    readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
-    readonly files?: ReadonlyArray<{
-      readonly uri: string
-      readonly name?: string
-      readonly description?: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly agents?: ReadonlyArray<{
-      readonly name: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly skills?: ReadonlyArray<{
-      readonly id: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
-  }["model"]
+  }["text"]
   readonly files?: {
-    readonly id?: string | null
     readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly text: string
     readonly files?: ReadonlyArray<{
       readonly uri: string
       readonly name?: string
@@ -3773,14 +3710,10 @@ export type SessionCommandInput = {
       readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
     }>
     readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
   }["files"]
   readonly agents?: {
-    readonly id?: string | null
     readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly text: string
     readonly files?: ReadonlyArray<{
       readonly uri: string
       readonly name?: string
@@ -3796,14 +3729,10 @@ export type SessionCommandInput = {
       readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
     }>
     readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
   }["agents"]
   readonly skills?: {
-    readonly id?: string | null
     readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly text: string
     readonly files?: ReadonlyArray<{
       readonly uri: string
       readonly name?: string
@@ -3819,14 +3748,10 @@ export type SessionCommandInput = {
       readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
     }>
     readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
   }["skills"]
   readonly delivery?: {
-    readonly id?: string | null
     readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly text: string
     readonly files?: ReadonlyArray<{
       readonly uri: string
       readonly name?: string
@@ -3842,34 +3767,10 @@ export type SessionCommandInput = {
       readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
     }>
     readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
   }["delivery"]
-  readonly resume?: {
-    readonly id?: string | null
-    readonly command: string
-    readonly arguments?: string | null
-    readonly agent?: string | null
-    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
-    readonly files?: ReadonlyArray<{
-      readonly uri: string
-      readonly name?: string
-      readonly description?: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly agents?: ReadonlyArray<{
-      readonly name: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly skills?: ReadonlyArray<{
-      readonly id: string
-      readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
-    }>
-    readonly delivery?: ("steer" | "queue") | null
-    readonly resume?: boolean | null
-  }["resume"]
 }
 
-export type SessionCommandOutput = { data: SessionInboxUser }["data"]
+export type SessionCommandOutput = void
 
 export type SessionSkillInput = {
   readonly sessionID: { readonly sessionID: string }["sessionID"]
@@ -4247,7 +4148,7 @@ export type IntegrationOauthConnectOutput = {
     url: string
     instructions: string
     mode: "auto" | "code"
-    time: { created: number | "Infinity" | "-Infinity" | "NaN"; expires: number | "Infinity" | "-Infinity" | "NaN" }
+    time: { created: number | ("Infinity" | "-Infinity" | "NaN"); expires: number | ("Infinity" | "-Infinity" | "NaN") }
   }
 }
 
@@ -4469,7 +4370,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "string"
             readonly format?: "email" | "uri" | "date" | "date-time"
@@ -4493,12 +4394,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "number"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4508,12 +4409,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "integer"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4523,7 +4424,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "boolean"
             readonly default?: boolean
@@ -4536,7 +4437,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "multiselect"
             readonly options: ReadonlyArray<{
@@ -4566,7 +4467,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "string"
             readonly format?: "email" | "uri" | "date" | "date-time"
@@ -4590,12 +4491,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "number"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4605,12 +4506,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "integer"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4620,7 +4521,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "boolean"
             readonly default?: boolean
@@ -4633,7 +4534,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "multiselect"
             readonly options: ReadonlyArray<{
@@ -4670,7 +4571,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "string"
             readonly format?: "email" | "uri" | "date" | "date-time"
@@ -4694,12 +4595,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "number"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4709,12 +4610,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "integer"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4724,7 +4625,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "boolean"
             readonly default?: boolean
@@ -4737,7 +4638,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "multiselect"
             readonly options: ReadonlyArray<{
@@ -4767,7 +4668,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "string"
             readonly format?: "email" | "uri" | "date" | "date-time"
@@ -4791,12 +4692,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "number"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4806,12 +4707,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "integer"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4821,7 +4722,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "boolean"
             readonly default?: boolean
@@ -4834,7 +4735,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "multiselect"
             readonly options: ReadonlyArray<{
@@ -4871,7 +4772,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "string"
             readonly format?: "email" | "uri" | "date" | "date-time"
@@ -4895,12 +4796,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "number"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4910,12 +4811,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "integer"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -4925,7 +4826,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "boolean"
             readonly default?: boolean
@@ -4938,7 +4839,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "multiselect"
             readonly options: ReadonlyArray<{
@@ -4968,7 +4869,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "string"
             readonly format?: "email" | "uri" | "date" | "date-time"
@@ -4992,12 +4893,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "number"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -5007,12 +4908,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "integer"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -5022,7 +4923,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "boolean"
             readonly default?: boolean
@@ -5035,7 +4936,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "multiselect"
             readonly options: ReadonlyArray<{
@@ -5072,7 +4973,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "string"
             readonly format?: "email" | "uri" | "date" | "date-time"
@@ -5096,12 +4997,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "number"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -5111,12 +5012,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "integer"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -5126,7 +5027,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "boolean"
             readonly default?: boolean
@@ -5139,7 +5040,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "multiselect"
             readonly options: ReadonlyArray<{
@@ -5169,7 +5070,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "string"
             readonly format?: "email" | "uri" | "date" | "date-time"
@@ -5193,12 +5094,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "number"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -5208,12 +5109,12 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "integer"
-            readonly minimum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly maximum?: number | "Infinity" | "-Infinity" | "NaN"
-            readonly default?: number | "Infinity" | "-Infinity" | "NaN"
+            readonly minimum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly maximum?: number | ("Infinity" | "-Infinity" | "NaN")
+            readonly default?: number | ("Infinity" | "-Infinity" | "NaN")
           }
         | {
             readonly key: string
@@ -5223,7 +5124,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "boolean"
             readonly default?: boolean
@@ -5236,7 +5137,7 @@ export type FormCreateInput = {
             readonly when?: ReadonlyArray<{
               readonly key: string
               readonly op: "eq" | "neq"
-              readonly value: string | number | "Infinity" | "-Infinity" | "NaN" | boolean
+              readonly value: string | number | ("Infinity" | "-Infinity" | "NaN") | boolean
             }>
             readonly type: "multiselect"
             readonly options: ReadonlyArray<{

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -1,26 +1,32 @@
 export * as Command from "./command.js"
 
-import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { Context, Effect, Layer, Schema, Types } from "effect"
 import { Command } from "@opencode-ai/schema/command"
-import { State } from "./state.js"
-import { MCP } from "./mcp/index.js"
+import type { PromptInput } from "@opencode-ai/schema/prompt-input"
+import type { Session } from "@opencode-ai/schema/session"
+import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
+import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { Context, Effect, Layer, Schema } from "effect"
 import { Bus } from "./bus.js"
-import { AppProcess } from "@opencode-ai/util/process"
-import { ChildProcess } from "effect/unstable/process"
-import { Location } from "./location.js"
-import { ShellSelect } from "./shell/select.js"
+import { State } from "./state.js"
 
 export const Info = Command.Info
 export type Info = Command.Info
 export { Event } from "@opencode-ai/schema/command"
 
-export type Evaluation = {
-  readonly text: string
+export interface Invocation {
+  readonly sessionID: Session.ID
+  readonly prompt: PromptInput.Prompt
+  readonly delivery: SessionInbox.Delivery
 }
 
-export type Data = {
-  commands: Map<string, Types.DeepMutable<Info>>
+export interface Definition {
+  readonly name: string
+  readonly description?: string
+  readonly execute: (input: Invocation) => Effect.Effect<void, unknown>
+}
+
+export type Draft = {
+  add: (definition: Definition) => void
 }
 
 export class NotFoundError extends Schema.TaggedError<NotFoundError>()("Command.NotFoundError", {
@@ -28,234 +34,73 @@ export class NotFoundError extends Schema.TaggedError<NotFoundError>()("Command.
   message: Schema.String,
 }) {}
 
-export class EvaluationError extends Schema.TaggedError<EvaluationError>()("Command.EvaluationError", {
+export class ExecutionError extends Schema.TaggedError<ExecutionError>()("Command.ExecutionError", {
   command: Schema.String,
   message: Schema.String,
 }) {}
 
-export type Draft = {
-  list: () => readonly Info[]
-  get: (name: string) => Info | undefined
-  update: (name: string, update: (command: Types.DeepMutable<Info>) => void) => void
-  remove: (name: string) => void
-}
-
 export interface Interface extends State.Transformable<Draft> {
   readonly get: (name: string) => Effect.Effect<Info | undefined>
   readonly list: () => Effect.Effect<Info[]>
-  readonly evaluate: (input: {
+  readonly execute: (input: {
     readonly name: string
-    readonly arguments?: string
-  }) => Effect.Effect<Evaluation, NotFoundError | EvaluationError>
+    readonly invocation: Invocation
+  }) => Effect.Effect<void, NotFoundError | ExecutionError>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Command") {}
 
-const layer = () =>
-  Layer.effect(
-    Service,
-    Effect.gen(function* () {
-      const mcp = yield* MCP.Service
-      const bus = yield* Bus.Service
-      const processes = yield* AppProcess.Service
-      const location = yield* Location.Service
-      const shell = yield* ShellSelect.Service
-      const state = State.create<Data, Draft>({
-        name: "command",
-        initial: () => ({ commands: new Map() }),
-        draft: (draft) => ({
-          list: () => Array.from(draft.commands.values()) as Info[],
-          get: (name) => draft.commands.get(name),
-          update: (name, update) => {
-            const current = draft.commands.get(name) ?? ({ name, template: "" } as Types.DeepMutable<Info>)
-            if (!draft.commands.has(name)) draft.commands.set(name, current)
-            update(current)
-            current.name = name
-          },
-          remove: (name) => {
-            draft.commands.delete(name)
-          },
-        }),
-        finalize: () => bus.publish(Command.Event.Updated, {}).pipe(Effect.asVoid),
-      })
-      const staticCommand = (name: string) => state.get().commands.get(name) as Info | undefined
-      const mcpCommands = Effect.fnUntraced(function* () {
-        return (yield* mcp.prompts()).map((prompt) =>
-          Info.make({
-            name: mcpCommandName(prompt.server, prompt.name),
-            template: "",
-            description: prompt.description,
-          }),
-        )
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const bus = yield* Bus.Service
+    const state = State.create<Map<string, Definition>, Draft>({
+      name: "command",
+      initial: () => new Map(),
+      draft: (draft) => ({
+        add: (definition) => draft.set(definition.name, definition),
+      }),
+      finalize: () => bus.publish(Command.Event.Updated, {}).pipe(Effect.asVoid),
+    })
+    const info = (definition: Definition) =>
+      Info.make({
+        name: definition.name,
+        description: definition.description,
       })
 
-      return Service.of({
-        reload: state.reload,
-        transform: state.transform,
-        get: Effect.fn("Command.get")(function* (name) {
-          const command = staticCommand(name)
-          if (command) return command
-          return (yield* mcpCommands()).find((command) => command.name === name)
+    return Service.of({
+      reload: state.reload,
+      transform: state.transform,
+      get: Effect.fn("Command.get")((name) =>
+        Effect.sync(() => {
+          const definition = state.get().get(name)
+          return definition ? info(definition) : undefined
         }),
-        list: Effect.fn("Command.list")(function* () {
-          const commands = Array.from(state.get().commands.values()) as Info[]
-          const names = new Set(commands.map((command) => command.name))
-          return [...commands, ...(yield* mcpCommands()).filter((command) => !names.has(command.name))]
-        }),
-        evaluate: Effect.fn("Command.evaluate")(function* (input) {
-          const command = staticCommand(input.name)
-          if (command)
-            return yield* evaluateTemplate(input.name, command.template, input.arguments ?? "", {
-              location,
-              processes,
-              shell,
-            })
-
-          const prompt = (yield* mcp.prompts()).find(
-            (prompt) => mcpCommandName(prompt.server, prompt.name) === input.name,
-          )
-          if (!prompt)
-            return yield* new NotFoundError({ command: input.name, message: `Command not found: ${input.name}` })
-          const result = yield* mcp
-            .prompt({
-              server: prompt.server,
-              name: prompt.name,
-              args: Object.fromEntries(
-                (prompt.arguments ?? []).map((argument, index) => [
-                  argument.name,
-                  parseArguments(input.arguments ?? "")[index] ?? "",
-                ]),
-              ),
-            })
-            .pipe(
-              Effect.catchTag("MCP.NotFoundError", () =>
-                Effect.fail(
-                  new EvaluationError({
-                    command: input.name,
-                    message: `MCP server could not be found while evaluating prompt: ${prompt.server}`,
-                  }),
-                ),
-              ),
-            )
-          if (!result)
-            return yield* new EvaluationError({
-              command: input.name,
-              message: `MCP prompt could not be evaluated: ${prompt.server}:${prompt.name}`,
-            })
-          return {
-            text: result.messages
-              .map((message) => promptMessageText(message.content))
-              .join("\n")
-              .trim(),
-          }
-        }),
-      })
-    }),
-  )
-
-function evaluateTemplate(
-  command: string,
-  template: string,
-  input: string,
-  services: {
-    readonly location: Location.Info
-    readonly processes: AppProcess.Interface
-    readonly shell: ShellSelect.Interface
-  },
-) {
-  return Effect.gen(function* () {
-    const expanded = evaluateArguments(template, input)
-    return { text: yield* evaluateShell(command, expanded, services) }
-  })
-}
-
-function evaluateArguments(template: string, input: string) {
-  const args = parseArguments(input)
-  const placeholders = template.match(placeholderRegex) ?? []
-  const last = Math.max(0, ...placeholders.map((item) => Number(item.slice(1))))
-  const expanded = template.replaceAll(placeholderRegex, (_, index) => {
-    const position = Number(index)
-    const argIndex = position - 1
-    if (argIndex >= args.length) return ""
-    if (position === last) return args.slice(argIndex).join(" ")
-    return args[argIndex]
-  })
-  const withArguments = expanded.replaceAll("$ARGUMENTS", input)
-  if (placeholders.length === 0 && !template.includes("$ARGUMENTS") && input.trim())
-    return `${withArguments}\n\n${input}`.trim()
-  return withArguments.trim()
-}
-
-const evaluateShell = Effect.fnUntraced(function* (
-  command: string,
-  text: string,
-  services: {
-    readonly location: Location.Info
-    readonly processes: AppProcess.Interface
-    readonly shell: ShellSelect.Interface
-  },
-) {
-  const matches = Array.from(text.matchAll(shellRegex))
-  if (matches.length === 0) return text
-  const shell = yield* services.shell.preferred()
-  const outputs = yield* Effect.forEach(
-    matches,
-    (match) => {
-      const source = match[1] ?? ""
-      return services.processes
-        .run(
-          ChildProcess.make(shell, ShellSelect.args(shell, source), {
-            cwd: services.location.directory,
-            stdin: "ignore",
-          }),
-          {
-            combineOutput: true,
-          },
+      ),
+      list: Effect.fn("Command.list")(() => Effect.sync(() => Array.from(state.get().values(), info))),
+      execute: Effect.fn("Command.execute")(function* (input) {
+        const definition = state.get().get(input.name)
+        if (!definition)
+          return yield* new NotFoundError({ command: input.name, message: `Command not found: ${input.name}` })
+        return yield* definition.execute(input.invocation).pipe(
+          Effect.tapError((error) => Effect.logError("command execution failed", { command: input.name, error })),
+          Effect.mapError((error) => new ExecutionError({ command: input.name, message: errorMessage(error) })),
         )
-        .pipe(
-          Effect.map((result) => (result.output ?? Buffer.concat([result.stdout, result.stderr])).toString("utf8")),
-          Effect.mapError(
-            (error) =>
-              new EvaluationError({
-                command,
-                message: `Shell interpolation failed for ${JSON.stringify(source)}: ${error.message}`,
-              }),
-          ),
-        )
-    },
-    { concurrency: 2 },
-  )
-  const iterator = outputs[Symbol.iterator]()
-  return text.replace(shellRegex, () => iterator.next().value ?? "")
-})
-
-function parseArguments(input: string) {
-  return (input.match(argsRegex) ?? []).map((arg) => arg.replace(quoteTrimRegex, ""))
-}
-
-function promptMessageText(content: unknown) {
-  if (typeof content === "string") return content
-  if (!content || typeof content !== "object") return ""
-  if (!("type" in content) || content.type !== "text") return ""
-  if (!("text" in content) || typeof content.text !== "string") return ""
-  return content.text
-}
-
-function mcpCommandName(server: string, prompt: string) {
-  return `${sanitize(server)}:${sanitize(prompt)}`
-}
-
-function sanitize(value: string) {
-  return value.replace(/[^a-zA-Z0-9_-]/g, "_")
-}
-
-const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi
-const placeholderRegex = /\$(\d+)/g
-const quoteTrimRegex = /^["']|["']$/g
-const shellRegex = /!`([^`]+)`/g
+      }),
+    })
+  }),
+)
 
 export const node = makeLocationNode({
   service: Service,
-  layer: layer(),
-  deps: [MCP.node, Bus.node, AppProcess.node, Location.node, ShellSelect.node],
+  layer,
+  deps: [Bus.node],
 })
+
+function errorMessage(error: unknown) {
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  if (error && typeof error === "object" && "message" in error && typeof error.message === "string")
+    return error.message
+  return "Command execution failed"
+}

--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -1,12 +1,18 @@
 export * as ConfigCommandPlugin from "./command.js"
 
 import { define } from "@opencode-ai/plugin/effect/plugin"
+import { Agent } from "@opencode-ai/schema/agent"
 import { Info, type Entry } from "@opencode-ai/schema/config"
 import { ConfigCommand } from "@opencode-ai/schema/config/command"
+import { Model } from "@opencode-ai/schema/model"
+import { Provider } from "@opencode-ai/schema/provider"
+import { AppProcess } from "@opencode-ai/util/process"
 import path from "path"
 import { Effect, Option, Schema, Stream } from "effect"
-import { Command } from "../../command.js"
+import { ChildProcess } from "effect/unstable/process"
 import { Config } from "../../config.js"
+import { Location } from "../../location.js"
+import { ShellSelect } from "../../shell/select.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { ConfigMarkdown } from "../markdown.js"
 
@@ -23,6 +29,9 @@ export const Plugin = define({
       const commands = yield* loadDirectory(fs, entry.path)
       return [{ commands: Object.fromEntries(commands.map((command) => [command.name, command.info])) }]
     })
+    const location = yield* Location.Service
+    const processes = yield* AppProcess.Service
+    const shell = yield* ShellSelect.Service
     const load = Effect.fn("ConfigCommandPlugin.load")(function* () {
       return yield* Effect.forEach(yield* config.entries(), loadEntry).pipe(Effect.map((documents) => documents.flat()))
     })
@@ -51,17 +60,41 @@ export const Plugin = define({
     yield* ctx.command.transform((draft) => {
       for (const document of loaded.documents) {
         for (const [name, command] of Object.entries(document.commands ?? {})) {
-          draft.update(name, (item) => {
-            item.template = command.template
-            if (command.description !== undefined) item.description = command.description
-            if (command.agent !== undefined) item.agent = command.agent
-            if (command.model !== undefined)
-              item.model = {
-                id: command.model.model,
-                providerID: command.model.providerID,
-                ...(command.model.variant === undefined ? {} : { variant: command.model.variant }),
-              }
-            if (command.subtask !== undefined) item.subtask = command.subtask
+          draft.add({
+            name,
+            description: command.description,
+            execute: (input) =>
+              Effect.gen(function* () {
+                const agent = command.agent === undefined ? undefined : Agent.ID.make(command.agent)
+                const commandAgent = yield* Effect.gen(function* () {
+                  if (agent === undefined) return
+                  const session = yield* ctx.session.get({ sessionID: input.sessionID })
+                  if (session.agent !== agent) yield* ctx.session.switchAgent({ sessionID: input.sessionID, agent })
+                  return (yield* ctx.agent.get({ agentID: agent })).data
+                })
+                const model =
+                  command.model === undefined
+                    ? commandAgent?.model
+                    : {
+                        id: Model.ID.make(command.model.model),
+                        providerID: Provider.ID.make(command.model.providerID),
+                        ...(command.model.variant === undefined
+                          ? {}
+                          : { variant: Model.VariantID.make(command.model.variant) }),
+                      }
+                if (model !== undefined) yield* ctx.session.switchModel({ sessionID: input.sessionID, model })
+                yield* ctx.session.prompt({
+                  ...input.prompt,
+                  sessionID: input.sessionID,
+                  text: yield* evaluateTemplate(command.template, input.prompt.text, {
+                    config,
+                    location,
+                    processes,
+                    shell,
+                  }),
+                  delivery: input.delivery,
+                })
+              }).pipe(Effect.asVoid),
           })
         }
       }
@@ -114,3 +147,67 @@ function decode(directory: string, filepath: string, content: string) {
     info,
   }
 }
+
+function evaluateTemplate(
+  template: string,
+  input: string,
+  services: {
+    readonly config: Config.Interface
+    readonly location: Location.Info
+    readonly processes: AppProcess.Interface
+    readonly shell: ShellSelect.Interface
+  },
+) {
+  return Effect.gen(function* () {
+    const args = parseArguments(input)
+    const placeholders = template.match(placeholderRegex) ?? []
+    const last = Math.max(0, ...placeholders.map((item) => Number(item.slice(1))))
+    const expanded = template.replaceAll(placeholderRegex, (_, index) => {
+      const position = Number(index)
+      const argIndex = position - 1
+      if (argIndex >= args.length) return ""
+      if (position === last) return args.slice(argIndex).join(" ")
+      return args[argIndex]
+    })
+    const withArguments = expanded.replaceAll("$ARGUMENTS", input)
+    const text =
+      placeholders.length === 0 && !template.includes("$ARGUMENTS") && input.trim()
+        ? `${withArguments}\n\n${input}`.trim()
+        : withArguments.trim()
+    const matches = Array.from(text.matchAll(shellRegex))
+    if (matches.length === 0) return text
+    const shell = yield* services.shell.preferred()
+    const outputs = yield* Effect.forEach(
+      matches,
+      (match) => {
+        const source = match[1] ?? ""
+        return services.processes
+          .run(
+            ChildProcess.make(shell, ShellSelect.args(shell, source), {
+              cwd: services.location.directory,
+              stdin: "ignore",
+            }),
+            { combineOutput: true },
+          )
+          .pipe(
+            Effect.map((result) => (result.output ?? Buffer.concat([result.stdout, result.stderr])).toString("utf8")),
+            Effect.mapError((error) =>
+              new Error(`Shell interpolation failed for ${JSON.stringify(source)}: ${error.message}`),
+            ),
+          )
+      },
+      { concurrency: 2 },
+    )
+    const iterator = outputs[Symbol.iterator]()
+    return text.replace(shellRegex, () => iterator.next().value ?? "")
+  })
+}
+
+function parseArguments(input: string) {
+  return (input.match(argsRegex) ?? []).map((arg) => arg.replace(quoteTrimRegex, ""))
+}
+
+const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi
+const placeholderRegex = /\$(\d+)/g
+const quoteTrimRegex = /^["']|["']$/g
+const shellRegex = /!`([^`]+)`/g

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -2,7 +2,7 @@ export * as MCP from "./index.js"
 
 import { Mcp } from "@opencode-ai/schema/mcp"
 import { McpEvent } from "@opencode-ai/schema/mcp-event"
-import { Command } from "@opencode-ai/schema/command"
+import { ephemeral } from "@opencode-ai/schema/event"
 import { createHash } from "node:crypto"
 import { isDeepStrictEqual } from "node:util"
 import { Cause, Context, Effect, Exit, FiberSet, Latch, Layer, Schema, Scope, Stream, Types } from "effect"
@@ -19,6 +19,7 @@ import { State } from "../state.js"
 import type { MCPClient } from "./client.js"
 
 export const ServerName = Schema.String.pipe(Schema.brand("MCP.ServerName"))
+export const PromptsChanged = ephemeral({ type: "mcp.prompts.changed", schema: { server: Schema.String } })
 export type ServerName = typeof ServerName.Type
 
 // The status union is a public wire contract, so it lives in @opencode-ai/schema and is re-exported here.
@@ -453,7 +454,7 @@ export const layer = (options?: Options) =>
           Effect.map((defs) => {
             entry.prompts = defs.map((def) => toPrompt(name, def))
           }),
-          Effect.andThen(bus.publish(Command.Event.Updated, {})),
+          Effect.andThen(bus.publish(PromptsChanged, { server: name })),
         )
 
       // Runs a connection callback under the server lock, dropping it if the connection is no longer
@@ -572,7 +573,7 @@ export const layer = (options?: Options) =>
         yield* Scope.close(scope, Exit.void)
         yield* bus.publish(McpEvent.ToolsChanged, { server: name }).pipe(Effect.ignore)
         yield* bus.publish(McpEvent.ResourcesChanged, { server: name }).pipe(Effect.ignore)
-        yield* bus.publish(Command.Event.Updated, {}).pipe(Effect.ignore)
+        yield* bus.publish(PromptsChanged, { server: name }).pipe(Effect.ignore)
       })
 
       const disposeServer = Effect.fnUntraced(function* (name: ServerName, entry: ServerEntry) {

--- a/packages/core/src/plugin/command.ts
+++ b/packages/core/src/plugin/command.ts
@@ -1,8 +1,10 @@
 export * as CommandPlugin from "./command.js"
 
 import { define } from "@opencode-ai/plugin/effect/plugin"
-import { Effect } from "effect"
+import { Effect, Stream } from "effect"
+import { Bus } from "../bus.js"
 import { Location } from "../location.js"
+import { MCP } from "../mcp/index.js"
 import PROMPT_INITIALIZE from "./command/initialize.txt"
 import PROMPT_REVIEW from "./command/review.txt"
 
@@ -10,15 +12,104 @@ export const Plugin = define({
   id: "opencode.command",
   effect: Effect.fn(function* (ctx) {
     const location = yield* Location.Service
+    const mcp = yield* MCP.Service
+    const bus = yield* Bus.Service
+    const loaded = { prompts: [] as MCP.Prompt[] }
+    yield* bus
+      .subscribe(MCP.PromptsChanged)
+      .pipe(
+        Stream.runForEach(() =>
+          mcp.prompts().pipe(
+            Effect.tap((prompts) => Effect.sync(() => (loaded.prompts = prompts))),
+            Effect.andThen(ctx.command.reload()),
+          ),
+        ),
+        Effect.forkScoped({ startImmediately: true }),
+      )
+    loaded.prompts = yield* mcp.prompts()
     yield* ctx.command.transform((draft) => {
-      draft.update("init", (command) => {
-        command.template = PROMPT_INITIALIZE.replace("${path}", location.project.directory)
-        command.description = "guided AGENTS.md setup"
+      draft.add({
+        name: "init",
+        description: "guided AGENTS.md setup",
+        execute: (input) =>
+          ctx.session
+            .prompt({
+              ...input.prompt,
+              sessionID: input.sessionID,
+              text: append(PROMPT_INITIALIZE.replace("${path}", location.project.directory), input.prompt.text),
+              delivery: input.delivery,
+            })
+            .pipe(Effect.asVoid),
       })
-      draft.update("review", (command) => {
-        command.template = PROMPT_REVIEW.replace("${path}", location.project.directory)
-        command.description = "review changes [commit|branch|pr], defaults to uncommitted"
+      draft.add({
+        name: "review",
+        description: "review changes [commit|branch|pr], defaults to uncommitted",
+        execute: (input) =>
+          ctx.session
+            .prompt({
+              ...input.prompt,
+              sessionID: input.sessionID,
+              text: append(PROMPT_REVIEW.replace("${path}", location.project.directory), input.prompt.text),
+              delivery: input.delivery,
+            })
+            .pipe(Effect.asVoid),
       })
+      for (const prompt of loaded.prompts) {
+        draft.add({
+          name: mcpCommandName(prompt.server, prompt.name),
+          description: prompt.description,
+          execute: (input) =>
+            Effect.gen(function* () {
+              const result = yield* mcp.prompt({
+                server: prompt.server,
+                name: prompt.name,
+                args: Object.fromEntries(
+                  (prompt.arguments ?? []).map((argument, index) => [
+                    argument.name,
+                    parseArguments(input.prompt.text)[index] ?? "",
+                  ]),
+                ),
+              })
+              if (!result) return yield* Effect.fail(new Error(`MCP prompt not found: ${prompt.server}:${prompt.name}`))
+              yield* ctx.session.prompt({
+                ...input.prompt,
+                sessionID: input.sessionID,
+                text: result.messages
+                  .map((message) => promptMessageText(message.content))
+                  .join("\n")
+                  .trim(),
+                delivery: input.delivery,
+              })
+            }).pipe(Effect.asVoid),
+        })
+      }
     })
   }),
 })
+
+function append(template: string, input: string) {
+  return [template, input.trim()].filter(Boolean).join("\n\n")
+}
+
+function parseArguments(input: string) {
+  return (input.match(argsRegex) ?? []).map((argument) => argument.replace(quoteTrimRegex, ""))
+}
+
+function promptMessageText(content: unknown) {
+  if (typeof content === "string") return content
+  if (!content || typeof content !== "object") return ""
+  if (!("type" in content) || content.type !== "text") return ""
+  if (!("text" in content) || typeof content.text !== "string") return ""
+  return content.text
+}
+
+function mcpCommandName(server: string, prompt: string) {
+  return `${sanitize(server)}:${sanitize(prompt)}`
+}
+
+function sanitize(value: string) {
+  return value.replace(/[^a-zA-Z0-9_-]/g, "_")
+}
+
+const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi
+const quoteTrimRegex = /^["']|["']$/g

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -246,26 +246,14 @@ export interface Interface {
     prompt: string
   }) => Effect.Effect<string, NotFoundError | SessionGenerate.Error>
   readonly command: (input: {
-    id?: SessionMessage.ID
     sessionID: SessionSchema.ID
     command: string
-    arguments?: string
-    agent?: Agent.ID
-    model?: Model.Ref
+    text: string
     files?: PromptInput.Prompt["files"]
     agents?: PromptInput.Prompt["agents"]
     skills?: PromptInput.Prompt["skills"]
     delivery?: SessionInbox.Delivery
-    resume?: boolean
-  }) => Effect.Effect<
-    SessionInbox.User,
-    | NotFoundError
-    | PromptConflictError
-    | AttachmentError
-    | SkillNotFoundError
-    | Command.NotFoundError
-    | Command.EvaluationError
-  >
+  }) => Effect.Effect<void, NotFoundError | Command.NotFoundError | Command.ExecutionError>
   readonly shell: (input: {
     id?: Event.ID
     sessionID: SessionSchema.ID
@@ -655,35 +643,19 @@ const layer = Layer.effect(
           yield* plugins.flush
           return yield* Command.Service
         }).pipe(Effect.provide(locations.get(session.location)))
-        const command = yield* commands.get(input.command)
-        if (!command)
-          return yield* new Command.NotFoundError({
-            command: input.command,
-            message: `Command not found: ${input.command}`,
-          })
-        const evaluated = yield* commands.evaluate({ name: input.command, arguments: input.arguments })
-
-        // TODO(v2 commands): decide whether command-level subtask/background execution belongs in v2 commands.
-        const agent = command.agent ?? input.agent
-        const commandAgent = yield* Effect.gen(function* () {
-          if (!command.agent) return undefined
-          const agents = yield* Agent.Service.pipe(Effect.provide(locations.get(session.location)))
-          return yield* agents.get(Agent.ID.make(command.agent))
-        })
-        const model = command.model ?? commandAgent?.model ?? input.model
-        if (agent !== undefined && session.agent !== Agent.ID.make(agent))
-          yield* result.switchAgent({ sessionID: input.sessionID, agent: Agent.ID.make(agent) })
-        if (model !== undefined) yield* result.switchModel({ sessionID: input.sessionID, model })
-
-        return yield* result.prompt({
-          id: input.id,
-          sessionID: input.sessionID,
-          text: evaluated.text,
-          files: input.files,
-          agents: input.agents,
-          skills: input.skills,
-          delivery: input.delivery,
-          resume: input.resume,
+        const delivery = input.delivery ?? "steer"
+        yield* commands.execute({
+          name: input.command,
+          invocation: {
+            sessionID: input.sessionID,
+            prompt: {
+              text: input.text,
+              files: input.files,
+              agents: input.agents,
+              skills: input.skills,
+            },
+            delivery,
+          },
         })
       }),
       shell: Effect.fn("Session.shell")(function* (input) {

--- a/packages/core/test/command.test.ts
+++ b/packages/core/test/command.test.ts
@@ -1,77 +1,71 @@
 import { describe, expect } from "bun:test"
-import { Effect } from "effect"
 import { Command } from "@opencode-ai/core/command"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
-import { Location } from "@opencode-ai/core/location"
-import { MCP } from "@opencode-ai/core/mcp/index"
-import { Model } from "@opencode-ai/core/model"
-import { Provider } from "@opencode-ai/core/provider"
-import { emptyMcpLayer, testLocationLayer } from "./fixture/mcp"
+import { Session } from "@opencode-ai/schema/session"
+import { Effect } from "effect"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(
-  AppNodeBuilder.build(Command.node, [
-    [MCP.node, emptyMcpLayer],
-    [Location.node, testLocationLayer],
-  ]),
-)
+const it = testEffect(AppNodeBuilder.build(Command.node))
 
 describe("Command", () => {
-  it.effect("applies command transforms and preserves later overrides", () =>
+  it.effect("registers and executes callback commands", () =>
     Effect.gen(function* () {
       const command = yield* Command.Service
-      yield* command.transform((editor) => {
-        editor.update("review", (command) => {
-          command.template = "First"
-          command.description = "Review code"
-        })
-        editor.update("review", (command) => {
-          command.template = "Second"
-          command.model = {
-            id: Model.ID.make("claude"),
-            providerID: Provider.ID.make("anthropic"),
-            variant: Model.VariantID.make("high"),
-          }
+      const calls: Command.Invocation[] = []
+      yield* command.transform((draft) => {
+        draft.add({
+          name: "goal",
+          description: "Manage the session goal",
+          execute: (input) => Effect.sync(() => calls.push(input)),
         })
       })
 
-      expect(yield* command.get("review")).toEqual(
-        Command.Info.make({
-          name: "review",
-          template: "Second",
-          description: "Review code",
-          model: {
-            id: Model.ID.make("claude"),
-            providerID: Provider.ID.make("anthropic"),
-            variant: Model.VariantID.make("high"),
-          },
-        }),
+      expect(yield* command.get("goal")).toEqual(
+        Command.Info.make({ name: "goal", description: "Manage the session goal" }),
       )
-      expect(yield* command.list()).toEqual([
-        Command.Info.make({
-          name: "review",
-          template: "Second",
-          description: "Review code",
-          model: {
-            id: Model.ID.make("claude"),
-            providerID: Provider.ID.make("anthropic"),
-            variant: Model.VariantID.make("high"),
-          },
-        }),
-      ])
+      const invocation = {
+        sessionID: Session.ID.make("ses_test"),
+        prompt: { text: "ship it", files: [{ uri: "file:///tmp/plan.md" }] },
+        delivery: "steer" as const,
+      }
+      yield* command.execute({ name: "goal", invocation })
+      expect(calls).toEqual([invocation])
     }),
   )
 
-  it.effect("evaluates command template shell blocks", () =>
+  it.effect("replaces commands with later definitions", () =>
     Effect.gen(function* () {
       const command = yield* Command.Service
-      yield* command.transform((editor) => {
-        editor.update("review", (command) => {
-          command.template = "Output: !`echo command-output`"
+      yield* command.transform((draft) => {
+        draft.add({ name: "goal", description: "First", execute: () => Effect.void })
+        draft.add({ name: "goal", description: "Second", execute: () => Effect.void })
+      })
+
+      expect(yield* command.list()).toEqual([Command.Info.make({ name: "goal", description: "Second" })])
+    }),
+  )
+
+  it.effect("returns callback error messages without stack traces", () =>
+    Effect.gen(function* () {
+      const command = yield* Command.Service
+      yield* command.transform((draft) => {
+        draft.add({
+          name: "fail",
+          execute: () => Effect.fail(new Error("command failed")),
         })
       })
 
-      expect((yield* command.evaluate({ name: "review" })).text.replace(/\r?\n$/, "")).toEqual("Output: command-output")
+      const error = yield* command
+        .execute({
+          name: "fail",
+          invocation: {
+            sessionID: Session.ID.make("ses_test"),
+            prompt: { text: "" },
+            delivery: "steer",
+          },
+        })
+        .pipe(Effect.flip)
+      expect(error).toMatchObject({ _tag: "Command.ExecutionError", message: "command failed" })
     }),
   )
 })

--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -1,11 +1,13 @@
 import fs from "fs/promises"
 import path from "path"
 import { describe, expect } from "bun:test"
-import { Deferred, Effect, Fiber, Layer, Option, PubSub, Schema, Stream } from "effect"
+import { DateTime, Deferred, Effect, Fiber, Layer, Option, PubSub, Schema, Stream } from "effect"
 import { advance, drain } from "../lib/clock"
 import { Directory, Document, Event, Info } from "@opencode-ai/schema/config"
+import { Session } from "@opencode-ai/schema/session"
+import { SessionInbox } from "@opencode-ai/schema/session-inbox"
+import { SessionMessage } from "@opencode-ai/schema/session-message"
 import { Command } from "@opencode-ai/core/command"
-import { Agent } from "@opencode-ai/core/agent"
 import { Config } from "@opencode-ai/core/config"
 import { ConfigCommandPlugin } from "@opencode-ai/core/config/plugin/command"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -15,11 +17,11 @@ import { Bus } from "@opencode-ai/core/bus"
 import { Credential } from "@opencode-ai/core/credential"
 import { WellKnown } from "@opencode-ai/core/wellknown"
 import { Global } from "@opencode-ai/util/global"
+import { AppProcess } from "@opencode-ai/util/process"
 import { Location } from "@opencode-ai/core/location"
 import { MCP } from "@opencode-ai/core/mcp/index"
-import { Model } from "@opencode-ai/core/model"
-import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { ShellSelect } from "@opencode-ai/core/shell/select"
 import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { emptyCredentialNode, emptyWellknownNode } from "../fixture/config-nodes"
 import { emptyConfigLayer, emptyMcpLayer, testLocationLayer } from "../fixture/mcp"
@@ -28,12 +30,25 @@ import { tmpdir } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 import { host } from "../plugin/host"
 
+const shellLayer = Layer.succeed(
+  ShellSelect.Service,
+  ShellSelect.Service.of({
+    preferred: () => Effect.succeed("sh"),
+    transform: () => Effect.die("unused shell.transform"),
+    reload: () => Effect.die("unused shell.reload"),
+  }),
+)
+
 const it = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Command.node, Bus.node, FSUtil.node]), [
-    [MCP.node, emptyMcpLayer],
-    [Config.node, emptyConfigLayer],
-    [Location.node, testLocationLayer],
-  ]),
+  AppNodeBuilder.build(
+    LayerNode.group([Command.node, Bus.node, FSUtil.node, AppProcess.node, Location.node, ShellSelect.node]),
+    [
+      [MCP.node, emptyMcpLayer],
+      [Config.node, emptyConfigLayer],
+      [Location.node, testLocationLayer],
+      [ShellSelect.node, shellLayer],
+    ],
+  ),
 )
 const decode = Schema.decodeUnknownSync(Info)
 
@@ -65,6 +80,7 @@ Review files`,
           const bus = yield* Bus.Service
           const update = yield* bus.publish(Event.Updated, {})
           const updates = yield* PubSub.unbounded<typeof update>()
+          const prompts: { text: string; files?: readonly { readonly uri: string }[]; delivery?: string }[] = []
           yield* ConfigCommandPlugin.Plugin.effect(
             host({
               command: {
@@ -73,6 +89,20 @@ Review files`,
                 reload: command.reload,
               },
               event: { subscribe: () => Stream.fromPubSub(updates) },
+              session: {
+                prompt: (input) =>
+                  Effect.sync(() => {
+                    prompts.push({ text: input.text, files: input.files, delivery: input.delivery })
+                    return SessionInbox.User.make({
+                      id: SessionMessage.ID.make("msg_test"),
+                      sessionID: input.sessionID,
+                      timeCreated: DateTime.makeUnsafe(0),
+                      type: "user",
+                      payload: { text: input.text },
+                      delivery: input.delivery ?? "steer",
+                    })
+                  }),
+              },
             }),
           ).pipe(
             Effect.provide(
@@ -89,28 +119,46 @@ Review files`,
           expect(yield* command.list()).toEqual([
             Command.Info.make({
               name: "review",
-              template: "Review files",
               description: "File review",
-              agent: Agent.ID.make("reviewer"),
-              model: {
-                providerID: Provider.ID.make("anthropic"),
-                id: Model.ID.make("claude"),
-                variant: Model.VariantID.make("high"),
-              },
-              subtask: true,
             }),
-            Command.Info.make({ name: "empty", template: "" }),
-            Command.Info.make({ name: "nested/docs", template: "Write docs" }),
+            Command.Info.make({ name: "empty" }),
+            Command.Info.make({ name: "nested/docs" }),
+          ])
+          yield* command.execute({
+            name: "nested/docs",
+            invocation: {
+              sessionID: Session.ID.make("ses_test"),
+              prompt: { text: "details", files: [{ uri: "file:///tmp/context.md" }] },
+              delivery: "queue",
+            },
+          })
+          expect(prompts).toEqual([
+            {
+              text: "Write docs\n\ndetails",
+              files: [{ uri: "file:///tmp/context.md" }],
+              delivery: "queue",
+            },
           ])
 
-          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "commands", "review.md"), "Review again"))
+          yield* Effect.promise(() =>
+            fs.writeFile(path.join(tmp.path, "commands", "review.md"), markdown("Review again", "Review again")),
+          )
           yield* Effect.sleep("10 millis")
           yield* PubSub.publish(updates, update)
           for (let attempt = 0; attempt < 100; attempt++) {
-            if ((yield* command.get("review"))?.template === "Review again") break
+            if ((yield* command.get("review"))?.description === "Review again") break
             yield* Effect.sleep("10 millis")
           }
-          expect((yield* command.get("review"))?.template).toBe("Review again")
+          expect((yield* command.get("review"))?.description).toBe("Review again")
+          yield* command.execute({
+            name: "review",
+            invocation: {
+              sessionID: Session.ID.make("ses_test"),
+              prompt: { text: "latest" },
+              delivery: "steer",
+            },
+          })
+          expect(prompts.at(-1)?.text).toBe("Review again\n\nlatest")
         }),
       ),
     ),
@@ -193,11 +241,13 @@ Review files`,
           yield* advance(() => reloads >= 1)
           expect(reloads).toBe(1)
 
-          yield* Effect.promise(() => fs.writeFile(path.join(directory, "review.md"), "Review twice"))
+          yield* Effect.promise(() =>
+            fs.writeFile(path.join(directory, "review.md"), markdown("Review twice", "Review twice")),
+          )
           yield* configTest.emitChange({ type: "update", path: path.join(directory, "review.md") })
           yield* advance(() => reloads >= 2)
           expect(reloads).toBe(2)
-          expect((yield* command.get("review"))?.template).toBe("Review twice")
+          expect((yield* command.get("review"))?.description).toBe("Review twice")
         }).pipe(Effect.provide(Config.testLayer([directoryEntry(tmp.path)]))),
       ),
     ),
@@ -232,10 +282,12 @@ Review files`,
           expect(reloads).toBe(0)
 
           // The feed stays live after unrelated updates.
-          yield* Effect.promise(() => fs.writeFile(path.join(directory, "review.md"), "Review related"))
+          yield* Effect.promise(() =>
+            fs.writeFile(path.join(directory, "review.md"), markdown("Review related", "Review related")),
+          )
           yield* configTest.emitChange({ type: "create", path: path.join(directory, "review.md") })
           yield* advance(() => reloads >= 1)
-          expect((yield* command.get("review"))?.template).toBe("Review related")
+          expect((yield* command.get("review"))?.description).toBe("Review related")
         }).pipe(Effect.provide(Config.testLayer([directoryEntry(tmp.path)]))),
       ),
     ),
@@ -272,28 +324,47 @@ describeNative("ConfigCommandPlugin native watcher", () => {
         yield* watchReady(config, global)
 
         const created = yield* nextCommandUpdate(bus)
-        yield* fs.writeFileString(path.join(global, "commands", "review.md"), "Review native")
+        yield* fs.writeFileString(
+          path.join(global, "commands", "review.md"),
+          markdown("Review native", "Review native"),
+        )
         yield* Fiber.join(created).pipe(Effect.timeout("10 seconds"))
-        expect((yield* command.get("review"))?.template).toBe("Review native")
+        expect((yield* command.get("review"))?.description).toBe("Review native")
 
         const updated = yield* nextCommandUpdate(bus)
-        yield* fs.writeFileString(path.join(global, "commands", "review.md"), "Review native again")
+        yield* fs.writeFileString(
+          path.join(global, "commands", "review.md"),
+          markdown("Review native again", "Review native again"),
+        )
         yield* Fiber.join(updated).pipe(Effect.timeout("10 seconds"))
-        expect((yield* command.get("review"))?.template).toBe("Review native again")
+        expect((yield* command.get("review"))?.description).toBe("Review native again")
       }).pipe(
         Effect.provide(
-          AppNodeBuilder.build(LayerNode.group([Command.node, Config.node, Bus.node, FSUtil.node]), [
-            [
+          AppNodeBuilder.build(
+            LayerNode.group([
+              Command.node,
+              Config.node,
+              Bus.node,
+              FSUtil.node,
+              AppProcess.node,
+              Global.node,
               Location.node,
-              Layer.succeed(
-                Location.Service,
-                Location.Service.of(location({ directory: AbsolutePath.make(path.join(tmp, "project")) })),
-              ),
+              ShellSelect.node,
+            ]),
+            [
+              [
+                Location.node,
+                Layer.succeed(
+                  Location.Service,
+                  Location.Service.of(location({ directory: AbsolutePath.make(path.join(tmp, "project")) })),
+                ),
+              ],
+              [Global.node, Global.layerWith({ config: global, home: path.join(global, "home") })],
+              [ShellSelect.node, shellLayer],
+              [Credential.node, emptyCredentialNode],
+              [WellKnown.node, emptyWellknownNode],
             ],
-            [Global.node, Global.layerWith({ config: global, home: path.join(global, "home") })],
-            [Credential.node, emptyCredentialNode],
-            [WellKnown.node, emptyWellknownNode],
-          ]),
+          ),
         ),
       )
     }),
@@ -337,6 +408,10 @@ function directoryEntry(directory: string) {
   return new Directory({ type: "directory", path: AbsolutePath.make(directory) })
 }
 
+function markdown(description: string, template: string) {
+  return `---\ndescription: ${description}\n---\n${template}`
+}
+
 function sourceCases() {
   return [
     {
@@ -345,33 +420,37 @@ function sourceCases() {
       mutate: (directory: string) =>
         Effect.promise(async () => {
           const file = path.join(directory, "review.md")
-          await fs.writeFile(file, "Review created")
+          await fs.writeFile(file, markdown("Review created", "Review created"))
           return [{ type: "create" as const, path: file }]
         }),
       verify: (command: Command.Interface) =>
         Effect.gen(function* () {
-          expect((yield* command.get("review"))?.template).toBe("Review created")
+          expect((yield* command.get("review"))?.description).toBe("Review created")
         }),
     },
     {
       name: "updated",
       prepare: (directory: string) =>
-        Effect.promise(() => fs.writeFile(path.join(directory, "review.md"), "Review first")),
+        Effect.promise(() =>
+          fs.writeFile(path.join(directory, "review.md"), markdown("Review first", "Review first")),
+        ),
       mutate: (directory: string) =>
         Effect.promise(async () => {
           const file = path.join(directory, "review.md")
-          await fs.writeFile(file, "Review updated")
+          await fs.writeFile(file, markdown("Review updated", "Review updated"))
           return [{ type: "update" as const, path: file }]
         }),
       verify: (command: Command.Interface) =>
         Effect.gen(function* () {
-          expect((yield* command.get("review"))?.template).toBe("Review updated")
+          expect((yield* command.get("review"))?.description).toBe("Review updated")
         }),
     },
     {
       name: "renamed",
       prepare: (directory: string) =>
-        Effect.promise(() => fs.writeFile(path.join(directory, "review.md"), "Review renamed")),
+        Effect.promise(() =>
+          fs.writeFile(path.join(directory, "review.md"), markdown("Review renamed", "Review renamed")),
+        ),
       mutate: (directory: string) =>
         Effect.promise(async () => {
           const previous = path.join(directory, "review.md")
@@ -385,7 +464,7 @@ function sourceCases() {
       verify: (command: Command.Interface) =>
         Effect.gen(function* () {
           expect(yield* command.get("review")).toBeUndefined()
-          expect((yield* command.get("release"))?.template).toBe("Review renamed")
+          expect((yield* command.get("release"))?.description).toBe("Review renamed")
         }),
     },
     {

--- a/packages/core/test/plugin/command.test.ts
+++ b/packages/core/test/plugin/command.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { Command } from "@opencode-ai/core/command"
+import { Bus } from "@opencode-ai/core/bus"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Location } from "@opencode-ai/core/location"
+import { MCP } from "@opencode-ai/core/mcp/index"
 import { CommandPlugin } from "@opencode-ai/core/plugin/command"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Session } from "@opencode-ai/schema/session"
+import { SessionInbox } from "@opencode-ai/schema/session-inbox"
+import { SessionMessage } from "@opencode-ai/schema/session-message"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { DateTime } from "effect"
+import { emptyMcpLayer } from "../fixture/mcp"
 import { location } from "../fixture/location"
 import { testEffect } from "../lib/effect"
 import { host } from "./host"
@@ -15,18 +23,38 @@ const locationLayer = Layer.succeed(
   Location.Service,
   Location.Service.of(location({ directory }, { projectDirectory: project })),
 )
-const it = testEffect(AppNodeBuilder.build(Command.node, [[Location.node, locationLayer]]))
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Command.node, MCP.node, Bus.node]), [
+    [MCP.node, emptyMcpLayer],
+    [Location.node, locationLayer],
+  ]),
+)
 
 describe("CommandPlugin.Plugin", () => {
   it.effect("registers built-in init and review commands", () =>
     Effect.gen(function* () {
       const command = yield* Command.Service
+      const prompts: { text: string; files?: readonly { readonly uri: string }[] }[] = []
       yield* CommandPlugin.Plugin.effect(
         host({
           command: {
             list: () => Effect.die("unused command.list"),
             transform: command.transform,
             reload: command.reload,
+          },
+          session: {
+            prompt: (input) =>
+              Effect.sync(() => {
+                prompts.push({ text: input.text, files: input.files })
+                return SessionInbox.User.make({
+                  id: SessionMessage.ID.make("msg_test"),
+                  sessionID: input.sessionID,
+                  timeCreated: DateTime.makeUnsafe(0),
+                  type: "user",
+                  payload: { text: input.text },
+                  delivery: input.delivery ?? "steer",
+                })
+              }),
           },
         }),
       ).pipe(
@@ -40,11 +68,24 @@ describe("CommandPlugin.Plugin", () => {
         name: "init",
         description: "guided AGENTS.md setup",
       })
-      expect((yield* command.get("init"))?.template).toContain("`/repo`")
       expect(yield* command.get("review")).toMatchObject({
         name: "review",
         description: "review changes [commit|branch|pr], defaults to uncommitted",
       })
+      yield* command.execute({
+        name: "init",
+        invocation: {
+          sessionID: Session.ID.make("ses_test"),
+          prompt: { text: "extra context", files: [{ uri: "file:///tmp/context.md" }] },
+          delivery: "queue",
+        },
+      })
+      expect(prompts).toEqual([
+        {
+          text: expect.stringContaining("extra context"),
+          files: [{ uri: "file:///tmp/context.md" }],
+        },
+      ])
     }),
   )
 })

--- a/packages/plugin/src/effect/command.ts
+++ b/packages/plugin/src/effect/command.ts
@@ -1,16 +1,27 @@
 import type { CommandApi } from "@opencode-ai/client/effect/api"
-import type { CommandInfo } from "@opencode-ai/client"
+import type { PromptInput } from "@opencode-ai/schema/prompt-input"
+import type { Session } from "@opencode-ai/schema/session"
+import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
 import type { Effect } from "effect"
 import type { Transform } from "./registration.js"
 
-export interface CommandDraft {
-  list(): readonly CommandInfo[]
-  get(name: string): CommandInfo | undefined
-  update(name: string, update: (command: CommandInfo) => void): void
-  remove(name: string): void
+export interface CommandInvocation {
+  readonly sessionID: Session.ID
+  readonly prompt: PromptInput.Prompt
+  readonly delivery: SessionInbox.Delivery
 }
 
-export interface CommandDomain extends CommandApi<unknown> {
+export interface CommandDefinition {
+  readonly name: string
+  readonly description?: string
+  readonly execute: (input: CommandInvocation) => Effect.Effect<void, unknown>
+}
+
+export interface CommandDraft {
+  add(definition: CommandDefinition): void
+}
+
+export interface CommandDomain extends Pick<CommandApi<unknown>, "list"> {
   readonly transform: Transform<CommandDraft>
   readonly reload: () => Effect.Effect<void>
 }

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -149,7 +149,19 @@ export function fromPromise(plugin: Plugin) {
           },
           command: {
             list: adaptApiMethod(CommandEndpoints["command.list"], host.command.list),
-            transform: transform(host.command),
+            transform: (callback) =>
+              register(
+                host.command.transform((draft) =>
+                  callback({
+                    add: (definition) =>
+                      draft.add({
+                        ...definition,
+                        execute: (input) =>
+                          Effect.tryPromise({ try: () => definition.execute(input), catch: (cause) => cause }),
+                      }),
+                  }),
+                ),
+              ),
             reload: () => run(host.command.reload()),
           },
           event: {

--- a/packages/plugin/src/promise/command.ts
+++ b/packages/plugin/src/promise/command.ts
@@ -1,15 +1,26 @@
 import type { CommandApi } from "@opencode-ai/client/promise/api"
-import type { CommandInfo } from "@opencode-ai/client"
+import type { PromptInput } from "@opencode-ai/schema/prompt-input"
+import type { Session } from "@opencode-ai/schema/session"
+import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
 import type { Transform } from "./registration.js"
 
-export interface CommandDraft {
-  list(): readonly CommandInfo[]
-  get(name: string): CommandInfo | undefined
-  update(name: string, update: (command: CommandInfo) => void): void
-  remove(name: string): void
+export interface CommandInvocation {
+  readonly sessionID: Session.ID
+  readonly prompt: PromptInput.Prompt
+  readonly delivery: SessionInbox.Delivery
 }
 
-export interface CommandDomain extends CommandApi {
+export interface CommandDefinition {
+  readonly name: string
+  readonly description?: string
+  readonly execute: (input: CommandInvocation) => Promise<void>
+}
+
+export interface CommandDraft {
+  add(definition: CommandDefinition): void
+}
+
+export interface CommandDomain extends Pick<CommandApi, "list"> {
   readonly transform: Transform<CommandDraft>
   readonly reload: () => Promise<void>
 }

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -109,7 +109,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -162,7 +192,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -236,7 +296,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -309,7 +399,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -378,11 +498,7 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "allOf": [
-                    {
-                      "pattern": "^wrk"
-                    }
-                  ]
+                  "pattern": "^wrk"
                 },
                 {
                   "type": "null"
@@ -428,7 +544,14 @@
             "name": "search",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_f090cb615c84"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           },
@@ -441,11 +564,7 @@
                   "anyOf": [
                     {
                       "type": "string",
-                      "allOf": [
-                        {
-                          "pattern": "^ses"
-                        }
-                      ]
+                      "pattern": "^ses"
                     },
                     {
                       "type": "string",
@@ -480,7 +599,14 @@
             "name": "project",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_f090cb615c84"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           },
@@ -618,11 +744,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "allOf": [
-                          {
-                            "pattern": "^ses"
-                          }
-                        ]
+                        "pattern": "^ses"
                       },
                       {
                         "type": "null"
@@ -630,7 +752,14 @@
                     ]
                   },
                   "title": {
-                    "$ref": "#/components/schemas/Union_f090cb615c84"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "agent": {
                     "anyOf": [
@@ -643,10 +772,24 @@
                     ]
                   },
                   "model": {
-                    "$ref": "#/components/schemas/Union_6a162d0a021d"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Model.Ref"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "location": {
-                    "$ref": "#/components/schemas/Union_5ee94d3ca88d"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Location.Ref"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -696,7 +839,14 @@
             "name": "project",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_f090cb615c84"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           },
@@ -704,7 +854,14 @@
             "name": "timezone",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_f090cb615c84"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           },
@@ -843,10 +1000,20 @@
                     "$ref": "#/components/schemas/Session.Info"
                   },
                   "messages": {
-                    "$ref": "#/components/schemas/Arrays_fa246a9267ec"
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Session.Message.Info"
+                    }
                   },
                   "location": {
-                    "$ref": "#/components/schemas/Union_5ee94d3ca88d"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Location.Ref"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["info", "messages"],
@@ -868,11 +1035,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -880,7 +1043,15 @@
             "name": "sanitize",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_e13209ef6bf4"
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["true", "false"]
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           }
@@ -1013,11 +1184,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1084,11 +1251,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1150,11 +1313,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1257,11 +1416,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1340,11 +1495,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1423,11 +1574,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1506,11 +1653,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1571,14 +1714,17 @@
                   },
                   "workspaceID": {
                     "type": "string",
-                    "allOf": [
-                      {
-                        "pattern": "^wrk"
-                      }
-                    ]
+                    "pattern": "^wrk"
                   },
                   "delivery": {
-                    "$ref": "#/components/schemas/Union_1f50b1b03235"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["directory"],
@@ -1600,11 +1746,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1692,28 +1834,59 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "$ref": "#/components/schemas/Union_f8b4c9e24aa0"
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^msg_"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "text": {
                     "type": "string"
                   },
                   "files": {
-                    "$ref": "#/components/schemas/Arrays_3ff7cb2a474f"
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PromptInput.FileAttachment"
+                    }
                   },
                   "agents": {
-                    "$ref": "#/components/schemas/Arrays_e1027de4b984"
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Prompt.AgentAttachment"
+                    }
                   },
                   "skills": {
-                    "$ref": "#/components/schemas/Arrays_c17502465996"
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PromptInput.SkillAttachment"
+                    }
                   },
                   "metadata": {
-                    "$ref": "#/components/schemas/Objects_a2c799262a3c"
+                    "type": "object"
                   },
                   "delivery": {
-                    "$ref": "#/components/schemas/Union_1f50b1b03235"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "resume": {
-                    "$ref": "#/components/schemas/Union_6a1762611a44"
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["text"],
@@ -1735,11 +1908,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1815,16 +1984,32 @@
                     "type": "string"
                   },
                   "files": {
-                    "$ref": "#/components/schemas/Arrays_3ff7cb2a474f"
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PromptInput.FileAttachment"
+                    }
                   },
                   "agents": {
-                    "$ref": "#/components/schemas/Arrays_e1027de4b984"
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Prompt.AgentAttachment"
+                    }
                   },
                   "skills": {
-                    "$ref": "#/components/schemas/Arrays_c17502465996"
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/PromptInput.SkillAttachment"
+                    }
                   },
                   "delivery": {
-                    "$ref": "#/components/schemas/Union_1f50b1b03235"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["command", "text"],
@@ -1846,11 +2031,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -1910,13 +2091,28 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "$ref": "#/components/schemas/Union_f8b4c9e24aa0"
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^msg_"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "skill": {
                     "type": "string"
                   },
                   "resume": {
-                    "$ref": "#/components/schemas/Union_6a1762611a44"
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["skill"],
@@ -1938,11 +2134,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2023,22 +2215,51 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "$ref": "#/components/schemas/Union_f8b4c9e24aa0"
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^msg_"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "text": {
                     "type": "string"
                   },
                   "description": {
-                    "$ref": "#/components/schemas/Union_f090cb615c84"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "metadata": {
-                    "$ref": "#/components/schemas/Objects_a2c799262a3c"
+                    "type": "object"
                   },
                   "delivery": {
-                    "$ref": "#/components/schemas/Union_1f50b1b03235"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "resume": {
-                    "$ref": "#/components/schemas/Union_6a1762611a44"
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["text"],
@@ -2060,11 +2281,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2124,11 +2341,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "allOf": [
-                          {
-                            "pattern": "^evt_"
-                          }
-                        ]
+                        "pattern": "^evt_"
                       },
                       {
                         "type": "null"
@@ -2158,11 +2371,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2243,10 +2452,25 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "$ref": "#/components/schemas/Union_f8b4c9e24aa0"
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "pattern": "^msg_"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "delivery": {
-                    "$ref": "#/components/schemas/Union_1f50b1b03235"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -2267,11 +2491,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2343,11 +2563,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2442,14 +2658,17 @@
                 "properties": {
                   "messageID": {
                     "type": "string",
-                    "allOf": [
-                      {
-                        "pattern": "^msg_"
-                      }
-                    ]
+                    "pattern": "^msg_"
                   },
                   "files": {
-                    "$ref": "#/components/schemas/Union_6a1762611a44"
+                    "anyOf": [
+                      {
+                        "type": "boolean"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["messageID"],
@@ -2471,11 +2690,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2556,11 +2771,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2631,11 +2842,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2717,11 +2924,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -2793,11 +2996,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -2806,11 +3005,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^msg_"
-                }
-              ]
+              "pattern": "^msg_"
             },
             "required": true
           }
@@ -2875,11 +3070,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -2888,11 +3079,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^msg_"
-                }
-              ]
+              "pattern": "^msg_"
             },
             "required": true
           }
@@ -2957,11 +3144,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -2970,11 +3153,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^msg_"
-                }
-              ]
+              "pattern": "^msg_"
             },
             "required": true
           }
@@ -3039,11 +3218,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -3122,11 +3297,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -3219,11 +3390,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -3293,11 +3460,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -3393,11 +3556,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -3420,7 +3579,15 @@
             "name": "follow",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_e13209ef6bf4"
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["true", "false"]
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           }
@@ -3563,11 +3730,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -3575,7 +3738,15 @@
             "name": "continue",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_e13209ef6bf4"
+              "anyOf": [
+                {
+                  "type": "string",
+                  "enum": ["true", "false"]
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           }
@@ -3637,11 +3808,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -3703,11 +3870,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -3716,11 +3879,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^msg_"
-                }
-              ]
+              "pattern": "^msg_"
             },
             "required": true
           }
@@ -3796,11 +3955,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -3875,11 +4030,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -3930,11 +4081,7 @@
                 "properties": {
                   "idle": {
                     "type": "integer",
-                    "allOf": [
-                      {
-                        "minimum": 0
-                      }
-                    ]
+                    "minimum": 0
                   }
                 },
                 "required": ["idle"],
@@ -3956,11 +4103,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -4087,7 +4230,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4163,7 +4336,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4243,7 +4446,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4312,7 +4545,14 @@
                     "type": "string"
                   },
                   "model": {
-                    "$ref": "#/components/schemas/Union_6a162d0a021d"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Model.Ref"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["prompt"],
@@ -4333,7 +4573,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4417,7 +4687,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4500,7 +4800,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4574,7 +4904,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4644,7 +5004,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4722,7 +5112,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4774,10 +5194,24 @@
                     "type": "string"
                   },
                   "answer": {
-                    "$ref": "#/components/schemas/Union_636af7bc29f5"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Form.Answer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "label": {
-                    "$ref": "#/components/schemas/Union_f090cb615c84"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["key"],
@@ -4806,7 +5240,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4875,10 +5339,24 @@
                     "type": "string"
                   },
                   "answer": {
-                    "$ref": "#/components/schemas/Union_636af7bc29f5"
+                    "anyOf": [
+                      {
+                        "$ref": "#/components/schemas/Form.Answer"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   },
                   "label": {
-                    "$ref": "#/components/schemas/Union_f090cb615c84"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["methodID"],
@@ -4915,7 +5393,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -4992,7 +5500,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5054,7 +5592,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5103,7 +5671,14 @@
                 "type": "object",
                 "properties": {
                   "code": {
-                    "$ref": "#/components/schemas/Union_f090cb615c84"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -5131,7 +5706,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5200,7 +5805,14 @@
                     "type": "string"
                   },
                   "label": {
-                    "$ref": "#/components/schemas/Union_f090cb615c84"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["methodID"],
@@ -5237,7 +5849,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5314,7 +5956,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5360,7 +6032,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5434,7 +6136,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5510,7 +6242,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5574,7 +6336,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5638,7 +6430,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5694,7 +6516,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5765,7 +6617,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5834,7 +6716,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5925,7 +6837,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -5978,7 +6920,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -6231,11 +7203,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^frm_"
-                }
-              ]
+              "pattern": "^frm_"
             },
             "required": true
           }
@@ -6322,11 +7290,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^frm_"
-                }
-              ]
+              "pattern": "^frm_"
             },
             "required": true
           }
@@ -6413,11 +7377,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^frm_"
-                }
-              ]
+              "pattern": "^frm_"
             },
             "required": true
           }
@@ -6517,11 +7477,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^frm_"
-                }
-              ]
+              "pattern": "^frm_"
             },
             "required": true
           }
@@ -6595,7 +7551,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -6661,7 +7647,14 @@
             "name": "projectID",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_f090cb615c84"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           }
@@ -6767,11 +7760,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -6790,11 +7779,7 @@
                       "properties": {
                         "id": {
                           "type": "string",
-                          "allOf": [
-                            {
-                              "pattern": "^per"
-                            }
-                          ]
+                          "pattern": "^per"
                         },
                         "effect": {
                           "$ref": "#/components/schemas/Permission.Effect"
@@ -6860,11 +7845,7 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "allOf": [
-                          {
-                            "pattern": "^per"
-                          }
-                        ]
+                        "pattern": "^per"
                       },
                       {
                         "type": "null"
@@ -6875,13 +7856,19 @@
                     "type": "string"
                   },
                   "resources": {
-                    "$ref": "#/components/schemas/Arrays_681004346c78"
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   },
                   "save": {
-                    "$ref": "#/components/schemas/Arrays_681004346c78"
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
                   },
                   "metadata": {
-                    "$ref": "#/components/schemas/Objects_a2c799262a3c"
+                    "type": "object"
                   },
                   "source": {
                     "$ref": "#/components/schemas/Permission.Source"
@@ -6914,11 +7901,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           }
@@ -6997,11 +7980,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -7010,11 +7989,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^per"
-                }
-              ]
+              "pattern": "^per"
             },
             "required": true
           }
@@ -7093,11 +8068,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^ses"
-                }
-              ]
+              "pattern": "^ses"
             },
             "required": true
           },
@@ -7106,11 +8077,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^per"
-                }
-              ]
+              "pattern": "^per"
             },
             "required": true
           }
@@ -7173,7 +8140,14 @@
                     "$ref": "#/components/schemas/Permission.Reply"
                   },
                   "message": {
-                    "$ref": "#/components/schemas/Union_f090cb615c84"
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "required": ["reply"],
@@ -7194,7 +8168,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -7248,7 +8252,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -7329,7 +8363,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -7427,7 +8491,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -7493,7 +8587,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -7682,7 +8806,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -7746,7 +8900,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -7844,11 +9028,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^pty"
-                }
-              ]
+              "pattern": "^pty"
             },
             "required": true
           },
@@ -7856,7 +9036,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -7928,11 +9138,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^pty"
-                }
-              ]
+              "pattern": "^pty"
             },
             "required": true
           },
@@ -7940,7 +9146,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8016,19 +9252,11 @@
                     "properties": {
                       "rows": {
                         "type": "integer",
-                        "allOf": [
-                          {
-                            "exclusiveMinimum": 0
-                          }
-                        ]
+                        "exclusiveMinimum": 0
                       },
                       "cols": {
                         "type": "integer",
-                        "allOf": [
-                          {
-                            "exclusiveMinimum": 0
-                          }
-                        ]
+                        "exclusiveMinimum": 0
                       }
                     },
                     "required": ["rows", "cols"],
@@ -8051,11 +9279,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^pty"
-                }
-              ]
+              "pattern": "^pty"
             },
             "required": true
           },
@@ -8063,7 +9287,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8120,11 +9374,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^pty"
-                }
-              ]
+              "pattern": "^pty"
             },
             "required": true
           },
@@ -8132,7 +9382,14 @@
             "name": "x-opencode-ticket",
             "in": "header",
             "schema": {
-              "$ref": "#/components/schemas/Union_f090cb615c84"
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false
           },
@@ -8140,7 +9397,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8224,11 +9511,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^pty"
-                }
-              ]
+              "pattern": "^pty"
             },
             "required": true
           },
@@ -8328,7 +9611,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8392,7 +9705,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8458,11 +9801,7 @@
                   },
                   "timeout": {
                     "type": "integer",
-                    "allOf": [
-                      {
-                        "minimum": 0
-                      }
-                    ]
+                    "minimum": 0
                   },
                   "metadata": {
                     "type": "object"
@@ -8487,11 +9826,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^sh_"
-                }
-              ]
+              "pattern": "^sh_"
             },
             "required": true
           },
@@ -8499,7 +9834,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8571,11 +9936,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^sh_"
-                }
-              ]
+              "pattern": "^sh_"
             },
             "required": true
           },
@@ -8583,7 +9944,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8640,11 +10031,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^sh_"
-                }
-              ]
+              "pattern": "^sh_"
             },
             "required": true
           },
@@ -8652,7 +10039,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8722,11 +10139,7 @@
                 "properties": {
                   "timeout": {
                     "type": "integer",
-                    "allOf": [
-                      {
-                        "minimum": 0
-                      }
-                    ]
+                    "minimum": 0
                   }
                 },
                 "required": ["timeout"],
@@ -8748,11 +10161,7 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^sh_"
-                }
-              ]
+              "pattern": "^sh_"
             },
             "required": true
           },
@@ -8760,7 +10169,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -8771,11 +10210,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
-                }
-              ]
+              "pattern": "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
             },
             "required": false
           },
@@ -8784,11 +10219,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "allOf": [
-                {
-                  "pattern": "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
-                }
-              ]
+              "pattern": "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
             },
             "required": false
           }
@@ -8806,7 +10237,25 @@
                       "$ref": "#/components/schemas/Location.InfoEncoded"
                     },
                     "data": {
-                      "$ref": "#/components/schemas/Objects_9d53a00b1efb"
+                      "type": "object",
+                      "properties": {
+                        "output": {
+                          "type": "string"
+                        },
+                        "cursor": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "size": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "truncated": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": ["output", "cursor", "size", "truncated"],
+                      "additionalProperties": false
                     }
                   },
                   "required": ["location", "data"],
@@ -8859,7 +10308,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -9178,7 +10657,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -9241,7 +10750,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -9307,7 +10846,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -9439,7 +11008,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -9517,11 +11116,7 @@
                               "anyOf": [
                                 {
                                   "type": "integer",
-                                  "allOf": [
-                                    {
-                                      "minimum": 0
-                                    }
-                                  ]
+                                  "minimum": 0
                                 },
                                 {
                                   "type": "null"
@@ -9532,11 +11127,7 @@
                               "anyOf": [
                                 {
                                   "type": "integer",
-                                  "allOf": [
-                                    {
-                                      "minimum": 0
-                                    }
-                                  ]
+                                  "minimum": 0
                                 },
                                 {
                                   "type": "null"
@@ -9604,7 +11195,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -9680,7 +11301,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -9780,7 +11431,37 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
             },
             "required": false,
             "style": "deepObject",
@@ -9866,11 +11547,7 @@
           },
           "steps": {
             "type": "integer",
-            "allOf": [
-              {
-                "exclusiveMinimum": 0
-              }
-            ]
+            "exclusiveMinimum": 0
           },
           "permissions": {
             "$ref": "#/components/schemas/Permission.Ruleset"
@@ -9895,54 +11572,6 @@
         },
         "required": ["_tag", "agentID", "message"],
         "additionalProperties": false
-      },
-      "Arrays_042d796a7901": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Prompt.FileAttachment"
-        }
-      },
-      "Arrays_3ff7cb2a474f": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/PromptInput.FileAttachment"
-        }
-      },
-      "Arrays_4df8e9fdc8e1": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Form.When"
-        }
-      },
-      "Arrays_681004346c78": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "Arrays_92aa8803e81f": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Prompt.SkillAttachment"
-        }
-      },
-      "Arrays_c17502465996": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/PromptInput.SkillAttachment"
-        }
-      },
-      "Arrays_e1027de4b984": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Prompt.AgentAttachment"
-        }
-      },
-      "Arrays_fa246a9267ec": {
-        "type": "array",
-        "items": {
-          "$ref": "#/components/schemas/Session.Message.Info"
-        }
       },
       "Command.Info": {
         "type": "object",
@@ -9995,16 +11624,43 @@
         "type": "object",
         "properties": {
           "model": {
-            "$ref": "#/components/schemas/Union_85ca62cf1a33"
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^[^/#]+\\/[^#]+(?:#[^#]+)?$"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "providerID": {
+                    "type": "string",
+                    "pattern": "^[^/#]+$"
+                  },
+                  "model": {
+                    "type": "string",
+                    "pattern": "^[^#]+$"
+                  },
+                  "variant": {
+                    "type": "string",
+                    "pattern": "^[^#]+$"
+                  }
+                },
+                "required": ["providerID", "model"],
+                "additionalProperties": false
+              }
+            ]
           },
           "request": {
             "type": "object",
             "properties": {
               "headers": {
-                "$ref": "#/components/schemas/Objects_3f161562db4a"
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
               },
               "body": {
-                "$ref": "#/components/schemas/Objects_a2c799262a3c"
+                "type": "object"
               }
             },
             "additionalProperties": false
@@ -10024,19 +11680,11 @@
           },
           "color": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^#[0-9a-fA-F]{6}$"
-              }
-            ]
+            "pattern": "^#[0-9a-fA-F]{6}$"
           },
           "steps": {
             "type": "integer",
-            "allOf": [
-              {
-                "exclusiveMinimum": 0
-              }
-            ]
+            "exclusiveMinimum": 0
           },
           "disabled": {
             "type": "boolean"
@@ -10088,7 +11736,31 @@
             "type": "string"
           },
           "model": {
-            "$ref": "#/components/schemas/Union_85ca62cf1a33"
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^[^/#]+\\/[^#]+(?:#[^#]+)?$"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "providerID": {
+                    "type": "string",
+                    "pattern": "^[^/#]+$"
+                  },
+                  "model": {
+                    "type": "string",
+                    "pattern": "^[^#]+$"
+                  },
+                  "variant": {
+                    "type": "string",
+                    "pattern": "^[^#]+$"
+                  }
+                },
+                "required": ["providerID", "model"],
+                "additionalProperties": false
+              }
+            ]
           },
           "subtask": {
             "type": "boolean"
@@ -10181,7 +11853,31 @@
             "type": "string"
           },
           "model": {
-            "$ref": "#/components/schemas/Union_85ca62cf1a33"
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^[^/#]+\\/[^#]+(?:#[^#]+)?$"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "providerID": {
+                    "type": "string",
+                    "pattern": "^[^/#]+$"
+                  },
+                  "model": {
+                    "type": "string",
+                    "pattern": "^[^#]+$"
+                  },
+                  "variant": {
+                    "type": "string",
+                    "pattern": "^[^#]+$"
+                  }
+                },
+                "required": ["providerID", "model"],
+                "additionalProperties": false
+              }
+            ]
           },
           "default_agent": {
             "type": "string"
@@ -10289,27 +11985,15 @@
                   },
                   "max_width": {
                     "type": "integer",
-                    "allOf": [
-                      {
-                        "exclusiveMinimum": 0
-                      }
-                    ]
+                    "exclusiveMinimum": 0
                   },
                   "max_height": {
                     "type": "integer",
-                    "allOf": [
-                      {
-                        "exclusiveMinimum": 0
-                      }
-                    ]
+                    "exclusiveMinimum": 0
                   },
                   "max_base64_bytes": {
                     "type": "integer",
-                    "allOf": [
-                      {
-                        "exclusiveMinimum": 0
-                      }
-                    ]
+                    "exclusiveMinimum": 0
                   }
                 },
                 "additionalProperties": false
@@ -10322,19 +12006,11 @@
             "properties": {
               "max_lines": {
                 "type": "integer",
-                "allOf": [
-                  {
-                    "exclusiveMinimum": 0
-                  }
-                ]
+                "exclusiveMinimum": 0
               },
               "max_bytes": {
                 "type": "integer",
-                "allOf": [
-                  {
-                    "exclusiveMinimum": 0
-                  }
-                ]
+                "exclusiveMinimum": 0
               }
             },
             "additionalProperties": false
@@ -10343,7 +12019,22 @@
             "type": "object",
             "properties": {
               "timeout": {
-                "$ref": "#/components/schemas/Objects_7b507c2fd81f"
+                "type": "object",
+                "properties": {
+                  "startup": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "catalog": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "execution": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  }
+                },
+                "additionalProperties": false
               },
               "servers": {
                 "type": "object",
@@ -10372,22 +12063,14 @@
                 "properties": {
                   "tokens": {
                     "type": "integer",
-                    "allOf": [
-                      {
-                        "minimum": 0
-                      }
-                    ]
+                    "minimum": 0
                   }
                 },
                 "additionalProperties": false
               },
               "buffer": {
                 "type": "integer",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
+                "minimum": 0
               }
             },
             "additionalProperties": false
@@ -10474,11 +12157,7 @@
               },
               "subagent_depth": {
                 "type": "integer",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
+                "minimum": 0
               },
               "policies": {
                 "type": "array",
@@ -10596,13 +12275,16 @@
             "type": "string"
           },
           "settings": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "headers": {
-            "$ref": "#/components/schemas/Objects_3f161562db4a"
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "body": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "capabilities": {
             "$ref": "#/components/schemas/Model.Capabilities"
@@ -10616,13 +12298,16 @@
                   "type": "string"
                 },
                 "settings": {
-                  "$ref": "#/components/schemas/Objects_a2c799262a3c"
+                  "type": "object"
                 },
                 "headers": {
-                  "$ref": "#/components/schemas/Objects_3f161562db4a"
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
                 },
                 "body": {
-                  "$ref": "#/components/schemas/Objects_a2c799262a3c"
+                  "type": "object"
                 }
               },
               "required": ["id"],
@@ -10692,13 +12377,16 @@
             "type": "string"
           },
           "settings": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "headers": {
-            "$ref": "#/components/schemas/Objects_3f161562db4a"
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "body": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "models": {
             "type": "object",
@@ -10788,7 +12476,14 @@
             "type": "string"
           },
           "resource": {
-            "$ref": "#/components/schemas/Union_f090cb615c84"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": ["_tag", "message"],
@@ -10846,19 +12541,11 @@
           },
           "additions": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "deletions": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "status": {
             "type": "string",
@@ -10918,7 +12605,10 @@
             "type": "boolean"
           },
           "when": {
-            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Form.When"
+            }
           },
           "type": {
             "type": "string",
@@ -10938,11 +12628,7 @@
             "anyOf": [
               {
                 "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^frm_"
-                  }
-                ]
+                "pattern": "^frm_"
               },
               {
                 "type": "null"
@@ -11048,11 +12734,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^frm_"
-              }
-            ]
+            "pattern": "^frm_"
           },
           "sessionID": {
             "type": "string"
@@ -11086,7 +12768,10 @@
             "type": "boolean"
           },
           "when": {
-            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Form.When"
+            }
           },
           "type": {
             "type": "string",
@@ -11098,7 +12783,8 @@
                 "type": "number"
               },
               {
-                "$ref": "#/components/schemas/Union_97d8d2942510"
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
               }
             ]
           },
@@ -11108,7 +12794,8 @@
                 "type": "number"
               },
               {
-                "$ref": "#/components/schemas/Union_97d8d2942510"
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
               }
             ]
           },
@@ -11118,7 +12805,8 @@
                 "type": "number"
               },
               {
-                "$ref": "#/components/schemas/Union_97d8d2942510"
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
               }
             ]
           }
@@ -11145,7 +12833,10 @@
             "type": "boolean"
           },
           "when": {
-            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Form.When"
+            }
           },
           "type": {
             "type": "string",
@@ -11159,19 +12850,11 @@
           },
           "minItems": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "maxItems": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "custom": {
             "type": "boolean"
@@ -11202,7 +12885,10 @@
             "type": "boolean"
           },
           "when": {
-            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Form.When"
+            }
           },
           "type": {
             "type": "string",
@@ -11214,7 +12900,8 @@
                 "type": "number"
               },
               {
-                "$ref": "#/components/schemas/Union_97d8d2942510"
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
               }
             ]
           },
@@ -11224,7 +12911,8 @@
                 "type": "number"
               },
               {
-                "$ref": "#/components/schemas/Union_97d8d2942510"
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
               }
             ]
           },
@@ -11234,7 +12922,8 @@
                 "type": "number"
               },
               {
-                "$ref": "#/components/schemas/Union_97d8d2942510"
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
               }
             ]
           }
@@ -11324,7 +13013,10 @@
             "type": "boolean"
           },
           "when": {
-            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Form.When"
+            }
           },
           "type": {
             "type": "string",
@@ -11336,19 +13028,11 @@
           },
           "minLength": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "maxLength": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "pattern": {
             "type": "string"
@@ -11378,7 +13062,15 @@
             "type": "string"
           },
           {
-            "$ref": "#/components/schemas/Union_00be4ed53f19"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
+              }
+            ]
           },
           {
             "type": "boolean"
@@ -11407,7 +13099,15 @@
                 "type": "string"
               },
               {
-                "$ref": "#/components/schemas/Union_00be4ed53f19"
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string",
+                    "enum": ["Infinity", "-Infinity", "NaN"]
+                  }
+                ]
               },
               {
                 "type": "boolean"
@@ -11501,12 +13201,8 @@
       },
       "InstructionEntry.Key": {
         "type": "string",
-        "allOf": [
-          {
-            "pattern": "^[a-z0-9][a-z0-9._-]*$",
-            "description": "Instruction entry key (lowercase alphanumerics plus . _ -)"
-          }
-        ]
+        "pattern": "^[a-z0-9][a-z0-9._-]*$",
+        "description": "Instruction entry key (lowercase alphanumerics plus . _ -)"
       },
       "InstructionEntryValueTooLargeErrorEncoded": {
         "type": "object",
@@ -11545,7 +13241,33 @@
             "enum": ["auto", "code"]
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_03af97aacac9"
+            "type": "object",
+            "properties": {
+              "created": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string",
+                    "enum": ["Infinity", "-Infinity", "NaN"]
+                  }
+                ]
+              },
+              "expires": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string",
+                    "enum": ["Infinity", "-Infinity", "NaN"]
+                  }
+                ]
+              }
+            },
+            "required": ["created", "expires"],
+            "additionalProperties": false
           }
         },
         "required": ["attemptID", "url", "instructions", "mode", "time"],
@@ -11561,7 +13283,33 @@
                 "enum": ["pending"]
               },
               "time": {
-                "$ref": "#/components/schemas/Objects_03af97aacac9"
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "expires": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["created", "expires"],
+                "additionalProperties": false
               }
             },
             "required": ["status", "time"],
@@ -11575,7 +13323,33 @@
                 "enum": ["complete"]
               },
               "time": {
-                "$ref": "#/components/schemas/Objects_03af97aacac9"
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "expires": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["created", "expires"],
+                "additionalProperties": false
               }
             },
             "required": ["status", "time"],
@@ -11592,7 +13366,33 @@
                 "type": "string"
               },
               "time": {
-                "$ref": "#/components/schemas/Objects_03af97aacac9"
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "expires": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["created", "expires"],
+                "additionalProperties": false
               }
             },
             "required": ["status", "message", "time"],
@@ -11606,7 +13406,33 @@
                 "enum": ["expired"]
               },
               "time": {
-                "$ref": "#/components/schemas/Objects_03af97aacac9"
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "expires": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["created", "expires"],
+                "additionalProperties": false
               }
             },
             "required": ["status", "time"],
@@ -11621,7 +13447,33 @@
             "type": "string"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_03af97aacac9"
+            "type": "object",
+            "properties": {
+              "created": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string",
+                    "enum": ["Infinity", "-Infinity", "NaN"]
+                  }
+                ]
+              },
+              "expires": {
+                "anyOf": [
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "string",
+                    "enum": ["Infinity", "-Infinity", "NaN"]
+                  }
+                ]
+              }
+            },
+            "required": ["created", "expires"],
+            "additionalProperties": false
           }
         },
         "required": ["attemptID", "time"],
@@ -11640,7 +13492,33 @@
                 "type": "string"
               },
               "time": {
-                "$ref": "#/components/schemas/Objects_03af97aacac9"
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "expires": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["created", "expires"],
+                "additionalProperties": false
               }
             },
             "required": ["status", "time"],
@@ -11654,7 +13532,33 @@
                 "enum": ["complete"]
               },
               "time": {
-                "$ref": "#/components/schemas/Objects_03af97aacac9"
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "expires": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["created", "expires"],
+                "additionalProperties": false
               }
             },
             "required": ["status", "time"],
@@ -11671,7 +13575,33 @@
                 "type": "string"
               },
               "time": {
-                "$ref": "#/components/schemas/Objects_03af97aacac9"
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "expires": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["created", "expires"],
+                "additionalProperties": false
               }
             },
             "required": ["status", "message", "time"],
@@ -11685,7 +13615,33 @@
                 "enum": ["expired"]
               },
               "time": {
-                "$ref": "#/components/schemas/Objects_03af97aacac9"
+                "type": "object",
+                "properties": {
+                  "created": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  },
+                  "expires": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "string",
+                        "enum": ["Infinity", "-Infinity", "NaN"]
+                      }
+                    ]
+                  }
+                },
+                "required": ["created", "expires"],
+                "additionalProperties": false
               }
             },
             "required": ["status", "time"],
@@ -11836,10 +13792,24 @@
             "type": "string"
           },
           "kind": {
-            "$ref": "#/components/schemas/Union_f090cb615c84"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "field": {
-            "$ref": "#/components/schemas/Union_f090cb615c84"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": ["_tag", "message"],
@@ -11853,11 +13823,7 @@
           },
           "workspaceID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^wrk"
-              }
-            ]
+            "pattern": "^wrk"
           },
           "project": {
             "type": "object",
@@ -11887,11 +13853,7 @@
           },
           "workspaceID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^wrk"
-              }
-            ]
+            "pattern": "^wrk"
           }
         },
         "required": ["directory"],
@@ -11926,7 +13888,22 @@
             "type": "boolean"
           },
           "timeout": {
-            "$ref": "#/components/schemas/Objects_7b507c2fd81f"
+            "type": "object",
+            "properties": {
+              "startup": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "catalog": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "execution": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "additionalProperties": false
           }
         },
         "required": ["type", "command"],
@@ -11946,12 +13923,8 @@
           },
           "callback_port": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 1,
-                "maximum": 65535
-              }
-            ]
+            "minimum": 1,
+            "maximum": 65535
           },
           "redirect_uri": {
             "type": "string"
@@ -11993,7 +13966,22 @@
             "type": "boolean"
           },
           "timeout": {
-            "$ref": "#/components/schemas/Objects_7b507c2fd81f"
+            "type": "object",
+            "properties": {
+              "startup": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "catalog": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              },
+              "execution": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "additionalProperties": false
           }
         },
         "required": ["type", "url"],
@@ -12294,13 +14282,16 @@
             "type": "string"
           },
           "settings": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "headers": {
-            "$ref": "#/components/schemas/Objects_3f161562db4a"
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "body": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "capabilities": {
             "$ref": "#/components/schemas/Model.Capabilities"
@@ -12404,13 +14395,16 @@
             "type": "string"
           },
           "settings": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "headers": {
-            "$ref": "#/components/schemas/Objects_3f161562db4a"
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "body": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           }
         },
         "required": ["id"],
@@ -12421,97 +14415,6 @@
       },
       "Money.USDPerMillionTokens": {
         "type": "number"
-      },
-      "Objects_03af97aacac9": {
-        "type": "object",
-        "properties": {
-          "created": {
-            "$ref": "#/components/schemas/Union_00be4ed53f19"
-          },
-          "expires": {
-            "$ref": "#/components/schemas/Union_00be4ed53f19"
-          }
-        },
-        "required": ["created", "expires"],
-        "additionalProperties": false
-      },
-      "Objects_3f161562db4a": {
-        "type": "object",
-        "additionalProperties": {
-          "type": "string"
-        }
-      },
-      "Objects_7b507c2fd81f": {
-        "type": "object",
-        "properties": {
-          "startup": {
-            "type": "integer",
-            "allOf": [
-              {
-                "exclusiveMinimum": 0
-              }
-            ]
-          },
-          "catalog": {
-            "type": "integer",
-            "allOf": [
-              {
-                "exclusiveMinimum": 0
-              }
-            ]
-          },
-          "execution": {
-            "type": "integer",
-            "allOf": [
-              {
-                "exclusiveMinimum": 0
-              }
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "Objects_9d53a00b1efb": {
-        "type": "object",
-        "properties": {
-          "output": {
-            "type": "string"
-          },
-          "cursor": {
-            "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
-          },
-          "size": {
-            "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
-          },
-          "truncated": {
-            "type": "boolean"
-          }
-        },
-        "required": ["output", "cursor", "size", "truncated"],
-        "additionalProperties": false
-      },
-      "Objects_a2c799262a3c": {
-        "type": "object"
-      },
-      "Objects_d7bbfd8ec2f6": {
-        "type": "object",
-        "properties": {
-          "created": {
-            "type": "number"
-          }
-        },
-        "required": ["created"],
-        "additionalProperties": false
       },
       "Permission.Effect": {
         "type": "string",
@@ -12526,31 +14429,29 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^per"
-              }
-            ]
+            "pattern": "^per"
           },
           "sessionID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^ses"
-              }
-            ]
+            "pattern": "^ses"
           },
           "action": {
             "type": "string"
           },
           "resources": {
-            "$ref": "#/components/schemas/Arrays_681004346c78"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "save": {
-            "$ref": "#/components/schemas/Arrays_681004346c78"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "source": {
             "$ref": "#/components/schemas/Permission.Source"
@@ -12819,27 +14720,15 @@
         "properties": {
           "created": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "updated": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "initialized": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           }
         },
         "required": ["created", "updated"],
@@ -12864,11 +14753,7 @@
       },
       "Prompt.Base64": {
         "type": "string",
-        "allOf": [
-          {
-            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
-          }
-        ]
+        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
       },
       "Prompt.FileAttachment": {
         "type": "object",
@@ -13008,13 +14893,16 @@
             "type": "string"
           },
           "settings": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "headers": {
-            "$ref": "#/components/schemas/Objects_3f161562db4a"
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           },
           "body": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           }
         },
         "required": ["id", "name", "activation", "package"],
@@ -13064,11 +14952,7 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^pty"
-              }
-            ]
+            "pattern": "^pty"
           },
           "title": {
             "type": "string"
@@ -13091,19 +14975,11 @@
           },
           "pid": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "exitCode": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           }
         },
         "required": ["id", "title", "command", "args", "cwd", "status", "pid"],
@@ -13134,11 +15010,7 @@
           },
           "expires_in": {
             "type": "integer",
-            "allOf": [
-              {
-                "exclusiveMinimum": 0
-              }
-            ]
+            "exclusiveMinimum": 0
           }
         },
         "required": ["ticket", "expires_in"],
@@ -13231,11 +15103,7 @@
           },
           "pid": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           }
         },
         "required": ["healthy", "version", "pid"],
@@ -13252,7 +15120,14 @@
             "type": "string"
           },
           "service": {
-            "$ref": "#/components/schemas/Union_f090cb615c84"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": ["_tag", "message"],
@@ -13269,11 +15144,7 @@
               },
               "messageID": {
                 "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^msg_"
-                  }
-                ]
+                "pattern": "^msg_"
               }
             },
             "required": ["type", "messageID"],
@@ -13288,11 +15159,7 @@
               },
               "messageID": {
                 "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^msg_"
-                  }
-                ]
+                "pattern": "^msg_"
               }
             },
             "required": ["type", "messageID"],
@@ -13311,11 +15178,7 @@
               },
               "messageID": {
                 "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^msg_"
-                  }
-                ]
+                "pattern": "^msg_"
               }
             },
             "required": ["type", "messageID"],
@@ -13339,19 +15202,11 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "sessionID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^ses"
-              }
-            ]
+            "pattern": "^ses"
           },
           "timeCreated": {
             "type": "number"
@@ -13405,19 +15260,11 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "sessionID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^ses"
-              }
-            ]
+            "pattern": "^ses"
           },
           "timeCreated": {
             "type": "number"
@@ -13457,19 +15304,11 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "sessionID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^ses"
-              }
-            ]
+            "pattern": "^ses"
           },
           "timeCreated": {
             "type": "number"
@@ -13509,19 +15348,11 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "sessionID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^ses"
-              }
-            ]
+            "pattern": "^ses"
           },
           "timeCreated": {
             "type": "number"
@@ -13547,16 +15378,25 @@
             "type": "string"
           },
           "files": {
-            "$ref": "#/components/schemas/Arrays_042d796a7901"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prompt.FileAttachment"
+            }
           },
           "agents": {
-            "$ref": "#/components/schemas/Arrays_e1027de4b984"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prompt.AgentAttachment"
+            }
           },
           "skills": {
-            "$ref": "#/components/schemas/Arrays_92aa8803e81f"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prompt.SkillAttachment"
+            }
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           }
         },
         "required": ["text"],
@@ -13567,30 +15407,18 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^ses"
-              }
-            ]
+            "pattern": "^ses"
           },
           "parentID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^ses"
-              }
-            ]
+            "pattern": "^ses"
           },
           "fork": {
             "type": "object",
             "properties": {
               "sessionID": {
                 "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^ses"
-                  }
-                ]
+                "pattern": "^ses"
               },
               "boundary": {
                 "$ref": "#/components/schemas/Session.ForkBoundary"
@@ -13661,17 +15489,20 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "type": {
             "type": "string",
@@ -13692,14 +15523,10 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
             "type": "object",
@@ -13819,11 +15646,7 @@
         "properties": {
           "attempt": {
             "type": "integer",
-            "allOf": [
-              {
-                "exclusiveMinimum": 0
-              }
-            ]
+            "exclusiveMinimum": 0
           },
           "at": {
             "type": "number"
@@ -13932,17 +15755,20 @@
           },
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "status": {
             "type": "string",
@@ -13971,17 +15797,20 @@
           },
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "status": {
             "type": "string",
@@ -14007,17 +15836,20 @@
           },
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "status": {
             "type": "string",
@@ -14076,17 +15908,20 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "type": {
             "type": "string",
@@ -14126,17 +15961,20 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "type": {
             "type": "string",
@@ -14172,14 +16010,10 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
             "type": "object",
@@ -14200,17 +16034,14 @@
           },
           "shellID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^sh_"
-              }
-            ]
+            "pattern": "^sh_"
           },
           "command": {
             "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/Union_b6d68a8b3572"
+            "type": "string",
+            "enum": ["running", "exited", "timeout", "killed"]
           },
           "exit": {
             "anyOf": [
@@ -14218,12 +16049,31 @@
                 "type": "number"
               },
               {
-                "$ref": "#/components/schemas/Union_97d8d2942510"
+                "type": "string",
+                "enum": ["Infinity", "-Infinity", "NaN"]
               }
             ]
           },
           "output": {
-            "$ref": "#/components/schemas/Objects_9d53a00b1efb"
+            "type": "object",
+            "properties": {
+              "output": {
+                "type": "string"
+              },
+              "cursor": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "size": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "truncated": {
+                "type": "boolean"
+              }
+            },
+            "required": ["output", "cursor", "size", "truncated"],
+            "additionalProperties": false
           }
         },
         "required": ["id", "time", "type", "shellID", "command", "status"],
@@ -14234,17 +16084,20 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "type": {
             "type": "string",
@@ -14268,17 +16121,20 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "text": {
             "type": "string"
@@ -14299,17 +16155,20 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "type": {
             "type": "string",
@@ -14422,29 +16281,41 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "metadata": {
-            "$ref": "#/components/schemas/Objects_a2c799262a3c"
+            "type": "object"
           },
           "time": {
-            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
+            "type": "object",
+            "properties": {
+              "created": {
+                "type": "number"
+              }
+            },
+            "required": ["created"],
+            "additionalProperties": false
           },
           "text": {
             "type": "string"
           },
           "files": {
-            "$ref": "#/components/schemas/Arrays_042d796a7901"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prompt.FileAttachment"
+            }
           },
           "agents": {
-            "$ref": "#/components/schemas/Arrays_e1027de4b984"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prompt.AgentAttachment"
+            }
           },
           "skills": {
-            "$ref": "#/components/schemas/Arrays_92aa8803e81f"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Prompt.SkillAttachment"
+            }
           },
           "type": {
             "type": "string",
@@ -14459,11 +16330,7 @@
         "properties": {
           "messageID": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
+            "pattern": "^msg_"
           },
           "partID": {
             "type": "string"
@@ -14492,12 +16359,8 @@
           },
           "status": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 100,
-                "maximum": 599
-              }
-            ]
+            "minimum": 100,
+            "maximum": 599
           }
         },
         "required": ["type", "message"],
@@ -14565,10 +16428,24 @@
             "type": "object",
             "properties": {
               "previous": {
-                "$ref": "#/components/schemas/Union_f090cb615c84"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               },
               "next": {
-                "$ref": "#/components/schemas/Union_f090cb615c84"
+                "anyOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -14602,11 +16479,7 @@
           },
           "steps": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           }
         },
         "required": ["date", "steps"],
@@ -14630,35 +16503,19 @@
           },
           "sessions": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "subagents": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "prompts": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "steps": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "tokens": {
             "$ref": "#/components/schemas/TokenUsage.Info"
@@ -14671,19 +16528,11 @@
           },
           "activeDays": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "streak": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "activity": {
             "type": "array",
@@ -14722,11 +16571,7 @@
           },
           "steps": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "tokens": {
             "$ref": "#/components/schemas/TokenUsage.Info"
@@ -14743,35 +16588,19 @@
         "properties": {
           "calls": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "succeeded": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "failed": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "unfinished": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           }
         },
         "required": ["calls", "succeeded", "failed", "unfinished"],
@@ -14785,35 +16614,19 @@
           },
           "calls": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "succeeded": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "failed": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "unfinished": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "durationP50": {
             "type": "number"
@@ -14878,7 +16691,10 @@
             "$ref": "#/components/schemas/Session.Info"
           },
           "messages": {
-            "$ref": "#/components/schemas/Arrays_fa246a9267ec"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Session.Message.Info"
+            }
           }
         },
         "required": ["info", "messages"],
@@ -14928,14 +16744,11 @@
         "properties": {
           "id": {
             "type": "string",
-            "allOf": [
-              {
-                "pattern": "^sh_"
-              }
-            ]
+            "pattern": "^sh_"
           },
           "status": {
-            "$ref": "#/components/schemas/Union_b6d68a8b3572"
+            "type": "string",
+            "enum": ["running", "exited", "timeout", "killed"]
           },
           "command": {
             "type": "string"
@@ -14951,11 +16764,7 @@
           },
           "pid": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "exit": {
             "type": "number"
@@ -15095,7 +16904,14 @@
             "type": "string"
           },
           "name": {
-            "$ref": "#/components/schemas/Union_f090cb615c84"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": ["type", "uri", "mime"],
@@ -15129,172 +16945,6 @@
         "required": ["_tag", "message"],
         "additionalProperties": false
       },
-      "Union_00be4ed53f19": {
-        "anyOf": [
-          {
-            "type": "number"
-          },
-          {
-            "$ref": "#/components/schemas/Union_97d8d2942510"
-          }
-        ]
-      },
-      "Union_1f50b1b03235": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/Session.Inbox.Delivery"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "Union_5ee94d3ca88d": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/Location.Ref"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "Union_636af7bc29f5": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/Form.Answer"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "Union_6a162d0a021d": {
-        "anyOf": [
-          {
-            "$ref": "#/components/schemas/Model.Ref"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "Union_6a1762611a44": {
-        "anyOf": [
-          {
-            "type": "boolean"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "Union_85ca62cf1a33": {
-        "anyOf": [
-          {
-            "type": "string",
-            "allOf": [
-              {
-                "pattern": "^[^/#]+\\/[^#]+(?:#[^#]+)?$"
-              }
-            ]
-          },
-          {
-            "type": "object",
-            "properties": {
-              "providerID": {
-                "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^[^/#]+$"
-                  }
-                ]
-              },
-              "model": {
-                "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^[^#]+$"
-                  }
-                ]
-              },
-              "variant": {
-                "type": "string",
-                "allOf": [
-                  {
-                    "pattern": "^[^#]+$"
-                  }
-                ]
-              }
-            },
-            "required": ["providerID", "model"],
-            "additionalProperties": false
-          }
-        ]
-      },
-      "Union_97d8d2942510": {
-        "type": "string",
-        "enum": ["Infinity", "-Infinity", "NaN"]
-      },
-      "Union_b6d68a8b3572": {
-        "type": "string",
-        "enum": ["running", "exited", "timeout", "killed"]
-      },
-      "Union_e13209ef6bf4": {
-        "anyOf": [
-          {
-            "type": "string",
-            "enum": ["true", "false"]
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "Union_f090cb615c84": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "Union_f8b4c9e24aa0": {
-        "anyOf": [
-          {
-            "type": "string",
-            "allOf": [
-              {
-                "pattern": "^msg_"
-              }
-            ]
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
-      "Union_ffefb7e3c81d": {
-        "anyOf": [
-          {
-            "type": "object",
-            "properties": {
-              "directory": {
-                "$ref": "#/components/schemas/Union_f090cb615c84"
-              },
-              "workspace": {
-                "$ref": "#/components/schemas/Union_f090cb615c84"
-              }
-            },
-            "additionalProperties": false
-          },
-          {
-            "type": "null"
-          }
-        ]
-      },
       "UnknownErrorEncoded": {
         "type": "object",
         "properties": {
@@ -15306,7 +16956,14 @@
             "type": "string"
           },
           "ref": {
-            "$ref": "#/components/schemas/Union_f090cb615c84"
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ]
           }
         },
         "required": ["_tag", "message"],
@@ -15336,19 +16993,11 @@
           },
           "additions": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "deletions": {
             "type": "integer",
-            "allOf": [
-              {
-                "minimum": 0
-              }
-            ]
+            "minimum": 0
           },
           "status": {
             "type": "string",
@@ -15469,7 +17118,14 @@
                 "type": "string"
               },
               "forceRequired": {
-                "$ref": "#/components/schemas/Union_6a1762611a44"
+                "anyOf": [
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
               }
             },
             "required": ["message"],

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -109,37 +109,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -192,37 +162,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -296,37 +236,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -399,37 +309,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -498,7 +378,11 @@
               "anyOf": [
                 {
                   "type": "string",
-                  "pattern": "^wrk"
+                  "allOf": [
+                    {
+                      "pattern": "^wrk"
+                    }
+                  ]
                 },
                 {
                   "type": "null"
@@ -544,14 +428,7 @@
             "name": "search",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_f090cb615c84"
             },
             "required": false
           },
@@ -564,7 +441,11 @@
                   "anyOf": [
                     {
                       "type": "string",
-                      "pattern": "^ses"
+                      "allOf": [
+                        {
+                          "pattern": "^ses"
+                        }
+                      ]
                     },
                     {
                       "type": "string",
@@ -599,14 +480,7 @@
             "name": "project",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_f090cb615c84"
             },
             "required": false
           },
@@ -744,7 +618,11 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "pattern": "^ses"
+                        "allOf": [
+                          {
+                            "pattern": "^ses"
+                          }
+                        ]
                       },
                       {
                         "type": "null"
@@ -752,14 +630,7 @@
                     ]
                   },
                   "title": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f090cb615c84"
                   },
                   "agent": {
                     "anyOf": [
@@ -772,24 +643,10 @@
                     ]
                   },
                   "model": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Model.Ref"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_6a162d0a021d"
                   },
                   "location": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Location.Ref"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_5ee94d3ca88d"
                   }
                 },
                 "additionalProperties": false
@@ -839,14 +696,7 @@
             "name": "project",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_f090cb615c84"
             },
             "required": false
           },
@@ -854,14 +704,7 @@
             "name": "timezone",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_f090cb615c84"
             },
             "required": false
           },
@@ -1000,20 +843,10 @@
                     "$ref": "#/components/schemas/Session.Info"
                   },
                   "messages": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Session.Message.Info"
-                    }
+                    "$ref": "#/components/schemas/Arrays_fa246a9267ec"
                   },
                   "location": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Location.Ref"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_5ee94d3ca88d"
                   }
                 },
                 "required": ["info", "messages"],
@@ -1035,7 +868,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -1043,15 +880,7 @@
             "name": "sanitize",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "enum": ["true", "false"]
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_e13209ef6bf4"
             },
             "required": false
           }
@@ -1184,7 +1013,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -1251,7 +1084,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -1313,7 +1150,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -1416,7 +1257,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -1495,7 +1340,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -1574,7 +1423,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -1653,7 +1506,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -1714,17 +1571,14 @@
                   },
                   "workspaceID": {
                     "type": "string",
-                    "pattern": "^wrk"
-                  },
-                  "delivery": {
-                    "anyOf": [
+                    "allOf": [
                       {
-                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
-                      },
-                      {
-                        "type": "null"
+                        "pattern": "^wrk"
                       }
                     ]
+                  },
+                  "delivery": {
+                    "$ref": "#/components/schemas/Union_1f50b1b03235"
                   }
                 },
                 "required": ["directory"],
@@ -1746,7 +1600,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -1834,59 +1692,28 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f8b4c9e24aa0"
                   },
                   "text": {
                     "type": "string"
                   },
                   "files": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/PromptInput.FileAttachment"
-                    }
+                    "$ref": "#/components/schemas/Arrays_3ff7cb2a474f"
                   },
                   "agents": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Prompt.AgentAttachment"
-                    }
+                    "$ref": "#/components/schemas/Arrays_e1027de4b984"
                   },
                   "skills": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/PromptInput.SkillAttachment"
-                    }
+                    "$ref": "#/components/schemas/Arrays_c17502465996"
                   },
                   "metadata": {
-                    "type": "object"
+                    "$ref": "#/components/schemas/Objects_a2c799262a3c"
                   },
                   "delivery": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_1f50b1b03235"
                   },
                   "resume": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_6a1762611a44"
                   }
                 },
                 "required": ["text"],
@@ -1908,43 +1735,26 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
         ],
         "security": [],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Session.Inbox.User"
-                    }
-                  },
-                  "required": ["data"],
-                  "additionalProperties": false
-                }
-              }
-            }
+          "204": {
+            "description": "<No Content>"
           },
           "400": {
             "description": "InvalidRequestError",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
-                    },
-                    {
-                      "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
                 }
               }
             }
@@ -1979,28 +1789,18 @@
               }
             }
           },
-          "409": {
-            "description": "ConflictError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConflictErrorEncoded"
-                }
-              }
-            }
-          },
           "500": {
-            "description": "CommandEvaluationError",
+            "description": "CommandExecutionError",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CommandEvaluationErrorEncoded"
+                  "$ref": "#/components/schemas/CommandExecutionErrorEncoded"
                 }
               }
             }
           }
         },
-        "description": "Resolve a slash command into prompt input, admit it durably, and schedule execution unless resume is false.",
+        "description": "Execute a slash command callback immediately.",
         "summary": "Run command",
         "requestBody": {
           "content": {
@@ -2008,90 +1808,26 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "id": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "command": {
                     "type": "string"
                   },
-                  "arguments": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "agent": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "model": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Model.Ref"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                  "text": {
+                    "type": "string"
                   },
                   "files": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/PromptInput.FileAttachment"
-                    }
+                    "$ref": "#/components/schemas/Arrays_3ff7cb2a474f"
                   },
                   "agents": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/Prompt.AgentAttachment"
-                    }
+                    "$ref": "#/components/schemas/Arrays_e1027de4b984"
                   },
                   "skills": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/PromptInput.SkillAttachment"
-                    }
+                    "$ref": "#/components/schemas/Arrays_c17502465996"
                   },
                   "delivery": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "resume": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_1f50b1b03235"
                   }
                 },
-                "required": ["command"],
+                "required": ["command", "text"],
                 "additionalProperties": false
               }
             }
@@ -2110,7 +1846,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -2170,28 +1910,13 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f8b4c9e24aa0"
                   },
                   "skill": {
                     "type": "string"
                   },
                   "resume": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_6a1762611a44"
                   }
                 },
                 "required": ["skill"],
@@ -2213,7 +1938,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -2294,51 +2023,22 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f8b4c9e24aa0"
                   },
                   "text": {
                     "type": "string"
                   },
                   "description": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f090cb615c84"
                   },
                   "metadata": {
-                    "type": "object"
+                    "$ref": "#/components/schemas/Objects_a2c799262a3c"
                   },
                   "delivery": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_1f50b1b03235"
                   },
                   "resume": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_6a1762611a44"
                   }
                 },
                 "required": ["text"],
@@ -2360,7 +2060,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -2420,7 +2124,11 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "pattern": "^evt_"
+                        "allOf": [
+                          {
+                            "pattern": "^evt_"
+                          }
+                        ]
                       },
                       {
                         "type": "null"
@@ -2450,7 +2158,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -2531,25 +2243,10 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f8b4c9e24aa0"
                   },
                   "delivery": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Session.Inbox.Delivery"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_1f50b1b03235"
                   }
                 },
                 "additionalProperties": false
@@ -2570,7 +2267,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -2642,7 +2343,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -2737,17 +2442,14 @@
                 "properties": {
                   "messageID": {
                     "type": "string",
-                    "pattern": "^msg_"
-                  },
-                  "files": {
-                    "anyOf": [
+                    "allOf": [
                       {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
+                        "pattern": "^msg_"
                       }
                     ]
+                  },
+                  "files": {
+                    "$ref": "#/components/schemas/Union_6a1762611a44"
                   }
                 },
                 "required": ["messageID"],
@@ -2769,7 +2471,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -2850,7 +2556,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -2921,7 +2631,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -3003,7 +2717,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -3075,7 +2793,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -3084,7 +2806,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^msg_"
+              "allOf": [
+                {
+                  "pattern": "^msg_"
+                }
+              ]
             },
             "required": true
           }
@@ -3149,7 +2875,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -3158,7 +2888,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^msg_"
+              "allOf": [
+                {
+                  "pattern": "^msg_"
+                }
+              ]
             },
             "required": true
           }
@@ -3223,7 +2957,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -3232,7 +2970,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^msg_"
+              "allOf": [
+                {
+                  "pattern": "^msg_"
+                }
+              ]
             },
             "required": true
           }
@@ -3297,7 +3039,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -3376,7 +3122,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -3469,7 +3219,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -3539,7 +3293,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -3635,7 +3393,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -3658,15 +3420,7 @@
             "name": "follow",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "enum": ["true", "false"]
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_e13209ef6bf4"
             },
             "required": false
           }
@@ -3809,7 +3563,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -3817,15 +3575,7 @@
             "name": "continue",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string",
-                  "enum": ["true", "false"]
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_e13209ef6bf4"
             },
             "required": false
           }
@@ -3887,7 +3637,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -3949,7 +3703,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -3958,7 +3716,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^msg_"
+              "allOf": [
+                {
+                  "pattern": "^msg_"
+                }
+              ]
             },
             "required": true
           }
@@ -4034,7 +3796,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -4109,7 +3875,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -4160,7 +3930,11 @@
                 "properties": {
                   "idle": {
                     "type": "integer",
-                    "minimum": 0
+                    "allOf": [
+                      {
+                        "minimum": 0
+                      }
+                    ]
                   }
                 },
                 "required": ["idle"],
@@ -4182,7 +3956,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -4309,37 +4087,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -4415,37 +4163,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -4525,37 +4243,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -4624,14 +4312,7 @@
                     "type": "string"
                   },
                   "model": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Model.Ref"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_6a162d0a021d"
                   }
                 },
                 "required": ["prompt"],
@@ -4652,37 +4333,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -4766,37 +4417,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -4879,37 +4500,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -4983,37 +4574,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -5083,37 +4644,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -5191,37 +4722,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -5273,24 +4774,10 @@
                     "type": "string"
                   },
                   "answer": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Form.Answer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_636af7bc29f5"
                   },
                   "label": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f090cb615c84"
                   }
                 },
                 "required": ["key"],
@@ -5319,37 +4806,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -5418,24 +4875,10 @@
                     "type": "string"
                   },
                   "answer": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Form.Answer"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_636af7bc29f5"
                   },
                   "label": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f090cb615c84"
                   }
                 },
                 "required": ["methodID"],
@@ -5472,37 +4915,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -5579,37 +4992,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -5671,37 +5054,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -5750,14 +5103,7 @@
                 "type": "object",
                 "properties": {
                   "code": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f090cb615c84"
                   }
                 },
                 "additionalProperties": false
@@ -5785,37 +5131,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -5884,14 +5200,7 @@
                     "type": "string"
                   },
                   "label": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f090cb615c84"
                   }
                 },
                 "required": ["methodID"],
@@ -5928,37 +5237,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6035,37 +5314,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6111,37 +5360,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6215,37 +5434,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6321,37 +5510,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6415,37 +5574,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6509,37 +5638,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6595,37 +5694,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6696,37 +5765,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6795,37 +5834,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6916,37 +5925,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -6999,37 +5978,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -7282,7 +6231,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^frm_"
+              "allOf": [
+                {
+                  "pattern": "^frm_"
+                }
+              ]
             },
             "required": true
           }
@@ -7369,7 +6322,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^frm_"
+              "allOf": [
+                {
+                  "pattern": "^frm_"
+                }
+              ]
             },
             "required": true
           }
@@ -7456,7 +6413,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^frm_"
+              "allOf": [
+                {
+                  "pattern": "^frm_"
+                }
+              ]
             },
             "required": true
           }
@@ -7556,7 +6517,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^frm_"
+              "allOf": [
+                {
+                  "pattern": "^frm_"
+                }
+              ]
             },
             "required": true
           }
@@ -7630,37 +6595,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -7726,14 +6661,7 @@
             "name": "projectID",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_f090cb615c84"
             },
             "required": false
           }
@@ -7839,7 +6767,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -7858,7 +6790,11 @@
                       "properties": {
                         "id": {
                           "type": "string",
-                          "pattern": "^per"
+                          "allOf": [
+                            {
+                              "pattern": "^per"
+                            }
+                          ]
                         },
                         "effect": {
                           "$ref": "#/components/schemas/Permission.Effect"
@@ -7924,7 +6860,11 @@
                     "anyOf": [
                       {
                         "type": "string",
-                        "pattern": "^per"
+                        "allOf": [
+                          {
+                            "pattern": "^per"
+                          }
+                        ]
                       },
                       {
                         "type": "null"
@@ -7935,19 +6875,13 @@
                     "type": "string"
                   },
                   "resources": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "$ref": "#/components/schemas/Arrays_681004346c78"
                   },
                   "save": {
-                    "type": "array",
-                    "items": {
-                      "type": "string"
-                    }
+                    "$ref": "#/components/schemas/Arrays_681004346c78"
                   },
                   "metadata": {
-                    "type": "object"
+                    "$ref": "#/components/schemas/Objects_a2c799262a3c"
                   },
                   "source": {
                     "$ref": "#/components/schemas/Permission.Source"
@@ -7980,7 +6914,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           }
@@ -8059,7 +6997,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -8068,7 +7010,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^per"
+              "allOf": [
+                {
+                  "pattern": "^per"
+                }
+              ]
             },
             "required": true
           }
@@ -8147,7 +7093,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^ses"
+              "allOf": [
+                {
+                  "pattern": "^ses"
+                }
+              ]
             },
             "required": true
           },
@@ -8156,7 +7106,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^per"
+              "allOf": [
+                {
+                  "pattern": "^per"
+                }
+              ]
             },
             "required": true
           }
@@ -8219,14 +7173,7 @@
                     "$ref": "#/components/schemas/Permission.Reply"
                   },
                   "message": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                    "$ref": "#/components/schemas/Union_f090cb615c84"
                   }
                 },
                 "required": ["reply"],
@@ -8247,37 +7194,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -8331,37 +7248,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -8442,37 +7329,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -8570,37 +7427,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -8666,37 +7493,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -8885,37 +7682,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -8979,37 +7746,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -9107,7 +7844,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^pty"
+              "allOf": [
+                {
+                  "pattern": "^pty"
+                }
+              ]
             },
             "required": true
           },
@@ -9115,37 +7856,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -9217,7 +7928,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^pty"
+              "allOf": [
+                {
+                  "pattern": "^pty"
+                }
+              ]
             },
             "required": true
           },
@@ -9225,37 +7940,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -9331,11 +8016,19 @@
                     "properties": {
                       "rows": {
                         "type": "integer",
-                        "exclusiveMinimum": 0
+                        "allOf": [
+                          {
+                            "exclusiveMinimum": 0
+                          }
+                        ]
                       },
                       "cols": {
                         "type": "integer",
-                        "exclusiveMinimum": 0
+                        "allOf": [
+                          {
+                            "exclusiveMinimum": 0
+                          }
+                        ]
                       }
                     },
                     "required": ["rows", "cols"],
@@ -9358,7 +8051,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^pty"
+              "allOf": [
+                {
+                  "pattern": "^pty"
+                }
+              ]
             },
             "required": true
           },
@@ -9366,37 +8063,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -9453,7 +8120,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^pty"
+              "allOf": [
+                {
+                  "pattern": "^pty"
+                }
+              ]
             },
             "required": true
           },
@@ -9461,14 +8132,7 @@
             "name": "x-opencode-ticket",
             "in": "header",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_f090cb615c84"
             },
             "required": false
           },
@@ -9476,37 +8140,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -9590,7 +8224,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^pty"
+              "allOf": [
+                {
+                  "pattern": "^pty"
+                }
+              ]
             },
             "required": true
           },
@@ -9690,37 +8328,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -9784,37 +8392,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -9880,7 +8458,11 @@
                   },
                   "timeout": {
                     "type": "integer",
-                    "minimum": 0
+                    "allOf": [
+                      {
+                        "minimum": 0
+                      }
+                    ]
                   },
                   "metadata": {
                     "type": "object"
@@ -9905,7 +8487,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^sh_"
+              "allOf": [
+                {
+                  "pattern": "^sh_"
+                }
+              ]
             },
             "required": true
           },
@@ -9913,37 +8499,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -10015,7 +8571,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^sh_"
+              "allOf": [
+                {
+                  "pattern": "^sh_"
+                }
+              ]
             },
             "required": true
           },
@@ -10023,37 +8583,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -10110,7 +8640,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^sh_"
+              "allOf": [
+                {
+                  "pattern": "^sh_"
+                }
+              ]
             },
             "required": true
           },
@@ -10118,37 +8652,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -10218,7 +8722,11 @@
                 "properties": {
                   "timeout": {
                     "type": "integer",
-                    "minimum": 0
+                    "allOf": [
+                      {
+                        "minimum": 0
+                      }
+                    ]
                   }
                 },
                 "required": ["timeout"],
@@ -10240,7 +8748,11 @@
             "in": "path",
             "schema": {
               "type": "string",
-              "pattern": "^sh_"
+              "allOf": [
+                {
+                  "pattern": "^sh_"
+                }
+              ]
             },
             "required": true
           },
@@ -10248,37 +8760,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -10289,7 +8771,11 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "pattern": "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
+              "allOf": [
+                {
+                  "pattern": "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
+                }
+              ]
             },
             "required": false
           },
@@ -10298,7 +8784,11 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "pattern": "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
+              "allOf": [
+                {
+                  "pattern": "^[+-]?\\d*\\.?\\d+(?:[Ee][+-]?\\d+)?$"
+                }
+              ]
             },
             "required": false
           }
@@ -10316,25 +8806,7 @@
                       "$ref": "#/components/schemas/Location.InfoEncoded"
                     },
                     "data": {
-                      "type": "object",
-                      "properties": {
-                        "output": {
-                          "type": "string"
-                        },
-                        "cursor": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "size": {
-                          "type": "integer",
-                          "minimum": 0
-                        },
-                        "truncated": {
-                          "type": "boolean"
-                        }
-                      },
-                      "required": ["output", "cursor", "size", "truncated"],
-                      "additionalProperties": false
+                      "$ref": "#/components/schemas/Objects_9d53a00b1efb"
                     }
                   },
                   "required": ["location", "data"],
@@ -10387,37 +8859,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -10736,37 +9178,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -10829,37 +9241,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -10925,37 +9307,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -11087,37 +9439,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -11195,7 +9517,11 @@
                               "anyOf": [
                                 {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "allOf": [
+                                    {
+                                      "minimum": 0
+                                    }
+                                  ]
                                 },
                                 {
                                   "type": "null"
@@ -11206,7 +9532,11 @@
                               "anyOf": [
                                 {
                                   "type": "integer",
-                                  "minimum": 0
+                                  "allOf": [
+                                    {
+                                      "minimum": 0
+                                    }
+                                  ]
                                 },
                                 {
                                   "type": "null"
@@ -11274,37 +9604,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -11380,37 +9680,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -11510,37 +9780,7 @@
             "name": "location",
             "in": "query",
             "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
+              "$ref": "#/components/schemas/Union_ffefb7e3c81d"
             },
             "required": false,
             "style": "deepObject",
@@ -11626,7 +9866,11 @@
           },
           "steps": {
             "type": "integer",
-            "exclusiveMinimum": 0
+            "allOf": [
+              {
+                "exclusiveMinimum": 0
+              }
+            ]
           },
           "permissions": {
             "$ref": "#/components/schemas/Permission.Ruleset"
@@ -11652,37 +9896,73 @@
         "required": ["_tag", "agentID", "message"],
         "additionalProperties": false
       },
+      "Arrays_042d796a7901": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Prompt.FileAttachment"
+        }
+      },
+      "Arrays_3ff7cb2a474f": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PromptInput.FileAttachment"
+        }
+      },
+      "Arrays_4df8e9fdc8e1": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Form.When"
+        }
+      },
+      "Arrays_681004346c78": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "Arrays_92aa8803e81f": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Prompt.SkillAttachment"
+        }
+      },
+      "Arrays_c17502465996": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/PromptInput.SkillAttachment"
+        }
+      },
+      "Arrays_e1027de4b984": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Prompt.AgentAttachment"
+        }
+      },
+      "Arrays_fa246a9267ec": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Session.Message.Info"
+        }
+      },
       "Command.Info": {
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "template": {
-            "type": "string"
-          },
           "description": {
             "type": "string"
-          },
-          "agent": {
-            "type": "string"
-          },
-          "model": {
-            "$ref": "#/components/schemas/Model.Ref"
-          },
-          "subtask": {
-            "type": "boolean"
           }
         },
-        "required": ["name", "template"],
+        "required": ["name"],
         "additionalProperties": false
       },
-      "CommandEvaluationErrorEncoded": {
+      "CommandExecutionErrorEncoded": {
         "type": "object",
         "properties": {
           "_tag": {
             "type": "string",
-            "enum": ["CommandEvaluationError"]
+            "enum": ["CommandExecutionError"]
           },
           "command": {
             "type": "string"
@@ -11715,43 +9995,16 @@
         "type": "object",
         "properties": {
           "model": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^[^/#]+\\/[^#]+(?:#[^#]+)?$"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "providerID": {
-                    "type": "string",
-                    "pattern": "^[^/#]+$"
-                  },
-                  "model": {
-                    "type": "string",
-                    "pattern": "^[^#]+$"
-                  },
-                  "variant": {
-                    "type": "string",
-                    "pattern": "^[^#]+$"
-                  }
-                },
-                "required": ["providerID", "model"],
-                "additionalProperties": false
-              }
-            ]
+            "$ref": "#/components/schemas/Union_85ca62cf1a33"
           },
           "request": {
             "type": "object",
             "properties": {
               "headers": {
-                "type": "object",
-                "additionalProperties": {
-                  "type": "string"
-                }
+                "$ref": "#/components/schemas/Objects_3f161562db4a"
               },
               "body": {
-                "type": "object"
+                "$ref": "#/components/schemas/Objects_a2c799262a3c"
               }
             },
             "additionalProperties": false
@@ -11771,11 +10024,19 @@
           },
           "color": {
             "type": "string",
-            "pattern": "^#[0-9a-fA-F]{6}$"
+            "allOf": [
+              {
+                "pattern": "^#[0-9a-fA-F]{6}$"
+              }
+            ]
           },
           "steps": {
             "type": "integer",
-            "exclusiveMinimum": 0
+            "allOf": [
+              {
+                "exclusiveMinimum": 0
+              }
+            ]
           },
           "disabled": {
             "type": "boolean"
@@ -11827,31 +10088,7 @@
             "type": "string"
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^[^/#]+\\/[^#]+(?:#[^#]+)?$"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "providerID": {
-                    "type": "string",
-                    "pattern": "^[^/#]+$"
-                  },
-                  "model": {
-                    "type": "string",
-                    "pattern": "^[^#]+$"
-                  },
-                  "variant": {
-                    "type": "string",
-                    "pattern": "^[^#]+$"
-                  }
-                },
-                "required": ["providerID", "model"],
-                "additionalProperties": false
-              }
-            ]
+            "$ref": "#/components/schemas/Union_85ca62cf1a33"
           },
           "subtask": {
             "type": "boolean"
@@ -11944,31 +10181,7 @@
             "type": "string"
           },
           "model": {
-            "anyOf": [
-              {
-                "type": "string",
-                "pattern": "^[^/#]+\\/[^#]+(?:#[^#]+)?$"
-              },
-              {
-                "type": "object",
-                "properties": {
-                  "providerID": {
-                    "type": "string",
-                    "pattern": "^[^/#]+$"
-                  },
-                  "model": {
-                    "type": "string",
-                    "pattern": "^[^#]+$"
-                  },
-                  "variant": {
-                    "type": "string",
-                    "pattern": "^[^#]+$"
-                  }
-                },
-                "required": ["providerID", "model"],
-                "additionalProperties": false
-              }
-            ]
+            "$ref": "#/components/schemas/Union_85ca62cf1a33"
           },
           "default_agent": {
             "type": "string"
@@ -12076,15 +10289,27 @@
                   },
                   "max_width": {
                     "type": "integer",
-                    "exclusiveMinimum": 0
+                    "allOf": [
+                      {
+                        "exclusiveMinimum": 0
+                      }
+                    ]
                   },
                   "max_height": {
                     "type": "integer",
-                    "exclusiveMinimum": 0
+                    "allOf": [
+                      {
+                        "exclusiveMinimum": 0
+                      }
+                    ]
                   },
                   "max_base64_bytes": {
                     "type": "integer",
-                    "exclusiveMinimum": 0
+                    "allOf": [
+                      {
+                        "exclusiveMinimum": 0
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -12097,11 +10322,19 @@
             "properties": {
               "max_lines": {
                 "type": "integer",
-                "exclusiveMinimum": 0
+                "allOf": [
+                  {
+                    "exclusiveMinimum": 0
+                  }
+                ]
               },
               "max_bytes": {
                 "type": "integer",
-                "exclusiveMinimum": 0
+                "allOf": [
+                  {
+                    "exclusiveMinimum": 0
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -12110,22 +10343,7 @@
             "type": "object",
             "properties": {
               "timeout": {
-                "type": "object",
-                "properties": {
-                  "startup": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0
-                  },
-                  "catalog": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0
-                  },
-                  "execution": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0
-                  }
-                },
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_7b507c2fd81f"
               },
               "servers": {
                 "type": "object",
@@ -12154,14 +10372,22 @@
                 "properties": {
                   "tokens": {
                     "type": "integer",
-                    "minimum": 0
+                    "allOf": [
+                      {
+                        "minimum": 0
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
               },
               "buffer": {
                 "type": "integer",
-                "minimum": 0
+                "allOf": [
+                  {
+                    "minimum": 0
+                  }
+                ]
               }
             },
             "additionalProperties": false
@@ -12248,7 +10474,11 @@
               },
               "subagent_depth": {
                 "type": "integer",
-                "minimum": 0
+                "allOf": [
+                  {
+                    "minimum": 0
+                  }
+                ]
               },
               "policies": {
                 "type": "array",
@@ -12366,16 +10596,13 @@
             "type": "string"
           },
           "settings": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "headers": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "$ref": "#/components/schemas/Objects_3f161562db4a"
           },
           "body": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "capabilities": {
             "$ref": "#/components/schemas/Model.Capabilities"
@@ -12389,16 +10616,13 @@
                   "type": "string"
                 },
                 "settings": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/Objects_a2c799262a3c"
                 },
                 "headers": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "type": "string"
-                  }
+                  "$ref": "#/components/schemas/Objects_3f161562db4a"
                 },
                 "body": {
-                  "type": "object"
+                  "$ref": "#/components/schemas/Objects_a2c799262a3c"
                 }
               },
               "required": ["id"],
@@ -12468,16 +10692,13 @@
             "type": "string"
           },
           "settings": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "headers": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "$ref": "#/components/schemas/Objects_3f161562db4a"
           },
           "body": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "models": {
             "type": "object",
@@ -12567,14 +10788,7 @@
             "type": "string"
           },
           "resource": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/Union_f090cb615c84"
           }
         },
         "required": ["_tag", "message"],
@@ -12632,11 +10846,19 @@
           },
           "additions": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "deletions": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "status": {
             "type": "string",
@@ -12696,10 +10918,7 @@
             "type": "boolean"
           },
           "when": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Form.When"
-            }
+            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
           },
           "type": {
             "type": "string",
@@ -12719,7 +10938,11 @@
             "anyOf": [
               {
                 "type": "string",
-                "pattern": "^frm_"
+                "allOf": [
+                  {
+                    "pattern": "^frm_"
+                  }
+                ]
               },
               {
                 "type": "null"
@@ -12825,7 +11048,11 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^frm_"
+            "allOf": [
+              {
+                "pattern": "^frm_"
+              }
+            ]
           },
           "sessionID": {
             "type": "string"
@@ -12859,10 +11086,7 @@
             "type": "boolean"
           },
           "when": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Form.When"
-            }
+            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
           },
           "type": {
             "type": "string",
@@ -12874,8 +11098,7 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "enum": ["Infinity", "-Infinity", "NaN"]
+                "$ref": "#/components/schemas/Union_97d8d2942510"
               }
             ]
           },
@@ -12885,8 +11108,7 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "enum": ["Infinity", "-Infinity", "NaN"]
+                "$ref": "#/components/schemas/Union_97d8d2942510"
               }
             ]
           },
@@ -12896,8 +11118,7 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "enum": ["Infinity", "-Infinity", "NaN"]
+                "$ref": "#/components/schemas/Union_97d8d2942510"
               }
             ]
           }
@@ -12924,10 +11145,7 @@
             "type": "boolean"
           },
           "when": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Form.When"
-            }
+            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
           },
           "type": {
             "type": "string",
@@ -12941,11 +11159,19 @@
           },
           "minItems": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "maxItems": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "custom": {
             "type": "boolean"
@@ -12976,10 +11202,7 @@
             "type": "boolean"
           },
           "when": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Form.When"
-            }
+            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
           },
           "type": {
             "type": "string",
@@ -12991,8 +11214,7 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "enum": ["Infinity", "-Infinity", "NaN"]
+                "$ref": "#/components/schemas/Union_97d8d2942510"
               }
             ]
           },
@@ -13002,8 +11224,7 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "enum": ["Infinity", "-Infinity", "NaN"]
+                "$ref": "#/components/schemas/Union_97d8d2942510"
               }
             ]
           },
@@ -13013,8 +11234,7 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "enum": ["Infinity", "-Infinity", "NaN"]
+                "$ref": "#/components/schemas/Union_97d8d2942510"
               }
             ]
           }
@@ -13104,10 +11324,7 @@
             "type": "boolean"
           },
           "when": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Form.When"
-            }
+            "$ref": "#/components/schemas/Arrays_4df8e9fdc8e1"
           },
           "type": {
             "type": "string",
@@ -13119,11 +11336,19 @@
           },
           "minLength": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "maxLength": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "pattern": {
             "type": "string"
@@ -13153,15 +11378,7 @@
             "type": "string"
           },
           {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "string",
-                "enum": ["Infinity", "-Infinity", "NaN"]
-              }
-            ]
+            "$ref": "#/components/schemas/Union_00be4ed53f19"
           },
           {
             "type": "boolean"
@@ -13190,15 +11407,7 @@
                 "type": "string"
               },
               {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string",
-                    "enum": ["Infinity", "-Infinity", "NaN"]
-                  }
-                ]
+                "$ref": "#/components/schemas/Union_00be4ed53f19"
               },
               {
                 "type": "boolean"
@@ -13292,8 +11501,12 @@
       },
       "InstructionEntry.Key": {
         "type": "string",
-        "pattern": "^[a-z0-9][a-z0-9._-]*$",
-        "description": "Instruction entry key (lowercase alphanumerics plus . _ -)"
+        "allOf": [
+          {
+            "pattern": "^[a-z0-9][a-z0-9._-]*$",
+            "description": "Instruction entry key (lowercase alphanumerics plus . _ -)"
+          }
+        ]
       },
       "InstructionEntryValueTooLargeErrorEncoded": {
         "type": "object",
@@ -13332,33 +11545,7 @@
             "enum": ["auto", "code"]
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string",
-                    "enum": ["Infinity", "-Infinity", "NaN"]
-                  }
-                ]
-              },
-              "expires": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string",
-                    "enum": ["Infinity", "-Infinity", "NaN"]
-                  }
-                ]
-              }
-            },
-            "required": ["created", "expires"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_03af97aacac9"
           }
         },
         "required": ["attemptID", "url", "instructions", "mode", "time"],
@@ -13374,33 +11561,7 @@
                 "enum": ["pending"]
               },
               "time": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  },
-                  "expires": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  }
-                },
-                "required": ["created", "expires"],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_03af97aacac9"
               }
             },
             "required": ["status", "time"],
@@ -13414,33 +11575,7 @@
                 "enum": ["complete"]
               },
               "time": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  },
-                  "expires": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  }
-                },
-                "required": ["created", "expires"],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_03af97aacac9"
               }
             },
             "required": ["status", "time"],
@@ -13457,33 +11592,7 @@
                 "type": "string"
               },
               "time": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  },
-                  "expires": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  }
-                },
-                "required": ["created", "expires"],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_03af97aacac9"
               }
             },
             "required": ["status", "message", "time"],
@@ -13497,33 +11606,7 @@
                 "enum": ["expired"]
               },
               "time": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  },
-                  "expires": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  }
-                },
-                "required": ["created", "expires"],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_03af97aacac9"
               }
             },
             "required": ["status", "time"],
@@ -13538,33 +11621,7 @@
             "type": "string"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string",
-                    "enum": ["Infinity", "-Infinity", "NaN"]
-                  }
-                ]
-              },
-              "expires": {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string",
-                    "enum": ["Infinity", "-Infinity", "NaN"]
-                  }
-                ]
-              }
-            },
-            "required": ["created", "expires"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_03af97aacac9"
           }
         },
         "required": ["attemptID", "time"],
@@ -13583,33 +11640,7 @@
                 "type": "string"
               },
               "time": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  },
-                  "expires": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  }
-                },
-                "required": ["created", "expires"],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_03af97aacac9"
               }
             },
             "required": ["status", "time"],
@@ -13623,33 +11654,7 @@
                 "enum": ["complete"]
               },
               "time": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  },
-                  "expires": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  }
-                },
-                "required": ["created", "expires"],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_03af97aacac9"
               }
             },
             "required": ["status", "time"],
@@ -13666,33 +11671,7 @@
                 "type": "string"
               },
               "time": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  },
-                  "expires": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  }
-                },
-                "required": ["created", "expires"],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_03af97aacac9"
               }
             },
             "required": ["status", "message", "time"],
@@ -13706,33 +11685,7 @@
                 "enum": ["expired"]
               },
               "time": {
-                "type": "object",
-                "properties": {
-                  "created": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  },
-                  "expires": {
-                    "anyOf": [
-                      {
-                        "type": "number"
-                      },
-                      {
-                        "type": "string",
-                        "enum": ["Infinity", "-Infinity", "NaN"]
-                      }
-                    ]
-                  }
-                },
-                "required": ["created", "expires"],
-                "additionalProperties": false
+                "$ref": "#/components/schemas/Objects_03af97aacac9"
               }
             },
             "required": ["status", "time"],
@@ -13883,24 +11836,10 @@
             "type": "string"
           },
           "kind": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/Union_f090cb615c84"
           },
           "field": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/Union_f090cb615c84"
           }
         },
         "required": ["_tag", "message"],
@@ -13914,7 +11853,11 @@
           },
           "workspaceID": {
             "type": "string",
-            "pattern": "^wrk"
+            "allOf": [
+              {
+                "pattern": "^wrk"
+              }
+            ]
           },
           "project": {
             "type": "object",
@@ -13944,7 +11887,11 @@
           },
           "workspaceID": {
             "type": "string",
-            "pattern": "^wrk"
+            "allOf": [
+              {
+                "pattern": "^wrk"
+              }
+            ]
           }
         },
         "required": ["directory"],
@@ -13979,22 +11926,7 @@
             "type": "boolean"
           },
           "timeout": {
-            "type": "object",
-            "properties": {
-              "startup": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              },
-              "catalog": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              },
-              "execution": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              }
-            },
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_7b507c2fd81f"
           }
         },
         "required": ["type", "command"],
@@ -14014,8 +11946,12 @@
           },
           "callback_port": {
             "type": "integer",
-            "minimum": 1,
-            "maximum": 65535
+            "allOf": [
+              {
+                "minimum": 1,
+                "maximum": 65535
+              }
+            ]
           },
           "redirect_uri": {
             "type": "string"
@@ -14057,22 +11993,7 @@
             "type": "boolean"
           },
           "timeout": {
-            "type": "object",
-            "properties": {
-              "startup": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              },
-              "catalog": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              },
-              "execution": {
-                "type": "integer",
-                "exclusiveMinimum": 0
-              }
-            },
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_7b507c2fd81f"
           }
         },
         "required": ["type", "url"],
@@ -14373,16 +12294,13 @@
             "type": "string"
           },
           "settings": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "headers": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "$ref": "#/components/schemas/Objects_3f161562db4a"
           },
           "body": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "capabilities": {
             "$ref": "#/components/schemas/Model.Capabilities"
@@ -14486,16 +12404,13 @@
             "type": "string"
           },
           "settings": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "headers": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "$ref": "#/components/schemas/Objects_3f161562db4a"
           },
           "body": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           }
         },
         "required": ["id"],
@@ -14506,6 +12421,97 @@
       },
       "Money.USDPerMillionTokens": {
         "type": "number"
+      },
+      "Objects_03af97aacac9": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "$ref": "#/components/schemas/Union_00be4ed53f19"
+          },
+          "expires": {
+            "$ref": "#/components/schemas/Union_00be4ed53f19"
+          }
+        },
+        "required": ["created", "expires"],
+        "additionalProperties": false
+      },
+      "Objects_3f161562db4a": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "Objects_7b507c2fd81f": {
+        "type": "object",
+        "properties": {
+          "startup": {
+            "type": "integer",
+            "allOf": [
+              {
+                "exclusiveMinimum": 0
+              }
+            ]
+          },
+          "catalog": {
+            "type": "integer",
+            "allOf": [
+              {
+                "exclusiveMinimum": 0
+              }
+            ]
+          },
+          "execution": {
+            "type": "integer",
+            "allOf": [
+              {
+                "exclusiveMinimum": 0
+              }
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "Objects_9d53a00b1efb": {
+        "type": "object",
+        "properties": {
+          "output": {
+            "type": "string"
+          },
+          "cursor": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
+          },
+          "size": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": ["output", "cursor", "size", "truncated"],
+        "additionalProperties": false
+      },
+      "Objects_a2c799262a3c": {
+        "type": "object"
+      },
+      "Objects_d7bbfd8ec2f6": {
+        "type": "object",
+        "properties": {
+          "created": {
+            "type": "number"
+          }
+        },
+        "required": ["created"],
+        "additionalProperties": false
       },
       "Permission.Effect": {
         "type": "string",
@@ -14520,29 +12526,31 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^per"
+            "allOf": [
+              {
+                "pattern": "^per"
+              }
+            ]
           },
           "sessionID": {
             "type": "string",
-            "pattern": "^ses"
+            "allOf": [
+              {
+                "pattern": "^ses"
+              }
+            ]
           },
           "action": {
             "type": "string"
           },
           "resources": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "$ref": "#/components/schemas/Arrays_681004346c78"
           },
           "save": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "$ref": "#/components/schemas/Arrays_681004346c78"
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "source": {
             "$ref": "#/components/schemas/Permission.Source"
@@ -14811,15 +12819,27 @@
         "properties": {
           "created": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "updated": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "initialized": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           }
         },
         "required": ["created", "updated"],
@@ -14844,7 +12864,11 @@
       },
       "Prompt.Base64": {
         "type": "string",
-        "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+        "allOf": [
+          {
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$"
+          }
+        ]
       },
       "Prompt.FileAttachment": {
         "type": "object",
@@ -14984,16 +13008,13 @@
             "type": "string"
           },
           "settings": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "headers": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "$ref": "#/components/schemas/Objects_3f161562db4a"
           },
           "body": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           }
         },
         "required": ["id", "name", "activation", "package"],
@@ -15043,7 +13064,11 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^pty"
+            "allOf": [
+              {
+                "pattern": "^pty"
+              }
+            ]
           },
           "title": {
             "type": "string"
@@ -15066,11 +13091,19 @@
           },
           "pid": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "exitCode": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           }
         },
         "required": ["id", "title", "command", "args", "cwd", "status", "pid"],
@@ -15101,7 +13134,11 @@
           },
           "expires_in": {
             "type": "integer",
-            "exclusiveMinimum": 0
+            "allOf": [
+              {
+                "exclusiveMinimum": 0
+              }
+            ]
           }
         },
         "required": ["ticket", "expires_in"],
@@ -15194,7 +13231,11 @@
           },
           "pid": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           }
         },
         "required": ["healthy", "version", "pid"],
@@ -15211,14 +13252,7 @@
             "type": "string"
           },
           "service": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/Union_f090cb615c84"
           }
         },
         "required": ["_tag", "message"],
@@ -15235,7 +13269,11 @@
               },
               "messageID": {
                 "type": "string",
-                "pattern": "^msg_"
+                "allOf": [
+                  {
+                    "pattern": "^msg_"
+                  }
+                ]
               }
             },
             "required": ["type", "messageID"],
@@ -15250,7 +13288,11 @@
               },
               "messageID": {
                 "type": "string",
-                "pattern": "^msg_"
+                "allOf": [
+                  {
+                    "pattern": "^msg_"
+                  }
+                ]
               }
             },
             "required": ["type", "messageID"],
@@ -15269,7 +13311,11 @@
               },
               "messageID": {
                 "type": "string",
-                "pattern": "^msg_"
+                "allOf": [
+                  {
+                    "pattern": "^msg_"
+                  }
+                ]
               }
             },
             "required": ["type", "messageID"],
@@ -15293,11 +13339,19 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "sessionID": {
             "type": "string",
-            "pattern": "^ses"
+            "allOf": [
+              {
+                "pattern": "^ses"
+              }
+            ]
           },
           "timeCreated": {
             "type": "number"
@@ -15351,11 +13405,19 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "sessionID": {
             "type": "string",
-            "pattern": "^ses"
+            "allOf": [
+              {
+                "pattern": "^ses"
+              }
+            ]
           },
           "timeCreated": {
             "type": "number"
@@ -15395,11 +13457,19 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "sessionID": {
             "type": "string",
-            "pattern": "^ses"
+            "allOf": [
+              {
+                "pattern": "^ses"
+              }
+            ]
           },
           "timeCreated": {
             "type": "number"
@@ -15439,11 +13509,19 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "sessionID": {
             "type": "string",
-            "pattern": "^ses"
+            "allOf": [
+              {
+                "pattern": "^ses"
+              }
+            ]
           },
           "timeCreated": {
             "type": "number"
@@ -15469,25 +13547,16 @@
             "type": "string"
           },
           "files": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Prompt.FileAttachment"
-            }
+            "$ref": "#/components/schemas/Arrays_042d796a7901"
           },
           "agents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Prompt.AgentAttachment"
-            }
+            "$ref": "#/components/schemas/Arrays_e1027de4b984"
           },
           "skills": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Prompt.SkillAttachment"
-            }
+            "$ref": "#/components/schemas/Arrays_92aa8803e81f"
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           }
         },
         "required": ["text"],
@@ -15498,18 +13567,30 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^ses"
+            "allOf": [
+              {
+                "pattern": "^ses"
+              }
+            ]
           },
           "parentID": {
             "type": "string",
-            "pattern": "^ses"
+            "allOf": [
+              {
+                "pattern": "^ses"
+              }
+            ]
           },
           "fork": {
             "type": "object",
             "properties": {
               "sessionID": {
                 "type": "string",
-                "pattern": "^ses"
+                "allOf": [
+                  {
+                    "pattern": "^ses"
+                  }
+                ]
               },
               "boundary": {
                 "$ref": "#/components/schemas/Session.ForkBoundary"
@@ -15580,20 +13661,17 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "type": {
             "type": "string",
@@ -15614,10 +13692,14 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
             "type": "object",
@@ -15737,7 +13819,11 @@
         "properties": {
           "attempt": {
             "type": "integer",
-            "exclusiveMinimum": 0
+            "allOf": [
+              {
+                "exclusiveMinimum": 0
+              }
+            ]
           },
           "at": {
             "type": "number"
@@ -15846,20 +13932,17 @@
           },
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "status": {
             "type": "string",
@@ -15888,20 +13971,17 @@
           },
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "status": {
             "type": "string",
@@ -15927,20 +14007,17 @@
           },
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "status": {
             "type": "string",
@@ -15999,20 +14076,17 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "type": {
             "type": "string",
@@ -16052,20 +14126,17 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "type": {
             "type": "string",
@@ -16101,10 +14172,14 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
             "type": "object",
@@ -16125,14 +14200,17 @@
           },
           "shellID": {
             "type": "string",
-            "pattern": "^sh_"
+            "allOf": [
+              {
+                "pattern": "^sh_"
+              }
+            ]
           },
           "command": {
             "type": "string"
           },
           "status": {
-            "type": "string",
-            "enum": ["running", "exited", "timeout", "killed"]
+            "$ref": "#/components/schemas/Union_b6d68a8b3572"
           },
           "exit": {
             "anyOf": [
@@ -16140,31 +14218,12 @@
                 "type": "number"
               },
               {
-                "type": "string",
-                "enum": ["Infinity", "-Infinity", "NaN"]
+                "$ref": "#/components/schemas/Union_97d8d2942510"
               }
             ]
           },
           "output": {
-            "type": "object",
-            "properties": {
-              "output": {
-                "type": "string"
-              },
-              "cursor": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "size": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "truncated": {
-                "type": "boolean"
-              }
-            },
-            "required": ["output", "cursor", "size", "truncated"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_9d53a00b1efb"
           }
         },
         "required": ["id", "time", "type", "shellID", "command", "status"],
@@ -16175,20 +14234,17 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "type": {
             "type": "string",
@@ -16212,20 +14268,17 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "text": {
             "type": "string"
@@ -16246,20 +14299,17 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "type": {
             "type": "string",
@@ -16372,41 +14422,29 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "metadata": {
-            "type": "object"
+            "$ref": "#/components/schemas/Objects_a2c799262a3c"
           },
           "time": {
-            "type": "object",
-            "properties": {
-              "created": {
-                "type": "number"
-              }
-            },
-            "required": ["created"],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/Objects_d7bbfd8ec2f6"
           },
           "text": {
             "type": "string"
           },
           "files": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Prompt.FileAttachment"
-            }
+            "$ref": "#/components/schemas/Arrays_042d796a7901"
           },
           "agents": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Prompt.AgentAttachment"
-            }
+            "$ref": "#/components/schemas/Arrays_e1027de4b984"
           },
           "skills": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Prompt.SkillAttachment"
-            }
+            "$ref": "#/components/schemas/Arrays_92aa8803e81f"
           },
           "type": {
             "type": "string",
@@ -16421,7 +14459,11 @@
         "properties": {
           "messageID": {
             "type": "string",
-            "pattern": "^msg_"
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
           },
           "partID": {
             "type": "string"
@@ -16450,8 +14492,12 @@
           },
           "status": {
             "type": "integer",
-            "minimum": 100,
-            "maximum": 599
+            "allOf": [
+              {
+                "minimum": 100,
+                "maximum": 599
+              }
+            ]
           }
         },
         "required": ["type", "message"],
@@ -16519,24 +14565,10 @@
             "type": "object",
             "properties": {
               "previous": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "$ref": "#/components/schemas/Union_f090cb615c84"
               },
               "next": {
-                "anyOf": [
-                  {
-                    "type": "string"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "$ref": "#/components/schemas/Union_f090cb615c84"
               }
             },
             "additionalProperties": false
@@ -16570,7 +14602,11 @@
           },
           "steps": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           }
         },
         "required": ["date", "steps"],
@@ -16594,19 +14630,35 @@
           },
           "sessions": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "subagents": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "prompts": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "steps": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "tokens": {
             "$ref": "#/components/schemas/TokenUsage.Info"
@@ -16619,11 +14671,19 @@
           },
           "activeDays": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "streak": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "activity": {
             "type": "array",
@@ -16662,7 +14722,11 @@
           },
           "steps": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "tokens": {
             "$ref": "#/components/schemas/TokenUsage.Info"
@@ -16679,19 +14743,35 @@
         "properties": {
           "calls": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "succeeded": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "failed": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "unfinished": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           }
         },
         "required": ["calls", "succeeded", "failed", "unfinished"],
@@ -16705,19 +14785,35 @@
           },
           "calls": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "succeeded": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "failed": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "unfinished": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "durationP50": {
             "type": "number"
@@ -16782,10 +14878,7 @@
             "$ref": "#/components/schemas/Session.Info"
           },
           "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Session.Message.Info"
-            }
+            "$ref": "#/components/schemas/Arrays_fa246a9267ec"
           }
         },
         "required": ["info", "messages"],
@@ -16835,11 +14928,14 @@
         "properties": {
           "id": {
             "type": "string",
-            "pattern": "^sh_"
+            "allOf": [
+              {
+                "pattern": "^sh_"
+              }
+            ]
           },
           "status": {
-            "type": "string",
-            "enum": ["running", "exited", "timeout", "killed"]
+            "$ref": "#/components/schemas/Union_b6d68a8b3572"
           },
           "command": {
             "type": "string"
@@ -16855,7 +14951,11 @@
           },
           "pid": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "exit": {
             "type": "number"
@@ -16995,14 +15095,7 @@
             "type": "string"
           },
           "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/Union_f090cb615c84"
           }
         },
         "required": ["type", "uri", "mime"],
@@ -17036,6 +15129,172 @@
         "required": ["_tag", "message"],
         "additionalProperties": false
       },
+      "Union_00be4ed53f19": {
+        "anyOf": [
+          {
+            "type": "number"
+          },
+          {
+            "$ref": "#/components/schemas/Union_97d8d2942510"
+          }
+        ]
+      },
+      "Union_1f50b1b03235": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Session.Inbox.Delivery"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "Union_5ee94d3ca88d": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Location.Ref"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "Union_636af7bc29f5": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Form.Answer"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "Union_6a162d0a021d": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/Model.Ref"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "Union_6a1762611a44": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "Union_85ca62cf1a33": {
+        "anyOf": [
+          {
+            "type": "string",
+            "allOf": [
+              {
+                "pattern": "^[^/#]+\\/[^#]+(?:#[^#]+)?$"
+              }
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "providerID": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[^/#]+$"
+                  }
+                ]
+              },
+              "model": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[^#]+$"
+                  }
+                ]
+              },
+              "variant": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[^#]+$"
+                  }
+                ]
+              }
+            },
+            "required": ["providerID", "model"],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "Union_97d8d2942510": {
+        "type": "string",
+        "enum": ["Infinity", "-Infinity", "NaN"]
+      },
+      "Union_b6d68a8b3572": {
+        "type": "string",
+        "enum": ["running", "exited", "timeout", "killed"]
+      },
+      "Union_e13209ef6bf4": {
+        "anyOf": [
+          {
+            "type": "string",
+            "enum": ["true", "false"]
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "Union_f090cb615c84": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "Union_f8b4c9e24aa0": {
+        "anyOf": [
+          {
+            "type": "string",
+            "allOf": [
+              {
+                "pattern": "^msg_"
+              }
+            ]
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "Union_ffefb7e3c81d": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "directory": {
+                "$ref": "#/components/schemas/Union_f090cb615c84"
+              },
+              "workspace": {
+                "$ref": "#/components/schemas/Union_f090cb615c84"
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
       "UnknownErrorEncoded": {
         "type": "object",
         "properties": {
@@ -17047,14 +15306,7 @@
             "type": "string"
           },
           "ref": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ]
+            "$ref": "#/components/schemas/Union_f090cb615c84"
           }
         },
         "required": ["_tag", "message"],
@@ -17084,11 +15336,19 @@
           },
           "additions": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "deletions": {
             "type": "integer",
-            "minimum": 0
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
           },
           "status": {
             "type": "string",
@@ -17209,14 +15469,7 @@
                 "type": "string"
               },
               "forceRequired": {
-                "anyOf": [
-                  {
-                    "type": "boolean"
-                  },
-                  {
-                    "type": "null"
-                  }
-                ]
+                "$ref": "#/components/schemas/Union_6a1762611a44"
               }
             },
             "required": ["message"],

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -117,8 +117,8 @@ export class CommandNotFoundError extends Schema.TaggedError<CommandNotFoundErro
   { httpApiStatus: 404 },
 ) {}
 
-export class CommandEvaluationError extends Schema.TaggedError<CommandEvaluationError>()(
-  "CommandEvaluationError",
+export class CommandExecutionError extends Schema.TaggedError<CommandExecutionError>()(
+  "CommandExecutionError",
   {
     command: Schema.String,
     message: Schema.String,

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -13,7 +13,7 @@ import { Context, Effect, Encoding, Result, Schema, SchemaGetter, Struct } from 
 import { HttpApiEndpoint, HttpApiGroup, HttpApiMiddleware, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
 import {
   ConflictError,
-  CommandEvaluationError,
+  CommandExecutionError,
   CommandNotFoundError,
   InvalidCursorError,
   InvalidRequestError,
@@ -358,27 +358,19 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
       HttpApiEndpoint.post("session.command", "/api/session/:sessionID/command", {
         params: { sessionID: Session.ID },
         payload: Schema.Struct({
-          id: SessionMessage.ID.pipe(Schema.optional),
           command: Schema.String,
-          arguments: Schema.String.pipe(Schema.optional),
-          agent: Agent.ID.pipe(Schema.optional),
-          model: Model.Ref.pipe(Schema.optional),
-          files: PromptInput.Prompt.fields.files,
-          agents: PromptInput.Prompt.fields.agents,
-          skills: PromptInput.Prompt.fields.skills,
+          ...PromptInput.Prompt.fields,
           delivery: SessionInbox.Delivery.pipe(Schema.optional),
-          resume: Schema.Boolean.pipe(Schema.optional),
         }),
-        success: Schema.Struct({ data: SessionInbox.User }),
-        error: [ConflictError, InvalidRequestError, SessionNotFoundError, CommandNotFoundError, CommandEvaluationError],
+        success: HttpApiSchema.NoContent,
+        error: [SessionNotFoundError, CommandNotFoundError, CommandExecutionError],
       })
         .middleware(sessionLocationMiddleware)
         .annotateMerge(
           OpenApi.annotations({
             identifier: "v2.session.command",
             summary: "Run command",
-            description:
-              "Resolve a slash command into prompt input, admit it durably, and schedule execution unless resume is false.",
+            description: "Execute a slash command callback immediately.",
           }),
         ),
     )

--- a/packages/schema/src/command.ts
+++ b/packages/schema/src/command.ts
@@ -3,19 +3,13 @@ export * as Command from "./command.js"
 import { Schema } from "effect"
 import { ephemeral, inventory } from "./event.js"
 import { optional } from "./schema.js"
-import { Model } from "./model.js"
-import { Agent } from "./agent.js"
 
 const Updated = ephemeral({ type: "command.updated", schema: {} })
 
 export interface Info extends Schema.Schema.Type<typeof Info> {}
 export const Info = Schema.Struct({
   name: Schema.String,
-  template: Schema.String,
   description: Schema.String.pipe(optional),
-  agent: Agent.ID.pipe(optional),
-  model: Model.Ref.pipe(optional),
-  subtask: Schema.Boolean.pipe(optional),
 }).annotate({ identifier: "Command.Info" })
 
 export const Event = {

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -8,7 +8,7 @@ import { Api } from "../api"
 import { SessionsCursor } from "@opencode-ai/protocol/groups/session"
 import {
   ConflictError,
-  CommandEvaluationError,
+  CommandExecutionError,
   CommandNotFoundError,
   InvalidRequestError,
   InvalidCursorError,
@@ -317,55 +317,36 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
       .handle(
         "session.command",
         Effect.fn(function* (ctx) {
-          return {
-            data: yield* session
-              .command({
-                sessionID: ctx.params.sessionID,
-                id: ctx.payload.id,
-                command: ctx.payload.command,
-                arguments: ctx.payload.arguments,
-                agent: ctx.payload.agent,
-                model: ctx.payload.model,
-                files: ctx.payload.files,
-                agents: ctx.payload.agents,
-                skills: ctx.payload.skills,
-                delivery: ctx.payload.delivery,
-                resume: ctx.payload.resume,
-              })
-              .pipe(
-                Effect.catchTag("Session.NotFoundError", missingSession),
-                Effect.catchTag("Command.NotFoundError", (error) =>
-                  Effect.fail(
-                    new CommandNotFoundError({
-                      command: error.command,
-                      message: error.message,
-                    }),
-                  ),
-                ),
-                Effect.catchTag("Command.EvaluationError", (error) =>
-                  Effect.fail(
-                    new CommandEvaluationError({
-                      command: error.command,
-                      message: error.message,
-                    }),
-                  ),
-                ),
-                Effect.catchTag("Session.PromptConflictError", (error) =>
-                  Effect.fail(
-                    new ConflictError({
-                      message: `Prompt message ID conflicts with an existing durable record: ${error.messageID}`,
-                      resource: error.messageID,
-                    }),
-                  ),
-                ),
-                Effect.catchTag("Session.AttachmentError", (error) =>
-                  Effect.fail(new InvalidRequestError({ message: error.message, field: "files" })),
-                ),
-                Effect.catchTag("Session.SkillNotFoundError", (error) =>
-                  Effect.fail(new InvalidRequestError({ message: `Skill not found: ${error.skill}`, field: "skills" })),
+          yield* session
+            .command({
+              sessionID: ctx.params.sessionID,
+              command: ctx.payload.command,
+              text: ctx.payload.text,
+              files: ctx.payload.files,
+              agents: ctx.payload.agents,
+              skills: ctx.payload.skills,
+              delivery: ctx.payload.delivery,
+            })
+            .pipe(
+              Effect.catchTag("Session.NotFoundError", missingSession),
+              Effect.catchTag("Command.NotFoundError", (error) =>
+                Effect.fail(
+                  new CommandNotFoundError({
+                    command: error.command,
+                    message: error.message,
+                  }),
                 ),
               ),
-          }
+              Effect.catchTag("Command.ExecutionError", (error) =>
+                Effect.fail(
+                  new CommandExecutionError({
+                    command: error.command,
+                    message: error.message,
+                  }),
+                ),
+              ),
+            )
+          return HttpApiSchema.NoContent.make()
         }),
       )
       .handle(

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1271,17 +1271,11 @@ export function Prompt(props: PromptProps) {
       dispatch(() => client.api.session.shell({ sessionID: target, command: inputText }))
       setStore("mode", "normal")
     } else if (slashHead && isCommand) {
-      move.startSubmit()
-      const model = { providerID: selection.providerID, id: selection.modelID, variant }
-      const cancelCommit = local.model.trackSessionCommit(target, model)
-
       const send = () =>
         client.api.session.command({
           sessionID: target,
           command: slashHead.name,
-          arguments: slashHead.arguments,
-          agent: agent.id,
-          model,
+          text: slashHead.arguments,
           files: entry.files,
           agents: entry.agents,
           skills: entry.skills?.length ? entry.skills : undefined,
@@ -1289,7 +1283,6 @@ export function Prompt(props: PromptProps) {
         })
       const setup = newSession
       void (setup ? setup.gate.then(send) : send()).catch((error) => {
-        cancelCommit()
         if (setup) return setup.recover(error)
         toast.show({ title: "Failed to run command", message: errorMessage(error), variant: "error" })
         restoreEntry()

--- a/packages/tui/src/mini/stream-v2.transport.ts
+++ b/packages/tui/src/mini/stream-v2.transport.ts
@@ -1657,17 +1657,12 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       )
     }
 
-    const selected = await resolveSelectedModel(input, client, next)
-    if (next.variant && !selected) throw new Error("Cannot select a variant before selecting a model")
     input.trace?.write("send.command", { sessionID: input.sessionID, messageID, command: command.name, delivery })
     return client.session.command(
       {
         sessionID: input.sessionID,
-        id: messageID,
         command: command.name,
-        arguments: command.arguments,
-        agent: next.agent,
-        model: selected,
+        text: command.arguments,
         files: attachments.files.length ? attachments.files : undefined,
         agents: agents.length ? agents : undefined,
         skills: skills.length ? skills : undefined,
@@ -1708,7 +1703,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
         throw new Error("This prompt cannot be queued")
       if (!state.connected) throw new Error("Event stream is reconnecting")
       const client = sdk
-      if (next.agent)
+      if (!next.prompt.command && next.agent)
         await client.session.switchAgent({ sessionID: input.sessionID, agent: next.agent }, { signal: next.signal })
       if (!next.prompt.command) {
         const selected = await resolveSelectedModel(input, client, next)
@@ -1716,7 +1711,8 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
         if (selected)
           await client.session.switchModel({ sessionID: input.sessionID, model: selected }, { signal: next.signal })
       }
-      mergePending(await admitPrompt(next, client, delivery))
+      const admitted = await admitPrompt(next, client, delivery)
+      if (admitted) mergePending(admitted)
       settlementClient = client
     },
     async waitForIdle() {
@@ -1754,13 +1750,8 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
         return
       }
       if (command) {
-        await runTurnWait(
-          next,
-          messageID,
-          client,
-          () => admitPrompt(next, client, next.prompt.delivery ?? "steer"),
-          admitted,
-        )
+        await admitPrompt(next, client, next.prompt.delivery ?? "steer")
+        admitted?.()
         return
       }
 

--- a/packages/tui/test/mini/stream-v2.transport.test.ts
+++ b/packages/tui/test/mini/stream-v2.transport.test.ts
@@ -2814,14 +2814,7 @@ describe("V2 mini transport", () => {
           data: { sessionID: "ses_1" },
         })
       })
-      return ok({
-        id: input.id ?? "msg_cmd",
-        sessionID: "ses_1",
-        type: "user" as const,
-        payload: { text: "evaluated template" },
-        delivery: "steer" as const,
-        timeCreated: 2,
-      })
+      return ok(undefined)
     })
 
     await transport.runPromptTurn({
@@ -2852,11 +2845,8 @@ describe("V2 mini transport", () => {
 
     expect(request).toMatchObject({
       sessionID: "ses_1",
-      id: "msg_cmd",
       command: "deploy",
-      arguments: "prod",
-      agent: "build",
-      model: { providerID: "test", id: "model" },
+      text: "prod",
       files: [
         { uri: "file:///tmp/context.txt", name: "context.txt" },
         {
@@ -2868,7 +2858,6 @@ describe("V2 mini transport", () => {
       skills: [{ id: "api-design", mention: { start: 13, end: 24, text: "/api-design" } }],
       delivery: "steer",
     })
-    // Selection rides the command payload; no separate client-side switch.
     expect(client.session.switchAgent).not.toHaveBeenCalled()
     expect(client.session.switchModel).not.toHaveBeenCalled()
     await transport.close()


### PR DESCRIPTION
## Summary
- replace prompt-template-specific command definitions with executable plugin callbacks
- pass the full prompt and delivery mode to command callbacks and execute them immediately
- adapt built-in, config, and MCP commands while updating API clients and UI/ACP consumers

## Testing
- full pre-push workspace typecheck (32 packages)
- focused core command/config/plugin tests
- TUI transport suite
- ACP event and service tests
- generated OpenAPI check