### PR TITLE
fix(core): make workspace destroy idempotent

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -1700,7 +1700,7 @@ export interface WorktreeApi<E = never> {
 }
 
 export type WorkspaceDestroyInput = { readonly workspaceID: Workspace.ID }
-export type WorkspaceDestroyOutput = { readonly destroyed: boolean }
+export type WorkspaceDestroyOutput = Workspace.DestroyResult
 export type WorkspaceDestroyOperation<E = never> = (
   input: WorkspaceDestroyInput,
 ) => Effect.Effect<WorkspaceDestroyOutput, E>

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -1699,6 +1699,16 @@ export interface WorktreeApi<E = never> {
   readonly refresh: WorktreeRefreshOperation<E>
 }
 
+export type WorkspaceDestroyInput = { readonly workspaceID: Workspace.ID }
+export type WorkspaceDestroyOutput = { readonly destroyed: boolean }
+export type WorkspaceDestroyOperation<E = never> = (
+  input: WorkspaceDestroyInput,
+) => Effect.Effect<WorkspaceDestroyOutput, E>
+
+export interface WorkspaceApi<E = never> {
+  readonly destroy: WorkspaceDestroyOperation<E>
+}
+
 export type VcsGetInput = {
   readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
 }
@@ -1816,6 +1826,7 @@ export interface AppApi<E = never> {
   readonly shell: ShellApi<E>
   readonly reference: ReferenceApi<E>
   readonly worktree: WorktreeApi<E>
+  readonly workspace: WorkspaceApi<E>
   readonly vcs: VcsApi<E>
   readonly debug: DebugApi<E>
   readonly migration: MigrationApi<E>

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -214,6 +214,8 @@ import type {
   WorktreeRemoveOutput,
   WorktreeRefreshInput,
   WorktreeRefreshOutput,
+  WorkspaceDestroyInput,
+  WorkspaceDestroyOutput,
   VcsGetInput,
   VcsGetOutput,
   VcsStatusInput,
@@ -1278,6 +1280,13 @@ const adaptGroupWorktree = (raw: RawClient["server.worktree"]) => ({
   refresh: EndpointWorktreeRefresh(raw),
 })
 
+const EndpointWorkspaceDestroy = (raw: RawClient["server.workspace"]) => (input: WorkspaceDestroyInput) =>
+  preserveEffect<WorkspaceDestroyOutput>()(
+    raw["workspace.destroy"]({ params: { workspaceID: input["workspaceID"] } }).pipe(Effect.mapError(mapClientError)),
+  )
+
+const adaptGroupWorkspace = (raw: RawClient["server.workspace"]) => ({ destroy: EndpointWorkspaceDestroy(raw) })
+
 const EndpointVcsGet = (raw: RawClient["server.vcs"]) => (input?: VcsGetInput) =>
   preserveEffect<VcsGetOutput>()(
     raw["vcs.get"]({ query: { location: input?.["location"] } }).pipe(Effect.mapError(mapClientError)),
@@ -1368,6 +1377,7 @@ const adaptClient = (raw: RawClient) => ({
   shell: adaptGroupShell(raw["server.shell"]),
   reference: adaptGroupReference(raw["server.reference"]),
   worktree: adaptGroupWorktree(raw["server.worktree"]),
+  workspace: adaptGroupWorkspace(raw["server.workspace"]),
   vcs: adaptGroupVcs(raw["server.vcs"]),
   debug: adaptGroupDebug(raw["server.debug"]),
   migration: adaptGroupMigration(raw["server.migration"]),

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -210,6 +210,8 @@ import type {
   WorktreeRemoveOutput,
   WorktreeRefreshInput,
   WorktreeRefreshOutput,
+  WorkspaceDestroyInput,
+  WorkspaceDestroyOutput,
   VcsGetInput,
   VcsGetOutput,
   VcsStatusInput,
@@ -1766,6 +1768,19 @@ export function make(options: ClientOptions) {
             successStatus: 204,
             declaredStatuses: [400, 401],
             empty: true,
+          },
+          requestOptions,
+        ),
+    },
+    workspace: {
+      destroy: (input: WorkspaceDestroyInput, requestOptions?: RequestOptions) =>
+        request<WorkspaceDestroyOutput>(
+          {
+            method: "DELETE",
+            path: `/api/workspace/${encodeURIComponent(input.workspaceID)}`,
+            successStatus: 200,
+            declaredStatuses: [500, 401, 400],
+            empty: false,
           },
           requestOptions,
         ),

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -378,6 +378,8 @@ export type WorktreeDirectory = { directory: string; strategy?: string }
 
 export type WorktreeInfo = { directory: string }
 
+export type WorkspaceDestroyResult = { destroyed: boolean }
+
 export type VcsBranch = { current?: string; default?: string }
 
 export type VcsFileStatus = {
@@ -5751,6 +5753,10 @@ export type WorktreeRemoveOutput = void
 export type WorktreeRefreshInput = { readonly projectID: { readonly projectID: string }["projectID"] }
 
 export type WorktreeRefreshOutput = void
+
+export type WorkspaceDestroyInput = { readonly workspaceID: { readonly workspaceID: string }["workspaceID"] }
+
+export type WorkspaceDestroyOutput = WorkspaceDestroyResult
 
 export type VcsGetInput = {
   readonly location?: {

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -30,6 +30,7 @@ test("exposes every standard HTTP API group", () => {
     "question",
     "reference",
     "worktree",
+    "workspace",
     "vcs",
     "debug",
     "migration",
@@ -278,6 +279,21 @@ test("worktree methods use the global project contract", async () => {
     name: "api",
   })
   expect(await requests[2]?.json()).toEqual({ directory: "/tmp/worktrees/api", force: false })
+})
+
+test("workspace.destroy returns the transition result", async () => {
+  let request: Request | undefined
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: async (input, init) => {
+      request = input instanceof Request ? input : new Request(input, init)
+      return Response.json({ destroyed: false })
+    },
+  })
+
+  expect(await client.workspace.destroy({ workspaceID: "wrk_missing" })).toEqual({ destroyed: false })
+  expect(request?.method).toBe("DELETE")
+  expect(request?.url).toBe("http://localhost:3000/api/workspace/wrk_missing")
 })
 
 test("shell list and remove use the public HTTP contract", async () => {

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -35,9 +35,10 @@ export interface Interface {
   readonly connect: (
     workspaceID: ID,
   ) => Effect.Effect<EnvironmentDriver, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
+  /** Makes the workspace absent; reports whether this call destroyed an existing workspace. */
   readonly destroy: (
     workspaceID: ID,
-  ) => Effect.Effect<void, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
+  ) => Effect.Effect<{ readonly destroyed: boolean }, WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
 }
 
 export interface Options {
@@ -267,9 +268,15 @@ const layer = (options: Options) =>
             attempts.delete(workspaceID)
             Deferred.doneUnsafe(attempt, Exit.fail(new NotFound({ workspaceID })))
           }
-          yield* locks.withLock(workspaceID)(
+          return yield* locks.withLock(workspaceID)(
             Effect.gen(function* () {
-              const row = yield* load(workspaceID)
+              const row = yield* db
+                .select()
+                .from(WorkspaceTable)
+                .where(eq(WorkspaceTable.id, workspaceID))
+                .get()
+                .pipe(Effect.orDie)
+              if (!row) return { destroyed: false }
               const connection = connections.get(workspaceID)
               connections.delete(workspaceID)
               if (connection) yield* Scope.close(connection.scope, Exit.void)
@@ -284,6 +291,7 @@ const layer = (options: Options) =>
                 ),
               )
               yield* db.delete(WorkspaceTable).where(eq(WorkspaceTable.id, workspaceID)).run().pipe(Effect.orDie)
+              return { destroyed: true }
             }),
           )
         }),

--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -36,9 +36,10 @@ export interface Interface {
     workspaceID: ID,
   ) => Effect.Effect<EnvironmentDriver, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
   /** Makes the workspace absent; reports whether this call destroyed an existing workspace. */
-  readonly destroy: (
-    workspaceID: ID,
-  ) => Effect.Effect<{ readonly destroyed: boolean }, WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
+  readonly destroy: (workspaceID: ID) => Effect.Effect<
+    Workspace.DestroyResult,
+    WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound
+  >
 }
 
 export interface Options {
@@ -80,13 +81,16 @@ const layer = (options: Options) =>
       const fork = yield* FiberSet.makeRuntime<never, void, never>()
       const idleThreshold = Duration.toMillis(options.idleThreshold ?? Duration.minutes(20))
 
-      const load = Effect.fn("Workspace.load")(function* (workspaceID: ID) {
-        const row = yield* db
+      const find = (workspaceID: ID) =>
+        db
           .select()
           .from(WorkspaceTable)
           .where(eq(WorkspaceTable.id, workspaceID))
           .get()
           .pipe(Effect.orDie)
+
+      const load = Effect.fn("Workspace.load")(function* (workspaceID: ID) {
+        const row = yield* find(workspaceID)
         if (!row) return yield* new NotFound({ workspaceID })
         return row
       })
@@ -270,12 +274,7 @@ const layer = (options: Options) =>
           }
           return yield* locks.withLock(workspaceID)(
             Effect.gen(function* () {
-              const row = yield* db
-                .select()
-                .from(WorkspaceTable)
-                .where(eq(WorkspaceTable.id, workspaceID))
-                .get()
-                .pipe(Effect.orDie)
+              const row = yield* find(workspaceID)
               if (!row) return { destroyed: false }
               const connection = connections.get(workspaceID)
               connections.delete(workspaceID)

--- a/packages/core/test/workspace.test.ts
+++ b/packages/core/test/workspace.test.ts
@@ -94,13 +94,34 @@ it.effect("destroys an unprovisioned workspace through the driver with a null bi
     const workspace = yield* Workspace.Service
     const workspaceID = yield* workspace.create("fake")
 
-    yield* workspace.destroy(workspaceID)
+    expect(yield* workspace.destroy(workspaceID)).toEqual({ destroyed: true })
     expect(calls).toEqual([{ operation: "destroy", binding: null }])
     expect(
       yield* Database.Service.use(({ db }) =>
         db.select().from(WorkspaceTable).where(eq(WorkspaceTable.id, workspaceID)).get(),
       ).pipe(Effect.orDie),
     ).toBeUndefined()
+  }),
+)
+
+it.effect("succeeds without calling the driver when the workspace does not exist", () =>
+  Effect.gen(function* () {
+    const workspace = yield* Workspace.Service
+    const workspaceID = Workspace.ID.create()
+
+    expect(yield* workspace.destroy(workspaceID)).toEqual({ destroyed: false })
+    expect(calls).toEqual([])
+  }),
+)
+
+it.effect("reports whether destroy removed an existing workspace", () =>
+  Effect.gen(function* () {
+    const workspace = yield* Workspace.Service
+    const workspaceID = yield* workspace.create("fake")
+
+    expect(yield* workspace.destroy(workspaceID)).toEqual({ destroyed: true })
+    expect(yield* workspace.destroy(workspaceID)).toEqual({ destroyed: false })
+    expect(calls).toEqual([{ operation: "destroy", binding: null }])
   }),
 )
 

--- a/packages/protocol/src/api.ts
+++ b/packages/protocol/src/api.ts
@@ -32,6 +32,7 @@ import { WorktreeGroup } from "./groups/worktree.js"
 import { VcsGroup } from "./groups/vcs.js"
 import { MigrationGroup } from "./groups/migration.js"
 import { ConfigGroup } from "./groups/config.js"
+import { WorkspaceGroup } from "./groups/workspace.js"
 
 type LocationGroups<LocationId extends HttpApiMiddleware.AnyId> =
   | HttpApiGroup.AddMiddleware<typeof LocationGroup, LocationId>
@@ -86,6 +87,7 @@ type ApiGroups<
   | typeof DebugGroup
   | typeof MigrationGroup
   | typeof WorktreeGroup
+  | typeof WorkspaceGroup
   | LocationGroups<LocationId>
   | FormGroups<LocationId, LocationService, FormLocationId, FormLocationService>
   | SessionGroups<SessionLocationId, SessionLocationService>
@@ -169,6 +171,7 @@ const makeApiFromGroup = <
     .add(ShellGroup.middleware(locationMiddleware))
     .add(ReferenceGroup.middleware(locationMiddleware))
     .add(WorktreeGroup)
+    .add(WorkspaceGroup)
     .add(VcsGroup.middleware(locationMiddleware))
     .add(DebugGroup)
     .add(MigrationGroup)

--- a/packages/protocol/src/client.ts
+++ b/packages/protocol/src/client.ts
@@ -60,6 +60,7 @@ export const groupNames = {
   "server.reference": "reference",
   "server.project": "project",
   "server.worktree": "worktree",
+  "server.workspace": "workspace",
   "server.vcs": "vcs",
   "server.config": "config",
 } as const

--- a/packages/protocol/src/groups/workspace.ts
+++ b/packages/protocol/src/groups/workspace.ts
@@ -1,0 +1,30 @@
+import { Workspace } from "@opencode-ai/schema/workspace"
+import { Schema } from "effect"
+import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
+import { UnknownError } from "../errors.js"
+
+export const DestroyResult = Schema.Struct({
+  destroyed: Schema.Boolean.annotate({
+    description: "True when this request transitioned the workspace from existing to destroyed.",
+  }),
+}).annotate({
+  identifier: "WorkspaceDestroyResult",
+  description: "Reports whether this request destroyed an existing workspace.",
+})
+
+export const WorkspaceGroup = HttpApiGroup.make("server.workspace")
+  .add(
+    HttpApiEndpoint.delete("workspace.destroy", "/api/workspace/:workspaceID", {
+      params: { workspaceID: Workspace.ID },
+      success: DestroyResult,
+      error: UnknownError,
+    }).annotateMerge(
+      OpenApi.annotations({
+        identifier: "v2.workspace.destroy",
+        summary: "Destroy workspace",
+        description:
+          "Make a workspace not exist. This operation is idempotent: an already-missing workspace succeeds with `destroyed: false`, while a workspace removed by this request returns `destroyed: true`.",
+      }),
+    ),
+  )
+  .annotateMerge(OpenApi.annotations({ title: "workspace", description: "Workspace lifecycle routes." }))

--- a/packages/protocol/src/groups/workspace.ts
+++ b/packages/protocol/src/groups/workspace.ts
@@ -1,22 +1,12 @@
 import { Workspace } from "@opencode-ai/schema/workspace"
-import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { UnknownError } from "../errors.js"
-
-export const DestroyResult = Schema.Struct({
-  destroyed: Schema.Boolean.annotate({
-    description: "True when this request transitioned the workspace from existing to destroyed.",
-  }),
-}).annotate({
-  identifier: "WorkspaceDestroyResult",
-  description: "Reports whether this request destroyed an existing workspace.",
-})
 
 export const WorkspaceGroup = HttpApiGroup.make("server.workspace")
   .add(
     HttpApiEndpoint.delete("workspace.destroy", "/api/workspace/:workspaceID", {
       params: { workspaceID: Workspace.ID },
-      success: DestroyResult,
+      success: Workspace.DestroyResult,
       error: UnknownError,
     }).annotateMerge(
       OpenApi.annotations({

--- a/packages/schema/src/workspace.ts
+++ b/packages/schema/src/workspace.ts
@@ -1,9 +1,20 @@
 export * as Workspace from "./workspace.js"
 
+import { Schema } from "effect"
 import { WorkspaceEvent } from "./workspace-event.js"
 import { WorkspaceID } from "./workspace-id.js"
 
 export const ID = WorkspaceID
 export type ID = WorkspaceID
+
+export const DestroyResult = Schema.Struct({
+  destroyed: Schema.Boolean.annotate({
+    description: "True when this request transitioned the workspace from existing to destroyed.",
+  }),
+}).annotate({
+  identifier: "WorkspaceDestroyResult",
+  description: "Reports whether this request destroyed an existing workspace.",
+})
+export interface DestroyResult extends Schema.Schema.Type<typeof DestroyResult> {}
 
 export const Event = WorkspaceEvent

--- a/packages/sdk/test/embedded.test.ts
+++ b/packages/sdk/test/embedded.test.ts
@@ -479,11 +479,10 @@ it.live("configures workspace providers through the SDK facade", () =>
       const session = yield* opencode.sessions.create({ location: workspaceLocation })
       expect(session.location.workspaceID).toBe(workspace.id)
 
-      yield* opencode.workspace.destroy({ workspaceID: workspace.id })
+      expect(yield* opencode.workspace.destroy({ workspaceID: workspace.id })).toEqual({ destroyed: true })
       expect(calls.map((call) => call.operation)).toEqual(["create", "destroy"])
-      expect((yield* opencode.workspace.destroy({ workspaceID: workspace.id }).pipe(Effect.flip))._tag).toBe(
-        "Workspace.NotFound",
-      )
+      expect(yield* opencode.workspace.destroy({ workspaceID: workspace.id })).toEqual({ destroyed: false })
+      expect(calls.map((call) => call.operation)).toEqual(["create", "destroy"])
     }),
   ),
 )

--- a/packages/server/src/handlers.ts
+++ b/packages/server/src/handlers.ts
@@ -29,6 +29,7 @@ import { VcsHandler } from "./handlers/vcs"
 import { EventFeed } from "./event-feed"
 import { MigrationHandler } from "./handlers/migration"
 import { ConfigHandler } from "./handlers/config"
+import { WorkspaceHandler } from "./handlers/workspace"
 
 export const handlers = Layer.mergeAll(
   HealthHandler,
@@ -58,6 +59,7 @@ export const handlers = Layer.mergeAll(
   ShellHandler,
   ReferenceHandler,
   WorktreeHandler,
+  WorkspaceHandler,
   VcsHandler,
   ConfigHandler,
 )

--- a/packages/server/src/handlers/workspace.ts
+++ b/packages/server/src/handlers/workspace.ts
@@ -1,0 +1,25 @@
+import { Workspace } from "@opencode-ai/core/workspace"
+import { UnknownError } from "@opencode-ai/protocol/errors"
+import { Effect } from "effect"
+import { HttpApiBuilder } from "effect/unstable/httpapi"
+import { Api } from "../api"
+
+export const WorkspaceHandler = HttpApiBuilder.group(Api, "server.workspace", (handlers) =>
+  Effect.gen(function* () {
+    const workspace = yield* Workspace.Service
+
+    return handlers.handle("workspace.destroy", (ctx) =>
+      workspace.destroy(ctx.params.workspaceID).pipe(
+        Effect.mapError(
+          (error) =>
+            new UnknownError({
+              message:
+                error._tag === "WorkspaceDriver.ProviderNotFound"
+                  ? `Workspace provider not found: ${error.provider}`
+                  : (error.message ?? "Workspace provider failed to destroy the workspace"),
+            }),
+        ),
+      ),
+    )
+  }),
+)

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -65,9 +65,9 @@ const applicationServiceNodes = [
   LocationServiceMap.node,
   LocationActivity.node,
   SessionRestart.node,
+  Workspace.node,
 ] as const
 const applicationServices = LayerNode.group(applicationServiceNodes)
-const embeddedApplicationServices = LayerNode.group([...applicationServiceNodes, Workspace.node])
 
 export function createRoutes(
   options: ServerOptions = {},
@@ -81,12 +81,11 @@ export function createRoutes(
     options,
     serviceURLs,
     overrides,
-    false,
   )
 }
 
 export function createEmbeddedRoutes(options: ServerOptions = {}, overrides: LayerNode.Replacements = []) {
-  return makeRoutes(ServerAuth.Config.configLayer({ password: Option.none() }), options, () => [], overrides, true)
+  return makeRoutes(ServerAuth.Config.configLayer({ password: Option.none() }), options, () => [], overrides)
 }
 
 function makeRoutes<AuthError, AuthServices>(
@@ -95,7 +94,6 @@ function makeRoutes<AuthError, AuthServices>(
   serviceURLs: () => ReadonlyArray<string>,
   // Runtime-profile replacements (e.g. workerd) applied after the standard set, so later entries win.
   overrides: LayerNode.Replacements,
-  embedded: boolean,
 ) {
   const pluginRuntimeCell = PluginRuntime.makeCell()
   const standard: LayerNode.Replacements = [
@@ -134,13 +132,10 @@ function makeRoutes<AuthError, AuthServices>(
         Effect.gen(function* () {
           const { simulationReplacements } = yield* Effect.promise(() => import("@opencode-ai/simulation/backend"))
           const simulation = yield* simulationReplacements({ version: App.make(options.app).version })
-          return AppNodeBuilder.build(embedded ? embeddedApplicationServices : applicationServices, [
-            ...replacements,
-            ...simulation,
-          ])
+          return AppNodeBuilder.build(applicationServices, [...replacements, ...simulation])
         }),
       )
-    : AppNodeBuilder.build(embedded ? embeddedApplicationServices : applicationServices, replacements)
+    : AppNodeBuilder.build(applicationServices, replacements)
   return serviceLayer.pipe(
     Layer.flatMap((context) => {
       const services = Layer.succeedContext(context)

--- a/packages/server/test/fetch.test.ts
+++ b/packages/server/test/fetch.test.ts
@@ -1,4 +1,5 @@
 import { expect } from "bun:test"
+import { Workspace } from "@opencode-ai/core/workspace"
 import { Effect } from "effect"
 import { it } from "../../core/test/lib/effect"
 import { ServerFetch } from "../src/fetch"
@@ -49,6 +50,22 @@ it.live("serves unauthenticated and answers CORS preflight when no password is c
       ),
     )
     expect(preflight.headers.get("access-control-allow-origin")).toBe("http://localhost:3000")
+  }).pipe(Effect.scoped),
+)
+
+it.live("treats destroying a missing workspace as success", () =>
+  Effect.gen(function* () {
+    const handler = yield* ServerFetch.make(options)
+    const response = yield* Effect.promise(() =>
+      handler(
+        new Request(`http://opencode.local/api/workspace/${Workspace.ID.create()}`, {
+          method: "DELETE",
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(yield* Effect.promise(() => response.json())).toEqual({ destroyed: false })
   }).pipe(Effect.scoped),
 )
 


### PR DESCRIPTION
## What

Make `workspace.destroy` postcondition-idempotent and report `{ destroyed: boolean }`: `true` when this call removed an existing workspace, `false` when it was already absent.

Durable callers retry the same workspace ID after failures and crashes. If teardown succeeded but its acknowledgement was lost, the old `Workspace.NotFound` response wedged that retry loop and forced every caller to special-case absence.

## How

- Treat an absent workspace as an already-satisfied destroy postcondition without invoking its provider driver.
- Keep `Workspace.NotFound` for operations where absence breaks the request, including connect and provision.
- Add and document the V2 `workspace.destroy` endpoint, thread the result through the server and SDK, and regenerate Promise and Effect clients.
- Cover existing, repeated, never-created, SDK, generated-client, and HTTP destroy behavior.

## Testing

- `bun run test` in `packages/core` (2239 passed, 16 skipped)
- `bun run test` in `packages/server` (27 passed)
- `bun run test` in `packages/sdk` (23 passed)
- `bun test test/promise.test.ts --test-name-pattern 'workspace.destroy returns the transition result'` in `packages/client`
- `bun typecheck` in `packages/core`, `packages/protocol`, `packages/server`, `packages/client`, and `packages/sdk`
- Push hook: repository-wide `bun turbo typecheck --concurrency=3` (32 packages passed)
