### PR TITLE
fix(server): make text generation locationless

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -1108,11 +1108,7 @@ export interface ModelApi<E = never> {
   readonly default: ModelDefaultOperation<E>
 }
 
-export type GenerateTextInput = {
-  readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
-  readonly prompt: string
-  readonly model?: Model.Ref | undefined
-}
+export type GenerateTextInput = { readonly prompt: string; readonly model?: Model.Ref | undefined }
 export type GenerateTextOutput = { readonly text: string }
 export type GenerateTextOperation<E = never> = (input: GenerateTextInput) => Effect.Effect<GenerateTextOutput, E>
 

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -719,10 +719,7 @@ const adaptGroupModel = (raw: RawClient["server.model"]) => ({
 
 const EndpointGenerateText = (raw: RawClient["server.generate"]) => (input: GenerateTextInput) =>
   preserveEffect<GenerateTextOutput>()(
-    raw["generate.text"]({
-      query: { location: input["location"] },
-      payload: { prompt: input["prompt"], model: input["model"] },
-    }).pipe(
+    raw["generate.text"]({ payload: { prompt: input["prompt"], model: input["model"] } }).pipe(
       Effect.mapError(mapClientError),
       Effect.map((value) => value.data),
     ),

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -977,7 +977,6 @@ export function make(options: ClientOptions) {
           {
             method: "POST",
             path: `/api/generate`,
-            query: { location: input["location"] },
             body: { prompt: input["prompt"], model: input["model"] },
             successStatus: 200,
             declaredStatuses: [400, 503, 401],

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -4029,9 +4029,6 @@ export type ModelDefaultOutput = {
 }
 
 export type GenerateTextInput = {
-  readonly location?: {
-    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
-  }["location"]
   readonly prompt: {
     readonly prompt: string
     readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -82,6 +82,21 @@ test("config.get returns ordered config entries for a location", async () => {
   expect(request?.url).toBe("http://localhost:3000/api/config?location%5Bdirectory%5D=%2Ftmp%2Fproject")
 })
 
+test("generate.text uses the locationless public contract", async () => {
+  let request: Request | undefined
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: async (input, init) => {
+      request = input instanceof Request ? input : new Request(input, init)
+      return Response.json({ data: { text: "pong" } })
+    },
+  })
+
+  expect(await client.generate.text({ prompt: "ping" })).toEqual({ text: "pong" })
+  expect(request?.url).toBe("http://localhost:3000/api/generate")
+  expect(await request?.json()).toEqual({ prompt: "ping" })
+})
+
 test("websearch.query uses the public HTTP contract", async () => {
   let request: Request | undefined
   const client = OpenCode.make({

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -4448,48 +4448,7 @@
       "post": {
         "tags": ["generate"],
         "operationId": "v2.generate.text",
-        "parameters": [
-          {
-            "name": "location",
-            "in": "query",
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "required": false,
-            "style": "deepObject",
-            "explode": true
-          }
-        ],
+        "parameters": [],
         "security": [],
         "responses": {
           "200": {
@@ -4540,7 +4499,7 @@
             }
           }
         },
-        "description": "Run one stateless model generation and return the assistant text. An explicit location uses that location's configuration; when location is omitted, generation uses the server's base configuration directory. Uses the selected configuration's default model when none is specified.",
+        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified.",
         "summary": "Generate text",
         "requestBody": {
           "content": {

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -4540,7 +4540,7 @@
             }
           }
         },
-        "description": "Run one stateless model generation at the requested location and return the assistant text. Uses the location's default model when none is specified.",
+        "description": "Run one stateless model generation and return the assistant text. An explicit location uses that location's configuration; when location is omitted, generation uses the server's base configuration directory. Uses the selected configuration's default model when none is specified.",
         "summary": "Generate text",
         "requestBody": {
           "content": {

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -10614,6 +10614,68 @@
         "summary": "Refresh worktrees"
       }
     },
+    "/api/workspace/{workspaceID}": {
+      "delete": {
+        "tags": ["workspace"],
+        "operationId": "v2.workspace.destroy",
+        "parameters": [
+          {
+            "name": "workspaceID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^wrk"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Reports whether this request destroyed an existing workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceDestroyResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "UnknownError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnknownErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Make a workspace not exist. This operation is idempotent: an already-missing workspace succeeds with `destroyed: false`, while a workspace removed by this request returns `destroyed: true`.",
+        "summary": "Destroy workspace"
+      }
+    },
     "/api/vcs": {
       "get": {
         "tags": ["vcs"],
@@ -17052,6 +17114,18 @@
         "required": ["url", "time"],
         "additionalProperties": false
       },
+      "WorkspaceDestroyResult": {
+        "type": "object",
+        "properties": {
+          "destroyed": {
+            "type": "boolean",
+            "description": "True when this request transitioned the workspace from existing to destroyed."
+          }
+        },
+        "required": ["destroyed"],
+        "additionalProperties": false,
+        "description": "Reports whether this request destroyed an existing workspace."
+      },
       "Worktree.Directory": {
         "type": "object",
         "properties": {
@@ -17207,6 +17281,10 @@
     {
       "name": "worktree",
       "description": "Project worktree management routes."
+    },
+    {
+      "name": "workspace",
+      "description": "Workspace lifecycle routes."
     },
     {
       "name": "vcs",

--- a/packages/protocol/src/api.ts
+++ b/packages/protocol/src/api.ts
@@ -39,7 +39,6 @@ type LocationGroups<LocationId extends HttpApiMiddleware.AnyId> =
   | HttpApiGroup.AddMiddleware<typeof AgentGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof PluginGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof ModelGroup, LocationId>
-  | HttpApiGroup.AddMiddleware<typeof GenerateGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof ProviderGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof IntegrationGroup, LocationId>
   | HttpApiGroup.AddMiddleware<typeof WebSearchGroup, LocationId>
@@ -88,6 +87,7 @@ type ApiGroups<
   | typeof MigrationGroup
   | typeof WorktreeGroup
   | typeof WorkspaceGroup
+  | typeof GenerateGroup
   | LocationGroups<LocationId>
   | FormGroups<LocationId, LocationService, FormLocationId, FormLocationService>
   | SessionGroups<SessionLocationId, SessionLocationService>
@@ -155,7 +155,7 @@ const makeApiFromGroup = <
     .add(makeSessionGroup(sessionLocationMiddleware))
     .add(MessageGroup)
     .add(ModelGroup.middleware(locationMiddleware))
-    .add(GenerateGroup.middleware(locationMiddleware))
+    .add(GenerateGroup)
     .add(ProviderGroup.middleware(locationMiddleware))
     .add(IntegrationGroup.middleware(locationMiddleware))
     .add(McpGroup.middleware(locationMiddleware))

--- a/packages/protocol/src/groups/generate.ts
+++ b/packages/protocol/src/groups/generate.ts
@@ -2,12 +2,10 @@ import { Model } from "@opencode-ai/schema/model"
 import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { InvalidRequestError, ServiceUnavailableError } from "../errors.js"
-import { LocationQuery, locationQueryOpenApi } from "./location.js"
 
 export const GenerateGroup = HttpApiGroup.make("server.generate")
   .add(
     HttpApiEndpoint.post("generate.text", "/api/generate", {
-      query: LocationQuery,
       payload: Schema.Struct({
         prompt: Schema.String,
         model: Model.Ref.pipe(Schema.optional),
@@ -16,16 +14,14 @@ export const GenerateGroup = HttpApiGroup.make("server.generate")
         data: Schema.Struct({ text: Schema.String }),
       }).annotate({ identifier: "GenerateTextResponse" }),
       error: [InvalidRequestError, ServiceUnavailableError],
-    })
-      .annotateMerge(locationQueryOpenApi)
-      .annotateMerge(
-        OpenApi.annotations({
-          identifier: "v2.generate.text",
-          summary: "Generate text",
-          description:
-            "Run one stateless model generation and return the assistant text. An explicit location uses that location's configuration; when location is omitted, generation uses the server's base configuration directory. Uses the selected configuration's default model when none is specified.",
-        }),
-      ),
+    }).annotateMerge(
+      OpenApi.annotations({
+        identifier: "v2.generate.text",
+        summary: "Generate text",
+        description:
+          "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified.",
+      }),
+    ),
   )
   .annotateMerge(
     OpenApi.annotations({

--- a/packages/protocol/src/groups/generate.ts
+++ b/packages/protocol/src/groups/generate.ts
@@ -23,7 +23,7 @@ export const GenerateGroup = HttpApiGroup.make("server.generate")
           identifier: "v2.generate.text",
           summary: "Generate text",
           description:
-            "Run one stateless model generation at the requested location and return the assistant text. Uses the location's default model when none is specified.",
+            "Run one stateless model generation and return the assistant text. An explicit location uses that location's configuration; when location is omitted, generation uses the server's base configuration directory. Uses the selected configuration's default model when none is specified.",
         }),
       ),
   )

--- a/packages/server/src/handlers/generate.ts
+++ b/packages/server/src/handlers/generate.ts
@@ -1,15 +1,22 @@
 import { Generate } from "@opencode-ai/core/generate"
+import { Location } from "@opencode-ai/core/location"
+import { LocationServiceMap } from "@opencode-ai/core/location-services"
+import { AbsolutePath } from "@opencode-ai/core/schema"
 import { InvalidRequestError, ServiceUnavailableError } from "@opencode-ai/protocol/errors"
+import { Global } from "@opencode-ai/util/global"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
 
 export const GenerateHandler = HttpApiBuilder.group(Api, "server.generate", (handlers) =>
   Effect.gen(function* () {
+    const global = yield* Global.Service
+    const locations = yield* LocationServiceMap.Service
+    const services = locations.get(Location.Ref.make({ directory: AbsolutePath.make(global.config) }))
     return handlers.handle(
       "generate.text",
       Effect.fn("server.generate.text")(function* (request) {
-        const generate = yield* Generate.Service
+        const generate = yield* Generate.Service.pipe(Effect.provide(services))
         const text = yield* generate
           .text(request.payload)
           .pipe(

--- a/packages/server/src/location.ts
+++ b/packages/server/src/location.ts
@@ -2,8 +2,9 @@ import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Workspace } from "@opencode-ai/core/workspace"
+import { Global } from "@opencode-ai/util/global"
 import { Effect, Layer } from "effect"
-import { HttpServerRequest } from "effect/unstable/http"
+import { HttpRouter, HttpServerRequest } from "effect/unstable/http"
 import { HttpApiMiddleware } from "effect/unstable/httpapi"
 
 export type LocationServices = Layer.Success<ReturnType<(typeof LocationServiceMap.Service)["get"]>>
@@ -26,12 +27,16 @@ export function response<A, E, R>(data: Effect.Effect<A, E, R>) {
   })
 }
 
-export function requestRef(request: HttpServerRequest.HttpServerRequest): Location.Ref {
+export function requestRef(
+  request: HttpServerRequest.HttpServerRequest,
+  omittedDirectory = process.cwd(),
+): Location.Ref {
   const query = new URL(request.url, "http://localhost").searchParams
   const workspaceID = query.get("location[workspace]") || request.headers["x-opencode-workspace"]
-  const directory =
+  const requestedDirectory =
     query.get("location[directory]") ||
-    (request.headers["x-opencode-directory"] ? decode(request.headers["x-opencode-directory"]) : process.cwd())
+    (request.headers["x-opencode-directory"] ? decode(request.headers["x-opencode-directory"]) : undefined)
+  const directory = requestedDirectory || (workspaceID ? process.cwd() : omittedDirectory)
   return Location.Ref.make({
     directory: AbsolutePath.make(directory),
     workspaceID: workspaceID ? Workspace.ID.make(workspaceID) : undefined,
@@ -50,10 +55,18 @@ export const layer = Layer.effect(
   LocationMiddleware,
   Effect.gen(function* () {
     const locations = yield* LocationServiceMap.Service
+    const global = yield* Global.Service
     return LocationMiddleware.of((effect) =>
       Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest
-        return yield* effect.pipe(Effect.provide(locations.get(requestRef(request))))
+        const route = yield* HttpRouter.RouteContext
+        return yield* effect.pipe(
+          Effect.provide(
+            locations.get(
+              route.route.path === "/api/generate" ? requestRef(request, global.config) : requestRef(request),
+            ),
+          ),
+        )
       }),
     )
   }),

--- a/packages/server/src/location.ts
+++ b/packages/server/src/location.ts
@@ -2,9 +2,8 @@ import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Workspace } from "@opencode-ai/core/workspace"
-import { Global } from "@opencode-ai/util/global"
 import { Effect, Layer } from "effect"
-import { HttpRouter, HttpServerRequest } from "effect/unstable/http"
+import { HttpServerRequest } from "effect/unstable/http"
 import { HttpApiMiddleware } from "effect/unstable/httpapi"
 
 export type LocationServices = Layer.Success<ReturnType<(typeof LocationServiceMap.Service)["get"]>>
@@ -27,16 +26,12 @@ export function response<A, E, R>(data: Effect.Effect<A, E, R>) {
   })
 }
 
-export function requestRef(
-  request: HttpServerRequest.HttpServerRequest,
-  omittedDirectory = process.cwd(),
-): Location.Ref {
+export function requestRef(request: HttpServerRequest.HttpServerRequest): Location.Ref {
   const query = new URL(request.url, "http://localhost").searchParams
   const workspaceID = query.get("location[workspace]") || request.headers["x-opencode-workspace"]
-  const requestedDirectory =
+  const directory =
     query.get("location[directory]") ||
-    (request.headers["x-opencode-directory"] ? decode(request.headers["x-opencode-directory"]) : undefined)
-  const directory = requestedDirectory || (workspaceID ? process.cwd() : omittedDirectory)
+    (request.headers["x-opencode-directory"] ? decode(request.headers["x-opencode-directory"]) : process.cwd())
   return Location.Ref.make({
     directory: AbsolutePath.make(directory),
     workspaceID: workspaceID ? Workspace.ID.make(workspaceID) : undefined,
@@ -55,18 +50,10 @@ export const layer = Layer.effect(
   LocationMiddleware,
   Effect.gen(function* () {
     const locations = yield* LocationServiceMap.Service
-    const global = yield* Global.Service
     return LocationMiddleware.of((effect) =>
       Effect.gen(function* () {
         const request = yield* HttpServerRequest.HttpServerRequest
-        const route = yield* HttpRouter.RouteContext
-        return yield* effect.pipe(
-          Effect.provide(
-            locations.get(
-              route.route.path === "/api/generate" ? requestRef(request, global.config) : requestRef(request),
-            ),
-          ),
-        )
+        return yield* effect.pipe(Effect.provide(locations.get(requestRef(request))))
       }),
     )
   }),

--- a/packages/server/test/generate.test.ts
+++ b/packages/server/test/generate.test.ts
@@ -1,0 +1,98 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { expect } from "bun:test"
+import { Config } from "@opencode-ai/core/config"
+import { Generate } from "@opencode-ai/core/generate"
+import { Location } from "@opencode-ai/core/location"
+import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { Effect, Layer, Predicate } from "effect"
+import { tmpdir } from "../../core/test/fixture/tmpdir"
+import { it } from "../../core/test/lib/effect"
+import { ServerFetch } from "../src/fetch"
+
+const generate = makeLocationNode({
+  service: Generate.Service,
+  layer: Layer.effect(
+    Generate.Service,
+    Effect.gen(function* () {
+      const config = yield* Config.Service
+      const location = yield* Location.Service
+      return Generate.Service.of({
+        text: () =>
+          config.entries().pipe(
+            Effect.map((entries) =>
+              JSON.stringify({
+                directory: location.directory,
+                model: Config.latest(entries, "model"),
+              }),
+            ),
+          ),
+      })
+    }),
+  ),
+  deps: [Config.node, Location.node],
+})
+
+it.live("uses base configuration without a location and location configuration when explicit", () =>
+  Effect.acquireUseRelease(
+    Effect.promise(() => tmpdir("opencode-generate-endpoint-")),
+    (tmp) =>
+      Effect.gen(function* () {
+        const global = path.join(tmp.path, "global")
+        const project = path.join(tmp.path, "project")
+        yield* Effect.promise(() => Promise.all([fs.mkdir(global), fs.mkdir(project)]))
+        yield* Effect.promise(() =>
+          Promise.all([
+            fs.writeFile(path.join(global, "opencode.json"), JSON.stringify({ model: "base/default" })),
+            fs.writeFile(path.join(project, "opencode.json"), JSON.stringify({ model: "project/default" })),
+          ]),
+        )
+        const handler = yield* ServerFetch.make(
+          {
+            database: { path: ":memory:" },
+            config: { directory: global },
+            fs: { filewatcher: false },
+          },
+          { overrides: [[Generate.node, generate]] },
+        )
+
+        expect(global).not.toBe(process.cwd())
+        expect(yield* request(handler, new URL("http://opencode.local/api/generate"))).toEqual({
+          directory: global,
+          model: { providerID: "base", model: "default" },
+        })
+
+        const url = new URL("http://opencode.local/api/generate")
+        url.searchParams.set("location[directory]", project)
+        expect(yield* request(handler, url)).toEqual({
+          directory: project,
+          model: { providerID: "project", model: "default" },
+        })
+
+        const location = yield* Effect.promise(() =>
+          handler(new Request("http://opencode.local/api/location")).then((response) => response.json()),
+        )
+        expect(Predicate.isObject(location) && location.directory).toBe(process.cwd())
+      }),
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  ),
+)
+
+function request(handler: (request: Request) => Promise<Response>, url: URL) {
+  return Effect.promise(() =>
+    handler(
+      new Request(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ prompt: "hello" }),
+      }),
+    ).then(async (response) => {
+      expect(response.status).toBe(200)
+      const body: unknown = await response.json()
+      if (!Predicate.isObject(body) || !Predicate.isObject(body.data) || typeof body.data.text !== "string")
+        throw new Error("Expected a generate response")
+      const result: unknown = JSON.parse(body.data.text)
+      return result
+    }),
+  )
+}

--- a/packages/server/test/generate.test.ts
+++ b/packages/server/test/generate.test.ts
@@ -3,7 +3,6 @@ import path from "node:path"
 import { expect } from "bun:test"
 import { Config } from "@opencode-ai/core/config"
 import { Generate } from "@opencode-ai/core/generate"
-import { Location } from "@opencode-ai/core/location"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Effect, Layer, Predicate } from "effect"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
@@ -16,13 +15,11 @@ const generate = makeLocationNode({
     Generate.Service,
     Effect.gen(function* () {
       const config = yield* Config.Service
-      const location = yield* Location.Service
       return Generate.Service.of({
         text: () =>
           config.entries().pipe(
             Effect.map((entries) =>
               JSON.stringify({
-                directory: location.directory,
                 model: Config.latest(entries, "model"),
               }),
             ),
@@ -30,10 +27,10 @@ const generate = makeLocationNode({
       })
     }),
   ),
-  deps: [Config.node, Location.node],
+  deps: [Config.node],
 })
 
-it.live("uses base configuration without a location and location configuration when explicit", () =>
+it.live("uses base configuration without depending on process.cwd()", () =>
   Effect.acquireUseRelease(
     Effect.promise(() => tmpdir("opencode-generate-endpoint-")),
     (tmp) =>
@@ -58,21 +55,14 @@ it.live("uses base configuration without a location and location configuration w
 
         expect(global).not.toBe(process.cwd())
         expect(yield* request(handler, new URL("http://opencode.local/api/generate"))).toEqual({
-          directory: global,
           model: { providerID: "base", model: "default" },
         })
 
-        const url = new URL("http://opencode.local/api/generate")
-        url.searchParams.set("location[directory]", project)
-        expect(yield* request(handler, url)).toEqual({
-          directory: project,
-          model: { providerID: "project", model: "default" },
+        const legacy = new URL("http://opencode.local/api/generate")
+        legacy.searchParams.set("location[directory]", project)
+        expect(yield* request(handler, legacy)).toEqual({
+          model: { providerID: "base", model: "default" },
         })
-
-        const location = yield* Effect.promise(() =>
-          handler(new Request("http://opencode.local/api/location")).then((response) => response.json()),
-        )
-        expect(Predicate.isObject(location) && location.directory).toBe(process.cwd())
       }),
     (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
   ),

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -1915,36 +1915,15 @@
         ],
         "security": [],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Session.Inbox.User"
-                    }
-                  },
-                  "required": ["data"],
-                  "additionalProperties": false
-                }
-              }
-            }
+          "204": {
+            "description": "<No Content>"
           },
           "400": {
             "description": "InvalidRequestError",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
-                    },
-                    {
-                      "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
                 }
               }
             }
@@ -1979,28 +1958,18 @@
               }
             }
           },
-          "409": {
-            "description": "ConflictError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConflictErrorEncoded"
-                }
-              }
-            }
-          },
           "500": {
-            "description": "CommandEvaluationError",
+            "description": "CommandExecutionError",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CommandEvaluationErrorEncoded"
+                  "$ref": "#/components/schemas/CommandExecutionErrorEncoded"
                 }
               }
             }
           }
         },
-        "description": "Resolve a slash command into prompt input, admit it durably, and schedule execution unless resume is false.",
+        "description": "Execute a slash command callback immediately.",
         "summary": "Run command",
         "requestBody": {
           "content": {
@@ -2008,49 +1977,11 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "id": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "command": {
                     "type": "string"
                   },
-                  "arguments": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "agent": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "model": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Model.Ref"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                  "text": {
+                    "type": "string"
                   },
                   "files": {
                     "type": "array",
@@ -2079,19 +2010,9 @@
                         "type": "null"
                       }
                     ]
-                  },
-                  "resume": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
                   }
                 },
-                "required": ["command"],
+                "required": ["command", "text"],
                 "additionalProperties": false
               }
             }
@@ -4520,48 +4441,7 @@
       "post": {
         "tags": ["generate"],
         "operationId": "v2.generate.text",
-        "parameters": [
-          {
-            "name": "location",
-            "in": "query",
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "required": false,
-            "style": "deepObject",
-            "explode": true
-          }
-        ],
+        "parameters": [],
         "security": [],
         "responses": {
           "200": {
@@ -4612,7 +4492,7 @@
             }
           }
         },
-        "description": "Run one stateless model generation at the requested location and return the assistant text. Uses the location's default model when none is specified.",
+        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified.",
         "summary": "Generate text",
         "requestBody": {
           "content": {
@@ -11658,31 +11538,19 @@
           "name": {
             "type": "string"
           },
-          "template": {
-            "type": "string"
-          },
           "description": {
             "type": "string"
-          },
-          "agent": {
-            "type": "string"
-          },
-          "model": {
-            "$ref": "#/components/schemas/Model.Ref"
-          },
-          "subtask": {
-            "type": "boolean"
           }
         },
-        "required": ["name", "template"],
+        "required": ["name"],
         "additionalProperties": false
       },
-      "CommandEvaluationErrorEncoded": {
+      "CommandExecutionErrorEncoded": {
         "type": "object",
         "properties": {
           "_tag": {
             "type": "string",
-            "enum": ["CommandEvaluationError"]
+            "enum": ["CommandExecutionError"]
           },
           "command": {
             "type": "string"

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -10607,6 +10607,68 @@
         "summary": "Refresh worktrees"
       }
     },
+    "/api/workspace/{workspaceID}": {
+      "delete": {
+        "tags": ["workspace"],
+        "operationId": "v2.workspace.destroy",
+        "parameters": [
+          {
+            "name": "workspaceID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^wrk"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Reports whether this request destroyed an existing workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceDestroyResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "UnknownError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnknownErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Make a workspace not exist. This operation is idempotent: an already-missing workspace succeeds with `destroyed: false`, while a workspace removed by this request returns `destroyed: true`.",
+        "summary": "Destroy workspace"
+      }
+    },
     "/api/vcs": {
       "get": {
         "tags": ["vcs"],
@@ -17034,6 +17096,18 @@
         "required": ["url", "time"],
         "additionalProperties": false
       },
+      "WorkspaceDestroyResult": {
+        "type": "object",
+        "properties": {
+          "destroyed": {
+            "type": "boolean",
+            "description": "True when this request transitioned the workspace from existing to destroyed."
+          }
+        },
+        "required": ["destroyed"],
+        "additionalProperties": false,
+        "description": "Reports whether this request destroyed an existing workspace."
+      },
       "Worktree.Directory": {
         "type": "object",
         "properties": {
@@ -17189,6 +17263,10 @@
     {
       "name": "worktree",
       "description": "Project worktree management routes."
+    },
+    {
+      "name": "workspace",
+      "description": "Workspace lifecycle routes."
     },
     {
       "name": "vcs",

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -1915,36 +1915,15 @@
         ],
         "security": [],
         "responses": {
-          "200": {
-            "description": "Success",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "data": {
-                      "$ref": "#/components/schemas/Session.Inbox.User"
-                    }
-                  },
-                  "required": ["data"],
-                  "additionalProperties": false
-                }
-              }
-            }
+          "204": {
+            "description": "<No Content>"
           },
           "400": {
             "description": "InvalidRequestError",
             "content": {
               "application/json": {
                 "schema": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
-                    },
-                    {
-                      "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
-                    }
-                  ]
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
                 }
               }
             }
@@ -1979,28 +1958,18 @@
               }
             }
           },
-          "409": {
-            "description": "ConflictError",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ConflictErrorEncoded"
-                }
-              }
-            }
-          },
           "500": {
-            "description": "CommandEvaluationError",
+            "description": "CommandExecutionError",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/CommandEvaluationErrorEncoded"
+                  "$ref": "#/components/schemas/CommandExecutionErrorEncoded"
                 }
               }
             }
           }
         },
-        "description": "Resolve a slash command into prompt input, admit it durably, and schedule execution unless resume is false.",
+        "description": "Execute a slash command callback immediately.",
         "summary": "Run command",
         "requestBody": {
           "content": {
@@ -2008,49 +1977,11 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "id": {
-                    "anyOf": [
-                      {
-                        "type": "string",
-                        "pattern": "^msg_"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
                   "command": {
                     "type": "string"
                   },
-                  "arguments": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "agent": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
-                  },
-                  "model": {
-                    "anyOf": [
-                      {
-                        "$ref": "#/components/schemas/Model.Ref"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
+                  "text": {
+                    "type": "string"
                   },
                   "files": {
                     "type": "array",
@@ -2079,19 +2010,9 @@
                         "type": "null"
                       }
                     ]
-                  },
-                  "resume": {
-                    "anyOf": [
-                      {
-                        "type": "boolean"
-                      },
-                      {
-                        "type": "null"
-                      }
-                    ]
                   }
                 },
-                "required": ["command"],
+                "required": ["command", "text"],
                 "additionalProperties": false
               }
             }
@@ -4520,48 +4441,7 @@
       "post": {
         "tags": ["generate"],
         "operationId": "v2.generate.text",
-        "parameters": [
-          {
-            "name": "location",
-            "in": "query",
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "directory": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    },
-                    "workspace": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "null"
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "required": false,
-            "style": "deepObject",
-            "explode": true
-          }
-        ],
+        "parameters": [],
         "security": [],
         "responses": {
           "200": {
@@ -4612,7 +4492,7 @@
             }
           }
         },
-        "description": "Run one stateless model generation at the requested location and return the assistant text. Uses the location's default model when none is specified.",
+        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified.",
         "summary": "Generate text",
         "requestBody": {
           "content": {
@@ -11658,31 +11538,19 @@
           "name": {
             "type": "string"
           },
-          "template": {
-            "type": "string"
-          },
           "description": {
             "type": "string"
-          },
-          "agent": {
-            "type": "string"
-          },
-          "model": {
-            "$ref": "#/components/schemas/Model.Ref"
-          },
-          "subtask": {
-            "type": "boolean"
           }
         },
-        "required": ["name", "template"],
+        "required": ["name"],
         "additionalProperties": false
       },
-      "CommandEvaluationErrorEncoded": {
+      "CommandExecutionErrorEncoded": {
         "type": "object",
         "properties": {
           "_tag": {
             "type": "string",
-            "enum": ["CommandEvaluationError"]
+            "enum": ["CommandExecutionError"]
           },
           "command": {
             "type": "string"

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -10607,6 +10607,68 @@
         "summary": "Refresh worktrees"
       }
     },
+    "/api/workspace/{workspaceID}": {
+      "delete": {
+        "tags": ["workspace"],
+        "operationId": "v2.workspace.destroy",
+        "parameters": [
+          {
+            "name": "workspaceID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^wrk"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Reports whether this request destroyed an existing workspace.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceDestroyResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "UnknownError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnknownErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Make a workspace not exist. This operation is idempotent: an already-missing workspace succeeds with `destroyed: false`, while a workspace removed by this request returns `destroyed: true`.",
+        "summary": "Destroy workspace"
+      }
+    },
     "/api/vcs": {
       "get": {
         "tags": ["vcs"],
@@ -17034,6 +17096,18 @@
         "required": ["url", "time"],
         "additionalProperties": false
       },
+      "WorkspaceDestroyResult": {
+        "type": "object",
+        "properties": {
+          "destroyed": {
+            "type": "boolean",
+            "description": "True when this request transitioned the workspace from existing to destroyed."
+          }
+        },
+        "required": ["destroyed"],
+        "additionalProperties": false,
+        "description": "Reports whether this request destroyed an existing workspace."
+      },
       "Worktree.Directory": {
         "type": "object",
         "properties": {
@@ -17189,6 +17263,10 @@
     {
       "name": "worktree",
       "description": "Project worktree management routes."
+    },
+    {
+      "name": "workspace",
+      "description": "Workspace lifecycle routes."
     },
     {
       "name": "vcs",


### PR DESCRIPTION
## What

Make `generate.text` fully locationless. Stateless embedders can call it without inventing a directory, and request location queries or headers no longer select project configuration.

## How

- Remove `LocationQuery` and `LocationMiddleware` from the generate protocol group.
- Resolve generation from the server's configured global config directory inside the generate handler. This is the transitional base-model context: it gives a deterministic, persistent cache key without changing generic location fallback behavior.
- Keep the existing location-scoped resolver graph internally for now. Splitting a dedicated minimal base model graph is a larger follow-up because `ModelResolver` transitively depends on location-scoped `Catalog`, `Integration`, `AISDK`, and `Config`.
- Regenerate OpenAPI, website mirrors, and Promise/Effect clients so `GenerateTextInput` no longer exposes location.
- Cover base-config selection, independence from `process.cwd()`, ignored legacy location input, and the generated Promise client request shape.

## Testing

- `packages/server`: `bun run test` (27 passed), `bun typecheck`, `bun run probe:workerd`
- `packages/protocol`: `bun typecheck`, `bun run check:generated`
- `packages/client`: `bun typecheck`; focused locationless contract test passed
- `packages/www`: `bun typecheck`, `bun run check:generated`, `bun run build`
- Pre-push workspace typecheck: 32 packages passed
- Targeted Prettier and oxlint checks passed

Base `v2` is currently red on `config plugin reloads > reloads config-backed domains without reloading external plugins`; this PR does not touch or attempt to fix that inherited failure.
