### PR TITLE
feat(core): resolve workspace prompt files

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -9,7 +9,6 @@ import { Workspace } from "./workspace.js"
 import { Model } from "./model.js"
 import { Location } from "./location.js"
 import { SessionMessage } from "./session/message.js"
-import { Base64, FileAttachment, Prompt } from "@opencode-ai/schema/prompt"
 import { PromptInput } from "@opencode-ai/schema/prompt-input"
 import { Bus } from "./bus.js"
 import { Database } from "./database/database.js"
@@ -28,7 +27,13 @@ import { SessionRunner } from "./session/runner/index.js"
 import { SessionStore } from "./session/store.js"
 import { SessionExecution } from "./session/execution.js"
 import { SessionModelTransport } from "./session/model-transport.js"
-import { ForkEmptyError, MessageDecodeError, NotFoundError } from "./session/error.js"
+import {
+  AttachmentError,
+  ForkEmptyError,
+  MessageDecodeError,
+  NotFoundError,
+  SkillNotFoundError,
+} from "./session/error.js"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { LocationServiceMap } from "./location-service-map.js"
 import { SessionEvent } from "./session/event.js"
@@ -39,9 +44,7 @@ import { Snapshot } from "./snapshot.js"
 import { SessionRevert } from "./session/revert.js"
 import { Session } from "@opencode-ai/schema/session"
 import { FSUtil } from "@opencode-ai/util/fs-util"
-import { Image } from "./image.js"
 import { PluginSupervisor } from "./plugin/supervisor-service.js"
-import { Mime } from "./mime.js"
 import type { EventLog } from "@opencode-ai/schema/event-log"
 import { Event } from "@opencode-ai/schema/event"
 import { Skill } from "./skill.js"
@@ -51,11 +54,10 @@ import { Shell } from "./shell.js"
 import { Global } from "@opencode-ai/util/global"
 import { Shell as ShellSchema } from "@opencode-ai/schema/shell"
 import { KeyedMutex } from "./effect/keyed-mutex.js"
-import { fileURLToPath } from "url"
 import { SessionEnvironment } from "./session/environment.js"
 import { SessionHistory } from "./session/history.js"
 import { InstructionEntry } from "./session/instruction-entry.js"
-import { Environment } from "./environment/index.js"
+import { PromptMaterializer } from "./session/prompt-materializer.js"
 
 // get project -> project.locations
 //
@@ -113,7 +115,7 @@ type ForkInput = {
   boundary: Session.ForkRequestBoundary
 }
 
-export { MessageDecodeError, NotFoundError }
+export { AttachmentError, MessageDecodeError, NotFoundError, SkillNotFoundError }
 
 export class PromptConflictError extends Schema.TaggedError<PromptConflictError>()("Session.PromptConflictError", {
   sessionID: SessionSchema.ID,
@@ -126,10 +128,6 @@ export class SyntheticConflictError extends Schema.TaggedError<SyntheticConflict
     inputID: SessionMessage.ID,
   },
 ) {}
-export class AttachmentError extends Schema.TaggedError<AttachmentError>()("Session.AttachmentError", {
-  uri: Schema.String,
-  message: Schema.String,
-}) {}
 export class CompactionConflictError extends Schema.TaggedError<CompactionConflictError>()(
   "Session.CompactionConflictError",
   {
@@ -145,9 +143,6 @@ export class InboxConflictError extends Schema.TaggedError<InboxConflictError>()
   inboxID: SessionMessage.ID,
 }) {}
 type InboxItemRef = { readonly sessionID: SessionSchema.ID; readonly inboxID: SessionMessage.ID }
-export class SkillNotFoundError extends Schema.TaggedError<SkillNotFoundError>()("Session.SkillNotFoundError", {
-  skill: Skill.ID,
-}) {}
 
 export class DestinationNotFoundError extends Schema.TaggedError<DestinationNotFoundError>()(
   "Session.DestinationNotFoundError",
@@ -309,6 +304,7 @@ const layer = Layer.effect(
     const store = yield* SessionStore.Service
     const locations = yield* LocationServiceMap.Service
     const fs = yield* FSUtil.Service
+    const promptMaterializer = yield* PromptMaterializer.Service
     const jobs = yield* Job.Service
     const environments = yield* SessionEnvironment.Service
     const scope = yield* Scope.Scope
@@ -590,30 +586,17 @@ const layer = Layer.effect(
             // A staged revert must be committed before admitting new input so the prompt
             // continues from the reverted boundary rather than stale post-boundary history.
             if (session.revert) yield* SessionRevert.commit(session).pipe(Effect.provideService(Bus.Service, bus))
-            // Resolved lazily so prompt admission only boots location services when an
-            // image attachment actually needs the resizer.
-            const image = Effect.gen(function* () {
-              const plugins = yield* PluginSupervisor.Service
-              yield* plugins.flush
-              return yield* Image.Service
-            }).pipe(Effect.provide(locations.get(session.location)))
-            const skills = Skill.Service.pipe(Effect.provide(locations.get(session.location)))
-            const workspace = session.location.workspaceID
-              ? {
-                  root: session.location.directory,
-                  environment: Environment.Service.pipe(Effect.provide(locations.get(session.location))),
-                }
-              : undefined
-            const prompt = yield* resolvePrompt(
-              { text: input.text, files: input.files, agents: input.agents, skills: input.skills },
-              image,
-              skills,
-              workspace,
-            ).pipe(Effect.provideService(FSUtil.Service, fs))
+            const prompt = yield* promptMaterializer.materialize(session.location, input)
             const messageID = input.id ?? SessionMessage.ID.create()
             const admittedInput = SessionInbox.Item.make({
               type: "user",
-              payload: { ...prompt, metadata: input.metadata },
+              payload: {
+                text: prompt.text,
+                files: prompt.files,
+                agents: prompt.agents,
+                skills: prompt.skills,
+                metadata: input.metadata,
+              },
               delivery: input.delivery ?? "steer",
             })
             const admitted = yield* SessionInbox.admit(db, bus, {
@@ -965,226 +948,6 @@ function synthesizeTerminalShellInfo(started: ShellSchema.Info): ShellSchema.Inf
   }
 }
 
-const resolvePrompt = Effect.fn("Session.resolvePrompt")(function* (
-  input: PromptInput.Prompt,
-  image: Effect.Effect<Image.Interface>,
-  skills: Effect.Effect<Skill.Interface>,
-  workspace: WorkspaceAttachmentSource | undefined,
-) {
-  const fs = yield* FSUtil.Service
-  const files = input.files
-    ? yield* Effect.forEach(input.files, (file) => materializeAttachment(fs, file, image, workspace), {
-        concurrency: 8,
-      })
-    : undefined
-  const requested = input.skills
-  const selected = yield* Effect.gen(function* () {
-    if (!requested?.length) return undefined
-    const skillService = yield* skills
-    const available = yield* skillService.list()
-    return yield* Effect.forEach(requested, (attachment) => {
-      const skill = available.find((item) => item.id === attachment.id)
-      if (!skill) return Effect.fail(new SkillNotFoundError({ skill: attachment.id }))
-      return Effect.succeed({
-        id: skill.id,
-        name: skill.name,
-        mention: attachment.mention,
-      })
-    })
-  })
-  return Prompt.make({ text: input.text, agents: input.agents, files, skills: selected?.length ? selected : undefined })
-})
-
-const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
-type WorkspaceAttachmentSource = {
-  readonly root: string
-  readonly environment: Effect.Effect<Environment.Interface>
-}
-
-const materializeAttachment = Effect.fn("Session.materializeAttachment")(function* (
-  fs: FSUtil.Interface,
-  input: PromptInput.FileAttachment,
-  image: Effect.Effect<Image.Interface>,
-  workspace: WorkspaceAttachmentSource | undefined,
-) {
-  const resolved = input.uri.startsWith("data:")
-    ? {
-        bytes: yield* decodeDataURL(input.uri),
-        source: { type: "inline" as const },
-        start: undefined,
-        end: undefined,
-        name: undefined,
-        mime: undefined,
-      }
-    : input.uri.startsWith("workspace:")
-      ? yield* readWorkspaceAttachment(workspace, input.uri)
-      : yield* readFileAttachment(fs, input.uri)
-  if (resolved.bytes.byteLength > MAX_ATTACHMENT_BYTES)
-    return yield* new AttachmentError({
-      uri: input.uri,
-      message: `Attachment exceeds the ${MAX_ATTACHMENT_BYTES} byte limit: ${input.uri}`,
-    })
-
-  const mime = resolved.mime ?? Mime.detect(resolved.bytes)
-  const content =
-    mime === "text/plain" && resolved.start !== undefined
-      ? Buffer.from(
-          Buffer.from(resolved.bytes)
-            .toString("utf8")
-            .split("\n")
-            .slice(resolved.start - 1, resolved.end)
-            .join("\n"),
-        )
-      : resolved.bytes
-  const normalized = yield* normalizeImageAttachment(input, Buffer.from(content).toString("base64"), mime, image)
-  return FileAttachment.create({
-    data: normalized.data,
-    mime: normalized.mime,
-    source: resolved.source,
-    name: input.name ?? resolved.name,
-    description: input.description,
-    mention: input.mention,
-  })
-})
-
-const normalizeImageAttachment = Effect.fn("Session.normalizeImageAttachment")(function* (
-  input: PromptInput.FileAttachment,
-  data: string,
-  mime: string,
-  image: Effect.Effect<Image.Interface>,
-) {
-  if (!mime.startsWith("image/")) return { data: Base64.make(data), mime }
-  const service = yield* image
-  const label = input.name ?? (input.uri.startsWith("data:") ? "inline attachment" : input.uri)
-  const content = { uri: label, content: data, encoding: "base64" as const, mime }
-  const normalized = yield* service.normalize(label, content).pipe(
-    Effect.catchTag("Image.ResizerUnavailableError", () => Effect.succeed(content)),
-    Effect.mapError((error) => new AttachmentError({ uri: label, message: error.message })),
-  )
-  return { data: Base64.make(normalized.content), mime: normalized.mime }
-})
-
-const readFileAttachment = Effect.fn("Session.readFileAttachment")(function* (fs: FSUtil.Interface, uri: string) {
-  const url = yield* Effect.try({
-    try: () => new URL(uri),
-    catch: () => new AttachmentError({ uri, message: `Invalid attachment URI: ${uri}` }),
-  })
-  if (url.protocol !== "file:")
-    return yield* new AttachmentError({ uri, message: `Unsupported attachment URI: ${uri}` })
-  const start = positiveInt(url.searchParams.get("start"))
-  const end = positiveInt(url.searchParams.get("end"))
-  const target = yield* Effect.try({
-    try: () => {
-      url.search = ""
-      url.hash = ""
-      return fileURLToPath(url)
-    },
-    catch: () => new AttachmentError({ uri, message: `Invalid file URI: ${uri}` }),
-  })
-  const info = yield* fs
-    .stat(target)
-    .pipe(Effect.mapError(() => new AttachmentError({ uri, message: `Unable to read attachment: ${uri}` })))
-  if (info.type === "Directory") {
-    const entries = yield* fs
-      .readDirectoryEntries(target)
-      .pipe(Effect.mapError(() => new AttachmentError({ uri, message: `Unable to read attachment: ${uri}` })))
-    return {
-      bytes: Buffer.from(
-        entries
-          .filter((entry) => entry.type === "file" || entry.type === "directory")
-          .sort((a, b) => (a.type === b.type ? a.name.localeCompare(b.name) : a.type === "directory" ? -1 : 1))
-          .map((entry) => entry.name + (entry.type === "directory" ? path.sep : ""))
-          .join("\n"),
-      ),
-      source: { type: "uri" as const, uri },
-      start: undefined,
-      end: undefined,
-      name: path.basename(target),
-      mime: "application/x-directory",
-    }
-  }
-  if (info.type !== "File") return yield* new AttachmentError({ uri, message: `Attachment is not a file: ${uri}` })
-  if (Number(info.size) > MAX_ATTACHMENT_BYTES)
-    return yield* new AttachmentError({
-      uri,
-      message: `Attachment exceeds the ${MAX_ATTACHMENT_BYTES} byte limit: ${uri}`,
-    })
-  const bytes = yield* fs
-    .readFile(target)
-    .pipe(Effect.mapError(() => new AttachmentError({ uri, message: `Unable to read attachment: ${uri}` })))
-  return { bytes, source: { type: "uri" as const, uri }, start, end, name: path.basename(target), mime: undefined }
-})
-
-const readWorkspaceAttachment = Effect.fn("Session.readWorkspaceAttachment")(function* (
-  workspace: WorkspaceAttachmentSource | undefined,
-  uri: string,
-) {
-  if (!workspace)
-    return yield* new AttachmentError({
-      uri,
-      message: `Workspace attachment requires a workspace-bound session: ${uri}`,
-    })
-  const url = yield* Effect.try({
-    try: () => new URL(uri),
-    catch: () => new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` }),
-  })
-  const relative = yield* Effect.try({
-    try: () => decodeURIComponent(url.pathname),
-    catch: () => new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` }),
-  })
-  if (url.protocol !== "workspace:" || url.host || !relative || path.isAbsolute(relative))
-    return yield* new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` })
-  const target = path.resolve(workspace.root, relative)
-  if (!FSUtil.contains(workspace.root, target))
-    return yield* new AttachmentError({ uri, message: `Workspace attachment escapes the workspace root: ${uri}` })
-  const service = yield* workspace.environment
-  const result = yield* service.files.read(target, { offset: 0, length: MAX_ATTACHMENT_BYTES + 1 }).pipe(
-    Effect.mapError(
-      (error) =>
-        new AttachmentError({
-          uri,
-          message:
-            error._tag === "Environment.NotFound"
-              ? `Workspace attachment not found: ${uri}`
-              : error._tag === "Environment.WrongKind"
-                ? `Workspace attachment is not a file: ${uri}`
-                : `Unable to read workspace attachment: ${uri}`,
-        }),
-    ),
-  )
-  return {
-    bytes: result.bytes,
-    source: { type: "uri" as const, uri },
-    start: positiveInt(url.searchParams.get("start")),
-    end: positiveInt(url.searchParams.get("end")),
-    name: path.basename(target),
-    mime: undefined,
-  }
-})
-
-function decodeDataURL(uri: string) {
-  return Effect.try({
-    try: () => {
-      const comma = uri.indexOf(",")
-      if (comma === -1) throw new Error("Invalid data URL")
-      const metadata = uri.slice(5, comma)
-      const payload = uri.slice(comma + 1)
-      if (!metadata.split(";").some((part) => part.toLowerCase() === "base64"))
-        return Buffer.from(decodeURIComponent(payload))
-      const bytes = Buffer.from(payload, "base64")
-      if (bytes.toString("base64") !== payload) throw new Error("Non-canonical base64")
-      return bytes
-    },
-    catch: () => new AttachmentError({ uri, message: "Invalid attachment data URL" }),
-  })
-}
-
-function positiveInt(value: string | null) {
-  if (value === null) return
-  const parsed = Number(value)
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
-}
-
 // Mirrors the shell tool's in-memory preview safety limit.
 const SHELL_MAX_CAPTURE_BYTES = 1024 * 1024
 
@@ -1200,6 +963,7 @@ export const node = makeGlobalNode({
     SessionExecution.node,
     SessionStore.node,
     LocationServiceMap.node,
+    PromptMaterializer.node,
     SessionProjector.node,
     FSUtil.node,
     Global.node,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1134,12 +1134,11 @@ const readWorkspaceAttachment = Effect.fn("Session.readWorkspaceAttachment")(fun
   })
   if (url.protocol !== "workspace:" || url.host || !relative || path.isAbsolute(relative))
     return yield* new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` })
-  const service = yield* workspace.environment
   const target = path.resolve(workspace.root, relative)
-  const within = path.relative(workspace.root, target)
-  if (within === ".." || within.startsWith(`..${path.sep}`) || path.isAbsolute(within))
+  if (!FSUtil.contains(workspace.root, target))
     return yield* new AttachmentError({ uri, message: `Workspace attachment escapes the workspace root: ${uri}` })
-  const result = yield* service.files.read(target).pipe(
+  const service = yield* workspace.environment
+  const result = yield* service.files.read(target, { offset: 0, length: MAX_ATTACHMENT_BYTES + 1 }).pipe(
     Effect.mapError(
       (error) =>
         new AttachmentError({

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -55,6 +55,7 @@ import { fileURLToPath } from "url"
 import { SessionEnvironment } from "./session/environment.js"
 import { SessionHistory } from "./session/history.js"
 import { InstructionEntry } from "./session/instruction-entry.js"
+import { Environment } from "./environment/index.js"
 
 // get project -> project.locations
 //
@@ -597,10 +598,17 @@ const layer = Layer.effect(
               return yield* Image.Service
             }).pipe(Effect.provide(locations.get(session.location)))
             const skills = Skill.Service.pipe(Effect.provide(locations.get(session.location)))
+            const workspace = session.location.workspaceID
+              ? {
+                  root: session.location.directory,
+                  environment: Environment.Service.pipe(Effect.provide(locations.get(session.location))),
+                }
+              : undefined
             const prompt = yield* resolvePrompt(
               { text: input.text, files: input.files, agents: input.agents, skills: input.skills },
               image,
               skills,
+              workspace,
             ).pipe(Effect.provideService(FSUtil.Service, fs))
             const messageID = input.id ?? SessionMessage.ID.create()
             const admittedInput = SessionInbox.Item.make({
@@ -961,10 +969,13 @@ const resolvePrompt = Effect.fn("Session.resolvePrompt")(function* (
   input: PromptInput.Prompt,
   image: Effect.Effect<Image.Interface>,
   skills: Effect.Effect<Skill.Interface>,
+  workspace: WorkspaceAttachmentSource | undefined,
 ) {
   const fs = yield* FSUtil.Service
   const files = input.files
-    ? yield* Effect.forEach(input.files, (file) => materializeAttachment(fs, file, image), { concurrency: 8 })
+    ? yield* Effect.forEach(input.files, (file) => materializeAttachment(fs, file, image, workspace), {
+        concurrency: 8,
+      })
     : undefined
   const requested = input.skills
   const selected = yield* Effect.gen(function* () {
@@ -985,11 +996,16 @@ const resolvePrompt = Effect.fn("Session.resolvePrompt")(function* (
 })
 
 const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
+type WorkspaceAttachmentSource = {
+  readonly root: string
+  readonly environment: Effect.Effect<Environment.Interface>
+}
 
 const materializeAttachment = Effect.fn("Session.materializeAttachment")(function* (
   fs: FSUtil.Interface,
   input: PromptInput.FileAttachment,
   image: Effect.Effect<Image.Interface>,
+  workspace: WorkspaceAttachmentSource | undefined,
 ) {
   const resolved = input.uri.startsWith("data:")
     ? {
@@ -1000,7 +1016,9 @@ const materializeAttachment = Effect.fn("Session.materializeAttachment")(functio
         name: undefined,
         mime: undefined,
       }
-    : yield* readFileAttachment(fs, input.uri)
+    : input.uri.startsWith("workspace:")
+      ? yield* readWorkspaceAttachment(workspace, input.uri)
+      : yield* readFileAttachment(fs, input.uri)
   if (resolved.bytes.byteLength > MAX_ATTACHMENT_BYTES)
     return yield* new AttachmentError({
       uri: input.uri,
@@ -1095,6 +1113,54 @@ const readFileAttachment = Effect.fn("Session.readFileAttachment")(function* (fs
     .readFile(target)
     .pipe(Effect.mapError(() => new AttachmentError({ uri, message: `Unable to read attachment: ${uri}` })))
   return { bytes, source: { type: "uri" as const, uri }, start, end, name: path.basename(target), mime: undefined }
+})
+
+const readWorkspaceAttachment = Effect.fn("Session.readWorkspaceAttachment")(function* (
+  workspace: WorkspaceAttachmentSource | undefined,
+  uri: string,
+) {
+  if (!workspace)
+    return yield* new AttachmentError({
+      uri,
+      message: `Workspace attachment requires a workspace-bound session: ${uri}`,
+    })
+  const url = yield* Effect.try({
+    try: () => new URL(uri),
+    catch: () => new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` }),
+  })
+  const relative = yield* Effect.try({
+    try: () => decodeURIComponent(url.pathname),
+    catch: () => new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` }),
+  })
+  if (url.protocol !== "workspace:" || url.host || !relative || path.isAbsolute(relative))
+    return yield* new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` })
+  const service = yield* workspace.environment
+  const target = path.resolve(workspace.root, relative)
+  const within = path.relative(workspace.root, target)
+  if (within === ".." || within.startsWith(`..${path.sep}`) || path.isAbsolute(within))
+    return yield* new AttachmentError({ uri, message: `Workspace attachment escapes the workspace root: ${uri}` })
+  const result = yield* service.files.read(target).pipe(
+    Effect.mapError(
+      (error) =>
+        new AttachmentError({
+          uri,
+          message:
+            error._tag === "Environment.NotFound"
+              ? `Workspace attachment not found: ${uri}`
+              : error._tag === "Environment.WrongKind"
+                ? `Workspace attachment is not a file: ${uri}`
+                : `Unable to read workspace attachment: ${uri}`,
+        }),
+    ),
+  )
+  return {
+    bytes: result.bytes,
+    source: { type: "uri" as const, uri },
+    start: positiveInt(url.searchParams.get("start")),
+    end: positiveInt(url.searchParams.get("end")),
+    name: path.basename(target),
+    mime: undefined,
+  }
 })
 
 function decodeDataURL(uri: string) {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -304,7 +304,6 @@ const layer = Layer.effect(
     const store = yield* SessionStore.Service
     const locations = yield* LocationServiceMap.Service
     const fs = yield* FSUtil.Service
-    const promptMaterializer = yield* PromptMaterializer.Service
     const jobs = yield* Job.Service
     const environments = yield* SessionEnvironment.Service
     const scope = yield* Scope.Scope
@@ -586,7 +585,9 @@ const layer = Layer.effect(
             // A staged revert must be committed before admitting new input so the prompt
             // continues from the reverted boundary rather than stale post-boundary history.
             if (session.revert) yield* SessionRevert.commit(session).pipe(Effect.provideService(Bus.Service, bus))
-            const prompt = yield* promptMaterializer.materialize(session.location, input)
+            const prompt = yield* PromptMaterializer.materialize(input, locations.get(session.location)).pipe(
+              Effect.provideService(FSUtil.Service, fs),
+            )
             const messageID = input.id ?? SessionMessage.ID.create()
             const admittedInput = SessionInbox.Item.make({
               type: "user",
@@ -963,7 +964,6 @@ export const node = makeGlobalNode({
     SessionExecution.node,
     SessionStore.node,
     LocationServiceMap.node,
-    PromptMaterializer.node,
     SessionProjector.node,
     FSUtil.node,
     Global.node,

--- a/packages/core/src/session/error.ts
+++ b/packages/core/src/session/error.ts
@@ -5,6 +5,7 @@ import { Agent } from "@opencode-ai/schema/agent"
 import { SessionMessage } from "./message.js"
 import { SessionSchema } from "./schema.js"
 import { SessionError } from "@opencode-ai/schema/session-error"
+import { Skill } from "@opencode-ai/schema/skill"
 
 export class NotFoundError extends Schema.TaggedError<NotFoundError>()("Session.NotFoundError", {
   sessionID: SessionSchema.ID,
@@ -52,3 +53,12 @@ export class UserInterruptedError extends Schema.TaggedError<UserInterruptedErro
     return "Session interrupted by user"
   }
 }
+
+export class AttachmentError extends Schema.TaggedError<AttachmentError>()("Session.AttachmentError", {
+  uri: Schema.String,
+  message: Schema.String,
+}) {}
+
+export class SkillNotFoundError extends Schema.TaggedError<SkillNotFoundError>()("Session.SkillNotFoundError", {
+  skill: Skill.ID,
+}) {}

--- a/packages/core/src/session/prompt-materializer.ts
+++ b/packages/core/src/session/prompt-materializer.ts
@@ -1,0 +1,265 @@
+export * as PromptMaterializer from "./prompt-materializer.js"
+
+import { PromptInput } from "@opencode-ai/schema/prompt-input"
+import { Base64, FileAttachment, Prompt } from "@opencode-ai/schema/prompt"
+import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
+import { FSUtil } from "@opencode-ai/util/fs-util"
+import { Context, Effect, Layer } from "effect"
+import path from "path"
+import { fileURLToPath } from "url"
+import { Environment } from "../environment/index.js"
+import { Image } from "../image.js"
+import { LocationServiceMap } from "../location-service-map.js"
+import { Location } from "../location.js"
+import { Mime } from "../mime.js"
+import { PluginSupervisor } from "../plugin/supervisor-service.js"
+import { Skill } from "../skill.js"
+import { AttachmentError, SkillNotFoundError } from "./error.js"
+
+export interface Interface {
+  readonly materialize: (
+    location: Location.Ref,
+    input: PromptInput.Prompt,
+  ) => Effect.Effect<Prompt, AttachmentError | SkillNotFoundError>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/Session/PromptMaterializer") {}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const fs = yield* FSUtil.Service
+    const locations = yield* LocationServiceMap.Service
+    return Service.of({
+      materialize: Effect.fn("PromptMaterializer.materialize")(function* (location, input) {
+        const services = locations.get(location)
+        const image = Effect.gen(function* () {
+          const plugins = yield* PluginSupervisor.Service
+          yield* plugins.flush
+          return yield* Image.Service
+        }).pipe(Effect.provide(services))
+        const environment = Environment.Service.pipe(Effect.provide(services))
+        const files = input.files
+          ? yield* Effect.forEach(
+              input.files,
+              (file) => materializeAttachment(fs, location, environment, file, image),
+              { concurrency: 8 },
+            )
+          : undefined
+        const selected = yield* Effect.gen(function* () {
+          if (!input.skills?.length) return undefined
+          const skills = yield* Skill.Service.pipe(Effect.provide(services))
+          const available = yield* skills.list()
+          return yield* Effect.forEach(input.skills, (attachment) => {
+            const skill = available.find((item) => item.id === attachment.id)
+            if (!skill) return Effect.fail(new SkillNotFoundError({ skill: attachment.id }))
+            return Effect.succeed({ id: skill.id, name: skill.name, mention: attachment.mention })
+          })
+        })
+        return Prompt.fromUserMessage({
+          text: input.text,
+          agents: input.agents,
+          files,
+          skills: selected?.length ? selected : undefined,
+        })
+      }),
+    })
+  }),
+)
+
+const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
+
+const materializeAttachment = Effect.fn("PromptMaterializer.materializeAttachment")(function* (
+  fs: FSUtil.Interface,
+  location: Location.Ref,
+  environment: Effect.Effect<Environment.Interface>,
+  input: PromptInput.FileAttachment,
+  image: Effect.Effect<Image.Interface>,
+) {
+  const resolved = input.uri.startsWith("data:")
+    ? {
+        bytes: yield* decodeDataURL(input.uri),
+        source: { type: "inline" as const },
+        start: undefined,
+        end: undefined,
+        name: undefined,
+        mime: undefined,
+      }
+    : input.uri.startsWith("workspace:")
+      ? yield* readWorkspaceAttachment(location, environment, input.uri)
+      : yield* readFileAttachment(fs, input.uri)
+  if (resolved.bytes.byteLength > MAX_ATTACHMENT_BYTES)
+    return yield* new AttachmentError({
+      uri: input.uri,
+      message: `Attachment exceeds the ${MAX_ATTACHMENT_BYTES} byte limit: ${input.uri}`,
+    })
+
+  const mime = resolved.mime ?? Mime.detect(resolved.bytes)
+  const content =
+    mime === "text/plain" && resolved.start !== undefined
+      ? Buffer.from(
+          Buffer.from(resolved.bytes)
+            .toString("utf8")
+            .split("\n")
+            .slice(resolved.start - 1, resolved.end)
+            .join("\n"),
+        )
+      : resolved.bytes
+  const normalized = yield* normalizeImageAttachment(input, Buffer.from(content).toString("base64"), mime, image)
+  return FileAttachment.create({
+    data: normalized.data,
+    mime: normalized.mime,
+    source: resolved.source,
+    name: input.name ?? resolved.name,
+    description: input.description,
+    mention: input.mention,
+  })
+})
+
+const normalizeImageAttachment = Effect.fn("PromptMaterializer.normalizeImageAttachment")(function* (
+  input: PromptInput.FileAttachment,
+  data: string,
+  mime: string,
+  image: Effect.Effect<Image.Interface>,
+) {
+  if (!mime.startsWith("image/")) return { data: Base64.make(data), mime }
+  const service = yield* image
+  const label = input.name ?? (input.uri.startsWith("data:") ? "inline attachment" : input.uri)
+  const content = { uri: label, content: data, encoding: "base64" as const, mime }
+  const normalized = yield* service.normalize(label, content).pipe(
+    Effect.catchTag("Image.ResizerUnavailableError", () => Effect.succeed(content)),
+    Effect.mapError((error) => new AttachmentError({ uri: label, message: error.message })),
+  )
+  return { data: Base64.make(normalized.content), mime: normalized.mime }
+})
+
+const readFileAttachment = Effect.fn("PromptMaterializer.readFileAttachment")(function* (
+  fs: FSUtil.Interface,
+  uri: string,
+) {
+  const url = yield* Effect.try({
+    try: () => new URL(uri),
+    catch: () => new AttachmentError({ uri, message: `Invalid attachment URI: ${uri}` }),
+  })
+  if (url.protocol !== "file:")
+    return yield* new AttachmentError({ uri, message: `Unsupported attachment URI: ${uri}` })
+  const start = positiveInt(url.searchParams.get("start"))
+  const end = positiveInt(url.searchParams.get("end"))
+  const target = yield* Effect.try({
+    try: () => {
+      url.search = ""
+      url.hash = ""
+      return fileURLToPath(url)
+    },
+    catch: () => new AttachmentError({ uri, message: `Invalid file URI: ${uri}` }),
+  })
+  const info = yield* fs
+    .stat(target)
+    .pipe(Effect.mapError(() => new AttachmentError({ uri, message: `Unable to read attachment: ${uri}` })))
+  if (info.type === "Directory") {
+    const entries = yield* fs
+      .readDirectoryEntries(target)
+      .pipe(Effect.mapError(() => new AttachmentError({ uri, message: `Unable to read attachment: ${uri}` })))
+    return {
+      bytes: Buffer.from(
+        entries
+          .filter((entry) => entry.type === "file" || entry.type === "directory")
+          .sort((a, b) => (a.type === b.type ? a.name.localeCompare(b.name) : a.type === "directory" ? -1 : 1))
+          .map((entry) => entry.name + (entry.type === "directory" ? path.sep : ""))
+          .join("\n"),
+      ),
+      source: { type: "uri" as const, uri },
+      start: undefined,
+      end: undefined,
+      name: path.basename(target),
+      mime: "application/x-directory",
+    }
+  }
+  if (info.type !== "File") return yield* new AttachmentError({ uri, message: `Attachment is not a file: ${uri}` })
+  if (Number(info.size) > MAX_ATTACHMENT_BYTES)
+    return yield* new AttachmentError({
+      uri,
+      message: `Attachment exceeds the ${MAX_ATTACHMENT_BYTES} byte limit: ${uri}`,
+    })
+  const bytes = yield* fs
+    .readFile(target)
+    .pipe(Effect.mapError(() => new AttachmentError({ uri, message: `Unable to read attachment: ${uri}` })))
+  return { bytes, source: { type: "uri" as const, uri }, start, end, name: path.basename(target), mime: undefined }
+})
+
+const readWorkspaceAttachment = Effect.fn("PromptMaterializer.readWorkspaceAttachment")(function* (
+  location: Location.Ref,
+  environment: Effect.Effect<Environment.Interface>,
+  uri: string,
+) {
+  if (!location.workspaceID)
+    return yield* new AttachmentError({
+      uri,
+      message: `Workspace attachment requires a workspace-bound session: ${uri}`,
+    })
+  const url = yield* Effect.try({
+    try: () => new URL(uri),
+    catch: () => new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` }),
+  })
+  const relative = yield* Effect.try({
+    try: () => decodeURIComponent(url.pathname),
+    catch: () => new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` }),
+  })
+  if (url.protocol !== "workspace:" || url.host || !relative || path.isAbsolute(relative))
+    return yield* new AttachmentError({ uri, message: `Invalid workspace attachment URI: ${uri}` })
+  const target = path.resolve(location.directory, relative)
+  if (!FSUtil.contains(location.directory, target))
+    return yield* new AttachmentError({ uri, message: `Workspace attachment escapes the workspace root: ${uri}` })
+  const service = yield* environment
+  const result = yield* service.files.read(target, { offset: 0, length: MAX_ATTACHMENT_BYTES + 1 }).pipe(
+    Effect.mapError(
+      (error) =>
+        new AttachmentError({
+          uri,
+          message:
+            error._tag === "Environment.NotFound"
+              ? `Workspace attachment not found: ${uri}`
+              : error._tag === "Environment.WrongKind"
+                ? `Workspace attachment is not a file: ${uri}`
+                : `Unable to read workspace attachment: ${uri}`,
+        }),
+    ),
+  )
+  return {
+    bytes: result.bytes,
+    source: { type: "uri" as const, uri },
+    start: positiveInt(url.searchParams.get("start")),
+    end: positiveInt(url.searchParams.get("end")),
+    name: path.basename(target),
+    mime: undefined,
+  }
+})
+
+function decodeDataURL(uri: string) {
+  return Effect.try({
+    try: () => {
+      const comma = uri.indexOf(",")
+      if (comma === -1) throw new Error("Invalid data URL")
+      const metadata = uri.slice(5, comma)
+      const payload = uri.slice(comma + 1)
+      if (!metadata.split(";").some((part) => part.toLowerCase() === "base64"))
+        return Buffer.from(decodeURIComponent(payload))
+      const bytes = Buffer.from(payload, "base64")
+      if (bytes.toString("base64") !== payload) throw new Error("Non-canonical base64")
+      return bytes
+    },
+    catch: () => new AttachmentError({ uri, message: "Invalid attachment data URL" }),
+  })
+}
+
+function positiveInt(value: string | null) {
+  if (value === null) return
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
+export const node = makeGlobalNode({
+  service: Service,
+  layer,
+  deps: [FSUtil.node, LocationServiceMap.node],
+})

--- a/packages/core/src/session/prompt-materializer.ts
+++ b/packages/core/src/session/prompt-materializer.ts
@@ -2,79 +2,59 @@ export * as PromptMaterializer from "./prompt-materializer.js"
 
 import { PromptInput } from "@opencode-ai/schema/prompt-input"
 import { Base64, FileAttachment, Prompt } from "@opencode-ai/schema/prompt"
-import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { FSUtil } from "@opencode-ai/util/fs-util"
-import { Context, Effect, Layer } from "effect"
+import { Effect, Layer } from "effect"
 import path from "path"
 import { fileURLToPath } from "url"
 import { Environment } from "../environment/index.js"
 import { Image } from "../image.js"
-import { LocationServiceMap } from "../location-service-map.js"
 import { Location } from "../location.js"
 import { Mime } from "../mime.js"
 import { PluginSupervisor } from "../plugin/supervisor-service.js"
 import { Skill } from "../skill.js"
 import { AttachmentError, SkillNotFoundError } from "./error.js"
 
-export interface Interface {
-  readonly materialize: (
-    location: Location.Ref,
-    input: PromptInput.Prompt,
-  ) => Effect.Effect<Prompt, AttachmentError | SkillNotFoundError>
-}
+type LocationServices =
+  | Environment.Service
+  | Image.Service
+  | Location.Service
+  | PluginSupervisor.Service
+  | Skill.Service
 
-export class Service extends Context.Service<Service, Interface>()("@opencode/Session/PromptMaterializer") {}
-
-const layer = Layer.effect(
-  Service,
-  Effect.gen(function* () {
-    const fs = yield* FSUtil.Service
-    const locations = yield* LocationServiceMap.Service
-    return Service.of({
-      materialize: Effect.fn("PromptMaterializer.materialize")(function* (location, input) {
-        const services = locations.get(location)
-        const image = Effect.gen(function* () {
-          const plugins = yield* PluginSupervisor.Service
-          yield* plugins.flush
-          return yield* Image.Service
-        }).pipe(Effect.provide(services))
-        const environment = Environment.Service.pipe(Effect.provide(services))
-        const files = input.files
-          ? yield* Effect.forEach(
-              input.files,
-              (file) => materializeAttachment(fs, location, environment, file, image),
-              { concurrency: 8 },
-            )
-          : undefined
-        const selected = yield* Effect.gen(function* () {
-          if (!input.skills?.length) return undefined
-          const skills = yield* Skill.Service.pipe(Effect.provide(services))
-          const available = yield* skills.list()
-          return yield* Effect.forEach(input.skills, (attachment) => {
-            const skill = available.find((item) => item.id === attachment.id)
-            if (!skill) return Effect.fail(new SkillNotFoundError({ skill: attachment.id }))
-            return Effect.succeed({ id: skill.id, name: skill.name, mention: attachment.mention })
-          })
+export const materialize = Effect.fn("PromptMaterializer.materialize")(function* (
+  input: PromptInput.Prompt,
+  services: Layer.Layer<LocationServices>,
+) {
+  const fs = yield* FSUtil.Service
+  const files = input.files
+    ? yield* Effect.forEach(input.files, (file) => materializeAttachment(fs, file, services), { concurrency: 8 })
+    : undefined
+  const requested = input.skills
+  const selected = requested?.length
+    ? yield* Effect.gen(function* () {
+        const skills = yield* Skill.Service
+        const available = yield* skills.list()
+        return yield* Effect.forEach(requested, (attachment) => {
+          const skill = available.find((item) => item.id === attachment.id)
+          if (!skill) return Effect.fail(new SkillNotFoundError({ skill: attachment.id }))
+          return Effect.succeed({ id: skill.id, name: skill.name, mention: attachment.mention })
         })
-        return Prompt.fromUserMessage({
-          text: input.text,
-          agents: input.agents,
-          files,
-          skills: selected?.length ? selected : undefined,
-        })
-      }),
-    })
-  }),
-)
+      }).pipe(Effect.provide(services))
+    : undefined
+  return Prompt.fromUserMessage({
+    text: input.text,
+    agents: input.agents,
+    files,
+    skills: selected?.length ? selected : undefined,
+  })
+})
 
 const MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
 
 const materializeAttachment = Effect.fn("PromptMaterializer.materializeAttachment")(function* (
   fs: FSUtil.Interface,
-  location: Location.Ref,
-  environment: Effect.Effect<Environment.Interface>,
   input: PromptInput.FileAttachment,
-  image: Effect.Effect<Image.Interface>,
+  services: Layer.Layer<LocationServices>,
 ) {
   const resolved = input.uri.startsWith("data:")
     ? {
@@ -86,7 +66,7 @@ const materializeAttachment = Effect.fn("PromptMaterializer.materializeAttachmen
         mime: undefined,
       }
     : input.uri.startsWith("workspace:")
-      ? yield* readWorkspaceAttachment(location, environment, input.uri)
+      ? yield* readWorkspaceAttachment(input.uri).pipe(Effect.provide(services))
       : yield* readFileAttachment(fs, input.uri)
   if (resolved.bytes.byteLength > MAX_ATTACHMENT_BYTES)
     return yield* new AttachmentError({
@@ -105,7 +85,7 @@ const materializeAttachment = Effect.fn("PromptMaterializer.materializeAttachmen
             .join("\n"),
         )
       : resolved.bytes
-  const normalized = yield* normalizeImageAttachment(input, Buffer.from(content).toString("base64"), mime, image)
+  const normalized = yield* normalizeImageAttachment(input, Buffer.from(content).toString("base64"), mime, services)
   return FileAttachment.create({
     data: normalized.data,
     mime: normalized.mime,
@@ -120,13 +100,17 @@ const normalizeImageAttachment = Effect.fn("PromptMaterializer.normalizeImageAtt
   input: PromptInput.FileAttachment,
   data: string,
   mime: string,
-  image: Effect.Effect<Image.Interface>,
+  services: Layer.Layer<LocationServices>,
 ) {
   if (!mime.startsWith("image/")) return { data: Base64.make(data), mime }
-  const service = yield* image
+  const image = yield* Effect.gen(function* () {
+    const plugins = yield* PluginSupervisor.Service
+    yield* plugins.flush
+    return yield* Image.Service
+  }).pipe(Effect.provide(services))
   const label = input.name ?? (input.uri.startsWith("data:") ? "inline attachment" : input.uri)
   const content = { uri: label, content: data, encoding: "base64" as const, mime }
-  const normalized = yield* service.normalize(label, content).pipe(
+  const normalized = yield* image.normalize(label, content).pipe(
     Effect.catchTag("Image.ResizerUnavailableError", () => Effect.succeed(content)),
     Effect.mapError((error) => new AttachmentError({ uri: label, message: error.message })),
   )
@@ -187,11 +171,8 @@ const readFileAttachment = Effect.fn("PromptMaterializer.readFileAttachment")(fu
   return { bytes, source: { type: "uri" as const, uri }, start, end, name: path.basename(target), mime: undefined }
 })
 
-const readWorkspaceAttachment = Effect.fn("PromptMaterializer.readWorkspaceAttachment")(function* (
-  location: Location.Ref,
-  environment: Effect.Effect<Environment.Interface>,
-  uri: string,
-) {
+const readWorkspaceAttachment = Effect.fn("PromptMaterializer.readWorkspaceAttachment")(function* (uri: string) {
+  const location = yield* Location.Service
   if (!location.workspaceID)
     return yield* new AttachmentError({
       uri,
@@ -210,8 +191,8 @@ const readWorkspaceAttachment = Effect.fn("PromptMaterializer.readWorkspaceAttac
   const target = path.resolve(location.directory, relative)
   if (!FSUtil.contains(location.directory, target))
     return yield* new AttachmentError({ uri, message: `Workspace attachment escapes the workspace root: ${uri}` })
-  const service = yield* environment
-  const result = yield* service.files.read(target, { offset: 0, length: MAX_ATTACHMENT_BYTES + 1 }).pipe(
+  const environment = yield* Environment.Service
+  const result = yield* environment.files.read(target, { offset: 0, length: MAX_ATTACHMENT_BYTES + 1 }).pipe(
     Effect.mapError(
       (error) =>
         new AttachmentError({
@@ -253,13 +234,7 @@ function decodeDataURL(uri: string) {
 }
 
 function positiveInt(value: string | null) {
-  if (value === null) return
+  if (value === null) return undefined
   const parsed = Number(value)
   return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined
 }
-
-export const node = makeGlobalNode({
-  service: Service,
-  layer,
-  deps: [FSUtil.node, LocationServiceMap.node],
-})

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -29,6 +29,9 @@ import type { LocationServices } from "@opencode-ai/core/location-services"
 import { Image } from "@opencode-ai/core/image"
 import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Snapshot } from "@opencode-ai/core/snapshot"
+import { Environment } from "@opencode-ai/core/environment/index"
+import { Workspace } from "@opencode-ai/core/workspace"
+import { toLLMMessages } from "@opencode-ai/core/session/runner/to-llm-message"
 import { testEffect } from "./lib/effect"
 
 const executionCalls: Session.ID[] = []
@@ -36,6 +39,8 @@ const interruptCalls: Session.ID[] = []
 const interruptContinuations: Array<boolean | undefined> = []
 const wakeCalls: Session.ID[] = []
 const activeSessions = new Set<Session.ID>()
+const workspaceDriver = Environment.makeMemoryDriver()
+const workspaceFiles = Environment.makeFiles(workspaceDriver)
 const execution = Layer.succeed(
   SessionExecution.Service,
   SessionExecution.Service.of({
@@ -82,6 +87,10 @@ const locations = Layer.effect(
               PluginSupervisor.Service,
               PluginSupervisor.Service.of({ flush: Effect.sync(() => (ready = true)) }),
             ),
+            Layer.succeed(
+              Environment.Service,
+              Environment.Service.of({ files: workspaceFiles, spawner: workspaceDriver.spawner }),
+            ),
           )
         }),
       ) as unknown as Layer.Layer<LocationServices>,
@@ -122,6 +131,17 @@ const setup = Effect.gen(function* () {
     .run()
     .pipe(Effect.orDie)
 })
+const setupWorkspace = (workspaceID: Workspace.ID) =>
+  Effect.gen(function* () {
+    yield* setup
+    const { db } = yield* Database.Service
+    yield* db
+      .update(SessionTable)
+      .set({ workspace_id: workspaceID })
+      .where(eq(SessionTable.id, sessionID))
+      .run()
+      .pipe(Effect.orDie)
+  })
 
 const admitted = (id: SessionMessage.ID) => Database.Service.use(({ db }) => SessionInbox.find(db, id))
 const admittedCount = Database.Service.use(({ db }) =>
@@ -428,6 +448,86 @@ describe("Session.prompt", () => {
       ])
       const stored = yield* admitted(message.id)
       expect(stored?.type === "user" ? stored.payload.files : undefined).toEqual(message.payload.files)
+    }),
+  )
+
+  it.effect("materializes workspace image content through the session environment", () =>
+    Effect.gen(function* () {
+      const workspaceID = Workspace.ID.ascending("wrk_prompt")
+      yield* setupWorkspace(workspaceID)
+      const session = yield* Session.Service
+      const bytes = Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=",
+        "base64",
+      )
+      yield* workspaceFiles.write("/project/uploads/image.png", bytes)
+
+      const message = yield* session.prompt({
+        sessionID,
+        text: "Inspect this image",
+        files: [{ uri: "workspace:uploads/image.png" }],
+        resume: false,
+      })
+
+      expect(message.payload.files).toEqual([
+        {
+          data: bytes.toString("base64"),
+          mime: "image/png",
+          source: { type: "uri", uri: "workspace:uploads/image.png" },
+          name: "image.png",
+        },
+      ])
+      const messages = toLLMMessages(
+        [
+          SessionMessage.User.make({
+            id: message.id,
+            type: "user",
+            ...message.payload,
+            time: { created: DateTime.makeUnsafe(0) },
+          }),
+        ],
+        Model.Ref.make({ id: Model.ID.make("model"), providerID: Provider.ID.make("provider") }),
+      )
+      expect(messages[0]?.content).toEqual([
+        { type: "text", text: "Inspect this image" },
+        { type: "media", mediaType: "image/png", data: bytes.toString("base64"), filename: "image.png" },
+      ])
+    }),
+  )
+
+  it.effect("rejects missing workspace attachments with a typed error", () =>
+    Effect.gen(function* () {
+      yield* setupWorkspace(Workspace.ID.ascending("wrk_prompt"))
+      const session = yield* Session.Service
+      const uri = "workspace:uploads/missing.png"
+
+      const error = yield* session
+        .prompt({ sessionID, text: "Inspect this", files: [{ uri }], resume: false })
+        .pipe(Effect.flip)
+
+      expect(error).toMatchObject({
+        _tag: "Session.AttachmentError",
+        uri,
+        message: `Workspace attachment not found: ${uri}`,
+      })
+    }),
+  )
+
+  it.effect("rejects workspace attachments for sessions without a workspace binding", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* Session.Service
+      const uri = "workspace:uploads/image.png"
+
+      const error = yield* session
+        .prompt({ sessionID, text: "Inspect this", files: [{ uri }], resume: false })
+        .pipe(Effect.flip)
+
+      expect(error).toMatchObject({
+        _tag: "Session.AttachmentError",
+        uri,
+        message: `Workspace attachment requires a workspace-bound session: ${uri}`,
+      })
     }),
   )
 

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -25,6 +25,7 @@ import { SessionInbox } from "@opencode-ai/core/session/inbox"
 import { SessionInboxTable, SessionMessageTable, SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
+import { Location } from "@opencode-ai/core/location"
 import type { LocationServices } from "@opencode-ai/core/location-services"
 import { Image } from "@opencode-ai/core/image"
 import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
@@ -64,7 +65,7 @@ const execution = Layer.succeed(
 const locations = Layer.effect(
   LocationServiceMap.Service,
   LayerMap.make(
-    () =>
+    (ref) =>
       // These operations resolve Location services lazily and must wait for plugin-projected state.
       // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
       Layer.unwrap(
@@ -80,8 +81,7 @@ const locations = Layer.effect(
             Layer.mock(Snapshot.Service, {
               capture: () =>
                 ready ? Effect.undefined : Effect.die(new Error("Snapshot used before plugins were ready")),
-              restore: () =>
-                ready ? Effect.void : Effect.die(new Error("Snapshot used before plugins were ready")),
+              restore: () => (ready ? Effect.void : Effect.die(new Error("Snapshot used before plugins were ready"))),
             }),
             Layer.succeed(
               PluginSupervisor.Service,
@@ -90,6 +90,14 @@ const locations = Layer.effect(
             Layer.succeed(
               Environment.Service,
               Environment.Service.of({ files: workspaceFiles, spawner: workspaceDriver.spawner }),
+            ),
+            Layer.succeed(
+              Location.Service,
+              Location.Service.of({
+                directory: ref.directory,
+                workspaceID: ref.workspaceID,
+                project: { id: Project.ID.global, directory: ref.directory, canonical: ref.directory },
+              }),
             ),
           )
         }),

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -1825,7 +1825,7 @@
             }
           }
         },
-        "description": "Durably admit one session input and schedule agent-loop execution unless resume is false.",
+        "description": "Durably admit one session input and schedule agent-loop execution unless resume is false. File attachments accept data:, file:, and workspace:relative/path URIs; workspace: URIs require a workspace-bound session and are resolved through that workspace when admitted.",
         "summary": "Send message",
         "requestBody": {
           "content": {
@@ -14845,7 +14845,8 @@
         "type": "object",
         "properties": {
           "uri": {
-            "type": "string"
+            "type": "string",
+            "description": "Attachment URI. data: URLs embed bytes inline; file: URLs are read from the server's local filesystem; workspace:relative/path URLs are read relative to the session directory through its bound workspace and require a workspace-bound session. Bytes are snapshotted when the prompt is admitted."
           },
           "name": {
             "type": "string"

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -350,7 +350,8 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           OpenApi.annotations({
             identifier: "v2.session.prompt",
             summary: "Send message",
-            description: "Durably admit one session input and schedule agent-loop execution unless resume is false.",
+            description:
+              "Durably admit one session input and schedule agent-loop execution unless resume is false. File attachments accept data:, file:, and workspace:relative/path URIs; workspace: URIs require a workspace-bound session and are resolved through that workspace when admitted.",
           }),
         ),
     )

--- a/packages/schema/src/prompt-input.ts
+++ b/packages/schema/src/prompt-input.ts
@@ -7,7 +7,10 @@ import { Skill } from "./skill.js"
 
 export interface FileAttachment extends Schema.Schema.Type<typeof FileAttachment> {}
 export const FileAttachment = Schema.Struct({
-  uri: Schema.String,
+  uri: Schema.String.annotate({
+    description:
+      "Attachment URI. data: URLs embed bytes inline; file: URLs are read from the server's local filesystem; workspace:relative/path URLs are read relative to the session directory through its bound workspace and require a workspace-bound session. Bytes are snapshotted when the prompt is admitted.",
+  }),
   name: Schema.String.pipe(optional),
   description: Schema.String.pipe(optional),
   mention: PromptMention.pipe(optional),

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -1825,7 +1825,7 @@
             }
           }
         },
-        "description": "Durably admit one session input and schedule agent-loop execution unless resume is false.",
+        "description": "Durably admit one session input and schedule agent-loop execution unless resume is false. File attachments accept data:, file:, and workspace:relative/path URIs; workspace: URIs require a workspace-bound session and are resolved through that workspace when admitted.",
         "summary": "Send message",
         "requestBody": {
           "content": {
@@ -14936,7 +14936,8 @@
         "type": "object",
         "properties": {
           "uri": {
-            "type": "string"
+            "type": "string",
+            "description": "Attachment URI. data: URLs embed bytes inline; file: URLs are read from the server's local filesystem; workspace:relative/path URLs are read relative to the session directory through its bound workspace and require a workspace-bound session. Bytes are snapshotted when the prompt is admitted."
           },
           "name": {
             "type": "string"

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -1825,7 +1825,7 @@
             }
           }
         },
-        "description": "Durably admit one session input and schedule agent-loop execution unless resume is false.",
+        "description": "Durably admit one session input and schedule agent-loop execution unless resume is false. File attachments accept data:, file:, and workspace:relative/path URIs; workspace: URIs require a workspace-bound session and are resolved through that workspace when admitted.",
         "summary": "Send message",
         "requestBody": {
           "content": {
@@ -14936,7 +14936,8 @@
         "type": "object",
         "properties": {
           "uri": {
-            "type": "string"
+            "type": "string",
+            "description": "Attachment URI. data: URLs embed bytes inline; file: URLs are read from the server's local filesystem; workspace:relative/path URLs are read relative to the session directory through its bound workspace and require a workspace-bound session. Bytes are snapshotted when the prompt is admitted."
           },
           "name": {
             "type": "string"

--- a/packages/www/src/docs/content/attachments.mdx
+++ b/packages/www/src/docs/content/attachments.mdx
@@ -32,20 +32,26 @@ Attachment controls and client-side limits depend on the interface. For programm
 [API reference](/api).
 
 V2 prompt and command inputs represent each attachment with a `uri` and
-optional `name` and `description`. Use an absolute `file:` URL for a file or
-directory available to the server, or an inline `data:` URL. For a text `file:`
-URL, optional positive `start` and `end` query parameters select one-based
-lines:
+optional `name` and `description`. Use an inline `data:` URL, an absolute
+`file:` URL for a file or directory available to the server process, or a
+`workspace:relative/path` URL for a file in the session's workspace directory.
+`workspace:` URLs require a workspace-bound session and are read through that
+workspace rather than the server's local filesystem. For text `file:` and
+`workspace:` URLs, optional positive `start` and `end` query parameters select
+one-based lines:
 
 ```text
 file:///home/me/project/src/server.ts?start=20&end=60
+workspace:src/server.ts?start=20&end=60
 ```
 
 HTTP and HTTPS attachment URLs are not supported. OpenCode materializes each
 attachment before admitting the prompt and rejects invalid URLs, unreadable
-paths, non-files other than directories, and attachments over 20 MiB decoded.
-The server infers the media type from the bytes. A supplied filename or data
-URL media type does not make an unsupported binary format model-visible.
+paths, `workspace:` paths outside the session directory, non-files other than
+local `file:` directories, and attachments over 20 MiB decoded. This admission
+snapshot keeps later retries and history independent of changes to the source
+file. The server infers the media type from the bytes. A supplied filename or
+data URL media type does not make an unsupported binary format model-visible.
 
 ## Configure image processing
 


### PR DESCRIPTION
## What

Allow prompt file attachments to use `workspace:relative/path` references. Core resolves and snapshots those files through the session's location-selected `Environment` when the prompt is admitted, while preserving existing `data:` and process-local `file:` behavior.

Workerd embedders do not have a usable local filesystem, so today they must persist base64 `data:` URLs in retry-safe prompt payloads even when the file already exists in the session workspace. That can put megabytes of base64 into durable storage with tight per-value limits. A workspace URI keeps the pending prompt reference small and lets Core read the already-materialized file from the bound workspace.

## How

- Add a deep `PromptMaterializer` module that owns URI policy, attachment limits, MIME detection, image normalization, and skill resolution.
- Keep `Session.prompt` focused on admission: it supplies the canonical prompt input and the session's location layer, then persists the materialized byte snapshot.
- Acquire location services lazily only for branches that need them: workspace reads, image normalization, or skill resolution. Plain prompts and local text files do not boot the location graph.
- Resolve `workspace:relative/path` against the location-scoped `Location.directory` through `Environment.files.read`; `Location.workspaceID` is only the workspace-scheme eligibility check.
- Require a workspace-bound session, reject invalid or lexically escaping paths, and map missing files and Environment read failures through the existing typed attachment and `InvalidRequestError` boundary.
- Continue resolving `file:` through process-local `FSUtil`; existing `data:` and `file:` semantics are unchanged.
- Document all three URI forms in the schema, prompt API operation, generated OpenAPI artifacts, and attachments guide.

## Scope

- This adds prompt attachment reads only; it does not add workspace URI support to unrelated file APIs.
- Admission still stores the resolved bytes, not a live URI, so retries and later execution observe the original snapshot.
- Existing prompt admission ordering, interruptibility, attachment budgets, image behavior, and skill behavior are unchanged.

## Testing

- `packages/core`: `bun typecheck`
- `packages/core`: `bun run test session-prompt.test.ts` (47/47 pass)
- `packages/core`: `bun run test` (2240 pass, 16 skip; one known inherited config-plugin reload failure)
- `packages/core`: focused runner/transfer regression set (162/162 pass)
- `packages/server`: `bun typecheck`; full suite 26/26 pass
- `packages/schema`, `packages/protocol`, `packages/client`: `bun typecheck`
- `packages/protocol`: generated OpenAPI check passes
- `packages/www`: typecheck and full build pass
- `packages/client`: 62/63 tests pass; the unrelated existing Promise client group expectation for `question` fails with no client files changed
- Pre-push workspace typecheck passes all 32 tasks across 38 scoped packages

## Flow

```mermaid
sequenceDiagram
    participant Client
    participant Session
    participant Materializer as PromptMaterializer
    participant Location as Location Environment
    participant Inbox

    Client->>Session: prompt(files: workspace:relative/path)
    Session->>Materializer: materialize(input, session location layer)
    Materializer->>Location: Location + Environment.files.read(resolved path)
    Location-->>Materializer: bytes
    Materializer->>Materializer: enforce limit, detect MIME, normalize image
    Materializer-->>Session: canonical Prompt with byte snapshot
    Session->>Inbox: admit durable user item
    Inbox-->>Client: admitted prompt
```
