### PR TITLE
test(core): provide command render services

### DIFF
--- a/packages/core/test/config/reload.test.ts
+++ b/packages/core/test/config/reload.test.ts
@@ -14,16 +14,22 @@ import { Bus } from "@opencode-ai/core/bus"
 import { Integration } from "@opencode-ai/core/integration"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Provider } from "@opencode-ai/core/provider"
 import { Reference } from "@opencode-ai/core/reference"
 import { Skill } from "@opencode-ai/core/skill"
+import { ShellSelect } from "@opencode-ai/core/shell/select"
 import { Global } from "@opencode-ai/util/global"
-import { Effect, Schema } from "effect"
+import { AppProcess } from "@opencode-ai/util/process"
+import { Effect, Layer, Schema } from "effect"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "../plugin/fixture"
 
-const it = testEffect(PluginTestLayer)
+const it = testEffect(
+  Layer.merge(PluginTestLayer, AppNodeBuilder.build(LayerNode.group([AppProcess.node, ShellSelect.node]))),
+)
 const decode = Schema.decodeUnknownSync(Info)
 const document = path.join(import.meta.dir, "opencode.json")
 


### PR DESCRIPTION
## Summary
- provide AppProcess and ShellSelect to the config plugin reload fixture
- cover the execution services required after config commands became callback adapters

## Testing
- `bun test test/config/reload.test.ts` from `packages/core`
- `bun typecheck` from `packages/core`
- full pre-push workspace typecheck (32 packages)