### PR TITLE
test: stabilize asynchronous integration checks

### DIFF
--- a/packages/cli/test/acp/service-usage.test.ts
+++ b/packages/cli/test/acp/service-usage.test.ts
@@ -12,13 +12,7 @@ describe("acp service prompt routing and usage", () => {
           return Response.json({ data: makeSession("ses_routes") })
         }
         if (request.method === "POST" && request.path === "/api/session/ses_routes/command") {
-          const id = requestID(request)
-          completeTurn(context, "ses_routes", {
-            id: `evt_${id}`,
-            type: "session.inbox.delivered",
-            data: { sessionID: "ses_routes", inboxID: id },
-          })
-          return Response.json({ data: {} })
+          return new Response(null, { status: 204 })
         }
         if (request.method === "POST" && request.path === "/api/session/ses_routes/skill") {
           const id = requestID(request)
@@ -65,9 +59,8 @@ describe("acp service prompt routing and usage", () => {
     const skill = fixture.requests.find((request) => request.path === "/api/session/ses_routes/skill")
     const compact = fixture.requests.find((request) => request.path === "/api/session/ses_routes/compact")
     expect(command?.body).toMatchObject({
-      id: expect.any(String),
       command: "review",
-      arguments: "now",
+      text: "now",
       files: [],
       delivery: "steer",
     })

--- a/packages/tui/test/component/session-tabs-mouse.test.tsx
+++ b/packages/tui/test/component/session-tabs-mouse.test.tsx
@@ -201,7 +201,7 @@ test("reflows held tabs when the pointer leaves the strip", async () => {
 
     await app.mockMouse.moveTo(0, 1)
     await app.mockMouse.moveTo(20, 0)
-    await app.waitForFrame((frame) => Array.from(frame.split("\n")[0] ?? "")[20] === "✕")
+    await app.waitForFrame((frame) => Array.from(frame.split("\n")[0] ?? "")[20] === "✕", { maxPasses: 100 })
     expect(Array.from(app.captureCharFrame().split("\n")[0] ?? "")[22]).not.toBe("✕")
   } finally {
     app.renderer.destroy()

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -263,7 +263,11 @@ test("stores session tabs for the current working directory by default", async (
 
   try {
     const file = path.join(setup.state, "test", "tui", "tabs.json")
-    await wait(() => Bun.file(file).size > 0)
+    await wait(async () => {
+      if (!(await Bun.file(file).exists())) return false
+      const stored = await Bun.file(file).json()
+      return stored.cwd[directory]?.tabs.some((tab: { sessionID: string }) => tab.sessionID === "first")
+    })
     const stored = await Bun.file(file).json()
     expect(stored.global).toEqual({ tabs: [], unread: {} })
     expect(Object.keys(stored.cwd)).toEqual([directory])


### PR DESCRIPTION
## What

Stabilize the ACP prompt-routing and TUI session-tab checks that pollute unrelated PRs.

## How

- Update the ACP command fixture for the immediate callback endpoint: commands return 204 and use `text`, with no inbox ID or terminal event. The stale fixture reproduced as `missing prompt id` on every rerun after the command API change.
- Let the held-tab reflow assertion consume the already-scheduled render work. The original 20-pass ceiling failed 2/50 runs with `hasScheduledRender: true`; no production timing changes are made.
- Wait for the expected cwd tab record instead of any nonempty `tabs.json` write. This removes the ordering race with earlier storage initialization writes.

## Testing

- ACP routing: 50 consecutive reruns
- Held-tab reflow: 100 consecutive reruns
- Cwd tab storage: 100 consecutive reruns
- Full affected files: 3 ACP tests and 24 TUI tab tests
- `bun typecheck` in `packages/cli` and `packages/tui`
- repository pre-push typecheck (32 packages)