### PR TITLE
fix(core): validate JSON schema tool input

### DIFF
--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -10,7 +10,7 @@ const jsonSchemas = Effect.runSync(
       Effect.try({
         try: () => jsonSchema(schema),
         catch: () => undefined,
-      }).pipe(Effect.catch(() => Effect.succeed(undefined))),
+      }).pipe(Effect.orElseSucceed(() => undefined)),
   }),
 )
 

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -1,9 +1,21 @@
 import type { ToolDefinition } from "@opencode-ai/ai"
 import { Tool } from "@opencode-ai/schema/tool"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
-import { Effect, JsonSchema, Schema, SchemaRepresentation } from "effect"
+import { Cache, Effect, JsonSchema, Schema, SchemaRepresentation } from "effect"
 
-const jsonSchemas = new WeakMap<JsonSchema.JsonSchema, Schema.Codec<unknown>>()
+const jsonSchemas = Effect.runSync(
+  Cache.make<JsonSchema.JsonSchema, Schema.Codec<unknown>, Tool.Error>({
+    capacity: 100,
+    lookup: (schema) =>
+      Effect.try({
+        try: () => jsonSchema(schema),
+        catch: (error) =>
+          new Tool.Error({
+            message: `Invalid tool input schema: ${error instanceof Error ? error.message : String(error)}`,
+          }),
+      }),
+  }),
+)
 
 export const definition = (tool: Tool.Info<any, any>): ToolDefinition => ({
   name: effectiveName(tool),
@@ -52,13 +64,7 @@ const decodeInput = (schema: Tool.ValueSchema<any>, value: unknown) => {
       Effect.mapError((error) => new Tool.Error({ message: `Invalid tool input: ${error.message}` })),
     )
   if (isStandardSchema(schema)) return validateStandard(schema, value, "Invalid tool input")
-  return Effect.try({
-    try: () => jsonSchema(schema),
-    catch: (error) =>
-      new Tool.Error({
-        message: `Invalid tool input schema: ${error instanceof Error ? error.message : String(error)}`,
-      }),
-  }).pipe(
+  return Cache.get(jsonSchemas, schema).pipe(
     Effect.flatMap((schema) => Schema.decodeUnknownEffect(schema)(value)),
     Effect.mapError((error) =>
       error instanceof Tool.Error ? error : new Tool.Error({ message: `Invalid tool input: ${error.message}` }),
@@ -67,15 +73,11 @@ const decodeInput = (schema: Tool.ValueSchema<any>, value: unknown) => {
 }
 
 const jsonSchema = (schema: JsonSchema.JsonSchema) => {
-  const cached = jsonSchemas.get(schema)
-  if (cached) return cached
   const draft =
     (typeof schema.$schema === "string" && schema.$schema.includes("draft-07")) || "definitions" in schema
       ? JsonSchema.fromSchemaDraft07(schema)
       : JsonSchema.fromSchemaDraft2020_12(schema)
-  const converted = Schema.make<Schema.Codec<unknown>>(SchemaRepresentation.fromJsonSchemaDocument(draft).ast)
-  jsonSchemas.set(schema, converted)
-  return converted
+  return Schema.make<Schema.Codec<unknown>>(SchemaRepresentation.fromJsonSchemaDocument(draft).ast)
 }
 
 const encodeOutput = (schema: Tool.ValueSchema<any>, value: unknown) => {

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -4,16 +4,13 @@ import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/sp
 import { Cache, Effect, JsonSchema, Schema, SchemaRepresentation } from "effect"
 
 const jsonSchemas = Effect.runSync(
-  Cache.make<JsonSchema.JsonSchema, Schema.Codec<unknown>, Tool.Error>({
+  Cache.make<JsonSchema.JsonSchema, Schema.Codec<unknown> | undefined>({
     capacity: 100,
     lookup: (schema) =>
       Effect.try({
         try: () => jsonSchema(schema),
-        catch: (error) =>
-          new Tool.Error({
-            message: `Invalid tool input schema: ${error instanceof Error ? error.message : String(error)}`,
-          }),
-      }),
+        catch: () => undefined,
+      }).pipe(Effect.catch(() => Effect.succeed(undefined))),
   }),
 )
 
@@ -65,10 +62,10 @@ const decodeInput = (schema: Tool.ValueSchema<any>, value: unknown) => {
     )
   if (isStandardSchema(schema)) return validateStandard(schema, value, "Invalid tool input")
   return Cache.get(jsonSchemas, schema).pipe(
-    Effect.flatMap((schema) => Schema.decodeUnknownEffect(schema)(value)),
-    Effect.mapError((error) =>
-      error instanceof Tool.Error ? error : new Tool.Error({ message: `Invalid tool input: ${error.message}` }),
+    Effect.flatMap((schema) =>
+      schema === undefined ? Effect.succeed(value) : Schema.decodeUnknownEffect(schema)(value),
     ),
+    Effect.mapError((error) => new Tool.Error({ message: `Invalid tool input: ${error.message}` })),
   )
 }
 

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -1,7 +1,9 @@
 import type { ToolDefinition } from "@opencode-ai/ai"
 import { Tool } from "@opencode-ai/schema/tool"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
-import { Effect, JsonSchema, Schema } from "effect"
+import { Effect, JsonSchema, Schema, SchemaRepresentation } from "effect"
+
+const jsonSchemas = new WeakMap<JsonSchema.JsonSchema, Schema.Codec<unknown>>()
 
 export const definition = (tool: Tool.Info<any, any>): ToolDefinition => ({
   name: effectiveName(tool),
@@ -50,7 +52,30 @@ const decodeInput = (schema: Tool.ValueSchema<any>, value: unknown) => {
       Effect.mapError((error) => new Tool.Error({ message: `Invalid tool input: ${error.message}` })),
     )
   if (isStandardSchema(schema)) return validateStandard(schema, value, "Invalid tool input")
-  return Effect.succeed(value)
+  return Effect.try({
+    try: () => jsonSchema(schema),
+    catch: (error) =>
+      new Tool.Error({
+        message: `Invalid tool input schema: ${error instanceof Error ? error.message : String(error)}`,
+      }),
+  }).pipe(
+    Effect.flatMap((schema) => Schema.decodeUnknownEffect(schema)(value)),
+    Effect.mapError((error) =>
+      error instanceof Tool.Error ? error : new Tool.Error({ message: `Invalid tool input: ${error.message}` }),
+    ),
+  )
+}
+
+const jsonSchema = (schema: JsonSchema.JsonSchema) => {
+  const cached = jsonSchemas.get(schema)
+  if (cached) return cached
+  const draft =
+    (typeof schema.$schema === "string" && schema.$schema.includes("draft-07")) || "definitions" in schema
+      ? JsonSchema.fromSchemaDraft07(schema)
+      : JsonSchema.fromSchemaDraft2020_12(schema)
+  const converted = Schema.make<Schema.Codec<unknown>>(SchemaRepresentation.fromJsonSchemaDocument(draft).ast)
+  jsonSchemas.set(schema, converted)
+  return converted
 }
 
 const encodeOutput = (schema: Tool.ValueSchema<any>, value: unknown) => {

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -234,6 +234,22 @@ test("raw JSON schemas resolve draft-07 definitions", async () => {
   )
 })
 
+test("raw JSON schemas pass input through when they cannot be imported", async () => {
+  const tool: Info = {
+    name: "invalid-schema",
+    description: "Invalid schema tool",
+    input: {
+      type: "object",
+      properties: { value: { $ref: "#/$defs/missing" } },
+    },
+    execute: (input) => Effect.succeed({ content: JSON.stringify(input) }),
+  }
+
+  expect(await Effect.runPromise(execute(tool, { value: 1, extra: true }, {} as Tool.Context))).toMatchObject({
+    content: [{ type: "text", text: '{"value":1,"extra":true}' }],
+  })
+})
+
 test("missing external input schemas fall back to an empty schema", () => {
   const tool = {
     name: "external",

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -152,19 +152,21 @@ test("portable schema failures become tool failures", async () => {
     },
   }
 
-  const error = await Effect.runPromiseExit(
-    execute(
-      {
-        name: "invalid",
-        description: "Invalid",
-        input,
-        execute: () => Effect.succeed({ content: "unused" }),
-      },
-      1,
-      {} as Tool.Context,
+  const error = await Effect.runPromise(
+    Effect.flip(
+      execute(
+        {
+          name: "invalid",
+          description: "Invalid",
+          input,
+          execute: () => Effect.succeed({ content: "unused" }),
+        },
+        1,
+        {} as Tool.Context,
+      ),
     ),
   )
-  expect(error.toString()).toContain("Invalid tool input: expected a string")
+  expect(error).toEqual(new Tool.Error({ message: "Invalid tool input: expected a string" }))
 })
 
 test("canonical results carry metadata with typed output", async () => {
@@ -188,7 +190,15 @@ test("canonical results carry metadata with typed output", async () => {
 test("raw JSON schemas validate and decode tool input", async () => {
   const input = {
     type: "object",
-    properties: { value: { type: "string" } },
+    properties: {
+      value: { type: "string" },
+      nested: {
+        type: "object",
+        properties: { count: { type: "integer", minimum: 1 } },
+        required: ["count"],
+        additionalProperties: false,
+      },
+    },
     required: ["value"],
     additionalProperties: false,
   }
@@ -208,8 +218,18 @@ test("raw JSON schemas validate and decode tool input", async () => {
     output: undefined,
     content: [{ type: "text", text: '{"value":"ok"}' }],
   })
-  expect((await Effect.runPromiseExit(execute(tool, { value: 1 }, {} as Tool.Context))).toString()).toContain(
-    "Invalid tool input",
+  expect(await Effect.runPromise(Effect.flip(execute(tool, { value: 1 }, {} as Tool.Context)))).toEqual(
+    new Tool.Error({ message: 'Invalid tool input: Expected string\n  at ["value"]' }),
+  )
+  expect(await Effect.runPromise(Effect.flip(execute(tool, {}, {} as Tool.Context)))).toEqual(
+    new Tool.Error({ message: 'Invalid tool input: Missing key\n  at ["value"]' }),
+  )
+  expect(
+    await Effect.runPromise(Effect.flip(execute(tool, { value: "ok", nested: { count: 0 } }, {} as Tool.Context))),
+  ).toEqual(
+    new Tool.Error({
+      message: 'Invalid tool input: Expected a value greater than or equal to 1\n  at ["nested"]["count"]',
+    }),
   )
 })
 
@@ -229,8 +249,8 @@ test("raw JSON schemas resolve draft-07 definitions", async () => {
   expect(await Effect.runPromise(execute(tool, { value: "ok" }, {} as Tool.Context))).toMatchObject({
     content: [{ type: "text", text: '{"value":"ok"}' }],
   })
-  expect((await Effect.runPromiseExit(execute(tool, { value: 1 }, {} as Tool.Context))).toString()).toContain(
-    "Invalid tool input",
+  expect(await Effect.runPromise(Effect.flip(execute(tool, { value: 1 }, {} as Tool.Context)))).toEqual(
+    new Tool.Error({ message: 'Invalid tool input: Expected value\n  at ["value"]' }),
   )
 })
 

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -185,8 +185,13 @@ test("canonical results carry metadata with typed output", async () => {
   })
 })
 
-test("raw JSON schemas are render-only and omitted output means model-only", async () => {
-  const input = { type: "object", properties: { value: { type: "string" } } }
+test("raw JSON schemas validate and decode tool input", async () => {
+  const input = {
+    type: "object",
+    properties: { value: { type: "string" } },
+    required: ["value"],
+    additionalProperties: false,
+  }
   const tool: Info = {
     name: "raw",
     description: "Raw tool",
@@ -197,12 +202,36 @@ test("raw JSON schemas are render-only and omitted output means model-only", asy
   expect(definition(tool)).toEqual({
     name: "raw",
     description: "Raw tool",
-    inputSchema: { type: "object", properties: { value: { type: "string" } } },
+    inputSchema: input,
   })
-  expect(await Effect.runPromise(execute(tool, { value: 1 }, {} as Tool.Context))).toEqual({
+  expect(await Effect.runPromise(execute(tool, { value: "ok", extra: true }, {} as Tool.Context))).toEqual({
     output: undefined,
-    content: [{ type: "text", text: '{"value":1}' }],
+    content: [{ type: "text", text: '{"value":"ok"}' }],
   })
+  expect((await Effect.runPromiseExit(execute(tool, { value: 1 }, {} as Tool.Context))).toString()).toContain(
+    "Invalid tool input",
+  )
+})
+
+test("raw JSON schemas resolve draft-07 definitions", async () => {
+  const tool: Info = {
+    name: "draft-07",
+    description: "Draft-07 tool",
+    input: {
+      type: "object",
+      properties: { value: { $ref: "#/definitions/value" } },
+      required: ["value"],
+      definitions: { value: { type: "string" } },
+    },
+    execute: (input) => Effect.succeed({ content: JSON.stringify(input) }),
+  }
+
+  expect(await Effect.runPromise(execute(tool, { value: "ok" }, {} as Tool.Context))).toMatchObject({
+    content: [{ type: "text", text: '{"value":"ok"}' }],
+  })
+  expect((await Effect.runPromiseExit(execute(tool, { value: 1 }, {} as Tool.Context))).toString()).toContain(
+    "Invalid tool input",
+  )
 })
 
 test("missing external input schemas fall back to an empty schema", () => {


### PR DESCRIPTION
## Summary
- import raw Draft 2020-12 and Draft-07 tool schemas into Effect Schema
- decode raw tool arguments before execution and surface failures as tool errors
- cache imported schemas and preserve Effect decoding behavior

## Tests
- `bun test test/tool-schema.test.ts test/tool-execute.test.ts test/session-runner-tool-registry.test.ts`
- `bun typecheck`