### PR TITLE
fix(tui): restore TUI sidebar modified-files diff

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -100,7 +100,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       params: { sessionID: SessionID }
       query: typeof DiffQuery.Type
     }) {
-      return yield* summary.diff({ sessionID: ctx.params.sessionID, messageID: ctx.query.messageID })
+      if (ctx.query.messageID) {
+        return yield* summary.diff({ sessionID: ctx.params.sessionID, messageID: ctx.query.messageID })
+      }
+      return yield* session.diff(ctx.params.sessionID)
     })
 
     const messages = Effect.fn("SessionHttpApi.messages")(function* (ctx: {

--- a/packages/opencode/src/session/git-path.ts
+++ b/packages/opencode/src/session/git-path.ts
@@ -1,0 +1,42 @@
+export function unquoteGitPath(input: string) {
+  if (!input.startsWith('"')) return input
+  if (!input.endsWith('"')) return input
+  const body = input.slice(1, -1)
+  const bytes: number[] = []
+  for (let i = 0; i < body.length; i++) {
+    const char = body[i]!
+    if (char !== "\\") {
+      bytes.push(char.charCodeAt(0))
+      continue
+    }
+    const next = body[i + 1]
+    if (!next) {
+      bytes.push("\\".charCodeAt(0))
+      continue
+    }
+    if (next >= "0" && next <= "7") {
+      const chunk = body.slice(i + 1, i + 4)
+      const match = chunk.match(/^[0-7]{1,3}/)
+      if (!match) {
+        bytes.push(next.charCodeAt(0))
+        i++
+        continue
+      }
+      bytes.push(parseInt(match[0], 8))
+      i += match[0].length
+      continue
+    }
+    const escaped =
+      next === "n" ? "\n"
+      : next === "r" ? "\r"
+      : next === "t" ? "\t"
+      : next === "b" ? "\b"
+      : next === "f" ? "\f"
+      : next === "v" ? "\v"
+      : next === "\\" || next === '"' ? next
+      : undefined
+    bytes.push((escaped ?? next).charCodeAt(0))
+    i++
+  }
+  return Buffer.from(bytes).toString()
+}

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -35,6 +35,7 @@ import { Snapshot } from "@/snapshot"
 import { ProjectV2 } from "@opencode-ai/core/project"
 import { WorkspaceV2 } from "@opencode-ai/core/workspace"
 import { SessionID, MessageID, PartID } from "./schema"
+import { unquoteGitPath } from "./git-path"
 
 import type { Provider } from "@/provider/provider"
 import { Global } from "@opencode-ai/core/global"
@@ -821,8 +822,20 @@ const layer: Layer.Layer<
     })
 
     const diff = Effect.fn("Session.diff")(function* (sessionID: SessionID) {
-      void sessionID
-      return [] as Snapshot.FileDiff[]
+      const all = yield* messages({ sessionID }).pipe(Effect.orDie)
+      const merged = new Map<string, Snapshot.FileDiff>()
+      for (const m of all) {
+        if (m.info.role !== "user") continue
+        for (const d of m.info.summary?.diffs ?? []) {
+          if (d.file === undefined) continue
+          const file = unquoteGitPath(d.file)
+          const prev = merged.get(file)
+          merged.set(file, prev
+            ? { ...prev, additions: (prev.additions ?? 0) + (d.additions ?? 0), deletions: (prev.deletions ?? 0) + (d.deletions ?? 0) }
+            : { ...d, file })
+        }
+      }
+      return [...merged.values()]
     })
 
     const messages: Interface["messages"] = Effect.fn("Session.messages")(function* (input) {

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -4,64 +4,9 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { Snapshot } from "@/snapshot"
 import { Session } from "./session"
+import { unquoteGitPath } from "./git-path"
 import { SessionID, MessageID } from "./schema"
 import { Config } from "@/config/config"
-
-function unquoteGitPath(input: string) {
-  if (!input.startsWith('"')) return input
-  if (!input.endsWith('"')) return input
-  const body = input.slice(1, -1)
-  const bytes: number[] = []
-
-  for (let i = 0; i < body.length; i++) {
-    const char = body[i]!
-    if (char !== "\\") {
-      bytes.push(char.charCodeAt(0))
-      continue
-    }
-
-    const next = body[i + 1]
-    if (!next) {
-      bytes.push("\\".charCodeAt(0))
-      continue
-    }
-
-    if (next >= "0" && next <= "7") {
-      const chunk = body.slice(i + 1, i + 4)
-      const match = chunk.match(/^[0-7]{1,3}/)
-      if (!match) {
-        bytes.push(next.charCodeAt(0))
-        i++
-        continue
-      }
-      bytes.push(parseInt(match[0], 8))
-      i += match[0].length
-      continue
-    }
-
-    const escaped =
-      next === "n"
-        ? "\n"
-        : next === "r"
-          ? "\r"
-          : next === "t"
-            ? "\t"
-            : next === "b"
-              ? "\b"
-              : next === "f"
-                ? "\f"
-                : next === "v"
-                  ? "\v"
-                  : next === "\\" || next === '"'
-                    ? next
-                    : undefined
-
-    bytes.push((escaped ?? next).charCodeAt(0))
-    i++
-  }
-
-  return Buffer.from(bytes).toString()
-}
 
 export interface Interface {
   readonly summarize: (input: { sessionID: SessionID; messageID: MessageID }) => Effect.Effect<void>
@@ -111,19 +56,23 @@ const layer = Layer.effect(
           files: 0,
         },
       })
-      yield* events.publish(Session.Event.Diff, { sessionID: input.sessionID, diff: [] })
-      if ((yield* config.get()).snapshot === false) return
-      const all = yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)
-      if (!all.length) return
-
-      const messages = all.filter(
-        (m) => m.info.id === input.messageID || (m.info.role === "assistant" && m.info.parentID === input.messageID),
-      )
-      const target = messages.find((m) => m.info.id === input.messageID)
-      if (!target || target.info.role !== "user") return
-      const msgDiffs = yield* computeDiff({ messages })
-      target.info.summary = { ...target.info.summary, diffs: msgDiffs }
-      yield* sessions.updateMessage(target.info)
+      let diff: Snapshot.FileDiff[] = []
+      if ((yield* config.get()).snapshot !== false) {
+        const all = yield* sessions.messages({ sessionID: input.sessionID }).pipe(Effect.orDie)
+        if (all.length) {
+          const messages = all.filter(
+            (m) => m.info.id === input.messageID || (m.info.role === "assistant" && m.info.parentID === input.messageID),
+          )
+          const target = messages.find((m) => m.info.id === input.messageID)
+          if (target && target.info.role === "user") {
+            const msgDiffs = yield* computeDiff({ messages })
+            target.info.summary = { ...target.info.summary, diffs: msgDiffs }
+            yield* sessions.updateMessage(target.info)
+            diff = yield* sessions.diff(input.sessionID)
+          }
+        }
+      }
+      yield* events.publish(Session.Event.Diff, { sessionID: input.sessionID, diff })
     })
 
     const diff = Effect.fn("SessionSummary.diff")(function* (input: { sessionID: SessionID; messageID?: MessageID }) {

--- a/packages/opencode/test/server/session-diff-session-level.test.ts
+++ b/packages/opencode/test/server/session-diff-session-level.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression test for #30877: the TUI "Modified Files" sidebar reads the
+ * session-level diff (Session.diff(sessionID) / GET /session/<id>/diff with no
+ * messageID). After #30127, Session.diff was hardcoded to return [], so the
+ * sidebar was always empty even though per-message turn diffs are still
+ * computed and stored on each user message's `info.summary.diffs`.
+ *
+ * This test asserts the session-level diff aggregates those per-message turn
+ * diffs. It currently FAILS (returns []) — that is the reproduction — and should
+ * pass once Session.diff aggregates the stored per-message diffs.
+ */
+import { afterEach, describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, Layer } from "effect"
+import { SessionPaths } from "@/server/routes/instance/httpapi/groups/session"
+import { Session } from "@/session/session"
+import { Storage } from "@/storage/storage"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { MessageID } from "@/session/schema"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { resetDatabase } from "../fixture/db"
+import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { httpApiLayer, requestInDirectory } from "./httpapi-layer"
+
+const it = testEffect(Layer.mergeAll(LayerNode.compile(LayerNode.group([Session.node, Storage.node])), httpApiLayer))
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+function pathFor(template: string, params: Record<string, string>) {
+  return Object.entries(params).reduce((result, [key, value]) => result.replace(`:${key}`, value), template)
+}
+
+const withSession = (input?: Parameters<Session.Interface["create"]>[0]) =>
+  Effect.acquireRelease(Session.use.create(input), (created) => Session.use.remove(created.id).pipe(Effect.ignore))
+
+describe("session-level diff aggregation (#30877)", () => {
+  it.instance(
+    "GET /session/<id>/diff returns aggregated turn diffs",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const session = yield* withSession({ title: "modified-files" })
+        const messageID = MessageID.ascending()
+        yield* Session.use.updateMessage({
+          id: messageID,
+          sessionID: session.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "build",
+          model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("model") },
+          summary: {
+            diffs: [{ file: "src/app.ts", additions: 3, deletions: 1, status: "modified" }],
+          },
+        } satisfies SessionV1.User)
+
+        const response = yield* requestInDirectory(
+          pathFor(SessionPaths.diff, { sessionID: session.id }),
+          test.directory,
+        )
+
+        expect(response.status).toBe(200)
+        expect(yield* response.json).toEqual([
+          { file: "src/app.ts", additions: 3, deletions: 1, status: "modified" },
+        ])
+      }),
+    { git: true, config: { formatter: false, lsp: false } },
+  )
+})

--- a/packages/opencode/test/session/summary-diff-event.test.ts
+++ b/packages/opencode/test/session/summary-diff-event.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Regression test for the sidebar "Modified Files" bug: `SessionSummary.summarize`
+ * used to publish the `session.diff` event with an empty array (`diff: []`), which
+ * wiped the TUI/app sidebar diff on every completed turn. The real diffs were stored
+ * on the message summary but never pushed to clients via the event.
+ *
+ * This test drives a real prompt through `SessionPrompt` (the production path that
+ * fires `summarize`) and captures the published `session.diff` event. It asserts the
+ * event carries the real merged diff — not `[]`. (We capture the event rather than
+ * reading `sessions.diff`, which reads the message summary and would pass under both
+ * the old and new code.)
+ */
+import { expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import fs from "fs/promises"
+import path from "path"
+import { Session } from "../../src/session/session"
+import { SessionPrompt } from "../../src/session/prompt"
+import { MessageV2 } from "../../src/session/message-v2"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Database } from "@opencode-ai/core/database/database"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { provideTmpdirServer } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { TestLLMServer } from "../lib/llm-server"
+import { LSP } from "@/lsp/lsp"
+import { MCP } from "../../src/mcp"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+
+const mcp = Layer.succeed(
+  MCP.Service,
+  MCP.Service.of({
+    status: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
+    instructions: () => Effect.succeed([]),
+    tools: () => Effect.succeed({}),
+    prompts: () => Effect.succeed({}),
+    resources: () => Effect.succeed({}),
+    resourceTemplates: () => Effect.succeed({}),
+    add: () => Effect.succeed({ status: { status: "disabled" as const } }),
+    connect: () => Effect.void,
+    disconnect: () => Effect.void,
+    getPrompt: () => Effect.succeed(undefined),
+    readResource: () => Effect.succeed(undefined),
+    startAuth: () => Effect.die("unexpected MCP auth"),
+    authenticate: () => Effect.die("unexpected MCP auth"),
+    finishAuth: () => Effect.die("unexpected MCP auth"),
+    removeAuth: () => Effect.void,
+    supportsOAuth: () => Effect.succeed(false),
+    hasStoredTokens: () => Effect.succeed(false),
+    getAuthStatus: () => Effect.succeed("not_authenticated" as const),
+  }),
+)
+
+const lsp = Layer.succeed(
+  LSP.Service,
+  LSP.Service.of({
+    init: () => Effect.void,
+    status: () => Effect.succeed([]),
+    hasClients: () => Effect.succeed(false),
+    touchFile: () => Effect.void,
+    diagnostics: () => Effect.succeed({}),
+    hover: () => Effect.succeed(undefined),
+    definition: () => Effect.succeed([]),
+    references: () => Effect.succeed([]),
+    implementation: () => Effect.succeed([]),
+    documentSymbol: () => Effect.succeed([]),
+    workspaceSymbol: () => Effect.succeed([]),
+    prepareCallHierarchy: () => Effect.succeed([]),
+    incomingCalls: () => Effect.succeed([]),
+    outgoingCalls: () => Effect.succeed([]),
+  }),
+)
+
+const root = LayerNode.group([
+  SessionPrompt.node,
+  Session.node,
+  SessionProjector.node,
+  EventV2Bridge.node,
+  Database.node,
+  CrossSpawnSpawner.node,
+  LayerNode.make({ service: TestLLMServer, layer: TestLLMServer.layer, deps: [] }),
+])
+const it = testEffect(
+  LayerNode.compile(root, [
+    [MCP.node, mcp],
+    [LSP.node, lsp],
+    [RuntimeFlags.node, RuntimeFlags.layer({ experimentalEventSystem: true })],
+  ]),
+)
+
+const providerCfg = (url: string) => ({
+  provider: {
+    test: {
+      name: "Test",
+      id: "test",
+      env: [],
+      npm: "@ai-sdk/openai-compatible",
+      models: {
+        "test-model": {
+          id: "test-model",
+          name: "Test Model",
+          attachment: false,
+          reasoning: false,
+          temperature: false,
+          tool_call: true,
+          release_date: "2025-01-01",
+          limit: { context: 100000, output: 10000 },
+          cost: { input: 0, output: 0 },
+          options: {},
+        },
+      },
+      options: {
+        apiKey: "test-key",
+        baseURL: url,
+      },
+    },
+  },
+})
+
+it.live("publishes the real merged diff in the session.diff event", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ dir, llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const events = yield* EventV2Bridge.Service
+
+      // Seed a file so the agent's edit shows up as a modification.
+      yield* Effect.promise(() => fs.writeFile(path.join(dir, "a.txt"), "hi\n"))
+
+      const session = yield* sessions.create({
+        title: "sidebar diff regression",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      const captured: Array<{ sessionID: string; diff: Array<{ file: string }> }> = []
+      const unsub = yield* events.listen((event) =>
+        Effect.gen(function* () {
+          if (event.type === "session.diff")
+            captured.push(event.data as { sessionID: string; diff: Array<{ file: string }> })
+          return
+        }),
+      )
+
+      const command = `printf 'world\\n' >> ${path.join(dir, "a.txt")}`
+      yield* llm.toolMatch((hit) => JSON.stringify(hit.body).includes("append"), "bash", { command })
+      yield* llm.textMatch((hit) => JSON.stringify(hit.body).includes("bash"), "done")
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "append a line to a.txt" }],
+      })
+      const result = yield* prompt.loop({ sessionID: session.id })
+      expect(result.info.role).toBe("assistant")
+
+      // summarize() is fire-and-forget; poll for the published event.
+      let last: { sessionID: string; diff: Array<{ file: string }> } | undefined
+      for (let i = 0; i < 50; i++) {
+        last = captured.filter((c) => c.sessionID === session.id).at(-1)
+        if (last && last.diff.length > 0) break
+        yield* Effect.sleep("100 millis")
+      }
+
+      yield* unsub
+
+      expect(last).toBeDefined()
+      expect(last!.diff.length).toBeGreaterThan(0)
+      expect(last!.diff.some((d) => d.file.includes("a.txt"))).toBe(true)
+
+      // Sanity: the file was actually edited.
+      const content = yield* Effect.promise(() => fs.readFile(path.join(dir, "a.txt"), "utf8"))
+      expect(content).toBe("hi\nworld\n")
+    }),
+    { git: true, config: providerCfg },
+  ),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #30877

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

PR #30127 intentionally changed `Session.diff` to return `[]` and `summarize` to publish an empty `session.diff` event, expecting the TUI to rely on per-message turn diffs. That left the TUI sidebar "Modified Files" list empty (regression #30877).

This PR restores the session-level diff:
- `Session.diff` aggregates the per-message turn diffs already stored on each user message (no full-session snapshot recompute, so #30127's performance concern is avoided).
- `summarize` publishes that merged diff in the `session.diff` event, so the sidebar populates live as turns complete.
- `GET /session/<id>/diff` (no messageID) routes to `Session.diff`.

### How did you verify your code works?

- `session-diff-session-level.test.ts` — asserts `Session.diff` aggregates the stored per-message diffs.
- `summary-diff-event.test.ts` — asserts the `session.diff` event publishes the real merged diff (it fails against the old empty-event behavior, confirming the regression is covered).
- Manual: ran `bun dev` in a git repo, edited a file, and confirmed the sidebar shows the "Modified Files" section with the edited file and its +/− counts.

### Screenshots / recordings

TUI UI change. Verified manually: the right sidebar now renders "Modified Files" with the modified file (e.g. `a.txt  +1`) after an edit, whereas before the section was absent. The original empty-sidebar report is in #30877.
<img width="1338" height="1078" alt="image" src="https://github.com/user-attachments/assets/490b8ff6-3d4f-4853-987c-9f8570b9870c" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Note: #30877 is assigned to @kommander — I left a comment offering the fix and am happy to hand it over if you're already on it.