### PR TITLE
tool: trim persisted LSP diagnostics in edit/write metadata

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -195,14 +195,21 @@ export const EditTool = Tool.define(
 
           let output = "Edit applied successfully."
           yield* lsp.touchFile(filePath, "document")
-          const diagnostics = yield* lsp.diagnostics()
+          const allDiagnostics = yield* lsp.diagnostics()
           const normalizedFilePath = FSUtil.normalizePath(filePath)
-          const block = LSP.Diagnostic.report(filePath, diagnostics[normalizedFilePath] ?? [])
+          const block = LSP.Diagnostic.report(filePath, allDiagnostics[normalizedFilePath] ?? [])
           if (block) output += `\n\nLSP errors detected in this file, please fix:\n${block}`
+
+          // Persist only the touched file's diagnostics in metadata so the session
+          // transcript does not balloon with workspace-wide diagnostics.
+          const touchedFileDiagnostics = allDiagnostics[normalizedFilePath] ?? []
+          const persistedDiagnostics = {
+            [normalizedFilePath]: touchedFileDiagnostics,
+          }
 
           return {
             metadata: {
-              diagnostics,
+              diagnostics: persistedDiagnostics,
               diff,
               filediff,
             },

--- a/packages/opencode/src/tool/write.ts
+++ b/packages/opencode/src/tool/write.ts
@@ -73,10 +73,10 @@ export const WriteTool = Tool.define(
 
           let output = "Wrote file successfully."
           yield* lsp.touchFile(filepath, "document")
-          const diagnostics = yield* lsp.diagnostics()
+          const allDiagnostics = yield* lsp.diagnostics()
           const normalizedFilepath = FSUtil.normalizePath(filepath)
           let projectDiagnosticsCount = 0
-          for (const [file, issues] of Object.entries(diagnostics)) {
+          for (const [file, issues] of Object.entries(allDiagnostics)) {
             const current = file === normalizedFilepath
             if (!current && projectDiagnosticsCount >= MAX_PROJECT_DIAGNOSTICS_FILES) continue
             const block = LSP.Diagnostic.report(current ? filepath : file, issues)
@@ -89,10 +89,18 @@ export const WriteTool = Tool.define(
             output += `\n\nLSP errors detected in other files:\n${block}`
           }
 
+          // Persist only the touched file's diagnostics in metadata so the session
+          // transcript does not balloon with workspace-wide diagnostics. The full
+          // map is kept in-memory above for the per-call output computation.
+          const touchedFileDiagnostics = allDiagnostics[normalizedFilepath] ?? []
+          const persistedDiagnostics = {
+            [normalizedFilepath]: touchedFileDiagnostics,
+          }
+
           return {
             title: path.relative(instance.worktree, filepath),
             metadata: {
-              diagnostics,
+              diagnostics: persistedDiagnostics,
               filepath,
               exists: exists,
             },

--- a/packages/opencode/test/tool/lsp-diagnostics-metadata.test.ts
+++ b/packages/opencode/test/tool/lsp-diagnostics-metadata.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, describe, expect } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Effect, Layer } from "effect"
+import { EditTool } from "../../src/tool/edit"
+import { WriteTool } from "../../src/tool/write"
+import { disposeAllInstances, TestInstance } from "../fixture/fixture"
+import { LSP } from "@/lsp/lsp"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { Format } from "../../src/format"
+import { Agent } from "../../src/agent/agent"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { Truncate } from "@/tool/truncate"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { SessionID, MessageID } from "../../src/session/schema"
+import * as Tool from "../../src/tool/tool"
+import { testEffect } from "../lib/effect"
+import type * as LSPClient from "@/lsp/client"
+
+// Workspace-wide diagnostics are fed through the LSP service. The persisted
+// metadata must only contain the touched file, not the whole workspace map.
+const state = {
+  diagnostics: {} as Record<string, LSPClient.Diagnostic[]>,
+}
+
+const fakeLSP = LayerNode.make({
+  service: LSP.Service,
+  layer: Layer.succeed(
+    LSP.Service,
+    LSP.Service.of({
+      init: () => Effect.void,
+      status: () => Effect.succeed([]),
+      hasClients: () => Effect.succeed(true),
+      touchFile: () => Effect.void,
+      diagnostics: () => Effect.succeed(state.diagnostics),
+      hover: () => Effect.succeed(undefined),
+      definition: () => Effect.succeed([]),
+      references: () => Effect.succeed([]),
+      implementation: () => Effect.succeed([]),
+      documentSymbol: () => Effect.succeed([]),
+      workspaceSymbol: () => Effect.succeed([]),
+      prepareCallHierarchy: () => Effect.succeed([]),
+      incomingCalls: () => Effect.succeed([]),
+      outgoingCalls: () => Effect.succeed([]),
+    }),
+  ),
+  deps: [],
+})
+
+const layer = LayerNode.compile(
+  LayerNode.group([
+    fakeLSP,
+    FSUtil.node,
+    Format.node,
+    EventV2Bridge.node,
+    Truncate.node,
+    Agent.node,
+    CrossSpawnSpawner.node,
+  ]),
+)
+
+const it = testEffect(layer)
+
+const ctx = {
+  sessionID: SessionID.make("ses_test-lsp-metadata"),
+  messageID: MessageID.make("msg_test"),
+  callID: "",
+  agent: "build",
+  abort: AbortSignal.any([]),
+  messages: [],
+  metadata: () => Effect.void,
+  ask: () => Effect.void,
+}
+
+afterEach(async () => {
+  await disposeAllInstances()
+  state.diagnostics = {}
+})
+
+const writeRun = Effect.fn("LSPMetadataTest.writeRun")(function* (
+  args: Tool.InferParameters<typeof WriteTool>,
+  next: Tool.Context = ctx,
+) {
+  const info = yield* WriteTool
+  const tool = yield* info.init()
+  return yield* tool.execute(args, next)
+})
+
+const editRun = Effect.fn("LSPMetadataTest.editRun")(function* (
+  args: Tool.InferParameters<typeof EditTool>,
+  next: Tool.Context = ctx,
+) {
+  const info = yield* EditTool
+  const tool = yield* info.init()
+  return yield* tool.execute(args, next)
+})
+
+const severity = (n: number): LSPClient.Diagnostic =>
+  ({
+    severity: n as LSPClient.Diagnostic["severity"],
+    message: `diag ${n}`,
+    range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+  }) as LSPClient.Diagnostic
+
+describe("tool diagnostics metadata", () => {
+  it.instance("write persists only touched file diagnostics", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const filePath = path.join(test.directory, "a.lua")
+      const normalizedFilepath = FSUtil.normalizePath(filePath)
+      const otherPath = FSUtil.normalizePath(path.join(test.directory, "b.lua"))
+      state.diagnostics = {
+        [normalizedFilepath]: [severity(1), severity(1)],
+        [otherPath]: Array.from({ length: 250 }, () => severity(1)),
+      }
+
+      const result = yield* writeRun({ filePath, content: "print('hi')" })
+
+      expect(Object.keys(result.metadata.diagnostics)).toEqual([normalizedFilepath])
+      expect(result.metadata.diagnostics[normalizedFilepath]?.length).toBe(2)
+    }),
+  )
+
+  it.instance("edit persists only touched file diagnostics", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const filePath = path.join(test.directory, "a.lua")
+      yield* Effect.promise(() => fs.writeFile(filePath, "hello\n", "utf-8"))
+      const normalizedFilepath = FSUtil.normalizePath(filePath)
+      const otherPath = FSUtil.normalizePath(path.join(test.directory, "b.lua"))
+      state.diagnostics = {
+        [normalizedFilepath]: [severity(1)],
+        [otherPath]: Array.from({ length: 250 }, () => severity(1)),
+      }
+
+      const result = yield* editRun({ filePath, oldString: "hello", newString: "world" })
+
+      expect(Object.keys(result.metadata.diagnostics)).toEqual([normalizedFilepath])
+      expect(result.metadata.diagnostics[normalizedFilepath]?.length).toBe(1)
+    }),
+  )
+})


### PR DESCRIPTION
## What & why

On every `edit`/`write`, `lsp.diagnostics()` returns the **whole workspace** map (every file across every LSP client). That full map is persisted verbatim into the tool-result `metadata`, which the session stores and replays/prompts on future turns. For workspace-wide Lua/TS/etc. diagnostics this balloons the session transcript and hastens compaction.

This trims the **persisted** `metadata.diagnostics` down to only the touched file, while keeping the full map in-memory for the per-call `output` computation (unchanged agent behavior).

## Changes
- `packages/opencode/src/tool/write.ts` — persist `{ [normalizedFilepath]: issues }` instead of the whole map.
- `packages/opencode/src/tool/edit.ts` — same trim (edit already only emits the touched file's diagnostics in output).
- `packages/opencode/test/tool/lsp-diagnostics-metadata.test.ts` — regression coverage: a fake LSP service returns a workspace-wide map and the tests assert persisted metadata contains only the touched file.

## Why it's safe
- Diagnostics are **recomputed per call** via `touchFile` + `diagnostics()`; metadata is persistence/debug only and not used to derive the model-facing output.
- The `output` block (which the agent actually reads) is unchanged — it already separates "this file" vs "other files" and is capped by `MAX_PROJECT_DIAGNOSTICS_FILES`.
- Follows the intent of the earlier closed PR #6671, re-implemented against the current Effect-based LSP service.

## Verification
- `tsgo --noEmit` clean
- `bun test test/tool/lsp-diagnostics-metadata.test.ts` — 2 pass
- Existing `write`/`edit` suites pass (one pre-existing umask-dependent file-permission test fails only under umask 0002, unrelated).