### PR TITLE
feat(merman): refine diagram styling

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -686,6 +686,7 @@
       "version": "1.18.4",
       "dependencies": {
         "@effect/platform-node": "catalog:",
+        "@effect/platform-node-shared": "catalog:",
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
         "@opencode-ai/schema": "workspace:*",

--- a/packages/core/src/worktree.ts
+++ b/packages/core/src/worktree.ts
@@ -274,11 +274,10 @@ const layer = Layer.effect(
         .pipe(Effect.orDie)
       const command = project?.commands?.start?.trim()
       if (command && project) {
-        const shell = process.platform === "win32" ? "cmd" : "bash"
-        const args = process.platform === "win32" ? ["/c", command] : ["-lc", command]
+        const windows = process.platform === "win32"
         yield* processService
           .run(
-            ChildProcess.make(shell, args, {
+            ChildProcess.make(windows ? command : "bash", windows ? [] : ["-lc", command], {
               cwd: result.directory,
               env: {
                 OPENCODE_WORKTREE_BASE: project.worktree,
@@ -286,6 +285,7 @@ const layer = Layer.effect(
               },
               extendEnv: true,
               stdin: "ignore",
+              shell: windows,
             }),
           )
           .pipe(Effect.flatMap(AppProcess.requireSuccess))

--- a/packages/merman/src/core/canvas.test.ts
+++ b/packages/merman/src/core/canvas.test.ts
@@ -104,6 +104,20 @@ describe("DiagramCanvas", () => {
     expect(runs).toEqual(["AB:state:A", "CD:state:B"])
   })
 
+  test("retains styled trailing padding in render runs without changing plain text", () => {
+    const canvas = new DiagramCanvas<"label">(8, 1)
+    const runs: string[] = []
+    canvas.setText(1, 0, " start ", "label")
+
+    canvas.forEachRun(
+      (run) => runs.push(run.text),
+      () => {},
+    )
+
+    expect(canvas.toString()).toBe("  start")
+    expect(runs).toEqual([" ", " start "])
+  })
+
   test("can trim bottom whitespace for renderers with dynamic height", () => {
     const canvas = new DiagramCanvas<"label">(3, 3)
     const runs: string[] = []

--- a/packages/merman/src/core/canvas.ts
+++ b/packages/merman/src/core/canvas.ts
@@ -197,7 +197,8 @@ export class DiagramCanvas<Style extends string, Metadata extends object = objec
 
     for (let rowIndex = rows.start; rowIndex < rows.end; rowIndex++) {
       const row = this.cells[rowIndex]!
-      const rowEnd = this.rowEnds[rowIndex]!
+      let rowEnd = this.rowEnds[rowIndex]!
+      while (rowEnd < row.length && row[rowEnd]?.style !== undefined) rowEnd += 1
 
       let currentCell: DiagramCanvasCell<Style, Metadata> | undefined
       let currentKey: readonly unknown[] | undefined

--- a/packages/merman/src/core/render-grid.ts
+++ b/packages/merman/src/core/render-grid.ts
@@ -29,3 +29,23 @@ export function renderDiagramGridStyledText<Style extends string, Metadata exten
 
   return new StyledText(chunks)
 }
+
+export function renderDiagramGridStyledTextByStyle<Style extends string, Metadata extends object = object>(
+  grid: DiagramCanvas<Style, Metadata>,
+  foregrounds: Readonly<Record<Style, TextChunk["fg"]>>,
+  backgrounds?: Readonly<Partial<Record<Style, TextChunk["bg"]>>>,
+  options?: DiagramCanvasRunOptions<Style, Metadata> & {
+    attributes?: (run: DiagramCanvasRun<Style, Metadata>) => TextChunk["attributes"]
+  },
+): StyledText {
+  const background =
+    backgrounds && Object.values(backgrounds).some((value) => value !== undefined)
+      ? (run: DiagramCanvasRun<Style, Metadata>) => (run.style ? backgrounds[run.style] : undefined)
+      : undefined
+  return renderDiagramGridStyledText(
+    grid,
+    (run) => (run.style ? foregrounds[run.style] : undefined),
+    background,
+    options,
+  )
+}

--- a/packages/merman/src/core/text.ts
+++ b/packages/merman/src/core/text.ts
@@ -13,6 +13,17 @@ export function diagramTextWidth(value: string): number {
   return stringWidth(value)
 }
 
+export const DIAGRAM_LABEL_PADDING_X = 1
+
+export function padDiagramLabelLine(value: string): string {
+  const padding = " ".repeat(DIAGRAM_LABEL_PADDING_X)
+  return `${padding}${value}${padding}`
+}
+
+export function measureDiagramLabelWidth(value: string, measure = diagramTextWidth): number {
+  return Math.max(...splitDiagramLines(value).map((line) => measure(line) + DIAGRAM_LABEL_PADDING_X * 2))
+}
+
 const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: "grapheme" })
 
 export function* diagramTextGraphemes(value: string): Generator<string> {

--- a/packages/merman/src/flowchart/drawing.ts
+++ b/packages/merman/src/flowchart/drawing.ts
@@ -1,7 +1,7 @@
 import { BorderChars, TextAttributes, type BorderCharacters, type BorderStyle } from "@opentui/core"
-import { walkOrthogonalSegment } from "../core/geometry.js"
+import { walkOrthogonalSegment, type DiagramDirection } from "../core/geometry.js"
 import { DiagramCanvas, type DiagramCanvasCell } from "../core/canvas.js"
-import { parseDiagramTextLines } from "../core/text.js"
+import { DIAGRAM_LABEL_PADDING_X, parseDiagramTextLines } from "../core/text.js"
 import type { DiagramTextRun } from "../core/text-lines.js"
 import {
   DIAGRAM_ARROW_HEADS,
@@ -158,19 +158,20 @@ function drawSubgraphLabel(grid: FlowchartGrid, bounds: FlowchartSubgraphBounds)
     const lines = parseDiagramTextLines(bounds.label)
     const labelY = bounds.labelSide === "top" ? bounds.top : bounds.top + bounds.height - lines.length
     for (const [index, line] of lines.entries()) {
-      grid.setText(bounds.left + 2, labelY + index, " ", "group")
-      const width = setRichText(grid, bounds.left + 3, labelY + index, line.runs, "group")
-      grid.setText(bounds.left + width + 3, labelY + index, " ", "group")
+      grid.setText(bounds.left + 2, labelY + index, " ", "groupLabel")
+      const width = setRichText(grid, bounds.left + 3, labelY + index, line.runs, "groupLabel")
+      grid.setText(bounds.left + width + 3, labelY + index, " ", "groupLabel")
     }
   }
 }
 
 function drawEdgeLabel(grid: FlowchartGrid, route: FlowchartEdgeRoute, style: FlowchartCellStyle): void {
   const label = flowchartRouteLabelLayout(route, visualLength)
+  const padding = " ".repeat(DIAGRAM_LABEL_PADDING_X)
   for (const [index, line] of parseDiagramTextLines(route.edge.label).entries()) {
-    grid.setText(label.point.x, label.point.y + index, " ", style)
-    const width = setRichText(grid, label.point.x + 1, label.point.y + index, line.runs, style)
-    grid.setText(label.point.x + width + 1, label.point.y + index, " ", style)
+    grid.setText(label.point.x, label.point.y + index, padding, style)
+    const width = setRichText(grid, label.point.x + DIAGRAM_LABEL_PADDING_X, label.point.y + index, line.runs, style)
+    grid.setText(label.point.x + width + DIAGRAM_LABEL_PADDING_X, label.point.y + index, padding, style)
   }
 }
 
@@ -260,6 +261,18 @@ function drawSourceConnectors(
 ): void {
   const nodesById = new Map(diagram.nodes.map((node) => [node.id, node]))
   const occupancy = routeCellOccupancy(routes)
+  const sourceJunctions = new Map<string, { directions: Set<DiagramDirection>; heavy: boolean }>()
+  for (const route of routes) {
+    const sourcePoint = route.points[0]
+    const next = route.points[1]
+    if (!sourcePoint || !next) continue
+    const key = `${route.edge.from}:${sourcePoint.x}:${sourcePoint.y}`
+    const direction = flowchartDirectionBetween(sourcePoint, next)
+    const junction = sourceJunctions.get(key) ?? { directions: new Set<DiagramDirection>(), heavy: true }
+    if (direction) junction.directions.add(direction)
+    junction.heavy &&= route.edge.style === "thick"
+    sourceJunctions.set(key, junction)
+  }
 
   for (const route of routes) {
     const from = bounds.get(route.edge.from)
@@ -268,18 +281,21 @@ function drawSourceConnectors(
     const styles = sourceFadeStyles(flowchartNodeStyle(nodesById.get(route.edge.from)))
     const connector = flowchartSourceConnector(from, sourcePoint)
     grid.setCell(connector.x, connector.y, connector.char, "edge")
-    const routeDirection = route.points[1] ? flowchartDirectionBetween(sourcePoint, route.points[1]!) : undefined
     const connectorDirection = flowchartDirectionBetween(sourcePoint, connector)
-    if (routeDirection && connectorDirection) {
+    if (connectorDirection) {
       const cell = grid.getCell(sourcePoint.x, sourcePoint.y)
       if (cell && cell.style !== "label" && !DIAGRAM_ARROW_HEADS.has(cell.char)) {
+        const key = `${route.edge.from}:${sourcePoint.x}:${sourcePoint.y}`
+        const junction = sourceJunctions.get(key)
+        const directions = new Set(junction?.directions)
+        directions.add(connectorDirection)
         grid.replaceCell(
           sourcePoint.x,
           sourcePoint.y,
           diagramLineGlyph(
-            new Set([routeDirection, connectorDirection]),
+            directions,
             "rounded",
-            route.edge.style === "thick" ? "heavy" : "single",
+            (junction?.heavy ?? route.edge.style === "thick") ? "heavy" : "single",
           ),
           "edge",
         )

--- a/packages/merman/src/flowchart/flowchart.test.ts
+++ b/packages/merman/src/flowchart/flowchart.test.ts
@@ -1098,6 +1098,78 @@ describe("FlowchartDiagram", () => {
     expect(boundsIntersect(layout.subgraphBounds.get("Left")!, layout.subgraphBounds.get("Right")!)).toBe(false)
   })
 
+  test.each([80, 144])("keeps nested deployment groups compact and dependency-ordered at width %s", (width) => {
+    const layout = layoutFlowchartDiagram(
+      `flowchart LR
+  Browser([Browser]) --> Gateway[Gateway]
+  subgraph Cloud[Cloud platform]
+    direction TB
+    subgraph Compute[Compute]
+      API[API service] --> Worker[Background worker]
+    end
+    subgraph Storage[Storage]
+      Database[(Database)]
+      Cache[(Cache)]
+    end
+    API --> Database
+    Worker --> Cache
+  end
+  Gateway --> API
+  Worker --> Result([Result])`,
+      { compact: true, layoutMaxWidth: width },
+    )
+    const cloud = layout.subgraphBounds.get("Cloud")!
+    const compute = layout.subgraphBounds.get("Compute")!
+    const storage = layout.subgraphBounds.get("Storage")!
+    const result = layout.bounds.get("Result")!
+
+    expect(layout.bounds.get("Worker")!.top).toBeGreaterThan(layout.bounds.get("API")!.top)
+    expect(layout.bounds.get("Database")!.centerY).toBe(layout.bounds.get("Cache")!.centerY)
+    expect(storage.top).toBeGreaterThan(compute.top + compute.height - 1)
+    expect(cloud.width).toBeLessThanOrEqual(50)
+    expect([...layout.subgraphBounds.values()].every((frame) => frame.labelSide === "top")).toBe(true)
+    expect(boundsContains(cloud, compute)).toBe(true)
+    expect(boundsContains(cloud, storage)).toBe(true)
+    expect(boundsIntersect(cloud, result)).toBe(false)
+    if (layout.diagram.direction === "TD") expect(result.top).toBeGreaterThan(cloud.top + cloud.height - 1)
+    if (layout.diagram.direction === "LR") expect(result.left).toBeGreaterThan(cloud.left + cloud.width - 1)
+
+    for (const route of layout.routes.filter(
+      (route) =>
+        (route.edge.from === "API" && route.edge.to === "Database") ||
+        (route.edge.from === "Worker" && route.edge.to === "Cache"),
+    )) {
+      for (const point of route.points) {
+        expect(point.x).toBeGreaterThan(cloud.left)
+        expect(point.x).toBeLessThan(cloud.left + cloud.width - 1)
+        expect(point.y).toBeGreaterThan(cloud.top)
+        expect(point.y).toBeLessThan(cloud.top + cloud.height - 1)
+      }
+    }
+  })
+
+  test("keeps responsive labeled fan-out on one rank with a shared source junction", () => {
+    const content = `flowchart LR
+  Request([Request]) --> Gateway[API gateway]
+  Gateway -->|authenticate| Auth[Authentication]
+  Gateway -->|rate limit| Limit[Rate limiter]
+  Gateway -->|cache lookup| Cache[(Response cache)]
+  Auth --> Worker[Request worker]
+  Limit --> Worker
+  Cache --> Worker
+  Worker --> Response([Response])`
+    const layout = layoutFlowchartDiagram(content, { compact: true, layoutMaxWidth: 80 })
+    const branches = layout.routes.filter((route) => route.edge.from === "Gateway")
+    const gateway = layout.bounds.get("Gateway")!
+
+    expect(new Set(["Auth", "Limit", "Cache"].map((id) => layout.bounds.get(id)!.centerY)).size).toBe(1)
+    expect(new Set(branches.map((route) => JSON.stringify(route.points[0]))).size).toBe(1)
+    expect(branches.flatMap((route) => route.points).every((point) => point.y > gateway.top)).toBe(true)
+    for (const label of ["authenticate", "rate limit", "cache lookup"]) {
+      expect(renderFlowchartDiagram(content, { compact: true, layoutMaxWidth: 80 })).toContain(label)
+    }
+  })
+
   test("does not change parallel routes for a non-binding width target", () => {
     const diagram = parseMermaidFlowchartDiagram(`flowchart TD
   A[A] -->|one| B[B]

--- a/packages/merman/src/flowchart/flowchart.test.ts
+++ b/packages/merman/src/flowchart/flowchart.test.ts
@@ -26,6 +26,29 @@ function layoutFlowchartDiagram(content: string, options?: Parameters<typeof lay
   return layoutParsedFlowchartDiagram(parseMermaidFlowchartDiagram(content), options)
 }
 
+test("separates subgraph labels from their frame style", () => {
+  const grid = drawFlowchartDiagramGrid(`flowchart LR
+  subgraph Group
+    A[Node]
+  end`)
+  const styles = grid.rows.flatMap((row) => row.map((cell) => cell.style))
+
+  expect(styles).toContain("group")
+  expect(styles).toContain("groupLabel")
+})
+
+test("keeps every branch connected at a shared source junction", () => {
+  const source = `flowchart TB
+  A --> B
+  A --> C`
+  const layout = layoutFlowchartDiagram(source, { compact: true })
+  const grid = drawFlowchartDiagramGrid(source, { compact: true })
+  const sourcePoint = layout.routes[0]!.points[0]!
+
+  expect(layout.routes[1]!.points[0]).toEqual(sourcePoint)
+  expect(grid.getCell(sourcePoint.x, sourcePoint.y)?.char).toBe("┴")
+})
+
 function routeRunsAlongHorizontalBorder(
   route: { points: readonly { x: number; y: number }[] },
   bounds: { left: number; top: number; width: number; height: number },
@@ -333,12 +356,12 @@ describe("FlowchartDiagram", () => {
                                ╭──────────────────────╮
                                │ DEPLOYMENT - Anomaly │
                                ╰───────────┬──────────╯
-                      ╭────────────────────╰────────────────────╮
+                      ╭────────────────────┴────────────────────╮
                       ▼                                         ▼
        ╭────────────────────────────╮            ╭────────────────────────────╮
        │ ClientApps: google, github │            │ ORG acme = guild/workspace │
        ╰────────────────────────────╯            ╰──────────────┬─────────────╯
-                            ╭───────────────────────────────────╰───────╮
+                            ╭───────────────────────────────────┴───────╮
                             ▼                                           ▼
       ╭───────────────────────────────────────────╮            ╭────────────────╮
       │ org grant: google, authed as bot@acme.com │            │ MEMBER juliana │
@@ -1029,6 +1052,31 @@ describe("FlowchartDiagram", () => {
     }
   })
 
+  test("keeps external nodes outside local-direction subgraph frames", () => {
+    const layout = layoutFlowchartDiagram(
+      `flowchart LR
+  Input([Input]) --> Parse
+  subgraph Outer[Outer orchestration]
+    direction RL
+    subgraph Inner[Inner pipeline]
+      direction TD
+      Parse[Parse request] --> Validate{Valid?}
+      Validate -->|yes| Cache[(Cache)]
+      Cache -->|stale| Validate
+    end
+    Validate --> Dispatch[[Dispatch work]]
+    Dispatch -->|requeue| Parse
+  end
+  Dispatch -. result .-> Output([Output])
+  Output -->|audit| Cache`,
+      { compact: true, layoutMaxWidth: 120 },
+    )
+    const outer = layout.subgraphBounds.get("Outer")!
+
+    expect(boundsIntersect(outer, layout.bounds.get("Input")!)).toBe(false)
+    expect(boundsIntersect(outer, layout.bounds.get("Output")!)).toBe(false)
+  })
+
   test("keeps responsive sibling subgraph frames and long titles disjoint", () => {
     const layout = layoutFlowchartDiagram(
       `flowchart TD
@@ -1534,6 +1582,19 @@ flowchart LR
     expect(output).toContain("second line")
     expect(output.indexOf("first")).toBeLessThan(output.indexOf("second line"))
     expect(output).not.toContain("<br")
+  })
+
+  test("renders edge labels with an independent background", () => {
+    const background = parseColor("#334455")
+    const styled = renderGridStyledText(
+      drawFlowchartDiagramGrid(`flowchart LR
+  A[Start] -->|route label| B[Finish]`),
+      resolveFlowchartStyleColors(),
+      { label: background },
+    )
+
+    expect(styled.chunks.some((chunk) => chunk.text.includes("route label") && chunk.bg === background)).toBe(true)
+    expect(styled.chunks.some((chunk) => chunk.text.includes("Start") && chunk.bg !== undefined)).toBe(false)
   })
 
   test("keeps quoted multiline labels compact and renders italic node text", () => {

--- a/packages/merman/src/flowchart/labels.ts
+++ b/packages/merman/src/flowchart/labels.ts
@@ -11,13 +11,12 @@ import {
   spanCapacity,
   type DiagramSegment,
 } from "../core/geometry.js"
-import { splitDiagramLines } from "../core/text.js"
+import { measureDiagramLabelWidth, padDiagramLabelLine, splitDiagramLines } from "../core/text.js"
 import type { FlowchartEdgeRoute, FlowchartPoint } from "./types.js"
 
 const LABEL_BUS_CLEARANCE = 3
 const LABEL_NODE_CLEARANCE = 2
 const LABEL_LINE_CLEARANCE = 2
-const LABEL_PADDING = 1
 const LABEL_TERMINAL_CLEARANCE = 1
 
 export interface FlowchartEdgeLabelLayout {
@@ -28,11 +27,11 @@ export interface FlowchartEdgeLabelLayout {
 }
 
 export function flowchartLabelText(label: string): string {
-  return `${" ".repeat(LABEL_PADDING)}${label}${" ".repeat(LABEL_PADDING)}`
+  return padDiagramLabelLine(label)
 }
 
 export function flowchartLabelWidth(label: string, measure: (text: string) => number): number {
-  return Math.max(...splitDiagramLines(label).map((line) => measure(line) + LABEL_PADDING * 2))
+  return measureDiagramLabelWidth(label, measure)
 }
 
 function minimumInlineLabelLength(labelWidth: number): number {

--- a/packages/merman/src/flowchart/layout.ts
+++ b/packages/merman/src/flowchart/layout.ts
@@ -472,7 +472,9 @@ function layoutRankedNodes(
           )
         })
       const nodeGap =
-        targetWidth !== undefined && naturalWidth > targetWidth && !needsLabelLanes ? minNodeGap : roomyNodeGap
+        targetWidth !== undefined && naturalWidth > targetWidth && (!needsLabelLanes || !diagram.subgraphs?.length)
+          ? minNodeGap
+          : roomyNodeGap
       const bands: { nodes: FlowchartNode[]; width: number; height: number }[] = []
       for (const node of nodes) {
         const size = sizes.get(node.id)!
@@ -529,9 +531,16 @@ function layoutLocalSubgraphDirections(
   targetWidth?: number,
 ): boolean {
   let wrapped = false
-  for (const subgraph of [...(diagram.subgraphs ?? [])].reverse()) {
-    if (!subgraph.direction || subgraph.direction === diagram.direction) continue
-    const childSubgraphs = (diagram.subgraphs ?? []).filter((child) => child.parentId === subgraph.id)
+  const subgraphs = diagram.subgraphs ?? []
+  const subgraphById = new Map(subgraphs.map((subgraph) => [subgraph.id, subgraph]))
+  for (const subgraph of [...subgraphs].reverse()) {
+    let parent = subgraph.parentId ? subgraphById.get(subgraph.parentId) : undefined
+    while (parent && !parent.direction) parent = parent.parentId ? subgraphById.get(parent.parentId) : undefined
+    const direction =
+      subgraph.direction ??
+      (parent && subgraphs.filter((child) => child.parentId === parent.id).length > 1 ? parent.direction : undefined)
+    if (!direction || direction === diagram.direction) continue
+    const childSubgraphs = subgraphs.filter((child) => child.parentId === subgraph.id)
     const coveredNodeIds = new Set(childSubgraphs.flatMap((child) => [...collectSubgraphNodeIds(diagram, child.id)]))
     const items = [
       ...childSubgraphs.flatMap((child) => {
@@ -558,7 +567,7 @@ function layoutLocalSubgraphDirections(
     }
     const nodes = items.map((item): FlowchartNode => ({ id: item.id, label: item.id, shape: "box" }))
     const localDiagram: FlowchartDiagram = {
-      direction: subgraph.direction,
+      direction,
       nodes,
       edges: diagram.edges.flatMap((edge) => {
         const from = itemByEndpoint.get(edge.from)
@@ -572,7 +581,7 @@ function layoutLocalSubgraphDirections(
     )
     const localLayout = layoutRankedNodes(
       localDiagram,
-      subgraph.direction,
+      direction,
       itemSizes,
       Math.max(minNodeGap, SUBGRAPH_PADDING_X * 2 + 1),
       requestedMinRankGap,
@@ -790,7 +799,21 @@ function separateTopLevelItems(
     }
   }
   if (hasLocalDirection) {
-    items.sort((a, b) => (horizontal ? a.bounds.centerX - b.bounds.centerX : a.bounds.centerY - b.bounds.centerY))
+    const outgoing = new Map(items.map((item) => [item.id, new Set<string>()]))
+    for (const edge of diagram.edges) {
+      const from = itemByEndpoint.get(edge.from)
+      const to = itemByEndpoint.get(edge.to)
+      if (from && to && from !== to) outgoing.get(from)?.add(to)
+    }
+    const ranks = rankGraphComponents(
+      items.map((item) => item.id),
+      outgoing,
+    )
+    items.sort(
+      (a, b) =>
+        ranks.get(a.id)! - ranks.get(b.id)! ||
+        (horizontal ? a.bounds.centerX - b.bounds.centerX : a.bounds.centerY - b.bounds.centerY),
+    )
     let cursor: number | undefined
     let moved = false
     for (const item of items) {

--- a/packages/merman/src/flowchart/layout.ts
+++ b/packages/merman/src/flowchart/layout.ts
@@ -738,9 +738,15 @@ function separateTopLevelItems(
     (subgraph) => subgraph.direction && subgraph.direction !== diagram.direction,
   )
   const coveredNodeIds = new Set<string>()
-  const items: { id: string; bounds: FlowchartBounds; nodeIds: Set<string>; rank: number }[] = []
+  const items: {
+    id: string
+    bounds: FlowchartBounds
+    nodeIds: Set<string>
+    rank: number
+  }[] = []
   const itemByEndpoint = new Map<string, string>()
   const subgraphs = diagram.subgraphs ?? []
+  const topLevelIds = new Set(subgraphs.filter((subgraph) => !subgraph.parentId).map((subgraph) => subgraph.id))
   const subgraphById = new Map(subgraphs.map((subgraph) => [subgraph.id, subgraph]))
   const topLevelSubgraphId = (id: string): string => {
     let current = subgraphById.get(id)
@@ -776,9 +782,15 @@ function separateTopLevelItems(
       const bounds = nodeBounds.get(nodeId)
       if (bounds) translateBounds(bounds, dx, dy)
     }
+    if (!topLevelIds.has(item.id)) return
+    for (const subgraph of subgraphs) {
+      if (topLevelSubgraphId(subgraph.id) !== item.id) continue
+      const bounds = subgraphBounds.get(subgraph.id)
+      if (bounds) translateBounds(bounds, dx, dy)
+    }
   }
   if (hasLocalDirection) {
-    items.sort((a, b) => (horizontal ? a.bounds.left - b.bounds.left : a.bounds.top - b.bounds.top))
+    items.sort((a, b) => (horizontal ? a.bounds.centerX - b.bounds.centerX : a.bounds.centerY - b.bounds.centerY))
     let cursor: number | undefined
     let moved = false
     for (const item of items) {
@@ -796,7 +808,6 @@ function separateTopLevelItems(
     return moved
   }
 
-  const topLevelIds = new Set(subgraphs.filter((subgraph) => !subgraph.parentId).map((subgraph) => subgraph.id))
   const rankedItems = items.filter((item) => topLevelIds.has(item.id))
   if (rankedItems.length < 2) return false
 
@@ -956,28 +967,16 @@ function layoutFlowchartWithDirection(
   const bounds = ranked.bounds
   const responsive = layoutLocalSubgraphDirections(diagram, bounds, minNodeGap, requestedMinRankGap, targetWidth)
   const directionAligned = responsiveFallback || responsive || ranked.wrapped
+  const route = (frames?: ReadonlyMap<string, FlowchartSubgraphBounds>) =>
+    routeFlowchartEdges(diagram, bounds, (edge) => edgeDirection(diagram, edge), frames, targetWidth, directionAligned)
 
   const subgraphs = diagram.subgraphs ?? []
   let subgraphBounds = new Map<string, FlowchartSubgraphBounds>()
   let routes: FlowchartEdgeRoute[]
   if (subgraphs.length === 0) {
-    routes = routeFlowchartEdges(
-      diagram,
-      bounds,
-      (edge) => edgeDirection(diagram, edge),
-      undefined,
-      targetWidth,
-      directionAligned,
-    )
+    routes = route()
   } else {
-    routes = routeFlowchartEdges(
-      diagram,
-      bounds,
-      (edge) => edgeDirection(diagram, edge),
-      undefined,
-      targetWidth,
-      directionAligned,
-    )
+    routes = route()
     subgraphBounds = layoutSubgraphs(diagram, bounds, routes)
     const moved = separateTopLevelItems(
       diagram,
@@ -987,25 +986,21 @@ function layoutFlowchartWithDirection(
       targetWidth,
     )
     if (moved) {
-      routes = routeFlowchartEdges(
-        diagram,
-        bounds,
-        (edge) => edgeDirection(diagram, edge),
-        undefined,
-        targetWidth,
-        directionAligned,
-      )
+      routes = route()
       subgraphBounds = layoutSubgraphs(diagram, bounds, routes)
     }
-    routes = routeFlowchartEdges(
+    routes = route(subgraphBounds)
+    subgraphBounds = layoutSubgraphs(diagram, bounds, routes)
+    // Frame-aware routes can expand a group after initial separation. Move the expanded frame rigidly
+    // before rerouting so external edges cannot grow it back across neighboring top-level items.
+    const expanded = separateTopLevelItems(
       diagram,
       bounds,
-      (edge) => edgeDirection(diagram, edge),
       subgraphBounds,
+      Math.max(1, Math.floor(requestedMinRankGap / 2)),
       targetWidth,
-      directionAligned,
     )
-    subgraphBounds = layoutSubgraphs(diagram, bounds, routes)
+    if (expanded) routes = route(subgraphBounds)
     avoidFlowchartFrameBorders(routes, bounds, subgraphBounds)
   }
   freezeRouteLabelPoints(routes)

--- a/packages/merman/src/flowchart/routing.ts
+++ b/packages/merman/src/flowchart/routing.ts
@@ -878,9 +878,35 @@ function avoidNodeObstacles(
   bounds: Map<string, FlowchartNodeBounds>,
   subgraphBounds: ReadonlyMap<string, FlowchartSubgraphBounds> | undefined,
   routeIndex: number,
+  diagram: FlowchartDiagram,
 ): FlowchartEdgeRoute {
   const allNodeBounds = [...bounds.values()]
   const allSubgraphBounds = [...(subgraphBounds?.values() ?? [])]
+  const subgraphs = diagram.subgraphs ?? []
+  const contains = (subgraph: FlowchartSubgraph, nodeId: string): boolean =>
+    subgraph.nodeIds.includes(nodeId) ||
+    subgraphs.some((child) => child.parentId === subgraph.id && contains(child, nodeId))
+  const owner = [...subgraphs].reverse().find((subgraph) => {
+    if (!contains(subgraph, route.edge.from) || !contains(subgraph, route.edge.to)) return false
+    const children = subgraphs.filter((child) => child.parentId === subgraph.id)
+    return (
+      children.some((child) => contains(child, route.edge.from)) &&
+      children.some((child) => contains(child, route.edge.to)) &&
+      !children.some((child) => contains(child, route.edge.from) && contains(child, route.edge.to))
+    )
+  })
+  const ownerBounds = owner ? subgraphBounds?.get(owner.id) : undefined
+  const leavesOwner = (candidate: FlowchartEdgeRoute): boolean =>
+    Boolean(
+      ownerBounds &&
+        candidate.points.some(
+          (point) =>
+            point.x <= ownerBounds.left ||
+            point.x >= ownerBounds.left + ownerBounds.width - 1 ||
+            point.y <= ownerBounds.top ||
+            point.y >= ownerBounds.top + ownerBounds.height - 1,
+        ),
+    )
   const otherRoutes = routes.filter((_, index) => index !== routeIndex)
   const otherLabels = otherRoutes.flatMap((otherRoute) =>
     otherRoute.edge.label ? [flowchartRouteLabelLayout(otherRoute, diagramTextWidth)] : [],
@@ -908,6 +934,7 @@ function avoidNodeObstacles(
   const intersectsObstacle = (candidate: FlowchartEdgeRoute): boolean => {
     const label = candidate.edge.label ? flowchartRouteLabelLayout(candidate, diagramTextWidth) : undefined
     return (
+      leavesOwner(candidate) ||
       intersectsRoutingObstacle(candidate) ||
       allNodeBounds.some((bound) => labelIntersectsBounds(label, bound)) ||
       allSubgraphBounds.some((bound) => labelIntersectsSubgraphFrame(label, bound)) ||
@@ -929,18 +956,28 @@ function avoidNodeObstacles(
   const rightBusXs = [
     ...new Set([
       rightBusX,
+      ...(ownerBounds ? [ownerBounds.left + ownerBounds.width - 2] : []),
       ...otherLabels.map((label) => Math.max(rightBusX, label.point.x + label.width - 1 + NODE_CLEARANCE)),
     ]),
   ].sort((left, right) => left - right)
   const leftBusXs = [
-    ...new Set([leftBusX, ...otherLabels.map((label) => Math.min(leftBusX, label.point.x - NODE_CLEARANCE))]),
+    ...new Set([
+      leftBusX,
+      ...(ownerBounds ? [ownerBounds.left + 1] : []),
+      ...otherLabels.map((label) => Math.min(leftBusX, label.point.x - NODE_CLEARANCE)),
+    ]),
   ].sort((left, right) => right - left)
   const topBusYs = [
-    ...new Set([topBusY, ...otherLabels.map((label) => Math.min(topBusY, label.point.y - NODE_CLEARANCE))]),
+    ...new Set([
+      topBusY,
+      ...(ownerBounds ? [ownerBounds.top + 1] : []),
+      ...otherLabels.map((label) => Math.min(topBusY, label.point.y - NODE_CLEARANCE)),
+    ]),
   ].sort((left, right) => right - left)
   const bottomBusYs = [
     ...new Set([
       bottomBusY,
+      ...(ownerBounds ? [ownerBounds.top + ownerBounds.height - 2] : []),
       ...otherLabels.map((label) => Math.max(bottomBusY, label.point.y + label.height - 1 + NODE_CLEARANCE)),
     ]),
   ].sort((left, right) => left - right)
@@ -1253,7 +1290,7 @@ export function routeFlowchartEdges(
     routes.push({ edge, points: edgePath(from, to, directionForEdge(edge), leftBoundary) })
   }
   for (let index = routes.length - 1; index >= 0; index--) {
-    routes[index] = avoidNodeObstacles(routes[index]!, routes, bounds, subgraphBounds, index)
+    routes[index] = avoidNodeObstacles(routes[index]!, routes, bounds, subgraphBounds, index, routedDiagram)
   }
   const subgraphs = diagram.subgraphs ?? []
   const subgraphById = new Map(subgraphs.map((subgraph) => [subgraph.id, subgraph]))

--- a/packages/merman/src/flowchart/style.ts
+++ b/packages/merman/src/flowchart/style.ts
@@ -1,6 +1,6 @@
 import { RGBA, type StyledText } from "@opentui/core"
 import type { DiagramCanvas } from "../core/canvas.js"
-import { renderDiagramGridStyledText } from "../core/render-grid.js"
+import { renderDiagramGridStyledTextByStyle } from "../core/render-grid.js"
 import {
   createColorRampTheme,
   DIAGRAM_FADE_STEPS,
@@ -10,7 +10,15 @@ import {
   type DiagramRgb,
 } from "../core/color/style.js"
 
-export type FlowchartBaseCellStyle = "node" | "nodeBorder" | "database" | "databaseBorder" | "edge" | "label" | "group"
+export type FlowchartBaseCellStyle =
+  | "node"
+  | "nodeBorder"
+  | "database"
+  | "databaseBorder"
+  | "edge"
+  | "label"
+  | "group"
+  | "groupLabel"
 export type FlowchartNodeEdgeFadeStyle = `nodeEdgeFade${DiagramFadeStep}`
 export type FlowchartDatabaseEdgeFadeStyle = `databaseEdgeFade${DiagramFadeStep}`
 export type FlowchartEdgeFadeStyle = FlowchartNodeEdgeFadeStyle | FlowchartDatabaseEdgeFadeStyle
@@ -20,6 +28,7 @@ export interface FlowchartCellMetadata {
 }
 export type FlowchartGrid = DiagramCanvas<FlowchartCellStyle, FlowchartCellMetadata>
 export type FlowchartStyleColors = Required<Record<FlowchartCellStyle, RGBA>>
+export type FlowchartStyleBackgroundColors = Partial<Record<FlowchartCellStyle, RGBA>>
 export const DEFAULT_THEME_RGB = {
   node: [228, 239, 232],
   nodeBorder: [141, 163, 151],
@@ -28,6 +37,7 @@ export const DEFAULT_THEME_RGB = {
   edge: [134, 225, 200],
   label: [134, 225, 200],
   group: [76, 99, 89],
+  groupLabel: [76, 99, 89],
 } as const satisfies Record<FlowchartBaseCellStyle, DiagramRgb>
 
 export const NODE_EDGE_FADE_STYLES = numberedStyleKeys("nodeEdgeFade", DIAGRAM_FADE_STEPS)
@@ -49,13 +59,18 @@ export function resolveFlowchartStyleColors(
     edge,
     label: colors.label ?? rgba(DEFAULT_THEME_RGB.label),
     group: colors.group ?? rgba(DEFAULT_THEME_RGB.group),
+    groupLabel: colors.groupLabel ?? colors.group ?? rgba(DEFAULT_THEME_RGB.groupLabel),
     ...createColorRampTheme(NODE_EDGE_FADE_STYLES, nodeBorder, edge),
     ...createColorRampTheme(DATABASE_EDGE_FADE_STYLES, databaseBorder, edge),
   }
 }
 
-export function renderGridStyledText(grid: FlowchartGrid, colors: FlowchartStyleColors): StyledText {
-  return renderDiagramGridStyledText(grid, (run) => (run.style ? colors[run.style] : undefined), undefined, {
+export function renderGridStyledText(
+  grid: FlowchartGrid,
+  colors: FlowchartStyleColors,
+  backgrounds?: FlowchartStyleBackgroundColors,
+): StyledText {
+  return renderDiagramGridStyledTextByStyle(grid, colors, backgrounds, {
     key: (cell) => [cell.style, cell.attributes],
     attributes: (run) => run.cell.attributes,
     trimTop: true,

--- a/packages/merman/src/markdown.ts
+++ b/packages/merman/src/markdown.ts
@@ -66,6 +66,16 @@ export interface MermaidMarkdownRendererOptions {
     response?: ColorInput
     note?: ColorInput
     noteBackground?: ColorInput
+    boxText?: ColorInput
+    boxBorder?: ColorInput
+    line?: ColorInput
+    group?: ColorInput
+    groupText?: ColorInput
+    marker?: ColorInput
+    noteBorder?: ColorInput
+    noteText?: ColorInput
+    noteConnector?: ColorInput
+    labelBackground?: ColorInput
   }
 }
 
@@ -140,14 +150,16 @@ function prepareDiagram(
         text: renderGridStyledText(
           grid,
           resolveFlowchartStyleColors({
-            node: color(colors.primary),
-            nodeBorder: color(colors.muted),
-            database: color(colors.primary),
-            databaseBorder: color(colors.muted),
-            edge: color(colors.secondary),
+            node: color(colors.boxText ?? colors.primary),
+            nodeBorder: color(colors.boxBorder ?? colors.muted),
+            database: color(colors.boxText ?? colors.primary),
+            databaseBorder: color(colors.boxBorder ?? colors.muted),
+            edge: color(colors.line ?? colors.secondary),
             label: color(colors.text),
-            group: color(colors.muted),
+            group: color(colors.group ?? colors.muted),
+            groupLabel: color(colors.groupText ?? colors.group ?? colors.muted),
           }),
+          { label: color(colors.labelBackground) },
         ),
         height: size.height,
       }
@@ -225,17 +237,20 @@ function prepareDiagram(
         text: renderStateGridStyledText(
           grid,
           resolveStateStyleColors({
-            state: color(colors.primary),
-            composite: color(colors.muted),
-            transition: color(colors.secondary),
+            state: color(colors.boxText ?? colors.primary),
+            stateBorder: color(colors.boxBorder ?? colors.primary),
+            composite: color(colors.group ?? colors.muted),
+            compositeLabel: color(colors.groupText ?? colors.group ?? colors.muted),
+            transition: color(colors.line ?? colors.secondary),
             label: color(colors.text),
-            noteBorder: color(colors.warning),
-            noteText: color(colors.warning),
-            noteConnector: color(colors.muted),
-            start: color(colors.muted),
-            end: color(colors.muted),
-            choice: color(colors.secondary),
+            noteBorder: color(colors.noteBorder ?? colors.warning),
+            noteText: color(colors.noteText ?? colors.warning),
+            noteConnector: color(colors.noteConnector ?? colors.muted),
+            start: color(colors.marker ?? colors.muted),
+            end: color(colors.marker ?? colors.muted),
+            choice: color(colors.marker ?? colors.secondary),
           }),
+          { label: color(colors.labelBackground) },
         ),
         height: size.height,
       }

--- a/packages/merman/src/markdown.ts
+++ b/packages/merman/src/markdown.ts
@@ -12,6 +12,7 @@ import {
   type StyledText,
 } from "@opentui/core"
 import { MermaidSyntaxError } from "./diagnostics.js"
+import type { OpenCodeDiagramPalette } from "./palette.js"
 import { DiagramCanvasSizeError } from "./core/canvas.js"
 import { detectMermaidDiagram } from "./detect.js"
 import { drawFlowchartDiagramGrid } from "./flowchart/drawing.js"
@@ -55,28 +56,7 @@ export interface MermaidMarkdownRendererOptions {
   layoutMaxWidth?: number
   /** Gantt-specific terminal rendering options. */
   gantt?: Omit<GanttDiagramRenderOptions, "layoutMaxWidth">
-  colors?: {
-    text?: ColorInput
-    primary?: ColorInput
-    secondary?: ColorInput
-    muted?: ColorInput
-    warning?: ColorInput
-    background?: ColorInput
-    request?: ColorInput
-    response?: ColorInput
-    note?: ColorInput
-    noteBackground?: ColorInput
-    boxText?: ColorInput
-    boxBorder?: ColorInput
-    line?: ColorInput
-    group?: ColorInput
-    groupText?: ColorInput
-    marker?: ColorInput
-    noteBorder?: ColorInput
-    noteText?: ColorInput
-    noteConnector?: ColorInput
-    labelBackground?: ColorInput
-  }
+  colors?: Partial<Record<keyof OpenCodeDiagramPalette, ColorInput>>
 }
 
 function color(value: ColorInput | undefined): RGBA | undefined {

--- a/packages/merman/src/palette.test.ts
+++ b/packages/merman/src/palette.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { RGBA } from "@opentui/core"
 import { blendColor } from "./core/color/style.js"
-import { createOpenCodeDiagramPalette } from "./palette.js"
+import { createOpenCodeDiagramPalette, resolveOpenCodeDiagramPalette } from "./palette.js"
 
 type Rgb = readonly [number, number, number]
 
@@ -69,5 +69,35 @@ describe("OpenCode diagram palette", () => {
     expect(palette.noteBorder).toBe(accent.soft)
     expect(palette.noteText).toBe(accent.clear)
     expect(palette.noteConnector).toBe(accent.soft)
+  })
+
+  test.each([
+    { mode: "dark", soft: 300, clear: 200 },
+    { mode: "light", soft: 700, clear: 800 },
+  ] as const)("uses the selected $mode mode even with a literal background", ({ mode, soft, clear }) => {
+    const accent = {
+      200: rgb([200, 100, 100]),
+      300: rgb([180, 90, 90]),
+      700: rgb([120, 60, 60]),
+      800: rgb([100, 50, 50]),
+    }
+    const theme = {
+      text: {
+        default: rgb([230, 232, 240]),
+        subdued: rgb([114, 120, 138]),
+        feedback: {
+          info: { default: rgb([40, 120, 220]) },
+          success: { default: rgb([80, 180, 120]) },
+          warning: { default: rgb([220, 160, 80]) },
+        },
+      },
+      background: { default: rgb([250, 250, 250]) },
+      categorical: [accent],
+    }
+    const palette = resolveOpenCodeDiagramPalette(theme, mode)
+
+    expect(palette.group).toBe(accent[soft])
+    expect(palette.noteBorder).toBe(accent[soft])
+    expect(palette.noteText).toBe(accent[clear])
   })
 })

--- a/packages/merman/src/palette.test.ts
+++ b/packages/merman/src/palette.test.ts
@@ -35,6 +35,10 @@ describe("OpenCode diagram palette", () => {
     const success = RGBA.fromInts(80, 180, 120)
     const warning = RGBA.fromInts(220, 160, 80)
     const background = RGBA.fromInts(10, 20, 30)
+    const accent = {
+      soft: RGBA.fromInts(180, 100, 40),
+      clear: RGBA.fromInts(240, 160, 80),
+    }
     const palette = createOpenCodeDiagramPalette({
       text: primary,
       subdued: rgb(subdued),
@@ -42,6 +46,7 @@ describe("OpenCode diagram palette", () => {
       success,
       warning,
       background,
+      accent,
     })
 
     expect(palette.text).toBe(primary)
@@ -54,5 +59,15 @@ describe("OpenCode diagram palette", () => {
     expect(palette.response).toBe(warning)
     expect(palette.note).toBe(primary)
     expect(palette.noteBackground.equals(blendColor(background, rgb(subdued), 0.25))).toBe(true)
+    expect(palette.boxText).toBe(primary)
+    expect(palette.boxBorder.equals(rgb(muted))).toBe(true)
+    expect(palette.line.equals(rgb(subdued))).toBe(true)
+    expect(palette.labelBackground.toInts()[3]).toBe(20)
+    expect(palette.group).toBe(accent.soft)
+    expect(palette.groupText).toBe(accent.soft)
+    expect(palette.marker.equals(rgb(secondary))).toBe(true)
+    expect(palette.noteBorder).toBe(accent.soft)
+    expect(palette.noteText).toBe(accent.clear)
+    expect(palette.noteConnector).toBe(accent.soft)
   })
 })

--- a/packages/merman/src/palette.ts
+++ b/packages/merman/src/palette.ts
@@ -1,4 +1,4 @@
-import type { RGBA } from "@opentui/core"
+import { RGBA } from "@opentui/core"
 import { blendColor } from "./core/color/style.js"
 
 export interface OpenCodeDiagramPaletteInput {
@@ -8,19 +8,35 @@ export interface OpenCodeDiagramPaletteInput {
   readonly success: RGBA
   readonly warning: RGBA
   readonly background: RGBA
+  readonly accent: {
+    readonly soft: RGBA
+    readonly clear: RGBA
+  }
 }
 
 export function createOpenCodeDiagramPalette(input: OpenCodeDiagramPaletteInput) {
+  const secondary = blendColor(input.text, input.subdued, 0.5)
+  const muted = blendColor(input.text, input.subdued, 0.7)
   return {
     text: input.text,
     primary: input.text,
-    secondary: blendColor(input.text, input.subdued, 0.5),
-    muted: blendColor(input.text, input.subdued, 0.7),
+    secondary,
+    muted,
     warning: input.info,
     background: input.background,
     request: input.success,
     response: input.warning,
     note: input.text,
     noteBackground: blendColor(input.background, input.subdued, 0.25),
+    boxText: input.text,
+    boxBorder: muted,
+    line: input.subdued,
+    labelBackground: RGBA.fromValues(input.text.r, input.text.g, input.text.b, 0.08),
+    group: input.accent.soft,
+    groupText: input.accent.soft,
+    marker: secondary,
+    noteBorder: input.accent.soft,
+    noteText: input.accent.clear,
+    noteConnector: input.accent.soft,
   }
 }

--- a/packages/merman/src/palette.ts
+++ b/packages/merman/src/palette.ts
@@ -14,6 +14,8 @@ export interface OpenCodeDiagramPaletteInput {
   }
 }
 
+export type OpenCodeDiagramPalette = ReturnType<typeof createOpenCodeDiagramPalette>
+
 export function createOpenCodeDiagramPalette(input: OpenCodeDiagramPaletteInput) {
   const secondary = blendColor(input.text, input.subdued, 0.5)
   const muted = blendColor(input.text, input.subdued, 0.7)
@@ -39,4 +41,35 @@ export function createOpenCodeDiagramPalette(input: OpenCodeDiagramPaletteInput)
     noteText: input.accent.clear,
     noteConnector: input.accent.soft,
   }
+}
+
+export function resolveOpenCodeDiagramPalette(
+  theme: {
+    readonly text: {
+      readonly default: RGBA
+      readonly subdued: RGBA
+      readonly feedback: {
+        readonly info: { readonly default: RGBA }
+        readonly success: { readonly default: RGBA }
+        readonly warning: { readonly default: RGBA }
+      }
+    }
+    readonly background: { readonly default: RGBA }
+    readonly categorical: readonly Readonly<Record<200 | 300 | 700 | 800, RGBA>>[]
+  },
+  mode: "dark" | "light",
+) {
+  const accent = theme.categorical[3] ?? theme.categorical[0]!
+  return createOpenCodeDiagramPalette({
+    text: theme.text.default,
+    subdued: theme.text.subdued,
+    info: theme.text.feedback.info.default,
+    success: theme.text.feedback.success.default,
+    warning: theme.text.feedback.warning.default,
+    background: theme.background.default,
+    accent: {
+      soft: accent[mode === "dark" ? 300 : 700],
+      clear: accent[mode === "dark" ? 200 : 800],
+    },
+  })
 }

--- a/packages/merman/src/plugin.ts
+++ b/packages/merman/src/plugin.ts
@@ -1,30 +1,15 @@
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { createMermaidCodeBlockRenderer } from "./markdown.js"
-import { createOpenCodeDiagramPalette } from "./palette.js"
+import { resolveOpenCodeDiagramPalette } from "./palette.js"
 
 export default Plugin.define({
   id: "opencode.merman",
   setup(context) {
     context.markdown.registerCodeBlockRenderer(
       "mermaid",
-      createMermaidCodeBlockRenderer(context.renderer, () => {
-        const accent = context.theme.categorical[3] ?? context.theme.categorical[0]!
-        const dark = (context.theme.source(context.theme.background.default)?.step ?? 800) >= 500
-        return {
-          colors: createOpenCodeDiagramPalette({
-            text: context.theme.text.default,
-            subdued: context.theme.text.subdued,
-            info: context.theme.text.feedback.info.default,
-            success: context.theme.text.feedback.success.default,
-            warning: context.theme.text.feedback.warning.default,
-            background: context.theme.background.default,
-            accent: {
-              soft: accent[dark ? 300 : 700],
-              clear: accent[dark ? 200 : 800],
-            },
-          }),
-        }
-      }),
+      createMermaidCodeBlockRenderer(context.renderer, () => ({
+        colors: resolveOpenCodeDiagramPalette(context.theme, context.themeMode),
+      })),
     )
   },
 })

--- a/packages/merman/src/plugin.ts
+++ b/packages/merman/src/plugin.ts
@@ -7,16 +7,24 @@ export default Plugin.define({
   setup(context) {
     context.markdown.registerCodeBlockRenderer(
       "mermaid",
-      createMermaidCodeBlockRenderer(context.renderer, () => ({
-        colors: createOpenCodeDiagramPalette({
-          text: context.theme.text.default,
-          subdued: context.theme.text.subdued,
-          info: context.theme.text.feedback.info.default,
-          success: context.theme.text.feedback.success.default,
-          warning: context.theme.text.feedback.warning.default,
-          background: context.theme.background.default,
-        }),
-      })),
+      createMermaidCodeBlockRenderer(context.renderer, () => {
+        const accent = context.theme.categorical[3] ?? context.theme.categorical[0]!
+        const dark = (context.theme.source(context.theme.background.default)?.step ?? 800) >= 500
+        return {
+          colors: createOpenCodeDiagramPalette({
+            text: context.theme.text.default,
+            subdued: context.theme.text.subdued,
+            info: context.theme.text.feedback.info.default,
+            success: context.theme.text.feedback.success.default,
+            warning: context.theme.text.feedback.warning.default,
+            background: context.theme.background.default,
+            accent: {
+              soft: accent[dark ? 300 : 700],
+              clear: accent[dark ? 200 : 800],
+            },
+          }),
+        }
+      }),
     )
   },
 })

--- a/packages/merman/src/state/diagram.test.ts
+++ b/packages/merman/src/state/diagram.test.ts
@@ -935,6 +935,34 @@ ${labels.map((label) => `  A --> B: ${label}`).join("\n")}`)
     `)
   })
 
+  test("leaves frame gaps where external transitions cross nested composite boundaries", () => {
+    const drawing = createStateDiagramDrawing(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  direction LR
+  state Session {
+    [*] --> Open
+    state Open {
+      [*] --> Clean
+    }
+  }
+  [*] --> Session: hydrate`),
+    )
+    const hydrate = drawing.transitionPlans.find((plan) => plan.route.transition.label === "hydrate")!
+    const crossings = hydrate.cells.filter((cell) =>
+      [...drawing.layout.compositeBounds.values()].some((bounds) => {
+        const right = bounds.left + bounds.width - 1
+        const bottom = bounds.top + bounds.height - 1
+        return (
+          ((cell.x === bounds.left || cell.x === right) && cell.y >= bounds.top && cell.y <= bottom) ||
+          ((cell.y === bounds.top || cell.y === bottom) && cell.x >= bounds.left && cell.x <= right)
+        )
+      }),
+    )
+
+    expect(crossings).toHaveLength(2)
+    for (const cell of crossings) expect(drawing.grid.getCell(cell.x, cell.y)?.char).toBe("─")
+  })
+
   test("keeps explicit choices visible in choice-only cycles", () => {
     const output = renderStateDiagram(`stateDiagram-v2
   direction TB
@@ -1179,7 +1207,7 @@ stateDiagram-v2
       "            ╭─ Authenticated ──────────────────╮
                   │                                  │ save
           login   │ ╭──────╮    open     ╭─────────╮ │ logout
-      ●───────────┼▶│ Idle ├────────────▶│ Editing ├─┼──────────▶◎
+      ●────────────▶│ Idle ├────────────▶│ Editing ├────────────▶◎
                   │ ╰──────╯             ╰─────────╯ │
                   │                                  │
                   ╰──────────────────────────────────╯"
@@ -1326,27 +1354,31 @@ stateDiagram-v2
     SecondInner --> [*]: second-out
   }
   FirstGroup --> SecondGroup: group-next
-  SecondGroup --> FirstGroup: group-back`
+    SecondGroup --> FirstGroup: group-back`
 
     for (const direction of ["LR", "TB"] as const) {
-      const lines = renderStateDiagram(source, { direction }).split("\n")
-      for (const title of ["FirstGroup", "SecondGroup"]) {
-        const top = lines.findIndex((line) => line.includes(title))
-        const left = lines[top]!.lastIndexOf("╭", lines[top]!.indexOf(title))
-        const right = lines[top]!.indexOf("╮", left)
-        const bottom = lines.findIndex((line, index) => index > top && line[left] === "╰" && line[right] === "╯")
+      const drawing = createStateDiagramDrawing(parseMermaidStateDiagram(source), { direction })
+      const output = drawing.grid.toString({ trimTop: true, trimBottom: true })
+      for (const id of ["FirstGroup", "SecondGroup"]) {
+        const bounds = drawing.layout.compositeBounds.get(id)!
+        const right = bounds.left + bounds.width - 1
+        const bottom = bounds.top + bounds.height - 1
+        const boundaryStyles = [
+          ...Array.from({ length: bounds.height - 2 }, (_, offset) => [
+            drawing.grid.getCell(bounds.left, bounds.top + offset + 1)?.style,
+            drawing.grid.getCell(right, bounds.top + offset + 1)?.style,
+          ]).flat(),
+          ...Array.from(
+            { length: bounds.width - 2 },
+            (_, offset) => drawing.grid.getCell(bounds.left + offset + 1, bottom)?.style,
+          ),
+        ]
 
-        expect(top).toBeGreaterThanOrEqual(0)
-        expect(left).toBeGreaterThanOrEqual(0)
-        expect(right).toBeGreaterThan(left)
-        expect(bottom).toBeGreaterThan(top)
+        expect(output.match(new RegExp(id, "g"))).toHaveLength(1)
         expect(
-          lines.slice(top + 1, bottom).every((line) => "│├┤┼".includes(line[left]!) && "│├┤┼".includes(line[right]!)),
-        ).toBe(true)
-        expect(
-          lines[bottom]!.slice(left + 1, right)
-            .split("")
-            .every((char) => "─┬┴┼".includes(char)),
+          boundaryStyles.every(
+            (style) => style === "composite" || style === "transition" || style?.startsWith("stateDepartureRamp"),
+          ),
         ).toBe(true)
       }
     }

--- a/packages/merman/src/state/diagram.test.ts
+++ b/packages/merman/src/state/diagram.test.ts
@@ -835,8 +835,8 @@ ${labels.map((label) => `  A --> B: ${label}`).join("\n")}`)
     expect(output).toMatchInlineSnapshot(`
       "╭───╮ alpha route label that is deliberately long
       │ A ├───┬──╮
-      ╰─┬─╯   │  │
-        │     │  │ gamma route label that is deliberately long
+      ╰─┬─╯   │  │ gamma route label that is deliberately long
+        │     │  │
         │     │  │ beta route label that is deliberately long
         │     │  │
         ▼     │  │

--- a/packages/merman/src/state/drawing.ts
+++ b/packages/merman/src/state/drawing.ts
@@ -8,6 +8,7 @@ import {
   fillDiagramFrameInterior,
   mergeDiagramLineGlyph,
 } from "../core/drawing.js"
+import { DIAGRAM_LABEL_PADDING_X, diagramTextWidth } from "../core/text.js"
 import {
   createStateDiagramLayout,
   expandCompositeBoundsForFeedback,
@@ -27,8 +28,8 @@ import {
   type StateTransitionRenderPlan,
 } from "./routing.js"
 import { createStateSearchBudget } from "./search.js"
+import { NOTE_CONNECTOR_RAMP_STYLES, STATE_DEPARTURE_RAMP_STYLES } from "./style.js"
 import type {
-  NoteConnectorRampStyle,
   StateCellStyle,
   StateDiagram,
   StateDiagramArrowHeadStyle,
@@ -57,7 +58,7 @@ function makeGrid(width: number, height: number): StateGrid {
     mergeCell: (existing, incoming): StateCell => {
       const existingIsTransition = existing.style === "transition" || existing.style?.startsWith("stateDepartureRamp")
       const incomingIsTransition = incoming.style === "transition" || incoming.style?.startsWith("stateDepartureRamp")
-      const shouldMerge = incomingIsTransition && (existingIsTransition || existing.style === "composite")
+      const shouldMerge = incomingIsTransition && existingIsTransition
       return {
         ...incoming,
         char: shouldMerge
@@ -89,11 +90,10 @@ function drawBox(
     setCell(grid, bounds.left, bounds.top, state.label, state.kind)
     return
   }
-  const style: StateCellStyle = "state"
-  fillDiagramFrameInterior(bounds, (x, y) => setCell(grid, x, y, " ", style))
-  drawStateFrame(grid, bounds, BorderChars[borderStyle], style)
+  fillDiagramFrameInterior(bounds, (x, y) => setCell(grid, x, y, " ", "state"))
+  drawStateFrame(grid, bounds, BorderChars[borderStyle], "stateBorder")
   lines.forEach((line, index) => {
-    setText(grid, bounds.left + 2, bounds.top + 1 + index, line, style)
+    setText(grid, bounds.left + 2, bounds.top + 1 + index, line, "state")
   })
 }
 
@@ -146,8 +146,7 @@ function drawNote(grid: StateGrid, bounds: StateNoteBounds, target: BoxBounds): 
     if (previous) directions.add(directionBetween(point, previous)!)
     if (next) directions.add(directionBetween(point, next)!)
     const distanceFromNote = points.length - index - 1
-    const style: StateCellStyle =
-      distanceFromNote < 3 ? (`noteConnectorRamp${3 - distanceFromNote}` as NoteConnectorRampStyle) : "noteConnector"
+    const style = distanceFromNote < 3 ? NOTE_CONNECTOR_RAMP_STYLES[2 - distanceFromNote]! : "noteConnector"
     setCell(grid, point.x, point.y, noteConnectorGlyph(directions), style)
   }
 
@@ -170,7 +169,7 @@ function drawTransitionRenderPlan(
 ): void {
   const departure = new Map(
     rampDeparture
-      ? plan.path.slice(0, 3).map(([x, y], index) => [`${x}:${y}`, `stateDepartureRamp${index + 1}` as StateCellStyle])
+      ? plan.path.slice(0, 3).map(([x, y], index) => [`${x}:${y}`, STATE_DEPARTURE_RAMP_STYLES[index]!])
       : [],
   )
   for (const cell of plan.cells) {
@@ -178,7 +177,14 @@ function drawTransitionRenderPlan(
     setCell(grid, cell.x, cell.y, char, departure.get(`${cell.x}:${cell.y}`) ?? "transition")
   }
   if (plan.label) {
-    plan.label.lines.forEach((line, index) => setText(grid, plan.label!.x, plan.label!.y + index, line, "label"))
+    plan.label.lines.forEach((line, index) => {
+      const y = plan.label!.y + index
+      const leftX = plan.label!.x - DIAGRAM_LABEL_PADDING_X
+      if (grid.getCell(leftX, y)?.char === " ") setCell(grid, leftX, y, " ", "label")
+      setText(grid, plan.label!.x, y, line, "label")
+      const rightX = plan.label!.x + diagramTextWidth(line) + DIAGRAM_LABEL_PADDING_X - 1
+      if (grid.getCell(rightX, y)?.char === " ") setCell(grid, rightX, y, " ", "label")
+    })
   }
 }
 
@@ -270,7 +276,10 @@ function createStateDiagramDrawingWithDirection(
     0,
     ...[...bounds.values(), ...noteBounds].map((bound) => bound.left),
     ...connectorPoints.map((point) => point.x),
-    ...transitionPlans.flatMap((plan) => [...plan.cells.map((cell) => cell.x), ...(plan.label ? [plan.label.x] : [])]),
+    ...transitionPlans.flatMap((plan) => [
+      ...plan.cells.map((cell) => cell.x),
+      ...(plan.label ? [plan.label.x - DIAGRAM_LABEL_PADDING_X] : []),
+    ]),
   )
   const contentTop = Math.min(
     0,
@@ -301,7 +310,9 @@ function createStateDiagramDrawingWithDirection(
     maxX,
     ...transitionPlans.flatMap((plan) => [
       ...plan.cells.map((cell) => cell.x + 1),
-      ...(plan.label ? [plan.label.x + measureStateTransitionLabel(plan.route.transition.label).width] : []),
+      ...(plan.label
+        ? [plan.label.x + measureStateTransitionLabel(plan.route.transition.label).width + DIAGRAM_LABEL_PADDING_X]
+        : []),
     ]),
   )
   const transitionBottom = Math.max(
@@ -337,7 +348,7 @@ function createStateDiagramDrawingWithDirection(
 
   for (const composite of diagram.composites) {
     const bound = compositeBounds.get(composite.id)
-    if (bound) drawContainerLabel(grid, bound, composite.label, "composite")
+    if (bound) drawContainerLabel(grid, bound, composite.label, "compositeLabel")
   }
 
   for (const noteBound of noteBounds) {

--- a/packages/merman/src/state/layout.test.ts
+++ b/packages/merman/src/state/layout.test.ts
@@ -211,6 +211,27 @@ describe("StateDiagramLayout", () => {
     expect(Math.sign(a.centerX - b.centerX)).toBe(expectedSign)
   })
 
+  test("continues the horizontal backbone through a reciprocal pair after an entry marker", () => {
+    const diagram = prepareVisibleStateDiagram(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  direction LR
+  [*] --> Clean
+  Clean --> Dirty: edit
+  Dirty --> Clean: save
+  Dirty --> Closing: request close
+  Closing --> [*]: closed`),
+    )
+    const layout = createStateDiagramLayout(diagram, { minStateGap: 5 })
+    const clean = layout.bounds.get("Clean")!
+    const dirty = layout.bounds.get("Dirty")!
+    const closing = layout.bounds.get("Closing")!
+
+    expect(clean.centerY).toBe(dirty.centerY)
+    expect(dirty.centerY).toBe(closing.centerY)
+    expect(clean.centerX).toBeLessThan(dirty.centerX)
+    expect(dirty.centerX).toBeLessThan(closing.centerX)
+  })
+
   test.each(["TB", "TD"] as const)(
     "contains nested internal feedback with strict margins in %s diagrams",
     (direction) => {

--- a/packages/merman/src/state/layout.test.ts
+++ b/packages/merman/src/state/layout.test.ts
@@ -232,6 +232,33 @@ describe("StateDiagramLayout", () => {
     expect(dirty.centerX).toBeLessThan(closing.centerX)
   })
 
+  test("does not reserve an unused right-side lane for aligned nested composite transitions", () => {
+    const diagram = prepareVisibleStateDiagram(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  direction TB
+  state Session {
+    [*] --> Open
+    state Open {
+      [*] --> Clean
+      Clean --> Dirty: edit
+      Dirty --> Clean: save
+      Dirty --> [*]
+    }
+    Open --> Closing: request close
+    Closing --> Open: cancel
+    Closing --> [*]: closed
+    note right of Dirty: unsaved changes
+  }
+  [*] --> Session: hydrate
+  Session --> [*]: release`),
+    )
+    const layout = createStateDiagramLayout(diagram, { minStateGap: 5 })
+    const open = layout.compositeBounds.get("Open")!
+    const session = layout.compositeBounds.get("Session")!
+
+    expect(session.width).toBeLessThanOrEqual(open.width + 4)
+  })
+
   test.each(["TB", "TD"] as const)(
     "contains nested internal feedback with strict margins in %s diagrams",
     (direction) => {

--- a/packages/merman/src/state/layout.ts
+++ b/packages/merman/src/state/layout.ts
@@ -132,7 +132,7 @@ function computeMainPath(diagram: StateDiagram): string[] {
         const toParent = statesById.get(transition.to)?.parentId
         return Boolean(fromParent && toParent && fromParent !== toParent)
       }) ??
-      (path.length === 1 && candidates.length === 1 ? candidates[0] : undefined)
+      (candidates.length === 1 ? candidates[0] : undefined)
     if (!next) break
     path.push(next.to)
     visited.add(next.to)

--- a/packages/merman/src/state/layout.ts
+++ b/packages/merman/src/state/layout.ts
@@ -419,6 +419,7 @@ function expandCompositeBoundsForInternalRouting(diagram: StateDiagram, layout: 
         innermostCommonCompositeId(transition, statesById, compositesById) === composite.id,
     )
     const endpointOccurrences = new Map<string, number>()
+    const hasNestedComposite = diagram.composites.some((candidate) => candidate.parentId === composite.id)
     const sideRoutes = internal.filter((transition) => {
       const from = layout.bounds.get(transition.from)
       const to = layout.bounds.get(transition.to)
@@ -428,7 +429,14 @@ function expandCompositeBoundsForInternalRouting(diagram: StateDiagram, layout: 
       endpointOccurrences.set(key, occurrence + 1)
       const fromParent = statesById.get(transition.from)?.parentId
       const toParent = statesById.get(transition.to)?.parentId
-      return occurrence > 0 || from.centerY > to.centerY || fromParent !== toParent
+      return (
+        occurrence > 0 ||
+        (from.centerY > to.centerY && (!hasNestedComposite || from.left - 1 <= bound.left)) ||
+        (fromParent !== toParent &&
+          (from.centerX !== to.centerX ||
+            statesById.get(transition.from)?.kind !== "state" ||
+            statesById.get(transition.to)?.kind !== "state"))
+      )
     })
     if (sideRoutes.length === 0) continue
     const childRight = Math.max(

--- a/packages/merman/src/state/render-grid.ts
+++ b/packages/merman/src/state/render-grid.ts
@@ -1,6 +1,6 @@
-import type { StyledText } from "@opentui/core"
+import type { RGBA, StyledText } from "@opentui/core"
 import type { DiagramCanvas } from "../core/canvas.js"
-import { renderDiagramGridStyledText } from "../core/render-grid.js"
+import { renderDiagramGridStyledTextByStyle } from "../core/render-grid.js"
 import type { StateStyleColors } from "./style.js"
 import type { StateCellStyle } from "./types.js"
 
@@ -10,8 +10,12 @@ export function renderStateGridText(grid: StateGrid): string {
   return grid.toString({ trimTop: true, trimBottom: true })
 }
 
-export function renderStateGridStyledText(grid: StateGrid, colors: StateStyleColors): StyledText {
-  return renderDiagramGridStyledText(grid, (run) => (run.style ? colors[run.style] : undefined), undefined, {
+export function renderStateGridStyledText(
+  grid: StateGrid,
+  colors: StateStyleColors,
+  backgrounds?: Partial<Record<StateCellStyle, RGBA>>,
+): StyledText {
+  return renderDiagramGridStyledTextByStyle(grid, colors, backgrounds, {
     trimTop: true,
     trimBottom: true,
   })

--- a/packages/merman/src/state/routing.test.ts
+++ b/packages/merman/src/state/routing.test.ts
@@ -286,6 +286,39 @@ describe("createStateTransitionRenderPlans", () => {
     }
   })
 
+  test("separates nested feedback labels without moving them outside their routes", () => {
+    const diagram = prepareVisibleStateDiagram(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  direction TB
+  state Session {
+    [*] --> Open
+    state Open {
+      [*] --> Clean
+      Clean --> Dirty: edit
+      Dirty --> Clean: save
+      Dirty --> [*]
+    }
+    Open --> Closing: request close
+    Closing --> Open: cancel
+    Closing --> [*]: closed
+    note right of Dirty: unsaved changes
+  }
+  [*] --> Session: hydrate
+  Session --> [*]: release`),
+    )
+    const layout = createStateDiagramLayout(diagram, { minStateGap: 5 })
+    const plans = createStateTransitionRenderPlans(diagram, layout.bounds, 30, { noteBounds: layout.noteBounds })
+    const crowded = plans.filter((plan) => ["edit", "save", "cancel"].includes(plan.route.transition.label))
+
+    for (const [index, plan] of crowded.entries()) {
+      expect(plan.label!.y).toBeGreaterThanOrEqual(Math.min(...plan.path.map(([, y]) => y)))
+      expect(plan.label!.y).toBeLessThanOrEqual(Math.max(...plan.path.map(([, y]) => y)))
+      for (const other of crowded.slice(index + 1)) {
+        expect(Math.abs(plan.label!.y - other.label!.y)).toBeGreaterThan(1)
+      }
+    }
+  })
+
   test("keeps vertical branch routes out of unrelated state bounds", () => {
     const diagram = prepareVisibleStateDiagram(
       parseMermaidStateDiagram(`stateDiagram-v2

--- a/packages/merman/src/state/routing.test.ts
+++ b/packages/merman/src/state/routing.test.ts
@@ -234,6 +234,58 @@ describe("createStateTransitionRenderPlans", () => {
     ])
   })
 
+  test("anchors choice labels to their distinct outgoing branches", () => {
+    const diagram = prepareVisibleStateDiagram(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  direction TB
+  [*] --> Pending
+  Pending --> Decision: review
+  state Decision <<choice>>
+  Decision --> Approved: accept
+  Decision --> Rejected: reject
+  Rejected --> Pending: retry
+  Approved --> [*]: complete`),
+    )
+    const layout = createStateDiagramLayout(diagram, { minStateGap: 5 })
+    const plans = createStateTransitionRenderPlans(diagram, layout.bounds, 30)
+    const accepted = plans.find((plan) => plan.route.transition.label === "accept")!
+    const rejected = plans.find((plan) => plan.route.transition.label === "reject")!
+
+    expect(rejected.label!.x).toBeGreaterThanOrEqual(accepted.label!.x + diagramTextWidth("accept") + 1)
+    expect(rejected.label!.x + diagramTextWidth("reject")).toBeLessThanOrEqual(rejected.route.to.centerX)
+  })
+
+  test("keeps crowded loop and forward labels below their source state", () => {
+    const diagram = prepareVisibleStateDiagram(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  direction TB
+  [*] --> Listening
+  Listening --> Listening: heartbeat
+  Listening --> Listening: refresh token
+  Listening --> Connected: client connected
+  Connected --> Connected: received message
+  Connected --> Listening: disconnected
+  Connected --> [*]: shutdown`),
+    )
+    const layout = createStateDiagramLayout(diagram, { minStateGap: 5 })
+    const plans = createStateTransitionRenderPlans(diagram, layout.bounds, 30)
+
+    for (const label of ["heartbeat", "refresh token", "client connected", "received message", "shutdown"]) {
+      const plan = plans.find((candidate) => candidate.route.transition.label === label)!
+      expect(plan.label!.y, label).toBeGreaterThanOrEqual(plan.route.from.top + plan.route.from.height)
+      expect(plan.label!.y, label).toBeLessThanOrEqual(Math.max(...plan.path.map(([, y]) => y)))
+    }
+
+    const crowded = plans.filter((plan) =>
+      ["heartbeat", "refresh token", "client connected", "disconnected"].includes(plan.route.transition.label),
+    )
+    for (const [index, plan] of crowded.entries()) {
+      for (const other of crowded.slice(index + 1)) {
+        expect(Math.abs(plan.label!.y - other.label!.y)).toBeGreaterThan(1)
+      }
+    }
+  })
+
   test("keeps vertical branch routes out of unrelated state bounds", () => {
     const diagram = prepareVisibleStateDiagram(
       parseMermaidStateDiagram(`stateDiagram-v2

--- a/packages/merman/src/state/routing.ts
+++ b/packages/merman/src/state/routing.ts
@@ -882,7 +882,14 @@ function addVerticalElbowTransition(builder: StateTransitionRenderBuilder): void
   const metrics = measureStateTransitionLabel(transition.label)
   if (topToBottom) {
     const leftLabelX = startX - metrics.width - 2
-    const labelX = hasReverse || endX < startX ? (leftLabelX >= 0 ? leftLabelX : startX + 4) : startX + 2
+    const labelX =
+      from.width === 1 && Math.abs(endX - startX) >= metrics.width + 2
+        ? Math.min(startX, endX) + Math.floor((Math.abs(endX - startX) - metrics.width) / 2)
+        : hasReverse || endX < startX
+          ? leftLabelX >= 0
+            ? leftLabelX
+            : startX + 4
+          : startX + 2
     addLabel(
       builder,
       labelX,
@@ -1289,14 +1296,26 @@ function placeStateTransitionLabels(
         width,
         height: plan.label!.lines.length,
       })
+    const sharesLoopCorridor = plans.some(
+      (candidate) =>
+        candidate.route.transition.from === plan.route.transition.from &&
+        candidate.route.kind === (plan.route.kind === "self" ? "vertical" : "self"),
+    )
+    const corridorTop =
+      sharesLoopCorridor &&
+      (plan.route.kind === "self" ||
+        (plan.route.kind === "vertical" && plan.route.from.centerY < plan.route.to.centerY))
+        ? plan.route.from.top + plan.route.from.height
+        : undefined
+    const corridorBottom = corridorTop === undefined ? undefined : Math.max(...plan.path.map(([, y]) => y))
     const isClear = (x: number, y: number): boolean => {
-      if (x < 0 || y < 0) return false
+      if (x < 0 || y < 0 || (corridorTop !== undefined && (y < corridorTop || y > corridorBottom!))) return false
       return space.isFree(labelClaim(x, y), {
         clearance: {
           body: statePadding,
-          label: { x: 1, y: 0 },
+          label: { x: 1, y: sharesLoopCorridor ? 1 : 0 },
           route:
-            plan.pathRepaired || plan.route.kind === "side-parallel" || needsLaneClearance
+            plan.pathRepaired || plan.route.kind === "side-parallel" || needsLaneClearance || corridorTop !== undefined
               ? {
                   x: 1,
                   y: 0,
@@ -1309,7 +1328,12 @@ function placeStateTransitionLabels(
     const candidates = stateTransitionLabelCandidates(plan, width, plan.label.lines.length)
     const nearby = candidates.find(
       (candidate) =>
-        (!(plan.pathRepaired || plan.route.kind === "side-parallel" || needsLaneClearance) ||
+        (!(
+          plan.pathRepaired ||
+          plan.route.kind === "side-parallel" ||
+          needsLaneClearance ||
+          corridorTop !== undefined
+        ) ||
           labelDistanceToPath(candidate.x, candidate.y, width, plan.label!.lines.length, plan.path) >= 2) &&
         isClear(candidate.x, candidate.y),
     )

--- a/packages/merman/src/state/routing.ts
+++ b/packages/merman/src/state/routing.ts
@@ -1302,18 +1302,21 @@ function placeStateTransitionLabels(
         candidate.route.kind === (plan.route.kind === "self" ? "vertical" : "self"),
     )
     const corridorTop =
-      sharesLoopCorridor &&
-      (plan.route.kind === "self" ||
-        (plan.route.kind === "vertical" && plan.route.from.centerY < plan.route.to.centerY))
-        ? plan.route.from.top + plan.route.from.height
-        : undefined
+      plan.route.kind === "side-parallel" &&
+      plans.some((candidate) => candidate !== plan && candidate.route.transition.to === plan.route.transition.to)
+        ? Math.min(...plan.path.map(([, y]) => y))
+        : sharesLoopCorridor &&
+            (plan.route.kind === "self" ||
+              (plan.route.kind === "vertical" && plan.route.from.centerY < plan.route.to.centerY))
+          ? plan.route.from.top + plan.route.from.height
+          : undefined
     const corridorBottom = corridorTop === undefined ? undefined : Math.max(...plan.path.map(([, y]) => y))
     const isClear = (x: number, y: number): boolean => {
       if (x < 0 || y < 0 || (corridorTop !== undefined && (y < corridorTop || y > corridorBottom!))) return false
       return space.isFree(labelClaim(x, y), {
         clearance: {
           body: statePadding,
-          label: { x: 1, y: sharesLoopCorridor ? 1 : 0 },
+          label: { x: 1, y: 1 },
           route:
             plan.pathRepaired || plan.route.kind === "side-parallel" || needsLaneClearance || corridorTop !== undefined
               ? {

--- a/packages/merman/src/state/style.test.ts
+++ b/packages/merman/src/state/style.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { RGBA } from "@opentui/core"
 import { drawStateDiagramGrid } from "./drawing.js"
 import { parseMermaidStateDiagram } from "./parser.js"
+import { renderStateGridStyledText } from "./render-grid.js"
 import { resolveStateStyleColors } from "./style.js"
 
 describe("state note connector styles", () => {
@@ -54,5 +55,59 @@ describe("state transition departure styles", () => {
 
     expect(rampStyles).toHaveLength(3)
     expect(new Set(rampStyles)).toEqual(new Set(["stateDepartureRamp1", "stateDepartureRamp2", "stateDepartureRamp3"]))
+  })
+})
+
+describe("state component styles", () => {
+  test("separates box and group text from their borders", () => {
+    const grid = drawStateDiagramGrid(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  state Group {
+    A --> [*]
+  }`),
+    )
+    const styles = grid.rows.flatMap((row) => row.map((cell) => cell.style))
+
+    expect(styles).toContain("state")
+    expect(styles).toContain("stateBorder")
+    expect(styles).toContain("composite")
+    expect(styles).toContain("compositeLabel")
+  })
+
+  test("resolves independent box and group text colors", () => {
+    const state = RGBA.fromInts(10, 0, 0, 255)
+    const stateBorder = RGBA.fromInts(20, 0, 0, 255)
+    const composite = RGBA.fromInts(30, 0, 0, 255)
+    const compositeLabel = RGBA.fromInts(40, 0, 0, 255)
+    const colors = resolveStateStyleColors({ state, stateBorder, composite, compositeLabel })
+
+    expect(colors.state).toBe(state)
+    expect(colors.stateBorder).toBe(stateBorder)
+    expect(colors.composite).toBe(composite)
+    expect(colors.compositeLabel).toBe(compositeLabel)
+  })
+
+  test("renders transition labels with an independent background", () => {
+    const background = RGBA.fromInts(30, 40, 50, 255)
+    const grid = drawStateDiagramGrid(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  A --> B: transition label`),
+    )
+    const styled = renderStateGridStyledText(grid, resolveStateStyleColors(), { label: background })
+    const row = grid.rows.find((cells) =>
+      cells
+        .map((cell) => cell.char)
+        .join("")
+        .includes("transition label"),
+    )!
+    const start = row
+      .map((cell) => cell.char)
+      .join("")
+      .indexOf("transition label")
+
+    expect(styled.chunks.some((chunk) => chunk.text.includes("transition label") && chunk.bg === background)).toBe(true)
+    expect(styled.chunks.some((chunk) => chunk.text.includes("A") && chunk.bg !== undefined)).toBe(false)
+    expect(row[start - 1]?.style).toBe("label")
+    expect(row[start + "transition label".length]?.style).toBe("label")
   })
 })

--- a/packages/merman/src/state/style.test.ts
+++ b/packages/merman/src/state/style.test.ts
@@ -105,7 +105,7 @@ describe("state component styles", () => {
       .join("")
       .indexOf("transition label")
 
-    expect(styled.chunks.some((chunk) => chunk.text.includes("transition label") && chunk.bg === background)).toBe(true)
+    expect(styled.chunks.some((chunk) => chunk.text === " transition label " && chunk.bg === background)).toBe(true)
     expect(styled.chunks.some((chunk) => chunk.text.includes("A") && chunk.bg !== undefined)).toBe(false)
     expect(row[start - 1]?.style).toBe("label")
     expect(row[start + "transition label".length]?.style).toBe("label")

--- a/packages/merman/src/state/style.ts
+++ b/packages/merman/src/state/style.ts
@@ -1,10 +1,12 @@
 import { RGBA } from "@opentui/core"
-import { createColorRampTheme, rgba, type DiagramRgb } from "../core/color/style.js"
+import { createColorRampTheme, numberedStyleKeys, rgba, type DiagramRgb } from "../core/color/style.js"
 import type { BaseStateCellStyle, NoteConnectorRampStyle, StateCellStyle, StateDepartureRampStyle } from "./types.js"
 
 const DEFAULT_THEME_RGB = {
   state: [228, 239, 232],
+  stateBorder: [228, 239, 232],
   composite: [111, 138, 126],
+  compositeLabel: [111, 138, 126],
   transition: [134, 225, 200],
   label: [134, 225, 200],
   noteBorder: [141, 169, 155],
@@ -14,16 +16,15 @@ const DEFAULT_THEME_RGB = {
   end: [230, 177, 126],
   choice: [134, 225, 200],
 } as const satisfies Record<BaseStateCellStyle, DiagramRgb>
-const NOTE_CONNECTOR_RAMP_STYLES = [
-  "noteConnectorRamp1",
-  "noteConnectorRamp2",
-  "noteConnectorRamp3",
-] as const satisfies readonly NoteConnectorRampStyle[]
-const STATE_DEPARTURE_RAMP_STYLES = [
-  "stateDepartureRamp1",
-  "stateDepartureRamp2",
-  "stateDepartureRamp3",
-] as const satisfies readonly StateDepartureRampStyle[]
+const STATE_RAMP_STEPS = [1, 2, 3] as const
+export const NOTE_CONNECTOR_RAMP_STYLES = numberedStyleKeys(
+  "noteConnectorRamp",
+  STATE_RAMP_STEPS,
+) satisfies readonly NoteConnectorRampStyle[]
+export const STATE_DEPARTURE_RAMP_STYLES = numberedStyleKeys(
+  "stateDepartureRamp",
+  STATE_RAMP_STEPS,
+) satisfies readonly StateDepartureRampStyle[]
 export type StateStyleColors = Required<Record<StateCellStyle, RGBA>>
 
 export function resolveStateStyleColors(
@@ -31,7 +32,9 @@ export function resolveStateStyleColors(
 ): StateStyleColors {
   const resolved = {
     state: colors.state ?? rgba(DEFAULT_THEME_RGB.state),
+    stateBorder: colors.stateBorder ?? colors.state ?? rgba(DEFAULT_THEME_RGB.stateBorder),
     composite: colors.composite ?? rgba(DEFAULT_THEME_RGB.composite),
+    compositeLabel: colors.compositeLabel ?? colors.composite ?? rgba(DEFAULT_THEME_RGB.compositeLabel),
     transition: colors.transition ?? rgba(DEFAULT_THEME_RGB.transition),
     label: colors.label ?? rgba(DEFAULT_THEME_RGB.label),
     noteBorder: colors.noteBorder ?? rgba(DEFAULT_THEME_RGB.noteBorder),
@@ -44,6 +47,6 @@ export function resolveStateStyleColors(
   return {
     ...resolved,
     ...createColorRampTheme(NOTE_CONNECTOR_RAMP_STYLES, resolved.noteConnector, resolved.noteBorder),
-    ...createColorRampTheme(STATE_DEPARTURE_RAMP_STYLES, resolved.state, resolved.transition),
+    ...createColorRampTheme(STATE_DEPARTURE_RAMP_STYLES, resolved.stateBorder, resolved.transition),
   }
 }

--- a/packages/merman/src/state/types.ts
+++ b/packages/merman/src/state/types.ts
@@ -49,7 +49,9 @@ export type NoteConnectorRampStyle = `noteConnectorRamp${1 | 2 | 3}`
 export type StateDepartureRampStyle = `stateDepartureRamp${1 | 2 | 3}`
 export type BaseStateCellStyle =
   | "state"
+  | "stateBorder"
   | "composite"
+  | "compositeLabel"
   | "transition"
   | "label"
   | "noteBorder"

--- a/packages/merman/src/state/visible-model.test.ts
+++ b/packages/merman/src/state/visible-model.test.ts
@@ -45,6 +45,28 @@ describe("prepareVisibleStateDiagram", () => {
     expect(visible.transitions.some((transition) => transition.to.includes(".__start"))).toBe(false)
   })
 
+  test("resolves an outgoing composite transition through its concrete exit state", () => {
+    const visible = prepareVisibleStateDiagram(
+      parseMermaidStateDiagram(`stateDiagram-v2
+  state Session {
+    [*] --> Open
+    state Open {
+      [*] --> Clean
+      Clean --> Dirty: edit
+      Dirty --> Clean: save
+      Dirty --> [*]
+    }
+    Open --> Closing: request close
+    Closing --> Open: cancel
+  }
+  [*] --> Session: hydrate`),
+    )
+
+    expect(visible.transitions).toContainEqual({ from: "Dirty", to: "Closing", label: "request close" })
+    expect(visible.transitions).toContainEqual({ from: "Closing", to: "Clean", label: "cancel" })
+    expect(visible.transitions.some((transition) => transition.from === "Open")).toBe(false)
+  })
+
   test("preserves labels on both sides of collapsed composite markers", () => {
     const visible = prepareVisibleStateDiagram(
       parseMermaidStateDiagram(`stateDiagram-v2

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -476,6 +476,7 @@ export interface Context {
   readonly data: Data
   readonly attention: Attention
   readonly theme: ResolvedTheme
+  readonly themeMode: "dark" | "light"
   readonly markdown: {
     registerCodeBlockRenderer(language: string, render: MarkdownCodeBlockRenderer): () => void
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@effect/platform-node": "catalog:",
+    "@effect/platform-node-shared": "catalog:",
     "@opencode-ai/core": "workspace:*",
     "@opencode-ai/protocol": "workspace:*",
     "@opencode-ai/schema": "workspace:*",

--- a/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
@@ -100,6 +100,113 @@ const fixtures = [
   [*] --> Session: hydrate
   Session --> [*]: release`,
   },
+  {
+    id: "flow-fanout",
+    title: "Fan-out and reconvergence",
+    source: `flowchart LR
+  Request([Request]) --> Gateway[API gateway]
+  Gateway -->|authenticate| Auth[Authentication]
+  Gateway -->|rate limit| Limit[Rate limiter]
+  Gateway -->|cache lookup| Cache[(Response cache)]
+  Auth --> Worker[Request worker]
+  Limit --> Worker
+  Cache --> Worker
+  Worker --> Response([Response])`,
+  },
+  {
+    id: "flow-feedback",
+    title: "Retry and failure routes",
+    source: `flowchart TD
+  Start([Incoming job]) --> Validate{Valid?}
+  Validate -->|yes| Queue[(Job queue)]
+  Validate -->|no| Reject[Reject request]
+  Queue --> Execute[Execute job]
+  Execute -->|retry| Queue
+  Execute -->|failed| Failed[Dead letter queue]
+  Execute -->|complete| Complete([Complete])`,
+  },
+  {
+    id: "flow-nested-groups",
+    title: "Nested deployment groups",
+    source: `flowchart LR
+  Browser([Browser]) --> Gateway[Gateway]
+  subgraph Cloud[Cloud platform]
+    direction TB
+    subgraph Compute[Compute]
+      API[API service] --> Worker[Background worker]
+    end
+    subgraph Storage[Storage]
+      Database[(Database)]
+      Cache[(Cache)]
+    end
+    API --> Database
+    Worker --> Cache
+  end
+  Gateway --> API
+  Worker --> Result([Result])`,
+  },
+  {
+    id: "flow-long-labels",
+    title: "Long route labels",
+    source: `flowchart LR
+  Client[Desktop client] -->|exchange authorization code| Auth[Authorization service]
+  Auth -->|validate signed access token| API[Application API]
+  API -->|read tenant configuration| Database[(Tenant database)]
+  API -->|publish background work item| Queue[(Work queue)]
+  Queue --> Worker[Background worker]
+  Worker -->|notify subscribed clients| Client`,
+  },
+  {
+    id: "state-choice",
+    title: "Choice and recovery",
+    source: `stateDiagram-v2
+  direction TB
+  [*] --> Pending
+  Pending --> Decision: review
+  state Decision <<choice>>
+  Decision --> Approved: accept
+  Decision --> Rejected: reject
+  Rejected --> Pending: retry
+  Approved --> [*]: complete`,
+  },
+  {
+    id: "state-parallel",
+    title: "Parallel transitions",
+    source: `stateDiagram-v2
+  direction LR
+  [*] --> Idle
+  Idle --> Active: first request
+  Idle --> Active: second request
+  Idle --> Active: resumed request
+  Active --> Idle: reset
+  Active --> [*]: shutdown`,
+  },
+  {
+    id: "state-notes",
+    title: "Notes and feedback routes",
+    source: `stateDiagram-v2
+  direction LR
+  [*] --> Draft
+  Draft --> Review: submit
+  Review --> Published: approve
+  Published --> Draft: revise
+  note left of Draft: Content is editable
+  note right of Review: Requires two approvals
+  note right of Published: Readers can subscribe`,
+  },
+  {
+    id: "state-self-loops",
+    title: "State self-transitions",
+    source: `stateDiagram-v2
+  direction TB
+  [*] --> Listening
+  Listening --> Listening: heartbeat
+  Listening --> Listening: refresh token
+  Listening --> Connected: client connected
+  Connected --> Connected: received message
+  Connected --> Listening: disconnected
+  Connected --> [*]: shutdown`,
+  },
 ] as const
 
 const components = [
@@ -429,6 +536,7 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
           { shortcut: "tab", label: "component" },
           { shortcut: "c", label: "color" },
           ...(component().dimmable ? [{ shortcut: "d", label: "dim" }] : []),
+          { shortcut: "drag", label: "pan" },
           { shortcut: "r", label: "reset" },
           { shortcut: "esc", label: "back" },
         ]}

--- a/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
@@ -90,6 +90,7 @@ const fixtures = [
       [*] --> Clean
       Clean --> Dirty: edit
       Dirty --> Clean: save
+      Dirty --> [*]
     }
     Open --> Closing: request close
     Closing --> Open: cancel
@@ -233,7 +234,12 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
       },
     }
   })
-  const rendered = createMemo(() => ({ fixture: fixture(), colors: presentation().colors, generation: generation() }))
+  const rendered = createMemo(() => ({
+    fixture: fixture(),
+    colors: presentation().colors,
+    generation: generation(),
+    width: dimensions().width,
+  }))
   const markdown = createMemo(() => `\`\`\`mermaid-story\n${fixture().source}\n\`\`\``)
   const moveFixture = (offset: number) =>
     setSelected((current) => (current + offset + fixtures.length) % fixtures.length)
@@ -271,7 +277,10 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
   onCleanup(
     props.context.markdown.registerCodeBlockRenderer(
       "mermaid-story",
-      createMermaidCodeBlockRenderer(props.context.renderer, () => ({ colors: presentation().colors })),
+      createMermaidCodeBlockRenderer(props.context.renderer, () => ({
+        colors: presentation().colors,
+        layoutMaxWidth: Math.max(1, dimensions().width - 5),
+      })),
     ),
   )
 

--- a/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
@@ -1,6 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin/tui"
 import { createMermaidCodeBlockRenderer } from "@opencode-ai/merman/markdown"
-import { createOpenCodeDiagramPalette } from "@opencode-ai/merman/palette"
+import { resolveOpenCodeDiagramPalette } from "@opencode-ai/merman/palette"
 import { RGBA } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
 import { createMemo, createSignal, For, onCleanup, Show } from "solid-js"
@@ -194,22 +194,10 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
     }
   })
   const presentation = createMemo(() => {
-    const accent = theme.categorical[3] ?? theme.categorical[0]!
-    const accentSteps = themes.mode() === "light" ? ([700, 800] as const) : ([300, 200] as const)
-    const base = createOpenCodeDiagramPalette({
-      text: theme.text.default,
-      subdued: theme.text.subdued,
-      info: theme.text.feedback.info.default,
-      success: theme.text.feedback.success.default,
-      warning: theme.text.feedback.warning.default,
-      background: theme.background.default,
-      accent: {
-        soft: accent[accentSteps[0]],
-        clear: accent[accentSteps[1]],
-      },
-    })
+    const base = resolveOpenCodeDiagramPalette(props.context.theme, props.context.themeMode)
     const neutral = [theme.text.subdued, base.muted, base.secondary, theme.text.default]
-    const steps = themes.mode() === "light" ? ([400, 500, 700, 800] as const) : ([600, 500, 300, 200] as const)
+    const steps =
+      props.context.themeMode === "light" ? ([400, 500, 700, 800] as const) : ([600, 500, 300, 200] as const)
     const color = (id: DiagramComponent, tone = settings()[id].tone) => {
       const value = settings()[id]
       if (value.color === 0) return neutral[tone] ?? neutral[2]!
@@ -370,9 +358,9 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
       flexDirection="column"
       backgroundColor={theme.background.default}
     >
-      <Show when={rendered()} keyed>
-        {(item) => (
-          <scrollbox flexGrow={1} minHeight={0} viewportOptions={{ paddingRight: 1 }}>
+      <scrollbox flexGrow={1} minHeight={0} viewportOptions={{ paddingRight: 1 }}>
+        <Show when={rendered()} keyed>
+          {(item) => (
             <box paddingLeft={2} paddingRight={2} paddingTop={1} flexDirection="column">
               <text fg={theme.text.default}>{item.fixture.title}</text>
               <text fg={theme.text.subdued}>{item.fixture.id}</text>
@@ -411,9 +399,9 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
                 renderNode={plugins.markdown()}
               />
             </box>
-          </scrollbox>
-        )}
-      </Show>
+          )}
+        </Show>
+      </scrollbox>
       <StoryFooter
         context={props.context}
         title="storybook / Mermaid color lab"

--- a/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
@@ -1,6 +1,9 @@
 import type { Plugin } from "@opencode-ai/plugin/tui"
+import { createMermaidCodeBlockRenderer } from "@opencode-ai/merman/markdown"
+import { createOpenCodeDiagramPalette } from "@opencode-ai/merman/palette"
+import { RGBA } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
-import { createMemo, createSignal, Show } from "solid-js"
+import { createMemo, createSignal, For, onCleanup, Show } from "solid-js"
 import { useTheme, useThemes } from "../../../context/theme"
 import { usePlugin } from "../../../plugin/context"
 import type { Story } from "./index"
@@ -25,6 +28,7 @@ const fixtures = [
   end
 
   subgraph AWS[AWS]
+    direction TB
     EKS[EKS cluster]
     API[Console API pod<br/>1 replica]
     OTEL[OTel collector]
@@ -49,40 +53,30 @@ const fixtures = [
   ECR --> API`,
   },
   {
-    id: "nested-flow",
-    title: "Nested directed groups",
+    id: "grouped-flow",
+    title: "Grouped request pipeline",
     source: `flowchart LR
-  Input([Input]) --> Parse
-  subgraph Outer[Outer orchestration]
-    direction RL
-    subgraph Inner[Inner pipeline]
-      direction TD
-      Parse[Parse request] --> Validate{Valid?}
-      Validate -->|yes| Cache[(Cache)]
-      Cache -->|stale| Validate
-    end
-    Validate --> Dispatch[[Dispatch work]]
-    Dispatch -->|requeue| Parse
+  Input([Input]) --> Gateway[API gateway]
+  subgraph Platform[Platform]
+    Gateway --> Auth[Authenticate]
+    Auth -->|accepted| Queue[(Work queue)]
+    Queue --> Worker[Worker] --> Store[(Result store)]
   end
-  Dispatch -. result .-> Output([Output])
-  Output -->|audit| Cache`,
+  Store --> Output([Output])`,
   },
   {
-    id: "state-feedback",
-    title: "Dense state feedback",
+    id: "state-lifecycle",
+    title: "Review lifecycle",
     source: `stateDiagram-v2
   direction TB
-  [*] --> Root
-  Root --> Alpha: dispatch alpha
-  Root --> Beta: dispatch beta
-  Alpha --> Merge: alpha complete
-  Beta --> Merge: beta complete
-  Merge --> Alpha: retry alpha
-  Merge --> Beta: retry beta
-  Merge --> [*]: finish
-  note right of Merge
-    Retries preserve the original request
-    and remain visible after compaction
+  [*] --> Ready
+  Ready --> Running: start
+  Running --> Review: submit
+  Review --> Done: approve
+  Done --> [*]: finish
+  note right of Review
+    Review preserves the original request
+    and records the final decision
   end note`,
   },
   {
@@ -107,17 +101,191 @@ const fixtures = [
   },
 ] as const
 
+const components = [
+  { id: "lines", label: "lines", dimmable: true },
+  { id: "boxes", label: "boxes", dimmable: true },
+  { id: "boxText", label: "box text", dimmable: false },
+  { id: "labels", label: "labels", dimmable: true },
+  { id: "notes", label: "notes", dimmable: true },
+  { id: "groups", label: "groups", dimmable: true },
+  { id: "markers", label: "markers", dimmable: true },
+] as const
+const dimness = ["dim", "muted", "soft", "clear"] as const
+type DiagramComponent = (typeof components)[number]["id"]
+type DiagramComponentOption = (typeof components)[number]
+type ComponentSettings = Readonly<Record<DiagramComponent, Readonly<{ color: number; tone: number }>>>
+
+const neutralSettings = {
+  lines: { color: 0, tone: 2 },
+  boxes: { color: 0, tone: 1 },
+  boxText: { color: 0, tone: 3 },
+  labels: { color: 0, tone: 0 },
+  notes: { color: 0, tone: 2 },
+  groups: { color: 0, tone: 1 },
+  markers: { color: 0, tone: 2 },
+} as const satisfies ComponentSettings
+
+const palettes = [
+  {
+    id: "neutral",
+    title: "Monochrome",
+    description: "Restrained neutral hierarchy",
+    styles: neutralSettings,
+  },
+  {
+    id: "routes",
+    title: "Colored routes",
+    description: "Neutral entities with a categorical signal color",
+    styles: {
+      ...neutralSettings,
+      lines: { color: 1, tone: 2 },
+      labels: { color: 1, tone: 0 },
+    },
+  },
+  {
+    id: "notes",
+    title: "Colored notes",
+    description: "Route and note accents with neutral structure",
+    styles: {
+      ...neutralSettings,
+      lines: { color: 1, tone: 2 },
+      labels: { color: 1, tone: 0 },
+      notes: { color: 2, tone: 2 },
+    },
+  },
+  {
+    id: "cool-groups",
+    title: "Cool groups",
+    description: "Color 4 groups and notes with restrained neutral routes",
+    styles: {
+      ...neutralSettings,
+      lines: { color: 0, tone: 0 },
+      notes: { color: 4, tone: 2 },
+      groups: { color: 4, tone: 2 },
+    },
+  },
+] as const satisfies readonly {
+  id: string
+  title: string
+  description: string
+  styles: ComponentSettings
+}[]
+
 function MermanLayoutsStory(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
   const theme = useTheme()
   const themes = useThemes()
   const plugins = usePlugin()
   const [selected, setSelected] = createSignal(0)
+  const [selectedPalette, setSelectedPalette] = createSignal<number | undefined>(3)
+  const [selectedComponent, setSelectedComponent] = createSignal(0)
+  const [settings, setSettings] = createSignal<ComponentSettings>(palettes[3].styles)
   const [generation, setGeneration] = createSignal(0)
   const fixture = createMemo(() => fixtures[selected()]!)
-  const rendered = createMemo(() => ({ fixture: fixture(), generation: generation() }))
-  const markdown = createMemo(() => `\`\`\`mermaid\n${fixture().source}\n\`\`\``)
-  const move = (offset: number) => setSelected((current) => (current + offset + fixtures.length) % fixtures.length)
+  const component = createMemo(() => components[selectedComponent()]!)
+  const componentSetting = createMemo(() => settings()[component().id])
+  const paletteOption = createMemo(() => {
+    const index = selectedPalette()
+    if (index !== undefined) return palettes[index]!
+    return {
+      id: "custom",
+      title: "Custom",
+      description: `Editing ${component().label} · ${componentSetting().color === 0 ? "neutral" : `color ${componentSetting().color}`}${component().dimmable ? ` · ${dimness[componentSetting().tone]}` : " · full brightness"}`,
+    }
+  })
+  const presentation = createMemo(() => {
+    const accent = theme.categorical[3] ?? theme.categorical[0]!
+    const accentSteps = themes.mode() === "light" ? ([700, 800] as const) : ([300, 200] as const)
+    const base = createOpenCodeDiagramPalette({
+      text: theme.text.default,
+      subdued: theme.text.subdued,
+      info: theme.text.feedback.info.default,
+      success: theme.text.feedback.success.default,
+      warning: theme.text.feedback.warning.default,
+      background: theme.background.default,
+      accent: {
+        soft: accent[accentSteps[0]],
+        clear: accent[accentSteps[1]],
+      },
+    })
+    const neutral = [theme.text.subdued, base.muted, base.secondary, theme.text.default]
+    const steps = themes.mode() === "light" ? ([400, 500, 700, 800] as const) : ([600, 500, 300, 200] as const)
+    const color = (id: DiagramComponent, tone = settings()[id].tone) => {
+      const value = settings()[id]
+      if (value.color === 0) return neutral[tone] ?? neutral[2]!
+      return theme.categorical[(value.color - 1) % theme.categorical.length]![steps[tone] ?? steps[2]]
+    }
+    const labelAccent = color("labels", 3)
+    const labelAlpha = [0.08, 0.12, 0.18, 0.24][settings().labels.tone] ?? 0.12
+
+    const colors = {
+      ...base,
+      text: theme.text.default,
+      boxText: color("boxText", 3),
+      boxBorder: color("boxes"),
+      line: color("lines"),
+      labelBackground: RGBA.fromValues(labelAccent.r, labelAccent.g, labelAccent.b, labelAlpha),
+      group: color("groups"),
+      groupText: color("groups"),
+      marker: color("markers"),
+      noteBorder: color("notes"),
+      noteText: color("notes", 3),
+      noteConnector: color("notes"),
+    }
+    return {
+      colors,
+      swatches: {
+        lines: colors.line,
+        boxes: colors.boxBorder,
+        boxText: colors.boxText,
+        labels: labelAccent,
+        notes: colors.noteBorder,
+        groups: colors.group,
+        markers: colors.marker,
+      },
+    }
+  })
+  const rendered = createMemo(() => ({ fixture: fixture(), colors: presentation().colors, generation: generation() }))
+  const markdown = createMemo(() => `\`\`\`mermaid-story\n${fixture().source}\n\`\`\``)
+  const moveFixture = (offset: number) =>
+    setSelected((current) => (current + offset + fixtures.length) % fixtures.length)
+  const applyPalette = (index: number) => {
+    setSelectedPalette(index)
+    setSettings(palettes[index]!.styles)
+  }
+  const movePalette = (offset: number) => {
+    const current = selectedPalette() ?? (offset > 0 ? -1 : 0)
+    applyPalette((current + offset + palettes.length) % palettes.length)
+  }
+  const cycleColor = () => {
+    const selected = component().id
+    setSettings((current) => ({
+      ...current,
+      [selected]: { ...current[selected], color: (current[selected].color + 1) % (theme.categorical.length + 1) },
+    }))
+    setSelectedPalette(undefined)
+  }
+  const cycleDimness = () => {
+    if (!component().dimmable) return
+    const selected = component().id
+    setSettings((current) => ({
+      ...current,
+      [selected]: { ...current[selected], tone: (current[selected].tone + 1) % dimness.length },
+    }))
+    setSelectedPalette(undefined)
+  }
+  const settingDescription = (item: DiagramComponentOption, separator = "/") => {
+    const value = settings()[item.id]
+    const color = value.color === 0 ? "neutral" : `color ${value.color}`
+    return item.dimmable ? `${color}${separator}${dimness[value.tone]}` : color
+  }
+
+  onCleanup(
+    props.context.markdown.registerCodeBlockRenderer(
+      "mermaid-story",
+      createMermaidCodeBlockRenderer(props.context.renderer, () => ({ colors: presentation().colors })),
+    ),
+  )
 
   props.context.keymap.layer(() => ({
     commands: [
@@ -128,23 +296,67 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
         run: () => props.context.ui.router.navigate({ type: "plugin", name: "storybook" }),
       },
       {
-        bind: "left,k",
+        bind: "up,k",
         title: "Previous fixture",
         group: "Storybook",
-        run: () => move(-1),
+        run: () => moveFixture(-1),
       },
       {
-        bind: "right,j",
+        bind: "down,j",
         title: "Next fixture",
         group: "Storybook",
-        run: () => move(1),
+        run: () => moveFixture(1),
       },
+      {
+        bind: "left,h",
+        title: "Previous palette",
+        group: "Storybook",
+        run: () => movePalette(-1),
+      },
+      {
+        bind: "right,l",
+        title: "Next palette",
+        group: "Storybook",
+        run: () => movePalette(1),
+      },
+      {
+        bind: "tab",
+        title: "Next diagram component",
+        group: "Storybook",
+        run: () => setSelectedComponent((current) => (current + 1) % components.length),
+      },
+      {
+        bind: "shift+tab",
+        title: "Previous diagram component",
+        group: "Storybook",
+        run: () => setSelectedComponent((current) => (current + components.length - 1) % components.length),
+      },
+      {
+        bind: "c",
+        title: "Cycle component color",
+        group: "Storybook",
+        run: cycleColor,
+      },
+      {
+        bind: "d",
+        title: "Cycle component dimness",
+        group: "Storybook",
+        run: cycleDimness,
+      },
+      ...palettes.map((item, index) => ({
+        bind: String(index + 1),
+        title: `Use ${item.title}`,
+        group: "Storybook",
+        run: () => applyPalette(index),
+      })),
       {
         bind: "r",
         title: "Reset fixture",
         group: "Storybook",
         run: () => {
           setSelected(0)
+          setSelectedComponent(0)
+          applyPalette(3)
           setGeneration((current) => current + 1)
         },
       },
@@ -165,6 +377,28 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
               <text fg={theme.text.default}>{item.fixture.title}</text>
               <text fg={theme.text.subdued}>{item.fixture.id}</text>
               <box height={1} />
+              <text fg={theme.text.default}>{paletteOption().title}</text>
+              <text fg={theme.text.subdued}>{paletteOption().description}</text>
+              <For each={[components.slice(0, 4), components.slice(4)]}>
+                {(row) => (
+                  <text>
+                    <For each={row}>
+                      {(value, index) => (
+                        <>
+                          <Show when={index() > 0}>
+                            <span style={{ fg: theme.text.subdued }}> · </span>
+                          </Show>
+                          <span style={{ fg: presentation().swatches[value.id] }}>
+                            {value.id === component().id ? "›" : ""}
+                            {value.label} {settingDescription(value)}
+                          </span>
+                        </>
+                      )}
+                    </For>
+                  </text>
+                )}
+              </For>
+              <box height={1} />
               <markdown
                 width="100%"
                 syntaxStyle={themes.currentSyntax()}
@@ -182,10 +416,22 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
       </Show>
       <StoryFooter
         context={props.context}
-        title="storybook / Mermaid layouts"
-        details={[`${selected() + 1}/${fixtures.length}`, fixture().id, `${dimensions().width}x${dimensions().height}`]}
+        title="storybook / Mermaid color lab"
+        details={[
+          `${selected() + 1}/${fixtures.length}`,
+          fixture().id,
+          selectedPalette() === undefined ? "custom" : `${selectedPalette()! + 1}/${palettes.length}`,
+          paletteOption().id,
+          `${dimensions().width}x${dimensions().height}`,
+        ]}
+        status={`Editing ${component().label}`}
+        message={`${componentSetting().color === 0 ? "neutral" : `color ${componentSetting().color}`}${component().dimmable ? ` · ${dimness[componentSetting().tone]}` : " · full brightness"}`}
         controls={[
-          { shortcut: "j/k or ←/→", label: "fixture" },
+          { shortcut: "↑/↓", label: "fixture" },
+          { shortcut: "←/→", label: "preset" },
+          { shortcut: "tab", label: "component" },
+          { shortcut: "c", label: "color" },
+          ...(component().dimmable ? [{ shortcut: "d", label: "dim" }] : []),
           { shortcut: "r", label: "reset" },
           { shortcut: "esc", label: "back" },
         ]}
@@ -196,6 +442,6 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
 
 export const mermanLayoutsStory: Story = {
   id: "merman-layouts",
-  title: "Mermaid layouts",
+  title: "Mermaid color lab",
   render: (context) => <MermanLayoutsStory context={context} />,
 }

--- a/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/merman-layouts.tsx
@@ -1,9 +1,6 @@
 import type { Plugin } from "@opencode-ai/plugin/tui"
-import { createMermaidCodeBlockRenderer } from "@opencode-ai/merman/markdown"
-import { resolveOpenCodeDiagramPalette } from "@opencode-ai/merman/palette"
-import { RGBA } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
-import { createMemo, createSignal, For, onCleanup, Show } from "solid-js"
+import { createMemo, createSignal, Show } from "solid-js"
 import { useTheme, useThemes } from "../../../context/theme"
 import { usePlugin } from "../../../plugin/context"
 import type { Story } from "./index"
@@ -28,7 +25,6 @@ const fixtures = [
   end
 
   subgraph AWS[AWS]
-    direction TB
     EKS[EKS cluster]
     API[Console API pod<br/>1 replica]
     OTEL[OTel collector]
@@ -53,30 +49,40 @@ const fixtures = [
   ECR --> API`,
   },
   {
-    id: "grouped-flow",
-    title: "Grouped request pipeline",
+    id: "nested-flow",
+    title: "Nested directed groups",
     source: `flowchart LR
-  Input([Input]) --> Gateway[API gateway]
-  subgraph Platform[Platform]
-    Gateway --> Auth[Authenticate]
-    Auth -->|accepted| Queue[(Work queue)]
-    Queue --> Worker[Worker] --> Store[(Result store)]
+  Input([Input]) --> Parse
+  subgraph Outer[Outer orchestration]
+    direction RL
+    subgraph Inner[Inner pipeline]
+      direction TD
+      Parse[Parse request] --> Validate{Valid?}
+      Validate -->|yes| Cache[(Cache)]
+      Cache -->|stale| Validate
+    end
+    Validate --> Dispatch[[Dispatch work]]
+    Dispatch -->|requeue| Parse
   end
-  Store --> Output([Output])`,
+  Dispatch -. result .-> Output([Output])
+  Output -->|audit| Cache`,
   },
   {
-    id: "state-lifecycle",
-    title: "Review lifecycle",
+    id: "state-feedback",
+    title: "Dense state feedback",
     source: `stateDiagram-v2
   direction TB
-  [*] --> Ready
-  Ready --> Running: start
-  Running --> Review: submit
-  Review --> Done: approve
-  Done --> [*]: finish
-  note right of Review
-    Review preserves the original request
-    and records the final decision
+  [*] --> Root
+  Root --> Alpha: dispatch alpha
+  Root --> Beta: dispatch beta
+  Alpha --> Merge: alpha complete
+  Beta --> Merge: beta complete
+  Merge --> Alpha: retry alpha
+  Merge --> Beta: retry beta
+  Merge --> [*]: finish
+  note right of Merge
+    Retries preserve the original request
+    and remain visible after compaction
   end note`,
   },
   {
@@ -90,7 +96,6 @@ const fixtures = [
       [*] --> Clean
       Clean --> Dirty: edit
       Dirty --> Clean: save
-      Dirty --> [*]
     }
     Open --> Closing: request close
     Closing --> Open: cancel
@@ -100,184 +105,7 @@ const fixtures = [
   [*] --> Session: hydrate
   Session --> [*]: release`,
   },
-  {
-    id: "flow-fanout",
-    title: "Fan-out and reconvergence",
-    source: `flowchart LR
-  Request([Request]) --> Gateway[API gateway]
-  Gateway -->|authenticate| Auth[Authentication]
-  Gateway -->|rate limit| Limit[Rate limiter]
-  Gateway -->|cache lookup| Cache[(Response cache)]
-  Auth --> Worker[Request worker]
-  Limit --> Worker
-  Cache --> Worker
-  Worker --> Response([Response])`,
-  },
-  {
-    id: "flow-feedback",
-    title: "Retry and failure routes",
-    source: `flowchart TD
-  Start([Incoming job]) --> Validate{Valid?}
-  Validate -->|yes| Queue[(Job queue)]
-  Validate -->|no| Reject[Reject request]
-  Queue --> Execute[Execute job]
-  Execute -->|retry| Queue
-  Execute -->|failed| Failed[Dead letter queue]
-  Execute -->|complete| Complete([Complete])`,
-  },
-  {
-    id: "flow-nested-groups",
-    title: "Nested deployment groups",
-    source: `flowchart LR
-  Browser([Browser]) --> Gateway[Gateway]
-  subgraph Cloud[Cloud platform]
-    direction TB
-    subgraph Compute[Compute]
-      API[API service] --> Worker[Background worker]
-    end
-    subgraph Storage[Storage]
-      Database[(Database)]
-      Cache[(Cache)]
-    end
-    API --> Database
-    Worker --> Cache
-  end
-  Gateway --> API
-  Worker --> Result([Result])`,
-  },
-  {
-    id: "flow-long-labels",
-    title: "Long route labels",
-    source: `flowchart LR
-  Client[Desktop client] -->|exchange authorization code| Auth[Authorization service]
-  Auth -->|validate signed access token| API[Application API]
-  API -->|read tenant configuration| Database[(Tenant database)]
-  API -->|publish background work item| Queue[(Work queue)]
-  Queue --> Worker[Background worker]
-  Worker -->|notify subscribed clients| Client`,
-  },
-  {
-    id: "state-choice",
-    title: "Choice and recovery",
-    source: `stateDiagram-v2
-  direction TB
-  [*] --> Pending
-  Pending --> Decision: review
-  state Decision <<choice>>
-  Decision --> Approved: accept
-  Decision --> Rejected: reject
-  Rejected --> Pending: retry
-  Approved --> [*]: complete`,
-  },
-  {
-    id: "state-parallel",
-    title: "Parallel transitions",
-    source: `stateDiagram-v2
-  direction LR
-  [*] --> Idle
-  Idle --> Active: first request
-  Idle --> Active: second request
-  Idle --> Active: resumed request
-  Active --> Idle: reset
-  Active --> [*]: shutdown`,
-  },
-  {
-    id: "state-notes",
-    title: "Notes and feedback routes",
-    source: `stateDiagram-v2
-  direction LR
-  [*] --> Draft
-  Draft --> Review: submit
-  Review --> Published: approve
-  Published --> Draft: revise
-  note left of Draft: Content is editable
-  note right of Review: Requires two approvals
-  note right of Published: Readers can subscribe`,
-  },
-  {
-    id: "state-self-loops",
-    title: "State self-transitions",
-    source: `stateDiagram-v2
-  direction TB
-  [*] --> Listening
-  Listening --> Listening: heartbeat
-  Listening --> Listening: refresh token
-  Listening --> Connected: client connected
-  Connected --> Connected: received message
-  Connected --> Listening: disconnected
-  Connected --> [*]: shutdown`,
-  },
 ] as const
-
-const components = [
-  { id: "lines", label: "lines", dimmable: true },
-  { id: "boxes", label: "boxes", dimmable: true },
-  { id: "boxText", label: "box text", dimmable: false },
-  { id: "labels", label: "labels", dimmable: true },
-  { id: "notes", label: "notes", dimmable: true },
-  { id: "groups", label: "groups", dimmable: true },
-  { id: "markers", label: "markers", dimmable: true },
-] as const
-const dimness = ["dim", "muted", "soft", "clear"] as const
-type DiagramComponent = (typeof components)[number]["id"]
-type DiagramComponentOption = (typeof components)[number]
-type ComponentSettings = Readonly<Record<DiagramComponent, Readonly<{ color: number; tone: number }>>>
-
-const neutralSettings = {
-  lines: { color: 0, tone: 2 },
-  boxes: { color: 0, tone: 1 },
-  boxText: { color: 0, tone: 3 },
-  labels: { color: 0, tone: 0 },
-  notes: { color: 0, tone: 2 },
-  groups: { color: 0, tone: 1 },
-  markers: { color: 0, tone: 2 },
-} as const satisfies ComponentSettings
-
-const palettes = [
-  {
-    id: "neutral",
-    title: "Monochrome",
-    description: "Restrained neutral hierarchy",
-    styles: neutralSettings,
-  },
-  {
-    id: "routes",
-    title: "Colored routes",
-    description: "Neutral entities with a categorical signal color",
-    styles: {
-      ...neutralSettings,
-      lines: { color: 1, tone: 2 },
-      labels: { color: 1, tone: 0 },
-    },
-  },
-  {
-    id: "notes",
-    title: "Colored notes",
-    description: "Route and note accents with neutral structure",
-    styles: {
-      ...neutralSettings,
-      lines: { color: 1, tone: 2 },
-      labels: { color: 1, tone: 0 },
-      notes: { color: 2, tone: 2 },
-    },
-  },
-  {
-    id: "cool-groups",
-    title: "Cool groups",
-    description: "Color 4 groups and notes with restrained neutral routes",
-    styles: {
-      ...neutralSettings,
-      lines: { color: 0, tone: 0 },
-      notes: { color: 4, tone: 2 },
-      groups: { color: 4, tone: 2 },
-    },
-  },
-] as const satisfies readonly {
-  id: string
-  title: string
-  description: string
-  styles: ComponentSettings
-}[]
 
 function MermanLayoutsStory(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
@@ -285,111 +113,11 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
   const themes = useThemes()
   const plugins = usePlugin()
   const [selected, setSelected] = createSignal(0)
-  const [selectedPalette, setSelectedPalette] = createSignal<number | undefined>(3)
-  const [selectedComponent, setSelectedComponent] = createSignal(0)
-  const [settings, setSettings] = createSignal<ComponentSettings>(palettes[3].styles)
   const [generation, setGeneration] = createSignal(0)
   const fixture = createMemo(() => fixtures[selected()]!)
-  const component = createMemo(() => components[selectedComponent()]!)
-  const componentSetting = createMemo(() => settings()[component().id])
-  const paletteOption = createMemo(() => {
-    const index = selectedPalette()
-    if (index !== undefined) return palettes[index]!
-    return {
-      id: "custom",
-      title: "Custom",
-      description: `Editing ${component().label} · ${componentSetting().color === 0 ? "neutral" : `color ${componentSetting().color}`}${component().dimmable ? ` · ${dimness[componentSetting().tone]}` : " · full brightness"}`,
-    }
-  })
-  const presentation = createMemo(() => {
-    const base = resolveOpenCodeDiagramPalette(props.context.theme, props.context.themeMode)
-    const neutral = [theme.text.subdued, base.muted, base.secondary, theme.text.default]
-    const steps =
-      props.context.themeMode === "light" ? ([400, 500, 700, 800] as const) : ([600, 500, 300, 200] as const)
-    const color = (id: DiagramComponent, tone = settings()[id].tone) => {
-      const value = settings()[id]
-      if (value.color === 0) return neutral[tone] ?? neutral[2]!
-      return theme.categorical[(value.color - 1) % theme.categorical.length]![steps[tone] ?? steps[2]]
-    }
-    const labelAccent = color("labels", 3)
-    const labelAlpha = [0.08, 0.12, 0.18, 0.24][settings().labels.tone] ?? 0.12
-
-    const colors = {
-      ...base,
-      text: theme.text.default,
-      boxText: color("boxText", 3),
-      boxBorder: color("boxes"),
-      line: color("lines"),
-      labelBackground: RGBA.fromValues(labelAccent.r, labelAccent.g, labelAccent.b, labelAlpha),
-      group: color("groups"),
-      groupText: color("groups"),
-      marker: color("markers"),
-      noteBorder: color("notes"),
-      noteText: color("notes", 3),
-      noteConnector: color("notes"),
-    }
-    return {
-      colors,
-      swatches: {
-        lines: colors.line,
-        boxes: colors.boxBorder,
-        boxText: colors.boxText,
-        labels: labelAccent,
-        notes: colors.noteBorder,
-        groups: colors.group,
-        markers: colors.marker,
-      },
-    }
-  })
-  const rendered = createMemo(() => ({
-    fixture: fixture(),
-    colors: presentation().colors,
-    generation: generation(),
-    width: dimensions().width,
-  }))
-  const markdown = createMemo(() => `\`\`\`mermaid-story\n${fixture().source}\n\`\`\``)
-  const moveFixture = (offset: number) =>
-    setSelected((current) => (current + offset + fixtures.length) % fixtures.length)
-  const applyPalette = (index: number) => {
-    setSelectedPalette(index)
-    setSettings(palettes[index]!.styles)
-  }
-  const movePalette = (offset: number) => {
-    const current = selectedPalette() ?? (offset > 0 ? -1 : 0)
-    applyPalette((current + offset + palettes.length) % palettes.length)
-  }
-  const cycleColor = () => {
-    const selected = component().id
-    setSettings((current) => ({
-      ...current,
-      [selected]: { ...current[selected], color: (current[selected].color + 1) % (theme.categorical.length + 1) },
-    }))
-    setSelectedPalette(undefined)
-  }
-  const cycleDimness = () => {
-    if (!component().dimmable) return
-    const selected = component().id
-    setSettings((current) => ({
-      ...current,
-      [selected]: { ...current[selected], tone: (current[selected].tone + 1) % dimness.length },
-    }))
-    setSelectedPalette(undefined)
-  }
-  const settingDescription = (item: DiagramComponentOption, separator = "/") => {
-    const value = settings()[item.id]
-    const color = value.color === 0 ? "neutral" : `color ${value.color}`
-    return item.dimmable ? `${color}${separator}${dimness[value.tone]}` : color
-  }
-
-  onCleanup(
-    props.context.markdown.registerCodeBlockRenderer(
-      "mermaid-story",
-      createMermaidCodeBlockRenderer(props.context.renderer, () => ({
-        colors: presentation().colors,
-        layoutMaxWidth: Math.max(1, dimensions().width - 5),
-      })),
-    ),
-  )
+  const rendered = createMemo(() => ({ fixture: fixture(), generation: generation() }))
+  const markdown = createMemo(() => `\`\`\`mermaid\n${fixture().source}\n\`\`\``)
+  const move = (offset: number) => setSelected((current) => (current + offset + fixtures.length) % fixtures.length)
 
   props.context.keymap.layer(() => ({
     commands: [
@@ -400,67 +128,23 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
         run: () => props.context.ui.router.navigate({ type: "plugin", name: "storybook" }),
       },
       {
-        bind: "up,k",
+        bind: "left,k",
         title: "Previous fixture",
         group: "Storybook",
-        run: () => moveFixture(-1),
+        run: () => move(-1),
       },
       {
-        bind: "down,j",
+        bind: "right,j",
         title: "Next fixture",
         group: "Storybook",
-        run: () => moveFixture(1),
+        run: () => move(1),
       },
-      {
-        bind: "left,h",
-        title: "Previous palette",
-        group: "Storybook",
-        run: () => movePalette(-1),
-      },
-      {
-        bind: "right,l",
-        title: "Next palette",
-        group: "Storybook",
-        run: () => movePalette(1),
-      },
-      {
-        bind: "tab",
-        title: "Next diagram component",
-        group: "Storybook",
-        run: () => setSelectedComponent((current) => (current + 1) % components.length),
-      },
-      {
-        bind: "shift+tab",
-        title: "Previous diagram component",
-        group: "Storybook",
-        run: () => setSelectedComponent((current) => (current + components.length - 1) % components.length),
-      },
-      {
-        bind: "c",
-        title: "Cycle component color",
-        group: "Storybook",
-        run: cycleColor,
-      },
-      {
-        bind: "d",
-        title: "Cycle component dimness",
-        group: "Storybook",
-        run: cycleDimness,
-      },
-      ...palettes.map((item, index) => ({
-        bind: String(index + 1),
-        title: `Use ${item.title}`,
-        group: "Storybook",
-        run: () => applyPalette(index),
-      })),
       {
         bind: "r",
         title: "Reset fixture",
         group: "Storybook",
         run: () => {
           setSelected(0)
-          setSelectedComponent(0)
-          applyPalette(3)
           setGeneration((current) => current + 1)
         },
       },
@@ -474,34 +158,12 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
       flexDirection="column"
       backgroundColor={theme.background.default}
     >
-      <scrollbox flexGrow={1} minHeight={0} viewportOptions={{ paddingRight: 1 }}>
-        <Show when={rendered()} keyed>
-          {(item) => (
+      <Show when={rendered()} keyed>
+        {(item) => (
+          <scrollbox flexGrow={1} minHeight={0} viewportOptions={{ paddingRight: 1 }}>
             <box paddingLeft={2} paddingRight={2} paddingTop={1} flexDirection="column">
               <text fg={theme.text.default}>{item.fixture.title}</text>
               <text fg={theme.text.subdued}>{item.fixture.id}</text>
-              <box height={1} />
-              <text fg={theme.text.default}>{paletteOption().title}</text>
-              <text fg={theme.text.subdued}>{paletteOption().description}</text>
-              <For each={[components.slice(0, 4), components.slice(4)]}>
-                {(row) => (
-                  <text>
-                    <For each={row}>
-                      {(value, index) => (
-                        <>
-                          <Show when={index() > 0}>
-                            <span style={{ fg: theme.text.subdued }}> · </span>
-                          </Show>
-                          <span style={{ fg: presentation().swatches[value.id] }}>
-                            {value.id === component().id ? "›" : ""}
-                            {value.label} {settingDescription(value)}
-                          </span>
-                        </>
-                      )}
-                    </For>
-                  </text>
-                )}
-              </For>
               <box height={1} />
               <markdown
                 width="100%"
@@ -515,28 +177,15 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
                 renderNode={plugins.markdown()}
               />
             </box>
-          )}
-        </Show>
-      </scrollbox>
+          </scrollbox>
+        )}
+      </Show>
       <StoryFooter
         context={props.context}
-        title="storybook / Mermaid color lab"
-        details={[
-          `${selected() + 1}/${fixtures.length}`,
-          fixture().id,
-          selectedPalette() === undefined ? "custom" : `${selectedPalette()! + 1}/${palettes.length}`,
-          paletteOption().id,
-          `${dimensions().width}x${dimensions().height}`,
-        ]}
-        status={`Editing ${component().label}`}
-        message={`${componentSetting().color === 0 ? "neutral" : `color ${componentSetting().color}`}${component().dimmable ? ` · ${dimness[componentSetting().tone]}` : " · full brightness"}`}
+        title="storybook / Mermaid layouts"
+        details={[`${selected() + 1}/${fixtures.length}`, fixture().id, `${dimensions().width}x${dimensions().height}`]}
         controls={[
-          { shortcut: "↑/↓", label: "fixture" },
-          { shortcut: "←/→", label: "preset" },
-          { shortcut: "tab", label: "component" },
-          { shortcut: "c", label: "color" },
-          ...(component().dimmable ? [{ shortcut: "d", label: "dim" }] : []),
-          { shortcut: "drag", label: "pan" },
+          { shortcut: "j/k or ←/→", label: "fixture" },
           { shortcut: "r", label: "reset" },
           { shortcut: "esc", label: "back" },
         ]}
@@ -547,6 +196,6 @@ function MermanLayoutsStory(props: { context: Plugin.Context }) {
 
 export const mermanLayoutsStory: Story = {
   id: "merman-layouts",
-  title: "Mermaid color lab",
+  title: "Mermaid layouts",
   render: (context) => <MermanLayoutsStory context={context} />,
 }

--- a/packages/tui/src/plugin/api.tsx
+++ b/packages/tui/src/plugin/api.tsx
@@ -121,6 +121,9 @@ export function createPluginContext(input: {
     get theme() {
       return host.themes.currentTokens()
     },
+    get themeMode() {
+      return host.themes.mode()
+    },
     markdown: {
       registerCodeBlockRenderer(language, render) {
         const name = infoStringToFiletype(language)

--- a/packages/tui/test/component/session-tabs-mouse.test.tsx
+++ b/packages/tui/test/component/session-tabs-mouse.test.tsx
@@ -199,9 +199,12 @@ test("reflows held tabs when the pointer leaves the strip", async () => {
     await app.mockMouse.click(22, 0)
     await app.waitForFrame((frame) => items().length === 3 && Array.from(frame.split("\n")[0] ?? "")[22] === "✕")
 
+    await app.renderOnce()
+    const held = app.captureCharFrame().split("\n")[0] ?? ""
     await app.mockMouse.moveTo(0, 1)
+    await app.waitForFrame((frame) => (frame.split("\n")[0] ?? "").indexOf("Third") < held.indexOf("Third"))
     await app.mockMouse.moveTo(20, 0)
-    await app.waitForFrame((frame) => Array.from(frame.split("\n")[0] ?? "")[20] === "✕", { maxPasses: 100 })
+    await app.waitForFrame((frame) => Array.from(frame.split("\n")[0] ?? "")[20] === "✕")
     expect(Array.from(app.captureCharFrame().split("\n")[0] ?? "")[22]).not.toBe("✕")
   } finally {
     app.renderer.destroy()


### PR DESCRIPTION
## What

Give Mermaid flowcharts and state diagrams one coherent visual hierarchy while preserving the extra structure state diagrams need.

- Adds component-level colors for routes, boxes, box text, labels, notes, groups, and markers.
- Applies the selected neutral route/box palette with color 4 accents for groups and notes.
- Gives flowchart and state transition labels the same subtle padded background treatment.
- Fixes route gaps at composite boundaries, shared-source fan-out junctions, and top-level group separation.
- Adds a fixture-driven Mermaid color lab that renders the production code-block renderer.

## Before / After

**Before:** state labels only tinted their text cells or one adjacent cell. Their badges did not match flowchart edge labels, and labels at a grid boundary could lose one side of their horizontal padding. Shared route sources and group boundaries could also render misleading intersections.

**After:** flowchart and state labels use the same foreground/background style pipeline and one-cell padding on both available sides. Composite crossings create visible frame gaps, fan-out sources preserve the complete junction, and externally placed nodes remain outside local-direction groups.

## How

- `packages/merman/src/core`: shares style-based foreground/background rendering and label padding primitives while preserving styled trailing spaces that plain-text diagram output deliberately trims.
- `packages/merman/src/flowchart`: separates node text, borders, group titles, and label backgrounds; hardens fan-out junctions, keeps sibling groups compact and dependency ordered, and contains cross-group routes inside their shared parent.
- `packages/merman/src/state`: separates state/group text from borders, applies the shared label backgrounds, preserves route gaps through composite frames, keeps reciprocal states on the main layout backbone, places choice/self-loop labels on their actual routes, separates competing transition badges without detaching them from their routes, and avoids unused composite routing gutters.
- `packages/merman/src/palette.ts`: defines the selected production palette and resolves its accents from the authoritative theme mode through one shared adapter.
- `packages/plugin/src/tui/context.ts` and `packages/tui/src/plugin/api.tsx`: expose the reactive selected light/dark mode to TUI plugins instead of inferring it from background colors.
- `packages/core/src/worktree.ts`: executes Windows worktree setup scripts through the supported shell path so nested command quotes survive process spawning.
- `packages/server/package.json`: pins the shared Effect platform runtime so clean packed-SDK consumers cannot resolve an incompatible prerelease.
- `packages/tui/test/component/session-tabs-mouse.test.tsx`: refreshes the pointer hit grid after tab removal and waits for the actual leave/reflow transition, stabilizing the existing Windows regression test.

## Scope

This changes component-level overrides for flowchart and state diagrams. Sequence, Gantt, git graph, and timeline retain their existing palette mappings.

## Testing

- `bun run test` in `packages/merman`: 496 passed, including custom-theme, nested group/composite, responsive fan-out, choice, self-loop, symmetric label padding, and badge separation regressions plus 306 layout-audit runs with zero violations and 38 total crossings.
- `bun run test` in `packages/tui`: 762 passed, 5 skipped.
- `bun run test` in `packages/plugin`: 3 passed.
- `bun run test test/component/session-tabs-mouse.test.tsx --rerun-each 100` in `packages/tui`: 400 passed.
- `OPENCODE_EXPERIMENTAL_DISABLE_FILEWATCHER=true bun run test test/component/session-tabs-mouse.test.tsx --rerun-each 50` in `packages/tui`: 200 passed under the Windows CI configuration.
- `bun run test test/worktree.test.ts` in `packages/core`: 20 passed, including worktree setup-script coverage.
- `bun run test test/workerd.test.ts` in `packages/server`: passed.
- `bun run verify:package` in `packages/sdk`: packed npm consumer booted successfully in workerd.
- `bun typecheck` in `packages/merman`.
- `bun typecheck` in `packages/tui`.
- `bun typecheck` in `packages/plugin`.
- `bun typecheck` in `packages/server`.
- `bun typecheck` in `packages/core`.
- Repository pre-push typecheck: 32 packages passed.
- Live TUI verification with `OPENCODE_STORY=merman-layouts bun run dev:live` at narrow and wide terminal widths.

## Demo

The fixture-driven story renders the real production Mermaid renderer. The first image shows the asymmetric state-label badge before the fix; the second shows equal horizontal padding after it.

| Before | After |
| --- | --- |
| ![State labels before](https://github.com/user-attachments/assets/0a85a349-20bf-4868-9e5f-b9d63e1a90dc) | ![State labels after](https://github.com/user-attachments/assets/834c2953-bb7b-44ab-b60e-a626c29fad8f) |

Nested composite state rendering keeps its primary lifecycle on one horizontal backbone at 160 columns and folds vertically without clipping labels at 96 columns:

| Wide terminal | Narrow terminal |
| --- | --- |
| ![Compact horizontal nested state](https://github.com/user-attachments/assets/bad1785a-b211-4719-a6ce-f2591fc1c8cf) | ![Responsive vertical nested state](https://github.com/user-attachments/assets/811b4983-a9e5-46dd-9433-4eb77c4561e1) |

Nested sibling flowchart groups remain compact, correctly ordered, and contained at narrow terminal widths:

![Compact nested flowchart groups](https://github.com/user-attachments/assets/87dc6fc8-d934-4a11-9679-c40f3bcb5b74)

## Flow

```mermaid
flowchart LR
  Theme[Resolved TUI theme] --> Palette[Component palette]
  Palette --> Renderer[Mermaid code-block renderer]
  Renderer --> Flowchart[Flowchart style table]
  Renderer --> State[State style table]
  Flowchart --> Grid[Shared styled-grid renderer]
  State --> Grid
  Grid --> TUI[OpenTUI output]
```
