### PR TITLE
fix(ai): ignore unknown Anthropic stream variants

### DIFF
--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -1236,6 +1236,7 @@ const onContentBlockDelta = Effect.fn("AnthropicMessages.onContentBlockDelta")(f
   const delta = event.delta
 
   if (delta?.type === "text_delta" && delta.text) {
+    if (!state.lifecycle.text.has(`text-${event.index ?? 0}`)) return [state, NO_EVENTS] satisfies StepResult
     const events: LLMEvent[] = []
     return [
       { ...state, lifecycle: Lifecycle.textDelta(state.lifecycle, events, `text-${event.index ?? 0}`, delta.text) },
@@ -1244,6 +1245,7 @@ const onContentBlockDelta = Effect.fn("AnthropicMessages.onContentBlockDelta")(f
   }
 
   if (delta?.type === "thinking_delta" && delta.thinking) {
+    if (!state.lifecycle.reasoning.has(`reasoning-${event.index ?? 0}`)) return [state, NO_EVENTS] satisfies StepResult
     const events: LLMEvent[] = []
     return [
       {
@@ -1256,6 +1258,7 @@ const onContentBlockDelta = Effect.fn("AnthropicMessages.onContentBlockDelta")(f
 
   if (delta?.type === "signature_delta" && delta.signature) {
     const index = event.index ?? 0
+    if (!state.lifecycle.reasoning.has(`reasoning-${index}`)) return [state, NO_EVENTS] satisfies StepResult
     return [
       {
         ...state,
@@ -1387,6 +1390,19 @@ const invalidStreamEvent = (event: AnthropicEvent) =>
   )
 
 const step = (state: ParserState, event: AnthropicEvent) => {
+  if (!SSE_EVENTS.has(event.type)) return Effect.succeed<StepResult>([state, NO_EVENTS])
+  if (
+    event.type !== "content_block_start" &&
+    event.content_block !== undefined &&
+    Option.isNone(decodeAnthropicStreamBlock(event.content_block))
+  )
+    return invalidStreamEvent(event)
+  if (
+    event.type !== "content_block_delta" &&
+    event.delta !== undefined &&
+    Option.isNone(decodeAnthropicStreamDelta(event.delta))
+  )
+    return invalidStreamEvent(event)
   if (event.type === "message_start") return Effect.succeed(onMessageStart(state, event))
   if (event.type === "content_block_start") {
     if (event.content_block === undefined) return Effect.succeed<StepResult>([state, NO_EVENTS])

--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -1405,7 +1405,6 @@ const step = (state: ParserState, event: AnthropicEvent) => {
     return invalidStreamEvent(event)
   if (event.type === "message_start") return Effect.succeed(onMessageStart(state, event))
   if (event.type === "content_block_start") {
-    if (event.content_block === undefined) return Effect.succeed<StepResult>([state, NO_EVENTS])
     if (!ProviderShared.isRecord(event.content_block) || typeof event.content_block.type !== "string")
       return invalidStreamEvent(event)
     if (!isKnownStreamBlockType(event.content_block.type)) return Effect.succeed<StepResult>([state, NO_EVENTS])
@@ -1423,7 +1422,6 @@ const step = (state: ParserState, event: AnthropicEvent) => {
     return Effect.succeed(onContentBlockStart(state, { ...event, content_block: block }))
   }
   if (event.type === "content_block_delta") {
-    if (event.delta === undefined) return Effect.succeed<StepResult>([state, NO_EVENTS])
     if (!ProviderShared.isRecord(event.delta)) return invalidStreamEvent(event)
     if (typeof event.delta.type === "string" && !isKnownStreamDeltaType(event.delta.type))
       return Effect.succeed<StepResult>([state, NO_EVENTS])
@@ -1433,7 +1431,6 @@ const step = (state: ParserState, event: AnthropicEvent) => {
   }
   if (event.type === "content_block_stop") return onContentBlockStop(state, event)
   if (event.type === "message_delta") {
-    if (event.delta === undefined) return Effect.succeed(onMessageDelta(state, { ...event, delta: undefined }))
     const decoded = decodeAnthropicStreamDelta(event.delta)
     if (Option.isNone(decoded)) return invalidStreamEvent(event)
     return Effect.succeed(onMessageDelta(state, { ...event, delta: decoded.value }))

--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -1389,6 +1389,7 @@ const invalidStreamEvent = (event: AnthropicEvent) =>
 const step = (state: ParserState, event: AnthropicEvent) => {
   if (event.type === "message_start") return Effect.succeed(onMessageStart(state, event))
   if (event.type === "content_block_start") {
+    if (event.content_block === undefined) return Effect.succeed<StepResult>([state, NO_EVENTS])
     if (!ProviderShared.isRecord(event.content_block) || typeof event.content_block.type !== "string")
       return invalidStreamEvent(event)
     if (!isKnownStreamBlockType(event.content_block.type)) return Effect.succeed<StepResult>([state, NO_EVENTS])
@@ -1406,8 +1407,10 @@ const step = (state: ParserState, event: AnthropicEvent) => {
     return Effect.succeed(onContentBlockStart(state, { ...event, content_block: block }))
   }
   if (event.type === "content_block_delta") {
-    if (!ProviderShared.isRecord(event.delta) || typeof event.delta.type !== "string") return invalidStreamEvent(event)
-    if (!isKnownStreamDeltaType(event.delta.type)) return Effect.succeed<StepResult>([state, NO_EVENTS])
+    if (event.delta === undefined) return Effect.succeed<StepResult>([state, NO_EVENTS])
+    if (!ProviderShared.isRecord(event.delta)) return invalidStreamEvent(event)
+    if (typeof event.delta.type === "string" && !isKnownStreamDeltaType(event.delta.type))
+      return Effect.succeed<StepResult>([state, NO_EVENTS])
     const decoded = decodeAnthropicStreamDelta(event.delta)
     if (Option.isNone(decoded)) return invalidStreamEvent(event)
     return onContentBlockDelta(state, { ...event, delta: decoded.value })

--- a/packages/ai/src/protocols/anthropic-messages.ts
+++ b/packages/ai/src/protocols/anthropic-messages.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer"
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
 import { Tool } from "@opencode-ai/schema/tool"
 import { Route } from "../route/client.js"
 import { Auth } from "../route/auth.js"
@@ -361,6 +361,8 @@ const AnthropicStreamBlock = Schema.Struct({
   tool_use_id: Schema.optional(Schema.String),
   content: Schema.optional(Schema.Unknown),
 })
+type AnthropicStreamBlock = Schema.Schema.Type<typeof AnthropicStreamBlock>
+const decodeAnthropicStreamBlock = Schema.decodeUnknownOption(AnthropicStreamBlock)
 
 const AnthropicStreamDelta = Schema.Struct({
   type: Schema.optional(Schema.String),
@@ -371,13 +373,15 @@ const AnthropicStreamDelta = Schema.Struct({
   stop_reason: optionalNull(Schema.String),
   stop_sequence: optionalNull(Schema.String),
 })
+type AnthropicStreamDelta = Schema.Schema.Type<typeof AnthropicStreamDelta>
+const decodeAnthropicStreamDelta = Schema.decodeUnknownOption(AnthropicStreamDelta)
 
 const AnthropicEvent = Schema.Struct({
   type: Schema.String,
   index: Schema.optional(Schema.Number),
   message: Schema.optional(Schema.Struct({ usage: Schema.optional(AnthropicUsage) })),
-  content_block: Schema.optional(AnthropicStreamBlock),
-  delta: Schema.optional(AnthropicStreamDelta),
+  content_block: Schema.optional(Schema.Unknown),
+  delta: Schema.optional(Schema.Unknown),
   usage: Schema.optional(AnthropicUsage),
   // `type` and `message` are both required per Anthropic's spec, but
   // OpenAI-compatible proxies and gateway translations occasionally drop one
@@ -1106,7 +1110,7 @@ const SERVER_TOOL_RESULT_NAMES: Record<AnthropicServerToolResultType, string> = 
 
 const isServerToolResultType = (type: string): type is AnthropicServerToolResultType => type in SERVER_TOOL_RESULT_NAMES
 
-const serverToolResultEvent = (block: NonNullable<AnthropicEvent["content_block"]>): LLMEvent | undefined => {
+const serverToolResultEvent = (block: AnthropicStreamBlock): LLMEvent | undefined => {
   if (!block.type || !isServerToolResultType(block.type)) return undefined
   const errorPayload =
     typeof block.content === "object" && block.content !== null && "type" in block.content
@@ -1133,7 +1137,10 @@ const onMessageStart = (state: ParserState, event: AnthropicEvent): StepResult =
   return [usage ? { ...state, usage: mergeUsage(state.usage, usage) } : state, NO_EVENTS]
 }
 
-const onContentBlockStart = (state: ParserState, event: AnthropicEvent): StepResult => {
+const onContentBlockStart = (
+  state: ParserState,
+  event: AnthropicEvent & { readonly content_block: AnthropicStreamBlock },
+): StepResult => {
   const block = event.content_block
   if (!block) return [state, NO_EVENTS]
 
@@ -1224,7 +1231,7 @@ const onContentBlockStart = (state: ParserState, event: AnthropicEvent): StepRes
 
 const onContentBlockDelta = Effect.fn("AnthropicMessages.onContentBlockDelta")(function* (
   state: ParserState,
-  event: AnthropicEvent,
+  event: AnthropicEvent & { readonly delta: AnthropicStreamDelta },
 ) {
   const delta = event.delta
 
@@ -1301,7 +1308,10 @@ const onContentBlockStop = Effect.fn("AnthropicMessages.onContentBlockStop")(fun
   return [{ ...state, lifecycle, tools: result.tools, reasoningSignatures }, events] satisfies StepResult
 })
 
-const onMessageDelta = (state: ParserState, event: AnthropicEvent): StepResult => {
+const onMessageDelta = (
+  state: ParserState,
+  event: AnthropicEvent & { readonly delta?: AnthropicStreamDelta },
+): StepResult => {
   const usage = mergeUsage(state.usage, mapUsage(event.usage))
   return [
     {
@@ -1356,11 +1366,36 @@ const onError = (event: AnthropicEvent) =>
     }),
   )
 
+const isKnownStreamBlockType = (type: string) =>
+  type === "text" ||
+  type === "thinking" ||
+  type === "redacted_thinking" ||
+  type === "tool_use" ||
+  type === "server_tool_use" ||
+  isServerToolResultType(type)
+
+const isKnownStreamDeltaType = (type: string) =>
+  type === "text_delta" || type === "thinking_delta" || type === "signature_delta" || type === "input_json_delta"
+
+const invalidStreamEvent = (event: AnthropicEvent) =>
+  Effect.fail(
+    ProviderShared.eventError(
+      ADAPTER,
+      "Invalid anthropic/anthropic-messages stream event",
+      ProviderShared.encodeJson(event),
+    ),
+  )
+
 const step = (state: ParserState, event: AnthropicEvent) => {
   if (event.type === "message_start") return Effect.succeed(onMessageStart(state, event))
   if (event.type === "content_block_start") {
-    const block = event.content_block
-    if (block && (block.type === "tool_use" || block.type === "server_tool_use")) {
+    if (!ProviderShared.isRecord(event.content_block) || typeof event.content_block.type !== "string")
+      return invalidStreamEvent(event)
+    if (!isKnownStreamBlockType(event.content_block.type)) return Effect.succeed<StepResult>([state, NO_EVENTS])
+    const decoded = decodeAnthropicStreamBlock(event.content_block)
+    if (Option.isNone(decoded)) return invalidStreamEvent(event)
+    const block = decoded.value
+    if (block.type === "tool_use" || block.type === "server_tool_use") {
       if (event.index === undefined)
         return Effect.fail(ProviderShared.eventError(ADAPTER, `Anthropic ${block.type} missing index`))
       if (!block.id)
@@ -1368,11 +1403,22 @@ const step = (state: ParserState, event: AnthropicEvent) => {
           ProviderShared.eventError(ADAPTER, `Anthropic tool_use missing id at index ${event.index}`),
         )
     }
-    return Effect.succeed(onContentBlockStart(state, event))
+    return Effect.succeed(onContentBlockStart(state, { ...event, content_block: block }))
   }
-  if (event.type === "content_block_delta") return onContentBlockDelta(state, event)
+  if (event.type === "content_block_delta") {
+    if (!ProviderShared.isRecord(event.delta) || typeof event.delta.type !== "string") return invalidStreamEvent(event)
+    if (!isKnownStreamDeltaType(event.delta.type)) return Effect.succeed<StepResult>([state, NO_EVENTS])
+    const decoded = decodeAnthropicStreamDelta(event.delta)
+    if (Option.isNone(decoded)) return invalidStreamEvent(event)
+    return onContentBlockDelta(state, { ...event, delta: decoded.value })
+  }
   if (event.type === "content_block_stop") return onContentBlockStop(state, event)
-  if (event.type === "message_delta") return Effect.succeed(onMessageDelta(state, event))
+  if (event.type === "message_delta") {
+    if (event.delta === undefined) return Effect.succeed(onMessageDelta(state, { ...event, delta: undefined }))
+    const decoded = decodeAnthropicStreamDelta(event.delta)
+    if (Option.isNone(decoded)) return invalidStreamEvent(event)
+    return Effect.succeed(onMessageDelta(state, { ...event, delta: decoded.value }))
+  }
   if (event.type === "message_stop") return onMessageStop(state)
   if (event.type === "error") return onError(event)
   return Effect.succeed<StepResult>([state, NO_EVENTS])

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -771,6 +771,74 @@ describe("Anthropic Messages route", () => {
     }),
   )
 
+  it.effect("ignores unknown content block and delta variants", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { type: "message_start", message: { usage: { input_tokens: 5 } } },
+              { type: "content_block_start", index: 0, content_block: { type: "future_block", text: 42 } },
+              { type: "content_block_delta", index: 0, delta: { type: "future_delta", text: 42 } },
+              { type: "content_block_stop", index: 0 },
+              { type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
+              { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "Hello" } },
+              { type: "content_block_stop", index: 1 },
+              { type: "message_delta", delta: { stop_reason: "end_turn" }, usage: { output_tokens: 1 } },
+              { type: "message_stop" },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.message.content).toEqual([{ type: "text", text: "Hello" }])
+      expect(response.finishReason).toEqual({ normalized: "stop", raw: "end_turn" })
+    }),
+  )
+
+  it.effect("rejects malformed recognized content block variants", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { type: "message_start", message: { usage: { input_tokens: 5 } } },
+              { type: "content_block_start", index: 0, content_block: { type: "text", text: 42 } },
+            ),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expect(error.reason).toMatchObject({
+        _tag: "InvalidProviderOutput",
+        message: "Invalid anthropic/anthropic-messages stream event",
+      })
+    }),
+  )
+
+  it.effect("rejects malformed recognized content delta variants", () =>
+    Effect.gen(function* () {
+      const error = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { type: "message_start", message: { usage: { input_tokens: 5 } } },
+              { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+              { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: 42 } },
+            ),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expect(error.reason).toMatchObject({
+        _tag: "InvalidProviderOutput",
+        message: "Invalid anthropic/anthropic-messages stream event",
+      })
+    }),
+  )
+
   it.effect("rejects malformed recognized SSE events", () =>
     Effect.gen(function* () {
       const error = yield* LLMClient.generate(request).pipe(

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -778,7 +778,10 @@ describe("Anthropic Messages route", () => {
           fixedResponse(
             sseEvents(
               { type: "message_start", message: { usage: { input_tokens: 5 } } },
+              { type: "content_block_start", index: 0 },
               { type: "content_block_start", index: 0, content_block: { type: "future_block", text: 42 } },
+              { type: "content_block_delta", index: 0 },
+              { type: "content_block_delta", index: 0, delta: { text: "ignored" } },
               { type: "content_block_delta", index: 0, delta: { type: "future_delta", text: 42 } },
               { type: "content_block_stop", index: 0 },
               { type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -778,11 +778,15 @@ describe("Anthropic Messages route", () => {
           fixedResponse(
             sseEvents(
               { type: "message_start", message: { usage: { input_tokens: 5 } } },
+              { type: "future_event", content_block: 42, delta: 42 },
               { type: "content_block_start", index: 0 },
               { type: "content_block_start", index: 0, content_block: { type: "future_block", text: 42 } },
               { type: "content_block_delta", index: 0 },
               { type: "content_block_delta", index: 0, delta: { text: "ignored" } },
               { type: "content_block_delta", index: 0, delta: { type: "future_delta", text: 42 } },
+              { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hidden" } },
+              { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "hidden" } },
+              { type: "content_block_delta", index: 0, delta: { type: "signature_delta", signature: "hidden" } },
               { type: "content_block_stop", index: 0 },
               { type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
               { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "Hello" } },
@@ -839,6 +843,32 @@ describe("Anthropic Messages route", () => {
         _tag: "InvalidProviderOutput",
         message: "Invalid anthropic/anthropic-messages stream event",
       })
+    }),
+  )
+
+  it.effect("rejects malformed payloads on unrelated stream events", () =>
+    Effect.gen(function* () {
+      const events = [
+        { type: "message_start", message: { usage: { input_tokens: 1 } }, delta: 42 },
+        { type: "content_block_stop", index: 0, content_block: { type: "text", text: 42 } },
+        { type: "message_delta", delta: { stop_reason: 42 } },
+        { type: "message_stop", delta: { text: 42 } },
+        { type: "error", error: { type: "overloaded_error", message: "busy" }, content_block: 42 },
+      ]
+
+      yield* Effect.forEach(events, (event) =>
+        Effect.gen(function* () {
+          const error = yield* LLMClient.generate(request).pipe(
+            Effect.provide(fixedResponse(sseEvents(event))),
+            Effect.flip,
+          )
+
+          expect(error.reason).toMatchObject({
+            _tag: "InvalidProviderOutput",
+            message: "Invalid anthropic/anthropic-messages stream event",
+          })
+        }),
+      )
     }),
   )
 

--- a/packages/ai/test/provider/anthropic-messages.test.ts
+++ b/packages/ai/test/provider/anthropic-messages.test.ts
@@ -779,9 +779,7 @@ describe("Anthropic Messages route", () => {
             sseEvents(
               { type: "message_start", message: { usage: { input_tokens: 5 } } },
               { type: "future_event", content_block: 42, delta: 42 },
-              { type: "content_block_start", index: 0 },
               { type: "content_block_start", index: 0, content_block: { type: "future_block", text: 42 } },
-              { type: "content_block_delta", index: 0 },
               { type: "content_block_delta", index: 0, delta: { text: "ignored" } },
               { type: "content_block_delta", index: 0, delta: { type: "future_delta", text: 42 } },
               { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hidden" } },
@@ -850,7 +848,10 @@ describe("Anthropic Messages route", () => {
     Effect.gen(function* () {
       const events = [
         { type: "message_start", message: { usage: { input_tokens: 1 } }, delta: 42 },
+        { type: "content_block_start", index: 0 },
+        { type: "content_block_delta", index: 0 },
         { type: "content_block_stop", index: 0, content_block: { type: "text", text: 42 } },
+        { type: "message_delta" },
         { type: "message_delta", delta: { stop_reason: 42 } },
         { type: "message_stop", delta: { text: 42 } },
         { type: "error", error: { type: "overloaded_error", message: "busy" }, content_block: 42 },


### PR DESCRIPTION
## Summary
- defer Anthropic content block and delta decoding until after discriminator dispatch
- ignore unknown nested variants while strictly validating recognized payloads
- preserve strict `message_delta` decoding

## Tests
- `bun typecheck` in `packages/ai`
- `bun test test/provider/anthropic-messages.test.ts --timeout 30000`
- `bun run lint packages/ai/src/protocols/anthropic-messages.ts packages/ai/test/provider/anthropic-messages.test.ts` (0 errors)