### PR TITLE
refactor(core): normalize tool input errors

### DIFF
--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -2,6 +2,7 @@ import type { ToolDefinition } from "@opencode-ai/ai"
 import { Tool } from "@opencode-ai/schema/tool"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import { Cache, Effect, JsonSchema, Schema, SchemaIssue, SchemaRepresentation } from "effect"
+import { $ZodType, toJSONSchema } from "zod/v4/core"
 
 const formatEffectIssues = SchemaIssue.makeFormatterStandardSchemaV1()
 
@@ -129,13 +130,15 @@ const encodeOutput = (schema: Tool.ValueSchema<any>, value: unknown) => {
   )
 }
 
-const isStandardSchema = (
-  schema: Tool.ValueSchema<any>,
-): schema is StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any> =>
+const isStandardSchema = (schema: Tool.ValueSchema<any>): schema is StandardSchemaV1<any, any> =>
   typeof schema === "object" && schema !== null && "~standard" in schema
 
+const isStandardJSONSchema = (
+  schema: StandardSchemaV1<any, any>,
+): schema is StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any> => "jsonSchema" in schema["~standard"]
+
 const validateStandard = (
-  schema: StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any>,
+  schema: StandardSchemaV1<any, any>,
   value: unknown,
 ): Effect.Effect<StandardSchemaV1.Result<unknown>> =>
   Effect.gen(function* () {
@@ -150,13 +153,19 @@ const validateStandard = (
 
 const inputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
   if (schema === undefined || schema === null) return {}
-  if (isStandardSchema(schema)) return schema["~standard"].jsonSchema.input({ target: "draft-2020-12" })
+  if (isStandardSchema(schema)) return standardJsonSchema(schema, "input")
   return Schema.isSchema(schema) ? toJsonSchema(schema) : schema
 }
 
 const outputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
-  if (isStandardSchema(schema)) return schema["~standard"].jsonSchema.output({ target: "draft-2020-12" })
+  if (isStandardSchema(schema)) return standardJsonSchema(schema, "output")
   return Schema.isSchema(schema) ? toJsonSchema(schema) : schema
+}
+
+const standardJsonSchema = (schema: StandardSchemaV1<any, any>, io: "input" | "output"): JsonSchema.JsonSchema => {
+  if (isStandardJSONSchema(schema)) return schema["~standard"].jsonSchema[io]({ target: "draft-2020-12" })
+  if (schema instanceof $ZodType) return toJSONSchema(schema, { target: "draft-2020-12", io })
+  throw new Error(`Schema vendor "${schema["~standard"].vendor}" does not support JSON Schema conversion`)
 }
 
 const toJsonSchema = (schema: Schema.Top): JsonSchema.JsonSchema => {

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -1,7 +1,17 @@
 import type { ToolDefinition } from "@opencode-ai/ai"
 import { Tool } from "@opencode-ai/schema/tool"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
-import { Cache, Effect, JsonSchema, Schema, SchemaRepresentation } from "effect"
+import { Cache, Effect, JsonSchema, Schema, SchemaIssue, SchemaRepresentation } from "effect"
+
+type InputIssue = {
+  readonly path: ReadonlyArray<PropertyKey>
+  readonly message: string
+}
+
+type InputResult = { readonly value: unknown } | { readonly issues: ReadonlyArray<InputIssue> }
+
+const formatEffectIssue = SchemaIssue.makeFormatterStandardSchemaV1()
+const inputIssueLimit = 5
 
 const jsonSchemas = Effect.runSync(
   Cache.make<JsonSchema.JsonSchema, Schema.Codec<unknown> | undefined>({
@@ -23,7 +33,7 @@ export const definition = (tool: Tool.Info<any, any>): ToolDefinition => ({
 
 export const execute = (tool: Tool.Info<any, any>, input: unknown, context: Tool.Context) =>
   Effect.gen(function* () {
-    const decoded = yield* decodeInput(tool.input, input)
+    const decoded = yield* decodeInput(tool, input)
     // Tool implementations declare `Tool.Error` but plugins can fail with anything at
     // runtime. A foreign typed failure would slip past every `catchTag("Tool.Error")`
     // downstream and leave its call permanently unsettled, so the declared contract is
@@ -55,19 +65,83 @@ export const execute = (tool: Tool.Info<any, any>, input: unknown, context: Tool
     }
   })
 
-const decodeInput = (schema: Tool.ValueSchema<any>, value: unknown) => {
-  if (Schema.isSchema(schema))
-    return Schema.decodeUnknownEffect(schema)(value).pipe(
-      Effect.mapError((error) => new Tool.Error({ message: `Invalid tool input: ${error.message}` })),
-    )
-  if (isStandardSchema(schema)) return validateStandard(schema, value, "Invalid tool input")
-  return Cache.get(jsonSchemas, schema).pipe(
-    Effect.flatMap((schema) =>
-      schema === undefined ? Effect.succeed(value) : Schema.decodeUnknownEffect(schema)(value),
+const decodeInput = (tool: Tool.Info<any, any>, value: unknown) =>
+  decodeInputResult(tool.input, value).pipe(
+    Effect.flatMap((result) =>
+      "issues" in result
+        ? Effect.fail(new Tool.Error({ message: formatInputIssues(effectiveName(tool), result.issues) }))
+        : Effect.succeed(result.value),
     ),
-    Effect.mapError((error) => new Tool.Error({ message: `Invalid tool input: ${error.message}` })),
+  )
+
+const decodeInputResult = (schema: Tool.ValueSchema<any>, value: unknown): Effect.Effect<InputResult> => {
+  if (Schema.isSchema(schema)) return decodeEffectInput(schema, value)
+  if (isStandardSchema(schema)) return validateStandardResult(schema, value)
+  return Cache.get(jsonSchemas, schema).pipe(
+    Effect.flatMap((schema) => (schema === undefined ? Effect.succeed({ value }) : decodeEffectInput(schema, value))),
   )
 }
+
+const decodeEffectInput = (schema: Schema.Codec<unknown>, value: unknown): Effect.Effect<InputResult> =>
+  Schema.decodeUnknownEffect(schema)(value, { errors: "all" }).pipe(
+    Effect.map((value) => ({ value })),
+    Effect.catch((error) => Effect.succeed({ issues: normalizeEffectIssues(error.issue) })),
+  )
+
+const normalizeEffectIssues = (issue: SchemaIssue.Issue): ReadonlyArray<InputIssue> =>
+  formatEffectIssue(issue).issues.map(normalizeStandardIssue)
+
+const normalizeStandardIssue = (issue: StandardSchemaV1.Issue): InputIssue => ({
+  path: issue.path?.map((segment) => (typeof segment === "object" ? segment.key : segment)) ?? [],
+  message: issue.message,
+})
+
+const validateStandardResult = (
+  schema: StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any>,
+  value: unknown,
+): Effect.Effect<InputResult> =>
+  Effect.gen(function* () {
+    const pending = yield* Effect.try({
+      try: () => schema["~standard"].validate(value),
+      catch: (error) => error,
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.succeed({ issues: [{ message: error instanceof Error ? error.message : String(error) }] }),
+      ),
+    )
+    const result =
+      pending instanceof Promise
+        ? yield* Effect.tryPromise({
+            try: () => pending,
+            catch: (error) => error,
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.succeed({ issues: [{ message: error instanceof Error ? error.message : String(error) }] }),
+            ),
+          )
+        : pending
+    if (result.issues) return { issues: result.issues.map(normalizeStandardIssue) }
+    return { value: result.value }
+  })
+
+const formatInputIssues = (tool: string, issues: ReadonlyArray<InputIssue>) => {
+  const visible = issues.slice(0, inputIssueLimit)
+  const remaining = issues.length - visible.length
+  const details = visible.map((issue) => `- ${formatInputPath(issue.path)}: ${issue.message}`)
+  if (remaining > 0) details.push(`- ...and ${remaining} more ${remaining === 1 ? "issue" : "issues"}`)
+  return `Invalid arguments for tool "${tool}":\n${details.join("\n")}\nCorrect the arguments and retry the tool.`
+}
+
+const formatInputPath = (path: ReadonlyArray<PropertyKey>) =>
+  path.reduce<string>(
+    (result, segment) =>
+      typeof segment === "number"
+        ? `${result}[${segment}]`
+        : result === ""
+          ? String(segment)
+          : `${result}.${String(segment)}`,
+    "",
+  ) || "root"
 
 const jsonSchema = (schema: JsonSchema.JsonSchema) => {
   const draft =
@@ -104,24 +178,15 @@ const validateStandard = (
   value: unknown,
   prefix: string,
 ) =>
-  Effect.gen(function* () {
-    const pending = yield* Effect.try({
-      try: () => schema["~standard"].validate(value),
-      catch: (error) => standardFailure(prefix, error),
-    })
-    const result =
-      pending instanceof Promise
-        ? yield* Effect.tryPromise({ try: () => pending, catch: (error) => standardFailure(prefix, error) })
-        : pending
-    if (result.issues)
-      return yield* new Tool.Error({
-        message: `${prefix}: ${result.issues.map((issue) => issue.message).join(", ")}`,
-      })
-    return result.value
-  })
-
-const standardFailure = (prefix: string, error: unknown) =>
-  new Tool.Error({ message: `${prefix}: ${error instanceof Error ? error.message : String(error)}` })
+  validateStandardResult(schema, value).pipe(
+    Effect.flatMap((result) =>
+      "issues" in result
+        ? Effect.fail(
+            new Tool.Error({ message: `${prefix}: ${result.issues.map((issue) => issue.message).join(", ")}` }),
+          )
+        : Effect.succeed(result.value),
+    ),
+  )
 
 const inputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
   if (schema === undefined || schema === null) return {}

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -3,15 +3,7 @@ import { Tool } from "@opencode-ai/schema/tool"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import { Cache, Effect, JsonSchema, Schema, SchemaIssue, SchemaRepresentation } from "effect"
 
-type InputIssue = {
-  readonly path: ReadonlyArray<PropertyKey>
-  readonly message: string
-}
-
-type InputResult = { readonly value: unknown } | { readonly issues: ReadonlyArray<InputIssue> }
-
-const formatEffectIssue = SchemaIssue.makeFormatterStandardSchemaV1()
-const inputIssueLimit = 5
+const formatEffectIssues = SchemaIssue.makeFormatterStandardSchemaV1()
 
 const jsonSchemas = Effect.runSync(
   Cache.make<JsonSchema.JsonSchema, Schema.Codec<unknown> | undefined>({
@@ -66,82 +58,43 @@ export const execute = (tool: Tool.Info<any, any>, input: unknown, context: Tool
   })
 
 const decodeInput = (tool: Tool.Info<any, any>, value: unknown) =>
-  decodeInputResult(tool.input, value).pipe(
-    Effect.flatMap((result) =>
-      "issues" in result
-        ? Effect.fail(new Tool.Error({ message: formatInputIssues(effectiveName(tool), result.issues) }))
-        : Effect.succeed(result.value),
-    ),
-  )
-
-const decodeInputResult = (schema: Tool.ValueSchema<any>, value: unknown): Effect.Effect<InputResult> => {
-  if (Schema.isSchema(schema)) return decodeEffectInput(schema, value)
-  if (isStandardSchema(schema)) return validateStandardResult(schema, value)
-  return Cache.get(jsonSchemas, schema).pipe(
-    Effect.flatMap((schema) => (schema === undefined ? Effect.succeed({ value }) : decodeEffectInput(schema, value))),
-  )
-}
-
-const decodeEffectInput = (schema: Schema.Codec<unknown>, value: unknown): Effect.Effect<InputResult> =>
-  Schema.decodeUnknownEffect(schema)(value, { errors: "all" }).pipe(
-    Effect.map((value) => ({ value })),
-    Effect.catch((error) => Effect.succeed({ issues: normalizeEffectIssues(error.issue) })),
-  )
-
-const normalizeEffectIssues = (issue: SchemaIssue.Issue): ReadonlyArray<InputIssue> =>
-  formatEffectIssue(issue).issues.map(normalizeStandardIssue)
-
-const normalizeStandardIssue = (issue: StandardSchemaV1.Issue): InputIssue => ({
-  path: issue.path?.map((segment) => (typeof segment === "object" ? segment.key : segment)) ?? [],
-  message: issue.message,
-})
-
-const validateStandardResult = (
-  schema: StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any>,
-  value: unknown,
-): Effect.Effect<InputResult> =>
   Effect.gen(function* () {
-    const pending = yield* Effect.try({
-      try: () => schema["~standard"].validate(value),
-      catch: (error) => error,
-    }).pipe(
-      Effect.catch((error) =>
-        Effect.succeed({ issues: [{ message: error instanceof Error ? error.message : String(error) }] }),
-      ),
-    )
-    const result =
-      pending instanceof Promise
-        ? yield* Effect.tryPromise({
-            try: () => pending,
-            catch: (error) => error,
-          }).pipe(
-            Effect.catch((error) =>
-              Effect.succeed({ issues: [{ message: error instanceof Error ? error.message : String(error) }] }),
-            ),
-          )
-        : pending
-    if (result.issues) return { issues: result.issues.map(normalizeStandardIssue) }
-    return { value: result.value }
+    const result = yield* validateInput(tool.input, value)
+    if (result.issues)
+      return yield* new Tool.Error({ message: formatInputIssues(effectiveName(tool), result.issues, value) })
+    return result.value
   })
 
-const formatInputIssues = (tool: string, issues: ReadonlyArray<InputIssue>) => {
-  const visible = issues.slice(0, inputIssueLimit)
-  const remaining = issues.length - visible.length
-  const details = visible.map((issue) => `- ${formatInputPath(issue.path)}: ${issue.message}`)
-  if (remaining > 0) details.push(`- ...and ${remaining} more ${remaining === 1 ? "issue" : "issues"}`)
-  return `Invalid arguments for tool "${tool}":\n${details.join("\n")}\nCorrect the arguments and retry the tool.`
+const validateInput = (
+  schema: Tool.ValueSchema<any>,
+  value: unknown,
+): Effect.Effect<StandardSchemaV1.Result<unknown>> => {
+  if (isStandardSchema(schema)) return validateStandard(schema, value)
+  return Effect.gen(function* () {
+    const codec = Schema.isSchema(schema) ? schema : yield* Cache.get(jsonSchemas, schema)
+    if (codec === undefined) return { value }
+    return yield* Schema.decodeUnknownEffect(codec)(value, { errors: "all" }).pipe(
+      Effect.match({
+        onFailure: (error) => formatEffectIssues(error.issue),
+        onSuccess: (value) => ({ value }),
+      }),
+    )
+  })
 }
 
-const formatInputPath = (path: ReadonlyArray<PropertyKey>) =>
-  path.reduce<string>(
-    (result, segment) =>
-      typeof segment === "number"
-        ? `${result}[${segment}]`
-        : result === ""
-          ? String(segment)
-          : `${result}.${String(segment)}`,
-    "",
-  ) || "root"
+const formatInputIssues = (tool: string, issues: ReadonlyArray<StandardSchemaV1.Issue>, value: unknown) => {
+  const details = issues.slice(0, 5).map((issue) => {
+    const path =
+      issue.path?.reduce<string>((path, segment) => {
+        const key = typeof segment === "object" ? segment.key : segment
+        if (typeof key === "number") return `${path}[${key}]`
+        return path === "" ? String(key) : `${path}.${String(key)}`
+      }, "") || "root"
+    return `- ${path}: ${issue.message}`
+  })
+  if (issues.length > 5) details.push(`- ...and ${issues.length - 5} more ${issues.length === 6 ? "issue" : "issues"}`)
+  return `Invalid arguments for tool "${tool}":\n${details.join("\n")}\n\nArguments provided:\n${JSON.stringify(value, null, 2)}\n\nUpdate the arguments and call the tool again.`
+}
 
 const jsonSchema = (schema: JsonSchema.JsonSchema) => {
   const draft =
@@ -160,7 +113,15 @@ const encodeOutput = (schema: Tool.ValueSchema<any>, value: unknown) => {
       ),
     )
   if (isStandardSchema(schema))
-    return validateStandard(schema, value, "Tool returned an invalid value for its output schema")
+    return validateStandard(schema, value).pipe(
+      Effect.flatMap((result) =>
+        result.issues
+          ? new Tool.Error({
+              message: `Tool returned an invalid value for its output schema: ${result.issues.map((issue) => issue.message).join(", ")}`,
+            })
+          : Effect.succeed(result.value),
+      ),
+    )
   return Schema.decodeUnknownEffect(Schema.Json)(value).pipe(
     Effect.mapError(
       (error) => new Tool.Error({ message: `Tool returned a non-JSON value for its output schema: ${error.message}` }),
@@ -176,16 +137,15 @@ const isStandardSchema = (
 const validateStandard = (
   schema: StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any>,
   value: unknown,
-  prefix: string,
-) =>
-  validateStandardResult(schema, value).pipe(
-    Effect.flatMap((result) =>
-      "issues" in result
-        ? Effect.fail(
-            new Tool.Error({ message: `${prefix}: ${result.issues.map((issue) => issue.message).join(", ")}` }),
-          )
-        : Effect.succeed(result.value),
-    ),
+): Effect.Effect<StandardSchemaV1.Result<unknown>> =>
+  Effect.gen(function* () {
+    const result = yield* Effect.try({ try: () => schema["~standard"].validate(value), catch: (error) => error })
+    return result instanceof Promise ? yield* Effect.tryPromise({ try: () => result, catch: (error) => error }) : result
+  }).pipe(
+    Effect.match({
+      onFailure: (error) => ({ issues: [{ message: error instanceof Error ? error.message : String(error) }] }),
+      onSuccess: (result) => result,
+    }),
   )
 
 const inputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -2,7 +2,6 @@ import type { ToolDefinition } from "@opencode-ai/ai"
 import { Tool } from "@opencode-ai/schema/tool"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import { Cache, Effect, JsonSchema, Schema, SchemaIssue, SchemaRepresentation } from "effect"
-import { $ZodType, toJSONSchema } from "zod/v4/core"
 
 const formatEffectIssues = SchemaIssue.makeFormatterStandardSchemaV1()
 
@@ -130,15 +129,13 @@ const encodeOutput = (schema: Tool.ValueSchema<any>, value: unknown) => {
   )
 }
 
-const isStandardSchema = (schema: Tool.ValueSchema<any>): schema is StandardSchemaV1<any, any> =>
+const isStandardSchema = (
+  schema: Tool.ValueSchema<any>,
+): schema is StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any> =>
   typeof schema === "object" && schema !== null && "~standard" in schema
 
-const isStandardJSONSchema = (
-  schema: StandardSchemaV1<any, any>,
-): schema is StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any> => "jsonSchema" in schema["~standard"]
-
 const validateStandard = (
-  schema: StandardSchemaV1<any, any>,
+  schema: StandardSchemaV1<any, any> & StandardJSONSchemaV1<any, any>,
   value: unknown,
 ): Effect.Effect<StandardSchemaV1.Result<unknown>> =>
   Effect.gen(function* () {
@@ -153,19 +150,13 @@ const validateStandard = (
 
 const inputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
   if (schema === undefined || schema === null) return {}
-  if (isStandardSchema(schema)) return standardJsonSchema(schema, "input")
+  if (isStandardSchema(schema)) return schema["~standard"].jsonSchema.input({ target: "draft-2020-12" })
   return Schema.isSchema(schema) ? toJsonSchema(schema) : schema
 }
 
 const outputJsonSchema = (schema: Tool.ValueSchema<any>): JsonSchema.JsonSchema => {
-  if (isStandardSchema(schema)) return standardJsonSchema(schema, "output")
+  if (isStandardSchema(schema)) return schema["~standard"].jsonSchema.output({ target: "draft-2020-12" })
   return Schema.isSchema(schema) ? toJsonSchema(schema) : schema
-}
-
-const standardJsonSchema = (schema: StandardSchemaV1<any, any>, io: "input" | "output"): JsonSchema.JsonSchema => {
-  if (isStandardJSONSchema(schema)) return schema["~standard"].jsonSchema[io]({ target: "draft-2020-12" })
-  if (schema instanceof $ZodType) return toJSONSchema(schema, { target: "draft-2020-12", io })
-  throw new Error(`Schema vendor "${schema["~standard"].vendor}" does not support JSON Schema conversion`)
 }
 
 const toJsonSchema = (schema: Schema.Top): JsonSchema.JsonSchema => {

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -511,7 +511,11 @@ describe("Tool", () => {
         }),
       ).toMatchObject({
         status: "error",
-        error: { type: "tool.execution", message: expect.stringContaining("Invalid tool input") },
+        error: {
+          type: "tool.execution",
+          message:
+            'Invalid arguments for tool "transformed":\n- value: Expected boolean\nCorrect the arguments and retry the tool.',
+        },
       })
       expect(executed).toEqual(["yes"])
 

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -514,7 +514,7 @@ describe("Tool", () => {
         error: {
           type: "tool.execution",
           message:
-            'Invalid arguments for tool "transformed":\n- value: Expected boolean\nCorrect the arguments and retry the tool.',
+            'Invalid arguments for tool "transformed":\n- value: Expected boolean\n\nArguments provided:\n{\n  "value": "yes"\n}\n\nUpdate the arguments and call the tool again.',
         },
       })
       expect(executed).toEqual(["yes"])

--- a/packages/core/test/tool-question.test.ts
+++ b/packages/core/test/tool-question.test.ts
@@ -100,7 +100,11 @@ describe("QuestionTool", () => {
         }),
       ).toMatchObject({
         status: "error",
-        error: { type: "tool.execution", message: expect.stringContaining("Invalid tool input") },
+        error: {
+          type: "tool.execution",
+          message:
+            'Invalid arguments for tool "question":\n- questions: Expected a value with a length of at least 1\nCorrect the arguments and retry the tool.',
+        },
       })
       expect(capturedInput()).toBeUndefined()
     }),

--- a/packages/core/test/tool-question.test.ts
+++ b/packages/core/test/tool-question.test.ts
@@ -103,7 +103,7 @@ describe("QuestionTool", () => {
         error: {
           type: "tool.execution",
           message:
-            'Invalid arguments for tool "question":\n- questions: Expected a value with a length of at least 1\nCorrect the arguments and retry the tool.',
+            'Invalid arguments for tool "question":\n- questions: Expected a value with a length of at least 1\n\nArguments provided:\n{\n  "questions": []\n}\n\nUpdate the arguments and call the tool again.',
         },
       })
       expect(capturedInput()).toBeUndefined()

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { Effect, Schema } from "effect"
+import { z } from "zod"
 import type { Info } from "@opencode-ai/schema/tool"
 import { Tool } from "../src/tool"
 import { definition, execute } from "../src/tool/runtime"
@@ -137,6 +138,43 @@ test("portable schemas validate and describe typed tools", async () => {
   })
   const result = await Effect.runPromise(execute(tool, { count: "41" }, {} as Tool.Context))
   expect(result.output).toBe("42")
+})
+
+test("Zod schemas validate, transform, and describe typed tools", async () => {
+  const tool: Info = {
+    name: "zod",
+    description: "Zod tool",
+    input: z.object({ count: z.string().transform(Number) }),
+    output: z.object({ count: z.number() }),
+    execute: ({ count }) => Effect.succeed({ output: { count: count + 1 } }),
+  }
+
+  expect(definition(tool)).toEqual({
+    name: "zod",
+    description: "Zod tool",
+    inputSchema: {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: { count: { type: "string" } },
+      required: ["count"],
+    },
+    outputSchema: {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "object",
+      properties: { count: { type: "number" } },
+      required: ["count"],
+      additionalProperties: false,
+    },
+  })
+  expect(await Effect.runPromise(execute(tool, { count: "41" }, {} as Tool.Context))).toMatchObject({
+    output: { count: 42 },
+  })
+  expect(await Effect.runPromise(Effect.flip(execute(tool, { count: 41 }, {} as Tool.Context)))).toEqual(
+    new Tool.Error({
+      message:
+        'Invalid arguments for tool "zod":\n- count: Invalid input: expected string, received number\n\nArguments provided:\n{\n  "count": 41\n}\n\nUpdate the arguments and call the tool again.',
+    }),
+  )
 })
 
 test("portable schema failures become tool failures", async () => {

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "bun:test"
 import { Effect, Schema } from "effect"
-import { z } from "zod"
 import type { Info } from "@opencode-ai/schema/tool"
 import { Tool } from "../src/tool"
 import { definition, execute } from "../src/tool/runtime"
@@ -138,43 +137,6 @@ test("portable schemas validate and describe typed tools", async () => {
   })
   const result = await Effect.runPromise(execute(tool, { count: "41" }, {} as Tool.Context))
   expect(result.output).toBe("42")
-})
-
-test("Zod schemas validate, transform, and describe typed tools", async () => {
-  const tool: Info = {
-    name: "zod",
-    description: "Zod tool",
-    input: z.object({ count: z.string().transform(Number) }),
-    output: z.object({ count: z.number() }),
-    execute: ({ count }) => Effect.succeed({ output: { count: count + 1 } }),
-  }
-
-  expect(definition(tool)).toEqual({
-    name: "zod",
-    description: "Zod tool",
-    inputSchema: {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      type: "object",
-      properties: { count: { type: "string" } },
-      required: ["count"],
-    },
-    outputSchema: {
-      $schema: "https://json-schema.org/draft/2020-12/schema",
-      type: "object",
-      properties: { count: { type: "number" } },
-      required: ["count"],
-      additionalProperties: false,
-    },
-  })
-  expect(await Effect.runPromise(execute(tool, { count: "41" }, {} as Tool.Context))).toMatchObject({
-    output: { count: 42 },
-  })
-  expect(await Effect.runPromise(Effect.flip(execute(tool, { count: 41 }, {} as Tool.Context)))).toEqual(
-    new Tool.Error({
-      message:
-        'Invalid arguments for tool "zod":\n- count: Invalid input: expected string, received number\n\nArguments provided:\n{\n  "count": 41\n}\n\nUpdate the arguments and call the tool again.',
-    }),
-  )
 })
 
 test("portable schema failures become tool failures", async () => {

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -174,7 +174,7 @@ test("portable schema failures become tool failures", async () => {
   expect(error).toEqual(
     new Tool.Error({
       message:
-        'Invalid arguments for tool "invalid":\n- value: expected a string\n- nested.count: expected a positive integer\nCorrect the arguments and retry the tool.',
+        'Invalid arguments for tool "invalid":\n- value: expected a string\n- nested.count: expected a positive integer\n\nArguments provided:\n1\n\nUpdate the arguments and call the tool again.',
     }),
   )
 })
@@ -195,7 +195,7 @@ test("Effect schema failures use normalized input issues", async () => {
   ).toEqual(
     new Tool.Error({
       message:
-        'Invalid arguments for tool "effect":\n- value: Expected string\n- nested.count: Expected a value greater than or equal to 1\nCorrect the arguments and retry the tool.',
+        'Invalid arguments for tool "effect":\n- value: Expected string\n- nested.count: Expected a value greater than or equal to 1\n\nArguments provided:\n{\n  "value": 1,\n  "nested": {\n    "count": 0\n  }\n}\n\nUpdate the arguments and call the tool again.',
     }),
   )
 })
@@ -224,7 +224,7 @@ test("input error prompts limit normalized issues", async () => {
   expect(await Effect.runPromise(Effect.flip(execute(tool, {}, {} as Tool.Context)))).toEqual(
     new Tool.Error({
       message:
-        'Invalid arguments for tool "limited":\n- root: issue 1\n- root: issue 2\n- root: issue 3\n- root: issue 4\n- root: issue 5\n- ...and 1 more issue\nCorrect the arguments and retry the tool.',
+        'Invalid arguments for tool "limited":\n- root: issue 1\n- root: issue 2\n- root: issue 3\n- root: issue 4\n- root: issue 5\n- ...and 1 more issue\n\nArguments provided:\n{}\n\nUpdate the arguments and call the tool again.',
     }),
   )
 })
@@ -280,12 +280,14 @@ test("raw JSON schemas validate and decode tool input", async () => {
   })
   expect(await Effect.runPromise(Effect.flip(execute(tool, { value: 1 }, {} as Tool.Context)))).toEqual(
     new Tool.Error({
-      message: 'Invalid arguments for tool "raw":\n- value: Expected string\nCorrect the arguments and retry the tool.',
+      message:
+        'Invalid arguments for tool "raw":\n- value: Expected string\n\nArguments provided:\n{\n  "value": 1\n}\n\nUpdate the arguments and call the tool again.',
     }),
   )
   expect(await Effect.runPromise(Effect.flip(execute(tool, {}, {} as Tool.Context)))).toEqual(
     new Tool.Error({
-      message: 'Invalid arguments for tool "raw":\n- value: Missing key\nCorrect the arguments and retry the tool.',
+      message:
+        'Invalid arguments for tool "raw":\n- value: Missing key\n\nArguments provided:\n{}\n\nUpdate the arguments and call the tool again.',
     }),
   )
   expect(
@@ -293,7 +295,7 @@ test("raw JSON schemas validate and decode tool input", async () => {
   ).toEqual(
     new Tool.Error({
       message:
-        'Invalid arguments for tool "raw":\n- nested.count: Expected a value greater than or equal to 1\nCorrect the arguments and retry the tool.',
+        'Invalid arguments for tool "raw":\n- nested.count: Expected a value greater than or equal to 1\n\nArguments provided:\n{\n  "value": "ok",\n  "nested": {\n    "count": 0\n  }\n}\n\nUpdate the arguments and call the tool again.',
     }),
   )
   expect(
@@ -301,7 +303,7 @@ test("raw JSON schemas validate and decode tool input", async () => {
   ).toEqual(
     new Tool.Error({
       message:
-        'Invalid arguments for tool "raw":\n- value: Expected string\n- nested.count: Expected a value greater than or equal to 1\nCorrect the arguments and retry the tool.',
+        'Invalid arguments for tool "raw":\n- value: Expected string\n- nested.count: Expected a value greater than or equal to 1\n\nArguments provided:\n{\n  "value": 1,\n  "nested": {\n    "count": 0\n  }\n}\n\nUpdate the arguments and call the tool again.',
     }),
   )
 })
@@ -325,7 +327,7 @@ test("raw JSON schemas resolve draft-07 definitions", async () => {
   expect(await Effect.runPromise(Effect.flip(execute(tool, { value: 1 }, {} as Tool.Context)))).toEqual(
     new Tool.Error({
       message:
-        'Invalid arguments for tool "draft-07":\n- value: Expected value\nCorrect the arguments and retry the tool.',
+        'Invalid arguments for tool "draft-07":\n- value: Expected value\n\nArguments provided:\n{\n  "value": 1\n}\n\nUpdate the arguments and call the tool again.',
     }),
   )
 })

--- a/packages/core/test/tool-schema.test.ts
+++ b/packages/core/test/tool-schema.test.ts
@@ -144,7 +144,12 @@ test("portable schema failures become tool failures", async () => {
     "~standard": {
       version: 1,
       vendor: "test",
-      validate: (_value: unknown) => ({ issues: [{ message: "expected a string" }] }),
+      validate: (_value: unknown) => ({
+        issues: [
+          { path: ["value"], message: "expected a string" },
+          { path: [{ key: "nested" }, { key: "count" }], message: "expected a positive integer" },
+        ],
+      }),
       jsonSchema: {
         input: () => ({ type: "string" }),
         output: () => ({ type: "string" }),
@@ -166,7 +171,62 @@ test("portable schema failures become tool failures", async () => {
       ),
     ),
   )
-  expect(error).toEqual(new Tool.Error({ message: "Invalid tool input: expected a string" }))
+  expect(error).toEqual(
+    new Tool.Error({
+      message:
+        'Invalid arguments for tool "invalid":\n- value: expected a string\n- nested.count: expected a positive integer\nCorrect the arguments and retry the tool.',
+    }),
+  )
+})
+
+test("Effect schema failures use normalized input issues", async () => {
+  const tool: Info = {
+    name: "effect",
+    description: "Effect tool",
+    input: Schema.Struct({
+      value: Schema.String,
+      nested: Schema.Struct({ count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(1)) }),
+    }),
+    execute: () => Effect.succeed({ content: "unused" }),
+  }
+
+  expect(
+    await Effect.runPromise(Effect.flip(execute(tool, { value: 1, nested: { count: 0 } }, {} as Tool.Context))),
+  ).toEqual(
+    new Tool.Error({
+      message:
+        'Invalid arguments for tool "effect":\n- value: Expected string\n- nested.count: Expected a value greater than or equal to 1\nCorrect the arguments and retry the tool.',
+    }),
+  )
+})
+
+test("input error prompts limit normalized issues", async () => {
+  const input = {
+    "~standard": {
+      version: 1,
+      vendor: "test",
+      validate: (_value: unknown) => ({
+        issues: Array.from({ length: 6 }, (_, index) => ({ message: `issue ${index + 1}` })),
+      }),
+      jsonSchema: {
+        input: () => ({}),
+        output: () => ({}),
+      },
+    },
+  }
+  const tool: Info = {
+    name: "limited",
+    description: "Limited issues",
+    input,
+    execute: () => Effect.succeed({ content: "unused" }),
+  }
+
+  expect(await Effect.runPromise(Effect.flip(execute(tool, {}, {} as Tool.Context)))).toEqual(
+    new Tool.Error({
+      message:
+        'Invalid arguments for tool "limited":\n- root: issue 1\n- root: issue 2\n- root: issue 3\n- root: issue 4\n- root: issue 5\n- ...and 1 more issue\nCorrect the arguments and retry the tool.',
+    }),
+  )
 })
 
 test("canonical results carry metadata with typed output", async () => {
@@ -219,16 +279,29 @@ test("raw JSON schemas validate and decode tool input", async () => {
     content: [{ type: "text", text: '{"value":"ok"}' }],
   })
   expect(await Effect.runPromise(Effect.flip(execute(tool, { value: 1 }, {} as Tool.Context)))).toEqual(
-    new Tool.Error({ message: 'Invalid tool input: Expected string\n  at ["value"]' }),
+    new Tool.Error({
+      message: 'Invalid arguments for tool "raw":\n- value: Expected string\nCorrect the arguments and retry the tool.',
+    }),
   )
   expect(await Effect.runPromise(Effect.flip(execute(tool, {}, {} as Tool.Context)))).toEqual(
-    new Tool.Error({ message: 'Invalid tool input: Missing key\n  at ["value"]' }),
+    new Tool.Error({
+      message: 'Invalid arguments for tool "raw":\n- value: Missing key\nCorrect the arguments and retry the tool.',
+    }),
   )
   expect(
     await Effect.runPromise(Effect.flip(execute(tool, { value: "ok", nested: { count: 0 } }, {} as Tool.Context))),
   ).toEqual(
     new Tool.Error({
-      message: 'Invalid tool input: Expected a value greater than or equal to 1\n  at ["nested"]["count"]',
+      message:
+        'Invalid arguments for tool "raw":\n- nested.count: Expected a value greater than or equal to 1\nCorrect the arguments and retry the tool.',
+    }),
+  )
+  expect(
+    await Effect.runPromise(Effect.flip(execute(tool, { value: 1, nested: { count: 0 } }, {} as Tool.Context))),
+  ).toEqual(
+    new Tool.Error({
+      message:
+        'Invalid arguments for tool "raw":\n- value: Expected string\n- nested.count: Expected a value greater than or equal to 1\nCorrect the arguments and retry the tool.',
     }),
   )
 })
@@ -250,7 +323,10 @@ test("raw JSON schemas resolve draft-07 definitions", async () => {
     content: [{ type: "text", text: '{"value":"ok"}' }],
   })
   expect(await Effect.runPromise(Effect.flip(execute(tool, { value: 1 }, {} as Tool.Context)))).toEqual(
-    new Tool.Error({ message: 'Invalid tool input: Expected value\n  at ["value"]' }),
+    new Tool.Error({
+      message:
+        'Invalid arguments for tool "draft-07":\n- value: Expected value\nCorrect the arguments and retry the tool.',
+    }),
   )
 })
 

--- a/packages/core/test/tool-search.test.ts
+++ b/packages/core/test/tool-search.test.ts
@@ -118,7 +118,8 @@ describe("search tools", () => {
               status: "error",
               error: {
                 type: "tool.execution",
-                message: 'Invalid tool input: Pattern must not be empty\n  at ["pattern"]',
+                message:
+                  'Invalid arguments for tool "grep":\n- pattern: Pattern must not be empty\nCorrect the arguments and retry the tool.',
               },
             })
           }),

--- a/packages/core/test/tool-search.test.ts
+++ b/packages/core/test/tool-search.test.ts
@@ -119,7 +119,7 @@ describe("search tools", () => {
               error: {
                 type: "tool.execution",
                 message:
-                  'Invalid arguments for tool "grep":\n- pattern: Pattern must not be empty\nCorrect the arguments and retry the tool.',
+                  'Invalid arguments for tool "grep":\n- pattern: Pattern must not be empty\n\nArguments provided:\n{\n  "pattern": ""\n}\n\nUpdate the arguments and call the tool again.',
               },
             })
           }),

--- a/packages/schema/src/tool.ts
+++ b/packages/schema/src/tool.ts
@@ -1,7 +1,7 @@
 export * as Tool from "./tool.js"
 
 import { Effect, JsonSchema, Schema } from "effect"
-import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
+import type { StandardSchemaV1 } from "@standard-schema/spec"
 import type { Agent } from "./agent.js"
 import type { Session } from "./session.js"
 import type { SessionMessage } from "./session-message.js"
@@ -36,10 +36,7 @@ export type Options = BaseOptions &
       }
   )
 
-export type ValueSchema<A = unknown> =
-  | Schema.Codec<A, any>
-  | (StandardSchemaV1<any, A> & StandardJSONSchemaV1<any, A>)
-  | JsonSchema.JsonSchema
+export type ValueSchema<A = unknown> = Schema.Codec<A, any> | StandardSchemaV1<any, A> | JsonSchema.JsonSchema
 
 type InputValue<S> = 0 extends 1 & S
   ? any

--- a/packages/schema/src/tool.ts
+++ b/packages/schema/src/tool.ts
@@ -1,7 +1,7 @@
 export * as Tool from "./tool.js"
 
 import { Effect, JsonSchema, Schema } from "effect"
-import type { StandardSchemaV1 } from "@standard-schema/spec"
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
 import type { Agent } from "./agent.js"
 import type { Session } from "./session.js"
 import type { SessionMessage } from "./session-message.js"
@@ -36,7 +36,10 @@ export type Options = BaseOptions &
       }
   )
 
-export type ValueSchema<A = unknown> = Schema.Codec<A, any> | StandardSchemaV1<any, A> | JsonSchema.JsonSchema
+export type ValueSchema<A = unknown> =
+  | Schema.Codec<A, any>
+  | (StandardSchemaV1<any, A> & StandardJSONSchemaV1<any, A>)
+  | JsonSchema.JsonSchema
 
 type InputValue<S> = 0 extends 1 & S
   ? any


### PR DESCRIPTION
## Summary
- normalize Effect, Standard Schema, and imported JSON Schema validation issues into one internal representation
- format actionable tool errors with field paths, multiple issues, tool names, and retry guidance
- preserve decoded values, output validation, and unsupported-schema passthrough

## Testing
- `bun test` from `packages/core` (2,250 passed, 16 skipped)
- `bun typecheck` from `packages/core`
- `bun run lint:effect-simplifications`