### PR TITLE
fix(cli): honor notification-only automatic updates

### DIFF
--- a/packages/cli/src/services/updater-action.ts
+++ b/packages/cli/src/services/updater-action.ts
@@ -1,5 +1,5 @@
 export type Policy = boolean | "notify"
-export type Action = "none" | "upgrade"
+export type Action = "none" | "notify" | "upgrade"
 
 const maximumComponent = "9007199254740991"
 const versionPattern =
@@ -12,7 +12,7 @@ export function action(current: string, latest: string, policy: Policy): Action 
   if (!currentVersion || !latestVersion || sameRelease(currentVersion, latestVersion)) return "none"
   // Major upgrades are never installed automatically.
   if (currentVersion.major !== latestVersion.major) return "none"
-  return "upgrade"
+  return policy === "notify" ? "notify" : "upgrade"
 }
 
 function parseReleaseVersion(input: string) {

--- a/packages/cli/src/services/updater.test.ts
+++ b/packages/cli/src/services/updater.test.ts
@@ -12,8 +12,12 @@ describe("updater", () => {
   test("automatically updates patches and minors", () => {
     expect(action("1.2.3", "1.2.4", true)).toBe("upgrade")
     expect(action("1.2.3", "1.3.0", true)).toBe("upgrade")
-    expect(action("1.2.3", "1.2.4", "notify")).toBe("upgrade")
-    expect(action("1.2.3", "1.3.0", "notify")).toBe("upgrade")
+  })
+
+  test("reports patches and minors without automatically installing them", () => {
+    expect(action("1.2.3", "1.2.4", "notify")).toBe("notify")
+    expect(action("1.2.3", "1.3.0", "notify")).toBe("notify")
+    expect(action("1.2.3", "1.2.3", "notify")).toBe("none")
   })
 
   test("skips when autoupdate is disabled", () => {

--- a/packages/cli/src/services/updater.ts
+++ b/packages/cli/src/services/updater.ts
@@ -162,6 +162,8 @@ export const layer = Layer.effect(
           })
           const next = action(OPENCODE_VERSION, version, policy)
           if (next === "none") return yield* Effect.logInfo("update check done", { action: "up-to-date" })
+          if (next === "notify")
+            return yield* Effect.logInfo("OpenCode update available", { current: OPENCODE_VERSION, latest: version })
           const detected = yield* method()
           if (!detected) return yield* Effect.logWarning("automatic update skipped: installation method not found")
           yield* upgrade(detected, version)

--- a/packages/www/src/docs/content/config.mdx
+++ b/packages/www/src/docs/content/config.mdx
@@ -128,9 +128,9 @@ agents.
 ### Autoupdate
 
 Control automatic updates from the global config. Set this to `false` to
-disable updates. The current beta treats `true` and `"notify"` identically and
-automatically installs compatible non-major updates; project-level values are
-ignored.
+disable updates, or `"notify"` to report available updates without installing
+them. Set this to `true` to automatically install compatible non-major updates.
+Project-level values are ignored.
 
 ```jsonc
 {


### PR DESCRIPTION
## Summary
- treat autoupdate notify as a notification-only policy instead of installing available updates
- log available compatible updates without detecting an installer or running package-manager commands
- cover notification-only patch/minor updates and unchanged versions in updater tests
- update the V2 configuration documentation

## Verification
- bun test src/services/updater.test.ts: 12 passing tests
- broader CLI typecheck currently fails on pre-existing Core node:sqlite typings and shell Buffer overload errors, also reproduced on the original checkout
- website checks/build are blocked by dependencies missing from the existing shared installation