### PR TITLE
fix(tui): resolve plugin SDK imports at runtime

### DIFF
--- a/packages/tui/src/plugin/runtime-plugin-support.bun.ts
+++ b/packages/tui/src/plugin/runtime-plugin-support.bun.ts
@@ -1,3 +1,8 @@
+import { Plugin, PluginContextProvider, usePlugin } from "@opencode-ai/plugin/tui"
 import { ensureRuntimePluginSupport } from "@opentui/solid/runtime-plugin-support/configure"
 
-ensureRuntimePluginSupport()
+ensureRuntimePluginSupport({
+  additional: {
+    "@opencode-ai/plugin/tui": { Plugin, PluginContextProvider, usePlugin },
+  },
+})

--- a/packages/www/src/docs/content/build/plugins/cli.mdx
+++ b/packages/www/src/docs/content/build/plugins/cli.mdx
@@ -15,6 +15,9 @@ export default Plugin.define({
 })
 ```
 
+Import `@opencode-ai/plugin/tui` directly. OpenCode resolves this import at runtime, so local CLI plugins do not need an
+absolute path to an OpenCode checkout.
+
 ## Context
 
 `setup` receives configuration, app metadata, the current location, the OpenCode client, cached data, theme tokens, the

--- a/packages/www/src/docs/content/cli/plugins.mdx
+++ b/packages/www/src/docs/content/cli/plugins.mdx
@@ -54,3 +54,6 @@ OpenCode also discovers JavaScript and TypeScript plugins from `plugins/tui` und
 <global-config>/plugins/tui/status.ts
 <project>/.opencode/plugins/tui/status.ts
 ```
+
+Discovered plugins can import `@opencode-ai/plugin/tui` directly; OpenCode resolves the package at runtime. See
+[Building CLI plugins](/build/plugins/cli) for examples.


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Expose `@opencode-ai/plugin/tui` through OpenTUI runtime module support so discovered CLI plugins use the running TUI SDK instead of resolving an incompatible globally installed package. Document direct imports in both CLI plugin guides.

### How did you verify your code works?

- Loaded a global TPS plugin importing `@opencode-ai/plugin/tui` directly and confirmed it appears enabled in the live TUI plugins dialog.
- `bun typecheck` and `bun test` from `packages/tui`: 762 passing tests, 5 skipped.
- `bun run check:generated` from `packages/www`.
- Repository pre-push hook completed the full monorepo typecheck, including `@opencode-ai/www`.

### Screenshots / recordings

Not applicable; plugin loading behavior only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR