### PR TITLE
docs: add SuperCompress MCP server example

### DIFF
--- a/packages/web/src/content/docs/mcp-servers.mdx
+++ b/packages/web/src/content/docs/mcp-servers.mdx
@@ -510,3 +510,37 @@ Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/)
 ```md title="AGENTS.md"
 If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
 ```
+
+---
+
+### SuperCompress
+
+Add the [SuperCompress](https://www.supercompress.dev) MCP server to compress large tool outputs, logs, diffs, and pasted files before they are sent to the model.
+
+```json title="opencode.json" {4-9}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "supercompress": {
+      "type": "local",
+      "command": ["npx", "-y", "-p", "supercompress-proxy", "supercompress-mcp"],
+      "enabled": true,
+      "timeout": 60000
+    }
+  }
+}
+```
+
+The `timeout` is raised above the 5 second default because the first run downloads the package through `npx`.
+
+The server exposes `compress_context`, `connect_account`, and `usage_summary`. The first time you compress, use the `connect_account` tool to link your SuperCompress account; it opens a browser sign-in and stores the key in `~/.supercompress`.
+
+```txt "use supercompress"
+Compress this build log down to what matters for the failing test. use supercompress
+```
+
+Alternatively, you can add something like this to your [AGENTS.md](/docs/rules/).
+
+```md title="AGENTS.md"
+When a tool dump, log, or diff is large, call `supercompress_compress_context` with the dump as `context` and the current question as `query`. Never compress the question itself.
+```


### PR DESCRIPTION
### Issue for this PR

No linked issue — the Examples section of the MCP servers doc says "You can submit a PR if you want to document other servers." Replaces #43306, which was auto-closed because I missed the template window.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a SuperCompress example to the Examples section of `mcp-servers.mdx`, after Grep by Vercel, following the same structure as the existing entries (config block, prompt sample, AGENTS.md alternative). It is a local server started through npx, so the example sets `timeout: 60000` — the first run downloads the package, which can blow past the 5s default and make the server look broken on first launch. The AGENTS.md snippet uses the prefixed tool name (`supercompress_compress_context`) since MCP tools are registered with the server name as prefix, per the note earlier in the same doc.

### How did you verify your code works?

Dropped the exact config from the example into a scratch project and ran `opencode mcp list` on opencode 1.18.21:

```
●  ✓ supercompress connected
       npx -y -p supercompress-proxy supercompress-mcp
```

Also confirmed all fields used (`type`, `command`, `enabled`, `timeout`) are in the local-server options table earlier in the doc, and Prettier passes on the file.

### Screenshots / recordings

Not a UI change — the `opencode mcp list` output above is the observable result.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Made with [Cursor](https://cursor.com)