### PR TITLE
fix(tui): refresh directory after move [v2]

### DIFF
--- a/packages/tui/src/component/prompt/move.tsx
+++ b/packages/tui/src/component/prompt/move.tsx
@@ -7,12 +7,14 @@ import { useClient } from "../../context/client"
 import { useToast } from "../../ui/toast"
 import { DialogMoveSession, type MoveSessionSelection } from "../dialog-move-session"
 import { useData } from "../../context/data"
+import { useLocation } from "../../context/location"
 
 export function usePromptMove(input: { projectID: () => string | undefined; sessionID: () => string | undefined }) {
   const dialog = useDialog()
   const client = useClient()
   const toast = useToast()
   const data = useData()
+  const location = useLocation()
   const paths = useTuiPaths()
   const [creating, setCreating] = createSignal(false)
   const [creatingDots, setCreatingDots] = createSignal(3)
@@ -80,6 +82,7 @@ export function usePromptMove(input: { projectID: () => string | undefined; sess
           const sessionID = input.sessionID()
           if (!sessionID) {
             setDestination(selection)
+            if (selection.type === "directory") location.set({ directory: selection.directory })
             dialog.clear()
             return
           }

--- a/packages/tui/test/cli/tui/prompt-move.test.tsx
+++ b/packages/tui/test/cli/tui/prompt-move.test.tsx
@@ -1,0 +1,85 @@
+/** @jsxImportSource @opentui/solid */
+import { testRender } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { ConfigProvider } from "../../../src/config"
+import { usePromptMove } from "../../../src/component/prompt/move"
+import { ClientProvider } from "../../../src/context/client"
+import { DataProvider } from "../../../src/context/data"
+import { Keymap } from "../../../src/context/keymap"
+import { LocationProvider, useLocation } from "../../../src/context/location"
+import { RouteProvider } from "../../../src/context/route"
+import { ThemeProvider } from "../../../src/context/theme"
+import { DialogProvider } from "../../../src/ui/dialog"
+import { ToastProvider } from "../../../src/ui/toast"
+import { emptyThemeSource } from "../../fixture/fixture"
+import { createApi, createEventStream, createFetch, json, type FetchHandler } from "../../fixture/tui-client"
+import { TestTuiContexts } from "../../fixture/tui-environment"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+
+test("selecting an existing worktree updates the new session location immediately", async () => {
+  const destination = "/tmp/opencode-existing-worktree"
+  const events = createEventStream()
+  const requests: { path: string; method: string }[] = []
+  const handler: FetchHandler = (url, request) => {
+    requests.push({ path: url.pathname, method: request.method })
+    if (url.pathname === "/api/worktree/proj_test" && request.method === "GET") {
+      return json([{ directory: destination, strategy: "git" }])
+    }
+    if (url.pathname === "/api/location") {
+      return json({
+        directory: destination,
+        project: { id: "proj_test", directory: destination, canonical: destination },
+      })
+    }
+  }
+  const calls = createFetch(handler, events)
+  let open!: () => Promise<void>
+  let location!: ReturnType<typeof useLocation>
+
+  function Probe() {
+    location = useLocation()
+    open = usePromptMove({ projectID: () => "proj_test", sessionID: () => undefined }).open
+    return <text>{location.ref?.directory ?? "no destination"}</text>
+  }
+
+  const app = await testRender(
+    () => (
+      <TestTuiContexts>
+        <ConfigProvider config={createTuiResolvedConfig()}>
+          <Keymap.Provider>
+            <ToastProvider>
+              <RouteProvider>
+                <ClientProvider api={createApi(calls.fetch)}>
+                  <DataProvider>
+                    <LocationProvider>
+                      <ThemeProvider mode="dark" source={emptyThemeSource}>
+                        <DialogProvider>
+                          <Probe />
+                        </DialogProvider>
+                      </ThemeProvider>
+                    </LocationProvider>
+                  </DataProvider>
+                </ClientProvider>
+              </RouteProvider>
+            </ToastProvider>
+          </Keymap.Provider>
+        </ConfigProvider>
+      </TestTuiContexts>
+    ),
+    { width: 100, height: 30, kittyKeyboard: true },
+  )
+  app.renderer.start()
+
+  try {
+    await app.waitFor(() => typeof open === "function")
+    await open()
+    await app.waitForFrame((frame) => frame.includes(destination))
+    app.mockInput.pressEnter()
+    await app.waitFor(() => location.ref?.directory === destination)
+    await app.waitForFrame((frame) => frame.includes(destination))
+    expect(requests.some((request) => request.path === "/api/session" && request.method === "POST")).toBeFalse()
+  } finally {
+    app.renderer.destroy()
+    events.disconnect()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #43938

Basically a one line fix. PR is for v2, issue is raised against v1.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `/move` selects an existing worktree before a new session has any turns, update the TUI location context immediately. The directory indicator now shows the selected worktree as soon as the move dialog closes instead of waiting for the first prompt to create the session.



Adds a regression test that selects an existing worktree from the real move dialog, verifies the location display updates, and confirms no session needs to be created.

### How did you verify your code works?

- `bun test test/cli/tui/prompt-move.test.tsx` in `packages/tui`
- `bun test` in `packages/tui` (763 pass, 5 skip)
- `bun typecheck` in `packages/tui`
- Prettier check for changed files
- `git diff --check`

### Screenshots / recordings

N/A — behavior-only refresh fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
