### PR TITLE
feat(cli): embed persistent PTY service binaries

### DIFF
--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -9,6 +9,7 @@ import type { BunPlugin } from "bun"
 import pkg from "../package.json"
 import { buildAppArchive } from "./app-assets"
 import { verifyArtifact, verifySimulationGraph } from "./verify-artifact"
+import { resolveOpencodePty } from "./opencode-pty"
 
 const dir = path.resolve(import.meta.dirname, "..")
 const binary = "opencode2"
@@ -78,6 +79,23 @@ const appAssetsPlugin: BunPlugin = {
 }
 
 for (const item of targets) {
+  const opencodePty = await resolveOpencodePty({
+    platform: item.os,
+    arch: item.arch,
+    ...(item.os === "linux" ? { libc: item.abi ?? "glibc" } : {}),
+  })
+  const opencodePtyPlugin: BunPlugin = {
+    name: "opencode-pty-binary",
+    setup(build) {
+      build.onLoad({ filter: /persistent-pty[/\\]asset\.ts$/ }, () => ({
+        loader: "js",
+        contents: opencodePty
+          ? `import file from ${JSON.stringify(opencodePty.source)} with { type: "file" }
+export default { path: file, version: ${JSON.stringify(opencodePty.version)}, sha256: ${JSON.stringify(opencodePty.sha256)} }`
+          : "export default undefined",
+      }))
+    },
+  }
   const simulationInputs = new Set<string>()
   const simulationGraphPlugin: BunPlugin = {
     name: "opencode-simulation-graph",
@@ -105,7 +123,7 @@ for (const item of targets) {
   const result = await Bun.build({
     entrypoints: ["./src/index.ts"],
     tsconfig: "./tsconfig.json",
-    plugins: [appAssetsPlugin, solidPlugin, parcelWatcherPlugin, simulationGraphPlugin],
+    plugins: [appAssetsPlugin, solidPlugin, parcelWatcherPlugin, opencodePtyPlugin, simulationGraphPlugin],
     external: ["node-gyp"],
     format: "esm",
     minify: true,

--- a/packages/cli/script/node-assets.ts
+++ b/packages/cli/script/node-assets.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url"
 import { getNodeAssets } from "@opentui/core/node-assets"
 import { attentionSoundAssets, type NodeTarget, photonWasmAsset, shellParserWasmAssets } from "../src/node/target"
 import { collectFiles } from "./files"
+import { resolveOpencodePty } from "./opencode-pty"
 
 const dir = path.resolve(import.meta.dirname, "..")
 
@@ -18,6 +19,11 @@ export type NodeAsset = {
 }
 
 export async function collectNodeAssets(target: NodeTarget) {
+  const opencodePty = await resolveOpencodePty({
+    platform: target.platform,
+    arch: target.arch,
+    ...(target.platform === "linux" ? { libc: "glibc" as const } : {}),
+  })
   const ptyEntry = fileURLToPath(import.meta.resolve(target.nodePtyPackage))
   const ptyRoot = path.resolve(path.dirname(ptyEntry), "..")
   const assets: NodeAsset[] = [
@@ -41,6 +47,7 @@ export async function collectNodeAssets(target: NodeTarget) {
       key,
       source: path.resolve(dir, "../ui/src/assets/audio", path.basename(key)),
     })),
+    ...(opencodePty && target.opencodePtyAsset ? [{ key: target.opencodePtyAsset, source: opencodePty.source }] : []),
     ...(await collectFiles(ptyRoot))
       .filter((relative) => !relative.endsWith(".map") && !relative.endsWith(".pdb"))
       .map((relative) => ({

--- a/packages/cli/script/opencode-pty.ts
+++ b/packages/cli/script/opencode-pty.ts
@@ -1,0 +1,102 @@
+import { spawnSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+const VERSION = "0.1.4"
+const RELEASE = `https://github.com/jlongster/opencode-pty/releases/download/v${VERSION}`
+const SHA256 = {
+  "aarch64-apple-darwin": "a91b790ee14a9d75d3dccf5ee40ded1326e5250d6882d5274b72e41e1455f8ec",
+  "aarch64-unknown-linux-gnu": "53e28264e9bad28f1f2d4900f6ad5e04d034b900ff3f341cc57be73a5152d5a6",
+  "aarch64-unknown-linux-musl": "00f018af1f3b2f6adf93c6d9b8866216c4266fe4e1d06e47a76bc001ae4aac46",
+  "x86_64-apple-darwin": "12fe4c456ad7895994e6af7d67112b4f65871f41267a7a51341e70227052d114",
+  "x86_64-unknown-linux-gnu": "9c03efc505ce86a6204b9bdfc03b30e2eb7d6edaca1c6435b0a839538d4c812f",
+  "x86_64-unknown-linux-musl": "2c5803822d9d88f8d6e201d3afd28c3a861d679e8f8c88e68c54bbfa1c12214a",
+} as const
+
+export type OpencodePtyAsset = {
+  readonly source: string
+  readonly version: string
+  readonly sha256: string
+}
+
+type Target = {
+  readonly platform: string
+  readonly arch: string
+  readonly libc?: "glibc" | "musl"
+}
+
+const pending = new Map<string, Promise<OpencodePtyAsset | undefined>>()
+
+export function resolveOpencodePty(target: Target) {
+  const rustTarget = targetName(target)
+  if (!rustTarget) return Promise.resolve(undefined)
+  const existing = pending.get(rustTarget)
+  if (existing) return existing
+  const result = acquire(rustTarget).catch((error) => {
+    pending.delete(rustTarget)
+    throw error
+  })
+  pending.set(rustTarget, result)
+  return result
+}
+
+async function acquire(target: keyof typeof SHA256): Promise<OpencodePtyAsset> {
+  const root = path.resolve(import.meta.dirname, "../.cache/opencode-pty", VERSION, target)
+  const executable = path.join(root, "opencode-pty")
+  const cached = await readFile(executable).catch(() => undefined)
+  if (cached)
+    return {
+      source: executable,
+      version: VERSION,
+      sha256: createHash("sha256").update(cached).digest("hex"),
+    }
+
+  await mkdir(root, { recursive: true })
+  const archiveName = `opencode-pty-${VERSION}-${target}.tar.gz`
+  const response = await fetch(`${RELEASE}/${archiveName}`)
+  if (!response.ok) throw new Error(`Failed to download ${archiveName}: ${response.status}`)
+  const archive = new Uint8Array(await response.arrayBuffer())
+  const actual = createHash("sha256").update(archive).digest("hex")
+  if (actual !== SHA256[target]) throw new Error(`Checksum mismatch for ${archiveName}`)
+
+  const temporary = await mkdtemp(path.join(os.tmpdir(), "opencode-pty-build-"))
+  try {
+    const archivePath = path.join(temporary, archiveName)
+    await writeFile(archivePath, archive)
+    run("tar", ["-xzf", archivePath, "-C", temporary])
+    const source = path.join(temporary, `opencode-pty-${VERSION}-${target}`, "opencode-pty")
+    const bytes = await readFile(source)
+    const staged = path.join(root, `opencode-pty.${process.pid}.${crypto.randomUUID()}.tmp`)
+    await writeFile(staged, bytes, { flag: "wx", mode: 0o755 })
+    await rename(staged, executable).catch(async (error) => {
+      await rm(staged, { force: true })
+      if (!(await readFile(executable).catch(() => undefined))) throw error
+    })
+    const installed = await readFile(executable)
+    return {
+      source: executable,
+      version: VERSION,
+      sha256: createHash("sha256").update(installed).digest("hex"),
+    }
+  } finally {
+    await rm(temporary, { recursive: true, force: true })
+  }
+}
+
+function targetName(target: Target): keyof typeof SHA256 | undefined {
+  const arch = target.arch === "arm64" ? "aarch64" : target.arch === "x64" ? "x86_64" : undefined
+  if (!arch) return undefined
+  if (target.platform === "darwin") return arch === "aarch64" ? "aarch64-apple-darwin" : "x86_64-apple-darwin"
+  if (target.platform === "linux" && target.libc === "musl")
+    return arch === "aarch64" ? "aarch64-unknown-linux-musl" : "x86_64-unknown-linux-musl"
+  if (target.platform === "linux") return arch === "aarch64" ? "aarch64-unknown-linux-gnu" : "x86_64-unknown-linux-gnu"
+  return undefined
+}
+
+function run(command: string, args: readonly string[]) {
+  const result = spawnSync(command, args, { stdio: "inherit" })
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error(`${command} exited with status ${result.status ?? "unknown"}`)
+}

--- a/packages/cli/src/node/target.ts
+++ b/packages/cli/src/node/target.ts
@@ -13,6 +13,7 @@ export function nodeTarget(platform: string, arch: string) {
   const parcelWatcherPackage = `@parcel/watcher-${targetPlatform}-${targetArch}${targetPlatform === "linux" ? "-glibc" : ""}`
   const fffPackage = `@ff-labs/fff-bin-${targetPlatform}-${targetArch}${targetPlatform === "linux" ? "-gnu" : ""}`
   const fffFfiPackage = `@yuuang/ffi-rs-${targetPlatform}-${targetArch}${targetPlatform === "linux" ? "-gnu" : targetPlatform === "win32" ? "-msvc" : ""}`
+  const opencodePtyAsset = targetPlatform === "win32" ? undefined : "opencode-pty/opencode-pty"
 
   return {
     platform: targetPlatform,
@@ -25,6 +26,7 @@ export function nodeTarget(platform: string, arch: string) {
     fffAsset: `${fffPackage}/${targetPlatform === "darwin" ? "libfff_c.dylib" : targetPlatform === "win32" ? "fff_c.dll" : "libfff_c.so"}`,
     fffFfiPackage,
     fffFfiAsset: `${fffFfiPackage}/ffi-rs.${targetPlatform}-${targetArch}${targetPlatform === "linux" ? "-gnu" : targetPlatform === "win32" ? "-msvc" : ""}.node`,
+    opencodePtyAsset,
   }
 }
 

--- a/packages/cli/test/node-assets.test.ts
+++ b/packages/cli/test/node-assets.test.ts
@@ -8,6 +8,7 @@ test("collects each SEA asset key once", async () => {
   const keys = assets.map((asset) => asset.key)
 
   expect(new Set(keys).size).toBe(keys.length)
+  if (process.platform !== "win32") expect(keys.filter((key) => key === "opencode-pty/opencode-pty")).toHaveLength(1)
   expect(assets.filter((asset) => asset.key === shellParserWasmAssets.runtime)).toEqual([
     {
       key: shellParserWasmAssets.runtime,

--- a/packages/cli/vite.node.config.ts
+++ b/packages/cli/vite.node.config.ts
@@ -120,6 +120,7 @@ function nodePrelude(input: NodeBuildInput) {
     input.target.platform === "darwin"
       ? `${input.target.nodePtyPackage}/prebuilds/darwin-${input.target.arch}/spawn-helper`
       : undefined
+  const opencodePtyAsset = input.target.opencodePtyAsset
   const promiseModule = `const sdk = globalThis[Symbol.for("opencode.plugin.v2.promise")]
 if (!sdk) throw new Error("OpenCode Promise plugin SDK is unavailable")
 export const Agent = sdk.Agent
@@ -200,6 +201,7 @@ if (__ocIsSea()) {
 const __ocAssetRoot = __ocIsSea()
   ? __ocPath.join(__ocCacheRoot, ${JSON.stringify(`${input.assetHash}-${input.target.platform}-${input.target.arch}`)})
   : __ocFileURLToPath(new URL("./assets/", import.meta.url))
+const __ocPersistentPty = ${JSON.stringify(opencodePtyAsset)}
 if (__ocIsSea()) {
   for (const __ocKey of __ocAssetKeys()) {
     const __ocTarget = __ocPath.join(__ocAssetRoot, __ocKey)
@@ -216,6 +218,7 @@ if (__ocIsSea()) {
   }
   const __ocPtySpawnHelper = ${JSON.stringify(nodePtySpawnHelper)}
   if (__ocPtySpawnHelper) __ocChmod(__ocPath.join(__ocAssetRoot, __ocPtySpawnHelper), 0o755)
+  if (__ocPersistentPty && process.platform !== "win32") __ocChmod(__ocPath.join(__ocAssetRoot, __ocPersistentPty), 0o755)
 }
 process.env.OPENCODE_NODE_ASSETS_DIR = __ocAssetRoot
 process.env.OTUI_ASSET_ROOT = __ocAssetRoot
@@ -227,6 +230,7 @@ process.env.OPENCODE_TREE_SITTER_BASH_WASM_PATH = __ocPath.join(__ocAssetRoot, $
 process.env.OPENCODE_TREE_SITTER_POWERSHELL_WASM_PATH = __ocPath.join(__ocAssetRoot, ${JSON.stringify(shellParserWasmAssets.powershell)})
 process.env.FFF_BINARY_PATH = __ocPath.join(__ocAssetRoot, ${JSON.stringify(input.target.fffAsset)})
 process.env.OPENCODE_FFF_FFI_PATH = __ocPath.join(__ocAssetRoot, ${JSON.stringify(input.target.fffFfiAsset)})
+if (__ocPersistentPty && !process.env.OPENCODE_PTY_BIN) process.env.OPENCODE_PTY_BIN = __ocPath.join(__ocAssetRoot, __ocPersistentPty)
 try {
   globalThis.__OPENCODE_FFF_FFI = require(process.env.OPENCODE_FFF_FFI_PATH)
 } catch {}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,12 @@
       "node": "./src/pty/pty.node.ts",
       "default": "./src/pty/pty.bun.ts"
     },
+    "#persistent-pty-binary": {
+      "workerd": "./src/persistent-pty/binary.workerd.ts",
+      "bun": "./src/persistent-pty/binary.bun.ts",
+      "node": "./src/persistent-pty/binary.node.ts",
+      "default": "./src/persistent-pty/binary.bun.ts"
+    },
     "#fff": {
       "workerd": "./src/filesystem/fff.workerd.ts",
       "bun": "./src/filesystem/fff.bun.ts",

--- a/packages/core/src/persistent-pty/asset.ts
+++ b/packages/core/src/persistent-pty/asset.ts
@@ -1,0 +1,3 @@
+const asset: { readonly path: string; readonly version: string; readonly sha256: string } | undefined = undefined
+
+export default asset

--- a/packages/core/src/persistent-pty/binary.bun.ts
+++ b/packages/core/src/persistent-pty/binary.bun.ts
@@ -1,0 +1,82 @@
+import { createHash } from "node:crypto"
+import { chmod, lstat, mkdir, open, readFile, rename, rm } from "node:fs/promises"
+import path from "node:path"
+import asset from "./asset.js"
+
+export async function resolveBinary(bin: string) {
+  if (process.env.OPENCODE_PTY_BIN) return process.env.OPENCODE_PTY_BIN
+  if (!asset) return "opencode-pty"
+  return install(bin, asset)
+}
+
+export async function install(
+  bin: string,
+  input: { readonly path: string; readonly version: string; readonly sha256: string },
+) {
+  const root = path.join(bin, "opencode-pty")
+  await privateDirectory(root)
+  const directory = path.join(root, `${input.version}-${input.sha256.slice(0, 16)}`)
+  await privateDirectory(directory)
+  const destination = path.join(directory, "opencode-pty")
+  if (await exists(destination, input.sha256)) return destination
+
+  const bytes = new Uint8Array(await Bun.file(input.path).arrayBuffer())
+  if (sha256(bytes) !== input.sha256) throw new Error("Embedded opencode-pty checksum mismatch")
+  const temporary = path.join(directory, `opencode-pty.${process.pid}.${crypto.randomUUID()}.tmp`)
+  try {
+    const file = await open(temporary, "wx", 0o700)
+    try {
+      await file.writeFile(bytes)
+      await file.sync()
+    } finally {
+      await file.close()
+    }
+    await chmod(temporary, 0o755)
+    await rename(temporary, destination).catch(async (error) => {
+      if (!(await exists(destination, input.sha256))) throw error
+    })
+  } finally {
+    await rm(temporary, { force: true })
+  }
+  return validate(destination, input.sha256)
+}
+
+async function privateDirectory(directory: string) {
+  await mkdir(directory, { recursive: true, mode: 0o700 })
+  const info = await lstat(directory)
+  if (!info.isDirectory() || info.isSymbolicLink()) throw new Error(`Unsafe opencode-pty directory: ${directory}`)
+  const uid = typeof process.getuid === "function" ? process.getuid() : undefined
+  if (uid !== undefined && info.uid !== uid)
+    throw new Error(`opencode-pty directory is owned by another user: ${directory}`)
+  await chmod(directory, 0o700)
+}
+
+async function exists(file: string, expected: string) {
+  try {
+    await validate(file, expected)
+    return true
+  } catch (error) {
+    if (isMissing(error)) return false
+    throw error
+  }
+}
+
+async function validate(file: string, expected?: string) {
+  const info = await lstat(file)
+  if (!info.isFile() || info.isSymbolicLink()) throw new Error(`Unsafe opencode-pty executable: ${file}`)
+  const uid = typeof process.getuid === "function" ? process.getuid() : undefined
+  if (uid !== undefined && info.uid !== uid)
+    throw new Error(`opencode-pty executable is owned by another user: ${file}`)
+  if (expected && sha256(await readFile(file)) !== expected)
+    throw new Error(`Cached opencode-pty checksum mismatch: ${file}`)
+  await chmod(file, 0o755)
+  return file
+}
+
+function sha256(bytes: Uint8Array) {
+  return createHash("sha256").update(bytes).digest("hex")
+}
+
+function isMissing(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === "ENOENT"
+}

--- a/packages/core/src/persistent-pty/binary.node.ts
+++ b/packages/core/src/persistent-pty/binary.node.ts
@@ -1,0 +1,3 @@
+export async function resolveBinary() {
+  return process.env.OPENCODE_PTY_BIN || "opencode-pty"
+}

--- a/packages/core/src/persistent-pty/binary.workerd.ts
+++ b/packages/core/src/persistent-pty/binary.workerd.ts
@@ -1,0 +1,3 @@
+export async function resolveBinary(): Promise<string> {
+  throw new Error("Persistent PTYs are unavailable in this runtime")
+}

--- a/packages/core/src/persistent-pty/index.ts
+++ b/packages/core/src/persistent-pty/index.ts
@@ -14,6 +14,8 @@ import { Session } from "@opencode-ai/schema/session"
 import { Bus } from "../bus.js"
 import { Database } from "../database/database.js"
 import { Pty } from "@opencode-ai/schema/pty"
+import { Global } from "@opencode-ai/util/global"
+import { resolveBinary } from "#persistent-pty-binary"
 
 const ProtocolVersion = 6
 const MaxFrameBytes = 8 * 1024 * 1024
@@ -217,9 +219,11 @@ export const layer = Layer.effect(
   Effect.gen(function* () {
     const bus = yield* Bus.Service
     const database = yield* Database.Service
+    const global = yield* Global.Service
     const context = yield* Effect.context()
     const runFork = Effect.runForkWith(context)
-    const client = new Client(runtimeDirectory(databasePath(database.db)))
+    let binary: Promise<string> | undefined
+    const client = new Client(runtimeDirectory(databasePath(database.db)), () => (binary ??= resolveBinary(global.bin)))
     const removing = new Set<Pty.ID>()
 
     const list = Effect.fn("PersistentPty.list")(function* (sessionID?: Session.ID) {
@@ -408,12 +412,15 @@ export const layer = Layer.effect(
   }),
 )
 
-export const node = makeGlobalNode({ service: Service, layer, deps: [Bus.node, Database.node] })
+export const node = makeGlobalNode({ service: Service, layer, deps: [Bus.node, Database.node, Global.node] })
 
 class Client {
   private registration?: Promise<Registration>
 
-  constructor(private readonly directory: string) {}
+  constructor(
+    private readonly directory: string,
+    private readonly binary: () => Promise<string>,
+  ) {}
 
   request(value: object, start = false): Promise<WireResponse> {
     return this.connect(start)
@@ -550,7 +557,7 @@ class Client {
   }
 
   private connect(start: boolean) {
-    this.registration ??= start ? ensure(this.directory) : discover(this.directory)
+    this.registration ??= start ? ensure(this.directory, this.binary) : discover(this.directory)
     return this.registration.catch((error) => {
       this.registration = undefined
       throw error
@@ -594,11 +601,12 @@ const runtimeDirectory = (databasePath?: string) => {
 
 const registrationPath = (directory: string) => path.join(directory, "service.json")
 
-async function ensure(directory: string) {
+async function ensure(directory: string, binary: () => Promise<string>) {
   const found = await discover(directory).catch(() => undefined)
   if (found) return found
+  const executable = await binary()
   await new Promise<void>((resolve, reject) => {
-    const child = spawn(process.env.OPENCODE_PTY_BIN || "opencode-pty", ["daemon"], {
+    const child = spawn(executable, ["daemon"], {
       detached: true,
       stdio: "ignore",
       env: { ...process.env, OPENCODE_PTY_RUNTIME_DIR: directory },

--- a/packages/core/test/persistent-pty-binary.test.ts
+++ b/packages/core/test/persistent-pty-binary.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test"
+import { createHash } from "node:crypto"
+import { chmod, lstat, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { install } from "../src/persistent-pty/binary.bun"
+
+test("installs an embedded persistent PTY executable into a content-addressed private directory", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "opencode-pty-binary-test-"))
+  try {
+    const source = path.join(root, "embedded-opencode-pty")
+    const bytes = Buffer.from("test opencode-pty executable")
+    const sha256 = createHash("sha256").update(bytes).digest("hex")
+    await writeFile(source, bytes)
+
+    const first = await install(path.join(root, "bin"), { path: source, version: "test", sha256 })
+    const second = await install(path.join(root, "bin"), { path: source, version: "test", sha256 })
+
+    expect(second).toBe(first)
+    expect(await readFile(first)).toEqual(bytes)
+    expect((await lstat(first)).mode & 0o777).toBe(0o755)
+    expect((await lstat(path.dirname(first))).mode & 0o777).toBe(0o700)
+
+    await chmod(first, 0o600)
+    expect(await install(path.join(root, "bin"), { path: source, version: "test", sha256 })).toBe(first)
+    expect((await lstat(first)).mode & 0o777).toBe(0o755)
+
+    await writeFile(first, "tampered executable")
+    await expect(install(path.join(root, "bin"), { path: source, version: "test", sha256 })).rejects.toThrow(
+      "Cached opencode-pty checksum mismatch",
+    )
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- pin `opencode-pty v0.1.4` and verify SHA-256 checksums for six Linux/macOS archives
- embed the native daemon into Bun executables and existing Node SEA asset bundles
- lazily extract Bun assets into private content-addressed executable caches with checksum, ownership, and permission checks
- preserve `OPENCODE_PTY_BIN` overrides and leave unsupported Windows targets unchanged

## Verification
- `bun run typecheck` in `packages/core` and `packages/cli`
- `bun test test/persistent-pty-binary.test.ts` in `packages/core`
- `bun test test/node-assets.test.ts` in `packages/cli`
- real `opencode-pty v0.1.4` server integration test passes
- compiled Bun smoke test embeds, extracts, starts the daemon, creates a terminal through the HTTP API, and snapshots its output

Stack: 3/5, based on #44832; next PR adds the TUI workspace.