### PR TITLE
feat(tui): add persistent terminal workspaces

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -31,7 +31,6 @@ import {
   batch,
   Show,
 } from "solid-js"
-import { createStore } from "solid-js/store"
 import {
   TuiLifecycleProvider,
   TuiAppProvider,
@@ -77,7 +76,6 @@ import { clampSessionTabsWidth, sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH 
 import { ThemeErrorToast } from "./component/theme-error-toast"
 import { createThemeSource, ThemeProvider, useTheme, useThemes } from "./context/theme"
 import { Home } from "./routes/home"
-import { Session } from "./routes/session"
 import { PromptHistoryProvider } from "./prompt/history"
 import { FrecencyProvider } from "./prompt/frecency"
 import { PromptStashProvider } from "./prompt/stash"
@@ -100,6 +98,8 @@ import { destroyRenderer } from "./util/renderer"
 import { cliErrorMessage, errorFormat } from "./util/error"
 import { AttentionProvider } from "./context/attention"
 import { StorageProvider, useStorage } from "./context/storage"
+import { PaneLayoutProvider } from "./context/pane-layout"
+import { PaneWorkspace } from "./component/pane-workspace"
 import { createTuiClipboard } from "./clipboard"
 
 registerOpencodeSpinner()
@@ -218,7 +218,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
         reconnect: async (signal: AbortSignal) => {
           const endpoint = await managed.reconnect(signal)
           const next = { baseUrl: endpoint.url, headers: Service.headers(endpoint) }
-          return { api: OpenCode.make(next) }
+          return { api: OpenCode.make(next), endpoint }
         },
         restart: managed.restart,
       }
@@ -373,48 +373,54 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                                                 : undefined
                                             }
                                           >
-                                            <ClientProvider api={api} service={service}>
+                                            <ClientProvider
+                                              api={api}
+                                              endpoint={input.server.endpoint}
+                                              service={service}
+                                            >
                                               <PermissionProvider>
                                                 <DataProvider>
                                                   <LocationProvider>
                                                     <SessionTabsProvider>
-                                                      <ThemeProvider
-                                                        mode={mode}
-                                                        source={createThemeSource(global.config)}
-                                                      >
-                                                        <ThemeErrorToast />
-                                                        <LocalProvider>
-                                                          <PromptStashProvider>
-                                                            <DialogProvider>
-                                                              <FrecencyProvider>
-                                                                <PromptHistoryProvider>
-                                                                  <PromptRefProvider>
-                                                                    <EditorContextProvider>
-                                                                      <AttentionProvider>
-                                                                        <PluginProvider
-                                                                          packages={input.packages}
-                                                                          directories={pluginDirectories}
-                                                                        >
-                                                                          <App
-                                                                            pair={
-                                                                              input.server.endpoint.auth
-                                                                                ? input.server.endpoint.auth
-                                                                                : {
-                                                                                    username: "opencode",
-                                                                                    password: "",
-                                                                                  }
-                                                                            }
-                                                                          />
-                                                                        </PluginProvider>
-                                                                      </AttentionProvider>
-                                                                    </EditorContextProvider>
-                                                                  </PromptRefProvider>
-                                                                </PromptHistoryProvider>
-                                                              </FrecencyProvider>
-                                                            </DialogProvider>
-                                                          </PromptStashProvider>
-                                                        </LocalProvider>
-                                                      </ThemeProvider>
+                                                      <PaneLayoutProvider>
+                                                        <ThemeProvider
+                                                          mode={mode}
+                                                          source={createThemeSource(global.config)}
+                                                        >
+                                                          <ThemeErrorToast />
+                                                          <LocalProvider>
+                                                            <PromptStashProvider>
+                                                              <DialogProvider>
+                                                                <FrecencyProvider>
+                                                                  <PromptHistoryProvider>
+                                                                    <PromptRefProvider>
+                                                                      <EditorContextProvider>
+                                                                        <AttentionProvider>
+                                                                          <PluginProvider
+                                                                            packages={input.packages}
+                                                                            directories={pluginDirectories}
+                                                                          >
+                                                                            <App
+                                                                              pair={
+                                                                                input.server.endpoint.auth
+                                                                                  ? input.server.endpoint.auth
+                                                                                  : {
+                                                                                      username: "opencode",
+                                                                                      password: "",
+                                                                                    }
+                                                                              }
+                                                                            />
+                                                                          </PluginProvider>
+                                                                        </AttentionProvider>
+                                                                      </EditorContextProvider>
+                                                                    </PromptRefProvider>
+                                                                  </PromptHistoryProvider>
+                                                                </FrecencyProvider>
+                                                              </DialogProvider>
+                                                            </PromptStashProvider>
+                                                          </LocalProvider>
+                                                        </ThemeProvider>
+                                                      </PaneLayoutProvider>
                                                     </SessionTabsProvider>
                                                   </LocationProvider>
                                                 </DataProvider>
@@ -1316,7 +1322,12 @@ function App(props: { pair?: DialogPairCredentials }) {
                 </Match>
                 <Match when={route.data.type === "session"}>
                   <Show when={route.data.type === "session" ? route.data.sessionID : undefined} keyed>
-                    {(_) => <Session verticalTabsWidth={verticalTabsVisible() ? verticalTabsWidth() : 0} />}
+                    {(sessionID) => (
+                      <PaneWorkspace
+                        sessionID={sessionID}
+                        verticalTabsWidth={verticalTabsVisible() ? verticalTabsWidth() : 0}
+                      />
+                    )}
                   </Show>
                 </Match>
                 <Match when={route.data.type === "plugin"}>

--- a/packages/tui/src/component/pane-workspace.tsx
+++ b/packages/tui/src/component/pane-workspace.tsx
@@ -1,0 +1,175 @@
+import { CliRenderEvents, RGBA, TextAttributes, type BoxRenderable, type Renderable } from "@opentui/core"
+import { useRenderer } from "@opentui/solid"
+import { createResource, createSignal, Match, onCleanup, Show, Switch, type JSX } from "solid-js"
+import { usePaneLayout } from "../context/pane-layout"
+import type { PaneLayoutNode } from "../context/pane-layout-model"
+import { useData } from "../context/data"
+import { usePromptRef } from "../context/prompt"
+import { useTheme } from "../context/theme"
+import { Session } from "../routes/session"
+import { PersistentTerminalPane } from "./persistent-terminal-pane"
+
+export function PaneWorkspace(props: { sessionID: string; verticalTabsWidth: number }) {
+  const panes = usePaneLayout()
+  createResource(
+    () => props.sessionID,
+    (sessionID) => panes.load(sessionID).catch(() => undefined),
+  )
+  const workspace = () => panes.get(props.sessionID)
+  return (
+    <Show when={workspace()} fallback={<Session verticalTabsWidth={props.verticalTabsWidth} />}>
+      {(value) => (
+        <PaneNode node={value().layout} rootSessionID={props.sessionID} verticalTabsWidth={props.verticalTabsWidth} />
+      )}
+    </Show>
+  )
+}
+
+function PaneNode(props: { node: PaneLayoutNode; rootSessionID?: string; verticalTabsWidth: number }) {
+  const panes = usePaneLayout()
+  const prompt = usePromptRef()
+  const theme = useTheme()
+  const data = useData()
+  return (
+    <Switch>
+      <Match when={props.node.type === "item" ? props.node.item : undefined}>
+        {(item) => {
+          let focusTerminal: (() => void) | undefined
+          const focus = () => {
+            if (item().type === "session" && item().id === props.rootSessionID) {
+              prompt.current?.focus()
+              return
+            }
+            focusTerminal?.()
+          }
+          return (
+            <PaneSurface
+              focus={focus}
+              title={
+                item().type === "terminal"
+                  ? "Terminal"
+                  : `Session · ${data.session.get(item().id)?.title ?? "Untitled"}`
+              }
+            >
+              <Switch>
+                <Match when={item().type === "session" && item().id === props.rootSessionID}>
+                  <Session verticalTabsWidth={props.verticalTabsWidth} />
+                </Match>
+                <Match when={item().type === "session"}>
+                  <UnavailablePane label={`Session ${item().id}`} />
+                </Match>
+                <Match when={item().type === "terminal"}>
+                  <PersistentTerminalPane
+                    ptyID={item().id}
+                    autoFocus={!props.rootSessionID || panes.shouldFocus(item().id)}
+                    onAutoFocus={() => panes.clearFocus(item().id)}
+                    onFocusRequest={(value) => (focusTerminal = value)}
+                  />
+                </Match>
+              </Switch>
+            </PaneSurface>
+          )
+        }}
+      </Match>
+      <Match when={props.node.type === "split" ? props.node : undefined}>
+        {(node) => (
+          <box
+            flexGrow={1}
+            minWidth={0}
+            minHeight={0}
+            flexDirection={node().direction === "horizontal" ? "row" : "column"}
+          >
+            <box flexGrow={node().ratio} flexBasis={0} minWidth={0} minHeight={0}>
+              <PaneNode
+                node={node().first}
+                rootSessionID={props.rootSessionID}
+                verticalTabsWidth={props.verticalTabsWidth}
+              />
+            </box>
+            <box flexGrow={1 - node().ratio} flexBasis={0} minWidth={0} minHeight={0}>
+              <PaneNode
+                node={node().second}
+                rootSessionID={props.rootSessionID}
+                verticalTabsWidth={props.verticalTabsWidth}
+              />
+            </box>
+          </box>
+        )}
+      </Match>
+    </Switch>
+  )
+}
+
+function PaneSurface(props: { focus: () => void; title: string; children: JSX.Element }) {
+  const renderer = useRenderer()
+  const theme = useTheme()
+  const [focused, setFocused] = createSignal(false)
+  let pane: BoxRenderable | undefined
+  const contains = (current: Renderable | null) => {
+    while (current) {
+      if (current === pane) return true
+      current = current.parent
+    }
+    return false
+  }
+  const onFocused = (current: Renderable | null) => setFocused(contains(current))
+  renderer.on(CliRenderEvents.FOCUSED_RENDERABLE, onFocused)
+  onCleanup(() => renderer.off(CliRenderEvents.FOCUSED_RENDERABLE, onFocused))
+  return (
+    <box
+      ref={(value) => {
+        pane = value
+        setFocused(contains(renderer.currentFocusedRenderable))
+      }}
+      flexGrow={1}
+      minWidth={0}
+      minHeight={0}
+      position="relative"
+      flexDirection="column"
+    >
+      <box
+        height={1}
+        flexShrink={0}
+        paddingLeft={1}
+        paddingRight={1}
+        backgroundColor={
+          focused() ? theme.raise(theme.raise(theme.background.surface.offset)) : theme.background.surface.offset
+        }
+      >
+        <text
+          fg={focused() ? theme.text.default : theme.text.subdued}
+          attributes={focused() ? TextAttributes.BOLD : undefined}
+          wrapMode="none"
+          truncate
+        >
+          {props.title}
+        </text>
+      </box>
+      <box flexGrow={1} minWidth={0} minHeight={0} position="relative">
+        {props.children}
+      </box>
+      <Show when={!focused()}>
+        <box
+          position="absolute"
+          left={0}
+          top={0}
+          width="100%"
+          height="100%"
+          zIndex={1}
+          backgroundColor={RGBA.fromInts(0, 0, 0)}
+          opacity={0.3}
+          onMouseDown={props.focus}
+        />
+      </Show>
+    </box>
+  )
+}
+
+function UnavailablePane(props: { label: string }) {
+  const theme = useTheme()
+  return (
+    <box flexGrow={1} alignItems="center" justifyContent="center">
+      <text fg={theme.text.subdued}>{props.label} is unavailable in this prototype.</text>
+    </box>
+  )
+}

--- a/packages/tui/src/component/persistent-terminal-pane.tsx
+++ b/packages/tui/src/component/persistent-terminal-pane.tsx
@@ -1,0 +1,370 @@
+import { EmbeddedTerminalRenderable, type RGBA } from "@opentui/core"
+import type { ResolvedThemeTokens } from "@opencode-ai/theme/tui"
+import { extend, useRenderer } from "@opentui/solid"
+import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js"
+import { useClient } from "../context/client"
+import { Keymap } from "../context/keymap"
+import { useTheme, useThemes } from "../context/theme"
+import { errorMessage } from "../util/error"
+
+declare module "@opentui/solid" {
+  interface OpenTUIComponents {
+    embeddedTerminal: typeof EmbeddedTerminalRenderable
+  }
+}
+
+extend({ embeddedTerminal: EmbeddedTerminalRenderable })
+
+type TerminalSize = { cols: number; rows: number }
+type StreamItem =
+  | { type: "output"; data: Uint8Array }
+  | { type: "resize"; size: TerminalSize; checkpoint?: Uint8Array }
+  | { type: "ready" }
+
+export function PersistentTerminalPane(props: {
+  ptyID: string
+  autoFocus?: boolean
+  onAutoFocus?: () => void
+  onFocusRequest?: (focus: (() => void) | undefined) => void
+}) {
+  const client = useClient()
+  const keymap = Keymap.use()
+  const theme = useTheme()
+  const themes = useThemes()
+  const renderer = useRenderer()
+  const [failure, setFailure] = createSignal<string>()
+  const attachmentID = crypto.randomUUID()
+  const stream: StreamItem[] = []
+  const pendingInput: Uint8Array[] = []
+  let terminal: EmbeddedTerminalRenderable | undefined
+  let socket: WebSocket | undefined
+  let attached = false
+  let controller = false
+  let restored = false
+  let wantsControl = false
+  let disposed = false
+  let size: TerminalSize | undefined
+  let canonicalSize: TerminalSize | undefined
+  let terminalSize: TerminalSize | undefined
+  let lastIntermediateRender = 0
+  let terminalTheme: Uint8Array | undefined
+  let waitingSize: { size: TerminalSize; resolve: () => void } | undefined
+
+  const setCanonicalSize = (value: TerminalSize) => {
+    canonicalSize = value
+    if (!terminal) return
+    terminal.width = value.cols
+    terminal.height = value.rows
+  }
+
+  const applyTerminalTheme = () => {
+    if (terminalTheme) terminal?.write(terminalTheme)
+  }
+
+  const send = (data: Uint8Array) => {
+    if (attached && socket?.readyState === WebSocket.OPEN) socket.send(data)
+  }
+
+  const interact = () => {
+    if (!restored) {
+      wantsControl = true
+      return
+    }
+    if (!size) return
+    send(interactionFrame(size))
+  }
+
+  const sendInput = (data: Uint8Array) => {
+    if (!restored) {
+      pendingInput.push(data)
+      return
+    }
+    if (size) send(interactionFrame(size, data))
+  }
+
+  const processStream = () => {
+    if (disposed || !terminal || !sameSize(canonicalSize, terminalSize)) return
+    while (stream.length > 0) {
+      const item = stream[0]!
+      if (item.type === "output") {
+        stream.shift()
+        const output = [item.data]
+        while (true) {
+          const next = stream[0]
+          if (!next || next.type !== "output") break
+          output.push(next.data)
+          stream.shift()
+        }
+        terminal.write(output.length === 1 ? output[0] : Buffer.concat(output))
+        continue
+      }
+      if (item.type === "resize") {
+        setCanonicalSize(item.size)
+        if (!sameSize(canonicalSize, terminalSize)) return
+        stream.shift()
+        if (item.checkpoint) {
+          terminal.write(Buffer.concat([Buffer.from("\x1bc"), Buffer.from(item.checkpoint)]))
+          applyTerminalTheme()
+        }
+        continue
+      }
+      stream.shift()
+      restored = true
+      const input = pendingInput.splice(0)
+      if (input.length > 0) input.forEach(sendInput)
+      if (input.length === 0 && (controller || wantsControl)) interact()
+      wantsControl = false
+    }
+  }
+
+  const enqueue = (item: StreamItem) => {
+    stream.push(item)
+    processStream()
+  }
+
+  const waitForTerminalSize = (value: TerminalSize) => {
+    if (sameSize(value, terminalSize)) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      waitingSize = { size: value, resolve }
+    })
+  }
+
+  const offKeys = keymap.intercept(
+    "key",
+    ({ event }) => {
+      if (!terminal?.focused) return
+      event.preventDefault()
+      event.stopPropagation()
+      terminal.handleKeyPress(event)
+    },
+    { priority: 100 },
+  )
+  createEffect(() => {
+    if (!props.autoFocus || !terminal) return
+    terminal.focus()
+    props.onAutoFocus?.()
+  })
+
+  createEffect(() => {
+    terminalTheme = terminalPalette(themes.currentTokens(), themes.mode())
+    applyTerminalTheme()
+  })
+
+  onMount(() => {
+    void connect().catch((error) => setFailure(errorMessage(error)))
+  })
+
+  onCleanup(() => {
+    disposed = true
+    waitingSize?.resolve()
+    socket?.close()
+    offKeys()
+    props.onFocusRequest?.(undefined)
+  })
+
+  async function connect() {
+    const endpoint = client.endpoint
+    if (!endpoint) throw new Error("Persistent terminal server endpoint is unavailable")
+    const snapshot = await client.api["server.persistentPty"].snapshot({ ptyID: props.ptyID })
+    if (disposed) return
+    setCanonicalSize(snapshot.info.size)
+    await waitForTerminalSize(snapshot.info.size)
+    if (disposed) return
+    terminal?.write(Buffer.from(snapshot.checkpoint, "base64"))
+    applyTerminalTheme()
+    const token = await client.api["server.persistentPty"].connectToken(
+      { ptyID: props.ptyID },
+      { headers: { "x-opencode-ticket": "1" } },
+    )
+    if (disposed) return
+    const url = new URL(`/api/persistent-pty/${encodeURIComponent(props.ptyID)}/connect`, endpoint.url)
+    url.protocol = url.protocol === "https:" ? "wss:" : "ws:"
+    url.searchParams.set("ticket", token.ticket)
+    url.searchParams.set("cursor", String(snapshot.info.output.tail))
+    url.searchParams.set("attachment_id", attachmentID)
+    url.searchParams.set("takeover", "true")
+    url.searchParams.set("input_protocol", "1")
+
+    const next = new WebSocket(url)
+    next.binaryType = "arraybuffer"
+    next.addEventListener("message", (event) => {
+      if (disposed) return
+      if (event.data instanceof ArrayBuffer) {
+        enqueue({ type: "output", data: new Uint8Array(event.data) })
+        const now = performance.now()
+        if (now - lastIntermediateRender >= 16) {
+          lastIntermediateRender = now
+          renderer.intermediateRender()
+        }
+        return
+      }
+      if (typeof event.data !== "string") return
+      const message: unknown = JSON.parse(event.data)
+      if (!message || typeof message !== "object" || !("type" in message)) return
+      if (
+        message.type === "resized" &&
+        "cols" in message &&
+        typeof message.cols === "number" &&
+        "rows" in message &&
+        typeof message.rows === "number" &&
+        "checkpoint" in message &&
+        typeof message.checkpoint === "string"
+      ) {
+        enqueue({
+          type: "resize",
+          size: { cols: message.cols, rows: message.rows },
+          checkpoint: Buffer.from(message.checkpoint, "base64"),
+        })
+        return
+      }
+      if (message.type === "replay_complete") {
+        enqueue({ type: "ready" })
+        return
+      }
+      if (
+        message.type === "controller_changed" &&
+        "attachmentID" in message &&
+        (typeof message.attachmentID === "string" || message.attachmentID === undefined)
+      ) {
+        const previous = controller
+        controller = message.attachmentID === attachmentID
+        if (controller && !previous && restored) interact()
+        return
+      }
+      if (message.type !== "attached") return
+      if (!("inputProtocol" in message) || message.inputProtocol !== 1) {
+        setFailure("Persistent terminal server is out of date; restart OpenCode")
+        next.close()
+        return
+      }
+      if (
+        "info" in message &&
+        message.info &&
+        typeof message.info === "object" &&
+        "size" in message.info &&
+        message.info.size &&
+        typeof message.info.size === "object" &&
+        "cols" in message.info.size &&
+        typeof message.info.size.cols === "number" &&
+        "rows" in message.info.size &&
+        typeof message.info.size.rows === "number"
+      )
+        enqueue({ type: "resize", size: { cols: message.info.size.cols, rows: message.info.size.rows } })
+      controller = "role" in message && message.role === "controller"
+      attached = true
+    })
+    next.addEventListener("error", () => {
+      if (!disposed) setFailure("Terminal connection failed")
+    })
+    next.addEventListener("close", () => {
+      if (!disposed) setFailure("Terminal disconnected")
+    })
+    socket = next
+  }
+
+  return (
+    <box
+      flexGrow={1}
+      minWidth={0}
+      minHeight={0}
+      overflow="hidden"
+      backgroundColor={theme.background.default}
+      onSizeChange={function () {
+        size = { cols: this.width, rows: this.height }
+        if (controller && restored) interact()
+      }}
+      // TODO: Revisit when embedded terminal mouse handlers can compose without replacing its internal focus handler.
+      onMouseDown={() => interact()}
+    >
+      <Show when={!failure()} fallback={<text fg={theme.text.feedback.error.default}>{failure()}</text>}>
+        <>
+          <embeddedTerminal
+          ref={(value) => {
+            terminal = value
+            props.onFocusRequest?.(() => {
+              value.focus()
+              interact()
+            })
+              terminalSize = { cols: 80, rows: 24 }
+              if (canonicalSize) {
+                value.width = canonicalSize.cols
+                value.height = canonicalSize.rows
+              }
+              applyTerminalTheme()
+            }}
+            position="absolute"
+            left={0}
+            top={0}
+            width={80}
+            height={24}
+            onData={(data, source) => {
+              if (source === "input") sendInput(data)
+            }}
+            onTerminalResize={(cols, rows) => {
+              terminalSize = { cols, rows }
+              if (waitingSize && sameSize(waitingSize.size, terminalSize)) {
+                waitingSize.resolve()
+                waitingSize = undefined
+              }
+              processStream()
+            }}
+          />
+        </>
+      </Show>
+    </box>
+  )
+}
+
+function sameSize(first: TerminalSize | undefined, second: TerminalSize | undefined) {
+  return !!first && !!second && first.cols === second.cols && first.rows === second.rows
+}
+
+function terminalPalette(theme: ResolvedThemeTokens, mode: "dark" | "light") {
+  const base = mode === "dark" ? 500 : 700
+  const bright = mode === "dark" ? 300 : 500
+  const colors = [
+    theme.background.default,
+    theme.text.feedback.error.default,
+    theme.text.feedback.success.default,
+    theme.text.feedback.warning.default,
+    theme.hue.blue[base],
+    theme.hue.purple[base],
+    theme.text.feedback.info.default,
+    theme.text.default,
+    theme.text.subdued,
+    theme.text.feedback.error.subdued,
+    theme.text.feedback.success.subdued,
+    theme.text.feedback.warning.subdued,
+    theme.hue.blue[bright],
+    theme.hue.purple[bright],
+    theme.hue.cyan[bright],
+    theme.hue.neutral[mode === "dark" ? 100 : 900],
+  ]
+  return Buffer.from(
+    colors
+      .map((color, index) => `\x1b]4;${index};${hex(color)}\x1b\\`)
+      .concat(
+        `\x1b]10;${hex(theme.text.default)}\x1b\\`,
+        `\x1b]11;${hex(theme.background.default)}\x1b\\`,
+      )
+      .join(""),
+  )
+}
+
+function hex(color: RGBA) {
+  return `#${color
+    .toInts()
+    .slice(0, 3)
+    .map((value) => value.toString(16).padStart(2, "0"))
+    .join("")}`
+}
+
+function interactionFrame(size: { cols: number; rows: number }, data?: Uint8Array) {
+  const frame = new Uint8Array(5 + (data?.byteLength ?? 0))
+  const view = new DataView(frame.buffer)
+  frame[0] = data ? 1 : 0
+  view.setUint16(1, size.cols)
+  view.setUint16(3, size.rows)
+  if (data) frame.set(data, 5)
+  return frame
+}

--- a/packages/tui/src/context/client.tsx
+++ b/packages/tui/src/context/client.tsx
@@ -1,12 +1,13 @@
 import type { OpenCodeClient, OpenCodeEvent } from "@opencode-ai/client"
 import { createClientConnection } from "@opencode-ai/client/solid"
+import type { Endpoint } from "@opencode-ai/client/service"
 import { createGlobalEmitter } from "@solid-primitives/event-bus"
 import { onCleanup } from "solid-js"
 import { createSimpleContext } from "./helper"
 import { useLog } from "./log"
 
 type ManagedService = {
-  reconnect: (signal: AbortSignal) => Promise<{ api: OpenCodeClient }>
+  reconnect: (signal: AbortSignal) => Promise<{ api: OpenCodeClient; endpoint?: Endpoint }>
   restart: () => Promise<void>
 }
 
@@ -14,16 +15,19 @@ type ClientEventMap = { [Type in OpenCodeEvent["type"]]: Extract<OpenCodeEvent, 
 
 export const { use: useClient, provider: ClientProvider } = createSimpleContext({
   name: "Client",
-  init: (props: { api: OpenCodeClient; service?: ManagedService }) => {
+  init: (props: { api: OpenCodeClient; endpoint?: Endpoint; service?: ManagedService }) => {
     const log = useLog({ component: "client" })
     const service = props.service
     const events = createGlobalEmitter<ClientEventMap>()
     let api = props.api
+    let endpoint = props.endpoint
 
     const connection = createClientConnection(api, {
       reconnect: service
         ? async (signal) => {
-            api = (await service.reconnect(signal)).api
+            const next = await service.reconnect(signal)
+            api = next.api
+            if (next.endpoint) endpoint = next.endpoint
             return api
           }
         : undefined,
@@ -40,6 +44,9 @@ export const { use: useClient, provider: ClientProvider } = createSimpleContext(
     return {
       get api() {
         return api
+      },
+      get endpoint() {
+        return endpoint
       },
       event: {
         on: events.on,

--- a/packages/tui/src/context/pane-layout-model.ts
+++ b/packages/tui/src/context/pane-layout-model.ts
@@ -1,0 +1,70 @@
+export type PaneItem = { type: "session"; id: string } | { type: "terminal"; id: string }
+
+export type PaneLayoutNode =
+  | { type: "item"; item: PaneItem }
+  | {
+      type: "split"
+      direction: "horizontal" | "vertical"
+      ratio: number
+      first: PaneLayoutNode
+      second: PaneLayoutNode
+    }
+
+export function defaultPaneLayout(items: readonly PaneItem[]): PaneLayoutNode | undefined {
+  const master = items[0]
+  if (!master) return undefined
+  const stack = items.slice(1)
+  if (stack.length === 0) return { type: "item", item: master }
+  return {
+    type: "split",
+    direction: "horizontal",
+    ratio: 0.5,
+    first: { type: "item", item: master },
+    second: stackLayout(stack),
+  }
+}
+
+function stackLayout(items: readonly PaneItem[]): PaneLayoutNode {
+  const first = items[0]
+  if (items.length === 1) return { type: "item", item: first }
+  return {
+    type: "split",
+    direction: "vertical",
+    ratio: 1 / items.length,
+    first: { type: "item", item: first },
+    second: stackLayout(items.slice(1)),
+  }
+}
+
+export function paneLayoutItems(node: PaneLayoutNode): PaneItem[] {
+  if (node.type === "item") return [node.item]
+  return paneLayoutItems(node.first).concat(paneLayoutItems(node.second))
+}
+
+export function removePaneLayoutItem(node: PaneLayoutNode, item: PaneItem): PaneLayoutNode | undefined {
+  if (node.type === "item") return itemKey(node.item) === itemKey(item) ? undefined : node
+  const first = removePaneLayoutItem(node.first, item)
+  const second = removePaneLayoutItem(node.second, item)
+  if (!first) return second
+  if (!second) return first
+  if (first === node.first && second === node.second) return node
+  return { ...node, first, second }
+}
+
+export function reconcilePaneLayout(node: PaneLayoutNode | undefined, items: readonly PaneItem[]) {
+  if (!node) return defaultPaneLayout(items)
+  const wanted = new Map(items.map((item) => [itemKey(item), item]))
+  const kept = paneLayoutItems(node).filter((item) => wanted.has(itemKey(item)))
+  if (kept.length !== items.length || kept.some((item, index) => itemKey(item) !== itemKey(items[index])))
+    return defaultPaneLayout(items)
+  return replaceItems(node, wanted)
+}
+
+function replaceItems(node: PaneLayoutNode, items: ReadonlyMap<string, PaneItem>): PaneLayoutNode {
+  if (node.type === "item") return { type: "item", item: items.get(itemKey(node.item)) ?? node.item }
+  return { ...node, first: replaceItems(node.first, items), second: replaceItems(node.second, items) }
+}
+
+function itemKey(item: PaneItem) {
+  return `${item.type}:${item.id}`
+}

--- a/packages/tui/src/context/pane-layout.tsx
+++ b/packages/tui/src/context/pane-layout.tsx
@@ -1,0 +1,92 @@
+import type { PersistentPtyInfo } from "@opencode-ai/client"
+import { createSignal, onCleanup } from "solid-js"
+import { createSimpleContext } from "./helper"
+import { useClient } from "./client"
+import { useData } from "./data"
+import { useEvent } from "./event"
+import { reconcilePaneLayout, type PaneItem, type PaneLayoutNode } from "./pane-layout-model"
+import { useStorage } from "./storage"
+
+type PaneWorkspace = {
+  sessionID: string
+  items: PaneItem[]
+  layout: PaneLayoutNode
+}
+
+type PaneLayoutState = {
+  workspaces: Record<string, PaneWorkspace>
+}
+
+export const { use: usePaneLayout, provider: PaneLayoutProvider } = createSimpleContext({
+  name: "PaneLayout",
+  init: () => {
+    const client = useClient()
+    const data = useData()
+    const event = useEvent()
+    const [focus, setFocus] = createSignal<string>()
+    const [store, update] = useStorage().store<PaneLayoutState>("pane-layout-v1", {
+      initial: { workspaces: {} },
+    })
+
+    const save = (sessionID: string, terminals: readonly PersistentPtyInfo[]) =>
+      update((draft) => {
+        const items: PaneItem[] = [
+          { type: "session", id: sessionID },
+          ...terminals.map((terminal) => ({ type: "terminal" as const, id: terminal.id })),
+        ]
+        const layout = reconcilePaneLayout(draft.workspaces[sessionID]?.layout, items)
+        if (!layout) return
+        draft.workspaces[sessionID] = { sessionID, items, layout }
+      })
+
+    const refresh = async (sessionID: string) => {
+      await save(sessionID, await client.api["server.persistentPty"].list({ sessionID }))
+    }
+
+    onCleanup(
+      event.on("persistent-pty.added", (evt) => {
+        if (!store.workspaces[evt.data.sessionID]) return
+        void refresh(evt.data.sessionID).catch((error) =>
+          console.error("Failed to add persistent terminal pane", error),
+        )
+      }),
+    )
+
+    onCleanup(
+      event.on("persistent-pty.removed", (evt) => {
+        if (!store.workspaces[evt.data.sessionID]) return
+        void refresh(evt.data.sessionID).catch((error) =>
+          console.error("Failed to remove persistent terminal pane", error),
+        )
+      }),
+    )
+
+    return {
+      get(sessionID: string) {
+        return store.workspaces[sessionID]
+      },
+      load: refresh,
+      refresh,
+      async newTerminal(sessionID: string, options?: { focus?: boolean }): Promise<PersistentPtyInfo> {
+        const session = data.session.get(sessionID)
+        const terminal = await client.api["server.persistentPty"].create({
+          sessionID,
+          command: process.env.SHELL || "/bin/sh",
+          args: [],
+          cwd: session?.location.directory ?? process.cwd(),
+          title: "Terminal",
+          env: {},
+        })
+        if (options?.focus !== false) setFocus(terminal.id)
+        await refresh(sessionID)
+        return terminal
+      },
+      shouldFocus(ptyID: string) {
+        return focus() === ptyID
+      },
+      clearFocus(ptyID: string) {
+        setFocus((current) => (current === ptyID ? undefined : current))
+      },
+    }
+  },
+})

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -110,6 +110,7 @@ import { createDelayedPresence } from "../../util/delayed-presence"
 import { SessionLocationMissing } from "./location-missing"
 import { isRecord } from "../../util/record"
 import { createHistoryPrepend } from "./history"
+import { usePaneLayout } from "../../context/pane-layout"
 
 addDefaultParsers(parsers.parsers)
 
@@ -280,6 +281,7 @@ export function Session(props: { verticalTabsWidth: number }) {
   const [navigationSlack, setNavigationSlack] = createSignal(0)
   const [synced, setSynced] = createSignal(false)
   const sessionTabs = useSessionTabs()
+  const panes = usePaneLayout()
   const [awayFromBottom, setAwayFromBottom] = createSignal(false)
   const [latestHovered, setLatestHovered] = createSignal(false)
   let ensureAllRowsPending: (() => void)[] | undefined
@@ -889,6 +891,16 @@ export function Session(props: { verticalTabsWidth: number }) {
           setSidebarOpen(!isVisible)
         })
         dialog.clear()
+      },
+    },
+    {
+      title: "New terminal",
+      id: "session.terminal",
+      group: "Session",
+      slash: { name: "terminal" },
+      run: async () => {
+        dialog.clear()
+        await panes.newTerminal(route.sessionID, { focus: false }).catch(toast.error)
       },
     },
     {

--- a/packages/tui/test/context/pane-layout-model.test.ts
+++ b/packages/tui/test/context/pane-layout-model.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import {
+  defaultPaneLayout,
+  paneLayoutItems,
+  reconcilePaneLayout,
+  removePaneLayoutItem,
+  type PaneItem,
+} from "../../src/context/pane-layout-model"
+
+const session = (id: string): PaneItem => ({ type: "session", id })
+const terminal = (id: string): PaneItem => ({ type: "terminal", id })
+
+describe("pane layout model", () => {
+  test("builds a master pane with an evenly divided right stack", () => {
+    const items = [session("ses_1"), terminal("pty_1"), terminal("pty_2"), terminal("pty_3")]
+    const layout = defaultPaneLayout(items)
+
+    expect(layout).toEqual({
+      type: "split",
+      direction: "horizontal",
+      ratio: 0.5,
+      first: { type: "item", item: items[0] },
+      second: {
+        type: "split",
+        direction: "vertical",
+        ratio: 1 / 3,
+        first: { type: "item", item: items[1] },
+        second: {
+          type: "split",
+          direction: "vertical",
+          ratio: 0.5,
+          first: { type: "item", item: items[2] },
+          second: { type: "item", item: items[3] },
+        },
+      },
+    })
+    expect(paneLayoutItems(layout!)).toEqual(items)
+  })
+
+  test("preserves stored split ratios when backend items still match", () => {
+    const items = [session("ses_1"), terminal("pty_1")]
+    const layout = defaultPaneLayout(items)!
+    if (layout.type !== "split") throw new Error("Expected a split")
+    layout.ratio = 0.65
+
+    expect(reconcilePaneLayout(layout, items)).toMatchObject({ ratio: 0.65 })
+  })
+
+  test("rebuilds the default layout when backend order changes", () => {
+    const items = [session("ses_1"), terminal("pty_1")]
+    const layout = defaultPaneLayout(items)!
+    if (layout.type !== "split") throw new Error("Expected a split")
+    layout.ratio = 0.65
+
+    expect(reconcilePaneLayout(layout, items.toReversed())).toMatchObject({ ratio: 0.5 })
+  })
+
+  test("removes a pane and preserves the remaining BSP layout", () => {
+    const items = [session("ses_1"), terminal("pty_1"), terminal("pty_2")]
+    const layout = defaultPaneLayout(items)!
+    if (layout.type !== "split" || layout.second.type !== "split") throw new Error("Expected nested splits")
+    layout.ratio = 0.65
+    layout.second.ratio = 0.3
+
+    expect(removePaneLayoutItem(layout, items[1])).toEqual({
+      type: "split",
+      direction: "horizontal",
+      ratio: 0.65,
+      first: { type: "item", item: items[0] },
+      second: { type: "item", item: items[2] },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- render persistent embedded terminals beside sessions and in terminal-only workspace tabs
- restore authoritative terminal snapshots/replay and synchronize controller input, resizing, and focus
- add pane layout state, terminal creation, slash commands, home entry points, and workspace cleanup
- preserve current `v2` server-backed unread/viewed state, focus acknowledgements, and closed-tab race protection
- exclude temporary screenshot tooling and active-tab repro redirects from the original umbrella branch

## Verification
- `bun run typecheck` in `packages/tui` and `packages/cli`
- `bun test test/context/pane-layout-model.test.ts test/context/session-tabs.test.tsx test/feature-plugins/prompt-footer.test.tsx` in `packages/tui` (28 tests)

Stack: 4/5, based on #44834; final PR applies the pending pane layout/presentation polish.