### PR TITLE
feat(app): add in-tab new session button

### DIFF
--- a/packages/app/src/components/dialog-custom-menu.tsx
+++ b/packages/app/src/components/dialog-custom-menu.tsx
@@ -1,0 +1,111 @@
+import { Component, createSignal, startTransition } from "solid-js"
+import { Dialog } from "@opencode-ai/ui/dialog"
+import { Tabs } from "@opencode-ai/ui/tabs"
+import { Collapsible } from "@opencode-ai/ui/collapsible"
+import { Icon } from "@opencode-ai/ui/icon"
+import { useLanguage } from "@/context/language"
+import { usePlatform } from "@/context/platform"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { SettingsGeneral } from "./settings-general"
+import { SettingsKeybinds } from "./settings-keybinds"
+import { SettingsProviders } from "./settings-providers"
+import { SettingsModels } from "./settings-models"
+import { SettingsServers } from "./settings-servers"
+
+export const DialogCustomMenu: Component<{ defaultValue?: string }> = (props) => {
+  const language = useLanguage()
+  const platform = usePlatform()
+  const dialog = useDialog()
+  const [tab, setTab] = createSignal(props.defaultValue ?? "general")
+
+  const showProviders = () => {
+    void dialog.show(() => <DialogCustomMenu defaultValue="providers" />)
+  }
+
+  return (
+    <Dialog size="x-large" transition>
+      <Tabs
+        orientation="vertical"
+        variant="settings"
+        value={tab()}
+        onChange={(value) => void startTransition(() => setTab(value))}
+        class="h-full settings-dialog"
+      >
+        <Tabs.List>
+          <div class="flex flex-col justify-between h-full w-full gap-4">
+            <div class="flex flex-col gap-3 w-full pt-3">
+              <div class="flex flex-col gap-1.5 w-full">
+                <Tabs.Trigger value="custom">
+                  <Icon name="plus" />
+                  {language.t("customMenu.tab.custom")}
+                </Tabs.Trigger>
+              </div>
+
+              <Collapsible variant="ghost" defaultOpen={false} class="w-full">
+                <Collapsible.Trigger class="flex items-center gap-1 px-1">
+                  <span>{language.t("customMenu.tab.settings")}</span>
+                  <Collapsible.Arrow />
+                </Collapsible.Trigger>
+                <Collapsible.Content>
+                  <div class="flex flex-col gap-3 pt-1">
+                    <div class="flex flex-col gap-1.5">
+                      <Tabs.SectionTitle>{language.t("settings.section.desktop")}</Tabs.SectionTitle>
+                      <div class="flex flex-col gap-1.5 w-full">
+                        <Tabs.Trigger value="general">
+                          <Icon name="sliders" />
+                          {language.t("settings.tab.general")}
+                        </Tabs.Trigger>
+                        <Tabs.Trigger value="shortcuts">
+                          <Icon name="keyboard" />
+                          {language.t("settings.tab.shortcuts")}
+                        </Tabs.Trigger>
+                        <Tabs.Trigger value="servers">
+                          <Icon name="server" />
+                          {language.t("status.popover.tab.servers")}
+                        </Tabs.Trigger>
+                      </div>
+                    </div>
+
+                    <div class="flex flex-col gap-1.5">
+                      <Tabs.SectionTitle>{language.t("settings.section.server")}</Tabs.SectionTitle>
+                      <div class="flex flex-col gap-1.5 w-full">
+                        <Tabs.Trigger value="providers">
+                          <Icon name="providers" />
+                          {language.t("settings.providers.title")}
+                        </Tabs.Trigger>
+                        <Tabs.Trigger value="models">
+                          <Icon name="models" />
+                          {language.t("settings.models.title")}
+                        </Tabs.Trigger>
+                      </div>
+                    </div>
+                  </div>
+                </Collapsible.Content>
+              </Collapsible>
+            </div>
+            <div class="flex flex-col gap-1 pl-1 py-1 text-12-medium text-text-weak">
+              <span>{language.t("app.name.desktop")}</span>
+              <span class="text-11-regular">v{platform.version}</span>
+            </div>
+          </div>
+        </Tabs.List>
+        <Tabs.Content value="custom" class="no-scrollbar" />
+        <Tabs.Content value="general" class="no-scrollbar">
+          <SettingsGeneral />
+        </Tabs.Content>
+        <Tabs.Content value="shortcuts" class="no-scrollbar">
+          <SettingsKeybinds />
+        </Tabs.Content>
+        <Tabs.Content value="servers" class="no-scrollbar">
+          <SettingsServers />
+        </Tabs.Content>
+        <Tabs.Content value="providers" class="no-scrollbar">
+          <SettingsProviders onBack={showProviders} />
+        </Tabs.Content>
+        <Tabs.Content value="models" class="no-scrollbar">
+          <SettingsModels />
+        </Tabs.Content>
+      </Tabs>
+    </Dialog>
+  )
+}

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -58,6 +58,11 @@ export function PromptInputV2Composer(props: PromptInputV2ComposerProps) {
         variantControlVisible={!props.controller.model.loading}
         attachKeybind={command.keybindParts("file.attach")}
         attachShortcut={command.keybind("file.attach")}
+        onCreateCustom={() => {
+          void import("@/components/dialog-custom-menu").then((module) => {
+            void dialog.show(() => <module.DialogCustomMenu />)
+          })
+        }}
         modelControl={
           <PromptInputV2ModelControl
             loading={props.controller.model.loading}

--- a/packages/app/src/components/titlebar-tab-gesture.test.ts
+++ b/packages/app/src/components/titlebar-tab-gesture.test.ts
@@ -1,16 +1,19 @@
 import { describe, expect, test } from "bun:test"
-import { canOpenTabRename, canStartTabDrag, forwardTabRef, isTabCloseTarget } from "./titlebar-tab-gesture"
+import { canOpenTabRename, canStartTabDrag, forwardTabRef, isTabActionTarget } from "./titlebar-tab-gesture"
 
 describe("titlebar tab gestures", () => {
-  test("excludes close controls from tab gestures", () => {
+  test("excludes close and new controls from tab gestures", () => {
     const close = document.createElement("div")
     const button = document.createElement("button")
     const link = document.createElement("a")
+    const fresh = document.createElement("div")
     close.dataset.slot = "tab-close"
     close.append(button)
-    expect(isTabCloseTarget(close)).toBe(true)
-    expect(isTabCloseTarget(button)).toBe(true)
-    expect(isTabCloseTarget(link)).toBe(false)
+    fresh.dataset.slot = "tab-new"
+    expect(isTabActionTarget(close)).toBe(true)
+    expect(isTabActionTarget(button)).toBe(true)
+    expect(isTabActionTarget(fresh)).toBe(true)
+    expect(isTabActionTarget(link)).toBe(false)
   })
 
   test("forwards component refs", () => {

--- a/packages/app/src/components/titlebar-tab-gesture.ts
+++ b/packages/app/src/components/titlebar-tab-gesture.ts
@@ -1,7 +1,7 @@
 import type { Ref } from "solid-js"
 
-export function isTabCloseTarget(target: EventTarget | null) {
-  return target instanceof Element && !!target.closest('[data-slot="tab-close"]')
+export function isTabActionTarget(target: EventTarget | null) {
+  return target instanceof Element && !!target.closest('[data-slot="tab-close"], [data-slot="tab-new"]')
 }
 
 export function canStartTabDrag(pointerType: string) {

--- a/packages/app/src/components/titlebar-tab-nav.css
+++ b/packages/app/src/components/titlebar-tab-nav.css
@@ -9,6 +9,17 @@
   justify-content: center;
 }
 
+[data-titlebar-tab] [data-slot="tab-new"] {
+  position: absolute;
+  top: 4px;
+  inset-inline-end: 28px;
+  display: flex;
+  height: 20px;
+  width: 20px;
+  align-items: center;
+  justify-content: center;
+}
+
 [data-titlebar-tab] {
   --tab-base: var(--v2-background-bg-deep);
   --tab-overlay: transparent;
@@ -27,11 +38,12 @@
   --tab-overlay: var(--v2-overlay-simple-overlay-pressed);
 }
 
+[data-titlebar-tab]:is(:hover, [data-state="pressed"]) [data-slot="tab-new"],
 [data-titlebar-tab]:is(:hover, [data-state="pressed"]) [data-slot="tab-close"] {
   background: linear-gradient(var(--tab-overlay), var(--tab-overlay)), var(--tab-base);
 }
 
-[data-titlebar-tab][data-editing="true"] [data-slot="tab-close"] {
+[data-titlebar-tab][data-editing="true"] [data-slot="tab-new"] {
   display: none;
 }
 
@@ -108,6 +120,11 @@
   --tab-title-fade-offset: 24px;
 }
 
+[data-titlebar-tab][data-titlebar-tab-new][data-title-overflow="true"]:is(:hover, [data-active="true"]):not([data-editing="true"])
+  [data-slot="tab-link"] {
+  --tab-title-fade-offset: 48px;
+}
+
 [data-titlebar-tab][data-title-overflow="true"]:not(:hover):not([data-active="true"]):not([data-editing="true"])
   [data-slot="tab-link"] {
   padding-inline-end: 0;
@@ -146,5 +163,9 @@
     right: auto;
     left: 50%;
     transform: translateX(-50%);
+  }
+
+  [data-slot="tab-new"] {
+    display: none;
   }
 }

--- a/packages/app/src/components/titlebar-tab-nav.tsx
+++ b/packages/app/src/components/titlebar-tab-nav.tsx
@@ -25,6 +25,7 @@ export function TabNavItem(props: {
   fallbackTitle?: string
   onRename: (title: string) => Promise<void>
   onClose: () => void
+  onNew: () => void
   onNavigate: () => void
   active?: boolean
   forceTruncate?: boolean
@@ -39,6 +40,7 @@ export function TabNavItem(props: {
   let titleEl!: HTMLSpanElement
   let measureFrame: number | undefined
   const rename = createMutation(() => ({ mutationFn: props.onRename }))
+  const language = useLanguage()
 
   const closeTab = (event: MouseEvent) => {
     event.preventDefault()
@@ -178,6 +180,7 @@ export function TabNavItem(props: {
         forwardTabRef(props.ref, el)
       }}
       data-titlebar-tab
+      data-titlebar-tab-new
       data-slot="titlebar-tab-item"
       data-title-overflow={titleOverflowing()}
       data-editing={editing()}
@@ -277,6 +280,25 @@ export function TabNavItem(props: {
           }}
         />
       </a>
+
+      <div data-slot="tab-new">
+        <IconButtonV2
+          size="small"
+          variant="ghost-muted"
+          class="hover-reveal relative z-10 group-hover:opacity-100 group-data-[active=true]:opacity-100 group-data-[editing=true]:opacity-100"
+          onPointerDown={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            props.onNew()
+          }}
+          icon={<IconV2 name="plus" />}
+          aria-label={language.t("command.session.new")}
+        />
+      </div>
 
       <div data-slot="tab-close">
         <IconButtonV2

--- a/packages/app/src/components/titlebar-tab-strip.tsx
+++ b/packages/app/src/components/titlebar-tab-strip.tsx
@@ -14,10 +14,10 @@ import { useGlobal, type ServerCtx } from "@/context/global"
 import { useLanguage } from "@/context/language"
 import { useCommand } from "@/context/command"
 import { useTabs } from "@/context/tabs"
-import { createTabPromptState } from "@/context/prompt"
+import { createTabPromptState, type PromptSession } from "@/context/prompt"
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { showToast } from "@/utils/toast"
-import { canStartTabDrag, isTabCloseTarget } from "./titlebar-tab-gesture"
+import { canStartTabDrag, isTabActionTarget } from "./titlebar-tab-gesture"
 import { adjacentTabKey, mergeVisibleTabOrder } from "./titlebar-tab-order"
 import type { Session } from "@opencode-ai/sdk/v2"
 
@@ -32,6 +32,7 @@ function SessionTabSlot(props: {
   onRename: (title: string) => Promise<void>
   onNavigate: (element: HTMLDivElement) => void
   onClose: () => void
+  onNew: () => void
 }) {
   const sortable = useSortable({
     get id() {
@@ -62,6 +63,7 @@ function SessionTabSlot(props: {
         onRename={props.onRename}
         onNavigate={() => props.onNavigate(ref)}
         onClose={props.onClose}
+        onNew={props.onNew}
         active={props.active()}
         forceTruncate={props.forceTruncate}
         dragging={sortable.isDragSource()}
@@ -117,6 +119,13 @@ function SessionTabEntry(props: {
     }
   }
 
+  const newInPlace = () => {
+    const value = session()
+    if (!value) return
+    const model = tabs.stateValue<PromptSession>(props.tab, "prompt")?.model.current()
+    void tabs.replaceWithDraft(props.tab, value.directory, "", model)
+  }
+
   createEffect(() => props.onVisibleChange(visible()))
 
   createEffect(() => {
@@ -162,6 +171,7 @@ function SessionTabEntry(props: {
         onRename={rename}
         onNavigate={props.onNavigate}
         onClose={props.onClose}
+        onNew={newInPlace}
       />
     </Show>
   )
@@ -297,7 +307,7 @@ export function TitlebarTabStrip(props: {
               activationConstraints: [new PointerActivationConstraints.Distance({ value: 4 })],
               preventActivation: (event) =>
                 !canStartTabDrag(event.pointerType) ||
-                isTabCloseTarget(event.target) ||
+                isTabActionTarget(event.target) ||
                 (event.target instanceof Element && !!event.target.closest('[contenteditable="true"]')),
             }),
           ]}

--- a/packages/app/src/context/tabs.tsx
+++ b/packages/app/src/context/tabs.tsx
@@ -220,6 +220,28 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
         })
         return tab
       },
+      async replaceWithDraft(tab: SessionTab, directory: string, prompt?: string, model?: PromptModel) {
+        const index = store.findIndex((item) => tabKey(item) === tabKey(tab))
+        if (index === -1) return
+        const draftID = uuid()
+        const draft = { type: "draft" as const, draftID, server: tab.server, directory }
+        memory.ensure(tabKey(draft), "prompt", () => createDraftPromptSession(draftID, { prompt, model }))
+        await startTransition(() => {
+          setStore(
+            produce((tabs) => {
+              const current = tabs[index]
+              if (!current || tabKey(current) !== tabKey(tab)) return
+              tabs[index] = draft
+            }),
+          )
+          if (recent.key === tabKey(tab)) setRecentKey(tabKey(draft))
+          navigate(draftHref(draftID))
+        })
+        updateClosed((stack) => pushClosedTab(stack, tab, index))
+        memory.remove(tabKey(tab))
+        removeInfo(tabKey(tab))
+        return draft
+      },
       updateDraft(draftID: string, draft: Partial<Omit<DraftTab, "type" | "draftID">>) {
         void startTransition(() => {
           setStore(

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -893,6 +893,8 @@ export const dict = {
   "settings.section.server": "Server",
   "settings.tab.general": "General",
   "settings.tab.shortcuts": "Shortcuts",
+  "customMenu.tab.settings": "Settings",
+  "customMenu.tab.custom": "Custom",
   "settings.desktop.section.wsl": "WSL",
   "settings.desktop.wsl.title": "WSL integration",
   "settings.desktop.wsl.description": "Run the OpenCode server inside WSL on Windows.",

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -44,6 +44,7 @@ export type PromptInputV2Props = {
   variantControlVisible?: boolean
   attachKeybind?: string[]
   attachShortcut?: string
+  onCreateCustom?: () => void
 }
 
 export function PromptInputV2(props: PromptInputV2Props) {
@@ -253,6 +254,11 @@ export function PromptInputV2(props: PromptInputV2Props) {
                 </Show>
               )}
             </Show>
+            <PromptInputV2CustomMenuButton
+              title={i18n.t("ui.promptInput.customMenu")}
+              keybind={["Shift", "Mod", "D"]}
+              onCreateCustom={props.onCreateCustom}
+            />
           </div>
           <PromptInputV2SubmitButton
             mode={state.mode}
@@ -545,6 +551,46 @@ function PromptInputV2ConfiguredSelect(props: {
       }
       onSelect={props.control.onSelect}
     />
+  )
+}
+
+function PromptInputV2CustomMenuButton(props: { title: string; keybind?: string[]; onCreateCustom?: () => void }) {
+  const i18n = useI18n()
+  return (
+    <TooltipV2
+      placement="top"
+      value={
+        <>
+          {props.title}
+          <KeybindV2 keys={props.keybind ?? []} variant="neutral" />
+        </>
+      }
+    >
+      <MenuV2 gutter={6} modal={false} placement="top-start">
+        <MenuV2.Trigger
+          as={ButtonV2}
+          variant="ghost-muted"
+          size="normal"
+          class="max-w-[220px] justify-start ![font-weight:440]"
+          aria-label={props.title}
+          data-action="custom_menu_button"
+        >
+          <span class="truncate capitalize leading-5">{i18n.t("ui.promptInput.customMenu")}</span>
+          <span class="-ms-0.5 -me-1 flex shrink-0">
+            <IconV2 name="chevron-down" />
+          </span>
+        </MenuV2.Trigger>
+        <MenuV2.Portal>
+          <MenuV2.Content>
+            <MenuV2.Item onSelect={props.onCreateCustom}>{i18n.t("ui.promptInput.createCustom")}</MenuV2.Item>
+            <MenuV2.Item>{" "}</MenuV2.Item>
+            <MenuV2.Item>{" "}</MenuV2.Item>
+            <MenuV2.Item>{" "}</MenuV2.Item>
+            <MenuV2.Item>{" "}</MenuV2.Item>
+          </MenuV2.Content>
+        </MenuV2.Portal>
+      </MenuV2>
+    </TooltipV2>
   )
 }
 

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -136,6 +136,8 @@ export const dict: Record<string, string> = {
   "ui.promptInput.chooseAgent": "Choose agent",
   "ui.promptInput.chooseModel": "Choose model",
   "ui.promptInput.chooseVariant": "Choose model variant",
+  "ui.promptInput.customMenu": "menu",
+  "ui.promptInput.createCustom": "Create custom...",
   "ui.promptInput.send": "Send",
   "ui.promptInput.stop": "Stop",
 


### PR DESCRIPTION
Hovering a session tab now shows a + button to the left of the close button that replaces the tab in place with a fresh draft session.