### PR TITLE
fix(core): materialize mentioned skills on prompts

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -476,7 +476,7 @@ export type PromptFileAttachment = {
 
 export type PromptAgentAttachment = { name: string; mention?: PromptMention }
 
-export type PromptSkillAttachment = { id: string; name: string; mention?: PromptMention }
+export type PromptSkillAttachment = { id: string; name: string; text?: string; mention?: PromptMention }
 
 export type SessionMessageAssistantText = { type: "text"; text: string; state?: SessionMessageProviderState }
 
@@ -2740,6 +2740,7 @@ export type SessionImportInput = {
           readonly skills?: ReadonlyArray<{
             readonly id: string
             readonly name: string
+            readonly text?: string
             readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
           }>
           readonly type: "user"
@@ -3015,6 +3016,7 @@ export type SessionImportInput = {
           readonly skills?: ReadonlyArray<{
             readonly id: string
             readonly name: string
+            readonly text?: string
             readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
           }>
           readonly type: "user"
@@ -3290,6 +3292,7 @@ export type SessionImportInput = {
           readonly skills?: ReadonlyArray<{
             readonly id: string
             readonly name: string
+            readonly text?: string
             readonly mention?: { readonly start: number; readonly end: number; readonly text: string }
           }>
           readonly type: "user"

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -596,7 +596,11 @@ const layer = Layer.effect(
               yield* plugins.flush
               return yield* Image.Service
             }).pipe(Effect.provide(locations.get(session.location)))
-            const skills = Skill.Service.pipe(Effect.provide(locations.get(session.location)))
+            const skills = Effect.gen(function* () {
+              const plugins = yield* PluginSupervisor.Service
+              yield* plugins.flush
+              return yield* Skill.Service
+            }).pipe(Effect.provide(locations.get(session.location)))
             const prompt = yield* resolvePrompt(
               { text: input.text, files: input.files, agents: input.agents, skills: input.skills },
               image,
@@ -717,16 +721,21 @@ const layer = Layer.effect(
       }),
       skill: Effect.fn("Session.skill")(function* (input) {
         const session = yield* result.get(input.sessionID)
-        const skills = yield* Skill.Service.pipe(Effect.provide(locations.get(session.location)))
-        const skill = (yield* skills.list()).find((item) => item.id === input.skill)
+        const skills = yield* Effect.gen(function* () {
+          const plugins = yield* PluginSupervisor.Service
+          yield* plugins.flush
+          return yield* Skill.Service
+        }).pipe(Effect.provide(locations.get(session.location)))
+        const skill = yield* skills.get(input.skill)
         if (!skill) return yield* new SkillNotFoundError({ skill: input.skill })
+        const prepared = yield* Skill.prepare(fs, skill).pipe(Effect.orDie)
         yield* bus.publish(
           SessionEvent.Skill.Activated,
           {
             sessionID: input.sessionID,
-            id: skill.id,
-            name: skill.name,
-            text: skill.content,
+            id: prepared.id,
+            name: prepared.name,
+            text: prepared.output,
           },
           { id: input.id ? Event.ID.make(input.id.replace(/^msg_/, "evt_")) : undefined },
         )
@@ -970,16 +979,21 @@ const resolvePrompt = Effect.fn("Session.resolvePrompt")(function* (
   const selected = yield* Effect.gen(function* () {
     if (!requested?.length) return undefined
     const skillService = yield* skills
-    const available = yield* skillService.list()
-    return yield* Effect.forEach(requested, (attachment) => {
-      const skill = available.find((item) => item.id === attachment.id)
-      if (!skill) return Effect.fail(new SkillNotFoundError({ skill: attachment.id }))
-      return Effect.succeed({
-        id: skill.id,
-        name: skill.name,
-        mention: attachment.mention,
-      })
-    })
+    const prepared = new Map<Skill.ID, string>()
+    return yield* Effect.forEach(requested, (attachment) =>
+      Effect.gen(function* () {
+        const skill = yield* skillService.get(attachment.id)
+        if (!skill) return yield* new SkillNotFoundError({ skill: attachment.id })
+        const text = prepared.get(skill.id) ?? (yield* Skill.prepare(fs, skill).pipe(Effect.orDie)).output
+        prepared.set(skill.id, text)
+        return {
+          id: skill.id,
+          name: skill.name,
+          text,
+          mention: attachment.mention,
+        }
+      }),
+    )
   })
   return Prompt.make({ text: input.text, agents: input.agents, files, skills: selected?.length ? selected : undefined })
 })

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -721,21 +721,16 @@ const layer = Layer.effect(
       }),
       skill: Effect.fn("Session.skill")(function* (input) {
         const session = yield* result.get(input.sessionID)
-        const skills = yield* Effect.gen(function* () {
-          const plugins = yield* PluginSupervisor.Service
-          yield* plugins.flush
-          return yield* Skill.Service
-        }).pipe(Effect.provide(locations.get(session.location)))
+        const skills = yield* Skill.Service.pipe(Effect.provide(locations.get(session.location)))
         const skill = yield* skills.get(input.skill)
         if (!skill) return yield* new SkillNotFoundError({ skill: input.skill })
-        const prepared = yield* Skill.prepare(fs, skill).pipe(Effect.orDie)
         yield* bus.publish(
           SessionEvent.Skill.Activated,
           {
             sessionID: input.sessionID,
-            id: prepared.id,
-            name: prepared.name,
-            text: prepared.output,
+            id: skill.id,
+            name: skill.name,
+            text: skill.content,
           },
           { id: input.id ? Event.ID.make(input.id.replace(/^msg_/, "evt_")) : undefined },
         )
@@ -979,17 +974,18 @@ const resolvePrompt = Effect.fn("Session.resolvePrompt")(function* (
   const selected = yield* Effect.gen(function* () {
     if (!requested?.length) return undefined
     const skillService = yield* skills
-    const prepared = new Map<Skill.ID, string>()
+    const prepared = new Map<Skill.ID, Skill.Name>()
     return yield* Effect.forEach(requested, (attachment) =>
       Effect.gen(function* () {
+        const name = prepared.get(attachment.id)
+        if (name !== undefined) return { id: attachment.id, name, mention: attachment.mention }
         const skill = yield* skillService.get(attachment.id)
         if (!skill) return yield* new SkillNotFoundError({ skill: attachment.id })
-        const text = prepared.get(skill.id) ?? (yield* Skill.prepare(fs, skill).pipe(Effect.orDie)).output
-        prepared.set(skill.id, text)
+        prepared.set(skill.id, skill.name)
         return {
           id: skill.id,
           name: skill.name,
-          text,
+          text: (yield* Skill.prepare(fs, skill).pipe(Effect.orDie)).output,
           mention: attachment.mention,
         }
       }),

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -139,7 +139,14 @@ const serialize = (message: SessionMessage.Info) => {
         (file) =>
           `[Attached ${file.mime}: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")}]`,
       ) ?? []
-    return [`[User]: ${message.text}`, ...files].join("\n")
+    const skills = Array.from(
+      new Map(
+        (message.skills ?? []).flatMap((skill) =>
+          skill.text === undefined ? [] : [[skill.id, `[Skill activated: ${skill.name}]\n${skill.text}`] as const],
+        ),
+      ).values(),
+    )
+    return [...skills, `[User]: ${message.text}`, ...files].join("\n")
   }
   if (message.type === "location-switched")
     return `[User]: The working directory has been changed to ${message.location.directory}.`

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -139,13 +139,10 @@ const serialize = (message: SessionMessage.Info) => {
         (file) =>
           `[Attached ${file.mime}: ${file.name ?? (file.source.type === "uri" ? file.source.uri : "inline attachment")}]`,
       ) ?? []
-    const skills = Array.from(
-      new Map(
-        (message.skills ?? []).flatMap((skill) =>
-          skill.text === undefined ? [] : [[skill.id, `[Skill activated: ${skill.name}]\n${skill.text}`] as const],
-        ),
-      ).values(),
-    )
+    const skills =
+      message.skills?.flatMap((skill) =>
+        skill.text === undefined ? [] : [`[Skill activated: ${skill.name}]\n${skill.text}`],
+      ) ?? []
     return [...skills, `[User]: ${message.text}`, ...files].join("\n")
   }
   if (message.type === "location-switched")

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -236,14 +236,7 @@ function toLLMMessage(message: SessionMessage.Info, model: Model.Ref, providerMe
       ]
     case "user":
       const content = [
-        ...Array.from(
-          new Map(
-            (message.skills ?? []).flatMap((skill) =>
-              skill.text === undefined ? [] : [[skill.id, skill.text] as const],
-            ),
-          ).values(),
-          Message.text,
-        ),
+        ...(message.skills ?? []).flatMap((skill) => (skill.text === undefined ? [] : [Message.text(skill.text)])),
         ...(message.text === "" ? [] : [Message.text(message.text)]),
         ...userAttachmentContent(message.files ?? []),
       ]

--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -236,6 +236,14 @@ function toLLMMessage(message: SessionMessage.Info, model: Model.Ref, providerMe
       ]
     case "user":
       const content = [
+        ...Array.from(
+          new Map(
+            (message.skills ?? []).flatMap((skill) =>
+              skill.text === undefined ? [] : [[skill.id, skill.text] as const],
+            ),
+          ).values(),
+          Message.text,
+        ),
         ...(message.text === "" ? [] : [Message.text(message.text)]),
         ...userAttachmentContent(message.files ?? []),
       ]

--- a/packages/core/src/session/transfer.ts
+++ b/packages/core/src/session/transfer.ts
@@ -220,6 +220,7 @@ function sanitizeMessage(message: SessionMessage.Info): SessionMessage.Info {
       skills: message.skills?.map((skill, index) => ({
         ...skill,
         name: Skill.Name.make(redact("skill-name", String(index), skill.name)),
+        text: skill.text === undefined ? undefined : redact("skill", String(index), skill.text),
         mention: skill.mention
           ? { ...skill.mention, text: redact("skill-mention", String(index), skill.mention.text) }
           : undefined,

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -1,6 +1,7 @@
 export * as Skill from "./skill.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { FSUtil } from "@opencode-ai/util/fs-util"
 import path from "path"
 import { Context, Effect, Layer, Types } from "effect"
 import { Skill } from "@opencode-ai/schema/skill"
@@ -52,6 +53,23 @@ export const toModelOutput = (skill: Info, files: ReadonlyArray<string>) => {
   ].join("\n")
 }
 
+export const prepare = Effect.fn("Skill.prepare")(function* (fs: FSUtil.Interface, skill: Info) {
+  const directory = path.dirname(skill.location)
+  const files =
+    path.basename(skill.location) === "SKILL.md"
+      ? (yield* fs.scan("**/*", { cwd: directory, absolute: true, include: "file", dot: true }))
+          .filter((file) => path.basename(file) !== "SKILL.md")
+          .toSorted()
+          .slice(0, 10)
+      : []
+  return {
+    id: skill.id,
+    name: skill.name,
+    directory,
+    output: toModelOutput(skill, files),
+  }
+})
+
 export type Data = {
   skills: Map<ID, Types.DeepMutable<Info>>
 }
@@ -64,6 +82,7 @@ export type Draft = {
 }
 
 export interface Interface extends State.Transformable<Draft> {
+  readonly get: (id: ID) => Effect.Effect<Info | undefined>
   readonly list: () => Effect.Effect<Info[]>
 }
 
@@ -98,6 +117,9 @@ const layer = Layer.effect(
     return Service.of({
       transform: state.transform,
       reload: state.reload,
+      get: Effect.fn("Skill.get")(function* (id) {
+        return state.get().skills.get(id)
+      }),
       list: Effect.fn("Skill.list")(function* () {
         return Array.from(state.get().skills.values())
       }),

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -1,7 +1,7 @@
 export * as Skill from "./skill.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { FSUtil } from "@opencode-ai/util/fs-util"
+import type { FSUtil } from "@opencode-ai/util/fs-util"
 import path from "path"
 import { Context, Effect, Layer, Types } from "effect"
 import { Skill } from "@opencode-ai/schema/skill"
@@ -63,8 +63,6 @@ export const prepare = Effect.fn("Skill.prepare")(function* (fs: FSUtil.Interfac
           .slice(0, 10)
       : []
   return {
-    id: skill.id,
-    name: skill.name,
     directory,
     output: toModelOutput(skill, files),
   }

--- a/packages/core/src/skill/instructions.ts
+++ b/packages/core/src/skill/instructions.ts
@@ -26,7 +26,6 @@ const render = (skills: ReadonlyArray<Summary>) =>
   [
     "Skills provide specialized instructions and workflows for specific tasks.",
     "Use the skill tool to load a skill when a task matches its description.",
-    "When the user references a skill with @skill-id, load that skill with the skill tool.",
     ...(skills.length === 0
       ? ["No skills are currently available."]
       : ["<available_skills>", ...entries(skills), "</available_skills>"]),

--- a/packages/core/src/tool/plugin/skill.ts
+++ b/packages/core/src/tool/plugin/skill.ts
@@ -56,8 +56,7 @@ export const Plugin = {
                   agent: context.agent,
                   source: { type: "tool", messageID: context.messageID, id: context.id },
                 })
-                const prepared = yield* Skill.prepare(fs, skill)
-                return { name: prepared.name, directory: prepared.directory, output: prepared.output }
+                return { name: skill.name, ...(yield* Skill.prepare(fs, skill)) }
               }).pipe(Effect.mapError((error) => unableToLoad(input.id, error)))
             }).pipe(
               Effect.map((output) => ({

--- a/packages/core/src/tool/plugin/skill.ts
+++ b/packages/core/src/tool/plugin/skill.ts
@@ -1,7 +1,6 @@
 export * as SkillTool from "./skill.js"
 
 import type { Context as PluginContext } from "@opencode-ai/plugin/effect/plugin"
-import path from "path"
 import { ToolFailure } from "@opencode-ai/ai"
 import { Effect, Schema } from "effect"
 import { FSUtil } from "@opencode-ai/util/fs-util"
@@ -9,7 +8,6 @@ import { Skill } from "../../skill.js"
 import { Permission } from "../../permission.js"
 
 export const name = "skill"
-const FILE_LIMIT = 10
 
 export const Input = Schema.Struct({
   id: Skill.ID.annotate({ description: "The ID of an available skill or a skill explicitly referenced by the user" }),
@@ -47,8 +45,7 @@ export const Plugin = {
           output: Output,
           execute: (input, context) =>
             Effect.gen(function* () {
-              const current = yield* skills.list()
-              const skill = current.find((skill) => skill.id === input.id)
+              const skill = yield* skills.get(input.id)
               if (!skill) return yield* unableToLoad(input.id)
               return yield* Effect.gen(function* () {
                 yield* permission.assert({
@@ -59,19 +56,8 @@ export const Plugin = {
                   agent: context.agent,
                   source: { type: "tool", messageID: context.messageID, id: context.id },
                 })
-                const directory = path.dirname(skill.location)
-                const files =
-                  path.basename(skill.location) === "SKILL.md"
-                    ? (yield* fs.scan("**/*", { cwd: directory, absolute: true, include: "file", dot: true }))
-                        .filter((file) => path.basename(file) !== "SKILL.md")
-                        .toSorted()
-                        .slice(0, FILE_LIMIT)
-                    : []
-                return {
-                  name: skill.name,
-                  directory,
-                  output: Skill.toModelOutput(skill, files),
-                }
+                const prepared = yield* Skill.prepare(fs, skill)
+                return { name: prepared.name, directory: prepared.directory, output: prepared.output }
               }).pipe(Effect.mapError((error) => unableToLoad(input.id, error)))
             }).pipe(
               Effect.map((output) => ({

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -23,6 +23,7 @@ import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
 import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Money } from "@opencode-ai/schema/money"
+import { Skill } from "@opencode-ai/schema/skill"
 import { DateTime, Effect, Fiber, Layer, Schema, Stream } from "effect"
 import { asc, eq } from "drizzle-orm"
 import { testEffect } from "./lib/effect"
@@ -231,6 +232,13 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
       id: SessionMessage.ID.create(),
       type: "user" as const,
       text: "Manual compaction should include this short conversation.",
+      skills: [
+        {
+          id: Skill.ID.make("effect"),
+          name: Skill.Name.make("Effect"),
+          text: "Use Effect services and generators.",
+        },
+      ],
       time: { created: DateTime.makeUnsafe(0) },
     }
     const session = yield* insertSession(sessionID, { parent_id: parentID })
@@ -261,6 +269,7 @@ it.effect("manual compaction summarizes short context instead of no-op", () =>
     })
     expect(requests[0]?.generation).toBeUndefined()
     expect(JSON.stringify(requests[0]?.messages)).toContain("Manual compaction should include this short conversation.")
+    expect(JSON.stringify(requests[0]?.messages)).toContain("Use Effect services and generators.")
     expect(yield* store.context(sessionID)).toMatchObject([
       { type: "compaction", reason: "manual", summary: "manual summary", recent: "" },
     ])

--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -5,6 +5,7 @@ import path from "path"
 import { DateTime, Effect, Layer, Stream } from "effect"
 import { Money } from "@opencode-ai/schema/money"
 import { Shell } from "@opencode-ai/schema/shell"
+import { Skill } from "@opencode-ai/schema/skill"
 import { Agent } from "@opencode-ai/core/agent"
 import { asc, eq } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
@@ -1178,6 +1179,13 @@ describe("SessionTransfer", () => {
               id: sourceMessageID,
               type: "user",
               text: "Imported message",
+              skills: [
+                {
+                  id: Skill.ID.make("effect"),
+                  name: Skill.Name.make("Effect"),
+                  text: "Private skill instructions from /private/project",
+                },
+              ],
               time: { created: DateTime.makeUnsafe(100) },
             },
             {
@@ -1207,7 +1215,11 @@ describe("SessionTransfer", () => {
       const sanitized = yield* transfer.export({ sessionID, sanitize: true })
       expect(sanitized.info.time).toMatchObject({ idle: DateTime.makeUnsafe(200), viewed: DateTime.makeUnsafe(150) })
       expect(sanitized.messages).toMatchObject([
-        { id: sourceMessageID, text: `[redacted:text:${sourceMessageID}]` },
+        {
+          id: sourceMessageID,
+          text: `[redacted:text:${sourceMessageID}]`,
+          skills: [{ id: "effect", name: "[redacted:skill-name:0]", text: "[redacted:skill:0]" }],
+        },
         { id: errorMessageID, error: { type: "test_error", message: "Original error" } },
       ])
 

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -222,7 +222,7 @@ Recent work
           id: id("user-skill-content"),
           type: "user",
           text: "Use @effect and @api-design",
-          skills: [effect, api, effect],
+          skills: [effect, api, SkillAttachment.make({ id: effect.id, name: effect.name })],
           time: { created },
         }),
       ],

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -205,6 +205,44 @@ Recent work
     })
   })
 
+  test("lowers each prepared skill once before the prompt", () => {
+    const effect = SkillAttachment.make({
+      id: Skill.ID.make("effect"),
+      name: Skill.Name.make("Effect"),
+      text: "<skill_content>Use Effect</skill_content>",
+    })
+    const api = SkillAttachment.make({
+      id: Skill.ID.make("api-design"),
+      name: Skill.Name.make("API design"),
+      text: "<skill_content>Design APIs</skill_content>",
+    })
+    const messages = toLLMMessages(
+      [
+        SessionMessage.User.make({
+          id: id("user-skill-content"),
+          type: "user",
+          text: "Use @effect and @api-design",
+          skills: [effect, api, effect],
+          time: { created },
+        }),
+      ],
+      model,
+    )
+
+    expect(messages).toEqual([
+      Message.make({
+        id: id("user-skill-content"),
+        role: "user",
+        content: [
+          { type: "text", text: "<skill_content>Use Effect</skill_content>" },
+          { type: "text", text: "<skill_content>Design APIs</skill_content>" },
+          { type: "text", text: "Use @effect and @api-design" },
+        ],
+        metadata: {},
+      }),
+    ])
+  })
+
   test("does not inject skill content for reference-only attachments", () => {
     const messages = toLLMMessages(
       [

--- a/packages/core/test/session-skill.test.ts
+++ b/packages/core/test/session-skill.test.ts
@@ -70,8 +70,11 @@ describe("Session.skill", () => {
       yield* sessions.prompt({
         id,
         sessionID: session.id,
-        text: "Apply @effect",
-        skills: [{ id: Skill.ID.make("effect"), mention: { start: 6, end: 13, text: "@effect" } }],
+        text: "Apply @effect and @effect",
+        skills: [
+          { id: Skill.ID.make("effect"), mention: { start: 6, end: 13, text: "@effect" } },
+          { id: Skill.ID.make("effect"), mention: { start: 18, end: 25, text: "@effect" } },
+        ],
         resume: false,
       })
       expect(yield* sessions.messages({ sessionID: session.id })).toEqual([])
@@ -81,13 +84,18 @@ describe("Session.skill", () => {
         expect.objectContaining({
           id,
           type: "user",
-          text: "Apply @effect",
+          text: "Apply @effect and @effect",
           skills: [
             {
               id: "effect",
               name: "Effect",
               text: Skill.toModelOutput(info, []),
               mention: { start: 6, end: 13, text: "@effect" },
+            },
+            {
+              id: "effect",
+              name: "Effect",
+              mention: { start: 18, end: 25, text: "@effect" },
             },
           ],
         }),
@@ -131,13 +139,7 @@ describe("Session.skill", () => {
       yield* sessions.skill({ id, sessionID: session.id, skill: Skill.ID.make("effect"), resume: false })
 
       expect(yield* sessions.messages({ sessionID: session.id })).toContainEqual(
-        expect.objectContaining({
-          id,
-          type: "skill",
-          skill: "effect",
-          name: "Effect",
-          text: Skill.toModelOutput(info, []),
-        }),
+        expect.objectContaining({ id, type: "skill", skill: "effect", name: "Effect", text: "Use Effect" }),
       )
     }),
   )

--- a/packages/core/test/session-skill.test.ts
+++ b/packages/core/test/session-skill.test.ts
@@ -9,6 +9,7 @@ import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
 import type { LocationServices } from "@opencode-ai/core/location-services"
 import { Project } from "@opencode-ai/core/project"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor-service"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
@@ -23,18 +24,20 @@ const location = Location.Ref.make({ directory: AbsolutePath.make("/project") })
 const projects = Layer.mock(Project.Service, {
   resolve: (directory) => Effect.succeed({ id: Project.ID.global, directory, canonical: directory }),
 })
-const skills = Layer.mock(Skill.Service, {
-  list: () =>
-    Effect.succeed([
-      Skill.Info.make({
-        id: Skill.ID.make("effect"),
-        name: Skill.Name.make("Effect"),
-        description: "Effect guidance",
-        location: AbsolutePath.make(path.resolve("/skills/effect/SKILL.md")),
-        content: "Use Effect",
-      }),
-    ]),
+const info = Skill.Info.make({
+  id: Skill.ID.make("effect"),
+  name: Skill.Name.make("Effect"),
+  description: "Effect guidance",
+  location: AbsolutePath.make(path.resolve("/skills/effect.md")),
+  content: "Use Effect",
 })
+const skills = Layer.merge(
+  Layer.mock(Skill.Service, {
+    get: (id) => Effect.succeed(id === info.id ? info : undefined),
+    list: () => Effect.succeed([info]),
+  }),
+  Layer.succeed(PluginSupervisor.Service, { flush: Effect.void }),
+)
 const locations = Layer.effect(
   LocationServiceMap.Service,
   LayerMap.make(
@@ -56,7 +59,7 @@ const it = testEffect(
 )
 
 describe("Session.skill", () => {
-  it.effect("keeps skill mentions as references on a normal prompt", () =>
+  it.effect("materializes mentioned skills on their owning prompt", () =>
     Effect.gen(function* () {
       const sessions = yield* Session.Service
       const database = yield* Database.Service
@@ -71,9 +74,10 @@ describe("Session.skill", () => {
         skills: [{ id: Skill.ID.make("effect"), mention: { start: 6, end: 13, text: "@effect" } }],
         resume: false,
       })
+      expect(yield* sessions.messages({ sessionID: session.id })).toEqual([])
       yield* SessionInbox.promote(database.db, bus, session.id, "steer")
 
-      expect(yield* sessions.messages({ sessionID: session.id })).toContainEqual(
+      expect(yield* sessions.messages({ sessionID: session.id })).toEqual([
         expect.objectContaining({
           id,
           type: "user",
@@ -82,11 +86,39 @@ describe("Session.skill", () => {
             {
               id: "effect",
               name: "Effect",
+              text: Skill.toModelOutput(info, []),
               mention: { start: 6, end: 13, text: "@effect" },
             },
           ],
         }),
-      )
+      ])
+    }),
+  )
+
+  it.effect("excludes mentioned skills when forking before their prompt", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const database = yield* Database.Service
+      const bus = yield* Bus.Service
+      const session = yield* sessions.create({ location })
+      const initial = SessionMessage.ID.make("msg_before_skill_attachment")
+      const selected = SessionMessage.ID.make("msg_fork_skill_attachment")
+
+      yield* sessions.prompt({ id: initial, sessionID: session.id, text: "Before the skill", resume: false })
+      yield* SessionInbox.promote(database.db, bus, session.id, "steer")
+      yield* sessions.prompt({
+        id: selected,
+        sessionID: session.id,
+        text: "Apply @effect",
+        skills: [{ id: info.id, mention: { start: 6, end: 13, text: "@effect" } }],
+        resume: false,
+      })
+      yield* SessionInbox.promote(database.db, bus, session.id, "steer")
+      const forked = yield* sessions.fork({ sessionID: session.id, boundary: { type: "before", messageID: selected } })
+
+      expect(yield* sessions.messages({ sessionID: forked.id })).toEqual([
+        expect.objectContaining({ type: "user", text: "Before the skill" }),
+      ])
     }),
   )
 
@@ -99,7 +131,13 @@ describe("Session.skill", () => {
       yield* sessions.skill({ id, sessionID: session.id, skill: Skill.ID.make("effect"), resume: false })
 
       expect(yield* sessions.messages({ sessionID: session.id })).toContainEqual(
-        expect.objectContaining({ id, type: "skill", skill: "effect", name: "Effect", text: "Use Effect" }),
+        expect.objectContaining({
+          id,
+          type: "skill",
+          skill: "effect",
+          name: "Effect",
+          text: Skill.toModelOutput(info, []),
+        }),
       )
     }),
   )

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -31,6 +31,8 @@ describe("Skill", () => {
       })
 
       expect(yield* skill.list()).toEqual([info("review", "Second"), info("deploy", "Deploy")])
+      expect(yield* skill.get(Skill.ID.make("review"))).toEqual(info("review", "Second"))
+      expect(yield* skill.get(Skill.ID.make("missing"))).toBeUndefined()
     }),
   )
 

--- a/packages/core/test/skill/instructions.test.ts
+++ b/packages/core/test/skill/instructions.test.ts
@@ -59,7 +59,6 @@ describe("SkillInstructions", () => {
         [
           "Skills provide specialized instructions and workflows for specific tasks.",
           "Use the skill tool to load a skill when a task matches its description.",
-          "When the user references a skill with @skill-id, load that skill with the skill tool.",
           "<available_skills>",
           "  <skill>",
           "    <id>effect</id>",

--- a/packages/core/test/tool-skill.test.ts
+++ b/packages/core/test/tool-skill.test.ts
@@ -74,6 +74,7 @@ describe("SkillTool", () => {
             Skill.Service.of({
               transform: (_transform) => Effect.die("unused"),
               reload: () => Effect.die("unused"),
+              get: (id) => Effect.succeed(current.find((skill) => skill.id === id)),
               list: () => Effect.succeed(current),
             }),
           )

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -16200,6 +16200,9 @@
           "name": {
             "type": "string"
           },
+          "text": {
+            "type": "string"
+          },
           "mention": {
             "$ref": "#/components/schemas/Prompt.Mention"
           }

--- a/packages/schema/src/prompt.ts
+++ b/packages/schema/src/prompt.ts
@@ -57,6 +57,7 @@ export interface SkillAttachment extends Schema.Schema.Type<typeof SkillAttachme
 export const SkillAttachment = Schema.Struct({
   id: Skill.ID,
   name: Skill.Name,
+  text: Schema.String.pipe(optional),
   mention: PromptMention.pipe(optional),
 }).annotate({ identifier: "Prompt.SkillAttachment" })
 

--- a/packages/schema/test/contract-hygiene.test.ts
+++ b/packages/schema/test/contract-hygiene.test.ts
@@ -6,6 +6,7 @@ import { Form } from "../src/form.js"
 import { Mcp } from "../src/mcp.js"
 import { Model } from "../src/model.js"
 import { Project } from "../src/project.js"
+import { SkillAttachment } from "../src/prompt.js"
 import { Provider } from "../src/provider.js"
 import { Pty } from "../src/pty.js"
 import { Session } from "../src/session.js"
@@ -77,6 +78,16 @@ describe("contract hygiene", () => {
         time: { ...info.time, idle: DateTime.makeUnsafe(2), viewed: DateTime.makeUnsafe(1) },
       }).time,
     ).toEqual({ created: 0, updated: 0, idle: 2, viewed: 1 })
+  })
+
+  test("skill attachments retain legacy references while accepting prepared instructions", () => {
+    const reference = { id: Skill.ID.make("effect"), name: Skill.Name.make("Effect") }
+    expect(Schema.decodeUnknownSync(SkillAttachment)(reference)).toEqual(reference)
+    expect(Schema.encodeSync(SkillAttachment)({ ...reference, text: undefined })).toEqual(reference)
+    expect(Schema.decodeUnknownSync(SkillAttachment)({ ...reference, text: "Use Effect" })).toEqual({
+      ...reference,
+      text: "Use Effect",
+    })
   })
 
   test("session inbox items omit the internal enqueue sequence", () => {

--- a/packages/tui/src/mini/stream-v2.transport.ts
+++ b/packages/tui/src/mini/stream-v2.transport.ts
@@ -190,6 +190,7 @@ function pendingPrompt(item: SessionInboxInfo): FooterQueuedPrompt | undefined {
     messageID: item.id,
     prompt: { messageID: item.id, text: item.payload.text, parts: [] },
     delivery: item.delivery,
+    ...(item.payload.skills?.length ? { skills: item.payload.skills } : {}),
   }
 }
 
@@ -956,15 +957,20 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       syncPending()
       const visible = state.messageIDs.has(event.data.inboxID)
       if (waiting || pending) state.messageIDs.add(event.data.inboxID)
-      if (!waiting && pending && !visible) {
+      if (pending && !visible) {
         write([
-          {
-            kind: "user",
-            source: "system",
-            text: pending.prompt.text,
-            phase: "start",
-            messageID: event.data.inboxID,
-          },
+          ...(pending.skills ?? []).map((skill) => skillCommit(event.data.inboxID, skill.name, skill.id)),
+          ...(!waiting
+            ? [
+                {
+                  kind: "user" as const,
+                  source: "system" as const,
+                  text: pending.prompt.text,
+                  phase: "start" as const,
+                  messageID: event.data.inboxID,
+                },
+              ]
+            : []),
         ])
       }
       write([], { phase: "running", status: "waiting for assistant" })
@@ -979,6 +985,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       if (state.messageIDs.has(event.data.inboxID)) return
       state.messageIDs.add(event.data.inboxID)
       write([
+        ...(pending.skills ?? []).map((skill) => skillCommit(event.data.inboxID, skill.name, skill.id)),
         {
           kind: "user",
           source: "system",

--- a/packages/tui/src/mini/stream-v2.transport.ts
+++ b/packages/tui/src/mini/stream-v2.transport.ts
@@ -190,7 +190,9 @@ function pendingPrompt(item: SessionInboxInfo): FooterQueuedPrompt | undefined {
     messageID: item.id,
     prompt: { messageID: item.id, text: item.payload.text, parts: [] },
     delivery: item.delivery,
-    ...(item.payload.skills?.length ? { skills: item.payload.skills } : {}),
+    ...(item.payload.skills?.length
+      ? { skills: item.payload.skills.map((skill) => ({ id: skill.id, name: skill.name })) }
+      : {}),
   }
 }
 
@@ -387,6 +389,12 @@ function skillCommit(messageID: string, name: string, skillID = messageID): Stre
     text: `→ Skill "${name}"`,
     phase: "start",
   }
+}
+
+function skillCommits(messageID: string, skills: FooterQueuedPrompt["skills"] = []) {
+  return Array.from(new Map(skills.map((skill) => [skill.id, skill])).values(), (skill) =>
+    skillCommit(messageID, skill.name, skill.id),
+  )
 }
 
 function compactionCommit(messageID: string): StreamCommit {
@@ -668,7 +676,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       if (!render) return
       if (reuseVisibleWait && waiting) return
       write([
-        ...(message.skills ?? []).map((skill) => skillCommit(message.id, skill.name, skill.id)),
+        ...skillCommits(message.id, message.skills),
         { kind: "user", source: "system", text: message.text, phase: "start", messageID: message.id },
       ])
       return
@@ -957,23 +965,16 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       syncPending()
       const visible = state.messageIDs.has(event.data.inboxID)
       if (waiting || pending) state.messageIDs.add(event.data.inboxID)
-      if (pending && !visible) {
-        write([
-          ...(pending.skills ?? []).map((skill) => skillCommit(event.data.inboxID, skill.name, skill.id)),
-          ...(!waiting
-            ? [
-                {
-                  kind: "user" as const,
-                  source: "system" as const,
-                  text: pending.prompt.text,
-                  phase: "start" as const,
-                  messageID: event.data.inboxID,
-                },
-              ]
-            : []),
-        ])
-      }
-      write([], { phase: "running", status: "waiting for assistant" })
+      const commits = pending && !visible ? skillCommits(event.data.inboxID, pending.skills) : []
+      if (!waiting && pending && !visible)
+        commits.push({
+          kind: "user",
+          source: "system",
+          text: pending.prompt.text,
+          phase: "start",
+          messageID: event.data.inboxID,
+        })
+      write(commits, { phase: "running", status: "waiting for assistant" })
       return
     }
     if (event.type === "session.inbox.delivery.changed") {
@@ -985,7 +986,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       if (state.messageIDs.has(event.data.inboxID)) return
       state.messageIDs.add(event.data.inboxID)
       write([
-        ...(pending.skills ?? []).map((skill) => skillCommit(event.data.inboxID, skill.name, skill.id)),
+        ...skillCommits(event.data.inboxID, pending.skills),
         {
           kind: "user",
           source: "system",

--- a/packages/tui/src/mini/types.ts
+++ b/packages/tui/src/mini/types.ts
@@ -93,6 +93,7 @@ export type FooterQueuedPrompt = {
   messageID: string
   prompt: RunPrompt
   delivery: RunDelivery
+  skills?: ReadonlyArray<{ id: string; name: string }>
 }
 
 export type QueuedPromptAction = "steer" | "cancel"

--- a/packages/tui/test/mini/stream-v2.transport.test.ts
+++ b/packages/tui/test/mini/stream-v2.transport.test.ts
@@ -669,7 +669,10 @@ describe("V2 mini transport", () => {
             type: "user",
             payload: {
               text: "follow up",
-              skills: [{ id: "effect", name: "Effect", text: "Use Effect services" }],
+              skills: [
+                { id: "effect", name: "Effect", text: "Use Effect services" },
+                { id: "effect", name: "Effect" },
+              ],
             },
             delivery: "queue",
           },

--- a/packages/tui/test/mini/stream-v2.transport.test.ts
+++ b/packages/tui/test/mini/stream-v2.transport.test.ts
@@ -667,7 +667,10 @@ describe("V2 mini transport", () => {
             sessionID: "ses_1",
             timeCreated: 1,
             type: "user",
-            payload: { text: "follow up" },
+            payload: {
+              text: "follow up",
+              skills: [{ id: "effect", name: "Effect", text: "Use Effect services" }],
+            },
             delivery: "queue",
           },
           {
@@ -706,9 +709,10 @@ describe("V2 mini transport", () => {
     })
     while (!ui.commits.some((item) => item.messageID === "msg_queued")) await Bun.sleep(0)
 
-    expect(ui.commits).toContainEqual(
-      expect.objectContaining({ kind: "user", messageID: "msg_queued", text: "follow up" }),
-    )
+    expect(ui.commits.filter((item) => item.messageID === "msg_queued")).toEqual([
+      expect.objectContaining({ kind: "system", partID: "skill:effect", text: '→ Skill "Effect"' }),
+      expect.objectContaining({ kind: "user", text: "follow up" }),
+    ])
     expect(pending()).toEqual([["msg_cancelled", "queue"]])
     events.push({
       id: "evt_queued",
@@ -739,7 +743,7 @@ describe("V2 mini transport", () => {
       data: { sessionID: "ses_1", inboxID: "msg_queued" },
     })
     while (pending()?.length !== 0) await Bun.sleep(0)
-    expect(ui.commits.filter((item) => item.messageID === "msg_queued")).toHaveLength(1)
+    expect(ui.commits.filter((item) => item.messageID === "msg_queued")).toHaveLength(2)
     const prompt = spyOn(client.session, "prompt").mockImplementation(
       (request) => ok(promptAdmission(request)) as never,
     )

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -16200,6 +16200,9 @@
           "name": {
             "type": "string"
           },
+          "text": {
+            "type": "string"
+          },
           "mention": {
             "$ref": "#/components/schemas/Prompt.Mention"
           }

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -16200,6 +16200,9 @@
           "name": {
             "type": "string"
           },
+          "text": {
+            "type": "string"
+          },
           "mention": {
             "$ref": "#/components/schemas/Prompt.Mention"
           }


### PR DESCRIPTION
## What

Make structured `@skill-id` selections deterministic by materializing their instructions on the user prompt that owns them.

The frontend still submits only the selected skill ID and mention range. Core resolves and prepares the skill, stores its model-facing text on the existing skill attachment, and lowers that attachment into the same user message before the prompt text.

## Before / After

**Before:** Selecting `@effect` created an attachment containing only its ID and display name. Model-message conversion ignored skill attachments, so the model saw `Use @effect` without the Effect instructions and had to independently decide whether to call the skill tool.

**After:** Selecting `@effect` prepares the skill once and stores its instructions on the existing prompt attachment. The model receives the skill instructions followed by `Use @effect` in one user message. Queued delivery, cancellation, forks, reverts, and transcript ownership continue to follow the existing user-message lifecycle.

## How

- `packages/schema/src/prompt.ts`: add optional prepared text to the existing skill attachment contract; historical reference-only attachments remain valid.
- `packages/core/src/skill.ts` and `packages/core/src/tool/plugin/skill.ts`: add direct skill registry lookup and share canonical skill preparation while preserving model-tool permission checks before filesystem scanning.
- `packages/core/src/session.ts`: wait for initialized skill plugins, materialize explicitly selected skills on their owning prompt, and prepare/store each repeated skill ID only once while preserving every mention reference.
- `packages/core/src/session/runner/to-llm-message.ts`: include each selected skill once before ordinary prompt text in the same model-visible user message.
- `packages/core/src/session/compaction.ts` and `packages/core/src/session/transfer.ts`: retain prepared skill context during compaction and redact it from sanitized exports.
- `packages/core/src/skill/instructions.ts`: remove obsolete guidance telling models to reload already-selected skills.
- `packages/tui/src/mini/stream-v2.transport.ts`: render selected-skill indicators immediately when pending prompts become visible, without relying on a separate activation event.
- Regenerate the Promise client, canonical Protocol OpenAPI document, and both published website OpenAPI copies.

## Scope

- Structured user selections are explicit user authorization; only model-initiated skill-tool calls perform agent permission checks.
- Plain-text `@skill-id` references remain plain text.
- Standalone skill activation keeps its existing event, message, and raw instruction behavior; structured mentions do not create additional activation events or messages.
- No inbox persistence, delivery orchestration, durable event definitions, or projector changes.

## Testing

- `packages/core`: `bun run test` (2,250 passed, 16 skipped)
- `packages/tui`: `bun run test` (762 passed, 5 skipped)
- `packages/core`: focused Session, skill, model-message, compaction, transfer, and instruction coverage (131 passed)
- `packages/tui`: `bun run test test/mini/stream-v2.transport.test.ts` (55 passed)
- `packages/schema`: focused legacy skill-attachment decoding and optional-field encoding regression passed
- `packages/core`, `packages/schema`, `packages/protocol`, `packages/client`, and `packages/tui`: `bun typecheck`
- `packages/www`: `bun typecheck` and `bun run build`
- `packages/client`, `packages/protocol`, and `packages/www`: `bun run check:generated`
- Pre-push workspace typecheck: 32 packages passed

## Flow

```mermaid
sequenceDiagram
  participant UI as TUI/App
  participant Session as Session.prompt
  participant Skill as Skill registry
  participant Inbox as Existing session inbox
  participant History as User message
  participant Model

  UI->>Session: prompt + { id, mention }
  Session->>Skill: get skill and prepare instructions
  Session->>Inbox: admit prompt with prepared skill attachment
  Inbox->>History: deliver the existing user message
  History->>Model: skill instructions, then prompt text
```
