### PR TITLE
fix(core): notify registries after state commits

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -87,7 +87,7 @@ const layer = Layer.effect(
           draft.agents.delete(id)
         },
       }),
-      finalize: () => bus.publish(Agent.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(Agent.Event.Updated, {}).pipe(Effect.asVoid),
     })
     const selectable = (agent: Info | undefined) =>
       agent && agent.mode !== "subagent" && !agent.hidden ? agent : undefined

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -134,7 +134,7 @@ const layer = Layer.effect(
         }
         return result
       },
-      finalize: Effect.fn("Catalog.finalize")(function* () {
+      notify: Effect.fn("Catalog.notify")(function* () {
         yield* bus.publish(Catalog.Event.Updated, {})
       }),
     })

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -60,7 +60,7 @@ export const layer = Layer.effect(
       draft: (draft) => ({
         add: (definition) => draft.set(definition.name, definition),
       }),
-      finalize: () => bus.publish(Command.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(Command.Event.Updated, {}).pipe(Effect.asVoid),
     })
     const info = (definition: Definition) =>
       Info.make({

--- a/packages/core/src/filesystem/location-watcher-policy.ts
+++ b/packages/core/src/filesystem/location-watcher-policy.ts
@@ -37,7 +37,11 @@ const layer = Layer.effect(
       finalize: (draft) =>
         Effect.sync(() => {
           current = [...draft.list()]
-        }).pipe(Effect.andThen(Effect.forEach(listeners, (listener) => listener(current), { discard: true }))),
+        }),
+      notify: () => {
+        const ignore = current
+        return Effect.forEach(listeners, (listener) => listener(ignore), { discard: true })
+      },
     })
     const observe = Effect.fn("LocationWatcherPolicy.observe")(function* (
       listener: (ignore: readonly string[]) => Effect.Effect<void>,

--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -72,7 +72,7 @@ export const layer = (options?: Options) =>
             draft.available = false
           },
         }),
-        finalize: () => bus.publish(Event.Updated, {}).pipe(Effect.asVoid),
+        notify: () => bus.publish(Event.Updated, {}).pipe(Effect.asVoid),
       })
 
       const source = (value: ReadonlyArray<File> | Instructions.Unavailable | Instructions.Removed) =>

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -328,7 +328,7 @@ const layer = Layer.effect(
           },
         },
       }),
-      finalize: () => bus.publish(Integration.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(Integration.Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     const createCredential = Effect.fnUntraced(function* (input: Parameters<Credential.Interface["create"]>[0]) {

--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -103,8 +103,8 @@ const layer = Layer.effect(
               Effect.forkIn(scope),
             )
           }
-          yield* bus.publish(Reference.Event.Updated, {})
         }),
+      notify: () => bus.publish(Reference.Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     return Service.of({

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -109,7 +109,7 @@ const layer = Layer.effect(
           draft.skills.delete(ID.make(id))
         },
       }),
-      finalize: () => bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     return Service.of({

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -1,6 +1,6 @@
 export * as State from "./state.js"
 
-import { Clock, Context, Deferred, Effect, Scope, Semaphore } from "effect"
+import { Clock, Context, Deferred, Effect, Exit, Scope, Semaphore } from "effect"
 
 /**
  * A replayable transform applied to a draft during reload.
@@ -30,10 +30,12 @@ export interface Transformable<DraftApi> {
   readonly reload: Reload
 }
 
+type Commit = () => Effect.Effect<Effect.Effect<void>>
+
 type Batch = {
   active: boolean
   readonly flush: boolean
-  readonly reloads: Set<Reload>
+  readonly commits: Set<Commit>
 }
 
 const CurrentBatch = Context.Reference<Batch | undefined>("@opencode/State/CurrentBatch", {
@@ -46,10 +48,13 @@ export function batch<A, E, R>(effect: Effect.Effect<A, E, R>, options: { readon
   return Effect.gen(function* () {
     const current = yield* CurrentBatch
     if (current?.active && options.flush !== false) return yield* effect
-    const batch: Batch = { active: true, flush: options.flush !== false, reloads: new Set() }
+    const batch: Batch = { active: true, flush: options.flush !== false, commits: new Set() }
     const exit = yield* effect.pipe(Effect.provideService(CurrentBatch, batch), Effect.exit)
     batch.active = false
-    if (batch.flush) yield* Effect.forEach(batch.reloads, (reload) => reload(), { discard: true })
+    if (batch.flush) {
+      const notifications = yield* Effect.forEach(batch.commits, (commit) => commit())
+      yield* Effect.forEach(notifications, (notify) => notify, { discard: true })
+    }
     return yield* exit
   })
 }
@@ -65,12 +70,10 @@ export interface Options<State, DraftApi> {
   readonly initial: () => State
   /** Wraps mutable state in a domain-specific draft API. */
   readonly draft: MakeDraft<State, DraftApi>
-  /**
-   * Runs after the rebuilt state becomes visible. Update events published here
-   * act as read barriers: subscribers refetching on the event observe the
-   * committed state.
-   */
+  /** Runs after the rebuilt state becomes visible while mutation coordination is held. */
   readonly finalize?: (draft: DraftApi) => Effect.Effect<void>
+  /** Runs after the rebuilt state is finalized and mutation coordination is released. */
+  readonly notify?: (draft: DraftApi) => Effect.Effect<void>
 }
 
 export interface Interface<State, DraftApi> extends Transformable<DraftApi> {
@@ -89,11 +92,14 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
 
   const commit = Effect.fn("State.commit")(function* (next: State) {
     state = next
-    if (options.finalize) yield* options.finalize(options.draft(next))
+    const draft = options.draft(next)
+    if (options.finalize) yield* options.finalize(draft)
+    const notify = options.notify
+    return notify ? Effect.suspend(() => notify(draft)) : Effect.void
   })
 
   const materialize = Effect.fnUntraced(function* () {
-    if (closed) return
+    if (closed) return Effect.void
     const next = options.initial()
     const api = options.draft(next)
     for (const transform of transforms) {
@@ -101,10 +107,11 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
         transform.run(api)
       })
     }
-    yield* commit(next)
+    return yield* commit(next)
   })
 
-  const materializeReload = () => semaphore.withPermit(materialize())
+  const materializeCommit = () => semaphore.withPermit(materialize())
+  const materializeReload = () => materializeCommit().pipe(Effect.flatMap((notify) => notify))
 
   const rebuild = (): Effect.Effect<void> =>
     Effect.gen(function* () {
@@ -114,15 +121,19 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
       if (clock.currentTimeMillisUnsafe() < requestedAt + reloadDebounce) return yield* rebuild()
 
       const target = generation
-      const exit = yield* materializeReload().pipe(Effect.exit)
+      const committed = yield* materializeCommit().pipe(Effect.exit)
       const completed = waiters.filter((waiter) => waiter.generation <= target)
       waiters = waiters.filter((waiter) => waiter.generation > target)
+      running = false
+      if (generation > target) {
+        running = true
+        yield* rebuild().pipe(Effect.forkDetach)
+      }
+      const exit = Exit.isFailure(committed) ? committed : yield* committed.value.pipe(Effect.exit)
       yield* Effect.forEach(completed, (waiter) => Deferred.done(waiter.done, exit), {
         concurrency: "unbounded",
         discard: true,
       })
-      if (generation > target) return yield* rebuild()
-      running = false
     })
 
   const reload = Effect.fnUntraced(function* () {
@@ -149,26 +160,28 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
           const transform = { run: update }
           let active = true
           const dispose = Effect.uninterruptible(
-            semaphore.withPermit(
-              Effect.suspend(() => {
-                if (!active) return Effect.void
-                active = false
-                transforms = transforms.filter((item) => item !== transform)
-                return Effect.gen(function* () {
-                  const batch = yield* CurrentBatch
-                  if (batch?.active) {
-                    // Detached debounced reloads must also stay quiet after teardown.
-                    if (!batch.flush) {
-                      closed = true
-                      return
+            semaphore
+              .withPermit(
+                Effect.suspend(() => {
+                  if (!active) return Effect.succeed(Effect.void)
+                  active = false
+                  transforms = transforms.filter((item) => item !== transform)
+                  return Effect.gen(function* () {
+                    const batch = yield* CurrentBatch
+                    if (batch?.active) {
+                      // Detached debounced reloads must also stay quiet after teardown.
+                      if (!batch.flush) {
+                        closed = true
+                        return Effect.void
+                      }
+                      batch.commits.add(materializeCommit)
+                      return Effect.void
                     }
-                    batch.reloads.add(materializeReload)
-                    return
-                  }
-                  yield* materialize()
-                })
-              }),
-            ),
+                    return yield* materialize()
+                  })
+                }),
+              )
+              .pipe(Effect.flatMap((notify) => notify)),
           )
           yield* semaphore.withPermit(
             Effect.sync(() => {
@@ -177,7 +190,7 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
           )
           yield* Scope.addFinalizer(scope, dispose)
           const batch = yield* CurrentBatch
-          if (batch?.active) batch.reloads.add(materializeReload)
+          if (batch?.active) batch.commits.add(materializeCommit)
           else yield* materializeReload()
           return { dispose }
         }),

--- a/packages/core/src/websearch.ts
+++ b/packages/core/src/websearch.ts
@@ -88,7 +88,7 @@ const layer = Layer.effect(
           set: (selection) => (draft.selection = selection),
         },
       }),
-      finalize: () => bus.publish(WebSearch.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(WebSearch.Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     const requireProvider = (providers: Map<ID, ProviderImplementation>, providerID: ID) => {

--- a/packages/core/test/command.test.ts
+++ b/packages/core/test/command.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect } from "bun:test"
+import { Bus } from "@opencode-ai/core/bus"
 import { Command } from "@opencode-ai/core/command"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Session } from "@opencode-ai/schema/session"
-import { Effect } from "effect"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Effect, Scope } from "effect"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(AppNodeBuilder.build(Command.node))
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([Command.node, Bus.node])))
 
 describe("Command", () => {
   it.effect("registers and executes callback commands", () =>
@@ -42,6 +44,31 @@ describe("Command", () => {
       })
 
       expect(yield* command.list()).toEqual([Command.Info.make({ name: "goal", description: "Second" })])
+    }),
+  )
+
+  it.effect("allows synchronous update listeners to mutate the registry", () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const command = yield* Command.Service
+      const scope = yield* Scope.Scope
+      let reentered = false
+      const unsubscribe = yield* bus.listen((event) => {
+        if (event.type !== Command.Event.Updated.type || reentered) return Effect.void
+        reentered = true
+        return command
+          .transform((draft) => {
+            draft.add({ name: "listener", execute: () => Effect.void })
+          })
+          .pipe(Scope.provide(scope), Effect.asVoid)
+      })
+      yield* Effect.addFinalizer(() => unsubscribe)
+
+      yield* command.transform((draft) => {
+        draft.add({ name: "source", execute: () => Effect.void })
+      })
+
+      expect((yield* command.list()).map((item) => item.name)).toEqual(["source", "listener"])
     }),
   )
 

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -78,9 +78,11 @@ describe("State", () => {
 
   it.effect("disposes a transform once and rebuilds remaining state", () =>
     Effect.gen(function* () {
+      let notified = 0
       const state = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () => Effect.sync(() => notified++),
       })
       yield* state.transform((editor) => {
         editor.add("first")
@@ -92,9 +94,11 @@ describe("State", () => {
 
       yield* registration.dispose
       expect(state.get().values).toEqual(["first"])
+      expect(notified).toBe(3)
 
       yield* registration.dispose
       expect(state.get().values).toEqual(["first"])
+      expect(notified).toBe(3)
     }),
   )
 
@@ -191,29 +195,137 @@ describe("State", () => {
     }),
   )
 
+  it.effect("commits every batched state before notifying", () =>
+    Effect.gen(function* () {
+      type Registry = State.Interface<
+        { values: string[] },
+        { add: (item: string) => void; list: () => readonly string[] }
+      >
+      const observed: string[][] = []
+      const first: Registry = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({
+          add: (item: string) => draft.values.push(item),
+          list: () => draft.values,
+        }),
+        notify: (draft) => Effect.sync(() => observed.push([...draft.list(), ...second.get().values])),
+      })
+      const second: Registry = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({
+          add: (item: string) => draft.values.push(item),
+          list: () => draft.values,
+        }),
+        notify: (draft) => Effect.sync(() => observed.push([...first.get().values, ...draft.list()])),
+      })
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* first.transform((draft) => {
+            draft.add("first")
+          })
+          yield* second.transform((draft) => {
+            draft.add("second")
+          })
+        }),
+      )
+
+      expect(observed).toEqual([
+        ["first", "second"],
+        ["first", "second"],
+      ])
+    }),
+  )
+
   it.effect("debounces reload bursts", () =>
     Effect.gen(function* () {
-      let finalized = 0
+      let notified = 0
       const state = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        finalize: () => Effect.sync(() => finalized++),
+        notify: () => Effect.sync(() => notified++),
       })
       yield* state.transform((draft) => {
         draft.add("value")
       })
-      finalized = 0
+      notified = 0
 
       const first = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
       yield* TestClock.adjust("250 millis")
       const second = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
       yield* TestClock.adjust("499 millis")
-      expect(finalized).toBe(0)
+      expect(notified).toBe(0)
       yield* TestClock.adjust("1 millis")
       yield* Fiber.join(first)
       yield* Fiber.join(second)
 
-      expect(finalized).toBe(1)
+      expect(notified).toBe(1)
+    }),
+  )
+
+  it.effect("allows debounced notifications to synchronously reload", () =>
+    Effect.gen(function* () {
+      let reenter = false
+      let notified = 0
+      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () =>
+          Effect.gen(function* () {
+            notified++
+            if (!reenter) return
+            reenter = false
+            yield* state.reload()
+          }),
+      })
+      yield* state.transform((draft) => {
+        draft.add("value")
+      })
+      notified = 0
+      reenter = true
+
+      const reload = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(reload)
+
+      expect(notified).toBe(2)
+    }),
+  )
+
+  it.effect("settles each reload after its own notification", () =>
+    Effect.gen(function* () {
+      const firstStarted = yield* Deferred.make<void>()
+      const releaseFirst = yield* Deferred.make<void>()
+      let block = false
+      let notified = 0
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () =>
+          Effect.gen(function* () {
+            notified++
+            if (!block || notified !== 1) return
+            yield* Deferred.succeed(firstStarted, undefined)
+            yield* Deferred.await(releaseFirst)
+          }),
+      })
+      yield* state.transform((draft) => {
+        draft.add("value")
+      })
+      notified = 0
+      block = true
+
+      const first = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Deferred.await(firstStarted)
+      const second = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(second)
+
+      expect(first.pollUnsafe()).toBeUndefined()
+      yield* Deferred.succeed(releaseFirst, undefined)
+      yield* Fiber.join(first)
     }),
   )
 })


### PR DESCRIPTION
## Why

A synchronous update listener can hang registry registration by trying to modify the registry that is notifying it: the update still holds the mutation lock, waits for the listener, and prevents that listener from acquiring the lock. Separately, a batch can announce one registry's new state before committing another related registry, exposing an inconsistent combination to listeners.

**Not ready to merge:** review reproduced lost notifications on batch failure and stale watcher-policy delivery after a reentrant update. The original-problem demonstrations below establish the need for the change, not correctness of every current implementation path. Outstanding findings are listed under Verification.

## What Changes

Separate committing state from announcing it. Finish the snapshot and coordinated derived state first, release mutation coordination, then invoke notification callbacks. For a successful batch, commit all participating registries before delivering their notifications.

### A command listener deadlocks registration

Fixture scenario: a synchronous listener registers `deploy-preview` after observing registration of `deploy`.

| Step | Outer registration | Synchronous listener |
|---|---|---|
| 1 | Acquires the registry lock. | |
| 2 | Commits `deploy`. | |
| 3 | Announces the update and waits for listeners. | Starts running. |
| 4 | Still holds the lock. | Tries to register `deploy-preview`; waits for the lock. |
| 5 | Waits for the listener to return. | Cannot proceed until the outer update releases the lock. |

The wait cycle is outer update -> listener -> registry lock -> outer update. Advancing the reproducer by **one virtual hour** does not resolve it: registration remains pending and `deploy-preview` is absent. If plugin activation awaits that registration, activation remains stuck too.

**Intended behavior:** release the lock before invoking the listener. Its nested registration can then acquire the lock and finish. This specific failure requires a synchronous listener that mutates the same registry; ordinary asynchronous stream subscribers do not automatically share the deadlock.

### An event exposes half of a batch

Fixture scenario: one update selects `experimental-model` for an agent and adds that model to the catalog.

| Moment | Selected model | Catalog contains it? |
|---|---|---|
| Before the batch | `stable-model` | Yes |
| Agent selection commits and announces | `experimental-model` | **No** |
| Catalog commits and announces | `experimental-model` | Yes |

The first listener sees a new selection and the old catalog. A listener validating or using that combination could report "model unavailable" or choose a fallback, even though the completed configuration is valid. The reproducer asserts the mixed snapshot; it does not claim an actual model request or UI action was executed.

**Intended behavior:** commit both registries before delivering either event, so each listener can refetch the completed batch.

## Commit Before Notification

```mermaid
sequenceDiagram
    participant Batch
    participant Agent as Agent registry
    participant Catalog
    participant Listener
    Batch->>Agent: Commit selection and finalize
    Batch->>Catalog: Commit model and finalize
    Note over Batch,Catalog: Mutation coordination released
    Batch->>Listener: Announce agent update
    Listener->>Catalog: Refetch committed models
    Catalog-->>Listener: Includes selected model
    Batch->>Listener: Announce catalog update
```

`State` gains a post-commit `notify` phase while retaining coordinated `finalize`. Registry Bus publications move to `notify`; reference materialization remains in `finalize`. Reload scheduling releases ownership before notification delivery so listeners can request another reload, while each reload waiter remains associated with its generation's notification result.

## Scope

This PR owns the commit/notification boundary, not the read-side debounce behavior in #44813. Durable Bus publication and MCP lifecycle reconciliation are unchanged. The rebase preserves current `v2` teardown suppression; failure delivery and watcher-policy reentrancy still need the corrections below.

## Verification

### Original failures reproduced

Both examples below ran twice against the real pre-fix `State` implementation with fixture data and Effect TestClock. No live session, network request, configuration discovery, or real plugin activation was involved. The fixture invokes its listener directly from `finalize`, reproducing the synchronous boundary used by pre-fix Bus publication.

These are **baseline caller-wiring reproductions**, not unchanged tests for the PR head: publishers covered by this PR must move their callbacks from `finalize` to `notify`.

<details>
<summary>Runnable baseline reproducers and observed output</summary>

From `packages/core` at the pre-fix revision `fa4c5b26dc`:

```sh
bun -e '
import assert from "node:assert/strict"
import { Effect, Scope } from "effect"
import { TestClock } from "effect/testing"
import { State } from "./src/state.ts"

const batch = Effect.gen(function* () {
  const observed: { event: string; model: string; models: string[]; available: boolean }[] = []
  const selection = State.create({
    initial: () => ({ model: "stable-model" }),
    draft: (draft) => draft,
    finalize: () => observe("agent.updated"),
  })
  const catalog = State.create({
    initial: () => ["stable-model"],
    draft: (draft) => draft,
    finalize: () => observe("catalog.updated"),
  })
  const observe = (event: string) => Effect.sync(() => {
    observed.push({
      event,
      model: selection.get().model,
      models: [...catalog.get()],
      available: catalog.get().includes(selection.get().model),
    })
  })
  yield* State.batch(Effect.gen(function* () {
    yield* selection.transform((draft) => { draft.model = "experimental-model" })
    yield* catalog.transform((draft) => draft.push("experimental-model"))
  }))
  assert.deepEqual(observed, [
    { event: "agent.updated", model: "experimental-model", models: ["stable-model"], available: false },
    { event: "catalog.updated", model: "experimental-model", models: ["stable-model", "experimental-model"], available: true },
  ])
  observed.forEach((entry, index) => console.log(`event ${index + 1}: ${JSON.stringify(entry)}`))
  assert.equal(catalog.get().includes(selection.get().model), true)
})
await Effect.runPromise(batch.pipe(Effect.scoped, Effect.provide(TestClock.layer())))

const listener = Effect.gen(function* () {
  const scope = yield* Scope.make()
  const trace: string[] = []
  let reentered = false
  const commands = State.create({
    initial: () => new Array<string>(),
    draft: (draft) => draft,
    finalize: () => Effect.gen(function* () {
      if (reentered) return
      reentered = true
      trace.push("Registry committed deploy; synchronous update listener entered.")
      trace.push("Listener awaits registration of its deploy-preview command.")
      yield* commands.transform((draft) => draft.push("deploy-preview")).pipe(Scope.provide(scope))
      trace.push("Listener returned.")
    }),
  })
  const update = yield* commands.transform((draft) => draft.push("deploy"))
    .pipe(Scope.provide(scope), Effect.forkDetach({ startImmediately: true }))
  yield* TestClock.adjust("1 hour")
  assert.equal(update.pollUnsafe(), undefined)
  assert.deepEqual(commands.get(), ["deploy"])
  assert.equal(trace.length, 2)
  trace.forEach((line, index) => console.log(`step ${index + 1}: ${line}`))
  console.log("After one virtual hour: outer update still pending; deploy-preview still missing.")
  console.log("Wait cycle: outer update -> listener -> registry lock -> outer update.")
})
await Effect.runPromise(listener.pipe(Effect.provide(TestClock.layer())))
// The intentional deadlock cannot unwind its scope. Process exit cleans up this fixture.
process.exit(0)
'
```

Observed:

```text
event 1: {"event":"agent.updated","model":"experimental-model","models":["stable-model"],"available":false}
event 2: {"event":"catalog.updated","model":"experimental-model","models":["stable-model","experimental-model"],"available":true}
step 1: Registry committed deploy; synchronous update listener entered.
step 2: Listener awaits registration of its deploy-preview command.
After one virtual hour: outer update still pending; deploy-preview still missing.
Wait cycle: outer update -> listener -> registry lock -> outer update.
```

Exit code zero means both original failure modes were observed and asserted, not that they are fixed. The intentionally deadlocked fixture has no external resources and is isolated to this short-lived process.

</details>

### Branch validation

Commands previously run from `packages/core`:

```sh
bun typecheck
bun run test test/state.test.ts test/agent.test.ts test/command.test.ts test/catalog.test.ts test/skill.test.ts test/websearch.test.ts test/reference.test.ts test/integration.test.ts test/instruction-discovery.test.ts
bun run test
```

- Earlier validation: **76 focused tests passed** and **2,252 Core tests passed, 16 skipped, 0 failed**; the workspace push-hook typecheck also passed.
- Pre-rebase review of `c990acf3eb`: **88 targeted tests passed**, including registry services and filesystem watchers, with isolated HOME/XDG/credentials; Core `bun typecheck` passed again.
- The pre-rebase red Linux job failed in **Verify packed workerd SDK**, not a registry test. Its shared Effect platform dependency fix is included in the new `v2` base.
- Checked-in tests cover successful listener mutation, successful batch ordering, disposal, debounce, listener-triggered reload, and per-generation notification settlement. Additional isolated probes reproduced the failures below despite those passing tests.

### Rebase validation

Rebased onto `v2` at `a841d6d046`; current head is `b5cca1a60f`. Preserved `State.batch(..., { flush: false })`, closed-state guards, and both sets of tests. Suppressed materialization and disposal paths return no-op notification effects instead of `undefined`.

- `bun install --frozen-lockfile`: passed; lockfile unchanged.
- `bun typecheck` from `packages/core`: passed.
- Hermetic Core tests for State, Command, filesystem watchers, Agent, Catalog, instruction discovery, Integration, Reference, Skill, and WebSearch: **91 passed, 0 failed** across 10 files.
- Formatting and diff checks passed; all **32 pre-push typecheck tasks** passed.

This was a rebase and upstream integration pass, not a fix for the review findings below.

### Outstanding review findings

These findings were reproduced before the rebase at `c990acf3eb`; line references refer to that revision. Their fixes remain outstanding.

- **P2: lost notifications after partial success.** A later commit failure prevents already-collected notifications from running; a notification failure also skips later notifications for already-committed registries. Their consumers can remain stale (`state.ts:52-53`).
- **P2: stale watcher policy delivered last.** A listener that adds `".git"` during notification causes another listener to receive `["dist", ".git"]`, followed by the outer notification's older `["dist"]`. The later stale callback can restore a watcher that the current policy says to ignore (`filesystem/location-watcher-policy.ts:41-43`).
- Integrate #44813 without reintroducing waits on the batch or notification currently executing.
