### PR TITLE
test(core): isolate host configuration and credentials

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
     "benchmark:location": "bun run script/benchmark-location.ts",
     "build": "bun run script/build.ts",
     "update-models-snapshot": "bun run script/update-models-snapshot.ts",
-    "test": "bun test --only-failures",
+    "test": "bun run script/test.ts",
     "typecheck": "tsgo -b tsconfig.json tsconfig.tests.json"
   },
   "exports": {

--- a/packages/core/script/test.ts
+++ b/packages/core/script/test.ts
@@ -1,0 +1,52 @@
+import fs from "fs/promises"
+import os from "os"
+import path from "path"
+
+const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "opencode-core-home-")))
+const temporary = path.join(home, "tmp")
+await fs.mkdir(temporary)
+
+const environment = {
+  ...Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => {
+      if (process.env.RECORD === "true" && name === "OPENAI_API_KEY") return true
+      if (
+        /^(?:AWS|AZURE|GOOGLE|GCP|GCLOUD|VERTEX|OPENAI|ANTHROPIC|GEMINI|XAI|CLOUDFLARE|CF_AIG|SNOWFLAKE|AICORE|GITLAB|NPM_CONFIG)_/i.test(
+          name,
+        )
+      ) {
+        return false
+      }
+      return !/(?:^|_)(?:API_KEY|AUTHORIZATION|TOKEN|SECRET|PASSWORD|CREDENTIALS?)$/i.test(name)
+    }),
+  ),
+  HOME: home,
+  OPENCODE_TEST_HOME: home,
+  XDG_CONFIG_HOME: path.join(home, ".config"),
+  XDG_DATA_HOME: path.join(home, ".local", "share"),
+  XDG_CACHE_HOME: path.join(home, ".cache"),
+  XDG_STATE_HOME: path.join(home, ".local", "state"),
+  OPENCODE_CONFIG_DIR: path.join(home, ".config", "opencode"),
+  OPENCODE_CONFIG: undefined,
+  OPENCODE_CONFIG_CONTENT: undefined,
+  TMPDIR: temporary,
+  ...(process.platform === "win32" ? { USERPROFILE: home, TMP: temporary, TEMP: temporary } : {}),
+}
+
+const child = Bun.spawn({
+  cmd: [process.execPath, "test", "--only-failures", ...process.argv.slice(2)],
+  env: environment,
+  stdin: "inherit",
+  stdout: "inherit",
+  stderr: "inherit",
+})
+const interrupt = () => child.kill("SIGINT")
+const terminate = () => child.kill("SIGTERM")
+process.once("SIGINT", interrupt)
+process.once("SIGTERM", terminate)
+const result = await child.exited
+process.off("SIGINT", interrupt)
+process.off("SIGTERM", terminate)
+
+await fs.rm(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+process.exitCode = result

--- a/packages/core/script/test.ts
+++ b/packages/core/script/test.ts
@@ -1,8 +1,9 @@
 import fs from "fs/promises"
-import os from "os"
 import path from "path"
+import { tmpdir } from "../test/fixture/tmpdir"
 
-const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "opencode-core-home-")))
+await using directory = await tmpdir("opencode-core-home-")
+const home = directory.path
 const temporary = path.join(home, "tmp")
 await fs.mkdir(temporary)
 
@@ -48,5 +49,4 @@ const result = await child.exited
 process.off("SIGINT", interrupt)
 process.off("SIGTERM", terminate)
 
-await fs.rm(home, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
 process.exitCode = result

--- a/packages/core/script/test.ts
+++ b/packages/core/script/test.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises"
 import path from "path"
 import { tmpdir } from "../test/fixture/tmpdir"
 
-await using directory = await tmpdir("opencode-core-home-")
+await using directory = await tmpdir("oc-")
 const home = directory.path
 const temporary = path.join(home, "tmp")
 await fs.mkdir(temporary)

--- a/packages/core/test/fixture/global.ts
+++ b/packages/core/test/fixture/global.ts
@@ -12,7 +12,7 @@ export const tempGlobalLayer = Layer.unwrap(
       const data = path.join(tmp.path, "data")
       const cache = path.join(tmp.path, "cache")
       return Global.layerWith({
-        home: path.join(tmp.path, "home"),
+        home: Global.Path.home,
         data,
         cache,
         config: path.join(tmp.path, "config"),

--- a/packages/core/test/fixture/global.ts
+++ b/packages/core/test/fixture/global.ts
@@ -12,7 +12,6 @@ export const tempGlobalLayer = Layer.unwrap(
       const data = path.join(tmp.path, "data")
       const cache = path.join(tmp.path, "cache")
       return Global.layerWith({
-        home: Global.Path.home,
         data,
         cache,
         config: path.join(tmp.path, "config"),

--- a/packages/core/test/preload.test.ts
+++ b/packages/core/test/preload.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test"
+import os from "os"
+import path from "path"
+import { Global } from "@opencode-ai/util/global"
+
+const within = (directory: string, root: string) => {
+  const relative = path.relative(root, directory)
+  return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)
+}
+
+describe("Core test environment", () => {
+  test("isolates global home and XDG roots", () => {
+    const home = process.env.OPENCODE_TEST_HOME
+    expect(home).toBeDefined()
+    if (!home) return
+
+    expect(os.homedir()).toBe(home)
+    expect(Global.Path.home).toBe(home)
+    expect(within(Global.Path.config, home)).toBeTrue()
+    expect(within(Global.Path.data, home)).toBeTrue()
+    expect(within(Global.Path.cache, home)).toBeTrue()
+    expect(within(Global.Path.state, home)).toBeTrue()
+    expect(within(os.tmpdir(), home)).toBeTrue()
+    expect(process.env.OPENCODE_CONFIG_DIR).toBe(Global.Path.config)
+    expect(process.env.OPENCODE_CONFIG).toBeUndefined()
+    expect(process.env.OPENCODE_CONFIG_CONTENT).toBeUndefined()
+    expect(process.env.AWS_REGION).toBeUndefined()
+    expect(process.env.GOOGLE_VERTEX_PROJECT).toBeUndefined()
+    expect(process.env.NPM_CONFIG_REGISTRY).toBeUndefined()
+    expect(process.env.UIDOTSH_AUTHORIZATION).toBeUndefined()
+    if (process.env.RECORD !== "true") expect(process.env.OPENAI_API_KEY).toBeUndefined()
+  })
+})

--- a/packages/core/test/preload.test.ts
+++ b/packages/core/test/preload.test.ts
@@ -3,11 +3,6 @@ import os from "os"
 import path from "path"
 import { Global } from "@opencode-ai/util/global"
 
-const within = (directory: string, root: string) => {
-  const relative = path.relative(root, directory)
-  return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative)
-}
-
 describe("Core test environment", () => {
   test("isolates global home and XDG roots", () => {
     const home = process.env.OPENCODE_TEST_HOME
@@ -16,11 +11,11 @@ describe("Core test environment", () => {
 
     expect(os.homedir()).toBe(home)
     expect(Global.Path.home).toBe(home)
-    expect(within(Global.Path.config, home)).toBeTrue()
-    expect(within(Global.Path.data, home)).toBeTrue()
-    expect(within(Global.Path.cache, home)).toBeTrue()
-    expect(within(Global.Path.state, home)).toBeTrue()
-    expect(within(os.tmpdir(), home)).toBeTrue()
+    expect(Global.Path.config).toBe(path.join(home, ".config", "opencode"))
+    expect(Global.Path.data).toBe(path.join(home, ".local", "share", "opencode"))
+    expect(Global.Path.cache).toBe(path.join(home, ".cache", "opencode"))
+    expect(Global.Path.state).toBe(path.join(home, ".local", "state", "opencode"))
+    expect(os.tmpdir()).toBe(path.join(home, "tmp"))
     expect(process.env.OPENCODE_CONFIG_DIR).toBe(Global.Path.config)
     expect(process.env.OPENCODE_CONFIG).toBeUndefined()
     expect(process.env.OPENCODE_CONFIG_CONTENT).toBeUndefined()

--- a/packages/core/test/session-remove.test.ts
+++ b/packages/core/test/session-remove.test.ts
@@ -16,6 +16,7 @@ import { SessionEnvironment } from "@opencode-ai/core/session/environment"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
 import { testEffect } from "./lib/effect"
 import { globalProjectLayer } from "./lib/project"
+import { tmpdir } from "./fixture/tmpdir"
 
 const closed: Session.ID[] = []
 const transport = Layer.succeed(
@@ -44,17 +45,23 @@ const it = testEffect(
     ],
   ),
 )
-const location = Location.Ref.make({ directory: AbsolutePath.make(import.meta.dir) })
 
 describe("Session.remove", () => {
   it.effect("removes a session and its children", () =>
     Effect.gen(function* () {
+      const temporary = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (directory) => Effect.promise(() => directory[Symbol.asyncDispose]()),
+      )
+      const location = Location.Ref.make({ directory: AbsolutePath.make(temporary.path) })
       const session = yield* Session.Service
       const parent = yield* session.create({ location })
       const child = yield* session.create({ parentID: parent.id })
       yield* session.environment({ sessionID: parent.id, variables: { SESSION_ENV: "parent" } })
       yield* session.environment({ sessionID: child.id, variables: { SESSION_ENV: "child" } })
-      yield* (yield* LocationServiceMap.Service).contextEffect(location)
+      const locations = yield* LocationServiceMap.Service
+      yield* locations.contextEffect(location)
+      yield* Effect.addFinalizer(() => locations.invalidate(location))
       closed.length = 0
 
       yield* session.remove(parent.id)

--- a/packages/core/test/session-remove.test.ts
+++ b/packages/core/test/session-remove.test.ts
@@ -60,8 +60,7 @@ describe("Session.remove", () => {
       yield* session.environment({ sessionID: parent.id, variables: { SESSION_ENV: "parent" } })
       yield* session.environment({ sessionID: child.id, variables: { SESSION_ENV: "child" } })
       const locations = yield* LocationServiceMap.Service
-      yield* locations.contextEffect(location)
-      yield* Effect.addFinalizer(() => locations.invalidate(location))
+      yield* Effect.acquireRelease(locations.contextEffect(location), () => locations.invalidate(location))
       closed.length = 0
 
       yield* session.remove(parent.id)


### PR DESCRIPTION
## What

Makes the Core test suite hermetic with respect to the developer's home directory, OpenCode configuration, credentials, provider settings, npm configuration, and temporary files.

Running `bun run test` no longer loads personal plugins or skills, starts configured personal MCP servers, or passes real API credentials into test subprocesses.

## Before / After

**Before:** Core tests started in the developer's actual process environment. Full location-service graphs discovered `~/.config/opencode/opencode.json`, personal `.opencode`/Claude skills, configured plugins, and enabled MCP servers. One captured run subscribed to **332 personal skill paths** and launched **eight personal MCP processes**. Host variables such as `GOOGLE_VERTEX_PROJECT`, `AWS_REGION`, and `NPM_CONFIG_REGISTRY` also changed provider/npm test results.

**After:** the package test command creates a fresh temporary home and starts Bun with isolated `HOME`, `OPENCODE_TEST_HOME`, XDG roots, OpenCode config, and temporary directories already installed. Provider configuration, authorization headers, API keys, tokens, secrets, and npm overrides are removed before any application module loads. Project fixtures and instruction watches remain inside the temporary home, and everything is removed when the run exits or receives SIGINT/SIGTERM.

## How

- `packages/core/script/test.ts` reuses the existing scoped temporary-directory fixture to launch the real Bun test process in an isolated environment, forward test arguments and termination signals, and clean up the temporary tree.
- Isolation happens before Bun starts because `os.homedir()` is cached before preload modules execute.
- `RECORD=true` deliberately preserves `OPENAI_API_KEY` for the existing opt-in HTTP cassette recording workflow; ordinary test runs do not inherit it.
- `packages/core/test/fixture/global.ts` keeps test Global services inside the process-owned fake home, so ancestor instruction discovery cannot escape into host directories.
- `packages/core/test/session-remove.test.ts` uses an isolated temporary project instead of the repository checkout and invalidates its cached location graph before removing that project.
- `packages/core/test/preload.test.ts` verifies isolated home/XDG/temp roots, cleared explicit OpenCode configuration, and stripped provider/npm/authorization credentials.

## Scope

- Changes only the Core package test command, test launcher, and test fixtures.
- Does not change production configuration discovery, plugin behavior, MCP startup, filesystem watchers, or other packages' test commands.
- Preserves explicit config/project/skill/MCP integration coverage and opt-in cassette recording.

## Testing

- `bun run test` in `packages/core`: **2,288 passed, 16 skipped, 0 failed** across 205 files.
- `bun typecheck` in `packages/core`.
- `bun run verify:package` in `packages/sdk`: packed workerd SDK consumer passed.
- Workspace push hook: **32 packages typechecked successfully**.
- `AWS_REGION=eu-north-1 GOOGLE_VERTEX_PROJECT=host-project NPM_CONFIG_REGISTRY=https://host.example.test OPENAI_API_KEY=host-sentinel UIDOTSH_AUTHORIZATION=host-sentinel bun run test test/preload.test.ts test/plugin/provider-google-vertex.test.ts test/plugin/provider-amazon-bedrock.test.ts test/npm-config.test.ts`: **35 passed**; each provider/npm override caused reproducible failures before filtering.
- Focused location, configuration, instruction, plugin, shell, MCP, and session-removal suites passed.
- Verified interrupted runs forward SIGINT/SIGTERM, preserve exit codes, terminate the Bun child, and delete the isolated home.
- Confirmed full-suite output contains no personal OpenCode config paths, dotfiles skills, or configured personal MCP commands.
- `bunx prettier --check packages/core/package.json packages/core/script/test.ts packages/core/test/preload.test.ts packages/core/test/session-remove.test.ts packages/core/test/fixture/global.ts`.
- `git diff --check`.

## Flow

```mermaid
sequenceDiagram
    participant Command as bun run test
    participant Launcher as Core test launcher
    participant Bun as Isolated Bun test process
    participant Graph as Location/config graph

    Command->>Launcher: forwarded test files and flags
    Launcher->>Launcher: create temporary HOME/XDG/TMPDIR
    Launcher->>Launcher: remove host credentials and config overrides
    Launcher->>Bun: spawn with isolated environment
    Bun->>Graph: load globals, config, skills, MCP fixtures
    Graph-->>Bun: only test-owned files and explicit fixtures
    Bun-->>Launcher: test result or forwarded termination
    Launcher->>Launcher: remove temporary home
    Launcher-->>Command: preserve test exit status
```
