### PR TITLE
feat(opencode): Adds support to AGENTS.override.md

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -58,10 +58,12 @@ const layer: Layer.Layer<
     const flags = yield* RuntimeFlags.Service
     const http = HttpClient.filterStatusOk(withTransientReadRetry(yield* HttpClient.HttpClient))
     const globalFiles = [
+      path.join(global.config, "AGENTS.override.md"),
       path.join(global.config, "AGENTS.md"),
       ...(!flags.disableClaudeCodePrompt ? [path.join(global.home, ".claude", "CLAUDE.md")] : []),
     ]
     const instructionFiles = [
+      "AGENTS.override.md",
       "AGENTS.md",
       ...(!flags.disableClaudeCodePrompt ? ["CLAUDE.md"] : []),
       "CONTEXT.md", // deprecated

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -209,6 +209,23 @@ describe("Instruction.resolve", () => {
   test.todo("fetches remote instructions from config URLs via HttpClient", () => {})
 })
 
+describe("Instruction.find", () => {
+  it.live("returns override over base in same directory", () =>
+    withFiles(
+      {
+        "AGENTS.override.md": "# Override",
+        "AGENTS.md": "# Base",
+      },
+      (dir) =>
+        Effect.gen(function* () {
+          const svc = yield* Instruction.Service
+          const found = yield* svc.find(dir)
+          expect(found).toBe(path.join(dir, "AGENTS.override.md"))
+        }),
+    ),
+  )
+})
+
 describe("Instruction.system", () => {
   it.live("loads both project and global AGENTS.md when both exist", () =>
     Effect.gen(function* () {
@@ -244,6 +261,27 @@ describe("Instruction.system", () => {
         provideInstance(projectTmp),
         provideInstruction({ home: globalTmp, config: globalTmp }, { disableClaudeCodePrompt: true }),
       )
+    }),
+  )
+
+  it.live("override in same directory wins over base in same directory", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpWithFiles({
+        "AGENTS.override.md": "# Override",
+        "AGENTS.md": "# Base",
+      })
+
+      yield* Effect.gen(function* () {
+        const svc = yield* Instruction.Service
+        const paths = yield* svc.systemPaths()
+        expect(paths.has(path.join(tmp, "AGENTS.override.md"))).toBe(true)
+        expect(paths.has(path.join(tmp, "AGENTS.md"))).toBe(false)
+
+        const rules = yield* svc.system()
+        expect(rules).toHaveLength(1)
+        expect(rules[0]).toContain("# Override")
+        expect(rules[0]).not.toContain("# Base")
+      }).pipe(provideInstance(tmp), provideInstruction({ home: tmp, config: tmp }))
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #44842

### Type of change

- [ ] Bug fix
- [X] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds support to AGENTS.override.md. When loading files for Instruction, if find AGENTS.override.md, it takes precedence over others system instructions files. Similar to codex behavior https://learn.chatgpt.com/docs/agent-configuration/agents-md.

I have added the AGENTS.override.md in project and global list to make it codex compatible.

This is related with others issues (like #4035) since this PR changes can work for ignore the AGENTS.md too, if we create a git ignored AGENTS.override.md.

### How did you verify your code works?

How I manually tested:

Without Override - Prompt `this is a scenario test. without call any tool respond: which AGENTS files have in you system prompt?`. It returns AGENTS.md and no AGENTS.override.md

With Override - created the packages/opencode/AGENTS.override.md, than same prompt returns AGENTS.override.md and no AGENTS.md

I have tested other prompts too like `this is a scenario test. without call any tool respond: how to running development server?`, without override it tells to run bun dev, with override it tells to run npm because it dont have the Instructions loaded.

### Screenshots / recordings

no UI changes.

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
