### PR TITLE
fix(ai): classify missing chat finish reasons as incomplete

### DIFF
--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -7,6 +7,7 @@ import { HttpTransport } from "../route/transport/index.js"
 import { Protocol } from "../route/protocol.js"
 import {
   AIError,
+  InvalidProviderOutputReason,
   LLMEvent,
   ProviderInternalReason,
   UnknownProviderReason,
@@ -1046,7 +1047,15 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
 
 const finishEvents = Effect.fn("OpenAIChat.finishEvents")(function* (state: ParserState) {
   if (state.finishReason === undefined && state.requireFinishReason)
-    return yield* ProviderShared.eventError(ADAPTER, "OpenAI Chat stream ended without finish_reason")
+    return yield* new AIError({
+      module: ADAPTER,
+      method: "stream",
+      reason: new InvalidProviderOutputReason({
+        classification: "incomplete-stream",
+        message: "OpenAI Chat stream ended without finish_reason",
+        route: ADAPTER,
+      }),
+    })
   const events: LLMEvent[] = []
   const toolCallEvents =
     state.finishReason === undefined && Object.keys(state.tools).length > 0

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -362,6 +362,7 @@ describe("OpenAI-compatible Chat route", () => {
 
       expect(error.reason).toMatchObject({
         _tag: "InvalidProviderOutput",
+        classification: "incomplete-stream",
         message: "OpenAI Chat stream ended without finish_reason",
       })
     }),


### PR DESCRIPTION
## Summary
- classify Chat Completions streams that end without a required finish reason as incomplete streams
- allow the existing session runner interrupted-stream recovery path to recognize these failures
- extend the existing Chat compatibility regression test to assert the classification

## Test plan
- `bun test test/provider/openai-chat.test.ts test/provider/openai-compatible-chat.test.ts` from `packages/ai`
- `bun typecheck` from `packages/ai`