### PR TITLE
fix(opencode): recover LSP clients after transport failure

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -134,6 +134,20 @@ export async function create(input: {
     new StreamMessageWriter(input.server.process.stdin as any),
   )
   input.server.process.stderr?.resume()
+  let alive = true
+  let shuttingDown = false
+  const deadListeners = new Set<() => void>()
+  const markDead = () => {
+    if (!alive || shuttingDown) return
+    alive = false
+    for (const listener of [...deadListeners]) listener()
+    emitRegistrationChange()
+  }
+  connection.onClose(markDead)
+  connection.onError(markDead)
+  input.server.process.stdout?.on("end", markDead)
+  input.server.process.stdout?.on("error", markDead)
+  input.server.process.once("exit", markDead)
   // --- Connection state ---
 
   const pushDiagnostics = new Map<string, Diagnostic[]>()
@@ -497,6 +511,7 @@ export async function create(input: {
   }
 
   async function waitForDocumentDiagnostics(request: { path: string; version: number; after?: number }) {
+    if (!alive) return
     const startedAt = request.after ?? Date.now()
     const pushWait = waitForFreshPush({
       path: request.path,
@@ -506,6 +521,7 @@ export async function create(input: {
     })
 
     while (Date.now() - startedAt < DIAGNOSTICS_DOCUMENT_WAIT_TIMEOUT_MS) {
+      if (!alive) return
       const result = await requestDocumentDiagnostics(request.path)
       if (result.matched) return
       const remaining = DIAGNOSTICS_DOCUMENT_WAIT_TIMEOUT_MS - (Date.now() - startedAt)
@@ -519,6 +535,7 @@ export async function create(input: {
   }
 
   async function waitForFullDiagnostics(request: { path: string; version: number; after?: number }) {
+    if (!alive) return
     const startedAt = request.after ?? Date.now()
     const pushWait = waitForFreshPush({
       path: request.path,
@@ -528,6 +545,7 @@ export async function create(input: {
     })
 
     while (Date.now() - startedAt < DIAGNOSTICS_FULL_WAIT_TIMEOUT_MS) {
+      if (!alive) return
       const result = await requestFullDiagnostics(request.path)
       if (result.handled || result.matched) return
       const remaining = DIAGNOSTICS_FULL_WAIT_TIMEOUT_MS - (Date.now() - startedAt)
@@ -546,6 +564,17 @@ export async function create(input: {
     root: input.root,
     get serverID() {
       return input.serverID
+    },
+    get isAlive() {
+      return alive
+    },
+    onDead(listener: () => void) {
+      if (!alive) {
+        listener()
+        return () => {}
+      }
+      deadListeners.add(listener)
+      return () => deadListeners.delete(listener)
     },
     get connection() {
       return connection
@@ -638,6 +667,8 @@ export async function create(input: {
       await waitForFullDiagnostics({ path: normalizedPath, version: request.version, after: request.after })
     },
     async shutdown() {
+      shuttingDown = true
+      alive = false
       connection.end()
       connection.dispose()
       await Process.stop(input.server.process)

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -241,6 +241,11 @@ const layer = Layer.effect(
 
           if (!client) return undefined
 
+          client.onDead(() => {
+            const index = s.clients.indexOf(client)
+            if (index !== -1) s.clients.splice(index, 1)
+          })
+
           const existing = s.clients.find((x) => x.root === root && x.serverID === server.id)
           if (existing) {
             await Process.stop(handle.process)
@@ -258,7 +263,7 @@ const layer = Layer.effect(
           if (!root) continue
           if (s.broken.has(root + server.id)) continue
 
-          const match = s.clients.find((x) => x.root === root && x.serverID === server.id)
+          const match = s.clients.find((x) => x.root === root && x.serverID === server.id && x.isAlive)
           if (match) {
             result.push(match)
             continue
@@ -314,7 +319,7 @@ const layer = Layer.effect(
       const ctx = yield* InstanceState.context
       const s = yield* InstanceState.get(state)
       const result: Status[] = []
-      for (const client of s.clients) {
+      for (const client of s.clients.filter((client) => client.isAlive)) {
         result.push({
           id: client.serverID,
           name: s.servers[client.serverID].id,

--- a/packages/opencode/test/fixture/lsp/fake-lsp-server.js
+++ b/packages/opencode/test/fixture/lsp/fake-lsp-server.js
@@ -201,6 +201,12 @@ function handle(raw) {
     return
   }
 
+  if (data.method === "test/close-stdout") {
+    sendResponse(data.id, null)
+    setImmediate(() => process.exit(0))
+    return
+  }
+
   if (data.method === "test/get-last-change") {
     sendResponse(data.id, lastChange)
     return

--- a/packages/opencode/test/lsp/client.test.ts
+++ b/packages/opencode/test/lsp/client.test.ts
@@ -40,6 +40,34 @@ describe("LSPClient interop", () => {
     await client.shutdown()
   })
 
+  test("reports a dead client after the transport closes", async () => {
+    const handle = spawnFakeServer() as any
+
+    const client = await withTestInstance({
+      directory: process.cwd(),
+      fn: (ctx) =>
+        LSPClient.create({
+          serverID: "fake",
+          server: handle as unknown as LSPServer.Handle,
+          root: process.cwd(),
+          directory: process.cwd(),
+          instance: ctx,
+        }),
+    })
+
+    let dead = false
+    client.onDead(() => {
+      dead = true
+    })
+    expect(client.isAlive).toBe(true)
+    await client.connection.sendRequest("test/close-stdout", {})
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(client.isAlive).toBe(false)
+    expect(dead).toBe(true)
+    await client.shutdown()
+  })
+
   test("handles client/registerCapability request", async () => {
     const handle = spawnFakeServer() as any
 


### PR DESCRIPTION
### Issue for this PR

Fixes #44855

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Marks LSP clients dead when their JSON-RPC transport or child process closes, removes dead clients from the cache, and filters them from status. The next request can therefore spawn a fresh client instead of reusing a stale transport.

### How did you verify your code works?

From packages/opencode: un test test/lsp/client.test.ts test/lsp/lifecycle.test.ts (27 passed) and Prettier check. Also ran 	sc --noEmit -p packages/opencode/tsconfig.json.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR