### PR TITLE
fix(desktop): suppress resize observer loop warnings

### DIFF
--- a/packages/desktop/src/renderer/diagnostics.ts
+++ b/packages/desktop/src/renderer/diagnostics.ts
@@ -2,66 +2,14 @@ const resizeLoopWarning = "ResizeObserver loop completed with undelivered notifi
 
 if (import.meta.env.DEV) {
   installConsoleStacks()
-  installResizeObserverStacks()
+  window.addEventListener("error", (event) => {
+    if (event.message === resizeLoopWarning) event.preventDefault()
+  })
 }
 
 function installConsoleStacks() {
   console.warn = tracedConsole(console.warn.bind(console), "Console warning")
   console.error = tracedConsole(console.error.bind(console), "Console error")
-}
-
-function installResizeObserverStacks() {
-  if (typeof ResizeObserver !== "function") return
-
-  const NativeResizeObserver = ResizeObserver
-  type ResizeTrace = {
-    created: string
-    last?: { at: number; targets: Element[] }
-  }
-  const observers = new Set<ResizeTrace>()
-
-  class TracedResizeObserver extends NativeResizeObserver {
-    private readonly trace: ResizeTrace
-
-    constructor(callback: ResizeObserverCallback) {
-      const trace: ResizeTrace = {
-        created: diagnosticStack("ResizeObserver created"),
-      }
-      super((entries, observer) => {
-        trace.last = { at: performance.now(), targets: entries.map((entry) => entry.target) }
-        callback(entries, observer)
-      })
-      this.trace = trace
-      observers.add(trace)
-    }
-
-    override disconnect() {
-      observers.delete(this.trace)
-      super.disconnect()
-    }
-  }
-
-  globalThis.ResizeObserver = TracedResizeObserver
-  window.addEventListener("error", (event) => {
-    if (event.message !== resizeLoopWarning) return
-    const now = performance.now()
-    const active = [...observers]
-      .flatMap((observer) => {
-        if (!observer.last || now - observer.last.at >= 100) return []
-        return [{ ...observer, last: observer.last }]
-      })
-      .sort((a, b) => b.last.at - a.last.at)
-      .slice(0, 5)
-    const detail = active.length
-      ? active
-          .map(
-            (observer, index) =>
-              `Recent ResizeObserver ${index + 1}; targets: ${observer.last.targets.map(describeElement).join(", ") || "none"}\n${observer.created}`,
-          )
-          .join("\n")
-      : "No ResizeObserver callback was recorded in the previous 100 ms."
-    console.warn(`[renderer diagnostics] ${resizeLoopWarning}\n${detail}`)
-  })
 }
 
 function tracedConsole(write: (...args: unknown[]) => void, label: string) {
@@ -83,15 +31,6 @@ function tracedConsole(write: (...args: unknown[]) => void, label: string) {
       if (entry.count) write(`${String(args[0])} (repeated ${entry.count} times)`)
     }, 1_000)
   }
-}
-
-function describeElement(element: Element) {
-  const id = element.id ? `#${element.id}` : ""
-  const classes = [...element.classList]
-    .slice(0, 3)
-    .map((name) => `.${name}`)
-    .join("")
-  return `${element.tagName.toLowerCase()}${id}${classes}`
 }
 
 function diagnosticStack(label: string) {


### PR DESCRIPTION
## Summary
- suppress benign ResizeObserver loop notifications in the desktop renderer
- remove development-only observer instrumentation that amplified these notifications
- preserve diagnostic stack traces for genuine console warnings and errors

## Test plan
- `bun typecheck` from `packages/desktop`
- repository pre-push typecheck across all configured packages