### PR TITLE
fix(opencode): seal partial reasoning/text parts before stream retries

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -536,6 +536,26 @@ const layer = Layer.effect(
         }
       })
 
+      // Finalize partially streamed parts so a failed attempt does not leave
+      // unclosed reasoning/text blocks behind before the stream is retried.
+      const sealPartialParts = Effect.fn("SessionProcessor.sealPartialParts")(function* () {
+        if (ctx.currentText) {
+          const end = Date.now()
+          ctx.currentText.time = { start: ctx.currentText.time?.start ?? end, end }
+          yield* session.updatePart(ctx.currentText)
+          ctx.currentText = undefined
+        }
+
+        for (const part of Object.values(ctx.reasoningMap)) {
+          const end = Date.now()
+          yield* session.updatePart({
+            ...part,
+            time: { start: part.time.start ?? end, end },
+          })
+        }
+        ctx.reasoningMap = {}
+      })
+
       const cleanup = Effect.fn("SessionProcessor.cleanup")(function* () {
         if (ctx.snapshot) {
           const patch = yield* snapshot.patch(ctx.snapshot)
@@ -552,21 +572,7 @@ const layer = Layer.effect(
           ctx.snapshot = undefined
         }
 
-        if (ctx.currentText) {
-          const end = Date.now()
-          ctx.currentText.time = { start: ctx.currentText.time?.start ?? end, end }
-          yield* session.updatePart(ctx.currentText)
-          ctx.currentText = undefined
-        }
-
-        for (const part of Object.values(ctx.reasoningMap)) {
-          const end = Date.now()
-          yield* session.updatePart({
-            ...part,
-            time: { start: part.time.start ?? end, end },
-          })
-        }
-        ctx.reasoningMap = {}
+        yield* sealPartialParts()
 
         yield* Effect.forEach(
           Object.values(ctx.toolcalls),
@@ -634,8 +640,9 @@ const layer = Layer.effect(
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
-            ctx.currentText = undefined
-            ctx.reasoningMap = {}
+            // A retried attempt replays the request from scratch, so close out
+            // any reasoning/text parts the failed attempt left dangling.
+            yield* sealPartialParts()
             yield* status.set(ctx.sessionID, { type: "busy" })
             const stream = llm.stream(streamInput)
 


### PR DESCRIPTION
### Issue for this PR

Closes #44894

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When an attempt fails mid-stream, parts persisted during that attempt were left without `time.end`: the retry path reset the in-memory maps without finalizing them. This extracts the existing finalization logic from `cleanup()` into `sealPartialParts()` and calls it before each stream attempt (no-op on the first), so each failed attempt's parts are closed before the next starts. Retry behavior is otherwise unchanged.

### How did you verify your code works?

- `bun test test/session/`: 420 passing, identical results on this branch and on `dev`
- `bun turbo typecheck --filter=opencode`: clean
- Inspected stored parts around retry storms before/after: previously-open reasoning parts now receive end timestamps

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
