### PR TITLE
fix(core): follow resource_metadata from the MCP OAuth 401 challenge

### DIFF
--- a/packages/core/src/mcp/oauth.ts
+++ b/packages/core/src/mcp/oauth.ts
@@ -1,6 +1,6 @@
 export * as MCPOAuth from "./oauth.js"
 
-import { auth, type OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
+import { auth, extractWWWAuthenticateParams, type OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
 import { Deferred, Effect } from "effect"
 import { Credential } from "@opencode-ai/schema/credential"
@@ -213,8 +213,33 @@ export const authorize = (input: {
       return toCredential({ methodID: input.methodID, serverUrl: input.config.url, tokens, client })
     })
 
+    // RFC 9728: a server can publish its protected-resource metadata at the exact URL it names in the
+    // 401 challenge's resource_metadata parameter (AWS Bedrock AgentCore does, with the ARN in the path).
+    // The SDK only tries origin-derived well-known paths when that URL is absent, which 404s on such
+    // servers and degrades to treating the resource host itself as the authorization server. Probe the
+    // endpoint once and thread the challenge URL into both auth() calls so discovery and the later code
+    // exchange resolve the same authorization server. Transport-driven connects already extract this
+    // URL from their own 401 handling; the interactive authorize() flow is the path that skipped it.
+    const challenge = yield* Effect.tryPromise({
+      try: async () => {
+        const response = await fetch(input.config.url, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+        })
+        await response.body?.cancel().catch(() => {})
+        return extractWWWAuthenticateParams(response).resourceMetadataUrl
+      },
+      catch: () => undefined,
+    })
+
     const result = yield* Effect.tryPromise({
-      try: () => auth(oauthProvider, { serverUrl: input.config.url, scope: oauth?.scope }),
+      try: () =>
+        auth(oauthProvider, {
+          serverUrl: input.config.url,
+          scope: oauth?.scope,
+          ...(challenge ? { resourceMetadataUrl: challenge } : {}),
+        }),
       catch: (error) => (error instanceof Error ? error : new Error(String(error))),
     })
 
@@ -238,7 +263,12 @@ export const authorize = (input: {
         Effect.flatMap((value) =>
           Effect.tryPromise({
             try: () =>
-              auth(oauthProvider, { serverUrl: input.config.url, authorizationCode: value, scope: oauth?.scope }),
+              auth(oauthProvider, {
+                serverUrl: input.config.url,
+                authorizationCode: value,
+                scope: oauth?.scope,
+                ...(challenge ? { resourceMetadataUrl: challenge } : {}),
+              }),
             catch: (error) => (error instanceof Error ? error : new Error(String(error))),
           }),
         ),

--- a/packages/core/test/mcp-oauth.test.ts
+++ b/packages/core/test/mcp-oauth.test.ts
@@ -73,4 +73,61 @@ describe("MCP OAuth", () => {
   test("rejects an invalid redirect URL", async () => {
     await expect(authorize("not a URL")).rejects.toThrow("cannot be parsed as a URL")
   })
+
+  test("follows the resource_metadata URL from the 401 challenge", async () => {
+    const issuer = Bun.serve({
+      port: 0,
+      fetch: (request) => {
+        const url = new URL(request.url)
+        if (url.pathname === "/.well-known/oauth-authorization-server")
+          return Response.json({
+            issuer: url.origin + "/",
+            authorization_endpoint: `${url.origin}/authorize`,
+            token_endpoint: `${url.origin}/token`,
+            response_types_supported: ["code"],
+          })
+        return new Response(null, { status: 404 })
+      },
+    })
+
+    // Path-shaped metadata that only the WWW-Authenticate challenge names; the origin-derived
+    // well-known lookups 404, so without the challenge URL discovery treats this host as the AS.
+    const resource = Bun.serve({
+      port: 0,
+      fetch: (request) => {
+        const url = new URL(request.url)
+        const endpoint = "/runtimes/arn%3Atest/invocations"
+        if (url.pathname === `${endpoint}/.well-known/oauth-protected-resource`)
+          return Response.json({ resource: url.origin + endpoint, authorization_servers: [issuer.url.href] })
+        if (url.pathname === endpoint)
+          return new Response(null, {
+            status: 401,
+            headers: {
+              "www-authenticate": `Bearer resource_metadata="${url.origin}${endpoint}/.well-known/oauth-protected-resource"`,
+            },
+          })
+        return new Response(null, { status: 404 })
+      },
+    })
+
+    const authorization = await Effect.runPromise(
+      Effect.scoped(
+        MCPOAuth.authorize({
+          name: "test",
+          config: new ConfigMCP.Remote({
+            type: "remote",
+            url: `${resource.url.href}runtimes/arn%3Atest/invocations`,
+            oauth: { client_id: "client" },
+          }),
+          methodID: Integration.MethodID.make("oauth"),
+        }).pipe(Effect.map((result) => new URL(result.url))),
+      ),
+    )
+
+    expect(authorization.origin).toBe(issuer.url.origin)
+    expect(authorization.pathname).toBe("/authorize")
+
+    resource.stop(true)
+    issuer.stop(true)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #44790

### Type of change

- [x] Bug fix

### What does this PR do?

The interactive `authorize()` flow in `packages/core/src/mcp/oauth.ts` called the SDK's `auth()` with only `serverUrl` and `scope` — no `resourceMetadataUrl`. With nothing else to go on, the SDK derives RFC 9728 well-known URLs from the origin (`/.well-known/oauth-protected-resource/<path>`, then the domain root). A server that publishes its protected-resource metadata at a path-shaped URL that only the challenge can name — AWS Bedrock AgentCore puts the runtime ARN in the path and announces `${endpoint}/.well-known/oauth-protected-resource?qualifier=...` in the 401 — 404s both derived lookups, and discovery falls back to treating the resource host itself as the authorization server. The browser then opens `${resource-origin}/authorize`, a dead page, which is the failure reported in the issue.

The fix probes the configured endpoint once before authenticating, reads the `WWW-Authenticate` challenge with the SDK's own `extractWWWAuthenticateParams`, and threads the extracted `resource_metadata` URL into both `auth()` calls — initial discovery and the later code exchange — so both resolve the same authorization server. If the probe fails or the server sends no challenge, behavior is unchanged. Transport-driven connects already extract this URL from their own 401 handling inside the SDK; `authorize()` was the one path that skipped it.

I confined the change to the challenge URL (not the challenge `scope`) because scope selection has its own config-driven semantics today and mixing them in would widen the review surface for no reported failure.

### How did you verify your code works?

- Sabotage run first: with the fix stashed, the new regression test in `packages/core/test/mcp-oauth.test.ts` fails exactly as the issue describes — the authorization URL lands on the resource origin instead of the issuer (`Expected http://localhost:<issuer> Received http://localhost:<resource>`).
- With the fix: `bun test test/mcp-oauth.test.ts` from `packages/core` → 5/5 pass. The new test stands up a resource server that 401s with a path-shaped `resource_metadata` (root well-known 404s, matching the Bedrock shape) and an issuer server, then asserts the returned authorization URL is on the issuer origin.
- `bun test test/mcp.test.ts test/mcp-instructions.test.ts test/mcp-import-boundary.test.ts` → 37/37 pass.
- `bun run typecheck` in `packages/core` (tsgo) and `prettier --check` on both files: clean. `oxlint` on the touched files reports only a pre-existing warning on an unrelated line.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR