### PR TITLE
fix(ai): respect prompt cache opt-out

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -666,7 +666,7 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
 
 const lowerOptions = (request: LLMRequest) => {
   const options = OpenResponsesOptions.resolve(request)
-  const cacheKey = request.cache === "none" ? undefined : ProviderShared.clampPromptCacheKey(request.promptCacheKey)
+  const cacheKey = ProviderShared.promptCacheKey(request)
   const parallelToolCalls = resolveParallelToolCalls(request)
   return {
     ...(options.instructions ? { instructions: options.instructions } : {}),

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -666,7 +666,7 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
 
 const lowerOptions = (request: LLMRequest) => {
   const options = OpenResponsesOptions.resolve(request)
-  const cacheKey = ProviderShared.clampPromptCacheKey(request.promptCacheKey)
+  const cacheKey = request.cache === "none" ? undefined : ProviderShared.clampPromptCacheKey(request.promptCacheKey)
   const parallelToolCalls = resolveParallelToolCalls(request)
   return {
     ...(options.instructions ? { instructions: options.instructions } : {}),

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -659,7 +659,7 @@ const detectZaiToolStream = (
 
 const lowerOptions = (request: LLMRequest, supportsStore: boolean) => {
   const options = OpenAIOptions.resolve(request)
-  const cacheKey = ProviderShared.clampPromptCacheKey(request.promptCacheKey)
+  const cacheKey = request.cache === "none" ? undefined : ProviderShared.clampPromptCacheKey(request.promptCacheKey)
   return {
     ...(supportsStore && options.store !== undefined ? { store: options.store } : {}),
     // For providers that support `store`, ensure stateless `store:false` is sent

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -659,7 +659,7 @@ const detectZaiToolStream = (
 
 const lowerOptions = (request: LLMRequest, supportsStore: boolean) => {
   const options = OpenAIOptions.resolve(request)
-  const cacheKey = request.cache === "none" ? undefined : ProviderShared.clampPromptCacheKey(request.promptCacheKey)
+  const cacheKey = ProviderShared.promptCacheKey(request)
   return {
     ...(supportsStore && options.store !== undefined ? { store: options.store } : {}),
     // For providers that support `store`, ensure stateless `store:false` is sent

--- a/packages/ai/src/protocols/shared.ts
+++ b/packages/ai/src/protocols/shared.ts
@@ -28,10 +28,10 @@ export const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64
 
 // OpenAI limits `prompt_cache_key` to 64 chars; DeepSeek and Zai inherit the same
 // limit via their OpenAI-compatible APIs. Clamp with unicode-aware slicing.
-export const clampPromptCacheKey = (key: string | undefined): string | undefined => {
-  if (key === undefined) return undefined
-  const chars = Array.from(key)
-  if (chars.length <= OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH) return key
+export const promptCacheKey = (request: LLMRequest): string | undefined => {
+  if (request.cache === "none" || request.promptCacheKey === undefined) return undefined
+  const chars = Array.from(request.promptCacheKey)
+  if (chars.length <= OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH) return request.promptCacheKey
   return chars.slice(0, OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH).join("")
 }
 

--- a/packages/ai/src/providers/openrouter.ts
+++ b/packages/ai/src/providers/openrouter.ts
@@ -9,7 +9,7 @@ import type { ProviderPackage } from "../provider-package.js"
 import * as OpenAICompatibleProfiles from "./openai-compatible-profile.js"
 import * as OpenAIChat from "../protocols/openai-chat.js"
 import { newBreakpoints, ttlBucket } from "../protocols/utils/cache.js"
-import { isRecord, ProviderShared } from "../protocols/shared.js"
+import { isRecord } from "../protocols/shared.js"
 
 export const profile = OpenAICompatibleProfiles.profiles.openrouter
 export const id = ProviderID.make(profile.provider)
@@ -115,12 +115,10 @@ export const protocol = Protocol.make({
               reasoning_details: reasoningDetails,
             }
           })
-          const cacheKey = ProviderShared.clampPromptCacheKey(request.promptCacheKey)
           return {
             ...body,
             messages,
             ...bodyOptions(request.providerOptions),
-            ...(cacheKey ? { prompt_cache_key: cacheKey } : {}),
           } as OpenRouterBody
         }),
       ),

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -192,6 +192,21 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("omits the prompt cache key when caching is disabled", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          prompt: "Hello",
+          promptCacheKey: "session_123",
+          cache: "none",
+        }),
+      )
+
+      expect(prepared.body).not.toHaveProperty("prompt_cache_key")
+    }),
+  )
+
   it.effect("maps the xAI Chat prompt cache key to conversation affinity", () =>
     LLMClient.generate(
       LLM.request({

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -1699,6 +1699,21 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
+  it.effect("omits the prompt cache key when caching is disabled", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          prompt: "Hello",
+          promptCacheKey: "request_cache",
+          cache: "none",
+        }),
+      )
+
+      expect(prepared.body).not.toHaveProperty("prompt_cache_key")
+    }),
+  )
+
   it.effect("parses text and usage stream fixtures", () =>
     Effect.gen(function* () {
       const body = sseEvents(

--- a/packages/ai/test/provider/openrouter.test.ts
+++ b/packages/ai/test/provider/openrouter.test.ts
@@ -190,6 +190,21 @@ describe("OpenRouter", () => {
     }),
   )
 
+  it.effect("omits the prompt cache key when caching is disabled", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model: OpenRouter.configure({ apiKey: "test-key" }).model("openai/gpt-4o-mini"),
+          prompt: "Hello",
+          promptCacheKey: "session_123",
+          cache: "none",
+        }),
+      )
+
+      expect(prepared.body).not.toHaveProperty("prompt_cache_key")
+    }),
+  )
+
   it.effect("filters invalid known OpenRouter options while preserving extensions", () =>
     Effect.gen(function* () {
       const invalid: Record<string, unknown> = {


### PR DESCRIPTION
## Summary
- omit `prompt_cache_key` from Chat and Responses requests when `cache: "none"` is configured
- remove redundant OpenRouter cache-key injection so it inherits the Chat opt-out behavior
- cover disabled caching across Chat, Responses, and OpenRouter

## Verification
- `bun test test/provider/openai-chat.test.ts test/provider/openai-responses.test.ts --timeout 30000 --only-failures`
- `bun test test/provider/openrouter.test.ts --test-name-pattern "prompt cache key|OpenRouter payload options|filters invalid known" --timeout 30000 --only-failures`
- `bun typecheck`