### PR TITLE
fix(app): drop archived sessions from home list right away

### DIFF
--- a/packages/app/src/context/global-sync/home-session-index.test.ts
+++ b/packages/app/src/context/global-sync/home-session-index.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test"
-import type { SessionV2Info } from "@opencode-ai/sdk/v2/client"
+import { QueryClient } from "@tanstack/solid-query"
+import type { Session, SessionV2Info } from "@opencode-ai/sdk/v2/client"
 import {
   applyHomeSessionEvent,
   appendHomeSessionEvent,
+  createHomeSessionIndexCache,
   HOME_V2_SESSION_PAGE_LIMIT,
   loadHomeSessionIndex,
   homeSessionIndexSessions,
@@ -150,5 +152,34 @@ describe("Home V2 session index", () => {
     expect(homeSessionIndexRefresh("server.connected", true)).toEqual({ connected: true, refetch: true })
     expect(homeSessionIndexRefresh("global.disposed", true).refetch).toBe(true)
     expect(homeSessionIndexRefresh("session.next.moved", true).refetch).toBe(true)
+  })
+
+  test("removes a session from the loaded Home index", () => {
+    const queryClient = new QueryClient()
+    const cache = createHomeSessionIndexCache(queryClient, "server")
+    const sessions = [
+      { id: "a", time: { created: 1, updated: 1 } },
+      { id: "b", time: { created: 1, updated: 1 } },
+    ] as Session[]
+    queryClient.setQueryData(cache.indexKey, { sessions, eventSequence: 0 })
+
+    cache.remove("a")
+
+    const index = queryClient.getQueryData<{ sessions: Session[] }>(cache.indexKey)
+    expect(index?.sessions.map((item) => item.id)).toEqual(["b"])
+  })
+
+  test("keeps the session out of the Home list when the index is not mounted", () => {
+    const queryClient = new QueryClient()
+    const cache = createHomeSessionIndexCache(queryClient, "server")
+    const sessions = [
+      { id: "a", time: { created: 1, updated: 1 } },
+      { id: "b", time: { created: 1, updated: 1 } },
+    ] as Session[]
+
+    cache.remove("a")
+
+    expect(queryClient.getQueryData(cache.indexKey)).toBeUndefined()
+    expect(cache.sessions({ sessions, eventSequence: 0 }, undefined).map((item) => item.id)).toEqual(["b"])
   })
 })

--- a/packages/app/src/context/global-sync/home-session-index.ts
+++ b/packages/app/src/context/global-sync/home-session-index.ts
@@ -85,6 +85,7 @@ export function createHomeSessionIndexCache(queryClient: QueryClient, server: st
   const indexKey = homeSessionIndexKey(server)
   const eventsKey = homeSessionEventsKey(server)
   let connected = false
+  const removed = new Set<string>()
 
   return {
     indexKey,
@@ -97,7 +98,8 @@ export function createHomeSessionIndexCache(queryClient: QueryClient, server: st
       queryClient.setQueryData<HomeSessionEvents>(eventsKey, (current) => trimHomeSessionEvents(current, sequence))
     },
     sessions(index: HomeSessionIndex | undefined, events: HomeSessionEvents | undefined) {
-      return homeSessionIndexSessions(index, events)
+      const sessions = homeSessionIndexSessions(index, events)
+      return removed.size === 0 ? sessions : sessions.filter((session) => !removed.has(session.id))
     },
     apply(event: HomeSessionEvent) {
       if (!queryClient.getQueryState(indexKey)) return
@@ -115,6 +117,16 @@ export function createHomeSessionIndexCache(queryClient: QueryClient, server: st
         })
       }
       queryClient.setQueryData<HomeSessionEvents>(eventsKey, { sequence: next.sequence, entries: [] })
+    },
+    remove(sessionID: string) {
+      removed.add(sessionID)
+      if (!queryClient.getQueryState(indexKey)) return
+      queryClient.setQueryData<HomeSessionIndex>(indexKey, (index) => {
+        if (!index) return index
+        const at = index.sessions.findIndex((session) => session.id === sessionID)
+        if (at === -1) return index
+        return { ...index, sessions: index.sessions.toSpliced(at, 1) }
+      })
     },
     refresh(event: Event["type"]) {
       const result = homeSessionIndexRefresh(event, connected)

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -219,13 +219,15 @@ export function createHomeSessionsController(home: HomeController) {
               directory: session.directory,
               time: { archived: Date.now() },
             }),
-          remove: () =>
+          remove: () => {
             setStore(
               produce((draft) => {
                 const match = Binary.search(draft.session, session.id, (item) => item.id)
                 if (match.found) draft.session.splice(match.index, 1)
               }),
-            ),
+            )
+            homeSessions().remove(session.id)
+          },
           onError: (cause) =>
             showToast({
               title: language.t("common.requestFailed"),

--- a/packages/app/src/pages/session/session-archive.ts
+++ b/packages/app/src/pages/session/session-archive.ts
@@ -3,6 +3,7 @@ import { produce } from "solid-js/store"
 import { notifySessionTabsRemoved } from "@/components/titlebar-session-events"
 import { useLanguage } from "@/context/language"
 import { useSDK } from "@/context/sdk"
+import { useServerSync } from "@/context/server-sync"
 import { useSync } from "@/context/sync"
 import { useTabs } from "@/context/tabs"
 import { errorMessage } from "@/pages/layout/helpers"
@@ -15,6 +16,7 @@ export function useSessionArchive() {
   const navigate = useNavigate()
   const sdk = useSDK()
   const sync = useSync()
+  const serverSync = useServerSync()
   const tabs = useTabs()
   const { params } = useSessionKey()
 
@@ -56,6 +58,7 @@ export function useSessionArchive() {
           }),
         )
         sync().session.evict(sessionID)
+        serverSync().homeSessions.remove(sessionID)
         navigateAfterRemoval(sessionID, session.parentID, nextSession?.id)
         notifySessionTabsRemoved({ directory: sdk().directory, sessionIDs: [sessionID] })
       })


### PR DESCRIPTION
### Issue for this PR
Closes #44619 

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
When a session is archived, it stayed visible in the Home list until a full refresh because the in-memory Home index cache was never updated.

This bug already existed before PR #41741 (register archive session command in both layouts), which re-enabled archiving . It was just hidden while archiving was broken. Restoring it brought the bug back.

This PR adds a `remove(sessionID)` method to the Home index cache (`home-session-index.ts`), and call it right after archiving, both from Home (`home-sessions-controller.tsx`) and from the session route (`session-archive.ts`), so the archived session disappears from the Home list immediately.

The remove call is a no-op when the Home index isn't mounted.

### How did you verify your code works?
bun typecheck
Unit tests for home-session-index: removal of a session from the loaded index, and no-op when the index isn't mounted

### Screenshots / recordings
#### Before
https://github.com/user-attachments/assets/2e73e8da-79b6-4c50-be6a-dabf777b95e0

#### After
https://github.com/user-attachments/assets/b8dbd452-782b-44d8-9588-30d43df3edab

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
