### PR TITLE
docs: add opencode-prewalk to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-prewalk](https://github.com/vivekascoder/opencode-prewalk)                               | Save token costs by planning with a frontier model, then finishing with a faster model             |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation-only ecosystem listing.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds opencode-prewalk to the ecosystem plugin table. The description highlights that it reduces token costs by using a frontier model for planning before finishing the same session with a faster model.

### How did you verify your code works?

Rendered the ecosystem page locally and ran `bun run build` from `packages/web`.

### Screenshots / recordings

N/A — this adds one row to the existing documentation table without changing its layout.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._