### PR TITLE
fix(provider): handle SSE reader cancel rejections

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -35,7 +35,7 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
         const id = setTimeout(() => {
           const err = new Error("SSE read timed out")
           ctl.abort(err)
-          void reader.cancel(err)
+          reader.cancel(err).catch(() => {})
           reject(err)
         }, ms)
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -46,7 +46,7 @@ function wrapSSE(res: Response, ms: number, ctl: AbortController) {
         const id = setTimeout(() => {
           const err = new ProviderError.ResponseStreamError("SSE read timed out")
           ctl.abort(err)
-          void reader.cancel(err)
+          reader.cancel(err).catch(() => {})
           reject(err)
         }, ms)
 

--- a/packages/opencode/test/server/httpapi-v2-pty.test.ts
+++ b/packages/opencode/test/server/httpapi-v2-pty.test.ts
@@ -81,7 +81,7 @@ describe("v2 pty HttpApi", () => {
     expect(body.data.title).toBe("v2")
 
     // The canonical surface keeps exited sessions observable with their exit code.
-    const deadline = Date.now() + 5_000
+    const deadline = Date.now() + 20_000
     let info: { status: string; exitCode?: number } | undefined
     while (Date.now() < deadline) {
       const found = await request(`/api/pty/${body.data.id}`, tmp.path)


### PR DESCRIPTION
### Issue for this PR

Closes #44943

### Type of change

- [x] Bug fix

### What does this PR do?

When the SSE chunk-timeout fires, the fetch-body reader is cancelled after the request signal is aborted. Under Bun 1.4 reader.cancel() then rejects and the voided promise surfaces as an unhandled rejection, which fails the running test even though its assertions passed. This handles the cancellation explicitly in both wrapSSE implementations (packages/opencode/src/provider/provider.ts, packages/core/src/aisdk.ts).

Also relaxes one PTY test's exit-poll deadline from 5s to 20s: under a fully parallel suite run the PTY exit event was observed at ~5.3s, so the poll deadline was exceeded despite correct behaviour. Assertion unchanged.

(Supersedes #44912, which was auto-closed before I could fix the template.)

### How did you verify your code works?

Full suite from packages/opencode under Bun 1.4.0 and Bun 1.3.14: 3339 tests, 0 fail with these changes (before: one deterministic failure under 1.4.0, one load-dependent PTY failure). tsgo typecheck clean. darwin-arm64 binaries built with both runtimes, smoke tests pass.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR