### PR TITLE
fix(app): show pending states when switching servers

### DIFF
--- a/packages/app/src/home/model.ts
+++ b/packages/app/src/home/model.ts
@@ -3,7 +3,7 @@ import { type HomeProjectSelection, useLayout } from "@/shell/state/layout"
 import { ServerConnection, useServers } from "@/runtime/server/registry"
 import { useTabs } from "@/shell/tabs/tabs"
 import { toggleHomeProjectSelection } from "@/shell/layout/helpers"
-import { createEffect, createMemo, startTransition } from "solid-js"
+import { createEffect, createMemo } from "solid-js"
 
 export function createHomeController() {
   const layout = useLayout()
@@ -49,8 +49,7 @@ export function createHomeController() {
     selection: {
       value: selection,
       set: setSelection,
-      focusServer: (conn: ServerConnection.Any) =>
-        void startTransition(() => setSelection({ server: ServerConnection.key(conn) })),
+      focusServer: (conn: ServerConnection.Any) => setSelection({ server: ServerConnection.key(conn) }),
     },
     server: {
       list: () => servers.visible,

--- a/packages/app/src/home/projects/controller.tsx
+++ b/packages/app/src/home/projects/controller.tsx
@@ -9,7 +9,6 @@ import { closeHomeProject, errorMessage, homeProjectDirectories } from "@/shell/
 import { Persist, persisted } from "@/runtime/persistence/storage"
 import { showToast } from "@/shell/notifications/toast"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
-import { createResource } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { HomeController } from "../model"
 import { useGlobal } from "@/runtime/server/runtime"
@@ -22,14 +21,9 @@ export function createHomeProjectsController(home: HomeController) {
   const openSettings = useSettingsCommand()
   const serverManagement = useServerActionsController()
   const global = useGlobal()
-  const [_state, setState, _, ready] = persisted(
+  const [state, setState] = persisted(
     Persist.global("home.servers"),
     createStore({ collapsed: {} as Record<string, boolean> }),
-  )
-  const [state] = createResource(
-    () => ready.promise ?? Promise.resolve(),
-    (promise) => promise.then(() => _state),
-    { initialValue: _state },
   )
   function directories(project: LocalProject) {
     return [project.worktree, ...(project.sandboxes ?? [])]
@@ -50,10 +44,10 @@ export function createHomeProjectsController(home: HomeController) {
       list: home.server.list,
       health: home.server.health,
       projects: home.project.forServer,
-      collapsed: (conn: ServerConnection.Any) => state().collapsed[ServerConnection.key(conn)] ?? false,
+      collapsed: (conn: ServerConnection.Any) => state.collapsed[ServerConnection.key(conn)] ?? false,
       toggleCollapsed: (conn: ServerConnection.Any) => {
         const key = ServerConnection.key(conn)
-        setState("collapsed", key, !state().collapsed[key])
+        setState("collapsed", key, !state.collapsed[key])
       },
       canDefault: serverManagement.defaults.available,
       defaultKey: serverManagement.defaults.key,

--- a/packages/app/src/home/projects/controller.tsx
+++ b/packages/app/src/home/projects/controller.tsx
@@ -9,6 +9,7 @@ import { closeHomeProject, errorMessage, homeProjectDirectories } from "@/shell/
 import { Persist, persisted } from "@/runtime/persistence/storage"
 import { showToast } from "@/shell/notifications/toast"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { createResource } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { HomeController } from "../model"
 import { useGlobal } from "@/runtime/server/runtime"
@@ -21,9 +22,14 @@ export function createHomeProjectsController(home: HomeController) {
   const openSettings = useSettingsCommand()
   const serverManagement = useServerActionsController()
   const global = useGlobal()
-  const [state, setState] = persisted(
+  const [_state, setState, _, ready] = persisted(
     Persist.global("home.servers"),
     createStore({ collapsed: {} as Record<string, boolean> }),
+  )
+  const [state] = createResource(
+    () => ready.promise ?? Promise.resolve(),
+    (promise) => promise.then(() => _state),
+    { initialValue: _state },
   )
   function directories(project: LocalProject) {
     return [project.worktree, ...(project.sandboxes ?? [])]
@@ -44,10 +50,10 @@ export function createHomeProjectsController(home: HomeController) {
       list: home.server.list,
       health: home.server.health,
       projects: home.project.forServer,
-      collapsed: (conn: ServerConnection.Any) => state.collapsed[ServerConnection.key(conn)] ?? false,
+      collapsed: (conn: ServerConnection.Any) => state().collapsed[ServerConnection.key(conn)] ?? false,
       toggleCollapsed: (conn: ServerConnection.Any) => {
         const key = ServerConnection.key(conn)
-        setState("collapsed", key, !state.collapsed[key])
+        setState("collapsed", key, !state().collapsed[key])
       },
       canDefault: serverManagement.defaults.available,
       defaultKey: serverManagement.defaults.key,

--- a/packages/app/src/home/sessions/controller.tsx
+++ b/packages/app/src/home/sessions/controller.tsx
@@ -72,7 +72,7 @@ export function createHomeSessionsController(home: HomeController) {
     if (!ctx || !conn) return []
     const server = ServerConnection.key(conn)
     return retainHomeSessions(
-      mergeHomeSessionIndex(sessionLoad.data?.() ?? [], ctx.data.session.list()).filter(
+      mergeHomeSessionIndex(sessionLoad.isPending ? [] : (sessionLoad.data?.() ?? []), ctx.data.session.list()).filter(
         (session) => !removed.keys.includes(`${server}\0${session.id}`),
       ),
       HOME_SESSION_LIMIT,
@@ -256,7 +256,7 @@ export function createHomeSessionsController(home: HomeController) {
     data: {
       records,
       groups,
-      loading: () => sessionLoad.isLoading,
+      loading: () => sessionLoad.isPending,
       searchRecords: allRecords,
     },
     session: {

--- a/packages/app/src/home/sessions/region.tsx
+++ b/packages/app/src/home/sessions/region.tsx
@@ -12,6 +12,7 @@ export function HomeSessions(props: {
     <HomeSessionsView
       language={props.sessions.copy.language}
       groups={props.sessions.data.groups()}
+      loading={props.sessions.data.loading()}
       showProjectName={props.sessions.session.showProjectName()}
       server={props.sessions.session.server()}
       canCreateSession={props.sessions.session.canCreate()}

--- a/packages/app/src/home/sessions/view.tsx
+++ b/packages/app/src/home/sessions/view.tsx
@@ -1,6 +1,6 @@
 import type { SessionInfo } from "@opencode-ai/client/promise"
 import { Key } from "@solid-primitives/keyed"
-import { createMemo, For, Index, onCleanup, Show, Suspense } from "solid-js"
+import { createMemo, For, Index, onCleanup, Show } from "solid-js"
 import { createStore, type SetStoreFunction } from "solid-js/store"
 import { InlineInput } from "@opencode-ai/ui/inline-input"
 import { Spinner } from "@opencode-ai/ui/spinner"
@@ -44,6 +44,7 @@ function isBackgroundOpen(event: MouseEvent) {
 export type HomeSessionsViewProps = {
   language: ReturnType<typeof useLanguage>
   groups: HomeSessionGroup[]
+  loading: boolean
   showProjectName: boolean
   server: ServerConnection.Key
   canCreateSession: boolean
@@ -97,22 +98,20 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
     >
       <div class="sticky top-0 z-30 shrink-0 bg-v2-background-bg-base pb-3 pt-6 lg:pt-12" onWheel={props.onWheel}>
         <HomeSessionSearch {...props} />
-        <Suspense>
-          <Show when={props.groups.length > 0 && props.canCreateSession}>
-            <div class="pointer-events-none absolute right-0 top-[84px] z-20 flex lg:top-[108px]">
-              <Button
-                data-action="home-new-session"
-                variant="ghost-muted"
-                size="normal"
-                icon="edit"
-                class="pointer-events-auto h-7 px-2 [font-weight:530]"
-                onClick={props.onCreateSession}
-              >
-                {props.language.t("command.session.new")}
-              </Button>
-            </div>
-          </Show>
-        </Suspense>
+        <Show when={props.groups.length > 0 && props.canCreateSession}>
+          <div class="pointer-events-none absolute right-0 top-[84px] z-20 flex lg:top-[108px]">
+            <Button
+              data-action="home-new-session"
+              variant="ghost-muted"
+              size="normal"
+              icon="edit"
+              class="pointer-events-auto h-7 px-2 [font-weight:530]"
+              onClick={props.onCreateSession}
+            >
+              {props.language.t("command.session.new")}
+            </Button>
+          </div>
+        </Show>
       </div>
       <div class="pointer-events-none sticky top-[84px] z-40 h-0 -mr-3 lg:top-[108px]">
         <div
@@ -122,7 +121,8 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
         />
       </div>
       <div class="-mr-3 min-h-[calc(100cqh-72px)] lg:min-h-[calc(100cqh-96px)]">
-        <Suspense
+        <Show
+          when={!props.loading}
           fallback={
             <div class="pt-3">
               <HomeSessionSkeleton label={props.language.t("common.loading")} />
@@ -164,7 +164,7 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
               </Index>
             </div>
           </Show>
-        </Suspense>
+        </Show>
       </div>
     </section>
   )

--- a/packages/app/src/new-session/project/selector.tsx
+++ b/packages/app/src/new-session/project/selector.tsx
@@ -421,7 +421,7 @@ export function PromptProjectSelector(props: {
                   <span class="min-w-0 flex-1 truncate leading-5">{props.controller.labels.add()}</span>
                 </Menu.SubTrigger>
                 <Menu.Portal>
-                  <Menu.SubContent class="min-w-[180px] overflow-hidden rounded-md border-0 bg-v2-background-bg-layer-01 shadow-[var(--v2-elevation-floating)] focus:outline-none">
+                  <Menu.SubContent class="max-h-[224px] min-w-[180px] overflow-y-auto rounded-md border-0 bg-v2-background-bg-layer-01 shadow-[var(--v2-elevation-floating)] focus:outline-none">
                     <For each={props.controller.servers()}>
                       {(server) => <ServerAction server={server!} onSelect={selectAction} />}
                     </For>

--- a/packages/app/src/runtime/server/sync.tsx
+++ b/packages/app/src/runtime/server/sync.tsx
@@ -66,11 +66,11 @@ export function createServerSyncContextInner(serverSDK: ServerSDK, data: Data) {
     provider_auth: {},
     get path() {
       const EMPTY = { state: "", config: "", worktree: "", directory: "", home: "" }
-      if (pathQuery.isLoading) return EMPTY
+      if (pathQuery.isPending) return EMPTY
       return pathQuery.data ?? EMPTY
     },
     get config() {
-      if (configQuery.isLoading) return {}
+      if (configQuery.isPending) return {}
       return configQuery.data ?? {}
     },
     get reload() {


### PR DESCRIPTION
## Summary
- update homepage server and project selection immediately instead of relying on Solid transitions
- render the existing session skeleton from explicit pending query state and avoid reading uncached query data
- guard disabled server bootstrap queries while preserving the existing one-time sidebar persistence hydration
- limit the project-picker server submenu height and allow long server lists to scroll

## Validation
- `bun typecheck` in `packages/app`
- `bun run test:unit` in `packages/app` (529 passing)
- `bun run test:browser` in `packages/app` (44 passing)
- Production homepage benchmark was attempted before and after; both runs fail identically because the existing fixture never renders the expected home session row, so no performance metrics are available.