### PR TITLE
feat(desktop): document preview for office files and PDFs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,6 +85,10 @@ _Avoid_: Local implementation
 A bounded ordered result containing `items` and opaque `previous` and `next` cursor links for navigating the same query in either direction.
 _Avoid_: Response envelope
 
+**Document Preview**:
+The desktop in-app surface that renders a document attachment or plugin-managed file — PDF natively, office drafts as markdown, real office files rendered — with comment overlay and draft editing.
+_Avoid_: File preview, Office preview, the office plugin's agent-facing `preview` action
+
 ## Relationships
 
 - A **System Context** is an opaque carrier composed from zero or more **Context Sources**.


### PR DESCRIPTION
## What

Document preview + plugin invoke foundation (from spec #44949):

- **T1**: `ctx.invoke` V2 capability + HTTP routes (`GET /api/plugin`, `POST /api/plugin/:pluginID/invoke`) — new `PluginInvoke` service in core; `@types/node` pinned to 24.12.2 for typecheck determinism
- **T2**: `server.plugin` protocol group + HTTP routes + regenerated SDK (`bun run generate` from `packages/client`)
- **T3**: `DocumentPreview` dialog in session-ui (native PDF via blob URL, DOCX via `docx-preview`, markdown via existing `Markdown`, fallback card for xlsx/pptx)
- **T4**: attachment cards for pdf/docx open in DocumentPreview on desktop (new `openInApp?` platform capability via the existing `openPath` IPC)

## Test plan

- `bun run test` in `packages/core`, `packages/protocol`, `packages/session-ui` — pass
- `bun typecheck` in `packages/opencode`, `packages/protocol`, `packages/core`, `packages/plugin`, `packages/session-ui` — pass
- Storybook stories for `DocumentPreview`

Closes #44950 #44951 #44952 #44953 #44955