### PR TITLE
fix(tui): omit NUL characters in clipboard writes

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -51,7 +51,9 @@ export function createClipboardAdapter(clipboard: CoreClipboardService): OwnedCl
       throw new Error(`Unexpected clipboard MIME type: ${result.representation.mimeType}`)
     },
     async write(text) {
-      const result = await clipboard.writeText(text, {
+      // Host clipboards reject NUL characters (e.g. from shell tool output);
+      // omit them so a single stray byte cannot fail the whole copy.
+      const result = await clipboard.writeText(text.replaceAll("\0", ""), {
         destination: "all-available",
         selection: "clipboard",
       })

--- a/packages/tui/test/clipboard.test.ts
+++ b/packages/tui/test/clipboard.test.ts
@@ -102,6 +102,18 @@ test("uses all available routes but skips the process host remotely", async () =
   expect(writes).toEqual({ host: 0, terminal: 1 })
 })
 
+test("omits NUL characters that host clipboards cannot carry", async () => {
+  const writes: [string, ClipboardWriteOptions][] = []
+  const clipboard = createClipboardAdapter(
+    coreClipboard({
+      onWrite: (text, input) => writes.push([text, input]),
+    }),
+  )
+
+  await clipboard.write("a\0b\0")
+  expect(writes).toEqual([["ab", { destination: "all-available", selection: "clipboard" }]])
+})
+
 test("rejects only when no clipboard route accepted the write", async () => {
   const writes: [string, ClipboardWriteOptions][] = []
   const failure = new Error("native clipboard failed")


### PR DESCRIPTION
### Issue for this PR

Closes #44198

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Shell tool output often contains NUL bytes, and the host clipboard rejects text containing NUL characters, so `/copy` failed entirely with "Failed to copy session transcript".

This strips NUL characters in the clipboard adapter (`packages/tui/src/clipboard.ts`) before the text reaches OpenTUI, so one stray byte no longer fails the whole copy — the rest of the transcript is copied as-is, which is the behavior requested in the issue.

### How did you verify your code works?

Added a regression test in `packages/tui/test/clipboard.test.ts`: writing `"a\0b\0"` through the adapter now passes `"ab"` to the clipboard service. `tsc`/typecheck and oxlint pass.

Reviewer repro:
```
printf 'a\x00b\x00c\n' > /tmp/nul.txt
# let the shell tool cat /tmp/nul.txt in a session, then run /copy
```
Before: error toast, clipboard unchanged. After: copy succeeds, pasted text
is `abc`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR