### PR TITLE
feat(tui): refine persistent terminal panes

### DIFF
--- a/packages/tui/src/component/persistent-terminal-pane.tsx
+++ b/packages/tui/src/component/persistent-terminal-pane.tsx
@@ -1,4 +1,4 @@
-import { EmbeddedTerminalRenderable, type RGBA } from "@opentui/core"
+import { CliRenderEvents, EmbeddedTerminalRenderable, type RGBA } from "@opentui/core"
 import type { ResolvedThemeTokens } from "@opencode-ai/theme/tui"
 import { extend, useRenderer } from "@opentui/solid"
 import { createEffect, createSignal, onCleanup, onMount, Show } from "solid-js"
@@ -26,11 +26,16 @@ export function PersistentTerminalPane(props: {
   autoFocus?: boolean
   onAutoFocus?: () => void
   onFocusRequest?: (focus: (() => void) | undefined) => void
+  onInfo?: (info: { cwd: string; title: string; foregroundProcess?: string }) => void
+  onTitleChange?: (title: string) => void
+  onForegroundProcessChange?: (process: string | undefined) => void
+  onDisconnect?: () => void
+  onFocusChange?: (focused: boolean) => void
 }) {
   const client = useClient()
   const keymap = Keymap.use()
   const leader = Keymap.useLeaderActive()
-  const theme = useTheme()
+  const theme = useTheme("elevated")
   const themes = useThemes()
   const renderer = useRenderer()
   const [failure, setFailure] = createSignal<string>()
@@ -141,6 +146,8 @@ export function PersistentTerminalPane(props: {
     },
     { priority: 100 },
   )
+  const onFocused = () => props.onFocusChange?.(terminal?.focused === true)
+  renderer.on(CliRenderEvents.FOCUSED_RENDERABLE, onFocused)
   createEffect(() => {
     if (!props.autoFocus || !terminal) return
     terminal.focus()
@@ -148,7 +155,8 @@ export function PersistentTerminalPane(props: {
   })
 
   createEffect(() => {
-    terminalTheme = terminalPalette(themes.currentTokens(), themes.mode())
+    const tokens = themes.currentTokens().contextual.elevated
+    terminalTheme = terminalPalette(tokens, themes.mode(), tokens.background.default)
     applyTerminalTheme()
   })
 
@@ -161,6 +169,8 @@ export function PersistentTerminalPane(props: {
     waitingSize?.resolve()
     socket?.close()
     offKeys()
+    renderer.off(CliRenderEvents.FOCUSED_RENDERABLE, onFocused)
+    props.onFocusChange?.(false)
     props.onFocusRequest?.(undefined)
   })
 
@@ -169,6 +179,11 @@ export function PersistentTerminalPane(props: {
     if (!endpoint) throw new Error("Persistent terminal server endpoint is unavailable")
     const snapshot = await client.api.experimental.persistentPty.snapshot({ ptyID: props.ptyID })
     if (disposed) return
+    props.onInfo?.({
+      cwd: snapshot.info.cwd,
+      title: snapshot.info.title,
+      foregroundProcess: snapshot.info.foregroundProcess ?? undefined,
+    })
     setCanonicalSize(snapshot.info.size)
     await waitForTerminalSize(snapshot.info.size)
     if (disposed) return
@@ -203,6 +218,18 @@ export function PersistentTerminalPane(props: {
       if (typeof event.data !== "string") return
       const message: unknown = JSON.parse(event.data)
       if (!message || typeof message !== "object" || !("type" in message)) return
+      if (message.type === "title_changed" && "title" in message && typeof message.title === "string") {
+        props.onTitleChange?.(message.title)
+        return
+      }
+      if (
+        message.type === "foreground_process_changed" &&
+        "process" in message &&
+        (typeof message.process === "string" || message.process === null)
+      ) {
+        props.onForegroundProcessChange?.(message.process ?? undefined)
+        return
+      }
       if (
         message.type === "resized" &&
         "cols" in message &&
@@ -256,10 +283,18 @@ export function PersistentTerminalPane(props: {
       attached = true
     })
     next.addEventListener("error", () => {
-      if (!disposed) setFailure("Terminal connection failed")
+      if (disposed) return
+      const focused = terminal?.focused
+      terminal = undefined
+      setFailure("Terminal connection failed")
+      if (focused) props.onDisconnect?.()
     })
     next.addEventListener("close", () => {
-      if (!disposed) setFailure("Terminal disconnected")
+      if (disposed) return
+      const focused = terminal?.focused
+      terminal = undefined
+      setFailure("Terminal disconnected")
+      if (focused) props.onDisconnect?.()
     })
     socket = next
   }
@@ -270,9 +305,9 @@ export function PersistentTerminalPane(props: {
       minWidth={0}
       minHeight={0}
       overflow="hidden"
-      backgroundColor={theme.background.default}
+      backgroundColor={themes.currentTokens().contextual.elevated.background.default}
       onSizeChange={function () {
-        size = { cols: this.width, rows: this.height }
+        size = { cols: Math.max(1, this.width - 2), rows: this.height }
         if (controller && restored) interact()
       }}
       // TODO: Revisit when embedded terminal mouse handlers can compose without replacing its internal focus handler.
@@ -295,7 +330,7 @@ export function PersistentTerminalPane(props: {
               applyTerminalTheme()
             }}
             position="absolute"
-            left={0}
+            left={1}
             top={0}
             width={80}
             height={24}
@@ -321,11 +356,11 @@ function sameSize(first: TerminalSize | undefined, second: TerminalSize | undefi
   return !!first && !!second && first.cols === second.cols && first.rows === second.rows
 }
 
-function terminalPalette(theme: ResolvedThemeTokens, mode: "dark" | "light") {
+function terminalPalette(theme: ResolvedThemeTokens, mode: "dark" | "light", background: RGBA) {
   const base = mode === "dark" ? 500 : 700
   const bright = mode === "dark" ? 300 : 500
   const colors = [
-    theme.background.default,
+    background,
     theme.text.feedback.error.default,
     theme.text.feedback.success.default,
     theme.text.feedback.warning.default,
@@ -345,7 +380,7 @@ function terminalPalette(theme: ResolvedThemeTokens, mode: "dark" | "light") {
   return Buffer.from(
     colors
       .map((color, index) => `\x1b]4;${index};${hex(color)}\x1b\\`)
-      .concat(`\x1b]10;${hex(theme.text.default)}\x1b\\`, `\x1b]11;${hex(theme.background.default)}\x1b\\`)
+      .concat(`\x1b]10;${hex(theme.text.default)}\x1b\\`, `\x1b]11;${hex(background)}\x1b\\`)
       .join(""),
   )
 }

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -79,6 +79,7 @@ export type PromptProps = {
   sessionID?: string
   visible?: boolean
   disabled?: boolean
+  muted?: boolean
   onSubmit?: () => void
   onEmptySubmit?: () => boolean | Promise<boolean>
   ref?: (ref: PromptRef | undefined) => void
@@ -195,6 +196,7 @@ export function Prompt(props: PromptProps) {
   const [inputTarget, setInputTarget] = createSignal<TextareaRenderable | undefined>()
 
   const leader = Keymap.useLeaderActive()
+  const muted = () => leader() || props.muted
   const local = useLocal()
   const args = useArgs()
   const paths = useTuiPaths()
@@ -1601,7 +1603,7 @@ export function Prompt(props: PromptProps) {
     },
   )
   const highlight = createMemo(() => {
-    if (leader()) return theme.border.default
+    if (muted()) return theme.border.default
     if (store.mode === "shell") return theme.text.action.primary.selected
     return promptDisplay().agentColor ?? theme.border.default
   })
@@ -1772,8 +1774,8 @@ export function Prompt(props: PromptProps) {
               width="100%"
               placeholder={placeholderText()}
               placeholderColor={theme.text.subdued}
-              textColor={leader() ? theme.text.subdued : theme.text.default}
-              focusedTextColor={leader() ? theme.text.subdued : theme.text.default}
+              textColor={muted() ? theme.text.subdued : theme.text.default}
+              focusedTextColor={muted() ? theme.text.subdued : theme.text.default}
               minHeight={1}
               maxHeight={maxHeight()}
               cursorStyle={config.cursor}
@@ -1870,7 +1872,7 @@ export function Prompt(props: PromptProps) {
                             minWidth={0}
                             wrapMode="none"
                             truncate
-                            fg={fadeColor(leader() ? theme.text.subdued : theme.text.default, modelMetaAlpha())}
+                            fg={fadeColor(muted() ? theme.text.subdued : theme.text.default, modelMetaAlpha())}
                           >
                             {promptDisplay().modelLabel}
                           </text>

--- a/packages/tui/src/component/session-frame.tsx
+++ b/packages/tui/src/component/session-frame.tsx
@@ -1,42 +1,69 @@
-import { createResource, createSignal, For, onCleanup, Show } from "solid-js"
+import type { PersistentPtyInfo } from "@opencode-ai/client"
+import { TextAttributes } from "@opentui/core"
+import { createEffect, createResource, createSignal, For, onCleanup, Show, type JSX } from "solid-js"
 import { Keymap } from "../context/keymap"
 import { useTerminalWorkspace } from "../context/terminal-workspace"
 import { usePromptRef } from "../context/prompt"
-import { useTheme } from "../context/theme"
+import { useTheme, useThemes } from "../context/theme"
 import { Session } from "../routes/session"
+import { SplitBorder } from "../ui/border"
 import { PersistentTerminalPane } from "./persistent-terminal-pane"
 
+type TerminalPickerState = {
+  entries: { id: string; title: string }[]
+  selected: number
+  onMove: (index: number) => void
+  onSelect: () => void
+  onClose: () => void
+}
+
 export function SessionFrame(props: { sessionID: string; verticalTabsWidth: number }) {
-  const workspaces = useTerminalWorkspace()
+  const panes = useTerminalWorkspace()
   const keymap = Keymap.use()
   const prompt = usePromptRef()
-  const theme = useTheme()
+  const [terminalTitles, setTerminalTitles] = createSignal<Record<string, string>>({})
+  const [terminalFocused, setTerminalFocused] = createSignal(false)
+  const [restoreTerminalFocus, setRestoreTerminalFocus] = createSignal(false)
   const [pickerOpen, setPickerOpen] = createSignal(false)
   const [pickerSelected, setPickerSelected] = createSignal(0)
   let focusTerminal: (() => void) | undefined
-
   createResource(
     () => props.sessionID,
-    (sessionID) => workspaces.load(sessionID).catch(() => undefined),
+    (sessionID) => panes.load(sessionID).catch(() => undefined),
   )
-
-  const terminals = () => workspaces.get(props.sessionID)?.terminals ?? []
+  const workspace = () => panes.get(props.sessionID)
+  const terminals = () => workspace()?.terminals ?? []
   const selectedTerminal = () => {
-    const workspace = workspaces.get(props.sessionID)
-    return (
-      workspace?.terminals.find((terminal) => terminal.id === workspace.selectedTerminalID) ??
-      workspace?.terminals.at(-1)
-    )
+    const value = workspace()
+    return value?.terminals.find((terminal) => terminal.id === value.selectedTerminalID) ?? value?.terminals.at(-1)
   }
-
+  createEffect(() => {
+    if (!restoreTerminalFocus() || terminals().length > 0) return
+    setRestoreTerminalFocus(false)
+    prompt.current?.focus()
+  })
+  const picker = (): TerminalPickerState | undefined => {
+    if (!pickerOpen()) return
+    return {
+      entries: terminals().map((terminal) => ({
+        id: terminal.id,
+        title: terminalTitles()[terminal.id] ?? terminal.foregroundProcess ?? terminal.title,
+      })),
+      selected: pickerSelected(),
+      onMove: setPickerSelected,
+      onSelect: selectTerminal,
+      onClose: () => setPickerOpen(false),
+    }
+  }
   const selectTerminal = () => {
-    const terminal = terminals()[pickerSelected()]
+    const list = terminals()
+    const selected = pickerSelected()
     setPickerOpen(false)
-    if (terminal) {
-      void workspaces.selectTerminal(props.sessionID, terminal.id)
+    if (selected < list.length) {
+      void panes.selectTerminal(props.sessionID, list[selected]!.id)
       return
     }
-    void workspaces.newTerminal(props.sessionID)
+    void panes.newTerminal(props.sessionID)
   }
 
   Keymap.createLayer(() => ({
@@ -65,85 +92,239 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
             setPickerOpen(false)
             return
           }
-          const selected = terminals().findIndex((terminal) => terminal.id === selectedTerminal()?.id)
-          setPickerSelected(Math.max(0, selected))
+          const current = selectedTerminal()
+          const index = terminals().findIndex((terminal) => terminal.id === current?.id)
+          setPickerSelected(index < 0 ? 0 : index)
           setPickerOpen(true)
-          void workspaces.refresh(props.sessionID)
+          void panes.refresh(props.sessionID)
         },
       },
     ],
   }))
 
-  onCleanup(
-    keymap.intercept(
-      "key",
-      ({ event }) => {
-        if (!pickerOpen()) return
-        event.preventDefault()
-        event.stopPropagation()
-        const count = terminals().length + 1
-        if (event.name === "escape") {
-          setPickerOpen(false)
-          return
-        }
-        if (event.name === "up" || event.name === "k") {
-          setPickerSelected((index) => (index + count - 1) % count)
-          return
-        }
-        if (event.name === "down" || event.name === "j") {
-          setPickerSelected((index) => (index + 1) % count)
-          return
-        }
-        if (event.name === "enter" || event.name === "return") selectTerminal()
-      },
-      { priority: 200 },
-    ),
+  const offPickerKeys = keymap.intercept(
+    "key",
+    ({ event }) => {
+      if (!pickerOpen()) return
+      event.preventDefault()
+      event.stopPropagation()
+      const count = terminals().length + 1
+      if (event.name === "escape") {
+        setPickerOpen(false)
+        return
+      }
+      if (event.name === "up" || event.name === "k") {
+        setPickerSelected((index) => (index + count - 1) % count)
+        return
+      }
+      if (event.name === "down" || event.name === "j") {
+        setPickerSelected((index) => (index + 1) % count)
+        return
+      }
+      if (event.name === "enter" || event.name === "return") selectTerminal()
+    },
+    { priority: 200 },
   )
+  onCleanup(offPickerKeys)
 
   return (
     <box flexGrow={1} minWidth={0} minHeight={0} flexDirection="row">
-      <box flexGrow={selectedTerminal() ? 0.5 : 1} flexBasis={0} minWidth={0} minHeight={0}>
-        <Session verticalTabsWidth={props.verticalTabsWidth} />
+      <box flexGrow={selectedTerminal() ? 0.5 : 1} flexBasis={0} minWidth={0} minHeight={0} position="relative">
+        <Session verticalTabsWidth={props.verticalTabsWidth} promptMuted={terminalFocused()} />
+        <Show when={terminalFocused()}>
+          <box
+            position="absolute"
+            left={0}
+            top={0}
+            width="100%"
+            height="100%"
+            zIndex={1}
+            onMouseDown={() => prompt.current?.focus()}
+          />
+        </Show>
       </box>
       <Show keyed when={selectedTerminal()}>
         {(terminal) => (
-          <box flexGrow={0.5} flexBasis={0} minWidth={0} minHeight={0} flexDirection="column">
-            <box height={1} flexShrink={0} paddingLeft={1} backgroundColor={theme.background.surface.offset}>
-              <text fg={theme.text.subdued} wrapMode="none" truncate>
-                Terminal: {terminal.foregroundProcess ?? terminal.title}
-              </text>
-            </box>
-            <box flexGrow={1} minWidth={0} minHeight={0}>
-              <PersistentTerminalPane
-                ptyID={terminal.id}
-                autoFocus={workspaces.shouldFocus(terminal.id)}
-                onAutoFocus={() => workspaces.clearFocus(terminal.id)}
-                onFocusRequest={(focus) => (focusTerminal = focus)}
-              />
-            </box>
-            <Show when={pickerOpen()}>
-              <box flexDirection="column" paddingLeft={1} paddingRight={1}>
-                <For each={[...terminals(), undefined]}>
-                  {(option, index) => (
-                    <box
-                      height={1}
-                      onMouseOver={() => setPickerSelected(index())}
-                      onMouseUp={() => {
-                        setPickerSelected(index())
-                        selectTerminal()
-                      }}
-                    >
-                      <text fg={index() === pickerSelected() ? theme.text.default : theme.text.subdued}>
-                        {option?.foregroundProcess ?? option?.title ?? "+ New terminal"}
-                      </text>
-                    </box>
-                  )}
-                </For>
-              </box>
-            </Show>
+          <box flexGrow={0.5} flexBasis={0} minWidth={0} minHeight={0}>
+            <TerminalPane
+              info={terminal}
+              picker={picker()}
+              onFocusChange={setTerminalFocused}
+              onFocusRequest={(value) => (focusTerminal = value)}
+              restoreFocus={restoreTerminalFocus()}
+              onAutoFocus={() => setRestoreTerminalFocus(false)}
+              onDisconnect={() => setRestoreTerminalFocus(true)}
+              onTitle={(title) => setTerminalTitles((titles) => ({ ...titles, [terminal.id]: title }))}
+            />
           </box>
         )}
       </Show>
+    </box>
+  )
+}
+
+function TerminalPane(props: {
+  info: PersistentPtyInfo
+  picker?: TerminalPickerState
+  onFocusChange: (focused: boolean) => void
+  onFocusRequest: (focus: (() => void) | undefined) => void
+  restoreFocus: boolean
+  onAutoFocus: () => void
+  onDisconnect: () => void
+  onTitle: (title: string) => void
+}) {
+  const panes = useTerminalWorkspace()
+  const [terminalTitle, setTerminalTitle] = createSignal(props.info.title)
+  const [foregroundProcess, setForegroundProcess] = createSignal(props.info.foregroundProcess ?? undefined)
+  const [focused, setFocused] = createSignal(false)
+  let focusTerminal: (() => void) | undefined
+  return (
+    <PaneSurface
+      focus={() => focusTerminal?.()}
+      title={foregroundProcess() ?? terminalTitle()}
+      focused={focused()}
+      picker={props.picker}
+    >
+      <PersistentTerminalPane
+        ptyID={props.info.id}
+        autoFocus={props.restoreFocus || panes.shouldFocus(props.info.id)}
+        onAutoFocus={() => {
+          panes.clearFocus(props.info.id)
+          props.onAutoFocus()
+        }}
+        onFocusRequest={(value) => {
+          focusTerminal = value
+          props.onFocusRequest(value)
+        }}
+        onDisconnect={props.onDisconnect}
+        onFocusChange={(value) => {
+          setFocused(value)
+          props.onFocusChange(value)
+        }}
+        onInfo={(info) => {
+          setTerminalTitle(info.title)
+          setForegroundProcess(info.foregroundProcess)
+          props.onTitle(info.foregroundProcess ?? info.title)
+        }}
+        onTitleChange={(title) => {
+          setTerminalTitle(title)
+          if (!foregroundProcess()) props.onTitle(title)
+        }}
+        onForegroundProcessChange={(process) => {
+          setForegroundProcess(process)
+          props.onTitle(process ?? terminalTitle())
+        }}
+      />
+    </PaneSurface>
+  )
+}
+
+function PaneSurface(props: {
+  focus: () => void
+  title: string
+  focused: boolean
+  picker?: TerminalPickerState
+  children: JSX.Element
+}) {
+  const theme = useTheme()
+  const themes = useThemes()
+  const shortcut = Keymap.useShortcut("terminal.select")
+  const background = () => themes.currentTokens().contextual.elevated.background.default
+  return (
+    <box flexGrow={1} minWidth={0} minHeight={0} flexDirection="column" backgroundColor={background()}>
+      <box
+        height={1}
+        flexShrink={0}
+        paddingLeft={1}
+        paddingRight={1}
+        flexDirection="row"
+        backgroundColor={background()}
+        onMouseDown={props.focus}
+      >
+        <text
+          fg={props.focused ? theme.text.formfield.selected : theme.text.subdued}
+          bg={background()}
+          wrapMode="none"
+          truncate
+          flexGrow={1}
+          minWidth={0}
+        >
+          Terminal: {props.title}
+        </text>
+        <Show when={shortcut()}>
+          {(value) => (
+            <>
+              <text fg={theme.text.default} bg={background()} wrapMode="none" flexShrink={0}>
+                {value()}
+              </text>
+              <text fg={theme.text.subdued} bg={background()} wrapMode="none" flexShrink={0}>
+                {" "}
+                terminals
+              </text>
+            </>
+          )}
+        </Show>
+      </box>
+      <box flexGrow={1} minWidth={0} minHeight={0} position="relative" backgroundColor={background()}>
+        {props.children}
+      </box>
+      <Show when={props.picker}>{(picker) => <TerminalPicker {...picker()} />}</Show>
+    </box>
+  )
+}
+
+function TerminalPicker(props: TerminalPickerState) {
+  const theme = useTheme("elevated")
+  const options = () => [...props.entries, { id: "", title: "+ New terminal" }]
+  const background = () => theme.raise(theme.background.default)
+  return (
+    <box
+      {...SplitBorder}
+      flexShrink={0}
+      flexDirection="column"
+      marginLeft={2}
+      marginRight={2}
+      marginBottom={1}
+      paddingLeft={2}
+      paddingRight={2}
+      paddingTop={1}
+      paddingBottom={1}
+      border={["left"]}
+      borderColor={theme.border.default}
+      backgroundColor={background()}
+    >
+      <box flexDirection="row" marginBottom={1}>
+        <text fg={theme.text.default} attributes={TextAttributes.BOLD} flexGrow={1}>
+          Terminals
+        </text>
+        <text fg={theme.text.subdued}>esc</text>
+      </box>
+      <For each={options()}>
+        {(option, index) => {
+          const selected = () => index() === props.selected
+          return (
+            <box
+              height={1}
+              backgroundColor={
+                selected() ? theme.background.action.primary.focused : theme.background.action.primary.default
+              }
+              onMouseOver={() => props.onMove(index())}
+              onMouseUp={() => {
+                props.onMove(index())
+                props.onSelect()
+              }}
+            >
+              <text
+                fg={selected() ? theme.text.action.primary.focused : theme.text.action.primary.default}
+                wrapMode="none"
+                truncate
+              >
+                {option.title}
+              </text>
+            </box>
+          )
+        }}
+      </For>
     </box>
   )
 }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -149,7 +149,7 @@ function use() {
   return ctx
 }
 
-export function Session(props: { verticalTabsWidth: number }) {
+export function Session(props: { verticalTabsWidth: number; promptMuted?: boolean }) {
   const setEpilogue = useEpilogue()
   const clipboard = useClipboard()
   const writeExport = async (file: string, content: string) => {
@@ -1346,6 +1346,7 @@ export function Session(props: { verticalTabsWidth: number }) {
                     visible={true}
                     ref={bind}
                     disabled={false}
+                    muted={props.promptMuted}
                     onSubmit={() => {
                       toBottom()
                     }}

--- a/packages/tui/src/util/selection.ts
+++ b/packages/tui/src/util/selection.ts
@@ -11,7 +11,11 @@ type FocusableSelectionTarget = {
 }
 
 type Renderer = {
-  getSelection: () => { getSelectedText: () => string; selectedRenderables: FocusableSelectionTarget[] } | null
+  getSelection: () => {
+    getSelectedText: () => string
+    selectedRenderables: FocusableSelectionTarget[]
+    isStart: boolean
+  } | null
   clearSelection: () => void
   currentFocusedRenderable?: FocusableSelectionTarget | null
 }
@@ -36,9 +40,16 @@ export function copyOnSelectRelease(
 export function copy(renderer: Renderer, toast: Toast, clipboard: ClipboardService): boolean {
   const selection = renderer.getSelection()
   if (!selection) return false
+  if (selection.isStart) {
+    renderer.clearSelection()
+    return false
+  }
 
   const text = selection.getSelectedText()
-  if (!text) return false
+  if (!text) {
+    renderer.clearSelection()
+    return false
+  }
 
   const focus = renderer.currentFocusedRenderable
   const clipboardText =

--- a/packages/tui/test/util/selection.test.ts
+++ b/packages/tui/test/util/selection.test.ts
@@ -1,14 +1,36 @@
 import { expect, test } from "bun:test"
-import { copy, copyOnSelectRelease } from "../../src/util/selection"
+import type { ClipboardService } from "../../src/context/clipboard"
+import { Selection, copy, copyOnSelectRelease } from "../../src/util/selection"
 
 function renderer() {
   return {
     getSelection: () => ({
       getSelectedText: () => "beta",
       selectedRenderables: [],
+      isStart: false,
     }),
     clearSelection: () => {},
   }
+}
+
+function setup(text: string, isStart: boolean) {
+  const writes: string[] = []
+  let clears = 0
+  const clipboard: ClipboardService = {
+    read: async () => undefined,
+    write: async (value) => {
+      writes.push(value)
+    },
+  }
+  const renderer = {
+    getSelection: () => ({ getSelectedText: () => text, selectedRenderables: [], isStart }),
+    clearSelection: () => {
+      clears++
+    },
+    currentFocusedRenderable: null,
+  }
+  const toast = { show: () => {}, error: () => {} }
+  return { clipboard, renderer, toast, writes, clears: () => clears }
 }
 
 test("copy writes selected text without clearing the highlight", () => {
@@ -18,6 +40,7 @@ test("copy writes selected text without clearing the highlight", () => {
       getSelection: () => ({
         getSelectedText: () => "beta",
         selectedRenderables: [],
+        isStart: false,
       }),
       clearSelection: () => {
         cleared = true
@@ -50,4 +73,26 @@ test("copy-on-select ignores a later non-drag release", () => {
   expect(copyOnSelectRelease({ isDragging: false }, renderer(), toast, clipboard)).toBe(false)
   expect(copyOnSelectRelease({ isDragging: true }, renderer(), toast, clipboard)).toBe(true)
   expect(writes).toEqual(["beta"])
+})
+
+test("clears a click-only selection without copying", () => {
+  const value = setup("x", true)
+  expect(Selection.copy(value.renderer, value.toast, value.clipboard)).toBeFalse()
+  expect(value.clears()).toBe(1)
+  expect(value.writes).toEqual([])
+})
+
+test("clears an empty dragged selection without copying", () => {
+  const value = setup("", false)
+  expect(Selection.copy(value.renderer, value.toast, value.clipboard)).toBeFalse()
+  expect(value.clears()).toBe(1)
+  expect(value.writes).toEqual([])
+})
+
+test("copies a non-empty dragged selection without clearing its highlight", async () => {
+  const value = setup("selected", false)
+  expect(Selection.copy(value.renderer, value.toast, value.clipboard)).toBeTrue()
+  await Promise.resolve()
+  expect(value.clears()).toBe(0)
+  expect(value.writes).toEqual(["selected"])
 })


### PR DESCRIPTION
## Summary
- refine session terminal pane layout, headers, focus ownership, render timing, and live foreground-process labels
- add pane-navigation keybindings and prompt/session focus handling
- simplify pane state to the selected terminal rather than a generic workspace tree
- handle click-only/empty selections while preserving current `v2` copy-highlight behavior

## Verification
- TUI and CLI typechecks
- focused session-tab and selection suites (25 tests)

Stack: 4/4, based on #44971.