### PR TITLE
fix(desktop): raise detectServerProtocol health-probe timeout to 60s

### DIFF
--- a/packages/app/src/utils/server-protocol.ts
+++ b/packages/app/src/utils/server-protocol.ts
@@ -10,10 +10,15 @@ function headers(server: ServerConnection.HttpBase) {
   }
 }
 
+// Cold-start Chromium network-service init (e.g. enumerating a large corporate CA store) can
+// stall a renderer's first fetch to the local sidecar for 15-20s+ even though the server itself
+// answers instantly — measured 19.5s on a locked-down corporate machine. A short timeout here
+// falsely triggers the "v2" default before the real (v1) health check ever completes. 60s matches
+// the sidecar's own SIDECAR_START_STALL_TIMEOUT in server.ts.
 async function probe(server: ServerConnection.HttpBase, fetch: typeof globalThis.fetch, path: string) {
   const response = await fetch(new URL(path, server.url), {
     headers: headers(server),
-    signal: AbortSignal.timeout(5_000),
+    signal: AbortSignal.timeout(60_000),
   })
   if (!response.ok || !response.headers.get("content-type")?.includes("application/json")) return
   const value: unknown = await response.json()


### PR DESCRIPTION
### Issue for this PR

Closes #40516

### Type of change

- [x] Bug fix

### What does this PR do?

`detectServerProtocol()` probes `/global/health` with a 5s timeout, falls back to `/api/health` with another 5s timeout, and defaults to `"v2"` if both time out. On my machine the renderer's first fetch to the local sidecar can take up to ~20s on a cold start (Chromium's network service init, not the server - Node's own fetch to the same URL is instant), so it blows through the 5s window and picks v2 even though the sidecar is actually v1. Once it's on v2 the client calls `/api` endpoints that aren't fully wired up, which is what causes the empty providers/MCP list and the `temperature` crash reported in #40516.

Bumped the timeout to 60s to match `SIDECAR_START_STALL_TIMEOUT` in `packages/desktop/src/main/server.ts`, which already handles this same slow-start case elsewhere. A fetch that succeeds fast still returns fast - this only changes how long it waits before giving up.

### How did you verify your code works?

Patched a built Desktop `app.asar` by hand and ran it through 10 clean open/close cycles across 1.18.22 and 1.18.23 with the timeout bumped, versus a reliably reproducible failure with the stock 5s timeout. Existing unit tests in `server-protocol.test.ts` still pass, and `bun turbo typecheck` is clean.

### Screenshots / recordings

N/A - not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
