### PR TITLE
feat(cli): support model flag in v2 tui

### DIFF
--- a/packages/cli/src/commands/commands.ts
+++ b/packages/cli/src/commands/commands.ts
@@ -54,6 +54,11 @@ const Root = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCODE_CLI_NAME
       Flag.optional,
     ),
     prompt: Flag.string("prompt").pipe(Flag.withDescription("Prompt to use"), Flag.optional),
+    model: Flag.string("model").pipe(
+      Flag.withAlias("m"),
+      Flag.withDescription("Model to use in the format provider/model"),
+      Flag.optional,
+    ),
   },
   commands: [
     Spec.make("acp", { description: "Start an Agent Client Protocol server" }),

--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -76,6 +76,7 @@ export default Runtime.handler(Commands, (input) =>
         continue: input.continue,
         sessionID: Option.getOrUndefined(input.session),
         prompt: Option.getOrUndefined(input.prompt),
+        model: Option.getOrUndefined(input.model),
         auto: input.auto || input.yolo || input.dangerouslySkipPermissions,
       },
       config: {

--- a/packages/cli/test/mini.test.ts
+++ b/packages/cli/test/mini.test.ts
@@ -117,6 +117,7 @@ describe("mini command", () => {
     const result = await cli(["--help"])
 
     expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain("--model")
     expect(result.stdout).toContain("mini       Start the minimal interactive interface")
     expect(result.stdout).toContain("run        Run OpenCode with a message")
   })

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -296,6 +296,49 @@ test("session startup prompt is submitted exactly once", async () => {
   }
 })
 
+test("uses the startup model argument for new sessions", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 24, useThread: false, kittyKeyboard: true })
+  setup.renderer.start()
+  const events = createEventStream()
+  const cwd = process.cwd()
+  const location = { directory: cwd, project: { id: "project", directory: cwd } }
+  const calls = createFetch((url) => {
+    if (url.pathname === "/api/location") return json(location)
+    if (url.pathname === "/api/session") return json({ data: [], cursor: {} })
+    if (url.pathname === "/api/agent")
+      return json({ location, data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }] })
+    if (url.pathname === "/api/provider") return json({ location, data: [{ id: "provider", name: "Provider" }] })
+    if (url.pathname === "/api/model")
+      return json({
+        location,
+        data: [{ id: "requested-model", providerID: "provider", name: "Requested Model", variants: [] }],
+      })
+  }, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: { get: async () => ({ animations: false }), update: async () => ({}) },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: () => {} }),
+        args: { model: "provider/requested-model" },
+        log: () => {},
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
+    )
+
+    await setup.waitForFrame((frame) => frame.includes("Requested Model"))
+    setup.renderer.destroy()
+    await task
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    await server.stop()
+  }
+})
+
 test("new session inherits the active session model", async () => {
   const setup = await createTestRenderer({ width: 80, height: 24, useThread: false, kittyKeyboard: true })
   setup.renderer.start()

--- a/packages/www/src/docs/content/cli/index.mdx
+++ b/packages/www/src/docs/content/cli/index.mdx
@@ -14,6 +14,12 @@ Pass a directory to work in a different project:
 opencode2 ~/code/my-project
 ```
 
+Select the model for a new session:
+
+```bash
+opencode2 --model anthropic/claude-sonnet-4-5
+```
+
 Suggested terminals:
 
 - [Ghostty](https://ghostty.org)


### PR DESCRIPTION
### Issue for this PR

No linked issue. This restores V1 model-selection parity in V2.

### Type of change

- [x] New feature
- [x] Documentation

### What does this PR do?

V2 already supports model selection inside the TUI. The root CLI command did not expose or forward the model flag.

This adds root-level `--model` and `-m` flags, then passes the selected model into the TUI.

Example:

```bash
opencode2 --model anthropic/claude-sonnet-4-5
```

### How did you verify your code works?

- CLI regression test passes.
- TUI startup model regression passes.
- CLI and TUI typechecks pass.
- Documentation checks and build pass.
- Verified locally with `opencode2-patch --model`.

### Screenshots / recordings

Not applicable. This changes startup argument handling.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR