### PR TITLE
feat(read): attach short video files for video-capable models

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -31,7 +31,7 @@ import { MessageTable, PartTable, SessionTable } from "@opencode-ai/core/session
 import { ProviderError } from "@/provider/error"
 import { iife } from "@/util/iife"
 import { errorMessage } from "@/util/error"
-import { isMedia } from "@/util/media"
+import { isMedia, isVideoAttachment } from "@/util/media"
 import type { SystemError } from "bun"
 import type { Provider } from "@/provider/provider"
 import { Effect, Schema } from "effect"
@@ -145,6 +145,17 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
   // Only apply this workaround if the model actually supports that media input -
   // otherwise unsupportedParts() will turn it into a user-visible error.
   const supportsMediaInToolResult = (attachment: { mime: string }) => {
+    // Video is far less uniformly carried in tool results than images/PDFs:
+    // only providers proven to accept inline video keep it there. Everything
+    // else extracts it into a user message, where unsupportedParts() gates it
+    // on the model's declared video capability.
+    if (isVideoAttachment(attachment.mime)) {
+      if (model.api.npm === "@ai-sdk/google") {
+        const id = model.api.id.toLowerCase()
+        return id.includes("gemini-3") && !id.includes("gemini-2")
+      }
+      return false
+    }
     if (model.api.npm === "@ai-sdk/anthropic") return true
     if (model.api.npm === "@ai-sdk/openai") return true
     if (model.api.npm === "@ai-sdk/amazon-bedrock/mantle") return true

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -17,6 +17,11 @@ const MAX_BYTES = 50 * 1024
 const MAX_BYTES_LABEL = `${MAX_BYTES / 1024} KB`
 const SAMPLE_BYTES = 4096
 const SUPPORTED_IMAGE_MIMES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp"])
+// Inline video only: providers cap request size well below what a long clip
+// base64-encodes to, so anything bigger fails before reaching the provider.
+const SUPPORTED_VIDEO_MIMES = new Set(["video/mp4", "video/webm", "video/quicktime"])
+const MAX_VIDEO_BYTES = 20 * 1024 * 1024
+const MAX_VIDEO_LABEL = `${MAX_VIDEO_BYTES / (1024 * 1024)} MB`
 
 class ReadStop extends Schema.TaggedErrorClass<ReadStop>()("ReadStop", {}) {}
 
@@ -306,6 +311,34 @@ export const ReadTool = Tool.define<
       if (isImage || isPdfAttachment(mime)) {
         const bytes = yield* fs.readFile(filepath)
         const msg = isPdfAttachment(mime) ? "PDF read successfully" : "Image read successfully"
+        return {
+          title,
+          output: msg,
+          metadata: {
+            preview: msg,
+            truncated: false,
+            loaded: loaded.map((item) => item.filepath),
+          },
+          attachments: [
+            {
+              type: "file" as const,
+              mime,
+              url: `data:${mime};base64,${Buffer.from(bytes).toString("base64")}`,
+            },
+          ],
+        }
+      }
+
+      if (SUPPORTED_VIDEO_MIMES.has(mime)) {
+        if (Number(stat.size) > MAX_VIDEO_BYTES) {
+          return yield* Effect.fail(
+            new Error(
+              `Video file too large to attach: ${filepath} (${(Number(stat.size) / (1024 * 1024)).toFixed(1)} MB, limit ${MAX_VIDEO_LABEL}). Trim or compress the clip and try again.`,
+            ),
+          )
+        }
+        const bytes = yield* fs.readFile(filepath)
+        const msg = "Video read successfully"
         return {
           title,
           output: msg,

--- a/packages/opencode/src/tool/read.txt
+++ b/packages/opencode/src/tool/read.txt
@@ -11,4 +11,4 @@ Usage:
 - Any line longer than 2000 characters is truncated.
 - Call this tool in parallel when you know there are multiple files you want to read.
 - Avoid tiny repeated slices (30 line chunks). If you need more context, read a larger window.
-- This tool can read image files and PDFs and return them as file attachments.
+- This tool can read image files, PDFs, and short video files (mp4/webm/mov up to 20 MB) and return them as file attachments. Video only reaches the model when the current model accepts video input; otherwise it is replaced with an explanatory error.

--- a/packages/opencode/src/util/media.ts
+++ b/packages/opencode/src/util/media.ts
@@ -4,8 +4,12 @@ export function isPdfAttachment(mime: string) {
   return mime === "application/pdf"
 }
 
+export function isVideoAttachment(mime: string) {
+  return mime.startsWith("video/")
+}
+
 export function isMedia(mime: string) {
-  return mime.startsWith("image/") || isPdfAttachment(mime)
+  return mime.startsWith("image/") || isPdfAttachment(mime) || isVideoAttachment(mime)
 }
 
 export function isImageAttachment(mime: string) {

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -514,6 +514,38 @@ describe("tool.read truncation", () => {
     }),
   )
 
+  it.live("attaches mp4 files as video attachments", () =>
+    Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      // Minimal bytes that are not sniffed as an image/PDF; the mime comes
+      // from the .mp4 extension via the mime-type fallback.
+      const clip = Buffer.from(Array.from({ length: 64 }, (_, i) => (i % 12) + 1))
+      yield* put(path.join(dir, "clip.mp4"), clip)
+
+      const result = yield* exec(dir, { filePath: path.join(dir, "clip.mp4") })
+      expect(result.output).toBe("Video read successfully")
+      expect(result.metadata.truncated).toBe(false)
+      expect(result.attachments?.length).toBe(1)
+      expect(result.attachments?.[0].mime).toBe("video/mp4")
+      expect(result.attachments?.[0].url.startsWith("data:video/mp4;base64,")).toBe(true)
+    }),
+  )
+
+  it.live("rejects oversized video files with a clear error", () => {
+    const originalLimit = 20 * 1024 * 1024
+    return Effect.gen(function* () {
+      const dir = yield* tmpdirScoped()
+      // Sparse-ish content just over the limit: repeat a chunk instead of
+      // allocating one huge buffer.
+      const chunk = Buffer.alloc(1024 * 1024, 7)
+      const chunks = Array.from({ length: Math.ceil((originalLimit + 1024) / chunk.length) }, () => chunk)
+      yield* put(path.join(dir, "big.mp4"), Buffer.concat(chunks))
+
+      const err = yield* fail(dir, { filePath: path.join(dir, "big.mp4") })
+      expect(err.message).toContain("Video file too large")
+    })
+  })
+
   it.live("large image files are properly attached without error", () =>
     Effect.gen(function* () {
       const result = yield* exec(FIXTURES_DIR, { filePath: path.join(FIXTURES_DIR, "large-image.png") })


### PR DESCRIPTION
### Issue for this PR

Related to #10531 (video part only, this PR does not attempt audio)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Right now the read tool rejects video files as binary, even when the model supports video input. The code for handling video already exists elsewhere in the codebase, it just never gets used because read refuses to attach the file. This PR fills that gap.

What changed:

- read.ts attaches mp4/webm/mov files up to 20 MB, same as images and PDFs today. Bigger files get a clear error asking to trim or compress first.
- media.ts treats video like other media, so compaction replaces old clips with placeholders instead of keeping them in context forever.
- message-v2.ts sends video through the same provider checks as images. If the current model cannot handle video, the user sees a clean explanation instead of a broken request.

One thing to know: tests here are unit level. I have not yet pushed a real mp4 through a live video-capable endpoint, so how OpenAI compatible providers serialize a video file part is the piece most worth reviewer attention.

Also, #18005 covers similar ground (and adds audio support, which this one does not). Happy to close this in favor of that PR or coordinate. This one is just the narrower slice.

### How did you verify your code works?

Added two tests: one checking that an mp4 comes back as a proper video attachment, one checking oversized files fail with a clear error. The full read suite (41 tests) and session suite (412 tests) pass, typecheck is clean.

### Screenshots / recordings

Not a UI change

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR