### PR TITLE
fix(app): wrap initial picker navigation

### DIFF
--- a/packages/app/src/components/directory-picker-domain.test.ts
+++ b/packages/app/src/components/directory-picker-domain.test.ts
@@ -297,6 +297,7 @@ test("clamps bridged tree wheel scrolling", () => {
 
 test("wraps autocomplete keyboard navigation", () => {
   expect(nextSuggestionIndex(-1, 1, 4)).toBe(0)
+  expect(nextSuggestionIndex(-1, -1, 4)).toBe(3)
   expect(nextSuggestionIndex(3, 1, 4)).toBe(0)
   expect(nextSuggestionIndex(0, -1, 4)).toBe(3)
   expect(nextSuggestionIndex(0, 1, 0)).toBe(-1)

--- a/packages/app/src/components/directory-picker-domain.ts
+++ b/packages/app/src/components/directory-picker-domain.ts
@@ -217,6 +217,7 @@ export function nextTreeScrollTop(current: number, delta: number, scrollHeight: 
 
 export function nextSuggestionIndex(current: number, delta: -1 | 1, count: number) {
   if (count === 0) return -1
+  if (current === -1) return delta === 1 ? 0 : count - 1
   return (current + delta + count) % count
 }
 


### PR DESCRIPTION
### Issue for this PR

Closes #44960

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The directory picker uses `-1` when no autocomplete suggestion is active. Applying the normal wraparound calculation to that sentinel made the first Up press select the penultimate result. This change handles the unselected state explicitly, so Down starts at the first suggestion and Up starts at the last, and adds a regression assertion for reverse navigation.

### How did you verify your code works?

From `packages/app`:

- `bun test src/components/directory-picker-domain.test.ts` — 23 tests passed
- `bun typecheck` — passed

### Screenshots / recordings

Not applicable. This changes keyboard navigation logic without changing the rendered UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR