### PR TITLE
fix(server): pin shared Effect platform runtime

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@effect/platform-node": "catalog:",
+    "@effect/platform-node-shared": "catalog:",
     "@opencode-ai/core": "workspace:*",
     "@opencode-ai/protocol": "workspace:*",
     "@opencode-ai/schema": "workspace:*",


### PR DESCRIPTION
## What

Fixes the packed Workerd SDK consumer so a clean npm install boots successfully under Miniflare instead of returning a 500 during the health check.

## Before / After

**Before:** `@opencode-ai/server` declared `@effect/platform-node` but not the shared runtime that participates in the built server bundle. A clean npm consumer could float the transitive `@effect/platform-node-shared` range away from the repository-pinned Effect version. The worker then failed during startup with `TypeError: Cannot read properties of undefined (reading 'set')`, surfaced by Miniflare at `entry.worker.js:4687`.

**After:** the server package directly declares the catalog-pinned shared runtime. Clean npm installs resolve the same Effect runtime version used to build the package, and the packed worker health check returns 200.

## How

- Adds `@effect/platform-node-shared` as a direct runtime dependency of `@opencode-ai/server`.
- Leaves Miniflare, Wrangler, SDK code, and the packed-consumer test unchanged.

## Scope

This only corrects the published server dependency graph. It does not pin or patch Wrangler/Miniflare.

## Testing

- Reproduced the exact packed health 500 before the change on macOS with Node 26.5.0 and Wrangler 4.110.0.
- `bun run verify:package` in `packages/sdk`: clean npm consumer installed 568 packages, Wrangler dry-run succeeded, and `packed SDK consumer OK`.
- `bun run test` in `packages/sdk`: 23 passed, 0 failed.
- `bun typecheck` in `packages/server` and `packages/sdk`.
- Push hook workspace typecheck: 32 packages passed.
- `bun run test` in `packages/server`: 29 passed, 3 unrelated local OAuth callback-port assertions failed; no listener owned ports 1455/1457, and the affected packed-consumer path passes.