### PR TITLE
test(tui): synchronize tab close frame before pointer moves

### DIFF
--- a/packages/tui/test/component/session-tabs-mouse.test.tsx
+++ b/packages/tui/test/component/session-tabs-mouse.test.tsx
@@ -197,11 +197,13 @@ test("reflows held tabs when the pointer leaves the strip", async () => {
     await app.mockMouse.moveTo(22, 0)
     await app.waitForFrame((frame) => Array.from(frame.split("\n")[0] ?? "")[22] === "✕")
     await app.mockMouse.click(22, 0)
-    await app.waitForFrame((frame) => items().length === 3 && Array.from(frame.split("\n")[0] ?? "")[22] === "✕")
+    await app.waitForFrame(
+      (frame) => !frame.includes("First") && items().length === 3 && Array.from(frame.split("\n")[0] ?? "")[22] === "✕",
+    )
 
     await app.mockMouse.moveTo(0, 1)
     await app.mockMouse.moveTo(20, 0)
-    await app.waitForFrame((frame) => Array.from(frame.split("\n")[0] ?? "")[20] === "✕", { maxPasses: 100 })
+    await app.waitForFrame((frame) => Array.from(frame.split("\n")[0] ?? "")[20] === "✕")
     expect(Array.from(app.captureCharFrame().split("\n")[0] ?? "")[22]).not.toBe("✕")
   } finally {
     app.renderer.destroy()


### PR DESCRIPTION
## What

Eliminate the independently reproducible Windows TUI CI flake in `reflows held tabs when the pointer leaves the strip` without increasing frame or test timeouts.

## Before / After

**Before:** Closing the first tab updates the Solid signal synchronously, but the test accepted the previously rendered frame because the old close glyph was already at column 22. Pointer movements could then run against the stale hit grid after its hovered tab had been destroyed. The strip never received its mouse-out event, the close hold remained active, and CI rendered 100 unchanged frames before failing. Concurrent local stress reproduced the identical Windows failure 26 times across 50 file reruns.

**After:** The test first requires a committed frame that no longer contains the closed `First` tab while retaining the replacement close glyph at column 22. Pointer movement therefore uses the refreshed hit grid, the strip receives its leave event, and the held layout reflows. The previous special `maxPasses: 100` override is removed entirely.

## How

- `packages/tui/test/component/session-tabs-mouse.test.tsx`: strengthen the post-close frame predicate to distinguish the committed replacement layout from the stale pre-close frame.
- Restore the normal frame-wait limit for the final reflow assertion.

## Scope

Only the existing TUI mouse regression test changes; production tab behavior and OpenTUI dependencies are unchanged.

## Testing

- `cd packages/tui && bun run test` - 764 passed, 5 skipped.
- `cd packages/tui && bun run test test/component/session-tabs-mouse.test.tsx --rerun-each=200 --concurrent --max-concurrency=20` - 800 passed, 0 failed.
- `cd packages/tui && bun typecheck` - passed.
- `bunx prettier --check packages/tui/test/component/session-tabs-mouse.test.tsx` - passed.
- Normal pre-push hook: `bun turbo typecheck --concurrency=3` - all 32 workspace typecheck tasks passed.