### PR TITLE
test(tui): require visible held tab reflow

### DIFF
--- a/packages/tui/test/component/session-tabs-mouse.test.tsx
+++ b/packages/tui/test/component/session-tabs-mouse.test.tsx
@@ -199,10 +199,15 @@ test("reflows held tabs when the pointer leaves the strip", async () => {
     await app.mockMouse.click(22, 0)
     await app.waitForFrame((frame) => items().length === 3 && Array.from(frame.split("\n")[0] ?? "")[22] === "✕")
 
+    // The matching held frame may still have a follow-up Solid render scheduled.
     await app.renderOnce()
-    const held = app.captureCharFrame().split("\n")[0] ?? ""
+    const heldThird = (app.captureCharFrame().split("\n")[0] ?? "").indexOf("Third")
+    expect(heldThird).toBeGreaterThanOrEqual(0)
     await app.mockMouse.moveTo(0, 1)
-    await app.waitForFrame((frame) => (frame.split("\n")[0] ?? "").indexOf("Third") < held.indexOf("Third"))
+    await app.waitForFrame((frame) => {
+      const reflowedThird = (frame.split("\n")[0] ?? "").indexOf("Third")
+      return reflowedThird >= 0 && reflowedThird < heldThird
+    })
     await app.mockMouse.moveTo(20, 0)
     await app.waitForFrame((frame) => Array.from(frame.split("\n")[0] ?? "")[20] === "✕")
     expect(Array.from(app.captureCharFrame().split("\n")[0] ?? "")[22]).not.toBe("✕")


### PR DESCRIPTION
## What

Make the held-tab mouse regression test synchronize on a real, visible reflow frame. This closes the Windows CI race without increasing timeouts, retrying, sleeping, skipping Windows, or weakening the visual behavior under test.

## Before / After

**Before:** Closing the hovered tab updates controller state immediately while OpenTUI can still have a follow-up Solid render scheduled. The prior frame predicate could accept the stale close glyph at column 22, and the test could send pointer-leave and pointer-enter events before observing the intermediate reflow. Windows then repeatedly forced unchanged native frames until `waitForFrame` reached frame 104 with `cellsUpdated: 0` and `hasScheduledRender: true`.

The first synchronization fix now on `v2` explicitly commits the pending held-layout frame and waits for `Third` to move left. Its predicate still considered `indexOf("Third") === -1` a successful leftward move, so a frame where the tab disappeared could falsely satisfy the regression test.

**After:** The test records a visible held `Third` tab, moves outside the strip, and accepts only a later frame where `Third` remains visible at a smaller column. Pointer re-entry happens only after that exact layout transition has committed.

## How

- `packages/tui/test/component/session-tabs-mouse.test.tsx`: document the pending Solid render boundary, assert the held tab is visible, and require the reflowed tab index to remain non-negative while moving left.

## Scope

- Test synchronization only; production tab layout and pointer behavior are unchanged.
- No timeout increases, arbitrary sleeps, blind retries, platform skips, dependency changes, or generated files.

## Testing

- `bun run test test/component/session-tabs-mouse.test.tsx --rerun-each 100` from `packages/tui`: 400 passed, 0 failed after rebasing onto current `v2`.
- `bun typecheck` from `packages/tui`: passed.
- `bunx prettier --check test/component/session-tabs-mouse.test.tsx` from `packages/tui`: passed.
- Push-hook workspace typecheck: 32 successful tasks.
- Earlier focused minimization reproduced the CI signature locally, including unchanged frames with a scheduled render; 200 post-fix reruns passed before the rebase.
