### PR TITLE
fix(tui): stop completed exploration groups from spinning

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1823,6 +1823,12 @@ function SessionGroupView(props: {
     })
   const grouped = createMemo(() => parts(props.refs))
   const pending = createMemo(() => parts(props.pending))
+  const completed = createMemo(
+    () =>
+      props.completed ||
+      (grouped().length > 0 &&
+        grouped().every((part) => part.state.status === "completed" || part.state.status === "error")),
+  )
   const label = createMemo(() => {
     const counts = grouped().reduce<Record<string, number>>((result, part) => {
       const tool = toolDisplay(part.name)
@@ -1833,7 +1839,7 @@ function SessionGroupView(props: {
     const tools = Object.entries(counts).map(
       ([name, count]) => `${count} ${count === 1 ? name : name === "search" ? "searches" : `${name}s`}`,
     )
-    return `${props.completed ? "Explored" : "Exploring"} — ${tools.join(", ")}`
+    return `${completed() ? "Explored" : "Exploring"} — ${tools.join(", ")}`
   })
   return (
     <Show when={grouped().length > 0 || pending().length > 0}>
@@ -1843,11 +1849,11 @@ function SessionGroupView(props: {
       >
         <Show when={grouped().length > 0}>
           <InlineToolRow
-            icon={props.completed ? "→" : "✱"}
+            icon={completed() ? "→" : "✱"}
             color={hover() ? theme.text.default : theme.text.subdued}
-            complete={props.completed}
+            complete={completed()}
             pending={label()}
-            spinner={!props.completed}
+            spinner={!completed()}
             onMouseOver={() => setHover(true)}
             onMouseOut={() => setHover(false)}
             onMouseUp={() => {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1824,10 +1824,7 @@ function SessionGroupView(props: {
   const grouped = createMemo(() => parts(props.refs))
   const pending = createMemo(() => parts(props.pending))
   const completed = createMemo(
-    () =>
-      props.completed ||
-      (grouped().length > 0 &&
-        grouped().every((part) => part.state.status === "completed" || part.state.status === "error")),
+    () => props.completed || (grouped().length > 0 && grouped().every((part) => part.time.completed !== undefined)),
   )
   const label = createMemo(() => {
     const counts = grouped().reduce<Record<string, number>>((result, part) => {


### PR DESCRIPTION
## What

Stop a completed exploration group from spinning while an unrelated sibling subagent continues running.

## Before / After

**Before:** One assistant response starts a foreground explore subagent alongside two grep calls and one read. The grep/read tools finish independently, but their final transcript group remains structurally open because the parent assistant cannot advance until the subagent completes. The TUI keeps showing a spinning `Exploring - 2 searches, 1 read` row until the unrelated subagent finishes or is backgrounded.

**After:** As soon as all three exploration tools finish, the row changes to `Explored - 2 searches, 1 read`, switches to its completed icon, and stops spinning. The independent subagent row continues spinning normally. Failed exploration tools are terminal; streaming exploration tools remain active.

## How

- `packages/tui/src/routes/session/index.tsx`: derive exploration-group completion reactively from its existing structural completion flag or the canonical `part.time.completed` marker on every grouped tool.
- Both successful and failed tools already receive the same completion timestamp from the server and Solid client projections, so no tool-status duplication, extra bookkeeping, or subscriptions are needed.
- Reuse the derived value consistently for the group label, icon, completion state, and spinner.

## Scope

TUI presentation only. Session-row reducer semantics, structural group closure, separately displayed permission-pending tools, grouping-disabled behavior, server events, tool execution, and subagent lifecycle remain unchanged.

## Testing

From `packages/tui`:

```bash
bun run test test/cli/tui/session-rows.test.ts test/cli/tui/inline-tool-wrap-snapshot.test.tsx
bun typecheck
bunx prettier --check src/routes/session/index.tsx
```

- Focused tests: 28 passed, including existing reducer and inline-rendering coverage.
- Package typecheck and formatting check passed.
- The normal pre-push hook completed the repository-wide typecheck successfully across 32 packages.
- Ran six deterministic OpenCode Drive scenarios against the real V2 TUI and native tools:
  1. Successful search/read tools complete while an independent sibling subagent remains running.
  2. A failed grep plus a successful read still completes the exploration group while the sibling remains running.
  3. A streaming exploration tool remains `Exploring` instead of completing prematurely.
  4. A completed search and a separately permission-blocked read both remain visible, and approving the read resumes execution.
  5. A subsequent transcript row preserves existing structural group closure even while the first search is still streaming.
  6. Disabling grouping through the actual V2 Settings UI continues rendering individual tools without an exploration header.
- Independently verified tool states through the server API instead of relying solely on visible labels.

## Demo

Matched, synchronized 60 fps OpenCode Drive recordings beginning before the prompt is submitted. Left: immutable `origin/v2` at `938a82226a`, where the completed exploration row keeps spinning. Right: this branch at `78fb91ce7c`, where the same row immediately reads `Explored` and stops spinning while the subagent continues. Model responses are simulated; the TUI, session runner, and grep/read tools are real.

https://github.com/user-attachments/assets/93ae65aa-a404-484d-857b-123ca96e3966
