### PR TITLE
fix(tui): support inline session rename and title regeneration

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -332,7 +332,7 @@ const layer = Layer.effect(
       // a blocked first step leaves pending inputs untouched.
       yield* InstructionState.prepare(db, bus, selected.instructions, selected.session.id)
       const promoted = promotable ? yield* SessionInbox.promote(db, bus, selected.session.id, promotable) : 0
-      if (promoted > 0)
+      if (promoted > 0 && !selected.session.parentID && SessionTitle.isUntitled(selected.session))
         yield* FiberMap.run(titles, sessionID, title.generate(sessionID).pipe(Effect.ignore), {
           onlyIfMissing: true,
         })

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -333,7 +333,7 @@ const layer = Layer.effect(
       yield* InstructionState.prepare(db, bus, selected.instructions, selected.session.id)
       const promoted = promotable ? yield* SessionInbox.promote(db, bus, selected.session.id, promotable) : 0
       if (promoted > 0)
-        yield* FiberMap.run(titles, sessionID, title.generateForFirstPrompt(sessionID).pipe(Effect.ignore), {
+        yield* FiberMap.run(titles, sessionID, title.generate(sessionID).pipe(Effect.ignore), {
           onlyIfMissing: true,
         })
       // Promoted input opens a fresh step allowance.

--- a/packages/core/src/session/title.ts
+++ b/packages/core/src/session/title.ts
@@ -21,6 +21,8 @@ import { SessionUsage } from "./usage.js"
 import { SessionStore } from "./store.js"
 
 const MAX_LENGTH = 100
+const MAX_CONTEXT_LENGTH = 8_000
+const MAX_FIRST_MESSAGE_LENGTH = 2_000
 const titleChanged = Symbol("Session title changed")
 
 type Dependencies = {
@@ -36,8 +38,8 @@ type Dependencies = {
 }
 
 export interface Interface {
-  /** Generates a title from the session's first user message when the session remains untitled. */
-  readonly generateForFirstPrompt: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  /** Generates an initial title or regenerates one from bounded conversation history when overwriting. */
+  readonly generate: (sessionID: SessionSchema.ID, options?: { readonly overwrite?: boolean }) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionTitle") {}
@@ -108,16 +110,39 @@ const attempt = Effect.fn("SessionTitle.attempt")(function* (
 const MINIMAL_REASONING_VARIANTS = ["none", "minimal", "low"].map((id) => Model.VariantID.make(id))
 
 const make = (dependencies: Dependencies) => {
-  const generateForFirstPrompt = Effect.fn("SessionTitle.generateForFirstPrompt")(function* (
+  const generate = Effect.fn("SessionTitle.generate")(function* (
     db: Database.Interface["db"],
     sessionID: SessionSchema.ID,
+    options?: { readonly overwrite?: boolean },
   ) {
     const session = yield* dependencies.store.get(sessionID)
     if (!session) return
-    if (session.parentID) return
-    if (!isUntitled(session)) return
+    if (session.parentID && !options?.overwrite) return
+    if (!options?.overwrite && !isUntitled(session)) return
     const firstUser = yield* SessionHistory.firstUserMessage(db, session.id)
     if (!firstUser) return
+    const text = options?.overwrite
+      ? yield* dependencies.store.context(session.id).pipe(
+          Effect.map((messages) => {
+            const original = `Original request:\n${firstUser.text.slice(0, MAX_FIRST_MESSAGE_LENGTH)}`
+            const recent = messages
+              .flatMap((message) => {
+                if (message.type === "user" && message.id !== firstUser.id) return [`User: ${message.text.trim()}`]
+                if (message.type !== "assistant") return []
+                const text = message.content
+                  .flatMap((part) => (part.type === "text" ? [part.text.trim()] : []))
+                  .filter(Boolean)
+                  .join("\n")
+                return text ? [`Assistant: ${text}`] : []
+              })
+              .join("\n\n")
+            if (!recent) return original
+            const prefix = `${original}\n\nRecent conversation:\n`
+            return `${prefix}${recent.slice(-(MAX_CONTEXT_LENGTH - prefix.length))}`
+          }),
+          Effect.orElseSucceed(() => firstUser.text),
+        )
+      : firstUser.text
     const agent = yield* dependencies.agents.get(Agent.ID.make("title"))
     if (!agent) return
     const primary = yield* dependencies.models.resolve(session).pipe(Effect.orElseSucceed(() => undefined))
@@ -143,14 +168,14 @@ const make = (dependencies: Dependencies) => {
     const selected = preferred ?? primary
     if (!selected) return
     const title =
-      (yield* attempt(dependencies, { session, agent, text: firstUser.text, model: selected })) ??
+      (yield* attempt(dependencies, { session, agent, text, model: selected })) ??
       (primary && !isDeepStrictEqual(selected.ref, primary.ref)
-        ? yield* attempt(dependencies, { session, agent, text: firstUser.text, model: primary })
+        ? yield* attempt(dependencies, { session, agent, text, model: primary })
         : undefined)
     if (!title) return
     const expectedSequence = (yield* Bus.latestSequence(db, sessionID)) + 1
     const current = yield* dependencies.store.get(sessionID)
-    if (!current || !isUntitled(current)) return
+    if (!current || current.title !== session.title || current.title === truncate(title)) return
     yield* dependencies.bus
       .publish(
         SessionEvent.Renamed,
@@ -162,7 +187,7 @@ const make = (dependencies: Dependencies) => {
       )
       .pipe(Effect.catchDefect((defect) => (defect === titleChanged ? Effect.void : Effect.die(defect))))
   })
-  return { generateForFirstPrompt }
+  return { generate }
 }
 
 export const layer = Layer.effect(
@@ -178,7 +203,7 @@ export const layer = Layer.effect(
     const database = yield* Database.Service
     const title = make({ bus, llm, agents, catalog, models, modelRequests, store })
     return Service.of({
-      generateForFirstPrompt: (sessionID) => title.generateForFirstPrompt(database.db, sessionID),
+      generate: (sessionID, options) => title.generate(database.db, sessionID, options),
     })
   }),
 )

--- a/packages/core/src/session/title.ts
+++ b/packages/core/src/session/title.ts
@@ -38,14 +38,14 @@ type Dependencies = {
 }
 
 export interface Interface {
-  /** Generates an initial title or regenerates one from bounded conversation history when overwriting. */
-  readonly generate: (sessionID: SessionSchema.ID, options?: { readonly overwrite?: boolean }) => Effect.Effect<void>
+  /** Generates an initial title or regenerates one from bounded conversation history. */
+  readonly generate: (sessionID: SessionSchema.ID) => Effect.Effect<void>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionTitle") {}
 
 const truncate = (value: string) => (value.length <= MAX_LENGTH ? value : `${value.slice(0, MAX_LENGTH - 3)}...`)
-const isUntitled = (session: SessionSchema.Info) =>
+export const isUntitled = (session: SessionSchema.Info) =>
   isExactRootFallback({
     title: session.title,
     time: { created: DateTime.toEpochMillis(session.time.created) },
@@ -113,15 +113,12 @@ const make = (dependencies: Dependencies) => {
   const generate = Effect.fn("SessionTitle.generate")(function* (
     db: Database.Interface["db"],
     sessionID: SessionSchema.ID,
-    options?: { readonly overwrite?: boolean },
   ) {
     const session = yield* dependencies.store.get(sessionID)
     if (!session) return
-    if (session.parentID && !options?.overwrite) return
-    if (!options?.overwrite && !isUntitled(session)) return
     const firstUser = yield* SessionHistory.firstUserMessage(db, session.id)
     if (!firstUser) return
-    const text = options?.overwrite
+    const text = !isUntitled(session)
       ? yield* dependencies.store.context(session.id).pipe(
           Effect.map((messages) => {
             const original = `Original request:\n${firstUser.text.slice(0, MAX_FIRST_MESSAGE_LENGTH)}`
@@ -203,7 +200,7 @@ export const layer = Layer.effect(
     const database = yield* Database.Service
     const title = make({ bus, llm, agents, catalog, models, modelRequests, store })
     return Service.of({
-      generate: (sessionID, options) => title.generate(database.db, sessionID, options),
+      generate: (sessionID) => title.generate(database.db, sessionID),
     })
   }),
 )

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -938,6 +938,21 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("does not automatically replace an existing session title", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      yield* prepareTitleGeneration
+      yield* session.rename({ sessionID, title: "Manual title" })
+      yield* admit(session, "Follow-up prompt")
+      yield* TestLLM.push(TestLLM.text("Assistant response", "text-response"))
+
+      yield* session.resume(sessionID)
+
+      expect(requests).toHaveLength(1)
+      expect((yield* session.get(sessionID)).title).toBe("Manual title")
+    }),
+  )
+
   it.effect("coalesces title generation while a request is active", () =>
     Effect.gen(function* () {
       const session = yield* setup

--- a/packages/core/test/session-title.test.ts
+++ b/packages/core/test/session-title.test.ts
@@ -212,7 +212,7 @@ it.effect("generates a title from the sole user message and renames the session"
 
     const store = yield* SessionStore.Service
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     expect(requests).toHaveLength(1)
     expect(requests[0]?.http?.headers).toEqual({
@@ -252,7 +252,7 @@ it.effect("uses a small model from the primary provider", () =>
     yield* prompt(sessionID, "Use a small model for this title")
 
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     expect(requests.map((request) => String(request.model.id))).toEqual(["title-small"])
     expect(selections[1]?.variant).toBe(Model.VariantID.make("none"))
@@ -299,7 +299,7 @@ it.effect("falls back to the primary model when the small model fails", () =>
     )
 
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     expect(requests.map((request) => String(request.model.id))).toEqual(["title-small", "title-model"])
     expect(attempted.map((model) => String(model.variant))).toEqual(["low", "high"])
@@ -327,7 +327,7 @@ it.effect("generates from the first user message after later messages exist", ()
 
     const store = yield* SessionStore.Service
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     expect(requests).toHaveLength(1)
     expect(JSON.stringify(requests[0]?.messages)).toContain("First message")
@@ -354,7 +354,7 @@ it.effect("retries a legacy persisted fallback title", () =>
     yield* prompt(sessionID, "Retry the legacy title")
 
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     const store = yield* SessionStore.Service
     expect(requests).toHaveLength(1)
@@ -362,7 +362,7 @@ it.effect("retries a legacy persisted fallback title", () =>
   }),
 )
 
-it.effect("does not generate for a child session", () =>
+it.effect("only generates for a child session when explicitly requested", () =>
   Effect.gen(function* () {
     requests = []
     titleStream = successfulTitle
@@ -398,9 +398,13 @@ it.effect("does not generate for a child session", () =>
     yield* prompt(sessionID, "Do this subtask")
 
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
-
+    yield* title.generate(sessionID)
     expect(requests).toHaveLength(0)
+
+    yield* title.generate(sessionID, { overwrite: true })
+    const store = yield* SessionStore.Service
+    expect(requests).toHaveLength(1)
+    expect((yield* store.get(sessionID))?.title).toBe("Generated Title")
   }),
 )
 
@@ -414,7 +418,7 @@ it.effect("does not generate when the title agent is removed", () =>
 
     const store = yield* SessionStore.Service
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     expect(requests).toHaveLength(0)
     const untouched = yield* store.get(sessionID)
@@ -433,11 +437,115 @@ it.effect("does not overwrite an explicit title", () =>
     yield* events.publish(SessionEvent.Renamed, { sessionID, title: "New session - 2099-01-01T00:00:00.000Z" })
 
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     const store = yield* SessionStore.Service
     expect(requests).toHaveLength(0)
     expect((yield* store.get(sessionID))?.title).toBe("New session - 2099-01-01T00:00:00.000Z")
+  }),
+)
+
+it.effect("regenerates an existing title using the title agent", () =>
+  Effect.gen(function* () {
+    const agentService = yield* Agent.Service
+    yield* agentService.transform((editor) => {
+      editor.update(Agent.ID.make("title"), (agent) => {
+        agent.mode = "primary"
+        agent.hidden = true
+        agent.system = "You are a title generator."
+      })
+    })
+    const sessionID = Session.ID.make("ses_title_regenerate")
+    yield* insertSession(sessionID, "Original title")
+    yield* prompt(sessionID, "Investigate the login failure")
+    const events = yield* Bus.Service
+    const assistantMessageID = SessionMessage.ID.create()
+    yield* events.publish(SessionEvent.Step.Started, {
+      sessionID,
+      assistantMessageID,
+      agent: Agent.ID.make("build"),
+      model: Model.Ref.make({ id: Model.ID.make("title-model"), providerID: Provider.ID.make("test") }),
+    })
+    yield* events.publish(SessionEvent.Reasoning.Started, { sessionID, assistantMessageID, ordinal: 0 })
+    yield* events.publish(SessionEvent.Reasoning.Ended, {
+      sessionID,
+      assistantMessageID,
+      ordinal: 0,
+      text: "Private reasoning that should not appear",
+    })
+    yield* events.publish(SessionEvent.Text.Started, { sessionID, assistantMessageID, ordinal: 1 })
+    yield* events.publish(SessionEvent.Text.Ended, {
+      sessionID,
+      assistantMessageID,
+      ordinal: 1,
+      text: "The actual issue is expired OAuth credentials.",
+    })
+    yield* prompt(sessionID, "Switch to fixing OAuth token refresh")
+
+    const title = yield* SessionTitle.Service
+    yield* title.generate(sessionID, { overwrite: true })
+
+    const store = yield* SessionStore.Service
+    expect(requests).toHaveLength(1)
+    expect(requests[0]?.system.map((part) => part.text)).toEqual(["You are a title generator."])
+    expect(JSON.stringify(requests[0]?.messages)).toContain("Investigate the login failure")
+    expect(JSON.stringify(requests[0]?.messages)).toContain("The actual issue is expired OAuth credentials.")
+    expect(JSON.stringify(requests[0]?.messages)).toContain("Switch to fixing OAuth token refresh")
+    expect(JSON.stringify(requests[0]?.messages)).not.toContain("Private reasoning that should not appear")
+    expect((yield* store.get(sessionID))?.title).toBe("Generated Title")
+  }),
+)
+
+it.effect("bounds regeneration context while preserving the original request and recent conversation", () =>
+  Effect.gen(function* () {
+    const agentService = yield* Agent.Service
+    yield* agentService.transform((editor) => {
+      editor.update(Agent.ID.make("title"), (agent) => {
+        agent.mode = "primary"
+        agent.hidden = true
+        agent.system = "You are a title generator."
+      })
+    })
+    const sessionID = Session.ID.make("ses_title_regenerate_bounded")
+    yield* insertSession(sessionID, "Original title")
+    yield* prompt(sessionID, `ORIGINAL_GOAL ${"a".repeat(3_000)} OMITTED_ORIGINAL_END`)
+    yield* prompt(sessionID, `OMITTED_OLD_CONTEXT ${"b".repeat(9_000)} RECENT_GOAL`)
+
+    const title = yield* SessionTitle.Service
+    yield* title.generate(sessionID, { overwrite: true })
+
+    const content = requests[0]?.messages[0]?.content[0]
+    expect(content?.type).toBe("text")
+    if (content?.type !== "text") return
+    expect(content.text.length).toBeLessThanOrEqual(8_000)
+    expect(content.text).toContain("ORIGINAL_GOAL")
+    expect(content.text).toContain("RECENT_GOAL")
+    expect(content.text).not.toContain("OMITTED_ORIGINAL_END")
+    expect(content.text).not.toContain("OMITTED_OLD_CONTEXT")
+  }),
+)
+
+it.effect("preserves the existing title when regeneration fails", () =>
+  Effect.gen(function* () {
+    const agentService = yield* Agent.Service
+    yield* agentService.transform((editor) => {
+      editor.update(Agent.ID.make("title"), (agent) => {
+        agent.mode = "primary"
+        agent.hidden = true
+        agent.system = "You are a title generator."
+      })
+    })
+    const sessionID = Session.ID.make("ses_title_regenerate_failure")
+    yield* insertSession(sessionID, "Original title")
+    yield* prompt(sessionID, "Fail to regenerate this title")
+    titleStream = () => Stream.make(LLMEvent.providerError({ message: "Provider unavailable" }))
+
+    const title = yield* SessionTitle.Service
+    yield* title.generate(sessionID, { overwrite: true })
+
+    const store = yield* SessionStore.Service
+    expect(requests).toHaveLength(1)
+    expect((yield* store.get(sessionID))?.title).toBe("Original title")
   }),
 )
 
@@ -458,9 +566,9 @@ it.effect("retries after a failed title request", () =>
     const title = yield* SessionTitle.Service
     titleStream = () => Stream.make(LLMEvent.providerError({ message: "Provider unavailable" }))
 
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
     titleStream = successfulTitle
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     const store = yield* SessionStore.Service
     expect(requests).toHaveLength(2)
@@ -491,7 +599,7 @@ it.effect("does not rename after a failed title stream", () =>
       )
 
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     const store = yield* SessionStore.Service
     expect(requests).toHaveLength(1)
@@ -524,7 +632,7 @@ it.effect("keeps session context hooks away from title requests", () =>
     yield* prompt(sessionID, "Hook this title request")
 
     const title = yield* SessionTitle.Service
-    yield* title.generateForFirstPrompt(sessionID)
+    yield* title.generate(sessionID)
 
     expect(requests).toHaveLength(1)
     expect(requests[0]?.system.map((part) => part.text)).toEqual(["You are a title generator."])
@@ -555,7 +663,7 @@ it.effect("preserves a manual rename completed while generation is in flight", (
         ),
       )
     const title = yield* SessionTitle.Service
-    const fiber = yield* title.generateForFirstPrompt(sessionID).pipe(Effect.forkScoped)
+    const fiber = yield* title.generate(sessionID).pipe(Effect.forkScoped)
     yield* Deferred.await(started)
     const events = yield* Bus.Service
     yield* events.publish(SessionEvent.Renamed, { sessionID, title: "Manual title" })

--- a/packages/core/test/session-title.test.ts
+++ b/packages/core/test/session-title.test.ts
@@ -362,7 +362,7 @@ it.effect("retries a legacy persisted fallback title", () =>
   }),
 )
 
-it.effect("only generates for a child session when explicitly requested", () =>
+it.effect("generates a title for an explicitly requested child session", () =>
   Effect.gen(function* () {
     requests = []
     titleStream = successfulTitle
@@ -399,9 +399,6 @@ it.effect("only generates for a child session when explicitly requested", () =>
 
     const title = yield* SessionTitle.Service
     yield* title.generate(sessionID)
-    expect(requests).toHaveLength(0)
-
-    yield* title.generate(sessionID, { overwrite: true })
     const store = yield* SessionStore.Service
     expect(requests).toHaveLength(1)
     expect((yield* store.get(sessionID))?.title).toBe("Generated Title")
@@ -423,25 +420,6 @@ it.effect("does not generate when the title agent is removed", () =>
     expect(requests).toHaveLength(0)
     const untouched = yield* store.get(sessionID)
     expect(untouched?.title).toBeUndefined()
-  }),
-)
-
-it.effect("does not overwrite an explicit title", () =>
-  Effect.gen(function* () {
-    requests = []
-    titleStream = successfulTitle
-    const sessionID = Session.ID.make("ses_title_explicit")
-    yield* insertSession(sessionID)
-    yield* prompt(sessionID, "Help me debug the failing build")
-    const events = yield* Bus.Service
-    yield* events.publish(SessionEvent.Renamed, { sessionID, title: "New session - 2099-01-01T00:00:00.000Z" })
-
-    const title = yield* SessionTitle.Service
-    yield* title.generate(sessionID)
-
-    const store = yield* SessionStore.Service
-    expect(requests).toHaveLength(0)
-    expect((yield* store.get(sessionID))?.title).toBe("New session - 2099-01-01T00:00:00.000Z")
   }),
 )
 
@@ -483,7 +461,7 @@ it.effect("regenerates an existing title using the title agent", () =>
     yield* prompt(sessionID, "Switch to fixing OAuth token refresh")
 
     const title = yield* SessionTitle.Service
-    yield* title.generate(sessionID, { overwrite: true })
+    yield* title.generate(sessionID)
 
     const store = yield* SessionStore.Service
     expect(requests).toHaveLength(1)
@@ -512,7 +490,7 @@ it.effect("bounds regeneration context while preserving the original request and
     yield* prompt(sessionID, `OMITTED_OLD_CONTEXT ${"b".repeat(9_000)} RECENT_GOAL`)
 
     const title = yield* SessionTitle.Service
-    yield* title.generate(sessionID, { overwrite: true })
+    yield* title.generate(sessionID)
 
     const content = requests[0]?.messages[0]?.content[0]
     expect(content?.type).toBe("text")
@@ -541,7 +519,7 @@ it.effect("preserves the existing title when regeneration fails", () =>
     titleStream = () => Stream.make(LLMEvent.providerError({ message: "Provider unavailable" }))
 
     const title = yield* SessionTitle.Service
-    yield* title.generate(sessionID, { overwrite: true })
+    yield* title.generate(sessionID)
 
     const store = yield* SessionStore.Service
     expect(requests).toHaveLength(1)

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -1,5 +1,6 @@
 import { Session } from "@opencode-ai/core/session"
 import { SessionStats } from "@opencode-ai/core/session/stats"
+import { SessionTitle } from "@opencode-ai/core/session/title"
 import { SessionTransfer } from "@opencode-ai/core/session/transfer"
 import { InstructionEntry } from "@opencode-ai/core/session/instruction-entry"
 import { DateTime, Effect, Stream } from "effect"
@@ -247,9 +248,14 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
       .handle(
         "session.rename",
         Effect.fn(function* (ctx) {
-          yield* session
-            .rename({ sessionID: ctx.params.sessionID, title: ctx.payload.title })
-            .pipe(Effect.catchTag("Session.NotFoundError", missingSession))
+          if (ctx.payload.title) {
+            yield* session
+              .rename({ sessionID: ctx.params.sessionID, title: ctx.payload.title })
+              .pipe(Effect.catchTag("Session.NotFoundError", missingSession))
+            return HttpApiSchema.NoContent.make()
+          }
+          const title = yield* SessionTitle.Service
+          yield* title.generate(ctx.params.sessionID, { overwrite: true })
           return HttpApiSchema.NoContent.make()
         }),
       )

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -255,7 +255,7 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
             return HttpApiSchema.NoContent.make()
           }
           const title = yield* SessionTitle.Service
-          yield* title.generate(ctx.params.sessionID, { overwrite: true })
+          yield* title.generate(ctx.params.sessionID)
           return HttpApiSchema.NoContent.make()
         }),
       )

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -768,8 +768,13 @@ export function Session(props: { verticalTabsWidth: number }) {
       title: "Rename session",
       id: "session.rename",
       group: "Session",
-      slash: { name: "rename" },
-      run: () => DialogSessionRename.show(dialog, route.sessionID, session()?.title),
+      slash: { name: "rename", arguments: true as const },
+      run: (input?: string) => {
+        if (input === undefined) return DialogSessionRename.show(dialog, route.sessionID, session()?.title)
+        void client.api.session
+          .rename({ sessionID: route.sessionID, title: input.trim() })
+          .catch((error) => toast.error(error))
+      },
     },
     {
       title: "Jump to message",

--- a/packages/tui/test/cli/tui/keymap-arguments.test.tsx
+++ b/packages/tui/test/cli/tui/keymap-arguments.test.tsx
@@ -36,8 +36,9 @@ test("dispatch passes slash input through the registered command", async () => {
   ))
   try {
     dispatch!("project.cd")
+    dispatch!("project.cd", "")
     dispatch!("project.cd", "src/components with spaces")
-    expect(received).toEqual([undefined, "src/components with spaces"])
+    expect(received).toEqual([undefined, "", "src/components with spaces"])
   } finally {
     app.renderer.destroy()
   }


### PR DESCRIPTION
## What

Make the session rename slash command useful directly from the composer:

- `/rename Focused debugging session` immediately updates the session title without adding a conversation message.
- `/rename` asks the built-in title agent to regenerate the title from the original request plus recent user and assistant conversation.
- The command palette and rename keyboard shortcut continue opening the existing rename dialog.

## Before / After

**Before:** `/rename Focused debugging session` is submitted to the model as an ordinary user message instead of renaming the session. `/rename` opens a dialog and cannot regenerate a title.

**After:** Slash arguments rename the session immediately without mutating conversation history. An argument-free slash command regenerates the title with the existing title agent, using the original request and a bounded recent tail of visible user/assistant text, including for child sessions. Automatic first-prompt title generation still never overwrites an existing title.

## How

- `packages/tui/src/routes/session/index.tsx`: register `/rename` as an argument-aware slash command and distinguish slash input from palette/keybinding invocation.
- `packages/server/src/handlers/session.ts`: reuse the existing rename endpoint; an empty title explicitly requests title-agent regeneration.
- `packages/core/src/session/title.ts` and `packages/core/src/session/runner/llm.ts`: expose one simple `generate(sessionID)` operation and keep automatic-renaming eligibility in the runner. Existing titles regenerate from an 8,000-character conversation context with up to 2,000 characters pinned from the original request. Recent context includes user messages and assistant text but excludes tool calls, reasoning, and system noise. Preserve concurrent manual renames and previous titles after failed generation, and skip redundant rename events when the generated title is unchanged.
- `packages/core/test/session-title.test.ts` and `packages/tui/test/cli/tui/keymap-arguments.test.tsx`: cover explicit regeneration, failed generation, child sessions, and empty slash arguments.

## Scope

This preserves the existing rename API shape and generated clients. It does not change command-palette behavior, the manual rename dialog, the built-in title agent's model selection, or first-message-only automatic initial naming.

## Testing

- `packages/core`: `bun typecheck`
- `packages/core`: `bun run test test/session-title.test.ts test/session-runner.test.ts` (177 passing)
- `packages/server`: `bun typecheck` and focused server tests excluding unrelated OAuth callback-port cases (23 passing, 1 skipped)
- `packages/tui`: `bun typecheck && bun run test` (765 passing, 5 skipped)
- Repository pre-push hook: full workspace typecheck (32 successful tasks)
- OpenCode Drive: the same deterministic script was run against an immutable `v2` worktree and this branch, with server-side assertions for both inline rename and regenerated title. The model responses in the recording are simulated.

## Demo

The first half runs the `v2` base revision and shows the slash command becoming a chat message, followed by the old rename dialog. The second half runs this branch with the identical interactions and shows the title changing immediately, then being regenerated by the built-in title agent.

https://github.com/user-attachments/assets/fb726a49-bab0-4e5d-95f8-72bd89107bfc

## Flow

```mermaid
flowchart TD
    A[Session rename command] --> B{Invocation}
    B -->|Palette or keyboard shortcut| C[Open existing rename dialog]
    B -->|Slash command with title| D[Rename endpoint with explicit title]
    B -->|Slash command without title| E[Rename endpoint with empty title]
    D --> F[Publish session renamed]
    E --> G[Build original-request plus recent-conversation context]
    G --> H[Run built-in title agent]
    H --> I{Generated title is usable and changed}
    I -->|Yes| F
    I -->|No| J[Preserve existing title]
```
