### PR TITLE
fix(llm): guard Object.prototype keys in tool-stream state

### DIFF
--- a/packages/llm/src/protocols/utils/tool-stream.ts
+++ b/packages/llm/src/protocols/utils/tool-stream.ts
@@ -39,6 +39,9 @@ export interface AppendOutcome<K extends StreamKey> {
 /** Create empty accumulator state for one provider stream. */
 export const empty = <K extends StreamKey>(): State<K> => ({})
 
+const read = <K extends StreamKey>(tools: State<K>, key: K): PendingTool | undefined =>
+  Object.hasOwn(tools, key) ? tools[key] : undefined
+
 const withTool = <K extends StreamKey>(tools: State<K>, key: K, tool: PendingTool): State<K> => {
   return { ...tools, [key]: tool }
 }
@@ -85,7 +88,7 @@ const appendTool = <K extends StreamKey>(
   text: string,
 ): AppendOutcome<K> => {
   const events: LLMEvent[] = []
-  if (!tools[key]) events.push(inputStart(tool))
+  if (!read(tools, key)) events.push(inputStart(tool))
   if (text.length > 0) events.push(inputDelta(tool, text))
   return {
     tools: withTool(tools, key, tool),
@@ -121,7 +124,7 @@ export const appendOrStart = <K extends StreamKey>(
   delta: { readonly id?: string; readonly name?: string; readonly text: string },
   missingToolMessage: string,
 ): AppendOutcome<K> | LLMError => {
-  const current = tools[key]
+  const current = read(tools, key)
   const id = delta.id ?? current?.id
   const name = delta.name ?? current?.name
   if (!id || !name) return eventError(route, missingToolMessage)
@@ -150,7 +153,7 @@ export const appendExisting = <K extends StreamKey>(
   text: string,
   missingToolMessage: string,
 ): AppendOutcome<K> | LLMError => {
-  const current = Object.hasOwn(tools, key) ? tools[key] : undefined
+  const current = read(tools, key)
   if (!current) return eventError(route, missingToolMessage)
   if (text.length === 0) return { tools, tool: current, events: [] }
   return appendTool(tools, key, { ...current, input: `${current.input}${text}` }, text)
@@ -163,7 +166,7 @@ export const appendExisting = <K extends StreamKey>(
  */
 export const finish = <K extends StreamKey>(route: string, tools: State<K>, key: K) =>
   Effect.gen(function* () {
-    const tool = Object.hasOwn(tools, key) ? tools[key] : undefined
+    const tool = read(tools, key)
     if (!tool) return { tools }
     return {
       tools: withoutTool(tools, key),
@@ -181,7 +184,7 @@ export const finish = <K extends StreamKey>(route: string, tools: State<K>, key:
  */
 export const finishWithInput = <K extends StreamKey>(route: string, tools: State<K>, key: K, input: string) =>
   Effect.gen(function* () {
-    const tool = Object.hasOwn(tools, key) ? tools[key] : undefined
+    const tool = read(tools, key)
     if (!tool) return { tools }
     return {
       tools: withoutTool(tools, key),

--- a/packages/llm/src/protocols/utils/tool-stream.ts
+++ b/packages/llm/src/protocols/utils/tool-stream.ts
@@ -150,7 +150,7 @@ export const appendExisting = <K extends StreamKey>(
   text: string,
   missingToolMessage: string,
 ): AppendOutcome<K> | LLMError => {
-  const current = tools[key]
+  const current = Object.hasOwn(tools, key) ? tools[key] : undefined
   if (!current) return eventError(route, missingToolMessage)
   if (text.length === 0) return { tools, tool: current, events: [] }
   return appendTool(tools, key, { ...current, input: `${current.input}${text}` }, text)
@@ -163,7 +163,7 @@ export const appendExisting = <K extends StreamKey>(
  */
 export const finish = <K extends StreamKey>(route: string, tools: State<K>, key: K) =>
   Effect.gen(function* () {
-    const tool = tools[key]
+    const tool = Object.hasOwn(tools, key) ? tools[key] : undefined
     if (!tool) return { tools }
     return {
       tools: withoutTool(tools, key),
@@ -181,7 +181,7 @@ export const finish = <K extends StreamKey>(route: string, tools: State<K>, key:
  */
 export const finishWithInput = <K extends StreamKey>(route: string, tools: State<K>, key: K, input: string) =>
   Effect.gen(function* () {
-    const tool = tools[key]
+    const tool = Object.hasOwn(tools, key) ? tools[key] : undefined
     if (!tool) return { tools }
     return {
       tools: withoutTool(tools, key),

--- a/packages/llm/test/tool-stream.test.ts
+++ b/packages/llm/test/tool-stream.test.ts
@@ -45,6 +45,35 @@ describe("ToolStream", () => {
     }),
   )
 
+  it.effect("starts a tool whose stream key is an Object.prototype member", () =>
+    Effect.gen(function* () {
+      const first = ToolStream.appendOrStart(
+        ADAPTER,
+        ToolStream.empty<string>(),
+        "toString",
+        { id: "call_1", name: "lookup", text: "{}" },
+        "missing tool",
+      )
+      if (ToolStream.isError(first)) return yield* first
+
+      expect(first.events).toEqual([
+        { type: "tool-input-start", id: "call_1", name: "lookup" },
+        { type: "tool-input-delta", id: "call_1", name: "lookup", text: "{}" },
+      ])
+    }),
+  )
+
+  it.effect("ignores inherited Object.prototype members when no tool was started", () =>
+    Effect.gen(function* () {
+      const error = ToolStream.appendExisting(ADAPTER, ToolStream.empty<string>(), "toString", "{}", "missing tool")
+      const finished = yield* ToolStream.finish(ADAPTER, ToolStream.empty<string>(), "constructor")
+
+      expect(error).toBeInstanceOf(LLMError)
+      if (ToolStream.isError(error)) expect(error.reason.message).toBe("missing tool")
+      expect(finished).toEqual({ tools: {} })
+    }),
+  )
+
   it.effect("uses final input override without losing accumulated deltas", () =>
     Effect.gen(function* () {
       const tools = ToolStream.start(ToolStream.empty<string>(), "item_1", {


### PR DESCRIPTION
### Issue for this PR

Closes #44625

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Provider-supplied tool stream keys can match `Object.prototype` names such as `toString` or `constructor`. The accumulator now uses an own-property check for every pending-tool lookup, so inherited values are never treated as started tool calls.

This replaces #44648, which was automatically closed for missing template sections and cannot be reopened by the author.

### How did you verify your code works?

From `packages/llm`:

- `bun test test/tool-stream.test.ts --timeout 30000` (6 passed)
- `bun typecheck`

The focused tests cover starting a `toString` key, rejecting an unstarted inherited key, and ignoring a `constructor` stop event.

### Screenshots / recordings

Not applicable (non-UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR