### PR TITLE
fix(llm): reject oversized Bedrock event-stream frames

### DIFF
--- a/packages/llm/src/protocols/bedrock-event-stream.ts
+++ b/packages/llm/src/protocols/bedrock-event-stream.ts
@@ -45,11 +45,10 @@ const consumeFrames = (route: string) => (state: FrameBufferState, chunk: Uint8A
       const view = cursor.buffer.subarray(cursor.offset)
       const totalLength = new DataView(view.buffer, view.byteOffset, view.byteLength).getUint32(0, false)
       if (totalLength > MAX_EVENT_STREAM_MESSAGE_LENGTH) {
-        yield* ProviderShared.eventError(
+        return yield* ProviderShared.eventError(
           route,
           `Bedrock event-stream frame declares ${totalLength} bytes, exceeding the 16 MiB protocol maximum`,
         )
-        break
       }
       if (view.length < totalLength) break
 

--- a/packages/llm/src/protocols/bedrock-event-stream.ts
+++ b/packages/llm/src/protocols/bedrock-event-stream.ts
@@ -11,6 +11,11 @@ import { ProviderShared } from "./shared"
 const eventCodec = new EventStreamCodec(toUtf8, fromUtf8)
 const utf8 = new TextDecoder()
 
+// AWS documents a 16 MiB maximum event-stream message. Reject frames that
+// declare a larger length to prevent unbounded buffer growth from malformed
+// or truncated responses.
+const MAX_EVENT_STREAM_MESSAGE_LENGTH = 16 * 1024 * 1024
+
 // Cursor-tracking buffer state. Bytes accumulate in `buffer`; `offset` is the
 // read position. Reading by `subarray` is zero-copy. We only allocate a fresh
 // buffer when a new network chunk arrives and we need to append.
@@ -39,6 +44,13 @@ const consumeFrames = (route: string) => (state: FrameBufferState, chunk: Uint8A
     while (cursor.buffer.length - cursor.offset >= 4) {
       const view = cursor.buffer.subarray(cursor.offset)
       const totalLength = new DataView(view.buffer, view.byteOffset, view.byteLength).getUint32(0, false)
+      if (totalLength > MAX_EVENT_STREAM_MESSAGE_LENGTH) {
+        yield* ProviderShared.eventError(
+          route,
+          `Bedrock event-stream frame declares ${totalLength} bytes, exceeding the 16 MiB protocol maximum`,
+        )
+        break
+      }
       if (view.length < totalLength) break
 
       const decoded = yield* Effect.try({

--- a/packages/llm/test/provider/bedrock-converse.test.ts
+++ b/packages/llm/test/provider/bedrock-converse.test.ts
@@ -388,6 +388,19 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
+  it.effect("rejects an event-stream frame above the 16 MiB maximum", () =>
+    Effect.gen(function* () {
+      const prelude = new Uint8Array(8)
+      new DataView(prelude.buffer).setUint32(0, 0xffffffff, false)
+      const error = yield* LLMClient.generate(baseRequest).pipe(
+        Effect.provide(fixedBytes(concat([prelude, new Uint8Array(64)]))),
+        Effect.flip,
+      )
+
+      expect(error.message).toContain("exceeding the 16 MiB protocol maximum")
+    }),
+  )
+
   it.effect("rejects requests with no auth path", () =>
     Effect.gen(function* () {
       const unsignedModel = AmazonBedrock.configure({


### PR DESCRIPTION
### Issue for this PR

Closes #44630

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bedrock event-stream frames declare their total length before the payload. This rejects lengths above AWS's 16 MiB message limit before buffering, returning a typed provider-output error instead of repeatedly copying data toward an impossible frame.

This replaces #44649, which was automatically closed for missing template sections and cannot be reopened by the author.

### How did you verify your code works?

From `packages/llm`:

- `bun test test/provider/bedrock-converse.test.ts --timeout 30000` (29 passed)
- `bun typecheck`

The regression test sends a frame prelude declaring `0xffffffff` bytes and verifies the 16 MiB error.

### Screenshots / recordings

Not applicable (non-UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR