### PR TITLE
fix(ci): fall back to body scan for closing keywords on non-default branches

### DIFF
--- a/.github/workflows/pr-standards.yml
+++ b/.github/workflows/pr-standards.yml
@@ -119,6 +119,7 @@ jobs:
               query($owner: String!, $repo: String!, $number: Int!) {
                 repository(owner: $owner, name: $repo) {
                   pullRequest(number: $number) {
+                    baseRefName
                     closingIssuesReferences(first: 1) {
                       totalCount
                     }
@@ -133,9 +134,18 @@ jobs:
               number: pr.number
             });
 
+            const baseRef = result.repository.pullRequest.baseRefName;
             const linkedIssues = result.repository.pullRequest.closingIssuesReferences.totalCount;
 
-            if (linkedIssues === 0) {
+            // When targeting a non-default branch, GitHub does not build closing
+            // references, so fall back to scanning the PR body for a keyword.
+            const closingKeywordPattern = /(fixes|closes|resolves)\s+#(\d+)/i;
+            const hasClosingKeyword = closingKeywordPattern.test(pr.body || '');
+            const hasLinkedIssues = baseRef === context.repo.default_branch
+              ? linkedIssues > 0
+              : hasClosingKeyword;
+
+            if (!hasLinkedIssues) {
               await addLabel('needs:issue');
               await comment('issue', `Thanks for your contribution!
 


### PR DESCRIPTION
### Issue for this PR

Closes #38407

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

GitHub does not populate `closingIssuesReferences` for pull requests targeting a non-default branch. The workflow now checks an explicit `Fixes`, `Closes`, or `Resolves` keyword in the PR body for those branches while preserving the GraphQL check for `dev`.

An equivalent fallback is already present on `v2` through #43964; this adds the generic handling to `dev`. It replaces #44650, which was automatically closed for missing template sections and cannot be reopened by the author.

### How did you verify your code works?

- Prettier check for `.github/workflows/pr-standards.yml`
- YAML parse with Bun
- Seven focused cases covering `dev`, `v2`, all accepted closing keywords, an unrelated reference, and a missing link

### Screenshots / recordings

Not applicable (CI workflow change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR