### PR TITLE
fix(ai): preserve unencrypted reasoning history

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -657,14 +657,7 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
     }
   }
 
-  // With store:false, Responses APIs only accept previous reasoning items when the
-  // complete item has encrypted state. Summary blocks for one item may carry
-  // that state only on the last block, so filter after they have been joined.
-  return store === false
-    ? input.filter(
-        (item) => !("type" in item) || item.type !== "reasoning" || typeof item.encrypted_content === "string",
-      )
-    : input
+  return input
 })
 
 const lowerOptions = (request: LLMRequest) => {

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -3157,7 +3157,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("skips non-persisted reasoning ids without encrypted state", () =>
+  it.effect("replays stateless reasoning without encrypted state", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(
         LLM.request({
@@ -3187,6 +3187,12 @@ describe("OpenAI Responses route", () => {
       expect(prepared.body).toMatchObject({
         input: [
           { role: "user", content: [{ type: "input_text", text: "What changed?" }] },
+          {
+            type: "reasoning",
+            id: "rs_1",
+            summary: [{ type: "summary_text", text: "Checked the previous diff." }],
+            encrypted_content: null,
+          },
           { role: "assistant", content: [{ type: "output_text", text: "The parser changed." }] },
           { role: "user", content: [{ type: "input_text", text: "Summarize it." }] },
         ],


### PR DESCRIPTION
## Summary
- stop dropping valid reasoning items from stateless Responses requests when `encrypted_content` is absent or null
- preserve reasoning IDs, visible summaries, and chronological conversation ordering regardless of encryption availability
- match Codex request construction, which replays reasoning items with `encrypted_content: null` while using `store: false`

## Before and after

Given prior assistant reasoning without encrypted state:

```json
{ "type": "reasoning", "id": "rs_1", "summary": [{ "type": "summary_text", "text": "Checked the previous diff." }], "encrypted_content": null }
```

**Before:** `store: false` removed the reasoning item entirely from the next request:

```json
{ "store": false, "input": [
  { "role": "user", "content": [{ "type": "input_text", "text": "What changed?" }] },
  { "role": "assistant", "content": [{ "type": "output_text", "text": "The parser changed." }] }
] }
```

**After:** The reasoning item remains in its original conversation position:

```json
{ "store": false, "input": [
  { "role": "user", "content": [{ "type": "input_text", "text": "What changed?" }] },
  { "type": "reasoning", "id": "rs_1", "summary": [{ "type": "summary_text", "text": "Checked the previous diff." }], "encrypted_content": null },
  { "role": "assistant", "content": [{ "type": "output_text", "text": "The parser changed." }] }
] }
```

## Verification
- `bun test test/partial-json.test.ts test/tool-stream.test.ts test/provider/openai-responses.test.ts test/provider/openai-compatible-responses.test.ts test/provider/openai-responses-websocket.recorded.test.ts test/provider/openai-chat.test.ts test/provider/anthropic-messages.test.ts test/provider/bedrock-converse.test.ts test/provider/xai-responses.test.ts test/response.test.ts test/tool-runtime.test.ts --timeout 30000 --only-failures` (363 passing)
- `RECORDED_PREFIX=openai-responses bun test test/provider/golden.recorded.test.ts --timeout 30000 --only-failures`
- `bun typecheck` from `packages/ai`
- `bunx prettier --check packages/ai/src/protocols/open-responses.ts packages/ai/test/provider/openai-responses.test.ts`