### PR TITLE
fix(ai): replay native hosted tool items

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -84,6 +84,11 @@ const OpenResponsesItemReference = Schema.Struct({
   id: Schema.String,
 })
 
+const OpenResponsesHostedToolItem = Schema.StructWithRest(
+  Schema.Struct({ type: Schema.String.check(Schema.isPattern(/^(?!function_call$).+_call$/)), id: Schema.String }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+)
+
 // `function_call_output.output` accepts either a plain string or an ordered
 // array of content items so tools can return images and files in addition to text.
 // https://www.openresponses.org/reference
@@ -124,6 +129,7 @@ export const InputItem = Schema.Union([
     call_id: Schema.String,
     output: OpenResponsesFunctionCallOutput,
   }),
+  OpenResponsesHostedToolItem,
 ])
 type OpenResponsesInputItem = Schema.Schema.Type<typeof InputItem>
 type LoweredInputItem =
@@ -619,8 +625,20 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
           if (store !== false && reference && !hostedToolReferences.has(reference))
             input.push({ type: "item_reference", id: reference })
           if (store === false) {
-            // The server is not storing this exchange, so the tool outcome has to
-            // travel in the input. Non-content results degrade to their text form.
+            if (
+              reference &&
+              part.result.type === "json" &&
+              ProviderShared.isRecord(part.result.value) &&
+              part.result.value.id === reference &&
+              typeof part.result.value.type === "string" &&
+              part.result.value.type !== "function_call" &&
+              part.result.value.type.endsWith("_call")
+            ) {
+              input.push({ ...part.result.value, id: reference, type: part.result.value.type })
+              hostedToolReferences.add(reference)
+              continue
+            }
+            // Foreign-provider items and image results cannot be replayed natively.
             const content: ReadonlyArray<Content> =
               part.result.type === "content"
                 ? part.result.value

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -2949,7 +2949,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("continues stateless hosted tool results with their text form", () =>
+  it.effect("replays stateless hosted tool results as native provider items", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(
         LLM.request({
@@ -2981,11 +2981,75 @@ describe("OpenAI Responses route", () => {
 
       expect(prepared.body.input).toEqual([
         { role: "user", content: [{ type: "input_text", text: "Search." }] },
+        { type: "web_search_call", id: "ws_1", status: "completed" },
+        { role: "user", content: [{ type: "input_text", text: "Continue." }] },
+      ])
+    }),
+  )
+
+  it.effect("preserves foreign hosted tool results as portable message content", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model: xaiModel,
+          messages: [
+            Message.assistant([
+              ToolCallPart.make({
+                id: "ws_1",
+                name: "web_search",
+                input: { query: "effect 4" },
+                providerExecuted: true,
+                providerMetadata: { openai: { itemId: "ws_1" } },
+              }),
+              {
+                type: "tool-result",
+                id: "ws_1",
+                name: "web_search",
+                result: { type: "json", value: { type: "web_search_call", id: "ws_1", status: "completed" } },
+                providerExecuted: true,
+                providerMetadata: { openai: { itemId: "ws_1" } },
+              },
+            ]),
+            Message.user("Continue."),
+          ],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
         {
           role: "user",
           content: [{ type: "input_text", text: '{"type":"web_search_call","id":"ws_1","status":"completed"}' }],
         },
         { role: "user", content: [{ type: "input_text", text: "Continue." }] },
+      ])
+    }),
+  )
+
+  it.effect("does not replay hosted tool items whose result id differs from provider metadata", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.assistant([
+              {
+                type: "tool-result",
+                id: "ws_1",
+                name: "web_search",
+                result: { type: "json", value: { type: "web_search_call", id: "ws_other", status: "completed" } },
+                providerExecuted: true,
+                providerMetadata: { openai: { itemId: "ws_1" } },
+              },
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
+        {
+          role: "user",
+          content: [{ type: "input_text", text: '{"type":"web_search_call","id":"ws_other","status":"completed"}' }],
+        },
       ])
     }),
   )

--- a/packages/ai/test/provider/xai-responses.test.ts
+++ b/packages/ai/test/provider/xai-responses.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
-import { LLM, LLMEvent } from "../../src/index.js"
+import { LLM, LLMEvent, Message } from "../../src/index.js"
 import { XAI } from "../../src/providers.js"
 import { OpenResponses } from "../../src/protocols/open-responses.js"
 import { OpenAIResponses } from "../../src/protocols/openai-responses.js"
@@ -103,6 +103,31 @@ describe("xAI Responses route", () => {
       expect(response.message.content.find((part) => part.type === "reasoning")).toMatchObject({
         providerMetadata: { xai: { itemId: "reasoning_1", reasoningEncryptedContent: "opaque" } },
       })
+    }),
+  )
+
+  it.effect("replays xAI hosted tool items when continuing with the same provider", () =>
+    Effect.gen(function* () {
+      const item = { type: "x_search_call", id: "x_search_1", status: "completed", action: { query: "news" } }
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.assistant([
+              {
+                type: "tool-result",
+                id: "x_search_1",
+                name: "x_search",
+                result: { type: "json", value: item },
+                providerExecuted: true,
+                providerMetadata: { xai: { itemId: "x_search_1" } },
+              },
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([item])
     }),
   )
 


### PR DESCRIPTION
## Summary
- replay completed provider-hosted tool items in their original native Responses shape when continuing with the same provider and `store: false`
- preserve existing portable message fallback when switching providers, when item IDs do not match provider metadata, or when the result is an image/error rather than a replayable JSON item
- retain stored-response item references and existing hosted image generation behavior
- cover OpenAI native replay, OpenAI-to-xAI provider switches, mismatched item IDs, and xAI-native hosted tools

## Before and after

A completed hosted search produces the provider-native item:

```json
{ "type": "web_search_call", "id": "ws_1", "status": "completed" }
```

**Before:** A subsequent stateless request rewrote that item as a synthetic user message:

```json
{ "role": "user", "content": [{ "type": "input_text", "text": "{\"type\":\"web_search_call\",\"id\":\"ws_1\",\"status\":\"completed\"}" }] }
```

**After:** Continuing with the same provider preserves the original item, matching Codex history replay:

```json
{ "type": "web_search_call", "id": "ws_1", "status": "completed" }
```

If the next model belongs to another provider, the original item is not replayed as foreign provider state; its portable text representation remains available instead. Hosted generated images likewise continue to replay as input images.

## Verification
- `bun test test/partial-json.test.ts test/tool-stream.test.ts test/provider/openai-responses.test.ts test/provider/openai-compatible-responses.test.ts test/provider/openai-responses-images.recorded.test.ts test/provider/openai-responses-websocket.recorded.test.ts test/provider/openai-chat.test.ts test/provider/anthropic-messages.test.ts test/provider/bedrock-converse.test.ts test/provider/xai-responses.test.ts test/response.test.ts test/tool-runtime.test.ts --timeout 30000 --only-failures` (367 passing)
- `RECORDED_PREFIX=openai-responses bun test test/provider/golden.recorded.test.ts --timeout 30000 --only-failures`
- `bun typecheck` from `packages/ai`
- `bunx prettier --check packages/ai/src/protocols/open-responses.ts packages/ai/test/provider/openai-responses.test.ts packages/ai/test/provider/xai-responses.test.ts`