### PR TITLE
fix(ai): omit empty chat assistant messages

### DIFF
--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -526,6 +526,8 @@ const lowerMessages = Effect.fn("OpenAIChat.lowerMessages")(function* (request: 
         )
       continue
     }
+    if (message.role === "assistant" && message.content.every((part) => part.type === "text" && part.text.trim() === ""))
+      continue
     if (message.role === "tool") {
       const lowered = yield* lowerToolMessages(message, options)
       messages.push(...lowered.messages)

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -85,6 +85,28 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("omits empty and whitespace-only assistant messages", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.user("Before."),
+            Message.assistant([]),
+            Message.assistant(""),
+            Message.assistant(" \n\t "),
+            Message.assistant("After."),
+          ],
+        }),
+      )
+
+      expect(prepared.body.messages).toEqual([
+        { role: "user", content: "Before." },
+        { role: "assistant", content: "After." },
+      ])
+    }),
+  )
+
   it.effect("replays canonical reasoning as OpenAI-compatible reasoning_content", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(


### PR DESCRIPTION
## Summary
- omit empty and whitespace-only assistant messages from Chat Completions transcripts
- preserve assistant messages containing tool calls or reasoning-only history
- cover empty message content, empty text, and whitespace-only text with a focused transcript regression test

## Test plan
- `bun test test/provider/openai-chat.test.ts test/provider/openai-compatible-chat.test.ts` from `packages/ai`
- `bun typecheck` from `packages/ai`