### PR TITLE
docs: add Stacktree to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+|[Stacktree](https://github.com/stevysmith/stacktree-skill)                                  | Publish HTML from a session to a private, shareable link         |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

No issue - docs-only addition to the ecosystem list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the ecosystem Projects table for Stacktree: publish HTML from a session to a private, unguessable link, with optional passcode and expiry. Republishing replaces the page in place, so a link you already sent stays current.

It hooks into OpenCode two ways:

- skill over HTTP via `skills.urls` -> `https://stacktr.ee/.well-known/skills/`
- local MCP server (`npx -y stacktree-mcp`)

English page only. Happy to reword the entry or move it to another table.

### How did you verify your code works?

Both integration paths were run against the live service before opening this PR: the skill URL loads and publishes from a session, and `npx -y stacktree-mcp` does the same over MCP.

For the docs change itself, the new row's pipes sit at the same offsets as the other rows in that table, so the source stays aligned.

### Screenshots / recordings

Not a UI change - one table row in `packages/web/src/content/docs/ecosystem.mdx`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
