### PR TITLE
fix(ai): bridge tool results for mistral family models

### DIFF
--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -478,12 +478,22 @@ const lowerMessages = Effect.fn("OpenAIChat.lowerMessages")(function* (request: 
           ]
         : [{ role: "system", content: ProviderShared.joinText(request.system) }]
   const messages = [...system]
+  const bridgeToolResults =
+    request.model.compatibility?.bridgeToolResults ??
+    ["mistral", "devstral", "codestral", "pixtral", "mixtral"].some((family) =>
+      request.model.id.toLowerCase().includes(family),
+    )
+  const bridgeTools = () => {
+    if (bridgeToolResults && messages.at(-1)?.role === "tool") messages.push({ role: "assistant", content: "Done." })
+  }
   const pendingImages: Array<Schema.Schema.Type<typeof OpenAIChatUserContent>> = []
   const flushImages = () => {
     if (pendingImages.length === 0) return
+    bridgeTools()
     messages.push({ role: "user", content: pendingImages.splice(0) })
   }
   for (const message of request.messages) {
+    if (message.role === "user") bridgeTools()
     if (message.role === "system") {
       const part = yield* ProviderShared.wrappedSystemUpdate("OpenAI Chat", message)
       if (pendingImages.length > 0) {

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -478,13 +478,13 @@ const lowerMessages = Effect.fn("OpenAIChat.lowerMessages")(function* (request: 
           ]
         : [{ role: "system", content: ProviderShared.joinText(request.system) }]
   const messages = [...system]
-  const bridgeToolResults =
-    request.model.compatibility?.bridgeToolResults ??
+  const requireAssistantAfterTool =
+    request.model.compatibility?.requireAssistantAfterTool ??
     ["mistral", "devstral", "codestral", "pixtral", "mixtral"].some((family) =>
       request.model.id.toLowerCase().includes(family),
     )
   const bridgeTools = () => {
-    if (bridgeToolResults && messages.at(-1)?.role === "tool") messages.push({ role: "assistant", content: "Done." })
+    if (requireAssistantAfterTool && messages.at(-1)?.role === "tool") messages.push({ role: "assistant", content: "Done." })
   }
   const pendingImages: Array<Schema.Schema.Type<typeof OpenAIChatUserContent>> = []
   const flushImages = () => {

--- a/packages/ai/src/schema/options.ts
+++ b/packages/ai/src/schema/options.ts
@@ -155,7 +155,7 @@ export class LanguageModelCompatibility extends Schema.Class<LanguageModelCompat
   reasoningField: Schema.optional(Schema.String),
   maxTokensField: Schema.optional(LanguageModelMaxTokensFieldCompatibility),
   requireFinishReason: Schema.optional(Schema.Boolean),
-  bridgeToolResults: Schema.optional(Schema.Boolean),
+  requireAssistantAfterTool: Schema.optional(Schema.Boolean),
   supportsStore: Schema.optional(Schema.Boolean),
   supportsUsageInStreaming: Schema.optional(Schema.Boolean),
   supportsStrictMode: Schema.optional(Schema.Boolean),

--- a/packages/ai/src/schema/options.ts
+++ b/packages/ai/src/schema/options.ts
@@ -155,6 +155,7 @@ export class LanguageModelCompatibility extends Schema.Class<LanguageModelCompat
   reasoningField: Schema.optional(Schema.String),
   maxTokensField: Schema.optional(LanguageModelMaxTokensFieldCompatibility),
   requireFinishReason: Schema.optional(Schema.Boolean),
+  bridgeToolResults: Schema.optional(Schema.Boolean),
   supportsStore: Schema.optional(Schema.Boolean),
   supportsUsageInStreaming: Schema.optional(Schema.Boolean),
   supportsStrictMode: Schema.optional(Schema.Boolean),

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -453,6 +453,30 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("bridges image tool results before their synthetic user message when required", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model: LanguageModel.update(model, { compatibility: { bridgeToolResults: true } }),
+          messages: [
+            Message.assistant([ToolCallPart.make({ id: "call_image", name: "read", input: {} })]),
+            Message.tool({
+              id: "call_image",
+              name: "read",
+              result: {
+                type: "content",
+                value: [{ type: "file", uri: "data:image/png;base64,AAECAw==", mime: "image/png", name: "pixel.png" }],
+              },
+            }),
+          ],
+        }),
+      )
+
+      expect(prepared.body.messages.map((message) => message.role)).toEqual(["assistant", "tool", "assistant", "user"])
+      expect(prepared.body.messages[2]).toEqual({ role: "assistant", content: "Done." })
+    }),
+  )
+
   it.effect("orders parallel tool responses before one aggregated vision message", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -457,7 +457,7 @@ describe("OpenAI Chat route", () => {
     Effect.gen(function* () {
       const prepared = yield* compileRequest(
         LLM.request({
-          model: LanguageModel.update(model, { compatibility: { bridgeToolResults: true } }),
+          model: LanguageModel.update(model, { compatibility: { requireAssistantAfterTool: true } }),
           messages: [
             Message.assistant([ToolCallPart.make({ id: "call_image", name: "read", input: {} })]),
             Message.tool({

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -238,6 +238,47 @@ describe("OpenAI-compatible Chat route", () => {
     }),
   )
 
+  it.effect("bridges tool results for Mistral-family models and honors compatibility overrides", () =>
+    Effect.gen(function* () {
+      const cases = [
+        { id: "mistral-small", bridge: true },
+        { id: "devstral-small", bridge: true },
+        { id: "codestral-latest", bridge: true },
+        { id: "pixtral-large", bridge: true },
+        { id: "open-mixtral-8x22b", bridge: true },
+        { id: "ordinary-model", bridge: false },
+        { id: "ordinary-model", override: true, bridge: true },
+        { id: "mistral-small", override: false, bridge: false },
+      ] as const
+
+      yield* Effect.forEach(cases, (item) =>
+        Effect.gen(function* () {
+          const selected = OpenAICompatibleChat.route
+            .with({ provider: "custom", endpoint: { baseURL: "https://api.custom.test/v1" } })
+            .model({
+              id: item.id,
+              compatibility: "override" in item ? { bridgeToolResults: item.override } : undefined,
+            })
+          const prepared = yield* compileRequest(
+            LLM.request({
+              model: selected,
+              messages: [
+                Message.assistant([ToolCallPart.make({ id: "call_1", name: "lookup", input: {} })]),
+                Message.tool({ id: "call_1", name: "lookup", result: "Sunny" }),
+                Message.user("What next?"),
+              ],
+            }),
+          )
+
+          expect(prepared.body.messages.map((message) => message.role)).toEqual(
+            item.bridge ? ["assistant", "tool", "assistant", "user"] : ["assistant", "tool", "user"],
+          )
+          if (item.bridge) expect(prepared.body.messages[2]).toEqual({ role: "assistant", content: "Done." })
+        }),
+      )
+    }),
+  )
+
   it.effect("posts to the configured compatible endpoint and parses text usage", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -257,7 +257,7 @@ describe("OpenAI-compatible Chat route", () => {
             .with({ provider: "custom", endpoint: { baseURL: "https://api.custom.test/v1" } })
             .model({
               id: item.id,
-              compatibility: "override" in item ? { bridgeToolResults: item.override } : undefined,
+              compatibility: "override" in item ? { requireAssistantAfterTool: item.override } : undefined,
             })
           const prepared = yield* compileRequest(
             LLM.request({

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -1312,6 +1312,7 @@ export type ModelCompatibility = {
   reasoningField?: ModelReasoningField
   maxTokensField?: ModelMaxTokensField
   requireFinishReason?: boolean
+  bridgeToolResults?: boolean
 }
 
 export type ModelCost = {

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -1312,7 +1312,7 @@ export type ModelCompatibility = {
   reasoningField?: ModelReasoningField
   maxTokensField?: ModelMaxTokensField
   requireFinishReason?: boolean
-  bridgeToolResults?: boolean
+  requireAssistantAfterTool?: boolean
 }
 
 export type ModelCost = {

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -392,6 +392,7 @@ describe("ModelResolver", () => {
             reasoningField: "vendor_reasoning",
             maxTokensField: "max_completion_tokens",
             requireFinishReason: false,
+            bridgeToolResults: true,
           },
           settings: {
             apiKey: "settings-secret",
@@ -417,6 +418,7 @@ describe("ModelResolver", () => {
       expect(resolved.compatibility?.reasoningField).toBe("vendor_reasoning")
       expect(resolved.compatibility?.maxTokensField).toBe("max_completion_tokens")
       expect(resolved.compatibility?.requireFinishReason).toBe(false)
+      expect(resolved.compatibility?.bridgeToolResults).toBe(true)
       expect(prepared.body).toMatchObject({ max_completion_tokens: 10 })
       expect(prepared.body).not.toHaveProperty("max_tokens")
       expect(resolved.route.endpoint.baseURL).toBe("https://compatible.example/v1")

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -392,7 +392,7 @@ describe("ModelResolver", () => {
             reasoningField: "vendor_reasoning",
             maxTokensField: "max_completion_tokens",
             requireFinishReason: false,
-            bridgeToolResults: true,
+            requireAssistantAfterTool: true,
           },
           settings: {
             apiKey: "settings-secret",
@@ -418,7 +418,7 @@ describe("ModelResolver", () => {
       expect(resolved.compatibility?.reasoningField).toBe("vendor_reasoning")
       expect(resolved.compatibility?.maxTokensField).toBe("max_completion_tokens")
       expect(resolved.compatibility?.requireFinishReason).toBe(false)
-      expect(resolved.compatibility?.bridgeToolResults).toBe(true)
+      expect(resolved.compatibility?.requireAssistantAfterTool).toBe(true)
       expect(prepared.body).toMatchObject({ max_completion_tokens: 10 })
       expect(prepared.body).not.toHaveProperty("max_tokens")
       expect(resolved.route.endpoint.baseURL).toBe("https://compatible.example/v1")

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -57,7 +57,7 @@ export const Compatibility = Schema.Struct({
   reasoningField: ReasoningField.pipe(optional),
   maxTokensField: MaxTokensField.pipe(optional),
   requireFinishReason: Schema.Boolean.pipe(optional),
-  bridgeToolResults: Schema.Boolean.pipe(optional),
+  requireAssistantAfterTool: Schema.Boolean.pipe(optional),
 }).annotate({ identifier: "Model.Compatibility" })
 
 export interface Capabilities extends Schema.Schema.Type<typeof Capabilities> {}

--- a/packages/schema/src/model.ts
+++ b/packages/schema/src/model.ts
@@ -57,6 +57,7 @@ export const Compatibility = Schema.Struct({
   reasoningField: ReasoningField.pipe(optional),
   maxTokensField: MaxTokensField.pipe(optional),
   requireFinishReason: Schema.Boolean.pipe(optional),
+  bridgeToolResults: Schema.Boolean.pipe(optional),
 }).annotate({ identifier: "Model.Compatibility" })
 
 export interface Capabilities extends Schema.Schema.Type<typeof Capabilities> {}

--- a/packages/schema/test/model.test.ts
+++ b/packages/schema/test/model.test.ts
@@ -42,13 +42,13 @@ describe("Model.Compatibility", () => {
         reasoningField: "vendor_reasoning",
         maxTokensField: "max_completion_tokens",
         requireFinishReason: false,
-        bridgeToolResults: true,
+        requireAssistantAfterTool: true,
       }),
     ).toEqual({
       reasoningField: "vendor_reasoning",
       maxTokensField: "max_completion_tokens",
       requireFinishReason: false,
-      bridgeToolResults: true,
+      requireAssistantAfterTool: true,
     })
   })
 })

--- a/packages/schema/test/model.test.ts
+++ b/packages/schema/test/model.test.ts
@@ -42,11 +42,13 @@ describe("Model.Compatibility", () => {
         reasoningField: "vendor_reasoning",
         maxTokensField: "max_completion_tokens",
         requireFinishReason: false,
+        bridgeToolResults: true,
       }),
     ).toEqual({
       reasoningField: "vendor_reasoning",
       maxTokensField: "max_completion_tokens",
       requireFinishReason: false,
+      bridgeToolResults: true,
     })
   })
 })


### PR DESCRIPTION
## Summary
- add the public `requireAssistantAfterTool` model compatibility option and propagate it into the AI model
- infer assistant messages after tool results for model IDs containing `mistral`, `devstral`, `codestral`, `pixtral`, or `mixtral` when no explicit override is supplied
- insert an assistant `Done.` message between tool results and following user content, including synthetic image-user messages
- cover all inferred model families, explicit enable/disable overrides, public schema decoding, model resolution, and generated client types

## Test plan
- `bun test test/provider/openai-chat.test.ts test/provider/openai-compatible-chat.test.ts && bun typecheck` from `packages/ai`
- `bun test test/model.test.ts && bun typecheck` from `packages/schema`
- `bun test test/model-resolver.test.ts && bun typecheck` from `packages/core`
- `bun run generate && bun typecheck` from `packages/client`