### PR TITLE
fix(tui): rank resume and clear above restart in slash autocomplete

### DIFF
--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -376,6 +376,8 @@ export interface KeymapCommand {
     readonly aliases?: string[]
     /** Keeps the slash command in the prompt and passes its raw input to run. */
     readonly arguments?: true
+    /** Breaks fuzzy-score ties in slash autocomplete; higher wins. */
+    readonly priority?: number
   }
   /** Promotes the command in discovery UI. */
   readonly suggested?: boolean | (() => boolean)

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -704,7 +704,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         title: "Switch session",
         category: "Session",
         suggested: data.session.list().length > 0,
-        slash: { name: "sessions", aliases: ["resume", "continue"] },
+        slash: { name: "sessions", aliases: ["resume", "continue"], priority: 2 },
         run: () => {
           dialog.replace(() => <DialogSessionList />)
         },
@@ -714,7 +714,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         title: "New session",
         suggested: route.data.type === "session",
         category: "Session",
-        slash: { name: "new", aliases: ["clear"] },
+        slash: { name: "new", aliases: ["clear", "reset"], priority: 1 },
         run: () => {
           const model = local.model.current()
           const current =
@@ -817,7 +817,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         suggested: true,
         category: "Agent",
         // Bias /mo toward /models over /move without changing global fuzzy scoring.
-        slash: { name: "models", aliases: ["mo"] },
+        slash: { name: "models", aliases: ["mo", "model", "m"], priority: 2 },
         run: () => {
           dialog.replace(() => <DialogModel />)
         },
@@ -871,7 +871,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         name: "mcp.list",
         title: "MCP servers",
         category: "Agent",
-        slash: { name: "mcps" },
+        slash: { name: "mcps", aliases: ["mcp"] },
         run: () => {
           dialog.replace(() => <DialogMcp />)
         },
@@ -937,7 +937,7 @@ function App(props: { pair?: DialogPairCredentials }) {
         name: "opencode.settings",
         title: "Open settings",
         suggested: true,
-        slash: { name: "settings" },
+        slash: { name: "settings", aliases: ["config"] },
         run: () => {
           dialog.replace(() => <DialogConfig />)
         },
@@ -994,7 +994,7 @@ function App(props: { pair?: DialogPairCredentials }) {
       {
         name: "theme.switch",
         title: "Switch theme",
-        slash: { name: "themes" },
+        slash: { name: "themes", aliases: ["theme"] },
         run: () => {
           dialog.replace(() => <DialogThemeList />)
         },

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -42,6 +42,7 @@ export type AutocompleteOption = {
   display: string
   value?: string
   aliases?: string[]
+  priority?: number
   disabled?: boolean
   description?: string
   isDirectory?: boolean
@@ -532,6 +533,7 @@ export function Autocomplete(props: {
         display: `/${slash.name}`,
         description: command.description ?? command.title,
         aliases: slash.aliases?.map((alias) => `/${alias}`),
+        priority: slash.priority,
         onSelect: slash.arguments ? () => insertSlash(slash.name) : command.run,
       }
     })
@@ -627,9 +629,12 @@ export function Autocomplete(props: {
           const displayResult = objResults[0]
           let score = objResults.score
           const prefix = store.visible === "reference" ? "@" : store.visible === "command" ? "/" : ""
-          if (displayResult && displayResult.target.startsWith(prefix + searchValue)) {
+          const startsWithPrefix = (target?: string) => target?.startsWith(prefix + searchValue) === true
+          if (startsWithPrefix(displayResult?.target) || objResults.obj.aliases?.some(startsWithPrefix)) {
             score *= 2
           }
+          const priority = objResults.obj.priority ?? 0
+          if (priority > 0) score *= 1 + priority
           const frecencyScore = objResults.obj.path ? frecency.getFrecency(objResults.obj.path) : 0
           return score * (1 + frecencyScore)
         },

--- a/packages/tui/src/context/keymap.tsx
+++ b/packages/tui/src/context/keymap.tsx
@@ -24,6 +24,7 @@ declare module "@opentui/keymap" {
       name: string
       aliases?: string[]
       arguments?: true
+      priority?: number
     }
   }
 }

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -768,7 +768,7 @@ export function Session(props: { verticalTabsWidth: number }) {
       title: "Rename session",
       id: "session.rename",
       group: "Session",
-      slash: { name: "rename" },
+      slash: { name: "rename", aliases: ["title"] },
       run: () => DialogSessionRename.show(dialog, route.sessionID, session()?.title),
     },
     {
@@ -790,7 +790,7 @@ export function Session(props: { verticalTabsWidth: number }) {
       title: "Fork session",
       id: "session.fork",
       group: "Session",
-      slash: { name: "fork" },
+      slash: { name: "fork", aliases: ["branch"] },
       run: () => {
         dialog.replace(() => (
           <DialogFork
@@ -837,7 +837,7 @@ export function Session(props: { verticalTabsWidth: number }) {
       title: "Undo previous message",
       id: "session.undo",
       group: "Session",
-      slash: { name: "undo" },
+      slash: { name: "undo", aliases: ["rewind"] },
       run: () => {
         const message = messagesBeforeRevert().findLast(
           (message): message is SessionMessageUser => message.type === "user" && !!message.text.trim(),

--- a/packages/tui/test/prompt/autocomplete-ranking.test.tsx
+++ b/packages/tui/test/prompt/autocomplete-ranking.test.tsx
@@ -1,0 +1,94 @@
+import { expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+import { Effect, FileSystem } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Global } from "@opencode-ai/util/global"
+import { createEventStream, createFetch, directory, json } from "../fixture/tui-client"
+import { takeDraft } from "../../src/component/prompt/draft-stash"
+
+function rowOf(frame: string, text: string) {
+  return frame.split("\n").findIndex((row) => row.includes(text))
+}
+
+// The first autocomplete row is the top-ranked slash command.
+function firstSlashRow(frame: string) {
+  const rows = frame.split("\n")
+  const index = rows.findIndex((row) => row.includes("┃ /"))
+  return index >= 0 ? rows[index] : ""
+}
+
+async function runApp(setup: Awaited<ReturnType<typeof createTestRenderer>>) {
+  // The draft stash is module-global; clear any draft left by a previous test.
+  takeDraft("dummy")
+  const events = createEventStream()
+  const calls = createFetch((url) => {
+    const session = {
+      id: "dummy",
+      title: "Demo session",
+      projectID: "project",
+      location: { directory },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: 0, updated: 0 },
+    }
+    if (url.pathname === "/api/session") return json({ data: [session], cursor: {} })
+    if (url.pathname === "/api/session/dummy") return json({ data: session })
+    if (url.pathname === "/api/session/dummy/message") return json({ data: [], cursor: {} })
+    if (url.pathname === "/api/session/dummy/inbox") return json({ data: [] })
+    if (url.pathname === "/api/session/dummy/permission") return json({ data: [] })
+  }, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+  const { run } = await import("../../src/app")
+  const task = Effect.runPromise(
+    run({
+      app: { name: "test", version: "test", channel: "test" },
+      server: { endpoint: { url: server.url.toString() } },
+      config: { get: async () => ({}), update: async () => ({}) },
+      packages: { resolve: async () => undefined },
+      terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: () => {} }),
+      args: { sessionID: "dummy" },
+      log: () => {},
+    }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
+  )
+  return { task, server }
+}
+
+test("slash autocomplete ranks resume first for /res", async () => {
+  const setup = await createTestRenderer({ width: 100, height: 30, useThread: false })
+  setup.renderer.start()
+  const { task, server } = await runApp(setup)
+  try {
+    await setup.waitForFrame((frame) => frame.includes("shift+tab agents"))
+    await setup.mockInput.typeText("/res")
+    const frame = await setup.waitForFrame((frame) => firstSlashRow(frame).includes("/sessions"))
+    const sessions = rowOf(frame, "/sessions")
+    const next = rowOf(frame, "/new")
+    expect(sessions).toBeGreaterThanOrEqual(0)
+    expect(next).toBeGreaterThanOrEqual(0)
+    expect(sessions).toBeLessThan(next)
+  } finally {
+    setup.renderer.destroy()
+    await task
+    await server.stop()
+  }
+})
+
+test("slash autocomplete ranks models first for /m", async () => {
+  const setup = await createTestRenderer({ width: 100, height: 30, useThread: false })
+  setup.renderer.start()
+  const { task, server } = await runApp(setup)
+  try {
+    await setup.waitForFrame((frame) => frame.includes("shift+tab agents"))
+    await setup.mockInput.typeText("/m")
+    const frame = await setup.waitForFrame((frame) => firstSlashRow(frame).includes("/models"))
+    const models = rowOf(frame, "/models")
+    const mcps = rowOf(frame, "/mcps")
+    expect(models).toBeGreaterThanOrEqual(0)
+    expect(mcps).toBeGreaterThanOrEqual(0)
+    expect(models).toBeLessThan(mcps)
+  } finally {
+    setup.renderer.destroy()
+    await task
+    await server.stop()
+  }
+})

--- a/packages/tui/test/prompt/autocomplete-ranking.test.tsx
+++ b/packages/tui/test/prompt/autocomplete-ranking.test.tsx
@@ -42,7 +42,10 @@ async function runApp(setup: Awaited<ReturnType<typeof createTestRenderer>>) {
   const task = Effect.runPromise(
     run({
       app: { name: "test", version: "test", channel: "test" },
-      server: { endpoint: { url: server.url.toString() } },
+      server: {
+        endpoint: { url: server.url.toString() },
+        service: { reconnect: async () => ({ url: server.url.toString() }), restart: async () => {} },
+      },
       config: { get: async () => ({}), update: async () => ({}) },
       packages: { resolve: async () => undefined },
       terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: () => {} }),
@@ -63,9 +66,12 @@ test("slash autocomplete ranks resume first for /res", async () => {
     const frame = await setup.waitForFrame((frame) => firstSlashRow(frame).includes("/sessions"))
     const sessions = rowOf(frame, "/sessions")
     const next = rowOf(frame, "/new")
+    const restart = rowOf(frame, "/restart")
     expect(sessions).toBeGreaterThanOrEqual(0)
     expect(next).toBeGreaterThanOrEqual(0)
+    expect(restart).toBeGreaterThanOrEqual(0)
     expect(sessions).toBeLessThan(next)
+    expect(next).toBeLessThan(restart)
   } finally {
     setup.renderer.destroy()
     await task


### PR DESCRIPTION
### Issue for this PR

Closes #38043

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

I often type `/res` to resume a session and press Enter quickly. Slash autocomplete ranked `/restart` first, so I kept restarting the service instead of opening the session picker.

This ranks the common resume and new-session actions above restart when those fuzzy matches overlap. Alias prefix matches now receive the same prefix boost as command names, with a small command priority for the ambiguous cases.

It also adds familiar aliases used by other coding assistants: `/clear` and `/reset` for a new session, `/model` and `/m` for models, `/mcp` for MCP servers, `/config` for settings, `/theme` for themes, `/title` for rename, `/branch` for fork, and `/rewind` for undo.

### How did you verify your code works?

- `bun test` in `packages/tui`, 765 passed and 5 skipped
- `bun typecheck` in `packages/tui`
- `bun typecheck` in `packages/plugin`
- `bun run build` in `packages/cli`
- full pre-push typecheck, 32 packages passed
- live TUI through `bun run dev:live` and terminal-control: typing `/res` put `/sessions` first and `/new` second; pressing Enter opened the session picker rather than restarting the service

### Screenshots / recordings

Terminal capture after typing `/res`:

```text
/sessions  Switch session
/new       New session
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR