### PR TITLE
fix(app): apply UI font to prompt input

### DIFF
--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -160,7 +160,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
             spellcheck={state.mode === "normal"}
             // @ts-expect-error
             autocomplete="off"
-            class="relative z-10 block min-h-[60px] max-h-[180px] w-full overflow-y-auto whitespace-pre-wrap bg-transparent px-4 pt-4 pb-2 text-[13px] font-[440] leading-5 text-v2-text-text-base focus:outline-none empty:before:content-['\200B'] [&_[data-mention=file]]:text-syntax-property [&_[data-mention=agent]]:text-syntax-type [&_[data-mention=reference]]:text-syntax-keyword"
+            class="relative z-10 block min-h-[60px] max-h-[180px] w-full overflow-y-auto whitespace-pre-wrap bg-transparent px-4 pt-4 pb-2 font-sans text-[13px] font-[440] leading-5 text-v2-text-text-base focus:outline-none empty:before:content-['\200B'] [&_[data-mention=file]]:text-syntax-property [&_[data-mention=agent]]:text-syntax-type [&_[data-mention=reference]]:text-syntax-keyword"
             classList={{ "font-mono!": state.mode === "shell", "opacity-50": props.disabled }}
             onInput={(event) => {
               const cursor = promptInputV2Cursor(event.currentTarget)
@@ -184,7 +184,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
           />
           <Show when={!props.controller.value()}>
             <div
-              class="pointer-events-none absolute inset-x-0 top-0 px-4 pt-4 text-[13px] font-[440] leading-5 text-v2-text-text-faint"
+              class="pointer-events-none absolute inset-x-0 top-0 px-4 pt-4 font-sans text-[13px] font-[440] leading-5 text-v2-text-text-faint"
               classList={{ "font-mono!": state.mode === "shell" }}
             >
               {view.placeholder?.() ??


### PR DESCRIPTION
## Summary

- make the V2 prompt editor use the configured UI font
- keep the placeholder font aligned with typed content
- preserve the existing monospace override in shell mode

Closes #44873

## Evidence

Base: ac1c048e6420eb4c728fd3e343a1ba7b076cba92
Head: 1b3987319b1722a320fb6e01b32b79f3989add95

The new-layout body uses the fixed text font, while appearance settings update the sans font variable. The V2 prompt editor and placeholder previously inherited the body font, so changing the UI font did not reach either element. Both now opt into the shared sans utility, which resolves to the configured font variable. Shell mode continues to apply its stronger monospace utility.

## Validation

- session-ui tests: 83 passed, 0 failed
- session-ui typecheck
- app typecheck
- repository pre-push typecheck: 30/30 packages
- Prettier check
- git diff --check

## Scope

This changes only the V2 prompt editor and placeholder font selection. It does not change font settings, terminal fonts, editor behavior, or shell-mode typography.