### PR TITLE
fix(agent): stop inheriting superseded parent session denies in subagents

### DIFF
--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -5,11 +5,19 @@ import type { Agent } from "./agent"
  * Build the `permission` ruleset for a subagent's session when it's spawned
  * via the task tool. Combines:
  *
- * 1. The parent session's deny rules and external_directory rules.
+ * 1. The parent session's effective deny rules and external_directory rules.
  *    Parent agent restrictions only govern that agent; the subagent's own
  *    permissions determine its capabilities.
  * 2. Default `todowrite` and `task` denies if the subagent's own ruleset
  *    doesn't already permit them.
+ *
+ * Session permission rules are append-only and evaluated last-match-wins, so
+ * a deny that a later rule supersedes for the same permission and pattern is
+ * no longer part of the parent's effective ceiling and must not be copied.
+ * A parent whose history is `[bash deny, bash allow]` is effectively allowed;
+ * copying the stale deny alone would leave every new subagent permanently
+ * denied. Denies are still inherited whenever the superseding rule targets a
+ * different pattern, keeping partial overrides conservative.
  */
 export function deriveSubagentSessionPermission(input: {
   parentSessionPermission: PermissionV1.Ruleset
@@ -17,9 +25,16 @@ export function deriveSubagentSessionPermission(input: {
 }): PermissionV1.Ruleset {
   const canTask = input.subagent.permission.some((rule) => rule.permission === "task")
   const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
+  const rules = input.parentSessionPermission
   return [
-    ...input.parentSessionPermission.filter(
-      (rule) => rule.permission === "external_directory" || rule.action === "deny",
+    ...rules.filter(
+      (rule, index) =>
+        rule.permission === "external_directory" ||
+        (rule.action === "deny" &&
+          !rules.some(
+            (later, laterIndex) =>
+              laterIndex > index && later.permission === rule.permission && later.pattern === rule.pattern,
+          )),
     ),
     ...(canTodo ? [] : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
     ...(canTask ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),

--- a/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
+++ b/packages/opencode/test/agent/plan-mode-subagent-bypass.test.ts
@@ -158,3 +158,87 @@ it.effect("subagent inherits parent session deny rules as hard runtime ceilings"
     expect(Permission.evaluate("bash", "git status", effective).action).toBe("deny")
   }),
 )
+
+it.effect("subagent does not inherit a parent session deny that a later rule re-allowed", () =>
+  Effect.sync(() => {
+    const executor = testAgent({
+      name: "executor",
+      mode: "subagent",
+      permission: {
+        bash: "allow",
+      },
+    })
+    // Session rules are append-only with last-match-wins evaluation. A parent
+    // that appended `bash deny` (e.g. a plan-style restriction) and later
+    // `bash allow` is effectively allowed, so its new subagents must not be
+    // pinned to the stale deny.
+    const parentSessionPermission: PermissionV1.Ruleset = [
+      { permission: "bash", pattern: "*", action: "deny" },
+      { permission: "bash", pattern: "*", action: "allow" },
+    ]
+    const derived = deriveSubagentSessionPermission({
+      parentSessionPermission,
+      subagent: executor,
+    })
+    const effective = Permission.merge(executor.permission, derived)
+
+    expect(Permission.evaluate("bash", "git status", parentSessionPermission).action).toBe("allow")
+    expect(derived.filter((rule) => rule.permission === "bash")).toEqual([])
+    expect(Permission.evaluate("bash", "git status", effective).action).toBe("allow")
+  }),
+)
+
+it.effect("subagent keeps a parent session deny that a later rule only partially overrides", () =>
+  Effect.sync(() => {
+    const executor = testAgent({
+      name: "executor",
+      mode: "subagent",
+      permission: {
+        bash: "allow",
+      },
+    })
+    // The later allow targets a narrower pattern, so the broad deny is still
+    // part of the parent's ceiling for everything else. Inheriting it stays
+    // conservative: the subagent is denied even the narrower pattern.
+    const effective = Permission.merge(
+      executor.permission,
+      deriveSubagentSessionPermission({
+        parentSessionPermission: [
+          { permission: "bash", pattern: "*", action: "deny" },
+          { permission: "bash", pattern: "git *", action: "allow" },
+        ],
+        subagent: executor,
+      }),
+    )
+
+    expect(Permission.evaluate("bash", "rm -rf /tmp/x", effective).action).toBe("deny")
+    expect(Permission.evaluate("bash", "git status", effective).action).toBe("deny")
+  }),
+)
+
+it.effect("re-allowing one permission does not drop unrelated parent session denies", () =>
+  Effect.sync(() => {
+    const executor = testAgent({
+      name: "executor",
+      mode: "subagent",
+      permission: {
+        bash: "allow",
+        edit: "allow",
+      },
+    })
+    const effective = Permission.merge(
+      executor.permission,
+      deriveSubagentSessionPermission({
+        parentSessionPermission: [
+          { permission: "bash", pattern: "*", action: "deny" },
+          { permission: "edit", pattern: "*", action: "deny" },
+          { permission: "bash", pattern: "*", action: "allow" },
+        ],
+        subagent: executor,
+      }),
+    )
+
+    expect(Permission.evaluate("bash", "git status", effective).action).toBe("allow")
+    expect(Permission.evaluate("edit", "/some/file.ts", effective).action).toBe("deny")
+  }),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #45078

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Session permission rules are append-only and evaluated last-match-wins, but `deriveSubagentSessionPermission` copies **every** parent-session deny into a task subagent, ignoring rule order. A parent whose rule history is `[bash deny, bash allow]` is effectively allowed — clients that implement plan-style restrictions append denies and later restore with allows, since PATCH is append-only — yet every new task child receives only the stale `bash deny` and is permanently blocked from bash even when its own agent policy allows it.

The fix filters the copied denies down to the parent's *effective* ceiling: a deny is dropped when a **later** rule targets the identical `(permission, pattern)` pair, because last-match-wins means that later rule, not the deny, is the parent's effective action for that key. This is deliberately conservative for partial overrides — a later allow with a *different* pattern (e.g. `bash "git *"` after `bash "*" deny`) does not drop the broad deny, so the inherited ceiling never widens beyond what the parent's own evaluation permits for the copied rule's exact pattern. `external_directory` inheritance and the default `todowrite`/`task` denies are unchanged, and the existing hard-ceiling behavior (`[bash deny]` alone still binds the child) is preserved.

### How did you verify your code works?

- Added three tests to `test/agent/plan-mode-subagent-bypass.test.ts` (the suite that already exercises this production helper): a re-allowed deny is not inherited, a partially-overridden deny still is, and re-allowing one permission does not drop unrelated denies. `bun test test/agent` → 52 pass.
- `bun test test/permission-task.test.ts test/session` → 433 pass, 0 fail; `tsgo --noEmit` clean.
- Live end-to-end on a 1.18.22 deployment with this commit cherry-picked: a parent with appended `[bash deny, bash allow]` spawned a task child whose session ruleset contained no bash deny, and the child completed a bash command. Stock 1.18.22 reproduces the stale inherited deny.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
