### PR TITLE
chore(www): regenerate documentation artifacts

### DIFF
--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -6749,6 +6749,90 @@
         "summary": "Remove credential"
       }
     },
+    "/api/credential/{credentialID}/activate": {
+      "post": {
+        "tags": ["credential"],
+        "operationId": "v2.credential.activate",
+        "parameters": [
+          {
+            "name": "credentialID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required": false,
+            "style": "deepObject",
+            "explode": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Activate a stored integration credential.",
+        "summary": "Activate credential"
+      }
+    },
     "/api/project": {
       "get": {
         "tags": ["project"],
@@ -6792,6 +6876,89 @@
         },
         "description": "List known projects.",
         "summary": "List projects"
+      }
+    },
+    "/api/project/{projectID}": {
+      "patch": {
+        "tags": ["project"],
+        "operationId": "v2.project.update",
+        "parameters": [
+          {
+            "name": "projectID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ProjectNotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectNotFoundErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update project display metadata and workspace commands.",
+        "summary": "Update project",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "$ref": "#/components/schemas/Project.Icon"
+                  },
+                  "commands": {
+                    "$ref": "#/components/schemas/Project.Commands"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
       }
     },
     "/api/project/current": {
@@ -11193,7 +11360,7 @@
             }
           }
         },
-        "description": "Create a worktree for a project.",
+        "description": "Create a worktree for a project and run its configured setup script.",
         "summary": "Create worktree",
         "requestBody": {
           "content": {
@@ -15194,6 +15361,9 @@
           },
           "requireFinishReason": {
             "type": "boolean"
+          },
+          "requireAssistantAfterTool": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -15436,6 +15606,9 @@
           },
           "source": {
             "$ref": "#/components/schemas/Permission.Source"
+          },
+          "message": {
+            "type": "string"
           }
         },
         "required": ["id", "sessionID", "action", "resources"],
@@ -15913,6 +16086,23 @@
       "Project.Vcs": {
         "type": "string",
         "enum": ["git", "hg"]
+      },
+      "ProjectNotFoundErrorEncoded": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["ProjectNotFoundError"]
+          },
+          "projectID": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "projectID", "message"],
+        "additionalProperties": false
       },
       "Prompt.AgentAttachment": {
         "type": "object",

--- a/packages/www/public/cli.json
+++ b/packages/www/public/cli.json
@@ -793,6 +793,14 @@
               "anyOf": [{ "$ref": "#/$defs/TuiKeybind.BindingValue" }, { "type": "null" }],
               "description": "Submit dialog prompt"
             },
+            "dialog.integration.rename": {
+              "anyOf": [{ "$ref": "#/$defs/TuiKeybind.BindingValue" }, { "type": "null" }],
+              "description": "Rename integration account"
+            },
+            "dialog.integration.delete": {
+              "anyOf": [{ "$ref": "#/$defs/TuiKeybind.BindingValue" }, { "type": "null" }],
+              "description": "Delete integration account"
+            },
             "dialog.worktree.generate": {
               "anyOf": [{ "$ref": "#/$defs/TuiKeybind.BindingValue" }, { "type": "null" }],
               "description": "Generate worktree name"
@@ -945,7 +953,7 @@
           "type": "object",
           "properties": {
             "timeout": {
-              "anyOf": [{ "type": "integer", "exclusiveMinimum": 0 }, { "type": "null" }],
+              "anyOf": [{ "type": "integer", "allOf": [{ "exclusiveMinimum": 0 }] }, { "type": "null" }],
               "description": "Time in milliseconds to wait for a key after the leader key"
             }
           },
@@ -961,7 +969,7 @@
           "type": "object",
           "properties": {
             "speed": {
-              "anyOf": [{ "type": "number", "minimum": 0.001 }, { "type": "null" }],
+              "anyOf": [{ "type": "number", "allOf": [{ "minimum": 0.001 }] }, { "type": "null" }],
               "description": "Distance scrolled per input tick"
             },
             "acceleration": {
@@ -990,7 +998,7 @@
             },
             "sound": { "anyOf": [{ "type": "boolean" }, { "type": "null" }], "description": "Play attention sounds" },
             "volume": {
-              "anyOf": [{ "type": "number", "minimum": 0, "maximum": 1 }, { "type": "null" }],
+              "anyOf": [{ "type": "number", "allOf": [{ "minimum": 0 }, { "maximum": 1 }] }, { "type": "null" }],
               "description": "Attention sound volume from 0 to 1"
             },
             "sound_pack": {
@@ -1189,7 +1197,7 @@
               "description": "Restore session history on resume and terminal resize"
             },
             "replay_limit": {
-              "anyOf": [{ "type": "integer", "exclusiveMinimum": 0 }, { "type": "null" }],
+              "anyOf": [{ "type": "integer", "allOf": [{ "exclusiveMinimum": 0 }] }, { "type": "null" }],
               "description": "Maximum number of newest messages restored during replay"
             }
           },
@@ -1303,8 +1311,7 @@
                 "preventDefault": { "anyOf": [{ "type": "boolean" }, { "type": "null" }] },
                 "fallthrough": { "anyOf": [{ "type": "boolean" }, { "type": "null" }] }
               },
-              "required": ["key"],
-              "allOf": [{ "type": "object", "additionalProperties": {} }]
+              "required": ["key"]
             }
           ]
         },
@@ -1351,8 +1358,7 @@
                   "preventDefault": { "anyOf": [{ "type": "boolean" }, { "type": "null" }] },
                   "fallthrough": { "anyOf": [{ "type": "boolean" }, { "type": "null" }] }
                 },
-                "required": ["key"],
-                "allOf": [{ "type": "object", "additionalProperties": {} }]
+                "required": ["key"]
               }
             ]
           }

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -6749,6 +6749,90 @@
         "summary": "Remove credential"
       }
     },
+    "/api/credential/{credentialID}/activate": {
+      "post": {
+        "tags": ["credential"],
+        "operationId": "v2.credential.activate",
+        "parameters": [
+          {
+            "name": "credentialID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required": false,
+            "style": "deepObject",
+            "explode": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "<No Content>"
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Activate a stored integration credential.",
+        "summary": "Activate credential"
+      }
+    },
     "/api/project": {
       "get": {
         "tags": ["project"],
@@ -6792,6 +6876,89 @@
         },
         "description": "List known projects.",
         "summary": "List projects"
+      }
+    },
+    "/api/project/{projectID}": {
+      "patch": {
+        "tags": ["project"],
+        "operationId": "v2.project.update",
+        "parameters": [
+          {
+            "name": "projectID",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Project",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Project"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "ProjectNotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectNotFoundErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update project display metadata and workspace commands.",
+        "summary": "Update project",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "icon": {
+                    "$ref": "#/components/schemas/Project.Icon"
+                  },
+                  "commands": {
+                    "$ref": "#/components/schemas/Project.Commands"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
       }
     },
     "/api/project/current": {
@@ -11193,7 +11360,7 @@
             }
           }
         },
-        "description": "Create a worktree for a project.",
+        "description": "Create a worktree for a project and run its configured setup script.",
         "summary": "Create worktree",
         "requestBody": {
           "content": {
@@ -15194,6 +15361,9 @@
           },
           "requireFinishReason": {
             "type": "boolean"
+          },
+          "requireAssistantAfterTool": {
+            "type": "boolean"
           }
         },
         "additionalProperties": false
@@ -15436,6 +15606,9 @@
           },
           "source": {
             "$ref": "#/components/schemas/Permission.Source"
+          },
+          "message": {
+            "type": "string"
           }
         },
         "required": ["id", "sessionID", "action", "resources"],
@@ -15913,6 +16086,23 @@
       "Project.Vcs": {
         "type": "string",
         "enum": ["git", "hg"]
+      },
+      "ProjectNotFoundErrorEncoded": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["ProjectNotFoundError"]
+          },
+          "projectID": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "projectID", "message"],
+        "additionalProperties": false
       },
       "Prompt.AgentAttachment": {
         "type": "object",


### PR DESCRIPTION
## Summary

- sync the website OpenAPI copies with `packages/protocol/openapi.json`
- regenerate the published CLI schema after the integration account keybinding changes
- fix the stale generated documentation failure in https://github.com/anomalyco/opencode/actions/runs/32898879734/job/97968634553

## Testing

- `cd packages/www && bun run check:generated`
- `git diff --check`