### PR TITLE
fix(ai): accept responses calls without item ids

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -945,25 +945,23 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
       events,
     ]
   }
-  if (item?.type !== "function_call" || !item.id) return [state, NO_EVENTS]
-  const metadata = providerMetadata(state, { itemId: item.id })
+  if (item?.type !== "function_call" || !item.call_id) return [state, NO_EVENTS]
+  const id = item.id ?? item.call_id
+  const metadata = item.id ? providerMetadata(state, { itemId: item.id }) : undefined
   const events: LLMEvent[] = []
   const lifecycle = Lifecycle.stepStart(state.lifecycle, events)
   return [
     {
       ...state,
       lifecycle,
-      tools: ToolStream.start(state.tools, item.id, {
-        id: item.call_id ?? item.id,
+      tools: ToolStream.start(state.tools, id, {
+        id: item.call_id,
         name: item.name ?? "",
         input: item.arguments ?? "",
         providerMetadata: metadata,
       }),
     },
-    [
-      ...events,
-      LLMEvent.toolInputStart({ id: item.call_id ?? item.id, name: item.name ?? "", providerMetadata: metadata }),
-    ],
+    [...events, LLMEvent.toolInputStart({ id: item.call_id, name: item.name ?? "", providerMetadata: metadata })],
   ]
 }
 
@@ -1095,18 +1093,19 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   }
 
   if (item.type === "function_call") {
-    if (!item.id || !item.call_id || !item.name) return [state, NO_EVENTS] satisfies StepResult
-    const tools = state.tools[item.id]
+    if (!item.call_id || !item.name) return [state, NO_EVENTS] satisfies StepResult
+    const id = item.id ?? item.call_id
+    const tools = state.tools[id]
       ? state.tools
-      : ToolStream.start(state.tools, item.id, {
+      : ToolStream.start(state.tools, id, {
           id: item.call_id,
           name: item.name,
-          providerMetadata: providerMetadata(state, { itemId: item.id }),
+          providerMetadata: item.id ? providerMetadata(state, { itemId: item.id }) : undefined,
         })
     const result =
       item.arguments === undefined
-        ? yield* ToolStream.finish(state.id, tools, item.id)
-        : yield* ToolStream.finishWithInput(state.id, tools, item.id, item.arguments)
+        ? yield* ToolStream.finish(state.id, tools, id)
+        : yield* ToolStream.finishWithInput(state.id, tools, id, item.arguments)
     const events: LLMEvent[] = []
     const resultEvents = result.events ?? []
     const lifecycle = resultEvents.length ? Lifecycle.stepStart(state.lifecycle, events) : state.lifecycle
@@ -1160,10 +1159,11 @@ const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (
           event.response?.output ?? [],
           () => [state, NO_EVENTS] satisfies StepResult,
           ([current, events], item) => {
+            const id = item.id ?? (item.type === "function_call" ? item.call_id : undefined)
             if (
-              !item.id ||
-              ((item.type !== "function_call" || !current.tools[item.id]) &&
-                (item.type !== "reasoning" || !current.reasoningItems[item.id]))
+              !id ||
+              ((item.type !== "function_call" || !current.tools[id]) &&
+                (item.type !== "reasoning" || !current.reasoningItems[id]))
             )
               return Effect.succeed([current, events] satisfies StepResult)
             return onOutputItemDone(current, { type: "response.output_item.done", item }).pipe(
@@ -1289,10 +1289,11 @@ export const step = (state: ParserState, input: Event) => {
   if (event.type === "response.output_item.added") {
     if (event.item?.type === "message" && !event.item.id)
       return ProviderShared.eventError(state.id, `${event.type} message is missing id`)
+    const id = event.item?.id ?? (event.item?.type === "function_call" ? event.item.call_id : undefined)
     return Effect.succeed(
       onOutputItemAdded(
-        event.output_index !== undefined && event.item?.id
-          ? { ...state, outputItems: { ...state.outputItems, [event.output_index]: event.item.id } }
+        event.output_index !== undefined && id
+          ? { ...state, outputItems: { ...state.outputItems, [event.output_index]: id } }
           : state,
         event,
       ),

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -288,6 +288,43 @@ describe("Open Responses-compatible route", () => {
     }),
   )
 
+  it.effect("streams function calls without optional item ids through the shared baseline", () =>
+    Effect.gen(function* () {
+      const model = configure({
+        apiKey: "test-key",
+        baseURL: "https://responses.example.test/v1",
+        provider: "example",
+      }).model("example-model")
+      const item = { type: "function_call", call_id: "call_1", name: "lookup", arguments: "" }
+      const response = yield* LLMClient.generate(LLM.request({ model, prompt: "Look it up." })).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { type: "response.output_item.added", output_index: 1, item },
+              {
+                type: "response.function_call_arguments.delta",
+                output_index: 1,
+                item_id: "opaque_item",
+                delta: '{"query":"shared"}',
+              },
+              {
+                type: "response.output_item.done",
+                output_index: 1,
+                item: { ...item, arguments: '{"query":"complete"}' },
+              },
+              { type: "response.completed", response: { id: "resp_1" } },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.events.filter(LLMEvent.is.toolCall)).toEqual([
+        expect.objectContaining({ id: "call_1", name: "lookup", input: { query: "complete" } }),
+      ])
+      expect(response.events.find(LLMEvent.is.toolCall)?.providerMetadata).toBeUndefined()
+    }),
+  )
+
   it.effect("finalizes pending function calls from completed response output", () =>
     Effect.gen(function* () {
       const model = configure({

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -469,7 +469,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("continues a tool call with only the new tool output", () =>
+  it.effect("continues an item-id-less tool call with only the new tool output", () =>
     Effect.gen(function* () {
       const firstRequest = {
         type: "response.create",
@@ -485,7 +485,6 @@ describe("OpenAI Responses route", () => {
           type: "response.output_item.done",
           item: {
             type: "function_call",
-            id: "fc_1",
             status: "completed",
             call_id: "call_1",
             name: "weather",
@@ -2120,6 +2119,47 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
+  it.effect("routes item-id-less function arguments by output index and prefers item completion", () =>
+    Effect.gen(function* () {
+      const item = { type: "function_call", call_id: "call_1", name: "lookup", arguments: "" }
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { type: "response.output_item.added", output_index: 2, item },
+              {
+                type: "response.function_call_arguments.delta",
+                output_index: 2,
+                item_id: "opaque_delta",
+                delta: '{"query":"streamed"}',
+              },
+              {
+                type: "response.function_call_arguments.done",
+                output_index: 2,
+                item_id: "opaque_done",
+                arguments: '{"query":"arguments-done"}',
+              },
+              {
+                type: "response.output_item.done",
+                output_index: 2,
+                item: { ...item, arguments: '{"query":"output-item-done"}' },
+              },
+              { type: "response.completed", response: { id: "resp_1" } },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.events.filter((event) => event.type === "tool-input-delta")).toMatchObject([
+        { id: "call_1", text: '{"query":"streamed"}' },
+      ])
+      expect(response.events.filter(LLMEvent.is.toolCall)).toEqual([
+        expect.objectContaining({ id: "call_1", name: "lookup", input: { query: "output-item-done" } }),
+      ])
+      expect(response.events.find(LLMEvent.is.toolCall)?.providerMetadata).toBeUndefined()
+    }),
+  )
+
   it.effect("routes reasoning summary events by output index", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(
@@ -2298,13 +2338,25 @@ describe("OpenAI Responses route", () => {
   it.effect("rejects function argument events without the spec-required item id", () =>
     Effect.gen(function* () {
       const events = [
-        { type: "response.function_call_arguments.delta", delta: "{}" },
-        { type: "response.function_call_arguments.done", arguments: "{}" },
+        { type: "response.function_call_arguments.delta", output_index: 0, delta: "{}" },
+        { type: "response.function_call_arguments.done", output_index: 0, arguments: "{}" },
       ]
 
       for (const event of events) {
         const error = yield* LLMClient.generate(request).pipe(
-          Effect.provide(fixedResponse(sseEvents(event, { type: "response.completed", response: { id: "resp_1" } }))),
+          Effect.provide(
+            fixedResponse(
+              sseEvents(
+                {
+                  type: "response.output_item.added",
+                  output_index: 0,
+                  item: { type: "function_call", call_id: "call_1", name: "lookup", arguments: "" },
+                },
+                event,
+                { type: "response.completed", response: { id: "resp_1" } },
+              ),
+            ),
+          ),
           Effect.flip,
         )
 
@@ -3457,6 +3509,43 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
+  it.effect("finalizes and replays a completed function call without an optional item id", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              {
+                type: "response.output_item.done",
+                item: { type: "function_call", call_id: "call_1", name: "lookup", arguments: '{"query":"weather"}' },
+              },
+              { type: "response.completed", response: { id: "resp_1" } },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.events.filter(LLMEvent.is.toolCall)).toEqual([
+        expect.objectContaining({ id: "call_1", name: "lookup", input: { query: "weather" } }),
+      ])
+      expect(response.events.find(LLMEvent.is.toolCall)?.providerMetadata).toBeUndefined()
+
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            response.message,
+            Message.tool({ id: "call_1", name: "lookup", resultType: "json", result: { forecast: "sunny" } }),
+          ],
+        }),
+      )
+      expect(prepared.body.input).toEqual([
+        { type: "function_call", call_id: "call_1", name: "lookup", arguments: '{"query":"weather"}' },
+        { type: "function_call_output", call_id: "call_1", output: '{"forecast":"sunny"}' },
+      ])
+    }),
+  )
+
   it.effect("emits only missing function arguments from the arguments done event", () =>
     Effect.gen(function* () {
       const body = sseEvents(
@@ -3678,6 +3767,37 @@ describe("OpenAI Responses route", () => {
       expect(response.events.filter(LLMEvent.is.toolInputEnd)).toHaveLength(1)
       expect(response.events.filter(LLMEvent.is.toolCall)).toHaveLength(1)
       expect(response.finishReason.normalized).toBe("tool-calls")
+    }),
+  )
+
+  it.effect("reconciles an item-id-less pending function call from completed response output", () =>
+    Effect.gen(function* () {
+      const item = { type: "function_call", call_id: "call_1", name: "lookup", arguments: "" }
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { type: "response.output_item.added", output_index: 0, item },
+              {
+                type: "response.function_call_arguments.delta",
+                output_index: 0,
+                item_id: "opaque_delta",
+                delta: '{"query":"partial',
+              },
+              {
+                type: "response.completed",
+                response: { id: "resp_1", output: [{ ...item, arguments: '{"query":"complete"}' }] },
+              },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.events.filter(LLMEvent.is.toolCall)).toEqual([
+        expect.objectContaining({ id: "call_1", name: "lookup", input: { query: "complete" } }),
+      ])
+      expect(response.events.find(LLMEvent.is.toolCall)?.providerMetadata).toBeUndefined()
+      expect(response.events.filter(LLMEvent.is.toolInputEnd)).toHaveLength(1)
     }),
   )
 


### PR DESCRIPTION
## Summary
- accept valid Responses `function_call` output items that include required `call_id` but omit optional provider item `id`
- route streamed arguments and terminal reconciliation using the actual item ID when present or `call_id` otherwise
- preserve public tool identity and call/result pairing by `call_id` without inventing provider item metadata
- retain required event-level `item_id` validation and existing WebSocket incremental continuation

## Before and after

The Responses API permits a completed function call without an item ID:

```json
{
  "type": "response.output_item.done",
  "item": {
    "type": "function_call",
    "call_id": "call_1",
    "name": "lookup",
    "arguments": "{\"query\":\"weather\"}"
  }
}
```

**Before:** OpenCode ignored the call because `item.id` was absent.

**After:** OpenCode emits the normal tool call with ID `call_1`, parses its arguments, and replays the subsequent history without fabricating a provider item ID:

```json
[
  { "type": "function_call", "call_id": "call_1", "name": "lookup", "arguments": "{\"query\":\"weather\"}" },
  { "type": "function_call_output", "call_id": "call_1", "output": "{\"forecast\":\"sunny\"}" }
]
```

Argument-stream events still require their own protocol-level `item_id`; when it differs from `call_id`, registered `output_index` routes the event to the correct pending call.

## Verification
- `bun test test/partial-json.test.ts test/tool-stream.test.ts test/provider/openai-responses.test.ts test/provider/openai-compatible-responses.test.ts test/provider/openai-responses-images.recorded.test.ts test/provider/openai-responses-websocket.recorded.test.ts test/provider/openai-chat.test.ts test/provider/anthropic-messages.test.ts test/provider/bedrock-converse.test.ts test/provider/xai-responses.test.ts test/response.test.ts test/tool-runtime.test.ts --timeout 30000 --only-failures` (379 passing)
- `RECORDED_PREFIX=openai-responses bun test test/provider/golden.recorded.test.ts --timeout 30000 --only-failures`
- `bun typecheck` from `packages/ai`
- `bunx prettier --check packages/ai/src/protocols/open-responses.ts packages/ai/test/provider/openai-responses.test.ts packages/ai/test/provider/openai-compatible-responses.test.ts`