### PR TITLE
fix(ai): ignore SSE retry directives without ending streams

### DIFF
--- a/packages/ai/src/protocols/shared.ts
+++ b/packages/ai/src/protocols/shared.ts
@@ -210,10 +210,9 @@ export const errorText = (error: unknown) => {
  * `framing` step for Server-Sent Events. Decodes UTF-8, runs the SSE channel
  * decoder, optionally filters named events, and drops empty / `[DONE]`
  * keep-alive events so the protocol event schema sees one JSON string per
- * element. The SSE channel emits a
- * `Retry` control event on its error channel; we drop it here (we don't
- * implement client-driven retries). Decoder failures become provider output
- * errors so the public error channel stays `AIError`.
+ * element. Retry control events are ignored without interrupting the stream.
+ * Decoder failures become provider output errors so the public error channel
+ * stays `AIError`.
  */
 export const sseFraming = (
   bytes: Stream.Stream<Uint8Array, AIError>,
@@ -221,9 +220,23 @@ export const sseFraming = (
 ): Stream.Stream<string, AIError> =>
   bytes.pipe(
     Stream.decodeText(),
-    Stream.pipeThroughChannel(Sse.decode()),
-    Stream.catchTag("Retry", () => Stream.empty),
-    Stream.catchTag("SseError", (error) => Stream.fail(eventError("sse", error.message))),
+    Stream.mapAccumEffect(
+      () => {
+        const output: Sse.Event[] = []
+        return {
+          output,
+          parser: Sse.makeParser((event) => {
+            if (event._tag === "Event") output.push(event)
+          }),
+        }
+      },
+      (state, chunk) =>
+        Effect.gen(function* () {
+          const error = state.parser.feed(chunk)
+          if (error) return yield* eventError("sse", error.message)
+          return [state, state.output.splice(0)] as const
+        }),
+    ),
     Stream.filter(
       (event) =>
         (events === undefined || events.has(event.event)) &&

--- a/packages/ai/test/schema.test.ts
+++ b/packages/ai/test/schema.test.ts
@@ -102,6 +102,38 @@ describe("AI.Usage", () => {
     expect(error.reason._tag).toBe("InvalidProviderOutput")
   })
 
+  test("sseFraming ignores retry directives without ending the stream", async () => {
+    const encoder = new TextEncoder()
+    const frames = await Effect.runPromise(
+      ProviderShared.sseFraming(
+        Stream.make(
+          encoder.encode("retry: 1000\n\n"),
+          encoder.encode('data: {"first":true}\n\n'),
+          encoder.encode("retry: 2000\n\n"),
+          encoder.encode('data: {"second":true}\n\n'),
+        ).pipe(Stream.rechunk(1)),
+      ).pipe(Stream.runCollect),
+    )
+
+    expect(Array.from(frames)).toEqual(['{"first":true}', '{"second":true}'])
+  })
+
+  test("sseFraming preserves event data around retry directives", async () => {
+    const encoder = new TextEncoder()
+    const frames = await Effect.runPromise(
+      ProviderShared.sseFraming(
+        Stream.make(
+          encoder.encode("event: update\ndata: first\n"),
+          encoder.encode("retry: 1000\n"),
+          encoder.encode("data: second\n\n"),
+        ).pipe(Stream.rechunk(1)),
+        new Set(["update"]),
+      ).pipe(Stream.runCollect),
+    )
+
+    expect(Array.from(frames)).toEqual(["first\nsecond"])
+  })
+
   test("visibleOutputTokens clamps reasoning > output to zero", () => {
     expect(new Usage({ outputTokens: 10, reasoningTokens: 4 }).visibleOutputTokens).toBe(6)
     expect(new Usage({ outputTokens: 10 }).visibleOutputTokens).toBe(10)


### PR DESCRIPTION
## Summary
- ignore SSE retry control directives without terminating provider response streams
- preserve named-event data across interleaved retry directives and retain typed decoder errors
- cover retry directives between events and inside partially accumulated events

## Test Plan
- `bun test test/schema.test.ts test/provider/anthropic-messages.test.ts test/provider/openai-chat.test.ts`
- `bun typecheck`

Refs #41932