### PR TITLE
chore(ci): scope workflow permissions and cancel stale typecheck runs

### DIFF
--- a/.github/workflows/notify-discord.yml
+++ b/.github/workflows/notify-discord.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released] # fires when a draft release is published
 
+permissions:
+  contents: read
+
 jobs:
   notify:
     runs-on: blacksmith-4vcpu-ubuntu-2404

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -25,6 +25,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: storybook build

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -7,6 +7,13 @@ on:
     branches: [dev]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ case(github.ref == 'refs/heads/dev', format('{0}-{1}', github.workflow, github.run_id), format('{0}-{1}', github.workflow, github.event.pull_request.number || github.ref)) }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     runs-on: blacksmith-4vcpu-ubuntu-2404


### PR DESCRIPTION
### Issue for this PR

Closes #44671
Closes #44669

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`typecheck.yml` had no `concurrency` and no `permissions`. `storybook.yml` and `notify-discord.yml` had no `permissions`. Other workflows pin `permissions: contents: read`, so these were oversights that leave `GITHUB_TOKEN` at the org default and waste runners on stale pushes.

Added the same dev/PR-isolated concurrency group from `test.yml` to `typecheck.yml` and added `permissions: contents: read` to all three workflows, keeping placement `concurrency -> permissions -> jobs`.

### How did you verify your code works?

- Ran `python3 -c "import yaml; yaml.safe_load(open(...))"` on all three workflows — parses OK.
- Ran `bun x prettier --check` on the three files — style OK.
- Compared `concurrency` group string to `test.yml:10-14` and verified `grep -L "permissions:"` no longer lists these files.

### Screenshots / recordings

N/A — CI config only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
