### PR TITLE
fix(tui): avoid false model availability warnings

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -347,7 +347,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           const info = models()?.find((item) => item.providerID === value.providerID && item.id === value.modelID)
           return {
             provider: provider?.name ?? value.providerID,
-            model: info?.name ?? `${value.modelID} (unavailable)`,
+            model: info?.name ?? value.modelID,
             reasoning: (info?.variants?.length ?? 0) !== 0,
           }
         }),

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -363,6 +363,75 @@ test("new session inherits the active session model", async () => {
   }
 })
 
+test("shows a selected model without claiming it is unavailable when catalog metadata is missing", async () => {
+  const setup = await createTestRenderer({ width: 100, height: 30, useThread: false })
+  setup.renderer.start()
+  const events = createEventStream()
+  const ready = Promise.withResolvers<void>()
+  const current = process.cwd()
+  const location = { directory: current, project: { id: "project", directory: current } }
+  const session = {
+    id: "dummy",
+    title: "Demo session",
+    projectID: "project",
+    location: { directory: current },
+    agent: "build",
+    model: { providerID: "provider", id: "example-model" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 0, updated: 0 },
+  }
+  let available = false
+  const calls = createFetch((url) => {
+    if (url.pathname === "/api/location") return json(location)
+    if (url.pathname === "/api/session") return json({ data: [session], cursor: {} })
+    if (url.pathname === "/api/session/dummy") return json({ data: session })
+    if (url.pathname === "/api/session/dummy/message") return json({ data: [], cursor: {} })
+    if (url.pathname === "/api/session/dummy/inbox") return json({ data: [] })
+    if (url.pathname === "/api/session/dummy/permission") return json({ data: [] })
+    if (url.pathname === "/api/agent")
+      return json({ location, data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }] })
+    if (url.pathname === "/api/provider") return json({ location, data: [{ id: "provider", name: "Provider" }] })
+    if (url.pathname === "/api/model")
+      return json({
+        location,
+        data: available
+          ? [{ id: "example-model", modelID: "upstream-example", providerID: "provider", name: "Example Model" }]
+          : [],
+      })
+  }, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: { get: async () => ({ animations: false }), update: async () => ({}) },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        args: { sessionID: "dummy" },
+        log: () => {},
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
+    )
+
+    await ready.promise
+    const missing = await setup.waitForFrame((frame) => frame.includes("Build · example-model"))
+    expect(missing).not.toContain("(unavailable)")
+
+    available = true
+    events.emit({ id: "evt_catalog", created: 1, type: "catalog.updated", location: { directory: current }, data: {} })
+    await setup.waitForFrame((frame) => frame.includes("Build · Example Model Provider"))
+
+    setup.renderer.destroy()
+    await task
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    await server.stop()
+  }
+})
+
 test("keeps the prompt display stable while a new location catalog loads", async () => {
   const setup = await createTestRenderer({ width: 100, height: 30, useThread: false, kittyKeyboard: true })
   setup.renderer.start()


### PR DESCRIPTION
## What

Stop the prompt from labeling a selected model `(unavailable)` merely because its display metadata is missing from the location-scoped client catalog.

## Before / After

**Before:** A session has a selected model, but the client catalog is stale, still loading, or temporarily missing that model. The prompt cannot resolve its friendly name and renders `example-model (unavailable)`, even though missing client metadata does not establish whether the server can execute the model.

**After:** The same session renders `example-model`. Once matching catalog metadata arrives, the prompt reactively upgrades the label to `Example Model`. Missing client-side metadata never masquerades as an authoritative execution failure.

## How

- `packages/tui/src/context/local.tsx`: fall back to the selected public model ID instead of appending a speculative availability warning.
- `packages/tui/test/app-lifecycle.test.tsx`: launch the production TUI against an initially empty model catalog, assert the selected model has no false warning, publish `catalog.updated`, and verify the friendly name appears. The fixture also distinguishes the public model ID from its upstream ID.

## Scope

Display fallback only. Model selection validation, provider availability, session execution, and catalog synchronization are unchanged.

## Testing

- `cd packages/tui && bun run test ./test/app-lifecycle.test.tsx` (8 lifecycle tests)
- `cd packages/tui && bun run test ./test/cli/tui/data.test.tsx ./test/context/local.test.ts` (48 catalog and local-context tests)
- `cd packages/tui && bun typecheck`
- Repository pre-push typecheck: 32 package checks passed.
- Identical OpenCode Drive scenario executed against the current V2 base and this branch.

## Demo

Left: V2 base `7f9e5e91ab`. Right: fix commit `61c85a2747`. Both recordings use the same isolated project, viewport, simulated provider, simulated LLM response, and fictional `example-model` selection.

https://github.com/user-attachments/assets/7dd15fcc-fe6b-4dbe-a538-d97bbd499842

## Flow

```mermaid
sequenceDiagram
    participant Session as Selected session
    participant Catalog as TUI model catalog
    participant Prompt as Prompt label
    Session->>Prompt: Selected public model ID
    Prompt->>Catalog: Look up provider and public model ID
    alt Metadata is present
        Catalog-->>Prompt: Friendly model name
    else Metadata is missing or stale
        Catalog-->>Prompt: No matching metadata
        Prompt->>Prompt: Display selected public model ID
    end
```