### PR TITLE
fix(tui): detect clipped transcript bottom

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -459,7 +459,7 @@ export function Session(props: { verticalTabsWidth: number }) {
   function isAwayFromBottom() {
     if (revealingOlderRows || revealingNewerRows || ensureAllRowsPending || navigationMessage()) return true
     if (visibleEnd() < rows.length) return true
-    return scroll.scrollTop < Math.max(0, scroll.scrollHeight - scroll.viewport.height) - 1
+    return scroll.scrollTop < Math.max(0, scroll.scrollHeight - scroll.viewport.height)
   }
   function updateAwayFromBottom() {
     const preserveWindow = revealingOlderRows || revealingNewerRows || !!ensureAllRowsPending

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import { type Renderable, ScrollBoxRenderable } from "@opentui/core"
 import { createTestRenderer } from "@opentui/core/testing"
 import { Effect, FileSystem } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -290,6 +291,91 @@ test("session startup prompt is submitted exactly once", async () => {
 
     expect(bodies).toHaveLength(1)
     expect(bodies[0]).toMatchObject({ text: "RESUME_READY" })
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    await server.stop()
+  }
+})
+
+test("shows jump to latest after scrolling one line above the final message", async () => {
+  const setup = await createTestRenderer({ width: 80, height: 20, useThread: false, kittyKeyboard: true })
+  setup.renderer.start()
+  const events = createEventStream()
+  const session = {
+    id: "dummy",
+    title: "Demo session",
+    projectID: "project",
+    location: { directory },
+    agent: "build",
+    model: { providerID: "provider", id: "model" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 0, updated: 0 },
+  }
+  const messages = Array.from({ length: 8 }, (_, index) => ({
+    id: `message-${index}`,
+    type: "user",
+    text: index === 7 ? "Final visible message" : `Earlier message ${index}`,
+    time: { created: index },
+  }))
+  const calls = createFetch((url) => {
+    if (url.pathname === "/api/session") return json({ data: [session], cursor: {} })
+    if (url.pathname === "/api/session/dummy") return json({ data: session })
+    if (url.pathname === "/api/session/dummy/message") return json({ data: messages.toReversed(), cursor: {} })
+    if (url.pathname === "/api/session/dummy/inbox") return json({ data: [] })
+    if (url.pathname === "/api/session/dummy/permission") return json({ data: [] })
+  }, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: {
+          get: async () => ({
+            animations: false,
+            keybinds: { "session.line.up": "f6", "session.line.down": "f7" },
+          }),
+          update: async () => ({}),
+        },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: () => {} }),
+        args: { sessionID: "dummy" },
+        log: () => {},
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
+    )
+
+    await setup.waitForFrame((frame) => frame.includes("Final visible message"))
+    const findScrollBox = (root: Renderable): ScrollBoxRenderable | undefined =>
+      root instanceof ScrollBoxRenderable && root.getRenderable("message-7")
+        ? root
+        : root.getChildren().map(findScrollBox).find(Boolean)
+    const scroll = findScrollBox(setup.renderer.root)
+    expect(scroll).toBeDefined()
+    if (!scroll) throw new Error("session transcript scrollbox was not found")
+    const maximum = () => Math.max(0, scroll.scrollHeight - scroll.viewport.height)
+
+    expect(scroll.scrollTop).toBe(maximum())
+    const initial = setup.captureCharFrame().split("\n")
+    expect(initial.find((line) => line.includes("Jump to latest"))).toBeUndefined()
+    expect(initial[initial.findIndex((line) => line.includes("Final visible message")) + 1]).toContain("┃")
+
+    setup.mockInput.pressKey("F6")
+    const clipped = (await setup.waitForFrame((frame) => frame.includes("Jump to latest"))).split("\n")
+    expect(scroll.scrollTop).toBe(maximum() - 1)
+    expect(clipped.find((line) => line.includes("Jump to latest"))).toBeDefined()
+    expect(clipped[clipped.findIndex((line) => line.includes("Final visible message")) + 1]).not.toContain("┃")
+
+    setup.mockInput.pressKey("F7")
+    const restored = (await setup.waitForFrame((frame) => !frame.includes("Jump to latest"))).split("\n")
+    expect(scroll.scrollTop).toBe(maximum())
+    expect(restored.find((line) => line.includes("Jump to latest"))).toBeUndefined()
+    expect(restored[restored.findIndex((line) => line.includes("Final visible message")) + 1]).toContain("┃")
+
+    setup.renderer.destroy()
+    await task
   } finally {
     if (!setup.renderer.isDestroyed) setup.renderer.destroy()
     await server.stop()


### PR DESCRIPTION
## What

Fix the TUI transcript incorrectly reporting that it is at the bottom when the final user message is still clipped by one terminal row.

## Before / After

**Before:** Scroll an overflowing transcript up by one line while a user message is the final row. Its bottom padding disappears, but OpenCode still considers the viewport to be at the bottom, so `Jump to latest` remains hidden and OpenTUI cannot reengage sticky-bottom scrolling.

**After:** The same one-line movement is correctly recognized as leaving the bottom. `Jump to latest` appears immediately, intentional one-line scrolling still works, and returning to the actual bottom restores the complete message and sticky scrolling.

## How

- `packages/tui/src/routes/session/index.tsx`: remove the one-row tolerance from bottom detection so it matches OpenTUI's exact maximum scroll offset.
- `packages/tui/test/app-lifecycle.test.tsx`: exercise the production session route and real scrollbox, assert one-line navigation, verify the recovery affordance, and check the user-message border/padding before clipping and after recovery.

## Scope

This changes transcript bottom detection only. It does not alter user-message styling, prompt submission ordering, transcript pagination, or intentional one-line navigation.

## Testing

- `bun run test` from `packages/tui`: 789 passing, 5 skipped.
- `bun typecheck` from `packages/tui`.
- Repository pre-push typechecking: 32 packages passed.
- OpenCode Drive end-to-end reproduction using an isolated simulated session, six completed exchanges, a delayed final response, exact one-line scrolling, terminal-frame inspection, and matched before/after screenshots.
- OpenCode Drive resize matrix: 36 frame-level checks across 12 viewports from `36x16` through `180x24` and `72x60`, covering resize preservation, exact one-line scrolling, recovery visibility, colored borders, and restored bottom padding.
- OpenCode Drive streaming matrix: 51 assertions across delayed and multiline responses, pending steers, dynamic transcript growth, four viewport sizes, recovery, and resumed sticky following; zero user messages clipped without a visible recovery action.
- OpenCode Drive history matrix: 82 persisted messages, 38 page-up backfill operations, seven one-line recovery cycles, scrolling during streaming, and continued following after new prompts.

## Demo

**Before: the final user-message card is clipped and no recovery action appears.**

![message-padding-clipped.png](https://github.com/user-attachments/assets/4b08288b-b91e-4fc4-be7a-c1ad3a03db95)

**After: the same one-line scroll reveals `Jump to latest`.**

![message-padding-recovery-visible.png](https://github.com/user-attachments/assets/085af4e1-abca-4df2-8d07-9a34dc2daa03)

**After recovery: the final user-message card, including its bottom padding, is fully visible again.**

![message-padding-restored.png](https://github.com/user-attachments/assets/c525feda-7469-4e19-ae69-55df3ccfcf66)
