### PR TITLE
fix(tui): preserve interrupted Mermaid diagrams

### DIFF
--- a/packages/merman/src/markdown.ts
+++ b/packages/merman/src/markdown.ts
@@ -262,10 +262,30 @@ export function createMermaidCodeBlockRenderer(
     } catch (error) {
       if (error instanceof MermaidSyntaxError) {
         const previous = key ? lastGood.get(key) : undefined
-        if (!previous || previous.kind !== kind) return undefined
-        const diagram = new StaticDiagramRenderable(ctx, previous)
-        claimLastGood(key!, previous, diagram, lastGood)
-        return diagram
+        if (previous?.kind === kind) {
+          const diagram = new StaticDiagramRenderable(ctx, previous)
+          claimLastGood(key!, previous, diagram, lastGood)
+          return diagram
+        }
+
+        const lines = token.text.split("\n")
+        if (error.lineNumber <= 2 || lines.slice(error.lineNumber).some((line) => line.trim())) return undefined
+
+        try {
+          const prepared = prepareDiagram(
+            kind,
+            lines.slice(0, error.lineNumber - 1).join("\n"),
+            options,
+            layoutMaxWidth,
+          )
+          if (!prepared.height) return undefined
+          const diagram = new StaticDiagramRenderable(ctx, prepared)
+          if (key) claimLastGood(key, prepared, diagram, lastGood)
+          return diagram
+        } catch (error) {
+          if (error instanceof MermaidSyntaxError || error instanceof DiagramCanvasSizeError) return undefined
+          throw error
+        }
       }
       if (error instanceof DiagramCanvasSizeError) return undefined
       throw error

--- a/packages/merman/src/test/markdown.test.ts
+++ b/packages/merman/src/test/markdown.test.ts
@@ -211,6 +211,32 @@ flowchart LR
   expect(testRenderer.captureCharFrame()).toContain("Current")
 })
 
+test("renders the valid prefix of an interrupted Mermaid fence", async () => {
+  const testRenderer = await createTestRenderer({ width: 100, height: 18 })
+  renderer = testRenderer.renderer
+  const markdown = new MarkdownRenderable(renderer, {
+    id: "markdown-interrupted-mermaid",
+    content: `\`\`\`mermaid
+flowchart TD
+  A[Resolve Project] --> B[Current directory]
+  B --> C[Search ancestors]
+  C --> D[Marker found]
+  C --> E[No marker found]
+  E --> G[Project root is`,
+    syntaxStyle,
+    internalBlockMode: "top-level",
+    renderNode: createMermaidMarkdownRenderer(renderer),
+  })
+
+  renderer.root.add(markdown)
+  await renderMarkdown(markdown, testRenderer.renderOnce)
+
+  const frame = testRenderer.captureCharFrame()
+  expect(frame).toContain("Resolve Project")
+  expect(frame).toContain("No marker found")
+  expect(frame).not.toContain("flowchart TD")
+})
+
 test("renders a Mermaid sequence fence inside MarkdownRenderable", async () => {
   const testRenderer = await createTestRenderer({ width: 80, height: 14 })
   renderer = testRenderer.renderer

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1612,7 +1612,11 @@ function SessionPartView(props: { partRef: PartRef; message: (messageID: string)
       {(item) => (
         <Switch>
           <Match when={item().type === "text"}>
-            <TextPart part={item() as SessionMessageAssistantText} last={false} />
+            <TextPart
+              part={item() as SessionMessageAssistantText}
+              message={message() as SessionMessageAssistant}
+              last={false}
+            />
           </Match>
           <Match when={item().type === "reasoning"}>
             <ReasoningPart
@@ -2426,7 +2430,7 @@ function ReasoningHeader(props: {
   )
 }
 
-function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
+function TextPart(props: { last: boolean; part: SessionMessageAssistantText; message: SessionMessageAssistant }) {
   const ctx = use()
   const theme = useTheme()
   const { currentSyntax: syntax } = useThemes()
@@ -2436,7 +2440,7 @@ function TextPart(props: { last: boolean; part: SessionMessageAssistantText }) {
       <box paddingLeft={3} flexShrink={0}>
         <markdown
           syntaxStyle={syntax()}
-          streaming={true}
+          streaming={props.message.time.completed === undefined}
           internalBlockMode="top-level"
           content={props.part.text.trim()}
           tableOptions={{ style: "grid", cellPaddingX: 1 }}


### PR DESCRIPTION
## What

Keep interrupted Mermaid flowcharts rendered when their final line is incomplete, including after the session is reopened.

## Before / After

**Before:** An assistant streams a valid flowchart, starts another node, and is interrupted before finishing it. Reopening the session discards the renderer's in-memory last-good diagram. The incomplete persisted fence fails to parse, so the TUI displays raw `flowchart TD` source instead of the diagram.

**After:** Reopening the same interrupted session reconstructs the diagram from every complete line preceding the malformed trailing line. The rendered flowchart remains visible, and assistant Markdown correctly leaves streaming mode when the response completes or is interrupted.

## How

- `packages/merman/src/markdown.ts`: preserve the existing last-good cache behavior, then recover a nonempty valid prefix when a fresh renderer encounters an incomplete trailing Mermaid line.
- `packages/merman/src/test/markdown.test.ts`: mount an already-interrupted Mermaid fence without any previous renderer state and assert that its valid flowchart renders instead of raw source.
- `packages/tui/src/routes/session/index.tsx`: pass the assistant message into `TextPart` and derive Markdown streaming from `message.time.completed`.

## Scope

- Applies to Mermaid diagrams with an otherwise valid prefix and a malformed trailing line.
- Keeps ordinary code fallback for diagrams without a valid renderable prefix and syntax errors followed by additional content.
- Does not change provider streaming, durable session data, or browser Mermaid rendering.

## Testing

- `cd packages/merman && bun run test` (327 tests, including the interrupted-fence regression)
- `cd packages/merman && bun typecheck`
- `cd packages/tui && bun run test test/plugin-markdown.test.ts test/cli/tui/session-rows.test.ts` (18 tests)
- `cd packages/tui && bun typecheck`
- `bun turbo typecheck --concurrency=3` (pre-push hook, 33 package tasks)
- `bunx prettier --check packages/merman/src/markdown.ts packages/merman/src/test/markdown.test.ts packages/tui/src/routes/session/index.tsx`
- Real isolated TUI end-to-end: ran one deterministic OpenCode Drive script against both an immutable `v2` checkout and this branch. The simulated model streams a flowchart, emits an incomplete final node, receives a real double-Escape interruption, and the script leaves and reopens the same persisted session. Assertions verify raw Mermaid on `v2` and a rendered diagram on this branch.

## Demo

The same OpenCode Drive fixture runs against `v2` on the left and this branch on the right. Model output is simulated; interruption, session persistence, session navigation, and TUI rendering are real.

https://github.com/user-attachments/assets/f3d47ee5-b476-40e8-9273-94a4f13864b5

## Flow

```mermaid
flowchart TD
  A[Assistant interrupted mid-diagram] --> B[Persist incomplete Mermaid fence]
  B --> C[Reopen session]
  C --> D{Last-good diagram cached?}
  D -->|Yes| E[Reuse rendered diagram]
  D -->|No| F{Only the trailing line is malformed?}
  F -->|Yes| G[Render the valid preceding lines]
  F -->|No| H[Show the original code block]
```
