### PR TITLE
fix(provider): resolve model IDs that repeat the provider prefix

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1877,7 +1877,12 @@ const layer = Layer.effect(
         return yield* new ModelNotFoundError({ providerID, modelID, suggestions })
       }
 
-      const info = provider.models[modelID]
+      // Some catalogs publish model IDs that repeat the provider name, so the registry key
+      // is e.g. `nvidia/nemotron-3-ultra-550b-a55b` under provider `nvidia`. `parseModel`
+      // splits a ref on its first slash, so the natural `<provider>/<model>` form drops the
+      // repeated segment and misses the key. Restore it once before giving up, which also
+      // stops the suggester from echoing the requested ref back as a "did you mean".
+      const info = provider.models[modelID] ?? provider.models[`${providerID}/${modelID}`]
       if (!info) {
         const current = modelSuggestions(provider, modelID, runtimeFlags.enableExperimentalModels)
         const suggestions = current.length

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -1200,6 +1200,73 @@ it.instance("ModelNotFoundError suggests catalog models for unloaded providers",
   }),
 )
 
+// Providers such as NVIDIA NIM, OpenRouter and Clarifai publish model IDs that
+// already carry a vendor segment, so a catalog key can repeat the provider name
+// (`nvidia/nemotron-3-ultra-550b-a55b` under provider `nvidia`). The provider ID
+// below is synthetic so the assertions never depend on the live models.dev catalog.
+const prefixedModelConfig = {
+  provider: {
+    "prefixed-provider": {
+      name: "Prefixed Provider",
+      npm: "@ai-sdk/openai-compatible",
+      api: "https://api.prefixed.test/v1",
+      models: {
+        "prefixed-provider/self-prefixed-model": { name: "Self Prefixed Model" },
+        "vendor/vendor-prefixed-model": { name: "Vendor Prefixed Model" },
+      },
+      options: { apiKey: "test-key" },
+    },
+  },
+}
+
+it.instance(
+  "getModel resolves a bare ref whose model ID repeats the provider prefix",
+  Effect.gen(function* () {
+    const info = yield* Provider.use.getModel(
+      ProviderV2.ID.make("prefixed-provider"),
+      ModelV2.ID.make("self-prefixed-model"),
+    )
+    expect(info.id).toBe(ModelV2.ID.make("prefixed-provider/self-prefixed-model"))
+  }),
+  { config: prefixedModelConfig },
+)
+
+it.instance(
+  "getModel still resolves the fully qualified form of a self-prefixed model ID",
+  Effect.gen(function* () {
+    const info = yield* Provider.use.getModel(
+      ProviderV2.ID.make("prefixed-provider"),
+      ModelV2.ID.make("prefixed-provider/self-prefixed-model"),
+    )
+    expect(info.id).toBe(ModelV2.ID.make("prefixed-provider/self-prefixed-model"))
+  }),
+  { config: prefixedModelConfig },
+)
+
+it.instance(
+  "getModel still resolves vendor-prefixed model IDs by exact match",
+  Effect.gen(function* () {
+    const info = yield* Provider.use.getModel(
+      ProviderV2.ID.make("prefixed-provider"),
+      ModelV2.ID.make("vendor/vendor-prefixed-model"),
+    )
+    expect(info.id).toBe(ModelV2.ID.make("vendor/vendor-prefixed-model"))
+  }),
+  { config: prefixedModelConfig },
+)
+
+it.instance(
+  "getModel still reports unknown models on a provider with self-prefixed keys",
+  Effect.gen(function* () {
+    const error = yield* Provider.use
+      .getModel(ProviderV2.ID.make("prefixed-provider"), ModelV2.ID.make("does-not-exist"))
+      .pipe(Effect.flip)
+    if (!Provider.ModelNotFoundError.isInstance(error)) throw error
+    expect(error.message).toContain("Model not found: prefixed-provider/does-not-exist")
+  }),
+  { config: prefixedModelConfig },
+)
+
 it.instance("getProvider returns undefined for nonexistent provider", () =>
   Effect.gen(function* () {
     const provider = yield* Provider.Service.use((svc) => svc.getProvider(ProviderV2.ID.make("nonexistent")))


### PR DESCRIPTION
### Issue for this PR

Closes #44799

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Providers whose model IDs already carry a vendor segment end up with registry keys that repeat the provider name — `nvidia/nemotron-3-ultra-550b-a55b` under provider `nvidia`, `openrouter/free` under `openrouter`, `orcarouter/auto`, and so on.

`parseModel` splits a ref on its first slash, so writing such a ref the natural way yields `providerID=nvidia`, `modelID=nemotron-3-ultra-550b-a55b`, and the exact-match lookup `provider.models[modelID]` in `getModel` misses the prefixed key. `modelSuggestions` then hands back the real key, which renders byte-identical to what was asked for:

```
Model not found: nvidia/nemotron-3-ultra-550b-a55b.
Did you mean: nvidia/nemotron-3-ultra-550b-a55b?
```

The fix is one extra lookup: when the exact match misses, retry with the provider segment restored (`${providerID}/${modelID}`) before reporting the model as missing. Exact matches are still tried first, so the doubled form `nvidia/nvidia/nemotron-...` that people currently use as a workaround keeps working, and vendor-prefixed keys that don't repeat the provider name (`moonshotai/kimi-k2.6`) are untouched — those already resolve by exact match. Since the model now resolves, the identical "did you mean" also disappears on this path.

I deliberately left `parseModel` alone — changing the split would break the doubled form, and URL-style provider IDs are a separate problem (#39926). I also skipped suffix matching, which would add ambiguity without covering anything the prefix retry misses.

**On the duplicate flag the bot left on #44799:** this is not #43662 / #43704. #43662 is the *doubled* form `openrouter/openrouter/free` being truncated by two destructuring sites in `packages/app`, and its own description lists `packages/opencode/src/provider/provider.ts` under "the codebase already has the correct pattern in other locations". This PR is the *bare* form failing in the server-side registry lookup, which #43704 does not touch — an agent-frontmatter `model:` pin is resolved by `getModel` and never goes through `packages/app`.

### How did you verify your code works?

Added four `getModel` cases to `packages/opencode/test/provider/provider.test.ts`. They use a synthetic provider ID so the assertions never depend on the live models.dev catalog:

- a bare ref whose model ID repeats the provider prefix resolves to the prefixed key — this one fails on `dev` with exactly the identical-suggestion error quoted above
- the fully qualified form still resolves (the current workaround keeps working)
- a vendor-prefixed key that does not repeat the provider name still resolves by exact match
- an unknown model still raises `ModelNotFoundError`

```
$ bun test test/provider/provider.test.ts test/cli/error.test.ts test/acp/config-option.test.ts
 128 pass, 0 fail

$ bun typecheck
(clean)
```

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
