### PR TITLE
fix(app): prevent clipped virtual timeline rows

### DIFF
--- a/packages/app/src/session/timeline/virtualizer.tsx
+++ b/packages/app/src/session/timeline/virtualizer.tsx
@@ -92,6 +92,15 @@ export function createTimelineVirtualizer(input: Input) {
     initialOffset: () => (input.pinned() ? Number.MAX_SAFE_INTEGER : 0),
     initialMeasurementsCache: initialMeasurements,
     estimateSize: () => fallbackItemSize,
+    // Do not replace this with TanStack's default measurer: without a ResizeObserver entry,
+    // it returns the cached height instead of reading the element (TanStack/virtual#1183).
+    // Restored sessions, deferred tools, and rewrapped content can then keep stale heights;
+    // our fixed-height, overflow-clipped rows will hide their content. Keep observer entries
+    // on the cheap precomputed path, but make explicit measurements read the real height.
+    measureElement: (element, entry) => {
+      const box = entry?.borderBoxSize[0]
+      return box ? Math.round(box.blockSize) : element.offsetHeight
+    },
     scrollToFn: (offset, options, instance) => {
       if (virtualContent) virtualContent.style.height = `${instance.getTotalSize()}px`
       elementScroll(offset, options, instance)

--- a/packages/app/test-browser/solid-virtual.test.ts
+++ b/packages/app/test-browser/solid-virtual.test.ts
@@ -113,6 +113,32 @@ test("reactive count updates preserve measured row sizes", () => {
   })
 })
 
+test("explicit measurement refreshes a cached row size with a custom measurer", () => {
+  const root = document.createElement("div")
+  const element = document.createElement("div")
+  element.dataset.index = "0"
+  Object.defineProperty(element, "offsetHeight", { value: 120 })
+
+  const virtualizer = new Virtualizer<HTMLDivElement, HTMLDivElement>({
+    count: 1,
+    estimateSize: () => 60,
+    initialRect: { width: 400, height: 200 },
+    getScrollElement: () => root,
+    scrollToFn: () => {},
+    observeElementRect: () => {},
+    observeElementOffset: () => {},
+    measureElement: (node) => node.offsetHeight,
+  })
+
+  virtualizer.getTotalSize()
+  virtualizer.resizeItem(0, 60)
+  virtualizer._willUpdate()
+  virtualizer.measureElement(element)
+
+  expect(virtualizer.itemSizeCache.get(0)).toBe(120)
+  expect(virtualizer.getTotalSize()).toBe(120)
+})
+
 test("initial rect projects rows before a scroll element connects", () => {
   createRoot((dispose) => {
     const virtualizer = createVirtualizer<HTMLDivElement, HTMLDivElement>({


### PR DESCRIPTION
## Summary
- force explicit timeline row measurements to read the current DOM height instead of reusing stale TanStack Virtual cache entries
- preserve the inexpensive ResizeObserver measurement path and document why removing the custom measurer causes clipped transcript rows
- cover cached row remeasurement with a focused browser regression

## Verification
- `bun run test:browser` (45 passing)
- `bun typecheck` from `packages/app`
- pre-push workspace typecheck (32 packages passing)
- production timeline benchmark attempted before and after the change; both runs fail identically on current `upstream/v2` because the production fixture renders a blank page and never finds its session heading, so comparative metrics are unavailable