### PR TITLE
fix(tui): preserve prompt metadata visibility across sessions

### DIFF
--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -102,6 +102,7 @@ export type PromptRef = {
 }
 
 const DRAFT_RETENTION_MIN_CHARS = 20
+const revealedPromptMetadata = new WeakSet<object>()
 
 function randomIndex(count: number) {
   if (count <= 0) return 0
@@ -1613,12 +1614,20 @@ export function Prompt(props: PromptProps) {
     return promptDisplay().agentColor ?? theme.border.default
   })
   const agentLabel = createMemo(() => (store.mode === "shell" ? "Shell" : promptDisplay().agentLabel))
-  const agentMetaAlpha = createFadeIn(() => !!agentLabel(), animationsEnabled)
-  const modelMetaAlpha = createFadeIn(() => !!promptDisplay().agentLabel && store.mode === "normal", animationsEnabled)
+  const animateMetadata = !revealedPromptMetadata.has(local)
+  const metadataAnimationsEnabled = () => animationsEnabled() && animateMetadata
+  const agentMetaAlpha = createFadeIn(() => !!agentLabel(), metadataAnimationsEnabled)
+  const modelMetaAlpha = createFadeIn(
+    () => !!promptDisplay().agentLabel && store.mode === "normal",
+    metadataAnimationsEnabled,
+  )
   const variantMetaAlpha = createFadeIn(
     () => !!promptDisplay().agentLabel && store.mode === "normal" && !!promptDisplay().variant,
-    animationsEnabled,
+    metadataAnimationsEnabled,
   )
+  createEffect(() => {
+    if (agentLabel()) revealedPromptMetadata.add(local)
+  })
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
   const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode })
 


### PR DESCRIPTION
## Why

Switching between sessions remounts the prompt, causing the agent, model, provider, and variant labels to replay their initial fade-in animation. This makes previously visible session metadata briefly disappear on every tab switch.

## What Changes

**Before:** Every session switch fades the prompt metadata back in over 160 ms.

**After:** Prompt metadata fades in once when the TUI first resolves it, then appears immediately when switching sessions.

The one-time reveal is scoped to the shared TUI context, so separate TUI instances retain independent startup behavior.

## Demo

https://github.com/user-attachments/assets/088cd245-efe5-4020-b448-bebe94c8294b

Real production TUI driven against the same isolated, deterministic two-session fixture. Left: base `v2` at `fa4c5b26dce42a2515ba1f02cc4af6fede581e9e`. Right: this change at `44109e6a5f3475d7f646cd8a116e8b7fa16a16ad`. Both runs switch six times between the fictional project root and its `harbor/` working directory with animations enabled, a fictional simulated model/provider, and 120 ms simulated frontend network latency. Playback is slowed to approximately 0.71x to make the 160 ms fade easier to inspect; red and green outlines highlight the affected prompt metadata.

## Scope

Only prompt metadata reveal behavior changes; initial startup animation and other TUI animations remain intact.

## Verification

```sh
cd packages/tui
bun typecheck
bun run test
bunx prettier --check src/component/prompt/index.tsx
```

The full TUI suite passes: 739 passed, five skipped, zero failed. The normal push hook also passed all 33 workspace typecheck tasks.
