### PR TITLE
fix(tui): stop stale instances from erasing pinned sessions

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -9,6 +9,8 @@ import { useArgs } from "./args"
 import { useSDK } from "./sdk"
 import { RGBA } from "@opentui/core"
 import { readJson, writeJsonAtomic } from "../util/persistence"
+import { Flock } from "@opencode-ai/core/util/flock"
+import { Global } from "@opencode-ai/core/global"
 import { useTheme } from "./theme"
 import { useToast } from "../ui/toast"
 import { useRoute } from "./route"
@@ -46,6 +48,34 @@ export function recentModels(
     })
     .slice(0, 10)
     .map((item) => ({ providerID: item.providerID, modelID: item.modelID }))
+}
+
+export function parsePinned(value: unknown) {
+  if (!value || typeof value !== "object") return []
+  const pinned = (value as Record<string, unknown>).pinned
+  if (!Array.isArray(pinned)) return []
+  return pinned.filter((item): item is string => typeof item === "string")
+}
+
+export function setPinned(pinned: string[], sessionID: string, pin: boolean) {
+  if (!pin) return pinned.filter((x) => x !== sessionID)
+  return pinned.includes(sessionID) ? pinned : [...pinned, sessionID]
+}
+
+// Every TUI instance writes this same file, so a change has to be applied to the file's
+// current contents under a lock. Writing the caller's snapshot instead would drop pins
+// made by another instance since that snapshot was loaded.
+export function persistPinned(filePath: string, sessionID: string, pin: boolean, options?: Flock.Options) {
+  return Flock.withLock(
+    `tui-session:${filePath}`,
+    async () => {
+      const current = await readJson<unknown>(filePath).catch(() => undefined)
+      const next = setPinned(parsePinned(current), sessionID, pin)
+      await writeJsonAtomic(filePath, { pinned: next })
+      return next
+    },
+    options,
+  )
 }
 
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
@@ -417,37 +447,33 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         pinned: [],
       })
 
+      // Touching Global here guarantees Flock's lock root is configured, same as the KV store.
+      void Global.Path.state
       const filePath = path.join(paths.state, "session.json")
-      const state = {
-        pending: false,
-      }
 
-      function save() {
-        if (!sessionStore.ready) {
-          state.pending = true
-          return
-        }
-        state.pending = false
-        void writeJsonAtomic(filePath, {
-          pinned: sessionStore.pinned,
-        })
-      }
-
-      readJson<unknown>(filePath)
+      // Writes chain off the initial read so they can never run before it completes.
+      let write = Flock.withLock(`tui-session:${filePath}`, () => readJson<unknown>(filePath))
         .then((x) => {
-          if (!x || typeof x !== "object") return
-          const pinned = (x as Record<string, unknown>).pinned
-          if (Array.isArray(pinned))
-            setSessionStore(
-              "pinned",
-              pinned.filter((item): item is string => typeof item === "string"),
-            )
+          setSessionStore("pinned", parsePinned(x))
         })
         .catch(() => {})
         .finally(() => {
           setSessionStore("ready", true)
-          if (state.pending) save()
         })
+
+      function update(sessionID: string, pin: boolean) {
+        // Reflect the change locally right away, then reconcile with whatever the merged
+        // file actually ends up containing.
+        setSessionStore("pinned", setPinned(sessionStore.pinned, sessionID, pin))
+        write = write
+          .then(() => persistPinned(filePath, sessionID, pin))
+          .then((next) => {
+            setSessionStore("pinned", next)
+          })
+          .catch((error) => {
+            console.error("Failed to write session state", { error })
+          })
+      }
 
       const slots = createMemo(() => {
         const existing = new Set(sync.data.session.filter((x) => x.parentID === undefined).map((x) => x.id))
@@ -455,15 +481,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       })
 
       function prune(sessionID: string) {
-        batch(() => {
-          if (sessionStore.pinned.includes(sessionID)) {
-            setSessionStore(
-              "pinned",
-              sessionStore.pinned.filter((x) => x !== sessionID),
-            )
-          }
-          save()
-        })
+        if (!sessionStore.pinned.includes(sessionID)) return
+        update(sessionID, false)
       }
 
       event.on("session.deleted", (evt) => {
@@ -482,14 +501,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return sessionStore.pinned.includes(sessionID)
         },
         togglePin(sessionID: string) {
-          batch(() => {
-            const exists = sessionStore.pinned.includes(sessionID)
-            const next = exists
-              ? sessionStore.pinned.filter((x) => x !== sessionID)
-              : [...sessionStore.pinned, sessionID]
-            setSessionStore("pinned", next)
-            save()
-          })
+          update(sessionID, !sessionStore.pinned.includes(sessionID))
         },
         quickSwitch(slot: number) {
           const target = slots()[slot - 1]

--- a/packages/tui/test/context/local.test.ts
+++ b/packages/tui/test/context/local.test.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "bun:test"
-import { parseModel, recentModels } from "../../src/context/local"
+import { mkdtemp } from "fs/promises"
+import { tmpdir } from "os"
+import path from "path"
+import { parseModel, parsePinned, persistPinned, recentModels, setPinned } from "../../src/context/local"
+import { readJson } from "../../src/util/persistence"
 
 test("parses model IDs containing slashes", () => {
   expect(parseModel("provider/family/model")).toEqual({
@@ -19,4 +23,55 @@ test("moves a model to the front, deduplicates, and limits recents", () => {
     ...recent.slice(0, 5),
     ...recent.slice(6, 10),
   ])
+})
+
+test("parses only string entries out of a stored pin list", () => {
+  expect(parsePinned({ pinned: ["a", 1, null, "b"] })).toEqual(["a", "b"])
+  expect(parsePinned({ pinned: "a" })).toEqual([])
+  expect(parsePinned(undefined)).toEqual([])
+})
+
+test("pins and unpins without duplicating entries", () => {
+  expect(setPinned(["a"], "b", true)).toEqual(["a", "b"])
+  expect(setPinned(["a", "b"], "b", true)).toEqual(["a", "b"])
+  expect(setPinned(["a", "b"], "a", false)).toEqual(["b"])
+  expect(setPinned(["a"], "b", false)).toEqual(["a"])
+})
+
+async function pinDir() {
+  const dir = await mkdtemp(path.join(tmpdir(), "opencode-pins-"))
+  return { file: path.join(dir, "session.json"), options: { dir: path.join(dir, "locks") } }
+}
+
+test("a pin written by another instance survives a later write", async () => {
+  const { file, options } = await pinDir()
+
+  await persistPinned(file, "a", true, options)
+  // Another TUI pins "b" while this instance still believes the list is just ["a"].
+  await persistPinned(file, "b", true, options)
+
+  expect(await persistPinned(file, "c", true, options)).toEqual(["a", "b", "c"])
+  expect(parsePinned(await readJson(file))).toEqual(["a", "b", "c"])
+})
+
+test("concurrent pin writes do not erase each other", async () => {
+  const { file, options } = await pinDir()
+
+  await Promise.all([
+    persistPinned(file, "a", true, options),
+    persistPinned(file, "b", true, options),
+    persistPinned(file, "c", true, options),
+  ])
+
+  expect(parsePinned(await readJson(file)).sort()).toEqual(["a", "b", "c"])
+})
+
+test("unpinning removes only the target session", async () => {
+  const { file, options } = await pinDir()
+
+  await persistPinned(file, "a", true, options)
+  await persistPinned(file, "b", true, options)
+
+  expect(await persistPinned(file, "a", false, options)).toEqual(["b"])
+  expect(parsePinned(await readJson(file))).toEqual(["b"])
 })


### PR DESCRIPTION
### Issue for this PR

Closes #44736

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`createSession()` in `packages/tui/src/context/local.tsx` read the global `session.json` pin list once at startup and kept a private in-memory copy. `togglePin`, `prune` and the `session.deleted` handler all rewrote the whole file from that copy through a fire-and-forget `writeJsonAtomic()` — no reread, no lock, no ordering. An instance holding a stale snapshot therefore replaced pins another instance had added. `writeJsonAtomic` prevents torn files, not stale writers.

Reproduced against the old semantics: two writers starting from an empty list, one pinning `a` and one pinning `b`, leave the file as `["b"]`.

The fix changes what gets persisted. Instead of writing a snapshot, each change is now an intent — a session ID plus pin/unpin — applied to the file's *current* contents inside `Flock.withLock`, the same lock `context/kv.tsx` already uses for `kv.json`. Writes chain off the initial read, so they can never run before the list has loaded and the `pending` flag is no longer needed. The in-memory store is still updated immediately so the UI doesn't wait on the write, then reconciled with whatever the merged file actually ended up containing.

`parsePinned`, `setPinned` and `persistPinned` are exported so the behaviour is testable directly, matching how `parseModel` / `recentModels` are already handled in this module.

Worth flagging: `kv.tsx` takes the lock but still writes its own snapshot, so `kv.json` has the same stale-writer shape. I left it alone to keep this focused — happy to follow up if you want it covered.

### How did you verify your code works?

Added tests to `packages/tui/test/context/local.test.ts`. They use a temp directory for both the file and the lock root, so nothing touches real state:

- three concurrent `persistPinned` calls all survive — this is the regression; under the old snapshot write the same shape collapses to a single pin
- a pin written by another instance survives a later write from an instance that never saw it
- unpinning removes only the target
- `parsePinned` drops non-string entries and bad shapes; `setPinned` doesn't duplicate

I also verified the old behaviour actually fails, by reimplementing the previous snapshot write in a scratch test:

```
OLD RESULT: ["b"]     # pin "a" lost
```

```
$ bun test                     # packages/tui
 198 pass, 1 skip, 0 fail

$ bun typecheck
(clean)
```

### Screenshots / recordings

No visible UI change — the pin list renders the same, it just stops losing entries.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
