### PR TITLE
feat(tui): add plugin update controls

### DIFF
--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -258,8 +258,8 @@ export const Definitions = {
   "plugins.toggle": keybind("space", "Toggle plugin"),
   "dialog.mcp.toggle": keybind("space", "Toggle MCP server"),
   "dialog.plugins.install": keybind("shift+i", "Install plugin from plugin dialog"),
-  "dialog.plugins.update": keybind("u", "Update selected plugin"),
-  "dialog.plugins.update_all": keybind("shift+u", "Update all plugins"),
+  "dialog.plugins.update": keybind("ctrl+r", "Update selected plugin"),
+  "dialog.plugins.update_all": keybind("ctrl+shift+r", "Update all plugins"),
 
   "terminal.suspend": keybind("ctrl+z", "Suspend terminal"),
   "terminal.title.toggle": keybind("none", "Toggle terminal title"),

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -258,6 +258,8 @@ export const Definitions = {
   "plugins.toggle": keybind("space", "Toggle plugin"),
   "dialog.mcp.toggle": keybind("space", "Toggle MCP server"),
   "dialog.plugins.install": keybind("shift+i", "Install plugin from plugin dialog"),
+  "dialog.plugins.update": keybind("u", "Update selected plugin"),
+  "dialog.plugins.update_all": keybind("shift+u", "Update all plugins"),
 
   "terminal.suspend": keybind("ctrl+z", "Suspend terminal"),
   "terminal.title.toggle": keybind("none", "Toggle terminal title"),

--- a/packages/tui/src/feature-plugins/system/plugins-model.ts
+++ b/packages/tui/src/feature-plugins/system/plugins-model.ts
@@ -1,0 +1,19 @@
+import type { PluginInfo, PluginUpdateInfo, PluginUpdateResult } from "@opencode-ai/client"
+
+type UpdateEntry = PluginUpdateInfo | PluginUpdateResult
+
+export function matchesPluginUpdate(plugin: PluginInfo, update: UpdateEntry) {
+  if (plugin.source.type !== update.source.type) return false
+  if (plugin.source.type === "package" && update.source.type === "package") {
+    return plugin.source.package === update.source.package
+  }
+  if (plugin.source.type === "local" && update.source.type === "local") return plugin.source.path === update.source.path
+  return plugin.id === update.name
+}
+
+export function pluginServerKey(plugin: PluginInfo) {
+  if (plugin.id) return `server:${plugin.id}`
+  if (plugin.source.type === "package") return `server:package:${plugin.source.package}`
+  if (plugin.source.type === "local") return `server:local:${plugin.source.path}`
+  return `server:${plugin.source.type}`
+}

--- a/packages/tui/src/feature-plugins/system/plugins-model.ts
+++ b/packages/tui/src/feature-plugins/system/plugins-model.ts
@@ -1,6 +1,6 @@
 import type { PluginInfo, PluginUpdateInfo, PluginUpdateResult } from "@opencode-ai/client"
 
-type UpdateEntry = PluginUpdateInfo | PluginUpdateResult
+export type UpdateEntry = PluginUpdateInfo | PluginUpdateResult
 
 export function matchesPluginUpdate(plugin: PluginInfo, update: UpdateEntry) {
   if (plugin.source.type !== update.source.type) return false

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -5,11 +5,10 @@ import { DialogErrorDetails } from "../../component/dialog-error-details"
 import { usePlugin } from "../../plugin/context"
 import { DialogSelect, type DialogSelectOption } from "../../ui/dialog-select"
 import { useDialog } from "../../ui/dialog"
-import { matchesPluginUpdate, pluginServerKey } from "./plugins-model"
+import { errorMessage } from "../../util/error"
+import { matchesPluginUpdate, pluginServerKey, type UpdateEntry } from "./plugins-model"
 
 const id = "opencode.plugins"
-
-type UpdateEntry = PluginUpdateInfo | PluginUpdateResult
 
 type Entry =
   | { readonly key: string; readonly runtime: "server"; readonly plugin: PluginInfo; readonly update?: UpdateEntry }
@@ -30,8 +29,6 @@ type PluginUpdateOperations = {
 
 export type PluginRegistry = Pick<ReturnType<typeof usePlugin>, "registered" | "list" | "activate" | "deactivate">
 
-type ServerEntry = Extract<Entry, { runtime: "server" }>
-
 export function PluginsDialog(props: {
   context: Plugin.Context
   plugins: PluginRegistry
@@ -44,7 +41,7 @@ export function PluginsDialog(props: {
   const [detail, setDetail] = createSignal<Entry>()
   const [initial, setInitial] = createSignal<string>()
   const [checking, setChecking] = createSignal(true)
-  const [operationError, setOperationError] = createSignal<string>()
+  const [operationError, setOperationError] = createSignal(false)
   const [updateEntries, setUpdateEntries] = createSignal<readonly UpdateEntry[]>([])
   const [updating, setUpdating] = createSignal<string>()
   const location = () => props.context.location ?? props.context.data.location.default()
@@ -62,7 +59,7 @@ export function PluginsDialog(props: {
     void operations
       .check()
       .then(setUpdateEntries)
-      .catch((cause) => setOperationError(errorMessage(cause)))
+      .catch(() => setOperationError(true))
       .finally(() => setChecking(false))
   })
   const entries = createMemo<Entry[]>(() => {
@@ -88,23 +85,12 @@ export function PluginsDialog(props: {
         error: plugin.status === "failed" ? plugin.error : undefined,
       }))
     const runtime = props.server?.() ?? server() ?? []
-    const matched = new Set<PluginInfo>()
-    const checked: ServerEntry[] = updateEntries().flatMap((update) => {
-      const plugin = runtime.find((candidate) => matchesPluginUpdate(candidate, update))
-      if (!plugin) return []
-      matched.add(plugin)
-      return [{ key: pluginServerKey(plugin), runtime: "server", plugin, update }]
-    })
-    const serverEntries: Entry[] = [
-      ...checked,
-      ...runtime
-        .filter((plugin) => !matched.has(plugin))
-        .map((plugin) => ({
-          key: pluginServerKey(plugin),
-          runtime: "server" as const,
-          plugin,
-        })),
-    ]
+    const serverEntries: Entry[] = runtime.map((plugin) => ({
+      key: pluginServerKey(plugin),
+      runtime: "server",
+      plugin,
+      update: updateEntries().find((update) => matchesPluginUpdate(plugin, update)),
+    }))
     return [
       ...[...builtins, ...external].sort((a, b) => label(a, props.context).localeCompare(label(b, props.context))),
       ...serverEntries.sort((a, b) => label(a, props.context).localeCompare(label(b, props.context))),
@@ -172,24 +158,19 @@ export function PluginsDialog(props: {
       .catch((cause) => {
         props.context.ui.toast.show({
           variant: "error",
-          message: cause instanceof Error ? cause.message : String(cause),
+          message: errorMessage(cause),
         })
       })
       .finally(() => setLocked(false))
   }
-  const update = (name: string) => {
+  const runUpdate = (updating: string, operation: () => Promise<void>) => {
     if (locked()) return
     setLocked(true)
-    setUpdating(name)
-    setOperationError()
-    void operations
-      .update(name)
-      .then(async (result) => {
-        setUpdateEntries((current) => current.map((entry) => (entry.name === name ? result : entry)))
-        if (!props.server && result.status === "updated") await refetchServer()
-      })
+    setUpdating(updating)
+    setOperationError(false)
+    void operation()
       .catch((cause) => {
-        setOperationError(errorMessage(cause))
+        setOperationError(true)
         props.context.ui.toast.show({ variant: "error", message: errorMessage(cause) })
       })
       .finally(() => {
@@ -197,26 +178,18 @@ export function PluginsDialog(props: {
         setLocked(false)
       })
   }
-  const updateAll = () => {
-    if (locked()) return
-    setLocked(true)
-    setUpdating("*")
-    setOperationError()
-    void operations
-      .updateAll()
-      .then(async (results) => {
-        setUpdateEntries(results)
-        if (!props.server && results.some((result) => result.status === "updated")) await refetchServer()
-      })
-      .catch((cause) => {
-        setOperationError(errorMessage(cause))
-        props.context.ui.toast.show({ variant: "error", message: errorMessage(cause) })
-      })
-      .finally(() => {
-        setUpdating()
-        setLocked(false)
-      })
-  }
+  const update = (name: string) =>
+    runUpdate(name, async () => {
+      const result = await operations.update(name)
+      setUpdateEntries((current) => current.map((entry) => (entry.name === name ? result : entry)))
+      if (!props.server && result.status === "updated") await refetchServer()
+    })
+  const updateAll = () =>
+    runUpdate("*", async () => {
+      const results = await operations.updateAll()
+      setUpdateEntries(results)
+      if (!props.server && results.some((result) => result.status === "updated")) await refetchServer()
+    })
 
   return (
     <box>
@@ -347,10 +320,6 @@ function pluginError(entry: Entry | undefined) {
     return
   }
   return entry?.error
-}
-
-function errorMessage(cause: unknown) {
-  return cause instanceof Error ? cause.message : String(cause)
 }
 
 function Commands(props: { context: Plugin.Context }) {

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -1,4 +1,4 @@
-import type { PluginInfo, PluginSource } from "@opencode-ai/client"
+import type { PluginInfo, PluginUpdateInfo, PluginUpdateResult } from "@opencode-ai/client"
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { createEffect, createMemo, createResource, createSignal, onMount, Show } from "solid-js"
 import { DialogErrorDetails } from "../../component/dialog-error-details"
@@ -7,24 +7,6 @@ import { DialogSelect, type DialogSelectOption } from "../../ui/dialog-select"
 import { useDialog } from "../../ui/dialog"
 
 const id = "opencode.plugins"
-
-export type PluginUpdateInfo = {
-  readonly name: string
-  readonly source: PluginSource
-  readonly status: "not-updateable" | "pinned" | "up-to-date" | "available" | "failed"
-  readonly currentVersion?: string
-  readonly latestVersion?: string
-  readonly error?: string
-}
-
-export type PluginUpdateResult = {
-  readonly name: string
-  readonly source: PluginSource
-  readonly status: "not-updateable" | "pinned" | "up-to-date" | "updated" | "failed"
-  readonly previousVersion?: string
-  readonly version?: string
-  readonly error?: string
-}
 
 type UpdateEntry = PluginUpdateInfo | PluginUpdateResult
 
@@ -49,16 +31,6 @@ export type PluginRegistry = Pick<ReturnType<typeof usePlugin>, "registered" | "
 
 type ServerEntry = Extract<Entry, { runtime: "server" }>
 
-type PendingPluginClient = Plugin.Context["client"]["plugin"] & {
-  check(input: { location: NonNullable<Plugin.Context["location"]> }): Promise<{ data: PluginUpdateInfo[] }>
-  update(input: { name: string; location: NonNullable<Plugin.Context["location"]> }): Promise<{
-    data: PluginUpdateResult
-  }>
-  updateAll(input: { location: NonNullable<Plugin.Context["location"]> }): Promise<{
-    data: PluginUpdateResult[]
-  }>
-}
-
 export function PluginsDialog(props: {
   context: Plugin.Context
   plugins: PluginRegistry
@@ -75,11 +47,10 @@ export function PluginsDialog(props: {
   const [updateEntries, setUpdateEntries] = createSignal<readonly UpdateEntry[]>([])
   const [updating, setUpdating] = createSignal<string>()
   const location = () => props.context.location ?? props.context.data.location.default()
-  const pending = props.context.client.plugin as PendingPluginClient
   const operations: PluginUpdateOperations = props.updates ?? {
-    check: () => pending.check({ location: location() }).then((result) => result.data),
-    update: (name) => pending.update({ name, location: location() }).then((result) => result.data),
-    updateAll: () => pending.updateAll({ location: location() }).then((result) => result.data),
+    check: () => props.context.client.plugin.check({ location: location() }).then((result) => result.data),
+    update: (name) => props.context.client.plugin.update({ name, location: location() }).then((result) => result.data),
+    updateAll: () => props.context.client.plugin.updateAll({ location: location() }).then((result) => result.data),
   }
   const [server, { refetch: refetchServer }] = createResource(
     () => (props.server ? undefined : location()),

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -45,6 +45,8 @@ type PluginUpdateOperations = {
   updateAll(): Promise<readonly PluginUpdateResult[]>
 }
 
+export type PluginRegistry = Pick<ReturnType<typeof usePlugin>, "registered" | "list" | "activate" | "deactivate">
+
 type ServerEntry = Extract<Entry, { runtime: "server" }>
 
 type PendingPluginClient = Plugin.Context["client"]["plugin"] & {
@@ -59,7 +61,7 @@ type PendingPluginClient = Plugin.Context["client"]["plugin"] & {
 
 export function PluginsDialog(props: {
   context: Plugin.Context
-  plugins: ReturnType<typeof usePlugin>
+  plugins: PluginRegistry
   server?: () => readonly PluginInfo[]
   updates?: PluginUpdateOperations
 }) {
@@ -79,7 +81,7 @@ export function PluginsDialog(props: {
     update: (name) => pending.update({ name, location: location() }).then((result) => result.data),
     updateAll: () => pending.updateAll({ location: location() }).then((result) => result.data),
   }
-  const [server] = createResource(
+  const [server, { refetch: refetchServer }] = createResource(
     () => (props.server ? undefined : location()),
     (location) => props.context.client.plugin.list({ location }).then((result) => result.data),
   )
@@ -116,17 +118,17 @@ export function PluginsDialog(props: {
     const runtime = props.server?.() ?? server() ?? []
     const matched = new Set<PluginInfo>()
     const checked: ServerEntry[] = updateEntries().flatMap((update) => {
-      const plugin = runtime.find((candidate) => sameSource(candidate.source, update.source))
+      const plugin = runtime.find((candidate) => matchesPluginUpdate(candidate, update))
       if (!plugin) return []
       matched.add(plugin)
-      return [{ key: `server:${update.name}`, runtime: "server", plugin, update }]
+      return [{ key: pluginServerKey(plugin), runtime: "server", plugin, update }]
     })
     const serverEntries: Entry[] = [
       ...checked,
       ...runtime
         .filter((plugin) => !matched.has(plugin))
         .map((plugin) => ({
-          key: `server:${plugin.id ?? source(plugin, props.context)}`,
+          key: pluginServerKey(plugin),
           runtime: "server" as const,
           plugin,
         })),
@@ -210,7 +212,10 @@ export function PluginsDialog(props: {
     setCheckError()
     void operations
       .update(name)
-      .then((result) => setUpdateEntries((current) => current.map((entry) => (entry.name === name ? result : entry))))
+      .then(async (result) => {
+        setUpdateEntries((current) => current.map((entry) => (entry.name === name ? result : entry)))
+        if (!props.server && result.status === "updated") await refetchServer()
+      })
       .catch((cause) => {
         setCheckError(errorMessage(cause))
         props.context.ui.toast.show({ variant: "error", message: errorMessage(cause) })
@@ -227,7 +232,10 @@ export function PluginsDialog(props: {
     setCheckError()
     void operations
       .updateAll()
-      .then(setUpdateEntries)
+      .then(async (results) => {
+        setUpdateEntries(results)
+        if (!props.server && results.some((result) => result.status === "updated")) await refetchServer()
+      })
       .catch((cause) => {
         setCheckError(errorMessage(cause))
         props.context.ui.toast.show({ variant: "error", message: errorMessage(cause) })
@@ -326,11 +334,20 @@ function label(entry: Entry, context: Plugin.Context) {
   return entry.plugin.id ?? source(entry.plugin, context)
 }
 
-function sameSource(left: PluginSource, right: PluginSource) {
-  if (left.type !== right.type) return false
-  if (left.type === "package" && right.type === "package") return left.package === right.package
-  if (left.type === "local" && right.type === "local") return left.path === right.path
-  return true
+export function matchesPluginUpdate(plugin: PluginInfo, update: UpdateEntry) {
+  if (plugin.source.type !== update.source.type) return false
+  if (plugin.source.type === "package" && update.source.type === "package") {
+    return plugin.source.package === update.source.package
+  }
+  if (plugin.source.type === "local" && update.source.type === "local") return plugin.source.path === update.source.path
+  return plugin.id === update.name
+}
+
+export function pluginServerKey(plugin: PluginInfo) {
+  if (plugin.id) return `server:${plugin.id}`
+  if (plugin.source.type === "package") return `server:package:${plugin.source.package}`
+  if (plugin.source.type === "local") return `server:local:${plugin.source.path}`
+  return `server:${plugin.source.type}`
 }
 
 function source(plugin: PluginInfo, context: Plugin.Context) {

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -5,6 +5,7 @@ import { DialogErrorDetails } from "../../component/dialog-error-details"
 import { usePlugin } from "../../plugin/context"
 import { DialogSelect, type DialogSelectOption } from "../../ui/dialog-select"
 import { useDialog } from "../../ui/dialog"
+import { matchesPluginUpdate, pluginServerKey } from "./plugins-model"
 
 const id = "opencode.plugins"
 
@@ -43,7 +44,7 @@ export function PluginsDialog(props: {
   const [detail, setDetail] = createSignal<Entry>()
   const [initial, setInitial] = createSignal<string>()
   const [checking, setChecking] = createSignal(true)
-  const [checkError, setCheckError] = createSignal<string>()
+  const [operationError, setOperationError] = createSignal<string>()
   const [updateEntries, setUpdateEntries] = createSignal<readonly UpdateEntry[]>([])
   const [updating, setUpdating] = createSignal<string>()
   const location = () => props.context.location ?? props.context.data.location.default()
@@ -61,7 +62,7 @@ export function PluginsDialog(props: {
     void operations
       .check()
       .then(setUpdateEntries)
-      .catch((cause) => setCheckError(errorMessage(cause)))
+      .catch((cause) => setOperationError(errorMessage(cause)))
       .finally(() => setChecking(false))
   })
   const entries = createMemo<Entry[]>(() => {
@@ -180,7 +181,7 @@ export function PluginsDialog(props: {
     if (locked()) return
     setLocked(true)
     setUpdating(name)
-    setCheckError()
+    setOperationError()
     void operations
       .update(name)
       .then(async (result) => {
@@ -188,7 +189,7 @@ export function PluginsDialog(props: {
         if (!props.server && result.status === "updated") await refetchServer()
       })
       .catch((cause) => {
-        setCheckError(errorMessage(cause))
+        setOperationError(errorMessage(cause))
         props.context.ui.toast.show({ variant: "error", message: errorMessage(cause) })
       })
       .finally(() => {
@@ -200,7 +201,7 @@ export function PluginsDialog(props: {
     if (locked()) return
     setLocked(true)
     setUpdating("*")
-    setCheckError()
+    setOperationError()
     void operations
       .updateAll()
       .then(async (results) => {
@@ -208,7 +209,7 @@ export function PluginsDialog(props: {
         if (!props.server && results.some((result) => result.status === "updated")) await refetchServer()
       })
       .catch((cause) => {
-        setCheckError(errorMessage(cause))
+        setOperationError(errorMessage(cause))
         props.context.ui.toast.show({ variant: "error", message: errorMessage(cause) })
       })
       .finally(() => {
@@ -269,8 +270,8 @@ export function PluginsDialog(props: {
               <Show
                 when={pluginError(focusedEntry())}
                 fallback={
-                  <Show when={checkError()}>
-                    <text fg={props.context.theme.text.feedback.error.default}>Update check failed</text>
+                  <Show when={operationError()}>
+                    <text fg={props.context.theme.text.feedback.error.default}>Plugin update failed</text>
                   </Show>
                 }
               >
@@ -305,22 +306,6 @@ function label(entry: Entry, context: Plugin.Context) {
   return entry.plugin.id ?? source(entry.plugin, context)
 }
 
-export function matchesPluginUpdate(plugin: PluginInfo, update: UpdateEntry) {
-  if (plugin.source.type !== update.source.type) return false
-  if (plugin.source.type === "package" && update.source.type === "package") {
-    return plugin.source.package === update.source.package
-  }
-  if (plugin.source.type === "local" && update.source.type === "local") return plugin.source.path === update.source.path
-  return plugin.id === update.name
-}
-
-export function pluginServerKey(plugin: PluginInfo) {
-  if (plugin.id) return `server:${plugin.id}`
-  if (plugin.source.type === "package") return `server:package:${plugin.source.package}`
-  if (plugin.source.type === "local") return `server:local:${plugin.source.path}`
-  return `server:${plugin.source.type}`
-}
-
 function source(plugin: PluginInfo, context: Plugin.Context) {
   if (plugin.source.type === "package") return plugin.source.package
   if (plugin.source.type === "local") return context.ui.format.path(plugin.source.path)
@@ -343,7 +328,7 @@ function statusLabel(entry: Entry, checking: boolean, updating: string | undefin
   if (updating === "*" || (update && updating === update.name)) return "updating …"
   if (entry.plugin.status === "failed") return "failed"
   if (!update) return checking ? "checking …" : undefined
-  if (update.status === "not-updateable") return update.source.type === "local" ? "local" : "not updateable"
+  if (update.status === "not-updateable") return update.source.type === "local" ? "local" : undefined
   const currentVersion =
     "currentVersion" in update ? update.currentVersion : "version" in update ? update.version : undefined
   if (update.status === "pinned") return currentVersion ? `${currentVersion} pinned` : "pinned"

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -1,4 +1,4 @@
-import type { PluginInfo } from "@opencode-ai/client"
+import type { PluginInfo, PluginSource } from "@opencode-ai/client"
 import { Plugin } from "@opencode-ai/plugin/tui"
 import { createEffect, createMemo, createResource, createSignal, onMount, Show } from "solid-js"
 import { DialogErrorDetails } from "../../component/dialog-error-details"
@@ -8,8 +8,28 @@ import { useDialog } from "../../ui/dialog"
 
 const id = "opencode.plugins"
 
+export type PluginUpdateInfo = {
+  readonly name: string
+  readonly source: PluginSource
+  readonly status: "not-updateable" | "pinned" | "up-to-date" | "available" | "failed"
+  readonly currentVersion?: string
+  readonly latestVersion?: string
+  readonly error?: string
+}
+
+export type PluginUpdateResult = {
+  readonly name: string
+  readonly source: PluginSource
+  readonly status: "not-updateable" | "pinned" | "up-to-date" | "updated" | "failed"
+  readonly previousVersion?: string
+  readonly version?: string
+  readonly error?: string
+}
+
+type UpdateEntry = PluginUpdateInfo | PluginUpdateResult
+
 type Entry =
-  | { readonly key: string; readonly runtime: "server"; readonly plugin: PluginInfo }
+  | { readonly key: string; readonly runtime: "server"; readonly plugin: PluginInfo; readonly update?: UpdateEntry }
   | {
       readonly key: string
       readonly runtime: "tui"
@@ -19,21 +39,58 @@ type Entry =
       readonly error?: string
     }
 
+type PluginUpdateOperations = {
+  check(): Promise<readonly PluginUpdateInfo[]>
+  update(name: string): Promise<PluginUpdateResult>
+  updateAll(): Promise<readonly PluginUpdateResult[]>
+}
+
+type ServerEntry = Extract<Entry, { runtime: "server" }>
+
+type PendingPluginClient = Plugin.Context["client"]["plugin"] & {
+  check(input: { location: NonNullable<Plugin.Context["location"]> }): Promise<{ data: PluginUpdateInfo[] }>
+  update(input: { name: string; location: NonNullable<Plugin.Context["location"]> }): Promise<{
+    data: PluginUpdateResult
+  }>
+  updateAll(input: { location: NonNullable<Plugin.Context["location"]> }): Promise<{
+    data: PluginUpdateResult[]
+  }>
+}
+
 export function PluginsDialog(props: {
   context: Plugin.Context
   plugins: ReturnType<typeof usePlugin>
   server?: () => readonly PluginInfo[]
+  updates?: PluginUpdateOperations
 }) {
   const dialog = useDialog()
   const [locked, setLocked] = createSignal(false)
   const [focused, setFocused] = createSignal<string>()
   const [detail, setDetail] = createSignal<Entry>()
   const [initial, setInitial] = createSignal<string>()
+  const [checking, setChecking] = createSignal(true)
+  const [checkError, setCheckError] = createSignal<string>()
+  const [updateEntries, setUpdateEntries] = createSignal<readonly UpdateEntry[]>([])
+  const [updating, setUpdating] = createSignal<string>()
+  const location = () => props.context.location ?? props.context.data.location.default()
+  const pending = props.context.client.plugin as PendingPluginClient
+  const operations: PluginUpdateOperations = props.updates ?? {
+    check: () => pending.check({ location: location() }).then((result) => result.data),
+    update: (name) => pending.update({ name, location: location() }).then((result) => result.data),
+    updateAll: () => pending.updateAll({ location: location() }).then((result) => result.data),
+  }
   const [server] = createResource(
-    () => (props.server ? undefined : (props.context.location ?? props.context.data.location.default())),
+    () => (props.server ? undefined : location()),
     (location) => props.context.client.plugin.list({ location }).then((result) => result.data),
   )
-  onMount(() => dialog.setSize("medium"))
+  onMount(() => {
+    dialog.setSize("medium")
+    void operations
+      .check()
+      .then(setUpdateEntries)
+      .catch((cause) => setCheckError(errorMessage(cause)))
+      .finally(() => setChecking(false))
+  })
   const entries = createMemo<Entry[]>(() => {
     const builtins: Entry[] = props.plugins
       .registered()
@@ -56,11 +113,24 @@ export function PluginsDialog(props: {
         status: plugin.status,
         error: plugin.status === "failed" ? plugin.error : undefined,
       }))
-    const serverEntries: Entry[] = (props.server?.() ?? server() ?? []).map((plugin) => ({
-      key: `server:${plugin.id ?? source(plugin, props.context)}`,
-      runtime: "server" as const,
-      plugin,
-    }))
+    const runtime = props.server?.() ?? server() ?? []
+    const matched = new Set<PluginInfo>()
+    const checked: ServerEntry[] = updateEntries().flatMap((update) => {
+      const plugin = runtime.find((candidate) => sameSource(candidate.source, update.source))
+      if (!plugin) return []
+      matched.add(plugin)
+      return [{ key: `server:${update.name}`, runtime: "server", plugin, update }]
+    })
+    const serverEntries: Entry[] = [
+      ...checked,
+      ...runtime
+        .filter((plugin) => !matched.has(plugin))
+        .map((plugin) => ({
+          key: `server:${plugin.id ?? source(plugin, props.context)}`,
+          runtime: "server" as const,
+          plugin,
+        })),
+    ]
     return [
       ...[...builtins, ...external].sort((a, b) => label(a, props.context).localeCompare(label(b, props.context))),
       ...serverEntries.sort((a, b) => label(a, props.context).localeCompare(label(b, props.context))),
@@ -81,11 +151,15 @@ export function PluginsDialog(props: {
         value: entry.key,
         category: entry.runtime === "tui" ? "TUI" : "Server",
         searchText: entry.runtime === "tui" ? entry.target : source(entry.plugin, props.context),
-        footer: status(entry) === "active" ? undefined : status(entry),
+        footer: statusLabel(entry, checking(), updating()),
         footerColor:
-          status(entry) === "failed"
+          status(entry) === "failed" || updateStatus(entry) === "failed"
             ? props.context.theme.text.feedback.error.default
-            : props.context.theme.text.subdued,
+            : updateStatus(entry) === "updated" || updateStatus(entry) === "up-to-date"
+              ? props.context.theme.text.feedback.success.default
+              : updateStatus(entry) === "available"
+                ? props.context.theme.text.feedback.info.default
+                : props.context.theme.text.subdued,
         gutter:
           status(entry) === "active"
             ? () => <text fg={props.context.theme.text.feedback.success.default}>✓</text>
@@ -96,6 +170,11 @@ export function PluginsDialog(props: {
     ),
   )
   const focusedEntry = createMemo(() => entries().find((entry) => entry.key === focused()))
+  const focusedUpdate = createMemo(() => {
+    const entry = focusedEntry()
+    if (entry?.runtime !== "server") return
+    return entry.update
+  })
   const focusedTui = createMemo(() => {
     const entry = focusedEntry()
     if (entry?.runtime !== "tui" || !entry.id) return
@@ -124,6 +203,40 @@ export function PluginsDialog(props: {
       })
       .finally(() => setLocked(false))
   }
+  const update = (name: string) => {
+    if (locked()) return
+    setLocked(true)
+    setUpdating(name)
+    setCheckError()
+    void operations
+      .update(name)
+      .then((result) => setUpdateEntries((current) => current.map((entry) => (entry.name === name ? result : entry))))
+      .catch((cause) => {
+        setCheckError(errorMessage(cause))
+        props.context.ui.toast.show({ variant: "error", message: errorMessage(cause) })
+      })
+      .finally(() => {
+        setUpdating()
+        setLocked(false)
+      })
+  }
+  const updateAll = () => {
+    if (locked()) return
+    setLocked(true)
+    setUpdating("*")
+    setCheckError()
+    void operations
+      .updateAll()
+      .then(setUpdateEntries)
+      .catch((cause) => {
+        setCheckError(errorMessage(cause))
+        props.context.ui.toast.show({ variant: "error", message: errorMessage(cause) })
+      })
+      .finally(() => {
+        setUpdating()
+        setLocked(false)
+      })
+  }
 
   return (
     <box>
@@ -141,19 +254,47 @@ export function PluginsDialog(props: {
               const entry = entries().find((entry) => entry.key === option.value)
               if (pluginError(entry)) setDetail(entry)
             }}
-            actions={
-              focusedTui()
+            actions={[
+              ...(focusedTui()
                 ? [
                     {
                       title: toggleTitle(),
                       command: "plugins.toggle",
-                      onTrigger: (option) => toggle(entries().find((entry) => entry.key === option.value)),
+                      onTrigger: (option: DialogSelectOption<string>) =>
+                        toggle(entries().find((entry) => entry.key === option.value)),
                     },
                   ]
-                : []
-            }
+                : []),
+              ...(focusedUpdate()?.status === "available"
+                ? [
+                    {
+                      title: "update",
+                      command: "dialog.plugins.update",
+                      onTrigger: (_option: DialogSelectOption<string>) => update(focusedUpdate()!.name),
+                    },
+                  ]
+                : []),
+              ...(updateEntries().some((entry) => entry.status === "available")
+                ? [
+                    {
+                      title: "update all",
+                      command: "dialog.plugins.update_all",
+                      selection: "none" as const,
+                      side: "right" as const,
+                      onTrigger: updateAll,
+                    },
+                  ]
+                : []),
+            ]}
             footer={
-              <Show when={pluginError(focusedEntry())}>
+              <Show
+                when={pluginError(focusedEntry())}
+                fallback={
+                  <Show when={checkError()}>
+                    <text fg={props.context.theme.text.feedback.error.default}>Update check failed</text>
+                  </Show>
+                }
+              >
                 <text>
                   <span style={{ fg: props.context.theme.text.default }}>
                     <b>enter</b>
@@ -185,6 +326,13 @@ function label(entry: Entry, context: Plugin.Context) {
   return entry.plugin.id ?? source(entry.plugin, context)
 }
 
+function sameSource(left: PluginSource, right: PluginSource) {
+  if (left.type !== right.type) return false
+  if (left.type === "package" && right.type === "package") return left.package === right.package
+  if (left.type === "local" && right.type === "local") return left.path === right.path
+  return true
+}
+
 function source(plugin: PluginInfo, context: Plugin.Context) {
   if (plugin.source.type === "package") return plugin.source.package
   if (plugin.source.type === "local") return context.ui.format.path(plugin.source.path)
@@ -196,9 +344,40 @@ function status(entry: Entry) {
   return entry.status
 }
 
+function updateStatus(entry: Entry) {
+  if (entry.runtime !== "server") return
+  return entry.update?.status
+}
+
+function statusLabel(entry: Entry, checking: boolean, updating: string | undefined) {
+  if (entry.runtime === "tui") return status(entry) === "active" ? undefined : status(entry)
+  const update = entry.update
+  if (updating === "*" || (update && updating === update.name)) return "updating …"
+  if (entry.plugin.status === "failed") return "failed"
+  if (!update) return checking ? "checking …" : undefined
+  if (update.status === "not-updateable") return update.source.type === "local" ? "local" : "not updateable"
+  const currentVersion =
+    "currentVersion" in update ? update.currentVersion : "version" in update ? update.version : undefined
+  if (update.status === "pinned") return currentVersion ? `${currentVersion} pinned` : "pinned"
+  if (update.status === "up-to-date") return currentVersion ? `${currentVersion} up to date` : "up to date"
+  if (update.status === "available") {
+    return `${update.currentVersion ?? "installed"} → ${update.latestVersion ?? "update available"}`
+  }
+  if (update.status === "updated") return `${update.previousVersion ?? "installed"} → ${update.version ?? "updated"} ✓`
+  return "failed"
+}
+
 function pluginError(entry: Entry | undefined) {
-  if (entry?.runtime === "server") return entry.plugin.status === "failed" ? entry.plugin.error : undefined
+  if (entry?.runtime === "server") {
+    if (entry.plugin.status === "failed") return entry.plugin.error
+    if (entry.update?.status === "failed") return entry.update.error
+    return
+  }
   return entry?.error
+}
+
+function errorMessage(cause: unknown) {
+  return cause instanceof Error ? cause.message : String(cause)
 }
 
 function Commands(props: { context: Plugin.Context }) {

--- a/packages/tui/src/feature-plugins/system/storybook/index.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/index.tsx
@@ -3,6 +3,7 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { createSignal, For, type JSX } from "solid-js"
 import { StoryFooter } from "./footer"
 import { mermanLayoutsStory } from "./merman-layouts"
+import { pluginUpdatesStory } from "./plugin-updates"
 import { sessionTabsStory } from "./session-tabs"
 import { sessionLocationMissingStory } from "./session-location-missing"
 
@@ -16,7 +17,7 @@ export type Story = {
   render: (context: Plugin.Context) => JSX.Element
 }
 
-const stories: Story[] = [mermanLayoutsStory, sessionTabsStory, sessionLocationMissingStory]
+const stories: Story[] = [mermanLayoutsStory, sessionTabsStory, sessionLocationMissingStory, pluginUpdatesStory]
 
 function Commands(props: { context: Plugin.Context }) {
   props.context.keymap.layer(() => ({

--- a/packages/tui/src/feature-plugins/system/storybook/plugin-updates.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/plugin-updates.tsx
@@ -94,7 +94,9 @@ function PluginUpdatesStory(props: { context: Plugin.Context }) {
               previousVersion: current?.currentVersion,
               version: current?.latestVersion,
             }
-            fixture = fixture.map((entry) => (entry.name === name ? { ...entry, status: "up-to-date" } : entry))
+            fixture = fixture.map((entry) =>
+              entry.name === name ? { ...entry, status: "up-to-date", currentVersion: entry.latestVersion } : entry,
+            )
             return result
           },
           async updateAll() {

--- a/packages/tui/src/feature-plugins/system/storybook/plugin-updates.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/plugin-updates.tsx
@@ -1,0 +1,177 @@
+import type { PluginInfo } from "@opencode-ai/client"
+import type { Plugin } from "@opencode-ai/plugin/tui"
+import { useTerminalDimensions } from "@opentui/solid"
+import { onMount } from "solid-js"
+import { usePlugin } from "../../../plugin/context"
+import { PluginsDialog, type PluginUpdateInfo, type PluginUpdateResult } from "../plugins"
+import type { Story } from "./index"
+import { StoryFooter } from "./footer"
+
+const server: PluginInfo[] = [
+  {
+    id: "fixture.analytics",
+    source: { type: "package", package: "@fixture/analytics@latest" },
+    status: "active",
+    tui: false,
+  },
+  {
+    id: "fixture.theme",
+    source: { type: "package", package: "@fixture/theme@2.4.0" },
+    status: "active",
+    tui: false,
+  },
+  {
+    id: "fixture.local",
+    source: { type: "local", path: "/fixture/plugins/local.ts" },
+    status: "active",
+    tui: false,
+  },
+  {
+    source: { type: "package", package: "@fixture/broken@latest" },
+    status: "failed",
+    error: "Plugin entrypoint could not be loaded",
+    tui: false,
+  },
+]
+
+const initial = (): PluginUpdateInfo[] => [
+  {
+    name: "@fixture/analytics@latest",
+    source: { type: "package", package: "@fixture/analytics@latest" },
+    status: "available",
+    currentVersion: "1.8.0",
+    latestVersion: "1.9.0",
+  },
+  {
+    name: "@fixture/theme@2.4.0",
+    source: { type: "package", package: "@fixture/theme@2.4.0" },
+    status: "pinned",
+    currentVersion: "2.4.0",
+  },
+  {
+    name: "/fixture/plugins/local.ts",
+    source: { type: "local", path: "/fixture/plugins/local.ts" },
+    status: "not-updateable",
+  },
+  {
+    name: "@fixture/broken@latest",
+    source: { type: "package", package: "@fixture/broken@latest" },
+    status: "failed",
+    error: "Registry request failed with status 503",
+  },
+]
+
+function PluginUpdatesStory(props: { context: Plugin.Context }) {
+  const dimensions = useTerminalDimensions()
+  const plugins = usePlugin()
+  const theme = props.context.theme.contextual.elevated
+  let fixture = initial()
+
+  const wait = () => new Promise<void>((resolve) => setTimeout(resolve, 500))
+  const open = () =>
+    props.context.ui.dialog.show(() => (
+      <PluginsDialog
+        context={props.context}
+        plugins={plugins}
+        server={() => server}
+        updates={{
+          async check() {
+            await wait()
+            return fixture
+          },
+          async update(name) {
+            await wait()
+            const current = fixture.find((entry) => entry.name === name)
+            const result: PluginUpdateResult = {
+              name,
+              source: current?.source ?? { type: "package", package: name },
+              status: "updated",
+              previousVersion: current?.currentVersion,
+              version: current?.latestVersion,
+            }
+            fixture = fixture.map((entry) => (entry.name === name ? { ...entry, status: "up-to-date" } : entry))
+            return result
+          },
+          async updateAll() {
+            await wait()
+            const results: PluginUpdateResult[] = fixture.map((entry) =>
+              entry.status === "available"
+                ? {
+                    name: entry.name,
+                    source: entry.source,
+                    status: "updated",
+                    previousVersion: entry.currentVersion,
+                    version: entry.latestVersion,
+                  }
+                : {
+                    name: entry.name,
+                    source: entry.source,
+                    status: entry.status,
+                    version: entry.currentVersion,
+                    error: entry.error,
+                  },
+            )
+            fixture = initial().map((entry) =>
+              entry.status === "available"
+                ? { ...entry, status: "up-to-date", currentVersion: entry.latestVersion }
+                : entry,
+            )
+            return results
+          },
+        }}
+      />
+    ))
+
+  props.context.keymap.layer(() => ({
+    commands: [
+      {
+        bind: "escape",
+        title: "Back to storybook",
+        group: "Storybook",
+        run: () => props.context.ui.router.navigate({ type: "plugin", name: "storybook" }),
+      },
+      { bind: "return", title: "Open plugin controls", group: "Storybook", run: open },
+      {
+        bind: "r",
+        title: "Reset plugin controls",
+        group: "Storybook",
+        run() {
+          fixture = initial()
+          open()
+        },
+      },
+    ],
+  }))
+
+  onMount(open)
+
+  return (
+    <box
+      width={dimensions().width}
+      height={dimensions().height}
+      flexDirection="column"
+      backgroundColor={theme.background.default}
+    >
+      <box flexGrow={1} paddingLeft={2} paddingTop={1}>
+        <text fg={theme.text.default}>Plugin update controls fixture</text>
+        <text fg={theme.text.subdued}>The production Plugins dialog opens automatically.</text>
+      </box>
+      <StoryFooter
+        context={props.context}
+        title="storybook / plugin updates"
+        status="fixture API · 500ms operations"
+        controls={[
+          { shortcut: "enter", label: "open" },
+          { shortcut: "r", label: "reset" },
+          { shortcut: "esc", label: "back" },
+        ]}
+      />
+    </box>
+  )
+}
+
+export const pluginUpdatesStory: Story = {
+  id: "plugin-updates",
+  title: "Plugin update controls",
+  render: (context) => <PluginUpdatesStory context={context} />,
+}

--- a/packages/tui/src/feature-plugins/system/storybook/plugin-updates.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/plugin-updates.tsx
@@ -1,8 +1,8 @@
-import type { PluginInfo } from "@opencode-ai/client"
+import type { PluginInfo, PluginUpdateInfo, PluginUpdateResult } from "@opencode-ai/client"
 import type { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
 import { onMount } from "solid-js"
-import { PluginsDialog, type PluginRegistry, type PluginUpdateInfo, type PluginUpdateResult } from "../plugins"
+import { PluginsDialog, type PluginRegistry } from "../plugins"
 import type { Story } from "./index"
 import { StoryFooter } from "./footer"
 

--- a/packages/tui/src/feature-plugins/system/storybook/plugin-updates.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/plugin-updates.tsx
@@ -2,8 +2,7 @@ import type { PluginInfo } from "@opencode-ai/client"
 import type { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
 import { onMount } from "solid-js"
-import { usePlugin } from "../../../plugin/context"
-import { PluginsDialog, type PluginUpdateInfo, type PluginUpdateResult } from "../plugins"
+import { PluginsDialog, type PluginRegistry, type PluginUpdateInfo, type PluginUpdateResult } from "../plugins"
 import type { Story } from "./index"
 import { StoryFooter } from "./footer"
 
@@ -61,9 +60,15 @@ const initial = (): PluginUpdateInfo[] => [
   },
 ]
 
+const plugins: PluginRegistry = {
+  registered: () => [{ id: "fixture.ui", source: "builtin", active: true }],
+  list: () => [],
+  activate: async () => true,
+  deactivate: async () => true,
+}
+
 function PluginUpdatesStory(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
-  const plugins = usePlugin()
   const theme = props.context.theme.contextual.elevated
   let fixture = initial()
 

--- a/packages/tui/test/feature-plugins/plugins.test.ts
+++ b/packages/tui/test/feature-plugins/plugins.test.ts
@@ -1,6 +1,6 @@
-import type { PluginInfo } from "@opencode-ai/client"
+import type { PluginInfo, PluginUpdateInfo } from "@opencode-ai/client"
 import { describe, expect, test } from "bun:test"
-import { matchesPluginUpdate, pluginServerKey, type PluginUpdateInfo } from "../../src/feature-plugins/system/plugins"
+import { matchesPluginUpdate, pluginServerKey } from "../../src/feature-plugins/system/plugins"
 
 const builtin = (id: string): PluginInfo => ({ id, source: { type: "builtin" }, status: "active", tui: false })
 

--- a/packages/tui/test/feature-plugins/plugins.test.ts
+++ b/packages/tui/test/feature-plugins/plugins.test.ts
@@ -1,6 +1,6 @@
 import type { PluginInfo, PluginUpdateInfo } from "@opencode-ai/client"
 import { describe, expect, test } from "bun:test"
-import { matchesPluginUpdate, pluginServerKey } from "../../src/feature-plugins/system/plugins"
+import { matchesPluginUpdate, pluginServerKey } from "../../src/feature-plugins/system/plugins-model"
 
 const builtin = (id: string): PluginInfo => ({ id, source: { type: "builtin" }, status: "active", tui: false })
 

--- a/packages/tui/test/feature-plugins/plugins.test.ts
+++ b/packages/tui/test/feature-plugins/plugins.test.ts
@@ -1,0 +1,62 @@
+import type { PluginInfo } from "@opencode-ai/client"
+import { describe, expect, test } from "bun:test"
+import { matchesPluginUpdate, pluginServerKey, type PluginUpdateInfo } from "../../src/feature-plugins/system/plugins"
+
+const builtin = (id: string): PluginInfo => ({ id, source: { type: "builtin" }, status: "active", tui: false })
+
+describe("plugin update row identity", () => {
+  test("does not join unrelated built-in plugins by source type", () => {
+    const update: PluginUpdateInfo = {
+      name: "fixture.second",
+      source: { type: "builtin" },
+      status: "not-updateable",
+    }
+
+    expect(matchesPluginUpdate(builtin("fixture.first"), update)).toBe(false)
+    expect(matchesPluginUpdate(builtin("fixture.second"), update)).toBe(true)
+  })
+
+  test("joins package and local plugins only by their exact source", () => {
+    const pkg = {
+      id: "fixture.package",
+      source: { type: "package", package: "@fixture/package@latest" },
+      status: "active",
+      tui: false,
+    } satisfies PluginInfo
+    const local = {
+      id: "fixture.local",
+      source: { type: "local", path: "/fixture/local.ts" },
+      status: "active",
+      tui: false,
+    } satisfies PluginInfo
+
+    expect(
+      matchesPluginUpdate(pkg, {
+        name: "@fixture/package@latest",
+        source: { type: "package", package: "@fixture/package@latest" },
+        status: "available",
+      }),
+    ).toBe(true)
+    expect(
+      matchesPluginUpdate(pkg, {
+        name: "fixture.package",
+        source: { type: "package", package: "@fixture/other@latest" },
+        status: "available",
+      }),
+    ).toBe(false)
+    expect(
+      matchesPluginUpdate(local, {
+        name: "/fixture/other.ts",
+        source: { type: "local", path: "/fixture/other.ts" },
+        status: "not-updateable",
+      }),
+    ).toBe(false)
+  })
+
+  test("derives stable keys only from runtime identity", () => {
+    const plugin = builtin("fixture.stable")
+
+    expect(pluginServerKey(plugin)).toBe("server:fixture.stable")
+    expect(pluginServerKey(plugin)).toBe(pluginServerKey({ ...plugin }))
+  })
+})

--- a/packages/www/src/docs/content/cli/keybinds.mdx
+++ b/packages/www/src/docs/content/cli/keybinds.mdx
@@ -308,29 +308,31 @@ Unknown command IDs are rejected.
 
 ## Dialogs And Autocomplete
 
-| ID                             | Default       | Description                         |
-| ------------------------------ | ------------- | ----------------------------------- |
-| `dialog.select.prev`           | `up,ctrl+p`   | Move to previous dialog item        |
-| `dialog.select.next`           | `down,ctrl+n` | Move to next dialog item            |
-| `dialog.select.page_up`        | `pageup`      | Move up one page in dialog          |
-| `dialog.select.page_down`      | `pagedown`    | Move down one page in dialog        |
-| `dialog.select.home`           | `home`        | Move to first dialog item           |
-| `dialog.select.end`            | `end`         | Move to last dialog item            |
-| `dialog.select.submit`         | `return`      | Submit selected dialog item         |
-| `dialog.prompt.submit`         | `return`      | Submit dialog prompt                |
-| `dialog.worktree.generate`     | `tab`         | Generate worktree name              |
-| `dialog.move_session.new`      | `ctrl+m`      | New worktree                        |
-| `dialog.move_session.delete`   | `ctrl+d`      | Delete worktree                     |
-| `dialog.move_session.refresh`  | `ctrl+r`      | Refresh worktrees                   |
-| `prompt.autocomplete.prev`     | `up,ctrl+p`   | Move to previous autocomplete item  |
-| `prompt.autocomplete.next`     | `down,ctrl+n` | Move to next autocomplete item      |
-| `prompt.autocomplete.hide`     | `escape`      | Hide autocomplete                   |
-| `prompt.autocomplete.select`   | `return`      | Select autocomplete item            |
-| `prompt.autocomplete.complete` | `tab`         | Complete autocomplete item          |
-| `permission.prompt.fullscreen` | `ctrl+f`      | Toggle permission prompt fullscreen |
-| `plugins.toggle`               | `space`       | Toggle plugin                       |
-| `dialog.mcp.toggle`            | `space`       | Toggle MCP server                   |
-| `dialog.plugins.install`       | `shift+i`     | Install plugin from plugin dialog   |
+| ID                             | Default        | Description                         |
+| ------------------------------ | -------------- | ----------------------------------- |
+| `dialog.select.prev`           | `up,ctrl+p`    | Move to previous dialog item        |
+| `dialog.select.next`           | `down,ctrl+n`  | Move to next dialog item            |
+| `dialog.select.page_up`        | `pageup`       | Move up one page in dialog          |
+| `dialog.select.page_down`      | `pagedown`     | Move down one page in dialog        |
+| `dialog.select.home`           | `home`         | Move to first dialog item           |
+| `dialog.select.end`            | `end`          | Move to last dialog item            |
+| `dialog.select.submit`         | `return`       | Submit selected dialog item         |
+| `dialog.prompt.submit`         | `return`       | Submit dialog prompt                |
+| `dialog.worktree.generate`     | `tab`          | Generate worktree name              |
+| `dialog.move_session.new`      | `ctrl+m`       | New worktree                        |
+| `dialog.move_session.delete`   | `ctrl+d`       | Delete worktree                     |
+| `dialog.move_session.refresh`  | `ctrl+r`       | Refresh worktrees                   |
+| `prompt.autocomplete.prev`     | `up,ctrl+p`    | Move to previous autocomplete item  |
+| `prompt.autocomplete.next`     | `down,ctrl+n`  | Move to next autocomplete item      |
+| `prompt.autocomplete.hide`     | `escape`       | Hide autocomplete                   |
+| `prompt.autocomplete.select`   | `return`       | Select autocomplete item            |
+| `prompt.autocomplete.complete` | `tab`          | Complete autocomplete item          |
+| `permission.prompt.fullscreen` | `ctrl+f`       | Toggle permission prompt fullscreen |
+| `plugins.toggle`               | `space`        | Toggle plugin                       |
+| `dialog.mcp.toggle`            | `space`        | Toggle MCP server                   |
+| `dialog.plugins.install`       | `shift+i`      | Install plugin from plugin dialog   |
+| `dialog.plugins.update`        | `ctrl+r`       | Update selected plugin              |
+| `dialog.plugins.update_all`    | `ctrl+shift+r` | Update all plugins                  |
 
 ## Terminal And Plugins
 

--- a/packages/www/src/docs/content/cli/plugins.mdx
+++ b/packages/www/src/docs/content/cli/plugins.mdx
@@ -6,6 +6,16 @@ Plugins configured in `opencode.json(c)` that expose a TUI component are loaded 
 to build plugins, see [Building plugins](/build/plugins). You do not need to add the same package to `cli.json`. The CLI
 gets the active plugin list from the connected OpenCode server, so this also works when the server is remote.
 
+## Manage installed plugins
+
+Run `/plugins`, or open **Plugins** from the command palette, to inspect server and CLI plugins. Select an installed server
+package or Git plugin, then use the actions in the dialog footer:
+
+- `ctrl+r` updates the selected plugin when an update is available.
+- `ctrl+shift+r` updates every plugin with an available update.
+
+The dialog marks pinned and local plugins that cannot be updated automatically.
+
 Use `cli.json` for CLI-only plugins. These plugins run locally in the terminal and remain active when the CLI connects
 to a remote server:
 


### PR DESCRIPTION
## Why

Plugin packages can now be checked and updated explicitly, but the existing `/plugins` dialog does not expose their update state or provide a safe way to apply updates. Users need version visibility and deliberate update actions without interrupting search, cluttering built-in plugins, or silently resetting plugin state.

## What Changes

**1. Inspect installed plugins**

The existing dialog preserves its normal layout and adds useful package/local status only where relevant.

```text
Plugins

  fixture.analytics         1.8.0 → 1.9.0
  fixture.theme             2.4.0 pinned
  fixture.local             local

  ctrl+r update    ctrl+shift+r update all
```

**2. Explicitly update a selected plugin**

Press `ctrl+r` to install and hot-reload the selected update; normal typing continues to filter the dialog. Press `ctrl+shift+r` to update every eligible plugin. Keyboard actions remain in the existing dialog footer.

**3. Refresh safely**

Successful updates refresh the server plugin inventory, failed updates show actionable errors, pinned/local sources are not updated, and built-in plugins retain their previous uncluttered appearance.

## Demo

Matched side-by-side `opencode-drive` recording of the real production `/plugins` dialog, using the same isolated local plugin fixture and interaction against parent revision `2bb6037d6f` (before) and change revision `3df5d7b31b` (after):

https://github.com/user-attachments/assets/d573b186-daa5-4590-94bb-75ee8fa10712

Additional production-component story recording with deterministic simulated plugin metadata, demonstrating safe search, the `ctrl+r` update action, and reopening with the updated package version:

https://github.com/user-attachments/assets/c0f9d669-6594-47af-b92a-b3d2ff39da54

The story uses isolated fictional fixtures; no real user plugins or private model information are included.

## Scope

Owns the existing TUI plugins modal, footer keybindings, isolated story coverage, focused identity tests, and CLI documentation. Package update policy and HTTP/generated-client contracts are supplied by #45118, stacked on #45110.

## Verification

```sh
# packages/tui
bun typecheck
bun run test test/feature-plugins/plugins.test.ts
bun run test test/feature-plugins/plugins.test.ts test/plugin-hot-reload.test.tsx test/plugin-discovery.test.ts test/plugin-reload.test.ts

# packages/www
bun typecheck
bun run check:generated
bun run build
```

The standalone plugin-model test passes independently, all 20 focused TUI tests pass, the documentation site builds with link validation, and the normal pre-push hook typechecks the entire workspace.

## Stack

1. #45110 Git plugin installation
2. #45118 Explicit plugin updates
3. **#45119 Plugin management UI and Drive demos (this PR)**

The complete TUI suite also passes: **792 tests passed, five skipped, zero failures**.