### PR TITLE
fix(tool): simplify the glob path parameter description

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -10,7 +10,8 @@ import * as Tool from "./tool"
 export const Parameters = Schema.Struct({
   pattern: Schema.String.annotate({ description: "The glob pattern to match files against" }),
   path: Schema.optional(Schema.String).annotate({
-    description: `The directory to search in. If not specified, the current working directory will be used. IMPORTANT: Omit this field to use the default directory. DO NOT enter "undefined" or "null" - simply omit it for the default behavior. Must be a valid directory path if provided.`,
+    description:
+      "The directory to search in. If omitted, the current working directory is used. Must be a valid directory path if provided.",
   }),
 })
 

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -78,7 +78,7 @@ exports[`tool parameters JSON Schema (wire shape) glob 1`] = `
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "properties": {
     "path": {
-      "description": "The directory to search in. If not specified, the current working directory will be used. IMPORTANT: Omit this field to use the default directory. DO NOT enter "undefined" or "null" - simply omit it for the default behavior. Must be a valid directory path if provided.",
+      "description": "The directory to search in. If omitted, the current working directory is used. Must be a valid directory path if provided.",
       "type": "string",
     },
     "pattern": {


### PR DESCRIPTION
### Issue for this PR

Closes #44489

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Simplifies the `path` parameter description on the `glob` tool.

The old string was:

```
The directory to search in. If not specified, the current working directory will be used. IMPORTANT: Omit this field to use the default directory. DO NOT enter "undefined" or "null" - simply omit it for the default behavior. Must be a valid directory path if provided.
```

`packages/opencode/src/tool/glob.ts` was the only place in the repo carrying that `IMPORTANT: ... DO NOT enter "undefined" or "null"` block. The neighbouring `grep` tool already uses `"The directory to search in. Defaults to the current working directory."`, and the v2 glob tool in `packages/core/src/tool/glob.ts` uses `"Relative directory to search. Defaults to the active Location."` — so this was the outlier, not the house style.

It also has a practical cost. #44489 reports Qwen3-Coder via llama.cpp producing repeated text, malformed tool-call-like output, and degenerate arguments full of `?` for `glob` specifically, in one case aborting the request with `Unexpected empty grammar stack after accepting piece: ?`. Rewriting only this description via the `tool.definition` hook made the same model call the tool correctly, with no schema change.

The semantics are unchanged. I kept the "must be a valid directory path if provided" clause because it is load-bearing — the tool throws `glob path must be a directory` when it isn't — and only dropped the negative instructions.

### How did you verify your code works?

The description is pinned by the wire-shape snapshot, which localises the change precisely — running the suite before updating it showed exactly one snapshot diff, the glob `path` description, and nothing else:

```
@@ -5,3 +5,3 @@
     "path": {
-      "description": "The directory to search in. If not specified, ... DO NOT enter "undefined" or "null" ... Must be a valid directory path if provided.",
+      "description": "The directory to search in. If omitted, the current working directory is used. Must be a valid directory path if provided.",
       "type": "string",
```

Snapshot updated, then:

```
$ bun test test/tool
 340 pass, 0 fail

$ bun typecheck
(clean)
```

I don't have the llama.cpp/Qwen3-Coder setup to reproduce the decoding failure itself, so the behavioural claim there is the reporter's, not mine. What this PR verifies is that the string change is isolated to the glob schema and breaks nothing else.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
