### PR TITLE
fix(sdk): keep packaged Effect runtime coherent

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -972,6 +972,7 @@
       "dependencies": {
         "@effect/opentelemetry": "catalog:",
         "@effect/platform-node": "catalog:",
+        "@effect/platform-node-shared": "catalog:",
         "@npmcli/arborist": "catalog:",
         "@npmcli/config": "10.8.1",
         "@opentelemetry/api": "1.9.0",

--- a/packages/sdk/script/verify-package.ts
+++ b/packages/sdk/script/verify-package.ts
@@ -173,6 +173,10 @@ for (const module of modules) {
   const sdk = archives.get("@opencode-ai/sdk")
   if (!sdk) throw new Error("Packed SDK archive was not created")
   await $`npm install --ignore-scripts --no-audit --no-fund --package-lock=false ${sdk} wrangler@4.110.0`.cwd(consumer)
+  const runtimes = (await $`npm ls effect --all --parseable`.cwd(consumer).text()).trim().split("\n")
+  if (runtimes.length !== 1) {
+    throw new Error(`Packed SDK consumer resolved multiple Effect runtimes:\n${runtimes.join("\n")}`)
+  }
   await $`bun imports.mjs`.cwd(consumer)
   await $`bun --conditions=workerd imports.mjs`.cwd(consumer)
   await $`node_modules/.bin/wrangler deploy --dry-run --config wrangler.jsonc --outdir dist`.cwd(consumer)

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@effect/opentelemetry": "catalog:",
     "@effect/platform-node": "catalog:",
+    "@effect/platform-node-shared": "catalog:",
     "@npmcli/arborist": "catalog:",
     "@npmcli/config": "10.8.1",
     "@opentelemetry/api": "1.9.0",


### PR DESCRIPTION
## Why

Fresh npm installations of the published SDK can resolve two incompatible Effect release candidates. The packed Cloudflare Worker then fails its health check with `TypeError: Cannot read properties of undefined (reading 'set')`, blocking Linux CI and breaking actual SDK consumers.

## What Changes

**Before:** `@effect/platform-node@4.0.0-rc.111` can float its `@effect/platform-node-shared` dependency to `4.0.0-rc.112`, which installs a second incompatible `effect` runtime. The packed workerd bundle grows to approximately 32 MB and fails to boot.

**After:** `@opencode-ai/util` explicitly depends on the catalog-pinned `@effect/platform-node-shared`, so published consumers resolve a single compatible Effect runtime. The packed workerd bundle is approximately 22 MB and its real health endpoint succeeds.

## Runtime Coherence

Workspace-level overrides do not travel with published packages, so the pin must live in the published runtime dependency graph. Packed SDK verification now checks `npm ls effect --all --parseable` immediately after installing the consumer and fails with an explicit diagnostic if multiple Effect runtimes are ever introduced again.

## Scope

This fixes the published SDK dependency graph and permanently guards packaged-consumer runtime coherence. It does not change application behavior or weaken the existing real workerd boot verification.

## Verification

```sh
cd packages/sdk && bun run verify:package
cd packages/sdk && bun run test
cd packages/sdk && bun typecheck
cd packages/util && bun run test
cd packages/util && bun typecheck
bun install --frozen-lockfile
```

- Packed SDK consumer installs successfully, resolves exactly one Effect runtime, bundles to approximately 22 MB, and passes the real workerd health check.
- SDK tests: 23 passed.
- Utility tests: 33 passed.
- Pre-push workspace typecheck: 32 packages passed.
