### PR TITLE
feat(core): enhanced compaction with ratios and combined context-restoration advancement

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -13,46 +13,29 @@ const DEFAULT_BUFFER = 20_000
 const DEFAULT_KEEP_TOKENS = 8_000
 const TOOL_OUTPUT_MAX_CHARS = 2_000
 const SUMMARY_OUTPUT_TOKENS = 4_096
-const SUMMARY_TEMPLATE = `Output exactly the Markdown structure shown inside <template> and keep the section order unchanged. Do not include the <template> tags in your response.
-<template>
-## Objective
-- [one or two brief sentences describing what the user is trying to accomplish]
+const SUMMARY_TEMPLATE = `You are creating a comprehensive context restoration document. This document will serve as the foundation for continued work - it must preserve critical knowledge that would otherwise be lost.
 
-## Important Details
-- [constraints/preferences, decisions and why, important facts/assumptions, exact context needed to continue, or "(none)"]
+Create a detailed summary with these sections:
+1. Current Task State - what is being worked on, next steps, blockers
+2. Resolved Code & Lessons Learned - working code verbatim, failed approaches, insights
+3. User Directives - explicit preferences, style rules, things to always/never do
+4. Custom Utilities & Commands - scripts, aliases, debugging commands
+5. Design Decisions & Derived Requirements - architecture decisions, API contracts, patterns
+6. Technical Facts - file paths, function names, config values, environment details
 
-## Work State
-### Completed
-- [finished work, verified facts, or changes made; otherwise "(none)"]
-
-### Active
-- [current work, partial changes, or investigation state; otherwise "(none)"]
-
-### Blocked
-- [blockers, failing commands, or unknowns; otherwise "(none)"]
-
-## Next Move
-1. [immediate concrete action, or "(none)"]
-2. [next action if known, or "(none)"]
-
-## Relevant Files
-- [file or directory path: why it matters, or "(none)"]
-</template>
-
-Rules:
-- Keep every section, even when empty.
-- Use terse bullets, not prose paragraphs.
-- Preserve exact file paths, symbols, commands, error strings, URLs, and identifiers when known.
-- Do not mention the summary process or that context was compacted.`
-const SUMMARY_UPDATE_INSTRUCTIONS = `The <prior-summary> summarizes everything that happened before the <conversation>. Construct a new summary that combines both. The <prior-summary> is discarded after this: anything you do not carry into the new summary is lost.
+Critical rules:
+- PRESERVE working code verbatim in fenced blocks
+- INCLUDE failed approaches with explanations
+- Be specific with paths, line numbers, function names
+- Capture the "why" behind decisions
+- User directives are sacred - never omit them`
+const NEWEST_GUIDANCE = `The following is recent context for reference (shows current state):`
+const SUMMARY_UPDATE_INSTRUCTIONS = `The <prior-summary> is the context restoration document from before the <conversation>. IMPORTANT: Merge all information from the <prior-summary> into your new document. Do not lose any historical context.
 
 When combining:
 - Carry forward objectives, constraints, user directives, decisions, and parallel workstreams from the <prior-summary> even when the <conversation> does not mention them. Drop only what is finished and no longer needed.
-- The <conversation> is more recent than the <prior-summary>. Where they conflict, the conversation wins: state the corrected fact and drop the old claim.
-- Add new progress, decisions, constraints, and context from the conversation.
-- Move completed work from "Active" to "Completed".
-- If a blocker has been resolved, update the summary to reflect that while keeping any details still needed to continue the work.
-- Update "Objective" and "Next Move" to reflect the current work state.`
+- The <conversation> is more recent than the <prior-summary>. Where they conflict, the newer content wins: state the corrected fact and drop the old claim.
+- Add new progress, decisions, constraints, and context from the <conversation>.`
 
 type Entry = {
   readonly seq: number
@@ -157,20 +140,30 @@ const select = (
   }
 }
 
-export const buildPrompt = (input: { readonly previousSummary?: string; readonly context: readonly string[] }) => {
-  const conversation = `Here is the conversation so far:\n\n<conversation>\n${input.context.join("\n\n")}\n</conversation>`
-  if (!input.previousSummary)
-    return [
-      conversation,
-      "Create a new anchored summary from the conversation history in the <conversation> tags above so another coding agent can continue the work.",
-      SUMMARY_TEMPLATE,
-    ].join("\n\n")
+export const buildPrompt = (input: {
+  readonly previousSummary?: string
+  readonly context: readonly string[]
+  readonly newest?: string
+}) => {
+  // Section order mirrors collapse 1.5: instructions first, then the prior summary
+  // to merge, the conversation to distill, the recent-context reference lens, and a
+  // final directive to generate the document.
+  const priorSummary = input.previousSummary
+    ? `<prior-summary>\n${SUMMARY_UPDATE_INSTRUCTIONS}\n\n${input.previousSummary}\n</prior-summary>`
+    : undefined
+  const conversation = `<conversation>\nThe following conversation content needs to be distilled into the summary:\n\n${input.context.join("\n\n")}\n</conversation>`
+  // newest_ratio (opt-in): the newest activity, preserved verbatim in the tail, shown
+  // only so the summary is weighted toward where the session is currently headed.
+  const newest = input.newest ? `<newest_context>\n${NEWEST_GUIDANCE}\n\n${input.newest}\n</newest_context>` : undefined
   return [
-    conversation,
-    `Here is the summary of the conversation before the <conversation> above:\n\n<prior-summary>\n${input.previousSummary}\n</prior-summary>`,
-    SUMMARY_UPDATE_INSTRUCTIONS,
     SUMMARY_TEMPLATE,
-  ].join("\n\n")
+    priorSummary,
+    conversation,
+    newest,
+    "Generate the context restoration document now.",
+  ]
+    .filter(Boolean)
+    .join("\n\n")
 }
 
 export const make = (dependencies: Dependencies) => {

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -2,6 +2,9 @@ export * as ConfigV1 from "./config"
 
 import { Schema } from "effect"
 import { NonNegativeInt, PositiveInt, type DeepMutable } from "../../schema"
+
+// A fraction in [0, 1], used for the opt-in proportional compaction knobs.
+const Ratio = Schema.Number.check(Schema.isGreaterThanOrEqualTo(0), Schema.isLessThanOrEqualTo(1))
 import { ConfigExperimental } from "../../config/experimental"
 import { ConfigReference } from "../../config/reference"
 import { ConfigAgentV1 } from "./agent"
@@ -163,6 +166,20 @@ export const Info = Schema.Struct({
       }),
       reserved: Schema.optional(NonNegativeInt).annotate({
         description: "Token buffer for compaction. Leaves enough window to avoid overflow during compaction.",
+      }),
+      // Opt-in proportional variants. When a *_ratio is set it overrides its absolute
+      // sibling and scales with the model's context instead of a fixed token count.
+      reserved_ratio: Schema.optional(Ratio).annotate({
+        description:
+          "Fraction of the context window (0-1) to reserve as headroom, overriding 'reserved'. Also sets the proactive compaction trigger: compaction fires once usable context is consumed. E.g. 0.15 reserves 15%.",
+      }),
+      preserve_recent_ratio: Schema.optional(Ratio).annotate({
+        description:
+          "Fraction of usable context (0-1) to keep verbatim as the recent tail, overriding 'preserve_recent_tokens'. The summarized head is the remainder. E.g. 0.6 keeps 60% verbatim and summarizes the oldest 40%.",
+      }),
+      newest_ratio: Schema.optional(Ratio).annotate({
+        description:
+          "Fraction of the scoped conversation (0-1) whose newest activity is shown to the summarizer as a relevance signal in <newest_context>. It is preserved verbatim in the tail, not removed; it only steers what the summary emphasizes. E.g. 0.15.",
       }),
     }),
   ),

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -31,6 +31,9 @@ const TOOL_OUTPUT_MAX_CHARS = 2_000
 const PRUNE_PROTECTED_TOOLS = ["skill"]
 const MIN_PRESERVE_RECENT_TOKENS = 2_000
 const MAX_PRESERVE_RECENT_TOKENS = 15_000
+// Default fraction of the scoped conversation shown to the summarizer as the
+// <newest_context> relevance lens when newest_ratio is not configured.
+const DEFAULT_NEWEST_RATIO = 0.15
 type Turn = {
   start: number
   end: number
@@ -112,7 +115,14 @@ function completedCompactions(messages: SessionV1.WithParts[]) {
   })
 }
 
-function preserveRecentBudget(input: { cfg: ConfigV1.Info; model: Provider.Model }) {
+function preserveRecentBudget(input: { cfg: ConfigV1.Info; model: Provider.Model; scopedTokens: number }) {
+  // preserve_recent_ratio (proportional) overrides the absolute preserve_recent_tokens
+  // when set: the verbatim tail is a fraction of the CURRENT SESSION's scoped tokens
+  // (the conversation being compacted), not the model window. So the split is always
+  // a proportion of the actual content -- e.g. 0.6 keeps the newest 60% verbatim and
+  // summarizes the oldest 40%, regardless of model context size.
+  const ratio = input.cfg.compaction?.preserve_recent_ratio
+  if (ratio !== undefined) return Math.floor(input.scopedTokens * ratio)
   return (
     input.cfg.compaction?.preserve_recent_tokens ??
     Math.min(MAX_PRESERVE_RECENT_TOKENS, Math.max(MIN_PRESERVE_RECENT_TOKENS, Math.floor(usable(input) * 0.25)))
@@ -227,7 +237,20 @@ const layer = Layer.effect(
     }) {
       const limit = input.cfg.compaction?.tail_turns
       if (limit !== undefined && limit <= 0) return { head: input.messages, tail_start_id: undefined }
-      const budget = preserveRecentBudget({ cfg: input.cfg, model: input.model })
+      // preserve_recent_ratio sizes the tail against the scoped session tokens, so
+      // estimate them once here; the absolute/default path ignores this value.
+      const scopedTokens =
+        input.cfg.compaction?.preserve_recent_ratio !== undefined
+          ? yield* estimate({ messages: input.messages, model: input.model })
+          : 0
+      const budget = preserveRecentBudget({ cfg: input.cfg, model: input.model, scopedTokens })
+      if (input.cfg.compaction?.preserve_recent_ratio !== undefined) {
+        yield* Effect.logInfo("preserve recent ratio", {
+          ratio: input.cfg.compaction.preserve_recent_ratio,
+          scopedTokens,
+          budget,
+        })
+      }
       const all = turns(input.messages)
       if (!all.length) return { head: input.messages, tail_start_id: undefined }
       const recent = limit === undefined ? all : all.slice(-limit)
@@ -266,6 +289,34 @@ const layer = Layer.effect(
         head: input.messages.slice(0, keep.start),
         tail_start_id: keep.id,
       }
+    })
+
+    // newest_ratio (opt-in): the newest slice of the scoped conversation, sized to
+    // newest_ratio of the scoped token total, serialized for the summarizer as a
+    // relevance signal. Returns undefined when the ratio is unset or the slice is empty.
+    const newestContext = Effect.fn("SessionCompaction.newestContext")(function* (input: {
+      messages: SessionV1.WithParts[]
+      cfg: ConfigV1.Info
+      model: Provider.Model
+    }) {
+      // The newest-context lens is on by default; set newest_ratio: 0 to disable it.
+      const ratio = input.cfg.compaction?.newest_ratio ?? DEFAULT_NEWEST_RATIO
+      if (ratio <= 0 || input.messages.length === 0) return undefined
+      const scopedTokens = yield* estimate({ messages: input.messages, model: input.model })
+      const budget = Math.floor(scopedTokens * ratio)
+      if (budget <= 0) return undefined
+      let total = 0
+      let start = input.messages.length
+      for (let i = input.messages.length - 1; i >= 0; i--) {
+        const size = yield* estimate({ messages: input.messages.slice(i, i + 1), model: input.model })
+        if (total + size > budget) break
+        total += size
+        start = i
+      }
+      const slice = input.messages.slice(start)
+      if (!slice.length) return undefined
+      yield* Effect.logInfo("newest context", { ratio, budget, messages: slice.length })
+      return slice.map(serialize).filter(Boolean).join("\n\n") || undefined
     })
 
     // goes backwards through parts until there are PRUNE_PROTECT tokens worth of tool
@@ -364,11 +415,16 @@ const layer = Layer.effect(
       const prior = completedCompactions(history)
       const hidden = new Set(prior.flatMap((item) => [item.userIndex, item.assistantIndex]))
       const previousSummary = prior.at(-1)?.summary
+      const scoped = history.filter((_, index) => !hidden.has(index))
       const selected = yield* select({
-        messages: history.filter((_, index) => !hidden.has(index)),
+        messages: scoped,
         cfg,
         model,
       })
+      // newest_ratio (opt-in): serialize the newest slice of the scoped conversation
+      // as a relevance signal for the summarizer. It stays verbatim in the tail; this
+      // only steers what the summary emphasizes toward the current direction.
+      const newest = yield* newestContext({ messages: scoped, cfg, model })
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",
@@ -384,6 +440,7 @@ const layer = Layer.effect(
           buildPrompt({
             previousSummary,
             context: [conversation],
+            newest,
           }),
           ...compacting.context,
         ]

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -11,6 +11,13 @@ export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outpu
   const context = input.model.limit.context
   if (context === 0) return 0
 
+  // reserved_ratio (proportional): reserve a fraction of the context window as
+  // headroom, scaling both the overflow trigger and the preserve-recent budget.
+  // Applied uniformly against the context so it takes effect regardless of whether
+  // the model advertises a separate input limit.
+  const reservedRatio = input.cfg.compaction?.reserved_ratio
+  if (reservedRatio !== undefined) return Math.max(0, context - Math.floor(context * reservedRatio))
+
   const reserved =
     input.cfg.compaction?.reserved ??
     Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))


### PR DESCRIPTION
### Issue for this PR

Closes #37551
Related: #43703, #37629, #41358

Note on #41358: that issue has two parts. This PR addresses the summary/context-loss part (keeping the task goal and user directives across the compaction boundary via the restoration-document prompt and newest-context signal). It does NOT address the session-loop concurrency/confirmation barrier, which stays tracked in #41358 (linked as Related, not Closes).

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Compaction sizing is absolute-token based (`preserve_recent_tokens`) and the auto-trigger uses a fixed `reserved` headroom. Two problems follow:

1. When a session is smaller than `preserve_recent_tokens`, `select()` walks every turn without exceeding the budget, ends with `keep.start === 0`, and returns "head = everything, no tail" — the whole conversation is summarized and nothing is kept verbatim.
2. A fixed `reserved` buffer makes the effective trigger point scale oddly across models with different context windows (#43703).

This adds three opt-in, proportional knobs. When unset, selection and trigger behavior are unchanged.

- `preserve_recent_ratio`: size the verbatim tail to `preserve_recent_ratio` of the current scoped conversation tokens, so it scales with the session. A small session is never fully summarized. `select()` uses this when set, otherwise the existing absolute `preserve_recent_tokens` budget.
- `reserved_ratio`: reserve a fraction of the context window as headroom in `usable()`, applied uniformly against the context (both the input-limit and context-minus-output branches). This drives the proactive trigger and scales with the window, which multi-model setups need.
- `newest_ratio`: pass the newest slice of the scoped conversation to the summarizer as a relevance signal (`<newest_context>`) so the summary is weighted toward the session's current direction (#41358). The tail stays verbatim; this is a signal only. Defaults on; set to `0` to disable.

The compaction prompt is a context-restoration document. `buildPrompt()` only includes the `<newest_context>` section when a caller supplies it, so the v2 path (which does not) is unaffected. All ratios are computed on demand from the scoped conversation (history minus hidden prior-compaction turns).

Why it works: the ratios move the head/tail boundary and trigger point from fixed token counts to proportions of the actual scoped conversation and context window, so `keep.start === 0` (summarize-everything) can no longer happen on a normal session, and the trigger behaves the same across models. The prompt change only adds an optional relevance section and does not alter the native storage/reassembly mechanics.

Recommended settings:

```jsonc
"compaction": {
  "reserved_ratio": 0.15,
  "preserve_recent_ratio": 0.6,
  "newest_ratio": 0.15
}
```

### How did you verify your code works?

- Ran real compactions on large (1500+ message) sessions with the ratios set and confirmed the head/tail split is proportional (~570-message verbatim tail at `preserve_recent_ratio: 0.6`, vs the tiny fixed tail the absolute default produces on the same session).
- Confirmed the native storage shape is unchanged: `tail_start_id` on the compaction part, summary appended at the end, and `filterCompacted` reassembly to `[trigger][summary][tail]`.
- Confirmed the produced summary follows the context-restoration document structure, and that a post-compaction turn runs cleanly against the reassembled context.
- Confirmed that with the ratios unset, `select()`/trigger reproduce the existing absolute-token behavior.

### Screenshots / recordings

N/A — no UI change (core compaction/config only).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
