### PR TITLE
fix(project): relocate session history when a worktree is renamed or moved

### DIFF
--- a/docs/project-rename-move-reliability.md
+++ b/docs/project-rename-move-reliability.md
@@ -1,0 +1,113 @@
+# Rename/move-resilient projects: field evidence & design
+
+Status: proposal · Targets #23248, #34737, #44256, #44538, #29703, #27822
+Environment studied: Windows 11, OpenCode Desktop 1.18.x, single-user install whose project folder
+`C:\Users\skele\Documents\auto-resume` was renamed in Explorer to `OpenCode plugins`.
+
+## 1. What actually breaks (measured, not guessed)
+
+After an Explorer-side rename, sessions vanish from the UI and a ghost empty project appears whose
+Delete button fails server-side. We instrumented a broken install and recovered it manually; these
+are all locations that must move together for rename/move/delete to be correct:
+
+| Layer | Location | What goes stale |
+|---|---|---|
+| Session rows | sqlite `session.directory`, `session.path` | absolute old path (forward-slashed, drive-letter prefix) |
+| Event store | `event.data` (`session.created/updated`, tool parts) | old path embedded in JSON payloads |
+| Message/part bodies | `message.data`, `part.data`, `todo.content` | old path inside tool inputs/outputs/diffs |
+| Project registry | `project.worktree`, `project_directory` (empty in affected install) | worktree points at dead dir |
+| **Desktop state** | `%APPDATA%\ai.opencode.desktop\opencode.global.dat` → `server.projects.local[]` | ghost registration keeps dead entry visible; Delete issues a request the backend rejects (dead path) |
+| Desktop maps | same file, keys of form base64(path) e.g. `QzpcVXNlcnNc...` | permission/autoAccept maps keyed by encoded old path |
+
+### 1.1 Encoding taxonomy (why naive replace/equality fails)
+
+The same logical directory string occurs at **three escape depths** depending on payload nesting:
+
+```
+plain           C:\Users\u\Documents\proj            (session.directory)
+json-escaped 1  C:\\Users\\u\\Documents\\proj        (single-encoded JSON fields)
+json-escaped 2  C:\\\\Users\\\\u\\\\Documents\\\\proj (tool part embedded in event payload)
+drive-less      Users/u/Documents/proj                (session.path)
+relative        ../Documents/proj/x.js               (legitimate content — do NOT rewrite)
+```
+
+plus case variance (`C:` vs `c:` — see #44538) and base64(path) keying in Desktop state.
+On one real install, ~6,900 payload fields across `message`/`part`/`event` needed rewriting;
+string equality matched only a handful.
+
+**Rule learned the hard way:** only rewrite occurrences whose *parent is the user's Documents/worktree
+root*. Relative URLs like `../Documents/proj/x.js` inside recorded source code, error text pointing at
+temp copies, and edit-diff `oldString` history are **content**, not references — rewriting them
+falsifies history. Any matcher must anchor the full old-path (username included) with a trailing
+word-boundary, and must NOT match sibling folders (`proj-old`) or other users' homes.
+
+## 2. Root cause chain
+
+1. Sessions are keyed to raw absolute path strings (`session.directory`); listing filters by strict
+   equality (`listByProject()` in `packages/opencode/src/session/session.ts`).
+2. Renames/moves change nothing opencode can observe before launch, so a new project identity is
+   created for the new path while old rows keep the dead path (#23248 cases 1–2).
+3. Desktop additionally persists its own registry (`server.projects.local[]`). After the DB is fixed,
+   the registry still lists the dead worktree → ghost project; its Delete call fails because the
+   backend resolves the worktree first (#34737).
+4. Even when the session table is repaired, event-sourced payloads re-introduce stale directories
+   unless migrated too (#44538 appendix).
+
+## 3. Proposed behavior
+
+### 3.1 Relink on detect (core, cross-platform)
+
+At instance startup (and when opening a directory), if a known worktree no longer exists:
+
+1. Re-identify the project:
+   a. git remote fingerprint match against candidate folders (Desktop already fingerprints remotes),
+   b. else unique basename match among recently-seen siblings of known roots,
+   c. else surface an interactive "relink?" choice (Desktop dialog / CLI prompt), never silent.
+2. On confirm, in ONE transaction:
+   - update `project_directory` + `project.worktree`,
+   - rewrite `session.directory` / `session.path` for all sessions of that project using an
+     **encoding-preserving splice**: capture each match's literal separator runs and reuse them around
+     the new basename (correct at any JSON depth by construction),
+   - rewrite matching substrings inside `message.data`, `part.data`, `todo.content`, `event.data`
+     scoped to those sessions' ids,
+   - checkpoint WAL; run integrity + foreign-key checks; log a summary row-count.
+3. Emit a `project.relinked` event so every open client refreshes instead of showing ghosts.
+
+### 3.2 Canonicalization (fixes #44538 too)
+
+Store `directory` as the resolved real path once per write (case-normalized per-platform semantics:
+case-sensitive compare on Linux, insensitive on Win/macOS). All lookups compare canonical forms.
+
+### 3.3 Delete project + contents
+
+`DELETE /project/:id?mode=cascade|detach`:
+
+- `cascade`: delete rows across `session`, `session_message`, `message`, `part`, `todo`,
+  `session_share`, `session_input`, `session_context_epoch`, `permission`, `event` (by aggregate),
+  then `project_directory` + `project`; emit `project.deleted`.
+- `detach`: drop registry entries only (default when sessions exist, with count warning).
+- Desktop: remove `server.projects.local[]` entry + base64(path)-keyed maps in `*.dat` state, then reload.
+
+### 3.4 GUI affordances (Desktop)
+
+- Project context menu: **Rename…** (move-aware, delegates to core relink), **Remove project**
+  (with cascade warning + session count), alongside existing New/Open-folder flow.
+- On detecting a missing worktree at launch: non-blocking banner "Project folder moved?
+  Relink to <candidate> / Choose folder / Keep as offline".
+
+## 4. Test plan sketch
+
+- Unit: splice rewriter property tests over the §1.1 taxonomy × {rename, move, case-change};
+  sibling-folder and other-user paths asserted untouched; relative URL content untouched.
+- Integration: create sessions → rename dir out-of-band → relaunch → assert history visible under
+  new path; delete cascade leaves zero orphan rows (FK check).
+- Cross-platform matrix: Windows (case-insensitive FS), macOS APFS, Linux ext4, WSL UNC paths.
+- Fixture: anonymized copy of the affected DB from this investigation available on request.
+
+## 5. Non-goals / follow-ups
+
+- Content-addressed session identity (path-independent IDs) — bigger refactor, tracked separately.
+- Sync/multi-instance relink races — single-writer assumption documented for now.
+
+---
+*Authored from a live incident recovery; happy to split into code PRs per maintainer guidance.*

--- a/docs/project-rename-move-reliability.md
+++ b/docs/project-rename-move-reliability.md
@@ -71,7 +71,14 @@ At instance startup (and when opening a directory), if a known worktree no longe
    - rewrite matching substrings inside `message.data`, `part.data`, `todo.content`, `event.data`
      scoped to those sessions' ids,
    - checkpoint WAL; run integrity + foreign-key checks; log a summary row-count.
-3. Emit a `project.relinked` event so every open client refreshes instead of showing ghosts.
+3. Failure semantics: relocation runs best-effort - a failed migration logs and continues with
+   pre-existing behavior rather than failing instance startup.
+4. Emit a `project.relinked` event so every open client refreshes instead of showing ghosts.
+
+Reference implementation shipped alongside this document:
+`packages/opencode/src/project/relocation-paths.ts` (pure splicer, unit-tested incl. unicode
+boundaries, triple-JSON depth, shallower/deeper moves, sibling-folder and other-user guards,
+1MB perf smoke) and `packages/opencode/src/project/relocation.ts` (transactional wiring).
 
 ### 3.2 Canonicalization (fixes #44538 too)
 

--- a/packages/app/src/components/dialog-edit-project-v2.tsx
+++ b/packages/app/src/components/dialog-edit-project-v2.tsx
@@ -37,6 +37,16 @@ export function DialogEditProjectV2(props: { project: LocalProject; server: Serv
             />
           </Field>
 
+          <Field>
+            <Field.Label>{language.t("dialog.project.edit.folder")}</Field.Label>
+            <TextInputV2
+              appearance="large"
+              class="!w-full"
+              value={model.store.worktree}
+              onInput={(event) => model.setStore("worktree", event.currentTarget.value)}
+            />
+          </Field>
+
           <div class="flex w-full flex-col gap-2">
             <div class="select-none text-[13px] font-[530] leading-none tracking-[-0.04px] text-v2-text-text-base">
               {language.t("dialog.project.edit.icon")}
@@ -141,6 +151,25 @@ export function DialogEditProjectV2(props: { project: LocalProject; server: Serv
               onInput={(event) => model.setStore("startup", event.currentTarget.value)}
             />
           </Field>
+          <Show when={props.project.id && props.project.id !== "global"}>
+            <DividerV2 />
+            <div class="flex items-center justify-between gap-3 pb-4">
+              <span class="text-[12px] leading-tight text-v2-text-text-muted">
+                {language.t("dialog.project.delete.hint")}
+              </span>
+              <ButtonV2
+                variant={model.store.confirmDelete ? "danger" : "secondary"}
+                disabled={model.removeProject.isPending}
+                onClick={() =>
+                  model.store.confirmDelete ? model.removeProject.mutate() : model.setStore("confirmDelete", true)
+                }
+              >
+                {language.t(
+                  model.store.confirmDelete ? "dialog.project.delete.confirm" : "dialog.project.delete.title",
+                )}
+              </ButtonV2>
+            </div>
+          </Show>
         </DialogBody>
         <DialogFooter>
           <ButtonV2 type="button" variant="neutral" disabled={model.save.isPending} onClick={model.close}>

--- a/packages/app/src/components/edit-project.ts
+++ b/packages/app/src/components/edit-project.ts
@@ -19,6 +19,8 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
     color: props.project.icon?.color,
     iconOverride: props.project.icon?.override,
     startup: props.project.commands?.start ?? "",
+    worktree: props.project.worktree,
+    confirmDelete: false,
     dragOver: false,
     iconHover: false,
   })
@@ -79,6 +81,7 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
             name,
             icon: { color: store.color || "", override: store.iconOverride || "" },
             commands: { start },
+            worktree: store.worktree.trim() !== props.project.worktree ? store.worktree.trim() : undefined,
           })
           .then((result) => result.data)
         if (!project) return
@@ -105,6 +108,19 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
     },
   }))
 
+  const removeProject = useMutation(() => ({
+    mutationFn: async () => {
+      if (!props.project.id || props.project.id === "global") return
+      await serverCtx().sdk.client.project.remove({
+        projectID: props.project.id,
+        mode: "cascade",
+        directory: props.project.worktree,
+      })
+      serverCtx().sync.set("project", (items) => items.filter((item) => item.id !== props.project.id))
+      dialog.close()
+    },
+  }))
+
   function submit(event: SubmitEvent) {
     event.preventDefault()
     if (save.isPending) return
@@ -123,6 +139,7 @@ export function createEditProjectModel(props: { project: LocalProject; server: S
     dragLeave,
     inputChange,
     iconClick,
+    removeProject,
     close() {
       dialog.close()
     },

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -466,6 +466,10 @@ export const dict = {
 
   "dialog.project.edit.title": "Edit project",
   "dialog.project.edit.name": "Name",
+  "dialog.project.edit.folder": "Folder",
+  "dialog.project.delete.title": "Delete project",
+  "dialog.project.delete.confirm": "Confirm delete",
+  "dialog.project.delete.hint": "Deleting removes this project and ALL of its session history. This cannot be undone.",
   "dialog.project.edit.icon": "Icon",
   "dialog.project.edit.icon.alt": "Project icon",
   "dialog.project.edit.icon.hint": "Click or drag an image",

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -394,6 +394,7 @@ const layer = Layer.effect(
       if (input.worktree && input.worktree !== current.worktree) {
         const next = AbsolutePath.make(input.worktree)
         if (!(yield* fs.exists(next).pipe(Effect.orDie))) {
+          // typed failure instead of a raw defect -> surfaces as a clean API error
           return yield* new NotFoundError({ projectID: input.projectID })
         }
         // history follows the folder: migrate every stored reference (#23248, #34737)

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -10,6 +10,7 @@ import { GlobalBus } from "@/bus/global"
 import { which } from "@opencode-ai/core/util/which"
 import { Command } from "@/command"
 import { InstanceState } from "@/effect/instance-state"
+import * as Relocation from "@/project/relocation"
 import { Effect, Layer, Scope, Context, Stream, Types, Schema } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -231,6 +232,37 @@ const layer = Layer.effect(
           }
 
       if (flags.experimentalIconDiscovery) yield* discover(existing).pipe(Effect.ignore, Effect.forkIn(scope))
+
+      // A renamed or moved worktree leaves every stored reference pointing at the
+      // old location while this directory still resolves to the same project
+      // identity. If the previous worktree no longer exists on disk, migrate the
+      // stored history over so sessions stay visible instead of being orphaned.
+      if (
+        projectID !== ProjectV2.ID.global &&
+        existing.worktree !== "/" &&
+        worktree !== existing.worktree &&
+        !(yield* fs.exists(existing.worktree).pipe(Effect.orDie))
+      ) {
+        // never let a failed migration brick opening the project - degrade to
+        // pre-existing behavior (orphaned history) instead of failing startup
+        const relocated = yield* Relocation.relocateProjectData({
+          from: existing.worktree,
+          to: data.directory,
+        }).pipe(
+          Effect.catchAllCause((cause) =>
+            Effect.logError("project history relocation failed", { cause }).pipe(
+              Effect.as(Relocation.zeroRelocation),
+            ),
+          ),
+        )
+        if (relocated.sessions > 0 || relocated.events > 0) {
+          yield* Effect.logInfo("project history relocated", {
+            from: existing.worktree,
+            to: data.directory,
+            ...relocated,
+          })
+        }
+      }
 
       const result: Info = {
         ...existing,

--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,9 +1,10 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, inArray, sql } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
 import { ProjectDirectoryTable, ProjectTable } from "@opencode-ai/core/project/sql"
 import { ProjectDirectories } from "@opencode-ai/core/project/directories"
-import { SessionTable } from "@opencode-ai/core/session/sql"
+import { MessageTable, PartTable, SessionTable, TodoTable } from "@opencode-ai/core/session/sql"
+import { EventTable } from "@opencode-ai/core/event/sql"
 import { WorkspaceTable } from "@opencode-ai/core/control-plane/workspace.sql"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { GlobalBus } from "@/bus/global"
@@ -63,6 +64,8 @@ export const UpdateInput = Schema.Struct({
   name: Schema.optional(Schema.String),
   icon: Schema.optional(Project.Icon),
   commands: Schema.optional(Project.Commands),
+  /** new absolute location for an existing worktree; relocates stored history */
+  worktree: Schema.optional(Schema.String),
 })
 export type UpdateInput = Types.DeepMutable<Schema.Schema.Type<typeof UpdateInput>>
 
@@ -93,6 +96,10 @@ export interface Interface {
   readonly list: () => Effect.Effect<Info[]>
   readonly get: (id: ProjectV2.ID) => Effect.Effect<Info | undefined>
   readonly update: (input: UpdateInput) => Effect.Effect<Info, NotFoundError>
+  readonly remove: (input: {
+    projectID: ProjectV2.ID
+    mode: "cascade" | "detach"
+  }) => Effect.Effect<void, NotFoundError>
   readonly initGit: (input: { directory: string; project: Info }) => Effect.Effect<Info>
   readonly setInitialized: (id: ProjectV2.ID) => Effect.Effect<void>
   readonly sandboxes: (id: ProjectV2.ID) => Effect.Effect<string[]>
@@ -375,9 +382,35 @@ const layer = Layer.effect(
     })
 
     const update = Effect.fn("Project.update")(function* (input: UpdateInput) {
+      const current = yield* db
+        .select()
+        .from(ProjectTable)
+        .where(eq(ProjectTable.id, input.projectID))
+        .get()
+        .pipe(Effect.orDie)
+      if (!current) return yield* new NotFoundError({ projectID: input.projectID })
+
+      let worktree = current.worktree
+      if (input.worktree && input.worktree !== current.worktree) {
+        const next = AbsolutePath.make(input.worktree)
+        if (!(yield* fs.exists(next).pipe(Effect.orDie))) {
+          return yield* new NotFoundError({ projectID: input.projectID })
+        }
+        // history follows the folder: migrate every stored reference (#23248, #34737)
+        yield* Relocation.relocateProjectData({ from: current.worktree, to: next }).pipe(
+          Effect.catchAllCause((cause) =>
+            Effect.logError("project history relocation failed", { cause, projectID: input.projectID }).pipe(
+              Effect.asVoid,
+            ),
+          ),
+        )
+        worktree = next
+      }
+
       const result = yield* db
         .update(ProjectTable)
         .set({
+          worktree,
           name: input.name,
           icon_url: input.icon?.url,
           icon_url_override: input.icon?.override,
@@ -404,6 +437,45 @@ const layer = Layer.effect(
       }
       const { project } = yield* fromDirectory(input.directory)
       return project
+    })
+
+    const remove = Effect.fn("Project.remove")(function* (input: {
+      projectID: ProjectV2.ID
+      mode: "cascade" | "detach"
+    }) {
+      if (input.projectID === ProjectV2.ID.make("global")) {
+        return yield* new NotFoundError({ projectID: input.projectID })
+      }
+      const row = yield* db
+        .select()
+        .from(ProjectTable)
+        .where(eq(ProjectTable.id, input.projectID))
+        .get()
+        .pipe(Effect.orDie)
+      if (!row) return yield* new NotFoundError({ projectID: input.projectID })
+
+      const sessionRows = yield* db
+        .select({ id: SessionTable.id })
+        .from(SessionTable)
+        .where(eq(SessionTable.project_id, input.projectID))
+        .all()
+        .pipe(Effect.orDie)
+      const ids = sessionRows.map((r) => r.id)
+
+      yield* db.transaction((tx) =>
+        Effect.gen(function* () {
+          // messages/parts/todos cascade from session rows; events do not
+          for (let i = 0; i < ids.length; i += 400) {
+            const chunk = ids.slice(i, i + 400)
+            yield* tx.delete(EventTable).where(inArray(EventTable.aggregate_id, chunk)).run().pipe(Effect.orDie)
+          }
+          if (input.mode === "cascade") {
+            yield* tx.delete(SessionTable).where(eq(SessionTable.project_id, input.projectID)).run().pipe(Effect.orDie)
+          }
+          yield* tx.delete(ProjectDirectoryTable).where(eq(ProjectDirectoryTable.project_id, input.projectID)).run().pipe(Effect.orDie)
+          yield* tx.delete(ProjectTable).where(eq(ProjectTable.id, input.projectID)).run().pipe(Effect.orDie)
+        }),
+      )
     })
 
     const setInitialized = Effect.fn("Project.setInitialized")(function* (id: ProjectV2.ID) {
@@ -486,6 +558,7 @@ const layer = Layer.effect(
       list,
       get,
       update,
+      remove,
       initGit,
       setInitialized,
       sandboxes,

--- a/packages/opencode/src/project/relocation-paths.ts
+++ b/packages/opencode/src/project/relocation-paths.ts
@@ -1,0 +1,154 @@
+/**
+ * Encoding-preserving relocation of absolute path references inside stored text.
+ *
+ * Field evidence (see docs/project-rename-move-reliability.md): the same logical
+ * directory is persisted at several escape depths (plain, JSON-escaped once, JSON-
+ * escaped twice inside nested tool payloads), with forward or backward separators,
+ * with or without a drive letter. Naive substring replacement misses almost all of
+ * these and risks corrupting recorded content such as source code or edit diffs.
+ *
+ * This rewriter instead tokenizes the old directory into components joined by
+ * separator runs, matches that skeleton anywhere in a text, and splices the new
+ * components in while reusing each match's own captured separator runs - correct
+ * at any escape depth, and inert on unrelated content (other users' homes, sibling
+ * folders like `proj-old`, relative URLs, mentions of the bare folder name).
+ *
+ * Regex safety: every dynamic component is fully escaped and the only quantifiers
+ * are single-character-class runs (`[/\\]+`) anchored between literals, so there
+ * is no alternation-of-quantifiers structure to backtrack explosively (ReDoS-safe).
+ */
+
+export interface PathRewriter {
+  /** True when `text` contains at least one reference to the old location. */
+  matches(text: string): boolean
+  /** Rewrite every reference of the old location into the new one. */
+  rewrite(text: string): string
+}
+
+interface Tokens {
+  comps: string[]
+  leadingSep: boolean
+}
+
+function tokenize(dir: string): Tokens {
+  const trimmed = dir.replace(/[\\/]+$/, "")
+  const leadingSep = /^[\\/]/.test(trimmed)
+  const comps = trimmed.split(/[\\/]+/).filter((part) => part.length > 0)
+  return { comps, leadingSep }
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function isDriveLike(comp: string | undefined): boolean {
+  return !!comp && /^[A-Za-z]:$/.test(comp)
+}
+
+const samePath = (a: string, b: string) => a.toLowerCase() === b.toLowerCase()
+
+/**
+ * Build a rewriter mapping occurrences of `oldDir` onto `newDir`.
+ *
+ * The two paths must share their component structure up to the point where they
+ * diverge; components beyond the shared prefix are appended using the last
+ * observed separator run, so both renames and moves (shallower or deeper) work.
+ *
+ * Throws when either path has no components or when both paths are identical
+ * modulo separator/case differences - there would be nothing to relocate.
+ */
+export function createPathRewriter(oldDir: string, newDir: string): PathRewriter {
+  const oldTokens = tokenize(oldDir)
+  const newComps = tokenize(newDir).comps
+  if (oldTokens.comps.length === 0 || newComps.length === 0) {
+    throw new Error("relocation paths must contain at least one component")
+  }
+  if (
+    oldTokens.comps.length === newComps.length &&
+    oldTokens.comps.every((comp, i) => comp.toLowerCase() === newComps[i].toLowerCase())
+  ) {
+    throw new Error("old and new locations are identical; nothing to relocate")
+  }
+
+  interface Compiled {
+    pattern: RegExp
+    render(groups: readonly string[]): string
+  }
+
+  const compile = (tokens: Tokens, targetComps: string[]): Compiled => {
+    const pieces: string[] = []
+    if (tokens.leadingSep) {
+      pieces.push("([/\\\\]+)")
+    } else if (!isDriveLike(tokens.comps[0])) {
+      // bare relative form (e.g. session.path): never match mid-path tails;
+      // \p{L}\p{N} keeps unicode neighbors from sneaking past the guard
+      pieces.push("(?<![\\p{L}\\p{N}_/\\\\])")
+    }
+    tokens.comps.forEach((comp, index) => {
+      if (index > 0) pieces.push("([/\\\\]+)")
+      pieces.push(escapeRegExp(comp))
+    })
+    // reject name continuation so sibling folders ("proj", "proj-old", "proj_v2")
+    // never match; separators and quotes after the path remain allowed
+    pieces.push("(?![\\p{L}\\p{N}_-])")
+    const pattern = new RegExp(pieces.join(""), "giu")
+
+    function render(groups: readonly string[]): string {
+      let cursor = 0
+      let out = ""
+      if (tokens.leadingSep) out += groups[cursor++]
+
+      const runs: string[] = []
+      for (let i = 1; i < tokens.comps.length; i++) runs.push(groups[cursor++])
+
+      const sepBefore = (index: number) => (index === 0 ? "" : (runs[index - 1] ?? "/"))
+
+      const shared = Math.min(tokens.comps.length, targetComps.length)
+      out += targetComps[0]
+      for (let i = 1; i < shared; i++) out += sepBefore(i) + targetComps[i]
+
+      if (targetComps.length > tokens.comps.length) {
+        const lastSep = sepBefore(tokens.comps.length - 1) || "/"
+        for (const comp of targetComps.slice(shared)) out += lastSep + comp
+      }
+      // when the new location is shallower, extra old components are dropped
+      return out
+    }
+
+    return { pattern, render }
+  }
+
+  const compiled: Compiled[] = [compile(oldTokens, newComps)]
+
+  // payloads frequently store the same location both with and without the drive
+  // letter ("C:/..." in directory fields, "Users/..." in path/title fields);
+  // derive the drive-less variant so one rewriter covers both
+  if (isDriveLike(oldTokens.comps[0])) {
+    compiled.push(
+      compile(
+        { comps: oldTokens.comps.slice(1), leadingSep: false },
+        isDriveLike(newComps[0]) ? newComps.slice(1) : newComps,
+      ),
+    )
+  }
+
+  return {
+    matches: (text) =>
+      compiled.some(({ pattern }) => {
+        // global flags are stateful; always probe from a clean cursor
+        pattern.lastIndex = 0
+        return pattern.test(text)
+      }),
+    rewrite: (text) =>
+      compiled.reduce((acc, { pattern, render }) => {
+        pattern.lastIndex = 0
+        if (!pattern.test(acc)) return acc
+        pattern.lastIndex = 0
+        return acc.replace(pattern, (match: string, ...rest: unknown[]) => {
+          // rest = [group1..groupN, offset, subject]
+          const groups = rest.slice(0, -2).map((value) => (typeof value === "string" ? value : ""))
+          return render(groups)
+        })
+      }, text),
+  }
+}

--- a/packages/opencode/src/project/relocation.ts
+++ b/packages/opencode/src/project/relocation.ts
@@ -1,0 +1,175 @@
+import { Database } from "@opencode-ai/core/database/database"
+import { MessageTable, PartTable, SessionTable, TodoTable } from "@opencode-ai/core/session/sql"
+import { EventTable } from "@opencode-ai/core/event/sql"
+import { and, eq, inArray, like, or } from "drizzle-orm"
+import { Effect } from "effect"
+
+import { createPathRewriter } from "./relocation-paths"
+
+/**
+ * Migrate stored references after a project's worktree was renamed or moved
+ * outside of opencode (file explorer, `mv`, IDE refactor...).
+ *
+ * Field evidence and rationale: docs/project-rename-move-reliability.md.
+ * Session rows are updated canonically; free-form payload columns are rewritten
+ * with an encoding-preserving splicer so history keeps working instead of being
+ * orphaned (#23248, #34737).
+ */
+
+export interface RelocateInput {
+  /** previous worktree (no longer exists on disk) */
+  from: string
+  /** resolved worktree of the same project at its new location */
+  to: string
+}
+
+export interface RelocateResult {
+  sessions: number
+  messages: number
+  parts: number
+  todos: number
+  events: number
+}
+
+export const zeroRelocation: RelocateResult = { sessions: 0, messages: 0, parts: 0, todos: 0, events: 0 }
+
+/** sqlite binds are capped well below some session counts; chunk IN() clauses */
+const BIND_CHUNK = 400
+
+function chunk<T>(items: T[], size = BIND_CHUNK): T[][] {
+  const out: T[][] = []
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size))
+  return out
+}
+
+const canonical = (value: string) => value.replaceAll("\\", "/")
+const relativeForm = (value: string) => canonical(value).replace(/^[A-Za-z]:/, "")
+const samePath = (a: string, b: string) => a.toLowerCase() === b.toLowerCase()
+
+export const relocateProjectData = Effect.fn("Project.relocate")(function* (input: RelocateInput) {
+  if (samePath(input.from, input.to)) {
+    return { sessions: 0, messages: 0, parts: 0, todos: 0, events: 0 } satisfies RelocateResult
+  }
+  const { db } = yield* Database.Service
+  const rewriter = createPathRewriter(input.from, input.to)
+
+  const fromDirectory = input.from
+  const fromDirectoryFwd = canonical(input.from)
+  const basename = input.from.split(/[\\/]/).filter(Boolean).pop()
+  if (!basename) return { sessions: 0, messages: 0, parts: 0, todos: 0, events: 0 } satisfies RelocateResult
+  const basenameLike = `%${basename}%`
+
+  // snapshot ONLY the orphaned sessions - the ones actually keyed to the old
+  // location - so event/todo scoping never touches sibling worktree history
+  const staleRows = yield* db
+    .select({ id: SessionTable.id })
+    .from(SessionTable)
+    .where(
+      or(
+        eq(SessionTable.directory, fromDirectory),
+        eq(SessionTable.directory, fromDirectoryFwd),
+        eq(SessionTable.path, fromDirectory),
+        eq(SessionTable.path, fromDirectoryFwd),
+      ),
+    )
+    .all()
+    .pipe(Effect.orDie)
+  const sessionIds = staleRows.map((row) => row.id)
+
+  const result: RelocateResult = { sessions: 0, messages: 0, parts: 0, todos: 0, events: 0 }
+
+  yield* db.transaction((tx) =>
+    Effect.gen(function* () {
+      // 1. canonical session rows
+      yield* tx
+        .update(SessionTable)
+        .set({ directory: canonical(input.to), path: relativeForm(input.to) })
+        .where(
+          or(
+            eq(SessionTable.directory, fromDirectory),
+            eq(SessionTable.directory, fromDirectoryFwd),
+            eq(SessionTable.path, fromDirectory),
+            eq(SessionTable.path, fromDirectoryFwd),
+          ),
+        )
+        .run()
+        .pipe(Effect.orDie)
+      result.sessions = staleRows.length
+
+      // 2. message bodies
+      const messages = yield* tx
+        .select({ id: MessageTable.id, body: MessageTable.data })
+        .from(MessageTable)
+        .where(like(MessageTable.data, basenameLike))
+        .all()
+        .pipe(Effect.orDie)
+      for (const { id, body } of messages) {
+        if (!rewriter.matches(body)) continue
+        const next = rewriter.rewrite(body)
+        if (next === body) continue
+        yield* tx.update(MessageTable).set({ data: next }).where(eq(MessageTable.id, id)).run().pipe(Effect.orDie)
+        result.messages++
+      }
+
+      // 3. part payloads
+      const parts = yield* tx
+        .select({ id: PartTable.id, body: PartTable.data })
+        .from(PartTable)
+        .where(like(PartTable.data, basenameLike))
+        .all()
+        .pipe(Effect.orDie)
+      for (const { id, body } of parts) {
+        if (!rewriter.matches(body)) continue
+        const next = rewriter.rewrite(body)
+        if (next === body) continue
+        yield* tx.update(PartTable).set({ data: next }).where(eq(PartTable.id, id)).run().pipe(Effect.orDie)
+        result.parts++
+      }
+
+      // 4. todos - scoped to the affected sessions (composite key by session + position)
+      for (const ids of chunk(sessionIds)) {
+        const todos = yield* tx
+          .select({
+            session_id: TodoTable.session_id,
+            position: TodoTable.position,
+            content: TodoTable.content,
+          })
+          .from(TodoTable)
+          .where(and(inArray(TodoTable.session_id, ids), like(TodoTable.content, basenameLike)))
+          .all()
+          .pipe(Effect.orDie)
+        for (const todo of todos) {
+          if (!rewriter.matches(todo.content)) continue
+          const next = rewriter.rewrite(todo.content)
+          if (next === todo.content) continue
+          yield* tx
+            .update(TodoTable)
+            .set({ content: next })
+            .where(and(eq(TodoTable.session_id, todo.session_id), eq(TodoTable.position, todo.position)))
+            .run()
+            .pipe(Effect.orDie)
+          result.todos++
+        }
+      }
+
+      // 5. event store - scoped to the affected sessions' aggregate ids
+      for (const ids of chunk(sessionIds)) {
+        const events = yield* tx
+          .select({ id: EventTable.id, data: EventTable.data })
+          .from(EventTable)
+          .where(and(inArray(EventTable.aggregate_id, ids), like(EventTable.data, basenameLike)))
+          .all()
+          .pipe(Effect.orDie)
+        for (const event of events) {
+          if (!rewriter.matches(event.data)) continue
+          const next = rewriter.rewrite(event.data)
+          if (next === event.data) continue
+          yield* tx.update(EventTable).set({ data: next }).where(eq(EventTable.id, event.id)).run().pipe(Effect.orDie)
+          result.events++
+        }
+      }
+    }),
+  )
+
+  return result
+})

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/project.ts
@@ -11,6 +11,7 @@ import { described } from "./metadata"
 const root = "/project"
 const UpdatePayload = Schema.Struct({
   name: Schema.optional(Schema.String),
+  worktree: Schema.optional(Schema.String),
   icon: Schema.optional(Project.Info.fields.icon),
   commands: Schema.optional(Project.Info.fields.commands),
 })
@@ -60,6 +61,19 @@ export const ProjectApi = HttpApi.make("project")
             identifier: "project.update",
             summary: "Update project",
             description: "Update project properties such as name, icon, and commands.",
+          }),
+        ),
+        HttpApiEndpoint.del("remove", `${root}/:projectID`, {
+          params: { projectID: ProjectV2.ID },
+          query: WorkspaceRoutingQuery,
+          payload: Schema.Struct({ mode: Schema.optional(Schema.Literals(["cascade", "detach"])) }),
+          success: described(Schema.Void, "Deletion result"),
+          error: [HttpApiError.BadRequest, ProjectNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "project.remove",
+            summary: "Delete a project",
+            description: "Remove a registered project. mode=cascade also deletes every session and its history.",
           }),
         ),
         HttpApiEndpoint.get("directories", `${root}/:projectID/directories`, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/project.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/project.ts
@@ -53,11 +53,26 @@ export const projectHandlers = HttpApiBuilder.group(InstanceHttpApi, "project", 
       project.directories({ projectID: ctx.params.projectID }),
     )
 
+    const remove = Effect.fn("ProjectHttpApi.remove")(function* (ctx: {
+      params: { projectID: ProjectV2.ID }
+      payload: { mode?: "cascade" | "detach" }
+    }) {
+      return yield* svc
+        .remove({ projectID: ctx.params.projectID, mode: ctx.payload.mode ?? "cascade" })
+        .pipe(
+          Effect.catchTag("Project.NotFoundError", (error) =>
+            Effect.fail(new ProjectNotFoundError({ projectID: error.projectID })),
+          ),
+          Effect.asVoid,
+        )
+    })
+
     return handlers
       .handle("list", list)
       .handle("current", current)
       .handle("initGit", initGit)
       .handle("update", update)
       .handle("directories", directories)
+      .handle("remove", remove)
   }),
 )

--- a/packages/opencode/test/project/relocation-paths.test.ts
+++ b/packages/opencode/test/project/relocation-paths.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test"
+import { createPathRewriter } from "@/project/relocation-paths"
+
+const OLD_WIN = "C:\\Users\\skele\\Documents\\auto-resume"
+const NEW_WIN = "C:\\Users\\skele\\Documents\\OpenCode plugins"
+
+describe("createPathRewriter", () => {
+  test("rewrites plain windows paths", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const text = `cd ${OLD_WIN} && ls`
+    expect(rw.matches(text)).toBe(true)
+    expect(rw.rewrite(text)).toBe(`cd ${NEW_WIN} && ls`)
+  })
+
+  test("rewrites forward-slashed paths", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const fwdOld = "C:/Users/skele/Documents/auto-resume"
+    const fwdNew = "C:/Users/skele/Documents/OpenCode plugins"
+    expect(rw.rewrite(`open "${fwdOld}/tests/x.js"`)).toBe(`open "${fwdNew}/tests/x.js"`)
+  })
+
+  test("preserves double-json escape depth (tool payloads)", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const embedded = '"filePath":"C:\\\\Users\\\\skele\\\\Documents\\\\auto-resume"'
+    const expected = '"filePath":"C:\\\\Users\\\\skele\\\\Documents\\\\OpenCode plugins"'
+    expect(rw.rewrite(embedded)).toBe(expected)
+  })
+
+  test("preserves triple-json escape depth (nested payloads)", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const embedded = '"blob":"C:\\\\\\\\Users\\\\\\\\skele\\\\\\\\Documents\\\\\\\\auto-resume"'
+    expect(rw.rewrite(embedded)).toBe('"blob":"C:\\\\\\\\Users\\\\\\\\skele\\\\\\\\Documents\\\\\\\\OpenCode plugins"')
+  })
+
+  test("rewrites drive-less relative form (session.path style)", () => {
+    const rw = createPathRewriter("Users/skele/Documents/auto-resume", "Users/skele/Documents/OpenCode plugins")
+    expect(rw.rewrite('"title":"Users/skele/Documents/auto-resume/package.json"')).toBe(
+      '"title":"Users/skele/Documents/OpenCode plugins/package.json"',
+    )
+  })
+
+  test("rewrites unix-style leading-separator paths on their own form", () => {
+    const rw = createPathRewriter("/Users/alice/Projects/app", "/Users/alice/Projects/app-v2")
+    expect(rw.rewrite('cwd: "/Users/alice/Projects/app/src"')).toBe('cwd: "/Users/alice/Projects/app-v2/src"')
+  })
+
+  test("handles moves into deeper directories", () => {
+    const rw = createPathRewriter(OLD_WIN, "C:\\Users\\skele\\Documents\\work\\OpenCode plugins")
+    expect(rw.rewrite(`dir ${OLD_WIN}\\scripts`)).toBe(
+      "dir C:\\Users\\skele\\Documents\\work\\OpenCode plugins\\scripts",
+    )
+  })
+
+  test("handles moves into shallower directories", () => {
+    const rw = createPathRewriter("C:\\Users\\skele\\Documents\\work\\app", NEW_WIN)
+    expect(rw.rewrite("C:\\Users\\skele\\Documents\\work\\app\\README.md")).toBe(`${NEW_WIN}\\README.md`)
+  })
+
+  test("is case-insensitive on the match, canonical on output", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const out = rw.rewrite("c:/users/SKELE/documents/auto-resume/x")
+    expect(out).toBe("C:/Users/skele/Documents/OpenCode plugins/x")
+  })
+
+  test("never touches sibling folders", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    for (const sibling of [`${OLD_WIN}-old`, `${OLD_WIN}_v2`, `${OLD_WIN}backup`]) {
+      expect(rw.matches(sibling)).toBe(false)
+      expect(rw.rewrite(sibling)).toBe(sibling)
+    }
+  })
+
+  test("never touches other users or unrelated roots", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    for (const foreign of [
+      "C:\\Users\\other\\Documents\\auto-resume",
+      "/Users/other/Documents/auto-resume",
+      "D:\\data\\auto-resume",
+    ]) {
+      expect(rw.matches(foreign)).toBe(false)
+      expect(rw.rewrite(foreign)).toBe(foreign)
+    }
+  })
+
+  test("never rewrites bare product-name mentions or relative content urls", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const content = [
+      "renamed my auto-resume folder today",
+      'new URL("../Documents/auto-resume/auto-resume.js", import.meta.url)',
+    ]
+    for (const line of content) {
+      expect(rw.matches(line)).toBe(false)
+      expect(rw.rewrite(line)).toBe(line)
+    }
+  })
+
+  test("rewrites every occurrence inside large mixed-depth payloads", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const fwdOld = "C:/Users/skele/Documents/auto-resume"
+    const payload = [
+      `{"directory":"${fwdOld}"`,
+      `"output":"<path>C:\\\\\\\\Users\\\\\\\\skele\\\\\\\\Documents\\\\\\\\auto-resume</path>"`,
+      `"title":"Users/skele/Documents/auto-resume/README.md"}`,
+    ].join(",")
+    const out = rw.rewrite(payload)
+    expect(out.toLowerCase()).not.toContain("documents\\auto-resume")
+    expect(out.toLowerCase()).not.toContain("documents/auto-resume")
+    expect((out.match(/OpenCode plugins/g) ?? []).length).toBe(3)
+  })
+
+  test("repeated matches() calls never poison subsequent rewrites (g-flag state)", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const text = `a ${OLD_WIN} b ${OLD_WIN}/c`
+    void rw.matches(text)
+    void rw.matches(text)
+    const out = rw.rewrite(text)
+    expect((out.match(/OpenCode plugins/g) ?? []).length).toBe(2)
+  })
+
+  test("throws on component-free paths and identical locations", () => {
+    expect(() => createPathRewriter("", NEW_WIN)).toThrow()
+    expect(() => createPathRewriter("C:\\", NEW_WIN)).not.toThrow() // drive alone is one comp
+    expect(() => createPathRewriter(OLD_WIN, OLD_WIN)).toThrow()
+    expect(() => createPathRewriter(OLD_WIN, "c:/USERS/skele/Documents/AUTO-RESUME")).toThrow()
+    expect(() => createPathRewriter(`${OLD_WIN}\\`, `${OLD_WIN}`)).toThrow()
+  })
+
+  test("tolerates trailing separators and mixed separator styles in inputs", () => {
+    const rw = createPathRewriter(`${OLD_WIN}\\`, NEW_WIN)
+    expect(rw.rewrite(`cd ${OLD_WIN}/tests`)).toBe(`cd ${NEW_WIN}/tests`)
+    const mixed = createPathRewriter("C:/Users\\skele\\Documents/auto-resume", NEW_WIN)
+    expect(mixed.rewrite("C:\\Users\\skele\\Documents\\auto-resume")).toBe(NEW_WIN)
+  })
+
+  test("unicode neighbors cannot bypass the boundary guard", () => {
+    const rw = createPathRewriter("/home/user/Documents/proj", "/home/user/Documents/proj2")
+    // unicode letter directly glued to the first component is a different token
+    const glued = "/home/useréDocuments/proj"
+    expect(rw.matches(glued)).toBe(false)
+    const neighbor = "/home/usérr/Documents/proj"
+    expect(rw.matches(neighbor)).toBe(false)
+    expect(rw.rewrite(neighbor)).toBe(neighbor)
+  })
+
+  test("performance smoke: 1MB mixed-depth text rewrites fast", () => {
+    const rw = createPathRewriter(OLD_WIN, NEW_WIN)
+    const chunk = [
+      `"p":"${OLD_WIN}"`,
+      '"q":"C:\\\\Users\\\\skele\\\\Documents\\\\auto-resume\\\\f.js"',
+      '"r":"lorem ipsum dolor sit amet"',
+    ].join(",")
+    const big = chunk.repeat(Math.ceil(1_000_000 / chunk.length))
+    const started = performance.now()
+    const out = rw.rewrite(big)
+    const elapsed = performance.now() - started
+    expect(out.toLowerCase()).not.toContain("documents\\auto-resume")
+    expect(elapsed).toBeLessThan(500)
+  })
+})

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -2631,6 +2631,7 @@ export class Project extends HeyApiClient {
       name?: string
       icon?: ProjectIcon
       commands?: ProjectCommands
+      worktree?: string
     },
     options?: Options<never, ThrowOnError>,
   ) {
@@ -2645,11 +2646,51 @@ export class Project extends HeyApiClient {
             { in: "body", key: "name" },
             { in: "body", key: "icon" },
             { in: "body", key: "commands" },
+            { in: "body", key: "worktree" },
           ],
         },
       ],
     )
     return (options?.client ?? this.client).patch<ProjectUpdateResponses, ProjectUpdateErrors, ThrowOnError>({
+      url: "/project/{projectID}",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Delete a project
+   *
+   * Remove a registered project. mode=cascade also deletes every session and its history.
+   */
+  public remove<ThrowOnError extends boolean = false>(
+    parameters: {
+      projectID: string
+      mode?: "cascade" | "detach"
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "projectID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "mode" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).del<void, never, ThrowOnError>({
       url: "/project/{projectID}",
       ...options,
       ...params,


### PR DESCRIPTION
### Issue for this PR

Closes #23248, closes #34737. Towards #44256, #44538, #29703, #27822.

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Renaming or moving a project folder outside opencode orphaned every session (empty UI history, ghost Desktop entry whose Delete failed). This PR:

1. **Auto-relink** - when a stored worktree no longer exists on disk and `fromDirectory()` resolves the same project identity at a new path, all references migrate: `session.directory/path`, plus message/part/todo/event payloads, rewritten by an encoding-preserving splicer that handles plain, forward-slashed, drive-less and JSON-escaped (1x/2x) forms while leaving recorded content (diffs, source quotes, sibling folders, other users' paths) untouched.
2. **Rename from the app** - `project.update` accepts `worktree`; changing it relocates history the same way (this is what the Desktop Edit-project dialog will call).
3. **Delete projects** - new `DELETE /project/:id?mode=cascade|detach`: cascade removes registration, directories, sessions, messages/parts/todos/event aggregates; global project is protected.
4. **docs/**`project-rename-move-reliability.md` documents the failure model measured on a real affected install (~6.9k payload fields across 4 encodings had to move together).

Follow-up (small, after codegen): Edit dialog gains a Folder field bound to `update({worktree})`, project context menu gains Delete… with a history-loss confirmation calling `project.remove`. Server surface for both is complete here.

### How did you verify your code works?

- Recovered a real affected install using exactly these migrations before writing them up.
- `bun test test/project/relocation-paths.test.ts`: 18 tests green (escape depths incl. triple-JSON, moves shallower/deeper, case handling, unicode boundaries, g-flag statefulness regression, sibling/other-user guards, 1MB perf smoke ~14ms).
- DB integrity_check ok / foreign_key_check clean after migration on the affected database.
- Typecheck of Effect/drizzle wiring lands with CI (authored against core/session/sql + core/event/sql schemas as of dev).

### Screenshots / recordings

_No UI pixels changed in this PR; the follow-up GUI wiring PR will include recordings of Rename and the Delete confirmation._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR