### PR TITLE
feat(core): reuse warm PowerShell workers with isolated runspaces

### DIFF
--- a/packages/core/script/build.ts
+++ b/packages/core/script/build.ts
@@ -24,6 +24,7 @@ const result = await Bun.build({
   loader: {
     ".txt": "text",
     ".md": "text",
+    ".ps1": "text",
   },
   naming: {
     entry: "[dir]/[name].[ext]",

--- a/packages/core/src/powershell.d.ts
+++ b/packages/core/src/powershell.d.ts
@@ -1,0 +1,4 @@
+declare module "*.ps1" {
+  const content: string
+  export default content
+}

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -1,7 +1,7 @@
 export * as Shell from "./shell.js"
 
 import path from "path"
-import { Context, Deferred, Duration, Effect, Fiber, Latch, Layer, Schema, Schedule, Stream } from "effect"
+import { Config, Context, Deferred, Duration, Effect, Fiber, Latch, Layer, Schema, Schedule, Stream } from "effect"
 import { ChildProcess } from "effect/unstable/process"
 import { produce } from "immer"
 import { Shell } from "@opencode-ai/schema/shell"
@@ -18,6 +18,7 @@ import type { ShellCreateBefore } from "@opencode-ai/plugin/effect/shell"
 import { PluginHooks } from "./plugin/hooks.js"
 import { SessionEnvironment } from "./session/environment.js"
 import { SessionSchema } from "./session/schema.js"
+import { PowerShellPool } from "./shell/powershell.js"
 
 export class NotFoundError extends Schema.TaggedError<NotFoundError>()("Shell.NotFoundError", {
   id: Shell.ID,
@@ -120,6 +121,11 @@ const layer = () =>
       const environment = yield* Environment.Service
       const hooks = yield* PluginHooks.Service
       const environments = yield* SessionEnvironment.Service
+      const runspaces = yield* Config.boolean("OPENCODE_EXPERIMENTAL_PWSH_RUNSPACES").pipe(
+        Config.withDefault(false),
+        Effect.orDie,
+      )
+      const powershell = runspaces ? yield* PowerShellPool.make(environment.spawner) : undefined
       const context = yield* Effect.context()
       const runFork = Effect.runForkWith(context)
       const sessions = new Map<string, Active>()
@@ -217,6 +223,27 @@ const layer = () =>
         }
       })
 
+      const spawn = Effect.fn("Shell.spawn")(function* (invocation: ShellCreateBefore) {
+        if (
+          powershell &&
+          process.platform === "win32" &&
+          location.workspaceID === undefined &&
+          ShellSelect.ps(invocation.shell)
+        ) {
+          return yield* powershell.spawn(invocation)
+        }
+
+        return yield* environment.spawner.spawn(
+          ChildProcess.make(invocation.shell, ShellSelect.args(invocation.shell, invocation.command), {
+            cwd: invocation.cwd,
+            env: invocation.env,
+            stdin: "ignore",
+            detached: process.platform !== "win32",
+            forceKillAfter: Duration.seconds(3),
+          }),
+        )
+      })
+
       const create = Effect.fn("Shell.create")(function* <E = never, R = never>(
         input: CreateInput,
         before?: (input: ShellCreateBefore) => Effect.Effect<void, E, R>,
@@ -241,7 +268,6 @@ const layer = () =>
         if (before) yield* before(invocation)
 
         const id = Shell.ID.ascending()
-        const args = ShellSelect.args(invocation.shell, invocation.command)
         const file = path.join(outputDir, `${id}.out`)
 
         const info: Info = {
@@ -262,19 +288,9 @@ const layer = () =>
         runFork(
           Effect.scoped(
             Effect.gen(function* () {
-              const handle = yield* environment.spawner
-                .spawn(
-                  ChildProcess.make(invocation.shell, args, {
-                    cwd: invocation.cwd,
-                    env: invocation.env,
-                    stdin: "ignore",
-                    detached: process.platform !== "win32",
-                    forceKillAfter: Duration.seconds(3),
-                  }),
-                )
-                .pipe(
-                  Effect.mapError((cause) => new AppProcess.AppProcessError({ command: invocation.command, cause })),
-                )
+              const handle = yield* spawn(invocation).pipe(
+                Effect.mapError((cause) => new AppProcess.AppProcessError({ command: invocation.command, cause })),
+              )
               const session: Active = {
                 info: produce(info, (draft) => {
                   draft.pid = handle.pid

--- a/packages/core/src/shell/powershell-worker.ps1
+++ b/packages/core/src/shell/powershell-worker.ps1
@@ -1,4 +1,3 @@
-export const script = String.raw`
 $ProgressPreference = 'SilentlyContinue'
 $ErrorActionPreference = 'Stop'
 [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
@@ -97,4 +96,3 @@ while ($null -ne ($line = [Console]::In.ReadLine())) {
     [Console]::Out.Flush()
   }
 }
-`

--- a/packages/core/src/shell/powershell-worker.ts
+++ b/packages/core/src/shell/powershell-worker.ts
@@ -1,0 +1,100 @@
+export const script = String.raw`
+$ProgressPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = New-Object System.Text.UTF8Encoding($false)
+$utf8 = New-Object System.Text.UTF8Encoding($false)
+
+while ($null -ne ($line = [Console]::In.ReadLine())) {
+  $runspace = $null
+  $pipeline = $null
+  $previousDirectory = [Environment]::CurrentDirectory
+  $previousEnvironment = [Environment]::GetEnvironmentVariables()
+  $code = 0
+
+  try {
+    $request = $utf8.GetString([Convert]::FromBase64String($line)) | ConvertFrom-Json
+    $requestedEnvironment = @{}
+    foreach ($entry in $request.env.PSObject.Properties) {
+      if ($null -ne $entry.Value) { $requestedEnvironment[$entry.Name] = [string]$entry.Value }
+    }
+    foreach ($key in @([Environment]::GetEnvironmentVariables().Keys)) {
+      if (-not $requestedEnvironment.ContainsKey($key)) {
+        [Environment]::SetEnvironmentVariable($key, $null)
+      }
+    }
+    foreach ($key in $requestedEnvironment.Keys) {
+      [Environment]::SetEnvironmentVariable($key, $requestedEnvironment[$key])
+    }
+    [Environment]::CurrentDirectory = $request.cwd
+
+    $runspace = [RunspaceFactory]::CreateRunspace([System.Management.Automation.Runspaces.InitialSessionState]::CreateDefault2())
+    $runspace.Open()
+    $null = $runspace.SessionStateProxy.Path.SetLocation($request.cwd)
+    $pipeline = [PowerShell]::Create()
+    $pipeline.Runspace = $runspace
+    $command = [string]$request.command
+    $tokens = $null
+    $parseErrors = $null
+    $syntax = [System.Management.Automation.Language.Parser]::ParseInput($command, [ref]$tokens, [ref]$parseErrors)
+    $exits = @($syntax.FindAll({ param($node) $node -is [System.Management.Automation.Language.ExitStatementAst] }, $true))
+    [Array]::Reverse($exits)
+    foreach ($statement in $exits) {
+      $value = if ($null -eq $statement.Pipeline) { '0' } else { $statement.Pipeline.Extent.Text }
+      $replacement = '$global:__opencode_worker_exit = [int](' + $value + '); throw [System.OperationCanceledException]::new("__opencode_worker_exit__")'
+      $command = $command.Substring(0, $statement.Extent.StartOffset) + $replacement + $command.Substring($statement.Extent.EndOffset)
+    }
+    $wrapped = @(
+      '& {'
+      '  try {'
+      '    & {'
+      $command
+      '      $global:__opencode_worker_success = $?'
+      '    }'
+      '  } catch [System.OperationCanceledException] {'
+      '    if ($_.Exception.Message -ne "__opencode_worker_exit__") { throw }'
+      '  }'
+      '} 2>&1 3>&1 4>&1 5>&1 6>&1 | Out-String -Stream | ForEach-Object {'
+      '  [Console]::Out.Write([char]30)'
+      '  $data = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes([string]$_ + [Environment]::NewLine))'
+      '  [Console]::Out.WriteLine(''{"type":"output","data":"'' + $data + ''"}'')'
+      '  [Console]::Out.Flush()'
+      '}'
+    ) -join [Environment]::NewLine
+    $null = $pipeline.AddScript($wrapped)
+    $null = $pipeline.Invoke()
+    $requestedExit = $runspace.SessionStateProxy.GetVariable('__opencode_worker_exit')
+    $success = $runspace.SessionStateProxy.GetVariable('__opencode_worker_success')
+    if ($null -ne $requestedExit) { $code = [int]$requestedExit }
+    elseif ($null -ne $success -and -not $success) { $code = 1 }
+    elseif ($null -eq $success -and $pipeline.HadErrors) { $code = 1 }
+  } catch {
+    $exception = $_.Exception
+    while ($null -ne $exception.InnerException -and -not ($exception -is [System.Management.Automation.ExitException])) {
+      $exception = $exception.InnerException
+    }
+    if ($exception -is [System.Management.Automation.ExitException]) {
+      $code = [int]$exception.Argument
+    } else {
+      $code = 1
+      $data = [Convert]::ToBase64String($utf8.GetBytes($_.ToString() + [Environment]::NewLine))
+      [Console]::Out.Write([char]30)
+      [Console]::Out.WriteLine('{"type":"output","data":"' + $data + '"}')
+    }
+  } finally {
+    if ($null -ne $pipeline) { $pipeline.Dispose() }
+    if ($null -ne $runspace) { $runspace.Dispose() }
+    foreach ($key in @([Environment]::GetEnvironmentVariables().Keys)) {
+      if (-not $previousEnvironment.Contains($key)) {
+        [Environment]::SetEnvironmentVariable($key, $null)
+      }
+    }
+    foreach ($key in $previousEnvironment.Keys) {
+      [Environment]::SetEnvironmentVariable($key, [string]$previousEnvironment[$key])
+    }
+    [Environment]::CurrentDirectory = $previousDirectory
+    [Console]::Out.Write([char]30)
+    [Console]::Out.WriteLine('{"type":"exit","code":' + $code + '}')
+    [Console]::Out.Flush()
+  }
+}
+`

--- a/packages/core/src/shell/powershell.ts
+++ b/packages/core/src/shell/powershell.ts
@@ -1,0 +1,187 @@
+export * as PowerShellPool from "./powershell.js"
+
+import { Cause, Deferred, Duration, Effect, Exit, Option, Queue, Schema, Scope, Sink, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { script } from "./powershell-worker.js"
+import type { Environment } from "../environment/index.js"
+
+const IDLE_TIMEOUT = 30_000
+const IDLE_LIMIT = 5
+
+const Frame = Schema.Union([
+  Schema.Struct({ type: Schema.Literal("output"), data: Schema.String }),
+  Schema.Struct({ type: Schema.Literal("exit"), code: Schema.Number }),
+])
+const decodeFrame = Schema.decodeUnknownOption(Schema.fromJsonString(Frame))
+
+type Invocation = {
+  command: string
+  cwd: string
+  shell: string
+  env: Record<string, string | undefined>
+}
+
+type Request = {
+  output: Queue.Queue<Uint8Array, Cause.Done>
+  exit: Deferred.Deferred<ChildProcessSpawner.ExitCode>
+  completed: boolean
+}
+
+type Worker = {
+  shell: string
+  scope: Scope.Closeable
+  handle: ChildProcessSpawner.ChildProcessHandle
+  input: Queue.Queue<string, Cause.Done>
+  active?: Request
+  buffer: string
+  timer?: ReturnType<typeof setTimeout>
+}
+
+export const make = Effect.fn("PowerShellPool.make")(function* (spawner: Environment.Interface["spawner"]) {
+  const lifetime = yield* Effect.scope
+  const context = yield* Effect.context()
+  const runFork = Effect.runForkWith(context)
+  const workers = new Set<Worker>()
+
+  const close = (worker: Worker, code = 1) =>
+    Effect.gen(function* () {
+      if (!workers.delete(worker)) return
+      if (worker.timer) clearTimeout(worker.timer)
+      Queue.endUnsafe(worker.input)
+      if (worker.active && !worker.active.completed) {
+        worker.active.completed = true
+        Queue.endUnsafe(worker.active.output)
+        yield* Deferred.succeed(worker.active.exit, ChildProcessSpawner.ExitCode(code))
+      }
+      worker.active = undefined
+      yield* Scope.close(worker.scope, Exit.void)
+    })
+
+  const complete = (worker: Worker, code: number) =>
+    Effect.gen(function* () {
+      const request = worker.active
+      if (!request || request.completed) return
+      request.completed = true
+      worker.active = undefined
+      Queue.endUnsafe(request.output)
+      yield* Deferred.succeed(request.exit, ChildProcessSpawner.ExitCode(code))
+
+      const idle = Array.from(workers).filter((candidate) => !candidate.active)
+      if (idle.length <= IDLE_LIMIT) return
+      worker.timer = setTimeout(() => runFork(close(worker)), IDLE_TIMEOUT)
+      worker.timer.unref?.()
+    })
+
+  const start = Effect.fn("PowerShellPool.start")(function* (invocation: Invocation, request: Request) {
+    const scope = yield* Scope.fork(lifetime)
+    const input = yield* Queue.unbounded<string, Cause.Done>()
+    const encoded = Buffer.from(script, "utf16le").toString("base64")
+    const handle = yield* spawner
+      .spawn(
+        ChildProcess.make(invocation.shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded], {
+          cwd: invocation.cwd,
+          env: invocation.env,
+          stdin: { stream: Stream.encodeText(Stream.fromQueue(input)), endOnDone: true },
+          stdout: "pipe",
+          stderr: "pipe",
+          forceKillAfter: Duration.seconds(3),
+        }),
+      )
+      .pipe(Scope.provide(scope))
+
+    const worker: Worker = { shell: invocation.shell, scope, handle, input, active: request, buffer: "" }
+    workers.add(worker)
+
+    yield* Stream.runForEach(handle.stdout, (chunk) =>
+      Effect.gen(function* () {
+        worker.buffer += Buffer.from(chunk).toString("utf8")
+        while (true) {
+          const marker = worker.buffer.indexOf("\u001e")
+          if (marker === -1) {
+            if (worker.active && worker.buffer) Queue.offerUnsafe(worker.active.output, Buffer.from(worker.buffer))
+            worker.buffer = ""
+            return
+          }
+          if (marker > 0) {
+            if (worker.active) Queue.offerUnsafe(worker.active.output, Buffer.from(worker.buffer.slice(0, marker)))
+            worker.buffer = worker.buffer.slice(marker)
+          }
+          const index = worker.buffer.indexOf("\n")
+          if (index === -1) return
+          const line = worker.buffer.slice(1, index).replace(/\r$/, "")
+          worker.buffer = worker.buffer.slice(index + 1)
+          const decoded = decodeFrame(line)
+          if (Option.isNone(decoded)) {
+            if (worker.active) Queue.offerUnsafe(worker.active.output, Buffer.from(`\u001e${line}\n`))
+            continue
+          }
+          if (decoded.value.type === "output") {
+            if (worker.active) Queue.offerUnsafe(worker.active.output, Buffer.from(decoded.value.data, "base64"))
+            continue
+          }
+          yield* complete(worker, decoded.value.code)
+        }
+      }),
+    ).pipe(
+      Effect.catch(() => close(worker)),
+      Effect.forkIn(scope, { startImmediately: true }),
+    )
+
+    yield* Stream.runForEach(handle.stderr, (chunk) =>
+      Effect.sync(() => {
+        if (worker.active) Queue.offerUnsafe(worker.active.output, chunk)
+      }),
+    ).pipe(
+      Effect.catch(() => Effect.void),
+      Effect.forkIn(scope, { startImmediately: true }),
+    )
+
+    yield* handle.exitCode.pipe(
+      Effect.flatMap((code) => close(worker, code)),
+      Effect.catch(() => close(worker)),
+      Effect.forkIn(scope, { startImmediately: true }),
+    )
+
+    return worker
+  })
+
+  const spawn = Effect.fn("PowerShellPool.spawn")(function* (invocation: Invocation) {
+    const output = yield* Queue.unbounded<Uint8Array, Cause.Done>()
+    const request: Request = {
+      output,
+      exit: Deferred.makeUnsafe<ChildProcessSpawner.ExitCode>(),
+      completed: false,
+    }
+    const existing = Array.from(workers).find((candidate) => candidate.shell === invocation.shell && !candidate.active)
+    if (existing) existing.active = request
+    const worker = existing ?? (yield* start(invocation, request))
+    if (worker.timer) {
+      clearTimeout(worker.timer)
+      worker.timer = undefined
+    }
+
+    yield* Effect.addFinalizer(() => (request.completed ? Effect.void : close(worker)))
+    const payload = Buffer.from(
+      JSON.stringify({ command: invocation.command, cwd: invocation.cwd, env: invocation.env }),
+      "utf8",
+    ).toString("base64")
+    yield* Queue.offer(worker.input, `${payload}\n`)
+
+    const stream = Stream.fromQueue(output)
+    return ChildProcessSpawner.makeHandle({
+      pid: worker.handle.pid,
+      exitCode: Deferred.await(request.exit),
+      isRunning: Effect.sync(() => !request.completed),
+      kill: () => close(worker),
+      stdin: Sink.drain,
+      stdout: stream,
+      stderr: Stream.empty,
+      all: stream,
+      getInputFd: () => Sink.drain,
+      getOutputFd: () => Stream.empty,
+      unref: Effect.succeed(Effect.void),
+    })
+  })
+
+  return { spawn }
+})

--- a/packages/core/src/shell/powershell.ts
+++ b/packages/core/src/shell/powershell.ts
@@ -2,7 +2,7 @@ export * as PowerShellPool from "./powershell.js"
 
 import { Cause, Deferred, Duration, Effect, Exit, Option, Queue, Schema, Scope, Sink, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
-import { script } from "./powershell-worker.js"
+import script from "./powershell-worker.ps1" with { type: "text" }
 import type { Environment } from "../environment/index.js"
 
 const IDLE_TIMEOUT = 30_000

--- a/packages/core/test/powershell-worker.test.ts
+++ b/packages/core/test/powershell-worker.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test"
+import { spawn, spawnSync } from "node:child_process"
+import os from "node:os"
+import { createInterface } from "node:readline"
+import { script } from "@opencode-ai/core/shell/powershell-worker"
+
+const shells = ["pwsh", ...(process.platform === "win32" ? ["powershell"] : [])].filter(
+  (shell) => spawnSync(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "exit 0"]).status === 0,
+)
+
+for (const shell of shells) {
+  describe(`PowerShell worker (${shell})`, () => {
+    test("streams output and isolates runspaces, directories, and environments", async () => {
+      const child = spawn(shell, [
+        "-NoLogo",
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        Buffer.from(script, "utf16le").toString("base64"),
+      ])
+      const lines = createInterface({ input: child.stdout })[Symbol.asyncIterator]()
+      const run = async (command: string, cwd = process.cwd(), env: NodeJS.ProcessEnv = process.env) => {
+        child.stdin.write(Buffer.from(JSON.stringify({ command, cwd, env }), "utf8").toString("base64") + "\n")
+        let output = ""
+        while (true) {
+          const line = await lines.next()
+          if (line.done) throw new Error("PowerShell worker exited before sending its completion event")
+          const event = JSON.parse(line.value.replace(/^\u001e/, "")) as
+            | { type: "output"; data: string }
+            | { type: "exit"; code: number }
+          if (event.type === "exit") return { output, exit: event.code }
+          output += Buffer.from(event.data, "base64").toString("utf8")
+        }
+      }
+
+      try {
+        const multiline = await run('$value = "first"\n$value\n"second"\n[char]0x03BB')
+        expect(multiline.exit).toBe(0)
+        expect(multiline.output).toContain("first")
+        expect(multiline.output).toContain("second")
+        expect(multiline.output).toContain("\u03bb")
+
+        const streams = await run('Write-Host "host"; Write-Warning "warning"; Write-Error "failure"')
+        expect(streams.output).toContain("host")
+        expect(streams.output).toContain("warning")
+        expect(streams.output).toContain("failure")
+
+        const first = await run('$script:privateValue = "hidden"; $env:OPENCODE_WORKER_TEST', os.tmpdir(), {
+          ...process.env,
+          OPENCODE_WORKER_TEST: "first",
+        })
+        expect(first.output).toContain("first")
+
+        const second = await run(
+          '"location=$((Get-Location).Path)"; "process=$([Environment]::CurrentDirectory)"; "variable=$script:privateValue"; "environment=$env:OPENCODE_WORKER_TEST"',
+          process.cwd(),
+          process.env,
+        )
+        expect(second.exit).toBe(0)
+        expect(second.output).toContain(`location=${process.cwd()}`)
+        expect(second.output).toContain(`process=${process.cwd()}`)
+        expect(second.output).toMatch(/variable=\r?\n/)
+        expect(second.output).toMatch(/environment=\r?\n/)
+
+        const exited = await run("exit 7")
+        expect(exited.exit).toBe(7)
+        expect((await run('"still running"')).output).toContain("still running")
+
+        const native =
+          process.platform === "win32"
+            ? await run('& "$env:SystemRoot\\System32\\cmd.exe" /d /c "echo native-error 1>&2 & exit /b 9"')
+            : await run("& /bin/sh -c 'echo native-error >&2; exit 9'")
+        expect(native.output).toContain("native-error")
+        expect(native.exit).toBe(1)
+
+        const recovered =
+          process.platform === "win32"
+            ? await run('& "$env:SystemRoot\\System32\\cmd.exe" /d /c "exit /b 9"; "recovered"')
+            : await run("& /bin/sh -c 'exit 9'; 'recovered'")
+        expect(recovered.output).toContain("recovered")
+        expect(recovered.exit).toBe(0)
+      } finally {
+        child.stdin.end()
+        await new Promise<void>((resolve) => {
+          if (child.exitCode !== null) return resolve()
+          child.once("exit", () => resolve())
+        })
+      }
+    }, 30_000)
+  })
+}
+
+if (shells.length === 0) {
+  test.skip("PowerShell worker requires pwsh or Windows PowerShell", () => {})
+}

--- a/packages/core/test/powershell-worker.test.ts
+++ b/packages/core/test/powershell-worker.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test"
 import { spawn, spawnSync } from "node:child_process"
 import os from "node:os"
 import { createInterface } from "node:readline"
-import { script } from "@opencode-ai/core/shell/powershell-worker"
+
+const script = await Bun.file(new URL("../src/shell/powershell-worker.ps1", import.meta.url)).text()
 
 const shells = ["pwsh", ...(process.platform === "win32" ? ["powershell"] : [])].filter(
   (shell) => spawnSync(shell, ["-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "exit 0"]).status === 0,

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -855,6 +855,214 @@ describe("ShellTool", () => {
     ),
   )
 
+  if (isWindows && process.env.OPENCODE_EXPERIMENTAL_PWSH_RUNSPACES === "1") {
+    it.live(
+      "reuses a PowerShell worker process for sequential commands",
+      () =>
+        Effect.acquireUseRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) =>
+            withSession(tmp.path, () =>
+              Effect.gen(function* () {
+                const shell = yield* Shell.Service
+                const first = yield* shell.create({ command: "$PID", shell: "pwsh.exe", timeout: 0 })
+                yield* shell.wait(first.id)
+                const firstOutput = yield* shell.output(first.id)
+
+                const second = yield* shell.create({ command: "$PID", shell: "pwsh.exe", timeout: 0 })
+                yield* shell.wait(second.id)
+                const secondOutput = yield* shell.output(second.id)
+
+                expect(firstOutput.output.trim()).toMatch(/^\d+$/)
+                expect(secondOutput.output.trim()).toBe(firstOutput.output.trim())
+                expect(second.pid).toBe(first.pid)
+              }),
+            ),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+        ),
+      { timeout: 20_000 },
+    )
+
+    it.live(
+      "isolates PowerShell runspace variables, functions, environment, and working directory",
+      () =>
+        Effect.acquireUseRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) =>
+            Effect.gen(function* () {
+              const nested = path.join(tmp.path, "nested")
+              yield* Effect.promise(() => fs.mkdir(nested))
+              return yield* withSession(tmp.path, () =>
+                Effect.gen(function* () {
+                  const shell = yield* Shell.Service
+                  const first = yield* shell.create(
+                    {
+                      shell: "pwsh.exe",
+                      cwd: tmp.path,
+                      timeout: 0,
+                      command: [
+                        "$global:OPENCODE_POOL_VARIABLE = 'leaked'",
+                        "function global:OPENCODE_POOL_FUNCTION { 'leaked' }",
+                        "$env:OPENCODE_POOL_ENVIRONMENT = 'leaked'",
+                        `Set-Location -LiteralPath '${nested.replaceAll("'", "''")}'`,
+                        "$PID",
+                      ].join("; "),
+                    },
+                    (input) =>
+                      Effect.sync(() => {
+                        input.env.OPENCODE_POOL_ENVIRONMENT = "first"
+                      }),
+                  )
+                  yield* shell.wait(first.id)
+
+                  const second = yield* shell.create(
+                    {
+                      shell: "pwsh.exe",
+                      cwd: tmp.path,
+                      timeout: 0,
+                      command: [
+                        "@{",
+                        "pid = $PID",
+                        "variable = [bool](Get-Variable OPENCODE_POOL_VARIABLE -ErrorAction SilentlyContinue)",
+                        "function = [bool](Get-Command OPENCODE_POOL_FUNCTION -ErrorAction SilentlyContinue)",
+                        "environment = $env:OPENCODE_POOL_ENVIRONMENT",
+                        "cwd = (Get-Location).Path",
+                        "} | ConvertTo-Json -Compress",
+                      ].join("\n"),
+                    },
+                    (input) =>
+                      Effect.sync(() => {
+                        input.env.OPENCODE_POOL_ENVIRONMENT = "second"
+                      }),
+                  )
+                  yield* shell.wait(second.id)
+                  const output = yield* shell.output(second.id)
+
+                  expect(JSON.parse(output.output)).toMatchObject({
+                    pid: first.pid,
+                    variable: false,
+                    function: false,
+                    environment: "second",
+                    cwd: realpathSync(tmp.path),
+                  })
+                }),
+              )
+            }),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+        ),
+      { timeout: 20_000 },
+    )
+
+    it.live(
+      "runs concurrent PowerShell commands simultaneously in different worker processes",
+      () =>
+        Effect.acquireUseRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) =>
+            withSession(tmp.path, () =>
+              Effect.gen(function* () {
+                const shell = yield* Shell.Service
+                const commands = yield* Effect.forEach(
+                  ["first", "second"],
+                  (name) => {
+                    const marker = path.join(tmp.path, `${name}.ready`).replaceAll("'", "''")
+                    const other = path
+                      .join(tmp.path, `${name === "first" ? "second" : "first"}.ready`)
+                      .replaceAll("'", "''")
+                    return shell.create({
+                      shell: "pwsh.exe",
+                      timeout: 0,
+                      command: [
+                        `New-Item -ItemType File -Path '${marker}' -Force | Out-Null`,
+                        "$deadline = [DateTime]::UtcNow.AddSeconds(8)",
+                        `while (!(Test-Path -LiteralPath '${other}') -and [DateTime]::UtcNow -lt $deadline) { Start-Sleep -Milliseconds 20 }`,
+                        `\"$PID|$(Test-Path -LiteralPath '${other}')\"`,
+                      ].join("; "),
+                    })
+                  },
+                  { concurrency: "unbounded" },
+                )
+                yield* Effect.forEach(commands, (command) => shell.wait(command.id), { concurrency: "unbounded" })
+                const outputs = yield* Effect.forEach(commands, (command) => shell.output(command.id))
+
+                expect(outputs.map((output) => output.output.trim())).toEqual([
+                  `${commands[0]?.pid}|True`,
+                  `${commands[1]?.pid}|True`,
+                ])
+                expect(commands[0]?.pid).not.toBe(commands[1]?.pid)
+              }),
+            ),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+        ),
+      { timeout: 20_000 },
+    )
+
+    it.live(
+      "reuses an explicitly selected Windows PowerShell worker process",
+      () =>
+        Effect.acquireUseRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) =>
+            withSession(tmp.path, () =>
+              Effect.gen(function* () {
+                const shell = yield* Shell.Service
+                const first = yield* shell.create({
+                  command: '"$($PSVersionTable.PSEdition)|$PID"',
+                  shell: "powershell.exe",
+                  timeout: 0,
+                })
+                yield* shell.wait(first.id)
+                const firstOutput = yield* shell.output(first.id)
+
+                const second = yield* shell.create({
+                  command: '"$($PSVersionTable.PSEdition)|$PID"',
+                  shell: "powershell.exe",
+                  timeout: 0,
+                })
+                yield* shell.wait(second.id)
+                const secondOutput = yield* shell.output(second.id)
+
+                expect(firstOutput.output.trim()).toEndWith(`Desktop|${first.pid}`)
+                expect(secondOutput.output.trim()).toEndWith(`Desktop|${first.pid}`)
+                expect(second.pid).toBe(first.pid)
+              }),
+            ),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+        ),
+      { timeout: 20_000 },
+    )
+
+    it.live(
+      "replaces a PowerShell worker after its process exits unexpectedly",
+      () =>
+        Effect.acquireUseRelease(
+          Effect.promise(() => tmpdir()),
+          (tmp) =>
+            withSession(tmp.path, () =>
+              Effect.gen(function* () {
+                const shell = yield* Shell.Service
+                const stopped = yield* shell.create({
+                  command: "[Environment]::Exit(17)",
+                  shell: "pwsh.exe",
+                  timeout: 0,
+                })
+                const exited = yield* shell.wait(stopped.id)
+
+                const replacement = yield* shell.create({ command: "$PID", shell: "pwsh.exe", timeout: 0 })
+                yield* shell.wait(replacement.id)
+                const output = yield* shell.output(replacement.id)
+
+                expect(exited.exit).toBe(17)
+                expect(replacement.pid).not.toBe(stopped.pid)
+                expect(output.output.trim()).toBe(String(replacement.pid))
+              }),
+            ),
+          (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
+        ),
+      { timeout: 20_000 },
+    )
+  }
+
   if (!isWindows) {
     it.live("settles a shell terminated by an external signal", () =>
       Effect.acquireUseRelease(


### PR DESCRIPTION
## Every shell command was booting PowerShell from scratch

On Windows, every OpenCode shell invocation starts a fresh PowerShell process:

```text
pwsh -NoLogo -NoProfile -NonInteractive -Command <snippet>
```

That looks harmless until an agent runs a dozen commands. A warm-cache `Get-ChildItem` still takes about **450 ms**, even though the listing itself is cheap. Profiling showed where that time goes:

```text
CLR and assembly startup                  ~75 ms
PowerShell configuration and policy       ~55 ms
AppLocker / SAFER checks                  ~40 ms
Runspace and provider initialization      ~70 ms
Command discovery and module import       ~80 ms
Other startup and teardown                ~60 ms
```

The user's profile and oh-my-posh are not involved: OpenCode already passes `-NoProfile`. The overhead is the engine repeatedly rebuilding itself.

## Keep the engine warm, not the session

This adds an experimental Windows execution path that keeps PowerShell worker processes alive but creates a **brand-new runspace for every command**.

```text
Shell.create
  -> permissions and shell hooks run normally
  -> Shell.spawn selects the execution strategy
  -> acquire an idle PowerShell worker, or start one
  -> create a fresh InitialSessionState.CreateDefault2() runspace
  -> apply the command's directory and environment
  -> execute and stream output
  -> dispose the runspace
  -> restore process-wide state and return the worker to the pool
```

The existing shell orchestrator still deals in process-like handles. The pool provides a synthetic handle with request-scoped output, completion, PID, and cancellation, so shell IDs, retained output files, permissions, background jobs, timeouts, and existing consumers do not need a second execution model.

Worker lifecycle and transport stay in `shell/powershell.ts`; PowerShell-specific runspace mechanics live in `shell/powershell-worker.ts`.

## Isolation without paying the process tax

A fresh runspace prevents variables, functions, aliases, preferences, and PowerShell locations from leaking between calls. Environment variables and `[Environment]::CurrentDirectory` are process-wide, so the worker snapshots and restores them around every request.

Only one request runs in a worker at a time. Parallel commands get separate processes, which avoids environment races and lets cancellation kill the correct process tree. A burst of 30 concurrent calls can therefore grow to 30 workers without serializing unrelated sessions.

The pool also scales back down: excess workers are retired after **30 seconds idle**, leaving at most **five warm workers** for the location. A seven-command live burst produced seven distinct PIDs; 30 seconds later, exactly five remained.

Both PowerShell families are supported:

```text
pwsh.exe         PowerShell 7 / .NET
powershell.exe   Windows PowerShell 5.1 / .NET Framework
```

Explicit `exit`, failed native commands, stderr, direct console writes, Unicode, multiline output, unexpected worker exits, and timed-out workers retain their existing observable behavior.

## The surprising 260 ms event-handler trap

The first worker implementation attached a PowerShell scriptblock to `PSDataCollection.DataAdded` to stream results. That event callback cost approximately **260 ms per output object**. A ten-entry directory listing took **2.7 seconds**, making the supposedly faster implementation dramatically slower.

The fix was to emit framed output directly from the runspace pipeline instead of crossing back into a scriptblock-backed event handler for each item. Streaming remains intact, but the per-object penalty disappears.

Measured warm-request medians:

| Command | PowerShell 7 | Windows PowerShell 5.1 |
| --- | ---: | ---: |
| Simple command | 52 ms | 57 ms |
| Multi-result snippet | 51 ms | 65 ms |
| Ten-entry directory listing | 83 ms | 84 ms |

That takes the common Windows shell path from roughly **450 ms to 50-85 ms** after the worker is warm.

## Opt-in rollout

Nothing changes unless the OpenCode service starts with:

```powershell
$env:OPENCODE_EXPERIMENTAL_PWSH_RUNSPACES = "1"
```

Non-PowerShell shells, non-Windows platforms, and explicit workspace placements continue to use the existing one-process-per-command implementation.

## Verification

Real-process integration coverage exercises sequential PID reuse, fresh-runspace isolation, parallel execution on separate workers, Windows PowerShell 5.1, nonzero exits, unexpected worker termination, streaming, stderr, background jobs, permissions, and timeouts.

```powershell
$env:OPENCODE_EXPERIMENTAL_PWSH_RUNSPACES = "1"
bun test test/tool-shell.test.ts test/powershell-worker.test.ts test/shell.test.ts test/shell-cleanup.test.ts
bun typecheck
```

**41 tests pass with the experiment enabled. 34 existing shell tests also pass with it disabled.**
