### PR TITLE
fix(snapshot): severe data loss on restore from a subdirectory

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -382,24 +382,43 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
         const restore = Effect.fnUntraced(function* (snapshot: string) {
           return yield* locked(
             Effect.gen(function* () {
-              yield* Effect.logInfo("restore", { commit: snapshot })
-              const result = yield* git([...core, ...args(["read-tree", snapshot])], { cwd: state.worktree })
-              if (result.code === 0) {
-                const checkout = yield* git([...core, ...args(["checkout-index", "-a", "-f"])], {
-                  cwd: state.worktree,
-                })
-                if (checkout.code === 0) return
-                yield* Effect.logError("failed to restore snapshot", {
+              yield* Effect.logInfo("restore", { commit: snapshot, cwd: state.directory })
+              // The snapshot index is shared across the whole project, but a snapshot taken from a
+              // subdirectory only updates that subdirectory's entries. Scope the restore to files
+              // under the session directory so entries for sibling directories (which may be stale)
+              // are not written back over the current worktree with checkout-index -a.
+              const prefix = path.relative(state.worktree, state.directory).replaceAll("\\", "/")
+              const spec = prefix ? `${prefix}/` : "."
+              const listed = yield* git([...quote, ...args(["ls-tree", "-r", "--name-only", snapshot, "--", spec])], {
+                cwd: state.worktree,
+              })
+              if (listed.code !== 0) {
+                yield* Effect.logError("failed to list snapshot files", {
                   snapshot,
-                  exitCode: checkout.code,
-                  stderr: checkout.stderr,
+                  exitCode: listed.code,
+                  stderr: listed.stderr,
                 })
                 return
               }
+              const files = listed.text.split("\n").filter(Boolean)
+              if (!files.length) return
+              const result = yield* git([...core, ...args(["read-tree", snapshot])], { cwd: state.worktree })
+              if (result.code !== 0) {
+                yield* Effect.logError("failed to restore snapshot", {
+                  snapshot,
+                  exitCode: result.code,
+                  stderr: result.stderr,
+                })
+                return
+              }
+              const checkout = yield* git([...core, ...args(["checkout-index", "-f", "--", ...files])], {
+                cwd: state.worktree,
+              })
+              if (checkout.code === 0) return
               yield* Effect.logError("failed to restore snapshot", {
                 snapshot,
-                exitCode: result.code,
-                stderr: result.stderr,
+                exitCode: checkout.code,
+                stderr: checkout.stderr,
               })
             }),
           )
@@ -527,8 +546,11 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
           return yield* locked(
             Effect.gen(function* () {
               yield* add()
+              // Run from the session directory so the "-- ." path spec scopes the diff to the
+              // current directory, matching what restore() writes back, rather than reporting
+              // changes for sibling directories that share the project-wide snapshot index.
               const result = yield* git([...quote, ...args(["diff", "--cached", "--no-ext-diff", hash, "--", "."])], {
-                cwd: state.worktree,
+                cwd: state.directory,
               })
               if (result.code !== 0) {
                 yield* Effect.logWarning("failed to get diff", {


### PR DESCRIPTION
### Issue for this PR

Closes #39513

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a data-loss bug: reverting or unreverting a session started in a subdirectory can silently overwrite an unrelated edit in a sibling directory.

The snapshot index is shared across the whole project (git worktree), but a snapshot taken from a subdirectory only updates that subdirectory's entries — `add()` runs `ls-files ... -- .` scoped with `cwd: state.directory`. `restore()`, however, ran `checkout-index -a -f`, which writes **every** entry in the shared index across the entire worktree. So a sibling directory's file that was captured in the index at an earlier (stale) revision, then edited on disk afterward, gets clobbered back to the stale blob on revert — destroying current work the session never touched. `diff()` had the matching scope gap (it ran `-- .` from `cwd: state.worktree`, reporting changes for unrelated directories).

The fix scopes both to the session directory:

- `restore()` lists the snapshot's files under the session-directory prefix (`ls-tree -r --name-only <snapshot> -- <prefix>/`) and checks out only those paths, instead of `checkout-index -a`.
- `diff()` runs from `cwd: state.directory` so its `-- .` path spec is relative to the session directory, consistent with `add()`, `patch()`, and `diffFull()`.

This is an urgent, minimal interim fix for live data loss. It is intentionally small and does not attempt the broader snapshot rework being discussed in #44511 (mutation epochs) — whose own acceptance criteria include "reverting one session cannot silently overwrite changes attributed to another actor." This PR delivers that guarantee for the subdirectory case today, while that design is still in discussion.

### How did you verify your code works?

- `bun typecheck` passes across all packages, rebased on current `dev`.
- Deterministic reproduction (full script in #39513): a git repo with `frontend/` and `backend/`, snapshot taken from `frontend/` (seeds the shared index with `backend` at its original revision), then `backend` edited on disk. Before the fix, `restore()`'s `checkout-index -a -f` overwrites the current `backend` file with the stale index blob. After the fix, restore lists only files under the `frontend/` prefix and leaves `backend`'s current edit untouched, restoring only `frontend/`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
