### PR TITLE
fix(ai): recover Anthropic request_too_large as overflow

### DIFF
--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -40,15 +40,16 @@ const patterns = [
   /model_context_window_exceeded/i,
   /too many tokens/i,
   /token limit exceeded/i,
+  /request_too_large/i,
 ]
 
-const payloadPatterns = [/request_too_large/i, /request entity too large/i, /payload too large/i, /request too large/i]
+const payloadPatterns = [/request entity too large/i, /payload too large/i, /request too large/i]
 
 const exclusions = [/^(throttling error|service unavailable):/i, /rate limit/i, /too many requests/i]
 
 export const isContextOverflow = (message: string) =>
   !exclusions.some((pattern) => pattern.test(message)) &&
-  (patterns.some((pattern) => pattern.test(message)) || /^400\s*(status code)?\s*\(no body\)/i.test(message))
+  (patterns.some((pattern) => pattern.test(message)) || /^4(?:00|13)\s*(status code)?\s*\(no body\)/i.test(message))
 
 export const isPayloadTooLarge = (message: string) => payloadPatterns.some((pattern) => pattern.test(message))
 
@@ -106,6 +107,7 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
     clientScoped &&
     (codes.includes("context_length_exceeded") ||
       codes.includes("model_context_window_exceeded") ||
+      codes.includes("request_too_large") ||
       isContextOverflow(text))
   )
     return new InvalidRequestReason({ ...common, classification: "context-overflow" })

--- a/packages/ai/test/executor.test.ts
+++ b/packages/ai/test/executor.test.ts
@@ -211,6 +211,28 @@ describe("RequestExecutor", () => {
     }).pipe(Effect.provide(responsesLayer([new Response("request too large", { status: 413 })]))),
   )
 
+  it.effect("classifies Anthropic request_too_large as context overflow", () =>
+    Effect.gen(function* () {
+      const executor = yield* RequestExecutor.Service
+      const error = yield* executor.execute(request).pipe(Effect.flip)
+
+      expectAIError(error)
+      expect(error.reason).toMatchObject({
+        _tag: "InvalidRequest",
+        classification: "context-overflow",
+        http: { response: { status: 413 } },
+      })
+    }).pipe(
+      Effect.provide(
+        responsesLayer([
+          new Response('{"error":{"type":"request_too_large","message":"Request exceeds the maximum size"}}', {
+            status: 413,
+          }),
+        ]),
+      ),
+    ),
+  )
+
   it.effect("does not classify ordinary invalid requests as context overflow", () =>
     Effect.gen(function* () {
       const executor = yield* RequestExecutor.Service

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -18,13 +18,19 @@ describe("provider error classification", () => {
     expect(messages.every(isContextOverflow)).toBe(true)
   })
 
-  test("classifies request size failures separately from context overflow", () => {
-    const failures = [
-      classifyProviderFailure({ message: "request too large", status: 413 }),
+  test("classifies Anthropic request_too_large as recoverable overflow", () => {
+    expect(
       classifyProviderFailure({
         message: '{"error":{"type":"request_too_large","message":"Request exceeds the maximum size"}}',
         status: 400,
       }),
+    ).toMatchObject({ _tag: "InvalidRequest", classification: "context-overflow" })
+    expect(isContextOverflow("413 status code (no body)")).toBe(true)
+  })
+
+  test("classifies generic request size failures separately from context overflow", () => {
+    const failures = [
+      classifyProviderFailure({ message: "request too large", status: 413 }),
       classifyProviderFailure({ message: "upstream request entity too large", status: 502 }),
     ]
 
@@ -33,7 +39,6 @@ describe("provider error classification", () => {
         expect.objectContaining({ _tag: "InvalidRequest", classification: "payload-too-large" }),
       ),
     )
-    expect(isContextOverflow("413 status code (no body)")).toBe(false)
   })
 
   test("does not classify rate limits as context overflow", () => {


### PR DESCRIPTION
## Summary
- treat Anthropic `request_too_large` and bodyless 413 as context overflow
- keep generic proxy 413s classified as payload-too-large
- let existing overflow recovery compact once and retry

## Test Plan
- `bun test test/provider-error.test.ts test/executor.test.ts` from `packages/ai`
- `bun typecheck` from `packages/ai`