### PR TITLE
fix(ai): disable bedrock mantle responses websockets

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock-mantle.ts
+++ b/packages/ai/src/providers/amazon-bedrock-mantle.ts
@@ -29,6 +29,11 @@ export interface Settings extends ProviderPackage.Settings {
 const responsesRoute = OpenAIResponses.route.with({
   id: "bedrock-mantle-responses",
   provider: id,
+  transport: OpenAIResponses.channelTransport({
+    id: "bedrock-mantle-responses",
+    name: "Bedrock Mantle Responses",
+    enabled: () => false,
+  }),
 })
 
 const chatRoute = OpenAIChat.route.with({

--- a/packages/ai/test/provider/bedrock-mantle.test.ts
+++ b/packages/ai/test/provider/bedrock-mantle.test.ts
@@ -59,6 +59,27 @@ describe("Amazon Bedrock Mantle provider", () => {
     }),
   )
 
+  it.effect("keeps Responses on HTTP when a WebSocket executor is available", () =>
+    Effect.gen(function* () {
+      const model = AmazonBedrockMantle.configure({ apiKey: "test-key" }).responses("openai.gpt-oss-120b")
+
+      yield* LLMClient.generate(LLM.request({ model, prompt: "Hi" }), {
+        webSocket: { execute: () => Effect.die("unexpected Mantle WebSocket request") },
+      }).pipe(
+        Effect.provide(
+          dynamicResponse((input) => {
+            expect(input.request.url).toBe("https://bedrock-mantle.us-east-1.api.aws/v1/responses")
+            return Effect.succeed(
+              input.respond(sseEvents({ type: "response.completed", response: {} }), {
+                headers: { "content-type": "text/event-stream" },
+              }),
+            )
+          }),
+        ),
+      )
+    }),
+  )
+
   it.effect("supports bearer authentication and custom base URLs", () =>
     Effect.gen(function* () {
       const seen: Array<{ readonly url: string; readonly authorization: string | undefined }> = []


### PR DESCRIPTION
## Summary
- disable WebSocket selection for Bedrock Mantle Responses while preserving the existing HTTP/SSE streaming path
- keep the change local to the Mantle provider; OpenAI, Azure, and xAI transport behavior remains unchanged
- add a regression proving Mantle still uses HTTP when a WebSocket executor is supplied

Amazon Bedrock does not support Responses WebSocket connections, although it supports HTTP streaming.

## Verification
- `bun test test/provider/bedrock-mantle.test.ts test/provider/openai-responses.test.ts test/provider/openai-compatible-responses.test.ts test/provider/openai-responses-websocket.recorded.test.ts test/provider/xai-responses.test.ts --timeout 30000 --only-failures` (171 passing)
- `bun typecheck` from `packages/ai`
- `bunx prettier --check packages/ai/src/providers/amazon-bedrock-mantle.ts packages/ai/test/provider/bedrock-mantle.test.ts`