### PR TITLE
feat(tui): investigate errors in a new session

### DIFF
--- a/packages/tui/src/component/dialog-error-details.tsx
+++ b/packages/tui/src/component/dialog-error-details.tsx
@@ -3,13 +3,22 @@ import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { useConfig } from "../config"
 import { useClipboard } from "../context/clipboard"
+import { useData } from "../context/data"
 import { Keymap } from "../context/keymap"
+import { useLocation } from "../context/location"
+import { useRoute } from "../context/route"
 import { getScrollAcceleration } from "../util/scroll"
 import { useTheme } from "../context/theme"
+import { emptyPrompt } from "../prompt/history"
+import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 
 export function DialogErrorDetails(props: { title: string; error: string; onBack: () => void }) {
   const clipboard = useClipboard()
+  const data = useData()
+  const dialog = useDialog()
+  const location = useLocation()
+  const route = useRoute()
   const toast = useToast()
   const theme = useTheme("elevated")
   const overlayTheme = useTheme("overlay")
@@ -49,11 +58,25 @@ export function DialogErrorDetails(props: { title: string; error: string; onBack
       .catch(toast.error)
   }
 
+  const investigate = () => {
+    const target = location.ref ?? data.location.default()
+    route.navigate({
+      type: "home",
+      location: target,
+      prompt: {
+        ...emptyPrompt(),
+        text: `Investigate this OpenCode failure in ${target.directory}.\n\n${props.title}\n${props.error}\n\nInspect the relevant configuration and logs, identify the root cause, and suggest a fix.`,
+      },
+    })
+    dialog.clear()
+  }
+
   Keymap.createLayer(() => ({
     mode: "modal",
     commands: [
       { bind: "escape", title: "Back", group: "Dialog", run: props.onBack },
       { bind: "c", title: "Copy details", group: "Dialog", run: copy },
+      { bind: "i", title: "Investigate error", group: "Dialog", run: investigate },
     ],
   }))
 
@@ -102,12 +125,20 @@ export function DialogErrorDetails(props: { title: string; error: string; onBack
           </span>
           <span style={{ fg: theme.text.subdued }}>{scrollable() ? " scroll" : ""}</span>
         </text>
-        <text onMouseUp={copy}>
-          <span style={{ fg: copied() ? theme.text.feedback.success.default : theme.text.default }}>
-            <b>{copied() ? "✓ copied" : "c"}</b>
-          </span>
-          <span style={{ fg: theme.text.subdued }}>{copied() ? "" : " copy details"}</span>
-        </text>
+        <box flexDirection="row" gap={3}>
+          <text onMouseUp={investigate}>
+            <span style={{ fg: theme.text.default }}>
+              <b>i</b>
+            </span>
+            <span style={{ fg: theme.text.subdued }}> investigate</span>
+          </text>
+          <text onMouseUp={copy}>
+            <span style={{ fg: copied() ? theme.text.feedback.success.default : theme.text.default }}>
+              <b>{copied() ? "✓ copied" : "c"}</b>
+            </span>
+            <span style={{ fg: theme.text.subdued }}>{copied() ? "" : " copy details"}</span>
+          </text>
+        </box>
       </box>
     </box>
   )

--- a/packages/tui/src/component/dialog-error-details.tsx
+++ b/packages/tui/src/component/dialog-error-details.tsx
@@ -3,7 +3,6 @@ import { useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { useConfig } from "../config"
 import { useClipboard } from "../context/clipboard"
-import { useData } from "../context/data"
 import { Keymap } from "../context/keymap"
 import { useLocation } from "../context/location"
 import { useRoute } from "../context/route"
@@ -15,7 +14,6 @@ import { useToast } from "../ui/toast"
 
 export function DialogErrorDetails(props: { title: string; error: string; onBack: () => void }) {
   const clipboard = useClipboard()
-  const data = useData()
   const dialog = useDialog()
   const location = useLocation()
   const route = useRoute()
@@ -59,13 +57,12 @@ export function DialogErrorDetails(props: { title: string; error: string; onBack
   }
 
   const investigate = () => {
-    const target = location.ref ?? data.location.default()
     route.navigate({
       type: "home",
-      location: target,
+      location: location.ref,
       prompt: {
         ...emptyPrompt(),
-        text: `Investigate this OpenCode failure in ${target.directory}.\n\n${props.title}\n${props.error}\n\nInspect the relevant configuration and logs, identify the root cause, and suggest a fix.`,
+        text: `Investigate this error:\n\n${props.title}\n${props.error}`,
       },
     })
     dialog.clear()
@@ -118,27 +115,25 @@ export function DialogErrorDetails(props: { title: string; error: string; onBack
           </text>
         </scrollbox>
       </box>
-      <box flexDirection="row" justifyContent="space-between" paddingLeft={2} paddingRight={2}>
-        <text>
+      <box flexDirection="row" gap={3} paddingLeft={2} paddingRight={2}>
+        <text flexGrow={1}>
           <span style={{ fg: theme.text.default }}>
             <b>{scrollable() ? "↑/↓" : ""}</b>
           </span>
           <span style={{ fg: theme.text.subdued }}>{scrollable() ? " scroll" : ""}</span>
         </text>
-        <box flexDirection="row" gap={3}>
-          <text onMouseUp={investigate}>
-            <span style={{ fg: theme.text.default }}>
-              <b>i</b>
-            </span>
-            <span style={{ fg: theme.text.subdued }}> investigate</span>
-          </text>
-          <text onMouseUp={copy}>
-            <span style={{ fg: copied() ? theme.text.feedback.success.default : theme.text.default }}>
-              <b>{copied() ? "✓ copied" : "c"}</b>
-            </span>
-            <span style={{ fg: theme.text.subdued }}>{copied() ? "" : " copy details"}</span>
-          </text>
-        </box>
+        <text onMouseUp={investigate}>
+          <span style={{ fg: theme.text.default }}>
+            <b>i</b>
+          </span>
+          <span style={{ fg: theme.text.subdued }}> investigate</span>
+        </text>
+        <text onMouseUp={copy}>
+          <span style={{ fg: copied() ? theme.text.feedback.success.default : theme.text.default }}>
+            <b>{copied() ? "✓ copied" : "c"}</b>
+          </span>
+          <span style={{ fg: theme.text.subdued }}>{copied() ? "" : " copy details"}</span>
+        </text>
       </box>
     </box>
   )

--- a/packages/tui/src/component/dialog-error-details.tsx
+++ b/packages/tui/src/component/dialog-error-details.tsx
@@ -12,7 +12,7 @@ import { emptyPrompt } from "../prompt/history"
 import { useDialog } from "../ui/dialog"
 import { useToast } from "../ui/toast"
 
-export function DialogErrorDetails(props: { title: string; error: string; onBack: () => void }) {
+export function DialogErrorDetails(props: { title: string; error: string; context?: string; onBack: () => void }) {
   const clipboard = useClipboard()
   const dialog = useDialog()
   const location = useLocation()
@@ -62,7 +62,7 @@ export function DialogErrorDetails(props: { title: string; error: string; onBack
       location: location.ref,
       prompt: {
         ...emptyPrompt(),
-        text: `Investigate this error:\n\n${props.title}\n${props.error}`,
+        text: `Investigate why this OpenCode component failed in the current project.\n\n${props.title}${props.context ? `\n${props.context}` : ""}\nError: ${props.error}\n\nInspect the relevant project and global OpenCode configuration, startup or loading behavior, required environment variables or credentials, dependencies, and logs. Identify the root cause and recommend a fix.`,
       },
     })
     dialog.clear()

--- a/packages/tui/src/component/dialog-mcp.tsx
+++ b/packages/tui/src/component/dialog-mcp.tsx
@@ -157,6 +157,9 @@ export function DialogMcp(props: { initialServer?: string; details?: boolean } =
           <DialogErrorDetails
             title={`MCP server: ${server().name}`}
             error={statusError(server().status) ?? "Unknown MCP connection error"}
+            context={`Status: failed\nConfiguration: mcp.servers.${server().name}${
+              server().integrationID ? `\nIntegration: ${server().integrationID}` : ""
+            }`}
             onBack={() => {
               setDetail(undefined)
               dialog.setSize("medium")

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -169,6 +169,7 @@ export function PluginsDialog(props: {
           <DialogErrorDetails
             title={`${entry().runtime === "tui" ? "TUI" : "Server"} plugin: ${label(entry(), props.context)}`}
             error={pluginError(entry()) ?? "Unknown plugin error"}
+            context={`Status: failed\nRuntime: ${entry().runtime}\nSource: ${pluginSource(entry(), props.context)}`}
             onBack={() => {
               setDetail()
               dialog.setSize("medium")
@@ -183,6 +184,11 @@ export function PluginsDialog(props: {
 function label(entry: Entry, context: Plugin.Context) {
   if (entry.runtime === "tui") return entry.id ?? entry.target
   return entry.plugin.id ?? source(entry.plugin, context)
+}
+
+function pluginSource(entry: Entry, context: Plugin.Context) {
+  if (entry.runtime === "tui") return entry.target
+  return source(entry.plugin, context)
 }
 
 function source(plugin: PluginInfo, context: Plugin.Context) {

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -55,10 +55,8 @@ export function Home() {
 
   createEffect(() => {
     const composer = ref()
-    const text = route.prompt?.text
-    if (!composer || text === undefined) return
     const prompt = route.prompt
-    if (!prompt) return
+    if (!composer || prompt?.text === undefined) return
     untrack(() => composer.set(prompt))
   })
 

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -48,16 +48,19 @@ export function Home() {
   const bind = (r: PromptRef | undefined) => {
     setRef(r)
     promptRef.set(r)
-    if (once || !r) return
-    if (route.prompt) {
-      r.set(route.prompt)
-      once = true
-      return
-    }
-    if (!args.prompt) return
+    if (once || !r || route.prompt || !args.prompt) return
     r.set({ text: args.prompt, files: [], agents: [], pasted: [] })
     once = true
   }
+
+  createEffect(() => {
+    const composer = ref()
+    const text = route.prompt?.text
+    if (!composer || text === undefined) return
+    const prompt = route.prompt
+    if (!prompt) return
+    untrack(() => composer.set(prompt))
+  })
 
   // Wait for the model store to be ready before auto-submitting --prompt.
   createEffect(() => {

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -297,6 +297,78 @@ test("session startup prompt is submitted exactly once", async () => {
   }
 })
 
+test("error investigations repeatedly seed editable home drafts without creating sessions", async () => {
+  const setup = await createTestRenderer({ width: 100, height: 30, useThread: false, kittyKeyboard: true })
+  setup.renderer.start()
+  const ready = Promise.withResolvers<void>()
+  const events = createEventStream()
+  const cwd = process.cwd()
+  const location = { directory: cwd, project: { id: "project", directory: cwd } }
+  let created = 0
+  const calls = createFetch((url, request) => {
+    if (url.pathname === "/api/location") return json(location)
+    if (url.pathname === "/api/mcp")
+      return json({
+        location,
+        data: [
+          { name: "alpha", status: { status: "failed", error: "Alpha connection refused" } },
+          { name: "beta", status: { status: "failed", error: "Beta initialization failed" } },
+        ],
+      })
+    if (url.pathname === "/api/session" && request.method === "POST") created++
+    return undefined
+  }, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: {
+          get: async () => ({ animations: false, keybinds: { "mcp.list": "f6" } }),
+          update: async () => ({}),
+        },
+        packages: { resolve: async () => undefined },
+        args: {},
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        log: () => {},
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
+    )
+    await ready.promise
+    await setup.waitForFrame((frame) => frame.includes("commands"))
+
+    setup.mockInput.pressKey("F6")
+    await setup.waitForFrame((frame) => frame.includes("MCP servers") && frame.includes("alpha"))
+    setup.mockInput.pressEnter()
+    await setup.waitForFrame((frame) => frame.includes("Alpha connection refused") && frame.includes("i investigate"))
+    setup.mockInput.pressKey("i")
+    await setup.waitForFrame((frame) => frame.includes("Alpha connection refused") && !frame.includes("i investigate"))
+
+    setup.mockInput.pressKey("F6")
+    await setup.waitForFrame((frame) => frame.includes("MCP servers"))
+    setup.mockInput.pressArrow("down")
+    setup.mockInput.pressEnter()
+    await setup.waitForFrame((frame) => frame.includes("Beta initialization failed") && frame.includes("i investigate"))
+    setup.mockInput.pressKey("i")
+    const draft = await setup.waitForFrame(
+      (frame) => frame.includes("Beta initialization failed") && !frame.includes("i investigate"),
+    )
+
+    expect(draft).not.toContain("Alpha connection refused")
+    expect(created).toBe(0)
+
+    setup.mockInput.pressKey("c", { ctrl: true })
+    await setup.waitForFrame((frame) => !frame.includes("Beta initialization failed"))
+    setup.renderer.destroy()
+    await task
+  } finally {
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    await server.stop()
+  }
+})
+
 test("shows jump to latest after scrolling one line above the final message", async () => {
   const setup = await createTestRenderer({ width: 80, height: 20, useThread: false, kittyKeyboard: true })
   setup.renderer.start()

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -300,7 +300,6 @@ test("session startup prompt is submitted exactly once", async () => {
 test("error investigations repeatedly seed editable home drafts without creating sessions", async () => {
   const setup = await createTestRenderer({ width: 100, height: 30, useThread: false, kittyKeyboard: true })
   setup.renderer.start()
-  const ready = Promise.withResolvers<void>()
   const events = createEventStream()
   const cwd = process.cwd()
   const location = { directory: cwd, project: { id: "project", directory: cwd } }
@@ -332,11 +331,10 @@ test("error investigations repeatedly seed editable home drafts without creating
         },
         packages: { resolve: async () => undefined },
         args: {},
-        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: () => {} }),
         log: () => {},
       }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
     )
-    await ready.promise
     await setup.waitForFrame((frame) => frame.includes("commands"))
 
     setup.mockInput.pressKey("F6")

--- a/packages/tui/test/cli/tui/dialog-mcp.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-mcp.test.tsx
@@ -7,7 +7,8 @@ import { ConfigProvider } from "../../../src/config"
 import { ClientProvider } from "../../../src/context/client"
 import { DataProvider, useData } from "../../../src/context/data"
 import { Keymap } from "../../../src/context/keymap"
-import { LocationProvider } from "../../../src/context/location"
+import { LocationProvider, useLocation } from "../../../src/context/location"
+import { RouteProvider, useRoute } from "../../../src/context/route"
 import { ThemeProvider } from "../../../src/context/theme"
 import { DialogProvider, useDialog } from "../../../src/ui/dialog"
 import { ToastProvider } from "../../../src/ui/toast"
@@ -32,19 +33,51 @@ test.each(["enter", "space"])("starts OAuth with %s for an MCP server requiring 
   }
 })
 
-async function renderMcp() {
+test("opens an investigation draft for a failed MCP server at its originating location", async () => {
+  const location = { directory: "/projects/example", workspaceID: "workspace_example" }
+  const fixture = await renderMcp({ failed: true, location })
+
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Failed !"))
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitForFrame((frame) => frame.includes("i investigate"))
+    fixture.app.mockInput.pressKey("i")
+    await fixture.app.waitForFrame((frame) => !frame.includes("MCP server: linear"))
+
+    expect(fixture.route.data.type).toBe("home")
+    if (fixture.route.data.type !== "home") throw new Error("Expected investigation to open a new session")
+    expect(fixture.route.data.location).toEqual(location)
+    expect(fixture.route.data.prompt?.text).toContain("MCP server: linear")
+    expect(fixture.route.data.prompt?.text).toContain("MCP error -32000: Connection closed")
+    expect(fixture.route.data.prompt?.text).toContain(location.directory)
+  } finally {
+    fixture.app.renderer.destroy()
+  }
+})
+
+async function renderMcp(options?: { failed?: boolean; location?: { directory: string; workspaceID?: string } }) {
   const events = createEventStream()
   let oauth = 0
   let connect = 0
+  let route!: ReturnType<typeof useRoute>
   const calls = createFetch((url, request) => {
     const location = {
-      directory: process.cwd(),
+      ...(options?.location ?? { directory: process.cwd() }),
       project: { id: "proj_test", directory: process.cwd(), canonical: process.cwd() },
     }
+    if (url.pathname === "/api/location") return json(location)
     if (url.pathname === "/api/mcp")
       return json({
         location,
-        data: [{ name: "linear", status: { status: "needs_auth" }, integrationID: "mcp_linear" }],
+        data: [
+          {
+            name: "linear",
+            status: options?.failed
+              ? { status: "failed", error: "MCP error -32000: Connection closed" }
+              : { status: "needs_auth" },
+            integrationID: "mcp_linear",
+          },
+        ],
       })
     if (url.pathname === "/api/integration")
       return json({
@@ -84,10 +117,14 @@ async function renderMcp() {
   function Probe() {
     const data = useData()
     const dialog = useDialog()
+    const location = useLocation()
+    route = useRoute()
     onMount(() => {
-      void Promise.all([data.location.mcp.server.sync(), data.location.integration.sync()]).then(() =>
-        dialog.replace(() => <DialogMcp />),
-      )
+      if (options?.location) location.set(options.location)
+      void Promise.all([
+        data.location.mcp.server.sync(options?.location),
+        data.location.integration.sync(options?.location),
+      ]).then(() => dialog.replace(() => <DialogMcp />))
     })
     return null
   }
@@ -98,17 +135,19 @@ async function renderMcp() {
         <ConfigProvider config={createTuiResolvedConfig()}>
           <Keymap.Provider>
             <ToastProvider>
-              <ClientProvider api={createApi(calls.fetch)}>
-                <DataProvider>
-                  <LocationProvider>
-                    <ThemeProvider mode="dark" source={emptyThemeSource}>
-                      <DialogProvider>
-                        <Probe />
-                      </DialogProvider>
-                    </ThemeProvider>
-                  </LocationProvider>
-                </DataProvider>
-              </ClientProvider>
+              <RouteProvider initialRoute={{ type: "session", sessionID: "ses_existing" }}>
+                <ClientProvider api={createApi(calls.fetch)}>
+                  <DataProvider>
+                    <LocationProvider>
+                      <ThemeProvider mode="dark" source={emptyThemeSource}>
+                        <DialogProvider>
+                          <Probe />
+                        </DialogProvider>
+                      </ThemeProvider>
+                    </LocationProvider>
+                  </DataProvider>
+                </ClientProvider>
+              </RouteProvider>
             </ToastProvider>
           </Keymap.Provider>
         </ConfigProvider>
@@ -119,6 +158,9 @@ async function renderMcp() {
   app.renderer.start()
   return {
     app,
+    get route() {
+      return route
+    },
     get oauth() {
       return oauth
     },

--- a/packages/tui/test/cli/tui/dialog-mcp.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-mcp.test.tsx
@@ -49,7 +49,7 @@ test("opens an investigation draft for a failed MCP server at its originating lo
     expect(fixture.route.data.location).toEqual(location)
     expect(fixture.route.data.prompt?.text).toContain("MCP server: linear")
     expect(fixture.route.data.prompt?.text).toContain("MCP error -32000: Connection closed")
-    expect(fixture.route.data.prompt?.text).toContain(location.directory)
+    expect(fixture.route.data.prompt?.text).not.toContain(location.directory)
   } finally {
     fixture.app.renderer.destroy()
   }

--- a/packages/tui/test/cli/tui/dialog-mcp.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-mcp.test.tsx
@@ -47,8 +47,13 @@ test("opens an investigation draft for a failed MCP server at its originating lo
     expect(fixture.route.data.type).toBe("home")
     if (fixture.route.data.type !== "home") throw new Error("Expected investigation to open a new session")
     expect(fixture.route.data.location).toEqual(location)
+    expect(fixture.route.data.prompt?.text).toContain("OpenCode component failed in the current project")
     expect(fixture.route.data.prompt?.text).toContain("MCP server: linear")
+    expect(fixture.route.data.prompt?.text).toContain("Status: failed")
+    expect(fixture.route.data.prompt?.text).toContain("Configuration: mcp.servers.linear")
+    expect(fixture.route.data.prompt?.text).toContain("Integration: mcp_linear")
     expect(fixture.route.data.prompt?.text).toContain("MCP error -32000: Connection closed")
+    expect(fixture.route.data.prompt?.text).toContain("project and global OpenCode configuration")
     expect(fixture.route.data.prompt?.text).not.toContain(location.directory)
   } finally {
     fixture.app.renderer.destroy()


### PR DESCRIPTION
## Why

MCP server and plugin failures currently end in an error-details dialog that can only copy the message. Investigating the failure requires manually opening another session, reconstructing the relevant OpenCode context, and hoping the session uses the project whose configuration caused the problem.

## What Changes

1. **Inspect the failure.** Open the existing MCP server or plugin error-details dialog.

   `MCP server: weather-tools    i investigate    c copy details`

2. **Press `i`.** The dialog closes and a new session tab opens in the current project with an editable, OpenCode-specific investigation prompt.

3. **Review and submit.** MCP prompts include the server name, failed status, exact `mcp.servers.<name>` configuration key, optional integration ID, and original error. Plugin prompts include the plugin name, failed status, runtime, source, and original error. Both direct the investigation toward project/global configuration, startup or loading behavior, environment variables, credentials, dependencies, and logs.

4. **Keep control.** The session is created only after the user edits or submits the draft. Repeating the flow replaces the existing Home draft instead of silently retaining an earlier error.

## Session Location

Investigations preserve the complete current location, including its workspace ID, rather than following the configurable new-session location or jumping to a global directory. Project-local MCP and plugin configuration remains available without embedding the project absolute path in the prompt.

## Demo

Matched OpenCode Drive runs against base commit `d01ac2069a` (left) and this change (right), using the same intentionally failing fictional MCP server and simulated provider. The right-hand run edits the contextual investigation draft, submits it, and receives a simulated diagnosis.

https://github.com/user-attachments/assets/daa80a29-3de5-45b6-a6c1-efac094c91df

## Scope

Applies to the shared error-details dialog used by failed MCP servers and failed TUI/server plugins. Session creation remains opt-in; global troubleshooting categories and configurable investigation workspaces are not part of this change.

## Verification

```sh
# From packages/tui
bun run test test/cli/tui/dialog-mcp.test.tsx
bun run test test/app-lifecycle.test.tsx --test-name-pattern "error investigations"
bun run test
bun typecheck

# Repository pre-push hook
bun typecheck
```

Full TUI suite: **797 passed, 5 skipped, 0 failed** across 112 files. The focused lifecycle regression verifies two consecutive investigations update the real Home composer without creating a session, and the MCP regression verifies diagnostic context plus directory/workspace-ID preservation. The pre-push hook additionally passed typechecking across all 32 workspace tasks.