### PR TITLE
feat(tui): add sticky prompt

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1310,6 +1310,7 @@ export function Session() {
               <StickyPrompt
                 scroll={() => scroll}
                 showTimestamps={showTimestamps}
+                scrollbarPadding={() => (showScrollbar() ? SCROLLBAR_VIEWPORT_PADDING : 0)}
                 container={() => sessionContent}
               />
               <box flexShrink={0}>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -74,6 +74,7 @@ import { setPreLayoutSiblingMargin } from "../../util/layout"
 import { useTuiConfig } from "../../config"
 import { useClipboard } from "../../context/clipboard"
 import { nextThinkingMode, reasoningSummary, useThinkingMode, type ThinkingMode } from "../../context/thinking"
+import { StickyPrompt } from "./sticky-prompt"
 import { getScrollAcceleration } from "../../util/scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { usePluginRuntime } from "../../plugin/runtime"
@@ -82,6 +83,9 @@ import { getRevertDiffFiles } from "../../util/revert-diff"
 import { OPENCODE_BASE_MODE, useBindings, useCommandShortcut, useOpencodeKeymap } from "../../keymap"
 import { usePathFormatter } from "../../context/path-format"
 import { LocationProvider } from "../../context/location"
+
+const SESSION_CONTENT_PADDING = 2
+const SCROLLBAR_VIEWPORT_PADDING = 1
 
 addDefaultParsers(parsers.parsers)
 
@@ -343,6 +347,7 @@ export function Session() {
 
   let seeded = false
   let scroll: ScrollBoxRenderable
+  let sessionContent: BoxRenderable | undefined
   let prompt: PromptRef | undefined
   const bind = (r: PromptRef | undefined) => {
     prompt = r
@@ -1176,12 +1181,20 @@ export function Session() {
         }}
       >
         <box flexDirection="row" flexGrow={1} minHeight={0}>
-          <box flexGrow={1} minHeight={0} paddingBottom={1} paddingLeft={2} paddingRight={2} gap={1}>
+          <box
+            ref={(box) => (sessionContent = box)}
+            flexGrow={1}
+            minHeight={0}
+            paddingBottom={1}
+            paddingLeft={SESSION_CONTENT_PADDING}
+            paddingRight={SESSION_CONTENT_PADDING}
+            gap={1}
+          >
             <Show when={session()}>
               <scrollbox
                 ref={(r) => (scroll = r)}
                 viewportOptions={{
-                  paddingRight: showScrollbar() ? 1 : 0,
+                  paddingRight: showScrollbar() ? SCROLLBAR_VIEWPORT_PADDING : 0,
                 }}
                 verticalScrollbarOptions={{
                   paddingLeft: 1,
@@ -1294,6 +1307,11 @@ export function Session() {
                   )}
                 </For>
               </scrollbox>
+              <StickyPrompt
+                scroll={() => scroll}
+                showTimestamps={showTimestamps}
+                container={() => sessionContent}
+              />
               <box flexShrink={0}>
                 <Show when={permissions().length > 0}>
                   <PermissionPrompt

--- a/packages/tui/src/routes/session/sticky-prompt.tsx
+++ b/packages/tui/src/routes/session/sticky-prompt.tsx
@@ -9,9 +9,18 @@ import { SplitBorder } from "../../ui/border"
 import { useDialog } from "../../ui/dialog"
 import { Locale } from "../../util/locale"
 
+const STICKY_PROMPT_PADDING_TOP = 1
+const STICKY_PROMPT_PADDING_BOTTOM = 1
+const STICKY_PROMPT_PADDING_LEFT = 2
+const STICKY_PROMPT_PADDING_RIGHT = 1
+const STICKY_PROMPT_TEXT_SAFETY_WIDTH = 2
+const STICKY_PROMPT_TEXT_LINES = 1
+const STICKY_PROMPT_TIMESTAMP_LINES = 1
+
 export function StickyPrompt(props: {
   scroll: () => ScrollBoxRenderable | undefined
   showTimestamps: () => boolean
+  scrollbarPadding: () => number
   container: () => BoxRenderable | undefined
 }) {
   const route = useRouteData("session")
@@ -31,6 +40,7 @@ export function StickyPrompt(props: {
       previous?.id === next?.id && previous?.text === next?.text && previous?.agent === next?.agent,
   })
   const [stickyGeometry, setStickyGeometry] = createSignal<{ left: number; width: number } | undefined>(undefined)
+  const [stickyHeight, setStickyHeight] = createSignal<number>()
   let attachedScroll: ScrollBoxRenderable | undefined
 
   const updateStickyAnchor = () => {
@@ -51,7 +61,7 @@ export function StickyPrompt(props: {
       scroll.getChildren(),
       new Set(eligibleMessages.map((message) => message.id)),
       scroll.y,
-      props.showTimestamps() ? 4 : 3,
+      getStickyPromptHeight(stickyHeight(), props.showTimestamps()),
     )
     if (!target || target.height <= 0) {
       setStickyAnchor(undefined)
@@ -74,7 +84,7 @@ export function StickyPrompt(props: {
     }
 
     const text = getStickyUserMessageText(sync.data.part[message.id] ?? [])
-    setStickyGeometry(getStickyPromptGeometry(container, target))
+    setStickyGeometry(getStickyPromptGeometry(container, target, props.scrollbarPadding()))
     setStickyAnchor(text ? { id: message.id, text, agent: message.agent, created: message.time.created } : undefined)
   }
 
@@ -106,15 +116,19 @@ export function StickyPrompt(props: {
               ref={(box) => {
                 promptContent = box
                 setPromptContentWidth(box.width)
+                setStickyHeight(box.height)
               }}
-              paddingTop={1}
-              paddingBottom={1}
-              paddingLeft={2}
-              paddingRight={1}
+              paddingTop={STICKY_PROMPT_PADDING_TOP}
+              paddingBottom={STICKY_PROMPT_PADDING_BOTTOM}
+              paddingLeft={STICKY_PROMPT_PADDING_LEFT}
+              paddingRight={STICKY_PROMPT_PADDING_RIGHT}
               width="100%"
               flexShrink={0}
               onSizeChange={() => {
-                if (promptContent) setPromptContentWidth(promptContent.width)
+                if (promptContent) {
+                  setPromptContentWidth(promptContent.width)
+                  setStickyHeight(promptContent.height)
+                }
               }}
               backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
               onMouseOver={() => setHover(true)}
@@ -128,7 +142,15 @@ export function StickyPrompt(props: {
             >
               <text fg={theme.text} width="100%" overflow="hidden" wrapMode="none">
                 {promptContentWidth() > 0
-                  ? truncateStickyPrompt(anchor().text, getStickyPromptTextWidth(promptContentWidth(), 2, 1, 2))
+                  ? truncateStickyPrompt(
+                      anchor().text,
+                      getStickyPromptTextWidth(
+                        promptContentWidth(),
+                        STICKY_PROMPT_PADDING_LEFT,
+                        STICKY_PROMPT_PADDING_RIGHT,
+                        STICKY_PROMPT_TEXT_SAFETY_WIDTH,
+                      ),
+                    )
                   : anchor().text}
               </text>
               <Show when={props.showTimestamps()}>
@@ -151,11 +173,22 @@ export function getStickyPromptTextWidth(
   return Math.max(1, contentWidth - paddingLeft - paddingRight - safetyWidth)
 }
 
+export function getStickyPromptHeight(measuredHeight: number | undefined, showTimestamps: boolean) {
+  if (measuredHeight !== undefined && measuredHeight > 0) return measuredHeight
+  return (
+    STICKY_PROMPT_PADDING_TOP +
+    STICKY_PROMPT_PADDING_BOTTOM +
+    STICKY_PROMPT_TEXT_LINES +
+    (showTimestamps ? STICKY_PROMPT_TIMESTAMP_LINES : 0)
+  )
+}
+
 export function getStickyPromptGeometry(
   container: { screenX: number },
   message: { screenX: number; width: number },
+  rightPadding = 0,
 ) {
-  return { left: message.screenX - container.screenX, width: message.width }
+  return { left: message.screenX - container.screenX, width: message.width + rightPadding }
 }
 
 export function getStickyPromptScrollDelta(childY: number, scrollY: number) {

--- a/packages/tui/src/routes/session/sticky-prompt.tsx
+++ b/packages/tui/src/routes/session/sticky-prompt.tsx
@@ -1,0 +1,219 @@
+import { createMemo, createSignal, onCleanup, Show } from "solid-js"
+import { type BoxRenderable, type ScrollBoxRenderable } from "@opentui/core"
+import { useLocal } from "../../context/local"
+import { useRouteData } from "../../context/route"
+import { useSync } from "../../context/sync"
+import { useTheme } from "../../context/theme"
+import { useRenderer } from "@opentui/solid"
+import { SplitBorder } from "../../ui/border"
+import { useDialog } from "../../ui/dialog"
+import { Locale } from "../../util/locale"
+
+export function StickyPrompt(props: {
+  scroll: () => ScrollBoxRenderable | undefined
+  showTimestamps: () => boolean
+  container: () => BoxRenderable | undefined
+}) {
+  const route = useRouteData("session")
+  const sync = useSync()
+  const local = useLocal()
+  const { theme } = useTheme()
+  const dialog = useDialog()
+  const renderer = useRenderer()
+  const messages = createMemo(() => sync.data.message[route.sessionID] ?? [])
+  const stickyUserMessages = createMemo(() =>
+    messages().filter((message) => hasEligibleUserText(message, sync.data.part[message.id] ?? [])),
+  )
+  const [stickyAnchor, setStickyAnchor] = createSignal<
+    { id: string; text: string; agent: string; created: number } | undefined
+  >(undefined, {
+    equals: (previous, next) =>
+      previous?.id === next?.id && previous?.text === next?.text && previous?.agent === next?.agent,
+  })
+  const [stickyGeometry, setStickyGeometry] = createSignal<{ left: number; width: number } | undefined>(undefined)
+  let attachedScroll: ScrollBoxRenderable | undefined
+
+  const updateStickyAnchor = () => {
+    const scroll = props.scroll()
+    if (scroll !== attachedScroll) {
+      if (attachedScroll) attachedScroll.onMouseScroll = undefined
+      attachedScroll = scroll
+      if (scroll) scroll.onMouseScroll = () => queueMicrotask(updateStickyAnchor)
+    }
+    if (!scroll || scroll.isDestroyed) {
+      setStickyAnchor(undefined)
+      setStickyGeometry(undefined)
+      return
+    }
+
+    const eligibleMessages = stickyUserMessages()
+    const target = findStickyUserMessage(
+      scroll.getChildren(),
+      new Set(eligibleMessages.map((message) => message.id)),
+      scroll.y,
+      props.showTimestamps() ? 4 : 3,
+    )
+    if (!target || target.height <= 0) {
+      setStickyAnchor(undefined)
+      setStickyGeometry(undefined)
+      return
+    }
+
+    const container = props.container()
+    if (!container) {
+      setStickyAnchor(undefined)
+      setStickyGeometry(undefined)
+      return
+    }
+
+    const message = eligibleMessages.find((item) => item.id === target.id)
+    if (!message) {
+      setStickyAnchor(undefined)
+      setStickyGeometry(undefined)
+      return
+    }
+
+    const text = getStickyUserMessageText(sync.data.part[message.id] ?? [])
+    setStickyGeometry(getStickyPromptGeometry(container, target))
+    setStickyAnchor(text ? { id: message.id, text, agent: message.agent, created: message.time.created } : undefined)
+  }
+
+  renderer.on("frame", updateStickyAnchor)
+  onCleanup(() => {
+    if (attachedScroll) attachedScroll.onMouseScroll = undefined
+    renderer.off("frame", updateStickyAnchor)
+  })
+
+  return (
+    <Show when={stickyAnchor()}>
+      {(anchor) => {
+        const [hover, setHover] = createSignal(false)
+        const [promptContentWidth, setPromptContentWidth] = createSignal(0)
+        let promptContent: BoxRenderable | undefined
+
+        return (
+          <box
+            position="absolute"
+            top={0}
+            left={stickyGeometry()?.left ?? 0}
+            width={stickyGeometry()?.width ?? 0}
+            zIndex={1}
+            border={["left"]}
+            borderColor={local.agent.color(anchor().agent)}
+            customBorderChars={SplitBorder.customBorderChars}
+          >
+            <box
+              ref={(box) => {
+                promptContent = box
+                setPromptContentWidth(box.width)
+              }}
+              paddingTop={1}
+              paddingBottom={1}
+              paddingLeft={2}
+              paddingRight={1}
+              width="100%"
+              flexShrink={0}
+              onSizeChange={() => {
+                if (promptContent) setPromptContentWidth(promptContent.width)
+              }}
+              backgroundColor={hover() ? theme.backgroundElement : theme.backgroundPanel}
+              onMouseOver={() => setHover(true)}
+              onMouseOut={() => setHover(false)}
+              onMouseUp={() => {
+                const scroll = props.scroll()
+                const child = scroll?.getChildren().find((child) => child.id === anchor().id)
+                if (scroll && child) scroll.scrollBy(getStickyPromptScrollDelta(child.y, scroll.y))
+                dialog.clear()
+              }}
+            >
+              <text fg={theme.text} width="100%" overflow="hidden" wrapMode="none">
+                {promptContentWidth() > 0
+                  ? truncateStickyPrompt(anchor().text, getStickyPromptTextWidth(promptContentWidth(), 2, 1, 2))
+                  : anchor().text}
+              </text>
+              <Show when={props.showTimestamps()}>
+                <text fg={theme.textMuted}>{Locale.todayTimeOrDateTime(anchor().created)}</text>
+              </Show>
+            </box>
+          </box>
+        )
+      }}
+    </Show>
+  )
+}
+
+export function getStickyPromptTextWidth(
+  contentWidth: number,
+  paddingLeft: number,
+  paddingRight: number,
+  safetyWidth = 0,
+) {
+  return Math.max(1, contentWidth - paddingLeft - paddingRight - safetyWidth)
+}
+
+export function getStickyPromptGeometry(
+  container: { screenX: number },
+  message: { screenX: number; width: number },
+) {
+  return { left: message.screenX - container.screenX, width: message.width }
+}
+
+export function getStickyPromptScrollDelta(childY: number, scrollY: number) {
+  return childY - scrollY
+}
+
+export function truncateStickyPrompt(text: string, maxWidth: number) {
+  const ellipsis = "…"
+  if (Bun.stringWidth(text) <= maxWidth) return text
+
+  const availableWidth = maxWidth - Bun.stringWidth(ellipsis)
+  let prefix = ""
+  for (const character of Array.from(text)) {
+    const next = prefix + character
+    if (Bun.stringWidth(next) > availableWidth) break
+    prefix = next
+  }
+  return prefix + ellipsis
+}
+
+type UserTextPart = { type: string; text?: string; synthetic?: boolean; ignored?: boolean }
+
+export function findStickyUserMessage<T extends { id?: string; y: number; height: number; screenX: number; width: number }>(
+  children: readonly T[],
+  userIDs: ReadonlySet<string>,
+  viewportTop: number,
+  stickyHeight: number,
+) {
+  const stickyBottom = viewportTop + stickyHeight
+  const overlapBottom = stickyBottom + 1
+  const result = children.reduce<{ candidate: T | undefined; blocked: boolean }>(
+    (state, child) => {
+      if (state.blocked || !child.id || !userIDs.has(child.id)) return state
+      if (child.y > overlapBottom) return { ...state, blocked: true }
+      if (child.y + child.height > stickyBottom) return { candidate: undefined, blocked: true }
+      return { candidate: child, blocked: false }
+    },
+    { candidate: undefined, blocked: false },
+  )
+  return result.candidate
+}
+
+export function hasEligibleUserText(
+  message: { role: string },
+  parts: readonly UserTextPart[],
+) {
+  if (message.role !== "user") return false
+  return parts.some(isVisibleTextPart)
+}
+
+export function getStickyUserMessageText(parts: readonly UserTextPart[]) {
+  return parts
+    .flatMap((part) => (isVisibleTextPart(part) ? [part.text ?? ""] : []))
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+function isVisibleTextPart(part: UserTextPart) {
+  return part.type === "text" && !part.synthetic && !part.ignored
+}

--- a/packages/tui/test/cli/tui/sticky-prompt.test.ts
+++ b/packages/tui/test/cli/tui/sticky-prompt.test.ts
@@ -7,6 +7,7 @@ import {
   truncateStickyPrompt,
   getStickyUserMessageText,
   hasEligibleUserText,
+  getStickyPromptHeight,
 } from "../../../src/routes/session/sticky-prompt"
 
 describe("hasEligibleUserText", () => {
@@ -52,9 +53,24 @@ describe("getStickyPromptTextWidth", () => {
   })
 })
 
+describe("getStickyPromptHeight", () => {
+  test("uses the measured height when available", () => {
+    expect(getStickyPromptHeight(7, false)).toBe(7)
+  })
+
+  test("falls back to the rendered line count before measurement", () => {
+    expect(getStickyPromptHeight(undefined, false)).toBe(3)
+    expect(getStickyPromptHeight(undefined, true)).toBe(4)
+  })
+})
+
 describe("getStickyPromptGeometry", () => {
   test("maps the user message bounds into the sticky container", () => {
     expect(getStickyPromptGeometry({ screenX: 10 }, { screenX: 12, width: 50 })).toEqual({ left: 2, width: 50 })
+  })
+
+  test("extends to the scrollbar when right viewport padding is reserved", () => {
+    expect(getStickyPromptGeometry({ screenX: 10 }, { screenX: 12, width: 50 }, 1)).toEqual({ left: 2, width: 51 })
   })
 })
 

--- a/packages/tui/test/cli/tui/sticky-prompt.test.ts
+++ b/packages/tui/test/cli/tui/sticky-prompt.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test"
+import {
+  findStickyUserMessage,
+  getStickyPromptTextWidth,
+  getStickyPromptGeometry,
+  getStickyPromptScrollDelta,
+  truncateStickyPrompt,
+  getStickyUserMessageText,
+  hasEligibleUserText,
+} from "../../../src/routes/session/sticky-prompt"
+
+describe("hasEligibleUserText", () => {
+  test("accepts a user message with visible text", () => {
+    expect(hasEligibleUserText({ role: "user" }, [{ type: "text", text: "hello" }])).toBe(true)
+  })
+
+  test("rejects synthetic text", () => {
+    expect(hasEligibleUserText({ role: "user" }, [{ type: "text", text: "hello", synthetic: true }])).toBe(false)
+  })
+
+  test("rejects ignored text", () => {
+    expect(hasEligibleUserText({ role: "user" }, [{ type: "text", text: "hello", ignored: true }])).toBe(false)
+  })
+
+  test("rejects non-user messages", () => {
+    expect(hasEligibleUserText({ role: "assistant" }, [{ type: "text", text: "hello" }])).toBe(false)
+  })
+})
+
+describe("getStickyUserMessageText", () => {
+  test("joins visible user text parts into one line", () => {
+    expect(
+      getStickyUserMessageText([
+        { type: "text", text: "first\nline" },
+        { type: "text", text: "ignored", ignored: true },
+        { type: "text", text: "second", synthetic: true },
+        { type: "text", text: "third" },
+      ]),
+    ).toBe("first line third")
+  })
+})
+
+describe("getStickyPromptTextWidth", () => {
+  test("uses the rendered content box instead of the parent width", () => {
+    expect(getStickyPromptTextWidth(40, 2, 1)).toBe(37)
+    expect(getStickyPromptTextWidth(2, 2, 1)).toBe(1)
+  })
+
+  test("reserves a safety width before the right edge", () => {
+    expect(getStickyPromptTextWidth(40, 2, 1, 2)).toBe(35)
+    expect(getStickyPromptTextWidth(4, 2, 1, 2)).toBe(1)
+  })
+})
+
+describe("getStickyPromptGeometry", () => {
+  test("maps the user message bounds into the sticky container", () => {
+    expect(getStickyPromptGeometry({ screenX: 10 }, { screenX: 12, width: 50 })).toEqual({ left: 2, width: 50 })
+  })
+})
+
+describe("getStickyPromptScrollDelta", () => {
+  test("aligns the original message with the sticky prompt top edge", () => {
+    expect(getStickyPromptScrollDelta(42, 10)).toBe(32)
+  })
+})
+
+describe("truncateStickyPrompt", () => {
+  test("truncates by terminal display width", () => {
+    expect(truncateStickyPrompt("你好世界", 5)).toBe("你好…")
+  })
+})
+
+describe("findStickyUserMessage", () => {
+  const children = [
+    { id: "user-1", y: 10, height: 20, screenX: 0, width: 50 },
+    { id: "user-2", y: 40, height: 20, screenX: 0, width: 50 },
+  ]
+  const userIDs = new Set(["user-1", "user-2"])
+
+  test("returns no message before the first user message reaches the top", () => {
+    expect(findStickyUserMessage(children, userIDs, 5, 10)).toBeUndefined()
+  })
+
+  test("hides the anchor when the next message overlaps the sticky region", () => {
+    expect(findStickyUserMessage(children, userIDs, 31, 10)).toBeUndefined()
+    expect(findStickyUserMessage(children, userIDs, 61, 10)).toBe(children[1])
+  })
+
+  test("filters ineligible children and selects the last eligible child", () => {
+    const childrenWithAssistant = [children[0], { id: "assistant-1", y: 30, height: 10, screenX: 0, width: 50 }, children[1]]
+
+    expect(findStickyUserMessage(childrenWithAssistant, userIDs, 61, 10)).toBe(children[1])
+  })
+
+  test("selects a prompt only after its bottom is fully covered", () => {
+    expect(findStickyUserMessage(children, userIDs, 5, 10)).toBeUndefined()
+    expect(findStickyUserMessage(children, userIDs, 31, 10)).toBeUndefined()
+    expect(findStickyUserMessage(children, userIDs, 40, 10)).toBeUndefined()
+    expect(findStickyUserMessage(children, userIDs, 61, 10)).toBe(children[1])
+  })
+
+  test("hides the current anchor while the next message overlaps the sticky region", () => {
+    const children = [
+      { id: "a", y: 0, height: 5, screenX: 0, width: 50 },
+      { id: "b", y: 6, height: 20, screenX: 0, width: 50 },
+    ]
+
+    expect(findStickyUserMessage(children, new Set(["a", "b"]), 0, 10)).toBeUndefined()
+  })
+
+  test("switches to the latest message fully covered by the sticky region", () => {
+    const children = [
+      { id: "a", y: 0, height: 5, screenX: 0, width: 50 },
+      { id: "b", y: 6, height: 4, screenX: 0, width: 50 },
+    ]
+
+    expect(findStickyUserMessage(children, new Set(["a", "b"]), 0, 10)).toBe(children[1])
+  })
+
+  test("treats a one-line gap as overlap", () => {
+    const children = [
+      { id: "a", y: 0, height: 5, screenX: 0, width: 50 },
+      { id: "b", y: 11, height: 5, screenX: 0, width: 50 },
+    ]
+
+    expect(findStickyUserMessage(children, new Set(["a", "b"]), 0, 10)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #28035

Related to #29063 and #5047

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a compact sticky user prompt to the TUI session view.

When the user prompt scrolls out of view while reading a long assistant
response, its content is shown in a single visual line at the top of the
message area. The original prompt remains in the transcript.

The sticky prompt preserves the existing user-message styling, supports both
the `build` and `plan` agents, and clicking it jumps back to the original
message.

This is a TUI-only change with no backend or session data model changes.

### How did you verify your code works?

- `bun test test/cli/tui/sticky-prompt.test.ts` from `packages/tui`
- `bun typecheck` from `packages/tui`
- `./packages/opencode/script/build.ts --single`
- Manually tested long responses, timestamps, sidebars, narrow terminals, and
  visible scrollbars

### Screenshots / recordings

<img width="1034" height="1047" alt="demo" src="https://github.com/user-attachments/assets/a9eb9cd4-8fba-48a5-8102-fbcf82e6237d" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR