### PR TITLE
feat(plugin): expose session move

### DIFF
--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -442,6 +442,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: Interface, p
       generate: (input) => runtime.session.generate(input).pipe(Effect.map((text) => ({ text }))),
       command: runtime.session.command,
       rename: runtime.session.rename,
+      move: runtime.session.move,
       synthetic: runtime.session.synthetic,
       interrupt: (input) =>
         runtime.session

--- a/packages/core/src/plugin/runtime.ts
+++ b/packages/core/src/plugin/runtime.ts
@@ -20,6 +20,7 @@ export interface Interface {
     | "generate"
     | "command"
     | "rename"
+    | "move"
     | "resume"
     | "switchAgent"
     | "switchModel"
@@ -76,6 +77,7 @@ export const layerWithCell = (cell: Cell) =>
         generate: (input) => require(cell, (runtime) => runtime.session.generate(input)),
         command: (input) => require(cell, (runtime) => runtime.session.command(input)),
         rename: (input) => require(cell, (runtime) => runtime.session.rename(input)),
+        move: (input) => require(cell, (runtime) => runtime.session.move(input)),
         resume: (sessionID) => require(cell, (runtime) => runtime.session.resume(sessionID)),
         switchAgent: (input) => require(cell, (runtime) => runtime.session.switchAgent(input)),
         switchModel: (input) => require(cell, (runtime) => runtime.session.switchModel(input)),

--- a/packages/core/test/plugin/host.ts
+++ b/packages/core/test/plugin/host.ts
@@ -140,6 +140,7 @@ export function host(overrides: Overrides = {}): Plugin.Context {
       generate: overrides.session?.generate ?? (() => Effect.die("unused session.generate")),
       command: overrides.session?.command ?? (() => Effect.die("unused session.command")),
       rename: overrides.session?.rename ?? (() => Effect.die("unused session.rename")),
+      move: overrides.session?.move ?? (() => Effect.die("unused session.move")),
       synthetic: overrides.session?.synthetic ?? (() => Effect.die("unused session.synthetic")),
       interrupt: overrides.session?.interrupt ?? (() => Effect.die("unused session.interrupt")),
       wait: overrides.session?.wait ?? (() => Effect.die("unused session.wait")),

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -137,6 +137,7 @@ describe("fromPromise", () => {
           switchAgent: (input) => Effect.sync(() => seen.push(input)),
           switchModel: (input) => Effect.sync(() => seen.push(input)),
           rename: (input) => Effect.sync(() => seen.push(input)),
+          move: (input) => Effect.sync(() => seen.push(input)),
           wait: (input) => Effect.sync(() => seen.push(input)),
         },
       })
@@ -157,6 +158,9 @@ describe("fromPromise", () => {
               }),
             ).toBeUndefined()
             expect(await ctx.session.rename({ sessionID: "ses_success", title: "Renamed" })).toBeUndefined()
+            expect(
+              await ctx.session.move({ sessionID: "ses_success", directory: "/destination", delivery: "queue" }),
+            ).toBeUndefined()
             expect(await ctx.session.wait({ sessionID: "ses_success" })).toBeUndefined()
           },
         }),
@@ -169,6 +173,11 @@ describe("fromPromise", () => {
           model: { providerID: Provider.ID.make("openai"), id: Model.ID.make("gpt-5") },
         },
         { sessionID: Session.ID.make("ses_success"), title: "Renamed" },
+        {
+          sessionID: Session.ID.make("ses_success"),
+          directory: AbsolutePath.make("/destination"),
+          delivery: "queue",
+        },
         { sessionID: Session.ID.make("ses_success") },
       ])
     }),

--- a/packages/plugin/src/effect/session.ts
+++ b/packages/plugin/src/effect/session.ts
@@ -57,6 +57,7 @@ export type SessionDomain = Pick<
   | "synthetic"
   | "interrupt"
   | "rename"
+  | "move"
   | "wait"
   | "context"
 > & {

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -366,6 +366,7 @@ export function fromPromise(plugin: Plugin) {
             synthetic: adaptApiMethod(SessionEndpoints["session.synthetic"], host.session.synthetic),
             interrupt: adaptApiMethod(SessionEndpoints["session.interrupt"], host.session.interrupt),
             rename: adaptApiMethod(SessionEndpoints["session.rename"], host.session.rename),
+            move: adaptApiMethod(SessionEndpoints["session.move"], host.session.move),
             wait: adaptApiMethod(SessionEndpoints["session.wait"], host.session.wait),
             context: adaptApiMethod(SessionEndpoints["session.context"], host.session.context),
           },

--- a/packages/plugin/src/promise/session.ts
+++ b/packages/plugin/src/promise/session.ts
@@ -57,6 +57,7 @@ export type SessionDomain = Pick<
   | "synthetic"
   | "interrupt"
   | "rename"
+  | "move"
   | "wait"
   | "context"
 > & {


### PR DESCRIPTION
## Summary
- expose `session.move` in Effect and Promise plugin contexts
- forward Promise calls through the existing session move endpoint
- cover protocol decoding and host forwarding

## Tests
- `bun typecheck` in `packages/plugin`
- `bun typecheck` in `packages/core`
- `bun test` in `packages/plugin`
- `bun test test/plugin/promise.test.ts` in `packages/core`
- repository pre-push typecheck