### PR TITLE
docs(ecosystem): add opencode-session-recall plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-session-recall](https://github.com/rmk40/opencode-session-recall)                        | Search and retrieve the agent's full history across sessions and projects, surviving compaction    |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation addition to the community ecosystem plugins list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-session-recall](https://github.com/rmk40/opencode-session-recall) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

The plugin adds recall tools that let the agent search and retrieve its own conversation history — messages, tool outputs, and reasoning traces — straight from OpenCode's storage. History that compaction pushed out of the context window stays searchable, across sessions and across projects. No separate memory layer, embeddings, or API keys.

I'm the plugin author. Only the English `ecosystem.mdx` is touched, matching how prior entries were added (e.g. #38709).

### How did you verify your code works?

One table row added; padding matches the existing 98-char column format so the table stays aligned. Verified the rendered markdown table locally.

### Screenshots / recordings

N/A — one row added to an existing docs table.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR