### PR TITLE
docs(ecosystem): add opencode-fleet-kit

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [opencode-fleet-kit](https://github.com/aniripsaretro-max/opencode-fleet-kit)                              | Run unattended fleets of OpenCode agents on one box: continuous loop supervisor templates, shared state file, and a dead-man-switch heartbeat plugin |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes # (no issue — docs table addition)

### Type of change

- [x] Documentation

### What does this PR do?

Adds one row to the Projects table in `packages/web/src/content/docs/ecosystem.mdx` for [opencode-fleet-kit](https://github.com/aniripsaretro-max/opencode-fleet-kit): MIT-licensed templates from a production setup running five unattended OpenCode loops on a single VPS — continuous supervisor + per-tick runner (flock locking, hard timeouts, per-tick prompt snapshots, FLEET_STOP kill switch, systemd user units) plus a `session.idle` → heartbeat dead-man-switch plugin, so silent loop death alerts instead of going unnoticed.

### How did you verify your code works?

Docs-only change: row follows the exact table format of neighboring entries (same columns/pipes), and the repo link resolves with a README describing the same components as the row text.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally (docs row: table syntax + link checks)
- [x] I have not included unrelated changes in this PR
