### PR TITLE
fix(tui): truncate locale strings by display width

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -9,6 +9,7 @@ import { ClipboardProvider, useClipboard } from "./context/clipboard"
 import { ExitProvider, useExit } from "./context/exit"
 import { EpilogueProvider } from "./context/epilogue"
 import * as Selection from "./util/selection"
+import { Locale } from "./util/locale"
 import { createCliRenderer, MouseButton } from "@opentui/core"
 import { RouteProvider, useRoute } from "./context/route"
 import {
@@ -465,7 +466,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         return
       }
 
-      const title = session.title.length > 40 ? session.title.slice(0, 37) + "..." : session.title
+      const title = Locale.truncate(session.title, 40)
       renderer.setTerminalTitle(`OC | ${title}`)
       return
     }

--- a/packages/tui/src/util/locale.ts
+++ b/packages/tui/src/util/locale.ts
@@ -1,3 +1,5 @@
+import { displaySlice, promptOffsetWidth } from "../prompt/display"
+
 export function titlecase(str: string) {
   return str.replace(/\b\w/g, (c) => c.toUpperCase())
 }
@@ -58,24 +60,38 @@ export function duration(input: number) {
   return `${days}d ${hours}h`
 }
 
+const graphemes = new Intl.Segmenter(undefined, { granularity: "grapheme" })
+
+// Longest prefix that fits the column budget; never splits a grapheme (emoji, CJK).
+function fitWidth(str: string, budget: number) {
+  let width = 0
+  for (const part of graphemes.segment(str)) {
+    const next = width + (part.segment === "\n" ? 1 : Bun.stringWidth(part.segment))
+    if (next > budget) return str.slice(0, part.index)
+    width = next
+  }
+  return str
+}
+
 export function truncate(str: string, len: number): string {
-  if (str.length <= len) return str
-  return str.slice(0, len - 1) + "…"
+  if (promptOffsetWidth(str) <= len) return str
+  return fitWidth(str, len - 1) + "…"
 }
 
 export function truncateLeft(str: string, len: number): string {
-  if (str.length <= len) return str
-  return "…" + str.slice(-(len - 1))
+  const width = promptOffsetWidth(str)
+  if (width <= len) return str
+  return "…" + displaySlice(str, width - (len - 1))
 }
 
 export function truncateMiddle(str: string, maxLength: number = 35): string {
-  if (str.length <= maxLength) return str
+  const width = promptOffsetWidth(str)
+  if (width <= maxLength) return str
 
-  const ellipsis = "…"
-  const keepStart = Math.ceil((maxLength - ellipsis.length) / 2)
-  const keepEnd = Math.floor((maxLength - ellipsis.length) / 2)
+  const keepStart = Math.ceil((maxLength - 1) / 2)
+  const keepEnd = Math.floor((maxLength - 1) / 2)
 
-  return str.slice(0, keepStart) + ellipsis + str.slice(-keepEnd)
+  return displaySlice(str, 0, keepStart) + "…" + displaySlice(str, width - keepEnd)
 }
 
 export function pluralize(count: number, singular: string, plural: string): string {

--- a/packages/tui/test/util/locale.test.ts
+++ b/packages/tui/test/util/locale.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test"
+import { truncate, truncateLeft, truncateMiddle } from "../../src/util/locale"
+
+function hasLoneSurrogate(str: string) {
+  for (const ch of str) {
+    const code = ch.codePointAt(0)
+    if (code !== undefined && code >= 0xd800 && code <= 0xdfff) return true
+  }
+  return false
+}
+
+describe("util.locale.truncate", () => {
+  test("returns strings within budget unchanged", () => {
+    expect(truncate("hello", 10)).toBe("hello")
+    expect(truncate("hello", 5)).toBe("hello")
+    expect(truncate("", 5)).toBe("")
+  })
+
+  test("matches legacy behavior for ASCII", () => {
+    expect(truncate("hello world", 5)).toBe("hell…")
+  })
+
+  test("does not split emoji surrogates", () => {
+    const title = "abcdefghijklmnopqrstuvwxyz0123456789🚀🚀🚀"
+    const result = truncate(title, 40)
+    expect(result).toBe("abcdefghijklmnopqrstuvwxyz0123456789🚀…")
+    expect(hasLoneSurrogate(result)).toBe(false)
+  })
+
+  test("measures CJK characters as two columns", () => {
+    const title = "一二三四五六七八九十".repeat(4)
+    expect(truncate(title, 80)).toBe(title)
+    expect(truncate(title, 61)).toBe("一二三四五六七八九十".repeat(3) + "…")
+    expect(truncate("中文", 3)).toBe("中…")
+  })
+})
+
+describe("util.locale.truncateLeft", () => {
+  test("returns strings within budget unchanged", () => {
+    expect(truncateLeft("hello", 5)).toBe("hello")
+    expect(truncateLeft("", 5)).toBe("")
+  })
+
+  test("matches legacy behavior for ASCII", () => {
+    expect(truncateLeft("hello", 3)).toBe("…lo")
+  })
+
+  test("does not split emoji surrogates", () => {
+    const result = truncateLeft("ab🚀cdefgh", 8)
+    expect(result).toBe("…🚀cdefgh")
+    expect(hasLoneSurrogate(result)).toBe(false)
+  })
+
+  test("measures CJK characters as two columns", () => {
+    const result = truncateLeft("一二三四五六七八九十", 7)
+    expect(result.startsWith("…")).toBe(true)
+    expect(hasLoneSurrogate(result)).toBe(false)
+  })
+})
+
+describe("util.locale.truncateMiddle", () => {
+  test("returns strings within budget unchanged", () => {
+    expect(truncateMiddle("hello", 35)).toBe("hello")
+    expect(truncateMiddle("hello")).toBe("hello")
+  })
+
+  test("matches legacy behavior for ASCII", () => {
+    expect(truncateMiddle("abcdefghijklmnopqrst", 11)).toBe("abcde…pqrst")
+  })
+
+  test("does not split emoji surrogates", () => {
+    const result = truncateMiddle("🚀".repeat(10), 5)
+    expect(result).toBe("🚀…🚀")
+    expect(hasLoneSurrogate(result)).toBe(false)
+  })
+
+  test("measures CJK characters as two columns", () => {
+    const result = truncateMiddle("一二三四五六七八九十一二三四五六七八九十", 9)
+    expect(result).toBe("一二…九十")
+    expect(hasLoneSurrogate(result)).toBe(false)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #44338

### Type of change

- [x] Bug fix

### What does this PR do?

`Locale.truncate` / `truncateLeft` / `truncateMiddle` measured strings in UTF-16
code units and sliced on those indices. Two visible bugs: a slice could land
between the surrogates of an emoji (broken glyph in the session list and the
terminal title), and CJK characters were counted as one column while they render
as two, so long Chinese titles were never truncated at all.

This reuses `promptOffsetWidth` / `displaySlice` from `prompt/display.ts` so the
three helpers measure display width and cut on grapheme boundaries. The terminal
title in `app.tsx` now goes through `Locale.truncate` as well. ASCII output is
unchanged.

Known edge carried over from the issue: `truncateLeft`/`truncateMiddle` can
overshoot the budget by one column when a wide character straddles the cut point.

### How did you verify your code works?

Reproduced both cases manually (session renamed to 36 ASCII chars + 🚀🚀🚀, and a
40-char Chinese title in an ~80 column terminal) and confirmed the truncation
points are clean after the change. Added `test/util/locale.test.ts`: issue repro
cases, lone-surrogate guard, and assertions that ASCII results stay identical to
the old implementation.

### Screenshots / recordings

_No screenshot attached; the fix is covered by the new tests in `test/util/locale.test.ts`._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
