### PR TITLE
fix(core): correct getDirectory and truncateMiddle edge cases

### DIFF
--- a/packages/core/src/util/path.ts
+++ b/packages/core/src/util/path.ts
@@ -9,6 +9,7 @@ export function getDirectory(path: string | undefined) {
   if (!path) return ""
   const trimmed = path.replace(/[/\\]+$/, "")
   const parts = trimmed.split(/[/\\]/)
+  if (parts.length < 2) return ""
   return parts.slice(0, parts.length - 1).join("/") + "/"
 }
 
@@ -21,6 +22,7 @@ export function getFileExtension(path: string | undefined) {
 export function getFilenameTruncated(path: string | undefined, maxLength: number = 20) {
   const filename = getFilename(path)
   if (filename.length <= maxLength) return filename
+  if (maxLength <= 0) return ""
   const lastDot = filename.lastIndexOf(".")
   const ext = lastDot <= 0 ? "" : filename.slice(lastDot)
   const available = maxLength - ext.length - 1 // -1 for ellipsis
@@ -30,8 +32,10 @@ export function getFilenameTruncated(path: string | undefined, maxLength: number
 
 export function truncateMiddle(text: string, maxLength: number = 20) {
   if (text.length <= maxLength) return text
+  if (maxLength <= 0) return ""
   const available = maxLength - 1 // -1 for ellipsis
   const start = Math.ceil(available / 2)
   const end = Math.floor(available / 2)
+  if (end === 0) return text.slice(0, start) + "…"
   return text.slice(0, start) + "…" + text.slice(-end)
 }

--- a/packages/core/test/util/path.test.ts
+++ b/packages/core/test/util/path.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+import { getDirectory, getFilenameTruncated, truncateMiddle } from "@opencode-ai/core/util/path"
+
+describe("util.path", () => {
+  describe("getDirectory", () => {
+    test("returns the parent directory with a trailing separator", () => {
+      expect(getDirectory("packages/core/src/util/path.ts")).toBe("packages/core/src/util/")
+      expect(getDirectory("src/index.ts")).toBe("src/")
+    })
+
+    test("returns an empty string for a path with no directory part", () => {
+      expect(getDirectory("README.md")).toBe("")
+      expect(getDirectory("")).toBe("")
+      expect(getDirectory(undefined)).toBe("")
+    })
+  })
+
+  describe("truncateMiddle", () => {
+    test("never returns more characters than maxLength", () => {
+      const text = "packages/core/src/util/path.ts"
+      for (const width of [0, 1, 2, 3, 4, 10, text.length - 1]) {
+        expect(truncateMiddle(text, width).length).toBeLessThanOrEqual(width)
+      }
+    })
+
+    test("keeps both ends once there is room for them", () => {
+      expect(truncateMiddle("abcdefgh", 1)).toBe("…")
+      expect(truncateMiddle("abcdefgh", 2)).toBe("a…")
+      expect(truncateMiddle("abcdefgh", 3)).toBe("a…h")
+      expect(truncateMiddle("abcdefgh", 5)).toBe("ab…gh")
+    })
+
+    test("returns the input unchanged when it already fits", () => {
+      expect(truncateMiddle("abc", 3)).toBe("abc")
+      expect(truncateMiddle("abc", 10)).toBe("abc")
+    })
+  })
+
+  describe("getFilenameTruncated", () => {
+    test("never returns more characters than maxLength", () => {
+      for (const width of [0, 1, 2, 5, 14]) {
+        expect(getFilenameTruncated("src/very-long-file-name.ts", width).length).toBeLessThanOrEqual(width)
+      }
+    })
+
+    test("keeps the extension when there is room for it", () => {
+      expect(getFilenameTruncated("src/very-long-file-name.ts", 14)).toBe("very-long-….ts")
+    })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45184

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two functions in `packages/core/src/util/path.ts` return wrong values for ordinary inputs.

**`getDirectory` returned `"/"` for a file with no directory part.** For `"README.md"` the split yields `["README.md"]`, the slice yields `[]`, and `[].join("/")` is `""` — so the function appended `"/"` to nothing and claimed the file lives at the filesystem root. The function already special-cases empty input to `""`, so `""` is the answer consistent with its own convention. Guarding on `parts.length < 2` is the smallest change that does it.

This surfaces wherever a repository-root file is listed, because most callers pass the path straight through — `dialog-select-file.tsx:135`, `dialog-command-palette-v2.tsx:282`, `message-timeline.tsx:192`. Notably `session-file-list-v2.tsx:108` already works around it with `value.includes("/") ? getDirectory(value) : undefined`, which suggests the `"/"` had been noticed at one call site without being fixed at the source.

**`truncateMiddle` could return more characters than `maxLength`.** With `maxLength <= 2`, `end` is `0` and `text.slice(-0)` is `text.slice(0)` — the whole string. `truncateMiddle("abcdefgh", 1)` returned `"…abcdefgh"`, nine characters for a one-character budget. `getFilenameTruncated` overruns the same way at `maxLength === 0`, where `filename.slice(0, -1)` drops one character and then appends an ellipsis.

Same `-0` defect as #45183, in a second copy of the helper. Fixed the same way: return `""` when nothing fits, and return `start + ellipsis` when `end` is `0` rather than falling through to `slice(-0)`.

`getFileExtension` in this file has a separate problem (it returns the whole filename when there is no dot). It has no callers, so I left it alone rather than widen this PR — noted in the issue instead.

### How did you verify your code works?

Added `packages/core/test/util/path.test.ts` and ran it against both versions with `bun test` (bun 1.4.0):

- against `dev` — **4 of 7 fail**: `getDirectory("README.md")` returns `"/"`, `truncateMiddle(text, 0)` returns 30 characters, `truncateMiddle("abcdefgh", 1)` returns `"…abcdefgh"`, and `getFilenameTruncated(..., 0)` returns 22 characters.
- against this branch — **7 pass, 0 fail, 24 expect() calls**.

The tests cover the normal paths too (`getDirectory("packages/core/src/util/path.ts")` → `"packages/core/src/util/"`, and `getFilenameTruncated("src/very-long-file-name.ts", 14)` → `"very-long-….ts"`) so the fix cannot silently break the common case.

### Screenshots / recordings

_Not a UI change in itself, though it removes a stray `/` from directory labels on root-level files._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
