### PR TITLE
fix(grep): scope the search to the file when path points to a file

### DIFF
--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -63,6 +63,7 @@ export const GrepTool = Tool.define(
           const result = yield* ripgrep.grep({
             cwd,
             pattern: params.pattern,
+            file: info?.type === "File" ? path.basename(search) : undefined,
             include: params.include,
             limit: 100,
           })


### PR DESCRIPTION
### Issue for this PR

Closes #45185

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the `grep` tool is given a `path` that points to a file, it searched that file's entire parent directory instead.

`packages/opencode/src/tool/grep.ts` widens `cwd` to the parent when the target is not a directory:

```ts
const cwd = info?.type === "Directory" ? search : path.dirname(search)
```

That branch shows the file case is anticipated, but nothing narrows the search back down afterwards, so ripgrep runs over every sibling file. The model asks about one file, gets matches from all of them, and the 100-match budget is spent on results it did not ask for.

The `Ripgrep` service already supports this. `GrepInput` declares `readonly file?: string` and the implementation passes it as ripgrep's path argument (`input.file ?? "."` in `packages/core/src/ripgrep.ts`). The v2 tool in `packages/core/src/tool/grep.ts:97-104` uses it correctly:

```ts
cwd: info?.type === "Directory" ? target : path.dirname(target),
file: info?.type === "File" ? path.basename(target) : undefined,
```

The tool actually wired into the registry is the one that omits it — `file` had no callers anywhere in the repo. This PR passes it, matching the v2 implementation exactly.

The existing path-resolution below is unaffected: with `file` set, ripgrep still reports paths relative to `cwd`, so `path.resolve(path.dirname(requested), item.entry.path)` resolves to the same file as before.

### How did you verify your code works?

`packages/opencode/src/tool/grep.ts` parses clean under `bun build --no-bundle` (bun 1.4.0).

I traced the behaviour through the ripgrep layer rather than running the full agent: `run()` builds the argv as `[..., "--", input.pattern, input.file ?? "."]`, so supplying `file` replaces the `.` positional and confines ripgrep to that single path, while `cwd` stays the parent directory so the returned relative paths — and therefore the `path.resolve(...)` on line 71 — are unchanged. This is the same argument shape the v2 grep tool already produces in production.

I did not add a test here: the tool's behaviour is only observable by spawning the real ripgrep binary, and there is no existing harness for the tool layer to extend. Happy to add one if you would like it.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
