### PR TITLE
fix(read): make the directory pagination hint match the file branch

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -277,7 +277,7 @@ export const ReadTool = Tool.define<
             `<entries>`,
             sliced.join("\n"),
             truncated
-              ? `\n(Showing ${sliced.length} of ${items.length} entries. Use 'offset' parameter to read beyond entry ${offset + sliced.length})`
+              ? `\n(Showing entries ${offset}-${offset + sliced.length - 1} of ${items.length}. Use offset=${offset + sliced.length} to continue.)`
               : `\n(${items.length} entries)`,
             `</entries>`,
           ].join("\n"),


### PR DESCRIPTION
### Issue for this PR

Closes #45187

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `read` pages through a directory, the continuation hint named the wrong entry, so following it literally skips one.

Before:

```
(Showing 100 of 250 entries. Use 'offset' parameter to read beyond entry 101)
```

`offset` is 1-indexed and `start = offset - 1`, so with `offset = 1` and 100 entries shown, entries **1–100** were returned and `offset + sliced.length` is `101` — the first entry *not* yet shown. Telling the model to read beyond entry 101 means starting at 102, which drops entry 101.

The file branch of this same tool already gets it right, and does so by not asking the model to do arithmetic at all:

```ts
output += `\n\n(Showing lines ${file.offset}-${last} of ${file.count}. Use offset=${next} to continue.)`
```

This PR makes the directory branch say the same kind of thing:

```
(Showing entries 1-100 of 250. Use offset=101 to continue.)
```

Inclusive range that was shown, then the exact value to pass next. Because this text is read by a model rather than a person, the ambiguity turns into a silently missing directory entry rather than a visible error, which is why it seemed worth fixing rather than leaving as a wording nit.

The value `offset + sliced.length` is unchanged — it was always the correct *offset* to pass next. Only the sentence around it changes, from describing it as an entry to boundary-step past to naming it as the offset to use.

### How did you verify your code works?

`packages/opencode/src/tool/read.ts` parses clean under `bun build --no-bundle` (bun 1.4.0).

Checked the arithmetic against the surrounding code: `start = offset - 1`, `sliced = items.slice(start, start + limit)`, so the entries shown are 1-indexed `offset` through `offset + sliced.length - 1`, and the next unread entry is at 1-indexed `offset + sliced.length`. Substituting the first page of a 250-entry directory (`offset = 1`, `limit = 100`) gives `Showing entries 1-100 of 250. Use offset=101 to continue.`, and passing `offset=101` sets `start = 100`, which is `items[100]` — entry 101, the first one not yet seen. The second page then reports `Showing entries 101-200 of 250`.

This branch is only reached when `truncated` is true, which is computed separately as `start + sliced.length < items.length` and is not affected.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
