### PR TITLE
fix(ai): keep bedrock mantle responses on http

### DIFF
--- a/packages/ai/src/providers/amazon-bedrock-mantle.ts
+++ b/packages/ai/src/providers/amazon-bedrock-mantle.ts
@@ -1,5 +1,5 @@
 import { Auth } from "../route/auth.js"
-import type { Route as RouteDef, RouteDefaultsInput } from "../route/client.js"
+import { Route, type RouteDefaultsInput } from "../route/client.js"
 import type { ProviderPackage } from "../provider-package.js"
 import { OpenAIChat } from "../protocols/openai-chat.js"
 import { OpenAIResponses } from "../protocols/openai-responses.js"
@@ -26,9 +26,15 @@ export interface Settings extends ProviderPackage.Settings {
   readonly providerOptions?: OpenAIProviderOptionsInput
 }
 
-const responsesRoute = OpenAIResponses.route.with({
+const responsesRoute = Route.make({
   id: "bedrock-mantle-responses",
   provider: id,
+  providerMetadataKey: OpenAIResponses.route.providerMetadataKey,
+  protocol: OpenAIResponses.protocol,
+  endpoint: OpenAIResponses.route.endpoint,
+  auth: OpenAIResponses.route.auth,
+  transport: OpenAIResponses.httpTransport,
+  defaults: OpenAIResponses.route.defaults,
 })
 
 const chatRoute = OpenAIChat.route.with({
@@ -38,7 +44,7 @@ const chatRoute = OpenAIChat.route.with({
 
 export const routes = [responsesRoute, chatRoute]
 
-const configuredRoute = <Body, Prepared>(route: RouteDef<Body, Prepared>, input: Config) => {
+const configuredRoute = <Body, Prepared>(route: Route<Body, Prepared>, input: Config) => {
   const region = input.region ?? input.credentials?.region ?? "us-east-1"
   const credentials = input.credentials === undefined ? undefined : { ...input.credentials, region }
   return route.with({

--- a/packages/ai/test/provider/bedrock-mantle.test.ts
+++ b/packages/ai/test/provider/bedrock-mantle.test.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect"
 import { HttpClientRequest } from "effect/unstable/http"
 import { LLM, Message } from "../../src/index.js"
 import { AmazonBedrockMantle } from "../../src/providers.js"
+import { OpenAIResponses } from "../../src/protocols/openai-responses.js"
 import { compileRequest, LLMClient } from "../../src/route/client.js"
 import { it } from "../lib/effect.js"
 import { dynamicResponse, fixedResponse } from "../lib/http.js"
@@ -19,6 +20,7 @@ describe("Amazon Bedrock Mantle provider", () => {
   it.effect("uses Chat by default and exposes Responses", () =>
     Effect.gen(function* () {
       const provider = AmazonBedrockMantle.configure({ credentials })
+      expect(provider.responses("openai.gpt-oss-120b").route.transport).toBe(OpenAIResponses.httpTransport)
       const chat = yield* compileRequest(LLM.request({ model: provider.model("openai.gpt-oss-120b"), prompt: "Hi" }))
       const responses = yield* compileRequest(
         LLM.request({ model: provider.responses("openai.gpt-oss-120b"), prompt: "Hi" }),


### PR DESCRIPTION
## summary
- construct Bedrock Mantle Responses routes with the HTTP-only OpenAI Responses transport
- preserve existing Responses protocol behavior and cover the configured transport in provider tests

## testing
- `bun test test/provider/bedrock-mantle.test.ts test/provider/openai-compatible-responses.test.ts` (22 passing)
- `bun typecheck` in `packages/ai`
- repository-wide pre-push typecheck (32 packages passing)
- full AI suite currently has unrelated existing failures in Anthropic recorded fixtures, OpenRouter reasoning assertions, and executor tests