### PR TITLE
fix(edit): count blank middle lines as matches in block anchor scoring

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -340,6 +340,9 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
         const searchLine = searchLines[j].trim()
         const maxLen = Math.max(originalLine.length, searchLine.length)
         if (maxLen === 0) {
+          // Both lines are blank, which is an exact match. Skipping here would leave
+          // the pair counted in linesToCheck while contributing nothing to the score.
+          similarity += 1 / linesToCheck
           continue
         }
         const distance = levenshtein(originalLine, searchLine)
@@ -389,6 +392,8 @@ export const BlockAnchorReplacer: Replacer = function* (content, find) {
         const searchLine = searchLines[j].trim()
         const maxLen = Math.max(originalLine.length, searchLine.length)
         if (maxLen === 0) {
+          // Both lines are blank, which is an exact match. See the single-candidate branch.
+          similarity += 1
           continue
         }
         const distance = levenshtein(originalLine, searchLine)


### PR DESCRIPTION
### Issue for this PR

Closes #45199

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`BlockAnchorReplacer` scores a candidate block by averaging per-line similarity across the middle lines. Blank middle lines were skipped with a bare `continue`, but the denominator (`linesToCheck`) is fixed before the loop starts, so every skipped pair silently removed `1 / linesToCheck` from the score.

A blank/blank pair is an **exact** match — `maxLen === 0` can only happen when both lines are empty after `trim()`. It was being scored as a total mismatch.

Because the loop runs exactly `linesToCheck` times, the arithmetic is off in a way that compounds: with 2 blank lines out of 5 middle lines, the maximum achievable score is 0.6, which is below the 0.65 threshold. Such a block **can never match**, no matter how identical the remaining lines are.

Running the scoring loop verbatim on a 7-line block with 2 blank middle lines, where `oldString` has drifted by one character:

```
current  similarity = 0.583   -> below threshold, no match
correct  similarity = 0.983   -> match
```

98% similar, scored 58%.

This matters more than the arithmetic suggests because of where the replacer sits. It is third in the chain, after `SimpleReplacer` and `LineTrimmedReplacer` — it only runs once exact and line-trimmed matching have already failed, which is exactly when the model's `oldString` has drifted and this fallback is the last thing between the user and a failed edit. Blank lines between statements are completely ordinary, so the fallback was weakest on the blocks most likely to reach it.

The fix adds the missing contribution in both branches: `similarity += 1 / linesToCheck` in the single-candidate path (which divides inline) and `similarity += 1` in the multiple-candidate path (which divides at the end). Nothing else about the scoring, the anchors, the candidate collection or the 0.65 threshold changes.

### How did you verify your code works?

`packages/opencode/src/tool/edit.ts` parses clean under `bun build --no-bundle` (bun 1.4.0).

I extracted the scoring loop verbatim into a standalone script and ran both versions against the same input, which produced the 0.583 / 0.983 numbers above. I also checked the loop bound against the denominator: the loop runs `j` from `1` while `j < searchBlockSize - 1 && j < actualBlockSize - 1`, giving exactly `min(searchBlockSize, actualBlockSize) - 2` iterations, which is `linesToCheck`. So each iteration owns exactly `1 / linesToCheck` of the average and contributing a full share for an exact match is the arithmetically correct value, not an approximation.

I did not add a test: there is no existing test that exercises the replacers directly, and the harness in `packages/opencode/test/tool/edit.test.ts` goes through the full instance fixture. `BlockAnchorReplacer` is exported and pure, so a direct unit test would be easy to add — happy to do that if you want it, though `test` currently sits at `action_required` on fork PRs so I would not be able to see it run.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
