### PR TITLE
fix(read): reject offset/limit of 0 instead of looping

### DIFF
--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -1,5 +1,5 @@
 import { Effect, Option, Schema, Scope, Stream } from "effect"
-import { NonNegativeInt } from "@opencode-ai/core/schema"
+import { PositiveInt } from "@opencode-ai/core/schema"
 import * as path from "path"
 import * as Tool from "./tool"
 import { FSUtil } from "@opencode-ai/core/fs-util"
@@ -27,10 +27,10 @@ class ReadStop extends Schema.TaggedErrorClass<ReadStop>()("ReadStop", {}) {}
 // unchanged; purely CLI-facing uses must now send numbers rather than strings.
 export const Parameters = Schema.Struct({
   filePath: Schema.String.annotate({ description: "The absolute path to the file or directory to read" }),
-  offset: Schema.optional(NonNegativeInt).annotate({
+  offset: Schema.optional(PositiveInt).annotate({
     description: "The line number to start reading from (1-indexed)",
   }),
-  limit: Schema.optional(NonNegativeInt).annotate({
+  limit: Schema.optional(PositiveInt).annotate({
     description: "The maximum number of lines to read (defaults to 2000)",
   }),
 })


### PR DESCRIPTION
### Issue for this PR

Closes #45200

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`read` declared `offset` and `limit` as `NonNegativeInt`, so `0` was a valid value. `limit: 0` puts the model in a loop it cannot get out of.

The chain is:

- `params.limit ?? DEFAULT_READ_LIMIT` keeps the `0`. `??` only falls back on `null`/`undefined`, so the 2000 default never applies.
- In `lines()`, `if (raw.length >= opts.limit)` is `0 >= 0` on the first line, so `more` is set and nothing is ever pushed.
- In `run()`, `last = file.offset + file.raw.length - 1` is `1 + 0 - 1 = 0` and `next = last + 1 = 1`.

The model gets no content plus this hint:

```
(Showing lines 1-0 of 250. Use offset=1 to continue.)
```

`offset=1` is the call it just made. Following the instruction reproduces the identical request, and nothing in the response points at `limit` as the cause — so the model has no way to correct itself.

`offset: 0` was accepted too and silently rewritten to `1` by `params.offset || 1`, which contradicts the field's own "1-indexed" description.

The v2 tool already treats both as positive (`packages/core/src/tool/read-filesystem.ts`):

```ts
export const PageInput = Schema.Struct({
  offset: PositiveInt.pipe(Schema.optional),
  limit: PositiveInt.check(Schema.isLessThanOrEqualTo(MAX_READ_LINES)).pipe(Schema.optional),
})
```

so on that path `0` is a schema error the model can see and fix. This PR makes the registered v1 tool agree, which is a two-word change plus the import.

I deliberately did not also add v2's `<= MAX_READ_LINES` bound. An oversized `limit` is harmless here — it is still bounded by `DEFAULT_READ_LIMIT`'s sibling byte cap — and adding a ceiling would reject calls that work today, which is a bigger behaviour change than this fix warrants.

### How did you verify your code works?

`packages/opencode/src/tool/read.ts` parses clean under `bun build --no-bundle` (bun 1.4.0), and I confirmed `NonNegativeInt` has no other use in the file (the import is now unused otherwise, so it is swapped rather than added).

I traced the failure by hand through the three steps above rather than running the agent. The key one is `??` versus `||`: `0 ?? 2000` is `0`, so the documented "defaults to 2000" does not apply to an explicit zero. That is what turns a nonsensical argument into a silent no-op instead of either a default or an error.

Note that `params.offset || 1` a few lines later *does* use `||`, so `offset: 0` was being coerced while `limit: 0` was not — the inconsistency between the two operators on adjacent fields is what hid this.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
