### PR TITLE
fix(tui): show readable Effect errors

### DIFF
--- a/packages/tui/src/util/error.ts
+++ b/packages/tui/src/util/error.ts
@@ -1,3 +1,4 @@
+import { Cause } from "effect"
 import { isRecord } from "./record"
 
 type ConfigIssue = { message: string; path: string[] }
@@ -95,6 +96,10 @@ function field(input: Record<string, unknown>, key: string) {
 }
 
 export function errorFormat(error: unknown): string {
+  if (Cause.isCause(error)) {
+    return Cause.pretty(error)
+  }
+
   if (error instanceof Error) {
     return error.stack ?? `${error.name}: ${error.message}`
   }

--- a/packages/tui/test/util/error.test.ts
+++ b/packages/tui/test/util/error.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { Cause } from "effect"
 import { errorData, errorFormat, errorMessage } from "../../src/util/error"
 
 describe("util.error", () => {
@@ -45,5 +46,14 @@ describe("util.error", () => {
     const data = errorData(err)
     expect(data.message).toBe("ResolveMessage: Cannot resolve module")
     expect(String(data.formatted)).toContain("ResolveMessage")
+  })
+
+  test("formats Effect causes without exposing raw internals", () => {
+    const cause = Cause.fail(new Error("MCP transport closed"))
+    const formatted = errorFormat(cause)
+
+    expect(formatted).toContain("MCP transport closed")
+    expect(formatted).not.toContain('"_id"')
+    expect(formatted).not.toContain('"Cause"')
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #34925


### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Effect `Cause` values were falling through to the generic `JSON.stringify` error formatter. This exposed internal fields like `_id: "Cause"` while hiding the useful error message.

This change detects Effect causes with `Cause.isCause()` and formats them using `Cause.pretty()`.

Also added a regression test that verifies the original error message is shown and the internal Cause structure is not exposed.

### How did you verify your code works?
I reproduced the issue with:

```bash
  bun -e 'import { Cause } from "effect"; import { errorFormat } from "./src/util/error"; console.log(errorFormat(Cause.fail(new
  Error("MCP transport closed"))))'
```

The above command creates the problematic Effect Cause and passes it through OpenCode’s real `errorFormat()` function. It now prints the useful error instead of the raw Cause object.

I also added a focused unit test and ran the full TUI test suite and typecheck.

I did not run Playwright MCP because the bug is isolated to error formatting. directly testing the Cause is deterministic and will avoid a flaky external-process test.

### Screenshots / recordings
Not applicable as there is no UI change. Below is the terminal output from the Bun reproduction command before and after the fix.

<img width="2544" height="842" alt="CleanShot 2026-08-26 at 14 07 00@2x" src="https://github.com/user-attachments/assets/39664ae9-353f-426b-a63a-1823998c74a3" />


_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
