### PR TITLE
fix(desktop): align and theme Windows caption controls

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -58,7 +58,7 @@ export function AppBaseProviders(
   props: ParentProps<{
     locale?: Locale
     onNativeTranslations?: Parameters<typeof LanguageProvider>[0]["onNativeTranslations"]
-    onThemeApplied?: () => void
+    onThemeApplied?: (mode: "light" | "dark", scheme: "system" | "light" | "dark") => void
   }>,
 ) {
   return (
@@ -67,7 +67,7 @@ export function AppBaseProviders(
       <ThemeProvider
         onThemeApplied={(_, mode, scheme) => {
           void window.api?.setTitlebar?.({ mode, scheme })
-          props.onThemeApplied?.()
+          props.onThemeApplied?.(mode, scheme)
         }}
       >
         <LanguageProvider locale={props.locale} onNativeTranslations={props.onNativeTranslations}>

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -54,7 +54,7 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
   const titlebarZoom = () => (windows() ? Math.max(zoom(), minTitlebarZoom) : zoom())
   const minHeight = () => {
     if (mac()) return `${titlebarHeight / zoom()}px`
-    if (windows()) return `${titlebarHeight / Math.min(titlebarZoom(), 1)}px`
+    if (windows()) return `env(titlebar-area-height, ${titlebarHeight / Math.min(titlebarZoom(), 1)}px)`
     return undefined
   }
   const windowsControlsWidth = () => `${windowsControlsBaseWidth / Math.max(titlebarZoom(), 1)}px`
@@ -324,7 +324,7 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
               <div
                 class="h-full flex-1 overflow-hidden flex flex-row items-center gap-1.5 px-2 md:pr-3"
                 classList={{
-                  "pt-2": !bottom(),
+                  "pt-2": !bottom() && !windows(),
                   "pb-2": bottom(),
                   "md:pl-2": macTrafficLights(),
                   "md:pl-4": !macTrafficLights(),

--- a/packages/desktop/src/main/windows/appearance.ts
+++ b/packages/desktop/src/main/windows/appearance.ts
@@ -72,8 +72,10 @@ export function getBackgroundColor() {
 
 export function setTitlebar(win: BrowserWindow, theme: Partial<TitlebarTheme> = {}) {
   titlebarThemes.set(win, theme)
-  // The macOS frame follows nativeTheme, not the renderer theme.
-  if (process.platform === "darwin") nativeTheme.themeSource = theme.scheme ?? theme.mode ?? "system"
+  // Native window controls follow nativeTheme, not the renderer theme.
+  if (process.platform === "darwin" || process.platform === "win32") {
+    nativeTheme.themeSource = theme.scheme ?? theme.mode ?? "system"
+  }
   updateTitlebar(win)
 }
 

--- a/packages/desktop/src/renderer/desktop-app.tsx
+++ b/packages/desktop/src/renderer/desktop-app.tsx
@@ -141,7 +141,10 @@ function DesktopWindow(props: {
       <AppBaseProviders
         locale={locale.latest}
         onNativeTranslations={(bundle) => void props.api.setNativeTranslations(bundle).catch(() => undefined)}
-        onThemeApplied={() => void props.api.themeReady()}
+        onThemeApplied={(mode, scheme) => {
+          void props.api.setTitlebar({ mode, scheme })
+          void props.api.themeReady()
+        }}
       >
         <Show when={true}>{(_) => <ReadyApp />}</Show>
       </AppBaseProviders>


### PR DESCRIPTION
## Summary
- Align the Windows title bar with Chromium's live native caption overlay geometry during zoom and display scaling changes.
- Route renderer theme changes through the desktop API so caption symbols update for light and dark themes.
- Synchronize Electron's native Windows theme so minimize and maximize hover states follow the selected color scheme.

## Verification
- bun typecheck in packages/app
- bun typecheck in packages/desktop
- Full pre-push workspace typecheck: 32 packages passed