### PR TITLE
fix(plugin): support documented tool registration

### DIFF
--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -561,17 +561,19 @@ describe("fromPromise", () => {
         id: "promise-tool",
         setup: async (ctx) => {
           await ctx.tool.transform((tools) => {
-            tools.add({
-              name: "hello",
-              options: { codemode: false },
-              description: "Hello",
-              input: Schema.Struct({ name: Schema.String }),
-              output: Schema.String,
-              execute: async ({ name }, context) => {
-                await context.progress({ phase: "greeting" })
-                return { output: `Hello, ${name}!` }
+            tools.add(
+              "hello",
+              {
+                description: "Hello",
+                input: Schema.Struct({ name: Schema.String }),
+                output: Schema.String,
+                execute: async ({ name }, context) => {
+                  await context.progress({ phase: "greeting" })
+                  return { output: `Hello, ${name}!` }
+                },
               },
-            })
+              { codemode: false },
+            )
           })
         },
       })

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -298,11 +298,16 @@ export function fromPromise(plugin: Plugin) {
               register(
                 host.tool.transform((draft) =>
                   callback({
-                    add: (tool: Info) =>
+                    add: (...args) => {
+                      const tool: Info =
+                        args.length === 1
+                          ? args[0]
+                          : { ...args[1], name: args[0], ...(args[2] === undefined ? {} : { options: args[2] }) }
                       draft.add({
                         ...tool,
                         execute: (input, context) => executePromiseTool(tool, input, context),
-                      }),
+                      })
+                    },
                   }),
                 ),
               ),

--- a/packages/plugin/src/promise/tool.ts
+++ b/packages/plugin/src/promise/tool.ts
@@ -22,9 +22,16 @@ export type Info<
   ) => Promise<Tool.Result<Output>>
 }
 
+type Definition<
+  Input extends Tool.ValueSchema<any> = Tool.ValueSchema<any>,
+  Output extends Tool.ValueSchema<any> | undefined = Tool.ValueSchema<any> | undefined,
+> = Omit<Info<Input, Output>, "name" | "options">
+
 interface ToolDraft {
   add<Input extends Tool.ValueSchema<any>, Output extends Tool.ValueSchema<any> | undefined>(
-    tool: Info<Input, Output>,
+    ...args:
+      | [tool: Info<Input, Output>]
+      | [name: string, definition: Definition<Input, Output>, options?: Tool.Options]
   ): void
 }
 


### PR DESCRIPTION
### Issue for this PR

Fixes #43753

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Promise plugin docs expose `tools.add(name, definition, options)`, but the adapter only handled a single object argument. Passing the documented string form spread the tool name into character keys, leaving `name` undefined and crashing during tool-name normalization.

This normalizes the documented form into a complete tool definition while preserving the existing object form.

### How did you verify your code works?

- Promise plugin tests: 16 passed
- Repository typecheck: 32 packages passed
- Changed-file oxlint: 0 errors

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR