### PR TITLE
feat(app): recover failed turns with another model, preserve continuity, and show error details

### DIFF
--- a/packages/app/src/components/dialog-select-model.tsx
+++ b/packages/app/src/components/dialog-select-model.tsx
@@ -225,14 +225,20 @@ export function ModelSelectorPopover(props: {
 export function ModelSelectorPopoverV2(props: {
   provider?: string
   model?: ModelState
+  exclude?: { modelID: string; providerID: string }
   trigger: ModelSelectorTrigger
   onClose?: () => void
+  onSelect?: (model: { modelID: string; providerID: string }) => void
 }) {
   const dialog = useDialog()
   const controller = createModelSelectorController({
     model: props.model,
     provider: () => props.provider,
-    onSelect: () => props.onClose?.(),
+    exclude: () => props.exclude,
+    onSelect: (item) => {
+      props.onSelect?.({ modelID: item.id, providerID: item.provider.id })
+      props.onClose?.()
+    },
   })
 
   return (
@@ -254,15 +260,19 @@ export function ModelSelectorPopoverV2(props: {
 
 function createModelSelectorController(input: {
   provider: () => string | undefined
+  exclude?: () => { modelID: string; providerID: string } | undefined
   model?: ModelState
-  onSelect: () => void
+  onSelect: (item: ModelItem) => void
 }) {
   const model = input.model ?? useLocal().model
   const allModels = createMemo(() =>
     model
       .list()
       .filter((item) => model.visible({ modelID: item.id, providerID: item.provider.id }))
-      .filter((item) => (input.provider() ? item.provider.id === input.provider() : true)),
+      .filter((item) => (input.provider() ? item.provider.id === input.provider() : true))
+      .filter(
+        (item) => item.id !== input.exclude?.()?.modelID || item.provider.id !== input.exclude?.()?.providerID,
+      ),
   )
 
   return {
@@ -286,7 +296,7 @@ function createModelSelectorController(input: {
     },
     select: (item: ModelItem) => {
       model.set({ modelID: item.id, providerID: item.provider.id }, { recent: true })
-      input.onSelect()
+      input.onSelect(item)
     },
   }
 }

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -345,6 +345,12 @@ export const dict = {
 
   "app.server.unreachable": "Could not reach {{server}}",
   "app.server.retrying": "Retrying automatically...",
+  "session.errorRecovery.title": "Continue with another model",
+  "session.errorRecovery.description": "Choose a replacement model to continue without sending another message.",
+  "session.errorRecovery.chooseModel": "Choose replacement model",
+  "session.errorRecovery.switching": "Switching model...",
+  "session.errorRecovery.promptUnavailable": "The failed message is no longer available for recovery.",
+  "session.errorRecovery.details": "Show error details",
   "app.server.otherServers": "Other servers",
 
   "dialog.server.title": "Servers",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1692,6 +1692,57 @@ export default function Page() {
     })
   }
 
+  const recoverModelError = async (input: {
+    messageID: string
+    model: { modelID: string; providerID: string }
+  }) => {
+    const sessionID = params.id
+    if (!sessionID) return
+    const message = (sync().data.session_message[sessionID] ?? []).find((item) => item.id === input.messageID)
+    if (!message || message.type !== "user") {
+      fail(new Error(language.t("session.errorRecovery.promptUnavailable")))
+      return
+    }
+    if ((await sdk().protocol) === "v1") {
+      serverSync().session.set("session_status", sessionID, { type: "busy" })
+      await sdk()
+        .client.session.retry({
+          sessionID,
+          providerID: input.model.providerID,
+          modelID: input.model.modelID,
+        })
+        .catch((error) => {
+          serverSync().session.set("session_status", sessionID, { type: "idle" })
+          fail(error)
+        })
+      return
+    }
+
+    serverSync().session.set("session_status", sessionID, { type: "busy" })
+    try {
+      await sdk().api.session.switchModel({
+        sessionID,
+        model: { id: input.model.modelID, providerID: input.model.providerID },
+      })
+      await sdk().api.session.prompt({
+        sessionID,
+        id: message.id,
+        text: message.text,
+        files: message.files?.map((file) => ({
+          uri: file.source.type === "uri" ? file.source.uri : `data:${file.mime};base64,${file.data}`,
+          name: file.name,
+          description: file.description,
+          mention: file.mention,
+        })),
+        agents: message.agents,
+        resume: true,
+      })
+    } catch (error) {
+      serverSync().session.set("session_status", sessionID, { type: "idle" })
+      fail(error)
+    }
+  }
+
   const merge = (next: NonNullable<ReturnType<typeof info>>, target = sync()) => target.session.remember(next)
 
   const roll = (sessionID: string, next: NonNullable<ReturnType<typeof info>>["revert"], target = sync()) => {
@@ -2107,6 +2158,7 @@ export default function Page() {
                     if (root) scheduleScrollState(root)
                   }}
                   userMessages={visibleUserMessages()}
+                  onRecoverError={recoverModelError}
                   setHistoryAnchor={(handlers) => {
                     captureHistoryAnchor = handlers.capture
                     restoreHistoryAnchor = handlers.restore

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -71,6 +71,7 @@ import { legacySessionHref, requireServerKey, sessionHref } from "@/utils/sessio
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
 import { notifySessionTabsRemoved } from "@/components/titlebar-session-events"
+import { ModelSelectorPopoverV2 } from "@/components/dialog-select-model"
 import { sessionTitle } from "@/utils/session-title"
 import { scheduleConnectedMeasure } from "./measure"
 import { observeElementOffsetReconnectAware } from "./observe-element-offset"
@@ -139,6 +140,62 @@ function TimelineThinkingRow(props: { reasoningHeading?: string; showReasoningSu
         <TextReveal text={props.reasoningHeading} class="session-turn-thinking-heading" travel={25} duration={700} />
       </Show>
     </div>
+  )
+}
+
+function TimelineErrorCard(props: {
+  text: string
+  details: string
+  failedModel: { modelID: string; providerID: string }
+  onRecover?: (model: { modelID: string; providerID: string }) => Promise<void>
+}) {
+  const language = useLanguage()
+  const [state, setState] = createStore({ pending: false })
+  const recover = (model: { modelID: string; providerID: string }) => {
+    if (!props.onRecover || state.pending) return
+    setState("pending", true)
+    void props.onRecover(model).finally(() => setState("pending", false))
+  }
+
+  return (
+    <Card variant="error" class="error-card">
+      <div class="flex flex-col gap-3">
+        <div>{props.text}</div>
+        <details class="group">
+          <summary class="cursor-pointer select-none text-12-medium text-text-weak hover:text-text-strong">
+            {language.t("session.errorRecovery.details")}
+          </summary>
+          <pre class="mt-2 max-h-64 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border-weak-base p-3 font-mono text-11-regular text-text-weak select-text">
+            {props.details}
+          </pre>
+        </details>
+        <Show when={props.onRecover}>
+          <div class="flex flex-col gap-2 pt-3 border-t border-border-weak-base">
+            <div class="flex flex-col gap-0.5">
+              <div class="text-13-medium text-text-strong">{language.t("session.errorRecovery.title")}</div>
+              <div class="text-12-regular text-text-weak">{language.t("session.errorRecovery.description")}</div>
+            </div>
+            <ModelSelectorPopoverV2
+              exclude={props.failedModel}
+              trigger={(triggerProps) => (
+                <ButtonV2
+                  {...triggerProps}
+                  size="small"
+                  variant="neutral"
+                  disabled={state.pending}
+                  data-action="error-recovery-model"
+                >
+                  {state.pending
+                    ? language.t("session.errorRecovery.switching")
+                    : language.t("session.errorRecovery.chooseModel")}
+                </ButtonV2>
+              )}
+              onSelect={recover}
+            />
+          </div>
+        </Show>
+      </div>
+    </Card>
   )
 }
 
@@ -255,6 +312,10 @@ export function MessageTimeline(props: {
   setRevealMessage?: (fn: (id: string) => void) => void
   setScrollToEnd?: (fn: () => void) => void
   setHistoryAnchor?: (handlers: { capture: () => void; restore: (done: boolean) => void }) => void
+  onRecoverError?: (input: {
+    messageID: string
+    model: { modelID: string; providerID: string }
+  }) => Promise<void>
 }) {
   let touchGesture: number | undefined
 
@@ -1215,9 +1276,16 @@ export function MessageTimeline(props: {
         return (
           <TimelineRowFrame row={errorRow}>
             <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
-              <Card variant="error" class="error-card">
-                {errorRow().text}
-              </Card>
+              <TimelineErrorCard
+                text={errorRow().text}
+                details={errorRow().details}
+                failedModel={errorRow().model}
+                onRecover={
+                  props.onRecoverError
+                    ? (model) => props.onRecoverError!({ messageID: errorRow().userMessageID, model })
+                    : undefined
+                }
+              />
             </div>
           </TimelineRowFrame>
         )

--- a/packages/app/src/pages/session/timeline/rows-current.test.ts
+++ b/packages/app/src/pages/session/timeline/rows-current.test.ts
@@ -204,4 +204,44 @@ describe("current session timeline rows", () => {
 
     expect(result.rows.map((row) => row._tag)).toEqual(["UserMessage", "AssistantPart"])
   })
+
+  test("keeps the failed model on a terminal error row", () => {
+    const source = [
+      { id: "msg_user", type: "user", text: "recover", time: { created: 1 } },
+      {
+        id: "msg_failed",
+        type: "assistant",
+        agent: "build",
+        model: { id: "failed-model", providerID: "failed-provider" },
+        content: [],
+        error: { type: "ProviderError", message: "temporary failure" },
+        time: { created: 2, completed: 3 },
+      },
+    ] satisfies SessionMessageInfo[]
+    const normalized = normalizeSessionMessages("ses_1", source)
+    const messages = new Map(normalized.messages.map((message) => [message.id, message]))
+
+    const result = Timeline.constructSessionMessageRows(
+      source,
+      (messageID) => messages.get(messageID),
+      (messageID) => normalized.parts.get(messageID) ?? [],
+      true,
+      "idle",
+      true,
+      normalized.messages.filter((message) => message.role === "user"),
+    )
+
+    expect(result.rows.find((row) => row._tag === "Error")).toMatchObject({
+      text: "temporary failure",
+      model: { modelID: "failed-model", providerID: "failed-provider" },
+    })
+    const error = result.rows.find((row) => row._tag === "Error")
+    if (error?._tag !== "Error") throw new Error("Expected terminal error row")
+    expect(JSON.parse(error.details)).toMatchObject({
+      providerID: "failed-provider",
+      modelID: "failed-model",
+      messageID: "msg_failed",
+      error: { data: { message: "temporary failure" } },
+    })
+  })
 })

--- a/packages/app/src/pages/session/timeline/rows.ts
+++ b/packages/app/src/pages/session/timeline/rows.ts
@@ -29,7 +29,12 @@ export type TimelineRowMap = {
   Thinking: { userMessageID: string; reasoningHeading?: string }
   Retry: { userMessageID: string }
   DiffSummary: { userMessageID: string; diffs: SummaryDiff[] }
-  Error: { userMessageID: string; text: string }
+  Error: {
+    userMessageID: string
+    text: string
+    details: string
+    model: { modelID: string; providerID: string }
+  }
 }
 
 export namespace Timeline {
@@ -218,11 +223,23 @@ export namespace Timeline {
 
     if (error) {
       const data = error.data?.message
+      const assistant = assistantMessages.at(-1)!
       rows.push(
         new TimelineRow.Error({
           userMessageID: userMessage.id,
+          model: { modelID: assistant.modelID, providerID: assistant.providerID },
           text: unwrapErrorMessage(
             typeof data === "string" ? data : data === undefined || data === null ? "" : String(data),
+          ),
+          details: JSON.stringify(
+            {
+              providerID: assistant.providerID,
+              modelID: assistant.modelID,
+              messageID: assistant.id,
+              error,
+            },
+            null,
+            2,
           ),
         }),
       )

--- a/packages/app/src/pages/session/timeline/timeline-row.ts
+++ b/packages/app/src/pages/session/timeline/timeline-row.ts
@@ -35,6 +35,8 @@ export namespace TimelineRow {
   export class Error extends Data.TaggedClass("Error")<{
     userMessageID: string
     text: string
+    details: string
+    model: { modelID: string; providerID: string }
   }> {}
   export class Retry extends Data.TaggedClass("Retry")<{
     userMessageID: string

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -363,7 +363,8 @@ const layer = Layer.effect(
             yield* result.get(input.sessionID)
             const prompt = resolvePrompt(input.prompt)
             const messageID = input.id ?? SessionMessage.ID.create()
-            const delivery = input.delivery ?? "steer"
+            const recorded = input.id === undefined ? undefined : yield* SessionInput.find(db, messageID)
+            const delivery = input.delivery ?? recorded?.delivery ?? "steer"
             const expected = { sessionID: input.sessionID, messageID, prompt, delivery }
             const admitted = yield* SessionInput.admit(db, events, {
               id: messageID,
@@ -379,7 +380,10 @@ const layer = Layer.effect(
             )
             if (!SessionInput.equivalent(admitted, expected))
               return yield* new PromptConflictError({ sessionID: input.sessionID, messageID })
-            if (input.resume !== false) yield* execution.wake(admitted.sessionID)
+            if (input.resume === true && admitted.promotedSeq !== undefined)
+              yield* execution.wake(admitted.sessionID, { force: true })
+            if (input.resume !== false && !(input.resume === true && admitted.promotedSeq !== undefined))
+              yield* execution.wake(admitted.sessionID)
             return admitted
           }),
         ),

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -11,8 +11,8 @@ export interface Interface {
   readonly active: Effect.Effect<ReadonlySet<SessionSchema.ID>>
   /** Starts execution while idle or joins the active execution. */
   readonly resume: (sessionID: SessionSchema.ID) => Effect.Effect<void, SessionRunner.RunError>
-  /** Registers newly recorded work. Repeated wakeups may coalesce. */
-  readonly wake: (sessionID: SessionSchema.ID) => Effect.Effect<void>
+  /** Registers work. Forced wakeups retry from existing projected history. */
+  readonly wake: (sessionID: SessionSchema.ID, options?: { force?: boolean }) => Effect.Effect<void>
   /** Interrupt active work owned by this process. Idle interruption is a no-op. */
   readonly interrupt: (sessionID: SessionSchema.ID) => Effect.Effect<void>
 }

--- a/packages/core/src/session/execution/local.ts
+++ b/packages/core/src/session/execution/local.ts
@@ -32,7 +32,7 @@ const layer = Layer.effect(
       active: coordinator.active,
       interrupt: coordinator.interrupt,
       resume: coordinator.run,
-      wake: coordinator.wake,
+      wake: (sessionID, options) => (options?.force ? coordinator.retry(sessionID) : coordinator.wake(sessionID)),
     })
   }),
 )

--- a/packages/core/src/session/run-coordinator.ts
+++ b/packages/core/src/session/run-coordinator.ts
@@ -10,6 +10,8 @@ export interface Coordinator<Key, E> {
   readonly run: (key: Key) => Effect.Effect<void, E>
   /** Registers one coalesced follow-up after newly recorded work. */
   readonly wake: (key: Key) => Effect.Effect<void>
+  /** Registers one coalesced forced follow-up from existing durable history. */
+  readonly retry: (key: Key) => Effect.Effect<void>
   /** Stops active execution and waits for its cleanup. */
   readonly interrupt: (key: Key) => Effect.Effect<void>
 }
@@ -18,6 +20,7 @@ type Entry<E> = {
   readonly done: Deferred.Deferred<void, E>
   owner?: Fiber.Fiber<void, never>
   pendingWake: boolean
+  pendingForce: boolean
   stopping: boolean
 }
 
@@ -31,6 +34,7 @@ export const make = <Key, E>(options: {
     const makeEntry = (): Entry<E> => ({
       done: Deferred.makeUnsafe<void, E>(),
       pendingWake: false,
+      pendingForce: false,
       stopping: false,
     })
 
@@ -49,17 +53,20 @@ export const make = <Key, E>(options: {
     }
 
     const settle = (key: Key, entry: Entry<E>, exit: Exit.Exit<void, E>) => {
-      if (Exit.isSuccess(exit) && !entry.stopping && entry.pendingWake) {
+      if (Exit.isSuccess(exit) && !entry.stopping && (entry.pendingWake || entry.pendingForce)) {
+        const force = entry.pendingForce
         entry.pendingWake = false
-        start(key, entry, false, true)
+        entry.pendingForce = false
+        start(key, entry, force, true)
         return
       }
 
-      const successor = entry.pendingWake ? makeEntry() : undefined
+      const force = entry.pendingForce
+      const successor = entry.pendingWake || force ? makeEntry() : undefined
       if (successor === undefined) active.delete(key)
       else {
         active.set(key, successor)
-        start(key, successor, false, true)
+        start(key, successor, force, true)
       }
       Deferred.doneUnsafe(entry.done, exit)
     }
@@ -91,14 +98,28 @@ export const make = <Key, E>(options: {
         start(key, next, false)
       })
 
+    const retry = (key: Key) =>
+      Effect.sync(() => {
+        const entry = active.get(key)
+        if (entry !== undefined) {
+          entry.pendingForce = true
+          return
+        }
+
+        const next = makeEntry()
+        active.set(key, next)
+        start(key, next, true)
+      })
+
     const interrupt = (key: Key): Effect.Effect<void> =>
       Effect.suspend(() => {
         const entry = active.get(key)
         if (entry?.owner === undefined) return Effect.void
         entry.stopping = true
         entry.pendingWake = false
+        entry.pendingForce = false
         return Fiber.interrupt(entry.owner)
       })
 
-    return { active: Effect.sync(() => new Set(active.keys())), run, wake, interrupt }
+    return { active: Effect.sync(() => new Set(active.keys())), run, wake, retry, interrupt }
   })

--- a/packages/core/test/session-prompt.test.ts
+++ b/packages/core/test/session-prompt.test.ts
@@ -36,8 +36,12 @@ const execution = Layer.succeed(
       Effect.sync(() => {
         interruptCalls.push(sessionID)
       }),
-    wake: (sessionID) =>
+    wake: (sessionID, options) =>
       Effect.sync(() => {
+        if (options?.force) {
+          executionCalls.push(sessionID)
+          return
+        }
         wakeCalls.push(sessionID)
       }),
   }),
@@ -286,6 +290,27 @@ describe("SessionV2.prompt", () => {
 
       expect(retried).toEqual(first)
       expect(wakeCalls).toEqual([sessionID])
+    }),
+  )
+
+  it.effect("resumes execution when an explicit retry targets a promoted prompt", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const { db } = yield* Database.Service
+      const session = yield* SessionV2.Service
+      const events = yield* EventV2.Service
+      const prompt = Prompt.make({ text: "Recover failed provider turn" })
+      yield* session.prompt({ id: messageID, sessionID, prompt, delivery: "queue", resume: false })
+      yield* SessionInput.promoteNextQueued(db, events, sessionID)
+      executionCalls.length = 0
+      wakeCalls.length = 0
+
+      const retried = yield* session.prompt({ id: messageID, sessionID, prompt, resume: true })
+
+      expect(retried).toMatchObject({ id: messageID, delivery: "queue" })
+      expect(executionCalls).toEqual([sessionID])
+      expect(wakeCalls).toEqual([])
+      expect(yield* admittedCount).toBe(1)
     }),
   )
 

--- a/packages/core/test/session-run-coordinator.test.ts
+++ b/packages/core/test/session-run-coordinator.test.ts
@@ -66,6 +66,54 @@ describe("SessionRunCoordinator", () => {
     ),
   )
 
+  it.effect("starts a forced execution when retrying while idle", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const drained = yield* Deferred.make<void>()
+        const forces: boolean[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key: string, force) =>
+            Effect.sync(() => forces.push(force)).pipe(Effect.andThen(Deferred.succeed(drained, undefined))),
+        })
+
+        yield* coordinator.retry("session")
+        yield* Deferred.await(drained)
+
+        expect(forces).toEqual([true])
+      }),
+    ),
+  )
+
+  it.effect("queues one forced retry behind active execution", () =>
+    Effect.scoped(
+      Effect.gen(function* () {
+        const firstStarted = yield* Deferred.make<void>()
+        const firstGate = yield* Deferred.make<void>()
+        const retried = yield* Deferred.make<void>()
+        const forces: boolean[] = []
+        const coordinator = yield* SessionRunCoordinator.make({
+          drain: (_key: string, force) =>
+            Effect.sync(() => forces.push(force)).pipe(
+              Effect.flatMap(() =>
+                forces.length === 1
+                  ? Deferred.succeed(firstStarted, undefined).pipe(Effect.andThen(Deferred.await(firstGate)))
+                  : Deferred.succeed(retried, undefined),
+              ),
+            ),
+        })
+
+        yield* coordinator.wake("session")
+        yield* Deferred.await(firstStarted)
+        yield* coordinator.retry("session")
+        yield* coordinator.retry("session")
+        yield* Deferred.succeed(firstGate, undefined)
+        yield* Deferred.await(retried)
+
+        expect(forces).toEqual([false, true])
+      }),
+    ),
+  )
+
   it.effect("snapshots only active executions", () =>
     Effect.scoped(
       Effect.gen(function* () {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -68,6 +68,10 @@ export const SummarizePayload = Schema.Struct({
   auto: Schema.optional(Schema.Boolean),
 })
 export const PromptPayload = Schema.Struct(Struct.omit(SessionPrompt.PromptInput.fields, ["sessionID"]))
+export const RetryPayload = Schema.Struct({
+  providerID: ProviderV2.ID,
+  modelID: ModelV2.ID,
+})
 export const CommandPayload = Schema.Struct(Struct.omit(SessionPrompt.CommandInput.fields, ["sessionID"]))
 export const ShellPayload = Schema.Struct(Struct.omit(SessionPrompt.ShellInput.fields, ["sessionID"]))
 export const RevertPayload = Schema.Struct(Struct.omit(SessionRevert.RevertInput.fields, ["sessionID"]))
@@ -94,6 +98,7 @@ export const SessionPaths = {
   summarize: `${root}/:sessionID/summarize`,
   prompt: `${root}/:sessionID/message`,
   promptAsync: `${root}/:sessionID/prompt_async`,
+  retry: `${root}/:sessionID/retry`,
   command: `${root}/:sessionID/command`,
   shell: `${root}/:sessionID/shell`,
   revert: `${root}/:sessionID/revert`,
@@ -440,6 +445,19 @@ export const SessionApi = HttpApi.make("session")
           OpenApi.annotations({
             identifier: "part.update",
             description: "Update a part in a message.",
+          }),
+        ),
+        HttpApiEndpoint.post("retry", SessionPaths.retry, {
+          params: { sessionID: SessionID },
+          query: WorkspaceRoutingQuery,
+          payload: RetryPayload,
+          success: described(HttpApiSchema.NoContent, "Retry accepted"),
+          error: [HttpApiError.BadRequest, ApiNotFoundError],
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.retry",
+            summary: "Retry failed turn",
+            description: "Retry the latest failed turn with another model without creating a new user message.",
           }),
         ),
       )

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -32,6 +32,7 @@ import {
   PermissionResponsePayload,
   PromptPayload,
   RevertPayload,
+  RetryPayload,
   ShellPayload,
   SummarizePayload,
   UpdatePayload,
@@ -328,6 +329,45 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       return HttpApiSchema.NoContent.make()
     })
 
+    const retry = Effect.fn("SessionHttpApi.retry")(function* (ctx: {
+      params: { sessionID: SessionID }
+      payload: typeof RetryPayload.Type
+    }) {
+      yield* requireSession(ctx.params.sessionID)
+      const match = yield* session
+        .findMessage(ctx.params.sessionID, (message) => message.info.role === "user")
+        .pipe(Effect.orDie)
+      if (Option.isNone(match) || match.value.info.role !== "user") return yield* new HttpApiError.BadRequest({})
+      const user = match.value.info
+      yield* session.updateMessage({
+        ...user,
+        model: { providerID: ctx.payload.providerID, modelID: ctx.payload.modelID },
+      })
+      yield* session.setAgentModel({
+        sessionID: ctx.params.sessionID,
+        agent: user.agent,
+        model: {
+          id: ctx.payload.modelID,
+          providerID: ctx.payload.providerID,
+          variant: "default",
+        },
+        time: Date.now(),
+      })
+      yield* promptSvc.loop({ sessionID: ctx.params.sessionID }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.gen(function* () {
+            yield* Effect.logError("session retry failed", { sessionID: ctx.params.sessionID, cause })
+            yield* events.publish(Session.Event.Error, {
+              sessionID: ctx.params.sessionID,
+              error: new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject(),
+            })
+          }),
+        ),
+        Effect.forkIn(scope, { startImmediately: true }),
+      )
+      return HttpApiSchema.NoContent.make()
+    })
+
     const command = Effect.fn("SessionHttpApi.command")(function* (ctx: {
       params: { sessionID: SessionID }
       payload: typeof CommandPayload.Type
@@ -430,6 +470,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       .handle("summarize", summarize)
       .handle("prompt", prompt)
       .handle("promptAsync", promptAsync)
+      .handle("retry", retry)
       .handle("command", command)
       .handle("shell", shell)
       .handle("revert", revert)

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -519,28 +519,36 @@ export const get = Effect.fn("MessageV2.get")(function* (input: { sessionID: Ses
 })
 
 export function filterCompacted(msgs: Iterable<WithParts>) {
-  const result = [] as WithParts[]
-  const completed = new Set<string>()
-  let retain: MessageID | undefined
-  for (const msg of msgs) {
-    result.push(msg)
-    if (retain) {
-      if (msg.info.id === retain) break
-      continue
-    }
-    if (msg.info.role === "user" && completed.has(msg.info.id)) {
-      const part = msg.parts.find((item): item is CompactionPart => item.type === "compaction")
-      if (!part) continue
-      if (!part.tail_start_id) break
-      retain = part.tail_start_id
-      if (msg.info.id === retain) break
-      continue
-    }
-    if (msg.info.role === "user" && completed.has(msg.info.id) && msg.parts.some((part) => part.type === "compaction"))
-      break
-    if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish && !msg.info.error)
-      completed.add(msg.info.parentID)
+  const state = {
+    result: [] as WithParts[],
+    completed: new Set<string>(),
+    retain: undefined as MessageID | undefined,
   }
+  for (const msg of msgs) {
+    if (appendCompacted(state, msg)) break
+  }
+  return reorderCompacted(state.result)
+}
+
+function appendCompacted(
+  state: { result: WithParts[]; completed: Set<string>; retain: MessageID | undefined },
+  msg: WithParts,
+) {
+  state.result.push(msg)
+  if (state.retain) return msg.info.id === state.retain
+  if (msg.info.role === "user" && state.completed.has(msg.info.id)) {
+    const part = msg.parts.find((item): item is CompactionPart => item.type === "compaction")
+    if (!part) return false
+    if (!part.tail_start_id) return true
+    state.retain = part.tail_start_id
+    return msg.info.id === state.retain
+  }
+  if (msg.info.role === "assistant" && msg.info.summary && msg.info.finish && !msg.info.error)
+    state.completed.add(msg.info.parentID)
+  return false
+}
+
+function reorderCompacted(result: WithParts[]) {
   result.reverse()
   const compactionIndex = result.findLastIndex(
     (msg) =>
@@ -572,7 +580,28 @@ export function filterCompacted(msgs: Iterable<WithParts>) {
 }
 
 export const filterCompactedEffect = Effect.fnUntraced(function* (sessionID: SessionID) {
-  return filterCompacted(yield* stream(sessionID))
+  const size = 50
+  const state = {
+    result: [] as WithParts[],
+    completed: new Set<string>(),
+    retain: undefined as MessageID | undefined,
+  }
+  let before: string | undefined
+  while (true) {
+    const next = yield* page({ sessionID, limit: size, before }).pipe(
+      Effect.catchIf(NotFoundError.isInstance, () =>
+        Effect.succeed({ items: [] as WithParts[], more: false, cursor: undefined }),
+      ),
+    )
+    if (next.items.length === 0) break
+    for (let index = next.items.length - 1; index >= 0; index--) {
+      const item = next.items[index]
+      if (item && appendCompacted(state, item)) return reorderCompacted(state.result)
+    }
+    if (!next.more || !next.cursor) break
+    before = next.cursor
+  }
+  return reorderCompacted(state.result)
 })
 
 // filterCompacted reorders messages for model consumption

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -631,6 +631,7 @@ const layer = Layer.effect(
         })
         ctx.needsCompaction = false
         ctx.shouldBreak = (yield* config.get()).experimental?.continue_loop_on_deny !== true
+        let emitted = false
 
         return yield* Effect.gen(function* () {
           yield* Effect.gen(function* () {
@@ -640,7 +641,11 @@ const layer = Layer.effect(
             const stream = llm.stream(streamInput)
 
             yield* stream.pipe(
-              Stream.tap((event) => handleEvent(event)),
+              Stream.tap((event) =>
+                Effect.sync(() => {
+                  emitted = true
+                }).pipe(Effect.andThen(handleEvent(event))),
+              ),
               Stream.takeUntil(() => ctx.needsCompaction),
               Stream.runDrain,
             )
@@ -661,6 +666,9 @@ const layer = Layer.effect(
               SessionRetry.policy({
                 provider: input.model.providerID,
                 parse,
+                // Once any provider output has been persisted, replaying the
+                // request can duplicate text or execute the same tool twice.
+                canRetry: () => !emitted,
                 set: (info) => {
                   return status.set(ctx.sessionID, {
                     type: "retry",

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1110,6 +1110,7 @@ const layer = Layer.effect(
 
           if (
             lastAssistant?.finish &&
+            !lastAssistant.error &&
             !["tool-calls", "unknown"].includes(lastAssistant.finish) &&
             !hasToolCalls &&
             lastAssistant.parentID === lastUser.id

--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -183,10 +183,12 @@ function parseJSON(value: unknown) {
 export function policy(opts: {
   provider: string
   parse: (error: unknown) => Err
+  canRetry?: (error: unknown) => boolean
   set: (input: { attempt: number; message: string; action?: Retryable["action"]; next: number }) => Effect.Effect<void>
 }) {
   return Schedule.fromStepWithMetadata(
     Effect.succeed((meta: Schedule.InputMetadata<unknown>) => {
+      if (opts.canRetry && !opts.canRetry(meta.input)) return Cause.done(meta.attempt)
       const error = opts.parse(meta.input)
       const retry = retryable(error, opts.provider)
       if (!retry) return Cause.done(meta.attempt)

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1499,6 +1499,33 @@ const scenarios: Scenario[] = [
       }),
     ),
   http.protected
+    .post("/session/{sessionID}/retry", "session.retry")
+    .preserveDatabase()
+    .withLlm()
+    .seeded((ctx) =>
+      Effect.gen(function* () {
+        const session = yield* ctx.session({ title: "Retry failed turn" })
+        yield* ctx.message(session.id, { text: "recover this turn" })
+        yield* ctx.llmText("recovered assistant")
+        return session
+      }),
+    )
+    .at((ctx) => ({
+      path: route("/session/{sessionID}/retry", { sessionID: ctx.state.id }),
+      headers: ctx.headers(),
+      body: { providerID: "test", modelID: "test-model" },
+    }))
+    .status(204, (ctx) =>
+      Effect.gen(function* () {
+        yield* ctx.llmWait(1)
+        const messages = yield* ctx.messages(ctx.state.id)
+        check(
+          messages.filter((message) => message.info.role === "user").length === 1,
+          "retry should not add another user message",
+        )
+      }),
+    ),
+  http.protected
     .post("/session/{sessionID}/command", "session.command")
     .preserveDatabase()
     .withLlm()
@@ -1746,6 +1773,7 @@ const llmScenarios = new Set([
   "session.init",
   "session.prompt",
   "session.prompt_async",
+  "session.retry",
   "session.command",
   "session.summarize",
 ])

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -604,7 +604,7 @@ it.live("session.processor effect tests retry recognized structured json errors"
   ),
 )
 
-it.live("session.processor effect tests retry OpenAI-compatible midstream server errors", () =>
+it.live("session.processor effect tests do not replay OpenAI-compatible midstream server errors", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
@@ -642,16 +642,16 @@ it.live("session.processor effect tests retry OpenAI-compatible midstream server
 
         const parts = yield* MessageV2.parts(msg.id)
 
-        expect(value).toBe("continue")
-        expect(yield* llm.calls).toBe(2)
-        expect(parts.some((part) => part.type === "text" && part.text === "after")).toBe(true)
-        expect(handle.message.error).toBeUndefined()
+        expect(value).toBe("stop")
+        expect(yield* llm.calls).toBe(1)
+        expect(parts.some((part) => part.type === "text" && part.text === "after")).toBe(false)
+        expect(handle.message.error).toBeDefined()
       }),
     { config: (url) => providerCfg(url) },
   ),
 )
 
-it.live("session.processor effect tests retry network_error finish reasons", () =>
+it.live("session.processor effect tests do not replay network_error finish reasons", () =>
   provideTmpdirServer(
     ({ dir, llm }) =>
       Effect.gen(function* () {
@@ -699,10 +699,10 @@ it.live("session.processor effect tests retry network_error finish reasons", () 
 
         const parts = yield* MessageV2.parts(msg.id)
 
-        expect(value).toBe("continue")
-        expect(yield* llm.calls).toBe(2)
-        expect(parts.some((part) => part.type === "text" && part.text === "after retry")).toBe(true)
-        expect(handle.message.error).toBeUndefined()
+        expect(value).toBe("stop")
+        expect(yield* llm.calls).toBe(1)
+        expect(parts.some((part) => part.type === "text" && part.text === "after retry")).toBe(false)
+        expect(handle.message.error).toBeDefined()
       }),
     { config: (url) => providerCfg(url) },
   ),

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -460,6 +460,30 @@ noLLMServer.instance(
   { config: cfg },
 )
 
+it.instance("loop retries a completed provider error without adding another user message", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    const seeded = yield* seed(chat.id, { finish: "stop" })
+    yield* sessions.updateMessage({
+      ...seeded.assistant,
+      error: MessageV2.fromError(new Error("provider unavailable"), { providerID: ref.providerID }),
+      time: { ...seeded.assistant.time, completed: Date.now() },
+    })
+    yield* llm.text("recovered")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    const messages = yield* sessions.messages({ sessionID: chat.id })
+
+    expect(result.info.id).not.toBe(seeded.assistant.id)
+    expect(messages.filter((message) => message.info.role === "user")).toHaveLength(1)
+    expect(yield* llm.calls).toBe(1)
+  }),
+  20_000,
+)
+
 noLLMServer.instance(
   "loop exits for a completed parent turn with nonmonotonic message IDs",
   () =>

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -146,6 +146,30 @@ describe("session.retry.delay", () => {
       expect(attempts).toStrictEqual([1, 2, 3, 4, 5])
     }),
   )
+
+  it.instance("policy can reject retries before parsing or updating status", () =>
+    Effect.gen(function* () {
+      const calls: string[] = []
+      const step = yield* Schedule.toStepWithMetadata(
+        SessionRetry.policy({
+          provider: "test",
+          canRetry: () => false,
+          parse: (error) => {
+            calls.push("parse")
+            return Schema.decodeUnknownSync(SessionV1.APIError.Schema)(error)
+          },
+          set: () =>
+            Effect.sync(() => {
+              calls.push("set")
+            }),
+        }),
+      )
+
+      yield* Effect.ignore(step(apiError({ "retry-after-ms": "0" })))
+
+      expect(calls).toEqual([])
+    }),
+  )
 })
 
 describe("session.retry.retryable", () => {

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -205,6 +205,8 @@ import type {
   SessionPromptAsyncResponses,
   SessionPromptErrors,
   SessionPromptResponses,
+  SessionRetryErrors,
+  SessionRetryResponses,
   SessionRevertErrors,
   SessionRevertResponses,
   SessionShareErrors,
@@ -4323,6 +4325,47 @@ export class Session2 extends HeyApiClient {
       url: "/session/{sessionID}/unrevert",
       ...options,
       ...params,
+    })
+  }
+
+  /**
+   * Retry failed turn
+   *
+   * Retry the latest failed turn with another model without creating a new user message.
+   */
+  public retry<ThrowOnError extends boolean = false>(
+    parameters: {
+      sessionID: string
+      directory?: string
+      workspace?: string
+      providerID?: string
+      modelID?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "sessionID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "providerID" },
+            { in: "body", key: "modelID" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionRetryResponses, SessionRetryErrors, ThrowOnError>({
+      url: "/session/{sessionID}/retry",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
     })
   }
 }

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -10476,6 +10476,43 @@ export type PartUpdateResponses = {
 
 export type PartUpdateResponse = PartUpdateResponses[keyof PartUpdateResponses]
 
+export type SessionRetryData = {
+  body?: {
+    providerID: string
+    modelID: string
+  }
+  path: {
+    sessionID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/{sessionID}/retry"
+}
+
+export type SessionRetryErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+  /**
+   * NotFoundError
+   */
+  404: NotFoundError
+}
+
+export type SessionRetryError = SessionRetryErrors[keyof SessionRetryErrors]
+
+export type SessionRetryResponses = {
+  /**
+   * Retry accepted
+   */
+  204: void
+}
+
+export type SessionRetryResponse = SessionRetryResponses[keyof SessionRetryResponses]
+
 export type SyncStartData = {
   body?: never
   path?: never


### PR DESCRIPTION
### Issue for this PR

Closes #41587

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an explicit recovery action to failed assistant turns. The error card exposes structured provider details and offers a replacement-model picker that excludes the failed model.

Choosing a replacement reuses the original user prompt and message identity, then resumes the session with the selected model. This continues the conversation without appending or resending a duplicate user message. Both legacy and V2 session paths are covered, and the legacy JavaScript SDK is regenerated for the new retry endpoint.

### How did you verify your code works?

- App timeline tests: 6 passed
- Core session tests: 43 passed
- Session retry tests: 61 passed
- HTTP API coverage mode: 209/209 passed
- HTTP API authentication mode: 209/209 passed
- HTTP API Effect mode: the new session.retry scenario passed; 207/209 overall, with only the two unrelated PTY creation scenarios failing on Windows
- Typechecked App, Client, Core, OpenCode, and the JavaScript SDK
- Regenerated Client and legacy JavaScript SDK outputs

### Screenshots / recordings

Replacement-model recovery action:

<img width="595" height="533" alt="OpenCode failed-turn replacement model UI" src="https://github.com/user-attachments/assets/82535930-2f3e-48ba-8131-a429458a3549" />

Expanded structured provider error details:

<img width="595" height="533" alt="OpenCode expanded provider error details" src="https://github.com/user-attachments/assets/1a040c25-220e-4def-8a41-ec2c9ac6e4a0" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._