### PR TITLE
fix(webfetch): apply the timeout to the body read

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -75,30 +75,36 @@ export const WebFetchTool = Tool.define(
 
           const request = HttpClientRequest.get(params.url).pipe(HttpClientRequest.setHeaders(headers))
 
-          // Retry with honest UA if blocked by Cloudflare bot detection (TLS fingerprint mismatch)
-          const response = yield* httpOk.execute(request).pipe(
-            Effect.catchIf(
-              (err) =>
-                err.reason._tag === "StatusCodeError" &&
-                err.reason.response.status === 403 &&
-                err.reason.response.headers["cf-mitigated"] === "challenge",
-              () =>
-                httpOk.execute(
-                  HttpClientRequest.get(params.url).pipe(
-                    HttpClientRequest.setHeaders({ ...headers, "User-Agent": "opencode" }),
+          // The deadline has to cover the body read too: a server that returns headers
+          // promptly and then stalls mid-body would otherwise never time out.
+          const { response, arrayBuffer } = yield* Effect.gen(function* () {
+            // Retry with honest UA if blocked by Cloudflare bot detection (TLS fingerprint mismatch)
+            const response = yield* httpOk.execute(request).pipe(
+              Effect.catchIf(
+                (err) =>
+                  err.reason._tag === "StatusCodeError" &&
+                  err.reason.response.status === 403 &&
+                  err.reason.response.headers["cf-mitigated"] === "challenge",
+                () =>
+                  httpOk.execute(
+                    HttpClientRequest.get(params.url).pipe(
+                      HttpClientRequest.setHeaders({ ...headers, "User-Agent": "opencode" }),
+                    ),
                   ),
-                ),
-            ),
+              ),
+            )
+
+            // Check content length
+            const contentLength = response.headers["content-length"]
+            if (contentLength && parseInt(contentLength) > MAX_RESPONSE_SIZE) {
+              throw new Error("Response too large (exceeds 5MB limit)")
+            }
+
+            return { response, arrayBuffer: yield* response.arrayBuffer }
+          }).pipe(
             Effect.timeoutOrElse({ duration: timeout, orElse: () => Effect.die(new Error("Request timed out")) }),
           )
 
-          // Check content length
-          const contentLength = response.headers["content-length"]
-          if (contentLength && parseInt(contentLength) > MAX_RESPONSE_SIZE) {
-            throw new Error("Response too large (exceeds 5MB limit)")
-          }
-
-          const arrayBuffer = yield* response.arrayBuffer
           if (arrayBuffer.byteLength > MAX_RESPONSE_SIZE) {
             throw new Error("Response too large (exceeds 5MB limit)")
           }

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
-import { Effect, Layer } from "effect"
+import { Effect, Exit, Layer } from "effect"
 import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { Agent } from "../../src/agent/agent"
 import { Truncate } from "@/tool/truncate"
@@ -113,6 +113,28 @@ describe("tool.webfetch", () => {
           const result = yield* exec({ url: new URL("/page.html", url).toString(), format: "text" })
           expect(result.output).toBe("Hello world")
           expect(result.attachments).toBeUndefined()
+        }),
+    ),
+  )
+
+  it.instance("times out when the body never finishes", () =>
+    withFetch(
+      () =>
+        new Response(
+          // Headers go out immediately, then the body stalls and is never closed.
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("partial"))
+            },
+          }),
+          { status: 200, headers: { "content-type": "text/plain; charset=utf-8" } },
+        ),
+      (url) =>
+        Effect.gen(function* () {
+          const exit = yield* Effect.exit(
+            exec({ url: new URL("/stall.txt", url).toString(), format: "text", timeout: 1 }),
+          )
+          expect(Exit.isFailure(exit)).toBe(true)
         }),
     ),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #45229

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`webfetch`'s timeout guarded the request but not the body read, so a server that answers headers promptly and then stalls mid-body was never cut off. @itsjeremyjohnson reports two calls with `timeout: 60` running for 55 minutes and holding a reviewer and parent session open.

`Effect.timeoutOrElse` closed over `httpOk.execute(request)` alone. `response.arrayBuffer` ran after that pipe had already completed, outside the deadline. Headers arriving inside the timeout satisfied it regardless of how long the body took — so `timeout: 60` was honoured for the headers and ignored for the body, and nothing put any ceiling on the body read at all.

The fix moves the request, the content-length check and the body read into one `Effect.gen` and applies `timeoutOrElse` to that.

Scope was narrowed on review. This PR is now only the body-timeout fix plus its test:

- The `Effect.die` → `Effect.fail` change is **dropped**. The `execute` pipe ends in `.pipe(Effect.orDie)`, which converts it straight back to a defect, so it was a no-op. Making a timeout a recoverable typed error means changing how the tool surfaces errors generally — a separate decision, not a drive-by.
- The `timeout` input bounds (`0` and negatives are currently accepted) and the parameters-snapshot regeneration are split into #47460.

### How did you verify your code works?

Added a regression test to `packages/opencode/test/tool/webfetch.test.ts` using the existing `withFetch` fixture. A `Response` whose body is a `ReadableStream` that enqueues once and is never closed sends headers immediately and then stalls — the 55-minute hang in miniature.

Ran the suite both ways with `bun test test/tool/webfetch.test.ts` (bun 1.4.0):

```
# on dev
(fail) tool.webfetch > times out when the body never finishes [5001.74ms]
  ^ this test timed out after 5000ms
 4 pass, 1 fail

# on this branch
 5 pass, 0 fail   [3.84s]
```

Without the fix the call never returns and bun kills the test at its own 5s limit; with the fix `timeout: 1` returns in about a second. I also confirmed each test passes in isolation on this branch, after an initial full run showed a slow first test — that was cold start right after `bun install`, not a regression: the warm run is 3.84s with everything green.

`bun test test/tool/parameters.test.ts` is also unaffected here (58 pass, 16 snapshots, 0 fail), since the schema change that would have moved the snapshot lives in #47460.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
