### PR TITLE
docs(plugins): stop listing hooks as subscribable events

### DIFF
--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -192,20 +192,15 @@ Plugins can subscribe to events as seen below in the Examples section. Here is a
 
 - `todo.updated`
 
-#### Shell Events
-
-- `shell.env`
-
-#### Tool Events
-
-- `tool.execute.after`
-- `tool.execute.before`
-
 #### TUI Events
 
 - `tui.prompt.append`
 - `tui.command.execute`
 - `tui.toast.show`
+
+`tool.execute.before`, `tool.execute.after` and `shell.env` are hooks rather than events. They are not
+delivered to the `event` hook; declare them as top-level keys taking `(input, output)`, as shown in the
+examples below.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #45231

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

The "events available" list in the plugin docs included three entries that are not events. A plugin author following it writes a handler that never fires, with no error to explain why.

`shell.env`, `tool.execute.before` and `tool.execute.after` have no `type: "..."` definition anywhere in the repo. They are top-level keys on the `Hooks` interface taking `(input, output)`:

```ts
"tool.execute.before"?: (
  input: { tool: string; sessionID: string; callID: string },
  output: { args: any },
) => Promise<void>
```

So this silently does nothing:

```js
event: async ({ event }) => {
  if (event.type === "tool.execute.before") { /* never runs */ }
}
```

The page already documents them correctly at lines 93, 250 and 268, where they appear as sibling keys with `(input, output)`. The examples were right and the list was wrong, so the same page contradicted itself.

This removes the two bogus sub-sections and adds a sentence after the list pointing readers at the hook form, so anyone who came looking for `tool.execute.before` in that list still finds out where it actually lives rather than concluding it was removed.

### How did you verify your code works?

I checked every entry in the list against the source rather than only the three I suspected. For each of the 28 documented names I counted `type: "<name>"` definitions in `packages/` and `"<name>"?:` declarations in `packages/plugin/src`:

```
command.executed             event=3  hook=0
file.edited                  event=3  hook=0
...
session.status               event=11 hook=0
todo.updated                 event=4  hook=0
shell.env                    event=0  hook=1
tool.execute.after           event=0  hook=1
tool.execute.before          event=0  hook=1
tui.prompt.append            event=4  hook=0
tui.command.execute          event=3  hook=0
tui.toast.show               event=3  hook=0
```

The other 25 are all genuine event types, so the correction is exactly these three and nothing else in the list needed touching.

### Screenshots / recordings

_Docs change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
