### PR TITLE
docs(config): document the tool_output truncation thresholds

### DIFF
--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -559,6 +559,28 @@ The default is `1`, which allows primary agents to launch subagents but prevents
 
 ---
 
+### Tool output
+
+Tool output larger than either threshold is written to the truncation directory and the model receives a
+preview plus the path to the full text. Raise these if tools you rely on are being truncated too eagerly.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "tool_output": {
+    "max_lines": 4000,
+    "max_bytes": 102400
+  }
+}
+```
+
+- `max_lines` - Maximum lines of tool output before truncation. Defaults to `2000`.
+- `max_bytes` - Maximum bytes of tool output before truncation. Defaults to `51200` (50 KB).
+
+Whichever limit is reached first triggers truncation.
+
+---
+
 ### Sharing
 
 You can configure the [share](/docs/share) feature through the `share` option.


### PR DESCRIPTION
### Issue for this PR

Closes #45232

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`tool_output` has worked since #23770 (merged 2026-04-22) and appears nowhere in the docs. Searching `packages/web/src/content/docs/` for `tool_output`, `max_lines` or `max_bytes` returns nothing.

That matters because the behaviour it controls is visible and often unwanted: once a tool's output crosses 2000 lines or 50 KB, the model gets a preview and a file path instead of the output. The only knob for that was undiscoverable — this adds a `### Tool output` section to `config.mdx` with an example, both fields, their defaults, and the fact that whichever limit trips first wins.

Defaults quoted from the schema annotations in `packages/core/src/v1/config/config.ts` (2000 lines, 51200 bytes), which match the `MAX_LINES` / `MAX_BYTES` constants in `packages/opencode/src/tool/truncate.ts`.

Placed before `### Sharing` so it sits next to the other runtime-behaviour options rather than in with the provider/model sections.

### How did you verify your code works?

I diffed all 36 top-level keys in the v1 config schema against `config.mdx` to check this was a real gap and not something documented under another name:

```
NOT mentioned anywhere in config.mdx:
  autoshare, config, enterprise, layout, mode, reference,
  references, remote_config, skills, tool_output, username
25/36 documented
```

`tool_output` genuinely appears nowhere. I confirmed the values I wrote by tracing the read path — `truncate.ts` resolves `cfg?.tool_output?.max_lines ?? MAX_LINES` and `cfg?.tool_output?.max_bytes ?? MAX_BYTES`, with `MAX_LINES = 2000` and `MAX_BYTES = 50 * 1024`, and `output()` truncates when `lines.length > maxLines || totalBytes > maxBytes`, which is what "whichever limit is reached first" describes.

I deliberately kept this to `tool_output` rather than closing all eleven gaps at once. Several of the others (`autoshare`, `mode`, `layout`) are legacy keys that probably should not be documented, and a bulk sync is a different kind of change. Happy to do the remaining live ones separately if you want them.

### Screenshots / recordings

_Docs change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
