### PR TITLE
docs(tui): document the plugin_enabled option

### DIFF
--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -402,6 +402,7 @@ This is separate from `opencode.json`, which configures server/runtime behavior.
 - `cursor` - Controls the terminal cursor in TUI input fields. `style` defaults to `"block"`, can be `"underline"`, `"line"`, or `"default"`; `blinking` defaults to `true`. When `style` is `"default"`, the terminal default cursor is restored, so `blinking` has no effect.
 - `mouse` - Enable or disable mouse capture in the TUI (default: `true`). When disabled, the terminal's native mouse selection/scrolling behavior is preserved.
 - `attention` - Configures TUI desktop notifications and sounds. Disabled by default.
+- `plugin_enabled` - Enables or disables individual TUI plugins by ID, for example `{ "my-plugin": false }`. Toggling a plugin from the command palette overrides the value set here.
 
 Use `OPENCODE_TUI_CONFIG` to load a custom TUI config path.
 


### PR DESCRIPTION
### Issue for this PR

Closes #45233

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`plugin_enabled` is the only `tui.json` key with no documentation anywhere. This adds it to the `Options` list in `tui.mdx`.

It is a real, wired option — `Schema.optional(Schema.Record(Schema.String, Schema.Boolean))` in `packages/tui/src/config/index.tsx:66`, read by `pluginEnabledState` in `packages/opencode/src/plugin/tui/runtime.ts:478`.

The entry also records one behaviour that is easy to trip over. The runtime resolves it as:

```ts
return {
  ...readPluginEnabledMap(config.plugin_enabled),
  ...readPluginEnabledMap(state.api.kv.get(KV_KEY, {})),
}
```

The KV store is spread **after** the config, so once a plugin has been toggled from the command palette that entry wins and the `tui.json` value for it appears to be ignored. The precedence looks deliberate — the runtime toggle is the more recent expression of intent — so I documented it rather than reporting it as a bug, but someone editing `tui.json` and seeing no effect deserves the sentence.

### How did you verify your code works?

I checked all twelve keys in the `tui.json` schema against every `.mdx` file to confirm this was an isolated gap rather than a general one:

```
theme                OK   config.mdx, themes.mdx, tui.mdx
keybinds             OK   config.mdx, keybinds.mdx, tui.mdx
plugin               OK   config.mdx, plugins.mdx, providers.mdx
plugin_enabled       MISSING
leader_timeout       OK   keybinds.mdx, tui.mdx
attention            OK   config.mdx, tui.mdx
prompt               OK   agents.mdx, config.mdx, github.mdx
scroll_speed         OK   config.mdx, tui.mdx
scroll_acceleration  OK   config.mdx, tui.mdx
diff_style           OK   config.mdx, tui.mdx
cursor               OK   config.mdx, ide.mdx, tui.mdx
mouse                OK   config.mdx, tui.mdx
```

Only `plugin_enabled` is absent, so this is one missing line rather than a docs sync.

One caveat on that table: the `plugin` and `prompt` hits are matches elsewhere in the docs, not entries in `tui.mdx`'s own `Options` list. I left them alone because I have not traced their behaviour in the TUI config specifically, and `plugin` is covered in the plugins docs. Noted in the issue.

### Screenshots / recordings

_Docs change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
