### PR TITLE
fix(console): keep content and tool_calls on one OA-compat chunk

### DIFF
--- a/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
+++ b/packages/console/app/src/routes/zen/util/provider/openai-compatible.ts
@@ -424,42 +424,26 @@ export function fromOaCompatibleChunk(chunk: string): CommonChunk | string {
     object: "chat.completion.chunk",
     created: json.created ?? Math.floor(Date.now() / 1000),
     model: json.model ?? "",
-    choices: [],
-  }
-
-  if (delta.content) {
-    result.choices.push({
-      index: choice.index ?? 0,
-      delta: { content: delta.content },
-      finish_reason: null,
-    })
-  }
-
-  if (delta.tool_calls) {
-    for (const toolCall of delta.tool_calls) {
-      result.choices.push({
+    choices: [
+      {
         index: choice.index ?? 0,
         delta: {
-          tool_calls: [
-            {
-              index: toolCall.index ?? 0,
-              id: toolCall.id,
-              type: toolCall.type ?? "function",
-              function: toolCall.function,
-            },
-          ],
+          ...(delta.role ? { role: delta.role } : {}),
+          ...(delta.content ? { content: delta.content } : {}),
+          ...(Array.isArray(delta.tool_calls)
+            ? {
+                tool_calls: delta.tool_calls.map((toolCall: any) => ({
+                  index: toolCall.index ?? 0,
+                  id: toolCall.id,
+                  type: toolCall.type ?? "function",
+                  function: toolCall.function,
+                })),
+              }
+            : {}),
         },
-        finish_reason: null,
-      })
-    }
-  }
-
-  if (choice.finish_reason) {
-    result.choices.push({
-      index: choice.index ?? 0,
-      delta: {},
-      finish_reason: choice.finish_reason,
-    })
+        finish_reason: choice.finish_reason ?? null,
+      },
+    ],
   }
 
   if (json.usage) {
@@ -492,49 +476,24 @@ export function toOaCompatibleChunk(chunk: CommonChunk): string {
 
   const choice = chunk.choices[0]
   const delta = choice.delta
-
-  if (delta?.role) {
-    result.choices.push({
-      index: choice.index,
-      delta: { role: delta.role },
-      finish_reason: null,
-    })
-  }
-
-  if (delta?.content) {
-    result.choices.push({
-      index: choice.index,
-      delta: { content: delta.content },
-      finish_reason: null,
-    })
-  }
-
-  if (delta?.tool_calls) {
-    for (const tc of delta.tool_calls) {
-      result.choices.push({
-        index: choice.index,
-        delta: {
-          tool_calls: [
-            {
+  result.choices.push({
+    index: choice.index,
+    delta: {
+      ...(delta?.role ? { role: delta.role } : {}),
+      ...(delta?.content ? { content: delta.content } : {}),
+      ...(delta?.tool_calls
+        ? {
+            tool_calls: delta.tool_calls.map((tc) => ({
               index: tc.index,
               id: tc.id,
               type: tc.type,
               function: tc.function,
-            },
-          ],
-        },
-        finish_reason: null,
-      })
-    }
-  }
-
-  if (choice.finish_reason) {
-    result.choices.push({
-      index: choice.index,
-      delta: {},
-      finish_reason: choice.finish_reason,
-    })
-  }
+            })),
+          }
+        : {}),
+    },
+    finish_reason: choice.finish_reason ?? null,
+  })
 
   if (chunk.usage) {
     result.usage = {

--- a/packages/console/app/test/openai-compatible-chunk.test.ts
+++ b/packages/console/app/test/openai-compatible-chunk.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test"
+import {
+  fromOaCompatibleChunk,
+  toOaCompatibleChunk,
+} from "../src/routes/zen/util/provider/openai-compatible"
+import { toAnthropicChunk } from "../src/routes/zen/util/provider/anthropic"
+
+const payload = {
+  id: "chatcmpl-1",
+  object: "chat.completion.chunk",
+  created: 1,
+  model: "test-model",
+  choices: [
+    {
+      index: 0,
+      delta: {
+        content: "fox",
+        tool_calls: [
+          {
+            index: 0,
+            id: "call_1",
+            type: "function",
+            function: { name: "get_time", arguments: "{}" },
+          },
+        ],
+      },
+      finish_reason: null,
+    },
+  ],
+}
+
+describe("OA-compat stream chunks", () => {
+  test("keeps tool_calls when a chunk also has content", () => {
+    const common = fromOaCompatibleChunk(`data: ${JSON.stringify(payload)}`)
+    expect(typeof common).toBe("object")
+    if (typeof common === "string") throw new Error("expected parsed chunk")
+
+    expect(common.choices).toHaveLength(1)
+    expect(common.choices[0]?.delta.content).toBe("fox")
+    expect(common.choices[0]?.delta.tool_calls).toEqual([
+      {
+        index: 0,
+        id: "call_1",
+        type: "function",
+        function: { name: "get_time", arguments: "{}" },
+      },
+    ])
+
+    const roundtrip = JSON.parse(toOaCompatibleChunk(common).slice("data: ".length))
+    expect(roundtrip.choices).toHaveLength(1)
+    expect(roundtrip.choices[0].delta.content).toBe("fox")
+    expect(roundtrip.choices[0].delta.tool_calls[0].function.name).toBe("get_time")
+  })
+
+  test("preserves tool_calls when converting the mixed chunk to Anthropic", () => {
+    const common = fromOaCompatibleChunk(`data: ${JSON.stringify(payload)}`)
+    if (typeof common === "string") throw new Error("expected parsed chunk")
+
+    const anthropic = JSON.parse(toAnthropicChunk(common))
+    expect(anthropic.type).toBe("content_block_start")
+    expect(anthropic.content_block).toMatchObject({ type: "tool_use", id: "call_1", name: "get_time" })
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #45240

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A single OA-compat SSE chunk can carry both `delta.content` and `delta.tool_calls`. `fromOaCompatibleChunk` split those into two `choices` entries, and `toOaCompatibleChunk` only emitted `choices[0]`, so the tool call disappeared after conversion.

Both functions now keep role, content, and tool_calls on one choice.

### How did you verify your code works?

- `bun test test/openai-compatible-chunk.test.ts` in `packages/console/app` — 2 pass
- `bun typecheck` in `packages/console/app` — clean
- Existing `packages/console/app` test failures in `providerUsage.test.ts` are pre-existing Google usage math and do not touch these files

### Screenshots / recordings

N/A — converter-only, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR