### PR TITLE
docs: clarify hidden agent behavior

### DIFF
--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -577,7 +577,7 @@ The `mode` option can be set to `primary`, `subagent`, or `all`. If no `mode` is
 
 ### Hidden
 
-Hide a subagent from the `@` autocomplete menu with `hidden: true`. Useful for internal subagents that should only be invoked programmatically by other agents via the Task tool.
+Set `hidden: true` to remove an agent from interactive selectors. For `subagent` and `all` agents, this hides the agent from the `@` autocomplete menu. For `primary` and `all` agents, it removes the agent from the primary-agent selector and Tab cycle.
 
 ```json title="opencode.json"
 {
@@ -590,11 +590,7 @@ Hide a subagent from the `@` autocomplete menu with `hidden: true`. Useful for i
 }
 ```
 
-This only affects user visibility in the autocomplete menu. Hidden agents can still be invoked by the model via the Task tool if permissions allow.
-
-:::note
-Only applies to `mode: subagent` agents.
-:::
+Hidden agents remain available for programmatic use. Hidden subagents can still be invoked through the Task tool when permissions allow, and hidden primary-capable agents can still be selected explicitly with `opencode run --agent <name>`.
 
 ---
 

--- a/packages/web/src/content/docs/agents.mdx
+++ b/packages/web/src/content/docs/agents.mdx
@@ -590,7 +590,7 @@ Set `hidden: true` to remove an agent from interactive selectors. For `subagent`
 }
 ```
 
-Hidden agents remain available for programmatic use. Hidden subagents can still be invoked through the Task tool when permissions allow, and hidden primary-capable agents can still be selected explicitly with `opencode run --agent <name>`.
+Hidden agents cannot be used as the `default_agent`, but they remain available for explicit programmatic use. Hidden subagents can still be invoked through the Task tool when permissions allow, and hidden primary-capable agents can still be selected explicitly with `opencode run --agent <name>`.
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #44751

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Clarifies that `hidden` applies to every agent mode, not only subagents. The docs now distinguish its effects on `@` autocomplete and primary-agent selection, explain that hidden agents remain available for explicit or permission-gated programmatic use, and note that they cannot be configured as `default_agent`.

### How did you verify your code works?

- `bun run --cwd packages/web build`
- `bun test test/agent.test.ts` in `packages/core`: 7 pass
- `bun test test/agent/agent.test.ts --test-name-pattern hidden --timeout 30000` in `packages/opencode`: 1 pass
- Repository pre-push typecheck: 30/30 packages passed
- `git diff --check`

### Screenshots / recordings

Not applicable; documentation-only behavior clarification.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR