### PR TITLE
fix(opencode2): hide background console windows on windows

### DIFF
--- a/.changeset/hide-windows-console.md
+++ b/.changeset/hide-windows-console.md
@@ -1,0 +1,6 @@
+---
+"@opencode-ai/client": patch
+"@opencode-ai/desktop": patch
+---
+
+Hide background console windows on Windows when spawning subprocesses and service contenders.

--- a/packages/client/src/service-contender.ts
+++ b/packages/client/src/service-contender.ts
@@ -17,6 +17,7 @@ export function spawnServiceContender(
 ): ServiceContender {
   const child = spawn(command, args, {
     detached: true,
+    windowsHide: true,
     stdio: ["ignore", "ignore", "pipe"],
     env: { ...process.env, ...env },
   })

--- a/packages/client/test/fixture/spawner.ts
+++ b/packages/client/test/fixture/spawner.ts
@@ -1,0 +1,8 @@
+import { spawnServiceContender } from "../../src/service-contender"
+
+const [command, fixture, registration, mode, envJson] = process.argv.slice(2)
+if (!command || !fixture || !registration || !mode) throw new Error("Missing spawner arguments")
+
+const env = envJson ? (JSON.parse(envJson) as Record<string, string>) : undefined
+spawnServiceContender(command, [fixture, registration, mode], env)
+process.exit(0)

--- a/packages/client/test/service-survival.test.ts
+++ b/packages/client/test/service-survival.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { waitForExit } from "./fixture/service-timing"
+
+const fixture = join(import.meta.dir, "fixture/service.ts")
+const spawnerFixture = join(import.meta.dir, "fixture/spawner.ts")
+
+test("spawned service contender survives spawner process exit and receives env", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "opencode-service-survival-"))
+  const registration = join(directory, "service.json")
+  const customEnv = { OPENCODE_SERVICE_ENV_TEST: "configured-survival" }
+
+  try {
+    const spawner = Bun.spawn(
+      [
+        process.execPath,
+        spawnerFixture,
+        process.execPath,
+        fixture,
+        registration,
+        "environment",
+        JSON.stringify(customEnv),
+      ],
+      {
+        stdout: "ignore",
+        stderr: "inherit",
+      },
+    )
+
+    const spawnerExitCode = await spawner.exited
+    expect(spawnerExitCode).toBe(0)
+
+    let registered = false
+    for (let attempt = 0; attempt < 600; attempt++) {
+      if (await Bun.file(registration).exists()) {
+        registered = true
+        break
+      }
+      await Bun.sleep(10)
+    }
+    expect(registered).toBe(true)
+
+    const info = await Bun.file(registration).json()
+    expect(info.url).toBeDefined()
+    expect(info.pid).toBeDefined()
+
+    const envContent = await Bun.file(registration + ".environment").text()
+    expect(envContent).toBe("configured-survival")
+
+    const response = await fetch(new URL("/api/health", info.url), {
+      signal: AbortSignal.timeout(2000),
+    })
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({ healthy: true, version: "test", pid: info.pid })
+
+    process.kill(info.pid, "SIGTERM")
+    await waitForExit(info.pid)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -25,7 +25,7 @@ async function signWindows(configuration: { path: string }) {
   await execFileAsync(
     "pwsh",
     ["-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", signScript, configuration.path],
-    { cwd: rootDir },
+    { cwd: rootDir, windowsHide: true },
   )
 }
 

--- a/packages/desktop/src/main/files/apps.ts
+++ b/packages/desktop/src/main/files/apps.ts
@@ -35,7 +35,7 @@ const checkMacosApp = Effect.fn("DesktopFiles.checkMacosApp")(function* (appName
 const resolveWindowsAppPath = Effect.fn("DesktopFiles.resolveWindowsAppPath")(function* (appName: string) {
   const fs = yield* FileSystem.FileSystem
   const path = yield* Path.Path
-  const result = yield* Effect.tryPromise(() => execFilePromise("where", [appName])).pipe(
+  const result = yield* Effect.tryPromise(() => execFilePromise("where", [appName], { windowsHide: true })).pipe(
     Effect.orElseSucceed(() => undefined),
   )
   if (!result) return null

--- a/packages/desktop/src/main/files/index.ts
+++ b/packages/desktop/src/main/files/index.ts
@@ -80,7 +80,9 @@ function make(fs: FileSystem.FileSystem, path: Path.Path) {
             process.platform === "darwin"
               ? { file: "open", arguments: ["-a", application, target] }
               : { file: application, arguments: [target] }
-          execFile(command.file, command.arguments, (error) => (error ? reject(error) : resolve()))
+          execFile(command.file, command.arguments, { windowsHide: true }, (error) =>
+            error ? reject(error) : resolve(),
+          )
         }),
       )
     }),


### PR DESCRIPTION
### Issue for this PR

Closes #42440 
Fixes #42440 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, `spawnServiceContender` starts the background service as a detached process (`DETACHED_PROCESS`). Because the detached service has no console attached, Windows kernel allocates a new visible console window (`ConsoleWindowClass` / `conhost.exe`) whenever the service spawns a child process (such as tool calls or background updater checks).

Depending on the user's settings, this will either translate into a black window appearing and disappearing after 40-150ms, or a new tab in the currently active terminal, taking focus and then disappearing, bringing the user to the last tab instead of the currently used tab

This PR adds `windowsHide: true` (`CREATE_NO_WINDOW`) to `spawnServiceContender` and internal desktop helper spawns while keeping `detached: true`, so the service starts without creating console windows and still persists across spawner CLI process exits.

This problem is at its worse when OpenCode 2 was started from Powershell 7.x (pwsh.exe)

This problem is new to Opencode 2, not present in Opencode 1

### How did you verify your code works?

1. Added `packages/client/test/service-survival.test.ts` to assert that the spawned service contender survives parent process exit and receives environment variables (`bun test test/service-survival.test.ts` passes).
2. Ran `bun typecheck` across all packages (0 errors).
3. Verified on Windows 11 with `EnumWindows` scanning during CLI and tool executions — zero visible console windows appear.

### Screenshots / recordings
Difficult to screenshot as it only appears for 40 ms, but it takes focus. When it's a tab, it doesnt bring you back to your initial focused tab, but to the last one instead.
<img width="2168" height="822" alt="image" src="https://github.com/user-attachments/assets/6f22d308-7184-4680-a532-9bab43ac977f" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
