### PR TITLE
fix(app): add provider visibility toggle to Settings Models

### DIFF
--- a/packages/app/src/providers/models/manage.tsx
+++ b/packages/app/src/providers/models/manage.tsx
@@ -158,7 +158,9 @@ export const DialogManageModels: Component = () => {
                             onChange={(checked) => setProviderVisibility(group.category, checked)}
                             hideLabel
                           >
-                            {group.items[0].provider.name}
+                            {language.t("dialog.model.manage.provider.toggle", {
+                              provider: group.items[0].provider.name,
+                            })}
                           </Switch>
                         </div>
                         <Show when={expanded()}>

--- a/packages/app/src/settings/models/models.tsx
+++ b/packages/app/src/settings/models/models.tsx
@@ -29,6 +29,15 @@ export const SettingsModels: Component = () => {
     createStore({ collapsed: {} as Record<string, boolean> }),
   )
 
+  const providerList = (providerID: string) => models.list().filter((x) => x.provider.id === providerID)
+  const providerVisible = (providerID: string) =>
+    providerList(providerID).every((x) => models.visible({ modelID: x.id, providerID: x.provider.id }))
+  const setProviderVisibility = (providerID: string, checked: boolean) => {
+    providerList(providerID).forEach((x) => {
+      models.setVisibility({ modelID: x.id, providerID: x.provider.id }, checked)
+    })
+  }
+
   const list = useFilteredList<ModelItem>({
     items: (_filter) => models.list(),
     key: (x) => `${x.provider.id}:${x.id}`,
@@ -119,7 +128,7 @@ export const SettingsModels: Component = () => {
                     data-component="settings-models-provider"
                     data-expanded={expanded() ? "" : undefined}
                   >
-                    <h3 class="settings-models-group-header">
+                    <div class="settings-models-group-header justify-between">
                       <button
                         type="button"
                         class="settings-models-group-trigger"
@@ -157,7 +166,17 @@ export const SettingsModels: Component = () => {
                           <span class="settings-section-title">{group.items[0].provider.name}</span>
                         </span>
                       </button>
-                    </h3>
+                      <Switch
+                        class="me-6"
+                        checked={providerVisible(group.category)}
+                        onChange={(checked) => setProviderVisibility(group.category, checked)}
+                        hideLabel
+                      >
+                        {language.t("dialog.model.manage.provider.toggle", {
+                          provider: group.items[0].provider.name,
+                        })}
+                      </Switch>
+                    </div>
                     <Show when={expanded()}>
                       <SettingsList>
                         <For each={group.items}>


### PR DESCRIPTION
### Issue for this PR

Closes #45225

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Settings → Models groups models by provider and already has a per-model visibility switch, but the provider-level master switch from **Manage models** was never added to this tab.

This reuses the existing `providerVisible` / `setProviderVisibility` logic in the Settings Models provider header so one switch can show or hide every model from that provider. The same i18n key (`dialog.model.manage.provider.toggle`) is now used for the switch label on both surfaces.

No backend or visibility-storage change.

### How did you verify your code works?

Compared the Settings Models header with the Manage models dialog and ran `bun typecheck` in `packages/app`. I have not run the desktop app locally in this checkout.

### Screenshots / recordings

<img width="1824" height="1138" alt="20260826065506_rec_" src="https://github.com/user-attachments/assets/d845066d-ccd6-4fe4-ad3d-68dc05949ca1" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR