### PR TITLE
ci(close-prs): surface bun exit code with ::warning:: on failure

### DIFF
--- a/.github/workflows/close-prs.yml
+++ b/.github/workflows/close-prs.yml
@@ -47,4 +47,8 @@ jobs:
             args+=("--execute")
           fi
 
-          bun script/github/close-prs.ts "${args[@]}"
+          bun script/github/close-prs.ts "${args[@]}" || {
+            exit_code=$?
+            echo "::warning::close-prs.ts exited with code $exit_code — check logs for GraphQL/token-scope errors"
+            exit $exit_code
+          }


### PR DESCRIPTION
## Summary
- Wrap the bun script invocation in the `close-prs` workflow so a non-zero exit code emits a `::warning::` annotation visible in the run log
- Makes the failure mode (GraphQL error, token-scope error, unhandled exception) diagnosable without reading the full log

## Motivation
Trialed against fork run #13 of `close-prs`: the workflow failed with no visible signal in the annotation summary; the root cause was only findable by digging through the raw log. This change surfaces such failures as warnings at the job level.

## Testing
- [x] Verified locally that a non-zero bun exit triggers the `::warning::` path (fork run)
- [x] Syntax-checked workflow YAML