### PR TITLE
fix(app): load full history for fork dialog

### DIFF
--- a/packages/app/src/session/commands/export.ts
+++ b/packages/app/src/session/commands/export.ts
@@ -1,5 +1,6 @@
 import type { SessionInfo, SessionMessageInfo } from "@opencode-ai/client/promise"
 import type { ServerApi } from "@/runtime/server/api"
+import { fetchSessionMessages } from "./messages"
 
 export type SessionExportData = {
   info: SessionInfo
@@ -10,26 +11,12 @@ export async function fetchSessionExport(input: {
   sessionID: string
   api: Pick<ServerApi, "session" | "message">
 }): Promise<SessionExportData> {
-  const [info, first] = await Promise.all([
+  const [info, messages] = await Promise.all([
     input.api.session.get({ sessionID: input.sessionID }),
-    input.api.message.list({ sessionID: input.sessionID, limit: 200, order: "asc" }),
+    fetchSessionMessages(input),
   ])
-  const pages = [first]
 
-  while (pages.at(-1)?.cursor.next) {
-    pages.push(
-      await input.api.message.list({
-        sessionID: input.sessionID,
-        limit: 200,
-        cursor: pages.at(-1)!.cursor.next ?? undefined,
-      }),
-    )
-  }
-
-  return {
-    info,
-    messages: pages.flatMap((page) => page.data),
-  }
+  return { info, messages }
 }
 
 export function sessionExportFilename(session: { id: string; title?: string; slug?: string }) {

--- a/packages/app/src/session/commands/fork-dialog.tsx
+++ b/packages/app/src/session/commands/fork-dialog.tsx
@@ -1,4 +1,4 @@
-import { Component, createMemo } from "solid-js"
+import { Component, createMemo, createResource, Show } from "solid-js"
 import { useNavigate, useParams } from "@solidjs/router"
 import { useData } from "@/runtime/server/current"
 import { useComposerState } from "@/composer/persistence"
@@ -13,11 +13,14 @@ import { extractPromptComments, extractPromptFromMessage } from "@/composer/prom
 import { useWorkspaceLocation } from "@/workspaces/location"
 import { useServer } from "@/runtime/server/current"
 import { sessionHref } from "@/shell/routes/session"
+import { fetchSessionMessages, selectForkableUserMessages } from "./messages"
+import type { SessionMessageUser } from "@opencode-ai/client/promise"
 
 interface ForkableMessage {
   id: string
   text: string
   time: string
+  message: SessionMessageUser
 }
 
 function formatTime(date: Date): string {
@@ -35,24 +38,24 @@ export const DialogFork: Component = () => {
   const language = useLanguage()
   const server = useServer()
 
+  const [history] = createResource(
+    () => params.id,
+    (sessionID) => fetchSessionMessages({ sessionID, api: serverSDK.api }),
+  )
+
   const messages = createMemo((): ForkableMessage[] => {
     const sessionID = params.id
-    if (!sessionID) return []
+    const loaded = history()
+    if (!sessionID || !loaded) return []
 
-    const msgs = data.session.message.list(sessionID)
-    const result: ForkableMessage[] = []
-
-    for (const message of msgs) {
-      if (message.type !== "user" || !message.text) continue
-
-      result.push({
+    return selectForkableUserMessages(loaded, data.session.get(sessionID)?.revert?.messageID)
+      .map((message) => ({
         id: message.id,
         text: message.text.replace(/\n/g, " ").slice(0, 200),
         time: formatTime(new Date(message.time.created)),
-      })
-    }
-
-    return result.reverse()
+        message,
+      }))
+      .toReversed()
   })
 
   const handleSelect = (item: ForkableMessage | undefined) => {
@@ -60,9 +63,7 @@ export const DialogFork: Component = () => {
 
     const sessionID = params.id
     if (!sessionID) return
-    const message = data.session.message.get(sessionID, item.id)
-    if (message?.type !== "user") return
-    const restored = extractPromptFromMessage(message, {
+    const restored = extractPromptFromMessage(item.message, {
       directory: location().directory,
       attachmentName: language.t("common.attachment"),
     })
@@ -76,7 +77,7 @@ export const DialogFork: Component = () => {
         const target = prompt.capture({ dir, id: forked.id })
         target.set(restored)
         target.context.replaceComments(
-          extractPromptComments(message).map((comment) => ({
+          extractPromptComments(item.message).map((comment) => ({
             type: "file",
             path: comment.path,
             selection: comment.selection,
@@ -99,22 +100,27 @@ export const DialogFork: Component = () => {
         <DialogTitle>{language.t("command.session.fork")}</DialogTitle>
       </DialogHeader>
       <DialogBody>
-        <List
-          class="flex-1 px-3 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0"
-          search={{ placeholder: language.t("common.search.placeholder"), autofocus: true }}
-          emptyMessage={language.t("dialog.fork.empty")}
-          key={(x) => x.id}
-          items={messages}
-          filterKeys={["text"]}
-          onSelect={handleSelect}
+        <Show
+          when={!history.loading}
+          fallback={<div class="flex-1 px-3 py-8 text-center text-text-weak">{language.t("common.loading")}</div>}
         >
-          {(item) => (
-            <div class="w-full flex items-center gap-2">
-              <span class="truncate flex-1 min-w-0 text-left font-normal">{item.text}</span>
-              <span class="text-text-weak shrink-0 font-normal">{item.time}</span>
-            </div>
-          )}
-        </List>
+          <List
+            class="flex-1 px-3 min-h-0 [&_[data-slot=list-scroll]]:flex-1 [&_[data-slot=list-scroll]]:min-h-0"
+            search={{ placeholder: language.t("common.search.placeholder"), autofocus: true }}
+            emptyMessage={language.t("dialog.fork.empty")}
+            key={(x) => x.id}
+            items={messages}
+            filterKeys={["text"]}
+            onSelect={handleSelect}
+          >
+            {(item) => (
+              <div class="w-full flex items-center gap-2">
+                <span class="truncate flex-1 min-w-0 text-left font-normal">{item.text}</span>
+                <span class="text-text-weak shrink-0 font-normal">{item.time}</span>
+              </div>
+            )}
+          </List>
+        </Show>
       </DialogBody>
     </Dialog>
   )

--- a/packages/app/src/session/commands/messages.test.ts
+++ b/packages/app/src/session/commands/messages.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import type { SessionMessageAssistant, SessionMessageInfo, SessionMessageUser } from "@opencode-ai/client/promise"
+import type { ServerApi } from "@/runtime/server/api"
+import { fetchSessionMessages, selectForkableUserMessages } from "./messages"
+
+describe("fetchSessionMessages", () => {
+  test("fetches every native message page without returning cursors", async () => {
+    const first = { id: "msg_1", type: "model-selected" } as unknown as SessionMessageInfo
+    const second = { id: "msg_2", type: "user" } as SessionMessageInfo
+    const calls: unknown[] = []
+    const api = {
+      message: {
+        list: async (input: { cursor?: string }) => {
+          calls.push(input)
+          if (!input.cursor) return { data: [first], cursor: { next: "page-2" } }
+          return { data: [second], cursor: {} }
+        },
+      },
+    } as unknown as Pick<ServerApi, "message">
+
+    const result = await fetchSessionMessages({ sessionID: "ses_1", api })
+
+    expect(result).toEqual([first, second])
+    expect(calls).toEqual([
+      { sessionID: "ses_1", limit: 200, order: "asc" },
+      { sessionID: "ses_1", limit: 200, cursor: "page-2" },
+    ])
+  })
+})
+
+describe("selectForkableUserMessages", () => {
+  const user = (id: string, text = id): SessionMessageUser => ({
+    id,
+    type: "user",
+    text,
+    time: { created: 0 },
+  })
+  const assistant: SessionMessageAssistant = {
+    id: "msg_2",
+    type: "assistant",
+    time: { created: 0 },
+    agent: "build",
+    model: { id: "model", providerID: "provider" },
+    content: [],
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  }
+
+  test("keeps visible user prompts and skips empty text", () => {
+    const messages: SessionMessageInfo[] = [user("msg_a"), assistant, user("msg_b", ""), user("msg_c")]
+    expect(selectForkableUserMessages(messages).map((message) => message.id)).toEqual(["msg_a", "msg_c"])
+    expect(selectForkableUserMessages(messages, "msg_c").map((message) => message.id)).toEqual(["msg_a"])
+  })
+})

--- a/packages/app/src/session/commands/messages.ts
+++ b/packages/app/src/session/commands/messages.ts
@@ -1,0 +1,30 @@
+import type { SessionMessageInfo } from "@opencode-ai/client/promise"
+import type { ServerApi } from "@/runtime/server/api"
+import { selectSessionUserMessages, selectVisibleSessionUserMessages } from "@/session/session-domain"
+
+const pageLimit = 200
+
+export async function fetchSessionMessages(input: {
+  sessionID: string
+  api: Pick<ServerApi, "message">
+}): Promise<SessionMessageInfo[]> {
+  const pages = [await input.api.message.list({ sessionID: input.sessionID, limit: pageLimit, order: "asc" })]
+
+  while (pages.at(-1)?.cursor.next) {
+    pages.push(
+      await input.api.message.list({
+        sessionID: input.sessionID,
+        limit: pageLimit,
+        cursor: pages.at(-1)!.cursor.next ?? undefined,
+      }),
+    )
+  }
+
+  return pages.flatMap((page) => page.data)
+}
+
+export function selectForkableUserMessages(messages: SessionMessageInfo[], revertMessageID?: string) {
+  return selectVisibleSessionUserMessages(selectSessionUserMessages(messages), revertMessageID).filter(
+    (message) => !!message.text,
+  )
+}


### PR DESCRIPTION
### Issue for this PR

Fixes #45242

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `/fork` dialog listed user prompts from `data.session.message.list()`, which is the paged timeline cache. After a restart, that cache only has the newest page, so earlier turns were missing until the timeline was scrolled to the top.

The dialog now fetches the session’s messages itself (same paging as export) and searches/selects against that list. Selecting a prompt uses the fetched message, not `data.session.message.get()`. The timeline cache is unchanged.

### How did you verify your code works?

Unit tests for `fetchSessionMessages` and `selectForkableUserMessages`, plus the existing export paging tests. I have not run the desktop app locally in this checkout.

### Screenshots / recordings

<img width="1824" height="1138" alt="20260826081308_rec_" src="https://github.com/user-attachments/assets/e47bb82b-235a-4866-958b-8dd19b91f117" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
