### PR TITLE
fix(app): include files in mention search

### DIFF
--- a/packages/app/src/workspaces/files/model.tsx
+++ b/packages/app/src/workspaces/files/model.tsx
@@ -212,7 +212,7 @@ export const { use: useFile, provider: FileProvider } = createSimpleContext({
           {
             location: { directory: sdk().directory },
             query,
-            type: dirs === "true" ? "directory" : "file",
+            type: dirs === "true" ? undefined : "file",
             limit: options?.limit,
           },
           { signal: options?.signal },


### PR DESCRIPTION
## Summary
- omit the filesystem type filter for combined file and directory searches
- restore file results in composer `@` mention suggestions
- preserve file-only filtering for file search consumers

## Testing
- `bun typecheck` in `packages/app`
- `bun run test:unit` in `packages/app` (540 passing)
- repository pre-push typecheck (32 packages)