### PR TITLE
fix(core): make FSUtil.resolve degrade on any realPath failure

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -93,10 +93,10 @@ export namespace FSUtil {
 
       const resolve = Effect.fn("FileSystem.resolve")(function* (path: string) {
         const resolved = pathResolve(windowsPath(path))
-        return yield* fs.realPath(resolved).pipe(
-          Effect.catchReason("PlatformError", "NotFound", () => Effect.succeed(resolved)),
-          Effect.orDie,
-        )
+        // Best-effort canonicalization: unreadable traversal components (ACLs,
+        // ELOOP) degrade to the lexical path instead of killing fibers whose
+        // callers treat the result as advisory.
+        return yield* fs.realPath(resolved).pipe(Effect.catch(() => Effect.succeed(resolved)))
       })
 
       const readJson = Effect.fn("FileSystem.readJson")(function* (path: string) {

--- a/packages/core/test/fs-util-resolve.test.ts
+++ b/packages/core/test/fs-util-resolve.test.ts
@@ -1,0 +1,56 @@
+import path from "path"
+import { describe, expect } from "bun:test"
+import { Effect, Layer, PlatformError } from "effect"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { filesystem } from "@opencode-ai/core/effect/app-node-platform"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { tmpdir } from "./fixture/tmpdir"
+import { testEffect } from "./lib/effect"
+
+const accessDenied = PlatformError.systemError({
+  _tag: "PermissionDenied",
+  module: "FileSystem",
+  method: "realPath",
+  pathOrDescriptor: "C:\\System Volume Information\\locked",
+})
+
+// Real FSUtil service with realPath forced to fail for a non-NotFound reason
+// (ACL-denied traversal component on Windows, ELOOP, ...).
+const deniedRealPath = Layer.effect(
+  FSUtil.Service,
+  Effect.gen(function* () {
+    const real = yield* FSUtil.Service
+    return FSUtil.Service.of({
+      ...real,
+      realPath: () => Effect.fail(accessDenied),
+    })
+  }),
+).pipe(Layer.provide(LayerNode.compile(LayerNode.group([FSUtil.node, filesystem]))))
+
+const it = testEffect(LayerNode.compile(LayerNode.group([FSUtil.node, filesystem])))
+const itDenied = testEffect(deniedRealPath)
+
+describe("FSUtil.resolve", () => {
+  itDenied.effect("degrades to the lexical path when realPath fails with a non-NotFound error", () =>
+    Effect.gen(function* () {
+      const fs = yield* FSUtil.Service
+      const target = path.join("C:", "System Volume Information", "locked")
+      // Regression lock: this used to die via Effect.orDie, aborting callers
+      // such as the bash tool's advisory external-directory scan.
+      expect(yield* fs.resolve(target)).toBe(target)
+    }),
+  )
+
+  it.live("canonicalizes existing paths", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const fs = yield* FSUtil.Service
+          const resolved = yield* fs.resolve(path.join(tmp.path, "file.txt"))
+          expect(resolved.toLowerCase()).toContain("file.txt")
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #45296

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`FSUtil.resolve()` only tolerated a `NotFound` failure from `realPath`; every other failure (for example `PermissionDenied` on an unreadable traversal component such as `C:\System Volume Information` on Windows, or `ELOOP`) escaped as a defect via `Effect.orDie` and killed the calling fiber. The worst caller is the bash tool's external-command scan, which resolves every absolute-looking command argument before the permission prompt and documents those warnings as "advisory only" — yet one unreadable path aborted the entire tool with an opaque defect. `resolve()` now falls back to the lexical path for any `realPath` error, matching its declared `Effect.Effect<string>` (no error channel) contract. `NotFound` behavior is unchanged.

### How did you verify your code works?

- `bun test --timeout 30000 test/fs-util-resolve.test.ts` → 2/2 pass
- `bun typecheck` (packages/core) → clean
- `oxlint` on changed files → 0 errors (4 pre-existing warnings on untouched lines 1/19/20)
- Dependent suites still green: instruction-context + repository tests (12 tests, 0 fail)

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
