### PR TITLE
fix(tui): reset permission sub-screen when the request changes

### DIFF
--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -1,6 +1,6 @@
 import { createStore } from "solid-js/store"
 import { dirname } from "node:path"
-import { createMemo, For, Match, Show, Switch } from "solid-js"
+import { createEffect, createMemo, For, Match, on, Show, Switch } from "solid-js"
 import { Portal, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import type { TextareaRenderable } from "@opentui/core"
 import { useTheme, selectedForeground } from "../../context/theme"
@@ -116,6 +116,19 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
     stage: "permission" as PermissionStage,
   })
   const pathFormatter = usePathFormatter()
+
+  // Only one PermissionPrompt instance is ever mounted (it always renders
+  // permissions()[0]); when the user resolves a request via the "always" or
+  // "reject" sub-screen, store.stage is left on that sub-screen. As soon as
+  // the next queued request becomes permissions()[0], the same instance is
+  // reused with a new request prop, so store.stage must be reset or the new
+  // request wrongly shows the "Always allow" / reject screen.
+  createEffect(
+    on(
+      () => props.request.id,
+      () => setStore("stage", "permission"),
+    ),
+  )
 
   const session = createMemo(() => sync.data.session.find((s) => s.id === props.request.sessionID))
 


### PR DESCRIPTION
### Issue for this PR

Fixes #45297

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When more than one permission request is queued, the session view renders a single `<PermissionPrompt request={permissions()[0]}>`. Resolving a request through the "always" or "reject" sub-screen leaves the component's local `store.stage` on that sub-screen. The next queued request becomes `permissions()[0]`, but Solid reuses the same component instance (the `Show` condition stays truthy) and only updates the `request` prop — so `store.stage` carries over and the new request is shown on the "Always allow" / reject screen instead of the permission prompt. This adds a `createEffect(on(() => props.request.id, ...))` that resets `store.stage` to `"permission"` whenever the request id changes, so every queued request starts on the correct screen.

### How did you verify your code works?

- `bun typecheck` (packages/tui) → clean
- Note: the repo's TUI "component" tests only exercise exported pure helpers (there is no Solid render harness), so this is verified by typecheck + the reproduction below rather than a unit test, consistent with how other TUI fixes in this repo are tested.
- Reproduction: queue two commands that each need permission so `permissions().length > 1`; for the first choose Allow always; request #2 becomes `permissions()[0]` but the prompt still showed the "Always allow" screen before this fix.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
