### PR TITLE
fix(app): focus new terminal from shortcut

### DIFF
--- a/packages/app/e2e/regression/terminal-composer-focus.spec.ts
+++ b/packages/app/e2e/regression/terminal-composer-focus.spec.ts
@@ -249,6 +249,55 @@ test("focuses a terminal created from the new-terminal button", async ({ page })
   await expect.poll(() => active.evaluate((element) => element.contains(document.activeElement))).toBe(true)
 })
 
+test("focuses terminals created from the new-terminal shortcut", async ({ page }) => {
+  const created = { count: 0 }
+  await page.route("**/api/pty*", (route) => {
+    created.count += 1
+    const next = created.count === 1 ? ptyInfo(ptyID, "Terminal 1") : ptyInfo(newPtyID, "Terminal 2")
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ location: ptyLocation(), data: next }),
+    })
+  })
+  await page.route(`**/api/pty/${newPtyID}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ location: ptyLocation(), data: ptyInfo(newPtyID, "Terminal 2") }),
+    }),
+  )
+  await page.route(`**/api/pty/${newPtyID}/connect-token*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      headers: { "access-control-allow-origin": "*" },
+      body: JSON.stringify({ location: ptyLocation(), data: { ticket: "e2e-ticket", expires_in: 60 } }),
+    }),
+  )
+  await page.routeWebSocket(new RegExp(`/api/pty/${newPtyID}/connect`), () => undefined)
+
+  await page.goto(`/server/${base64Encode(server)}/session/${sessionID}`)
+  await expectSessionTitle(page, "Terminal composer focus")
+
+  const composer = page.locator('[data-component="composer-editor"]')
+  const chatPanel = page.locator('[data-slot="session-chat-panel"]')
+  await composer.fill("keep this draft")
+  await expect(composer).toHaveText("keep this draft")
+
+  await page.keyboard.press("Control+Alt+T")
+  await expect(page.getByRole("tab", { name: "Terminal 1" })).toHaveAttribute("aria-selected", "true")
+  const firstTerminal = page.locator(`#terminal-wrapper-${ptyID} [data-component="terminal"]`)
+  await expect.poll(() => firstTerminal.evaluate((element) => element.contains(document.activeElement))).toBe(true)
+
+  await chatPanel.click({ position: { x: 100, y: 200 } })
+  await page.keyboard.press("Control+Alt+T")
+  await expect(page.getByRole("tab", { name: "Terminal 2" })).toHaveAttribute("aria-selected", "true")
+  const secondTerminal = page.locator(`#terminal-wrapper-${newPtyID} [data-component="terminal"]`)
+  await expect.poll(() => secondTerminal.evaluate((element) => element.contains(document.activeElement))).toBe(true)
+  await expect(composer).toHaveText("keep this draft")
+})
+
 function seedCachedTerminal(page: Page) {
   return page.addInitScript(
     ({ terminalKey, ptyID }) => {

--- a/packages/app/src/session/terminal/terminal.tsx
+++ b/packages/app/src/session/terminal/terminal.tsx
@@ -453,11 +453,12 @@ export const Terminal = (props: TerminalProps) => {
         handleLinkClick,
       })
 
-      if (local.autoFocus === true) {
+      const autoFocus = local.autoFocus === true
+      if (autoFocus) {
         focusTerminal()
         local.onAutoFocus?.()
       }
-      if (local.autoFocus !== true) {
+      if (!autoFocus) {
         const restoreFocus = () => {
           const current = document.activeElement
           if (current !== container && !container.contains(current)) return


### PR DESCRIPTION
### Issue for this PR

Fixes #45272

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The New terminal button focuses the new terminal correctly, but the keyboard shortcut could leave focus in the currently active panel after creating and selecting a tab.

The terminal now captures the autofocus state before consuming the autofocus request. This prevents the previous-focus restore path from running after the request is consumed, so `Ctrl+Alt+T` focuses the new terminal input.

### How did you verify your code works?

- `bun run test:e2e -- e2e/regression/terminal-composer-focus.spec.ts --workers=1`
- `bun typecheck` from `packages/app`
- `bun typecheck:e2e` from `packages/app`
- Manual verification with `bun run dev:desktop`

The regression covers both first and subsequent shortcut-created tabs, selection, terminal focus, and draft retention.

The production session-tab benchmark was also rerun but remains blocked by an existing fixture failure, so it produced no metrics.

### Screenshots / recordings

#### Before

https://github.com/user-attachments/assets/4a58e274-3122-43c2-a67f-9b42fdd0c3e7

#### After

https://github.com/user-attachments/assets/784b98a4-74b2-4f0a-87bd-48a887f347bd

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR