### PR TITLE
fix(app): direct session URLs no longer redirect to lastProjectSession

### DIFF
--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -305,9 +305,13 @@ export default function LegacyLayout(props: ParentProps) {
   createEffect(() => {
     if (!state.autoselect) return
     const dir = params.dir
-    if (!dir) return
-    const directory = decode64(dir)
-    if (!directory) return
+    const id = params.id
+    // Direct session URL must not be overridden by autoselect — see #43667
+    if (!dir && !id) return
+    if (dir) {
+      const directory = decode64(dir)
+      if (!directory) return
+    }
     setState("autoselect", false)
   })
 


### PR DESCRIPTION
## Problem

Direct navigation to a session URL redirects to whatever session was last visited in that project (`lastProjectSession` in localStorage), ignoring the session ID in the URL.

Reproduce:
1. Open opencode at `/server/{key}/session/{id}` (or legacy `/{dir}/session/{id}`) for a session that is **not** the last one visited in its project.
2. Observe the URL changes to a different session ID — the `lastProjectSession` for that project root — instead of staying on the requested session.

Reported in #43667.

## Root cause

In `packages/app/src/pages/layout.tsx`, the autoselect-disabling `createEffect` (around line 305) only checks `params.dir`:

```ts
createEffect(() => {
  if (!state.autoselect) return
  const dir = params.dir
  if (!dir) return          // ← on /server/{key}/session/{id}, params.dir is undefined
  const directory = decode64(dir)
  if (!directory) return
  setState("autoselect", false)
})
```

On the `/server/:serverKey/session/:id` route there is no `dir` param, so `autoselect` stays `true`. The `autoselecting` resource (line 539) then runs `openProject(last, true)`, which calls `navigateToProject` → reads `store.lastProjectSession[root]` → navigates to a different session, overriding the URL.

The same bug affects the legacy `/:dir/session/:id` route when `dir` happens to be missing/invalid.

## Fix

Also consider `params.id` — if either `dir` or `id` is set in the URL, autoselect is disabled and the URL-specified session is preserved:

```ts
createEffect(() => {
  if (!state.autoselect) return
  const dir = params.dir
  const id = params.id
  // Direct session URL must not be overridden by autoselect — see #43667
  if (!dir && !id) return
  if (dir) {
    const directory = decode64(dir)
    if (!directory) return
  }
  setState("autoselect", false)
})
```

## Verification

Built the app from source (`bun install && bun run dev`) and tested both routes in a browser:

- ✅ `/server/{key}/session/{id}` — URL stays at the requested session ID; messages from that session load correctly. Before the fix, URL redirected to a different session ID from `lastProjectSession`.
- ✅ `/{dir}/session/{id}` legacy route — same behavior preserved.
- ✅ Project root URL (`/server/{key}`) without session — autoselect still kicks in and navigates to `lastProjectSession` as before (no regression).
- ✅ `bun run typecheck` passes.

Closes #43667