### PR TITLE
fix(tui): preserve multi-click text selection

### DIFF
--- a/packages/tui/src/util/selection.ts
+++ b/packages/tui/src/util/selection.ts
@@ -1,3 +1,4 @@
+import type { SelectionBehavior } from "@opentui/core"
 import type { ClipboardService } from "../context/clipboard"
 
 type Toast = {
@@ -15,6 +16,7 @@ type Renderer = {
     getSelectedText: () => string
     selectedRenderables: FocusableSelectionTarget[]
     isStart: boolean
+    behavior: SelectionBehavior
   } | null
   clearSelection: () => void
   currentFocusedRenderable?: FocusableSelectionTarget | null
@@ -34,13 +36,16 @@ export function copyOnSelectRelease(
   clipboard: ClipboardService,
 ): boolean {
   if (!event.isDragging) return false
+  // Clearing a click-only or empty release also resets OpenTUI's multi-click counter.
+  const selection = renderer.getSelection()
+  if (!selection || (selection.isStart && selection.behavior === "cell") || !selection.getSelectedText()) return false
   return copy(renderer, toast, clipboard)
 }
 
 export function copy(renderer: Renderer, toast: Toast, clipboard: ClipboardService): boolean {
   const selection = renderer.getSelection()
   if (!selection) return false
-  if (selection.isStart) {
+  if (selection.isStart && selection.behavior === "cell") {
     renderer.clearSelection()
     return false
   }

--- a/packages/tui/test/util/selection-copy-on-select.test.tsx
+++ b/packages/tui/test/util/selection-copy-on-select.test.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 import { expect, test } from "bun:test"
+import { BoxRenderable, EmbeddedTerminalRenderable } from "@opentui/core"
+import { createTestRenderer, ManualClock } from "@opentui/core/testing"
 import { testRender, useRenderer } from "@opentui/solid"
 import { useClipboard } from "../../src/context/clipboard"
 import { copyOnSelectRelease } from "../../src/util/selection"
@@ -45,6 +47,7 @@ test("copy-on-select keeps a word highlight so a third click can select the line
 
     await app.mockMouse.click(6, 0)
     expect(app.renderer.getSelection()?.getSelectedText() ?? "").toBe("")
+    expect(writes).toEqual([])
 
     await app.mockMouse.click(6, 0)
     expect(app.renderer.getSelection()?.getSelectedText()).toBe("beta")
@@ -53,6 +56,46 @@ test("copy-on-select keeps a word highlight so a third click can select the line
     await app.mockMouse.click(6, 0)
     expect(app.renderer.getSelection()?.getSelectedText()).toBe("alpha beta gamma")
     expect(writes).toEqual(["beta", "alpha beta gamma"])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("terminal copy-on-select ignores clicks and empty drags but preserves a copied drag", async () => {
+  const writes: string[] = []
+  const app = await createTestRenderer({ width: 20, height: 2, clock: new ManualClock() })
+  const clipboard = {
+    async read() {
+      return undefined
+    },
+    async write(text: string) {
+      writes.push(text)
+    },
+  }
+  const toast = { show: () => {}, error: () => {} }
+  const box = new BoxRenderable(app.renderer, {
+    onMouseUp: (event) => copyOnSelectRelease(event, app.renderer, toast, clipboard),
+  })
+  const terminal = new EmbeddedTerminalRenderable(app.renderer, { cols: 20, rows: 2 })
+  box.add(terminal)
+  app.renderer.root.add(box)
+
+  try {
+    terminal.write(Buffer.from("alpha beta gamma"))
+    await app.renderOnce()
+
+    await app.mockMouse.pressDown(6, 0)
+    expect(app.renderer.getSelection()?.getSelectedText()).toBe("b")
+    await app.mockMouse.release(6, 0)
+    expect(writes).toEqual([])
+
+    await app.mockMouse.drag(0, 0, 4, 0)
+    expect(app.renderer.getSelection()?.getSelectedText()).toBe("alpha")
+    expect(writes).toEqual(["alpha"])
+
+    await app.mockMouse.drag(16, 0, 19, 0)
+    expect(app.renderer.getSelection()?.getSelectedText()).toBe("")
+    expect(writes).toEqual(["alpha"])
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/util/selection.test.ts
+++ b/packages/tui/test/util/selection.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test"
+import type { SelectionBehavior } from "@opentui/core"
 import type { ClipboardService } from "../../src/context/clipboard"
 import { Selection, copy, copyOnSelectRelease } from "../../src/util/selection"
 
@@ -8,12 +9,13 @@ function renderer() {
       getSelectedText: () => "beta",
       selectedRenderables: [],
       isStart: false,
+      behavior: "cell" as const,
     }),
     clearSelection: () => {},
   }
 }
 
-function setup(text: string, isStart: boolean) {
+function setup(text: string, isStart: boolean, behavior: SelectionBehavior = "cell") {
   const writes: string[] = []
   let clears = 0
   const clipboard: ClipboardService = {
@@ -23,7 +25,7 @@ function setup(text: string, isStart: boolean) {
     },
   }
   const renderer = {
-    getSelection: () => ({ getSelectedText: () => text, selectedRenderables: [], isStart }),
+    getSelection: () => ({ getSelectedText: () => text, selectedRenderables: [], isStart, behavior }),
     clearSelection: () => {
       clears++
     },
@@ -41,6 +43,7 @@ test("copy writes selected text without clearing the highlight", () => {
         getSelectedText: () => "beta",
         selectedRenderables: [],
         isStart: false,
+        behavior: "cell",
       }),
       clearSelection: () => {
         cleared = true
@@ -86,6 +89,24 @@ test("clears an empty dragged selection without copying", () => {
   const value = setup("", false)
   expect(Selection.copy(value.renderer, value.toast, value.clipboard)).toBeFalse()
   expect(value.clears()).toBe(1)
+  expect(value.writes).toEqual([])
+})
+
+test.each(["word", "line"] as const)("copies a non-dragged %s selection without clearing", (behavior) => {
+  const value = setup("selected", true, behavior)
+  expect(Selection.copy(value.renderer, value.toast, value.clipboard)).toBeTrue()
+  expect(value.clears()).toBe(0)
+  expect(value.writes).toEqual(["selected"])
+})
+
+test.each([
+  { text: "x", isStart: true },
+  { text: "", isStart: true },
+  { text: "", isStart: false },
+])("copy-on-select ignores $text / isStart=$isStart without resetting clicks", (input) => {
+  const value = setup(input.text, input.isStart)
+  expect(Selection.copyOnSelectRelease({ isDragging: true }, value.renderer, value.toast, value.clipboard)).toBeFalse()
+  expect(value.clears()).toBe(0)
   expect(value.writes).toEqual([])
 })
 


### PR DESCRIPTION
## Why

The click-only selection guard introduced with #44971 clears selection on mouse release. OpenTUI also resets its multi-click counter when selection is cleared, so double- and triple-clicks never reach word or line selection when copy-on-select is enabled.

This caused the deterministic selection-test failures seen in #45157. That branch passed locally because it lacked the upstream guard, while CI tested the combined merge commit.

## What Changes

| Interaction | Result |
| --- | --- |
| Bare terminal click | Does not copy or reset click history |
| Double-click | Selects and copies the word, preserving its highlight |
| Triple-click | Selects and copies the line, preserving its highlight |
| Empty drag | Does not copy or reset click history |
| Explicit copy of an invalid selection | Still clears the invalid selection |

## Selection History

Stationary word and line selections can still report `isStart = true`. Only a start-only cell selection is treated as a bare click. Mouse-release copying ignores invalid selections instead of clearing them, preserving the renderer-owned click count without private-state manipulation.

## Demo

Matched real OpenCode Drive recordings: base `cbef698861` on the left and fix `aa6297f7ae` on the right. Both use the same fictional simulated response and native SGR mouse input through the real TUI. Before: double/triple clicks select nothing. After: word and line highlights remain visible and clipboard confirmation appears.

https://github.com/user-attachments/assets/fe81a551-416e-4926-a39b-ea693fe07511

## Scope

Restores real double/triple-click behavior without weakening the existing dialog or selection tests. A bare embedded-terminal click retains its native single-cell highlight until another interaction clears or replaces it, but never auto-copies that cell. Explicit copy retains its existing invalid-selection cleanup.

## Verification

```sh
# From packages/tui
bun run test test/cli/tui/dialog-select.test.tsx test/util/selection-copy-on-select.test.tsx test/util/selection.test.ts --rerun-each=20
bun run test
bun typecheck

# From repository root
bun run lint packages/tui/src/util/selection.ts packages/tui/test/util/selection.test.ts packages/tui/test/util/selection-copy-on-select.test.tsx
bunx prettier --check packages/tui/src/util/selection.ts packages/tui/test/util/selection.test.ts packages/tui/test/util/selection-copy-on-select.test.tsx
```

Focused tests: **560 passed** across 20 repeats. Full TUI suite: **810 passed, 5 skipped, 0 failed**. Typecheck, lint, formatting, and all 32 pre-push workspace typecheck tasks passed. Includes real embedded-terminal coverage for click suppression, nonempty drag copying/highlight preservation, and empty drags. Local validation was on macOS; Linux and Windows validation runs in CI.