### PR TITLE
fix(tui): skip question reject when dialog is open

### DIFF
--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -8,6 +8,7 @@ import { useSDK } from "../../context/sdk"
 import { SplitBorder } from "../../ui/border"
 import { useTuiConfig } from "../../config"
 import { useBindings, useOpencodeModeStack } from "../../keymap"
+import { useDialog } from "../../ui/dialog"
 
 const QUESTION_MODE = "question"
 
@@ -17,6 +18,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
   const modeStack = useOpencodeModeStack()
+  const dialog = useDialog()
 
   const questions = createMemo(() => props.request.questions)
   const single = createMemo(() => questions().length === 1 && questions()[0]?.multiple !== true)
@@ -220,6 +222,7 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
           title: "Reject question",
           category: "Question",
           run() {
+            if (dialog.stack.length > 0) return
             reject()
           },
         },
@@ -250,7 +253,15 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
         ...(confirm()
           ? [
               { key: "return", desc: "Submit answer", group: "Question", cmd: () => submit() },
-              { key: "escape", desc: "Reject question", group: "Question", cmd: () => reject() },
+              {
+                key: "escape",
+                desc: "Reject question",
+                group: "Question",
+                cmd: () => {
+                  if (dialog.stack.length > 0) return
+                  reject()
+                },
+              },
               ...tuiConfig.keybinds.get("app.exit"),
             ]
           : [
@@ -278,7 +289,15 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
               { key: "down", desc: "Next answer", group: "Question", cmd: () => moveTo((store.selected + 1) % total) },
               { key: "j", desc: "Next answer", group: "Question", cmd: () => moveTo((store.selected + 1) % total) },
               { key: "return", desc: "Select answer", group: "Question", cmd: () => selectOption() },
-              { key: "escape", desc: "Reject question", group: "Question", cmd: () => reject() },
+              {
+                key: "escape",
+                desc: "Reject question",
+                group: "Question",
+                cmd: () => {
+                  if (dialog.stack.length > 0) return
+                  reject()
+                },
+              },
               ...tuiConfig.keybinds.get("app.exit"),
             ]),
       ],


### PR DESCRIPTION
Fixes #45304

When a dialog is open (e.g. model picker) and the agent asks a question in the background, pressing ESC closes the dialog AND rejects the question simultaneously. The question disappears and the agent's execution is interrupted.

**What changed**

Guard the ESC and `app.exit` handlers in `QuestionPrompt` to skip `reject()` when a dialog is currently open (`dialog.stack.length > 0`). This prevents the question from being rejected while a dialog is being dismissed. Once the dialog is closed, ESC works normally to reject the question.

**How to verify**

1. Open model picker (`<leader>m`)
2. Have agent ask a question in the background
3. Press ESC — dialog closes, question remains visible
4. Press ESC again — question is rejected (as expected when no dialog is open)