### PR TITLE
fix(sdk): identify workspace dependencies by version specifier

### DIFF
--- a/packages/sdk/script/verify-package.ts
+++ b/packages/sdk/script/verify-package.ts
@@ -38,9 +38,9 @@ try {
     const archive = join(temporary, `${name}.tgz`)
 
     if (pkg.dependencies) {
-      const unpacked = Object.keys(pkg.dependencies).filter(
-        (dependency) => dependency.startsWith("@opencode-ai/") && !archives.has(dependency),
-      )
+      const unpacked = Object.entries(pkg.dependencies)
+        .filter(([dependency, version]) => version.startsWith("workspace:") && !archives.has(dependency))
+        .map(([dependency]) => dependency)
       if (unpacked.length > 0)
         throw new Error(`${pkg.name} has unpacked workspace dependencies: ${unpacked.join(", ")}`)
       pkg.dependencies = Object.fromEntries(


### PR DESCRIPTION
## Why

The packed workerd SDK check fails with `@opencode-ai/core has unpacked workspace dependencies: @opencode-ai/pty`, including in [the CI run investigated during #45292](https://github.com/anomalyco/opencode/actions/runs/32983694544/job/98226339313). Since #45248, Core depends on the published `@opencode-ai/pty@0.1.9` package, but the verifier assumes every dependency in the `@opencode-ai` scope belongs to this workspace.

## What Changes

Identify dependencies that require a local archive by their `workspace:` version specifier instead of their package-name scope.

| Dependency | Verification behavior |
| --- | --- |
| Published `@opencode-ai/pty: 0.1.9` | Keep its registry version; do not require a workspace archive. |
| `@opencode-ai/schema: workspace:*`, already packed | Use its local archive, as before. |
| `@opencode-ai/schema: workspace:*`, not yet packed | Fail with the existing unpacked-workspace-dependency error. |

## Scope

Only changes dependency classification in the SDK package-verification script. No package-specific exception or runtime/API change; this is separate from the TUI selection fix in #45292.

## Verification

```sh
# Repository root, Bun 1.3.14 on macOS arm64
bun install --frozen-lockfile
bunx prettier --check packages/sdk/script/verify-package.ts
bunx oxlint packages/sdk/script/verify-package.ts
git diff --check

# packages/sdk
bun run verify:package
bun typecheck
bun run test
bun run ../core/script/test.ts --timeout 5000
```

- Reproduced the exact `@opencode-ai/pty` failure with the original verifier on `f4a9b93013`.
- The fixed verifier passes end to end: builds and packs all 11 packages, installs into a clean npm consumer, checks a single Effect runtime and all four SDK entrypoints, bundles with Wrangler, checks for Bun-only leaks, and boots the workerd health endpoint (`packed SDK consumer OK`).
- Negative control: temporarily moved `protocol` before `schema` in the packing order and reran the real verifier. It still rejected the missing archive with `@opencode-ai/protocol has unpacked workspace dependencies: @opencode-ai/schema`; restored the original order before the passing run.
- Typechecking, formatting, linting, and whitespace checks pass. No package manifest or generated-file changes remain.
- The unmodified pre-push hook also passed all 32 repository typecheck tasks.
- The direct SDK test command had four timeouts while loading local user MCP configuration. Running the same SDK tests through Core's existing isolated-home runner with the same five-second timeout passed: **24 pass, 0 fail**. No test/runtime changes were made for that environment issue.
- Used the actual package-verification command as regression coverage rather than extracting a single-use helper solely to unit-test this predicate.
