### PR TITLE
fix: apply_patch move to same path deletes the file

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -234,6 +234,13 @@ export const ApplyPatchTool = Tool.define(
 
           case "move":
             if (change.movePath) {
+              // Move to the same path degenerates to an update — otherwise write+remove would delete the file just written.
+              if (change.movePath === change.filePath) {
+                yield* afs.writeWithDirs(change.filePath, Bom.join(change.newContent, change.bom))
+                updates.push({ file: change.filePath, event: "change" })
+                break
+              }
+
               // Create parent directories (recursive: true is safe on existing/root dirs)
 
               yield* afs.writeWithDirs(change.movePath!, Bom.join(change.newContent, change.bom))

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -298,6 +298,21 @@ describe("tool.apply_patch freeform", () => {
     }),
   )
 
+  it.instance("treats move-to-same-path as an update", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx } = makeCtx()
+      const target = path.join(test.directory, "same.txt")
+      yield* writeText(target, "old content\n")
+
+      const patchText =
+        "*** Begin Patch\n*** Update File: same.txt\n*** Move to: same.txt\n@@\n-old content\n+new content\n*** End Patch"
+
+      yield* execute({ patchText }, ctx)
+      expect(yield* readText(target)).toBe("new content\n")
+    }),
+  )
+
   it.instance("adds file overwriting existing file", () =>
     Effect.gen(function* () {
       const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #45310

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When apply_patch receives a patch that updates a file and moves it to the same path, the case "move" branch executes write(movePath, newContent) then remove(filePath). Because both paths resolve to the same absolute path, the remove deletes the file just written — the file ends up missing instead of updated.

  The fix adds an early check at the top of the case "move" branch: when movePath === filePath, the move degenerates to an update (write + emit a single "change" event, then break). This skips the remove step that would undo the write.


### How did you verify your code works?
 - Added a regression test `treats move-to-same-path as an update` in `packages/opencode/test/tool/apply_patch.test.ts` covering the same-path move scenario.
  - Ran the full `apply_patch.test.ts` suite: 28 pass, 0 fail. No regressions in existing move / update / add / delete tests. 

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
