### PR TITLE
fix(core): allow non-letter tool name prefixes

### DIFF
--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -271,12 +271,12 @@ function schemaMakeError(error: unknown) {
 }
 
 const validateName = (name: string) =>
-  /^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(name)
+  /^[A-Za-z0-9_-]{1,64}$/.test(name)
     ? Effect.void
     : Effect.fail(new RegistrationError({ name, message: `Invalid tool name: ${name}` }))
 
 const validateNamespace = (namespace: string) =>
-  namespace.split(".").every((segment) => /^[A-Za-z][A-Za-z0-9_-]{0,63}$/.test(segment))
+  namespace.split(".").every((segment) => /^[A-Za-z0-9_-]{1,64}$/.test(segment))
     ? Effect.void
     : Effect.fail(
         new RegistrationError({

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -85,14 +85,77 @@ describe("Tool", () => {
   it.effect("rejects invalid and colliding normalized names", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
-      const invalid = yield* transform(service, { "123": make() }, { codemode: false }).pipe(Effect.flip)
-      expect(invalid.message).toBe("Invalid tool name: 123")
+      for (const name of ["", "x".repeat(65)]) {
+        const invalid = yield* transform(service, { [name]: make() }, { codemode: false }).pipe(Effect.flip)
+        expect(invalid.message).toBe(`Invalid tool name: ${name}`)
+      }
 
       const collision = yield* transform(service, { "echo.tool": make(), echo_tool: make() }, { codemode: false }).pipe(
         Effect.flip,
       )
       expect(collision.message).toBe("Duplicate normalized tool name: echo_tool")
       expect((yield* service.snapshot()).definitions.map((tool) => tool.name)).toEqual(["execute"])
+    }),
+  )
+
+  it.effect("executes native tools without requiring letter-leading names or namespace segments", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      yield* transform(
+        service,
+        { "2d_get_scene": make(), "123": make(), _lookup: make(), "-lookup": make() },
+        { codemode: false },
+      )
+      yield* transform(service, { "2d_get_scene": make() }, { namespace: "123._private.-tools", codemode: false })
+
+      const snapshot = yield* service.snapshot()
+      expect(snapshot.definitions.map((tool) => tool.name)).toEqual([
+        "-lookup",
+        "123",
+        "123__private_-tools_2d_get_scene",
+        "2d_get_scene",
+        "_lookup",
+        "execute",
+      ])
+      for (const name of ["2d_get_scene", "123", "_lookup", "-lookup", "123__private_-tools_2d_get_scene"]) {
+        expect((yield* snapshot.execute(call(name))).output).toEqual({ text: name })
+      }
+    }),
+  )
+
+  it.effect("executes Code Mode tools without requiring letter-leading names or namespace segments", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      yield* transform(service, { "2d_get_scene": make(), "123": make(), _lookup: make(), "-lookup": make() })
+      yield* transform(service, { "2d_get_scene": make() }, { namespace: "123._private.-tools", codemode: true })
+
+      const snapshot = yield* service.snapshot()
+      expect(snapshot.definitions.map((tool) => tool.name)).toEqual(["execute"])
+      expect(snapshot.codeModeCatalog?.map((tool) => tool.path)).toEqual([
+        "-lookup",
+        "123",
+        "123._private.-tools.2d_get_scene",
+        "2d_get_scene",
+        "_lookup",
+      ])
+      const result = yield* snapshot.execute({
+        ...call("execute"),
+        call: {
+          type: "tool-call",
+          id: "call-nonletter-names",
+          name: "execute",
+          input: {
+            code: `const results = await Promise.all([
+              tools["2d_get_scene"]({ text: "digit" }),
+              tools["123"]({ text: "numeric" }),
+              tools._lookup({ text: "underscore" }),
+              tools["-lookup"]({ text: "hyphen" }),
+              tools["123"]._private["-tools"]["2d_get_scene"]({ text: "namespaced" }),
+            ]); return results.map(result => result.text).join(",");`,
+          },
+        },
+      })
+      expect(result.content).toEqual([{ type: "text", text: "digit,numeric,underscore,hyphen,namespaced" }])
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Related to #45307: digit-leading MCP tool names are rejected during registration.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Remove the requirement that tool names and dotted namespace segments start with a letter, for both native tools and Code Mode. Digits, underscores, and hyphens are now allowed in the first position too.

Anthropic documents `^[a-zA-Z0-9_-]{1,64}$`, and OpenAI Chat Completions documents the same character set and 64-character maximum without a letter-first requirement:
- https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools#specifying-client-tools
- https://platform.openai.com/docs/api-reference/chat/create

Keep existing length limits, normalization, collision checks, and registration-error behavior unchanged. Unlike #45307, this does not split native and Code Mode validation or change which name is checked.

### How did you verify your code works?

- Confirmed the two new execution tests fail with the original regexes.
- `bun run test test/session-runner-tool-registry.test.ts test/codemode.test.ts test/mcp.test.ts` from `packages/core`: 56 passed.
- `bun typecheck` from `packages/core`: passed.
- Prettier check and `git diff --check`: passed.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR