### PR TITLE
fix(tui): guard server-synced store fields against null responses

### DIFF
--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -50,10 +50,10 @@ export function DialogStatus() {
           esc
         </text>
       </box>
-      <Show when={Object.keys(sync.data.mcp).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
+      <Show when={Object.keys(sync.data.mcp ?? {}).length > 0} fallback={<text fg={theme.text}>No MCP Servers</text>}>
         <box>
-          <text fg={theme.text}>{Object.keys(sync.data.mcp).length} MCP Servers</text>
-          <For each={Object.entries(sync.data.mcp)}>
+          <text fg={theme.text}>{Object.keys(sync.data.mcp ?? {}).length} MCP Servers</text>
+          <For each={Object.entries(sync.data.mcp ?? {})}>
             {([key, item]) => (
               <box flexDirection="row" gap={1}>
                 <text

--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -504,11 +504,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const mcp = {
       isEnabled(name: string) {
-        const status = sync.data.mcp[name]
+        const status = sync.data.mcp?.[name]
         return status?.status === "connected"
       },
       async toggle(name: string) {
-        const status = sync.data.mcp[name]
+        const status = sync.data.mcp?.[name]
         if (status?.status === "connected") {
           // Disable: disconnect the MCP
           await sdk.client.mcp.disconnect({ name })

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -477,12 +477,14 @@ export const {
         ...(args.continue ? [sessionListPromise] : []),
       ])
         .then(async () => {
-          const providersResponse = providersPromise.then((x) => x.data!)
-          const providerListResponse = providerListPromise.then((x) => x.data!)
+          const providersResponse = providersPromise.then((x) => x.data ?? { providers: [], default: {} })
+          const providerListResponse = providerListPromise.then(
+            (x) => x.data ?? { all: [], default: {}, connected: [] },
+          )
           const capabilitiesResponse = capabilitiesPromise
           const consoleStateResponse = consoleStatePromise
           const agentsResponse = agentsPromise.then((x) => x.data ?? [])
-          const configResponse = configPromise.then((x) => x.data!)
+          const configResponse = configPromise.then((x) => x.data ?? {})
           const sessionListResponse = args.continue ? sessionListPromise : undefined
 
           return Promise.all([
@@ -503,14 +505,14 @@ export const {
             const sessions = responses[6]
 
             batch(() => {
-              setStore("provider", reconcile(providers.providers))
-              setStore("provider_default", reconcile(providers.default))
-              setStore("provider_next", reconcile(providerList))
+              setStore("provider", reconcile(providers?.providers ?? []))
+              setStore("provider_default", reconcile(providers?.default ?? {}))
+              setStore("provider_next", reconcile(providerList ?? { all: [], default: {}, connected: [] }))
               setStore("capabilities", "experimentalBackgroundSubagents", capabilities?.backgroundSubagents === true)
-              setStore("console_state", reconcile(consoleState))
-              setStore("agent", reconcile(agents))
-              setStore("config", reconcile(config))
-              if (sessions !== undefined) setStore("session", reconcile(sessions))
+              setStore("console_state", reconcile(consoleState ?? emptyConsoleState))
+              setStore("agent", reconcile(agents ?? []))
+              setStore("config", reconcile(config ?? {}))
+              if (sessions !== undefined) setStore("session", reconcile(sessions ?? []))
             })
           })
         })
@@ -519,7 +521,7 @@ export const {
           // non-blocking
           void Promise.all([
             ...(args.continue ? [] : [sessionListPromise.then((sessions) => setStore("session", reconcile(sessions)))]),
-            consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState))),
+            consoleStatePromise.then((consoleState) => setStore("console_state", reconcile(consoleState ?? emptyConsoleState))),
             sdk.client.command.list({ workspace }).then((x) => setStore("command", reconcile(x.data ?? []))),
             sdk.client.lsp.status({ workspace }).then((x) => setStore("lsp", reconcile(x.data ?? []))),
             sdk.client.mcp.status({ workspace }).then((x) => setStore("mcp", reconcile(x.data ?? {}))),
@@ -531,7 +533,7 @@ export const {
               setStore("session_status", reconcile(x.data ?? {}))
             }),
             sdk.client.provider.auth({ workspace }).then((x) => setStore("provider_auth", reconcile(x.data ?? {}))),
-            sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data))),
+            sdk.client.vcs.get({ workspace }).then((x) => setStore("vcs", reconcile(x.data ?? undefined))),
             project.workspace.sync(),
           ]).then(() => {
             setStore("status", "complete")

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -151,7 +151,7 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
       return sync.data.lsp.map((item) => ({ id: item.id, root: item.root, status: item.status }))
     },
     mcp() {
-      return Object.entries(sync.data.mcp)
+      return Object.entries(sync.data.mcp ?? {})
         .sort(([a], [b]) => a.localeCompare(b))
         .map(([name, item]) => ({
           name,

--- a/packages/tui/src/routes/session/footer.tsx
+++ b/packages/tui/src/routes/session/footer.tsx
@@ -10,9 +10,9 @@ export function Footer() {
   const { theme } = useTheme()
   const sync = useSync()
   const route = useRoute()
-  const mcp = createMemo(() => Object.values(sync.data.mcp).filter((x) => x.status === "connected").length)
-  const mcpError = createMemo(() => Object.values(sync.data.mcp).some((x) => x.status === "failed"))
-  const lsp = createMemo(() => Object.keys(sync.data.lsp))
+  const mcp = createMemo(() => Object.values(sync.data.mcp ?? {}).filter((x) => x.status === "connected").length)
+  const mcpError = createMemo(() => Object.values(sync.data.mcp ?? {}).some((x) => x.status === "failed"))
+  const lsp = createMemo(() => Object.keys(sync.data.lsp ?? []))
   const permissions = createMemo(() => {
     if (route.data.type !== "session") return []
     return sync.data.permission[route.data.sessionID] ?? []

--- a/packages/tui/src/theme/index.ts
+++ b/packages/tui/src/theme/index.ts
@@ -264,7 +264,7 @@ export function resolveTheme(theme: ThemeJson, mode: "dark" | "light") {
   }
 
   const resolved = Object.fromEntries(
-    Object.entries(theme.theme)
+    Object.entries(theme.theme ?? {})
       .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu" && key !== "thinkingOpacity")
       .map(([key, value]) => {
         return [key, resolveColor(value as ColorValue)]


### PR DESCRIPTION
### Issue for this PR

Fixes a recurring TUI crash family:

```
TypeError: Object.entries requires that input parameter not be null or undefined
    at entries (unknown)
    at w (chunk-...js)
```

Previously reported as #21014, #20388, #5151 (v1 fixed the MCP slice via #22105 / #22206; this extends the same treatment to the remaining unguarded fields and consumers).

### Type of change

- [x] Bug fix

### What does this PR do?

During TUI bootstrap, several endpoints are read with non-null assertions (`x.data!`):

```ts
const providersResponse = providersPromise.then((x) => x.data!)
const providerListResponse = providerListPromise.then((x) => x.data!)
const configResponse = configPromise.then((x) => x.data!)
```

If any response arrives with null/undefined data (server busy, transient failure, version-mismatched background service restarting mid-bootstrap), that null is written straight into the Solid store. Every component then calling `Object.entries`/`Object.keys`/`Object.values` on it throws inside a reactive computation and kills the whole session with the "OpenCode crashed" screen.

**Root fix** (`context/sync.tsx`): replace all bootstrap `x.data!` assertions with fallback shapes (`?? { providers: [], default: {} }`, `?? []`, `?? {}`, ...) so object/array-typed store fields can never receive null.

**Defense-in-depth** at consumption sites, so even a transiently undefined store value during recomputation cannot crash:

| File | Change |
|------|--------|
| `plugin/adapters.tsx` | `Object.entries(sync.data.mcp)` → `?? {}` |
| `component/dialog-status.tsx` | 3 MCP sites → `?? {}` |
| `routes/session/footer.tsx` | mcp/lsp sites → `?? {}` / `?? []` |
| `context/local.tsx` | `sync.data.mcp[name]` → `sync.data.mcp?.[name]` |
| `theme/index.ts` | `Object.entries(theme.theme)` → `?? {}` |

### How did you verify your code works?

- `bun run typecheck` in `packages/tui` passes (tsgo, no errors)
- `oxlint packages/tui/src` reports 0 errors
- `bun test test/cli/cmd/tui/sync.test.tsx` passes
- Repo pre-push hooks (turbo, 30 tasks) passed on push

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR