### PR TITLE
fix(ai): accept empty Responses stream IDs and null items

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -346,7 +346,8 @@ export const Event = Schema.StructWithRest(
     item_id: Schema.optional(Schema.String),
     output_index: Schema.optional(Schema.Number),
     summary_index: Schema.optional(Schema.Number),
-    item: Schema.optional(StreamItem),
+    // OutputItemAdded/Done permit a null item in the Open Responses OpenAPI schema.
+    item: optionalNull(StreamItem),
     response: Schema.optional(
       Schema.StructWithRest(
         Schema.Struct({
@@ -812,7 +813,7 @@ export const providerMetadata = (state: ParserState, metadata: Record<string, un
 })
 
 const isReasoningItem = (item: StreamItem): item is StreamItem & { type: "reasoning"; id: string } =>
-  item.type === "reasoning" && typeof item.id === "string" && item.id.length > 0
+  item.type === "reasoning" && typeof item.id === "string"
 
 export type StepResult = readonly [ParserState, ReadonlyArray<LLMEvent>]
 
@@ -891,7 +892,7 @@ const reasoningMetadata = (state: ParserState, item: StreamItem & { id: string }
 // best-effort, not guaranteed.
 const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
   const item = event.item
-  if (item?.type === "message" && item.id) {
+  if (item?.type === "message" && item.id !== undefined) {
     const phase = messagePhase(item.phase)
     return [
       {
@@ -922,7 +923,7 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
   }
   if (item?.type !== "function_call" || !item.call_id) return [state, NO_EVENTS]
   const id = item.id ?? item.call_id
-  const metadata = item.id ? providerMetadata(state, { itemId: item.id }) : undefined
+  const metadata = item.id !== undefined ? providerMetadata(state, { itemId: item.id }) : undefined
   const events: LLMEvent[] = []
   const lifecycle = Lifecycle.stepStart(state.lifecycle, events)
   return [
@@ -941,7 +942,7 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
 }
 
 const onReasoningSummaryPartAdded = (state: ParserState, event: Event): StepResult => {
-  if (!event.item_id || event.summary_index === undefined) return [state, NO_EVENTS]
+  if (event.item_id === undefined || event.summary_index === undefined) return [state, NO_EVENTS]
   const item = state.reasoningItems[event.item_id]
   if (!item) return [state, NO_EVENTS]
   if (event.summary_index === 0) return [state, NO_EVENTS]
@@ -988,7 +989,7 @@ const onReasoningSummaryPartAdded = (state: ParserState, event: Event): StepResu
 }
 
 const onReasoningSummaryPartDone = (state: ParserState, event: Event): StepResult => {
-  if (!event.item_id || event.summary_index === undefined) return [state, NO_EVENTS]
+  if (event.item_id === undefined || event.summary_index === undefined) return [state, NO_EVENTS]
   const item = state.reasoningItems[event.item_id]
   if (!item) return [state, NO_EVENTS]
   return [
@@ -1013,7 +1014,7 @@ const onFunctionCallArgumentsDelta = Effect.fn("OpenResponses.onFunctionCallArgu
   state: ParserState,
   event: Event,
 ) {
-  if (!event.item_id) return [state, NO_EVENTS] satisfies StepResult
+  if (event.item_id === undefined) return [state, NO_EVENTS] satisfies StepResult
   const tool = state.tools[event.item_id]
   if (!tool) return [state, NO_EVENTS] satisfies StepResult
   const final = event.type === "response.function_call_arguments.done" ? event.arguments : undefined
@@ -1044,7 +1045,7 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   const item = event.item
   if (!item) return [state, NO_EVENTS] satisfies StepResult
 
-  if (item.type === "message" && item.id) {
+  if (item.type === "message" && item.id !== undefined) {
     const itemPhase = messagePhase(item.phase)
     const phase = itemPhase === undefined ? state.messagePhases[item.id] : itemPhase
     const events: LLMEvent[] = []
@@ -1075,7 +1076,7 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
       : ToolStream.start(state.tools, id, {
           id: item.call_id,
           name: item.name,
-          providerMetadata: item.id ? providerMetadata(state, { itemId: item.id }) : undefined,
+          providerMetadata: item.id !== undefined ? providerMetadata(state, { itemId: item.id }) : undefined,
         })
     const result =
       item.arguments === undefined
@@ -1136,7 +1137,7 @@ const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (
           ([current, events], item) => {
             const id = item.id ?? (item.type === "function_call" ? item.call_id : undefined)
             if (
-              !id ||
+              id === undefined ||
               ((item.type !== "function_call" || !current.tools[id]) &&
                 (item.type !== "reasoning" || !current.reasoningItems[id]))
             )
@@ -1219,12 +1220,13 @@ export const providerFailure = (id: string, event: Event, fallback: string) => {
 const providerError = (state: ParserState, event: Event, fallback: string) => providerFailure(state.id, event, fallback)
 
 export const step = (state: ParserState, input: Event) => {
+  // The OpenAPI requires string IDs but imposes no minLength; empty is not missing.
   const event =
-    input.item_id && outputItemID(state, input) !== input.item_id
+    input.item_id !== undefined && outputItemID(state, input) !== input.item_id
       ? { ...input, item_id: outputItemID(state, input) }
       : input
   if (event.type === "response.output_text.delta" || event.type === "response.output_text.done") {
-    if (!event.item_id) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
+    if (event.item_id === undefined) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
     return Effect.succeed(
       event.type === "response.output_text.delta"
         ? onOutputTextDelta(state, event, event.item_id)
@@ -1233,7 +1235,7 @@ export const step = (state: ParserState, input: Event) => {
   }
   if (event.type === "response.refusal.delta" || event.type === "response.refusal.done") {
     const value = event.type === "response.refusal.delta" ? event.delta : event.refusal
-    if (!event.item_id || typeof value !== "string")
+    if (event.item_id === undefined || typeof value !== "string")
       return ProviderShared.eventError(state.id, `${event.type} is malformed`)
     return Effect.succeed(
       event.type === "response.refusal.delta"
@@ -1242,7 +1244,7 @@ export const step = (state: ParserState, input: Event) => {
     )
   }
   if (event.type === "response.reasoning.delta" || event.type === "response.reasoning_summary_text.delta") {
-    if (!event.item_id) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
+    if (event.item_id === undefined) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
     return Effect.succeed(onReasoningDelta(state, event, event.item_id))
   }
   if (
@@ -1250,24 +1252,24 @@ export const step = (state: ParserState, input: Event) => {
     event.type === "response.reasoning_summary_text.done" ||
     event.type === "response.reasoning_text.done"
   ) {
-    if (!event.item_id) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
+    if (event.item_id === undefined) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
     return Effect.succeed(onReasoningDone(state, event, event.item_id))
   }
   if (event.type === "response.reasoning_summary_part.added")
-    return event.item_id
+    return event.item_id !== undefined
       ? Effect.succeed(onReasoningSummaryPartAdded(state, event))
       : ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
   if (event.type === "response.reasoning_summary_part.done")
-    return event.item_id
+    return event.item_id !== undefined
       ? Effect.succeed(onReasoningSummaryPartDone(state, event))
       : ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
   if (event.type === "response.output_item.added") {
-    if (event.item?.type === "message" && !event.item.id)
+    if (event.item?.type === "message" && event.item.id === undefined)
       return ProviderShared.eventError(state.id, `${event.type} message is missing id`)
     const id = event.item?.id ?? (event.item?.type === "function_call" ? event.item.call_id : undefined)
     return Effect.succeed(
       onOutputItemAdded(
-        event.output_index !== undefined && id
+        event.output_index !== undefined && id !== undefined
           ? { ...state, outputItems: { ...state.outputItems, [event.output_index]: id } }
           : state,
         event,
@@ -1275,11 +1277,11 @@ export const step = (state: ParserState, input: Event) => {
     )
   }
   if (event.type === "response.function_call_arguments.delta" || event.type === "response.function_call_arguments.done")
-    return event.item_id
+    return event.item_id !== undefined
       ? onFunctionCallArgumentsDelta(state, event)
       : ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
   if (event.type === "response.output_item.done") {
-    if (event.item?.type === "message" && !event.item.id)
+    if (event.item?.type === "message" && event.item.id === undefined)
       return ProviderShared.eventError(state.id, `${event.type} message is missing id`)
     return onOutputItemDone(state, event)
   }

--- a/packages/ai/src/protocols/openai-responses.ts
+++ b/packages/ai/src/protocols/openai-responses.ts
@@ -184,7 +184,7 @@ const HOSTED_TOOLS = {
 
 const step = (state: OpenResponses.ParserState, event: OpenResponses.Event) => {
   if (event.type === "response.reasoning_text.delta")
-    return event.item_id
+    return event.item_id !== undefined
       ? Effect.succeed(
           OpenResponses.onReasoningDelta(state, event, OpenResponses.outputItemID(state, event) ?? event.item_id),
         )

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -307,6 +307,287 @@ describe("Open Responses-compatible route", () => {
     }),
   )
 
+  describe("stream validation", () => {
+    const request = LLM.request({
+      model: configure({ apiKey: "test-key", baseURL: "https://responses.example.test/v1" }).model("example-model"),
+      prompt: "Respond.",
+    })
+
+    const fixtures = [
+      {
+        item: { type: "message" },
+        events: [
+          { type: "response.output_text.delta", delta: "Preserved" },
+          { type: "response.output_text.done", text: "Preserved" },
+          { type: "response.refusal.delta", delta: "Preserved" },
+          { type: "response.refusal.done", refusal: "Preserved" },
+        ],
+      },
+      {
+        item: { type: "reasoning", encrypted_content: "encrypted-state" },
+        events: [
+          { type: "response.reasoning.delta", delta: "Preserved" },
+          { type: "response.reasoning.done", text: "Preserved" },
+          { type: "response.reasoning_summary_text.delta", delta: "Preserved" },
+          { type: "response.reasoning_summary_text.done", text: "Preserved" },
+          { type: "response.reasoning_text.done", text: "Preserved" },
+        ],
+      },
+      {
+        item: { type: "function_call", call_id: "call_1", name: "lookup" },
+        events: [
+          { type: "response.function_call_arguments.delta", delta: '{"query":"Preserved"}' },
+          { type: "response.function_call_arguments.done", arguments: '{"query":"Preserved"}' },
+        ],
+      },
+    ]
+
+    const routings = [
+      { name: "empty item and event IDs", id: "", item_id: "" },
+      { name: "empty event ID with registered index", id: "item_1", item_id: "", output_index: 2 },
+      { name: "empty stored ID with registered index", id: "", item_id: "wrong_item", output_index: 2 },
+      { name: "empty item and event IDs with registered index", id: "", item_id: "", output_index: 2 },
+    ]
+
+    fixtures.forEach((fixture) => {
+      fixture.events.forEach((event) => {
+        routings.forEach((routing) => {
+          it.effect(`${event.type} preserves content with ${routing.name}`, () =>
+            Effect.gen(function* () {
+              const item = { ...fixture.item, id: routing.id }
+              const response = yield* LLMClient.generate(request).pipe(
+                Effect.provide(
+                  fixedResponse(
+                    sseEvents(
+                      { type: "response.output_item.added", output_index: routing.output_index, item },
+                      { ...event, item_id: routing.item_id, output_index: routing.output_index },
+                      { type: "response.output_item.done", output_index: routing.output_index, item },
+                      { type: "response.completed", response: { id: "resp_1" } },
+                    ),
+                  ),
+                ),
+              )
+
+              const metadata = { openresponses: { itemId: routing.id } }
+              if (fixture.item.type === "function_call") {
+                expect(response.toolCalls).toEqual([
+                  expect.objectContaining({
+                    id: "call_1",
+                    name: "lookup",
+                    input: { query: "Preserved" },
+                    providerMetadata: metadata,
+                  }),
+                ])
+                return
+              }
+              if (fixture.item.type === "reasoning") {
+                expect(response.message.content).toEqual([
+                  {
+                    type: "reasoning",
+                    text: "Preserved",
+                    providerMetadata: {
+                      openresponses: { itemId: routing.id, reasoningEncryptedContent: "encrypted-state" },
+                    },
+                  },
+                ])
+                expect(response.events.filter(LLMEvent.is.reasoningEnd)).toHaveLength(1)
+                return
+              }
+              expect(response.message.content).toEqual([
+                { type: "text", text: "Preserved", providerMetadata: metadata },
+              ])
+              expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
+                expect.objectContaining({ id: routing.id, providerMetadata: metadata }),
+              ])
+            }),
+          )
+        })
+      })
+    })
+
+    routings.forEach((routing) => {
+      it.effect(`preserves reasoning summary boundaries and terminal metadata with ${routing.name}`, () =>
+        Effect.gen(function* () {
+          const address = { item_id: routing.item_id, output_index: routing.output_index }
+          const response = yield* LLMClient.generate(request).pipe(
+            Effect.provide(
+              fixedResponse(
+                sseEvents(
+                  {
+                    type: "response.output_item.added",
+                    output_index: routing.output_index,
+                    item: { type: "reasoning", id: routing.id },
+                  },
+                  { type: "response.reasoning_summary_part.added", ...address, summary_index: 0 },
+                  { type: "response.reasoning_summary_text.delta", ...address, summary_index: 0, delta: "First." },
+                  { type: "response.reasoning_summary_text.done", ...address, summary_index: 0, text: "First." },
+                  { type: "response.reasoning_summary_part.done", ...address, summary_index: 0 },
+                  { type: "response.reasoning_summary_part.added", ...address, summary_index: 1 },
+                  { type: "response.reasoning_summary_text.done", ...address, summary_index: 1, text: "Second." },
+                  { type: "response.reasoning_summary_part.done", ...address, summary_index: 1 },
+                  {
+                    type: "response.completed",
+                    response: { output: [{ type: "reasoning", id: routing.id, encrypted_content: "final-state" }] },
+                  },
+                ),
+              ),
+            ),
+          )
+
+          expect(response.message.content).toEqual([
+            {
+              type: "reasoning",
+              text: "First.",
+              providerMetadata: { openresponses: { itemId: routing.id } },
+            },
+            {
+              type: "reasoning",
+              text: "Second.",
+              providerMetadata: { openresponses: { itemId: routing.id, reasoningEncryptedContent: "final-state" } },
+            },
+          ])
+          expect(response.events.filter(LLMEvent.is.reasoningEnd)).toEqual([
+            expect.objectContaining({
+              id: `${routing.id}:0`,
+              providerMetadata: { openresponses: { itemId: routing.id } },
+            }),
+            expect.objectContaining({
+              id: `${routing.id}:1`,
+              providerMetadata: { openresponses: { itemId: routing.id, reasoningEncryptedContent: "final-state" } },
+            }),
+          ])
+        }),
+      )
+    })
+
+    it.effect("reconciles pending empty-ID function arguments from completed output", () =>
+      Effect.gen(function* () {
+        const item = { type: "function_call", id: "", call_id: "call_1", name: "lookup" }
+        const response = yield* LLMClient.generate(request).pipe(
+          Effect.provide(
+            fixedResponse(
+              sseEvents(
+                { type: "response.output_item.added", item },
+                { type: "response.function_call_arguments.delta", item_id: "", delta: '{"query":"partial' },
+                {
+                  type: "response.completed",
+                  response: { output: [{ ...item, arguments: '{"query":"complete"}' }] },
+                },
+              ),
+            ),
+          ),
+        )
+
+        expect(response.toolCalls).toEqual([
+          expect.objectContaining({
+            id: "call_1",
+            name: "lookup",
+            input: { query: "complete" },
+            providerMetadata: { openresponses: { itemId: "" } },
+          }),
+        ])
+      }),
+    )
+
+    it.effect("treats null output items as no-ops without disturbing registered items", () =>
+      Effect.gen(function* () {
+        const response = yield* LLMClient.generate(request).pipe(
+          Effect.provide(
+            fixedResponse(
+              sseEvents(
+                { type: "response.output_item.added", output_index: 0, item: null },
+                { type: "response.output_item.done", output_index: 0, item: null },
+                { type: "response.output_item.added", output_index: 0, item: { type: "message", id: "msg_1" } },
+                { type: "response.output_text.delta", output_index: 0, item_id: "wrong_item", delta: "Before " },
+                { type: "response.output_item.added", output_index: 0, item: null },
+                { type: "response.output_item.done", output_index: 0, item: null },
+                { type: "response.output_text.delta", output_index: 0, item_id: "wrong_item", delta: "after" },
+                { type: "response.output_item.done", output_index: 0, item: { type: "message", id: "msg_1" } },
+                { type: "response.completed", response: { id: "resp_1" } },
+              ),
+            ),
+          ),
+        )
+
+        expect(response.message.content).toEqual([
+          { type: "text", text: "Before after", providerMetadata: { openresponses: { itemId: "msg_1" } } },
+        ])
+        expect(response.events.map((event) => event.type)).toEqual([
+          "step-start",
+          "text-start",
+          "text-delta",
+          "text-delta",
+          "text-end",
+          "step-finish",
+          "finish",
+        ])
+      }),
+    )
+
+    it.effect("rejects missing, null, and non-string event IDs even with a registered output index", () =>
+      Effect.gen(function* () {
+        yield* Effect.forEach(
+          [
+            ...fixtures.flatMap((fixture) => fixture.events.map((event) => ({ item: fixture.item, event }))),
+            ...["response.reasoning_summary_part.added", "response.reasoning_summary_part.done"].map((type) => ({
+              item: { type: "reasoning" },
+              event: { type, summary_index: 0 },
+            })),
+          ],
+          (fixture) =>
+            Effect.forEach([undefined, null, 0, false, {}, []], (item_id) =>
+              Effect.gen(function* () {
+                const error = yield* LLMClient.generate(request).pipe(
+                  Effect.provide(
+                    fixedResponse(
+                      sseEvents(
+                        {
+                          type: "response.output_item.added",
+                          output_index: 0,
+                          item: { ...fixture.item, id: "item_1" },
+                        },
+                        { ...fixture.event, output_index: 0, item_id },
+                        { type: "response.completed", response: { id: "resp_1" } },
+                      ),
+                    ),
+                  ),
+                  Effect.flip,
+                )
+                expect(error.reason._tag).toBe("InvalidProviderOutput")
+              }),
+            ),
+        )
+      }),
+    )
+
+    it.effect("keeps malformed output item IDs invalid", () =>
+      Effect.gen(function* () {
+        yield* Effect.forEach(["response.output_item.added", "response.output_item.done"], (type) =>
+          Effect.forEach(fixtures, (fixture) =>
+            Effect.forEach(
+              fixture.item.type === "message" ? [undefined, null, 0, false, {}, []] : [null, 0, false, {}, []],
+              (id) =>
+                Effect.gen(function* () {
+                  const error = yield* LLMClient.generate(request).pipe(
+                    Effect.provide(
+                      fixedResponse(
+                        sseEvents(
+                          { type, item: { ...fixture.item, id } },
+                          { type: "response.completed", response: { id: "resp_1" } },
+                        ),
+                      ),
+                    ),
+                    Effect.flip,
+                  )
+                  expect(error.reason._tag).toBe("InvalidProviderOutput")
+                }),
+            ),
+          ),
+        )
+      }),
+    )
+  })
+
   it.effect("streams function calls without optional item ids through the shared baseline", () =>
     Effect.gen(function* () {
       const model = configure({

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -2229,6 +2229,35 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
+  it.effect("accepts empty IDs for native reasoning text deltas", () =>
+    Effect.gen(function* () {
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { type: "response.output_item.added", output_index: 1, item: { type: "reasoning", id: "" } },
+              { type: "response.reasoning_text.delta", output_index: 1, item_id: "", delta: "Raw" },
+              {
+                type: "response.output_item.done",
+                output_index: 1,
+                item: { type: "reasoning", id: "", encrypted_content: "state" },
+              },
+              { type: "response.completed", response: { id: "resp_1" } },
+            ),
+          ),
+        ),
+      )
+
+      expect(response.message.content).toEqual([
+        {
+          type: "reasoning",
+          text: "Raw",
+          providerMetadata: { openai: { itemId: "", reasoningEncryptedContent: "state" } },
+        },
+      ])
+    }),
+  )
+
   it.effect("falls back to item ids when an output index was not registered", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(request).pipe(


### PR DESCRIPTION
## Summary

Align three incoming Responses stream validation cases with the published [Open Responses OpenAPI document](https://www.openresponses.org/openapi/openapi.json), version `2026-04-24`.

| Incoming value | Before | After |
| --- | --- | --- |
| Message or reasoning item with `id: ""` | Message errors; reasoning is skipped | Process supported content and metadata through the existing item lifecycle |
| Supported text, refusal, reasoning, or function-argument event with `item_id: ""` | Stream errors | Route and process the event, retaining registered `output_index` precedence |
| `response.output_item.added` / `.done` with `item: null` | Schema-decoding error | Accept as a no-op |

Replace truthiness checks with presence checks through item registration, event routing, summary lifecycle handling, and pending terminal reconciliation. Preserve empty function item IDs in incoming metadata as well, without changing the required `call_id`. Apply the same event-ID presence check to the OpenAI raw-reasoning extension.

## Specification References

The following paths are JSON Pointers into the [OpenAPI document](https://www.openresponses.org/openapi/openapi.json):

- `/components/schemas/Message/properties/id` and `/components/schemas/ReasoningBody/properties/id` are `type: "string"` with no `minLength`. These IDs are required, but an empty string is not an absent field.
- `/components/schemas/ResponseOutputTextDeltaStreamingEvent/properties/item_id` and `/components/schemas/ResponseFunctionCallArgumentsDeltaStreamingEvent/properties/item_id` are also strings without `minLength`. The corresponding done events, refusal events, reasoning delta/done events, reasoning-summary text events, and reasoning-summary part events use the same constraint. Their `required` arrays include `item_id` alongside `output_index`.
- `/components/schemas/ResponseOutputItemAddedStreamingEvent/properties/item` and `/components/schemas/ResponseOutputItemDoneStreamingEvent/properties/item` explicitly include `{ "type": "null" }` in `anyOf`.

This follows literal OpenAPI schema acceptance. It does not recommend empty IDs: the [specification's required item fields](https://www.openresponses.org/specification#extending-items) still describe IDs as unique, opaque identifiers that allow unambiguous references.

## Scope

- Keep outgoing `prefix_suffix` filtering unchanged; this PR does not change replay policy.
- Do not generate IDs or make additional incoming ID fields optional or nullable.
- Keep missing message IDs and missing event `item_id` fields rejected, even when an `output_index` is supplied. Keep the existing optional function item-ID fallback.
- Do not change hosted-tool ID validation or function `call_id` validation.
- No live requests or recording updates.

## Verification

- `bun typecheck` from `packages/ai`.
- 253 tests passed across the three Responses provider suites, route/response/tool-stream/schema suites, and recorded Responses WebSocket/cache/image suites.
- Four recorded OpenAI Responses scenarios replayed successfully; no live calls or cassette changes.
- Prettier and `git diff --check` passed.
- Oxlint: no errors; one existing unused-variable warning in an unrelated image-history test.

New regressions exercise empty IDs with and without output indexes, both directions of conflicting index/ID routing, summary boundaries, terminal encrypted-reasoning and function-argument reconciliation, the OpenAI raw-reasoning extension, null-item no-ops, and unchanged rejection of missing/null/non-string IDs.
