### PR TITLE
fix: always include background parameter in task tool schema

### DIFF
--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -363,7 +363,7 @@ export const TaskTool = Tool.define(
         ? [DESCRIPTION, BACKGROUND_DESCRIPTION].join("\n\n")
         : DESCRIPTION,
       parameters: Parameters,
-      jsonSchema: flags.experimentalBackgroundSubagents ? undefined : ToolJsonSchema.fromSchema(BaseParameters),
+      jsonSchema: ToolJsonSchema.fromSchema(Parameters),
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         run(params, ctx).pipe(Effect.orDie),
     }


### PR DESCRIPTION
### Issue for this PR

Closes #45345

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`, the `background` parameter on the task tool is set to `undefined` in the schema, making it invisible to agents. They can't discover it and never use background execution.

The fix changes line 366 in `packages/opencode/src/tool/task.ts` from:

```typescript
jsonSchema: flags.experimentalBackgroundSubagents
  ? undefined
  : ToolJsonSchema.fromSchema(BaseParameters),
```

to:

```typescript
jsonSchema: ToolJsonSchema.fromSchema(Parameters),
```

This always includes the full parameter schema (which contains `background`) regardless of the flag. The flag still controls the description hint and execute function behavior, so the feature gating remains intact.

### How did you verify your code works?

- Built the binary with `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true`
- Confirmed the `background` parameter appears in the tool schema (inspected via compiled output)
- Verified background subagents spawn and return immediately instead of blocking

### Screenshots / recordings

N/A - CLI tool, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
