### PR TITLE
fix(app): prevent stale service worker startup failures

### DIFF
--- a/packages/app/e2e/service-worker/cache.spec.ts
+++ b/packages/app/e2e/service-worker/cache.spec.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "@playwright/test"
+import { readFile } from "node:fs/promises"
+import { createServer } from "node:http"
+import { once } from "node:events"
+
+const legacy = `
+self.addEventListener("install", event => event.waitUntil(
+  caches.open("workbox-precache-v2-" + self.registration.scope).then(cache =>
+    cache.addAll(["/index.html", "/assets/app-old.js", "/assets/lazy-old.js"])
+  )
+))
+self.addEventListener("fetch", event => {
+  if (event.request.mode === "navigate") {
+    event.respondWith(caches.match("/index.html"))
+    return
+  }
+  event.respondWith(caches.match(event.request).then(response => response || fetch(event.request)))
+})
+`
+
+const fixture = test.extend<{ site: { url: string; upgrade: () => void; repair: () => void } }>({
+  site: async ({}, use) => {
+    const worker = await readFile(new URL("../../dist/sw.js", import.meta.url), "utf8")
+    const state = { version: "old", repaired: false }
+    const server = createServer((request, response) => {
+      const pathname = new URL(request.url ?? "/", "http://localhost").pathname
+      const prefix = state.version === "old" ? "/assets" : "/_assets"
+      response.setHeader("cache-control", "no-store")
+      if (pathname === "/sw.js") {
+        response.setHeader("content-type", "text/javascript")
+        response.end(state.version === "old" ? legacy : worker)
+        return
+      }
+      if (pathname === `${prefix}/app-${state.version}.js`) {
+        response.setHeader("content-type", "text/javascript")
+        response.end(`import "${prefix}/startup-${state.version}.js"`)
+        return
+      }
+      if (pathname === `${prefix}/startup-${state.version}.js`) {
+        response.setHeader("content-type", "text/javascript")
+        response.end(`
+          document.getElementById("root").innerHTML = '<h1>${state.version}</h1><label>Draft<input></label><button>Load older chunk</button><output></output>'
+          document.querySelector("button").onclick = () => import("/assets/lazy-old.js")
+        `)
+        return
+      }
+      if (
+        (pathname === "/assets/lazy-old.js" && state.version === "old") ||
+        (pathname === "/_assets/retry.js" && state.repaired)
+      ) {
+        response.setHeader("content-type", "text/javascript")
+        response.end('document.querySelector("output").textContent = "Older chunk loaded"')
+        return
+      }
+      // Deliberately retain the old server's fallback so the worker must reject HTML asset responses itself.
+      response.setHeader("content-type", "text/html")
+      response.end(`<div id="root"></div><script type="module" src="${prefix}/app-${state.version}.js"></script>`)
+    })
+    server.listen(0, "127.0.0.1")
+    await once(server, "listening")
+    const address = server.address()
+    if (!address || typeof address === "string") throw new Error("Expected a TCP address")
+    try {
+      await use({
+        url: `http://127.0.0.1:${address.port}`,
+        upgrade: () => (state.version = "new"),
+        repair: () => (state.repaired = true),
+      })
+    } finally {
+      server.closeAllConnections()
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
+  },
+})
+
+fixture("updates a legacy worker without reloading drafts or deleting old chunks", async ({ page, site }) => {
+  await page.goto(site.url)
+  await expect(page.getByRole("heading")).toHaveText("old")
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.register("/sw.js")
+    await navigator.serviceWorker.ready
+  })
+  await page.goto(site.url)
+  await expect(page.getByRole("heading")).toHaveText("old")
+  await page.getByLabel("Draft").fill("Keep this unsent prompt")
+
+  site.upgrade()
+  await page.evaluate(async () => {
+    const cache = await caches.open("opencode-assets")
+    await cache.put(
+      "/_assets/startup-new.js",
+      new Response("<html>stale fallback</html>", {
+        headers: { "content-type": "text/html" },
+      }),
+    )
+    const changed = new Promise<void>((resolve) =>
+      navigator.serviceWorker.addEventListener("controllerchange", () => resolve(), { once: true }),
+    )
+    const registration = await navigator.serviceWorker.getRegistration()
+    if (!registration) throw new Error("Missing legacy worker")
+    await registration.update()
+    await changed
+  })
+
+  await expect(page.getByLabel("Draft")).toHaveValue("Keep this unsent prompt")
+  await page.getByRole("button", { name: "Load older chunk" }).click()
+  await expect(page.getByRole("status")).toHaveText("Older chunk loaded")
+
+  await page.goto(`${site.url}/workspace/example`)
+  await expect(page.getByRole("heading")).toHaveText("new")
+  await expect
+    .poll(() =>
+      page.evaluate(async () =>
+        (await (await caches.open("opencode-assets")).match("/_assets/startup-new.js"))?.headers.get("content-type"),
+      ),
+    )
+    .toBe("text/javascript")
+})
+
+fixture("does not cache HTML responses under asset URLs", async ({ page, site }) => {
+  site.upgrade()
+  await page.goto(site.url)
+  await expect(page.getByRole("heading")).toHaveText("new")
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.register("/sw.js")
+    await navigator.serviceWorker.ready
+  })
+  await page.goto(site.url)
+  await expect(page.getByRole("heading")).toHaveText("new")
+  expect(await page.evaluate(async () => (await fetch("/_assets/retry.js")).headers.get("content-type"))).toBe(
+    "text/html",
+  )
+  site.repair()
+  expect(await page.evaluate(async () => (await fetch("/_assets/retry.js")).headers.get("content-type"))).toBe(
+    "text/javascript",
+  )
+})

--- a/packages/app/e2e/service-worker/playwright.config.ts
+++ b/packages/app/e2e/service-worker/playwright.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "*.spec.ts",
+  outputDir: "../test-results/service-worker",
+  timeout: 30_000,
+  use: { browserName: "chromium" },
+})

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -28,6 +28,7 @@
     "test:e2e:local": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report e2e/playwright-report",
+    "test:service-worker": "bun run build && playwright test --config e2e/service-worker/playwright.config.ts",
     "test:stability": "bun test ./e2e/performance/unit/visual-stability.test.ts && playwright test --config e2e/performance/timeline-stability/playwright.config.ts",
     "test:bench": "bun test ./e2e/performance/unit && playwright test --config e2e/performance/playwright.config.ts",
     "test:bench:devex": "bun test ./e2e/performance/unit/desktop-startup.test.ts && playwright test --config e2e/performance/devex/playwright.config.ts"

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -9,7 +9,10 @@ const reuse = !process.env.CI
 const workers = Number(process.env.PLAYWRIGHT_WORKERS ?? (process.env.CI ? 5 : 0)) || undefined
 export default defineConfig({
   testDir: "./e2e",
-  testIgnore: process.env.OPENCODE_PERFORMANCE === "1" ? "performance/**/*.test.ts" : "performance/**",
+  testIgnore: [
+    "service-worker/**",
+    process.env.OPENCODE_PERFORMANCE === "1" ? "performance/**/*.test.ts" : "performance/**",
+  ],
   outputDir: "./e2e/test-results",
   timeout: 60_000,
   expect: {

--- a/packages/app/public/_headers
+++ b/packages/app/public/_headers
@@ -1,10 +1,10 @@
-/assets/*.js
+/_assets/*.js
   Content-Type: application/javascript
 
-/assets/*.mjs
+/_assets/*.mjs
   Content-Type: application/javascript
 
-/assets/*.css
+/_assets/*.css
   Content-Type: text/css
 
 /*.js

--- a/packages/app/vite.config.ts
+++ b/packages/app/vite.config.ts
@@ -29,33 +29,44 @@ export default defineConfig({
       injectRegister: false,
       manifest: false,
       workbox: {
-        cleanupOutdatedCaches: true,
         clientsClaim: false,
-        skipWaiting: false,
+        skipWaiting: true,
         inlineWorkboxRuntime: true,
-        navigateFallback: "/index.html",
-        navigateFallbackDenylist: [/^\/api(?:\/|$)/],
-        globPatterns: [
-          "index.html",
-          "site.webmanifest",
-          "favicon*",
-          "apple-touch-icon*",
-          "web-app-manifest*",
-          "assets/index-*.{js,css}",
-          "assets/session-*.js",
-          "assets/IBMPlexMono-Text-*.woff2",
-          "assets/Inter.ttf",
-          "assets/JetBrainsMonoNerdFontMono-Regular.woff2",
-        ],
+        // Always fetch the current HTML. Precaching a partial build can strand it without its chunks after an upgrade.
+        navigateFallback: null,
+        globPatterns: [],
         runtimeCaching: [
           {
-            urlPattern: ({ url }) => url.origin === self.location.origin && url.pathname.startsWith("/assets/"),
+            urlPattern: ({ url }) =>
+              url.origin === self.location.origin &&
+              (url.pathname.startsWith("/_assets/") || url.pathname.startsWith("/assets/")),
             handler: "CacheFirst",
             options: {
               cacheName: "opencode-assets",
-              cacheableResponse: {
-                statuses: [200],
-              },
+              plugins: [
+                {
+                  cachedResponseWillBeUsed: async ({ request, cachedResponse }) => {
+                    if (
+                      cachedResponse?.status === 200 &&
+                      !/^(text\/html|application\/xhtml\+xml)\b/i.test(cachedResponse.headers.get("content-type") ?? "")
+                    )
+                      return cachedResponse
+                    // Keep old tabs' precached chunks usable without retaining their stale HTML navigation handler.
+                    const response = await caches.match(request, {
+                      cacheName: `workbox-precache-v2-${self.location.origin}/`,
+                    })
+                    return response?.status === 200 &&
+                      !/^(text\/html|application\/xhtml\+xml)\b/i.test(response.headers.get("content-type") ?? "")
+                      ? response
+                      : null
+                  },
+                  cacheWillUpdate: async ({ response }) =>
+                    response.status === 200 &&
+                    !/^(text\/html|application\/xhtml\+xml)\b/i.test(response.headers.get("content-type") ?? "")
+                      ? response
+                      : null,
+                },
+              ],
               expiration: {
                 maxEntries: 1000,
               },
@@ -72,6 +83,7 @@ export default defineConfig({
     port: 3000,
   },
   build: {
+    assetsDir: "_assets",
     target: "esnext",
     sourcemap: true,
   },

--- a/packages/cli/src/services/web-ui.ts
+++ b/packages/cli/src/services/web-ui.ts
@@ -26,6 +26,8 @@ export const handler = Effect.fn("cli.web-ui.handler")(function* (options?: { re
 
 function serveUI(request: HttpServerRequest.HttpServerRequest, url: URL, assets: AssetMap) {
   const key = url.pathname.replace(/^\//, "")
+  if (key.startsWith("_assets/") && assets[key] === undefined)
+    return Effect.succeed(HttpServerResponse.empty({ status: 404, headers: { "cache-control": "no-store" } }))
   const name = assets[key] !== undefined ? key : "index.html"
   const file = assets[name]
   if (!file) return Effect.succeed(HttpServerResponse.empty({ status: 404 }))

--- a/packages/cli/test/web-ui.test.ts
+++ b/packages/cli/test/web-ui.test.ts
@@ -19,7 +19,7 @@ describe("web UI", () => {
     await writeFile(asset, "console.log('embedded')")
     const assets = {
       "index.html": await Bun.file(index).text(),
-      "app.js": await Bun.file(asset).text(),
+      "_assets/app.js": await Bun.file(asset).text(),
       "sw.js": "service worker",
       "registerSW.js": "registration",
       "font.woff2": new Uint8Array([0, 1, 2, 255]),
@@ -53,7 +53,16 @@ describe("web UI", () => {
           expect(missing.status).toBe(404)
           expect(yield* Effect.promise(() => missing.text())).toBe("")
 
-          const script = yield* Effect.promise(() => fetch(`${origin}/app.js`))
+          yield* Effect.forEach(["/_assets/old.js", "/_assets/old.css", "/_assets/missing"], (pathname) =>
+            Effect.gen(function* () {
+              const missing = yield* Effect.promise(() => fetch(`${origin}${pathname}`))
+              expect(missing.status).toBe(404)
+              expect(missing.headers.get("cache-control")).toBe("no-store")
+              expect(yield* Effect.promise(() => missing.text())).toBe("")
+            }),
+          )
+
+          const script = yield* Effect.promise(() => fetch(`${origin}/_assets/app.js`))
           expect(yield* Effect.promise(() => script.text())).toBe("console.log('embedded')")
           expect(script.headers.get("content-type")).toContain("javascript")
           expect(script.headers.get("cache-control")).toBe("public, max-age=31536000, immutable")
@@ -74,6 +83,14 @@ describe("web UI", () => {
           expect(yield* Effect.promise(() => fallback.text())).toContain("embedded")
           expect(fallback.headers.get("content-security-policy")).toContain("default-src 'self'")
           expect(fallback.headers.get("content-security-policy")).toContain("connect-src * data: blob:")
+
+          const dotted = yield* Effect.promise(() => fetch(`${origin}/workspace/example.js`))
+          expect(dotted.status).toBe(200)
+          expect(yield* Effect.promise(() => dotted.text())).toContain("embedded")
+
+          const legacy = yield* Effect.promise(() => fetch(`${origin}/assets/missing.js`))
+          expect(legacy.status).toBe(200)
+          expect(yield* Effect.promise(() => legacy.text())).toContain("embedded")
         }),
       ).pipe(Effect.provide(NodeFileSystem.layer)),
     )


### PR DESCRIPTION
### Issue for this PR

Reported while using `opencode serve`: a stale service worker left the web app blank after an upgrade. No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The old worker served cached HTML pointing to chunks no longer available on the server. Missing chunks returned the SPA HTML, which was then cached as JavaScript or CSS.

- Stop precaching build generations and intercepting HTML navigation. Keep runtime asset caching, reject HTML on cache reads and writes, and retain access to legacy cached chunks for open tabs.
- Activate worker updates without forcing document reloads or discarding drafts.
- Emit bundles under `/_assets/`. Missing files there return non-cacheable 404s; other non-API paths keep the HTML fallback.

HTML now requires the network instead of using a cached app shell. Existing blank tabs can recover on a subsequent navigation after the updated worker activates; working tabs are not forcibly reloaded.

### How did you verify your code works?

- `packages/app`: `bun run test:service-worker` builds the production worker and passes Chromium upgrade/cache tests, including draft preservation, old chunks, and poisoned-cache recovery.
- `packages/app`: `bun typecheck` and `bun run typecheck:e2e` pass.
- `packages/cli`: `bun test test/web-ui.test.ts` passes, covering asset 404s and preserved HTML fallback.
- `packages/cli`: `bun typecheck` passes.
- The pre-push repository-wide typecheck passes all 32 tasks.

### Screenshots / recordings

No layout or styling changes. Browser regressions exercise the generated production service worker against isolated HTTP fixtures.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
