### PR TITLE
feat(tui): make session tab status explicit

### DIFF
--- a/packages/cli/src/services/update-preflight.tsx
+++ b/packages/cli/src/services/update-preflight.tsx
@@ -94,7 +94,7 @@ async function open(from?: string): Promise<Session> {
     screenMode: "split-footer",
     footerHeight: 4,
     targetFps: 60,
-    useKittyKeyboard: { events: true, allKeysAsEscapes: true },
+    useKittyKeyboard: { events: true, allKeysAsEscapes: true, reportText: true },
     consoleOptions: {
       keyBindings: [{ name: "y", ctrl: true, action: "copy-selection" }],
     },

--- a/packages/cli/src/services/update-preflight.tsx
+++ b/packages/cli/src/services/update-preflight.tsx
@@ -94,7 +94,7 @@ async function open(from?: string): Promise<Session> {
     screenMode: "split-footer",
     footerHeight: 4,
     targetFps: 60,
-    useKittyKeyboard: {},
+    useKittyKeyboard: { events: true, allKeysAsEscapes: true },
     consoleOptions: {
       keyBindings: [{ name: "y", ctrl: true, action: "copy-selection" }],
     },

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -21,6 +21,7 @@
   },
   "scripts": {
     "build": "bun run script/build.ts",
+    "test": "bun test --timeout 30000",
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {

--- a/packages/theme/src/tui/defaults.ts
+++ b/packages/theme/src/tui/defaults.ts
@@ -125,7 +125,7 @@ export const DEFAULT_THEME = {
         running: "$hue.interactive.800",
         question: "$text.feedback.info.default",
         permission: "$text.feedback.warning.default",
-        unread: "$hue.interactive.800",
+        unread: "$hue.accent.800",
       },
       feedback: {
         error: { default: "$hue.red.700", subdued: "$hue.red.600" },
@@ -346,7 +346,7 @@ export const DEFAULT_THEME = {
         running: "$hue.interactive.200",
         question: "$text.feedback.info.default",
         permission: "$text.feedback.warning.default",
-        unread: "$hue.interactive.200",
+        unread: "$hue.accent.200",
       },
       feedback: {
         error: { default: "$hue.red.300", subdued: "$hue.red.400" },

--- a/packages/theme/src/tui/defaults.ts
+++ b/packages/theme/src/tui/defaults.ts
@@ -125,6 +125,7 @@ export const DEFAULT_THEME = {
         running: "$hue.interactive.800",
         question: "$text.feedback.info.default",
         permission: "$text.feedback.warning.default",
+        unread: "$hue.interactive.800",
       },
       feedback: {
         error: { default: "$hue.red.700", subdued: "$hue.red.600" },
@@ -345,6 +346,7 @@ export const DEFAULT_THEME = {
         running: "$hue.interactive.200",
         question: "$text.feedback.info.default",
         permission: "$text.feedback.warning.default",
+        unread: "$hue.interactive.200",
       },
       feedback: {
         error: { default: "$hue.red.300", subdued: "$hue.red.400" },

--- a/packages/theme/src/tui/defaults.ts
+++ b/packages/theme/src/tui/defaults.ts
@@ -121,6 +121,11 @@ export const DEFAULT_THEME = {
         $disabled: "$hue.neutral.500",
         $selected: "$hue.interactive.700",
       },
+      status: {
+        running: "$hue.interactive.800",
+        question: "$text.feedback.info.default",
+        permission: "$text.feedback.warning.default",
+      },
       feedback: {
         error: { default: "$hue.red.700", subdued: "$hue.red.600" },
         warning: { default: "$hue.yellow.800", subdued: "$hue.yellow.700" },
@@ -335,6 +340,11 @@ export const DEFAULT_THEME = {
         $pressed: "$hue.neutral.200",
         $disabled: "$hue.neutral.500",
         $selected: "$hue.interactive.500",
+      },
+      status: {
+        running: "$hue.interactive.200",
+        question: "$text.feedback.info.default",
+        permission: "$text.feedback.warning.default",
       },
       feedback: {
         error: { default: "$hue.red.300", subdued: "$hue.red.400" },

--- a/packages/theme/src/tui/fallback.ts
+++ b/packages/theme/src/tui/fallback.ts
@@ -1,7 +1,7 @@
-import type { ThemeTokensDefinition } from "./index.js"
+import type { Mode, ThemeTokensDefinition } from "./index.js"
 import { ActionVariant, FeedbackKind } from "./schema.js"
 
-export function fallback(): ThemeTokensDefinition {
+export function fallback(mode: Mode): ThemeTokensDefinition {
   const red = "#ff0000"
 
   return {
@@ -9,6 +9,11 @@ export function fallback(): ThemeTokensDefinition {
       default: red,
       action: Object.fromEntries(ActionVariant.literals.map((variant) => [variant, { default: red }])),
       formfield: { default: red },
+      status: {
+        running: mode === "light" ? "$hue.interactive.800" : "$hue.interactive.200",
+        question: "$text.feedback.info.default",
+        permission: "$text.feedback.warning.default",
+      },
       feedback: Object.fromEntries(FeedbackKind.literals.map((kind) => [kind, { default: red }])),
     },
     background: {

--- a/packages/theme/src/tui/fallback.ts
+++ b/packages/theme/src/tui/fallback.ts
@@ -13,6 +13,7 @@ export function fallback(mode: Mode): ThemeTokensDefinition {
         running: mode === "light" ? "$hue.interactive.800" : "$hue.interactive.200",
         question: "$text.feedback.info.default",
         permission: "$text.feedback.warning.default",
+        unread: mode === "light" ? "$hue.interactive.800" : "$hue.interactive.200",
       },
       feedback: Object.fromEntries(FeedbackKind.literals.map((kind) => [kind, { default: red }])),
     },

--- a/packages/theme/src/tui/fallback.ts
+++ b/packages/theme/src/tui/fallback.ts
@@ -1,4 +1,5 @@
 import type { Mode, ThemeTokensDefinition } from "./index.js"
+import { DEFAULT_THEME } from "./defaults.js"
 import { ActionVariant, FeedbackKind } from "./schema.js"
 
 export function fallback(mode: Mode): ThemeTokensDefinition {
@@ -9,12 +10,7 @@ export function fallback(mode: Mode): ThemeTokensDefinition {
       default: red,
       action: Object.fromEntries(ActionVariant.literals.map((variant) => [variant, { default: red }])),
       formfield: { default: red },
-      status: {
-        running: mode === "light" ? "$hue.interactive.800" : "$hue.interactive.200",
-        question: "$text.feedback.info.default",
-        permission: "$text.feedback.warning.default",
-        unread: mode === "light" ? "$hue.interactive.800" : "$hue.interactive.200",
-      },
+      status: DEFAULT_THEME[mode].text.status,
       feedback: Object.fromEntries(FeedbackKind.literals.map((kind) => [kind, { default: red }])),
     },
     background: {

--- a/packages/theme/src/tui/resolve.ts
+++ b/packages/theme/src/tui/resolve.ts
@@ -46,7 +46,7 @@ export function resolveThemeDocument(document: ThemeDocument, mode?: "light" | "
   const selected = selectThemeMode(document, mode)
   const definition = selected.expanded ? selected.theme : expandTheme(selected.theme)
   const defaults = expandTheme(selectTheme(DEFAULT_THEME, selected.mode))
-  const core = expandTokens(fallback())
+  const core = expandTokens(fallback(selected.mode))
   const merged = document.standalone ? mergeTheme(core, definition) : mergeTheme(core, defaults, definition)
   if (!merged["hue"]) throw new Error("Standalone themes must provide hues")
   return resolveExpandedTheme({

--- a/packages/theme/src/tui/schema.ts
+++ b/packages/theme/src/tui/schema.ts
@@ -113,6 +113,7 @@ const TextDefinition = Schema.Struct({
       running: Schema.optional(ColorValue),
       question: Schema.optional(ColorValue),
       permission: Schema.optional(ColorValue),
+      unread: Schema.optional(ColorValue),
     }),
   ),
   feedback: Schema.optional(

--- a/packages/theme/src/tui/schema.ts
+++ b/packages/theme/src/tui/schema.ts
@@ -108,6 +108,13 @@ const TextDefinition = Schema.Struct({
   subdued: Schema.optional(ColorValue),
   action: Schema.optional(ActionColorDefinition),
   formfield: Schema.optional(StatefulColorDefinition),
+  status: Schema.optional(
+    Schema.Struct({
+      running: Schema.optional(ColorValue),
+      question: Schema.optional(ColorValue),
+      permission: Schema.optional(ColorValue),
+    }),
+  ),
   feedback: Schema.optional(
     Schema.Struct({
       error: Schema.optional(TextFeedbackDefinition),

--- a/packages/theme/src/tui/types.ts
+++ b/packages/theme/src/tui/types.ts
@@ -34,6 +34,7 @@ export type ResolvedThemeTokens = {
       readonly running: RGBA
       readonly question: RGBA
       readonly permission: RGBA
+      readonly unread: RGBA
     }
     readonly feedback: Readonly<Record<FeedbackKind, { readonly default: RGBA; readonly subdued: RGBA }>>
   }

--- a/packages/theme/src/tui/types.ts
+++ b/packages/theme/src/tui/types.ts
@@ -30,6 +30,11 @@ export type ResolvedThemeTokens = {
     readonly subdued: RGBA
     readonly action: Readonly<Record<ActionVariant, StatefulColor>>
     readonly formfield: FormfieldColor
+    readonly status: {
+      readonly running: RGBA
+      readonly question: RGBA
+      readonly permission: RGBA
+    }
     readonly feedback: Readonly<Record<FeedbackKind, { readonly default: RGBA; readonly subdued: RGBA }>>
   }
   readonly background: {

--- a/packages/theme/test/status.test.ts
+++ b/packages/theme/test/status.test.ts
@@ -19,13 +19,14 @@ test.each(["light", "dark"] as const)("resolves built-in %s status colors", (mod
   expect(theme.text.status.question).toBe(theme.hue.cyan[mode === "light" ? 700 : 300])
   expect(theme.text.status.permission).toBe(theme.text.feedback.warning.default)
   expect(theme.text.status.permission).toBe(theme.hue.yellow[mode === "light" ? 800 : 200])
+  expect(theme.text.status.unread).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
   expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
   expect(theme.contextual.overlay.text.status).toEqual(theme.text.status)
 })
 
 test.each(["light", "dark"] as const)("custom %s themes inherit status colors from their hues and feedback", (mode) => {
   const definition = {
-    hue: { interactive: "$hue.purple" },
+    hue: { interactive: "$hue.purple", accent: "$hue.orange" },
     text: {
       feedback: { info: { default: "#123456" }, warning: { default: "#654321" } },
     },
@@ -36,23 +37,27 @@ test.each(["light", "dark"] as const)("custom %s themes inherit status colors fr
   expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
   expect(theme.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
   expect(theme.text.status.permission.equals(RGBA.fromHex("#654321"))).toBeTrue()
+  expect(theme.text.status.unread).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+  expect(theme.text.status.unread.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
 })
 
 test("decodes partial status overrides and resolves colors and references", () => {
   const document = Schema.decodeUnknownSync(ThemeDocument)({
     version: 2,
-    light: { text: { status: { question: "#123456" } } },
+    light: { text: { status: { question: "#123456", unread: "#abcdef" } } },
     dark: { text: { status: { running: "$hue.purple.300", permission: "transparent" } } },
   })
   const light = resolveThemeDocument(document, "light")
   const dark = resolveThemeDocument(document, "dark")
 
   expect(light.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
+  expect(light.text.status.unread.equals(RGBA.fromHex("#abcdef"))).toBeTrue()
   expect(light.text.status.running).toBe(light.hue.interactive[800])
   expect(light.text.status.permission).toBe(light.text.feedback.warning.default)
   expect(dark.text.status.running).toBe(dark.hue.purple[300])
   expect(dark.text.status.question).toBe(dark.text.feedback.info.default)
   expect(dark.text.status.permission.toInts()).toEqual([0, 0, 0, 0])
+  expect(dark.text.status.unread).toBe(dark.hue.interactive[200])
   expect(() =>
     Schema.decodeUnknownSync(ThemeDocument)({ version: 2, light: { text: { status: { running: "opaque" } } } }),
   ).toThrow()
@@ -64,7 +69,7 @@ test("contextual status overrides inherit remaining tokens and rewire feedback r
     dark: {
       "@context:elevated": {
         text: {
-          status: { running: "$hue.purple.300" },
+          status: { running: "$hue.purple.300", unread: "$hue.orange.300" },
           feedback: { info: { default: "#123456" } },
         },
       },
@@ -74,6 +79,7 @@ test("contextual status overrides inherit remaining tokens and rewire feedback r
   expect(theme.contextual.elevated.text.status.running).toBe(theme.hue.purple[300])
   expect(theme.contextual.elevated.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
   expect(theme.contextual.elevated.text.status.permission).toBe(theme.text.status.permission)
+  expect(theme.contextual.elevated.text.status.unread).toBe(theme.hue.orange[300])
   expect(theme.contextual.overlay.text.status).toEqual(theme.text.status)
 })
 
@@ -81,7 +87,7 @@ test.each(["light", "dark"] as const)(
   "standalone %s themes inherit existing semantic colors when status tokens are omitted",
   (mode) => {
     const definition = {
-      hue: { ...DEFAULT_THEME[mode].hue, interactive: "$hue.purple" },
+      hue: { ...DEFAULT_THEME[mode].hue, interactive: "$hue.purple", accent: "$hue.orange" },
       text: {
         feedback: { info: { default: "#22d3ee" }, warning: { default: "#eab308" } },
       },
@@ -99,11 +105,14 @@ test.each(["light", "dark"] as const)(
     expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
     expect(theme.text.status.question.equals(RGBA.fromHex("#22d3ee"))).toBeTrue()
     expect(theme.text.status.permission.equals(RGBA.fromHex("#eab308"))).toBeTrue()
+    expect(theme.text.status.unread).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+    expect(theme.text.status.unread.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
     expect(theme.text.default.toInts()).toEqual([255, 0, 0, 255])
     expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
     expect(overridden.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
     expect(overridden.text.status.running.equals(theme.text.status.running)).toBeTrue()
     expect(overridden.text.status.permission.equals(theme.text.status.permission)).toBeTrue()
+    expect(overridden.text.status.unread.equals(theme.text.status.unread)).toBeTrue()
   },
 )
 
@@ -121,6 +130,7 @@ test.each(["light", "dark"] as const)(
     expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
     expect(theme.text.status.question.equals(theme.text.feedback.info.default)).toBeTrue()
     expect(theme.text.status.permission.equals(theme.text.feedback.warning.default)).toBeTrue()
+    expect(theme.text.status.unread).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
     expect(Object.values(theme.text.status).every((color) => !color.equals(RGBA.fromHex("#ff0000")))).toBeTrue()
   },
 )

--- a/packages/theme/test/status.test.ts
+++ b/packages/theme/test/status.test.ts
@@ -1,136 +1,42 @@
 import { expect, test } from "bun:test"
 import { RGBA } from "@opentui/core"
 import { Schema } from "effect"
-import {
-  DEFAULT_THEME,
-  ThemeDocument,
-  migrateV1,
-  resolveTheme,
-  resolveThemeDocument,
-  selectTheme,
-} from "../src/tui/index.js"
+import { DEFAULT_THEME, ThemeDocument, migrateV1, resolveThemeDocument } from "../src/tui/index.js"
 import type { ThemeV1Json } from "../src/tui/v1.js"
 
-test.each(["light", "dark"] as const)("resolves built-in %s status colors", (mode) => {
-  const theme = resolveTheme(selectTheme(DEFAULT_THEME, mode))
-
-  expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
-  expect(theme.text.status.question).toBe(theme.text.feedback.info.default)
-  expect(theme.text.status.question).toBe(theme.hue.cyan[mode === "light" ? 700 : 300])
-  expect(theme.text.status.permission).toBe(theme.text.feedback.warning.default)
-  expect(theme.text.status.permission).toBe(theme.hue.yellow[mode === "light" ? 800 : 200])
-  expect(theme.text.status.unread).toBe(theme.hue.accent[mode === "light" ? 800 : 200])
-  expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
-  expect(theme.contextual.overlay.text.status).toEqual(theme.text.status)
-})
-
-test.each(["light", "dark"] as const)("custom %s themes inherit status colors from their hues and feedback", (mode) => {
-  const definition = {
-    hue: { interactive: "$hue.purple", accent: "$hue.orange" },
-    text: {
-      feedback: { info: { default: "#123456" }, warning: { default: "#654321" } },
-    },
-  } as const
-  const theme = resolveThemeDocument({ version: 2, light: definition, dark: definition }, mode)
-
-  expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
-  expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
-  expect(theme.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
-  expect(theme.text.status.permission.equals(RGBA.fromHex("#654321"))).toBeTrue()
-  expect(theme.text.status.unread).toBe(theme.hue.accent[mode === "light" ? 800 : 200])
-  expect(theme.text.status.unread.equals(theme.hue.orange[mode === "light" ? 800 : 200])).toBeTrue()
-})
-
-test("decodes partial status overrides and resolves colors and references", () => {
-  const document = Schema.decodeUnknownSync(ThemeDocument)({
-    version: 2,
-    light: { text: { status: { question: "#123456", unread: "#abcdef" } } },
-    dark: { text: { status: { running: "$hue.purple.300", permission: "transparent" } } },
-  })
-  const light = resolveThemeDocument(document, "light")
-  const dark = resolveThemeDocument(document, "dark")
-
-  expect(light.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
-  expect(light.text.status.unread.equals(RGBA.fromHex("#abcdef"))).toBeTrue()
-  expect(light.text.status.running).toBe(light.hue.interactive[800])
-  expect(light.text.status.permission).toBe(light.text.feedback.warning.default)
-  expect(dark.text.status.running).toBe(dark.hue.purple[300])
-  expect(dark.text.status.question).toBe(dark.text.feedback.info.default)
-  expect(dark.text.status.permission.toInts()).toEqual([0, 0, 0, 0])
-  expect(dark.text.status.unread).toBe(dark.hue.accent[200])
-  expect(() =>
-    Schema.decodeUnknownSync(ThemeDocument)({ version: 2, light: { text: { status: { running: "opaque" } } } }),
-  ).toThrow()
-})
-
-test("contextual status overrides inherit remaining tokens and rewire feedback references", () => {
-  const theme = resolveThemeDocument({
-    version: 2,
-    dark: {
-      "@context:elevated": {
-        text: {
-          status: { running: "$hue.purple.300", unread: "$hue.orange.300" },
-          feedback: { info: { default: "#123456" } },
-        },
-      },
-    },
-  })
-
-  expect(theme.contextual.elevated.text.status.running).toBe(theme.hue.purple[300])
-  expect(theme.contextual.elevated.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
-  expect(theme.contextual.elevated.text.status.permission).toBe(theme.text.status.permission)
-  expect(theme.contextual.elevated.text.status.unread).toBe(theme.hue.orange[300])
-  expect(theme.contextual.overlay.text.status).toEqual(theme.text.status)
-})
-
-test.each(["light", "dark"] as const)(
-  "standalone %s themes inherit existing semantic colors when status tokens are omitted",
-  (mode) => {
-    const definition = {
-      hue: { ...DEFAULT_THEME[mode].hue, interactive: "$hue.purple", accent: "$hue.orange" },
-      text: {
-        feedback: { info: { default: "#22d3ee" }, warning: { default: "#eab308" } },
-      },
-    } as const
-    const document = { version: 2, standalone: true, light: definition, dark: definition } as const
+test.each(["light", "dark"] as const)("built-in %s themes resolve status colors", async (mode) => {
+  const source: ThemeV1Json = await Bun.file(
+    new URL("../../tui/src/theme/assets/opencode.json", import.meta.url),
+  ).json()
+  for (const document of [DEFAULT_THEME, migrateV1(source)]) {
     const theme = resolveThemeDocument(document, mode)
-    const override = { ...definition, text: { ...definition.text, status: { question: "#123456" } } } as const
-    const overridden = resolveThemeDocument({
-      version: 2,
-      standalone: true,
-      ...(mode === "light" ? { light: override } : { dark: override }),
-    })
-
-    expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
-    expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
-    expect(theme.text.status.question.equals(RGBA.fromHex("#22d3ee"))).toBeTrue()
-    expect(theme.text.status.permission.equals(RGBA.fromHex("#eab308"))).toBeTrue()
-    expect(theme.text.status.unread).toBe(theme.hue.accent[mode === "light" ? 800 : 200])
-    expect(theme.text.status.unread.equals(theme.hue.orange[mode === "light" ? 800 : 200])).toBeTrue()
-    expect(theme.text.default.toInts()).toEqual([255, 0, 0, 255])
-    expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
-    expect(overridden.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
-    expect(overridden.text.status.running.equals(theme.text.status.running)).toBeTrue()
-    expect(overridden.text.status.permission.equals(theme.text.status.permission)).toBeTrue()
-    expect(overridden.text.status.unread.equals(theme.text.status.unread)).toBeTrue()
-  },
-)
-
-test.each(["light", "dark"] as const)(
-  "built-in opencode JSON inherits %s status colors without new tokens",
-  async (mode) => {
-    const source: ThemeV1Json = await Bun.file(
-      new URL("../../tui/src/theme/assets/opencode.json", import.meta.url),
-    ).json()
-    const document = migrateV1(source)
-    const theme = resolveThemeDocument(document, mode)
-
-    expect(document.standalone).toBeTrue()
-    expect(document[mode]?.text?.status).toBeUndefined()
-    expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+    expect(theme.text.status.running.equals(theme.hue.interactive[mode === "light" ? 800 : 200])).toBeTrue()
     expect(theme.text.status.question.equals(theme.text.feedback.info.default)).toBeTrue()
     expect(theme.text.status.permission.equals(theme.text.feedback.warning.default)).toBeTrue()
-    expect(theme.text.status.unread).toBe(theme.hue.accent[mode === "light" ? 800 : 200])
-    expect(Object.values(theme.text.status).every((color) => !color.equals(RGBA.fromHex("#ff0000")))).toBeTrue()
-  },
-)
+    expect(theme.text.status.unread.equals(theme.hue.accent[mode === "light" ? 800 : 200])).toBeTrue()
+    expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
+  }
+})
+
+test.each(["light", "dark"] as const)("custom %s themes inherit and override status colors", (mode) => {
+  for (const standalone of [false, true]) {
+    const theme = resolveThemeDocument(
+      Schema.decodeUnknownSync(ThemeDocument)({
+        version: 2,
+        standalone,
+        [mode]: {
+          hue: { ...DEFAULT_THEME[mode].hue, interactive: "$hue.purple", accent: "$hue.orange" },
+          text: {
+            feedback: { warning: { default: "#654321" } },
+            status: { question: "#123456" },
+          },
+        },
+      }),
+      mode,
+    )
+    expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
+    expect(theme.text.status.unread.equals(theme.hue.orange[mode === "light" ? 800 : 200])).toBeTrue()
+    expect(theme.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
+    expect(theme.text.status.permission.equals(RGBA.fromHex("#654321"))).toBeTrue()
+  }
+})

--- a/packages/theme/test/status.test.ts
+++ b/packages/theme/test/status.test.ts
@@ -1,0 +1,126 @@
+import { expect, test } from "bun:test"
+import { RGBA } from "@opentui/core"
+import { Schema } from "effect"
+import {
+  DEFAULT_THEME,
+  ThemeDocument,
+  migrateV1,
+  resolveTheme,
+  resolveThemeDocument,
+  selectTheme,
+} from "../src/tui/index.js"
+import type { ThemeV1Json } from "../src/tui/v1.js"
+
+test.each(["light", "dark"] as const)("resolves built-in %s status colors", (mode) => {
+  const theme = resolveTheme(selectTheme(DEFAULT_THEME, mode))
+
+  expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+  expect(theme.text.status.question).toBe(theme.text.feedback.info.default)
+  expect(theme.text.status.question).toBe(theme.hue.cyan[mode === "light" ? 700 : 300])
+  expect(theme.text.status.permission).toBe(theme.text.feedback.warning.default)
+  expect(theme.text.status.permission).toBe(theme.hue.yellow[mode === "light" ? 800 : 200])
+  expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
+  expect(theme.contextual.overlay.text.status).toEqual(theme.text.status)
+})
+
+test.each(["light", "dark"] as const)("custom %s themes inherit status colors from their hues and feedback", (mode) => {
+  const definition = {
+    hue: { interactive: "$hue.purple" },
+    text: {
+      feedback: { info: { default: "#123456" }, warning: { default: "#654321" } },
+    },
+  } as const
+  const theme = resolveThemeDocument({ version: 2, light: definition, dark: definition }, mode)
+
+  expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+  expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
+  expect(theme.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
+  expect(theme.text.status.permission.equals(RGBA.fromHex("#654321"))).toBeTrue()
+})
+
+test("decodes partial status overrides and resolves colors and references", () => {
+  const document = Schema.decodeUnknownSync(ThemeDocument)({
+    version: 2,
+    light: { text: { status: { question: "#123456" } } },
+    dark: { text: { status: { running: "$hue.purple.300", permission: "transparent" } } },
+  })
+  const light = resolveThemeDocument(document, "light")
+  const dark = resolveThemeDocument(document, "dark")
+
+  expect(light.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
+  expect(light.text.status.running).toBe(light.hue.interactive[800])
+  expect(light.text.status.permission).toBe(light.text.feedback.warning.default)
+  expect(dark.text.status.running).toBe(dark.hue.purple[300])
+  expect(dark.text.status.question).toBe(dark.text.feedback.info.default)
+  expect(dark.text.status.permission.toInts()).toEqual([0, 0, 0, 0])
+  expect(() =>
+    Schema.decodeUnknownSync(ThemeDocument)({ version: 2, light: { text: { status: { running: "opaque" } } } }),
+  ).toThrow()
+})
+
+test("contextual status overrides inherit remaining tokens and rewire feedback references", () => {
+  const theme = resolveThemeDocument({
+    version: 2,
+    dark: {
+      "@context:elevated": {
+        text: {
+          status: { running: "$hue.purple.300" },
+          feedback: { info: { default: "#123456" } },
+        },
+      },
+    },
+  })
+
+  expect(theme.contextual.elevated.text.status.running).toBe(theme.hue.purple[300])
+  expect(theme.contextual.elevated.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
+  expect(theme.contextual.elevated.text.status.permission).toBe(theme.text.status.permission)
+  expect(theme.contextual.overlay.text.status).toEqual(theme.text.status)
+})
+
+test.each(["light", "dark"] as const)(
+  "standalone %s themes inherit existing semantic colors when status tokens are omitted",
+  (mode) => {
+    const definition = {
+      hue: { ...DEFAULT_THEME[mode].hue, interactive: "$hue.purple" },
+      text: {
+        feedback: { info: { default: "#22d3ee" }, warning: { default: "#eab308" } },
+      },
+    } as const
+    const document = { version: 2, standalone: true, light: definition, dark: definition } as const
+    const theme = resolveThemeDocument(document, mode)
+    const override = { ...definition, text: { ...definition.text, status: { question: "#123456" } } } as const
+    const overridden = resolveThemeDocument({
+      version: 2,
+      standalone: true,
+      ...(mode === "light" ? { light: override } : { dark: override }),
+    })
+
+    expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+    expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
+    expect(theme.text.status.question.equals(RGBA.fromHex("#22d3ee"))).toBeTrue()
+    expect(theme.text.status.permission.equals(RGBA.fromHex("#eab308"))).toBeTrue()
+    expect(theme.text.default.toInts()).toEqual([255, 0, 0, 255])
+    expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
+    expect(overridden.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
+    expect(overridden.text.status.running.equals(theme.text.status.running)).toBeTrue()
+    expect(overridden.text.status.permission.equals(theme.text.status.permission)).toBeTrue()
+  },
+)
+
+test.each(["light", "dark"] as const)(
+  "built-in opencode JSON inherits %s status colors without new tokens",
+  async (mode) => {
+    const source: ThemeV1Json = await Bun.file(
+      new URL("../../tui/src/theme/assets/opencode.json", import.meta.url),
+    ).json()
+    const document = migrateV1(source)
+    const theme = resolveThemeDocument(document, mode)
+
+    expect(document.standalone).toBeTrue()
+    expect(document[mode]?.text?.status).toBeUndefined()
+    expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+    expect(theme.text.status.question.equals(theme.text.feedback.info.default)).toBeTrue()
+    expect(theme.text.status.permission.equals(theme.text.feedback.warning.default)).toBeTrue()
+    expect(Object.values(theme.text.status).every((color) => !color.equals(RGBA.fromHex("#ff0000")))).toBeTrue()
+  },
+)

--- a/packages/theme/test/status.test.ts
+++ b/packages/theme/test/status.test.ts
@@ -19,7 +19,7 @@ test.each(["light", "dark"] as const)("resolves built-in %s status colors", (mod
   expect(theme.text.status.question).toBe(theme.hue.cyan[mode === "light" ? 700 : 300])
   expect(theme.text.status.permission).toBe(theme.text.feedback.warning.default)
   expect(theme.text.status.permission).toBe(theme.hue.yellow[mode === "light" ? 800 : 200])
-  expect(theme.text.status.unread).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+  expect(theme.text.status.unread).toBe(theme.hue.accent[mode === "light" ? 800 : 200])
   expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
   expect(theme.contextual.overlay.text.status).toEqual(theme.text.status)
 })
@@ -37,8 +37,8 @@ test.each(["light", "dark"] as const)("custom %s themes inherit status colors fr
   expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
   expect(theme.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
   expect(theme.text.status.permission.equals(RGBA.fromHex("#654321"))).toBeTrue()
-  expect(theme.text.status.unread).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
-  expect(theme.text.status.unread.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
+  expect(theme.text.status.unread).toBe(theme.hue.accent[mode === "light" ? 800 : 200])
+  expect(theme.text.status.unread.equals(theme.hue.orange[mode === "light" ? 800 : 200])).toBeTrue()
 })
 
 test("decodes partial status overrides and resolves colors and references", () => {
@@ -57,7 +57,7 @@ test("decodes partial status overrides and resolves colors and references", () =
   expect(dark.text.status.running).toBe(dark.hue.purple[300])
   expect(dark.text.status.question).toBe(dark.text.feedback.info.default)
   expect(dark.text.status.permission.toInts()).toEqual([0, 0, 0, 0])
-  expect(dark.text.status.unread).toBe(dark.hue.interactive[200])
+  expect(dark.text.status.unread).toBe(dark.hue.accent[200])
   expect(() =>
     Schema.decodeUnknownSync(ThemeDocument)({ version: 2, light: { text: { status: { running: "opaque" } } } }),
   ).toThrow()
@@ -105,8 +105,8 @@ test.each(["light", "dark"] as const)(
     expect(theme.text.status.running.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
     expect(theme.text.status.question.equals(RGBA.fromHex("#22d3ee"))).toBeTrue()
     expect(theme.text.status.permission.equals(RGBA.fromHex("#eab308"))).toBeTrue()
-    expect(theme.text.status.unread).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
-    expect(theme.text.status.unread.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
+    expect(theme.text.status.unread).toBe(theme.hue.accent[mode === "light" ? 800 : 200])
+    expect(theme.text.status.unread.equals(theme.hue.orange[mode === "light" ? 800 : 200])).toBeTrue()
     expect(theme.text.default.toInts()).toEqual([255, 0, 0, 255])
     expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
     expect(overridden.text.status.question.equals(RGBA.fromHex("#123456"))).toBeTrue()
@@ -130,7 +130,7 @@ test.each(["light", "dark"] as const)(
     expect(theme.text.status.running).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
     expect(theme.text.status.question.equals(theme.text.feedback.info.default)).toBeTrue()
     expect(theme.text.status.permission.equals(theme.text.feedback.warning.default)).toBeTrue()
-    expect(theme.text.status.unread).toBe(theme.hue.interactive[mode === "light" ? 800 : 200])
+    expect(theme.text.status.unread).toBe(theme.hue.accent[mode === "light" ? 800 : 200])
     expect(Object.values(theme.text.status).every((color) => !color.equals(RGBA.fromHex("#ff0000")))).toBeTrue()
   },
 )

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -231,7 +231,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
         targetFps: 60,
         gatherStats: false,
         exitOnCtrlC: false,
-        useKittyKeyboard: {},
+        useKittyKeyboard: { events: true, allKeysAsEscapes: true },
         autoFocus: false,
         openConsoleOnError: false,
         useMouse: config.mouse,

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -231,7 +231,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
         targetFps: 60,
         gatherStats: false,
         exitOnCtrlC: false,
-        useKittyKeyboard: { events: true, allKeysAsEscapes: true },
+        useKittyKeyboard: { events: true, allKeysAsEscapes: true, reportText: true },
         autoFocus: false,
         openConsoleOnError: false,
         useMouse: config.mouse,

--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -145,6 +145,15 @@ export const settings: Setting[] = [
     keywords: ["sidebar", "orientation", "left"],
   },
   {
+    title: "Indicators",
+    category: "Tabs",
+    path: ["tabs", "indicators"],
+    default: "status",
+    values: ["status", "numbers"],
+    labels: ["status icons", "always show numbers"],
+    keywords: ["tab numbers", "number mode", "status icons"],
+  },
+  {
     title: "Layout",
     category: "Diffs",
     path: ["diffs", "view"],

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -465,10 +465,11 @@ export function SessionTabs(
   } = {},
 ) {
   const keymap = Keymap.use()
-  const [numbers, setNumbers] = createSignal(false)
+  const config = useConfig().data
+  const [numbers, setNumbers] = createSignal(config.tabs.indicators === "numbers")
   createEffect(() => {
-    if (!keymap.control()) {
-      setNumbers(false)
+    if (config.tabs.indicators === "numbers" || !keymap.control()) {
+      setNumbers(config.tabs.indicators === "numbers")
       return
     }
     // Brief Control chords should not flash the tab numbers.

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -45,8 +45,8 @@ import { SPINNER_FRAMES } from "./spinner-frames"
 registerOpencodeSpinner()
 
 export const TAB_SPINNERS = {
-  arcs: { frames: ["◜", "◝", "◞", "◟"], interval: 120 },
   dots: { frames: SPINNER_FRAMES, interval: 80 },
+  arcs: { frames: ["◜", "◝", "◞", "◟"], interval: 120 },
   quadrants: { frames: ["◴", "◷", "◶", "◵"], interval: 120 },
   line: { frames: ["|", "/", "-", "\\"], interval: 120 },
 }
@@ -118,14 +118,12 @@ function TabIndicator(props: {
   attributes?: number
 }) {
   const runs = () => props.status.busy && !props.status.attention
-  const spinner = () => TAB_SPINNERS[props.spinner ?? "arcs"]
+  const spinner = () => TAB_SPINNERS[props.spinner ?? "dots"]
   const label = () => {
     if (props.numbers) return props.label
     if (props.status.attention === "permission") return "!"
     if (props.status.attention === "question") return "?"
     if (runs()) return spinner().frames[0]
-    if (props.status.unread === "error") return "×"
-    if (props.status.unread === "activity") return "✓"
     return props.label
   }
   return (
@@ -416,7 +414,6 @@ export function SessionTabs(
     controller?: SessionTabsController
     animations?: boolean
     spinner?: TabSpinner
-    statusPosition?: "inline" | "below"
     orientation?: "horizontal" | "vertical"
     width?: number
   } = {},
@@ -430,7 +427,6 @@ export function SessionTabs(
           controller={props.controller}
           animations={props.animations}
           spinner={props.spinner}
-          statusPosition={props.statusPosition}
           numbers={keymap.control()}
           width={props.width}
         />
@@ -452,7 +448,6 @@ function VerticalSessionTabs(props: {
   animations?: boolean
   numbers: boolean
   spinner?: TabSpinner
-  statusPosition?: "inline" | "below"
   width?: number
 }) {
   const contextTabs = useSessionTabs()
@@ -462,8 +457,7 @@ function VerticalSessionTabs(props: {
   const config = useConfig().data
   const animations = () => props.animations ?? config.animations ?? true
   const width = () => props.width ?? SESSION_SIDEBAR_WIDTH
-  const below = () => props.statusPosition === "below"
-  const accent = () => theme.text.feedback.success.default
+  const unreadColor = () => theme.text.status.unread
   const activeNumber = () => theme.text.status.running
   const idleNumber = () => tint(theme.text.formfield.default, theme.background.default, 0.55)
   const separatorUpperPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.04))
@@ -653,13 +647,13 @@ function VerticalSessionTabs(props: {
                 return selected() ? theme.text.default : theme.text.subdued
               }
               const complete = () => status().complete
-              // Latched so a resolving glow fades out in the hue it lit with instead of snapping to accent.
+              // Latched so a resolving glow fades out in the hue it lit with instead of snapping to the unread color.
               let lastGlowHue: RGBA | undefined
               const glowHue = () => {
                 const feedback = tabFeedbackColor(status(), theme)
                 if (feedback) return (lastGlowHue = feedback)
-                if (status().unread !== undefined) return (lastGlowHue = accent())
-                return lastGlowHue ?? accent()
+                if (status().unread !== undefined) return (lastGlowHue = unreadColor())
+                return lastGlowHue ?? unreadColor()
               }
               const pulseColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.25))
               const flashColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.7))
@@ -702,8 +696,8 @@ function VerticalSessionTabs(props: {
               const previousGlowHue = () => {
                 const feedback = tabFeedbackColor(previousStatus(), theme)
                 if (feedback) return (lastPreviousGlowHue = feedback)
-                if (previousStatus().unread !== undefined) return (lastPreviousGlowHue = accent())
-                return lastPreviousGlowHue ?? accent()
+                if (previousStatus().unread !== undefined) return (lastPreviousGlowHue = unreadColor())
+                return lastPreviousGlowHue ?? unreadColor()
               }
               const separatorUpperColor = createMemo(() => tint(theme.background.default, previousGlowHue(), 0.1))
               const separatorLowerColor = createMemo(() => tint(theme.background.default, glowHue(), 0.12))
@@ -838,7 +832,7 @@ function VerticalSessionTabs(props: {
                         width={numberWidth()}
                         color={numberColor()}
                         animations={animations()}
-                        numbers={below() || props.numbers}
+                        numbers={props.numbers}
                         spinner={props.spinner}
                         attributes={selected() ? TextAttributes.BOLD : undefined}
                       />
@@ -905,24 +899,7 @@ function VerticalSessionTabs(props: {
                       completionColor={detailGlowColor()}
                       backgroundColor={pulseBackground()}
                     />
-                    <box
-                      zIndex={1}
-                      width="100%"
-                      flexDirection="row"
-                      paddingLeft={below() ? 0 : numberWidth() + 1}
-                      paddingRight={2}
-                    >
-                      <Show when={below()}>
-                        <TabIndicator
-                          status={status()}
-                          label=""
-                          width={numberWidth()}
-                          color={numberColor()}
-                          animations={animations()}
-                          numbers={false}
-                          spinner={props.spinner}
-                        />
-                      </Show>
+                    <box zIndex={1} width="100%" flexDirection="row" paddingLeft={numberWidth() + 1} paddingRight={2}>
                       <text fg={detailColor()} wrapMode="none" selectable={false}>
                         <Show when={detailFades()} fallback={visibleDetail()}>
                           <For each={visibleDetailParts()}>
@@ -1060,7 +1037,7 @@ function HorizontalSessionTabs(props: {
   onCleanup(clearCloseHold)
   // A captured drag ends with a synthetic up on its drop target; do not turn that into a click.
   let suppressClick = false
-  const accent = () => theme.text.feedback.success.default
+  const unreadColor = () => theme.text.status.unread
   const activeNumber = () => theme.text.status.running
   const idleNumber = () => tint(theme.text.formfield.default, theme.background.default, 0.55)
   const newTab = () => tabs.newTab?.() ?? false
@@ -1311,7 +1288,7 @@ function HorizontalSessionTabs(props: {
           // so it reads as a lift of the pulse color rather than a different hue.
           const flashColor = () => tint(background(), theme.text.default, 0.65)
           const feedbackColor = () => tabFeedbackColor(status(), theme)
-          const glowColor = () => feedbackColor() ?? accent()
+          const glowColor = () => feedbackColor() ?? unreadColor()
           const glows = () =>
             !selected() && Boolean(status().attention || (!status().busy && status().unread !== undefined))
           const title = () => tab.title ?? "Untitled session"
@@ -1369,7 +1346,7 @@ function HorizontalSessionTabs(props: {
               hovered() === tab.sessionID && !selected()
                 ? foreground()
                 : tint(idleNumber(), tint(theme.text.default, background(), 0.25), selection())
-            const color = runs() ? activeNumber() : (feedback ?? tint(base, accent(), activity()))
+            const color = runs() ? activeNumber() : (feedback ?? tint(base, unreadColor(), activity()))
             // The number brightens faintly as the running sweep passes beneath it.
             return tint(color, theme.text.default, Math.max(numberIgnition.value().level, 0.15 * sweepLevel()))
           }
@@ -1423,7 +1400,7 @@ function HorizontalSessionTabs(props: {
                 color={pulseColor()}
                 glowColor={glowColor()}
                 flashColor={flashColor()}
-                completionColor={accent()}
+                completionColor={unreadColor()}
                 backgroundColor={background()}
                 onLevel={setSweepLevel}
               />

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -52,6 +52,14 @@ export const TAB_SPINNERS = {
 }
 export type TabSpinner = keyof typeof TAB_SPINNERS
 
+export const TAB_UNREAD_MARKERS = {
+  "small-dot": "•",
+  dot: "●",
+  square: "▪",
+  "large-square": "■",
+}
+export type TabUnreadMarker = keyof typeof TAB_UNREAD_MARKERS
+
 // A long title fades out over its last cells instead of cutting hard.
 const FADE_WIDTH = 4
 // The add button renders as " + " at the end of the strip, so the tab layout leaves it room.
@@ -112,26 +120,54 @@ function TabIndicator(props: {
   label: string
   width: number
   color: RGBA
+  unreadColor: RGBA
+  backgroundColor: RGBA
+  flashColor: RGBA
   animations: boolean
   numbers: boolean
   spinner?: TabSpinner
+  unreadMarker?: TabUnreadMarker
   attributes?: number
 }) {
   const runs = () => props.status.busy && !props.status.attention
+  const pending = createMemo(() => props.status.busy || Boolean(props.status.attention))
+  const unread = createMemo(() => Boolean(props.status.unread) && !pending())
+  const unreadColor = createMemo<RGBA>((previous) => (unread() ? props.unreadColor : previous), props.unreadColor)
+  const fade = createAnimatable(
+    { opacity: unread() ? 1 : 0 },
+    { enabled: () => props.animations, transition: tween({ duration: 0.18 }) },
+  )
+  createComputed(() => {
+    if (unread()) return fade.jump({ opacity: 1 })
+    if (pending()) return fade.jump({ opacity: 0 })
+    fade.animate({ opacity: 0 })
+  })
+  const fading = () => !props.status.unread && fade.value().opacity > 0
+  const color = () => {
+    if (props.numbers) return props.color
+    if (unread()) return props.unreadColor
+    if (!fading()) return props.color
+    const opacity = fade.value().opacity
+    // Brighten during the first fifth, then dissolve into the tab background.
+    const flash = Math.max(0, 1 - Math.abs(opacity - 0.8) / 0.2)
+    return tint(props.backgroundColor, tint(unreadColor(), props.flashColor, flash * 0.3), Math.min(1, opacity / 0.8))
+  }
   const spinner = () => TAB_SPINNERS[props.spinner ?? "dots"]
   const label = () => {
     if (props.numbers) return props.label
     if (props.status.attention === "permission") return "!"
     if (props.status.attention === "question") return "?"
     if (runs()) return spinner().frames[0]
-    return props.label === "+" ? "+" : "▪"
+    if (props.label === "+") return "+"
+    if (props.status.unread || fading()) return TAB_UNREAD_MARKERS[props.unreadMarker ?? "small-dot"]
+    return ""
   }
   return (
     <box width={props.width + 1} flexShrink={0} flexDirection="row" justifyContent="flex-end" paddingRight={1}>
       <Show
         when={runs() && props.animations && !props.numbers}
         fallback={
-          <text fg={props.color} selectable={false} attributes={props.attributes}>
+          <text fg={color()} selectable={false} attributes={props.attributes}>
             {label()}
           </text>
         }
@@ -157,6 +193,15 @@ function createPreviewDoubleClick(tabs: SessionTabsController) {
     }
     previous = { sessionID, time: now }
   }
+}
+
+function createGlowLevel(dimmed: () => boolean, animations: () => boolean) {
+  const motion = createAnimatable(
+    { level: dimmed() ? 0.7 : 1 },
+    { enabled: animations, transition: tween({ duration: 0.2 }) },
+  )
+  createEffect(() => motion.animate({ level: dimmed() ? 0.7 : 1 }))
+  return () => motion.value().level
 }
 
 function createNumberIgnition(runs: () => boolean, prompt: () => number, animations: () => boolean) {
@@ -414,6 +459,7 @@ export function SessionTabs(
     controller?: SessionTabsController
     animations?: boolean
     spinner?: TabSpinner
+    unreadMarker?: TabUnreadMarker
     orientation?: "horizontal" | "vertical"
     width?: number
   } = {},
@@ -426,7 +472,7 @@ export function SessionTabs(
       return
     }
     // Brief Control chords should not flash the tab numbers.
-    const timeout = setTimeout(() => setNumbers(true), 150)
+    const timeout = setTimeout(() => setNumbers(true), 300)
     onCleanup(() => clearTimeout(timeout))
   })
 
@@ -437,6 +483,7 @@ export function SessionTabs(
           controller={props.controller}
           animations={props.animations}
           spinner={props.spinner}
+          unreadMarker={props.unreadMarker}
           numbers={numbers()}
           width={props.width}
         />
@@ -446,6 +493,7 @@ export function SessionTabs(
           controller={props.controller}
           animations={props.animations}
           spinner={props.spinner}
+          unreadMarker={props.unreadMarker}
           numbers={numbers()}
         />
       </Match>
@@ -458,6 +506,7 @@ function VerticalSessionTabs(props: {
   animations?: boolean
   numbers: boolean
   spinner?: TabSpinner
+  unreadMarker?: TabUnreadMarker
   width?: number
 }) {
   const contextTabs = useSessionTabs()
@@ -503,9 +552,9 @@ function VerticalSessionTabs(props: {
               ...status,
               complete: sessionTabComplete(status.unread, status.busy),
               runs: status.busy && !status.attention,
-              glows:
-                tab.sessionID !== activeID() &&
-                Boolean(status.attention || (!status.busy && status.unread !== undefined)),
+              glows: Boolean(
+                status.attention || (tab.sessionID !== activeID() && !status.busy && status.unread !== undefined),
+              ),
             },
           ] as const
         }),
@@ -667,10 +716,11 @@ function VerticalSessionTabs(props: {
               }
               const pulseColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.25))
               const flashColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.7))
-              const glowColor = createMemo(() => tint(pulseBackground(), glowHue(), 0.45))
+              const glowLevel = createGlowLevel(() => selected() && Boolean(status().attention), animations)
+              const glowColor = createMemo(() => tint(pulseBackground(), glowHue(), 0.45 * glowLevel()))
               const detailPulseColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.13))
               const detailFlashColor = createMemo(() => tint(pulseBackground(), theme.text.default, 0.42))
-              const detailGlowColor = createMemo(() => tint(pulseBackground(), glowHue(), 0.25))
+              const detailGlowColor = createMemo(() => tint(pulseBackground(), glowHue(), 0.25 * glowLevel()))
               const detailColor = createMemo(() => tint(theme.text.subdued, pulseBackground(), 0.35))
               const detailTextColor = (index: number) =>
                 detailFades()
@@ -701,6 +751,10 @@ function VerticalSessionTabs(props: {
               })
               const previousGlows = () => previousStatus().glows
               const previousRuns = () => previousStatus().runs
+              const previousGlowLevel = createGlowLevel(
+                () => previous()?.sessionID === activeID() && Boolean(previousStatus().attention),
+                animations,
+              )
               const indicatorWidth = 10
               let lastPreviousGlowHue: RGBA | undefined
               const previousGlowHue = () => {
@@ -709,8 +763,12 @@ function VerticalSessionTabs(props: {
                 if (previousStatus().unread !== undefined) return (lastPreviousGlowHue = unreadColor())
                 return lastPreviousGlowHue ?? unreadColor()
               }
-              const separatorUpperColor = createMemo(() => tint(theme.background.default, previousGlowHue(), 0.1))
-              const separatorLowerColor = createMemo(() => tint(theme.background.default, glowHue(), 0.12))
+              const separatorUpperColor = createMemo(() =>
+                tint(theme.background.default, previousGlowHue(), 0.1 * previousGlowLevel()),
+              )
+              const separatorLowerColor = createMemo(() =>
+                tint(theme.background.default, glowHue(), 0.12 * glowLevel()),
+              )
               const titleColor = (index: number, separator: boolean) => {
                 const level = titleGlow.value().level
                 const color =
@@ -810,11 +868,11 @@ function VerticalSessionTabs(props: {
                       outerColor={tint(theme.background.default, theme.text.default, 0.006)}
                       flashColor={tint(theme.background.default, theme.text.default, 0.18)}
                       flashTail={8}
-                      glowColor={tint(theme.background.default, glowHue(), 0.1)}
+                      glowColor={tint(theme.background.default, glowHue(), 0.1 * glowLevel())}
                       outerGlowColor={theme.background.default}
                       glowTail={8}
                       outerGlowTail={5}
-                      completionColor={tint(theme.background.default, glowHue(), 0.1)}
+                      completionColor={tint(theme.background.default, glowHue(), 0.1 * glowLevel())}
                       outerCompletionColor={theme.background.default}
                       backgroundColor={theme.background.default}
                     />
@@ -841,9 +899,13 @@ function VerticalSessionTabs(props: {
                         label={sessionTabNumberLabel(index())}
                         width={numberWidth()}
                         color={numberColor()}
+                        unreadColor={tabFeedbackColor(status(), theme) ?? unreadColor()}
+                        backgroundColor={pulseBackground()}
+                        flashColor={theme.text.default}
                         animations={animations()}
                         numbers={props.numbers}
                         spinner={props.spinner}
+                        unreadMarker={props.unreadMarker}
                         attributes={selected() ? TextAttributes.BOLD : undefined}
                       />
                       <text
@@ -1010,6 +1072,7 @@ function HorizontalSessionTabs(props: {
   controller?: SessionTabsController
   animations?: boolean
   spinner?: TabSpinner
+  unreadMarker?: TabUnreadMarker
   numbers: boolean
 }) {
   const tabs = props.controller ?? useSessionTabs()
@@ -1298,9 +1361,10 @@ function HorizontalSessionTabs(props: {
           // so it reads as a lift of the pulse color rather than a different hue.
           const flashColor = () => tint(background(), theme.text.default, 0.65)
           const feedbackColor = () => tabFeedbackColor(status(), theme)
-          const glowColor = () => feedbackColor() ?? unreadColor()
+          const glowLevel = createGlowLevel(() => selected() && Boolean(status().attention), animations)
+          const glowColor = createMemo(() => tint(background(), feedbackColor() ?? unreadColor(), glowLevel()))
           const glows = () =>
-            !selected() && Boolean(status().attention || (!status().busy && status().unread !== undefined))
+            Boolean(status().attention || (!selected() && !status().busy && status().unread !== undefined))
           const title = () => tab.title ?? "Untitled session"
           const tabNumber = createMemo(() => items().findIndex((item) => item.sessionID === tab.sessionID) + 1)
           const numberWidth = () => Math.max(2, String(items().length).length)
@@ -1420,9 +1484,13 @@ function HorizontalSessionTabs(props: {
                   label={tab === NEW_SESSION_TAB ? "+" : sessionTabNumberLabel(tabNumber() - 1)}
                   width={numberWidth()}
                   color={numberColor()}
+                  unreadColor={feedbackColor() ?? unreadColor()}
+                  backgroundColor={background()}
+                  flashColor={theme.text.default}
                   animations={animations()}
                   numbers={props.numbers}
                   spinner={props.spinner}
+                  unreadMarker={props.unreadMarker}
                   attributes={bold()}
                 />
                 <text

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -12,11 +12,11 @@ import {
   onCleanup,
   untrack,
 } from "solid-js"
-import { Portal, useTerminalDimensions } from "@opentui/solid"
+import { Portal, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { useConfig } from "../config"
 import { useSessionTabs } from "../context/session-tabs"
 import { useData } from "../context/data"
-import { useTheme, useThemes } from "../context/theme"
+import { useTheme } from "../context/theme"
 import {
   adaptiveSessionTabLayout,
   moveSessionTab,
@@ -39,6 +39,18 @@ import { marqueeCycleWidth, marqueeOverflows, marqueeTextParts } from "../util/m
 import { useDialog } from "../ui/dialog"
 import { DialogSessionRename } from "./dialog-session-rename"
 import { Keymap } from "../context/keymap"
+import { registerOpencodeSpinner } from "./register-spinner"
+import { SPINNER_FRAMES } from "./spinner-frames"
+
+registerOpencodeSpinner()
+
+export const TAB_SPINNERS = {
+  arcs: { frames: ["◜", "◝", "◞", "◟"], interval: 120 },
+  dots: { frames: SPINNER_FRAMES, interval: 80 },
+  quadrants: { frames: ["◴", "◷", "◶", "◵"], interval: 120 },
+  line: { frames: ["|", "/", "-", "\\"], interval: 120 },
+}
+export type TabSpinner = keyof typeof TAB_SPINNERS
 
 // A long title fades out over its last cells instead of cutting hard.
 const FADE_WIDTH = 4
@@ -88,6 +100,49 @@ export type SessionTabsController = Pick<ContextController, "tabs" | "current" |
 const NEW_SESSION_TAB: SessionTab = { sessionID: "new", title: NEW_SESSION_TAB_TITLE }
 const glowTextColor = (base: RGBA, glow: RGBA, index: number, width: number, level = 1) =>
   tint(base, glow, 0.12 * unreadGlowIntensity(index, width) * level)
+
+function tabFeedbackColor(status: SessionTabsStatus, theme: ReturnType<typeof useTheme>) {
+  if (status.attention) return theme.text.status[status.attention]
+  if (status.unread === "error") return theme.text.feedback.error.default
+  return undefined
+}
+
+function TabIndicator(props: {
+  status: SessionTabsStatus
+  label: string
+  width: number
+  color: RGBA
+  animations: boolean
+  numbers: boolean
+  spinner?: TabSpinner
+  attributes?: number
+}) {
+  const runs = () => props.status.busy && !props.status.attention
+  const spinner = () => TAB_SPINNERS[props.spinner ?? "arcs"]
+  const label = () => {
+    if (props.numbers) return props.label
+    if (props.status.attention === "permission") return "!"
+    if (props.status.attention === "question") return "?"
+    if (runs()) return spinner().frames[0]
+    if (props.status.unread === "error") return "×"
+    if (props.status.unread === "activity") return "✓"
+    return props.label
+  }
+  return (
+    <box width={props.width + 1} flexShrink={0} flexDirection="row" justifyContent="flex-end" paddingRight={1}>
+      <Show
+        when={runs() && props.animations && !props.numbers}
+        fallback={
+          <text fg={props.color} selectable={false} attributes={props.attributes}>
+            {label()}
+          </text>
+        }
+      >
+        <spinner frames={spinner().frames} interval={spinner().interval} color={props.color} />
+      </Show>
+    </box>
+  )
+}
 
 function createPreviewDoubleClick(tabs: SessionTabsController) {
   let previous: { sessionID: string; time: number } | undefined
@@ -360,35 +415,67 @@ export function SessionTabs(
   props: {
     controller?: SessionTabsController
     animations?: boolean
+    spinner?: TabSpinner
+    statusPosition?: "inline" | "below"
     orientation?: "horizontal" | "vertical"
     width?: number
   } = {},
 ) {
+  const renderer = useRenderer()
+  const [numbers, setNumbers] = createSignal(false)
+  useKeyboard(
+    (key) => {
+      if (key.name === "leftctrl" || key.name === "rightctrl") setNumbers(key.eventType !== "release")
+    },
+    { release: true },
+  )
+  const blur = () => setNumbers(false)
+  renderer.on("blur", blur)
+  onCleanup(() => renderer.off("blur", blur))
+
   return (
     <Switch>
       <Match when={props.orientation === "vertical"}>
-        <VerticalSessionTabs controller={props.controller} animations={props.animations} width={props.width} />
+        <VerticalSessionTabs
+          controller={props.controller}
+          animations={props.animations}
+          spinner={props.spinner}
+          statusPosition={props.statusPosition}
+          numbers={numbers()}
+          width={props.width}
+        />
       </Match>
       <Match when={true}>
-        <HorizontalSessionTabs controller={props.controller} animations={props.animations} />
+        <HorizontalSessionTabs
+          controller={props.controller}
+          animations={props.animations}
+          spinner={props.spinner}
+          numbers={numbers()}
+        />
       </Match>
     </Switch>
   )
 }
 
-function VerticalSessionTabs(props: { controller?: SessionTabsController; animations?: boolean; width?: number }) {
+function VerticalSessionTabs(props: {
+  controller?: SessionTabsController
+  animations?: boolean
+  numbers: boolean
+  spinner?: TabSpinner
+  statusPosition?: "inline" | "below"
+  width?: number
+}) {
   const contextTabs = useSessionTabs()
   const tabs: SessionTabsController = props.controller ?? contextTabs
   const data = useData()
   const theme = useTheme("elevated")
-  const { mode } = useThemes()
   const config = useConfig().data
   const animations = () => props.animations ?? config.animations ?? true
   const width = () => props.width ?? SESSION_SIDEBAR_WIDTH
-  const hueStep = () => (mode() === "light" ? 800 : 200)
-  const accent = () => theme.hue.accent[hueStep()]
-  const activeNumber = () => theme.hue.interactive[hueStep()]
-  const idleNumber = () => tint(theme.text.subdued, theme.background.default, 0.35)
+  const below = () => props.statusPosition === "below"
+  const accent = () => theme.text.feedback.success.default
+  const activeNumber = () => theme.text.status.running
+  const idleNumber = () => tint(theme.text.formfield.default, theme.background.default, 0.55)
   const separatorUpperPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.04))
   const separatorLowerPulseColor = createMemo(() => tint(theme.background.default, theme.text.default, 0.05))
   const [addHovered, setAddHovered] = createSignal(false)
@@ -423,7 +510,8 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               complete: sessionTabComplete(status.unread, status.busy),
               runs: status.busy && !status.attention,
               glows:
-                tab.sessionID !== activeID() && (status.attention || (!status.busy && status.unread !== undefined)),
+                tab.sessionID !== activeID() &&
+                Boolean(status.attention || (!status.busy && status.unread !== undefined)),
             },
           ] as const
         }),
@@ -564,7 +652,7 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                   hovered() === tab.sessionID && !selected()
                     ? foreground()
                     : tint(idleNumber(), tint(theme.text.default, pulseBackground(), 0.25), Number(selected()))
-                const color = tint(base, glowHue(), numberGlow.value().level)
+                const color = tabFeedbackColor(status(), theme) ?? tint(base, glowHue(), numberGlow.value().level)
                 const runningColor = runs() ? activeNumber() : color
                 return sweepLevel() === 0
                   ? tint(runningColor, theme.text.default, numberIgnition.value().level)
@@ -578,8 +666,8 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               // Latched so a resolving glow fades out in the hue it lit with instead of snapping to accent.
               let lastGlowHue: RGBA | undefined
               const glowHue = () => {
-                if (status().attention) return (lastGlowHue = theme.text.feedback.warning.default)
-                if (status().unread === "error") return (lastGlowHue = theme.text.feedback.error.default)
+                const feedback = tabFeedbackColor(status(), theme)
+                if (feedback) return (lastGlowHue = feedback)
                 if (status().unread !== undefined) return (lastGlowHue = accent())
                 return lastGlowHue ?? accent()
               }
@@ -622,9 +710,8 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
               const indicatorWidth = 10
               let lastPreviousGlowHue: RGBA | undefined
               const previousGlowHue = () => {
-                if (previousStatus().attention) return (lastPreviousGlowHue = theme.text.feedback.warning.default)
-                if (previousStatus().unread === "error")
-                  return (lastPreviousGlowHue = theme.text.feedback.error.default)
+                const feedback = tabFeedbackColor(previousStatus(), theme)
+                if (feedback) return (lastPreviousGlowHue = feedback)
                 if (previousStatus().unread !== undefined) return (lastPreviousGlowHue = accent())
                 return lastPreviousGlowHue ?? accent()
               }
@@ -755,14 +842,16 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       onLevel={setSweepLevel}
                     />
                     <box zIndex={1} width="100%" flexDirection="row" paddingRight={1}>
-                      <text
-                        width={numberWidth() + 1}
-                        fg={numberColor()}
-                        selectable={false}
+                      <TabIndicator
+                        status={status()}
+                        label={sessionTabNumberLabel(index())}
+                        width={numberWidth()}
+                        color={numberColor()}
+                        animations={animations()}
+                        numbers={below() || props.numbers}
+                        spinner={props.spinner}
                         attributes={selected() ? TextAttributes.BOLD : undefined}
-                      >
-                        {sessionTabNumberLabel(index()).padStart(numberWidth())}
-                      </text>
+                      />
                       <text
                         width={titleWidth()}
                         fg={foreground()}
@@ -826,7 +915,24 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
                       completionColor={detailGlowColor()}
                       backgroundColor={pulseBackground()}
                     />
-                    <box zIndex={1} width="100%" flexDirection="row" paddingLeft={numberWidth() + 1} paddingRight={2}>
+                    <box
+                      zIndex={1}
+                      width="100%"
+                      flexDirection="row"
+                      paddingLeft={below() ? 0 : numberWidth() + 1}
+                      paddingRight={2}
+                    >
+                      <Show when={below()}>
+                        <TabIndicator
+                          status={status()}
+                          label=""
+                          width={numberWidth()}
+                          color={numberColor()}
+                          animations={animations()}
+                          numbers={false}
+                          spinner={props.spinner}
+                        />
+                      </Show>
                       <text fg={detailColor()} wrapMode="none" selectable={false}>
                         <Show when={detailFades()} fallback={visibleDetail()}>
                           <For each={visibleDetailParts()}>
@@ -923,11 +1029,15 @@ function VerticalSessionTabs(props: { controller?: SessionTabsController; animat
   )
 }
 
-function HorizontalSessionTabs(props: { controller?: SessionTabsController; animations?: boolean } = {}) {
+function HorizontalSessionTabs(props: {
+  controller?: SessionTabsController
+  animations?: boolean
+  spinner?: TabSpinner
+  numbers: boolean
+}) {
   const tabs = props.controller ?? useSessionTabs()
   const dimensions = useTerminalDimensions()
   const theme = useTheme()
-  const { mode } = useThemes()
   const config = useConfig().data
   const animations = () => props.animations ?? config.animations ?? true
   const [addHovered, setAddHovered] = createSignal(false)
@@ -960,10 +1070,9 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
   onCleanup(clearCloseHold)
   // A captured drag ends with a synthetic up on its drop target; do not turn that into a click.
   let suppressClick = false
-  const hueStep = () => (mode() === "light" ? 800 : 200)
-  const accent = () => theme.hue.accent[hueStep()]
-  const activeNumber = () => theme.hue.interactive[hueStep()]
-  const idleNumber = () => tint(theme.text.subdued, theme.background.default, 0.35)
+  const accent = () => theme.text.feedback.success.default
+  const activeNumber = () => theme.text.status.running
+  const idleNumber = () => tint(theme.text.formfield.default, theme.background.default, 0.55)
   const newTab = () => tabs.newTab?.() ?? false
   const activeID = createMemo(() => (newTab() ? NEW_SESSION_TAB.sessionID : tabs.current()))
   const ordered = createMemo(() => {
@@ -1211,13 +1320,10 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
           // The edge flash washes toward a brighter stop on the same background-to-text ramp,
           // so it reads as a lift of the pulse color rather than a different hue.
           const flashColor = () => tint(background(), theme.text.default, 0.65)
-          const feedbackColor = () => {
-            if (status().attention) return theme.text.feedback.warning.default
-            if (status().unread === "error") return theme.text.feedback.error.default
-            return undefined
-          }
+          const feedbackColor = () => tabFeedbackColor(status(), theme)
           const glowColor = () => feedbackColor() ?? accent()
-          const glows = () => !selected() && (status().attention || (!status().busy && status().unread !== undefined))
+          const glows = () =>
+            !selected() && Boolean(status().attention || (!status().busy && status().unread !== undefined))
           const title = () => tab.title ?? "Untitled session"
           const tabNumber = createMemo(() => items().findIndex((item) => item.sessionID === tab.sessionID) + 1)
           const numberWidth = () => Math.max(2, String(items().length).length)
@@ -1273,7 +1379,7 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
               hovered() === tab.sessionID && !selected()
                 ? foreground()
                 : tint(idleNumber(), tint(theme.text.default, background(), 0.25), selection())
-            const color = feedback ?? (runs() ? activeNumber() : tint(base, accent(), activity()))
+            const color = runs() ? activeNumber() : (feedback ?? tint(base, accent(), activity()))
             // The number brightens faintly as the running sweep passes beneath it.
             return tint(color, theme.text.default, Math.max(numberIgnition.value().level, 0.15 * sweepLevel()))
           }
@@ -1332,9 +1438,16 @@ function HorizontalSessionTabs(props: { controller?: SessionTabsController; anim
                 onLevel={setSweepLevel}
               />
               <box zIndex={1} width="100%" flexDirection="row">
-                <text width={numberWidth() + 1} fg={numberColor()} selectable={false} attributes={bold()}>
-                  {(tab === NEW_SESSION_TAB ? "+" : sessionTabNumberLabel(tabNumber() - 1)).padStart(numberWidth())}
-                </text>
+                <TabIndicator
+                  status={status()}
+                  label={tab === NEW_SESSION_TAB ? "+" : sessionTabNumberLabel(tabNumber() - 1)}
+                  width={numberWidth()}
+                  color={numberColor()}
+                  animations={animations()}
+                  numbers={props.numbers}
+                  spinner={props.spinner}
+                  attributes={bold()}
+                />
                 <text
                   width={availableTitleWidth()}
                   fg={foreground()}

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -12,7 +12,7 @@ import {
   onCleanup,
   untrack,
 } from "solid-js"
-import { Portal, useKeyboard, useRenderer, useTerminalDimensions } from "@opentui/solid"
+import { Portal, useTerminalDimensions } from "@opentui/solid"
 import { useConfig } from "../config"
 import { useSessionTabs } from "../context/session-tabs"
 import { useData } from "../context/data"
@@ -421,17 +421,7 @@ export function SessionTabs(
     width?: number
   } = {},
 ) {
-  const renderer = useRenderer()
-  const [numbers, setNumbers] = createSignal(false)
-  useKeyboard(
-    (key) => {
-      if (key.name === "leftctrl" || key.name === "rightctrl") setNumbers(key.eventType !== "release")
-    },
-    { release: true },
-  )
-  const blur = () => setNumbers(false)
-  renderer.on("blur", blur)
-  onCleanup(() => renderer.off("blur", blur))
+  const keymap = Keymap.use()
 
   return (
     <Switch>
@@ -441,7 +431,7 @@ export function SessionTabs(
           animations={props.animations}
           spinner={props.spinner}
           statusPosition={props.statusPosition}
-          numbers={numbers()}
+          numbers={keymap.control()}
           width={props.width}
         />
       </Match>
@@ -450,7 +440,7 @@ export function SessionTabs(
           controller={props.controller}
           animations={props.animations}
           spinner={props.spinner}
-          numbers={numbers()}
+          numbers={keymap.control()}
         />
       </Match>
     </Switch>

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -124,7 +124,7 @@ function TabIndicator(props: {
     if (props.status.attention === "permission") return "!"
     if (props.status.attention === "question") return "?"
     if (runs()) return spinner().frames[0]
-    return props.label
+    return props.label === "+" ? "+" : "▪"
   }
   return (
     <box width={props.width + 1} flexShrink={0} flexDirection="row" justifyContent="flex-end" paddingRight={1}>
@@ -419,6 +419,16 @@ export function SessionTabs(
   } = {},
 ) {
   const keymap = Keymap.use()
+  const [numbers, setNumbers] = createSignal(false)
+  createEffect(() => {
+    if (!keymap.control()) {
+      setNumbers(false)
+      return
+    }
+    // Brief Control chords should not flash the tab numbers.
+    const timeout = setTimeout(() => setNumbers(true), 150)
+    onCleanup(() => clearTimeout(timeout))
+  })
 
   return (
     <Switch>
@@ -427,7 +437,7 @@ export function SessionTabs(
           controller={props.controller}
           animations={props.animations}
           spinner={props.spinner}
-          numbers={keymap.control()}
+          numbers={numbers()}
           width={props.width}
         />
       </Match>
@@ -436,7 +446,7 @@ export function SessionTabs(
           controller={props.controller}
           animations={props.animations}
           spinner={props.spinner}
-          numbers={keymap.control()}
+          numbers={numbers()}
         />
       </Match>
     </Switch>

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -159,6 +159,9 @@ export const Info = Schema.Struct({
       layout: Schema.optional(Schema.Literals(["horizontal", "vertical"])).annotate({
         description: "Show tabs in a horizontal strip or vertical sidebar",
       }),
+      indicators: Schema.optional(Schema.Literals(["status", "numbers"])).annotate({
+        description: "Show status icons with numbers on held Control, or always show tab numbers",
+      }),
     }),
   ).annotate({ description: "Tab strip settings" }),
   mini: Schema.optional(
@@ -231,6 +234,7 @@ export type Resolved = Omit<Info, "attention" | "cursor" | "keybinds" | "leader"
     enabled: boolean
     scope: "global" | "cwd"
     layout: "horizontal" | "vertical"
+    indicators: "status" | "numbers"
   }
 }
 
@@ -283,6 +287,7 @@ export function resolve(input: Info, options: { terminalSuspend: boolean }): Res
       enabled: input.tabs?.enabled ?? true,
       scope: input.tabs?.scope ?? "cwd",
       layout: input.tabs?.layout ?? "horizontal",
+      indicators: input.tabs?.indicators ?? "status",
     },
   }
 }

--- a/packages/tui/src/context/keymap.tsx
+++ b/packages/tui/src/context/keymap.tsx
@@ -58,7 +58,7 @@ function Provider(props: ParentProps<{ config?: KeymapConfig }>) {
   const mode = createMode(keymap)
   const [control, setControl] = createSignal(false)
   const modifier = (event: KeyEvent) => {
-    if (!/^(?:(left|right)(ctrl|shift|alt|super|hyper|meta)|isolevel[35]shift)$/.test(event.name)) return
+    if (!/^(?:(left|right)(ctrl|shift|alt|super|hyper|meta)|iso_level[35]_shift)$/.test(event.name)) return
     if (event.name === "leftctrl" || event.name === "rightctrl") setControl(event.eventType !== "release")
     // Modifier-only reports are state changes, not input that cancels a selection or pending chord.
     event.preventDefault()

--- a/packages/tui/src/context/keymap.tsx
+++ b/packages/tui/src/context/keymap.tsx
@@ -13,7 +13,7 @@ import { formatCommandBindings, formatKeySequence } from "@opentui/keymap/extras
 import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
 import { KeymapProvider, useBindings, useKeymapSelector } from "@opentui/keymap/solid"
 import { useRenderer } from "@opentui/solid"
-import { createContext, onCleanup, useContext, type Accessor, type ParentProps } from "solid-js"
+import { createContext, createSignal, onCleanup, useContext, type Accessor, type ParentProps } from "solid-js"
 import { useConfig } from "../config"
 import { TuiKeybind } from "../config/keybind"
 
@@ -46,6 +46,7 @@ const Context = createContext<{
   readonly keymap: OpenTuiKeymap
   readonly config: KeymapConfig
   readonly mode: Mode
+  readonly control: Accessor<boolean>
   readonly dispatch: (id: string, input?: string) => void
   readonly input: (id: string) => string | undefined
 }>()
@@ -55,6 +56,23 @@ function Provider(props: ParentProps<{ config?: KeymapConfig }>) {
   const config: KeymapConfig = props.config ?? useConfig().data
   const keymap = createDefaultOpenTuiKeymap(renderer)
   const mode = createMode(keymap)
+  const [control, setControl] = createSignal(false)
+  const modifier = (event: KeyEvent) => {
+    if (!/^(?:(left|right)(ctrl|shift|alt|super|hyper|meta)|isolevel[35]shift)$/.test(event.name)) return
+    if (event.name === "leftctrl" || event.name === "rightctrl") setControl(event.eventType !== "release")
+    // Modifier-only reports are state changes, not input that cancels a selection or pending chord.
+    event.preventDefault()
+    event.stopPropagation()
+  }
+  const blur = () => setControl(false)
+  renderer.keyInput.prependListener("keypress", modifier)
+  renderer.keyInput.prependListener("keyrelease", modifier)
+  renderer.on("blur", blur)
+  onCleanup(() => {
+    renderer.keyInput.off("keypress", modifier)
+    renderer.keyInput.off("keyrelease", modifier)
+    renderer.off("blur", blur)
+  })
   let invocation: { readonly id: string; readonly input?: string } | undefined
   const dispatch = (id: string, input?: string) => {
     const previous = invocation
@@ -145,6 +163,7 @@ function Provider(props: ParentProps<{ config?: KeymapConfig }>) {
           keymap,
           config,
           mode,
+          control,
           dispatch,
           input: (id) => (invocation?.id === id ? invocation.input : undefined),
         }}
@@ -158,6 +177,8 @@ function Provider(props: ParentProps<{ config?: KeymapConfig }>) {
 export type { KeymapCommand, KeymapLayer } from "@opencode-ai/plugin/tui/context"
 
 export interface Keymap {
+  /** Whether Control is held, when the terminal reports modifier events. */
+  readonly control: Accessor<boolean>
   /** Dispatches a reachable command by ID. */
   dispatch(id: string, input?: string): void
   /** Controls mutually exclusive OpenCode input modes. */
@@ -182,6 +203,7 @@ function use(): Keymap {
       value.dispatch(id, input)
     },
     mode: value.mode,
+    control: value.control,
     intercept: value.keymap.intercept.bind(value.keymap),
     isLeader,
   }

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -167,9 +167,11 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
             ? ("error" as const)
             : ("activity" as const),
         promptPulse: promptPulses()[session] ?? 0,
-        attention: members.some(
-          (id) => (data.session.permission.list(id)?.length ?? 0) > 0 || (data.session.form.list(id)?.length ?? 0) > 0,
-        ),
+        attention: members.some((id) => (data.session.permission.list(id)?.length ?? 0) > 0)
+          ? ("permission" as const)
+          : members.some((id) => (data.session.form.list(id)?.length ?? 0) > 0)
+            ? ("question" as const)
+            : (false as const),
         busy: members.some((id) => data.session.status(id) === "running" || data.session.pending.list(id).length > 0),
       }
     }

--- a/packages/tui/src/feature-plugins/system/storybook/footer.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/footer.tsx
@@ -26,26 +26,23 @@ export function StoryFooter(props: {
       </box>
       <Show when={props.status || props.message}>
         <box height={1} paddingLeft={1} paddingRight={1} flexDirection="row">
-          <text fg={theme.text.default}>{props.status ?? ""}</text>
-          <Show when={props.status && props.message}>
-            <text fg={theme.text.subdued}> · </text>
-          </Show>
-          <text fg={theme.text.subdued}>{props.message ?? ""}</text>
+          <text fg={theme.text.default} wrapMode="none">
+            {props.status ?? ""}
+            <span style={{ fg: theme.text.subdued }}>
+              {props.status && props.message ? " · " : ""}
+              {props.message ?? ""}
+            </span>
+          </text>
         </box>
       </Show>
-      <box height={1} paddingLeft={1} paddingRight={1} flexDirection="row">
-        <text fg={theme.text.default} wrapMode="none">
-          <For each={props.controls}>
-            {(control, index) => (
-              <>
-                <Show when={index() > 0}>
-                  <span> </span>
-                </Show>
-                {control.shortcut} <span style={{ fg: theme.text.subdued }}>{control.label}</span>
-              </>
-            )}
-          </For>
-        </text>
+      <box paddingLeft={1} paddingRight={1} flexDirection="row" flexWrap="wrap" columnGap={1}>
+        <For each={props.controls}>
+          {(control) => (
+            <text fg={theme.text.default} wrapMode="none" flexShrink={0}>
+              {control.shortcut} <span style={{ fg: theme.text.subdued }}>{control.label}</span>
+            </text>
+          )}
+        </For>
       </box>
       {/* The app-wide feature footer overlays the terminal's final row. */}
       <box height={1} />

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -63,9 +63,8 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
   const [lastEvent, setLastEvent] = createSignal("idle / working / question / permission / complete / error")
   const [statuses, setStatuses] = createSignal<Record<string, FixtureStatus>>(FIXTURE_STATUSES)
   const [orientation, setOrientation] = createSignal<"horizontal" | "vertical">("vertical")
-  const [statusPosition, setStatusPosition] = createSignal<"inline" | "below">("below")
   const spinners = Object.keys(TAB_SPINNERS) as TabSpinner[]
-  const [spinner, setSpinner] = createSignal<TabSpinner>("arcs")
+  const [spinner, setSpinner] = createSignal<TabSpinner>("dots")
   const [animations, setAnimations] = createSignal(true)
   // Unread clears on select, so the transcript remembers how each session's last run ended.
   const [outcomes, setOutcomes] = createSignal<Record<string, "completed" | "failed">>(FIXTURE_OUTCOMES)
@@ -260,10 +259,9 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       setStatuses(showcase ? FIXTURE_STATUSES : {})
       setOutcomes(showcase ? FIXTURE_OUTCOMES : {})
       setActive("fixture-1")
-      setSpinner("arcs")
+      setSpinner("dots")
       setAnimations(true)
       setOrientation("vertical")
-      setStatusPosition("below")
     })
     setLastEvent(showcase ? "all six states are visible" : "reset; all tabs idle")
   }
@@ -386,15 +384,6 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         run: () => setSpinner((value) => spinners[(spinners.indexOf(value) + 1) % spinners.length]),
       },
       { bind: "m", title: "Toggle animations", group: "Storybook", run: () => setAnimations((value) => !value) },
-      {
-        bind: "b",
-        title: "Toggle status below vertical tab titles",
-        group: "Storybook",
-        run() {
-          setOrientation("vertical")
-          setStatusPosition((value) => (value === "inline" ? "below" : "inline"))
-        },
-      },
       { bind: "t", title: "Add tab", group: "Storybook", run: addTab },
       { bind: "d", title: "Close tab", group: "Storybook", run: () => controller.close() },
       {
@@ -422,7 +411,6 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           controller={controller}
           orientation={orientation()}
           spinner={spinner()}
-          statusPosition={statusPosition()}
           animations={animations()}
         />
         <box flexGrow={1} paddingLeft={2} paddingRight={2} paddingTop={1} flexDirection="column">
@@ -440,7 +428,6 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         title="storybook / tabs"
         details={[
           orientation() === "vertical" ? "left rail" : "top strip",
-          ...(orientation() === "vertical" ? [`status ${statusPosition()}`] : []),
           spinner(),
           animations() ? "animated" : "still",
         ]}
@@ -457,7 +444,6 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           { shortcut: "m", label: "motion" },
           { shortcut: "↑/↓", label: "select" },
           { shortcut: "o", label: "layout" },
-          { shortcut: "b", label: "rail inline/below" },
           { shortcut: "r", label: "reset idle" },
           { shortcut: "v", label: "all states" },
           { shortcut: "esc", label: "back" },

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -6,8 +6,10 @@ import {
   EMPTY_SESSION_TAB_STATUS,
   SessionTabs,
   TAB_SPINNERS,
+  TAB_UNREAD_MARKERS,
   type SessionTabsController,
   type TabSpinner,
+  type TabUnreadMarker,
 } from "../../../component/session-tabs"
 import { closeSessionTab, cycleSessionTab, moveSessionTab } from "../../../context/session-tabs-model"
 import { StoryFooter } from "./footer"
@@ -65,6 +67,8 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
   const [orientation, setOrientation] = createSignal<"horizontal" | "vertical">("vertical")
   const spinners = Object.keys(TAB_SPINNERS) as TabSpinner[]
   const [spinner, setSpinner] = createSignal<TabSpinner>("dots")
+  const markers = Object.keys(TAB_UNREAD_MARKERS) as TabUnreadMarker[]
+  const [marker, setMarker] = createSignal<TabUnreadMarker>("small-dot")
   const [animations, setAnimations] = createSignal(true)
   // Unread clears on select, so the transcript remembers how each session's last run ended.
   const [outcomes, setOutcomes] = createSignal<Record<string, "completed" | "failed">>(FIXTURE_OUTCOMES)
@@ -260,6 +264,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       setOutcomes(showcase ? FIXTURE_OUTCOMES : {})
       setActive("fixture-1")
       setSpinner("dots")
+      setMarker("small-dot")
       setAnimations(true)
       setOrientation("vertical")
     })
@@ -383,6 +388,12 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         group: "Storybook",
         run: () => setSpinner((value) => spinners[(spinners.indexOf(value) + 1) % spinners.length]),
       },
+      {
+        bind: "u",
+        title: "Cycle unread marker",
+        group: "Storybook",
+        run: () => setMarker((value) => markers[(markers.indexOf(value) + 1) % markers.length]),
+      },
       { bind: "m", title: "Toggle animations", group: "Storybook", run: () => setAnimations((value) => !value) },
       { bind: "t", title: "Add tab", group: "Storybook", run: addTab },
       { bind: "d", title: "Close tab", group: "Storybook", run: () => controller.close() },
@@ -411,6 +422,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           controller={controller}
           orientation={orientation()}
           spinner={spinner()}
+          unreadMarker={marker()}
           animations={animations()}
         />
         <box flexGrow={1} paddingLeft={2} paddingRight={2} paddingTop={1} flexDirection="column">
@@ -429,6 +441,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         details={[
           orientation() === "vertical" ? "left rail" : "top strip",
           spinner(),
+          `${TAB_UNREAD_MARKERS[marker()]} ${marker()}`,
           animations() ? "animated" : "still",
         ]}
         status={stateSummary()}
@@ -440,6 +453,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           { shortcut: "i", label: "idle" },
           { shortcut: "f/x", label: "complete/fail" },
           { shortcut: "c", label: "spinner" },
+          { shortcut: "u", label: "unread marker" },
           { shortcut: "hold ctrl", label: "numbers" },
           { shortcut: "m", label: "motion" },
           { shortcut: "↑/↓", label: "select" },

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -2,7 +2,13 @@ import { Plugin } from "@opencode-ai/plugin/tui"
 import { useTerminalDimensions } from "@opentui/solid"
 import { batch, createSignal, For } from "solid-js"
 import { createStore, reconcile } from "solid-js/store"
-import { EMPTY_SESSION_TAB_STATUS, SessionTabs, type SessionTabsController } from "../../../component/session-tabs"
+import {
+  EMPTY_SESSION_TAB_STATUS,
+  SessionTabs,
+  TAB_SPINNERS,
+  type SessionTabsController,
+  type TabSpinner,
+} from "../../../component/session-tabs"
 import { closeSessionTab, cycleSessionTab, moveSessionTab } from "../../../context/session-tabs-model"
 import { StoryFooter } from "./footer"
 import type { Story } from "./index"
@@ -23,6 +29,15 @@ const FIXTURE_TABS = [
   { sessionID: "fixture-11", title: "Run focused tests", project: "opencode" },
   { sessionID: "fixture-12", title: "Prepare review", project: "opencode-drive" },
 ]
+
+const FIXTURE_STATUSES: Record<string, FixtureStatus> = {
+  "fixture-2": { ...EMPTY_SESSION_TAB_STATUS, busy: true },
+  "fixture-3": { ...EMPTY_SESSION_TAB_STATUS, busy: true, attention: "question" },
+  "fixture-4": { ...EMPTY_SESSION_TAB_STATUS, busy: true, attention: "permission" },
+  "fixture-5": { ...EMPTY_SESSION_TAB_STATUS, unread: "activity" },
+  "fixture-6": { ...EMPTY_SESSION_TAB_STATUS, unread: "error" },
+}
+const FIXTURE_OUTCOMES = { "fixture-5": "completed", "fixture-6": "failed" } as const
 
 // Plausible targets for the fake transcript's tool calls, picked per fixture index.
 const TRANSCRIPT_FILES = [
@@ -45,23 +60,25 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
   const setItems = (next: { sessionID: string; title?: string }[]) =>
     setTabStore("items", reconcile(next, { key: "sessionID" }))
   const [active, setActive] = createSignal<string | undefined>("fixture-1")
-  const [lastEvent, setLastEvent] = createSignal("press space to start a random tab")
-  const [statuses, setStatuses] = createSignal<Record<string, FixtureStatus>>({})
+  const [lastEvent, setLastEvent] = createSignal("idle / working / question / permission / complete / error")
+  const [statuses, setStatuses] = createSignal<Record<string, FixtureStatus>>(FIXTURE_STATUSES)
   const [orientation, setOrientation] = createSignal<"horizontal" | "vertical">("vertical")
+  const [statusPosition, setStatusPosition] = createSignal<"inline" | "below">("below")
+  const spinners = Object.keys(TAB_SPINNERS) as TabSpinner[]
+  const [spinner, setSpinner] = createSignal<TabSpinner>("arcs")
+  const [animations, setAnimations] = createSignal(true)
   // Unread clears on select, so the transcript remembers how each session's last run ended.
-  const [outcomes, setOutcomes] = createSignal<Record<string, "completed" | "failed">>({})
+  const [outcomes, setOutcomes] = createSignal<Record<string, "completed" | "failed">>(FIXTURE_OUTCOMES)
   const number = (sessionID: string) => tabs().findIndex((tab) => tab.sessionID === sessionID) + 1
 
-  function finishRun(sessionID: string) {
+  function finishRun(sessionID: string, failed = Math.random() >= 0.75) {
     if (!tabs().some((item) => item.sessionID === sessionID)) return
-    const roll = Math.random()
-    const failed = roll >= 0.75
     const unread = active() === sessionID ? undefined : failed ? ("error" as const) : ("activity" as const)
     batch(() => {
       setOutcomes((current) => ({ ...current, [sessionID]: failed ? "failed" : "completed" }))
       setStatuses((current) => ({
         ...current,
-        [sessionID]: { ...(current[sessionID] ?? EMPTY_SESSION_TAB_STATUS), busy: false, unread },
+        [sessionID]: { ...(current[sessionID] ?? EMPTY_SESSION_TAB_STATUS), busy: false, attention: false, unread },
       }))
       // An untitled session earns its title after its first completed run, like a real summarization.
       const index = number(sessionID) - 1
@@ -77,8 +94,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     const status = statuses()[sessionID]
     batch(() => {
       setActive(sessionID)
-      if (status && (status.unread || status.attention))
-        setStatuses((current) => ({ ...current, [sessionID]: { ...status, unread: undefined, attention: false } }))
+      if (status?.unread) setStatuses((current) => ({ ...current, [sessionID]: { ...status, unread: undefined } }))
     })
   }
 
@@ -134,7 +150,12 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
   const startRun = (sessionID: string) => {
     setStatuses((current) => ({
       ...current,
-      [sessionID]: { ...(current[sessionID] ?? EMPTY_SESSION_TAB_STATUS), busy: true, unread: undefined },
+      [sessionID]: {
+        ...(current[sessionID] ?? EMPTY_SESSION_TAB_STATUS),
+        busy: true,
+        attention: false,
+        unread: undefined,
+      },
     }))
     setOutcomes((current) => {
       const next = { ...current }
@@ -170,7 +191,10 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
     return pool[Math.floor(Math.random() * pool.length)]
   }
   const randomRunningTab = () => {
-    const candidates = tabs().filter((tab) => controller.status(tab.sessionID).busy)
+    const candidates = tabs().filter((tab) => {
+      const status = controller.status(tab.sessionID)
+      return status.busy && !status.attention
+    })
     return candidates[Math.floor(Math.random() * candidates.length)]
   }
   // A fake transcript for the selected session so tab switches feel like moving between real
@@ -190,7 +214,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       { text: `> ${fixture.title}`, color: theme.text.default },
       { text: "", color: theme.text.default },
     ]
-    if (!status.busy && outcome === undefined) {
+    if (!status.busy && !status.attention && outcome === undefined) {
       lines.push({ text: "no activity yet — press s to run this session", color: theme.text.subdued })
       return lines
     }
@@ -202,7 +226,11 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       { text: `  ✱ Bash bun run test`, color: theme.text.subdued },
       { text: "", color: theme.text.default },
     )
-    if (status.busy) lines.push({ text: "● Working…", color: theme.text.subdued })
+    if (status.attention === "question")
+      lines.push({ text: "? Which approach should I take?", color: theme.text.status.question })
+    else if (status.attention === "permission")
+      lines.push({ text: "! Waiting for permission to run the command", color: theme.text.status.permission })
+    else if (status.busy) lines.push({ text: "● Working…", color: theme.text.status.running })
     else if (outcome === "failed")
       lines.push({
         text: `✗ bun run test failed — 3 tests failing in ${file}`,
@@ -218,9 +246,26 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
 
   const stateSummary = () => {
     const values = tabs().map((tab) => controller.status(tab.sessionID))
-    const running = values.filter((status) => status.busy).length
+    const running = values.filter((status) => status.busy && !status.attention).length
+    const waiting = values.filter((status) => status.attention).length
     const unread = values.filter((status) => status.unread !== undefined).length
-    return [`selected ${number(active() ?? "")}`, `${running} running`, `${unread} unread`].join("  ·  ")
+    return [`selected ${number(active() ?? "")}`, `${running} running`, `${waiting} waiting`, `${unread} unread`].join(
+      "  ·  ",
+    )
+  }
+
+  const reset = (showcase = false) => {
+    batch(() => {
+      setItems(FIXTURE_TABS.slice(0, 6).map((tab) => ({ ...tab })))
+      setStatuses(showcase ? FIXTURE_STATUSES : {})
+      setOutcomes(showcase ? FIXTURE_OUTCOMES : {})
+      setActive("fixture-1")
+      setSpinner("arcs")
+      setAnimations(true)
+      setOrientation("vertical")
+      setStatusPosition("below")
+    })
+    setLastEvent(showcase ? "all six states are visible" : "reset; all tabs idle")
   }
 
   props.context.keymap.layer(() => ({
@@ -236,7 +281,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       { bind: "up,k,left,h", title: "Previous tab", group: "Storybook", run: () => cycle(-1) },
       { bind: "down,j,right,l", title: "Next tab", group: "Storybook", run: () => cycle(1) },
       ...Array.from({ length: 10 }, (_, index) => ({
-        bind: String((index + 1) % 10),
+        bind: `${(index + 1) % 10},ctrl+${(index + 1) % 10}`,
         title: `Select tab ${index + 1}`,
         group: "Storybook",
         run() {
@@ -289,11 +334,65 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         run() {
           const current = active()
           if (!current) return
-          if (controller.status(current).busy) {
+          if (controller.status(current).busy && !controller.status(current).attention) {
             setLastEvent(`tab ${number(current)} is already running`)
             return
           }
           startRun(current)
+        },
+      },
+      ...(
+        [
+          { bind: "q", title: "Ask a question", attention: "question" },
+          { bind: "a", title: "Request permission", attention: "permission" },
+          { bind: "i", title: "Set idle", attention: false },
+        ] as const
+      ).map((state) => ({
+        bind: state.bind,
+        title: state.title,
+        group: "Storybook",
+        run() {
+          const current = active()
+          if (!current) return
+          startRun(current)
+          setStatuses((statuses) => ({
+            ...statuses,
+            [current]: { ...EMPTY_SESSION_TAB_STATUS, busy: Boolean(state.attention), attention: state.attention },
+          }))
+          setLastEvent(`tab ${number(current)} ${state.attention || "idle"}`)
+        },
+      })),
+      ...(
+        [
+          { bind: "f", title: "Complete selected tab", failed: false },
+          { bind: "x", title: "Fail selected tab", failed: true },
+        ] as const
+      ).map((state) => ({
+        bind: state.bind,
+        title: state.title,
+        group: "Storybook",
+        run() {
+          const current = active()
+          if (!current) return
+          // Leave the result unread so its indicator can be inspected before selecting it again.
+          cycle(1)
+          finishRun(current, state.failed)
+        },
+      })),
+      {
+        bind: "c",
+        title: "Cycle spinner shape",
+        group: "Storybook",
+        run: () => setSpinner((value) => spinners[(spinners.indexOf(value) + 1) % spinners.length]),
+      },
+      { bind: "m", title: "Toggle animations", group: "Storybook", run: () => setAnimations((value) => !value) },
+      {
+        bind: "b",
+        title: "Toggle status below vertical tab titles",
+        group: "Storybook",
+        run() {
+          setOrientation("vertical")
+          setStatusPosition((value) => (value === "inline" ? "below" : "inline"))
         },
       },
       { bind: "t", title: "Add tab", group: "Storybook", run: addTab },
@@ -306,20 +405,8 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           setOrientation((value) => (value === "vertical" ? "horizontal" : "vertical"))
         },
       },
-      {
-        bind: "r",
-        title: "Reset",
-        group: "Storybook",
-        run() {
-          batch(() => {
-            setItems(FIXTURE_TABS.slice(0, 6).map((tab) => ({ ...tab })))
-            setStatuses({})
-            setOutcomes({})
-            setActive("fixture-1")
-          })
-          setLastEvent("reset; press space to start a random tab")
-        },
-      },
+      { bind: "r,shift+r", title: "Reset to idle", group: "Storybook", run: () => reset() },
+      { bind: "v", title: "Show all states", group: "Storybook", run: () => reset(true) },
     ],
   }))
 
@@ -331,7 +418,13 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       backgroundColor={theme.background.default}
     >
       <box flexGrow={1} flexDirection={orientation() === "vertical" ? "row" : "column"}>
-        <SessionTabs controller={controller} orientation={orientation()} />
+        <SessionTabs
+          controller={controller}
+          orientation={orientation()}
+          spinner={spinner()}
+          statusPosition={statusPosition()}
+          animations={animations()}
+        />
         <box flexGrow={1} paddingLeft={2} paddingRight={2} paddingTop={1} flexDirection="column">
           <For each={transcript()}>
             {(line) => (
@@ -345,16 +438,28 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
       <StoryFooter
         context={props.context}
         title="storybook / tabs"
-        details={[orientation() === "vertical" ? "left rail" : "top strip"]}
+        details={[
+          orientation() === "vertical" ? "left rail" : "top strip",
+          ...(orientation() === "vertical" ? [`status ${statusPosition()}`] : []),
+          spinner(),
+          animations() ? "animated" : "still",
+        ]}
         status={stateSummary()}
         message={lastEvent()}
         controls={[
-          { shortcut: "space", label: "start" },
-          { shortcut: "p", label: "prompt" },
-          { shortcut: "e", label: "end" },
+          { shortcut: "s", label: "work" },
+          { shortcut: "q", label: "question" },
+          { shortcut: "a", label: "permission" },
+          { shortcut: "i", label: "idle" },
+          { shortcut: "f/x", label: "complete/fail" },
+          { shortcut: "c", label: "spinner" },
+          { shortcut: "hold ctrl", label: "numbers" },
+          { shortcut: "m", label: "motion" },
           { shortcut: "↑/↓", label: "select" },
           { shortcut: "o", label: "layout" },
-          { shortcut: "r", label: "reset" },
+          { shortcut: "b", label: "rail inline/below" },
+          { shortcut: "r", label: "reset idle" },
+          { shortcut: "v", label: "all states" },
           { shortcut: "esc", label: "back" },
         ]}
       />

--- a/packages/tui/src/plugin/api.tsx
+++ b/packages/tui/src/plugin/api.tsx
@@ -177,11 +177,15 @@ export function createPluginContext(input: {
       tabs: {
         enabled: host.sessionTabs.enabled,
         list: () =>
-          host.sessionTabs.tabs().map((tab) => ({
-            ...tab,
-            active: host.sessionTabs.current() === tab.sessionID,
-            ...host.sessionTabs.status(tab.sessionID),
-          })),
+          host.sessionTabs.tabs().map((tab) => {
+            const status = host.sessionTabs.status(tab.sessionID)
+            return {
+              ...tab,
+              active: host.sessionTabs.current() === tab.sessionID,
+              ...status,
+              attention: Boolean(status.attention),
+            }
+          }),
         open(sessionID) {
           if (!host.sessionTabs.enabled()) return false
           host.sessionTabs.select(sessionID)

--- a/packages/tui/test/component/session-tabs-mouse.test.tsx
+++ b/packages/tui/test/component/session-tabs-mouse.test.tsx
@@ -34,7 +34,9 @@ test("releasing a transcript selection over tab controls does not activate them"
         <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
           <ThemeProvider mode="dark" source={emptyThemeSource}>
             <box flexDirection="column">
-              <SessionTabs controller={controller} animations={false} />
+              <Keymap.Provider>
+                <SessionTabs controller={controller} animations={false} />
+              </Keymap.Provider>
               <text>selectable transcript text</text>
             </box>
           </ThemeProvider>
@@ -145,7 +147,9 @@ test("double-clicking a preview tab keeps it open without promoting permanent ta
       <TestTuiContexts>
         <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
           <ThemeProvider mode="dark" source={emptyThemeSource}>
-            <SessionTabs controller={controller} animations={false} />
+            <Keymap.Provider>
+              <SessionTabs controller={controller} animations={false} />
+            </Keymap.Provider>
           </ThemeProvider>
         </ConfigProvider>
       </TestTuiContexts>
@@ -190,7 +194,9 @@ test("middle-click closes a session tab without selecting it", async () => {
       <TestTuiContexts>
         <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
           <ThemeProvider mode="dark" source={emptyThemeSource}>
-            <SessionTabs controller={controller} animations={false} />
+            <Keymap.Provider>
+              <SessionTabs controller={controller} animations={false} />
+            </Keymap.Provider>
           </ThemeProvider>
         </ConfigProvider>
       </TestTuiContexts>
@@ -238,7 +244,9 @@ test("keeps consecutive close controls fixed across overflow window changes", as
       <TestTuiContexts>
         <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
           <ThemeProvider mode="dark" source={emptyThemeSource}>
-            <SessionTabs controller={controller} animations={false} />
+            <Keymap.Provider>
+              <SessionTabs controller={controller} animations={false} />
+            </Keymap.Provider>
           </ThemeProvider>
         </ConfigProvider>
       </TestTuiContexts>
@@ -290,7 +298,9 @@ test("reflows held tabs when the pointer leaves the strip", async () => {
         <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
           <ThemeProvider mode="dark" source={emptyThemeSource}>
             <box flexDirection="column">
-              <SessionTabs controller={controller} animations={false} />
+              <Keymap.Provider>
+                <SessionTabs controller={controller} animations={false} />
+              </Keymap.Provider>
               <text>outside</text>
             </box>
           </ThemeProvider>

--- a/packages/tui/test/component/session-tabs-status.test.tsx
+++ b/packages/tui/test/component/session-tabs-status.test.tsx
@@ -1,15 +1,17 @@
 /** @jsxImportSource @opentui/solid */
 import { testRender } from "@opentui/solid"
 import { expect, test } from "bun:test"
-import { createSignal } from "solid-js"
+import { batch, createSignal } from "solid-js"
 import { ConfigProvider } from "../../src/config"
 import {
   EMPTY_SESSION_TAB_STATUS,
   SessionTabs,
   TAB_SPINNERS,
+  TAB_UNREAD_MARKERS,
   type SessionTabsController,
   type SessionTabsStatus,
   type TabSpinner,
+  type TabUnreadMarker,
 } from "../../src/component/session-tabs"
 import { ClientProvider } from "../../src/context/client"
 import { DataProvider } from "../../src/context/data"
@@ -32,6 +34,7 @@ for (const orientation of ["horizontal", "vertical"] as const) {
     const [active, setActive] = createSignal("second")
     const [animations, setAnimations] = createSignal(false)
     const [spinner, setSpinner] = createSignal<TabSpinner>("dots")
+    const [marker, setMarker] = createSignal<TabUnreadMarker>("small-dot")
     const [newTab, setNewTab] = createSignal(false)
     let theme!: ReturnType<typeof useTheme>
     function Colors() {
@@ -45,7 +48,12 @@ for (const orientation of ["horizontal", "vertical"] as const) {
       ],
       current: active,
       newTab,
-      select: setActive,
+      select(sessionID: string) {
+        batch(() => {
+          setActive(sessionID)
+          if (sessionID === "first") setStatus((current) => ({ ...current, unread: undefined }))
+        })
+      },
       close() {},
       move() {},
       detail: () => "project",
@@ -70,6 +78,7 @@ for (const orientation of ["horizontal", "vertical"] as const) {
                                 orientation={orientation}
                                 animations={animations()}
                                 spinner={spinner()}
+                                unreadMarker={marker()}
                               />
                             </Keymap.Provider>
                           </ThemeProvider>
@@ -88,20 +97,20 @@ for (const orientation of ["horizontal", "vertical"] as const) {
 
     try {
       app.renderer.start()
-      await app.waitForFrame((frame) => frame.includes("\u25aa First") && frame.includes("\u25aa Second"))
+      await app.waitForFrame((frame) => frame.includes("   First") && frame.includes("   Second"))
       const pressed = performance.now()
       await app.mockInput.pressKeys(["\x1b[57442;5u"])
       await app.waitForFrame((frame) => frame.includes("1 First") && frame.includes("2 Second"))
-      expect(performance.now() - pressed).toBeGreaterThanOrEqual(150)
+      expect(performance.now() - pressed).toBeGreaterThanOrEqual(300)
       await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
-      await app.waitForFrame((frame) => frame.includes("\u25aa First"))
+      await app.waitForFrame((frame) => frame.includes("   First"))
 
       await app.mockInput.pressKeys(["\x1b[57442;5u"])
       await app.renderOnce()
       await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
-      await Bun.sleep(175)
+      await Bun.sleep(325)
       await app.renderOnce()
-      expect(app.captureCharFrame()).toContain("\u25aa First")
+      expect(app.captureCharFrame()).toContain("   First")
 
       const titleColumn = app
         .captureCharFrame()
@@ -112,16 +121,17 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         { status: { busy: true }, label: TAB_SPINNERS.dots.frames[0] },
         { status: { busy: true, attention: "question" }, label: "?" },
         { status: { busy: true, attention: "permission" }, label: "!" },
-        { status: { unread: "activity" }, label: "\u25aa" },
-        { status: { unread: "error" }, label: "\u25aa" },
-        { status: {}, label: "\u25aa" },
+        { status: { unread: "activity" }, label: TAB_UNREAD_MARKERS["small-dot"] },
+        { status: { unread: "error" }, label: TAB_UNREAD_MARKERS["small-dot"] },
+        { status: {}, label: "" },
       ]
       for (const selected of [false, true]) {
         setActive(selected ? "first" : "second")
         for (const state of states) {
+          const label = `${state.label.padStart(2)} First`
           setStatus({ ...EMPTY_SESSION_TAB_STATUS, ...state.status })
           await app.renderOnce()
-          await app.waitForFrame((frame) => frame.includes(`${state.label} First`))
+          await app.waitForFrame((frame) => frame.includes(label))
           expect(
             app
               .captureCharFrame()
@@ -135,7 +145,7 @@ for (const orientation of ["horizontal", "vertical"] as const) {
             const indicator = app
               .captureSpans()
               .lines.flatMap((line) => line.spans)
-              .find((span) => span.text.trim() === "\u25aa")
+              .find((span) => span.text.trim() === state.label)
             expect(indicator).toBeDefined()
             expect(indicator!.fg.toInts()).toEqual(
               (state.status.unread === "error" ? theme.text.feedback.error.default : theme.text.status.unread).toInts(),
@@ -148,9 +158,133 @@ for (const orientation of ["horizontal", "vertical"] as const) {
           await app.renderOnce()
           expect(app.captureCharFrame()).toContain("1 First")
           await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
-          await app.waitForFrame((frame) => frame.includes(`${state.label} First`))
+          await app.waitForFrame((frame) => frame.includes(label))
         }
       }
+
+      setActive("second")
+      for (const name of Object.keys(TAB_UNREAD_MARKERS) as TabUnreadMarker[]) {
+        setMarker(name)
+        for (const unread of ["activity", "error"] as const) {
+          setStatus({ ...EMPTY_SESSION_TAB_STATUS, unread })
+          await app.renderOnce()
+          await app.waitForFrame((frame) => frame.includes(`${TAB_UNREAD_MARKERS[name]} First`))
+          expect(
+            app
+              .captureCharFrame()
+              .split("\n")
+              .find((line) => line.includes("First"))!
+              .indexOf("First"),
+          ).toBe(titleColumn)
+        }
+        setStatus(EMPTY_SESSION_TAB_STATUS)
+        await app.waitForFrame((frame) => frame.includes("   First"))
+      }
+
+      setMarker("small-dot")
+      for (const unread of ["activity", "error"] as const) {
+        setAnimations(true)
+        setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
+        await app.waitForFrame((frame) => TAB_SPINNERS.dots.frames.some((glyph) => frame.includes(`${glyph} First`)))
+        setStatus({ ...EMPTY_SESSION_TAB_STATUS, unread })
+        await app.renderOnce()
+        const indicator = app
+          .captureSpans()
+          .lines.flatMap((line) => line.spans)
+          .find((span) => span.text.trim() === TAB_UNREAD_MARKERS["small-dot"])
+        expect(indicator).toBeDefined()
+        expect(indicator!.fg.toInts()).toEqual(
+          (unread === "error" ? theme.text.feedback.error.default : theme.text.status.unread).toInts(),
+        )
+        setAnimations(false)
+        setStatus(EMPTY_SESSION_TAB_STATUS)
+        await app.renderOnce()
+      }
+
+      for (const attention of ["question", "permission"] as const) {
+        setAnimations(false)
+        setActive("second")
+        setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true, attention })
+        await app.renderOnce()
+        const glow = () => {
+          const colors = app
+            .captureSpans()
+            .lines[
+              orientation === "vertical" ? 1 : 0
+            ]!.spans.flatMap((span) => Array.from({ length: span.width }, () => span.bg))
+          return (
+            Math.abs(colors[1]!.r - colors[18]!.r) +
+            Math.abs(colors[1]!.g - colors[18]!.g) +
+            Math.abs(colors[1]!.b - colors[18]!.b)
+          )
+        }
+        const full = glow()
+        expect(full).toBeGreaterThan(0)
+        setActive("first")
+        await app.renderOnce()
+        const dim = glow()
+        expect(dim).toBeGreaterThan(0)
+        expect(dim).toBeLessThan(full)
+        setActive("second")
+        await app.renderOnce()
+        setAnimations(true)
+        await app.renderOnce()
+        expect(app.renderer.root.liveCount).toBe(0)
+
+        setActive("first")
+        await app.renderOnce()
+        expect(app.renderer.root.liveCount).toBe(0)
+        await app.waitForFrame(() => glow() > dim && glow() < full)
+        await app.waitForFrame(() => glow() === dim, { maxPasses: 60 })
+        setActive("second")
+        await app.renderOnce()
+        expect(app.renderer.root.liveCount).toBe(0)
+        await app.waitForFrame(() => glow() > dim && glow() < full)
+        await app.waitForFrame(() => glow() === full, { maxPasses: 60 })
+
+        setStatus(EMPTY_SESSION_TAB_STATUS)
+        await app.renderOnce()
+        expect(app.renderer.root.liveCount).toBeGreaterThan(0)
+      }
+
+      const glyph = TAB_UNREAD_MARKERS["small-dot"]
+      setMarker("small-dot")
+      for (const unread of ["activity", "error"] as const) {
+        setAnimations(false)
+        setActive("second")
+        setStatus({ ...EMPTY_SESSION_TAB_STATUS, unread })
+        await app.renderOnce()
+        await app.waitForFrame((frame) => frame.includes(`${glyph} First`))
+        const brightness = () => {
+          const color = app
+            .captureSpans()
+            .lines.flatMap((line) => line.spans)
+            .find((span) => span.text.trim() === glyph)?.fg
+          return color ? color.r + color.g + color.b : undefined
+        }
+        const initial = brightness()
+        expect(initial).toBeDefined()
+        setAnimations(true)
+        await app.mockMouse.click(1, orientation === "vertical" ? 1 : 0)
+        await app.renderOnce()
+        expect(active()).toBe("first")
+        expect(status().unread).toBeUndefined()
+        expect(app.captureCharFrame()).toContain(`${glyph} First`)
+        await app.waitForFrame((frame) => frame.includes(`${glyph} First`) && (brightness() ?? -1) > initial!)
+        const peak = brightness()!
+        await app.waitForFrame((frame) => frame.includes(`${glyph} First`) && (brightness() ?? Infinity) < peak)
+        await app.waitForFrame((frame) => frame.includes("   First"), { maxPasses: 60 })
+      }
+
+      setAnimations(false)
+      setStatus({ ...EMPTY_SESSION_TAB_STATUS, unread: "activity" })
+      await app.renderOnce()
+      setAnimations(true)
+      await app.mockMouse.click(1, orientation === "vertical" ? 1 : 0)
+      setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
+      await app.waitForFrame((frame) => TAB_SPINNERS.dots.frames.some((glyph) => frame.includes(`${glyph} First`)))
+      setStatus(EMPTY_SESSION_TAB_STATUS)
+      await app.waitForFrame((frame) => frame.includes("   First"))
 
       setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
       setAnimations(true)

--- a/packages/tui/test/component/session-tabs-status.test.tsx
+++ b/packages/tui/test/component/session-tabs-status.test.tsx
@@ -2,7 +2,7 @@
 import { testRender } from "@opentui/solid"
 import { expect, test } from "bun:test"
 import { batch, createSignal } from "solid-js"
-import { ConfigProvider } from "../../src/config"
+import { ConfigProvider, useConfig, type Info } from "../../src/config"
 import {
   EMPTY_SESSION_TAB_STATUS,
   SessionTabs,
@@ -31,8 +31,11 @@ for (const orientation of ["horizontal", "vertical"] as const) {
     const [active, setActive] = createSignal("second")
     const [animations, setAnimations] = createSignal(false)
     const [newTab, setNewTab] = createSignal(false)
+    const settings: Info = { tabs: { enabled: true } }
+    let config!: ReturnType<typeof useConfig>
     let theme!: ReturnType<typeof useTheme>
     function Colors() {
+      config = useConfig()
       theme = orientation === "vertical" ? useTheme("elevated") : useTheme()
       return null
     }
@@ -59,7 +62,16 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         <TestTuiContexts paths={{ state: temporary.path }}>
           <TuiAppProvider value={{ name: "test", version: "test", channel: "test" }}>
             <StorageProvider>
-              <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
+              <ConfigProvider
+                config={createTuiResolvedConfig(settings)}
+                service={{
+                  get: async () => settings,
+                  update: async (update) => {
+                    update(settings)
+                    return settings
+                  },
+                }}
+              >
                 <RouteProvider initialRoute={{ type: "home" }}>
                   <ClientProvider api={createApi(createFetch(undefined, createEventStream()).fetch)}>
                     <DataProvider directory={temporary.path}>
@@ -218,6 +230,20 @@ for (const orientation of ["horizontal", "vertical"] as const) {
       await app.waitForFrame((frame) => frame.includes("1 First"))
       app.renderer.emit("blur")
       await app.waitForFrame((frame) => frame.includes("? First"))
+
+      await config.update((draft) => {
+        draft.tabs.indicators = "numbers"
+      })
+      await app.waitForFrame((frame) => frame.includes("1 First") && frame.includes("2 Second"))
+      await app.mockInput.pressKeys(["\x1b[57442;5u", "\x1b[57442;1:3u"])
+      app.renderer.emit("blur")
+      setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
+      await app.renderOnce()
+      expect(app.captureCharFrame()).toContain("1 First")
+      await config.update((draft) => {
+        draft.tabs.indicators = "status"
+      })
+      await app.waitForFrame((frame) => SPINNER_FRAMES.some((glyph) => frame.includes(`${glyph} First`)))
 
       setNewTab(true)
       await app.waitForFrame((frame) => frame.includes("+ New session"))

--- a/packages/tui/test/component/session-tabs-status.test.tsx
+++ b/packages/tui/test/component/session-tabs-status.test.tsx
@@ -19,7 +19,7 @@ import { RouteProvider } from "../../src/context/route"
 import { TuiAppProvider } from "../../src/context/runtime"
 import { SessionTabsProvider } from "../../src/context/session-tabs"
 import { StorageProvider } from "../../src/context/storage"
-import { ThemeProvider } from "../../src/context/theme"
+import { ThemeProvider, useTheme } from "../../src/context/theme"
 import { emptyThemeSource, tmpdir } from "../fixture/fixture"
 import { createApi, createEventStream, createFetch } from "../fixture/tui-client"
 import { TestTuiContexts } from "../fixture/tui-environment"
@@ -31,8 +31,12 @@ for (const orientation of ["horizontal", "vertical"] as const) {
     const [status, setStatus] = createSignal<SessionTabsStatus>(EMPTY_SESSION_TAB_STATUS)
     const [active, setActive] = createSignal("second")
     const [animations, setAnimations] = createSignal(false)
-    const [spinner, setSpinner] = createSignal<TabSpinner>("arcs")
-    const [statusPosition, setStatusPosition] = createSignal<"inline" | "below">("inline")
+    const [spinner, setSpinner] = createSignal<TabSpinner>("dots")
+    let theme!: ReturnType<typeof useTheme>
+    function Colors() {
+      theme = orientation === "vertical" ? useTheme("elevated") : useTheme()
+      return null
+    }
     const controller = {
       tabs: () => [
         { sessionID: "first", title: "First" },
@@ -57,13 +61,13 @@ for (const orientation of ["horizontal", "vertical"] as const) {
                       <LocationProvider>
                         <SessionTabsProvider>
                           <ThemeProvider mode="dark" source={emptyThemeSource}>
+                            <Colors />
                             <Keymap.Provider>
                               <SessionTabs
                                 controller={controller}
                                 orientation={orientation}
                                 animations={animations()}
                                 spinner={spinner()}
-                                statusPosition={statusPosition()}
                               />
                             </Keymap.Provider>
                           </ThemeProvider>
@@ -89,17 +93,18 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         .find((line) => line.includes("First"))!
         .indexOf("First")
       const states: { status: Partial<SessionTabsStatus>; label: string }[] = [
-        { status: { busy: true }, label: TAB_SPINNERS.arcs.frames[0] },
+        { status: { busy: true }, label: TAB_SPINNERS.dots.frames[0] },
         { status: { busy: true, attention: "question" }, label: "?" },
         { status: { busy: true, attention: "permission" }, label: "!" },
-        { status: { unread: "activity" }, label: "\u2713" },
-        { status: { unread: "error" }, label: "\u00d7" },
+        { status: { unread: "activity" }, label: "1" },
+        { status: { unread: "error" }, label: "1" },
         { status: {}, label: "1" },
       ]
       for (const selected of [false, true]) {
         setActive(selected ? "first" : "second")
         for (const state of states) {
           setStatus({ ...EMPTY_SESSION_TAB_STATUS, ...state.status })
+          await app.renderOnce()
           await app.waitForFrame((frame) => frame.includes(`${state.label} First`))
           expect(
             app
@@ -108,6 +113,18 @@ for (const orientation of ["horizontal", "vertical"] as const) {
               .find((line) => line.includes("First"))!
               .indexOf("First"),
           ).toBe(titleColumn)
+          const rows = app.captureCharFrame().split("\n")
+          expect(rows[orientation === "vertical" ? 2 : 1]?.trim()).toBe(orientation === "vertical" ? "project" : "")
+          if (state.status.unread) {
+            const number = app
+              .captureSpans()
+              .lines.flatMap((line) => line.spans)
+              .find((span) => span.text.trim() === "1")
+            expect(number).toBeDefined()
+            expect(number!.fg.toInts()).toEqual(
+              (state.status.unread === "error" ? theme.text.feedback.error.default : theme.text.status.unread).toInts(),
+            )
+          }
           await app.mockInput.pressKeys(["\x1b[57442;5u"])
           await app.waitForFrame((frame) => frame.includes("1 First") && frame.includes("2 Second"))
           // Releasing a chord's digit is not releasing Control.
@@ -136,51 +153,6 @@ for (const orientation of ["horizontal", "vertical"] as const) {
       await app.waitForFrame((frame) => frame.includes("1 First"))
       app.renderer.emit("blur")
       await app.waitForFrame((frame) => frame.includes("? First"))
-
-      setStatusPosition("below")
-      if (orientation === "horizontal") {
-        await app.renderOnce()
-        expect(app.captureCharFrame().split("\n")[0]).toContain("? First")
-        expect(app.captureCharFrame().split("\n")[1]?.trim()).toBe("")
-      }
-      if (orientation === "vertical") {
-        setAnimations(false)
-        setSpinner("arcs")
-        for (const state of states) {
-          setStatus({ ...EMPTY_SESSION_TAB_STATUS, ...state.status })
-          await app.waitForFrame((frame) => {
-            const rows = frame.split("\n")
-            return (
-              rows[1]?.includes("1 First") &&
-              rows[2]?.trim() === (state.label === "1" ? "project" : `${state.label} project`)
-            )
-          })
-          expect(app.captureCharFrame().split("\n")[1]!.indexOf("First")).toBe(titleColumn)
-          expect(app.captureCharFrame().split("\n")[4]).toContain("2 Second")
-          if (state.label !== "1") {
-            const frame = app.captureSpans()
-            const number = frame.lines[1]!.spans.find((span) => span.text.trim() === "1")
-            const icon = frame.lines[2]!.spans.find((span) => span.text.trim() === state.label)
-            expect(number).toBeDefined()
-            expect(icon).toBeDefined()
-            expect(number!.fg.toInts()).toEqual(icon!.fg.toInts())
-          }
-        }
-        setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true, attention: "question" })
-        await app.waitForFrame((frame) => frame.split("\n")[2]?.trim() === "? project")
-        await app.mockInput.pressKeys(["\x1b[57442;5u"])
-        await app.renderOnce()
-        expect(app.captureCharFrame().split("\n")[1]).toContain("1 First")
-        expect(app.captureCharFrame().split("\n")[2]?.trim()).toBe("? project")
-        await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
-        setActive("second")
-        await app.mockMouse.click(1, 2)
-        expect(active()).toBe("first")
-        setStatusPosition("inline")
-        await app.waitForFrame(
-          (frame) => frame.split("\n")[1]?.includes("? First") && frame.split("\n")[2]?.trim() === "project",
-        )
-      }
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/component/session-tabs-status.test.tsx
+++ b/packages/tui/test/component/session-tabs-status.test.tsx
@@ -6,13 +6,10 @@ import { ConfigProvider } from "../../src/config"
 import {
   EMPTY_SESSION_TAB_STATUS,
   SessionTabs,
-  TAB_SPINNERS,
-  TAB_UNREAD_MARKERS,
   type SessionTabsController,
   type SessionTabsStatus,
-  type TabSpinner,
-  type TabUnreadMarker,
 } from "../../src/component/session-tabs"
+import { SPINNER_FRAMES } from "../../src/component/spinner-frames"
 import { ClientProvider } from "../../src/context/client"
 import { DataProvider } from "../../src/context/data"
 import { LocationProvider } from "../../src/context/location"
@@ -33,8 +30,6 @@ for (const orientation of ["horizontal", "vertical"] as const) {
     const [status, setStatus] = createSignal<SessionTabsStatus>(EMPTY_SESSION_TAB_STATUS)
     const [active, setActive] = createSignal("second")
     const [animations, setAnimations] = createSignal(false)
-    const [spinner, setSpinner] = createSignal<TabSpinner>("dots")
-    const [marker, setMarker] = createSignal<TabUnreadMarker>("small-dot")
     const [newTab, setNewTab] = createSignal(false)
     let theme!: ReturnType<typeof useTheme>
     function Colors() {
@@ -77,8 +72,6 @@ for (const orientation of ["horizontal", "vertical"] as const) {
                                 controller={controller}
                                 orientation={orientation}
                                 animations={animations()}
-                                spinner={spinner()}
-                                unreadMarker={marker()}
                               />
                             </Keymap.Provider>
                           </ThemeProvider>
@@ -118,87 +111,20 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         .find((line) => line.includes("First"))!
         .indexOf("First")
       const states: { status: Partial<SessionTabsStatus>; label: string }[] = [
-        { status: { busy: true }, label: TAB_SPINNERS.dots.frames[0] },
+        { status: { busy: true }, label: SPINNER_FRAMES[0] },
         { status: { busy: true, attention: "question" }, label: "?" },
         { status: { busy: true, attention: "permission" }, label: "!" },
-        { status: { unread: "activity" }, label: TAB_UNREAD_MARKERS["small-dot"] },
-        { status: { unread: "error" }, label: TAB_UNREAD_MARKERS["small-dot"] },
+        { status: { unread: "activity" }, label: "\u2022" },
+        { status: { unread: "error" }, label: "\u2022" },
         { status: {}, label: "" },
       ]
-      for (const selected of [false, true]) {
-        setActive(selected ? "first" : "second")
-        for (const state of states) {
-          const label = `${state.label.padStart(2)} First`
-          setStatus({ ...EMPTY_SESSION_TAB_STATUS, ...state.status })
-          await app.renderOnce()
-          await app.waitForFrame((frame) => frame.includes(label))
-          expect(
-            app
-              .captureCharFrame()
-              .split("\n")
-              .find((line) => line.includes("First"))!
-              .indexOf("First"),
-          ).toBe(titleColumn)
-          const rows = app.captureCharFrame().split("\n")
-          expect(rows[orientation === "vertical" ? 2 : 1]?.trim()).toBe(orientation === "vertical" ? "project" : "")
-          if (state.status.unread) {
-            const indicator = app
-              .captureSpans()
-              .lines.flatMap((line) => line.spans)
-              .find((span) => span.text.trim() === state.label)
-            expect(indicator).toBeDefined()
-            expect(indicator!.fg.toInts()).toEqual(
-              (state.status.unread === "error" ? theme.text.feedback.error.default : theme.text.status.unread).toInts(),
-            )
-          }
-          await app.mockInput.pressKeys(["\x1b[57442;5u"])
-          await app.waitForFrame((frame) => frame.includes("1 First") && frame.includes("2 Second"))
-          // Releasing a chord's digit is not releasing Control.
-          await app.mockInput.pressKeys(["\x1b[49;5:3u"])
-          await app.renderOnce()
-          expect(app.captureCharFrame()).toContain("1 First")
-          await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
-          await app.waitForFrame((frame) => frame.includes(label))
-        }
-      }
-
-      setActive("second")
-      for (const name of Object.keys(TAB_UNREAD_MARKERS) as TabUnreadMarker[]) {
-        setMarker(name)
-        for (const unread of ["activity", "error"] as const) {
-          setStatus({ ...EMPTY_SESSION_TAB_STATUS, unread })
-          await app.renderOnce()
-          await app.waitForFrame((frame) => frame.includes(`${TAB_UNREAD_MARKERS[name]} First`))
-          expect(
-            app
-              .captureCharFrame()
-              .split("\n")
-              .find((line) => line.includes("First"))!
-              .indexOf("First"),
-          ).toBe(titleColumn)
-        }
-        setStatus(EMPTY_SESSION_TAB_STATUS)
-        await app.waitForFrame((frame) => frame.includes("   First"))
-      }
-
-      setMarker("small-dot")
-      for (const unread of ["activity", "error"] as const) {
-        setAnimations(true)
-        setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
-        await app.waitForFrame((frame) => TAB_SPINNERS.dots.frames.some((glyph) => frame.includes(`${glyph} First`)))
-        setStatus({ ...EMPTY_SESSION_TAB_STATUS, unread })
+      for (const state of states) {
+        setStatus({ ...EMPTY_SESSION_TAB_STATUS, ...state.status })
         await app.renderOnce()
-        const indicator = app
-          .captureSpans()
-          .lines.flatMap((line) => line.spans)
-          .find((span) => span.text.trim() === TAB_UNREAD_MARKERS["small-dot"])
-        expect(indicator).toBeDefined()
-        expect(indicator!.fg.toInts()).toEqual(
-          (unread === "error" ? theme.text.feedback.error.default : theme.text.status.unread).toInts(),
-        )
-        setAnimations(false)
-        setStatus(EMPTY_SESSION_TAB_STATUS)
-        await app.renderOnce()
+        await app.waitForFrame((frame) => frame.includes(`${state.label.padStart(2)} First`))
+        const rows = app.captureCharFrame().split("\n")
+        expect(rows.find((line) => line.includes("First"))!.indexOf("First")).toBe(titleColumn)
+        expect(rows[orientation === "vertical" ? 2 : 1]?.trim()).toBe(orientation === "vertical" ? "project" : "")
       }
 
       for (const attention of ["question", "permission"] as const) {
@@ -247,30 +173,34 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         expect(app.renderer.root.liveCount).toBeGreaterThan(0)
       }
 
-      const glyph = TAB_UNREAD_MARKERS["small-dot"]
-      setMarker("small-dot")
+      const glyph = "\u2022"
       for (const unread of ["activity", "error"] as const) {
         setAnimations(false)
         setActive("second")
+        setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
+        await app.renderOnce()
+        setAnimations(true)
         setStatus({ ...EMPTY_SESSION_TAB_STATUS, unread })
         await app.renderOnce()
-        await app.waitForFrame((frame) => frame.includes(`${glyph} First`))
-        const brightness = () => {
-          const color = app
+        const color = () =>
+          app
             .captureSpans()
             .lines.flatMap((line) => line.spans)
             .find((span) => span.text.trim() === glyph)?.fg
-          return color ? color.r + color.g + color.b : undefined
+        expect(color()?.toInts()).toEqual(
+          (unread === "error" ? theme.text.feedback.error.default : theme.text.status.unread).toInts(),
+        )
+        const brightness = () => {
+          const value = color()
+          return value ? value.r + value.g + value.b : undefined
         }
-        const initial = brightness()
-        expect(initial).toBeDefined()
-        setAnimations(true)
+        const initial = brightness()!
         await app.mockMouse.click(1, orientation === "vertical" ? 1 : 0)
         await app.renderOnce()
         expect(active()).toBe("first")
         expect(status().unread).toBeUndefined()
         expect(app.captureCharFrame()).toContain(`${glyph} First`)
-        await app.waitForFrame((frame) => frame.includes(`${glyph} First`) && (brightness() ?? -1) > initial!)
+        await app.waitForFrame((frame) => frame.includes(`${glyph} First`) && (brightness() ?? -1) > initial)
         const peak = brightness()!
         await app.waitForFrame((frame) => frame.includes(`${glyph} First`) && (brightness() ?? Infinity) < peak)
         await app.waitForFrame((frame) => frame.includes("   First"), { maxPasses: 60 })
@@ -282,22 +212,7 @@ for (const orientation of ["horizontal", "vertical"] as const) {
       setAnimations(true)
       await app.mockMouse.click(1, orientation === "vertical" ? 1 : 0)
       setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
-      await app.waitForFrame((frame) => TAB_SPINNERS.dots.frames.some((glyph) => frame.includes(`${glyph} First`)))
-      setStatus(EMPTY_SESSION_TAB_STATUS)
-      await app.waitForFrame((frame) => frame.includes("   First"))
-
-      setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
-      setAnimations(true)
-      for (const name of Object.keys(TAB_SPINNERS) as TabSpinner[]) {
-        setSpinner(name)
-        await app.waitForFrame((frame) => TAB_SPINNERS[name].frames.some((glyph) => frame.includes(`${glyph} First`)))
-        const first = app.captureCharFrame()
-        await app.waitForFrame((frame) => frame !== first)
-        await app.mockInput.pressKeys(["\x1b[57448;5u"])
-        await app.waitForFrame((frame) => frame.includes("1 First"))
-        await app.mockInput.pressKeys(["\x1b[57448;1:3u"])
-        await app.waitForFrame((frame) => TAB_SPINNERS[name].frames.some((glyph) => frame.includes(`${glyph} First`)))
-      }
+      await app.waitForFrame((frame) => SPINNER_FRAMES.slice(1).some((glyph) => frame.includes(`${glyph} First`)))
       await app.mockInput.pressKeys(["\x1b[57442;5u"])
       setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true, attention: "question" })
       await app.waitForFrame((frame) => frame.includes("1 First"))

--- a/packages/tui/test/component/session-tabs-status.test.tsx
+++ b/packages/tui/test/component/session-tabs-status.test.tsx
@@ -1,0 +1,188 @@
+/** @jsxImportSource @opentui/solid */
+import { testRender } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { createSignal } from "solid-js"
+import { ConfigProvider } from "../../src/config"
+import {
+  EMPTY_SESSION_TAB_STATUS,
+  SessionTabs,
+  TAB_SPINNERS,
+  type SessionTabsController,
+  type SessionTabsStatus,
+  type TabSpinner,
+} from "../../src/component/session-tabs"
+import { ClientProvider } from "../../src/context/client"
+import { DataProvider } from "../../src/context/data"
+import { LocationProvider } from "../../src/context/location"
+import { Keymap } from "../../src/context/keymap"
+import { RouteProvider } from "../../src/context/route"
+import { TuiAppProvider } from "../../src/context/runtime"
+import { SessionTabsProvider } from "../../src/context/session-tabs"
+import { StorageProvider } from "../../src/context/storage"
+import { ThemeProvider } from "../../src/context/theme"
+import { emptyThemeSource, tmpdir } from "../fixture/fixture"
+import { createApi, createEventStream, createFetch } from "../fixture/tui-client"
+import { TestTuiContexts } from "../fixture/tui-environment"
+import { createTuiResolvedConfig } from "../fixture/tui-runtime"
+
+for (const orientation of ["horizontal", "vertical"] as const) {
+  test(`${orientation} tabs replace ordinals with status without moving titles`, async () => {
+    await using temporary = await tmpdir()
+    const [status, setStatus] = createSignal<SessionTabsStatus>(EMPTY_SESSION_TAB_STATUS)
+    const [active, setActive] = createSignal("second")
+    const [animations, setAnimations] = createSignal(false)
+    const [spinner, setSpinner] = createSignal<TabSpinner>("arcs")
+    const [statusPosition, setStatusPosition] = createSignal<"inline" | "below">("inline")
+    const controller = {
+      tabs: () => [
+        { sessionID: "first", title: "First" },
+        { sessionID: "second", title: "Second" },
+      ],
+      current: active,
+      select: setActive,
+      close() {},
+      move() {},
+      detail: () => "project",
+      status: (sessionID: string) => (sessionID === "first" ? status() : EMPTY_SESSION_TAB_STATUS),
+    } satisfies SessionTabsController
+    const app = await testRender(
+      () => (
+        <TestTuiContexts paths={{ state: temporary.path }}>
+          <TuiAppProvider value={{ name: "test", version: "test", channel: "test" }}>
+            <StorageProvider>
+              <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
+                <RouteProvider initialRoute={{ type: "home" }}>
+                  <ClientProvider api={createApi(createFetch(undefined, createEventStream()).fetch)}>
+                    <DataProvider>
+                      <LocationProvider>
+                        <SessionTabsProvider>
+                          <ThemeProvider mode="dark" source={emptyThemeSource}>
+                            <Keymap.Provider>
+                              <SessionTabs
+                                controller={controller}
+                                orientation={orientation}
+                                animations={animations()}
+                                spinner={spinner()}
+                                statusPosition={statusPosition()}
+                              />
+                            </Keymap.Provider>
+                          </ThemeProvider>
+                        </SessionTabsProvider>
+                      </LocationProvider>
+                    </DataProvider>
+                  </ClientProvider>
+                </RouteProvider>
+              </ConfigProvider>
+            </StorageProvider>
+          </TuiAppProvider>
+        </TestTuiContexts>
+      ),
+      { width: 60, height: 10, kittyKeyboard: true },
+    )
+
+    try {
+      app.renderer.start()
+      await app.waitForFrame((frame) => frame.includes("1 First") && frame.includes("2 Second"))
+      const titleColumn = app
+        .captureCharFrame()
+        .split("\n")
+        .find((line) => line.includes("First"))!
+        .indexOf("First")
+      const states: { status: Partial<SessionTabsStatus>; label: string }[] = [
+        { status: { busy: true }, label: TAB_SPINNERS.arcs.frames[0] },
+        { status: { busy: true, attention: "question" }, label: "?" },
+        { status: { busy: true, attention: "permission" }, label: "!" },
+        { status: { unread: "activity" }, label: "\u2713" },
+        { status: { unread: "error" }, label: "\u00d7" },
+        { status: {}, label: "1" },
+      ]
+      for (const selected of [false, true]) {
+        setActive(selected ? "first" : "second")
+        for (const state of states) {
+          setStatus({ ...EMPTY_SESSION_TAB_STATUS, ...state.status })
+          await app.waitForFrame((frame) => frame.includes(`${state.label} First`))
+          expect(
+            app
+              .captureCharFrame()
+              .split("\n")
+              .find((line) => line.includes("First"))!
+              .indexOf("First"),
+          ).toBe(titleColumn)
+          await app.mockInput.pressKeys(["\x1b[57442;5u"])
+          await app.waitForFrame((frame) => frame.includes("1 First") && frame.includes("2 Second"))
+          // Releasing a chord's digit is not releasing Control.
+          await app.mockInput.pressKeys(["\x1b[49;5:3u"])
+          await app.renderOnce()
+          expect(app.captureCharFrame()).toContain("1 First")
+          await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
+          await app.waitForFrame((frame) => frame.includes(`${state.label} First`))
+        }
+      }
+
+      setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true })
+      setAnimations(true)
+      for (const name of Object.keys(TAB_SPINNERS) as TabSpinner[]) {
+        setSpinner(name)
+        await app.waitForFrame((frame) => TAB_SPINNERS[name].frames.some((glyph) => frame.includes(`${glyph} First`)))
+        const first = app.captureCharFrame()
+        await app.waitForFrame((frame) => frame !== first)
+        await app.mockInput.pressKeys(["\x1b[57448;5u"])
+        await app.waitForFrame((frame) => frame.includes("1 First"))
+        await app.mockInput.pressKeys(["\x1b[57448;1:3u"])
+        await app.waitForFrame((frame) => TAB_SPINNERS[name].frames.some((glyph) => frame.includes(`${glyph} First`)))
+      }
+      await app.mockInput.pressKeys(["\x1b[57442;5u"])
+      setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true, attention: "question" })
+      await app.waitForFrame((frame) => frame.includes("1 First"))
+      app.renderer.emit("blur")
+      await app.waitForFrame((frame) => frame.includes("? First"))
+
+      setStatusPosition("below")
+      if (orientation === "horizontal") {
+        await app.renderOnce()
+        expect(app.captureCharFrame().split("\n")[0]).toContain("? First")
+        expect(app.captureCharFrame().split("\n")[1]?.trim()).toBe("")
+      }
+      if (orientation === "vertical") {
+        setAnimations(false)
+        setSpinner("arcs")
+        for (const state of states) {
+          setStatus({ ...EMPTY_SESSION_TAB_STATUS, ...state.status })
+          await app.waitForFrame((frame) => {
+            const rows = frame.split("\n")
+            return (
+              rows[1]?.includes("1 First") &&
+              rows[2]?.trim() === (state.label === "1" ? "project" : `${state.label} project`)
+            )
+          })
+          expect(app.captureCharFrame().split("\n")[1]!.indexOf("First")).toBe(titleColumn)
+          expect(app.captureCharFrame().split("\n")[4]).toContain("2 Second")
+          if (state.label !== "1") {
+            const frame = app.captureSpans()
+            const number = frame.lines[1]!.spans.find((span) => span.text.trim() === "1")
+            const icon = frame.lines[2]!.spans.find((span) => span.text.trim() === state.label)
+            expect(number).toBeDefined()
+            expect(icon).toBeDefined()
+            expect(number!.fg.toInts()).toEqual(icon!.fg.toInts())
+          }
+        }
+        setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true, attention: "question" })
+        await app.waitForFrame((frame) => frame.split("\n")[2]?.trim() === "? project")
+        await app.mockInput.pressKeys(["\x1b[57442;5u"])
+        await app.renderOnce()
+        expect(app.captureCharFrame().split("\n")[1]).toContain("1 First")
+        expect(app.captureCharFrame().split("\n")[2]?.trim()).toBe("? project")
+        await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
+        setActive("second")
+        await app.mockMouse.click(1, 2)
+        expect(active()).toBe("first")
+        setStatusPosition("inline")
+        await app.waitForFrame(
+          (frame) => frame.split("\n")[1]?.includes("? First") && frame.split("\n")[2]?.trim() === "project",
+        )
+      }
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+}

--- a/packages/tui/test/component/session-tabs-status.test.tsx
+++ b/packages/tui/test/component/session-tabs-status.test.tsx
@@ -67,7 +67,7 @@ for (const orientation of ["horizontal", "vertical"] as const) {
               <ConfigProvider config={createTuiResolvedConfig({ tabs: { enabled: true } })}>
                 <RouteProvider initialRoute={{ type: "home" }}>
                   <ClientProvider api={createApi(createFetch(undefined, createEventStream()).fetch)}>
-                    <DataProvider>
+                    <DataProvider directory={temporary.path}>
                       <LocationProvider>
                         <SessionTabsProvider>
                           <ThemeProvider mode="dark" source={emptyThemeSource}>

--- a/packages/tui/test/component/session-tabs-status.test.tsx
+++ b/packages/tui/test/component/session-tabs-status.test.tsx
@@ -32,6 +32,7 @@ for (const orientation of ["horizontal", "vertical"] as const) {
     const [active, setActive] = createSignal("second")
     const [animations, setAnimations] = createSignal(false)
     const [spinner, setSpinner] = createSignal<TabSpinner>("dots")
+    const [newTab, setNewTab] = createSignal(false)
     let theme!: ReturnType<typeof useTheme>
     function Colors() {
       theme = orientation === "vertical" ? useTheme("elevated") : useTheme()
@@ -43,6 +44,7 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         { sessionID: "second", title: "Second" },
       ],
       current: active,
+      newTab,
       select: setActive,
       close() {},
       move() {},
@@ -86,7 +88,21 @@ for (const orientation of ["horizontal", "vertical"] as const) {
 
     try {
       app.renderer.start()
+      await app.waitForFrame((frame) => frame.includes("\u25aa First") && frame.includes("\u25aa Second"))
+      const pressed = performance.now()
+      await app.mockInput.pressKeys(["\x1b[57442;5u"])
       await app.waitForFrame((frame) => frame.includes("1 First") && frame.includes("2 Second"))
+      expect(performance.now() - pressed).toBeGreaterThanOrEqual(150)
+      await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
+      await app.waitForFrame((frame) => frame.includes("\u25aa First"))
+
+      await app.mockInput.pressKeys(["\x1b[57442;5u"])
+      await app.renderOnce()
+      await app.mockInput.pressKeys(["\x1b[57442;1:3u"])
+      await Bun.sleep(175)
+      await app.renderOnce()
+      expect(app.captureCharFrame()).toContain("\u25aa First")
+
       const titleColumn = app
         .captureCharFrame()
         .split("\n")
@@ -96,9 +112,9 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         { status: { busy: true }, label: TAB_SPINNERS.dots.frames[0] },
         { status: { busy: true, attention: "question" }, label: "?" },
         { status: { busy: true, attention: "permission" }, label: "!" },
-        { status: { unread: "activity" }, label: "1" },
-        { status: { unread: "error" }, label: "1" },
-        { status: {}, label: "1" },
+        { status: { unread: "activity" }, label: "\u25aa" },
+        { status: { unread: "error" }, label: "\u25aa" },
+        { status: {}, label: "\u25aa" },
       ]
       for (const selected of [false, true]) {
         setActive(selected ? "first" : "second")
@@ -116,12 +132,12 @@ for (const orientation of ["horizontal", "vertical"] as const) {
           const rows = app.captureCharFrame().split("\n")
           expect(rows[orientation === "vertical" ? 2 : 1]?.trim()).toBe(orientation === "vertical" ? "project" : "")
           if (state.status.unread) {
-            const number = app
+            const indicator = app
               .captureSpans()
               .lines.flatMap((line) => line.spans)
-              .find((span) => span.text.trim() === "1")
-            expect(number).toBeDefined()
-            expect(number!.fg.toInts()).toEqual(
+              .find((span) => span.text.trim() === "\u25aa")
+            expect(indicator).toBeDefined()
+            expect(indicator!.fg.toInts()).toEqual(
               (state.status.unread === "error" ? theme.text.feedback.error.default : theme.text.status.unread).toInts(),
             )
           }
@@ -153,6 +169,9 @@ for (const orientation of ["horizontal", "vertical"] as const) {
       await app.waitForFrame((frame) => frame.includes("1 First"))
       app.renderer.emit("blur")
       await app.waitForFrame((frame) => frame.includes("? First"))
+
+      setNewTab(true)
+      await app.waitForFrame((frame) => frame.includes("+ New session"))
     } finally {
       app.renderer.destroy()
     }

--- a/packages/tui/test/config-v2.test.tsx
+++ b/packages/tui/test/config-v2.test.tsx
@@ -20,9 +20,10 @@ test("validates mini replay settings", () => {
 test("validates the session tabs setting", () => {
   const decode = Schema.decodeUnknownSync(Info)
 
-  expect(decode({ tabs: { enabled: true, layout: "vertical" } })).toEqual({
-    tabs: { enabled: true, layout: "vertical" },
+  expect(decode({ tabs: { enabled: true, layout: "vertical", indicators: "numbers" } })).toEqual({
+    tabs: { enabled: true, layout: "vertical", indicators: "numbers" },
   })
+  expect(() => decode({ tabs: { indicators: "unknown" } })).toThrow()
   expect(() => decode({ tabs: { layout: true } })).toThrow()
   expect(() => decode({ tabs: { enabled: "on" } })).toThrow()
   expect(decode({ prompt: { image_preview: true } })).toEqual({ prompt: { image_preview: true } })
@@ -49,7 +50,7 @@ test("resolves nested config and keybind defaults", () => {
   expect(config.scroll).toEqual({ speed: 2, acceleration: true })
   expect(config.diffs).toEqual({ view: "split" })
   expect(config.debug).toEqual({ devtools: true })
-  expect(config.tabs).toEqual({ enabled: true, scope: "cwd", layout: "horizontal" })
+  expect(config.tabs).toEqual({ enabled: true, scope: "cwd", layout: "horizontal", indicators: "status" })
   expect(config.session.new_location).toBe("launch")
   expect(config.session.tps).toBe(true)
 })
@@ -58,6 +59,10 @@ test("shows resolved tab defaults in settings", () => {
   expect(settings.find((setting) => setting.path.join(".") === "tabs.enabled")?.default).toBe(true)
   expect(settings.find((setting) => setting.path.join(".") === "tabs.scope")?.default).toBe("cwd")
   expect(settings.find((setting) => setting.path.join(".") === "tabs.layout")?.default).toBe("horizontal")
+  expect(settings.find((setting) => setting.path.join(".") === "tabs.indicators")).toMatchObject({
+    default: "status",
+    values: ["status", "numbers"],
+  })
 })
 
 test("shows the new session location default in settings", () => {

--- a/packages/tui/test/context/session-tabs.test.tsx
+++ b/packages/tui/test/context/session-tabs.test.tsx
@@ -752,6 +752,64 @@ test("ignores subagent unread state on the root tab", async () => {
   }
 })
 
+test("distinguishes family questions and permissions without clearing them on selection", async () => {
+  const setup = await renderSessionTabs("root", {
+    home: true,
+    persisted: ["root"],
+    sessionParents: { child: "root" },
+  })
+  try {
+    await wait(() => setup.data.session.get("child") !== undefined)
+    expect(setup.tabs.status("root").attention).toBe(false)
+
+    setup.emit({
+      id: "evt_question",
+      created: 1,
+      type: "form.created",
+      data: {
+        form: {
+          id: "frm_question",
+          sessionID: "child",
+          title: "Choose an approach",
+          fields: [{ key: "approach", type: "string", title: "Approach" }],
+        },
+      },
+    })
+    await wait(() => setup.tabs.status("root").attention === "question")
+
+    setup.tabs.select("root")
+    await wait(() => setup.tabs.current() === "root")
+    expect(setup.tabs.status("root").attention).toBe("question")
+
+    setup.emit({
+      id: "evt_permission",
+      created: 2,
+      type: "permission.asked",
+      data: { id: "per_command", sessionID: "root", action: "shell", resources: ["bun run test"] },
+    })
+    await wait(() => setup.tabs.status("root").attention === "permission")
+    expect(setup.tabs.status("child").attention).toBe("permission")
+
+    setup.emit({
+      id: "evt_permission_reply",
+      created: 3,
+      type: "permission.replied",
+      data: { sessionID: "root", requestID: "per_command", reply: "once" },
+    })
+    await wait(() => setup.tabs.status("root").attention === "question")
+
+    setup.emit({
+      id: "evt_question_reply",
+      created: 4,
+      type: "form.replied",
+      data: { sessionID: "child", id: "frm_question", answer: {} },
+    })
+    await wait(() => setup.tabs.status("root").attention === false)
+  } finally {
+    await setup.destroy()
+  }
+})
+
 test("concurrent TUIs do not alternate shared tab titles from divergent session caches", async () => {
   await using temporary = await tmpdir()
   const state = temporary.path

--- a/packages/tui/test/keymap-kitty.test.tsx
+++ b/packages/tui/test/keymap-kitty.test.tsx
@@ -77,6 +77,10 @@ test("Kitty modifier-only events preserve a pending shifted leader sequence", as
   try {
     await app.mockInput.pressKeys(["\x1b[57442;5u", "\x1b[120;5u"])
     expect(leader()).toBeTrue()
+    for (const code of [57453, 57454]) {
+      await app.mockInput.pressKeys([`\x1b[${code}u`, `\x1b[${code};1:3u`])
+      expect(leader()).toBeTrue()
+    }
     await app.mockInput.pressKeys(["\x1b[120;5:3u", "\x1b[57442;1:3u", "\x1b[57441;2u"])
     expect(leader()).toBeTrue()
     await app.mockInput.pressKeys(["\x1b[114:82;2u", "\x1b[114:82;2:3u", "\x1b[57441;1:3u"])

--- a/packages/tui/test/keymap-kitty.test.tsx
+++ b/packages/tui/test/keymap-kitty.test.tsx
@@ -1,0 +1,129 @@
+/** @jsxImportSource @opentui/solid */
+import type { TextareaRenderable } from "@opentui/core"
+import { testRender, useRenderer } from "@opentui/solid"
+import { expect, test } from "bun:test"
+import { onCleanup, type JSX } from "solid-js"
+import { ConfigProvider } from "../src/config"
+import { Keymap } from "../src/context/keymap"
+import { handleSelectionKey } from "../src/util/selection"
+import { createTuiResolvedConfig } from "./fixture/tui-runtime"
+
+function renderKeymap(Content: () => JSX.Element) {
+  return testRender(
+    () => (
+      <ConfigProvider config={createTuiResolvedConfig({ keybinds: { leader: "ctrl+x" } })}>
+        <Keymap.Provider>
+          <Content />
+        </Keymap.Provider>
+      </ConfigProvider>
+    ),
+    { width: 30, height: 5, useKittyKeyboard: { events: true, allKeysAsEscapes: true, reportText: true } },
+  )
+}
+
+test("Kitty Ctrl down preserves transcript selection for Ctrl+C instead of exiting", async () => {
+  const writes: string[] = []
+  let exits = 0
+  const app = await renderKeymap(() => {
+    const renderer = useRenderer()
+    const keymap = Keymap.use()
+    onCleanup(
+      keymap.intercept(
+        "key",
+        ({ event }) =>
+          handleSelectionKey(renderer, { show() {}, error() {} }, event, {
+            read: async () => undefined,
+            async write(text) {
+              writes.push(text)
+            },
+          }),
+        { priority: 1 },
+      ),
+    )
+    Keymap.createLayer(() => ({
+      mode: "global",
+      commands: [{ id: "app.exit", run: () => void exits++ }],
+    }))
+    return <text>alpha beta gamma</text>
+  })
+
+  try {
+    await app.renderOnce()
+    await app.mockMouse.click(6, 0)
+    await app.mockMouse.click(6, 0)
+    expect(app.renderer.getSelection()?.getSelectedText()).toBe("beta")
+
+    await app.mockInput.pressKeys(["\x1b[57442;5u"])
+    expect(app.renderer.getSelection()?.getSelectedText()).toBe("beta")
+    await app.mockInput.pressKeys(["\x1b[99;5u", "\x1b[99;5:3u", "\x1b[57442;1:3u"])
+    expect(writes).toEqual(["beta"])
+    expect(exits).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("Kitty modifier-only events preserve a pending shifted leader sequence", async () => {
+  let calls = 0
+  let leader = () => false
+  const app = await renderKeymap(() => {
+    leader = Keymap.useLeaderActive()
+    Keymap.createLayer(() => ({
+      commands: [{ bind: "<leader>shift+r", run: () => void calls++ }],
+    }))
+    return <box />
+  })
+
+  try {
+    await app.mockInput.pressKeys(["\x1b[57442;5u", "\x1b[120;5u"])
+    expect(leader()).toBeTrue()
+    await app.mockInput.pressKeys(["\x1b[120;5:3u", "\x1b[57442;1:3u", "\x1b[57441;2u"])
+    expect(leader()).toBeTrue()
+    await app.mockInput.pressKeys(["\x1b[114:82;2u", "\x1b[114:82;2:3u", "\x1b[57441;1:3u"])
+    expect(calls).toBe(1)
+    expect(leader()).toBeFalse()
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("Kitty associated text preserves Caps Lock and Shift+Caps Lock casing in a textarea", async () => {
+  let textarea!: TextareaRenderable
+  const app = await renderKeymap(() => <textarea ref={textarea} focused={true} />)
+
+  try {
+    await app.renderOnce()
+    await app.mockInput.pressKeys(["\x1b[97;65;65u", "\x1b[97;65:3u"])
+    expect(textarea.plainText).toBe("A")
+    await app.mockInput.pressKeys(["\x1b[57441;66u", "\x1b[97;66;97u", "\x1b[97;66:3u", "\x1b[57441;65:3u"])
+    expect(textarea.plainText).toBe("Aa")
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("Control state follows either Kitty Control key, ignores chord releases, and clears on blur", async () => {
+  let keymap!: Keymap
+  const app = await renderKeymap(() => {
+    keymap = Keymap.use()
+    return <box />
+  })
+
+  try {
+    expect(keymap.control()).toBeFalse()
+    for (const code of [57442, 57448]) {
+      await app.mockInput.pressKeys([`\x1b[${code};5u`])
+      expect(keymap.control()).toBeTrue()
+      await app.mockInput.pressKeys(["\x1b[49;5u", "\x1b[49;5:3u"])
+      expect(keymap.control()).toBeTrue()
+      await app.mockInput.pressKeys([`\x1b[${code};1:3u`])
+      expect(keymap.control()).toBeFalse()
+      await app.mockInput.pressKeys([`\x1b[${code};5u`])
+      expect(keymap.control()).toBeTrue()
+      app.renderer.emit("blur")
+      expect(keymap.control()).toBeFalse()
+    }
+  } finally {
+    app.renderer.destroy()
+  }
+})

--- a/packages/www/src/docs/content/cli/config.mdx
+++ b/packages/www/src/docs/content/cli/config.mdx
@@ -156,6 +156,20 @@ Configure diff presentation:
 | `single` | boolean                       | Shows only the selected file patch.                           |
 | `view`   | `auto`, `split`, or `unified` | Sets the layout. `auto` chooses based on the available width. |
 
+## Tabs
+
+Choose **Tabs > Indicators** in settings, or set `tabs.indicators` in `cli.json`:
+
+```json title="cli.json"
+{
+  "tabs": {
+    "indicators": "numbers"
+  }
+}
+```
+
+`status` (the default) shows status icons and reveals tab numbers while Control is held. `numbers` always shows tab numbers, retaining their status colors and background animations. Both modes work with horizontal and vertical tabs.
+
 ## Terminal
 
 Configure terminal integration:


### PR DESCRIPTION
**Why**
Session tabs distinguish running work and pending input mostly through subtle colors and the wave animation. It is easy to miss that a background session is waiting for an answer or permission rather than still working.

**What Changes**
Keep the wave, but give each state a recognizable indicator beside the title in both the top strip and sidebar:

**Settings > Tabs > Indicators** switches between **status icons** (default) and **always show numbers**. The latter keeps the numbered-tab presentation without holding Control, while retaining status colors and background animations. The preference is saved as `tabs.indicators` (`status` or `numbers`) in `cli.json` and applies immediately in both layouts.

| State | Default Indicator |
| --- | --- |
| Working | Standard Braille spinner |
| Question pending | `?` |
| Permission pending | `!` |
| Finished with unread activity | Small bullet, original unread/accent color |
| Unread failure | Same bullet, error red |
| Idle/read | Blank |
| New-session placeholder | `+` |

The unread bullet appears in its final color immediately. Reading it gives a subtle brighten-and-fade into the current tab background over 180 ms, then leaves the slot blank. It never transitions through the running color. The existing background wave and clear pulse remain.

Selecting a pending `?` or `!` keeps its glow active, easing to 70% strength over 200 ms. Leaving restores full strength without replaying ignition; the clear pulse runs only when the request resolves. Requests include child sessions, and permission takes precedence when both kinds are pending. The public plugin API still exposes `attention` as a Boolean.

In status-icon mode, hold Control for 300 ms to reveal numbers with their existing colors and pulse. Release or terminal blur hides them immediately. Brief chords do not flash numbers, and jump bindings are not delayed. Kitty modifier-only reports update held state before command matching, preserving transcript selections and leader sequences; associated-text reporting preserves casing.

Semantic `text.status.running`, `question`, `permission`, and `unread` theme tokens distinguish running, attention, and unread colors. Built-in light/dark and standalone themes inherit defaults from their own hues and feedback tokens. The Tabs story retains alternate spinner/marker controls, reduced motion, both layouts, and idle/showcase resets for exploration.

**Demo**
Before `2602dcd0a7`, after `d521be850a`. The same deterministic fixture drives real isolated sessions and the production TUI with a fictional simulated model. This 12-second, real-time sidebar crop shows the unchanged default status-icon mode: working, pending question/permission selection, unread clearing, and Control reveal/release. Setup and gaps are trimmed; no story controls or acceleration. The subsequently added number-mode setting is shown below.

https://github.com/user-attachments/assets/8c8d9485-2451-4788-b145-f3f45bdca512

Number-mode setting at `de2ecc2c4c`, exercised through the real settings dialog in an isolated Drive session:

![Tabs indicator setting](https://github.com/user-attachments/assets/fe194bd1-8a16-4f29-b142-123d96b4a30e)

**Scope**
This changes tab presentation and modifier tracking, not the execution-outcome model. Alternate spinner and unread-marker styles are story controls only; production defaults are the Braille spinner and small bullet.

**Verification**
```sh
cd packages/tui
bun run test ./test/config-v2.test.tsx ./test/component/session-tabs-status.test.tsx ./test/keymap-kitty.test.tsx ./test/component/session-tabs-mouse.test.tsx ./test/component/tab-pulse.test.tsx
bun run test ./test/keymap-kitty.test.tsx ./test/keymap.test.tsx ./test/component/session-tabs-status.test.tsx ./test/component/session-tabs-mouse.test.tsx ./test/component/tab-pulse.test.tsx ./test/context/session-tabs.test.tsx ./test/theme/v2 ./test/util/selection.test.ts
bun run test ./test/keymap-kitty.test.tsx ./test/keymap.test.tsx ./test/component/session-tabs-status.test.tsx ./test/component/session-tabs-mouse.test.tsx ./test/component/tab-pulse.test.tsx ./test/context/session-tabs.test.tsx ./test/theme/v2 ./test/app-lifecycle.test.tsx ./test/util/selection.test.ts
bun run test ./test/app-lifecycle.test.tsx -t 'shows jump to latest after scrolling one line above the final message'
bun run test ./test/component/session-tabs-status.test.tsx
bun typecheck
cd ../theme
bun run test
bun typecheck
cd ../cli
bun typecheck
cd ../www
bun typecheck
bun run check:generated
bun run build
```

The latest mode-setting regression batch passed 37 tests (404 assertions). After the preceding test cleanup, the focused TUI suite passed all 103 tests (689 assertions); the four consolidated theme tests passed with 36 assertions. TUI, CLI, and website typechecks passed, as did all 32 normal pre-push typecheck tasks. The website build, formatting, and `git diff --check` passed.

The website's generated-file check initially found pre-existing stale message-update API snapshots. The build regenerated them and the check passed; those unrelated generated diffs are excluded from this PR.

Before the test cleanup, the broader TUI batch passed 112 tests and hit the previously observed timeout in `shows jump to latest after scrolling one line above the final message`; the isolated rerun passed. No scrolling code changed. An earlier full TUI run had the same intermittent failure (813 passed, 5 skipped).

Coverage includes first-frame unread/error colors, marker fade and interruption, animated attention dimming without clear/reignition, delayed and cancelled Control reveal, left/right Control and focus loss, selection copying, shifted leader sequences, Caps Lock text, child-request precedence, inline layout, mouse behavior, and light/dark/custom/standalone theme fallback. The real story was also exercised at narrow and wide terminal sizes.

A separate real Drive run passed the settings workflow: switch to numbers, verify the saved preference, resize from the sidebar to the narrow top strip, and switch back to status icons. Component tests verify that number mode survives Control release and blur and can be toggled without remounting.

Both Drive captures reached every checkpoint, but its bundled Ghostty replay crashed during export. The published clip replays the unchanged PTY bytes and timestamps through Drive's alternate-parser interface with xterm-headless, using the same rendering and encoding path. All eight comparison phases and the dot's fade were visually inspected. Capture commands are not counted as passing end-to-end tests.
