### PR TITLE
fix(opencode): use public Copilot host for github.com

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/copilot.ts
+++ b/packages/opencode/src/plugin/github-copilot/copilot.ts
@@ -24,7 +24,10 @@ function getUrls(domain: string) {
 }
 
 function base(enterpriseUrl?: string) {
-  return enterpriseUrl ? `https://copilot-api.${normalizeDomain(enterpriseUrl)}` : "https://api.githubcopilot.com"
+  const domain = enterpriseUrl ? normalizeDomain(enterpriseUrl) : undefined
+  return !domain || domain.toLowerCase() === "github.com"
+    ? "https://api.githubcopilot.com"
+    : `https://copilot-api.${domain}`
 }
 
 // Check if a message is a synthetic user msg used to attach an image from a tool call

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -490,3 +490,41 @@ test("remaps fallback oauth model urls to the enterprise host", async () => {
   expect(models.claude.api.url).toBe("https://copilot-api.ghe.example.com")
   expect(models.claude.api.npm).toBe("@ai-sdk/github-copilot")
 })
+
+test("uses the public Copilot host for github.com OAuth accounts", async () => {
+  const urls: string[] = []
+  globalThis.fetch = mock((input: RequestInfo | URL) => {
+    urls.push(input instanceof URL ? input.href : typeof input === "string" ? input : input.url)
+    return Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 }))
+  }) as unknown as typeof fetch
+
+  const hooks = await CopilotAuthPlugin({
+    client: {} as never,
+    project: {} as never,
+    directory: "",
+    worktree: "",
+    experimental_workspace: {
+      register() {},
+    },
+    serverUrl: new URL("https://example.com"),
+    $: {} as never,
+  })
+
+  await hooks.provider!.models!(
+    {
+      id: "github-copilot",
+      models: {},
+    } as never,
+    {
+      auth: {
+        type: "oauth",
+        refresh: "token",
+        access: "token",
+        expires: Date.now() + 60_000,
+        enterpriseUrl: "github.com",
+      } as never,
+    },
+  )
+
+  expect(urls).toEqual(["https://api.githubcopilot.com/models"])
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45302

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Older or enterprise OAuth records can contain enterpriseUrl set to github.com. The Copilot URL helper treated every non-empty enterprise URL as a GHE host and produced the invalid copilot-api.github.com endpoint.

This keeps github.com on the public api.githubcopilot.com host while preserving copilot-api.<domain> for real GHE deployments. Supersedes the closed #33662.

### How did you verify your code works?

- Added a regression test that failed against dev with the wrong models URL, then passed with the fix.
- bun test test/plugin/github-copilot-models.test.ts (8 passed)
- bun typecheck from packages/opencode
- Repository pre-push typecheck (30/30 tasks)
- Prettier check and git diff --check

### Screenshots / recordings

Not applicable; this is an OAuth endpoint fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._