### PR TITLE
fix(app): use module-level slot for TitlebarRight to fix direct session URL crash

### DIFF
--- a/packages/app/src/shell/titlebar/right-slot.tsx
+++ b/packages/app/src/shell/titlebar/right-slot.tsx
@@ -1,4 +1,4 @@
-import { createContext, onCleanup, onMount, Show, useContext, type ParentProps } from "solid-js"
+import { onCleanup, onMount, Show, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Portal } from "solid-js/web"
 
@@ -14,16 +14,35 @@ type TitlebarRightSlot = {
   setMount: (mount: HTMLElement) => void
 }
 
-const TitlebarRightContext = createContext<TitlebarRightSlot>()
+// Module-level singleton slot. The provider and consumers all reference this
+// instance, which sidesteps SolidJS context propagation issues across lazy-loaded
+// route chunks where useSlot would otherwise throw "must be used within
+// TitlebarRightProvider" even though the provider is mounted.
+const [slotStore, setSlotStore] = createStore<{ mount?: HTMLElement; registrations: symbol[] }>({
+  registrations: [],
+})
+
+const slot: TitlebarRightSlot = {
+  mount: () => slotStore.mount,
+  setMount: (mount) => setSlotStore("mount", mount),
+  createRegistration() {
+    const id = Symbol()
+    return {
+      active: () => slotStore.registrations.at(-1) === id,
+      register: () => setSlotStore("registrations", (items) => [...items, id]),
+      unregister: () => setSlotStore("registrations", (items) => items.filter((item) => item !== id)),
+    }
+  },
+}
 
 export function TitlebarRightProvider(props: ParentProps) {
-  return (
-    <TitlebarRightContext.Provider value={createTitlebarRightSlot()}>{props.children}</TitlebarRightContext.Provider>
-  )
+  return <>{props.children}</>
 }
 
 export function createTitlebarRightSlot(): TitlebarRightSlot {
-  const [store, setStore] = createStore<{ mount?: HTMLElement; registrations: symbol[] }>({ registrations: [] })
+  const [store, setStore] = createStore<{ mount?: HTMLElement; registrations: symbol[] }>({
+    registrations: [],
+  })
   return {
     mount: () => store.mount,
     setMount: (mount) => setStore("mount", mount),
@@ -39,12 +58,10 @@ export function createTitlebarRightSlot(): TitlebarRightSlot {
 }
 
 export function TitlebarRightMount() {
-  const slot = useTitlebarRightSlot()
   return <div ref={slot.setMount} id="opencode-titlebar-right" class="flex shrink-0 items-center justify-end gap-0" />
 }
 
 export function TitlebarRight(props: ParentProps) {
-  const slot = useTitlebarRightSlot()
   const registration = slot.createRegistration()
   onMount(() => {
     registration.register()
@@ -56,10 +73,4 @@ export function TitlebarRight(props: ParentProps) {
       {(mount) => <Portal mount={mount}>{props.children}</Portal>}
     </Show>
   )
-}
-
-function useTitlebarRightSlot() {
-  const slot = useContext(TitlebarRightContext)
-  if (!slot) throw new Error("TitlebarRight must be used within TitlebarRightProvider")
-  return slot
 }


### PR DESCRIPTION
## Summary

Direct navigation to `/server/{key}/session/{id}` routes crashes with:

```
Error: TitlebarRight must be used within TitlebarRightProvider
```

even though the provider is mounted. The error boundary catches it and shows "Something went wrong".

## Root cause

SolidJS context propagation across lazy-loaded route chunks: the `useContext` lookup in `TitlebarRight` (`session-header.tsx`, in route chunk) fails to find the provider that lives in the main chunk (`shell.tsx`).

Verified via console logs in production build:
- `[Provider] mounted` fires successfully in the main chunk
- `[Mount] has slot` — `TitlebarRightMount` (in `shell.tsx`, same chunk as Provider) sees the context
- `[useSlot] context lookup: MISSING` — `TitlebarRight` (in lazy-loaded `route-*.js` chunk) cannot find the context

This is the same class of bug as #30898 ("ServerSync context must be used within a context provider"), which is still open.

In Vite dev mode (HMR) the bug does not reproduce — context propagation works correctly there.

## Fix

Replace `createContext`/`useContext` with a **module-level singleton slot**. Both the provider and consumers reference the same module-level instance, sidesteping the cross-chunk context lookup entirely.

- `TitlebarRightProvider` becomes a no-op wrapper (kept for backward compatibility / minimal diff)
- `createTitlebarRightSlot` factory is preserved for the existing unit test
- All other call sites (`TitlebarRightMount`, `TitlebarRight`) reference the module-level `slot` directly

## Verification

Built `opencode2` v2 binary from this branch, deployed, and tested:

- ✅ Direct URL navigation to `/server/{key}/session/{id}` loads session content
- ✅ Click from home page session list works
- ✅ Back/forward browser navigation works
- ✅ Newly created sessions display correctly (v1/v2 storage mismatch also resolved via PR #43045 in v2 branch)

```
$ curl -u opencode:**** http://127.0.0.1:4096/api/session/ses_.../message?limit=20 | jq '.data | length'
3
```

## Diff

Single file change (`packages/app/src/shell/titlebar/right-slot.tsx`):

```diff
-const TitlebarRightContext = createContext<TitlebarRightSlot>()
+// Module-level singleton slot. The provider and consumers all reference this
+// instance, which sidesteps SolidJS context propagation issues across lazy-loaded
+// route chunks where useSlot would otherwise throw "must be used within
+// TitlebarRightProvider" even though the provider is mounted.
+const [slotStore, setSlotStore] = createStore<{ mount?: HTMLElement; registrations: symbol[] }>({
+  registrations: [],
+})
+
+const slot: TitlebarRightSlot = { ... }
 
 export function TitlebarRightProvider(props: ParentProps) {
-  return (
-    <TitlebarRightContext.Provider value={createTitlebarRightSlot()}>{props.children}</TitlebarRightContext.Provider>
-  )
+  return <>{props.children}</>
 }
```

## Related

- Refs #30898 — same class of bug ("ServerSync context must be used within a context provider" on direct session route)
- Depends on #43045 (remove V1 client compatibility) which is already merged into v2