### PR TITLE
fix(core): label migrated credentials by auth type

### DIFF
--- a/packages/core/src/database/migration/20260805200742_import_legacy_credentials.ts
+++ b/packages/core/src/database/migration/20260805200742_import_legacy_credentials.ts
@@ -80,10 +80,11 @@ export function importLegacyCredentials(tx: Parameters<DatabaseMigration.Migrati
                       }
                     : undefined,
               })
+      const label = credential.type === "oauth" ? "OAuth" : "API key"
       const now = Date.now()
       yield* tx.run(sql`
         INSERT INTO credential (id, integration_id, label, value, time_created, time_updated)
-        VALUES (${Credential.ID.create()}, ${integrationID}, 'default', ${JSON.stringify(credential)}, ${now}, ${now})
+        VALUES (${Credential.ID.create()}, ${integrationID}, ${label}, ${JSON.stringify(credential)}, ${now}, ${now})
       `)
     }
 

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -385,6 +385,9 @@ describe("DatabaseMigration", () => {
     const content = JSON.stringify({
       openai: { type: "oauth", refresh: "refresh", access: "access", expires: 123, accountId: "account" },
       anthropic: { type: "api", key: "legacy-key", metadata: { region: "us" } },
+      google: { type: "api", key: "google-key", metadata: { region: "us" } },
+      "github-copilot": { type: "oauth", refresh: "refresh", access: "access", expires: 123 },
+      "custom-provider": { type: "api", key: "custom-key" },
       "https://example.com/": { type: "wellknown", key: "TOKEN", token: "wellknown-key" },
       invalid: { type: "unknown" },
     })
@@ -402,6 +405,7 @@ describe("DatabaseMigration", () => {
 
         yield* db.run(sql`DELETE FROM migration WHERE id = ${legacyCredentialsMigration.id}`)
         yield* DatabaseMigration.applyOnly(db, [legacyCredentialsMigration])
+        yield* DatabaseMigration.applyOnly(db, [legacyCredentialsMigration])
 
         expect(yield* db.all(sql`SELECT integration_id, label, value FROM credential ORDER BY integration_id`)).toEqual(
           [
@@ -411,13 +415,34 @@ describe("DatabaseMigration", () => {
               value: JSON.stringify({ type: "key", key: "current-key" }),
             },
             {
+              integration_id: "custom-provider",
+              label: "API key",
+              value: JSON.stringify({ type: "key", key: "custom-key" }),
+            },
+            {
+              integration_id: "github-copilot",
+              label: "OAuth",
+              value: JSON.stringify({
+                type: "oauth",
+                methodID: "device",
+                refresh: "refresh",
+                access: "access",
+                expires: 123,
+              }),
+            },
+            {
+              integration_id: "google",
+              label: "API key",
+              value: JSON.stringify({ type: "key", key: "google-key", metadata: { region: "us" } }),
+            },
+            {
               integration_id: "https://example.com",
-              label: "default",
+              label: "API key",
               value: JSON.stringify({ type: "key", key: "wellknown-key" }),
             },
             {
               integration_id: "openai",
-              label: "default",
+              label: "OAuth",
               value: JSON.stringify({
                 type: "oauth",
                 methodID: "chatgpt-browser",


### PR DESCRIPTION
### Issue for this PR

None.

### Type of change

- [x] Bug fix

### What does this PR do?

Use `API key` or `OAuth` instead of `default` when importing legacy credentials. The provider is already shown by the CLI/TUI, so the label does not repeat it.

Only future imports change. Existing credentials, completed migrations, and new `/connect` naming are unchanged.

### How did you verify your code works?

- `bun test test/database-migration.test.ts` from `packages/core`: 17 passing tests.
- `bun typecheck` from `packages/core`: passed.
- Prettier check: passed.

Coverage includes OAuth, API keys, custom providers, wellknown tokens, preserving existing credentials/source files, and repeated migration processing.

### Screenshots / recordings

Not applicable; migration-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR