### PR TITLE
fix: NVIDIA NIM model compatibility issues

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1879,6 +1879,14 @@ const layer = Layer.effect(
 
       const info = provider.models[modelID]
       if (!info) {
+        // For NVIDIA NIM models, the model ID itself contains slashes (e.g., "nvidia/nemotron-3-ultra-550b-a55b").
+        // Try prepending the provider ID to the model ID to handle the full model path.
+        if (providerID === "nvidia") {
+          const fullModelID = ModelV2.ID.make(`${providerID}/${modelID}`)
+          const fullInfo = provider.models[fullModelID]
+          if (fullInfo) return fullInfo
+        }
+
         const current = modelSuggestions(provider, modelID, runtimeFlags.enableExperimentalModels)
         const suggestions = current.length
           ? current
@@ -2056,6 +2064,29 @@ export function parseModel(model: string) {
     providerID: ProviderV2.ID.make(providerID),
     modelID: ModelV2.ID.make(rest.join("/")),
   }
+}
+
+// Try to resolve a model reference that may contain multiple slashes.
+// For NVIDIA NIM models, the model ID itself contains slashes (e.g., "nvidia/nemotron-3-ultra-550b-a55b"),
+// so the full reference is "nvidia/nvidia/nemotron-3-ultra-550b-a55b".
+export function parseModelRef(model: string, providers: Record<string, any>) {
+  // First try the standard split (first slash = provider)
+  const parsed = parseModel(model)
+  if (providers[parsed.providerID]?.models[parsed.modelID]) {
+    return parsed
+  }
+
+  // Try splitting on the second slash (for NVIDIA-style IDs like "nvidia/nvidia/model-name")
+  const parts = model.split("/")
+  if (parts.length >= 3) {
+    const providerID = ProviderV2.ID.make(parts[0])
+    const modelID = ModelV2.ID.make(parts.slice(1).join("/"))
+    if (providers[providerID]?.models[modelID]) {
+      return { providerID, modelID }
+    }
+  }
+
+  return parsed
 }
 
 export const node = LayerNode.make({

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -736,9 +736,10 @@ export function variants(model: Provider.Model): Record<string, Record<string, a
     ["@ai-sdk/anthropic", "@ai-sdk/openai-compatible"].includes(model.api.npm)
   ) {
     if (["nvidia", "lilac"].includes(model.providerID)) {
+      // NIM only accepts thinking.type "enabled" or "disabled" (not "adaptive")
       return {
-        none: { chat_template_kwargs: { thinking_mode: "disabled" } },
-        thinking: { chat_template_kwargs: { thinking_mode: "enabled" } },
+        none: { thinking: { type: "disabled" } },
+        thinking: { thinking: { type: "enabled" } },
       }
     }
     return {
@@ -1232,6 +1233,28 @@ export function options(input: {
     result["thinking"] = { type: "adaptive" }
   }
 
+  // NVIDIA NIM DeepSeek v4 models require chat_template_kwargs to enable thinking.
+  // Without it, NIM silently stalls and never returns a response.
+  // See: https://github.com/anomalyco/opencode/issues/24264
+  if (
+    input.model.providerID === "nvidia" &&
+    input.model.api.npm === "@ai-sdk/openai-compatible" &&
+    modelId.includes("deepseek-v4")
+  ) {
+    result["chat_template_kwargs"] = { enable_thinking: true, thinking: true }
+  }
+
+  // NVIDIA NIM Nemotron 3 Ultra and other Nemotron reasoning models may hang
+  // without explicit thinking enablement. Enable thinking by default.
+  // See: https://github.com/anomalyco/opencode/issues/34026
+  if (
+    input.model.providerID === "nvidia" &&
+    input.model.api.npm === "@ai-sdk/openai-compatible" &&
+    modelId.includes("nemotron-3-ultra")
+  ) {
+    result["chat_template_kwargs"] = { enable_thinking: true }
+  }
+
   // Moonshot's Anthropic-compatible API uses adaptive effort rather than token budgets.
   // Request summaries so thinking content survives replay on subsequent turns.
   if (
@@ -1344,6 +1367,35 @@ export function smallOptions(model: Provider.Model) {
   if (model.providerID === "venice") {
     if (Object.keys(small).length > 0) return small
     return { veniceParameters: { disableThinking: true } }
+  }
+
+  // NVIDIA NIM DeepSeek v4 models require chat_template_kwargs even for small requests
+  // (title/summary generation). Without it, NIM silently stalls.
+  const modelId = model.api.id.toLowerCase()
+  if (
+    model.providerID === "nvidia" &&
+    model.api.npm === "@ai-sdk/openai-compatible" &&
+    modelId.includes("deepseek-v4")
+  ) {
+    return mergeDeep(small, { chat_template_kwargs: { enable_thinking: true, thinking: true } })
+  }
+
+  // NVIDIA NIM Nemotron 3 Ultra also needs thinking enabled for small requests
+  if (
+    model.providerID === "nvidia" &&
+    model.api.npm === "@ai-sdk/openai-compatible" &&
+    modelId.includes("nemotron-3-ultra")
+  ) {
+    return mergeDeep(small, { chat_template_kwargs: { enable_thinking: true } })
+  }
+
+  // NVIDIA NIM MiniMax M3 needs thinking enabled for small requests
+  if (
+    model.providerID === "nvidia" &&
+    model.api.npm === "@ai-sdk/openai-compatible" &&
+    modelId.includes("minimax-m3")
+  ) {
+    return mergeDeep(small, { thinking: { type: "enabled" } })
   }
 
   return small

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3749,7 +3749,7 @@ describe("ProviderTransform.variants", () => {
     })
   })
 
-  test.each(["nvidia", "lilac"])("%s minimax m3 returns chat template thinking toggles", (providerID) => {
+  test.each(["nvidia", "lilac"])("%s minimax m3 returns thinking type toggles (NIM compatible)", (providerID) => {
     const model = createMockModel({
       id: `${providerID}/minimaxai/minimax-m3`,
       providerID,
@@ -3759,9 +3759,10 @@ describe("ProviderTransform.variants", () => {
         npm: "@ai-sdk/openai-compatible",
       },
     })
+    // NIM only accepts thinking.type "enabled" or "disabled" (not "adaptive")
     expect(ProviderTransform.variants(model)).toEqual({
-      none: { chat_template_kwargs: { thinking_mode: "disabled" } },
-      thinking: { chat_template_kwargs: { thinking_mode: "enabled" } },
+      none: { thinking: { type: "disabled" } },
+      thinking: { thinking: { type: "enabled" } },
     })
   })
 


### PR DESCRIPTION
## Summary

This PR fixes several NVIDIA NIM model compatibility issues:

### 1. DeepSeek v4 silent stall (fixes #24264)
- **Problem**: NIM silently stalls and never returns a response when thinking is not explicitly enabled
- **Fix**: Add `chat_template_kwargs: { enable_thinking: true, thinking: true }` for DeepSeek v4 models on NVIDIA NIM
- **Applied to**: Both main requests (`options()`) and small requests like title/summary generation (`smallOptions()`)

### 2. Nemotron 3 Ultra hang (fixes #34026)
- **Problem**: NIM hangs indefinitely without explicit thinking enablement
- **Fix**: Add `chat_template_kwargs: { enable_thinking: true }` for Nemotron 3 Ultra models on NVIDIA NIM
- **Applied to**: Both main requests and small requests

### 3. MiniMax M3 thinking variant failure
- **Problem**: NIM rejects `thinking.type: 'adaptive'` with error: `thinking.type` must be `enabled` or `disabled`
- **Fix**: Use `thinking.type: 'enabled'` instead of `chat_template_kwargs` for MiniMax M3 on NVIDIA NIM
- **Note**: NIM only accepts `thinking.type` values of `enabled` or `disabled`, not `adaptive`

### 4. Model ID slash resolution (fixes #44799)
- **Problem**: NVIDIA NIM model IDs contain slashes (e.g., `nvidia/nemotron-3-ultra-550b-a55b`), causing `ProviderModelNotFoundError` when users type the full model path
- **Fix**: In `getModel()`, try prepending the provider ID to the model ID for NVIDIA NIM models when the initial lookup fails

## Changes

- `packages/opencode/src/provider/transform.ts`: Added NVIDIA-specific thinking enablement for DeepSeek v4, Nemotron 3 Ultra, and MiniMax M3 models
- `packages/opencode/src/provider/provider.ts`: Added fallback model ID resolution for NVIDIA NIM models with slash-containing IDs
- `packages/opencode/test/provider/transform.test.ts`: Updated test to match new MiniMax M3 variant behavior

## Testing

All existing tests pass. The new behavior is:
- DeepSeek v4 models on NVIDIA NIM will now work without hanging
- Nemotron 3 Ultra models on NVIDIA NIM will now work without hanging
- MiniMax M3 models on NVIDIA NIM will now accept `/variant thinking` without errors
- Users can reference NVIDIA NIM models using the full path (e.g., `nvidia/nvidia/nemotron-3-ultra-550b-a55b`)
