### PR TITLE
refactor(ai): remove derived HTTP request ID

### DIFF
--- a/packages/ai/src/route/executor.ts
+++ b/packages/ai/src/route/executor.ts
@@ -40,17 +40,6 @@ const headerDetails = (headers: Headers.Headers) =>
 const normalizedHeaders = (headers: Headers.Headers) =>
   Object.fromEntries(Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]))
 
-const requestId = (headers: Record<string, string>) => {
-  return (
-    headers["x-request-id"] ??
-    headers["request-id"] ??
-    headers["x-amzn-requestid"] ??
-    headers["x-amz-request-id"] ??
-    headers["x-goog-request-id"] ??
-    headers["cf-ray"]
-  )
-}
-
 const retryAfterMs = (headers: Record<string, string>) => {
   const millis = Number(headers["retry-after-ms"])
   if (Number.isFinite(millis)) return Math.max(0, millis)
@@ -147,14 +136,12 @@ const responseHttp = (input: {
   readonly request: HttpClientRequest.HttpClientRequest
   readonly response: HttpClientResponse.HttpClientResponse
   readonly body: ReturnType<typeof responseBody>
-  readonly requestId?: string | undefined
   readonly rateLimit?: HttpRateLimitDetails | undefined
 }) =>
   new HttpContext({
     request: requestDetails(input.request),
     response: responseDetails(input.response),
     ...input.body,
-    requestId: input.requestId,
     rateLimit: input.rateLimit,
   })
 
@@ -179,7 +166,6 @@ const statusError =
             request,
             response,
             body: details,
-            requestId: requestId(headers),
             rateLimit,
           }),
         }),
@@ -216,7 +202,6 @@ export const classifyHttpFailure = (input: {
           ? undefined
           : new HttpResponseDetails({ status: input.status, headers: headerDetails(Headers.fromInput(headers)) }),
       ...details,
-      requestId: requestId(headers),
       rateLimit,
     }),
   })

--- a/packages/ai/src/schema/errors.ts
+++ b/packages/ai/src/schema/errors.ts
@@ -29,7 +29,6 @@ export class HttpContext extends Schema.Class<HttpContext>("AI.HttpContext")({
   response: Schema.optional(HttpResponseDetails),
   body: Schema.optional(Schema.String),
   bodyTruncated: Schema.optional(Schema.Boolean),
-  requestId: Schema.optional(Schema.String),
   rateLimit: Schema.optional(HttpRateLimitDetails),
 }) {}
 

--- a/packages/ai/test/executor.test.ts
+++ b/packages/ai/test/executor.test.ts
@@ -327,7 +327,6 @@ describe("RequestExecutor", () => {
           retryAfterMs: 0,
           rateLimit: { retryAfterMs: 0 },
           http: {
-            requestId: "req_123",
             request: {
               method: "POST",
               url: "https://provider.test/v1/chat?api_key=secret&key=secret&debug=1",


### PR DESCRIPTION
## Summary
- Remove `HttpContext.requestId` and its provider-header extraction logic from both HTTP failure paths.
- Keep complete response headers, including provider request IDs, unchanged.
- Remove the derived-field assertion while retaining header-preservation coverage.

## Verification
- `bun typecheck` in `packages/ai` and `packages/core`: passed.
- `bun test test/executor.test.ts -t RequestExecutor`: 22 passed.
- `bun test test/schema.test.ts test/provider-error.test.ts`: 26 passed.
- Scoped lint: 0 errors, 1 existing warning.
- Full run of the three test files: 51 passed, 2 failed. Both failures reproduce on the unchanged base commit `94bd9f6c8b`: `uses HTTP when no per-call WebSocket executor is provided` and `commits channel execution only after complete consumption` expect `Hi` but receive empty text. No unrelated fixes included.