### PR TITLE
fix(core): avoid nested MCP code mode

### DIFF
--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -207,7 +207,10 @@ export const connect = Effect.fnUntraced(function* (
     }
     if (!URL.canParse(config.url))
       return yield* new ConnectError({ server, message: `Invalid MCP URL for "${server}"` })
-    return new StreamableHTTPClientTransport(new URL(config.url), {
+    // Prefer raw tools for our Code Mode without changing the configured URL used for OAuth identity.
+    const url = new URL(config.url)
+    if (config.codemode !== false && !url.searchParams.has("codemode")) url.searchParams.set("codemode", "false")
+    return new StreamableHTTPClientTransport(url, {
       requestInit: config.headers ? { headers: config.headers } : undefined,
       authProvider,
     })

--- a/packages/core/src/plugin/mcp-codemode-exclusion.ts
+++ b/packages/core/src/plugin/mcp-codemode-exclusion.ts
@@ -3,7 +3,7 @@ export * as MCPCodeModeExclusionPlugin from "./mcp-codemode-exclusion.js"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect } from "effect"
 
-// These servers execute code themselves, so expose them directly instead of nesting code execution.
+// These servers provide Code Mode, so expose them directly instead of nesting them inside OpenCode Code Mode.
 const urls = [/^https:\/\/executor\.sh\/[^/]+\/mcp$/]
 
 export const Plugin = define({
@@ -13,16 +13,6 @@ export const Plugin = define({
       for (const [, server] of draft.list()) {
         if (server.codemode !== undefined) continue
         if (server.type === "local") {
-          const command = server.command[0]
-            ?.split(/[\\/]/)
-            .at(-1)
-            ?.replace(/\.exe$/i, "")
-          if (
-            command === "blender-mcp" ||
-            ((command === "uvx" || (command === "uv" && server.command[1] === "tool" && server.command[2] === "run")) &&
-              server.command.slice(1).some((arg) => /^blender-mcp(?:@[^/\\]+)?$/.test(arg)))
-          )
-            server.codemode = false
           if (server.command[0] === "executor" && server.command[1] === "mcp") server.codemode = false
           continue
         }

--- a/packages/core/src/plugin/mcp-codemode-exclusion.ts
+++ b/packages/core/src/plugin/mcp-codemode-exclusion.ts
@@ -3,8 +3,8 @@ export * as MCPCodeModeExclusionPlugin from "./mcp-codemode-exclusion.js"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect } from "effect"
 
-// These servers provide Code Mode, so expose them directly instead of nesting them inside OpenCode Code Mode.
-const urls = [/^https:\/\/mcp\.cloudflare\.com\/mcp$/, /^https:\/\/executor\.sh\/[^/]+\/mcp$/]
+// These servers execute code themselves, so expose them directly instead of nesting code execution.
+const urls = [/^https:\/\/executor\.sh\/[^/]+\/mcp$/]
 
 export const Plugin = define({
   id: "opencode.mcp.codemode.exclusion",
@@ -13,6 +13,16 @@ export const Plugin = define({
       for (const [, server] of draft.list()) {
         if (server.codemode !== undefined) continue
         if (server.type === "local") {
+          const command = server.command[0]
+            ?.split(/[\\/]/)
+            .at(-1)
+            ?.replace(/\.exe$/i, "")
+          if (
+            command === "blender-mcp" ||
+            ((command === "uvx" || (command === "uv" && server.command[1] === "tool" && server.command[2] === "run")) &&
+              server.command.slice(1).some((arg) => /^blender-mcp(?:@[^/\\]+)?$/.test(arg)))
+          )
+            server.codemode = false
           if (server.command[0] === "executor" && server.command[1] === "mcp") server.codemode = false
           continue
         }

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -77,6 +77,7 @@ function resourceServer(
         templateLists: 0,
         toolLists: 0,
         initializations: 0,
+        urls: [] as string[],
       }
       const protocol = new Server(
         { name: "mcp-resources", version: "1.0.0" },
@@ -145,6 +146,7 @@ function resourceServer(
       const http = Bun.serve({
         port: 0,
         fetch: async (request) => {
+          state.urls.push(request.url)
           const body: unknown = request.method === "POST" ? await request.clone().json() : undefined
           if (typeof body === "object" && body !== null && "method" in body && body.method === "initialize") {
             state.initializations += 1
@@ -717,6 +719,40 @@ test("applies configured MCP timeouts to resource operations", async () => {
   )
   await expect(read).rejects.toThrow("Request timed out")
 })
+
+for (const entry of [
+  { name: "default", query: "", codemode: undefined, expected: "?codemode=false" },
+  { name: "explicit local code mode", query: "", codemode: true, expected: "?codemode=false" },
+  { name: "direct tools", query: "", codemode: false, expected: "" },
+  {
+    name: "existing query",
+    query: "?source=opencode",
+    codemode: undefined,
+    expected: "?source=opencode&codemode=false",
+  },
+  { name: "explicit remote code mode", query: "?codemode=true", codemode: undefined, expected: "?codemode=true" },
+  { name: "explicit remote opt-out", query: "?codemode=false", codemode: undefined, expected: "?codemode=false" },
+  { name: "portal opt-out", query: "?codemode=off", codemode: undefined, expected: "?codemode=off" },
+]) {
+  testEffect(Layer.empty).live(`remote MCP code mode preference: ${entry.name}`, () =>
+    Effect.gen(function* () {
+      const server = yield* resourceServer()
+      const config = new ConfigMCP.Remote({
+        type: "remote",
+        url: server.url + entry.query,
+        oauth: false,
+        codemode: entry.codemode,
+      })
+      const connection = yield* connect("resources", config, import.meta.dir)
+      yield* connection.tools()
+      expect(server.state.initializations).toBe(1)
+      expect(server.state.toolLists).toBe(1)
+      expect(server.state.urls.length).toBeGreaterThanOrEqual(3)
+      expect(new Set(server.state.urls)).toEqual(new Set([server.url + entry.expected]))
+      expect(config.url).toBe(server.url + entry.query)
+    }),
+  )
+}
 
 test("lists, reads, and reports MCP resource changes", async () => {
   await Effect.runPromise(

--- a/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
+++ b/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
@@ -5,7 +5,7 @@ import { Effect, type Types } from "effect"
 import { it } from "../lib/effect"
 import { host } from "./host"
 
-it.effect("defaults only known Code Mode MCP servers to direct tools", () =>
+it.effect("defaults only known code-executing MCP servers to direct tools", () =>
   Effect.gen(function* () {
     const cases: Array<{
       name: string
@@ -21,7 +21,12 @@ it.effect("defaults only known Code Mode MCP servers to direct tools", () =>
       {
         name: "cloudflare code mode",
         server: { type: "remote", url: "https://mcp.cloudflare.com/mcp/" },
-        codemode: false,
+        codemode: undefined,
+      },
+      {
+        name: "cloudflare raw tools",
+        server: { type: "remote", url: "https://mcp.cloudflare.com/mcp?codemode=false" },
+        codemode: undefined,
       },
       {
         name: "cloudflare docs",
@@ -40,6 +45,40 @@ it.effect("defaults only known Code Mode MCP servers to direct tools", () =>
       },
       { name: "exa", server: { type: "remote", url: "https://mcp.exa.ai/mcp" }, codemode: undefined },
       { name: "unrelated", server: { type: "remote", url: "https://example.com/mcp" }, codemode: undefined },
+      ...[
+        ["uvx", "blender-mcp"],
+        ["uvx", "--python", "3.11", "blender-mcp@1.8.7"],
+        ["/opt/homebrew/bin/uvx", "blender-mcp"],
+        ["C:\\Users\\test\\.local\\bin\\uvx.exe", "blender-mcp"],
+        ["uv", "tool", "run", "blender-mcp"],
+        ["blender-mcp"],
+        ["/usr/local/bin/blender-mcp"],
+        ["C:\\tools\\blender-mcp.exe"],
+      ].map((command) => ({
+        name: command.join(" "),
+        server: { type: "local" as const, command },
+        codemode: false,
+      })),
+      {
+        name: "blender explicit true",
+        server: { type: "local", command: ["uvx", "blender-mcp"], codemode: true },
+        codemode: true,
+      },
+      {
+        name: "blender explicit false",
+        server: { type: "local", command: ["blender-mcp"], codemode: false },
+        codemode: false,
+      },
+      {
+        name: "blender-like package",
+        server: { type: "local", command: ["uvx", "blender-mcp-other"] },
+        codemode: undefined,
+      },
+      {
+        name: "unrelated command argument",
+        server: { type: "local", command: ["node", "server.js", "blender-mcp"] },
+        codemode: undefined,
+      },
     ]
     const servers: Record<string, Types.DeepMutable<Mcp.ServerConfig>> = Object.fromEntries(
       cases.map((test) => [test.name, test.server]),

--- a/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
+++ b/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
@@ -5,7 +5,7 @@ import { Effect, type Types } from "effect"
 import { it } from "../lib/effect"
 import { host } from "./host"
 
-it.effect("defaults only known code-executing MCP servers to direct tools", () =>
+it.effect("defaults only known Code Mode MCP servers to direct tools", () =>
   Effect.gen(function* () {
     const cases: Array<{
       name: string
@@ -45,40 +45,6 @@ it.effect("defaults only known code-executing MCP servers to direct tools", () =
       },
       { name: "exa", server: { type: "remote", url: "https://mcp.exa.ai/mcp" }, codemode: undefined },
       { name: "unrelated", server: { type: "remote", url: "https://example.com/mcp" }, codemode: undefined },
-      ...[
-        ["uvx", "blender-mcp"],
-        ["uvx", "--python", "3.11", "blender-mcp@1.8.7"],
-        ["/opt/homebrew/bin/uvx", "blender-mcp"],
-        ["C:\\Users\\test\\.local\\bin\\uvx.exe", "blender-mcp"],
-        ["uv", "tool", "run", "blender-mcp"],
-        ["blender-mcp"],
-        ["/usr/local/bin/blender-mcp"],
-        ["C:\\tools\\blender-mcp.exe"],
-      ].map((command) => ({
-        name: command.join(" "),
-        server: { type: "local" as const, command },
-        codemode: false,
-      })),
-      {
-        name: "blender explicit true",
-        server: { type: "local", command: ["uvx", "blender-mcp"], codemode: true },
-        codemode: true,
-      },
-      {
-        name: "blender explicit false",
-        server: { type: "local", command: ["blender-mcp"], codemode: false },
-        codemode: false,
-      },
-      {
-        name: "blender-like package",
-        server: { type: "local", command: ["uvx", "blender-mcp-other"] },
-        codemode: undefined,
-      },
-      {
-        name: "unrelated command argument",
-        server: { type: "local", command: ["node", "server.js", "blender-mcp"] },
-        codemode: undefined,
-      },
     ]
     const servers: Record<string, Types.DeepMutable<Mcp.ServerConfig>> = Object.fromEntries(
       cases.map((test) => [test.name, test.server]),


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prefer individual remote MCP tools behind OpenCode's Code Mode instead of nesting server-side code execution.

- Default remote transport URLs to `codemode=false`, which Cloudflare's API MCP supports. Preserve explicit query values and skip servers configured for direct tools.
- Keep configured URLs unchanged so existing MCP OAuth credential identities remain stable.
- Remove the Cloudflare exclusion so its expanded tool list stays behind OpenCode's bounded catalog.

The query parameter is a best-effort server convention, not an MCP standard. Cloudflare MCP Portals uses `codemode=off`; explicitly configured values remain untouched.

### How did you verify your code works?

- 60 tests passed across MCP transport, OAuth, exclusions, and Code Mode catalog tests, including new real-HTTP query checks.
- `bun typecheck` passed in `packages/core`.
- Prettier and `git diff --check` passed. Oxlint reported no errors and three existing test-file warnings.
- Confirmed the flag against upstream documentation and source. No live authenticated Cloudflare session was exercised.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
