### PR TITLE
fix(core): preserve renamed files when undoing changes

### DIFF
--- a/.changeset/rename-undo.md
+++ b/.changeset/rename-undo.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Include both paths of renamed files in new snapshot change lists so undo restores the original file instead of only deleting the renamed file.

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -507,9 +507,11 @@ const layer = Layer.effect(
       from: TreeID
       to: TreeID
     }) {
+      // Undo needs both paths of a rename, not only its destination.
       return (yield* repositoryOperation("list_files", input.repository, [
         "diff",
         "--name-only",
+        "--no-renames",
         "-z",
         input.from,
         input.to,

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -131,6 +131,37 @@ describe("Git worktrees", () => {
 })
 
 describe("Git trees", () => {
+  it.live("lists both sides of a rename as separate file changes", () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+      )
+      yield* Effect.promise(async () => {
+        await initRepo(root.path)
+        await $`git config diff.renames true`.cwd(root.path).quiet()
+        await Bun.write(path.join(root.path, "old name.txt"), "Preserve this content.\n")
+      })
+      const git = yield* Git.Service
+      const repository = yield* git.repo.discover(AbsolutePath.make(root.path))
+      if (!repository) throw new Error("Repository not found")
+      const before = yield* git.tree.capture({ repository, scopes: [RelativePath.make(".")] })
+      yield* Effect.promise(() => fs.rename(path.join(root.path, "old name.txt"), path.join(root.path, "new name.txt")))
+      const after = yield* git.tree.capture({ repository, scopes: [RelativePath.make(".")] })
+
+      expect(yield* git.tree.files({ repository, from: before, to: after })).toEqual([
+        RelativePath.make("new name.txt"),
+        RelativePath.make("old name.txt"),
+      ])
+      expect(
+        (yield* git.tree.diff({ repository, from: before, to: after })).map((file) => [file.file, file.status]),
+      ).toEqual([
+        ["new name.txt", "added"],
+        ["old name.txt", "deleted"],
+      ])
+    }),
+  )
+
   it.live("captures, compares, previews, and restores scoped trees", () =>
     Effect.gen(function* () {
       const root = yield* Effect.acquireRelease(

--- a/packages/core/test/session-revert.test.ts
+++ b/packages/core/test/session-revert.test.ts
@@ -1,0 +1,117 @@
+import { $ } from "bun"
+import { describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Effect } from "effect"
+import { Agent } from "@opencode-ai/core/agent"
+import { Bus } from "@opencode-ai/core/bus"
+import { Database } from "@opencode-ai/core/database/database"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
+import { Model } from "@opencode-ai/core/model"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
+import { Provider } from "@opencode-ai/core/provider"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Session } from "@opencode-ai/core/session"
+import { SessionEvent } from "@opencode-ai/core/session/event"
+import { SessionExecution } from "@opencode-ai/core/session/execution"
+import { SessionInbox } from "@opencode-ai/core/session/inbox"
+import { SessionMessage } from "@opencode-ai/core/session/message"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { Snapshot } from "@opencode-ai/core/snapshot"
+import { Money } from "@opencode-ai/schema/money"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Global } from "@opencode-ai/util/global"
+import { tempGlobalLayer } from "./fixture/global"
+import { tmpdir } from "./fixture/tmpdir"
+import { testEffect } from "./lib/effect"
+
+const it = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Database.node, Bus.node, SessionProjector.node, Session.node, LocationServiceMap.node]),
+    [
+      [Bus.node, Bus.configured({ persist: true })],
+      [Global.node, tempGlobalLayer],
+      [SessionExecution.node, SessionExecution.noopLayer],
+    ],
+  ),
+)
+
+describe("Session.revert files", () => {
+  it.live("undoes and restores a file rename without losing either path", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const directory = path.join(tmp.path, "project")
+      const original = path.join(directory, "old name.txt")
+      const renamed = path.join(directory, "new name.txt")
+      yield* Effect.promise(async () => {
+        await fs.mkdir(directory)
+        await Bun.write(original, "Preserve this content.\n")
+        await Bun.write(path.join(directory, "unrelated.txt"), "Unrelated content.\n")
+        await $`git init -q`.cwd(directory).quiet()
+        await $`git -c core.fsmonitor=false add .`.cwd(directory).quiet()
+      })
+
+      const session = yield* Session.Service
+      const database = yield* Database.Service
+      const bus = yield* Bus.Service
+      const created = yield* session.create({ location: { directory: AbsolutePath.make(directory) } })
+      const prompt = yield* session.prompt({ sessionID: created.id, text: "Rename the file", resume: false })
+      yield* SessionInbox.promote(database.db, bus, created.id, "steer")
+
+      yield* Effect.gen(function* () {
+        const plugins = yield* PluginSupervisor.Service
+        yield* plugins.flush
+        const snapshot = yield* Snapshot.Service
+        const before = yield* snapshot.capture()
+        if (!before) throw new Error("Initial snapshot missing")
+        const assistantMessageID = SessionMessage.ID.create()
+        yield* bus.publish(SessionEvent.Step.Started, {
+          sessionID: created.id,
+          assistantMessageID,
+          agent: Agent.defaultID,
+          model: { id: Model.ID.make("test-model"), providerID: Provider.ID.make("test-provider") },
+          snapshot: before,
+        })
+        yield* Effect.promise(() => fs.rename(original, renamed))
+        const after = yield* snapshot.capture()
+        if (!after) throw new Error("Renamed snapshot missing")
+        yield* bus.publish(SessionEvent.Step.Ended, {
+          sessionID: created.id,
+          assistantMessageID,
+          finish: "stop",
+          cost: Money.USD.zero,
+          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+          snapshot: after,
+          files: yield* snapshot.files({ from: before, to: after }),
+        })
+
+        yield* Effect.promise(() => Bun.write(path.join(directory, "unrelated.txt"), "Keep this later edit.\n"))
+        const reverted = yield* session.revert.stage({ sessionID: created.id, messageID: prompt.id })
+        expect({
+          original: yield* Effect.promise(() => Bun.file(original).exists()),
+          renamed: yield* Effect.promise(() => Bun.file(renamed).exists()),
+        }).toEqual({ original: true, renamed: false })
+        expect(yield* Effect.promise(() => Bun.file(original).text())).toBe("Preserve this content.\n")
+        expect(reverted.files?.map((file) => [file.file, file.status])).toEqual([
+          ["new name.txt", "deleted"],
+          ["old name.txt", "added"],
+        ])
+        expect(yield* Effect.promise(() => Bun.file(path.join(directory, "unrelated.txt")).text())).toBe(
+          "Keep this later edit.\n",
+        )
+
+        yield* session.revert.clear(created.id)
+        expect(yield* Effect.promise(() => Bun.file(original).exists())).toBe(false)
+        expect(yield* Effect.promise(() => Bun.file(renamed).text())).toBe("Preserve this content.\n")
+        expect(yield* Effect.promise(() => Bun.file(path.join(directory, "unrelated.txt")).text())).toBe(
+          "Keep this later edit.\n",
+        )
+        expect((yield* session.get(created.id)).revert).toBeUndefined()
+      }).pipe(Effect.provide(LocationServiceMap.Service.get(created.location)))
+    }),
+  )
+})


### PR DESCRIPTION
## Why

Undoing a file rename can remove the renamed file without restoring its original path. Snapshot change lists use rename-aware `git diff --name-only`, which reports only the destination; the revert plan therefore removes that destination but never restores the source.

## What Changes

Enumerate tree changes with `--no-renames`, matching the existing per-file diff behavior. Both paths are then included in newly recorded snapshot change lists.

| Operation | Before | After |
| --- | --- | --- |
| Record `old name.txt` renamed to `new name.txt` | Only the new path is recorded | Both paths are recorded |
| Stage Undo | Both paths can be absent | Original path and content are restored; new path is removed |

The regression uses a real Git repository, Location-scoped snapshots, durable Session event projection, and the public `Session.revert.stage` / `clear` operations. It also verifies that clearing staged Undo restores the renamed path and content, and that unrelated later edits survive both operations. Only model execution is disabled. A lower-level test verifies filename enumeration and added/deleted diffs with Git rename detection explicitly enabled.

## Scope

One Git comparison flag, its explanation, regression coverage, and a Core patch changeset. This fixes newly computed snapshot file lists; it does not rewrite older Session history whose persisted file lists already omitted a rename source.

## Verification

```sh
# packages/core
bun run test test/git.test.ts test/snapshot.test.ts test/session-revert.test.ts test/session-prompt.test.ts
bun run test test/git.test.ts test/session-revert.test.ts --test-name-pattern 'both sides of a rename|undoes and restores a file rename' --rerun-each 10
bun run test
bun typecheck
bun run build

# worktree root
bunx prettier --check packages/core/src/git.ts packages/core/test/git.test.ts packages/core/test/session-revert.test.ts .changeset/rename-undo.md
bunx oxlint packages/core/src/git.ts packages/core/test/git.test.ts packages/core/test/session-revert.test.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/git.ts packages/core/test/git.test.ts packages/core/test/session-revert.test.ts
git diff --check
# Normal push hook also ran all workspace typecheck tasks.
git push -u origin fix-rename-undo
```

- Both new regressions failed on the unchanged production code across three repetitions: the old path was omitted, and public Undo left both paths absent.
- Focused suites: 56 passed, 184 assertions.
- Repeated regressions after the fix: 20 passed, 100 assertions.
- Full Core suite: 3,654 passed, 39 skipped, 0 failed across 217 files; 78,250 assertions.
- Core typecheck, build, formatting, Effect simplification scan, and whitespace checks passed.
- Oxlint: no errors; one pre-existing `consistent-return` warning in `git.ts`.
- All 33 workspace pre-push typecheck tasks passed.
- Independent read-only correctness review found no issues. Windows execution is left to CI; local verification was on macOS.
