### PR TITLE
refactor(tui): simplify terminal selection state

### DIFF
--- a/packages/tui/src/component/session-frame.tsx
+++ b/packages/tui/src/component/session-frame.tsx
@@ -29,12 +29,10 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
     (sessionID) => sessions.refresh(sessionID).catch(() => undefined),
   )
   const session = () => sessions.get(props.sessionID)
-  const terminals = () => session()?.terminals ?? []
   const selectedTerminal = () => {
     if (!config.data.session.terminal) return
     const value = session()
-    if (value?.hidden) return
-    return value?.terminals.find((terminal) => terminal.id === value.selectedTerminalID) ?? value?.terminals.at(-1)
+    return value.terminals.find((terminal) => terminal.id === value.selectedTerminalID)
   }
   createEffect(
     on(
@@ -54,7 +52,7 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
   const rightPane = createMemo(() => {
     if (sidebarOpen() && sidebarVisible()) return "sidebar"
     if (selectedTerminal()) return "terminal"
-    if (sidebarVisible() && !session()?.hidden) return "sidebar"
+    if (sidebarVisible()) return "sidebar"
   })
   const toggleSidebar = () => {
     batch(() => {
@@ -65,11 +63,11 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
         })
         .catch(toast.error)
       setSidebarOpen(!visible)
-      if (!visible && selectedTerminal()) void sessions.hideTerminal(props.sessionID).catch(toast.error)
+      if (!visible && selectedTerminal()) void sessions.selectTerminal(props.sessionID, null).catch(toast.error)
     })
   }
   createEffect(() => {
-    if (!restoreTerminalFocus() || terminals().length > 0) return
+    if (!restoreTerminalFocus() || selectedTerminal()) return
     setRestoreTerminalFocus(false)
     prompt.current?.focus()
   })
@@ -139,13 +137,13 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
           <Show
             when={rightPane() === "sidebar"}
             fallback={
-              <Show keyed when={selectedTerminal()}>
-                {(terminal) => (
+              <Show keyed when={selectedTerminal()?.id}>
+                {(ptyID) => (
                   <TerminalPane
-                    ptyID={terminal.id}
-                    autoFocus={restoreTerminalFocus() || sessions.shouldFocus(terminal.id)}
+                    ptyID={ptyID}
+                    autoFocus={restoreTerminalFocus() || sessions.shouldFocus(ptyID)}
                     onAutoFocus={() => {
-                      sessions.clearFocus(terminal.id)
+                      sessions.clearFocus(ptyID)
                       setRestoreTerminalFocus(false)
                     }}
                     onFocusChange={setTerminalFocused}

--- a/packages/tui/src/context/session-terminals.tsx
+++ b/packages/tui/src/context/session-terminals.tsx
@@ -7,14 +7,8 @@ import { useData } from "./data"
 import { useEvent } from "./event"
 import { useStorage } from "./storage"
 
-type SessionTerminals = {
-  terminals: PersistentPtyInfo[]
-  selectedTerminalID?: string
-  hidden?: boolean
-}
-
 type SessionTerminalsState = {
-  sessions: Record<string, SessionTerminals>
+  sessions: Record<string, string | null>
 }
 
 export const { use: useSessionTerminals, provider: SessionTerminalsProvider } = createSimpleContext({
@@ -25,56 +19,62 @@ export const { use: useSessionTerminals, provider: SessionTerminalsProvider } = 
     const data = useData()
     const event = useEvent()
     const [focus, setFocus] = createSignal<string>()
-    const [store, update] = useStorage().store<SessionTerminalsState>("session-terminals-v1", {
+    const storage = useStorage()
+    const [store, update] = storage.store<SessionTerminalsState>("session-terminal-selection", {
       initial: { sessions: {} },
     })
-
-    const save = (sessionID: string, terminals: PersistentPtyInfo[], selectedTerminalID?: string) =>
-      update((draft) => {
-        const current = draft.sessions[sessionID]?.selectedTerminalID
-        const selected = selectedTerminalID ?? current
-        draft.sessions[sessionID] = {
-          terminals,
-          selectedTerminalID: terminals.some((terminal) => terminal.id === selected) ? selected : terminals.at(-1)?.id,
-          ...(selectedTerminalID === undefined && draft.sessions[sessionID]?.hidden ? { hidden: true } : {}),
-        }
-      })
+    const [terminals, updateTerminals] = storage.memory<Record<string, PersistentPtyInfo[]>>("session-terminals", {
+      initial: {},
+    })
 
     const refresh = async (sessionID: string) => {
-      await save(sessionID, await client.api.experimental.persistentPty.list({ sessionID }))
+      if (!terminals[sessionID]) updateTerminals((draft) => (draft[sessionID] = []))
+      const result = await client.api.experimental.persistentPty.list({ sessionID })
+      updateTerminals((draft) => (draft[sessionID] = result))
+      const selected = store.sessions[sessionID]
+      if (!selected || result.some((terminal) => terminal.id === selected)) return
+      await update((draft) => {
+        if (draft.sessions[sessionID] !== selected) return
+        draft.sessions[sessionID] = null
+      })
+    }
+
+    const selectTerminal = async (sessionID: string, ptyID: string | null) => {
+      if (ptyID !== null && !terminals[sessionID]?.some((terminal) => terminal.id === ptyID)) return
+      setFocus(ptyID ?? undefined)
+      await update((draft) => {
+        draft.sessions[sessionID] = ptyID
+      })
     }
 
     for (const type of ["persistent-pty.added", "persistent-pty.removed"] as const) {
       onCleanup(
         event.on(type, (evt) => {
-          if (!config.session.terminal || !store.sessions[evt.data.sessionID]) return
+          if (!config.session.terminal || !terminals[evt.data.sessionID]) return
           void refresh(evt.data.sessionID).catch((error) =>
             console.error("Failed to refresh persistent terminal panes", error),
           )
         }),
       )
     }
+    onCleanup(
+      event.on("server.connected", () => {
+        if (!config.session.terminal) return
+        Object.keys(terminals).forEach((sessionID) => {
+          void refresh(sessionID).catch((error) => console.error("Failed to refresh persistent terminal panes", error))
+        })
+      }),
+    )
 
     return {
       get(sessionID: string) {
-        return store.sessions[sessionID]
+        return {
+          terminals: terminals[sessionID] ?? [],
+          selectedTerminalID: store.sessions[sessionID] ?? null,
+        }
       },
       refresh,
-      selectTerminal(sessionID: string, ptyID: string) {
-        setFocus(ptyID)
-        return update((draft) => {
-          const session = draft.sessions[sessionID]
-          if (!session?.terminals.some((terminal) => terminal.id === ptyID)) return
-          session.selectedTerminalID = ptyID
-          delete session.hidden
-        })
-      },
-      hideTerminal(sessionID: string) {
-        return update((draft) => {
-          const session = draft.sessions[sessionID]
-          if (session) session.hidden = true
-        })
-      },
+      selectTerminal,
       async newTerminal(sessionID: string): Promise<PersistentPtyInfo> {
         const session = data.session.get(sessionID)
         const terminal = await client.api.experimental.persistentPty.create({
@@ -85,8 +85,8 @@ export const { use: useSessionTerminals, provider: SessionTerminalsProvider } = 
           title: "Terminal",
           env: {},
         })
-        setFocus(terminal.id)
-        await save(sessionID, await client.api.experimental.persistentPty.list({ sessionID }), terminal.id)
+        await refresh(sessionID)
+        await selectTerminal(sessionID, terminal.id)
         return terminal
       },
       shouldFocus(ptyID: string) {

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -903,15 +903,19 @@ export function Session(props: {
             id: "terminal.toggle",
             group: "Session",
             run: () => {
+              const sessionID = route.sessionID
               if (props.visibleTerminalID) {
                 promptRef.current?.focus()
-                void terminals.hideTerminal(route.sessionID).catch(toast.error)
+                void terminals.selectTerminal(sessionID, null).catch(toast.error)
               } else {
-                const state = terminals.get(route.sessionID)
-                const terminal =
-                  state?.terminals.find((item) => item.id === state.selectedTerminalID) ?? state?.terminals.at(-1)
-                if (terminal) void terminals.selectTerminal(route.sessionID, terminal.id).catch(terminalError)
-                else void terminals.newTerminal(route.sessionID).catch(terminalError)
+                void terminals
+                  .refresh(sessionID)
+                  .then(async () => {
+                    const terminal = terminals.get(sessionID).terminals.at(-1)
+                    if (terminal) return terminals.selectTerminal(sessionID, terminal.id)
+                    await terminals.newTerminal(sessionID)
+                  })
+                  .catch(terminalError)
               }
               dialog.clear()
             },
@@ -934,7 +938,7 @@ export function Session(props: {
             enabled: props.visibleTerminalID !== undefined,
             run: () => {
               promptRef.current?.focus()
-              void terminals.hideTerminal(route.sessionID).catch(toast.error)
+              void terminals.selectTerminal(route.sessionID, null).catch(toast.error)
               dialog.clear()
             },
           },


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Persist only a selected terminal ID or `null` for each session. `null` hides the terminal pane; showing it again selects the last available terminal.

Keep terminal inventories in memory and refresh them from the server on session load, terminal events, and reconnection. Metadata refreshes no longer remount the selected terminal pane.

Use a new selection-only storage key. Old terminal caches are ignored, not migrated, so existing selections reset without touching running terminals. No daemon lifecycle changes or added tests are included.

### How did you verify your code works?

- `bun run test` from `packages/tui`
- `bun typecheck` from `packages/tui`
- Prettier and `git diff --check`

### Screenshots / recordings

No visual styling changes; no screenshots attached.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
