### PR TITLE
fix(tui): restore session focus during permission prompts

### DIFF
--- a/packages/tui/src/component/session-frame.tsx
+++ b/packages/tui/src/component/session-frame.tsx
@@ -1,5 +1,5 @@
 import { RGBA } from "@opentui/core"
-import { useTerminalDimensions } from "@opentui/solid"
+import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { batch, createEffect, createMemo, createResource, createSignal, on, Show } from "solid-js"
 import { useConfig } from "../config"
 import { useData } from "../context/data"
@@ -18,6 +18,7 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
   const config = useConfig()
   const data = useData()
   const toast = useToast()
+  const renderer = useRenderer()
   const dimensions = useTerminalDimensions()
   const [sidebarOpen, setSidebarOpen] = createSignal(false)
   const [sessionWidth, setSessionWidth] = createSignal<number>()
@@ -68,10 +69,15 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
       if (!visible && selectedTerminal()) void sessions.hideTerminal(props.sessionID).catch(toast.error)
     })
   }
+  const focusSession = () => {
+    // Permission prompts replace the input, so returning focus must not depend on it.
+    if (terminalFocused()) renderer.currentFocusedRenderable?.blur()
+    prompt.current?.focus()
+  }
   createEffect(() => {
     if (!restoreTerminalFocus() || terminals().length > 0) return
     setRestoreTerminalFocus(false)
-    prompt.current?.focus()
+    focusSession()
   })
   Keymap.createLayer(() => ({
     enabled: () => config.data.session.terminal === true,
@@ -79,9 +85,7 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
       {
         id: "pane.focus.left",
         title: "Focus session pane",
-        run: () => {
-          prompt.current?.focus()
-        },
+        run: focusSession,
       },
       {
         id: "pane.focus.right",
@@ -121,7 +125,8 @@ export function SessionFrame(props: { sessionID: string; verticalTabsWidth: numb
             width="100%"
             height="100%"
             zIndex={1}
-            onMouseDown={() => prompt.current?.focus()}
+            // Consume the release before revealing permission buttons underneath.
+            onMouseUp={focusSession}
           />
         </Show>
       </box>

--- a/packages/tui/src/component/terminal-pane.tsx
+++ b/packages/tui/src/component/terminal-pane.tsx
@@ -143,7 +143,8 @@ export function TerminalPane(props: {
     },
     { priority: 100 },
   )
-  const onFocused = () => props.onFocusChange?.(terminal?.focused === true)
+  // Blur emits this event before updating the terminal's own focused flag.
+  const onFocused = () => props.onFocusChange?.(renderer.currentFocusedRenderable === terminal)
   renderer.on(CliRenderEvents.FOCUSED_RENDERABLE, onFocused)
   createEffect(() => {
     if (!props.autoFocus || !terminal) return


### PR DESCRIPTION
### Issue for this PR

Reported during development; no linked issue.

### Type of change

- [x] Bug fix

### What does this PR do?

Returning from the embedded terminal only focused the message input. Permission prompts replace that input, so both the focus-session shortcut and the session click overlay became no-ops while the terminal kept consuming keys.

Share a session-focus handler that explicitly blurs the terminal before focusing the input if present. Read the renderer's current focus target in the focus-change listener: OpenTUI emits the blur notification before clearing the terminal's own focused flag, which otherwise leaves the click overlay stuck. Handle the overlay click on mouse release so the focus click cannot also activate a permission button underneath.

### How did you verify your code works?

- `bun typecheck` in `packages/tui` passed.
- Existing keymap, permission, and session-tab mouse tests passed: 11 tests.
- An ad hoc check with an actual embedded terminal renderable confirmed repeated focus/blur cycles report true/false correctly using the renderer focus target.
- Prettier and `git diff --check` passed.
- No new tests added, as requested. Full live terminal interaction has not been verified.

### Screenshots / recordings

None; focus handling only, with no visual layout changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR