### PR TITLE
style(tui): brighten embedded terminal palette

### DIFF
--- a/packages/tui/src/component/terminal-pane.tsx
+++ b/packages/tui/src/component/terminal-pane.tsx
@@ -330,8 +330,8 @@ function sameSize(first: TerminalSize | undefined, second: TerminalSize | undefi
 }
 
 function terminalPalette(theme: ResolvedThemeTokens, mode: "dark" | "light", background: RGBA) {
-  const base = mode === "dark" ? 500 : 700
-  const bright = mode === "dark" ? 300 : 500
+  const base = mode === "dark" ? 200 : 800
+  const bright = mode === "dark" ? 100 : 900
   const colors = [
     background,
     theme.text.feedback.error.default,


### PR DESCRIPTION
## Summary
- use stronger hue steps for normal embedded terminal colors
- use the scale endpoints for bright ANSI colors in dark and light modes
- leave system theme generation and shared theme tokens unchanged

## Testing
- `bun typecheck` in `packages/tui`