### PR TITLE
fix(desktop): restore compact Windows titlebar spacing

### DIFF
--- a/packages/app/src/home/route.tsx
+++ b/packages/app/src/home/route.tsx
@@ -17,7 +17,7 @@ export function Home() {
   return (
     <div
       class={`
-        m-2 min-h-0 flex-1 self-stretch overflow-hidden rounded-[10px]
+        mx-2 mb-2 mt-[var(--shell-top-inset,8px)] min-h-0 flex-1 self-stretch overflow-hidden rounded-[10px]
         bg-v2-background-bg-base shadow-[var(--v2-elevation-raised)]
       `}
     >

--- a/packages/app/src/new-session/screen.tsx
+++ b/packages/app/src/new-session/screen.tsx
@@ -73,7 +73,7 @@ export default function NewSessionPage(props: { draftId: string }) {
     <div class="relative size-full overflow-hidden flex flex-col">
       {suspendUntilPromptReady()}
       <NewSessionStatus visible={settings.visibility.status()} />
-      <div class="flex-1 min-h-0 flex flex-col gap-2 p-2">
+      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
         <NewSessionView composer={model} project={project} workspace={workspace} />
       </div>
     </div>

--- a/packages/app/src/session/route.tsx
+++ b/packages/app/src/session/route.tsx
@@ -44,9 +44,7 @@ function TargetSessionSettingsCommand() {
   return null
 }
 
-function SessionRouteErrorBoundary(
-  props: ParentProps<{ sessionID?: string; serverKey?: ServerConnection.Key }>,
-) {
+function SessionRouteErrorBoundary(props: ParentProps<{ sessionID?: string; serverKey?: ServerConnection.Key }>) {
   return (
     <ErrorBoundary
       fallback={(error) => (
@@ -106,7 +104,7 @@ function PendingSessionState(props: { sessionID: string }) {
 
 function SessionStatePanel(props: ParentProps) {
   return (
-    <div class="flex min-h-0 flex-1 p-2">
+    <div class="flex min-h-0 flex-1 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
       <SessionPanelFrame raised>{props.children}</SessionPanelFrame>
     </div>
   )

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -164,7 +164,7 @@ export function SessionScreen(props: { session: SessionModel }) {
   return (
     <>
       <SessionHeader />
-      <div class="flex-1 min-h-0 flex flex-col gap-2 p-2">
+      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
         <div ref={screen.panel.ref} class="relative flex-1 min-h-0 flex flex-col md:flex-row gap-2">
           <div
             classList={{

--- a/packages/app/src/session/session-frame.tsx
+++ b/packages/app/src/session/session-frame.tsx
@@ -2,7 +2,10 @@ import type { ParentProps } from "solid-js"
 
 export function SessionRouteFrame(props: ParentProps<{ padded?: boolean }>) {
   return (
-    <div class="relative flex size-full flex-col overflow-hidden" classList={{ "p-2": props.padded }}>
+    <div
+      class="relative flex size-full flex-col overflow-hidden"
+      classList={{ "px-2 pb-2 pt-[var(--shell-top-inset,8px)]": props.padded }}
+    >
       {props.children}
     </div>
   )

--- a/packages/app/src/shell/routes/routes.tsx
+++ b/packages/app/src/shell/routes/routes.tsx
@@ -36,7 +36,7 @@ export function AppRoutes() {
           <SessionRouteFrame>
             <Suspense
               fallback={
-                <div class="flex min-h-0 flex-1 p-2">
+                <div class="flex min-h-0 flex-1 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
                   <SessionPanelFrame raised />
                 </div>
               }

--- a/packages/app/src/shell/shell.tsx
+++ b/packages/app/src/shell/shell.tsx
@@ -43,6 +43,13 @@ export default function Layout(props: ParentProps) {
         style={{
           "padding-top": "env(safe-area-inset-top, 0px)",
           "padding-bottom": "env(safe-area-inset-bottom, 0px)",
+          // The native Windows titlebar already includes the gap above the content panels.
+          "--shell-top-inset":
+            platform.platform === "desktop" &&
+            platform.os === "windows" &&
+            !(mobile() && preferences.general.mobileTitlebarPosition() === "bottom")
+              ? "0px"
+              : "8px",
         }}
       >
         <Titlebar
@@ -59,7 +66,7 @@ export default function Layout(props: ParentProps) {
             <aside
               ref={(element) => setState("tabsMount", element)}
               data-slot="vertical-tabs-sidebar"
-              class="relative flex min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 py-2"
+              class="relative flex min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 pb-2 pt-[var(--shell-top-inset,8px)]"
               style={{ width: `${state.tabsWidth}px` }}
             >
               <ResizeHandle

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -27,6 +27,7 @@ import { newTabTooltipKeybind } from "@/shell/commands/tooltip-keybind"
 import { TitlebarRightMount } from "@/shell/titlebar/right-slot"
 
 const titlebarHeight = 36
+const windowsTitlebarHeight = 44 // Includes the content inset; matches the native Windows overlay.
 const minTitlebarZoom = 0.25
 const windowsControlsBaseWidth = 138 // 3 native Windows caption buttons at 46px each.
 const macTrafficLightsBaseWidth = 84
@@ -59,7 +60,7 @@ export function Titlebar(props: {
   const titlebarZoom = () => (windows() ? Math.max(zoom(), minTitlebarZoom) : zoom())
   const minHeight = () => {
     if (mac()) return `${titlebarHeight / zoom()}px`
-    if (windows()) return `env(titlebar-area-height, ${titlebarHeight / Math.min(titlebarZoom(), 1)}px)`
+    if (windows()) return `env(titlebar-area-height, ${windowsTitlebarHeight / Math.min(titlebarZoom(), 1)}px)`
     return undefined
   }
   const windowsControlsWidth = () => `${windowsControlsBaseWidth / Math.max(titlebarZoom(), 1)}px`

--- a/packages/desktop/src/main/windows/appearance.ts
+++ b/packages/desktop/src/main/windows/appearance.ts
@@ -17,7 +17,8 @@ const oc2Background = {
 }
 const titlebarThemes = new WeakMap<BrowserWindow, Partial<TitlebarTheme>>()
 const pinchZoomEnabled = new WeakMap<BrowserWindow, boolean>()
-const titlebarHeight = 40
+// Match the renderer's 36px titlebar plus its former 8px content inset.
+const titlebarHeight = 44
 const maxZoomLevel = 10
 const minZoomLevel = 0.2
 let backgroundColor: string | undefined


### PR DESCRIPTION
## Summary

Fix the extra space below Windows titlebar controls introduced by #45208 without losing native caption-control alignment, zoom scaling, or theme integration.

- Use a 44px Windows overlay/titlebar at 100% zoom, matching the previous 36px titlebar plus 8px content inset.
- Center app controls and native caption controls in that shared band. Keep native-control width reservation and the existing zoom calculation.
- Let the shell supply the outer content top inset: 0px below the Windows titlebar, 8px elsewhere. Apply it consistently to home, drafts, sessions, loading/error surfaces, and the vertical-tab sidebar. Preserve side/bottom spacing and the top inset when the narrow-window titlebar is at the bottom.
- Leave non-Windows titlebar sizing and native theme handling unchanged.

## Verification

- `packages/app`: `bun typecheck` passed.
- Production app build passed.
- 16 titlebar/session-panel unit tests passed.
- 7 Playwright regressions passed: `tab-navigate-mousedown.spec.ts` and `new-session-panel-corner.spec.ts`, including vertical tabs and mobile fallback.
- Isolated Electron window with the production app components and fixture-backed API: native overlay and app header both measured 44px; 28px titlebar controls had 8px above and below; the session panel began immediately below the header. Checked LTR and forced RTL at 100% zoom without restarting the running app or server. Zoom arithmetic is unchanged, but a multi-zoom native visual check was not completed.
- Prettier and `git diff --check` passed.

## Existing Verification Blockers

- Desktop type checking reports TS7031 in unchanged `src/main/storage/drafts.ts` at lines 26, 35, and 36.
- The production home-to-session benchmark failed both before and after these changes, without reporting metrics. The benchmark harness first intercepted its own static assets when app/server origins matched; using separate hostnames allowed navigation but the milestone check still timed out. No performance comparison is claimed.

Based on `upstream/v2` at `df6317d23c`.
