### PR TITLE
fix(app): stop progress for completed background shells

### DIFF
--- a/packages/app/src/shell/routes/session-ui-provider.tsx
+++ b/packages/app/src/shell/routes/session-ui-provider.tsx
@@ -55,6 +55,7 @@ export function SessionUIProvider(
       data={sessionUIData()}
       directory={directory()}
       sessionID={params.id}
+      shellRunning={(id) => data.shell.get(id)?.status === "running"}
       shellOutput={(input) => serverSDK.api.shell.output(input)}
       onNavigateToSession={navigateToSession}
       onSessionHref={href}

--- a/packages/session-ui/component-tests/shell-background.spec.ts
+++ b/packages/session-ui/component-tests/shell-background.spec.ts
@@ -1,0 +1,59 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+story("stops background shell progress and polling while the parent stays busy", async ({ mount, page }) => {
+  await page.clock.install()
+  const timeline = await mount("current-session-terminal-work--background-command")
+  const shell = timeline.locator('[data-timeline-part-id="tool_background_shell"]')
+  const shimmer = shell.locator('[data-component="text-shimmer"]')
+  await expect(shimmer).toHaveAttribute("data-active", "true")
+  await expect(shell).toContainText("Installing packages")
+  const reads = timeline.getByLabel("Output reads")
+  const before = Number(await reads.textContent())
+  await page.clock.runFor(2_000)
+  await expect(reads).toHaveText(String(before + 2))
+  await timeline.getByRole("button", { name: "Complete command", exact: true }).click()
+  await expect(shimmer).toHaveAttribute("data-active", "false")
+  await expect(shell.locator('[data-slot="bash-result"]')).toHaveText("Installing packages\n2528 packages installed\n")
+  const completed = await reads.textContent()
+  await page.clock.runFor(3_000)
+  await expect(reads).toHaveText(completed!)
+  await timeline.getByRole("button", { name: "Remount command", exact: true }).click()
+  await expect(shimmer).toHaveAttribute("data-active", "false")
+  await expect(shell).toContainText("2528 packages installed")
+})
+
+story("loads an already finished background shell without showing progress", async ({ mount, page }) => {
+  await page.clock.install()
+  const timeline = await mount("current-session-terminal-work--background-command", { args: { completed: true } })
+  const shell = timeline.locator('[data-timeline-part-id="tool_background_shell"]')
+  await expect(shell.locator('[data-component="text-shimmer"]')).toHaveAttribute("data-active", "false")
+  await expect(shell).toContainText("2528 packages installed")
+  const reads = timeline.getByLabel("Output reads")
+  await expect(reads).toHaveText("1")
+  await page.clock.runFor(3_000)
+  await expect(reads).toHaveText("1")
+})
+
+story("drains all finished output pages without repeating captured output", async ({ mount, page }) => {
+  await page.clock.install()
+  const timeline = await mount("current-session-terminal-work--background-command", {
+    args: { completed: true, paged: true },
+  })
+  const shell = timeline.locator('[data-timeline-part-id="tool_background_shell"]')
+  await expect(shell.locator('[data-slot="bash-result"]')).toHaveText("Installing packages\n2528 packages installed\n")
+  await expect(timeline.getByLabel("Output reads")).toHaveText("2")
+  await page.clock.runFor(3_000)
+  await expect(timeline.getByLabel("Output reads")).toHaveText("2")
+})
+
+story("does not show model-facing background instructions as shell output", async ({ mount, page }) => {
+  await page.clock.install()
+  const timeline = await mount("current-session-terminal-work--background-command", {
+    args: { completed: true, empty: true },
+  })
+  const shell = timeline.locator('[data-timeline-part-id="tool_background_shell"]')
+  await expect(timeline.getByLabel("Output reads")).toHaveText("1")
+  await expect(shell.locator('[data-component="text-shimmer"]')).toHaveAttribute("data-active", "false")
+  await expect(shell.locator('[data-slot="bash-result"]')).toHaveCount(0)
+  await expect(shell).not.toContainText("moved to the background")
+})

--- a/packages/session-ui/src/context/data.tsx
+++ b/packages/session-ui/src/context/data.tsx
@@ -46,6 +46,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     data: Data
     directory: string
     sessionID?: string
+    shellRunning?: (id: string) => boolean
     shellOutput?: (input: ShellOutputInput) => Promise<ShellOutputOutput>
     onNavigateToSession?: NavigateToSessionFn
     onSessionHref?: SessionHrefFn
@@ -62,6 +63,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       },
       navigateToSession: props.onNavigateToSession,
       sessionHref: props.onSessionHref,
+      shellRunning: props.shellRunning,
       shellOutput: props.shellOutput,
     }
   },

--- a/packages/session-ui/src/storybook/current-session-story.tsx
+++ b/packages/session-ui/src/storybook/current-session-story.tsx
@@ -6,14 +6,21 @@ import type { SessionUserPresentation } from "../timeline/session-timeline"
 import { SessionTimeline } from "../timeline/session-timeline"
 import { FileComponentProvider } from "@opencode-ai/ui/context/file"
 import { Button } from "@opencode-ai/ui/button"
-import { Show, createSignal, type JSX } from "solid-js"
+import { Show, createSignal, type ComponentProps, type JSX } from "solid-js"
 import { CURRENT_SESSION_ID, STORY_TIME } from "./current-session-fixtures"
 
-export function CurrentSessionProviders(props: { document: SessionDocument; children: JSX.Element }) {
+export function CurrentSessionProviders(
+  props: { document: SessionDocument; children: JSX.Element } & Pick<
+    ComponentProps<typeof DataProvider>,
+    "shellRunning" | "shellOutput"
+  >,
+) {
   return (
     <DataProvider
       directory="C:/workspaces/opencode"
       sessionID={props.document.sessionID}
+      shellRunning={props.shellRunning}
+      shellOutput={props.shellOutput}
       data={{
         agent: [
           { name: "build", color: "blue" },

--- a/packages/session-ui/src/timeline/terminal-work.stories.tsx
+++ b/packages/session-ui/src/timeline/terminal-work.stories.tsx
@@ -1,5 +1,5 @@
 import type { SessionMessageAssistant } from "@opencode-ai/client/promise"
-import { createMemo } from "solid-js"
+import { createMemo, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { CurrentSessionProviders, CurrentSessionTimelineStory } from "../storybook/current-session-story"
 import {
@@ -87,6 +87,77 @@ export const TestsPassed = {
       shellToolDefaultOpen
     />
   ),
+}
+
+export const BackgroundCommand = {
+  args: { completed: false, paged: false, empty: false },
+  render: (args: { completed: boolean; paged: boolean; empty: boolean }) => {
+    const [state, setState] = createStore({ running: !args.completed, reads: 0, revision: 1 })
+    const document = storyDocument(
+      [
+        storyTool(
+          "tool_background_shell",
+          "shell",
+          "completed",
+          { command: "bun install", background: true },
+          {
+            metadata: { status: "running", shellID: "shell_background" },
+            output: "The command was moved to the background.",
+          },
+        ),
+      ],
+      true,
+    )
+    return (
+      <section class="mx-auto flex w-full max-w-[720px] flex-col gap-4 p-6">
+        <div class="flex gap-3">
+          <button type="button" onClick={() => setState("running", false)}>
+            Complete command
+          </button>
+          <button type="button" onClick={() => setState("revision", (value) => value + 1)}>
+            Remount command
+          </button>
+        </div>
+        <output aria-label="Output reads">{state.reads}</output>
+        <Show when={state.revision} keyed>
+          {() => (
+            <CurrentSessionProviders
+              document={document}
+              shellRunning={(id) => id === "shell_background" && state.running}
+              shellOutput={async (input) => {
+                await Promise.resolve()
+                setState("reads", (value) => value + 1)
+                const output = args.empty
+                  ? ""
+                  : state.running
+                    ? "Installing packages\n"
+                    : "Installing packages\n2528 packages installed\n"
+                const cursor = Math.min(output.length, (input.cursor ?? 0) + (args.paged ? 24 : output.length))
+                return {
+                  location: {
+                    directory: "C:/workspaces/opencode",
+                    project: {
+                      id: "project_story",
+                      directory: "C:/workspaces/opencode",
+                      canonical: "C:/workspaces/opencode",
+                    },
+                  },
+                  data: {
+                    output: output.slice(input.cursor ?? 0, cursor),
+                    cursor,
+                    size: output.length,
+                    truncated: false,
+                  },
+                }
+              }}
+            >
+              <SessionTimeline document={document} shellToolDefaultOpen />
+            </CurrentSessionProviders>
+          )}
+        </Show>
+      </section>
+    )
+  },
 }
 
 export const ExpandedShell = {

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -1396,31 +1396,47 @@ ToolRegistry.register({
     const i18n = useI18n()
     const data = useData()
     const streaming = () => props.status === "streaming"
-    const pending = () => streaming() || props.status === "running" || props.metadata.status === "running"
+    // Background tool metadata describes admission, not the live shell state.
+    const pending = createMemo(
+      () =>
+        streaming() ||
+        props.status === "running" ||
+        (typeof props.metadata.shellID === "string" && data.shellRunning?.(props.metadata.shellID) === true),
+    )
     const sawStreaming = streaming()
     const [streamed, setStreamed] = createSignal("")
     createEffect(() => {
       const id = props.metadata.shellID
       const shellOutput = data.shellOutput
-      if (typeof id !== "string" || !pending() || !shellOutput) return
+      if (typeof id !== "string" || !shellOutput) return
       const directory = data.directory
       let cursor = 0
-      let loading = false
-      let disposed = false
-      const load = async () => {
-        if (loading) return
-        loading = true
-        const response = await shellOutput({ id, location: { directory }, cursor }).catch(() => undefined)
-        if (disposed) return
-        if (response?.data.output) setStreamed((output) => output + response.data.output)
-        if (response) cursor = response.data.cursor
-        loading = false
-      }
-      void load()
-      const interval = setInterval(() => void load(), 1_000)
-      onCleanup(() => {
-        disposed = true
-        clearInterval(interval)
+      setStreamed("")
+      createEffect(() => {
+        const running = pending()
+        let loading = false
+        let disposed = false
+        const load = async () => {
+          if (loading) return
+          loading = true
+          do {
+            const response = await shellOutput({ id, location: { directory }, cursor }).catch(() => undefined)
+            if (disposed) return
+            if (!response) break
+            if (response.data.output) setStreamed((output) => output + response.data.output)
+            if (response.data.cursor <= cursor) break
+            cursor = response.data.cursor
+            if (cursor >= response.data.size) break
+          } while (!running)
+          loading = false
+        }
+        void load()
+        // Drain the remaining pages on completion without discarding already captured output.
+        const interval = running ? setInterval(() => void load(), 1_000) : undefined
+        onCleanup(() => {
+          disposed = true
+          clearInterval(interval)
+        })
       })
     })
     const command = () => {
@@ -1428,7 +1444,13 @@ ToolRegistry.register({
       if (typeof props.metadata.command === "string") return props.metadata.command
       return ""
     }
-    const output = createMemo(() => stripAnsi((pending() && streamed()) || props.output || "").replace(/\r\n?/g, "\n"))
+    const output = createMemo(() =>
+      stripAnsi(
+        (typeof props.metadata.shellID === "string"
+          ? streamed() || (props.metadata.status === "running" ? "" : props.output)
+          : props.output) ?? "",
+      ).replace(/\r\n?/g, "\n"),
+    )
     return (
       <BasicTool
         {...props}


### PR DESCRIPTION
### Issue for this PR

Reported locally: a background `bun install` exited successfully but its desktop row kept shimmering and polling.

### Type of change

- [x] Bug fix

### What does this PR do?

Use the Client's live shell state instead of the tool result's historical `status: running` metadata. Background shells continue to show captured stdout/stderr while running. On completion, stop shimmer and polling, drain the remaining output pages, and retain that output across remounts.

Do not render the model-facing "moved to the background" instructions as command output. No Core execution or process-cleanup changes; the separate shell hang is out of scope.

### How did you verify your code works?

- `bun typecheck` in `packages/app` and `packages/session-ui`.
- `bun test src --only-failures` in `packages/session-ui`: 112 passed.
- Production Storybook build; 12 Playwright tests passed across `shell-background.spec.ts` and `session-lifecycle.spec.ts`.
- The two initial regression tests fail against the original renderer.
- Production fixture measurement: after completion, polling dropped from 3 reads per 3 simulated seconds to 0, and shimmer changed from active to inactive. The parent remains busy throughout.

### Screenshots / recordings

Verified at 1000x800 and 390x844 using the production Storybook `OpenCode / Work / Terminal / Background Command` story. Screenshots were captured locally; the fixture and regression tests are included for review.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
