### PR TITLE
refactor(plugin): manage MCP servers through transforms

### DIFF
--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -288,26 +288,6 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: Interface, p
         if (ref && !isCurrentLocation(ref)) return runtime.location.mcp.list(ref)
         return response(mcp.servers())
       },
-      add: (input) => {
-        const ref = locationRef(input)
-        if (ref && !isCurrentLocation(ref)) return runtime.location.mcp.add(ref, input.server, input.config)
-        return mcp.add(input.server, input.config)
-      },
-      remove: (input) => {
-        const ref = locationRef(input)
-        if (ref && !isCurrentLocation(ref)) return runtime.location.mcp.remove(ref, input.server)
-        return mcp.remove(input.server)
-      },
-      connect: (input) => {
-        const ref = locationRef(input)
-        if (ref && !isCurrentLocation(ref)) return runtime.location.mcp.connect(ref, input.server)
-        return mcp.connect(input.server)
-      },
-      disconnect: (input) => {
-        const ref = locationRef(input)
-        if (ref && !isCurrentLocation(ref)) return runtime.location.mcp.disconnect(ref, input.server)
-        return mcp.disconnect(input.server)
-      },
       reload: mcp.reload,
       transform: (callback) =>
         mcp.transform((draft) => {

--- a/packages/core/src/plugin/runtime.ts
+++ b/packages/core/src/plugin/runtime.ts
@@ -2,7 +2,6 @@ export * as PluginRuntime from "./runtime.js"
 
 import { Context, Effect, Layer } from "effect"
 import { Agent } from "../agent.js"
-import { Mcp } from "@opencode-ai/schema/mcp"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { Job } from "../job.js"
 import { Location } from "../location.js"
@@ -40,10 +39,6 @@ export interface Interface {
       readonly list: (
         ref: Location.Ref,
       ) => Effect.Effect<{ readonly location: Location.Info; readonly data: MCP.ServerInfo[] }, unknown>
-      readonly add: (ref: Location.Ref, server: string, config: Mcp.ServerConfig) => Effect.Effect<void, unknown>
-      readonly remove: (ref: Location.Ref, server: string) => Effect.Effect<void, unknown>
-      readonly connect: (ref: Location.Ref, server: string) => Effect.Effect<void, unknown>
-      readonly disconnect: (ref: Location.Ref, server: string) => Effect.Effect<void, unknown>
     }
   }
 }
@@ -101,10 +96,6 @@ export const layerWithCell = (cell: Cell) =>
         },
         mcp: {
           list: (ref) => require(cell, (runtime) => runtime.location.mcp.list(ref)),
-          add: (ref, server, config) => require(cell, (runtime) => runtime.location.mcp.add(ref, server, config)),
-          remove: (ref, server) => require(cell, (runtime) => runtime.location.mcp.remove(ref, server)),
-          connect: (ref, server) => require(cell, (runtime) => runtime.location.mcp.connect(ref, server)),
-          disconnect: (ref, server) => require(cell, (runtime) => runtime.location.mcp.disconnect(ref, server)),
         },
       },
     }),
@@ -149,14 +140,6 @@ export const providerLayerWithCell = (cell: Cell) =>
                   data: yield* mcp.servers(),
                 }
               }).pipe(Effect.provide(locations.get(ref))),
-            add: (ref, server, config) =>
-              MCP.Service.use((mcp) => mcp.add(server, config)).pipe(Effect.provide(locations.get(ref))),
-            remove: (ref, server) =>
-              MCP.Service.use((mcp) => mcp.remove(server)).pipe(Effect.provide(locations.get(ref))),
-            connect: (ref, server) =>
-              MCP.Service.use((mcp) => mcp.connect(server)).pipe(Effect.provide(locations.get(ref))),
-            disconnect: (ref, server) =>
-              MCP.Service.use((mcp) => mcp.disconnect(server)).pipe(Effect.provide(locations.get(ref))),
           },
         },
       }

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -1032,6 +1032,58 @@ test("adds, disconnects, and reconnects MCP servers at runtime", async () => {
   )
 })
 
+testEffect(resourceMcpLayer(new ConfigMCP.Local({ type: "local", command: ["unused"], disabled: true }))).live(
+  "manages live MCP servers entirely through scoped transforms",
+  () =>
+    Effect.gen(function* () {
+      const service = yield* MCP.Service
+
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          yield* service.transform((draft) => {
+            draft.set("dynamic", {
+              type: "local",
+              command: [process.execPath, path.join(import.meta.dir, "fixture/mcp-output-schema.ts")],
+            })
+          })
+          expect((yield* service.servers()).find((server) => server.name === "dynamic")?.status.status).toBe(
+            "connected",
+          )
+          expect(yield* service.tools()).toHaveLength(2)
+
+          const settings = { disabled: true }
+          yield* service.transform((draft) => {
+            draft.update("dynamic", (server) => {
+              server.disabled = settings.disabled
+            })
+          })
+          expect((yield* service.servers()).find((server) => server.name === "dynamic")?.status.status).toBe("disabled")
+          expect(yield* service.tools()).toEqual([])
+
+          settings.disabled = false
+          yield* service.reload()
+          expect((yield* service.servers()).find((server) => server.name === "dynamic")?.status.status).toBe(
+            "connected",
+          )
+          expect(yield* service.tools()).toHaveLength(2)
+
+          const removed = yield* service.transform((draft) => draft.remove("dynamic"))
+          expect((yield* service.servers()).some((server) => server.name === "dynamic")).toBe(false)
+          expect(yield* service.tools()).toEqual([])
+
+          yield* removed.dispose
+          expect((yield* service.servers()).find((server) => server.name === "dynamic")?.status.status).toBe(
+            "connected",
+          )
+          expect(yield* service.tools()).toHaveLength(2)
+        }),
+      )
+
+      expect((yield* service.servers()).map((server) => server.name)).toEqual([MCP.ServerName.make("resources")])
+      expect(yield* service.tools()).toEqual([])
+    }),
+)
+
 test("restores runtime MCP config when a transform is disposed", async () => {
   await Effect.runPromise(
     Effect.scoped(

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -43,7 +43,7 @@ describe("Plugin", () => {
     }),
   )
 
-  it.effect("routes explicit MCP locations through the plugin runtime", () =>
+  it.effect("exposes MCP reads and transforms and routes explicit read locations", () =>
     Effect.gen(function* () {
       const plugins = yield* Plugin.Service
       const runtime = yield* PluginRuntime.Service
@@ -72,10 +72,6 @@ describe("Plugin", () => {
                       data: [],
                     }
                   }),
-                add: (ref) => Effect.sync(() => routed.push(`add:${ref.directory}`)),
-                remove: (ref) => Effect.sync(() => routed.push(`remove:${ref.directory}`)),
-                connect: (ref) => Effect.sync(() => routed.push(`connect:${ref.directory}`)),
-                disconnect: (ref) => Effect.sync(() => routed.push(`disconnect:${ref.directory}`)),
               },
             },
           }),
@@ -83,14 +79,9 @@ describe("Plugin", () => {
       )
       const location = { directory: target }
 
-      yield* host.mcp
-        .add({ location, server: "routed", config: { type: "local", command: ["unused"], disabled: true } })
-        .pipe(Effect.orDie)
-      yield* host.mcp.remove({ location, server: "routed" }).pipe(Effect.orDie)
-      yield* host.mcp.connect({ location, server: "routed" }).pipe(Effect.orDie)
-      yield* host.mcp.disconnect({ location, server: "routed" }).pipe(Effect.orDie)
+      expect(Object.keys(host.mcp).sort()).toEqual(["list", "reload", "transform"])
       expect((yield* host.mcp.list({ location }).pipe(Effect.orDie)).location.directory).toBe(target)
-      expect(routed).toEqual(["add:/target", "remove:/target", "connect:/target", "disconnect:/target", "list:/target"])
+      expect(routed).toEqual(["list:/target"])
     }),
   )
 

--- a/packages/core/test/plugin/host.ts
+++ b/packages/core/test/plugin/host.ts
@@ -77,10 +77,6 @@ export function host(overrides: Overrides = {}): Plugin.Context {
     },
     mcp: overrides.mcp ?? {
       list: () => Effect.die("unused mcp.list"),
-      add: () => Effect.die("unused mcp.add"),
-      remove: () => Effect.die("unused mcp.remove"),
-      connect: () => Effect.die("unused mcp.connect"),
-      disconnect: () => Effect.die("unused mcp.disconnect"),
       transform: () => Effect.die("unused mcp.transform"),
       reload: () => Effect.die("unused mcp.reload"),
     },

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -242,12 +242,14 @@ describe("fromPromise", () => {
       const promisePlugin = define({
         id: "promise-client-reads",
         setup: async (ctx) => {
+          expect(Object.keys(ctx.mcp).sort()).toEqual(["list", "reload", "transform"])
           const results = await Promise.all([
             ctx.agent.list(),
             ctx.catalog.provider.list(),
             ctx.catalog.model.list(),
             ctx.command.list(),
             ctx.integration.list(),
+            ctx.mcp.list(),
             ctx.plugin.list(),
             ctx.reference.list(),
             ctx.skill.list(),
@@ -259,7 +261,7 @@ describe("fromPromise", () => {
 
       yield* PluginPromise.fromPromise(promisePlugin).effect(host)
 
-      expect(seen).toHaveLength(8)
+      expect(seen).toHaveLength(9)
       expect(new Set(seen).size).toBe(1)
     }),
   )

--- a/packages/plugin/src/effect/mcp.ts
+++ b/packages/plugin/src/effect/mcp.ts
@@ -11,7 +11,7 @@ export interface MCPDraft {
   remove(name: string): void
 }
 
-export interface MCPDomain extends Omit<McpApi<unknown>, "resource"> {
+export interface MCPDomain extends Pick<McpApi<unknown>, "list"> {
   readonly transform: Transform<MCPDraft>
   readonly reload: () => Effect.Effect<void>
 }

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -260,10 +260,6 @@ export function fromPromise(plugin: Plugin) {
           },
           mcp: {
             list: adaptApiMethod(McpEndpoints["mcp.list"], host.mcp.list),
-            add: adaptApiMethod(McpEndpoints["mcp.add"], host.mcp.add),
-            remove: adaptApiMethod(McpEndpoints["mcp.remove"], host.mcp.remove),
-            connect: adaptApiMethod(McpEndpoints["mcp.connect"], host.mcp.connect),
-            disconnect: adaptApiMethod(McpEndpoints["mcp.disconnect"], host.mcp.disconnect),
             transform: transform(host.mcp),
             reload: () => run(host.mcp.reload()),
           },

--- a/packages/plugin/src/promise/mcp.ts
+++ b/packages/plugin/src/promise/mcp.ts
@@ -11,7 +11,7 @@ export interface MCPDraft {
   remove(name: string): void
 }
 
-export interface MCPDomain extends Omit<McpApi, "resource"> {
+export interface MCPDomain extends Pick<McpApi, "list"> {
   readonly transform: Transform<MCPDraft>
   readonly reload: () => Promise<void>
 }

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -533,32 +533,43 @@ interface IntegrationDomain extends Omit<IntegrationApi<unknown>, "wellknown"> {
 
 ### MCP
 
-List servers and change connection state.
+List MCP servers and their current connection state.
 
 ```ts
 effect: (ctx) =>
   Effect.gen(function* () {
     const mcp = ctx.mcp
     const servers = yield* mcp.list().pipe(Effect.orDie)
-    yield* mcp.connect({ server: "docs" }).pipe(Effect.orDie)
-    yield* mcp.disconnect({ server: "docs" }).pipe(Effect.orDie)
     yield* Effect.logInfo("MCP servers", { count: servers.data.length })
   }),
 ```
 
-Add servers through the API, or transform and reload their configuration.
+Plugins manage MCP servers only through transforms. Use `draft.set` to add or replace a server, `draft.update` to
+change its configuration, and `draft.remove` to remove it. Inspect configuration with `draft.list` and `draft.get`.
 
 ```ts
 effect: (ctx) =>
   Effect.gen(function* () {
     const mcp = ctx.mcp
-    yield* mcp
-      .add({ server: "docs", config: { type: "remote", url: "https://mcp.example.com" } })
-      .pipe(Effect.orDie)
     yield* mcp.transform((draft) => {
+      const servers = draft.list()
+      const docs = draft.get("docs")
+      draft.set("docs", { type: "remote", url: "https://mcp.example.com" })
       draft.update("docs", (server) => (server.disabled = false))
       draft.remove("legacy")
     })
+  }),
+```
+
+Set `disabled: true` in a transform to disable a server and disconnect it, or `disabled: false` to enable it and allow
+OpenCode to connect. OpenCode reconciles server lifecycle from the transformed configuration.
+
+Call `reload()` after external state used by a transform changes to reapply transforms and reconcile the servers.
+
+```ts
+effect: (ctx) =>
+  Effect.gen(function* () {
+    const mcp = ctx.mcp
     yield* mcp.reload()
   }),
 ```
@@ -575,7 +586,7 @@ interface MCPDraft {
   remove(name: string): void
 }
 
-interface MCPDomain extends Omit<McpApi<unknown>, "resource"> {
+interface MCPDomain extends Pick<McpApi<unknown>, "list"> {
   readonly transform: Transform<MCPDraft>
   readonly reload: () => Effect.Effect<void>
 }

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -488,25 +488,14 @@ interface IntegrationDraft {
 
 ### MCP
 
-List MCP servers or change their connection state.
+List MCP servers and their current connection state.
 
 ```ts
 const servers = await ctx.mcp.list()
-await ctx.mcp.connect({ server: "docs" })
-await ctx.mcp.disconnect({ server: "docs" })
 ```
 
-Add or remove a server through the connected API.
-
-```ts
-await ctx.mcp.add({
-  server: "docs",
-  config: { type: "remote", url: "https://mcp.example.com" },
-})
-await ctx.mcp.remove({ server: "legacy" })
-```
-
-Register a transform to inspect, set, update, or remove server configuration.
+Plugins manage MCP servers only through transforms. Use `draft.set` to add or replace a server, `draft.update` to
+change its configuration, and `draft.remove` to remove it. Inspect configuration with `draft.list` and `draft.get`.
 
 ```ts
 await ctx.mcp.transform((draft) => {
@@ -520,7 +509,10 @@ await ctx.mcp.transform((draft) => {
 })
 ```
 
-Reload MCP configuration after external state used by a transform changes.
+Set `disabled: true` in a transform to disable a server and disconnect it, or `disabled: false` to enable it and allow
+OpenCode to connect. OpenCode reconciles server lifecycle from the transformed configuration.
+
+Call `reload()` after external state used by a transform changes to reapply transforms and reconcile the servers.
 
 ```ts
 await ctx.mcp.reload()
@@ -534,10 +526,6 @@ Schemas: [`Mcp.Server`](/api#schema-Mcp.Server), [`Mcp.LocalConfigEncoded`](/api
 ```ts
 interface MCPContext {
   list(input?: McpListInput, requestOptions?: RequestOptions): Promise<McpListOutput>
-  add(input: McpAddInput, requestOptions?: RequestOptions): Promise<void>
-  remove(input: McpRemoveInput, requestOptions?: RequestOptions): Promise<void>
-  connect(input: McpConnectInput, requestOptions?: RequestOptions): Promise<void>
-  disconnect(input: McpDisconnectInput, requestOptions?: RequestOptions): Promise<void>
   transform(callback: (draft: MCPDraft) => void): Promise<Registration>
   reload(): Promise<void>
 }


### PR DESCRIPTION
## Summary
- Remove top-level MCP add, remove, connect, and disconnect from the Promise and Effect plugin APIs, leaving list, transform, and reload.
- Delete the associated plugin adapters and cross-location mutation routing; update both plugin guides.
- Retain the existing State.create transform engine, which already handles ordered composition, reload, reconciliation, and scoped disposal.
- Add a live-server regression test covering transform-based creation, disabling, re-enabling, removal, restoration, and scope cleanup.

## Scope
This intentionally breaks plugin callers using the removed methods. Server definitions and enabled/disabled state should be managed through transforms. Public HTTP/client operations and their core implementations remain unchanged for ACP and UI callers.

## Validation
- 87 focused core tests passed across MCP, plugin host, Promise adapter, State, skills, and MCP Code Mode exclusion tests.
- 5 plugin package tests passed.
- Core and plugin typechecks passed.
- Website build, link validation, and generated-content check passed.
- TypeScript formatting and git diff --check passed.
- Website typecheck is blocked by an unrelated Astro/Shiki dependency type mismatch in astro.config.ts:16.