### PR TITLE
fix(core): dispatch providers whose AI SDK package has no native route

### DIFF
--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -5,6 +5,8 @@ import { type Model } from "@opencode-ai/llm"
 import * as AnthropicMessages from "@opencode-ai/llm/protocols/anthropic-messages"
 import * as OpenAICompatibleChat from "@opencode-ai/llm/protocols/openai-compatible-chat"
 import * as OpenAIResponses from "@opencode-ai/llm/protocols/openai-responses"
+import * as OpenAICompatibleProfile from "@opencode-ai/llm/providers/openai-compatible-profile"
+import * as OpenRouter from "@opencode-ai/llm/providers/openrouter"
 import { Auth, type AnyRoute } from "@opencode-ai/llm/route"
 import { Context, Effect, Layer, Schema } from "effect"
 import { produce } from "immer"
@@ -87,14 +89,14 @@ const apiKey = (model: ModelV2.Info, credential?: Credential.Value) => {
   if (typeof value === "string") return Auth.value(value)
 }
 
-const withDefaults = (model: ModelV2.Info, route: AnyRoute) => {
+const withDefaults = (model: ModelV2.Info, route: AnyRoute, baseURL = model.api.url) => {
   const body = model.request.body
   const httpBody = Object.hasOwn(body, "apiKey")
     ? Object.fromEntries(Object.entries(body).filter(([key]) => key !== "apiKey"))
     : body
   return route.with({
     provider: model.providerID,
-    endpoint: model.api.url === undefined ? undefined : { baseURL: model.api.url },
+    endpoint: baseURL === undefined ? undefined : { baseURL },
     headers: model.request.headers,
     http: { body: httpBody },
     limits: { context: model.limit.context, output: model.limit.output },
@@ -160,6 +162,14 @@ export const fromCatalogModel = (
         .model({ id: resolved.api.id }),
     )
   }
+  const profile = compatibleProfile(resolved)
+  if (profile) {
+    return Effect.succeed(
+      withDefaults(resolved, profile.route, resolved.api.url ?? profile.baseURL)
+        .with({ auth: key === undefined ? Auth.none : Auth.bearer(key) })
+        .model({ id: resolved.api.id }),
+    )
+  }
   return Effect.fail(
     new UnsupportedApiError({
       providerID: resolved.providerID,
@@ -169,6 +179,26 @@ export const fromCatalogModel = (
   )
 }
 
+/**
+ * The route for a provider whose AI SDK package this runner has no protocol for
+ * but whose API is OpenAI-compatible, from the profile table the LLM package
+ * already keeps. Without it the catalog lists models — every `openrouter` model
+ * (`@openrouter/ai-sdk-provider`) and every `groq` one (`@ai-sdk/groq`) — that a
+ * keyed provider then fails to dispatch.
+ *
+ * `openrouter` gets its own route rather than the generic one so its usage,
+ * reasoning and prompt-cache body options survive.
+ */
+const compatibleProfile = (model: ModelV2.Info) => {
+  if (model.api.type !== "aisdk") return undefined
+  const profile = OpenAICompatibleProfile.byProvider[model.providerID]
+  if (!profile) return undefined
+  return {
+    baseURL: profile.baseURL,
+    route: model.providerID === OpenRouter.profile.provider ? OpenRouter.route : OpenAICompatibleChat.route,
+  }
+}
+
 export const resolve = (session: SessionSchema.Info, model: ModelV2.Info, credential?: Credential.Value) =>
   withVariant(model, session.model?.variant).pipe(Effect.flatMap((model) => fromCatalogModel(model, credential)))
 
@@ -176,7 +206,8 @@ export const supported = (model: ModelV2.Info) =>
   model.api.type === "aisdk" &&
   (model.api.package === "@ai-sdk/openai" ||
     model.api.package === "@ai-sdk/anthropic" ||
-    (model.api.package === "@ai-sdk/openai-compatible" && model.api.url !== undefined))
+    (model.api.package === "@ai-sdk/openai-compatible" && model.api.url !== undefined) ||
+    compatibleProfile(model) !== undefined)
 
 /** Resolves models from the catalog belonging to the current Location runtime. */
 export const locationLayer = Layer.effect(

--- a/packages/core/test/session-runner-model.test.ts
+++ b/packages/core/test/session-runner-model.test.ts
@@ -329,6 +329,51 @@ describe("SessionRunnerModel", () => {
     }),
   )
 
+  it.effect("routes an unmapped AI SDK package through the provider's OpenAI-compatible profile", () =>
+    Effect.gen(function* () {
+      const resolved = yield* SessionRunnerModel.fromCatalogModel(
+        ModelV2.Info.make({
+          ...model({ type: "aisdk", package: "@ai-sdk/groq" }),
+          providerID: ProviderV2.ID.make("groq"),
+        }),
+      )
+
+      expect(resolved.route).toMatchObject({
+        id: "openai-compatible-chat",
+        endpoint: { baseURL: "https://api.groq.com/openai/v1" },
+      })
+    }),
+  )
+
+  it.effect("keeps the catalog URL when the profile only supplies a fallback", () =>
+    Effect.gen(function* () {
+      const resolved = yield* SessionRunnerModel.fromCatalogModel(
+        ModelV2.Info.make({
+          ...model({ type: "aisdk", package: "@ai-sdk/groq", url: "https://groq.example/v1" }),
+          providerID: ProviderV2.ID.make("groq"),
+        }),
+      )
+
+      expect(resolved.route).toMatchObject({ endpoint: { baseURL: "https://groq.example/v1" } })
+    }),
+  )
+
+  it.effect("routes OpenRouter through its own chat route", () =>
+    Effect.gen(function* () {
+      const resolved = yield* SessionRunnerModel.fromCatalogModel(
+        ModelV2.Info.make({
+          ...model({ type: "aisdk", package: "@openrouter/ai-sdk-provider" }),
+          providerID: ProviderV2.ID.make("openrouter"),
+        }),
+      )
+
+      expect(resolved.route).toMatchObject({
+        id: "openrouter",
+        endpoint: { baseURL: "https://openrouter.ai/api/v1" },
+      })
+    }),
+  )
+
   it.effect("reports whether a catalog model has a supported native route", () =>
     Effect.sync(() => {
       expect(
@@ -342,6 +387,14 @@ describe("SessionRunnerModel", () => {
         ),
       ).toBe(false)
       expect(SessionRunnerModel.supported(model({ type: "native", settings: {} }))).toBe(false)
+      expect(
+        SessionRunnerModel.supported(
+          ModelV2.Info.make({
+            ...model({ type: "aisdk", package: "@ai-sdk/groq" }),
+            providerID: ProviderV2.ID.make("groq"),
+          }),
+        ),
+      ).toBe(true)
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #45426

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`SessionRunnerModel.fromCatalogModel` routes exactly three AI SDK packages: `@ai-sdk/openai`, `@ai-sdk/anthropic`, and `@ai-sdk/openai-compatible` with a URL. Anything else fails with `UnsupportedApiError` the moment a session drains.

Two providers in the catalog are always something else. Every `openrouter` model carries `@openrouter/ai-sdk-provider` and every `groq` model carries `@ai-sdk/groq`, so with a valid key stored, both list their models (356 and 15 here) and then dispatch none of them. The failure surfaces late and misleadingly — the session is created, produces no assistant message, and the log says:

```
SessionRunnerModel.UnsupportedApiError: Unsupported API for openrouter/minimax/minimax-m2.7:free: aisdk:@openrouter/ai-sdk-provider
```

Both APIs are OpenAI-compatible, and the LLM package already says so: `packages/llm/src/providers/openai-compatible-profile.ts` lists openrouter and groq (plus cerebras, deepseek, fireworks, togetherai, xai, baseten, deepinfra) with their base URLs. `fromCatalogModel` just never consulted it.

So: after the three package checks, look the provider ID up in `byProvider`. On a hit, route through `OpenAICompatibleChat` with the catalog URL if the model has one, else the profile's base URL — groq's catalog entries have no URL at all, which is why the profile matters. `openrouter` gets `providers/openrouter`'s own route instead of the generic one, so its `usage`, `reasoning` and `prompt_cache_key` body options keep working. `supported()` uses the same helper so model selection and dispatch cannot disagree.

A provider outside the profile table is unaffected and still fails as before — `@ai-sdk/google` on the `opencode` provider, for instance.

### How did you verify your code works?

Unit tests in `packages/core/test/session-runner-model.test.ts` (3 added): groq resolves to `openai-compatible-chat` at the profile base URL; a catalog URL still wins over the profile fallback; openrouter resolves to its own `openrouter` route. `bun test` in `packages/core` and `bun run typecheck` both pass — the only failures in the full run are 5 pre-existing `NpmConfig` ones that also fail on a clean checkout on this machine.

Live, against a server built from this branch with real groq and OpenRouter keys, in an isolated `XDG_DATA_HOME`/`XDG_CONFIG_HOME` with no provider config of any kind. Catalog still reports `@ai-sdk/groq` and `@openrouter/ai-sdk-provider`; all three answered:

- `groq/openai/gpt-oss-20b` -> "ok", finish `stop`, 111ms
- `openrouter/nvidia/nemotron-3.5-lightning:free` -> "ok", finish `stop`, 110ms
- `openrouter/minimax/minimax-m3:free` -> "ok", finish `stop`, 107ms

Before the change the same requests produced no assistant message at all. Two other free OpenRouter models returned HTTP 429 and one groq model HTTP 404 `model_not_found` — upstream rate limits and a retired model, reached over the new route.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
