### PR TITLE
fix(app): prevent settings loading flicker

### DIFF
--- a/packages/app/e2e/regression/settings-loading.spec.ts
+++ b/packages/app/e2e/regression/settings-loading.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+const directory = "C:/Projects/settings-demo"
+const sandboxes = Array.from({ length: 12 }, (_, index) => `${directory}/workspace-${index + 1}`)
+
+test.use({ viewport: { width: 1440, height: 1000 }, colorScheme: "dark" })
+
+test.beforeEach(async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: "proj_settings_demo",
+      canonical: directory,
+      name: "Settings demo",
+      vcs: "git",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes,
+    },
+    provider: { all: [], connected: [], default: {} },
+    sessions: sandboxes.map((directory, index) => ({
+      id: `ses_settings_${index + 1}`,
+      title: `Workspace ${index + 1} session`,
+      directory,
+      projectID: "proj_settings_demo",
+      time: { created: 1700000000000, updated: 1700000000000 },
+    })),
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.goto("/")
+  await page.getByRole("button", { name: "Settings", exact: true }).click()
+  await expect(page.getByTestId("settings-screen").getByRole("tab", { name: "Preferences" })).toBeVisible()
+})
+
+test("workspaces opens without waiting for inventory or sessions", async ({ page }) => {
+  const inventory = Promise.withResolvers<void>()
+  const sessions = Promise.withResolvers<void>()
+  await page.route("**/api/worktree/*", async (route) => {
+    await inventory.promise
+    await route.fallback()
+  })
+  await page.route("**/api/session?*", async (route) => {
+    if (new URL(route.request().url()).searchParams.has("directory")) await sessions.promise
+    await route.fallback()
+  })
+  const settings = page.getByTestId("settings-screen")
+  const requested = page.waitForRequest((request) => new URL(request.url()).pathname.startsWith("/api/worktree/"))
+  await settings.getByRole("tab", { name: "Workspaces", exact: true }).click()
+  await requested
+  await expect(settings.getByRole("heading", { name: "Workspaces", exact: true })).toBeVisible()
+  await expect(settings.getByRole("button", { name: "Back to app" })).toBeVisible()
+  await expect(settings.getByText("No workspaces", { exact: true })).toHaveCount(0)
+
+  inventory.resolve()
+  await expect(settings.getByText(sandboxes[0], { exact: true })).toBeVisible()
+  await expect(settings.getByText("12 workspaces", { exact: true })).toBeVisible()
+  sessions.resolve()
+  await expect(settings.getByText("Workspace 1 session", { exact: true })).toBeVisible()
+
+  const refresh = Promise.withResolvers<void>()
+  await page.route("**/api/worktree/*", async (route) => {
+    await refresh.promise
+    await route.fallback()
+  })
+  await settings.getByRole("tab", { name: "Preferences", exact: true }).click()
+  await settings.getByRole("tab", { name: "Workspaces", exact: true }).click()
+  await expect(settings.getByText("Workspace 1 session", { exact: true })).toBeVisible()
+  refresh.resolve()
+})
+
+test("extensions opens without waiting for MCPs or plugins", async ({ page }) => {
+  const mcps = Promise.withResolvers<void>()
+  const plugins = Promise.withResolvers<void>()
+  await page.route("**/api/mcp", async (route) => {
+    await mcps.promise
+    await route.fulfill({
+      json: { location: { directory }, data: [{ name: "demo-mcp", status: { status: "connected" } }] },
+    })
+  })
+  await page.route("**/api/plugin", async (route) => {
+    await plugins.promise
+    await route.fulfill({
+      json: {
+        location: { directory },
+        data: [
+          { id: "demo-plugin", source: { type: "package", package: "demo-plugin" }, status: "active", tui: false },
+        ],
+      },
+    })
+  })
+  const settings = page.getByTestId("settings-screen")
+  const requested = page.waitForRequest((request) => new URL(request.url()).pathname === "/api/mcp")
+  await settings.getByRole("tab", { name: "Extensions", exact: true }).click()
+  await requested
+  await expect(settings.getByRole("heading", { name: "Extensions", exact: true })).toBeVisible()
+  await expect(settings.getByRole("button", { name: "Back to app" })).toBeVisible()
+  await settings.getByRole("tab", { name: "Plugins", exact: true }).click()
+  await expect(settings.getByRole("tab", { name: "Plugins", exact: true })).toHaveAttribute("aria-selected", "true")
+  plugins.resolve()
+  await expect(settings.getByText("demo-plugin", { exact: true })).toBeVisible()
+  mcps.resolve()
+  await settings.getByRole("tab", { name: "MCPs", exact: true }).click()
+  await expect(settings.getByRole("switch", { name: "demo-mcp" })).toBeChecked()
+})
+
+test("workspace inventory uses the settings panel scroll area", async ({ page }) => {
+  const settings = page.getByTestId("settings-screen")
+  await settings.getByRole("tab", { name: "Workspaces", exact: true }).click()
+  await expect(settings.getByText("Workspace 1 session", { exact: true })).toBeVisible()
+  const list = settings.locator('[data-component="settings-list"]')
+  await expect(list).toHaveCSS("max-height", "none")
+  await expect(list).toHaveCSS("overflow-y", "visible")
+  await settings.getByText("Workspace 12 session", { exact: true }).scrollIntoViewIfNeeded()
+  await expect(settings.getByText("Workspace 12 session", { exact: true })).toBeInViewport()
+  await expect(settings.getByRole("button", { name: "Back to app" })).toBeInViewport()
+  await page.setViewportSize({ width: 390, height: 844 })
+  await expect(list).toHaveCSS("max-height", "none")
+  await expect(list).toHaveCSS("overflow-y", "visible")
+  await settings.getByText("Workspace 12 session", { exact: true }).scrollIntoViewIfNeeded()
+  await expect(settings.getByText("Workspace 12 session", { exact: true })).toBeInViewport()
+})

--- a/packages/app/src/settings/providers/extensions.tsx
+++ b/packages/app/src/settings/providers/extensions.tsx
@@ -27,6 +27,7 @@ export const SettingsExtensions: Component = () => {
   const [mcpList, { refetch: refetchMcp }] = createResource(
     () => serverSdk.connection.status() === "connected",
     () => serverSdk.api.mcp.list().then((result) => result.data),
+    { initialValue: [] },
   )
   const toggleMcp = useMcpToggle(() => undefined, refetchMcp)
   const mcps = createMemo<McpRowItem[]>(() => {
@@ -44,6 +45,7 @@ export const SettingsExtensions: Component = () => {
   const [pluginList] = createResource(
     () => serverSdk.connection.status() === "connected",
     () => serverSdk.api.plugin.list().then((result) => result.data),
+    { initialValue: [] },
   )
   const plugins = createMemo<PluginRowItem[]>(() => pluginLabels(pluginList.latest ?? []).map((name) => ({ name })))
 

--- a/packages/app/src/settings/settings.css
+++ b/packages/app/src/settings/settings.css
@@ -885,8 +885,6 @@
   display: flex;
   flex-direction: column;
   gap: 0;
-  max-height: 480px;
-  overflow-y: auto;
   padding: 20px;
   border-radius: 6px;
   background-color: var(--v2-background-bg-base);
@@ -1048,8 +1046,6 @@
   }
 
   .settings-workspaces-inventory [data-component="settings-list"] {
-    max-height: none;
-    overflow-y: visible;
     padding: 14px;
   }
 
@@ -1082,8 +1078,6 @@
   }
 
   .settings-workspaces-inventory [data-component="settings-list"] {
-    max-height: none;
-    overflow-y: visible;
     padding: 14px;
   }
 

--- a/packages/app/src/settings/workspaces/workspaces.tsx
+++ b/packages/app/src/settings/workspaces/workspaces.tsx
@@ -60,6 +60,7 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
 
   const projectQuery = useQuery(() => ({
     queryKey: [serverSDK.scope, "settings-workspace-projects"] as const,
+    enabled: serverSDK.connection.status() === "connected",
     queryFn: async () =>
       Promise.all(
         (await serverSDK.api.project.list()).map(async (project) => {
@@ -71,10 +72,9 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
       ),
     refetchOnMount: "always",
   }))
-  const workspaces = createMemo(() => workspaceInventory(projectQuery.data ?? []))
-  const projects = createMemo(() =>
-    (projectQuery.data ?? []).filter((project) => managedWorkspaceDirectories(project).length > 0),
-  )
+  const inventory = createMemo(() => (projectQuery.isPending ? [] : (projectQuery.data ?? [])))
+  const workspaces = createMemo(() => workspaceInventory(inventory()))
+  const projects = createMemo(() => inventory().filter((project) => managedWorkspaceDirectories(project).length > 0))
   const projectName = (project: Project) => project.name || getFilename(project.worktree)
   const projectOptions = createMemo(() => [
     { id: "all", label: language.t("settings.workspaces.filter.all") },
@@ -110,18 +110,18 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
       workspaceDirectories().map((directory) => String(pathKey(directory))),
     ] as const,
     queryFn: () => loadSessions(workspaceDirectories()),
-    enabled: workspaceDirectories().length > 0,
+    enabled: serverSDK.connection.status() === "connected" && workspaceDirectories().length > 0,
     refetchOnMount: "always",
   }))
-  const sessionsByWorkspace = createMemo(
-    () =>
-      new Map(
-        workspaces().map((workspace) => [
-          pathKey(workspace.directory),
-          sessionQuery.data ? sessionsForWorkspace(sessionQuery.data, workspace.directory) : [],
-        ]),
-      ),
-  )
+  const sessionsByWorkspace = createMemo(() => {
+    const sessions = sessionQuery.isPending ? [] : (sessionQuery.data ?? [])
+    return new Map(
+      workspaces().map((workspace) => [
+        pathKey(workspace.directory),
+        sessionsForWorkspace(sessions, workspace.directory),
+      ]),
+    )
+  })
   const workspaceSessions = (workspace: Workspace) => sessionsByWorkspace().get(pathKey(workspace.directory)) ?? []
   const sessionCount = (workspace: Workspace) => {
     if (sessionQuery.isPending) return language.t("session.messages.loading")
@@ -279,7 +279,9 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
       <div class="settings-tab-body settings-workspaces">
         <div class="settings-workspaces-toolbar">
           <span class="settings-workspaces-count">
-            {language.plural("settings.workspaces.count", filtered().length)}
+            <Show when={!projectQuery.isPending && !projectQuery.isError}>
+              {language.plural("settings.workspaces.count", filtered().length)}
+            </Show>
           </span>
           <div class="settings-workspaces-toolbar-actions">
             <Show when={projects().length > 1}>
@@ -332,7 +334,17 @@ export const SettingsWorkspaces: Component<{ activeDirectory?: string }> = (prop
         <div class="settings-workspaces-inventory">
           <Show
             when={filtered().length > 0}
-            fallback={<div class="settings-workspaces-empty">{language.t("settings.workspaces.empty")}</div>}
+            fallback={
+              <div class="settings-workspaces-empty">
+                {language.t(
+                  projectQuery.isPending
+                    ? "common.loading"
+                    : projectQuery.isError
+                      ? "common.requestFailed"
+                      : "settings.workspaces.empty",
+                )}
+              </div>
+            }
           >
             <SettingsList>
               <For each={filtered()}>


### PR DESCRIPTION
### Issue for this PR

Reported directly; no linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops Workspaces and Extensions from blanking the settings screen while their requests load. Initialize the Extensions resources and guard pending Workspace query reads, retaining the existing cache for quick repeat visits. Show a local loading state rather than an empty workspace count.

Remove the workspace list's 480px height cap and nested scrollbar. The settings panel handles scrolling at every window size.

### How did you verify your code works?

- Reproduced all three regressions before the fix: both panels blanked with responses held pending, and the workspace list was capped at 480px.
- Seven targeted Chromium tests pass, covering delayed inventory/session/MCP/plugin responses, cached Workspace re-entry, desktop/mobile scrolling, and remote-server settings.
- App and E2E type checks pass.
- Prettier and `git diff --check` pass.

### Screenshots / recordings

Fixture data, same window size. Extensions with MCP/plugin responses held pending:

Before:

![Before: unresolved requests blank the settings screen](https://github.com/user-attachments/assets/fc66eab7-3bb4-4d37-9fc5-791f3ac9a4ef)

After:

![After: settings navigation and Extensions render while requests are pending](https://github.com/user-attachments/assets/3b618ed8-3ddb-4af1-a1fc-890761151b91)

Workspace list before:

![Before: workspace inventory stops at 480px](https://github.com/user-attachments/assets/8dee829f-9e7d-428f-b480-bd5d1ed934ae)

Workspace list after:

![After: workspace inventory uses the full settings panel](https://github.com/user-attachments/assets/1628e039-9e39-4c88-9f37-87c11b7e1fc8)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
