### PR TITLE
fix(app): keep project extensions inside settings

### DIFF
--- a/packages/app/e2e/regression/project-extensions.spec.ts
+++ b/packages/app/e2e/regression/project-extensions.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/util/encode"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+const directory = "C:/Projects/extensions-demo"
+const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+const session = {
+  id: "ses_project_extensions",
+  title: "Existing session",
+  directory,
+  projectID: "proj_extensions_demo",
+  time: { created: 1700000000000, updated: 1700000000000 },
+}
+
+test.use({ viewport: { width: 1440, height: 1000 }, colorScheme: "dark" })
+
+test("project Extensions stays inside settings while plugins load", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: session.projectID,
+      canonical: directory,
+      name: "Extensions demo",
+      vcs: "git",
+      time: session.time,
+      sandboxes: [],
+    },
+    provider: { all: [], connected: [], default: {} },
+    sessions: [session],
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.addInitScript(
+    ({ server, sessionID, directory }) => {
+      localStorage.setItem(
+        "opencode.global.dat:server",
+        JSON.stringify({ projects: { local: [{ worktree: directory, expanded: true }] } }),
+      )
+      localStorage.setItem(
+        "opencode.window.browser.dat:tabs",
+        JSON.stringify([{ type: "session", server, sessionId: sessionID }]),
+      )
+    },
+    { server, sessionID: session.id, directory },
+  )
+  const href = `/server/${base64Encode(server)}/session/${session.id}`
+  await page.goto(href)
+  await expect(page.getByRole("heading", { name: session.title, exact: true })).toBeVisible()
+  await page.keyboard.press("Control+,")
+  const settings = page.getByTestId("settings-screen")
+  await settings.getByRole("tab", { name: "Projects", exact: true }).click()
+  await settings.getByText("Extensions demo", { exact: true }).click()
+  const dialog = page.getByRole("dialog")
+  await expect(dialog.getByRole("textbox", { name: "Name", exact: true })).toBeFocused()
+
+  const globalPlugins = Promise.withResolvers<void>()
+  const projectPlugins = Promise.withResolvers<void>()
+  await page.route(
+    (url) => url.pathname === "/api/plugin",
+    async (route) => {
+      const project = new URL(route.request().url()).searchParams.get("location[directory]")
+      await (project ? projectPlugins : globalPlugins).promise
+      await route.fulfill({
+        json: {
+          location: project ? { directory: project } : {},
+          data: (project ? ["shared-plugin", "project-plugin"] : ["shared-plugin"]).map((id) => ({
+            id,
+            source: { type: "package", package: id },
+            status: "active",
+            tui: false,
+          })),
+        },
+      })
+    },
+  )
+  const requested = page.waitForRequest((request) => {
+    const url = new URL(request.url())
+    return url.pathname === "/api/plugin" && url.searchParams.get("location[directory]") === directory
+  })
+  await dialog.getByRole("tab", { name: "Extensions", exact: true }).click()
+  await requested
+  await expect(page).toHaveURL(href)
+  await expect(dialog.getByRole("heading", { name: "Extensions", exact: true })).toBeVisible()
+  await expect(settings).toBeVisible()
+  await expect(page.getByRole("heading", { name: session.title, exact: true, includeHidden: true })).toBeHidden()
+  await dialog.getByRole("tab", { name: "Plugins", exact: true }).click()
+  await expect(dialog.getByRole("tab", { name: "Plugins", exact: true })).toHaveAttribute("aria-selected", "true")
+
+  globalPlugins.resolve()
+  await dialog.getByRole("tab", { name: "Scripts", exact: true }).click()
+  await expect(dialog.getByRole("heading", { name: "Scripts", exact: true })).toBeVisible()
+  await dialog.getByRole("tab", { name: "Extensions", exact: true }).click()
+  projectPlugins.resolve()
+  await dialog.getByRole("tab", { name: "Plugins", exact: true }).click()
+  await expect(dialog.getByText("project-plugin", { exact: true })).toBeVisible()
+  await dialog.getByRole("button", { name: "Shared with all projects 1", exact: true }).click()
+  await expect(dialog.getByText("shared-plugin", { exact: true })).toBeVisible()
+  await expect(page).toHaveURL(href)
+
+  await page.keyboard.press("Escape")
+  await expect(dialog).toBeHidden()
+  await expect(settings.getByRole("tab", { name: "Projects", exact: true })).toHaveAttribute("aria-selected", "true")
+  await expect(page.getByRole("heading", { name: session.title, exact: true, includeHidden: true })).toBeHidden()
+})

--- a/packages/app/src/settings/workspaces/project-extensions.tsx
+++ b/packages/app/src/settings/workspaces/project-extensions.tsx
@@ -97,10 +97,12 @@ export const ProjectSettingsExtensions: Component = () => {
   const [globalPluginList] = createResource(
     () => serverSDK.connection.status() === "connected",
     () => serverSDK.api.plugin.list().then((result) => result.data),
+    { initialValue: [] },
   )
   const [projectPluginList] = createResource(
     () => (serverSDK.connection.status() === "connected" ? directorySDK().directory : undefined),
     (directory) => serverSDK.api.plugin.list({ location: { directory } }).then((result) => result.data),
+    { initialValue: [] },
   )
   const globalPlugins = createMemo(() => pluginLabels(globalPluginList.latest ?? []))
   const projectPlugins = createMemo(() => {


### PR DESCRIPTION
### Issue for this PR

Reported directly. Follow-up to #45427 for the separate project settings dialog.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Initialize both plugin resources in project Extensions with empty lists so their first `.latest` reads cannot suspend the surrounding settings screen.

Reproduced with an existing session open: selecting Projects > a project > Extensions removed the fullscreen settings UI behind the dialog while plugin requests were pending. The URL did not change in this reproduction. With this fix, settings remains visible, the dialog stays usable, and closing it returns to Projects rather than exposing the session.

### How did you verify your code works?

- Added a regression test with global and project plugin responses held pending. It failed before the fix and passes after it.
- Verify the URL stays unchanged, the session stays hidden, dialog tabs work during loading, project/shared plugins render, and Escape returns to Projects.
- App and E2E type checks pass.
- Related settings loading and dialog-focus browser tests pass.
- Prettier and `git diff --check` pass.

### Screenshots / recordings

Same fixture and pending plugin requests.

Before: the settings screen disappears behind the project dialog.

![Before: project Extensions suspends the surrounding settings screen](https://github.com/user-attachments/assets/a1f66678-69df-4103-bcf6-de586e5dc8dd)

After: Projects remains behind the usable Extensions dialog.

![After: project Extensions remains inside settings](https://github.com/user-attachments/assets/e4272ee0-307d-4e2b-842a-6ebd98884f6b)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
