### PR TITLE
feat(app): remote control via QR + mobile attach

### DIFF
--- a/RC_PROPOSAL.md
+++ b/RC_PROPOSAL.md
@@ -1,0 +1,37 @@
+# RFC: Remote Control (RC) — like Claude Code
+
+## Problem
+Opencode `serve` + `web` already allows remote, but no first-class mobile RC:
+- No QR to pair phone quickly
+- No `opencode rc` command like `claude rc`
+- Mobile web needs manual URL + no session sync UX
+
+## Proposal — `feat(rc): remote control via QR + mobile attach`
+
+### CLI
+- `opencode rc` — start RC server, print QR with `opencode attach <url>` + web URL
+- `opencode rc --qr` — only print QR
+- Reuse existing `listen()` + `MDNS` + `CorsOptions` (server.ts:listen)
+
+### Server (`packages/opencode/src/server`)
+- New route `GET /rc/qr` → returns `{ url, qrDataUrl }` (qr = `opencode attach <url>`)
+- New route `GET /rc/status` → `{ hostname, port, url, mdnsDomain }`
+- No auth bypass — reuse existing auth/CORS layer
+
+### Web (`packages/app/src`)
+- New page `/rc` — shows QR, copy button, `Attach` deep-link (`opencode://attach?url=...`)
+- Hook into `app.tsx` header: add "Remote" button next to session
+
+### Mobile open
+- Phone just opens `https://<host>:<port>` or scans QR → same `packages/app` UI (responsive, PWA)
+- No native app needed — "Add to Home Screen" = Claude-like
+- Alternative: `opencode attach <url>` from another laptop/termux
+
+## Verification
+- `bun dev` → `opencode rc` → scan QR from phone → session continues
+- `curl /rc/qr` returns valid data URL
+- No regression: existing `opencode serve/web/attach` untouched
+
+## Issue First
+This doc will be the GitHub issue body (feature request template) before PR. Small PR, focused, with screenshots.
+


### PR DESCRIPTION
### Issue for this PR

Closes #45437
Related to #41392 — complementary: #41392 is Desktop LAN-only with ticket/grant, this is web/CLI QR for `opencode serve` + `app` PWA (see comment below).

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Current `opencode serve`/`web` allows remote but has no first-class mobile pairing: users must manually copy `http://host:port` and there is no `opencode rc`-like entrypoint or QR flow like Claude Code's Remote Control.

This PR (currently proposal + scaffold, next commits add code) introduces a lightweight QR-based RC for the existing HTTP API:

- CLI: `opencode rc` starts server via existing `packages/opencode/src/server/server.ts:listen()` (reuses MDNS/CORS/auth), prints `opencode attach <url>` + web URL and QR. `opencode rc --qr` prints QR only.
- Server: `GET /rc/qr` → `{ url, qrDataUrl }` and `GET /rc/status` → `{ hostname, port, url, mdnsDomain }`, no auth bypass.
- Web: new `/rc` page in `packages/app/src` showing QR, copy button, and `opencode://attach?url=...` deep-link; header in `app.tsx` gets a "Remote" button.
- Mobile: phone opens `https://<host>:<port>` or scans QR → same `app` UI (PWA, Add to Home Screen works). Works from another laptop via `opencode attach <url>` or Termux.

Design reuses existing stack and intentionally does NOT expose full sidecar API beyond the proxied session, mirroring the narrow scope of #41392.

### How did you verify your code works?

- Proposal verified against `server.ts:listen`, `mdns.ts`, and `app.tsx` structure — no regression to `serve/web/attach`.
- Next commits will add unit coverage for `/rc/qr` ticket lifecycle and `app/pages/rc.tsx` rendering, plus `bun dev` manual test: `opencode rc` → scan QR from phone on same LAN → session continues, `curl /rc/qr` returns valid data URL.
- This scaffold commit only adds `RC_PROPOSAL.md`; CI not affected.

### Screenshots / recordings

Proposal stage — no UI yet. Demo will be added with `app/pages/rc.tsx` (QR page) and will include screenshot comparable to #41392. For now see design in `RC_PROPOSAL.md`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
