### PR TITLE
feat(plugin): add tool draft reads

### DIFF
--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -24,6 +24,8 @@ export class RegistrationError extends Schema.TaggedError<RegistrationError>()("
 }) {}
 
 export interface Draft {
+  readonly list: () => readonly (readonly [string, Tool.Info])[]
+  readonly get: (id: string) => Tool.Info | undefined
   readonly add: (tool: Tool.Info) => void
   readonly update: (id: string, update: (tool: Types.Mutable<Tool.Info>) => void) => void
   readonly remove: (id: string) => void
@@ -150,6 +152,8 @@ const layer = Layer.effect(
         errors: [],
       }),
       draft: (draft) => ({
+        list: () => Array.from(draft.tools),
+        get: (id) => draft.tools.get(id),
         add: (tool) => {
           const error = registrationError(tool)
           if (error) {

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -24,15 +24,15 @@ export class RegistrationError extends Schema.TaggedError<RegistrationError>()("
 }) {}
 
 export interface Draft {
-  readonly list: () => readonly (readonly [string, Tool.Info])[]
-  readonly get: (id: string) => Tool.Info | undefined
+  readonly list: () => readonly (Tool.Info & { readonly id: string })[]
+  readonly get: (id: string) => (Tool.Info & { readonly id: string }) | undefined
   readonly add: (tool: Tool.Info) => void
   readonly update: (id: string, update: (tool: Types.Mutable<Tool.Info>) => void) => void
   readonly remove: (id: string) => void
 }
 
 type Data = {
-  tools: Map<string, Tool.Info>
+  tools: Map<string, Tool.Info & { readonly id: string }>
   errors: { tool: Tool.Info; error: RegistrationError }[]
 }
 
@@ -152,7 +152,7 @@ const layer = Layer.effect(
         errors: [],
       }),
       draft: (draft) => ({
-        list: () => Array.from(draft.tools),
+        list: () => Array.from(draft.tools.values()),
         get: (id) => draft.tools.get(id),
         add: (tool) => {
           const error = registrationError(tool)
@@ -160,7 +160,8 @@ const layer = Layer.effect(
             draft.errors.push({ tool, error })
             return
           }
-          draft.tools.set(effectiveName(tool), { ...tool, options: tool.options && { ...tool.options } })
+          const id = effectiveName(tool)
+          draft.tools.set(id, { ...tool, id, options: tool.options && { ...tool.options } })
         },
         update: (id, update) => {
           const current = draft.tools.get(id)
@@ -168,6 +169,7 @@ const layer = Layer.effect(
           const tool = { ...current, options: current.options && { ...current.options } }
           update(tool)
           tool.name = current.name
+          tool.id = id
           if (tool.options?.namespace !== current.options?.namespace)
             tool.options = { ...tool.options, namespace: current.options?.namespace }
           const error = registrationError(tool)

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -657,6 +657,9 @@ describe("fromPromise", () => {
                 options: { codemode: false },
                 execute: async () => ({ output: description }),
               })
+              expect(draft.list().map(([id]) => id)).toEqual(["reloadable"])
+              expect(draft.get("reloadable")?.name).toBe("reloadable")
+              expect(draft.get("missing")).toBeUndefined()
             })
             registrations.push({ reload: ctx.tool.reload, dispose: registration.dispose })
           },

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -657,7 +657,8 @@ describe("fromPromise", () => {
                 options: { codemode: false },
                 execute: async () => ({ output: description }),
               })
-              expect(draft.list().map(([id]) => id)).toEqual(["reloadable"])
+              expect(draft.list().map((tool) => tool.id)).toEqual(["reloadable"])
+              expect(draft.get("reloadable")?.id).toBe("reloadable")
               expect(draft.get("reloadable")?.name).toBe("reloadable")
               expect(draft.get("missing")).toBeUndefined()
             })

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -78,7 +78,8 @@ describe("Tool", () => {
       const service = yield* Tool.Service
       yield* transform(service, { echo: make() }, { namespace: "acme", codemode: false })
       yield* service.transform((draft) => {
-        expect(draft.list().map(([id]) => id)).toEqual(["acme_echo"])
+        expect(draft.list().map((tool) => tool.id)).toEqual(["acme_echo"])
+        expect(draft.get("acme_echo")?.id).toBe("acme_echo")
         expect(draft.get("acme_echo")?.name).toBe("echo")
         expect(draft.get("missing")).toBeUndefined()
       })

--- a/packages/core/test/session-runner-tool-registry.test.ts
+++ b/packages/core/test/session-runner-tool-registry.test.ts
@@ -73,6 +73,18 @@ const transform = (service: Tool.Interface, tools: Readonly<Record<string, Info>
   )
 
 describe("Tool", () => {
+  it.effect("reads the current draft tools by effective name", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      yield* transform(service, { echo: make() }, { namespace: "acme", codemode: false })
+      yield* service.transform((draft) => {
+        expect(draft.list().map(([id]) => id)).toEqual(["acme_echo"])
+        expect(draft.get("acme_echo")?.name).toBe("echo")
+        expect(draft.get("missing")).toBeUndefined()
+      })
+    }),
+  )
+
   it.effect("replays mutations on refreshed sources and restores tools on disposal and scope cleanup", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -6,6 +6,8 @@ import type { Effect, JsonSchema, Types } from "effect"
 import type { Hooks, Transform } from "./registration.js"
 
 export interface ToolDraft {
+  list(): readonly (readonly [string, Tool.Info])[]
+  get(id: string): Tool.Info | undefined
   add<Input extends Tool.ValueSchema<any>, Output extends Tool.ValueSchema<any> | undefined>(
     tool: Tool.Info<Input, Output>,
   ): void

--- a/packages/plugin/src/effect/tool.ts
+++ b/packages/plugin/src/effect/tool.ts
@@ -6,8 +6,8 @@ import type { Effect, JsonSchema, Types } from "effect"
 import type { Hooks, Transform } from "./registration.js"
 
 export interface ToolDraft {
-  list(): readonly (readonly [string, Tool.Info])[]
-  get(id: string): Tool.Info | undefined
+  list(): readonly (Tool.Info & { readonly id: string })[]
+  get(id: string): (Tool.Info & { readonly id: string }) | undefined
   add<Input extends Tool.ValueSchema<any>, Output extends Tool.ValueSchema<any> | undefined>(
     tool: Tool.Info<Input, Output>,
   ): void

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -99,6 +99,20 @@ export function fromPromise(plugin: Plugin) {
 
         const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseWith(context)(effect)
 
+        const promiseTool = (tool: Tool.Info): Info => {
+          const execute = tool.execute
+          return {
+            ...tool,
+            execute: (input, context) =>
+              run(
+                execute(input, {
+                  ...context,
+                  progress: (update) => Effect.promise(() => context.progress(update)),
+                }),
+              ),
+          }
+        }
+
         const adaptApiMethod = <PromiseMethod>(
           endpoint: HttpApiEndpoint.Top,
           method: (input: never) => Effect.Effect<unknown, unknown>,
@@ -296,6 +310,11 @@ export function fromPromise(plugin: Plugin) {
               register(
                 host.tool.transform((draft) =>
                   callback({
+                    list: () => draft.list().map(([id, tool]) => [id, promiseTool(tool)] as const),
+                    get: (id) => {
+                      const tool = draft.get(id)
+                      return tool ? promiseTool(tool) : undefined
+                    },
                     add: (tool: Info) =>
                       draft.add({
                         ...tool,

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -99,7 +99,7 @@ export function fromPromise(plugin: Plugin) {
 
         const run = <A, E>(effect: Effect.Effect<A, E>) => Effect.runPromiseWith(context)(effect)
 
-        const promiseTool = (tool: Tool.Info): Info => {
+        const promiseTool = (tool: Tool.Info & { readonly id: string }): Info & { readonly id: string } => {
           const execute = tool.execute
           return {
             ...tool,
@@ -310,7 +310,7 @@ export function fromPromise(plugin: Plugin) {
               register(
                 host.tool.transform((draft) =>
                   callback({
-                    list: () => draft.list().map(([id, tool]) => [id, promiseTool(tool)] as const),
+                    list: () => draft.list().map((tool) => promiseTool(tool)),
                     get: (id) => {
                       const tool = draft.get(id)
                       return tool ? promiseTool(tool) : undefined

--- a/packages/plugin/src/promise/tool.ts
+++ b/packages/plugin/src/promise/tool.ts
@@ -23,6 +23,8 @@ export type Info<
 }
 
 interface ToolDraft {
+  list(): readonly (readonly [string, Info])[]
+  get(id: string): Info | undefined
   add<Input extends Tool.ValueSchema<any>, Output extends Tool.ValueSchema<any> | undefined>(
     tool: Info<Input, Output>,
   ): void

--- a/packages/plugin/src/promise/tool.ts
+++ b/packages/plugin/src/promise/tool.ts
@@ -23,8 +23,8 @@ export type Info<
 }
 
 interface ToolDraft {
-  list(): readonly (readonly [string, Info])[]
-  get(id: string): Info | undefined
+  list(): readonly (Info & { readonly id: string })[]
+  get(id: string): (Info & { readonly id: string }) | undefined
   add<Input extends Tool.ValueSchema<any>, Output extends Tool.ValueSchema<any> | undefined>(
     tool: Info<Input, Output>,
   ): void

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -857,7 +857,7 @@ effect: (ctx) =>
 Call `yield* ctx.tool.reload()` after changing source data captured by the callback. Reload replays active transforms
 without changing their order; it does not rerun the plugin effect.
 
-`list()` returns `[id, tool]` pairs and `get()` returns `undefined` when the effective name is not present. Use
+Tools have an `id` containing their effective name, and `get()` returns `undefined` when that ID is not present. Use
 `update` and `remove` with the effective tool name, including its namespace (`acme_greeting` above). Dots in
 namespaces and unsupported characters in tool names become `_`. Missing names are ignored; creating a tool requires
 `add` with a complete definition. Updates preserve the name and namespace. Assign new schemas or options to replace
@@ -887,8 +887,8 @@ Schemas: [`Tool.Content`](/api#schema-Tool.Content), [`Tool.TextContent`](/api#s
 
 ```ts
 interface ToolDraft {
-  list(): readonly (readonly [string, Tool.Info])[]
-  get(id: string): Tool.Info | undefined
+  list(): readonly (Tool.Info & { readonly id: string })[]
+  get(id: string): (Tool.Info & { readonly id: string }) | undefined
   add<Input extends Tool.ValueSchema<any>, Output extends Tool.ValueSchema<any> | undefined>(
     tool: Tool.Info<Input, Output>,
   ): void

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -857,7 +857,8 @@ effect: (ctx) =>
 Call `yield* ctx.tool.reload()` after changing source data captured by the callback. Reload replays active transforms
 without changing their order; it does not rerun the plugin effect.
 
-`update` and `remove` target the effective tool name, including its namespace (`acme_greeting` above). Dots in
+`list()` returns `[id, tool]` pairs and `get()` returns `undefined` when the effective name is not present. Use
+`update` and `remove` with the effective tool name, including its namespace (`acme_greeting` above). Dots in
 namespaces and unsupported characters in tool names become `_`. Missing names are ignored; creating a tool requires
 `add` with a complete definition. Updates preserve the name and namespace. Assign new schemas or options to replace
 them rather than mutating nested values. Invalid updates are logged and leave the previous definition intact.
@@ -886,6 +887,8 @@ Schemas: [`Tool.Content`](/api#schema-Tool.Content), [`Tool.TextContent`](/api#s
 
 ```ts
 interface ToolDraft {
+  list(): readonly (readonly [string, Tool.Info])[]
+  get(id: string): Tool.Info | undefined
   add<Input extends Tool.ValueSchema<any>, Output extends Tool.ValueSchema<any> | undefined>(
     tool: Tool.Info<Input, Output>,
   ): void

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -815,7 +815,9 @@ changing their order; it does not rerun plugin setup.
 await ctx.tool.reload()
 ```
 
-Use `update` and `remove` with the effective tool name, including its namespace (`acme_greeting` above). Dots in
+Use `list()` and `get()` to inspect tools currently in the draft. `list()` returns `[id, tool]` pairs and `get()`
+returns `undefined` when the effective name is not present. Use `update` and `remove` with the effective tool name,
+including its namespace (`acme_greeting` above). Dots in
 namespaces and unsupported characters in tool names become `_`. Missing names are ignored; creating a tool requires
 `add` with a complete definition. Updates preserve the name and namespace. Assign new schemas or options to replace
 them rather than mutating nested values. Invalid updates are logged and leave the previous definition intact.
@@ -855,6 +857,8 @@ interface ToolContext {
 }
 
 interface ToolDraft {
+  list(): readonly (readonly [string, ToolInfo])[]
+  get(id: string): ToolInfo | undefined
   add(tool: ToolInfo): void
   update(id: string, update: (tool: Types.Mutable<ToolInfo>) => void): void
   remove(id: string): void

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -815,8 +815,8 @@ changing their order; it does not rerun plugin setup.
 await ctx.tool.reload()
 ```
 
-Use `list()` and `get()` to inspect tools currently in the draft. `list()` returns `[id, tool]` pairs and `get()`
-returns `undefined` when the effective name is not present. Use `update` and `remove` with the effective tool name,
+Use `list()` and `get()` to inspect tools currently in the draft. Tools have an `id` containing their effective name,
+and `get()` returns `undefined` when that ID is not present. Use `update` and `remove` with the effective tool name,
 including its namespace (`acme_greeting` above). Dots in
 namespaces and unsupported characters in tool names become `_`. Missing names are ignored; creating a tool requires
 `add` with a complete definition. Updates preserve the name and namespace. Assign new schemas or options to replace
@@ -857,8 +857,8 @@ interface ToolContext {
 }
 
 interface ToolDraft {
-  list(): readonly (readonly [string, ToolInfo])[]
-  get(id: string): ToolInfo | undefined
+  list(): readonly (ToolInfo & { readonly id: string })[]
+  get(id: string): (ToolInfo & { readonly id: string }) | undefined
   add(tool: ToolInfo): void
   update(id: string, update: (tool: Types.Mutable<ToolInfo>) => void): void
   remove(id: string): void


### PR DESCRIPTION
## Summary
- Add `draft.list()` and `draft.get(id)` to the tool transform draft for Effect and Promise plugins.
- Return effective tool IDs from `list()` and `undefined` for a missing `get()` ID. Tool mutation remains through the existing `update`/`remove` methods.
- Adapt Effect tool definitions to the Promise `list`/`get` surface while preserving Promise executor and progress behavior.
- Add draft and Promise adapter coverage and document the reads.

## Scope
Builds on #45436 and adds the remaining draft read methods only. No standalone tool service reads, HTTP endpoints, generated client changes, or deep-copy behavior.

## Validation
- Core `session-runner-tool-registry` and Promise plugin tests passed (52 tests).
- `bun typecheck` passed in core, plugin, and www.
- Website `check:generated` and build passed.
- Plugin package tests passed (5 tests).