### PR TITLE
refactor(core): simplify duplicate test layers

### DIFF
--- a/packages/core/test/lib/effect.ts
+++ b/packages/core/test/lib/effect.ts
@@ -1,6 +1,5 @@
 import { test, type TestOptions } from "bun:test"
-import { Cause, Effect, Exit, Layer } from "effect"
-import type * as Scope from "effect/Scope"
+import { Cause, Effect, Exit, Layer, Scope } from "effect"
 import * as TestClock from "effect/testing/TestClock"
 import * as TestConsole from "effect/testing/TestConsole"
 

--- a/packages/core/test/session-instructions.test.ts
+++ b/packages/core/test/session-instructions.test.ts
@@ -69,7 +69,6 @@ const testLayer = AppNodeBuilder.build(
     ReadToolFileSystem.node,
     readToolNode,
     Tool.node,
-    Tool.node,
     PluginHooks.node,
     SessionInstructions.node,
     Global.node,

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -446,8 +446,6 @@ const it = testEffect(
       Agent.node,
       Catalog.node,
       Tool.node,
-      Tool.node,
-      PluginHooks.node,
       PluginHooks.node,
       echoNode,
       SessionRunnerModel.node,


### PR DESCRIPTION
## Why
Duplicate service nodes in test layers make the fixture dependencies harder to inspect. The core test helper also used a star `Scope` import, which does not match the project’s Effect import style.

## What Changes
- Remove duplicate `Tool.node` and `PluginHooks.node` entries from core test layer fixtures.
- Use the named `Scope` import from `effect` in the core test helper while keeping the same scope type.

## Scope
This is a test-only cleanup slice from the broader core test simplification review. It does not change production behavior.

## Verification
```sh
cd packages/core && bun typecheck
cd packages/core && bun run test test/session-instructions.test.ts test/session-runner.test.ts
```
Both commands passed; the focused test run passed 180 tests.