### PR TITLE
refactor(core): simplify Effect test setup

### DIFF
--- a/packages/core/test/instructions/index.test.ts
+++ b/packages/core/test/instructions/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { Cause, Effect, Exit, Option, Schema } from "effect"
 import { Instructions } from "@opencode-ai/core/instructions/index"
 import { it } from "../lib/effect"
@@ -177,73 +177,63 @@ describe("Instructions", () => {
     }),
   )
 
-  it.effect("hashes objects independently of key order", () =>
-    Effect.sync(() => {
-      expect(Instructions.hash({ a: 1, b: { x: true, y: false } })).toBe(
-        Instructions.hash({ b: { y: false, x: true }, a: 1 }),
-      )
-    }),
-  )
+  test("hashes objects independently of key order", () => {
+    expect(Instructions.hash({ a: 1, b: { x: true, y: false } })).toBe(
+      Instructions.hash({ b: { y: false, x: true }, a: 1 }),
+    )
+  })
 
-  it.effect("renders sources in composition order", () =>
-    Effect.sync(() => {
-      const instructions = Instructions.combine([
-        source({ key: "core/date", value: "date" }),
-        source({ key: "core/location", value: "location" }),
-      ])
+  test("renders sources in composition order", () => {
+    const instructions = Instructions.combine([
+      source({ key: "core/date", value: "date" }),
+      source({ key: "core/location", value: "location" }),
+    ])
 
-      expect(Instructions.renderInitial(instructions, { "core/date": "date", "core/location": "location" })).toBe(
-        "date\n\nlocation",
-      )
-    }),
-  )
+    expect(Instructions.renderInitial(instructions, { "core/date": "date", "core/location": "location" })).toBe(
+      "date\n\nlocation",
+    )
+  })
 
-  it.effect("rejects duplicate source keys", () =>
-    Effect.sync(() => {
-      expect(() =>
-        Instructions.combine([source({ key: "core/date", value: "one" }), source({ key: "core/date", value: "two" })]),
-      ).toThrow(new Instructions.DuplicateKeyError({ key: key("core/date") }))
-    }),
-  )
+  test("rejects duplicate source keys", () => {
+    expect(() =>
+      Instructions.combine([source({ key: "core/date", value: "one" }), source({ key: "core/date", value: "two" })]),
+    ).toThrow(new Instructions.DuplicateKeyError({ key: key("core/date") }))
+  })
 
-  it.effect("rejects empty model-visible renderings", () =>
-    Effect.sync(() => {
-      const instructions = source({ key: "core/empty", value: "value", initial: () => "" })
+  test("rejects empty model-visible renderings", () => {
+    const instructions = source({ key: "core/empty", value: "value", initial: () => "" })
 
-      expect(() => Instructions.renderInitial(instructions, { "core/empty": "value" })).toThrow(
-        "Instruction source core/empty rendered an empty initial",
-      )
-    }),
-  )
+    expect(() => Instructions.renderInitial(instructions, { "core/empty": "value" })).toThrow(
+      "Instruction source core/empty rendered an empty initial",
+    )
+  })
 
-  it.effect("diffs list values by key", () =>
-    Effect.sync(() => {
-      const previous = [
-        { name: "effect", description: "Build with Effect" },
-        { name: "retired", description: "Old" },
-      ]
-      const current = [
-        { name: "effect", description: "Build with Effect v4" },
-        { name: "writing", description: "Write prose" },
-      ]
+  test("diffs list values by key", () => {
+    const previous = [
+      { name: "effect", description: "Build with Effect" },
+      { name: "retired", description: "Old" },
+    ]
+    const current = [
+      { name: "effect", description: "Build with Effect v4" },
+      { name: "writing", description: "Write prose" },
+    ]
 
-      expect(
-        Instructions.diffByKey(
-          previous,
-          current,
-          (value) => value.name,
-          (before, after) => before.description !== after.description,
-        ),
-      ).toEqual({
-        added: [{ name: "writing", description: "Write prose" }],
-        removed: [{ name: "retired", description: "Old" }],
-        changed: [
-          {
-            previous: { name: "effect", description: "Build with Effect" },
-            current: { name: "effect", description: "Build with Effect v4" },
-          },
-        ],
-      })
-    }),
-  )
+    expect(
+      Instructions.diffByKey(
+        previous,
+        current,
+        (value) => value.name,
+        (before, after) => before.description !== after.description,
+      ),
+    ).toEqual({
+      added: [{ name: "writing", description: "Write prose" }],
+      removed: [{ name: "retired", description: "Old" }],
+      changed: [
+        {
+          previous: { name: "effect", description: "Build with Effect" },
+          current: { name: "effect", description: "Build with Effect v4" },
+        },
+      ],
+    })
+  })
 })

--- a/packages/core/test/session-instructions.test.ts
+++ b/packages/core/test/session-instructions.test.ts
@@ -120,7 +120,7 @@ const seedSynthetic = (sessionID: Session.ID, paths: string[]) =>
   })
 
 describe("SessionInstructions", () => {
-  it.effect("injects AGENTS.md files above a read, excludes the Location root, and dedups across reads", () =>
+  it.live("injects AGENTS.md files above a read, excludes the Location root, and dedups across reads", () =>
     Effect.gen(function* () {
       const location = yield* Location.Service
       const dir = location.directory
@@ -170,7 +170,7 @@ describe("SessionInstructions", () => {
     }),
   )
 
-  it.effect("does not re-inject paths already recorded in durable session history", () =>
+  it.live("does not re-inject paths already recorded in durable session history", () =>
     Effect.gen(function* () {
       const location = yield* Location.Service
       const dir = location.directory
@@ -197,7 +197,7 @@ describe("SessionInstructions", () => {
     }),
   )
 
-  it.effect(
+  it.live(
     "discovers AGENTS.md on a directory listing, including the listed directory's own, and dedups with a later file read",
     () =>
       Effect.gen(function* () {
@@ -233,7 +233,7 @@ describe("SessionInstructions", () => {
       }),
   )
 
-  it.effect("re-injects nested instructions dropped from history by compaction", () =>
+  it.live("re-injects nested instructions dropped from history by compaction", () =>
     Effect.gen(function* () {
       const location = yield* Location.Service
       const dir = location.directory
@@ -264,7 +264,7 @@ describe("SessionInstructions", () => {
     }),
   )
 
-  it.effect("listing the Location root directory injects no instructions", () =>
+  it.live("listing the Location root directory injects no instructions", () =>
     Effect.gen(function* () {
       const location = yield* Location.Service
       const dir = location.directory
@@ -286,7 +286,7 @@ describe("SessionInstructions", () => {
     }),
   )
 
-  it.effect("loads instructions directly without a read", () =>
+  it.live("loads instructions directly without a read", () =>
     Effect.gen(function* () {
       const location = yield* Location.Service
       const dir = location.directory


### PR DESCRIPTION
## Why
Some instruction tests only assert synchronous algebra and rendering behavior, but wrap that code in `Effect.sync` inside an Effect test. The session instruction tests use a real temporary Location and filesystem while running through the test-clock helper, which obscures that they are real-resource tests.

## What Changes
- Pure assertions in `packages/core/test/instructions/index.test.ts` now use Bun `test` directly instead of an unnecessary `Effect.sync` wrapper.
- The six session instruction tests that use the temporary Location now use `it.live`, keeping the console capture while using the live clock environment.

The tests that read instruction sources still use `it.effect`, and the assertions and production behavior are unchanged.

## Scope
This is a test-only cleanup of Effect test setup for instruction algebra and session instruction filesystem cases.

## Verification
```sh
cd packages/core && bun typecheck
cd packages/core && bun run test test/instructions/index.test.ts
cd packages/core && bun run test test/session-instructions.test.ts
```
All passed; the focused runs passed 14 and 7 tests respectively.