### PR TITLE
fix(server): wait for plugins before text generation

### DIFF
--- a/packages/sdk/test/embedded.test.ts
+++ b/packages/sdk/test/embedded.test.ts
@@ -6,6 +6,7 @@ import { OpenAIChat } from "@opencode-ai/ai/protocols"
 import { TestLLM } from "@opencode-ai/ai/testing"
 import { llmClient } from "@opencode-ai/core/effect/app-node-platform"
 import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
 import { Deferred, Effect, Fiber, Latch, Layer, Option, Ref, Schema, Stream } from "effect"
@@ -33,6 +34,70 @@ const sessionID = (fixture: Fixture) => fixture.sdk.Session.ID.create()
 
 const location = (fixture: Fixture) =>
   fixture.sdk.Location.Ref.make({ directory: fixture.sdk.AbsolutePath.make(fixture.directory) })
+
+for (const selection of ["explicit", "default"] as const) {
+  it.live(`first generate.text waits for inline providers with ${selection} model selection`, () =>
+    withEmbedded("opencode-embedded-generate-", (fixture) =>
+      Effect.gen(function* () {
+        const release = yield* Latch.make()
+        const llm = yield* TestLLM.Service.pipe(
+          Effect.provide(TestLLM.layer({ fallback: TestLLM.text("ready", "answer") })),
+        )
+        const supervisor = Layer.effect(
+          PluginSupervisor.Service,
+          Effect.gen(function* () {
+            const plugins = yield* PluginSupervisor.Service
+            return { flush: release.open.pipe(Effect.andThen(plugins.flush)) }
+          }),
+        ).pipe(Layer.provide(PluginSupervisor.layer))
+        const opencode = yield* fixture.sdk.OpenCode.create(
+          {
+            config: {
+              directory: fixture.directory,
+              project: false,
+              content: JSON.stringify({
+                model: "custom/fictional-chat",
+                providers: {
+                  custom: {
+                    package: "aisdk:@ai-sdk/openai-compatible",
+                    settings: { baseURL: "https://provider.example/v1" },
+                    models: { "fictional-chat": {} },
+                  },
+                },
+              }),
+            },
+            models: { fetch: false },
+            fs: { filewatcher: false },
+          },
+          {
+            overrides: [
+              [llmClient, Layer.succeed(LLMClient.Service, llm.client)],
+              [PluginSupervisor.node, { ...PluginSupervisor.node, implementation: supervisor }],
+            ],
+          },
+        )
+        // Hold provider activation until the request reaches readiness, regardless of startup speed.
+        yield* opencode.plugin({ id: "gate-catalog", effect: () => release.await })
+
+        const result = yield* opencode.generate.text({
+          prompt: "Say ready",
+          ...(selection === "explicit"
+            ? {
+                model: fixture.sdk.Model.Ref.make({
+                  providerID: fixture.sdk.Provider.ID.make("custom"),
+                  id: fixture.sdk.Model.ID.make("fictional-chat"),
+                }),
+              }
+            : {}),
+        })
+
+        expect(result.text).toBe("ready")
+        expect(llm.requests).toHaveLength(1)
+        expect(llm.requests[0]?.model).toMatchObject({ provider: "custom", id: "fictional-chat" })
+      }),
+    ),
+  )
+}
 
 it.live("exposes app metadata to plugins", () =>
   withEmbedded("opencode-embedded-app-", (fixture) =>

--- a/packages/server/src/handlers/generate.ts
+++ b/packages/server/src/handlers/generate.ts
@@ -7,6 +7,15 @@ import { Global } from "@opencode-ai/util/global"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
+import { pluginReadiness } from "./plugin-readiness"
+
+const flushPlugins = pluginReadiness(
+  () =>
+    new ServiceUnavailableError({
+      message: "Model catalog initialization timed out",
+      service: "model.catalog",
+    }),
+)
 
 export const GenerateHandler = HttpApiBuilder.group(Api, "server.generate", (handlers) =>
   Effect.gen(function* () {
@@ -16,7 +25,8 @@ export const GenerateHandler = HttpApiBuilder.group(Api, "server.generate", (han
     return handlers.handle(
       "generate.text",
       Effect.fn("server.generate.text")(function* (request) {
-        const generate = yield* Generate.Service.pipe(Effect.provide(services))
+        yield* flushPlugins
+        const generate = yield* Generate.Service
         const text = yield* generate
           .text(request.payload)
           .pipe(
@@ -27,7 +37,7 @@ export const GenerateHandler = HttpApiBuilder.group(Api, "server.generate", (han
             ),
           )
         return { data: { text } }
-      }),
+      }, Effect.provide(services)),
     )
   }),
 )


### PR DESCRIPTION
## Why

The first locationless `generate.text` call can report `Model unavailable` even when its model is configured correctly. The base-config location starts with an empty catalog while provider plugins initialize asynchronously. Retrying immediately with a fallback model can hit the same empty catalog.

## What Changes

| Cold first request | Before | After |
| --- | --- | --- |
| Explicit inline-provider model | Can fail with `Model unavailable` | Waits for provider initialization, then generates |
| Configured default model | Can fail with `No model specified and no supported model is available` | Waits for initialization, then resolves the default |

The handler uses the existing bounded `pluginReadiness` helper, inside the same base-config location scope as generation. An initialization timeout remains a typed service-unavailable error rather than a model-selection error.

Two embedded SDK regressions hold plugin activation behind a latch until the request reaches readiness. They exercise the real router, supervisor, catalog, and resolver without a preceding model-list/session request or timing sleeps; only the model completion is simulated.

## Scope

Two files: the generation handler and embedded SDK tests. No protocol or generated-client changes, provider routing changes, or new retry behavior.

## Verification

```sh
# packages/sdk and packages/server
bun typecheck

# packages/sdk, with model fetching disabled and the existing isolated test wrapper
bun run ../core/script/test.ts

# packages/server, with the same isolated environment
bun run ../core/script/test.ts test/generate.test.ts test/handler-policy.test.ts

# packages/core
bun run test test/generate.test.ts
```

Both new regressions fail against the exact unmodified handler and pass with this patch. The isolated SDK suite passes 26 tests; focused server tests pass 4; core generation tests pass 2. The push hook passes all 33 typecheck tasks. Scoped formatting, lint, and diff checks pass.

The full isolated server suite has 32 passing tests, 1 skipped test, and 3 OAuth callback-port failures in `test/fetch.test.ts`; the same three failures reproduce on the unmodified base. Raw package test scripts also inherit local configuration, so the verification above uses the existing core isolation wrapper with `OPENCODE_DISABLE_MODELS_FETCH=true` and `OPENCODE_MODELS_PATH` pointing at the repository's models-dev test fixture.
