### PR TITLE
fix(core): refresh Console models after session moves

### DIFF
--- a/.changeset/move-model-refresh.md
+++ b/.changeset/move-model-refresh.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Refresh Console model inventories in cached Locations so Session movement and newly selected models do not require a server restart to recover availability. Preserve destination policy and retain same-account inventories through transient refresh failures.

--- a/.changeset/move-model-refresh.md
+++ b/.changeset/move-model-refresh.md
@@ -2,4 +2,4 @@
 "@opencode-ai/core": patch
 ---
 
-Refresh Console model inventories in cached Locations so Session movement and newly selected models do not require a server restart to recover availability. Preserve destination policy and retain same-account inventories through transient refresh failures.
+Refresh Console model inventories after Session moves into cached Locations and retry missing selected models once, without bypassing destination policy. Retain cached inventory on same-account refresh failures.

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -68,7 +68,6 @@ const layer = Layer.effect(
     const integrations = yield* Integration.Service
     const sources = new Set<() => Effect.Effect<boolean>>()
     const refreshing = Semaphore.makeUnsafe(1)
-    let generation = 0
 
     const available = (provider: Provider.Info, integration: Integration.Info | undefined) => {
       if (provider.activation === "disabled") return false
@@ -144,18 +143,15 @@ const layer = Layer.effect(
         yield* bus.publish(Catalog.Event.Updated, {})
       }),
     })
-    const refresh = Effect.fn("Catalog.refresh")(function* () {
-      const observed = generation
-      yield* refreshing.withPermit(
+    const refresh = Effect.fn("Catalog.refresh")(() =>
+      refreshing.withPermit(
         Effect.gen(function* () {
-          // A concurrent caller joins the completed fetch and replay instead of fetching again.
-          if (generation !== observed) return
           const changed = yield* Effect.forEach(sources, (source) => source())
-          if (changed.some(Boolean)) yield* state.reload()
-          generation++
+          // Keep the permit until captured changes are visible, even if the caller is interrupted.
+          if (changed.some(Boolean)) yield* state.reload().pipe(Effect.uninterruptible)
         }),
-      )
-    })
+      ),
+    )
     const result: Interface = {
       transform: state.transform,
       reload: state.reload,

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -1,7 +1,7 @@
 export * as Catalog from "./catalog.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { Array, Context, Effect, Layer, Order, pipe } from "effect"
+import { Array, Context, Effect, Layer, Order, pipe, Scope, Semaphore } from "effect"
 import { Catalog } from "@opencode-ai/schema/catalog"
 import { Model } from "./model.js"
 import { Provider } from "./provider.js"
@@ -42,6 +42,9 @@ export type Draft = {
 }
 
 export interface Interface extends State.Transformable<Draft> {
+  /** Internal sources update captured data and report whether ordered transforms need replaying. */
+  readonly onRefresh: (source: (force: boolean) => Effect.Effect<boolean>) => Effect.Effect<void, never, Scope.Scope>
+  readonly refresh: (force?: boolean) => Effect.Effect<void>
   readonly provider: {
     readonly get: (providerID: Provider.ID) => Effect.Effect<Provider.Info | undefined>
     readonly all: () => Effect.Effect<Provider.Info[]>
@@ -63,6 +66,8 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const bus = yield* Bus.Service
     const integrations = yield* Integration.Service
+    const sources = new Set<(force: boolean) => Effect.Effect<boolean>>()
+    const refreshing = Semaphore.makeUnsafe(1)
 
     const available = (provider: Provider.Info, integration: Integration.Info | undefined) => {
       if (provider.activation === "disabled") return false
@@ -138,9 +143,26 @@ const layer = Layer.effect(
         yield* bus.publish(Catalog.Event.Updated, {})
       }),
     })
+    const refresh = Effect.fn("Catalog.refresh")((force = true) =>
+      refreshing.withPermit(
+        Effect.gen(function* () {
+          const changed = yield* Effect.forEach(sources, (source) => source(force))
+          if (changed.some(Boolean)) yield* state.reload()
+        }),
+      ),
+    )
     const result: Interface = {
       transform: state.transform,
       reload: state.reload,
+      onRefresh: (source) =>
+        Effect.acquireRelease(
+          Effect.sync(() => sources.add(source)),
+          () =>
+            Effect.sync(() => {
+              sources.delete(source)
+            }),
+        ).pipe(Effect.asVoid),
+      refresh,
 
       provider: {
         get: Effect.fn("Catalog.provider.get")(function* (providerID) {
@@ -152,6 +174,7 @@ const layer = Layer.effect(
         }),
 
         available: Effect.fn("Catalog.provider.available")(function* () {
+          yield* refresh(false)
           const active = new Map((yield* integrations.list()).map((integration) => [integration.id, integration]))
           return (yield* result.provider.all()).filter((provider) =>
             available(provider, active.get(provider.integrationID ?? Integration.ID.make(provider.id))),
@@ -194,6 +217,7 @@ const layer = Layer.effect(
         }),
 
         default: Effect.fn("Catalog.model.default")(function* () {
+          yield* refresh(false)
           const defaultModel = state.get().defaultModel
           if (defaultModel) {
             const provider = yield* result.provider.get(defaultModel.providerID)

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -43,8 +43,8 @@ export type Draft = {
 
 export interface Interface extends State.Transformable<Draft> {
   /** Internal sources update captured data and report whether ordered transforms need replaying. */
-  readonly onRefresh: (source: (force: boolean) => Effect.Effect<boolean>) => Effect.Effect<void, never, Scope.Scope>
-  readonly refresh: (force?: boolean) => Effect.Effect<void>
+  readonly onRefresh: (source: () => Effect.Effect<boolean>) => Effect.Effect<void, never, Scope.Scope>
+  readonly refresh: () => Effect.Effect<void>
   readonly provider: {
     readonly get: (providerID: Provider.ID) => Effect.Effect<Provider.Info | undefined>
     readonly all: () => Effect.Effect<Provider.Info[]>
@@ -66,8 +66,9 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const bus = yield* Bus.Service
     const integrations = yield* Integration.Service
-    const sources = new Set<(force: boolean) => Effect.Effect<boolean>>()
+    const sources = new Set<() => Effect.Effect<boolean>>()
     const refreshing = Semaphore.makeUnsafe(1)
+    let generation = 0
 
     const available = (provider: Provider.Info, integration: Integration.Info | undefined) => {
       if (provider.activation === "disabled") return false
@@ -143,14 +144,18 @@ const layer = Layer.effect(
         yield* bus.publish(Catalog.Event.Updated, {})
       }),
     })
-    const refresh = Effect.fn("Catalog.refresh")((force = true) =>
-      refreshing.withPermit(
+    const refresh = Effect.fn("Catalog.refresh")(function* () {
+      const observed = generation
+      yield* refreshing.withPermit(
         Effect.gen(function* () {
-          const changed = yield* Effect.forEach(sources, (source) => source(force))
+          // A concurrent caller joins the completed fetch and replay instead of fetching again.
+          if (generation !== observed) return
+          const changed = yield* Effect.forEach(sources, (source) => source())
           if (changed.some(Boolean)) yield* state.reload()
+          generation++
         }),
-      ),
-    )
+      )
+    })
     const result: Interface = {
       transform: state.transform,
       reload: state.reload,
@@ -174,7 +179,6 @@ const layer = Layer.effect(
         }),
 
         available: Effect.fn("Catalog.provider.available")(function* () {
-          yield* refresh(false)
           const active = new Map((yield* integrations.list()).map((integration) => [integration.id, integration]))
           return (yield* result.provider.all()).filter((provider) =>
             available(provider, active.get(provider.integrationID ?? Integration.ID.make(provider.id))),
@@ -217,7 +221,6 @@ const layer = Layer.effect(
         }),
 
         default: Effect.fn("Catalog.model.default")(function* () {
-          yield* refresh(false)
           const defaultModel = state.get().defaultModel
           if (defaultModel) {
             const provider = yield* result.provider.get(defaultModel.providerID)

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -1,17 +1,21 @@
-import { Duration, Effect, Schema, Semaphore, Stream } from "effect"
+import { Clock, Duration, Effect, Schema, Semaphore, Stream } from "effect"
 import type { Scope } from "effect"
 import type { IntegrationOAuthMethodRegistration } from "@opencode-ai/plugin/effect/integration"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { Bus } from "../../bus.js"
+import { Catalog } from "../../catalog.js"
 import { Credential } from "../../credential.js"
 import { Integration } from "../../integration.js"
+import { Location } from "../../location.js"
 import { Model } from "../../model.js"
 import { Provider } from "../../provider.js"
 import { ConfigProviderV1 } from "../../v1/config/provider.js"
 import { Money } from "@opencode-ai/schema/money"
 import { ConfigProviderOptionsV1 } from "../../v1/config/provider-options.js"
 import { ConfigV1 } from "../../v1/config/config.js"
+import { SessionEvent } from "../../session/event.js"
+import { isDeepStrictEqual } from "node:util"
 
 const defaultServer = "https://opencode.ai/console"
 const clientID = "opencode-cli"
@@ -82,124 +86,159 @@ function oauth(http: HttpClient.HttpClient) {
   } satisfies IntegrationOAuthMethodRegistration
 }
 
-export const OpencodePlugin = define<HttpClient.HttpClient | Bus.Service | Scope.Scope>({
-  id: "opencode.provider.opencode",
-  effect: Effect.fn(function* (ctx) {
-    const bus = yield* Bus.Service
-    const http = yield* HttpClient.HttpClient
-    const loading = Semaphore.makeUnsafe(1)
-    let connected = false
-    let providers: typeof ConfigV1.Info.Type.provider | undefined
+export function make(interval: Duration.Input = "5 minutes") {
+  return define<HttpClient.HttpClient | Bus.Service | Catalog.Service | Location.Service | Scope.Scope>({
+    id: "opencode.provider.opencode",
+    effect: Effect.fn(function* (ctx) {
+      const bus = yield* Bus.Service
+      const catalog = yield* Catalog.Service
+      const http = yield* HttpClient.HttpClient
+      const location = yield* Location.Service
+      const loading = Semaphore.makeUnsafe(1)
+      let connected = false
+      let providers: typeof ConfigV1.Info.Type.provider | undefined
+      let source: string | undefined
+      let checked = Number.NEGATIVE_INFINITY
 
-    const load = Effect.fn("OpencodePlugin.load")(function* () {
-      const connection = yield* ctx.integration.connection.active("opencode")
-      const credential = connection
-        ? yield* ctx.integration.connection.resolve(connection).pipe(Effect.orElseSucceed(() => undefined))
-        : undefined
-      connected = connection !== undefined
-      providers = credential
-        ? yield* fetchProviders(http, credential).pipe(
-            Effect.catch((cause) =>
-              Effect.logWarning("failed to load OpenCode provider config", { cause }).pipe(Effect.as(undefined)),
-            ),
-          )
-        : undefined
-    })
+      const load = Effect.fn("OpencodePlugin.load")((force: boolean) =>
+        loading.withPermit(
+          Effect.gen(function* () {
+            const connection = yield* ctx.integration.connection.active("opencode")
+            const id = connection?.type === "credential" ? connection.id : connection?.name
+            const now = yield* Clock.currentTimeMillis
+            if (!force && id === source && now < checked + Duration.toMillis(interval)) return false
+            const next = connection
+              ? yield* ctx.integration.connection.resolve(connection).pipe(
+                  Effect.flatMap((credential) => (credential ? fetchProviders(http, credential) : Effect.undefined)),
+                  Effect.timeout("5 seconds"),
+                  Effect.catch((cause) =>
+                    // Retain inventory through same-account outages, never across an account switch.
+                    Effect.logWarning("failed to load OpenCode provider config", { cause }).pipe(
+                      Effect.as(id === source ? providers : undefined),
+                    ),
+                  ),
+                )
+              : undefined
+            const changed = connected !== (connection !== undefined) || !isDeepStrictEqual(providers, next)
+            source = id
+            connected = connection !== undefined
+            providers = next
+            checked = yield* Clock.currentTimeMillis
+            return changed
+          }),
+        ),
+      )
 
-    yield* ctx.integration.transform((draft) => {
-      draft.update("opencode", (integration) => {
-        integration.name = "OpenCode"
-      })
-      draft.method.update(oauth(http))
-      draft.method.update({ integrationID: "opencode", method: { type: "key", label: "API key (service account)" } })
-    })
-
-    yield* load()
-    yield* ctx.catalog.transform((catalog) => {
-      for (const [providerID, item] of Object.entries(providers ?? {})) {
-        catalog.provider.update(providerID, (provider) => {
-          provider.integrationID = Integration.ID.make("opencode")
-          if (item.name !== undefined) provider.name = item.name
-          provider.package = item.npm ? Provider.aisdk(item.npm) : ""
-          provider.settings = {
-            ...provider.settings,
-            ...withoutCredentials(item.options),
-            ...(item.api ? { baseURL: item.api } : {}),
-          }
-          provider.headers = { ...provider.headers, ...item.options?.headers }
+      yield* ctx.integration.transform((draft) => {
+        draft.update("opencode", (integration) => {
+          integration.name = "OpenCode"
         })
+        draft.method.update(oauth(http))
+        draft.method.update({ integrationID: "opencode", method: { type: "key", label: "API key (service account)" } })
+      })
 
-        for (const [modelID, config] of Object.entries(item.models ?? {})) {
-          catalog.model.update(providerID, modelID, (model) => {
-            if (config.family !== undefined) model.family = Model.Family.make(config.family)
-            if (config.name !== undefined) model.name = config.name
-            if (config.id !== undefined) model.modelID = Model.ID.make(config.id)
-            model.compatibility = Model.compatibility(config.interleaved) ?? model.compatibility
-            if (config.provider !== undefined) {
-              model.package = config.provider.npm ? Provider.aisdk(config.provider.npm) : undefined
-              if (config.provider.api) model.settings = { ...model.settings, baseURL: config.provider.api }
+      yield* load(true)
+      yield* ctx.catalog.transform((catalog) => {
+        for (const [providerID, item] of Object.entries(providers ?? {})) {
+          catalog.provider.update(providerID, (provider) => {
+            provider.integrationID = Integration.ID.make("opencode")
+            if (item.name !== undefined) provider.name = item.name
+            provider.package = item.npm ? Provider.aisdk(item.npm) : ""
+            provider.settings = {
+              ...provider.settings,
+              ...withoutCredentials(item.options),
+              ...(item.api ? { baseURL: item.api } : {}),
             }
-            if (config.tool_call !== undefined) model.capabilities.tools = config.tool_call
-            if (config.modalities?.input !== undefined) model.capabilities.input = [...config.modalities.input]
-            if (config.modalities?.output !== undefined) model.capabilities.output = [...config.modalities.output]
-            model.headers = { ...model.headers, ...config.headers }
-            model.settings = { ...model.settings, ...ConfigProviderOptionsV1.model(withoutCredentials(config.options)) }
-            if (config.variants !== undefined) {
-              model.variants ??= []
-              for (const [id, options] of Object.entries(config.variants)) {
-                const variantID = Model.VariantID.make(id)
-                let existing = model.variants.find((item) => item.id === variantID)
-                if (!existing) {
-                  existing = { id: variantID }
-                  model.variants.push(existing)
-                }
-                existing.headers = { ...existing.headers, ...options.headers }
-                existing.settings = {
-                  ...existing.settings,
-                  ...ConfigProviderOptionsV1.model(withoutCredentials(options)),
+            provider.headers = { ...provider.headers, ...item.options?.headers }
+          })
+
+          for (const [modelID, config] of Object.entries(item.models ?? {})) {
+            catalog.model.update(providerID, modelID, (model) => {
+              if (config.family !== undefined) model.family = Model.Family.make(config.family)
+              if (config.name !== undefined) model.name = config.name
+              if (config.id !== undefined) model.modelID = Model.ID.make(config.id)
+              model.compatibility = Model.compatibility(config.interleaved) ?? model.compatibility
+              if (config.provider !== undefined) {
+                model.package = config.provider.npm ? Provider.aisdk(config.provider.npm) : undefined
+                if (config.provider.api) model.settings = { ...model.settings, baseURL: config.provider.api }
+              }
+              if (config.tool_call !== undefined) model.capabilities.tools = config.tool_call
+              if (config.modalities?.input !== undefined) model.capabilities.input = [...config.modalities.input]
+              if (config.modalities?.output !== undefined) model.capabilities.output = [...config.modalities.output]
+              model.headers = { ...model.headers, ...config.headers }
+              model.settings = {
+                ...model.settings,
+                ...ConfigProviderOptionsV1.model(withoutCredentials(config.options)),
+              }
+              if (config.variants !== undefined) {
+                model.variants ??= []
+                for (const [id, options] of Object.entries(config.variants)) {
+                  const variantID = Model.VariantID.make(id)
+                  let existing = model.variants.find((item) => item.id === variantID)
+                  if (!existing) {
+                    existing = { id: variantID }
+                    model.variants.push(existing)
+                  }
+                  existing.headers = { ...existing.headers, ...options.headers }
+                  existing.settings = {
+                    ...existing.settings,
+                    ...ConfigProviderOptionsV1.model(withoutCredentials(options)),
+                  }
                 }
               }
-            }
-            if (config.release_date !== undefined) {
-              const released = Date.parse(config.release_date)
-              model.time.released = Number.isFinite(released) ? released : 0
-            }
-            if (config.cost !== undefined) {
-              model.cost = remoteCost(config.cost)
-            }
-            model.status = config.status ?? "active"
-            model.enabled = config.status !== "deprecated"
-            if (config.limit !== undefined) model.limit = { ...config.limit }
+              if (config.release_date !== undefined) {
+                const released = Date.parse(config.release_date)
+                model.time.released = Number.isFinite(released) ? released : 0
+              }
+              if (config.cost !== undefined) {
+                model.cost = remoteCost(config.cost)
+              }
+              model.status = config.status ?? "active"
+              model.enabled = config.status !== "deprecated"
+              if (config.limit !== undefined) model.limit = { ...config.limit }
+            })
+          }
+        }
+
+        const item = catalog.provider.get(Provider.ID.opencode)
+        if (!item) return
+        const hasKey = Boolean(process.env.OPENCODE_API_KEY || connected || item.provider.settings?.apiKey)
+        catalog.provider.update(item.provider.id, (provider) => {
+          if (!hasKey) {
+            provider.activation = "enabled"
+            provider.settings = { ...provider.settings, apiKey: "public" }
+          }
+        })
+        if (hasKey) return
+        for (const model of item.models.values()) {
+          if (!model.cost.some((cost) => cost.input > 0)) continue
+          catalog.model.update(item.provider.id, model.id, (draft) => {
+            draft.enabled = false
           })
         }
-      }
-
-      const item = catalog.provider.get(Provider.ID.opencode)
-      if (!item) return
-      const hasKey = Boolean(process.env.OPENCODE_API_KEY || connected || item.provider.settings?.apiKey)
-      catalog.provider.update(item.provider.id, (provider) => {
-        if (!hasKey) {
-          provider.activation = "enabled"
-          provider.settings = { ...provider.settings, apiKey: "public" }
-        }
       })
-      if (hasKey) return
-      for (const model of item.models.values()) {
-        if (!model.cost.some((cost) => cost.input > 0)) continue
-        catalog.model.update(item.provider.id, model.id, (draft) => {
-          draft.enabled = false
-        })
-      }
-    })
 
-    const refresh = () => loading.withPermit(load().pipe(Effect.andThen(ctx.catalog.reload())))
-    yield* bus.subscribe(Credential.Event.Switched).pipe(
-      Stream.filter((event) => event.data.integrationID === Integration.ID.make("opencode")),
-      Stream.runForEach(refresh),
-      Effect.forkScoped({ startImmediately: true }),
-    )
-  }),
-})
+      yield* catalog.onRefresh(load)
+      yield* bus.subscribe([Credential.Event.Switched, SessionEvent.Moved]).pipe(
+        Stream.filter((event) =>
+          event.type === "credential.switched"
+            ? event.data.integrationID === Integration.ID.make("opencode")
+            : event.data.location.directory === location.directory &&
+              event.data.location.workspaceID === location.workspaceID,
+        ),
+        Stream.runForEach(() => catalog.refresh()),
+        Effect.forkScoped({ startImmediately: true }),
+      )
+      yield* Effect.sleep(interval).pipe(
+        Effect.andThen(catalog.refresh(false)),
+        Effect.forever,
+        Effect.forkScoped({ startImmediately: true }),
+      )
+    }),
+  })
+}
+
+export const OpencodePlugin = make()
 
 function fetchProviders(http: HttpClient.HttpClient, value: Credential.Value) {
   const metadata = value.metadata

--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -1,4 +1,4 @@
-import { Clock, Duration, Effect, Schema, Semaphore, Stream } from "effect"
+import { Duration, Effect, Schema, Stream } from "effect"
 import type { Scope } from "effect"
 import type { IntegrationOAuthMethodRegistration } from "@opencode-ai/plugin/effect/integration"
 import { define } from "@opencode-ai/plugin/effect/plugin"
@@ -7,7 +7,6 @@ import { Bus } from "../../bus.js"
 import { Catalog } from "../../catalog.js"
 import { Credential } from "../../credential.js"
 import { Integration } from "../../integration.js"
-import { Location } from "../../location.js"
 import { Model } from "../../model.js"
 import { Provider } from "../../provider.js"
 import { ConfigProviderV1 } from "../../v1/config/provider.js"
@@ -86,159 +85,135 @@ function oauth(http: HttpClient.HttpClient) {
   } satisfies IntegrationOAuthMethodRegistration
 }
 
-export function make(interval: Duration.Input = "5 minutes") {
-  return define<HttpClient.HttpClient | Bus.Service | Catalog.Service | Location.Service | Scope.Scope>({
-    id: "opencode.provider.opencode",
-    effect: Effect.fn(function* (ctx) {
-      const bus = yield* Bus.Service
-      const catalog = yield* Catalog.Service
-      const http = yield* HttpClient.HttpClient
-      const location = yield* Location.Service
-      const loading = Semaphore.makeUnsafe(1)
-      let connected = false
-      let providers: typeof ConfigV1.Info.Type.provider | undefined
-      let source: string | undefined
-      let checked = Number.NEGATIVE_INFINITY
+export const OpencodePlugin = define<HttpClient.HttpClient | Bus.Service | Catalog.Service | Scope.Scope>({
+  id: "opencode.provider.opencode",
+  effect: Effect.fn(function* (ctx) {
+    const bus = yield* Bus.Service
+    const catalog = yield* Catalog.Service
+    const http = yield* HttpClient.HttpClient
+    let providers: typeof ConfigV1.Info.Type.provider | undefined
+    let source: string | undefined
 
-      const load = Effect.fn("OpencodePlugin.load")((force: boolean) =>
-        loading.withPermit(
-          Effect.gen(function* () {
-            const connection = yield* ctx.integration.connection.active("opencode")
-            const id = connection?.type === "credential" ? connection.id : connection?.name
-            const now = yield* Clock.currentTimeMillis
-            if (!force && id === source && now < checked + Duration.toMillis(interval)) return false
-            const next = connection
-              ? yield* ctx.integration.connection.resolve(connection).pipe(
-                  Effect.flatMap((credential) => (credential ? fetchProviders(http, credential) : Effect.undefined)),
-                  Effect.timeout("5 seconds"),
-                  Effect.catch((cause) =>
-                    // Retain inventory through same-account outages, never across an account switch.
-                    Effect.logWarning("failed to load OpenCode provider config", { cause }).pipe(
-                      Effect.as(id === source ? providers : undefined),
-                    ),
-                  ),
-                )
-              : undefined
-            const changed = connected !== (connection !== undefined) || !isDeepStrictEqual(providers, next)
-            source = id
-            connected = connection !== undefined
-            providers = next
-            checked = yield* Clock.currentTimeMillis
-            return changed
-          }),
-        ),
-      )
+    const load = Effect.fn("OpencodePlugin.load")(function* () {
+      const connection = yield* ctx.integration.connection.active("opencode")
+      const id = connection?.type === "credential" ? connection.id : connection?.name
+      const next = connection
+        ? yield* ctx.integration.connection.resolve(connection).pipe(
+            Effect.flatMap((credential) => (credential ? fetchProviders(http, credential) : Effect.undefined)),
+            Effect.timeout("5 seconds"),
+            Effect.catch((cause) =>
+              // Retain inventory through same-account outages, never across an account switch.
+              Effect.logWarning("failed to load OpenCode provider config", { cause }).pipe(
+                Effect.as(id === source ? providers : undefined),
+              ),
+            ),
+          )
+        : undefined
+      const changed = source !== id || !isDeepStrictEqual(providers, next)
+      source = id
+      providers = next
+      return changed
+    })
 
-      yield* ctx.integration.transform((draft) => {
-        draft.update("opencode", (integration) => {
-          integration.name = "OpenCode"
-        })
-        draft.method.update(oauth(http))
-        draft.method.update({ integrationID: "opencode", method: { type: "key", label: "API key (service account)" } })
+    yield* ctx.integration.transform((draft) => {
+      draft.update("opencode", (integration) => {
+        integration.name = "OpenCode"
       })
+      draft.method.update(oauth(http))
+      draft.method.update({ integrationID: "opencode", method: { type: "key", label: "API key (service account)" } })
+    })
 
-      yield* load(true)
-      yield* ctx.catalog.transform((catalog) => {
-        for (const [providerID, item] of Object.entries(providers ?? {})) {
-          catalog.provider.update(providerID, (provider) => {
-            provider.integrationID = Integration.ID.make("opencode")
-            if (item.name !== undefined) provider.name = item.name
-            provider.package = item.npm ? Provider.aisdk(item.npm) : ""
-            provider.settings = {
-              ...provider.settings,
-              ...withoutCredentials(item.options),
-              ...(item.api ? { baseURL: item.api } : {}),
+    yield* load()
+    yield* ctx.catalog.transform((catalog) => {
+      for (const [providerID, item] of Object.entries(providers ?? {})) {
+        catalog.provider.update(providerID, (provider) => {
+          provider.integrationID = Integration.ID.make("opencode")
+          if (item.name !== undefined) provider.name = item.name
+          provider.package = item.npm ? Provider.aisdk(item.npm) : ""
+          provider.settings = {
+            ...provider.settings,
+            ...withoutCredentials(item.options),
+            ...(item.api ? { baseURL: item.api } : {}),
+          }
+          provider.headers = { ...provider.headers, ...item.options?.headers }
+        })
+
+        for (const [modelID, config] of Object.entries(item.models ?? {})) {
+          catalog.model.update(providerID, modelID, (model) => {
+            if (config.family !== undefined) model.family = Model.Family.make(config.family)
+            if (config.name !== undefined) model.name = config.name
+            if (config.id !== undefined) model.modelID = Model.ID.make(config.id)
+            model.compatibility = Model.compatibility(config.interleaved) ?? model.compatibility
+            if (config.provider !== undefined) {
+              model.package = config.provider.npm ? Provider.aisdk(config.provider.npm) : undefined
+              if (config.provider.api) model.settings = { ...model.settings, baseURL: config.provider.api }
             }
-            provider.headers = { ...provider.headers, ...item.options?.headers }
-          })
-
-          for (const [modelID, config] of Object.entries(item.models ?? {})) {
-            catalog.model.update(providerID, modelID, (model) => {
-              if (config.family !== undefined) model.family = Model.Family.make(config.family)
-              if (config.name !== undefined) model.name = config.name
-              if (config.id !== undefined) model.modelID = Model.ID.make(config.id)
-              model.compatibility = Model.compatibility(config.interleaved) ?? model.compatibility
-              if (config.provider !== undefined) {
-                model.package = config.provider.npm ? Provider.aisdk(config.provider.npm) : undefined
-                if (config.provider.api) model.settings = { ...model.settings, baseURL: config.provider.api }
-              }
-              if (config.tool_call !== undefined) model.capabilities.tools = config.tool_call
-              if (config.modalities?.input !== undefined) model.capabilities.input = [...config.modalities.input]
-              if (config.modalities?.output !== undefined) model.capabilities.output = [...config.modalities.output]
-              model.headers = { ...model.headers, ...config.headers }
-              model.settings = {
-                ...model.settings,
-                ...ConfigProviderOptionsV1.model(withoutCredentials(config.options)),
-              }
-              if (config.variants !== undefined) {
-                model.variants ??= []
-                for (const [id, options] of Object.entries(config.variants)) {
-                  const variantID = Model.VariantID.make(id)
-                  let existing = model.variants.find((item) => item.id === variantID)
-                  if (!existing) {
-                    existing = { id: variantID }
-                    model.variants.push(existing)
-                  }
-                  existing.headers = { ...existing.headers, ...options.headers }
-                  existing.settings = {
-                    ...existing.settings,
-                    ...ConfigProviderOptionsV1.model(withoutCredentials(options)),
-                  }
+            if (config.tool_call !== undefined) model.capabilities.tools = config.tool_call
+            if (config.modalities?.input !== undefined) model.capabilities.input = [...config.modalities.input]
+            if (config.modalities?.output !== undefined) model.capabilities.output = [...config.modalities.output]
+            model.headers = { ...model.headers, ...config.headers }
+            model.settings = { ...model.settings, ...ConfigProviderOptionsV1.model(withoutCredentials(config.options)) }
+            if (config.variants !== undefined) {
+              model.variants ??= []
+              for (const [id, options] of Object.entries(config.variants)) {
+                const variantID = Model.VariantID.make(id)
+                let existing = model.variants.find((item) => item.id === variantID)
+                if (!existing) {
+                  existing = { id: variantID }
+                  model.variants.push(existing)
+                }
+                existing.headers = { ...existing.headers, ...options.headers }
+                existing.settings = {
+                  ...existing.settings,
+                  ...ConfigProviderOptionsV1.model(withoutCredentials(options)),
                 }
               }
-              if (config.release_date !== undefined) {
-                const released = Date.parse(config.release_date)
-                model.time.released = Number.isFinite(released) ? released : 0
-              }
-              if (config.cost !== undefined) {
-                model.cost = remoteCost(config.cost)
-              }
-              model.status = config.status ?? "active"
-              model.enabled = config.status !== "deprecated"
-              if (config.limit !== undefined) model.limit = { ...config.limit }
-            })
-          }
-        }
-
-        const item = catalog.provider.get(Provider.ID.opencode)
-        if (!item) return
-        const hasKey = Boolean(process.env.OPENCODE_API_KEY || connected || item.provider.settings?.apiKey)
-        catalog.provider.update(item.provider.id, (provider) => {
-          if (!hasKey) {
-            provider.activation = "enabled"
-            provider.settings = { ...provider.settings, apiKey: "public" }
-          }
-        })
-        if (hasKey) return
-        for (const model of item.models.values()) {
-          if (!model.cost.some((cost) => cost.input > 0)) continue
-          catalog.model.update(item.provider.id, model.id, (draft) => {
-            draft.enabled = false
+            }
+            if (config.release_date !== undefined) {
+              const released = Date.parse(config.release_date)
+              model.time.released = Number.isFinite(released) ? released : 0
+            }
+            if (config.cost !== undefined) {
+              model.cost = remoteCost(config.cost)
+            }
+            model.status = config.status ?? "active"
+            model.enabled = config.status !== "deprecated"
+            if (config.limit !== undefined) model.limit = { ...config.limit }
           })
         }
+      }
+
+      const item = catalog.provider.get(Provider.ID.opencode)
+      if (!item) return
+      const hasKey = Boolean(process.env.OPENCODE_API_KEY || source !== undefined || item.provider.settings?.apiKey)
+      catalog.provider.update(item.provider.id, (provider) => {
+        if (!hasKey) {
+          provider.activation = "enabled"
+          provider.settings = { ...provider.settings, apiKey: "public" }
+        }
       })
+      if (hasKey) return
+      for (const model of item.models.values()) {
+        if (!model.cost.some((cost) => cost.input > 0)) continue
+        catalog.model.update(item.provider.id, model.id, (draft) => {
+          draft.enabled = false
+        })
+      }
+    })
 
-      yield* catalog.onRefresh(load)
-      yield* bus.subscribe([Credential.Event.Switched, SessionEvent.Moved]).pipe(
-        Stream.filter((event) =>
-          event.type === "credential.switched"
-            ? event.data.integrationID === Integration.ID.make("opencode")
-            : event.data.location.directory === location.directory &&
-              event.data.location.workspaceID === location.workspaceID,
-        ),
-        Stream.runForEach(() => catalog.refresh()),
-        Effect.forkScoped({ startImmediately: true }),
-      )
-      yield* Effect.sleep(interval).pipe(
-        Effect.andThen(catalog.refresh(false)),
-        Effect.forever,
-        Effect.forkScoped({ startImmediately: true }),
-      )
-    }),
-  })
-}
-
-export const OpencodePlugin = make()
+    yield* catalog.onRefresh(load)
+    yield* bus.subscribe([Credential.Event.Switched, SessionEvent.Moved]).pipe(
+      Stream.filter((event) =>
+        event.type === "credential.switched"
+          ? event.data.integrationID === Integration.ID.make("opencode")
+          : event.data.location.directory === ctx.location.directory &&
+            event.data.location.workspaceID === ctx.location.workspaceID,
+      ),
+      Stream.runForEach(() => catalog.refresh()),
+      Effect.forkScoped({ startImmediately: true }),
+    )
+  }),
+})
 
 function fetchProviders(http: HttpClient.HttpClient, value: Credential.Value) {
   const metadata = value.metadata

--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -80,9 +80,16 @@ const layer = Layer.effect(
           if (resolved) return resolved
           return yield* new ModelNotSelectedError({ sessionID: session.id })
         }
-        const selected = (yield* catalog.model.available()).find(
-          (model) => model.providerID === session.model?.providerID && model.id === session.model.id,
-        )
+        const select = catalog.model
+          .available()
+          .pipe(
+            Effect.map((models) =>
+              models.find((model) => model.providerID === session.model?.providerID && model.id === session.model.id),
+            ),
+          )
+        const current = yield* select
+        // A cached Location may predate a newly advertised model. Reapply its policy after one refresh.
+        const selected = current ?? (yield* catalog.refresh().pipe(Effect.andThen(select)))
         if (!selected)
           return yield* new ModelUnavailableError({
             providerID: session.model.providerID,

--- a/packages/core/src/session/runner/model.ts
+++ b/packages/core/src/session/runner/model.ts
@@ -87,9 +87,8 @@ const layer = Layer.effect(
               models.find((model) => model.providerID === session.model?.providerID && model.id === session.model.id),
             ),
           )
-        const current = yield* select
         // A cached Location may predate a newly advertised model. Reapply its policy after one refresh.
-        const selected = current ?? (yield* catalog.refresh().pipe(Effect.andThen(select)))
+        const selected = (yield* select) ?? (yield* catalog.refresh().pipe(Effect.andThen(select)))
         if (!selected)
           return yield* new ModelUnavailableError({
             providerID: session.model.providerID,

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -30,11 +30,10 @@ const catalogLayer = AppNodeBuilder.build(
 const it = testEffect(catalogLayer)
 
 describe("Catalog", () => {
-  it.effect("refreshes scoped sources before reads and replays only changed snapshots", () =>
+  it.effect("refreshes scoped sources and replays only changed snapshots", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service
-      const source = { fresh: false }
-      const calls: boolean[] = []
+      const source = { fresh: false, calls: 0 }
       yield* catalog.transform((draft) => {
         if (!source.fresh) return
         draft.model.update(Provider.ID.make("example"), Model.ID.make("chat"), () => {})
@@ -42,25 +41,26 @@ describe("Catalog", () => {
       })
       yield* Effect.scoped(
         Effect.gen(function* () {
-          yield* catalog.onRefresh((force) =>
+          yield* catalog.onRefresh(() =>
             Effect.sync(() => {
-              calls.push(force)
+              source.calls++
               if (source.fresh) return false
               source.fresh = true
               return true
             }),
           )
-          const read = yield* catalog.model.default().pipe(Effect.forkScoped)
+          expect(yield* catalog.model.default()).toBeUndefined()
+          const refresh = yield* catalog.refresh().pipe(Effect.forkScoped)
           yield* TestClock.adjust("1 second")
-          expect((yield* Fiber.join(read))?.id).toBe(Model.ID.make("chat"))
-          expect(calls.every((force) => !force)).toBe(true)
+          yield* Fiber.join(refresh)
+          expect((yield* catalog.model.default())?.id).toBe(Model.ID.make("chat"))
+          expect(source.calls).toBe(1)
           yield* catalog.refresh()
-          expect(calls.at(-1)).toBe(true)
+          expect(source.calls).toBe(2)
         }),
       )
-      const count = calls.length
       yield* catalog.refresh()
-      expect(calls).toHaveLength(count)
+      expect(source.calls).toBe(2)
     }),
   )
 

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -64,6 +64,36 @@ describe("Catalog", () => {
     }),
   )
 
+  it.effect("finishes replay before releasing an interrupted refresh", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const source = { fresh: false }
+      yield* catalog.transform((draft) => {
+        if (source.fresh) draft.model.update(Provider.ID.make("example"), Model.ID.make("chat"), () => {})
+      })
+      yield* catalog.onRefresh(() =>
+        Effect.sync(() => {
+          if (source.fresh) return false
+          source.fresh = true
+          return true
+        }),
+      )
+      const refresh = yield* catalog.refresh().pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* TestClock.adjust("0 millis")
+      const interrupted = yield* Fiber.interrupt(refresh).pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* TestClock.adjust("0 millis")
+      const retry = yield* catalog.refresh().pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* TestClock.adjust("0 millis")
+      expect(retry.pollUnsafe()).toBeUndefined()
+      yield* TestClock.adjust("1 second")
+      yield* Fiber.join(interrupted)
+      yield* Fiber.join(retry)
+      expect((yield* catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat")))?.id).toBe(
+        Model.ID.make("chat"),
+      )
+    }),
+  )
+
   it.effect("publishes an updated event after catalog changes", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -30,6 +30,40 @@ const catalogLayer = AppNodeBuilder.build(
 const it = testEffect(catalogLayer)
 
 describe("Catalog", () => {
+  it.effect("refreshes scoped sources before reads and replays only changed snapshots", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const source = { fresh: false }
+      const calls: boolean[] = []
+      yield* catalog.transform((draft) => {
+        if (!source.fresh) return
+        draft.model.update(Provider.ID.make("example"), Model.ID.make("chat"), () => {})
+        draft.model.default.set(Provider.ID.make("example"), Model.ID.make("chat"))
+      })
+      yield* Effect.scoped(
+        Effect.gen(function* () {
+          yield* catalog.onRefresh((force) =>
+            Effect.sync(() => {
+              calls.push(force)
+              if (source.fresh) return false
+              source.fresh = true
+              return true
+            }),
+          )
+          const read = yield* catalog.model.default().pipe(Effect.forkScoped)
+          yield* TestClock.adjust("1 second")
+          expect((yield* Fiber.join(read))?.id).toBe(Model.ID.make("chat"))
+          expect(calls.every((force) => !force)).toBe(true)
+          yield* catalog.refresh()
+          expect(calls.at(-1)).toBe(true)
+        }),
+      )
+      const count = calls.length
+      yield* catalog.refresh()
+      expect(calls).toHaveLength(count)
+    }),
+  )
+
   it.effect("publishes an updated event after catalog changes", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service

--- a/packages/core/test/location-model-refresh.test.ts
+++ b/packages/core/test/location-model-refresh.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "bun:test"
-import { Effect, Schedule } from "effect"
+import { Effect, Fiber, Schedule } from "effect"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -32,25 +32,29 @@ it.live("keeps a Console model available after moving into a cached Location", (
     )
     const destination = Location.Ref.make({ directory: AbsolutePath.make(directories[0].path) })
     const source = Location.Ref.make({ directory: AbsolutePath.make(directories[1].path) })
-    const inventory = { published: false, extra: false, requests: 0 }
+    const inventory = { published: false, requests: 0 }
+    const requested = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    yield* Effect.addFinalizer(() => Effect.sync(() => release.resolve()))
     const server = yield* Effect.acquireRelease(
       Effect.sync(() =>
         Bun.serve({
           port: 0,
-          fetch: (request) => {
+          fetch: async (request) => {
             inventory.requests++
+            if (inventory.requests === 3) {
+              requested.resolve()
+              await release.promise
+            }
             return Response.json({
               config: {
                 provider: {
                   "example-console": {
                     npm: "@ai-sdk/openai",
                     api: `${new URL(request.url).origin}/v1`,
-                    models: {
-                      ...(inventory.published
-                        ? { "example-chat": { name: "Example Chat", variants: { swift: {} } } }
-                        : {}),
-                      ...(inventory.extra ? { "example-followup": { variants: { swift: {} } } } : {}),
-                    },
+                    models: inventory.published
+                      ? { "example-chat": { name: "Example Chat", variants: { swift: {} } } }
+                      : {},
                   },
                 },
               },
@@ -100,7 +104,12 @@ it.live("keeps a Console model available after moving into a cached Location", (
     yield* session.move({ sessionID: created.id, directory: destination.directory })
     yield* session.resume(created.id)
     expect((yield* session.get(created.id)).location).toEqual(destination)
-    // The idle move must refresh the list without relying on model resolution to repair it.
+    // The idle move starts the fetch; a lookup during that fetch must wait for replay, not reject the old snapshot.
+    yield* Effect.promise(() => requested.promise).pipe(Effect.timeout("2 seconds"))
+    const continuation = yield* resolve.pipe(Effect.forkScoped({ startImmediately: true }))
+    yield* Effect.yieldNow
+    expect(continuation.pollUnsafe()).toBeUndefined()
+    release.resolve()
     const listed = yield* cached.model.available().pipe(
       Effect.repeat({
         until: (models) => models.some((item) => item.id === model.id),
@@ -109,23 +118,16 @@ it.live("keeps a Console model available after moving into a cached Location", (
       Effect.timeout("2 seconds"),
     )
     expect(listed.map((item) => item.id)).toContain(model.id)
-    expect((yield* resolve).ref).toEqual(model)
+    expect((yield* Fiber.join(continuation)).ref).toEqual(model)
     expect(yield* ready.pipe(Effect.provide(locations.get(destination)))).toBe(cached)
     expect(inventory.requests).toBe(3)
 
-    // A selected-model miss also recovers without a move, even inside the normal refresh interval.
-    inventory.extra = true
-    const extra = Model.Ref.make({ ...model, id: Model.ID.make("example-followup") })
-    yield* session.switchModel({ sessionID: created.id, model: extra })
-    expect((yield* resolve).ref).toEqual(extra)
-    expect(inventory.requests).toBe(4)
-
     yield* cached.transform((draft) =>
-      draft.model.update(extra.providerID, extra.id, (item) => {
+      draft.model.update(model.providerID, model.id, (item) => {
         item.enabled = false
       }),
     )
     expect(yield* resolve.pipe(Effect.flip)).toBeInstanceOf(SessionRunnerModel.ModelUnavailableError)
-    expect(inventory.requests).toBe(5)
+    expect(inventory.requests).toBe(4)
   }),
 )

--- a/packages/core/test/location-model-refresh.test.ts
+++ b/packages/core/test/location-model-refresh.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "bun:test"
-import { Effect, Fiber, Schedule } from "effect"
+import { Effect, Fiber, Stream } from "effect"
+import { Bus } from "@opencode-ai/core/bus"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -19,115 +20,123 @@ import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Credential.node, Session.node, LocationServiceMap.node]), [
+  AppNodeBuilder.build(LayerNode.group([Bus.node, Credential.node, Session.node, LocationServiceMap.node]), [
     [Global.node, tempGlobalLayer],
   ]),
 )
 
-it.live("keeps a Console model available after moving into a cached Location", () =>
-  Effect.gen(function* () {
-    const directories = yield* Effect.acquireRelease(
-      Effect.promise(() => Promise.all([tmpdir(), tmpdir()] as const)),
-      (dirs) => Effect.promise(() => Promise.all(dirs.map((dir) => dir[Symbol.asyncDispose]()))),
-    )
-    const destination = Location.Ref.make({ directory: AbsolutePath.make(directories[0].path) })
-    const source = Location.Ref.make({ directory: AbsolutePath.make(directories[1].path) })
-    const inventory = { published: false, requests: 0 }
-    const requested = Promise.withResolvers<void>()
-    const release = Promise.withResolvers<void>()
-    yield* Effect.addFinalizer(() => Effect.sync(() => release.resolve()))
-    const server = yield* Effect.acquireRelease(
-      Effect.sync(() =>
-        Bun.serve({
-          port: 0,
-          fetch: async (request) => {
-            inventory.requests++
-            if (inventory.requests === 3) {
-              requested.resolve()
-              await release.promise
-            }
-            return Response.json({
-              config: {
-                provider: {
-                  "example-console": {
-                    npm: "@ai-sdk/openai",
-                    api: `${new URL(request.url).origin}/v1`,
-                    models: inventory.published
-                      ? { "example-chat": { name: "Example Chat", variants: { swift: {} } } }
-                      : {},
+it.live(
+  "keeps a Console model available after moving into a cached Location",
+  () =>
+    Effect.gen(function* () {
+      const directories = yield* Effect.acquireRelease(
+        Effect.promise(() => Promise.all([tmpdir(), tmpdir()] as const)),
+        (dirs) => Effect.promise(() => Promise.all(dirs.map((dir) => dir[Symbol.asyncDispose]()))),
+      )
+      const destination = Location.Ref.make({ directory: AbsolutePath.make(directories[0].path) })
+      const source = Location.Ref.make({ directory: AbsolutePath.make(directories[1].path) })
+      const inventory = { published: false, name: "Example Chat", requests: 0 }
+      const requested = Promise.withResolvers<void>()
+      const release = Promise.withResolvers<void>()
+      yield* Effect.addFinalizer(() => Effect.sync(() => release.resolve()))
+      const server = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.serve({
+            port: 0,
+            fetch: async (request) => {
+              inventory.requests++
+              if (inventory.requests === 3) {
+                requested.resolve()
+                await release.promise
+              }
+              return Response.json({
+                config: {
+                  provider: {
+                    "example-console": {
+                      npm: "@ai-sdk/openai",
+                      api: `${new URL(request.url).origin}/v1`,
+                      models: inventory.published
+                        ? { "example-chat": { name: inventory.name, variants: { swift: {} } } }
+                        : {},
+                    },
                   },
                 },
-              },
-            })
-          },
-        }),
-      ),
-      (server) => Effect.promise(() => server.stop(true)),
-    )
-    const credentials = yield* Credential.Service
-    yield* credentials.create({
-      integrationID: Integration.ID.make("opencode"),
-      value: Credential.Key.make({ type: "key", key: "fixture-key", metadata: { server: server.url.origin } }),
-    })
-    const locations = yield* LocationServiceMap.Service
-    const ready = Effect.gen(function* () {
-      const plugins = yield* PluginSupervisor.Service
-      yield* plugins.flush
-      return yield* Catalog.Service
-    })
-    const cached = yield* ready.pipe(Effect.provide(locations.get(destination)))
-    expect(inventory.requests).toBe(1)
-    inventory.published = true
-    yield* ready.pipe(Effect.provide(locations.get(source)))
-    expect(inventory.requests).toBe(2)
-
-    const session = yield* Session.Service
-    const model = Model.Ref.make({
-      providerID: Provider.ID.make("example-console"),
-      id: Model.ID.make("example-chat"),
-      variant: Model.VariantID.make("swift"),
-    })
-    const created = yield* session.create({
-      location: source,
-      model,
-    })
-    const resolve = Effect.gen(function* () {
-      const current = yield* session.get(created.id)
-      return yield* Effect.gen(function* () {
+              })
+            },
+          }),
+        ),
+        (server) => Effect.promise(() => server.stop(true)),
+      )
+      const credentials = yield* Credential.Service
+      yield* credentials.create({
+        integrationID: Integration.ID.make("opencode"),
+        value: Credential.Key.make({ type: "key", key: "fixture-key", metadata: { server: server.url.origin } }),
+      })
+      const locations = yield* LocationServiceMap.Service
+      const ready = Effect.gen(function* () {
         const plugins = yield* PluginSupervisor.Service
         yield* plugins.flush
-        const models = yield* SessionRunnerModel.Service
-        return yield* models.resolve(current)
-      }).pipe(Effect.provide(locations.get(current.location)))
-    })
-    expect((yield* resolve).ref).toEqual(model)
-    yield* session.move({ sessionID: created.id, directory: destination.directory })
-    yield* session.resume(created.id)
-    expect((yield* session.get(created.id)).location).toEqual(destination)
-    // The idle move starts the fetch; a lookup during that fetch must wait for replay, not reject the old snapshot.
-    yield* Effect.promise(() => requested.promise).pipe(Effect.timeout("2 seconds"))
-    const continuation = yield* resolve.pipe(Effect.forkScoped({ startImmediately: true }))
-    yield* Effect.yieldNow
-    expect(continuation.pollUnsafe()).toBeUndefined()
-    release.resolve()
-    const listed = yield* cached.model.available().pipe(
-      Effect.repeat({
-        until: (models) => models.some((item) => item.id === model.id),
-        schedule: Schedule.spaced("10 millis"),
-      }),
-      Effect.timeout("2 seconds"),
-    )
-    expect(listed.map((item) => item.id)).toContain(model.id)
-    expect((yield* Fiber.join(continuation)).ref).toEqual(model)
-    expect(yield* ready.pipe(Effect.provide(locations.get(destination)))).toBe(cached)
-    expect(inventory.requests).toBe(3)
+        return yield* Catalog.Service
+      })
+      const cached = yield* ready.pipe(Effect.provide(locations.get(destination)))
+      expect(inventory.requests).toBe(1)
+      inventory.published = true
+      yield* ready.pipe(Effect.provide(locations.get(source)))
+      expect(inventory.requests).toBe(2)
 
-    yield* cached.transform((draft) =>
-      draft.model.update(model.providerID, model.id, (item) => {
-        item.enabled = false
-      }),
-    )
-    expect(yield* resolve.pipe(Effect.flip)).toBeInstanceOf(SessionRunnerModel.ModelUnavailableError)
-    expect(inventory.requests).toBe(4)
-  }),
+      const session = yield* Session.Service
+      const model = Model.Ref.make({
+        providerID: Provider.ID.make("example-console"),
+        id: Model.ID.make("example-chat"),
+        variant: Model.VariantID.make("swift"),
+      })
+      const created = yield* session.create({
+        location: source,
+        model,
+      })
+      const resolve = Effect.gen(function* () {
+        const current = yield* session.get(created.id)
+        return yield* Effect.gen(function* () {
+          const plugins = yield* PluginSupervisor.Service
+          yield* plugins.flush
+          const models = yield* SessionRunnerModel.Service
+          return yield* models.resolve(current)
+        }).pipe(Effect.provide(locations.get(current.location)))
+      })
+      expect((yield* resolve).ref).toEqual(model)
+      const bus = yield* Bus.Service
+      const updated = yield* bus.subscribe(Catalog.Event.Updated).pipe(
+        Stream.filter((event) => event.location?.directory === destination.directory),
+        Stream.take(1),
+        Stream.mapEffect((event) => cached.model.available().pipe(Effect.map((models) => ({ event, models })))),
+        Stream.runCollect,
+        Effect.forkScoped({ startImmediately: true }),
+      )
+      yield* session.move({ sessionID: created.id, directory: destination.directory })
+      yield* session.resume(created.id)
+      expect((yield* session.get(created.id)).location).toEqual(destination)
+      // The idle move starts the fetch; a lookup during that fetch must wait for replay, not reject the old snapshot.
+      yield* Effect.promise(() => requested.promise).pipe(Effect.timeout("2 seconds"))
+      const continuation = yield* resolve.pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* Effect.yieldNow
+      expect(continuation.pollUnsafe()).toBeUndefined()
+      release.resolve()
+      const updates = yield* Fiber.join(updated).pipe(Effect.timeout("2 seconds"))
+      expect(updates[0]?.event.location).toEqual(destination)
+      expect(updates[0]?.models.map((item) => item.id)).toContain(model.id)
+      expect((yield* Fiber.join(continuation)).ref).toEqual(model)
+      expect(yield* ready.pipe(Effect.provide(locations.get(destination)))).toBe(cached)
+      expect(inventory.requests).toBe(4)
+
+      yield* cached.transform((draft) =>
+        draft.model.update(model.providerID, model.id, (item) => {
+          item.enabled = false
+        }),
+      )
+      inventory.name = "Updated Example Chat"
+      expect(yield* resolve.pipe(Effect.flip)).toBeInstanceOf(SessionRunnerModel.ModelUnavailableError)
+      expect((yield* cached.model.get(model.providerID, model.id))?.name).toBe(inventory.name)
+      expect(inventory.requests).toBe(5)
+    }),
+  { timeout: 15_000 },
 )

--- a/packages/core/test/location-model-refresh.test.ts
+++ b/packages/core/test/location-model-refresh.test.ts
@@ -1,0 +1,131 @@
+import { expect } from "bun:test"
+import { Effect, Schedule } from "effect"
+import { Catalog } from "@opencode-ai/core/catalog"
+import { Credential } from "@opencode-ai/core/credential"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Integration } from "@opencode-ai/core/integration"
+import { Location } from "@opencode-ai/core/location"
+import { LocationServiceMap } from "@opencode-ai/core/location-services"
+import { Model } from "@opencode-ai/core/model"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
+import { Provider } from "@opencode-ai/core/provider"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Session } from "@opencode-ai/core/session"
+import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
+import { Global } from "@opencode-ai/util/global"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { tempGlobalLayer } from "./fixture/global"
+import { tmpdir } from "./fixture/tmpdir"
+import { testEffect } from "./lib/effect"
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Credential.node, Session.node, LocationServiceMap.node]), [
+    [Global.node, tempGlobalLayer],
+  ]),
+)
+
+it.live("keeps a Console model available after moving into a cached Location", () =>
+  Effect.gen(function* () {
+    const directories = yield* Effect.acquireRelease(
+      Effect.promise(() => Promise.all([tmpdir(), tmpdir()] as const)),
+      (dirs) => Effect.promise(() => Promise.all(dirs.map((dir) => dir[Symbol.asyncDispose]()))),
+    )
+    const destination = Location.Ref.make({ directory: AbsolutePath.make(directories[0].path) })
+    const source = Location.Ref.make({ directory: AbsolutePath.make(directories[1].path) })
+    const inventory = { published: false, extra: false, requests: 0 }
+    const server = yield* Effect.acquireRelease(
+      Effect.sync(() =>
+        Bun.serve({
+          port: 0,
+          fetch: (request) => {
+            inventory.requests++
+            return Response.json({
+              config: {
+                provider: {
+                  "example-console": {
+                    npm: "@ai-sdk/openai",
+                    api: `${new URL(request.url).origin}/v1`,
+                    models: {
+                      ...(inventory.published
+                        ? { "example-chat": { name: "Example Chat", variants: { swift: {} } } }
+                        : {}),
+                      ...(inventory.extra ? { "example-followup": { variants: { swift: {} } } } : {}),
+                    },
+                  },
+                },
+              },
+            })
+          },
+        }),
+      ),
+      (server) => Effect.promise(() => server.stop(true)),
+    )
+    const credentials = yield* Credential.Service
+    yield* credentials.create({
+      integrationID: Integration.ID.make("opencode"),
+      value: Credential.Key.make({ type: "key", key: "fixture-key", metadata: { server: server.url.origin } }),
+    })
+    const locations = yield* LocationServiceMap.Service
+    const ready = Effect.gen(function* () {
+      const plugins = yield* PluginSupervisor.Service
+      yield* plugins.flush
+      return yield* Catalog.Service
+    })
+    const cached = yield* ready.pipe(Effect.provide(locations.get(destination)))
+    expect(inventory.requests).toBe(1)
+    inventory.published = true
+    yield* ready.pipe(Effect.provide(locations.get(source)))
+    expect(inventory.requests).toBe(2)
+
+    const session = yield* Session.Service
+    const model = Model.Ref.make({
+      providerID: Provider.ID.make("example-console"),
+      id: Model.ID.make("example-chat"),
+      variant: Model.VariantID.make("swift"),
+    })
+    const created = yield* session.create({
+      location: source,
+      model,
+    })
+    const resolve = Effect.gen(function* () {
+      const current = yield* session.get(created.id)
+      return yield* Effect.gen(function* () {
+        const plugins = yield* PluginSupervisor.Service
+        yield* plugins.flush
+        const models = yield* SessionRunnerModel.Service
+        return yield* models.resolve(current)
+      }).pipe(Effect.provide(locations.get(current.location)))
+    })
+    expect((yield* resolve).ref).toEqual(model)
+    yield* session.move({ sessionID: created.id, directory: destination.directory })
+    yield* session.resume(created.id)
+    expect((yield* session.get(created.id)).location).toEqual(destination)
+    // The idle move must refresh the list without relying on model resolution to repair it.
+    const listed = yield* cached.model.available().pipe(
+      Effect.repeat({
+        until: (models) => models.some((item) => item.id === model.id),
+        schedule: Schedule.spaced("10 millis"),
+      }),
+      Effect.timeout("2 seconds"),
+    )
+    expect(listed.map((item) => item.id)).toContain(model.id)
+    expect((yield* resolve).ref).toEqual(model)
+    expect(yield* ready.pipe(Effect.provide(locations.get(destination)))).toBe(cached)
+    expect(inventory.requests).toBe(3)
+
+    // A selected-model miss also recovers without a move, even inside the normal refresh interval.
+    inventory.extra = true
+    const extra = Model.Ref.make({ ...model, id: Model.ID.make("example-followup") })
+    yield* session.switchModel({ sessionID: created.id, model: extra })
+    expect((yield* resolve).ref).toEqual(extra)
+    expect(inventory.requests).toBe(4)
+
+    yield* cached.transform((draft) =>
+      draft.model.update(extra.providerID, extra.id, (item) => {
+        item.enabled = false
+      }),
+    )
+    expect(yield* resolve.pipe(Effect.flip)).toBeInstanceOf(SessionRunnerModel.ModelUnavailableError)
+    expect(inventory.requests).toBe(5)
+  }),
+)

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Money } from "@opencode-ai/schema/money"
-import { Effect, Stream } from "effect"
+import { Effect, Fiber, Stream } from "effect"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { Bus } from "@opencode-ai/core/bus"
@@ -358,6 +358,65 @@ describe("OpencodePlugin", () => {
         }),
       ({ server }) => Effect.promise(() => server.stop(true)),
     ),
+  )
+
+  it.live("loads the new account after a switch during an in-flight refresh", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const credentials = yield* Credential.Service
+      const requested = Promise.withResolvers<void>()
+      const release = Promise.withResolvers<void>()
+      const started = Promise.withResolvers<void>()
+      const completed = Promise.withResolvers<void>()
+      const requests: string[] = []
+      yield* Effect.addFinalizer(() => Effect.sync(() => release.resolve()))
+      const server = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.serve({
+            port: 0,
+            fetch: async (request) => {
+              const account = request.headers.get("authorization") === "Bearer account-a" ? "account-a" : "account-b"
+              requests.push(account)
+              if (requests.length === 2) {
+                requested.resolve()
+                await release.promise
+              }
+              return Response.json({
+                config: { provider: { example: { models: { [account]: { name: account } } } } },
+              })
+            },
+          }),
+        ),
+        (server) => Effect.promise(() => server.stop(true)),
+      )
+      const create = (key: string) =>
+        credentials.create({
+          integrationID: Integration.ID.make("opencode"),
+          value: Credential.Key.make({ type: "key", key, metadata: { server: server.url.origin } }),
+        })
+      yield* create("account-a")
+      // Observe the event caller entering and leaving the real refresh boundary.
+      yield* addPlugin().pipe(
+        Effect.provideService(Catalog.Service, {
+          ...catalog,
+          refresh: () =>
+            Effect.gen(function* () {
+              started.resolve()
+              yield* catalog.refresh()
+              completed.resolve()
+            }),
+        }),
+      )
+      const refresh = yield* catalog.refresh().pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* Effect.promise(() => requested.promise)
+      yield* create("account-b")
+      yield* Effect.promise(() => started.promise)
+      release.resolve()
+      yield* Fiber.join(refresh)
+      yield* Effect.promise(() => completed.promise)
+      expect(requests).toEqual(["account-a", "account-a", "account-b"])
+      expect((yield* catalog.model.available()).map((model) => model.id)).toEqual([Model.ID.make("account-b")])
+    }),
   )
 
   it.live("retains same-account inventory on failure but clears it after a failed account switch", () =>

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Money } from "@opencode-ai/schema/money"
-import { Effect } from "effect"
+import { Duration, Effect, Stream } from "effect"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { Bus } from "@opencode-ai/core/bus"
@@ -8,22 +8,21 @@ import { Integration } from "@opencode-ai/core/integration"
 import { Model } from "@opencode-ai/core/model"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
-import { OpencodePlugin } from "@opencode-ai/core/plugin/provider/opencode"
+import { make } from "@opencode-ai/core/plugin/provider/opencode"
 import { Provider } from "@opencode-ai/core/provider"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "./fixture"
 
 const it = testEffect(PluginTestLayer)
 
-const addPlugin = Effect.fn(function* () {
+const addPlugin = Effect.fn(function* (interval?: Duration.Input) {
   const plugin = yield* Plugin.Service
   const host = yield* PluginHost.make(plugin)
   const bus = yield* Bus.Service
   const integration = yield* Integration.Service
-  yield* OpencodePlugin.effect(host).pipe(
-    Effect.provideService(Bus.Service, bus),
-    Effect.provideService(Integration.Service, integration),
-  )
+  yield* make(interval)
+    .effect(host)
+    .pipe(Effect.provideService(Bus.Service, bus), Effect.provideService(Integration.Service, integration))
 })
 
 function required<T>(value: T | undefined): T {
@@ -358,6 +357,106 @@ describe("OpencodePlugin", () => {
         }),
       ({ server }) => Effect.promise(() => server.stop(true)),
     ),
+  )
+
+  it.live("retries initial inventory failures and refreshes periodically without changing accounts", () =>
+    Effect.gen(function* () {
+      const inventory = { name: "Initial Chat", fail: true, requests: 0 }
+      const server = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.serve({
+            port: 0,
+            fetch: () => {
+              inventory.requests++
+              if (inventory.fail) return new Response("Unavailable", { status: 503 })
+              return Response.json({
+                config: { provider: { example: { models: { chat: { name: inventory.name } } } } },
+              })
+            },
+          }),
+        ),
+        (server) => Effect.promise(() => server.stop(true)),
+      )
+      const credentials = yield* Credential.Service
+      const catalog = yield* Catalog.Service
+      yield* credentials.create({
+        integrationID: Integration.ID.make("opencode"),
+        value: Credential.Key.make({ type: "key", key: "fixture-key", metadata: { server: server.url.origin } }),
+      })
+      yield* addPlugin("10 millis")
+      expect(yield* catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat"))).toBeUndefined()
+      inventory.fail = false
+      yield* eventually(
+        catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat")),
+        (model) => model?.name === "Initial Chat",
+      )
+      inventory.name = "Updated Chat"
+      expect(
+        (yield* eventually(
+          catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat")),
+          (model) => model?.name === "Updated Chat",
+        ))?.name,
+      ).toBe("Updated Chat")
+      expect(inventory.requests).toBeGreaterThan(1)
+    }),
+  )
+
+  it.live("retains same-account inventory on failure but clears it after a failed account switch", () =>
+    Effect.gen(function* () {
+      const inventory = { fail: false, requests: 0 }
+      const server = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.serve({
+            port: 0,
+            fetch: () => {
+              inventory.requests++
+              if (inventory.fail) return new Response("Unavailable", { status: 503 })
+              return Response.json({
+                config: { provider: { example: { models: { chat: { name: "Example Chat" } } } } },
+              })
+            },
+          }),
+        ),
+        (server) => Effect.promise(() => server.stop(true)),
+      )
+      const credentials = yield* Credential.Service
+      const catalog = yield* Catalog.Service
+      const bus = yield* Bus.Service
+      yield* credentials.create({
+        integrationID: Integration.ID.make("opencode"),
+        value: Credential.Key.make({ type: "key", key: "first", metadata: { server: server.url.origin } }),
+      })
+      yield* addPlugin()
+      const updates: number[] = []
+      yield* bus.subscribe(Catalog.Event.Updated).pipe(
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            updates.push(event.created)
+          }),
+        ),
+        Effect.forkScoped({ startImmediately: true }),
+      )
+      yield* catalog.model.available()
+      expect(inventory.requests).toBe(1)
+      yield* catalog.refresh()
+      expect(inventory.requests).toBe(2)
+      expect(updates).toEqual([])
+
+      inventory.fail = true
+      yield* catalog.refresh()
+      expect((yield* catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat")))?.name).toBe("Example Chat")
+      expect(updates).toEqual([])
+
+      yield* credentials.create({
+        integrationID: Integration.ID.make("opencode"),
+        value: Credential.Key.make({ type: "key", key: "second", metadata: { server: server.url.origin } }),
+      })
+      yield* eventually(
+        catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat")),
+        (model) => model === undefined,
+      )
+      expect(inventory.requests).toBe(4)
+    }),
   )
 
   it.effect("uses a public key and disables paid models without credentials", () =>

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Money } from "@opencode-ai/schema/money"
-import { Duration, Effect, Stream } from "effect"
+import { Effect, Stream } from "effect"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
 import { Bus } from "@opencode-ai/core/bus"
@@ -8,21 +8,22 @@ import { Integration } from "@opencode-ai/core/integration"
 import { Model } from "@opencode-ai/core/model"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
-import { make } from "@opencode-ai/core/plugin/provider/opencode"
+import { OpencodePlugin } from "@opencode-ai/core/plugin/provider/opencode"
 import { Provider } from "@opencode-ai/core/provider"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "./fixture"
 
 const it = testEffect(PluginTestLayer)
 
-const addPlugin = Effect.fn(function* (interval?: Duration.Input) {
+const addPlugin = Effect.fn(function* () {
   const plugin = yield* Plugin.Service
   const host = yield* PluginHost.make(plugin)
   const bus = yield* Bus.Service
   const integration = yield* Integration.Service
-  yield* make(interval)
-    .effect(host)
-    .pipe(Effect.provideService(Bus.Service, bus), Effect.provideService(Integration.Service, integration))
+  yield* OpencodePlugin.effect(host).pipe(
+    Effect.provideService(Bus.Service, bus),
+    Effect.provideService(Integration.Service, integration),
+  )
 })
 
 function required<T>(value: T | undefined): T {
@@ -359,48 +360,6 @@ describe("OpencodePlugin", () => {
     ),
   )
 
-  it.live("retries initial inventory failures and refreshes periodically without changing accounts", () =>
-    Effect.gen(function* () {
-      const inventory = { name: "Initial Chat", fail: true, requests: 0 }
-      const server = yield* Effect.acquireRelease(
-        Effect.sync(() =>
-          Bun.serve({
-            port: 0,
-            fetch: () => {
-              inventory.requests++
-              if (inventory.fail) return new Response("Unavailable", { status: 503 })
-              return Response.json({
-                config: { provider: { example: { models: { chat: { name: inventory.name } } } } },
-              })
-            },
-          }),
-        ),
-        (server) => Effect.promise(() => server.stop(true)),
-      )
-      const credentials = yield* Credential.Service
-      const catalog = yield* Catalog.Service
-      yield* credentials.create({
-        integrationID: Integration.ID.make("opencode"),
-        value: Credential.Key.make({ type: "key", key: "fixture-key", metadata: { server: server.url.origin } }),
-      })
-      yield* addPlugin("10 millis")
-      expect(yield* catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat"))).toBeUndefined()
-      inventory.fail = false
-      yield* eventually(
-        catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat")),
-        (model) => model?.name === "Initial Chat",
-      )
-      inventory.name = "Updated Chat"
-      expect(
-        (yield* eventually(
-          catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat")),
-          (model) => model?.name === "Updated Chat",
-        ))?.name,
-      ).toBe("Updated Chat")
-      expect(inventory.requests).toBeGreaterThan(1)
-    }),
-  )
-
   it.live("retains same-account inventory on failure but clears it after a failed account switch", () =>
     Effect.gen(function* () {
       const inventory = { fail: false, requests: 0 }
@@ -456,6 +415,10 @@ describe("OpencodePlugin", () => {
         (model) => model === undefined,
       )
       expect(inventory.requests).toBe(4)
+      inventory.fail = false
+      yield* catalog.refresh()
+      expect((yield* catalog.model.get(Provider.ID.make("example"), Model.ID.make("chat")))?.name).toBe("Example Chat")
+      expect(inventory.requests).toBe(5)
     }),
   )
 


### PR DESCRIPTION
## Why

A model can work in a newly initialized directory, then become unavailable when its Session moves into an older cached Location. The Console plugin captured its inventory at activation or an account switch; ordinary Catalog reloads replayed that old snapshot, so recovery required rebuilding the Location or restarting the server.

## What Changes

| Scenario | New behavior |
| --- | --- |
| Move into a cached Location with an outdated Console inventory | Refresh the destination inventory and update its model list without evicting its services. |
| Selected model is missing from the cached inventory | Await one source refresh, then retry selection through the available catalog. |
| Same-account inventory refresh fails | Retain the last successful inventory. |
| Account switch fails to load an inventory | Do not retain the previous account's inventory. |
| Account changes during a lookup-triggered refresh | Serialize the switch refresh after the pending fetch so the new account is loaded. |
| Destination policy disables a model | Continue rejecting it after refresh. |

## Catalog Refresh

Inventory fetching stays in the Console plugin. Core Catalog gains an explicit scoped refresh boundary, separate from transform-only `reload()`, that serializes callers and waits for changed snapshots to be replayed. Once replay starts, cancellation waits for it to finish before releasing the lock; HTTP remains interruptible. Console refreshes on account switches and destination moves, with a five-second load timeout. `SessionContext.resolveModel` refreshes once on `ModelUnavailableError`, then retries selection through the same policy-filtered availability callback. It does not retry an LLM request or choose a different model.

Ordinary Catalog reads remain snapshot reads. There are no polling timers, TTL checks, force options, or extra plugin lock. Changed inventory/account state triggers replay and `catalog.updated`, which refreshes existing TUI model/provider caches. Ordered Location transforms remain authoritative.

## Demo

https://github.com/user-attachments/assets/793e0f44-36eb-4ab7-a799-faaacd4694c4

Before: `5cc81a497c`. After: `3387eb70df`. Both were freshly captured with the same unchanged fixture against the real production TUI and Console plugin. Device OAuth, Console inventory, and model output are simulated; an identical temporary adapter forwards only the exact loopback fixture origin's non-`/v1` requests. Movement uses the SDK, and the continuation is admitted through the API. Playback is not accelerated.

Before shows an unavailable selection and unanswered continuation, with `ModelUnavailableError` verified in the isolated server log. After continues with the same model and a refreshed destination list.

## Scope

This fixes move-triggered Console inventory refresh and the selected-model safeguard, not general background model discovery. Inventories remain Location-scoped, with no Location eviction or HTTP/plugin API changes. Includes a Core patch changeset.

## Tradeoffs

Moves refresh asynchronously, so their model list can briefly show the old snapshot. Every missing explicit selection can trigger a Console request, even for a disabled or unrelated model. Concurrent triggers serialize rather than deduplicate, potentially making an extra request. Each load has a five-second budget, including initial loading; changed inventories also wait for the existing catalog replay debounce.

Same-account failures retain stale metadata, including on authorization or decode errors, but do not bypass provider authentication or destination policy. There is no periodic recovery: lists/default reads, existing-model hits, and missing variants do not trigger refresh, so a failed load waits for another move, account switch, or missing explicit selection.

## Verification

```sh
# From packages/core
bun run test test/location-model-refresh.test.ts test/plugin/provider-opencode.test.ts test/catalog.test.ts test/session-move.test.ts test/location-layer.test.ts test/session-runner.test.ts test/bus-session-routing.test.ts test/session-title.test.ts test/session-compaction.test.ts test/session-generate.test.ts test/session-compact.test.ts
bun run test --only-failures
bun typecheck

# From packages/server
bun run test test/model.test.ts
bun typecheck
```

The full Core suite passes after integrating the upstream runner-assembly refactor: 3,683 passed, 39 skipped, zero failures. All 266 focused Core tests and the server model endpoint test also pass. The move regression holds the inventory fetch in flight while a model lookup is pending, reads the destination model list from `catalog.updated`, and preserves the cached Catalog instance and selected variant. A changed remote inventory verifies that replay still respects the destination's disabled-model policy. Deterministic regressions cover an account switch during a pending fetch and cancellation during replay; both failed before their corrections. Source tests also cover same-account failure retention, account isolation/recovery, unchanged-inventory event suppression, and scoped refresher disposal.

Changed-file formatting and Effect-pattern lint checks pass. The normal pre-push repository typecheck passed all 33 tasks. The isolated before/after TUI fixture verifies the unavailable-model failure before the patch and successful continuation after it.
