### PR TITLE
refactor(core): isolate tool test fixture state

### DIFF
--- a/packages/core/test/file-mutation.test.ts
+++ b/packages/core/test/file-mutation.test.ts
@@ -22,7 +22,7 @@ function provide(directory: string, transformFiles: EnvironmentFilesTransform = 
   return Effect.provide(
     AppNodeBuilder.build(LayerNode.group([LocationMutation.node, FileMutation.node]), [
       [Location.node, activeLocation],
-      [Environment.node, transformEnvironmentFiles(activeLocation, transformFiles)],
+      [Environment.node, transformEnvironmentFiles(transformFiles)],
     ]),
   )
 }

--- a/packages/core/test/fixture/environment.ts
+++ b/packages/core/test/fixture/environment.ts
@@ -1,6 +1,4 @@
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Environment } from "@opencode-ai/core/environment/index"
-import { Location } from "@opencode-ai/core/location"
 import { CrossSpawnSpawner } from "@opencode-ai/util/cross-spawn-spawner"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Effect, Layer } from "effect"
@@ -40,10 +38,8 @@ export const recordingEnvironmentLayer = (spawns: Array<ChildProcess.Command>) =
 
 export type EnvironmentFilesTransform = (files: Environment.Files) => Partial<Environment.Files>
 
-export function transformEnvironmentFiles(
-  location: Layer.Layer<Location.Service>,
-  transform: EnvironmentFilesTransform = () => ({}),
-) {
+// Wrap real host filesystem operations without constructing workspace services.
+export function transformEnvironmentFiles(transform: EnvironmentFilesTransform = () => ({})) {
   return Layer.effect(
     Environment.Service,
     Effect.gen(function* () {
@@ -53,5 +49,5 @@ export function transformEnvironmentFiles(
         files: { ...current.files, ...transform(current.files) },
       })
     }),
-  ).pipe(Layer.provide(AppNodeBuilder.build(Environment.node, [[Location.node, location]])))
+  ).pipe(Layer.provide(hostEnvironmentLayer))
 }

--- a/packages/core/test/fixture/tmpdir.ts
+++ b/packages/core/test/fixture/tmpdir.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises"
 import { tmpdir as osTmpdir } from "os"
 import path from "path"
+import { Effect } from "effect"
 
 export const tmpdir = async (prefix = "opencode-core-test-") => {
   const dir = await fs.realpath(await fs.mkdtemp(path.join(osTmpdir(), prefix)))
@@ -11,6 +12,13 @@ export const tmpdir = async (prefix = "opencode-core-test-") => {
     },
   }
 }
+
+export const withTempDir = <A, E, R>(body: (tmp: Awaited<ReturnType<typeof tmpdir>>) => Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.promise(() => tmpdir()),
+    body,
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  )
 
 async function remove(dir: string, retries = 30): Promise<void> {
   try {

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -37,44 +37,74 @@ const editToolNode = makeLocationNode({
 })
 
 const sessionID = Session.ID.make("ses_edit_tool_test")
-const assertions: Permission.AssertInput[] = []
-const writes: string[] = []
-let reads = 0
-let denyAction: string | undefined
-let afterRead = (_target: string, _content: Uint8Array): Effect.Effect<void> => Effect.void
-let formatFile = (_target: string): Effect.Effect<boolean> => Effect.succeed(false)
+const makeEditFixture = () => {
+  const assertions: Permission.AssertInput[] = []
+  const writes: string[] = []
+  let reads = 0
+  let denyAction: string | undefined
+  let afterRead = (_target: string, _content: Uint8Array): Effect.Effect<void> => Effect.void
+  let formatFile = (_target: string): Effect.Effect<boolean> => Effect.succeed(false)
 
-const permission = permissionLayer({
-  assert: (input) =>
-    Effect.sync(() => assertions.push(input)).pipe(
-      Effect.andThen(
-        input.action === denyAction
-          ? Effect.fail(
-              new Permission.BlockedError({
-                rules: [],
-                permission: input.action,
-                resources: input.resources,
-              }),
-            )
-          : Effect.void,
+  const permission = permissionLayer({
+    assert: (input) =>
+      Effect.sync(() => assertions.push(input)).pipe(
+        Effect.andThen(
+          input.action === denyAction
+            ? Effect.fail(
+                new Permission.BlockedError({
+                  rules: [],
+                  permission: input.action,
+                  resources: input.resources,
+                }),
+              )
+            : Effect.void,
+        ),
       ),
-    ),
-})
+  })
 
-const formatter = Layer.mock(Formatter.Service, {
-  file: (target) => formatFile(target),
-})
+  const formatter = Layer.mock(Formatter.Service, {
+    file: (target) => formatFile(target),
+  })
 
-const reset = () => {
-  assertions.length = 0
-  writes.length = 0
-  reads = 0
-  denyAction = undefined
-  afterRead = () => Effect.void
-  formatFile = () => Effect.succeed(false)
+  return {
+    assertions,
+    writes,
+    get reads() {
+      return reads
+    },
+    reset() {
+      assertions.length = 0
+      writes.length = 0
+      reads = 0
+      denyAction = undefined
+      afterRead = () => Effect.void
+      formatFile = () => Effect.succeed(false)
+    },
+    set denyAction(action: string | undefined) {
+      denyAction = action
+    },
+    set afterRead(next: (target: string, content: Uint8Array) => Effect.Effect<void>) {
+      afterRead = next
+    },
+    set formatFile(next: (target: string) => Effect.Effect<boolean>) {
+      formatFile = next
+    },
+    recordRead(target: string, content: Uint8Array) {
+      return Effect.sync(() => reads++).pipe(Effect.andThen(Effect.suspend(() => afterRead(target, content))))
+    },
+    recordWrite(target: string) {
+      writes.push(target)
+    },
+    permission,
+    formatter,
+  }
 }
 
-const withTool = <A, E, R>(directory: string, body: (registry: Tool.Interface) => Effect.Effect<A, E, R>) => {
+const withTool = <A, E, R>(
+  directory: string,
+  fixture: ReturnType<typeof makeEditFixture>,
+  body: (registry: Tool.Interface) => Effect.Effect<A, E, R>,
+) => {
   const activeLocation = Layer.succeed(
     Location.Service,
     Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
@@ -88,22 +118,14 @@ const withTool = <A, E, R>(directory: string, body: (registry: Tool.Interface) =
           Environment.node,
           transformEnvironmentFiles(activeLocation, (files) => ({
             read: (target, range) =>
-              files
-                .read(target, range)
-                .pipe(
-                  Effect.tap((result) =>
-                    Effect.sync(() => reads++).pipe(
-                      Effect.andThen(Effect.suspend(() => afterRead(target, result.bytes))),
-                    ),
-                  ),
-                ),
+              files.read(target, range).pipe(Effect.tap((result) => fixture.recordRead(target, result.bytes))),
             write: (target, content) =>
-              Effect.sync(() => writes.push(target)).pipe(Effect.andThen(files.write(target, content))),
+              Effect.sync(() => fixture.recordWrite(target)).pipe(Effect.andThen(files.write(target, content))),
           })),
         ],
         [Location.node, activeLocation],
-        [Formatter.node, formatter],
-        [Permission.node, permission],
+        [Formatter.node, fixture.formatter],
+        [Permission.node, fixture.permission],
       ]),
     ),
   )
@@ -126,11 +148,11 @@ const withTempDir = <A, E, R>(body: (tmp: Awaited<ReturnType<typeof tmpdir>>) =>
 describe("EditTool", () => {
   it.live("registers and replaces relative exact text through FileMutation once", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "hello.txt")
       return Effect.promise(() => fs.writeFile(target, "before\nrest\n")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             Effect.gen(function* () {
               expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["edit", "execute"])
               expect(
@@ -167,8 +189,10 @@ describe("EditTool", () => {
                 ],
               })
               expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after\nrest\n")
-              expect(assertions).toMatchObject([{ sessionID, action: "edit", resources: ["hello.txt"], save: ["*"] }])
-              expect(assertions[0]?.metadata).toMatchObject({
+              expect(edit.assertions).toMatchObject([
+                { sessionID, action: "edit", resources: ["hello.txt"], save: ["*"] },
+              ])
+              expect(edit.assertions[0]?.metadata).toMatchObject({
                 files: [
                   {
                     file: "hello.txt",
@@ -179,7 +203,7 @@ describe("EditTool", () => {
                   },
                 ],
               })
-              expect(writes).toEqual([yield* Effect.promise(() => fs.realpath(target))])
+              expect(edit.writes).toEqual([yield* Effect.promise(() => fs.realpath(target))])
             }),
           ),
         ),
@@ -189,16 +213,16 @@ describe("EditTool", () => {
 
   it.live("returns the diff for final formatted content", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "formatted.txt")
-      formatFile = (file) =>
+      edit.formatFile = (file) =>
         Effect.promise(async () => {
           await fs.writeFile(file, (await fs.readFile(file, "utf8")).replace("after", "AFTER"))
           return true
         })
       return Effect.promise(() => fs.writeFile(target, "before\n")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             Effect.gen(function* () {
               const settled = yield* executeTool(
                 registry,
@@ -218,18 +242,18 @@ describe("EditTool", () => {
 
   it.live("accepts an absolute file path inside the active Location", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "absolute.txt")
       return Effect.promise(() => fs.writeFile(target, "before")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             executeTool(registry, call({ path: target, oldString: "before", newString: "after" })),
           ),
         ),
         Effect.andThen((result) =>
           Effect.gen(function* () {
             expect(result.status).toBe("completed")
-            expect(assertions.map((input) => input.action)).toEqual(["edit"])
+            expect(edit.assertions.map((input) => input.action)).toEqual(["edit"])
             expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after")
           }),
         ),
@@ -241,7 +265,7 @@ describe("EditTool", () => {
     Effect.acquireUseRelease(
       Effect.promise(() => Promise.all([tmpdir(), tmpdir()])),
       ([active, outside]) => {
-        reset()
+        const edit = makeEditFixture()
         if (process.platform === "win32") return Effect.void
         const target = path.join(outside.path, "external.txt")
         const link = path.join(active.path, "link.txt")
@@ -250,15 +274,15 @@ describe("EditTool", () => {
           await fs.symlink(target, link)
         }).pipe(
           Effect.andThen(
-            withTool(active.path, (registry) =>
+            withTool(active.path, edit, (registry) =>
               executeTool(registry, call({ path: "link.txt", oldString: "before", newString: "after" })),
             ),
           ),
           Effect.andThen((result) =>
             Effect.sync(() => {
               expect(result.status).toBe("completed")
-              expect(assertions.map((input) => input.action)).toEqual(["edit"])
-              expect(assertions[0]?.resources).toEqual(["link.txt"])
+              expect(edit.assertions.map((input) => input.action)).toEqual(["edit"])
+              expect(edit.assertions[0]?.resources).toEqual(["link.txt"])
             }),
           ),
           Effect.andThen(Effect.promise(() => fs.readFile(target, "utf8"))),
@@ -276,20 +300,20 @@ describe("EditTool", () => {
     Effect.acquireUseRelease(
       Effect.promise(() => Promise.all([tmpdir(), tmpdir()])),
       ([active, outside]) => {
-        reset()
+        const edit = makeEditFixture()
         const target = path.join(outside.path, "external.txt")
         return Effect.promise(() => fs.writeFile(target, "before")).pipe(
           Effect.andThen(
-            withTool(active.path, (registry) =>
+            withTool(active.path, edit, (registry) =>
               executeTool(registry, call({ path: target, oldString: "before", newString: "after" })),
             ),
           ),
           Effect.andThen((result) =>
             Effect.gen(function* () {
               expect(result.status).toBe("completed")
-              expect(assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
+              expect(edit.assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
               expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after")
-              expect(writes).toHaveLength(1)
+              expect(edit.writes).toHaveLength(1)
             }),
           ),
         )
@@ -308,33 +332,33 @@ describe("EditTool", () => {
         Effect.gen(function* () {
           const external = path.join(outside.path, "denied.txt")
           yield* Effect.promise(() => fs.writeFile(external, "before"))
-          reset()
-          denyAction = "external_directory"
+          const edit = makeEditFixture()
+          edit.denyAction = "external_directory"
           expect(
-            yield* withTool(active.path, (registry) =>
+            yield* withTool(active.path, edit, (registry) =>
               executeTool(registry, call({ path: external, oldString: "before", newString: "after" })),
             ),
           ).toEqual({
             status: "error",
             error: { type: "permission.rejected", message: "Permission denied: external_directory" },
           })
-          expect(assertions.map((input) => input.action)).toEqual(["external_directory"])
-          expect(reads).toBe(0)
-          expect(writes).toEqual([])
+          expect(edit.assertions.map((input) => input.action)).toEqual(["external_directory"])
+          expect(edit.reads).toBe(0)
+          expect(edit.writes).toEqual([])
 
-          reset()
-          denyAction = "edit"
+          edit.reset()
+          edit.denyAction = "edit"
           expect(
-            yield* withTool(active.path, (registry) =>
+            yield* withTool(active.path, edit, (registry) =>
               executeTool(registry, call({ path: external, oldString: "before", newString: "after" })),
             ),
           ).toEqual({
             status: "error",
             error: { type: "permission.rejected", message: "Permission denied: edit" },
           })
-          expect(assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
-          expect(reads).toBe(1)
-          expect(writes).toEqual([])
+          expect(edit.assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
+          expect(edit.reads).toBe(1)
+          expect(edit.writes).toEqual([])
           expect(yield* Effect.promise(() => fs.readFile(external, "utf8"))).toBe("before")
         }),
       ([active, outside]) =>
@@ -346,12 +370,12 @@ describe("EditTool", () => {
 
   it.live("denied edit does not disclose whether oldString matches", () =>
     withTempDir((tmp) => {
-      reset()
-      denyAction = "edit"
+      const edit = makeEditFixture()
+      edit.denyAction = "edit"
       const target = path.join(tmp.path, "secret.txt")
       return Effect.promise(() => fs.writeFile(target, "secret content")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             Effect.gen(function* () {
               const matching = yield* executeTool(
                 registry,
@@ -367,9 +391,9 @@ describe("EditTool", () => {
                 error: { type: "permission.rejected", message: "Permission denied: edit" },
               })
               expect(missing).toEqual(matching)
-              expect(assertions.map((input) => input.action)).toEqual(["edit", "edit"])
-              expect(reads).toBe(2)
-              expect(writes).toEqual([])
+              expect(edit.assertions.map((input) => input.action)).toEqual(["edit", "edit"])
+              expect(edit.reads).toBe(2)
+              expect(edit.writes).toEqual([])
             }),
           ),
         ),
@@ -379,11 +403,11 @@ describe("EditTool", () => {
 
   it.live("rejects no-op, empty, missing, and ambiguous exact replacements", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "matches.txt")
       return Effect.promise(() => fs.writeFile(target, "same same")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             Effect.gen(function* () {
               expect(
                 yield* executeTool(registry, call({ path: "matches.txt", oldString: "same", newString: "same" })),
@@ -423,7 +447,7 @@ describe("EditTool", () => {
                     "Found 2 matches for oldString, but expected exactly one. Add more surrounding context to make oldString unique, or set replaceAll to true to replace every occurrence.",
                 },
               })
-              expect(writes).toEqual([])
+              expect(edit.writes).toEqual([])
             }),
           ),
         ),
@@ -433,11 +457,11 @@ describe("EditTool", () => {
 
   it.live("returns specific missing file and directory errors", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const directory = path.join(tmp.path, "src")
       return Effect.promise(() => fs.mkdir(directory)).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             Effect.gen(function* () {
               expect(
                 yield* executeTool(registry, call({ path: "missing.ts", oldString: "before", newString: "after" })),
@@ -451,7 +475,7 @@ describe("EditTool", () => {
                 status: "error",
                 error: { type: "tool.execution", message: "Path is a directory, not a file: src" },
               })
-              expect(writes).toEqual([])
+              expect(edit.writes).toEqual([])
             }),
           ),
         ),
@@ -461,11 +485,11 @@ describe("EditTool", () => {
 
   it.live("replaces every exact occurrence when replaceAll is true", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "all.txt")
       return Effect.promise(() => fs.writeFile(target, "same same same")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             executeTool(registry, call({ path: "all.txt", oldString: "same", newString: "after", replaceAll: true })),
           ),
         ),
@@ -476,7 +500,7 @@ describe("EditTool", () => {
             expect(settled.output).toMatchObject({ replacements: 3 })
             expect(settled.content).toEqual([{ type: "text", text: "Edited all.txt (3 replacements)" }])
             expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after after after")
-            expect(writes).toHaveLength(1)
+            expect(edit.writes).toHaveLength(1)
           }),
         ),
       )
@@ -485,13 +509,13 @@ describe("EditTool", () => {
 
   it.live("normalizes Unicode typography only after exact matching fails", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "unicode.txt")
       return Effect.promise(() =>
         fs.writeFile(target, "exact - match\ncurly “quotes”\nminus − one\nspace\u00A0here\nexact − match\n"),
       ).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             Effect.gen(function* () {
               const normalized = yield* executeTool(
                 registry,
@@ -520,11 +544,11 @@ describe("EditTool", () => {
 
   it.live("ignores trailing whitespace while preserving untouched lines", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "whitespace.txt")
       return Effect.promise(() => fs.writeFile(target, "before  \nmatch  \nnext\t\nafter  \n")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             executeTool(registry, call({ path: "whitespace.txt", oldString: "match\nnext", newString: "changed" })),
           ),
         ),
@@ -537,14 +561,14 @@ describe("EditTool", () => {
 
   it.live("uses non-overlapping trailing-whitespace matches and preserves CRLF", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const overlap = path.join(tmp.path, "overlap.txt")
       const windows = path.join(tmp.path, "windows.txt")
       return Effect.promise(() =>
         Promise.all([fs.writeFile(overlap, "a  \na  \na  \n"), fs.writeFile(windows, "a  \r\nb\t\r\n")]),
       ).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             Effect.gen(function* () {
               const replaced = yield* executeTool(
                 registry,
@@ -568,16 +592,16 @@ describe("EditTool", () => {
 
   it.live("preserves BOM and CRLF line endings", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "windows.txt")
-      formatFile = (file) =>
+      edit.formatFile = (file) =>
         Effect.promise(async () => {
           await fs.writeFile(file, (await fs.readFile(file, "utf8")).replace(/^\uFEFF/, ""))
           return true
         })
       return Effect.promise(() => fs.writeFile(target, "\uFEFFbefore\r\nrest\r\n")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             executeTool(registry, call({ path: "windows.txt", oldString: "before\nrest", newString: "after\nrest" })),
           ),
         ),
@@ -589,12 +613,12 @@ describe("EditTool", () => {
 
   it.live("serializes concurrent edit transactions", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "concurrent.txt")
-      afterRead = () => (reads === 1 ? Effect.sleep("50 millis") : Effect.void)
+      edit.afterRead = () => (edit.reads === 1 ? Effect.sleep("50 millis") : Effect.void)
       return Effect.promise(() => fs.writeFile(target, "one\ntwo\n")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             Effect.all(
               [
                 executeTool(
@@ -622,12 +646,12 @@ describe("EditTool", () => {
 
   it.live("applies the edit when content changes after matching", () =>
     withTempDir((tmp) => {
-      reset()
+      const edit = makeEditFixture()
       const target = path.join(tmp.path, "concurrent.txt")
-      afterRead = () => (reads === 1 ? Effect.promise(() => fs.writeFile(target, "newer\n")) : Effect.void)
+      edit.afterRead = () => (edit.reads === 1 ? Effect.promise(() => fs.writeFile(target, "newer\n")) : Effect.void)
       return Effect.promise(() => fs.writeFile(target, "before\n")).pipe(
         Effect.andThen(
-          withTool(tmp.path, (registry) =>
+          withTool(tmp.path, edit, (registry) =>
             executeTool(registry, call({ path: "concurrent.txt", oldString: "before", newString: "after" })),
           ),
         ),
@@ -635,7 +659,7 @@ describe("EditTool", () => {
           Effect.gen(function* () {
             expect(result).toMatchObject({ status: "completed", output: { replacements: 1 } })
             expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after\n")
-            expect(writes).toEqual([target])
+            expect(edit.writes).toEqual([target])
           }),
         ),
       )

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -83,31 +83,28 @@ const withTool = <A, E, R>(directory: string, body: (registry: Tool.Interface) =
     return yield* body(yield* Tool.Service)
   }).pipe(
     Effect.provide(
-      AppNodeBuilder.build(
-        LayerNode.group([Tool.node, Tool.node, LocationMutation.node, FileMutation.node, editToolNode]),
+      AppNodeBuilder.build(LayerNode.group([Tool.node, LocationMutation.node, FileMutation.node, editToolNode]), [
         [
-          [
-            Environment.node,
-            transformEnvironmentFiles(activeLocation, (files) => ({
-              read: (target, range) =>
-                files
-                  .read(target, range)
-                  .pipe(
-                    Effect.tap((result) =>
-                      Effect.sync(() => reads++).pipe(
-                        Effect.andThen(Effect.suspend(() => afterRead(target, result.bytes))),
-                      ),
+          Environment.node,
+          transformEnvironmentFiles(activeLocation, (files) => ({
+            read: (target, range) =>
+              files
+                .read(target, range)
+                .pipe(
+                  Effect.tap((result) =>
+                    Effect.sync(() => reads++).pipe(
+                      Effect.andThen(Effect.suspend(() => afterRead(target, result.bytes))),
                     ),
                   ),
-              write: (target, content) =>
-                Effect.sync(() => writes.push(target)).pipe(Effect.andThen(files.write(target, content))),
-            })),
-          ],
-          [Location.node, activeLocation],
-          [Formatter.node, formatter],
-          [Permission.node, permission],
+                ),
+            write: (target, content) =>
+              Effect.sync(() => writes.push(target)).pipe(Effect.andThen(files.write(target, content))),
+          })),
         ],
-      ),
+        [Location.node, activeLocation],
+        [Formatter.node, formatter],
+        [Permission.node, permission],
+      ]),
     ),
   )
 }
@@ -119,131 +116,125 @@ const call = (input: typeof EditTool.Input.Type, id = "call-edit") => ({
 })
 
 const it = testEffect(Layer.empty)
+const withTempDir = <A, E, R>(body: (tmp: Awaited<ReturnType<typeof tmpdir>>) => Effect.Effect<A, E, R>) =>
+  Effect.acquireUseRelease(
+    Effect.promise(() => tmpdir()),
+    body,
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  )
 
 describe("EditTool", () => {
   it.live("registers and replaces relative exact text through FileMutation once", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "hello.txt")
-        return Effect.promise(() => fs.writeFile(target, "before\nrest\n")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.gen(function* () {
-                expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["edit", "execute"])
-                expect(
-                  (yield* toolDefinitions(registry, [{ action: "edit", resource: "*", effect: "deny" }])).map(
-                    (tool) => tool.name,
-                  ),
-                ).toEqual(["execute"])
-                const settled = yield* executeTool(
-                  registry,
-                  call({ path: "hello.txt", oldString: "before", newString: "after" }),
-                )
-                expect(settled.status).toBe("completed")
-                if (settled.status !== "completed") return
-                expect(settled.content).toEqual([
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "hello.txt")
+      return Effect.promise(() => fs.writeFile(target, "before\nrest\n")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["edit", "execute"])
+              expect(
+                (yield* toolDefinitions(registry, [{ action: "edit", resource: "*", effect: "deny" }])).map(
+                  (tool) => tool.name,
+                ),
+              ).toEqual(["execute"])
+              const settled = yield* executeTool(
+                registry,
+                call({ path: "hello.txt", oldString: "before", newString: "after" }),
+              )
+              expect(settled.status).toBe("completed")
+              if (settled.status !== "completed") return
+              expect(settled.content).toEqual([
+                {
+                  type: "text",
+                  text: "Edited hello.txt (1 replacement)",
+                },
+              ])
+              // Compact UI metadata carries the file diffs the TUI renders.
+              expect(settled.metadata).toMatchObject({
+                files: [{ file: "hello.txt", status: "modified", additions: 1, deletions: 1 }],
+              })
+              expect(settled.output).toEqual({
+                replacements: 1,
+                files: [
                   {
-                    type: "text",
-                    text: "Edited hello.txt (1 replacement)",
+                    file: "hello.txt",
+                    status: "modified",
+                    additions: 1,
+                    deletions: 1,
+                    patch: expect.stringContaining("-before\n+after"),
                   },
-                ])
-                // Compact UI metadata carries the file diffs the TUI renders.
-                expect(settled.metadata).toMatchObject({
-                  files: [{ file: "hello.txt", status: "modified", additions: 1, deletions: 1 }],
-                })
-                expect(settled.output).toEqual({
-                  replacements: 1,
-                  files: [
-                    {
-                      file: "hello.txt",
-                      status: "modified",
-                      additions: 1,
-                      deletions: 1,
-                      patch: expect.stringContaining("-before\n+after"),
-                    },
-                  ],
-                })
-                expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after\nrest\n")
-                expect(assertions).toMatchObject([{ sessionID, action: "edit", resources: ["hello.txt"], save: ["*"] }])
-                expect(assertions[0]?.metadata).toMatchObject({
-                  files: [
-                    {
-                      file: "hello.txt",
-                      status: "modified",
-                      additions: 1,
-                      deletions: 1,
-                      patch: expect.stringContaining("-before\n+after"),
-                    },
-                  ],
-                })
-                expect(writes).toEqual([yield* Effect.promise(() => fs.realpath(target))])
-              }),
-            ),
+                ],
+              })
+              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after\nrest\n")
+              expect(assertions).toMatchObject([{ sessionID, action: "edit", resources: ["hello.txt"], save: ["*"] }])
+              expect(assertions[0]?.metadata).toMatchObject({
+                files: [
+                  {
+                    file: "hello.txt",
+                    status: "modified",
+                    additions: 1,
+                    deletions: 1,
+                    patch: expect.stringContaining("-before\n+after"),
+                  },
+                ],
+              })
+              expect(writes).toEqual([yield* Effect.promise(() => fs.realpath(target))])
+            }),
           ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+      )
+    }),
   )
 
   it.live("returns the diff for final formatted content", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "formatted.txt")
-        formatFile = (file) =>
-          Effect.promise(async () => {
-            await fs.writeFile(file, (await fs.readFile(file, "utf8")).replace("after", "AFTER"))
-            return true
-          })
-        return Effect.promise(() => fs.writeFile(target, "before\n")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.gen(function* () {
-                const settled = yield* executeTool(
-                  registry,
-                  call({ path: "formatted.txt", oldString: "before", newString: "after" }),
-                )
-                expect(settled.status).toBe("completed")
-                if (settled.status !== "completed") return
-                expect(settled.output.files[0]?.patch).toContain("-before\n+AFTER")
-                expect(settled.metadata?.files?.[0]?.patch).toContain("-before\n+AFTER")
-                expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("AFTER\n")
-              }),
-            ),
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "formatted.txt")
+      formatFile = (file) =>
+        Effect.promise(async () => {
+          await fs.writeFile(file, (await fs.readFile(file, "utf8")).replace("after", "AFTER"))
+          return true
+        })
+      return Effect.promise(() => fs.writeFile(target, "before\n")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              const settled = yield* executeTool(
+                registry,
+                call({ path: "formatted.txt", oldString: "before", newString: "after" }),
+              )
+              expect(settled.status).toBe("completed")
+              if (settled.status !== "completed") return
+              expect(settled.output.files[0]?.patch).toContain("-before\n+AFTER")
+              expect(settled.metadata?.files?.[0]?.patch).toContain("-before\n+AFTER")
+              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("AFTER\n")
+            }),
           ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+      )
+    }),
   )
 
   it.live("accepts an absolute file path inside the active Location", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "absolute.txt")
-        return Effect.promise(() => fs.writeFile(target, "before")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              executeTool(registry, call({ path: target, oldString: "before", newString: "after" })),
-            ),
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "absolute.txt")
+      return Effect.promise(() => fs.writeFile(target, "before")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            executeTool(registry, call({ path: target, oldString: "before", newString: "after" })),
           ),
-          Effect.andThen((result) =>
-            Effect.gen(function* () {
-              expect(result.status).toBe("completed")
-              expect(assertions.map((input) => input.action)).toEqual(["edit"])
-              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after")
-            }),
-          ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+        Effect.andThen((result) =>
+          Effect.gen(function* () {
+            expect(result.status).toBe("completed")
+            expect(assertions.map((input) => input.action)).toEqual(["edit"])
+            expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after")
+          }),
+        ),
+      )
+    }),
   )
 
   it.live("edits an external symlink target with only its in-location permission", () =>
@@ -354,342 +345,300 @@ describe("EditTool", () => {
   )
 
   it.live("denied edit does not disclose whether oldString matches", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        denyAction = "edit"
-        const target = path.join(tmp.path, "secret.txt")
-        return Effect.promise(() => fs.writeFile(target, "secret content")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.gen(function* () {
-                const matching = yield* executeTool(
-                  registry,
-                  call({ path: "secret.txt", oldString: "secret content", newString: "replacement" }),
-                )
-                const missing = yield* executeTool(
-                  registry,
-                  call({ path: "secret.txt", oldString: "not present", newString: "replacement" }),
-                )
+    withTempDir((tmp) => {
+      reset()
+      denyAction = "edit"
+      const target = path.join(tmp.path, "secret.txt")
+      return Effect.promise(() => fs.writeFile(target, "secret content")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              const matching = yield* executeTool(
+                registry,
+                call({ path: "secret.txt", oldString: "secret content", newString: "replacement" }),
+              )
+              const missing = yield* executeTool(
+                registry,
+                call({ path: "secret.txt", oldString: "not present", newString: "replacement" }),
+              )
 
-                expect(matching).toEqual({
-                  status: "error",
-                  error: { type: "permission.rejected", message: "Permission denied: edit" },
-                })
-                expect(missing).toEqual(matching)
-                expect(assertions.map((input) => input.action)).toEqual(["edit", "edit"])
-                expect(reads).toBe(2)
-                expect(writes).toEqual([])
-              }),
-            ),
+              expect(matching).toEqual({
+                status: "error",
+                error: { type: "permission.rejected", message: "Permission denied: edit" },
+              })
+              expect(missing).toEqual(matching)
+              expect(assertions.map((input) => input.action)).toEqual(["edit", "edit"])
+              expect(reads).toBe(2)
+              expect(writes).toEqual([])
+            }),
           ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+      )
+    }),
   )
 
   it.live("rejects no-op, empty, missing, and ambiguous exact replacements", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "matches.txt")
-        return Effect.promise(() => fs.writeFile(target, "same same")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.gen(function* () {
-                expect(
-                  yield* executeTool(registry, call({ path: "matches.txt", oldString: "same", newString: "same" })),
-                ).toEqual({
-                  status: "error",
-                  error: {
-                    type: "tool.execution",
-                    message: "No changes to apply: oldString and newString are identical.",
-                  },
-                })
-                expect(
-                  yield* executeTool(registry, call({ path: "matches.txt", oldString: "", newString: "after" })),
-                ).toEqual({
-                  status: "error",
-                  error: {
-                    type: "tool.execution",
-                    message: "oldString must not be empty. Use write to create or overwrite a file.",
-                  },
-                })
-                expect(
-                  yield* executeTool(registry, call({ path: "matches.txt", oldString: "missing", newString: "after" })),
-                ).toEqual({
-                  status: "error",
-                  error: {
-                    type: "tool.execution",
-                    message:
-                      "Could not find oldString in matches.txt. It must match exactly, including whitespace and indentation.",
-                  },
-                })
-                expect(
-                  yield* executeTool(registry, call({ path: "matches.txt", oldString: "same", newString: "after" })),
-                ).toEqual({
-                  status: "error",
-                  error: {
-                    type: "tool.execution",
-                    message:
-                      "Found 2 matches for oldString, but expected exactly one. Add more surrounding context to make oldString unique, or set replaceAll to true to replace every occurrence.",
-                  },
-                })
-                expect(writes).toEqual([])
-              }),
-            ),
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "matches.txt")
+      return Effect.promise(() => fs.writeFile(target, "same same")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              expect(
+                yield* executeTool(registry, call({ path: "matches.txt", oldString: "same", newString: "same" })),
+              ).toEqual({
+                status: "error",
+                error: {
+                  type: "tool.execution",
+                  message: "No changes to apply: oldString and newString are identical.",
+                },
+              })
+              expect(
+                yield* executeTool(registry, call({ path: "matches.txt", oldString: "", newString: "after" })),
+              ).toEqual({
+                status: "error",
+                error: {
+                  type: "tool.execution",
+                  message: "oldString must not be empty. Use write to create or overwrite a file.",
+                },
+              })
+              expect(
+                yield* executeTool(registry, call({ path: "matches.txt", oldString: "missing", newString: "after" })),
+              ).toEqual({
+                status: "error",
+                error: {
+                  type: "tool.execution",
+                  message:
+                    "Could not find oldString in matches.txt. It must match exactly, including whitespace and indentation.",
+                },
+              })
+              expect(
+                yield* executeTool(registry, call({ path: "matches.txt", oldString: "same", newString: "after" })),
+              ).toEqual({
+                status: "error",
+                error: {
+                  type: "tool.execution",
+                  message:
+                    "Found 2 matches for oldString, but expected exactly one. Add more surrounding context to make oldString unique, or set replaceAll to true to replace every occurrence.",
+                },
+              })
+              expect(writes).toEqual([])
+            }),
           ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+      )
+    }),
   )
 
   it.live("returns specific missing file and directory errors", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const directory = path.join(tmp.path, "src")
-        return Effect.promise(() => fs.mkdir(directory)).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.gen(function* () {
-                expect(
-                  yield* executeTool(registry, call({ path: "missing.ts", oldString: "before", newString: "after" })),
-                ).toEqual({
-                  status: "error",
-                  error: { type: "tool.execution", message: "File not found: missing.ts" },
-                })
-                expect(
-                  yield* executeTool(registry, call({ path: "src", oldString: "before", newString: "after" })),
-                ).toEqual({
-                  status: "error",
-                  error: { type: "tool.execution", message: "Path is a directory, not a file: src" },
-                })
-                expect(writes).toEqual([])
-              }),
-            ),
+    withTempDir((tmp) => {
+      reset()
+      const directory = path.join(tmp.path, "src")
+      return Effect.promise(() => fs.mkdir(directory)).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              expect(
+                yield* executeTool(registry, call({ path: "missing.ts", oldString: "before", newString: "after" })),
+              ).toEqual({
+                status: "error",
+                error: { type: "tool.execution", message: "File not found: missing.ts" },
+              })
+              expect(
+                yield* executeTool(registry, call({ path: "src", oldString: "before", newString: "after" })),
+              ).toEqual({
+                status: "error",
+                error: { type: "tool.execution", message: "Path is a directory, not a file: src" },
+              })
+              expect(writes).toEqual([])
+            }),
           ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+      )
+    }),
   )
 
   it.live("replaces every exact occurrence when replaceAll is true", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "all.txt")
-        return Effect.promise(() => fs.writeFile(target, "same same same")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              executeTool(registry, call({ path: "all.txt", oldString: "same", newString: "after", replaceAll: true })),
-            ),
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "all.txt")
+      return Effect.promise(() => fs.writeFile(target, "same same same")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            executeTool(registry, call({ path: "all.txt", oldString: "same", newString: "after", replaceAll: true })),
           ),
-          Effect.andThen((settled) =>
-            Effect.gen(function* () {
-              expect(settled.status).toBe("completed")
-              if (settled.status !== "completed") return
-              expect(settled.output).toMatchObject({ replacements: 3 })
-              expect(settled.content).toEqual([{ type: "text", text: "Edited all.txt (3 replacements)" }])
-              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after after after")
-              expect(writes).toHaveLength(1)
-            }),
-          ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+        Effect.andThen((settled) =>
+          Effect.gen(function* () {
+            expect(settled.status).toBe("completed")
+            if (settled.status !== "completed") return
+            expect(settled.output).toMatchObject({ replacements: 3 })
+            expect(settled.content).toEqual([{ type: "text", text: "Edited all.txt (3 replacements)" }])
+            expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after after after")
+            expect(writes).toHaveLength(1)
+          }),
+        ),
+      )
+    }),
   )
 
   it.live("normalizes Unicode typography only after exact matching fails", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "unicode.txt")
-        return Effect.promise(() =>
-          fs.writeFile(target, "exact - match\ncurly “quotes”\nminus − one\nspace\u00A0here\nexact − match\n"),
-        ).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.gen(function* () {
-                const normalized = yield* executeTool(
-                  registry,
-                  call({
-                    path: "unicode.txt",
-                    oldString: 'curly "quotes"\nminus - one\nspace here',
-                    newString: "normalized",
-                  }),
-                )
-                expect(normalized.status).toBe("completed")
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "unicode.txt")
+      return Effect.promise(() =>
+        fs.writeFile(target, "exact - match\ncurly “quotes”\nminus − one\nspace\u00A0here\nexact − match\n"),
+      ).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              const normalized = yield* executeTool(
+                registry,
+                call({
+                  path: "unicode.txt",
+                  oldString: 'curly "quotes"\nminus - one\nspace here',
+                  newString: "normalized",
+                }),
+              )
+              expect(normalized.status).toBe("completed")
 
-                const exact = yield* executeTool(
-                  registry,
-                  call({ path: "unicode.txt", oldString: "exact - match", newString: "selected" }),
-                )
-                expect(exact.status).toBe("completed")
-                expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe(
-                  "selected\nnormalized\nexact − match\n",
-                )
-              }),
-            ),
+              const exact = yield* executeTool(
+                registry,
+                call({ path: "unicode.txt", oldString: "exact - match", newString: "selected" }),
+              )
+              expect(exact.status).toBe("completed")
+              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe(
+                "selected\nnormalized\nexact − match\n",
+              )
+            }),
           ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+      )
+    }),
   )
 
   it.live("ignores trailing whitespace while preserving untouched lines", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "whitespace.txt")
-        return Effect.promise(() => fs.writeFile(target, "before  \nmatch  \nnext\t\nafter  \n")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              executeTool(registry, call({ path: "whitespace.txt", oldString: "match\nnext", newString: "changed" })),
-            ),
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "whitespace.txt")
+      return Effect.promise(() => fs.writeFile(target, "before  \nmatch  \nnext\t\nafter  \n")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            executeTool(registry, call({ path: "whitespace.txt", oldString: "match\nnext", newString: "changed" })),
           ),
-          Effect.tap((result) => Effect.sync(() => expect(result.status).toBe("completed"))),
-          Effect.andThen(Effect.promise(() => fs.readFile(target, "utf8"))),
-          Effect.tap((content) => Effect.sync(() => expect(content).toBe("before  \nchanged\nafter  \n"))),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+        Effect.tap((result) => Effect.sync(() => expect(result.status).toBe("completed"))),
+        Effect.andThen(Effect.promise(() => fs.readFile(target, "utf8"))),
+        Effect.tap((content) => Effect.sync(() => expect(content).toBe("before  \nchanged\nafter  \n"))),
+      )
+    }),
   )
 
   it.live("uses non-overlapping trailing-whitespace matches and preserves CRLF", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const overlap = path.join(tmp.path, "overlap.txt")
-        const windows = path.join(tmp.path, "windows.txt")
-        return Effect.promise(() =>
-          Promise.all([fs.writeFile(overlap, "a  \na  \na  \n"), fs.writeFile(windows, "a  \r\nb\t\r\n")]),
-        ).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.gen(function* () {
-                const replaced = yield* executeTool(
-                  registry,
-                  call({ path: "overlap.txt", oldString: "a\na", newString: "x", replaceAll: true }),
-                )
-                expect(replaced).toMatchObject({ status: "completed", output: { replacements: 1 } })
-                yield* executeTool(registry, call({ path: "windows.txt", oldString: "a\nb", newString: "x" }))
-              }),
-            ),
-          ),
-          Effect.andThen(
-            Effect.promise(() => Promise.all([fs.readFile(overlap, "utf8"), fs.readFile(windows, "utf8")])),
-          ),
-          Effect.tap(([overlapContent, windowsContent]) =>
-            Effect.sync(() => {
-              expect(overlapContent).toBe("x\na  \n")
-              expect(windowsContent).toBe("x\r\n")
+    withTempDir((tmp) => {
+      reset()
+      const overlap = path.join(tmp.path, "overlap.txt")
+      const windows = path.join(tmp.path, "windows.txt")
+      return Effect.promise(() =>
+        Promise.all([fs.writeFile(overlap, "a  \na  \na  \n"), fs.writeFile(windows, "a  \r\nb\t\r\n")]),
+      ).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            Effect.gen(function* () {
+              const replaced = yield* executeTool(
+                registry,
+                call({ path: "overlap.txt", oldString: "a\na", newString: "x", replaceAll: true }),
+              )
+              expect(replaced).toMatchObject({ status: "completed", output: { replacements: 1 } })
+              yield* executeTool(registry, call({ path: "windows.txt", oldString: "a\nb", newString: "x" }))
             }),
           ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+        Effect.andThen(Effect.promise(() => Promise.all([fs.readFile(overlap, "utf8"), fs.readFile(windows, "utf8")]))),
+        Effect.tap(([overlapContent, windowsContent]) =>
+          Effect.sync(() => {
+            expect(overlapContent).toBe("x\na  \n")
+            expect(windowsContent).toBe("x\r\n")
+          }),
+        ),
+      )
+    }),
   )
 
   it.live("preserves BOM and CRLF line endings", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "windows.txt")
-        formatFile = (file) =>
-          Effect.promise(async () => {
-            await fs.writeFile(file, (await fs.readFile(file, "utf8")).replace(/^\uFEFF/, ""))
-            return true
-          })
-        return Effect.promise(() => fs.writeFile(target, "\uFEFFbefore\r\nrest\r\n")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              executeTool(registry, call({ path: "windows.txt", oldString: "before\nrest", newString: "after\nrest" })),
-            ),
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "windows.txt")
+      formatFile = (file) =>
+        Effect.promise(async () => {
+          await fs.writeFile(file, (await fs.readFile(file, "utf8")).replace(/^\uFEFF/, ""))
+          return true
+        })
+      return Effect.promise(() => fs.writeFile(target, "\uFEFFbefore\r\nrest\r\n")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            executeTool(registry, call({ path: "windows.txt", oldString: "before\nrest", newString: "after\nrest" })),
           ),
-          Effect.andThen(() => Effect.promise(() => fs.readFile(target, "utf8"))),
-          Effect.tap((content) => Effect.sync(() => expect(content).toBe("\uFEFFafter\r\nrest\r\n"))),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+        Effect.andThen(() => Effect.promise(() => fs.readFile(target, "utf8"))),
+        Effect.tap((content) => Effect.sync(() => expect(content).toBe("\uFEFFafter\r\nrest\r\n"))),
+      )
+    }),
   )
 
   it.live("serializes concurrent edit transactions", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "concurrent.txt")
-        afterRead = () => (reads === 1 ? Effect.sleep("50 millis") : Effect.void)
-        return Effect.promise(() => fs.writeFile(target, "one\ntwo\n")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.all(
-                [
-                  executeTool(
-                    registry,
-                    call({ path: "concurrent.txt", oldString: "one", newString: "ONE" }, "call-edit-one"),
-                  ),
-                  executeTool(
-                    registry,
-                    call({ path: "concurrent.txt", oldString: "two", newString: "TWO" }, "call-edit-two"),
-                  ),
-                ],
-                { concurrency: "unbounded" },
-              ),
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "concurrent.txt")
+      afterRead = () => (reads === 1 ? Effect.sleep("50 millis") : Effect.void)
+      return Effect.promise(() => fs.writeFile(target, "one\ntwo\n")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            Effect.all(
+              [
+                executeTool(
+                  registry,
+                  call({ path: "concurrent.txt", oldString: "one", newString: "ONE" }, "call-edit-one"),
+                ),
+                executeTool(
+                  registry,
+                  call({ path: "concurrent.txt", oldString: "two", newString: "TWO" }, "call-edit-two"),
+                ),
+              ],
+              { concurrency: "unbounded" },
             ),
           ),
-          Effect.andThen((results) =>
-            Effect.gen(function* () {
-              expect(results.map((result) => result.status)).toEqual(["completed", "completed"])
-              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("ONE\nTWO\n")
-            }),
-          ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+        Effect.andThen((results) =>
+          Effect.gen(function* () {
+            expect(results.map((result) => result.status)).toEqual(["completed", "completed"])
+            expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("ONE\nTWO\n")
+          }),
+        ),
+      )
+    }),
   )
 
   it.live("applies the edit when content changes after matching", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "concurrent.txt")
-        afterRead = () => (reads === 1 ? Effect.promise(() => fs.writeFile(target, "newer\n")) : Effect.void)
-        return Effect.promise(() => fs.writeFile(target, "before\n")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              executeTool(registry, call({ path: "concurrent.txt", oldString: "before", newString: "after" })),
-            ),
+    withTempDir((tmp) => {
+      reset()
+      const target = path.join(tmp.path, "concurrent.txt")
+      afterRead = () => (reads === 1 ? Effect.promise(() => fs.writeFile(target, "newer\n")) : Effect.void)
+      return Effect.promise(() => fs.writeFile(target, "before\n")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, (registry) =>
+            executeTool(registry, call({ path: "concurrent.txt", oldString: "before", newString: "after" })),
           ),
-          Effect.andThen((result) =>
-            Effect.gen(function* () {
-              expect(result).toMatchObject({ status: "completed", output: { replacements: 1 } })
-              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after\n")
-              expect(writes).toEqual([target])
-            }),
-          ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+        Effect.andThen((result) =>
+          Effect.gen(function* () {
+            expect(result).toMatchObject({ status: "completed", output: { replacements: 1 } })
+            expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("after\n")
+            expect(writes).toEqual([target])
+          }),
+        ),
+      )
+    }),
   )
 })

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -16,7 +16,7 @@ import { Tool } from "@opencode-ai/core/tool"
 import { EditTool } from "@opencode-ai/core/tool/plugin/edit"
 import { transformEnvironmentFiles } from "./fixture/environment"
 import { location } from "./fixture/location"
-import { tmpdir } from "./fixture/tmpdir"
+import { tmpdir, withTempDir } from "./fixture/tmpdir"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { testEffect } from "./lib/effect"
 import { permissionLayer } from "./lib/permission"
@@ -138,12 +138,6 @@ const call = (input: typeof EditTool.Input.Type, id = "call-edit") => ({
 })
 
 const it = testEffect(Layer.empty)
-const withTempDir = <A, E, R>(body: (tmp: Awaited<ReturnType<typeof tmpdir>>) => Effect.Effect<A, E, R>) =>
-  Effect.acquireUseRelease(
-    Effect.promise(() => tmpdir()),
-    body,
-    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-  )
 
 describe("EditTool", () => {
   it.live("registers and replaces relative exact text through FileMutation once", () =>

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -94,7 +94,7 @@ const withTool = <A, E, R>(
       AppNodeBuilder.build(LayerNode.group([Tool.node, LocationMutation.node, FileMutation.node, editToolNode]), [
         [
           Environment.node,
-          transformEnvironmentFiles(activeLocation, (files) => ({
+          transformEnvironmentFiles((files) => ({
             read: (target, range) =>
               files
                 .read(target, range)

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -38,18 +38,26 @@ const editToolNode = makeLocationNode({
 
 const sessionID = Session.ID.make("ses_edit_tool_test")
 const makeEditFixture = () => {
-  const assertions: Permission.AssertInput[] = []
-  const writes: string[] = []
-  let reads = 0
-  let denyAction: string | undefined
-  let afterRead = (_target: string, _content: Uint8Array): Effect.Effect<void> => Effect.void
-  let formatFile = (_target: string): Effect.Effect<boolean> => Effect.succeed(false)
+  const fixture: {
+    assertions: Permission.AssertInput[]
+    writes: string[]
+    reads: number
+    denyAction?: string
+    afterRead: () => Effect.Effect<void>
+    formatFile: (target: string) => Effect.Effect<boolean>
+  } = {
+    assertions: [],
+    writes: [],
+    reads: 0,
+    afterRead: () => Effect.void,
+    formatFile: () => Effect.succeed(false),
+  }
 
   const permission = permissionLayer({
     assert: (input) =>
-      Effect.sync(() => assertions.push(input)).pipe(
+      Effect.sync(() => fixture.assertions.push(input)).pipe(
         Effect.andThen(
-          input.action === denyAction
+          input.action === fixture.denyAction
             ? Effect.fail(
                 new Permission.BlockedError({
                   rules: [],
@@ -63,41 +71,10 @@ const makeEditFixture = () => {
   })
 
   const formatter = Layer.mock(Formatter.Service, {
-    file: (target) => formatFile(target),
+    file: (target) => fixture.formatFile(target),
   })
 
-  return {
-    assertions,
-    writes,
-    get reads() {
-      return reads
-    },
-    reset() {
-      assertions.length = 0
-      writes.length = 0
-      reads = 0
-      denyAction = undefined
-      afterRead = () => Effect.void
-      formatFile = () => Effect.succeed(false)
-    },
-    set denyAction(action: string | undefined) {
-      denyAction = action
-    },
-    set afterRead(next: (target: string, content: Uint8Array) => Effect.Effect<void>) {
-      afterRead = next
-    },
-    set formatFile(next: (target: string) => Effect.Effect<boolean>) {
-      formatFile = next
-    },
-    recordRead(target: string, content: Uint8Array) {
-      return Effect.sync(() => reads++).pipe(Effect.andThen(Effect.suspend(() => afterRead(target, content))))
-    },
-    recordWrite(target: string) {
-      writes.push(target)
-    },
-    permission,
-    formatter,
-  }
+  return Object.assign(fixture, { permission, formatter })
 }
 
 const withTool = <A, E, R>(
@@ -110,7 +87,8 @@ const withTool = <A, E, R>(
     Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
   )
   return Effect.gen(function* () {
-    return yield* body(yield* Tool.Service)
+    const registry = yield* Tool.Service
+    return yield* body(registry)
   }).pipe(
     Effect.provide(
       AppNodeBuilder.build(LayerNode.group([Tool.node, LocationMutation.node, FileMutation.node, editToolNode]), [
@@ -118,9 +96,13 @@ const withTool = <A, E, R>(
           Environment.node,
           transformEnvironmentFiles(activeLocation, (files) => ({
             read: (target, range) =>
-              files.read(target, range).pipe(Effect.tap((result) => fixture.recordRead(target, result.bytes))),
+              files
+                .read(target, range)
+                .pipe(
+                  Effect.tap(() => Effect.sync(() => fixture.reads++).pipe(Effect.andThen(() => fixture.afterRead()))),
+                ),
             write: (target, content) =>
-              Effect.sync(() => fixture.recordWrite(target)).pipe(Effect.andThen(files.write(target, content))),
+              Effect.sync(() => fixture.writes.push(target)).pipe(Effect.andThen(files.write(target, content))),
           })),
         ],
         [Location.node, activeLocation],
@@ -340,19 +322,19 @@ describe("EditTool", () => {
           expect(edit.reads).toBe(0)
           expect(edit.writes).toEqual([])
 
-          edit.reset()
-          edit.denyAction = "edit"
+          const deniedEdit = makeEditFixture()
+          deniedEdit.denyAction = "edit"
           expect(
-            yield* withTool(active.path, edit, (registry) =>
+            yield* withTool(active.path, deniedEdit, (registry) =>
               executeTool(registry, call({ path: external, oldString: "before", newString: "after" })),
             ),
           ).toEqual({
             status: "error",
             error: { type: "permission.rejected", message: "Permission denied: edit" },
           })
-          expect(edit.assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
-          expect(edit.reads).toBe(1)
-          expect(edit.writes).toEqual([])
+          expect(deniedEdit.assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
+          expect(deniedEdit.reads).toBe(1)
+          expect(deniedEdit.writes).toEqual([])
           expect(yield* Effect.promise(() => fs.readFile(external, "utf8"))).toBe("before")
         }),
       ([active, outside]) =>

--- a/packages/core/test/tool-patch.test.ts
+++ b/packages/core/test/tool-patch.test.ts
@@ -102,7 +102,7 @@ const withTool = <A, E, R>(
       AppNodeBuilder.build(LayerNode.group([Tool.node, LocationMutation.node, FileMutation.node, patchToolNode]), [
         [
           Environment.node,
-          transformEnvironmentFiles(activeLocation, (files) => ({
+          transformEnvironmentFiles((files) => ({
             read: (target, range) =>
               Effect.sync(() => {
                 if (!editApproved) readsBeforeEditApproval++

--- a/packages/core/test/tool-write.test.ts
+++ b/packages/core/test/tool-write.test.ts
@@ -16,7 +16,7 @@ import { Tool } from "@opencode-ai/core/tool"
 import { WriteTool } from "@opencode-ai/core/tool/plugin/write"
 import { transformEnvironmentFiles } from "./fixture/environment"
 import { location } from "./fixture/location"
-import { tmpdir } from "./fixture/tmpdir"
+import { tmpdir, withTempDir } from "./fixture/tmpdir"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { testEffect } from "./lib/effect"
 import { permissionLayer } from "./lib/permission"
@@ -29,40 +29,61 @@ const writeToolNode = makeLocationNode({
 })
 
 const sessionID = Session.ID.make("ses_write_tool_test")
-const assertions: Permission.AssertInput[] = []
-const writes: string[] = []
-let formatFile = (_target: string): Effect.Effect<boolean> => Effect.succeed(false)
-let denyAction: string | undefined
+const makeWriteFixture = () => {
+  const assertions: Permission.AssertInput[] = []
+  const writes: string[] = []
+  let formatFile = (_target: string): Effect.Effect<boolean> => Effect.succeed(false)
+  let denyAction: string | undefined
 
-const permission = permissionLayer({
-  assert: (input) =>
-    Effect.sync(() => assertions.push(input)).pipe(
-      Effect.andThen(
-        input.action === denyAction
-          ? Effect.fail(
-              new Permission.BlockedError({
-                rules: [],
-                permission: input.action,
-                resources: input.resources,
-              }),
-            )
-          : Effect.void,
+  const permission = permissionLayer({
+    assert: (input) =>
+      Effect.sync(() => assertions.push(input)).pipe(
+        Effect.andThen(
+          input.action === denyAction
+            ? Effect.fail(
+                new Permission.BlockedError({
+                  rules: [],
+                  permission: input.action,
+                  resources: input.resources,
+                }),
+              )
+            : Effect.void,
+        ),
       ),
-    ),
-})
+  })
 
-const formatter = Layer.mock(Formatter.Service, {
-  file: (target) => formatFile(target),
-})
+  const formatter = Layer.mock(Formatter.Service, {
+    file: (target) => formatFile(target),
+  })
 
-const reset = () => {
-  assertions.length = 0
-  writes.length = 0
-  formatFile = () => Effect.succeed(false)
-  denyAction = undefined
+  return {
+    assertions,
+    writes,
+    reset() {
+      assertions.length = 0
+      writes.length = 0
+      formatFile = () => Effect.succeed(false)
+      denyAction = undefined
+    },
+    set formatFile(next: (target: string) => Effect.Effect<boolean>) {
+      formatFile = next
+    },
+    set denyAction(action: string | undefined) {
+      denyAction = action
+    },
+    recordWrite(target: string) {
+      writes.push(target)
+    },
+    permission,
+    formatter,
+  }
 }
 
-const withTool = <A, E, R>(directory: string, body: (registry: Tool.Interface) => Effect.Effect<A, E, R>) => {
+const withTool = <A, E, R>(
+  directory: string,
+  fixture: ReturnType<typeof makeWriteFixture>,
+  body: (registry: Tool.Interface) => Effect.Effect<A, E, R>,
+) => {
   const activeLocation = Layer.succeed(
     Location.Service,
     Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
@@ -71,21 +92,18 @@ const withTool = <A, E, R>(directory: string, body: (registry: Tool.Interface) =
     return yield* body(yield* Tool.Service)
   }).pipe(
     Effect.provide(
-      AppNodeBuilder.build(
-        LayerNode.group([Tool.node, Tool.node, LocationMutation.node, FileMutation.node, writeToolNode]),
+      AppNodeBuilder.build(LayerNode.group([Tool.node, LocationMutation.node, FileMutation.node, writeToolNode]), [
         [
-          [
-            Environment.node,
-            transformEnvironmentFiles(activeLocation, (files) => ({
-              write: (target, content) =>
-                Effect.sync(() => writes.push(target)).pipe(Effect.andThen(files.write(target, content))),
-            })),
-          ],
-          [Location.node, activeLocation],
-          [Formatter.node, formatter],
-          [Permission.node, permission],
+          Environment.node,
+          transformEnvironmentFiles(activeLocation, (files) => ({
+            write: (target, content) =>
+              Effect.sync(() => fixture.recordWrite(target)).pipe(Effect.andThen(files.write(target, content))),
+          })),
         ],
-      ),
+        [Location.node, activeLocation],
+        [Formatter.node, fixture.formatter],
+        [Permission.node, fixture.permission],
+      ]),
     ),
   )
 }
@@ -100,175 +118,158 @@ const it = testEffect(Layer.empty)
 
 describe("WriteTool", () => {
   it.live("registers and creates a relative file through FileMutation once", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        return withTool(tmp.path, (registry) =>
-          Effect.gen(function* () {
-            expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["write", "execute"])
-            const settled = yield* executeTool(registry, call({ path: "src/new.txt", content: "created" }))
-            expect(settled).toEqual({
-              status: "completed",
-              output: {
-                operation: "write",
-                target: path.join(yield* Effect.promise(() => fs.realpath(tmp.path)), "src", "new.txt"),
-                resource: "src/new.txt",
-                existed: false,
+    withTempDir((tmp) => {
+      const fixture = makeWriteFixture()
+      return withTool(tmp.path, fixture, (registry) =>
+        Effect.gen(function* () {
+          expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["write", "execute"])
+          const settled = yield* executeTool(registry, call({ path: "src/new.txt", content: "created" }))
+          expect(settled).toEqual({
+            status: "completed",
+            output: {
+              operation: "write",
+              target: path.join(yield* Effect.promise(() => fs.realpath(tmp.path)), "src", "new.txt"),
+              resource: "src/new.txt",
+              existed: false,
+            },
+            content: [{ type: "text", text: "Created file successfully: src/new.txt" }],
+          })
+          expect(yield* Effect.promise(() => fs.readFile(path.join(tmp.path, "src", "new.txt"), "utf8"))).toBe(
+            "created",
+          )
+          expect(fixture.assertions).toMatchObject([
+            { sessionID, action: "edit", resources: ["src/new.txt"], save: ["*"] },
+          ])
+          expect(fixture.assertions[0]?.metadata).toMatchObject({
+            files: [
+              {
+                file: "src/new.txt",
+                status: "added",
+                additions: 1,
+                deletions: 0,
+                patch: expect.stringContaining("+created"),
               },
-              content: [{ type: "text", text: "Created file successfully: src/new.txt" }],
-            })
-            expect(yield* Effect.promise(() => fs.readFile(path.join(tmp.path, "src", "new.txt"), "utf8"))).toBe(
-              "created",
-            )
-            expect(assertions).toMatchObject([{ sessionID, action: "edit", resources: ["src/new.txt"], save: ["*"] }])
-            expect(assertions[0]?.metadata).toMatchObject({
-              files: [
-                {
-                  file: "src/new.txt",
-                  status: "added",
-                  additions: 1,
-                  deletions: 0,
-                  patch: expect.stringContaining("+created"),
-                },
-              ],
-            })
-            expect(writes).toEqual([path.join(yield* Effect.promise(() => fs.realpath(tmp.path)), "src", "new.txt")])
-          }),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+            ],
+          })
+          expect(fixture.writes).toEqual([
+            path.join(yield* Effect.promise(() => fs.realpath(tmp.path)), "src", "new.txt"),
+          ])
+        }),
+      )
+    }),
   )
 
   it.live("formats the committed file", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "formatted.txt")
-        formatFile = (file) =>
-          Effect.promise(async () => {
-            await fs.writeFile(file, (await fs.readFile(file, "utf8")).toUpperCase())
-            return true
+    withTempDir((tmp) => {
+      const fixture = makeWriteFixture()
+      const target = path.join(tmp.path, "formatted.txt")
+      fixture.formatFile = (file) =>
+        Effect.promise(async () => {
+          await fs.writeFile(file, (await fs.readFile(file, "utf8")).toUpperCase())
+          return true
+        })
+      return withTool(tmp.path, fixture, (registry) =>
+        Effect.gen(function* () {
+          expect(yield* executeTool(registry, call({ path: "formatted.txt", content: "format me" }))).toMatchObject({
+            status: "completed",
           })
-        return withTool(tmp.path, (registry) =>
-          Effect.gen(function* () {
-            expect(yield* executeTool(registry, call({ path: "formatted.txt", content: "format me" }))).toMatchObject({
-              status: "completed",
-            })
-            expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("FORMAT ME")
-          }),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+          expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("FORMAT ME")
+        }),
+      )
+    }),
   )
 
   it.live("overwrites a relative existing file and reports that it wrote the file", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        return Effect.promise(() => fs.writeFile(path.join(tmp.path, "existing.txt"), "before")).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) => executeTool(registry, call({ path: "existing.txt", content: "after" }))),
+    withTempDir((tmp) => {
+      const fixture = makeWriteFixture()
+      return Effect.promise(() => fs.writeFile(path.join(tmp.path, "existing.txt"), "before")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, fixture, (registry) =>
+            executeTool(registry, call({ path: "existing.txt", content: "after" })),
           ),
-          Effect.andThen((settled) =>
-            Effect.gen(function* () {
-              expect(settled.status).toBe("completed")
-              if (settled.status !== "completed") return
-              expect(settled.content).toEqual([{ type: "text", text: "Wrote file successfully: existing.txt" }])
-              expect(settled.output).toMatchObject({ resource: "existing.txt", existed: true })
-              expect(assertions[0]?.metadata).toMatchObject({
-                files: [
-                  {
-                    file: "existing.txt",
-                    status: "modified",
-                    additions: 1,
-                    deletions: 1,
-                    patch: expect.stringMatching(/-before[\s\S]*\+after/),
-                  },
-                ],
-              })
-              expect(yield* Effect.promise(() => fs.readFile(path.join(tmp.path, "existing.txt"), "utf8"))).toBe(
-                "after",
-              )
-              expect(writes).toHaveLength(1)
-            }),
-          ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+        Effect.andThen((settled) =>
+          Effect.gen(function* () {
+            expect(settled.status).toBe("completed")
+            if (settled.status !== "completed") return
+            expect(settled.content).toEqual([{ type: "text", text: "Wrote file successfully: existing.txt" }])
+            expect(settled.output).toMatchObject({ resource: "existing.txt", existed: true })
+            expect(fixture.assertions[0]?.metadata).toMatchObject({
+              files: [
+                {
+                  file: "existing.txt",
+                  status: "modified",
+                  additions: 1,
+                  deletions: 1,
+                  patch: expect.stringMatching(/-before[\s\S]*\+after/),
+                },
+              ],
+            })
+            expect(yield* Effect.promise(() => fs.readFile(path.join(tmp.path, "existing.txt"), "utf8"))).toBe("after")
+            expect(fixture.writes).toHaveLength(1)
+          }),
+        ),
+      )
+    }),
   )
 
   it.live("preserves exactly one BOM when overwriting existing files", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const preserved = path.join(tmp.path, "preserved.txt")
-        const deduplicated = path.join(tmp.path, "deduplicated.txt")
-        formatFile = (target) =>
-          Effect.promise(async () => {
-            await fs.writeFile(
-              target,
-              `\uFEFF\uFEFF\uFEFF${(await fs.readFile(target, "utf8")).replace(/^\uFEFF+/, "")}`,
-            )
-            return true
-          })
-        return Effect.promise(() =>
-          Promise.all([fs.writeFile(preserved, "\uFEFFbefore"), fs.writeFile(deduplicated, "\uFEFFbefore")]),
-        ).pipe(
-          Effect.andThen(
-            withTool(tmp.path, (registry) =>
-              Effect.gen(function* () {
-                yield* executeTool(registry, call({ path: "preserved.txt", content: "after" }, "call-preserved"))
-                yield* executeTool(
-                  registry,
-                  call({ path: "deduplicated.txt", content: "\uFEFFafter" }, "call-deduplicated"),
-                )
+    withTempDir((tmp) => {
+      const fixture = makeWriteFixture()
+      const preserved = path.join(tmp.path, "preserved.txt")
+      const deduplicated = path.join(tmp.path, "deduplicated.txt")
+      fixture.formatFile = (target) =>
+        Effect.promise(async () => {
+          await fs.writeFile(target, `\uFEFF\uFEFF\uFEFF${(await fs.readFile(target, "utf8")).replace(/^\uFEFF+/, "")}`)
+          return true
+        })
+      return Effect.promise(() =>
+        Promise.all([fs.writeFile(preserved, "\uFEFFbefore"), fs.writeFile(deduplicated, "\uFEFFbefore")]),
+      ).pipe(
+        Effect.andThen(
+          withTool(tmp.path, fixture, (registry) =>
+            Effect.gen(function* () {
+              yield* executeTool(registry, call({ path: "preserved.txt", content: "after" }, "call-preserved"))
+              yield* executeTool(
+                registry,
+                call({ path: "deduplicated.txt", content: "\uFEFFafter" }, "call-deduplicated"),
+              )
 
-                expect(yield* Effect.promise(() => fs.readFile(preserved, "utf8"))).toBe("\uFEFFafter")
-                expect(yield* Effect.promise(() => fs.readFile(deduplicated, "utf8"))).toBe("\uFEFFafter")
-              }),
-            ),
+              expect(yield* Effect.promise(() => fs.readFile(preserved, "utf8"))).toBe("\uFEFFafter")
+              expect(yield* Effect.promise(() => fs.readFile(deduplicated, "utf8"))).toBe("\uFEFFafter")
+            }),
           ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+        ),
+      )
+    }),
   )
 
   it.live("accepts an absolute file path inside the active Location", () =>
-    Effect.acquireUseRelease(
-      Effect.promise(() => tmpdir()),
-      (tmp) => {
-        reset()
-        const target = path.join(tmp.path, "absolute.txt")
-        return withTool(tmp.path, (registry) => executeTool(registry, call({ path: target, content: "inside" }))).pipe(
-          Effect.andThen((result) =>
-            Effect.gen(function* () {
-              expect(result).toMatchObject({
-                status: "completed",
-                content: [{ type: "text", text: "Created file successfully: absolute.txt" }],
-              })
-              expect(assertions.map((input) => input.action)).toEqual(["edit"])
-              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("inside")
-            }),
-          ),
-        )
-      },
-      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-    ),
+    withTempDir((tmp) => {
+      const fixture = makeWriteFixture()
+      const target = path.join(tmp.path, "absolute.txt")
+      return withTool(tmp.path, fixture, (registry) =>
+        executeTool(registry, call({ path: target, content: "inside" })),
+      ).pipe(
+        Effect.andThen((result) =>
+          Effect.gen(function* () {
+            expect(result).toMatchObject({
+              status: "completed",
+              content: [{ type: "text", text: "Created file successfully: absolute.txt" }],
+            })
+            expect(fixture.assertions.map((input) => input.action)).toEqual(["edit"])
+            expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("inside")
+          }),
+        ),
+      )
+    }),
   )
 
-  it.live("writes an external symlink target with only its in-location permission", () =>
+  it.live("fixture.writes an external symlink target with only its in-location permission", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => Promise.all([tmpdir(), tmpdir()])),
       ([active, outside]) => {
-        reset()
+        const fixture = makeWriteFixture()
         if (process.platform === "win32") return Effect.void
         const target = path.join(outside.path, "external.txt")
         const link = path.join(active.path, "link.txt")
@@ -277,13 +278,15 @@ describe("WriteTool", () => {
           await fs.symlink(target, link)
         }).pipe(
           Effect.andThen(
-            withTool(active.path, (registry) => executeTool(registry, call({ path: "link.txt", content: "after" }))),
+            withTool(active.path, fixture, (registry) =>
+              executeTool(registry, call({ path: "link.txt", content: "after" })),
+            ),
           ),
           Effect.andThen((result) =>
             Effect.sync(() => {
               expect(result.status).toBe("completed")
-              expect(assertions.map((input) => input.action)).toEqual(["edit"])
-              expect(assertions[0]?.resources).toEqual(["link.txt"])
+              expect(fixture.assertions.map((input) => input.action)).toEqual(["edit"])
+              expect(fixture.assertions[0]?.resources).toEqual(["link.txt"])
             }),
           ),
           Effect.andThen(Effect.promise(() => fs.readFile(target, "utf8"))),
@@ -301,19 +304,22 @@ describe("WriteTool", () => {
     Effect.acquireUseRelease(
       Effect.promise(() => Promise.all([tmpdir(), tmpdir()])),
       ([active, outside]) => {
-        reset()
+        const fixture = makeWriteFixture()
         const target = path.join(outside.path, "external.txt")
-        return withTool(active.path, (registry) =>
+        return withTool(active.path, fixture, (registry) =>
           executeTool(registry, call({ path: target, content: "external" })),
         ).pipe(
           Effect.andThen((settled) =>
             Effect.gen(function* () {
               const absoluteTarget = target
-              expect(assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
-              expect(assertions[0]).toMatchObject({
+              expect(fixture.assertions.map((input) => input.action)).toEqual(["external_directory", "edit"])
+              expect(fixture.assertions[0]).toMatchObject({
                 resources: [path.join(outside.path, "*").replaceAll("\\", "/")],
               })
-              expect(assertions[1]).toMatchObject({ resources: [absoluteTarget.replaceAll("\\", "/")], save: ["*"] })
+              expect(fixture.assertions[1]).toMatchObject({
+                resources: [absoluteTarget.replaceAll("\\", "/")],
+                save: ["*"],
+              })
               expect(settled).toMatchObject({
                 status: "completed",
                 output: {
@@ -323,7 +329,7 @@ describe("WriteTool", () => {
                 },
               })
               expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("external")
-              expect(writes).toEqual([absoluteTarget])
+              expect(fixture.writes).toEqual([absoluteTarget])
             }),
           ),
         )
@@ -339,7 +345,7 @@ describe("WriteTool", () => {
     Effect.acquireUseRelease(
       Effect.promise(() => Promise.all([tmpdir(), tmpdir()])),
       ([active, outside]) => {
-        reset()
+        const fixture = makeWriteFixture()
         const repo = path.join(outside.path, "repo")
         const nested = path.join(repo, "packages", "app")
         const target = path.join(nested, "external.txt")
@@ -347,11 +353,13 @@ describe("WriteTool", () => {
           Promise.all([fs.mkdir(path.join(repo, ".git"), { recursive: true }), fs.mkdir(nested, { recursive: true })]),
         ).pipe(
           Effect.andThen(
-            withTool(active.path, (registry) => executeTool(registry, call({ path: target, content: "external" }))),
+            withTool(active.path, fixture, (registry) =>
+              executeTool(registry, call({ path: target, content: "external" })),
+            ),
           ),
           Effect.andThen(
             Effect.gen(function* () {
-              expect(assertions[0]).toMatchObject({
+              expect(fixture.assertions[0]).toMatchObject({
                 action: "external_directory",
                 resources: [path.join(nested, "*").replaceAll("\\", "/")],
                 save: [path.join(repo, "*").replaceAll("\\", "/")],
@@ -373,31 +381,31 @@ describe("WriteTool", () => {
       ([active, outside]) =>
         Effect.gen(function* () {
           const external = path.join(outside.path, "denied.txt")
-          reset()
-          denyAction = "external_directory"
+          const fixture = makeWriteFixture()
+          fixture.denyAction = "external_directory"
           expect(
-            yield* withTool(active.path, (registry) =>
+            yield* withTool(active.path, fixture, (registry) =>
               executeTool(registry, call({ path: external, content: "blocked" })),
             ),
           ).toEqual({
             status: "error",
             error: { type: "permission.rejected", message: "Permission denied: external_directory" },
           })
-          expect(assertions.map((input) => input.action)).toEqual(["external_directory"])
-          expect(writes).toEqual([])
+          expect(fixture.assertions.map((input) => input.action)).toEqual(["external_directory"])
+          expect(fixture.writes).toEqual([])
 
-          reset()
-          denyAction = "edit"
+          fixture.reset()
+          fixture.denyAction = "edit"
           expect(
-            yield* withTool(active.path, (registry) =>
+            yield* withTool(active.path, fixture, (registry) =>
               executeTool(registry, call({ path: "denied.txt", content: "blocked" })),
             ),
           ).toEqual({
             status: "error",
             error: { type: "permission.rejected", message: "Permission denied: edit" },
           })
-          expect(assertions.map((input) => input.action)).toEqual(["edit"])
-          expect(writes).toEqual([])
+          expect(fixture.assertions.map((input) => input.action)).toEqual(["edit"])
+          expect(fixture.writes).toEqual([])
         }),
       ([active, outside]) =>
         Effect.promise(() =>

--- a/packages/core/test/tool-write.test.ts
+++ b/packages/core/test/tool-write.test.ts
@@ -82,7 +82,7 @@ const withTool = <A, E, R>(
       AppNodeBuilder.build(LayerNode.group([Tool.node, LocationMutation.node, FileMutation.node, writeToolNode]), [
         [
           Environment.node,
-          transformEnvironmentFiles(activeLocation, (files) => ({
+          transformEnvironmentFiles((files) => ({
             write: (target, content) =>
               Effect.sync(() => fixture.writes.push(target)).pipe(Effect.andThen(files.write(target, content))),
           })),

--- a/packages/core/test/tool-write.test.ts
+++ b/packages/core/test/tool-write.test.ts
@@ -30,16 +30,22 @@ const writeToolNode = makeLocationNode({
 
 const sessionID = Session.ID.make("ses_write_tool_test")
 const makeWriteFixture = () => {
-  const assertions: Permission.AssertInput[] = []
-  const writes: string[] = []
-  let formatFile = (_target: string): Effect.Effect<boolean> => Effect.succeed(false)
-  let denyAction: string | undefined
+  const fixture: {
+    assertions: Permission.AssertInput[]
+    writes: string[]
+    denyAction?: string
+    formatFile: (target: string) => Effect.Effect<boolean>
+  } = {
+    assertions: [],
+    writes: [],
+    formatFile: () => Effect.succeed(false),
+  }
 
   const permission = permissionLayer({
     assert: (input) =>
-      Effect.sync(() => assertions.push(input)).pipe(
+      Effect.sync(() => fixture.assertions.push(input)).pipe(
         Effect.andThen(
-          input.action === denyAction
+          input.action === fixture.denyAction
             ? Effect.fail(
                 new Permission.BlockedError({
                   rules: [],
@@ -53,30 +59,10 @@ const makeWriteFixture = () => {
   })
 
   const formatter = Layer.mock(Formatter.Service, {
-    file: (target) => formatFile(target),
+    file: (target) => fixture.formatFile(target),
   })
 
-  return {
-    assertions,
-    writes,
-    reset() {
-      assertions.length = 0
-      writes.length = 0
-      formatFile = () => Effect.succeed(false)
-      denyAction = undefined
-    },
-    set formatFile(next: (target: string) => Effect.Effect<boolean>) {
-      formatFile = next
-    },
-    set denyAction(action: string | undefined) {
-      denyAction = action
-    },
-    recordWrite(target: string) {
-      writes.push(target)
-    },
-    permission,
-    formatter,
-  }
+  return Object.assign(fixture, { permission, formatter })
 }
 
 const withTool = <A, E, R>(
@@ -89,7 +75,8 @@ const withTool = <A, E, R>(
     Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
   )
   return Effect.gen(function* () {
-    return yield* body(yield* Tool.Service)
+    const registry = yield* Tool.Service
+    return yield* body(registry)
   }).pipe(
     Effect.provide(
       AppNodeBuilder.build(LayerNode.group([Tool.node, LocationMutation.node, FileMutation.node, writeToolNode]), [
@@ -97,7 +84,7 @@ const withTool = <A, E, R>(
           Environment.node,
           transformEnvironmentFiles(activeLocation, (files) => ({
             write: (target, content) =>
-              Effect.sync(() => fixture.recordWrite(target)).pipe(Effect.andThen(files.write(target, content))),
+              Effect.sync(() => fixture.writes.push(target)).pipe(Effect.andThen(files.write(target, content))),
           })),
         ],
         [Location.node, activeLocation],
@@ -265,7 +252,7 @@ describe("WriteTool", () => {
     }),
   )
 
-  it.live("fixture.writes an external symlink target with only its in-location permission", () =>
+  it.live("writes an external symlink target with only its in-location permission", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => Promise.all([tmpdir(), tmpdir()])),
       ([active, outside]) => {
@@ -394,18 +381,18 @@ describe("WriteTool", () => {
           expect(fixture.assertions.map((input) => input.action)).toEqual(["external_directory"])
           expect(fixture.writes).toEqual([])
 
-          fixture.reset()
-          fixture.denyAction = "edit"
+          const deniedEdit = makeWriteFixture()
+          deniedEdit.denyAction = "edit"
           expect(
-            yield* withTool(active.path, fixture, (registry) =>
+            yield* withTool(active.path, deniedEdit, (registry) =>
               executeTool(registry, call({ path: "denied.txt", content: "blocked" })),
             ),
           ).toEqual({
             status: "error",
             error: { type: "permission.rejected", message: "Permission denied: edit" },
           })
-          expect(fixture.assertions.map((input) => input.action)).toEqual(["edit"])
-          expect(fixture.writes).toEqual([])
+          expect(deniedEdit.assertions.map((input) => input.action)).toEqual(["edit"])
+          expect(deniedEdit.writes).toEqual([])
         }),
       ([active, outside]) =>
         Effect.promise(() =>


### PR DESCRIPTION
## Why
Edit and write tool tests keep permission recorders, file tracking, hooks, and denial settings in module-scoped mutable variables. Each test must reset shared state, making fixture ownership implicit.

The file-operation fixture also constructs workspace services for tests whose Locations are all implicit-local, despite an existing fixture for the same real host driver.

## What Changes
- Each edit/write test creates fresh recorder state and permission/formatter layers. Hooks and denial settings are ordinary fields rather than setter-backed closure state.
- The two denial scenarios create separate fixtures instead of maintaining reset methods.
- A narrow shared `withTempDir` owns the existing single-directory acquire/release lifecycle. Two-directory cases retain explicit setup.
- Duplicate `Tool.node` entries are removed.
- The shared file-operation wrapper reuses `hostEnvironmentLayer`, matching its process-recording counterpart. It no longer takes a Location layer or constructs workspace services.

The file wrapper's four callers remain on the real local filesystem driver. Location resolution, locks, permissions, read/write tracking, formatting, and failure injection remain unchanged.

## Scope
Test-only cleanup of the edit/write suites, temporary-directory fixture, and local file-operation fixture. Patch and file-mutation tests only drop the now-unnecessary fixture argument.

## Verification
Run from `packages/core`:

```sh
bun typecheck
bun run test test/tool-edit.test.ts test/tool-write.test.ts
bun run test test/file-mutation.test.ts test/tool-edit.test.ts test/tool-write.test.ts test/tool-patch.test.ts test/environment.test.ts test/location-mutation.test.ts
```

Focused edit/write verification passed 25 tests and 102 assertions. Broader verification passed 103 tests with 9 existing skips and 318 assertions. Package and pre-push repository typechecks, formatting, and whitespace checks passed.
