### PR TITLE
fix(core): preserve downloaded skill directory IDs

### DIFF
--- a/.changeset/skill-directory-ids.md
+++ b/.changeset/skill-directory-ids.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Use parent directory names for SKILL.md IDs so individually downloaded skills do not overwrite each other.

--- a/packages/core/src/config/plugin/skill-file.ts
+++ b/packages/core/src/config/plugin/skill-file.ts
@@ -39,7 +39,9 @@ export function parse(directory: string, filepath: string, content: string): Par
   if (Result.isFailure(decoded)) return { _tag: "Skipped", reason: "frontmatter", issue: decoded.failure }
   const frontmatter = decoded.success
   const id =
-    path.dirname(filepath) === directory ? path.basename(filepath, ".md") : path.basename(path.dirname(filepath))
+    path.dirname(filepath) === directory && path.basename(filepath) !== "SKILL.md"
+      ? path.basename(filepath, ".md")
+      : path.basename(path.dirname(filepath))
   const slash = metadataBoolean(frontmatter.metadata, "opencode/slash") ?? frontmatter.slash
   const autoinvoke = metadataBoolean(frontmatter.metadata, "opencode/autoinvoke")
   return {

--- a/packages/core/test/config/skill.test.ts
+++ b/packages/core/test/config/skill.test.ts
@@ -162,6 +162,10 @@ metadata:
         _tag: "Parsed",
         skill: { id: Skill.ID.make("foo") },
       })
+      expect(SkillFile.parse("/repo/skills/manual", "/repo/skills/manual/SKILL.md", "# manual")).toMatchObject({
+        _tag: "Parsed",
+        skill: { id: Skill.ID.make("manual"), name: Skill.Name.make("manual") },
+      })
       expect(
         SkillFile.parse(directory, "/repo/skills/broken.md", "---\ndescription: foo: bar\nmetadata: [\n---\n# broken"),
       ).toEqual({ _tag: "Skipped", reason: "markdown" })
@@ -214,7 +218,7 @@ describe("ConfigSkillPlugin.Plugin", () => {
     ),
   )
 
-  it.live("loads directory and URL sources with later-source precedence", () =>
+  it.live("loads directory and individual downloaded skill roots with later-source precedence", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
@@ -225,14 +229,24 @@ describe("ConfigSkillPlugin.Plugin", () => {
           const second = path.join(tmp.path, "second")
           yield* Effect.promise(async () => {
             await fs.mkdir(path.join(first, "review"), { recursive: true })
+            await fs.mkdir(path.join(second, "deploy"), { recursive: true })
             await fs.mkdir(path.join(second, "review"), { recursive: true })
             await write(first, "review", "First")
+            await write(second, "deploy", "Deploy")
             await write(second, "review", "Second")
           })
           pulls = 0
-          urls.set("https://example.test/skills/", [AbsolutePath.make(second)])
+          urls.set("https://example.test/skills/", [
+            AbsolutePath.make(path.join(second, "deploy")),
+            AbsolutePath.make(path.join(second, "review")),
+          ])
 
           const skill = yield* start([first, "https://example.test/skills/"], tmp.path)
+          expect((yield* skill.list()).map((item) => item.id).toSorted()).toEqual([
+            Skill.ID.make("deploy"),
+            Skill.ID.make("review"),
+          ])
+          expect((yield* skill.list()).find((item) => item.id === "deploy")?.description).toBe("Deploy")
           expect((yield* skill.list()).find((item) => item.id === "review")?.description).toBe("Second")
           expect(pulls).toBe(1)
         }),


### PR DESCRIPTION
## Why

Downloaded `deploy/SKILL.md` and `review/SKILL.md` both receive the ID `SKILL` because discovery returns each individual skill directory as a root. The skill loader deduplicates by ID, so one downloaded skill silently overwrites the other. The existing URL fixture returned a collection directory and hid this behavior.

## What Changes

Always derive `SKILL.md` IDs from the parent directory, including when the file is directly inside the supplied root.

| Supplied root | File | Before ID | After ID |
| --- | --- | --- | --- |
| `/cache/deploy` | `/cache/deploy/SKILL.md` | `SKILL` | `deploy` |
| `/cache/review` | `/cache/review/SKILL.md` | `SKILL` | `review` |
| `/repo/skills` | `/repo/skills/foo.md` | `foo` | `foo` |
| `/repo/skills` | `/repo/skills/manual/SKILL.md` | `manual` | `manual` |

Correct the URL fixture to return separate `deploy` and `review` roots and assert that both survive with later-source precedence intact. Also cover the root-level parser ID and fallback name. The regression uses local files and the existing discovery stub, with no network requests.

## Scope

V2 skill-file identity only, with a patch changeset for `@opencode-ai/core`. Discovery, watcher behavior, and ID-based precedence are unchanged.

## Verification

```sh
# Repository root
bun install --frozen-lockfile
bunx prettier --check packages/core/src/config/plugin/skill-file.ts packages/core/test/config/skill.test.ts .changeset/skill-directory-ids.md
git diff --check
git push -u origin skill-directory-ids

# packages/core
bun run test test/config/skill.test.ts --test-name-pattern 'SkillFile.parse|individual downloaded'
bun run test test/config/skill.test.ts test/skill.test.ts test/plugin/skill.test.ts test/tool-skill.test.ts test/session-skill.test.ts test/skill-discovery.test.ts
bun typecheck
```

The two regression checks failed on the unchanged parser in two consecutive runs, showing `SKILL` instead of the directory ID and a missing downloaded `deploy` skill. After the fix, both pass. All 27 skill-related tests across six files pass; core typechecking, formatting, and whitespace checks pass. The existing discovery tests use a local HTTP fixture, not external services.

The unmodified pre-push hook also passed the workspace typecheck: 33 successful tasks, including 27 cache hits. No hooks were bypassed.
