### PR TITLE
refactor(core): rename model package predicate

### DIFF
--- a/.changeset/model-package-name.md
+++ b/.changeset/model-package-name.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": minor
+---
+
+Rename ModelResolver.supported to ModelResolver.hasPackage. Consumers of the old export must update the name; the predicate remains Boolean(model.package), checking only whether a catalog model declares a provider package, not whether it can be loaded. Default-model selection behavior is unchanged.

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -261,7 +261,7 @@ export const resolveModel = (
   dependencies?: Dependencies,
 ) => withVariant(model, variant).pipe(Effect.flatMap((model) => fromCatalogModel(model, credential, dependencies)))
 
-export const supported = (model: Info) => Boolean(model.package)
+export const hasPackage = (model: Info) => Boolean(model.package)
 
 /** Resolves catalog selections into runtime models for the current Location. */
 export const layer = Layer.effect(
@@ -309,9 +309,9 @@ export const layer = Layer.effect(
               .default()
               .pipe(
                 Effect.flatMap((model) =>
-                  model && supported(model)
+                  model && hasPackage(model)
                     ? Effect.succeed(model)
-                    : Effect.map(catalog.model.available(), (models) => models.find(supported)),
+                    : Effect.map(catalog.model.available(), (models) => models.find(hasPackage)),
                 ),
               )
         if (!selected) return undefined

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -1306,9 +1306,9 @@ describe("ModelResolver", () => {
 
   it.effect("reports whether a catalog model declares a provider package", () =>
     Effect.sync(() => {
-      expect(ModelResolver.supported(model(Provider.aisdk("@ai-sdk/openai")))).toBe(true)
-      expect(ModelResolver.supported(model("@opencode-ai/ai/providers/custom"))).toBe(true)
-      expect(ModelResolver.supported(model(undefined))).toBe(false)
+      expect(ModelResolver.hasPackage(model(Provider.aisdk("@ai-sdk/openai")))).toBe(true)
+      expect(ModelResolver.hasPackage(model("@opencode-ai/ai/providers/custom"))).toBe(true)
+      expect(ModelResolver.hasPackage(model(undefined))).toBe(false)
     }),
   )
 })


### PR DESCRIPTION
## Why
`ModelResolver.supported` sounds like a runtime-support check, but it only checks whether a catalog model declares a provider package. The name can mislead callers into assuming that package loading or validation has already succeeded.

## What Changes
Rename the export to `ModelResolver.hasPackage`, updating both default-model selection callsites and the existing predicate assertions. The implementation remains exactly `Boolean(model.package)`: a nonempty package declaration returns true, and an absent package returns false. Model selection and fallback behavior are unchanged.

## Scope
Naming-only Core cleanup with a small changeset documenting the exported-name migration. Consumers of the old export must update their callsites; no documented consumers were found in repository searches and no compatibility alias is added. Package loading, validation, error tags, and other model APIs are unchanged.

## Verification
```sh
# Worktree root
bun install --frozen-lockfile

# packages/core
bun run test test/model-resolver.test.ts
bun typecheck

# Worktree root
bunx prettier --check packages/core/src/model-resolver.ts packages/core/test/model-resolver.test.ts .changeset/model-package-name.md
git diff --check
git diff --cached --check
git push -u origin model-package-name
```
The focused suite passed before and after the rename: 39 tests, 0 failures, 174 assertions. Core typechecking passed on both revisions; formatting and diff checks passed. The normal pre-push hook also passed the repository typecheck: 33 successful tasks, including 27 cache hits. No hooks were bypassed.