### PR TITLE
refactor(core): align model content helper names

### DIFF
--- a/.changeset/model-content-names.md
+++ b/.changeset/model-content-names.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Rename the write, patch, and question tool formatting helpers from `toModelOutput` to `toModelContent` to match the result field they populate. Direct imports of these helpers must use the new name; generated content and declared machine output are unchanged.

--- a/packages/core/src/tool/plugin/patch.ts
+++ b/packages/core/src/tool/plugin/patch.ts
@@ -36,7 +36,7 @@ export const Output = Schema.Struct({
 })
 export type Output = typeof Output.Type
 
-export const toModelOutput = (output: Output) =>
+export const toModelContent = (output: Output) =>
   [
     "Success. Updated the following files:",
     ...output.applied.map(
@@ -296,7 +296,7 @@ export const Plugin = {
               fileMutation.withLock(lockTargets),
               Effect.map((output) => ({
                 output,
-                content: toModelOutput(output),
+                content: toModelContent(output),
                 metadata: { files: output.files },
               })),
               Effect.mapError((error) =>

--- a/packages/core/src/tool/plugin/question.ts
+++ b/packages/core/src/tool/plugin/question.ts
@@ -35,7 +35,7 @@ export class CancelledError extends Schema.TaggedError<CancelledError>()("Questi
   }
 }
 
-export const toModelOutput = (questions: ReadonlyArray<Question.Prompt>, answers: ReadonlyArray<Question.Answer>) => {
+export const toModelContent = (questions: ReadonlyArray<Question.Prompt>, answers: ReadonlyArray<Question.Answer>) => {
   const formatted = questions
     .map(
       (question, index) =>
@@ -101,7 +101,7 @@ export const Plugin = {
                   }
                   return Effect.succeed({
                     output,
-                    content: toModelOutput(input.questions, output.answers),
+                    content: toModelContent(input.questions, output.answers),
                     metadata: { answers: output.answers },
                   })
                 }),

--- a/packages/core/src/tool/plugin/write.ts
+++ b/packages/core/src/tool/plugin/write.ts
@@ -35,7 +35,7 @@ export const Output = Schema.Struct({
 })
 export type Output = typeof Output.Type
 
-export const toModelOutput = (output: Output) =>
+export const toModelContent = (output: Output) =>
   `${output.existed ? "Wrote" : "Created"} file successfully: ${output.resource}`
 
 /** Deferred write UX integrations remain visible at the model-facing seam. */
@@ -98,7 +98,7 @@ export const Plugin = {
               }
               return result
             }).pipe(
-              Effect.map((output) => ({ output, content: toModelOutput(output) })),
+              Effect.map((output) => ({ output, content: toModelContent(output) })),
               Effect.mapError((error) => new ToolFailure({ message: `Unable to write ${input.path}`, error })),
             ),
         }),


### PR DESCRIPTION
**Why**
The write, patch, and question built-ins call their formatting helpers `toModelOutput`, even though those helpers populate `result.content`, not the declared machine output. This obscures the distinction between model-visible content and `result.output` and differs from read, glob, and grep.

**What Changes**
Rename the three exported helpers and their executor call sites to `toModelContent`. Their signatures and implementations are otherwise identical: for example, creating `src/new.txt` still emits `Created file successfully: src/new.txt`, while `result.output` remains the same structured write result.

All generated strings, declared `Output` schemas, machine output, metadata, permissions, and execution behavior remain unchanged. Existing literal-content and machine-output assertions are reused without test changes.

**Scope**
Only the write, patch, and question helper names and a Core changeset. `Skill.toModelOutput` remains unchanged because it also populates the skill output pathway; no shared formatter or compatibility aliases are introduced. The helpers are reachable through Core package exports, so direct imports must use the new name. No documented or additional in-repo helper consumers were found.

**Verification**
```bash
# Repository root
bun install --frozen-lockfile

# packages/core
bun run test ./test/tool-write.test.ts ./test/tool-patch.test.ts ./test/tool-question.test.ts ./test/patch.test.ts
bun typecheck

# Repository root
git diff --check
git diff --cached --check
git push -u origin model-content-names
```
Focused tests: 97 passed, 0 failed across four files, including patch helper coverage. Core typecheck and both whitespace checks passed. The enabled pre-push hook also passed the repository typecheck: 33 successful tasks, 27 cached. No UI behavior change or demo is involved.