### PR TITLE
fix(core): reuse ignore checks during index refresh

### DIFF
--- a/.changeset/git-ignore-check.md
+++ b/.changeset/git-ignore-check.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Propagate fatal Git ignore-check errors during index refresh so best-effort snapshot capture returns unavailable instead of treating the check as having no matches.

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -398,22 +398,16 @@ const layer = Layer.effect(
         ],
         { concurrency: 2 },
       )
-      const candidates = Array.from(new Set([...tracked, ...untracked]))
+      const candidates = Array.from(new Set([...tracked, ...untracked])).map((file) => RelativePath.make(file))
       if (!candidates.length) return { skipped: [] }
-      const ignored = input.ignores
-        ? new Set(
-            (yield* repositoryOperation("refresh", input.ignores, ["check-ignore", "--no-index", "--stdin", "-z"], {
-              stdin: candidates.join("\0") + "\0",
-            }).pipe(Effect.orElseSucceed(() => ({ text: "", stderr: "" })))).text
-              .split("\0")
-              .filter(Boolean),
-          )
-        : new Set<string>()
-      const allowed = candidates.filter((item) => !ignored.has(item))
+      const excluded = input.ignores
+        ? yield* ignored({ repository: input.ignores, paths: candidates })
+        : new Set<RelativePath>()
+      const allowed = candidates.filter((item) => !excluded.has(item))
       const maximum = input.maximumUntrackedFileBytes
       const skipped = maximum
         ? (yield* Effect.forEach(
-            untracked.filter((item) => allowed.includes(item)),
+            untracked.filter((item) => allowed.includes(RelativePath.make(item))),
             (item) =>
               fs.stat(path.join(input.repository.worktree, item)).pipe(
                 Effect.map((info) =>
@@ -424,8 +418,8 @@ const layer = Layer.effect(
             { concurrency: 8 },
           )).filter((item): item is RelativePath => item !== undefined)
         : []
-      const stage = allowed.filter((item) => !skipped.includes(RelativePath.make(item)))
-      const remove = [...ignored, ...skipped]
+      const stage = allowed.filter((item) => !skipped.includes(item))
+      const remove = [...excluded, ...skipped]
       if (remove.length)
         yield* repositoryOperation(
           "refresh",

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -131,6 +131,66 @@ describe("Git worktrees", () => {
 })
 
 describe("Git trees", () => {
+  ;[0, 1, 128].forEach((exitCode) => {
+    it.live(`refresh handles check-ignore exit ${exitCode}`, () =>
+      Effect.gen(function* () {
+        const root = yield* Effect.acquireRelease(
+          Effect.promise(() => tmpdir()),
+          (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+        )
+        const project = path.join(root.path, "project")
+        const paths = ["scope/allowed.txt", "scope/ignored name.txt"].map((file) => RelativePath.make(file))
+        yield* Effect.promise(async () => {
+          await fs.mkdir(path.join(project, "scope"), { recursive: true })
+          await initRepo(project)
+          await Promise.all(paths.map((file) => Bun.write(path.join(project, file), "one\n")))
+          await $`git add .`.cwd(project).quiet()
+          await $`git commit -m initial`.cwd(project).quiet()
+        })
+        const git = yield* Git.Service
+        const source = yield* git.repo.discover(AbsolutePath.make(project))
+        if (!source) throw new Error("Repository not found")
+        const repository = yield* git.repo.create({
+          worktree: source.worktree,
+          gitDirectory: AbsolutePath.make(path.join(root.path, "storage")),
+          seed: source,
+        })
+        const before = yield* git.tree.write(repository)
+        yield* Effect.promise(async () => {
+          await Promise.all(paths.map((file) => Bun.write(path.join(project, file), "two\n")))
+          await Bun.write(path.join(source.gitDirectory, "info", "exclude"), exitCode === 0 ? `${paths[1]}\n` : "")
+          if (exitCode === 128) await Bun.write(path.join(source.gitDirectory, "config"), "[broken\n")
+          const result =
+            await $`git --git-dir ${source.gitDirectory} --work-tree ${source.worktree} check-ignore --no-index --stdin -z < ${Buffer.from(paths.join("\0") + "\0")}`
+              .cwd(project)
+              .quiet()
+              .nothrow()
+          expect(result.exitCode).toBe(exitCode)
+        })
+        const refresh = git.index.refresh({ repository, scope: RelativePath.make("scope"), ignores: source })
+        if (exitCode === 128) {
+          const error = yield* refresh.pipe(Effect.flip)
+          expect(error).toBeInstanceOf(Git.OperationError)
+          expect(error.message).toContain("bad config line")
+          expect(yield* git.tree.write(repository)).toBe(before)
+          expect(
+            yield* git.index.refresh({ repository, scope: RelativePath.make("missing"), ignores: source }),
+          ).toEqual({ skipped: [] })
+          return
+        }
+        expect(yield* git.index.ignored({ repository: source, paths })).toEqual(
+          new Set(exitCode === 0 ? [paths[1]] : []),
+        )
+        expect(yield* refresh).toEqual({ skipped: [] })
+        const after = yield* git.tree.write(repository)
+        expect((yield* git.tree.diff({ repository, from: before, to: after })).map((file) => file.status)).toEqual([
+          "modified",
+          exitCode === 0 ? "deleted" : "modified",
+        ])
+      }),
+    )
+  })
+
   it.live("lists both sides of a rename as separate file changes", () =>
     Effect.gen(function* () {
       const root = yield* Effect.acquireRelease(

--- a/packages/core/test/snapshot.test.ts
+++ b/packages/core/test/snapshot.test.ts
@@ -127,6 +127,31 @@ describe("Snapshot", () => {
     ),
   )
 
+  testEffect(Layer.empty).live("treats fatal ignore checks as unavailable captures", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          const project = path.join(tmp.path, "project")
+          yield* Effect.promise(async () => {
+            await fs.mkdir(project)
+            await Bun.write(path.join(project, "tracked.txt"), "one\n")
+            await initGit(project)
+          })
+          yield* Effect.gen(function* () {
+            const snapshot = yield* Snapshot.Service
+            expect(yield* snapshot.capture()).toBeDefined()
+            yield* Effect.promise(async () => {
+              await Bun.write(path.join(project, "tracked.txt"), "two\n")
+              await Bun.write(path.join(project, ".git", "config"), "[broken\n")
+            })
+            expect(yield* snapshot.capture()).toBeUndefined()
+          }).pipe(Effect.provide(snapshotLayer(tmp.path, project)))
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   testEffect(Layer.empty).live("applies availability transforms", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
## Why
A fatal source-repository `git check-ignore` error currently looks like no matching ignore rules during index refresh. This lets best-effort snapshot capture return a tree even though ignore evaluation failed.

## What Changes
`index.refresh` reuses the existing `index.ignored` helper instead of duplicating the command and swallowing every error. Candidate paths retain `RelativePath` branding, and the local result is renamed to avoid shadowing the helper.

| Ignore-check outcome | Refresh behavior |
| --- | --- |
| Exit 0: matching paths | Exclude matches from staging and remove matching cached entries. |
| Exit 1: no matches | Continue normally with an empty ignored set. |
| Fatal exit, including 128 | Propagate `Git.OperationError` before staging or removing entries. |

No-ignore and no-candidate behavior stays unchanged. `Snapshot.capture` remains the best-effort boundary: it logs a capture failure and returns `undefined` rather than exposing the Git error to callers.

Real-Git regressions cover source-only exclude rules for tracked paths, a filename containing spaces, exit 1, and deterministic exit 128 from a malformed source config. The fatal case checks that the index is unchanged and that an empty scope still succeeds. A separate Snapshot regression verifies the existing best-effort policy.

## Scope
A small core helper reuse, focused Git/Snapshot regression coverage, and an `@opencode-ai/core` patch changeset. No Git/Snapshot API redesign or UI changes.

## Verification
```sh
# Worktree root
bun install --frozen-lockfile

# packages/core
bun run test ./test/git.test.ts ./test/snapshot.test.ts ./test/config/snapshot.test.ts
bun typecheck

# Worktree root
bunx prettier --check packages/core/src/git.ts packages/core/test/git.test.ts packages/core/test/snapshot.test.ts .changeset/git-ignore-check.md
git diff --check
git diff --cached --check
git push -u origin git-ignore-check
```

- Baseline `1e7c60adce`: 12 focused tests passed; core typechecking passed.
- New regressions before the fix: 14 passed, 2 failed. Refresh incorrectly succeeded after exit 128, and Snapshot incorrectly returned a tree ID.
- After the fix: 16 focused tests passed, 0 failed, with 66 assertions. Core typechecking, formatting, and whitespace checks passed.
- Push succeeded with hooks enabled. The pre-push repository typecheck reported 33 successful tasks, including 27 cache hits.
- No unrelated baseline failures encountered. The full core test suite was not run.
