### PR TITLE
refactor(core): align MCP namespace casing

### DIFF
--- a/.changeset/mcp-namespace-case.md
+++ b/.changeset/mcp-namespace-case.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": minor
+---
+
+Rename the Core namespace exports `McpTool` and `McpInstructions` to `MCPTool` and `MCPInstructions`. Update imports to use the new names; module paths and runtime service keys are unchanged.

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -47,7 +47,7 @@ import { InstructionBuiltIns } from "./instructions/builtins.js"
 import { InstructionEntry } from "./session/instruction-entry.js"
 import { SessionInstructions } from "./session/instructions.js"
 import { SessionGenerateNode } from "./session/generate-node.js"
-import { McpTool } from "./tool/mcp.js"
+import { MCPTool } from "./tool/mcp.js"
 import { ReadToolFileSystem } from "./tool/read-filesystem.js"
 import { Tool } from "./tool.js"
 import { ToolOutput } from "./tool-output.js"
@@ -94,7 +94,7 @@ const locationServiceNodes = [
   Generate.node,
   SessionGenerateNode.node,
   ReadToolFileSystem.node,
-  McpTool.node,
+  MCPTool.node,
   SessionInstructions.node,
   SessionRunnerModel.node,
   SessionModelTransport.node,

--- a/packages/core/src/mcp/instructions.ts
+++ b/packages/core/src/mcp/instructions.ts
@@ -1,10 +1,10 @@
-export * as McpInstructions from "./instructions.js"
+export * as MCPInstructions from "./instructions.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Context, Effect, Layer, Schema } from "effect"
 import { Agent } from "../agent.js"
 import { Permission } from "../permission.js"
-import { McpTool } from "../tool/mcp.js"
+import { MCPTool } from "../tool/mcp.js"
 import { MCP } from "./index.js"
 import { Instructions } from "../instructions/index.js"
 
@@ -20,7 +20,7 @@ const entries = (servers: ReadonlyArray<Summary>) =>
     const result = [`  <server name="${server.server}">`]
     if (server.codemode !== false)
       result.push(
-        `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(McpTool.namespace(server.server))}]\`.`,
+        `    Use tools from this server through \`execute\` under \`tools[${JSON.stringify(MCPTool.namespace(server.server))}]\`.`,
       )
     result.push(...server.instructions.split("\n").map((line) => `    ${line}`), "  </server>")
     return result
@@ -93,7 +93,7 @@ export const layer = Layer.effect(
             if (
               !owned.some(
                 (tool) =>
-                  Permission.evaluate(McpTool.name(tool.server, tool.name), "*", agent.permissions).effect !== "deny",
+                  Permission.evaluate(MCPTool.name(tool.server, tool.name), "*", agent.permissions).effect !== "deny",
               )
             )
               return []

--- a/packages/core/src/session/context.ts
+++ b/packages/core/src/session/context.ts
@@ -9,8 +9,8 @@ import { InstructionDiscovery } from "../instruction-discovery.js"
 import { Instructions } from "../instructions/index.js"
 import { InstructionBuiltIns } from "../instructions/builtins.js"
 import { Location } from "../location.js"
-import { McpInstructions } from "../mcp/instructions.js"
-import { McpTool } from "../tool/mcp.js"
+import { MCPInstructions } from "../mcp/instructions.js"
+import { MCPTool } from "../tool/mcp.js"
 import { PluginSupervisor } from "../plugin/supervisor.js"
 import { ReferenceInstructions } from "../reference/instructions.js"
 import { SkillInstructions } from "../skill/instructions.js"
@@ -64,8 +64,8 @@ const layer = Layer.effect(
     const discovery = yield* InstructionDiscovery.Service
     const entries = yield* InstructionEntry.Service
     const location = yield* Location.Service
-    const mcpInstructions = yield* McpInstructions.Service
-    const mcpTools = yield* McpTool.Service
+    const mcpInstructions = yield* MCPInstructions.Service
+    const mcpTools = yield* MCPTool.Service
     const models = yield* SessionRunnerModel.Service
     const plugins = yield* PluginSupervisor.Service
     const referenceInstructions = yield* ReferenceInstructions.Service
@@ -138,8 +138,8 @@ export const node = makeLocationNode({
     InstructionDiscovery.node,
     InstructionEntry.node,
     Location.node,
-    McpInstructions.node,
-    McpTool.node,
+    MCPInstructions.node,
+    MCPTool.node,
     PluginSupervisor.node,
     ReferenceInstructions.node,
     SessionRunnerModel.node,

--- a/packages/core/src/tool/mcp.ts
+++ b/packages/core/src/tool/mcp.ts
@@ -1,4 +1,4 @@
-export * as McpTool from "./mcp.js"
+export * as MCPTool from "./mcp.js"
 
 import { ToolFailure } from "@opencode-ai/ai"
 import { McpEvent } from "@opencode-ai/schema/mcp-event"

--- a/packages/core/test/mcp-instructions.test.ts
+++ b/packages/core/test/mcp-instructions.test.ts
@@ -3,9 +3,9 @@ import { Effect, Layer } from "effect"
 import { Agent } from "@opencode-ai/core/agent"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { MCP } from "@opencode-ai/core/mcp/index"
-import { McpInstructions } from "@opencode-ai/core/mcp/instructions"
+import { MCPInstructions } from "@opencode-ai/core/mcp/instructions"
 import { Permission } from "@opencode-ai/core/permission"
-import { McpTool } from "@opencode-ai/core/tool/mcp"
+import { MCPTool } from "@opencode-ai/core/tool/mcp"
 import { it } from "./lib/effect"
 import { readInitial, readUpdate } from "./lib/instructions"
 
@@ -22,7 +22,7 @@ const instructions = (server: string, text: string) =>
 const tool = (server: string, name = "search") => new MCP.Tool({ server: MCP.ServerName.make(server), name })
 
 const layer = (catalog: () => MCP.ServerInstructions[], tools: () => MCP.Tool[]) =>
-  AppNodeBuilder.build(McpInstructions.node, [
+  AppNodeBuilder.build(MCPInstructions.node, [
     [
       MCP.node,
       Layer.mock(MCP.Service, {
@@ -32,15 +32,15 @@ const layer = (catalog: () => MCP.ServerInstructions[], tools: () => MCP.Tool[])
     ],
   ])
 
-describe("McpInstructions", () => {
+describe("MCPInstructions", () => {
   it.effect("renders instructions for servers with at least one permitted tool", () =>
     Effect.gen(function* () {
-      const service = yield* McpInstructions.Service
+      const service = yield* MCPInstructions.Service
       const generation = yield* service
         .load(
           selection([
-            { action: McpTool.name("alpha", "restricted"), resource: "*", effect: "deny" },
-            { action: McpTool.name("hidden", "search"), resource: "*", effect: "deny" },
+            { action: MCPTool.name("alpha", "restricted"), resource: "*", effect: "deny" },
+            { action: MCPTool.name("hidden", "search"), resource: "*", effect: "deny" },
           ]),
         )
         .pipe(Effect.flatMap(readInitial))
@@ -77,7 +77,7 @@ describe("McpInstructions", () => {
 
   it.effect("omits instructions when the agent cannot use execute", () =>
     Effect.gen(function* () {
-      const service = yield* McpInstructions.Service
+      const service = yield* MCPInstructions.Service
       const generation = yield* service
         .load(selection([{ action: "execute", resource: "*", effect: "deny" }]))
         .pipe(Effect.flatMap(readInitial))
@@ -95,7 +95,7 @@ describe("McpInstructions", () => {
 
   it.effect("keeps MCP instructions when Code Mode is disabled and execute is denied", () =>
     Effect.gen(function* () {
-      const service = yield* McpInstructions.Service
+      const service = yield* MCPInstructions.Service
       const generation = yield* service
         .load(selection([{ action: "execute", resource: "*", effect: "deny" }]))
         .pipe(Effect.flatMap(readInitial))
@@ -122,7 +122,7 @@ describe("McpInstructions", () => {
   it.effect("restates guidance when Code Mode is disabled for a server", () => {
     let tools = [tool("alpha")]
     return Effect.gen(function* () {
-      const service = yield* McpInstructions.Service
+      const service = yield* MCPInstructions.Service
       const initialized = yield* service.load(selection()).pipe(Effect.flatMap(readInitial))
 
       tools = [new MCP.Tool({ server: MCP.ServerName.make("alpha"), name: "search", codemode: false })]
@@ -151,7 +151,7 @@ describe("McpInstructions", () => {
     let catalog = [instructions("alpha", "Alpha instructions")]
     const tools = [tool("alpha"), tool("beta")]
     return Effect.gen(function* () {
-      const service = yield* McpInstructions.Service
+      const service = yield* MCPInstructions.Service
       const initialized = yield* service.load(selection()).pipe(Effect.flatMap(readInitial))
 
       catalog = [instructions("alpha", "Alpha instructions"), instructions("beta", "Beta instructions")]

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -33,7 +33,7 @@ import { MCPStdio } from "@opencode-ai/core/mcp/stdio"
 import { Permission } from "@opencode-ai/core/permission"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
-import { McpTool } from "@opencode-ai/core/tool/mcp"
+import { MCPTool } from "@opencode-ai/core/tool/mcp"
 import { Tool } from "@opencode-ai/core/tool"
 import { DateTime, Deferred, Effect, Exit, Fiber, Layer, PubSub, Ref, Schedule, Schema, Sink, Stream } from "effect"
 import { TestClock } from "effect/testing"
@@ -351,7 +351,7 @@ const permissions = Layer.mock(Permission.Service, {
 })
 const events = Layer.mock(Bus.Service, { subscribe: () => Stream.never })
 const it = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Tool.node, McpTool.node]), [
+  AppNodeBuilder.build(LayerNode.group([Tool.node, MCPTool.node]), [
     [MCP.node, mcp],
     [Permission.node, permissions],
     [Bus.node, events],
@@ -371,8 +371,8 @@ describe("MCP errors", () => {
 })
 
 test("MCP tool names match V1 sanitization", () => {
-  expect(McpTool.namespace("context 7")).toBe("context_7")
-  expect(McpTool.name("context 7", "resolve.library/id")).toBe("context_7_resolve_library_id")
+  expect(MCPTool.namespace("context 7")).toBe("context_7")
+  expect(MCPTool.name("context 7", "resolve.library/id")).toBe("context_7_resolve_library_id")
 })
 
 test("preserves output schema validation across paginated tool discovery", async () => {
@@ -1298,7 +1298,7 @@ testEffect(Layer.empty).live("isolates invalid MCP tools and preserves plugin tr
 
     yield* Effect.gen(function* () {
       const registry = yield* Tool.Service
-      const registration = yield* McpTool.Service
+      const registration = yield* MCPTool.Service
       const bus = yield* Bus.Service
       yield* registration.flush
       expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual([
@@ -1408,7 +1408,7 @@ testEffect(Layer.empty).live("isolates invalid MCP tools and preserves plugin tr
     }).pipe(
       Effect.provide(
         Layer.fresh(
-          AppNodeBuilder.build(LayerNode.group([Tool.node, McpTool.node, Bus.node]), [
+          AppNodeBuilder.build(LayerNode.group([Tool.node, MCPTool.node, Bus.node]), [
             [
               MCP.node,
               Layer.mock(MCP.Service, {
@@ -1437,7 +1437,7 @@ testEffect(Layer.empty).effect("coalesces queued MCP tool notifications after in
   let reads = 0
   return Effect.gen(function* () {
     const registry = yield* Tool.Service
-    const registration = yield* McpTool.Service
+    const registration = yield* MCPTool.Service
     const bus = yield* Bus.Service
     yield* registration.flush
     expect(reads).toBe(1)
@@ -1451,7 +1451,7 @@ testEffect(Layer.empty).effect("coalesces queued MCP tool notifications after in
     expect((yield* toolDefinitions(registry)).map((tool) => tool.name)).toEqual(["demo_read_3", "execute"])
   }).pipe(
     Effect.provide(
-      AppNodeBuilder.build(LayerNode.group([Tool.node, McpTool.node, Bus.node]), [
+      AppNodeBuilder.build(LayerNode.group([Tool.node, MCPTool.node, Bus.node]), [
         [
           MCP.node,
           Layer.mock(MCP.Service, {

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -21,7 +21,7 @@ import { InstructionDiscovery } from "@opencode-ai/core/instruction-discovery"
 import { Instructions } from "@opencode-ai/core/instructions/index"
 import { InstructionBuiltIns } from "@opencode-ai/core/instructions/builtins"
 import { Location } from "@opencode-ai/core/location"
-import { McpInstructions } from "@opencode-ai/core/mcp/instructions"
+import { MCPInstructions } from "@opencode-ai/core/mcp/instructions"
 import { ID } from "@opencode-ai/core/model"
 import { Project } from "@opencode-ai/core/project"
 import { Provider } from "@opencode-ai/core/provider"
@@ -109,7 +109,7 @@ const discovery = Layer.mock(InstructionDiscovery.Service, {
 })
 const skills = Layer.mock(SkillInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
 const references = Layer.mock(ReferenceInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
-const mcp = Layer.mock(McpInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
+const mcp = Layer.mock(MCPInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
 const plugins = Layer.mock(PluginSupervisor.Service, { flush: Effect.void })
 const tools = Layer.mock(Tool.Service, {
   snapshot: () =>
@@ -148,7 +148,7 @@ const it = testEffect(
       [InstructionDiscovery.node, discovery],
       [SkillInstructions.node, skills],
       [ReferenceInstructions.node, references],
-      [McpInstructions.node, mcp],
+      [MCPInstructions.node, mcp],
       [PluginSupervisor.node, plugins],
       [Tool.node, tools],
       [Location.node, Location.boundNode({ directory: AbsolutePath.make("/project") })],

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -34,7 +34,7 @@ import { InstructionDiscovery } from "@opencode-ai/core/instruction-discovery"
 import { Instructions } from "@opencode-ai/core/instructions/index"
 import { SkillInstructions } from "@opencode-ai/core/skill/instructions"
 import { ReferenceInstructions } from "@opencode-ai/core/reference/instructions"
-import { McpInstructions } from "@opencode-ai/core/mcp/instructions"
+import { MCPInstructions } from "@opencode-ai/core/mcp/instructions"
 import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
 import { SystemPromptPlugin } from "@opencode-ai/core/plugin/system-prompt"
@@ -83,7 +83,7 @@ const skillInstructions = Layer.mock(SkillInstructions.Service, { load: () => Ef
 const referenceInstructions = Layer.mock(ReferenceInstructions.Service, {
   load: () => Effect.succeed(Instructions.empty),
 })
-const mcpInstructions = Layer.mock(McpInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
+const mcpInstructions = Layer.mock(MCPInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
 const config = Config.testLayer()
 const pluginSupervisor = Layer.succeed(PluginSupervisor.Service, PluginSupervisor.Service.of({ flush: Effect.void }))
 const promptCatalog = Layer.mock(Catalog.Service, {
@@ -110,7 +110,7 @@ const runnerLayer = (llmClient: Layer.Layer<typeof LLMClient.Service>) =>
     [Location.node, Location.boundNode({ directory: AbsolutePath.make("/project") })],
     [SkillInstructions.node, skillInstructions],
     [ReferenceInstructions.node, referenceInstructions],
-    [McpInstructions.node, mcpInstructions],
+    [MCPInstructions.node, mcpInstructions],
     [Config.node, config],
     [Permission.node, permission],
     [PluginSupervisor.node, pluginSupervisor],

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -71,7 +71,7 @@ import { InstructionBuiltIns } from "@opencode-ai/core/instructions/builtins"
 import { InstructionDiscovery } from "@opencode-ai/core/instruction-discovery"
 import { SkillInstructions } from "@opencode-ai/core/skill/instructions"
 import { ReferenceInstructions } from "@opencode-ai/core/reference/instructions"
-import { McpInstructions } from "@opencode-ai/core/mcp/instructions"
+import { MCPInstructions } from "@opencode-ai/core/mcp/instructions"
 import { SessionSystemPrompt } from "@opencode-ai/core/session/system-prompt"
 import { ID } from "@opencode-ai/core/model"
 import { Location } from "@opencode-ai/core/location"
@@ -358,7 +358,7 @@ const skillInstructions = Layer.mock(SkillInstructions.Service, {
 const referenceInstructions = Layer.mock(ReferenceInstructions.Service, {
   load: () => Effect.succeed(Instructions.empty),
 })
-const mcpInstructions = Layer.mock(McpInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
+const mcpInstructions = Layer.mock(MCPInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })
 const config = Config.testLayer([
   new Document({
     type: "document",
@@ -402,7 +402,7 @@ const runnerLayer = AppNodeBuilder.build(SessionRunnerLLM.node, [
   [ReferenceInstructions.node, referenceInstructions],
   [Permission.node, permission],
   [Config.node, config],
-  [McpInstructions.node, mcpInstructions],
+  [MCPInstructions.node, mcpInstructions],
   [PluginSupervisor.node, pluginSupervisor],
   [SessionModelTransport.node, modelTransport],
 ])


### PR DESCRIPTION
## Why

Core's `McpTool` and `McpInstructions` namespace exports use different acronym casing from neighboring `MCP`, `MCPClient`, `MCPStdio`, and `MCPOAuth` modules. Aligning the names makes imports consistent.

## What Changes

| Before | After |
| --- | --- |
| `McpTool` | `MCPTool` |
| `McpInstructions` | `MCPInstructions` |

Update all repository callers and existing test references, and add a Core changeset documenting the import rename. Runtime `Context.Service` keys remain `@opencode/McpTool` and `@opencode/McpInstructions`; the existing trace label is unchanged.

## Scope

V2 namespace/import naming only, with no filename moves, schema/wire/error changes, or runtime/UI behavior changes. No aliases were added: repository documentation and targeted GitHub code searches found no confirmed external consumer of these namespace imports.

## Verification

```bash
# Worktree root
bun install --frozen-lockfile
git diff --check
git diff --cached --check
git diff HEAD^ --name-only | xargs bunx prettier --check
git push -u origin mcp-namespace-case

# packages/core
bun run test ./test/mcp-instructions.test.ts ./test/mcp.test.ts ./test/session-generate.test.ts
bun typecheck
```

The fresh base (`1e7c60adce`) and changed branch both passed Core typechecking and all 48 targeted tests (182 assertions). Installation, whitespace checks, and formatting passed. Tests use local/in-memory MCP fixtures and a stub LLM; remote credential/provider integration tests were not run. No baseline failures were observed in these checks.

Push hooks were not bypassed. The pre-push workspace typecheck passed all 33 tasks (27 cached).
