### PR TITLE
fix(app): keep active tools in existing groups

### DIFF
--- a/packages/app/e2e/regression/session-timeline-notices.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-notices.spec.ts
@@ -208,6 +208,56 @@ test("navigates from a running subagent card and hides background controls in th
   await expect(page.getByText(/move running work to the background/i)).toHaveCount(0)
 })
 
+for (const name of ["shell", "subagent"] as const) {
+  test(`keeps the background shortcut available for a grouped running ${name}`, async ({ page }) => {
+    const message = assistant(false, true)
+    await setupTimeline(page, {
+      sessionMessages: [
+        user,
+        {
+          ...message,
+          content: [
+            {
+              type: "tool",
+              id: "call_read",
+              name: "read",
+              state: {
+                status: "completed",
+                input: { path: "src/example.ts" },
+                content: [{ type: "text", text: "export const example = true" }],
+                metadata: {},
+              },
+              time: { created: 1, completed: 2 },
+            },
+            {
+              type: "tool",
+              id: "call_running",
+              name,
+              state: {
+                status: "running",
+                input:
+                  name === "shell" ? { command: "echo checking" } : { agent: "general", description: "Inspect code" },
+                metadata: {},
+              },
+              time: { created: 3 },
+            },
+          ],
+        },
+      ],
+    })
+    const group = page.locator('[data-timeline-part-ids="call_read,call_running"]')
+    await expect(group).toBeVisible()
+    await expect(group.locator('[data-slot="collapsible-trigger"]')).toHaveAttribute("aria-expanded", "false")
+    await expect(page.locator('[data-component="session-background-hint"]')).toBeVisible()
+    const request = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" && new URL(request.url()).pathname === `/api/session/${sessionID}/background`,
+    )
+    await page.keyboard.press("Control+b")
+    await request
+  })
+}
+
 test("shows a badge for active background work", async ({ page }) => {
   const childID = "ses_background_child"
   await setupTimeline(page, {

--- a/packages/app/e2e/regression/session-timeline-reducer-projection.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-reducer-projection.spec.ts
@@ -44,7 +44,7 @@ test("expands a mixed collapsed tool stack without expanding its individual call
   const group = page.locator(
     '[data-timeline-part-ids="prt_stack_shell_1,prt_stack_explore,prt_stack_patch,prt_stack_shell_2"]',
   )
-  const summary = group.getByRole("button", { name: "Used Shell, Explore, Patch" })
+  const summary = group.getByRole("button", { name: "Used Shell, Agent, Patch" })
   await expect(summary).toHaveAttribute("aria-expanded", "false")
   await expect(summary).toHaveCSS("height", "28px")
   await expect(group.locator('[data-component="tag"]')).toHaveText("4")

--- a/packages/app/e2e/regression/subagent-child-navigation.spec.ts
+++ b/packages/app/e2e/regression/subagent-child-navigation.spec.ts
@@ -52,7 +52,7 @@ test("shows parent lineage while the child timeline loads", async ({ page }) => 
 
   await page.goto(sessionHref(parentID))
   await expectSessionTitle(page, parentTitle)
-  await page.getByRole("button", { name: "Used Explore" }).click()
+  await page.getByRole("button", { name: "Used Agent" }).click()
   await page.locator(`a[href="${sessionHref(childID)}"]`).click()
   await Promise.all([requested.promise, expect(page).toHaveURL(sessionHref(childID))])
   await Promise.all([
@@ -77,7 +77,7 @@ test("keeps the parent visible while the child session resolves", async ({ page 
   await page.goto(sessionHref(parentID))
   await expectSessionTitle(page, parentTitle)
 
-  await page.getByRole("button", { name: "Used Explore" }).click()
+  await page.getByRole("button", { name: "Used Agent" }).click()
   await page.locator(`a[href="${sessionHref(childID)}"]`).click()
   await requested.promise
   await Promise.all([expect(page).toHaveURL(sessionHref(parentID)), expectSessionTitle(page, parentTitle)]).finally(
@@ -195,7 +195,7 @@ async function setup(page: Page, events?: () => OpenCodeEvent[]) {
 async function openChildFromParent(page: Page) {
   await page.goto(sessionHref(parentID))
   await expectSessionTitle(page, parentTitle)
-  await page.getByRole("button", { name: "Used Explore" }).click()
+  await page.getByRole("button", { name: "Used Agent" }).click()
 
   const card = page.locator(`a[href="${sessionHref(childID)}"]`)
   await expect(card).toBeVisible()

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -349,8 +349,7 @@ function MessageTimelineView(
       : projects.find((item) => containsDirectory(item.worktree, sessionDirectory()))
   })
   const workspaceSession = createMemo(() => isWorkspaceDirectory(project(), sessionDirectory()))
-  const showProjectIcon = () =>
-    import.meta.env.VITE_OPENCODE_CHANNEL !== "prod" && settings.general.showProjectIcon()
+  const showProjectIcon = () => import.meta.env.VITE_OPENCODE_CHANNEL !== "prod" && settings.general.showProjectIcon()
   const avatarProject = createMemo(() => {
     if (!showProjectIcon()) return
     const session = props.session.data.info()
@@ -469,13 +468,13 @@ function MessageTimelineView(
   })
   const backgroundHintPartID = createMemo(() => {
     const blocking = new Set(props.background.blocking().map((task) => task.partID))
-    const row = projection
+    if (blocking.size === 0) return
+    return projection
       .rows()
-      .findLast(
-        (row) => row._tag === "AssistantPart" && row.group.type === "part" && blocking.has(row.group.ref.partID),
+      .flatMap((row) =>
+        row._tag === "AssistantPart" ? (row.group.type === "part" ? [row.group.ref] : row.group.refs) : [],
       )
-    if (row?._tag !== "AssistantPart" || row.group.type !== "part") return
-    return row.group.ref.partID
+      .findLast((ref) => blocking.has(ref.partID))?.partID
   })
   const [backgroundHintRef, setBackgroundHintRef] = createSignal<HTMLDivElement>()
   const backgroundHintPresence = createAnimatedPresence(backgroundHintPartID, () => backgroundHintRef() ?? null)

--- a/packages/session-ui/component-tests/session-lifecycle.spec.ts
+++ b/packages/session-ui/component-tests/session-lifecycle.spec.ts
@@ -1,5 +1,32 @@
 import { expect, story } from "../../storybook/playwright/story"
 
+for (const tool of ["shell", "execute", "subagent"]) {
+  for (const open of [false, true]) {
+    story(`keeps ${tool} inside an existing ${open ? "open" : "closed"} group through execution`, async ({ mount }) => {
+      const timeline = await mount("current-session-terminal-work--terminal-commands", {
+        args: { existingGroup: true, tool },
+      })
+      const group = timeline.locator('[data-component="collapsed-tool-group"]')
+      const trigger = group.locator(':scope > [data-component="collapsible"] > [data-slot="collapsible-trigger"]')
+      await expect(group).toHaveAttribute("data-timeline-part-ids", "tool_context_lifecycle")
+      if (open) await trigger.click()
+      await expect(trigger).toHaveAttribute("aria-expanded", String(open))
+      await timeline.getByRole("button", { name: "Start tool", exact: true }).click()
+      await expect(group).toHaveAttribute("data-timeline-part-ids", "tool_context_lifecycle,tool_shell_lifecycle")
+      const original = await group.elementHandle()
+      for (const action of [undefined, "Complete input", "Run command", "Complete command"]) {
+        if (action) await timeline.getByRole("button", { name: action, exact: true }).click()
+        await expect(group).toHaveAttribute("data-timeline-part-ids", "tool_context_lifecycle,tool_shell_lifecycle")
+        await expect(group.locator('[data-component="tag"]')).toHaveText("2")
+        await expect(timeline.locator('[data-timeline-row="AssistantPart"]')).toHaveCount(1)
+        await expect(trigger).toHaveAttribute("aria-expanded", String(open))
+        expect(await original!.evaluate((node) => node.isConnected)).toBe(true)
+        if (open) await expect(group.locator('[data-timeline-part-id="tool_shell_lifecycle"]')).toBeVisible()
+      }
+    })
+  }
+}
+
 for (const expanded of [false, true]) {
   // Moved from packages/app/e2e/regression/session-timeline-lifecycle-state.spec.ts
   story(`preserves shell user intent from a ${expanded ? "expanded" : "collapsed"} default`, async ({ mount }) => {

--- a/packages/session-ui/component-tests/tool-group.spec.ts
+++ b/packages/session-ui/component-tests/tool-group.spec.ts
@@ -1,0 +1,51 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+story("summarizes subagents as Agent while retaining their card titles", async ({ mount }) => {
+  const root = await mount("current-tool-group--mixed-tools")
+  const group = root.locator('[data-component="collapsed-tool-group"]')
+  await expect(group.getByRole("button", { name: "Used Shell, Read, Agent", exact: true })).toBeVisible()
+  await expect(group.locator('[data-component="tag"]')).toHaveText("4")
+  await expect(group.locator('[data-component="task-tool-title"]')).toHaveText(["General", "Explore"])
+})
+
+for (const width of [840, 390]) {
+  story(`keeps grouped cards inside their trigger bounds at ${width}px`, async ({ mount, page }) => {
+    await page.setViewportSize({ width, height: 600 })
+    const root = await mount("current-tool-group--mixed-tools")
+    const group = root.locator('[data-component="collapsed-tool-group"]')
+    const cards = group.locator('[data-component="task-tool-surface"]')
+    await expect(cards).toHaveCount(2)
+    await expect
+      .poll(() =>
+        cards.evaluateAll((nodes) =>
+          nodes.map((node) => {
+            const card = node.getBoundingClientRect()
+            const trigger = node.closest('[data-component="tool-trigger"]')!.getBoundingClientRect()
+            const item = node.closest('[data-slot="context-tool-group-item"]')!.getBoundingClientRect()
+            return (
+              card.height === 36 &&
+              card.top >= trigger.top &&
+              card.bottom <= trigger.bottom &&
+              card.top >= item.top &&
+              card.bottom <= item.bottom
+            )
+          }),
+        ),
+      )
+      .toEqual([true, true])
+    const shell = group.locator('[data-timeline-part-id="group_shell"]')
+    await expect(shell.locator('[data-slot="collapsible-trigger"]')).toHaveCSS("height", "28px")
+    await shell.getByRole("button").click()
+    await expect(shell.locator('[data-slot="bash-command"]')).toHaveText("printf 'group geometry'")
+    await expect(shell.locator('[data-slot="bash-result"]')).toHaveText("group geometry")
+    await expect
+      .poll(() =>
+        shell.evaluate((node) => {
+          const card = node.querySelector('[data-component="bash-output"]')!.getBoundingClientRect()
+          const item = node.closest('[data-slot="context-tool-group-item"]')!.getBoundingClientRect()
+          return card.top >= item.top && card.bottom <= item.bottom
+        }),
+      )
+      .toBe(true)
+  })
+}

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -724,7 +724,9 @@
       width: 100%;
     }
 
-    > [data-component="tool-part-wrapper"] > [data-component="collapsible"] > [data-slot="collapsible-trigger"] {
+    > [data-component="tool-part-wrapper"]
+      > [data-component="collapsible"]
+      > [data-slot="collapsible-trigger"]:not([data-hide-details="true"]) {
       height: 28px;
     }
 

--- a/packages/session-ui/src/timeline/projection.ts
+++ b/packages/session-ui/src/timeline/projection.ts
@@ -508,7 +508,9 @@ function groupContent(
 
   items.forEach((item) => {
     const type =
-      item.content.type === "tool" ? toolGroupType(item.content, shellToolDefaultOpen, editToolDefaultOpen) : undefined
+      item.content.type === "tool"
+        ? toolGroupType(item.content, shellToolDefaultOpen, editToolDefaultOpen, adjacent?.type === "context")
+        : undefined
     if (type) {
       if (adjacent?.type !== type) flush()
       adjacent ??= { type, refs: [] }
@@ -526,7 +528,12 @@ function groupContent(
   return groups
 }
 
-function toolGroupType(content: Extract<Content, { type: "tool" }>, shellExpanded: boolean, editExpanded: boolean) {
+function toolGroupType(
+  content: Extract<Content, { type: "tool" }>,
+  shellExpanded: boolean,
+  editExpanded: boolean,
+  hasContextGroup: boolean,
+) {
   if (content.name === "question" || hasLoadedFiles(content)) return undefined
   if (content.state.status === "error") {
     if ((content.name === "shell" || content.name === "execute") && shellExpanded) return undefined
@@ -535,6 +542,7 @@ function toolGroupType(content: Extract<Content, { type: "tool" }>, shellExpande
     return "context"
   }
   if (
+    !hasContextGroup &&
     (content.state.status !== "completed" ||
       ("metadata" in content.state && content.state.metadata?.status === "running")) &&
     (content.name === "shell" || content.name === "execute" || content.name === "subagent")

--- a/packages/session-ui/src/timeline/rows-current.test.ts
+++ b/packages/session-ui/src/timeline/rows-current.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { SessionMessageAssistantTool, SessionMessageInfo } from "@opencode-ai/client/promise"
-import { Timeline, TimelineRow } from "./projection"
+import { storyDocument, storyTool } from "../storybook/current-session-scenarios"
+import { createTimelineProjection, Timeline, TimelineRow } from "./projection"
 
 describe("current session timeline rows", () => {
   test("derives turns and tagged rows from chronological current messages", () => {
@@ -724,7 +725,72 @@ describe("current session timeline rows", () => {
     expect(rows.flatMap((row) => (row._tag === "AssistantPart" ? [row.group.type] : []))).toEqual([...types])
   })
 
-  test("keeps active and background work visible outside collapsed stacks", () => {
+  test.each(["shell", "execute", "subagent"])("keeps %s in an existing group throughout execution", (name) => {
+    const initial = createTimelineProjection({
+      sessionMessages: storyDocument([storyTool("earlier", "read", "completed", {})]).messages,
+      status: { type: "busy" },
+      showReasoningSummaries: false,
+    })
+    const phases = [
+      { status: "streaming" },
+      { status: "running" },
+      { status: "completed", metadata: { status: "running" } },
+      { status: "completed" },
+      { status: "error" },
+    ] as const
+    phases.reduce((previousRows, phase, index) => {
+      const result = createTimelineProjection({
+        sessionMessages: [
+          ...storyDocument([storyTool("earlier", "read", "completed", {})]).messages,
+          ...storyDocument([
+            storyTool("active", name, phase.status, {}, "metadata" in phase ? { metadata: phase.metadata } : {}),
+          ])
+            .messages.filter((message) => message.type === "assistant")
+            .map((message) => ({ ...message, id: "next-step" })),
+        ],
+        status: { type: "busy" },
+        showReasoningSummaries: false,
+        previousRows,
+      })
+      const groups = result.rows.filter((row) => row._tag === "AssistantPart")
+      expect(groups).toHaveLength(1)
+      expect(groups[0].group).toMatchObject({
+        type: "context",
+        refs: [
+          { messageID: "msg_tool_projection_assistant", partID: "earlier" },
+          { messageID: "next-step", partID: "active" },
+        ],
+      })
+      expect(TimelineRow.key(groups[0])).toBe(TimelineRow.key(initial.rows[1]))
+      if (index > 0) expect(groups[0]).toBe(previousRows.find((row) => row._tag === "AssistantPart")!)
+      return result.rows
+    }, initial.rows)
+  })
+
+  test.each([
+    { name: "shell", expanded: true, types: ["context", "part"] },
+    { name: "execute", expanded: true, types: ["context", "part"] },
+    { name: "subagent", expanded: true, types: ["context"] },
+    { name: "shell", separator: "text", types: ["context", "part", "part"] },
+    { name: "shell", separator: "reasoning", showReasoning: true, types: ["context", "part", "part"] },
+    { name: "shell", separator: "reasoning", showReasoning: false, types: ["context"] },
+  ] as const)("respects active tool grouping boundaries: %j", (profile) => {
+    const content = [
+      storyTool("earlier", "read", "completed", {}),
+      ...(profile.separator ? [{ type: profile.separator, text: "Visible boundary" }] : []),
+      storyTool("active", profile.name, "running", {}),
+    ]
+    const rows = Timeline.constructSessionMessageRows(
+      storyDocument(content).messages,
+      profile.showReasoning ?? false,
+      { type: "busy" },
+      undefined,
+      profile.expanded ?? false,
+    ).rows
+    expect(rows.flatMap((row) => (row._tag === "AssistantPart" ? [row.group.type] : []))).toEqual([...profile.types])
+  })
+
+  test("keeps active and background work standalone when no group precedes them", () => {
     const source: SessionMessageInfo[] = [
       { id: "msg_user", type: "user", text: "work", time: { created: 1 } },
       {

--- a/packages/session-ui/src/timeline/terminal-work.stories.tsx
+++ b/packages/session-ui/src/timeline/terminal-work.stories.tsx
@@ -125,34 +125,63 @@ export const TestFailed = {
   ),
 }
 
-function InteractiveCommandStory(props: { expanded?: boolean; streaming?: boolean }) {
+function InteractiveCommandStory(props: {
+  expanded?: boolean
+  streaming?: boolean
+  existingGroup?: boolean
+  tool?: "shell" | "execute" | "subagent"
+}) {
   const [state, setState] = createStore({
     phase: props.streaming ? "streaming" : "completed",
+    started: !props.existingGroup,
     lines: 3,
     sibling: false,
     busy: false,
   })
   const document = createMemo(() => {
     const phase = state.phase as "streaming" | "input" | "running" | "completed"
-    const command = phase === "streaming" ? "" : "printf ready"
     const content: SessionMessageAssistant["content"] = [
-      storyTool("tool_shell_lifecycle", "shell", phase === "input" ? "streaming" : phase, command ? { command } : {}, {
-        output:
-          phase === "running"
-            ? "still running"
-            : Array.from({ length: state.lines }, (_, index) => `line ${index + 1}`).join("\n"),
-        ...(phase === "streaming" ? { raw: "" } : {}),
-      }),
+      ...(props.existingGroup
+        ? [storyTool("tool_context_lifecycle", "read", "completed", { filePath: "/workspace/README.md" })]
+        : []),
+      ...(state.started
+        ? [
+            storyTool(
+              "tool_shell_lifecycle",
+              props.tool ?? "shell",
+              phase === "input" ? "streaming" : phase,
+              phase === "streaming"
+                ? {}
+                : props.tool === "execute"
+                  ? { code: 'console.log("ready")' }
+                  : props.tool === "subagent"
+                    ? { description: "Inspect lifecycle", agent: "explore", prompt: "Inspect lifecycle" }
+                    : { command: "printf ready" },
+              {
+                output:
+                  phase === "running"
+                    ? "still running"
+                    : Array.from({ length: state.lines }, (_, index) => `line ${index + 1}`).join("\n"),
+                ...(phase === "streaming" ? { raw: "" } : {}),
+              },
+            ),
+          ]
+        : []),
       ...(state.sibling ? [{ type: "text" as const, text: "Sibling content" }] : []),
     ]
     return {
-      ...storyDocument(content, phase !== "completed"),
-      status: { type: phase !== "completed" || state.busy ? ("busy" as const) : ("idle" as const) },
+      ...storyDocument(content, state.started && phase !== "completed"),
+      status: { type: (state.started && phase !== "completed") || state.busy ? ("busy" as const) : ("idle" as const) },
     }
   })
   return (
     <section class="mx-auto flex w-full max-w-[720px] flex-col gap-4 p-6">
-      <div class="flex gap-3">
+      <div class="flex flex-wrap gap-3">
+        {props.existingGroup && (
+          <button type="button" onClick={() => setState({ started: true, phase: "streaming" })}>
+            Start tool
+          </button>
+        )}
         <button type="button" onClick={() => setState("phase", "input")}>
           Complete input
         </button>
@@ -182,16 +211,19 @@ function InteractiveCommandStory(props: { expanded?: boolean; streaming?: boolea
   )
 }
 
-const RunACommand = {
-  args: { expanded: false, streaming: false },
-  render: (args: { expanded: boolean; streaming: boolean }) => <InteractiveCommandStory {...args} />,
-}
-
 export const TerminalCommands = {
-  args: { scenario: "command", expanded: false, streaming: false },
-  argTypes: { scenario: { control: "select", options: ["command", "collapsed"] } },
-  render: (args: { scenario: string; expanded: boolean; streaming: boolean }) =>
-    args.scenario === "collapsed" ? CollapsedShell.render() : RunACommand.render(args),
+  args: { scenario: "command", expanded: false, streaming: false, existingGroup: false, tool: "shell" },
+  argTypes: {
+    scenario: { control: "select", options: ["command", "collapsed"] },
+    tool: { control: "select", options: ["shell", "execute", "subagent"] },
+  },
+  render: (args: {
+    scenario: string
+    expanded: boolean
+    streaming: boolean
+    existingGroup: boolean
+    tool: "shell" | "execute" | "subagent"
+  }) => (args.scenario === "collapsed" ? CollapsedShell.render() : <InteractiveCommandStory {...args} />),
 }
 
 export const FixedAndPassed = {

--- a/packages/session-ui/src/tools/tool-group.stories.tsx
+++ b/packages/session-ui/src/tools/tool-group.stories.tsx
@@ -1,0 +1,35 @@
+import { createSignal } from "solid-js"
+import { CurrentSessionProviders } from "../storybook/current-session-story"
+import { storyDocument, storyTool } from "../storybook/current-session-scenarios"
+import { CurrentContextToolGroup } from "./tool-renderer"
+
+export default {
+  title: "OpenCode/Work/Tool group",
+  id: "current-tool-group",
+  component: CurrentContextToolGroup,
+}
+
+export const MixedTools = {
+  render: () => {
+    const [open, setOpen] = createSignal(true)
+    const tools = [
+      storyTool(
+        "group_shell",
+        "shell",
+        "completed",
+        { command: "printf 'group geometry'" },
+        { output: "group geometry" },
+      ),
+      storyTool("group_read", "read", "completed", { path: "src/group.ts" }),
+      storyTool("group_general", "subagent", "completed", { agent: "general", description: "Inspect grouped tools" }),
+      storyTool("group_explore", "subagent", "completed", { agent: "explore", description: "Check card geometry" }),
+    ]
+    return (
+      <section style={{ width: "100%", "max-width": "720px", padding: "24px" }}>
+        <CurrentSessionProviders document={storyDocument(tools)}>
+          <CurrentContextToolGroup tools={tools} busy={false} open={open()} onOpenChange={setOpen} />
+        </CurrentSessionProviders>
+      </section>
+    )
+  },
+}

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -487,8 +487,7 @@ export function CurrentContextToolGroup(props: {
         props.tools.map((tool) => {
           const input = currentToolInput(tool)
           if (tool.name === "skill") return i18n.t("ui.tool.skill")
-          if (tool.name === "subagent" && typeof input.agent === "string" && input.agent)
-            return input.agent[0]!.toUpperCase() + input.agent.slice(1)
+          if (tool.name === "subagent") return i18n.t("ui.tool.agent.default")
           return getToolInfo(tool.name, input, currentToolMetadata(tool)).title
         }),
       ),


### PR DESCRIPTION
## Summary

- Append streaming/running shell, execute, and subagent calls directly to an adjacent Used group instead of showing a standalone row that disappears on completion.
- Keep a first active tool standalone; respect expanded-tool preferences and visible text/reasoning boundaries.
- Use the localized Agent label in mixed-tool summaries. Detail cards retain their specific agent names.
- Stop forcing 36px agent cards into 28px grouped rows, which clipped 4px from each edge. Compact shell rows stay 28px; expanded shell output is also covered by bounds checks.
- Keep the Ctrl+B background shortcut available for grouped running tools.

Individual tool/file disclosure-state preservation across regrouping is intentionally reserved for a separate follow-up PR.

## Screenshots

Real production components with deterministic fixtures, no model selector or private session data. Images are hosted outside the code branch.

Before: the running shell is outside the existing group.

![Running shell before](https://raw.githubusercontent.com/Hona/opencode/793d75047e1a05e4734bfda16b4dea18a5ae0574/.github/pr-evidence/steady-tool-groups/before-running.png)

After: it is already inside Used Shell, and the background shortcut remains available.

![Running shell after](https://raw.githubusercontent.com/Hona/opencode/793d75047e1a05e4734bfda16b4dea18a5ae0574/.github/pr-evidence/steady-tool-groups/after-running.png)

Before: specific agent names in the summary and clipped detail cards.

![Group before](https://raw.githubusercontent.com/Hona/opencode/793d75047e1a05e4734bfda16b4dea18a5ae0574/.github/pr-evidence/steady-tool-groups/before-group.png)

After: Agent in the summary, with full-height detail cards.

![Group after](https://raw.githubusercontent.com/Hona/opencode/793d75047e1a05e4734bfda16b4dea18a5ae0574/.github/pr-evidence/steady-tool-groups/after-group.png)

## Verification

- New projection tests fail before the grouping fix and pass after it.
- Session UI: 122 unit tests passed; typecheck passed.
- App: 543 unit tests and 56 browser-runtime tests passed; app and E2E typechecks passed.
- 19 relevant app E2E tests passed, including grouped background actions and child-session navigation.
- Six lifecycle component cases passed at desktop width and again at 390px: shell/execute/subagent, open/closed outer groups, streaming through completion without status-driven remounts.
- Three label/card geometry component tests passed, including desktop and 390px layouts.
- Component tests ran through a temporary Vite fixture harness with the production components and providers because the local Storybook executable was unavailable.
- Original and final production builds both rendered the running-shell screenshot reproduction successfully.
- Formatting and `git diff --check` passed.

## Production Benchmark

A production baseline was recorded before changes. The same streaming scenario was repeated serially against preserved builds: Chromium, one worker, no retries, 72 history entries, 32 deltas, 6x CPU throttle.

| Sample Set | Median Completion | Median RAF p95 |
| --- | ---: | ---: |
| Original build, 3 runs | 8929 ms | 583 ms |
| Final build, 3 runs | 11848 ms | 683 ms |
| Original build again, 3 runs | 8024 ms | 517 ms |

All runs delivered all deltas with no row/markdown replacement, bottom drift, or blank geometry. The final samples were slower; these measurements do not establish performance equivalence or isolate a cause. No machine-dependent threshold was added or weakened.

Based on `upstream/v2` at `8d7caa178b`.
