### PR TITLE
test(server): simplify scoped endpoint fixtures

### DIFF
--- a/packages/server/test/config.test.ts
+++ b/packages/server/test/config.test.ts
@@ -3,75 +3,60 @@ import path from "node:path"
 import { expect } from "bun:test"
 import { Config } from "@opencode-ai/schema/config"
 import { Effect, Schema } from "effect"
-import { HttpServer } from "effect/unstable/http"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import { it } from "../../core/test/lib/effect"
-import { ServerProcess } from "../src/process"
+import { startServer } from "./fixture/server"
 import { AbsolutePath } from "@opencode-ai/schema/schema"
 
 it.live("returns ordered config entries for the requested directory", () =>
-  Effect.acquireUseRelease(
-    Effect.promise(() => tmpdir("opencode-config-endpoint-")),
-    (tmp) =>
-      Effect.gen(function* () {
-        const global = path.join(tmp.path, "global")
-        const project = path.join(tmp.path, "project")
-        const config = path.join(project, "opencode.json")
-        yield* Effect.promise(() =>
-          Promise.all([fs.mkdir(global, { recursive: true }), fs.mkdir(project, { recursive: true })]),
-        )
-        yield* Effect.promise(() =>
-          fs.writeFile(
-            config,
-            JSON.stringify({
-              permissions: [
-                { action: "shell", resource: "*", effect: "ask" },
-                { action: "shell", resource: "git status", effect: "allow" },
-              ],
-              mcp: { servers: { docs: { type: "remote", url: "https://example.com/mcp" } } },
-            }),
-          ),
-        )
-        const server = yield* ServerProcess.start<never, never>({
-          hostname: "127.0.0.1",
-          port: 0,
-          password: "secret",
-          app: { version: "test-version" },
-          database: { path: ":memory:" },
-          config: { directory: global },
-          fs: { filewatcher: false },
-        })
-        const url = new URL("/api/config", HttpServer.formatAddress(server.address))
-        url.searchParams.set("location[directory]", project)
-        const response = yield* Effect.promise(() =>
-          fetch(url, { headers: { authorization: `Basic ${btoa("opencode:secret")}` } }),
-        )
-        const body: unknown = yield* Effect.promise(() => response.json())
-        const entries = Schema.decodeUnknownSync(Schema.Array(Config.Entry))(body)
+  Effect.gen(function* () {
+    const tmp = yield* Effect.acquireDisposable(Effect.promise(() => tmpdir("opencode-config-endpoint-")))
+    const global = path.join(tmp.path, "global")
+    const project = path.join(tmp.path, "project")
+    const config = path.join(project, "opencode.json")
+    yield* Effect.promise(() =>
+      Promise.all([fs.mkdir(global, { recursive: true }), fs.mkdir(project, { recursive: true })]),
+    )
+    yield* Effect.promise(() =>
+      fs.writeFile(
+        config,
+        JSON.stringify({
+          permissions: [
+            { action: "shell", resource: "*", effect: "ask" },
+            { action: "shell", resource: "git status", effect: "allow" },
+          ],
+          mcp: { servers: { docs: { type: "remote", url: "https://example.com/mcp" } } },
+        }),
+      ),
+    )
+    const server = yield* startServer(global)
+    const url = new URL("/api/config", server.base)
+    url.searchParams.set("location[directory]", project)
+    const response = yield* Effect.promise(() => fetch(url, { headers: server.headers }))
+    const body: unknown = yield* Effect.promise(() => response.json())
+    const entries = Schema.decodeUnknownSync(Schema.Array(Config.Entry))(body)
 
-        expect(response.status).toBe(200)
-        expect(Array.isArray(entries)).toBe(true)
-        const document = entries.find(
-          (entry): entry is Config.Document => entry.type === "document" && entry.path === config,
-        )
-        expect(document?.info.permissions).toEqual([
-          { action: "shell", resource: "*", effect: "ask" },
-          { action: "shell", resource: "git status", effect: "allow" },
-        ])
-        expect(document?.path).toBe(AbsolutePath.make(config))
-        if (!Array.isArray(body)) throw new Error("Expected a config entry array")
-        const raw = body.find((entry) => isRecord(entry) && entry["type"] === "document" && entry["path"] === config)
-        if (!isRecord(raw) || !isRecord(raw["info"])) throw new Error("Expected a config document")
-        expect(raw["info"]).not.toHaveProperty("default_agent")
-        expect(raw["info"]).not.toHaveProperty("model")
-        const mcp = raw["info"]["mcp"]
-        if (!isRecord(mcp) || !isRecord(mcp["servers"]) || !isRecord(mcp["servers"]["docs"]))
-          throw new Error("Expected an MCP server config")
-        expect(mcp["servers"]["docs"]).not.toHaveProperty("headers")
-        expect(mcp["servers"]["docs"]).not.toHaveProperty("oauth")
-      }),
-    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-  ),
+    expect(response.status).toBe(200)
+    expect(Array.isArray(entries)).toBe(true)
+    const document = entries.find(
+      (entry): entry is Config.Document => entry.type === "document" && entry.path === config,
+    )
+    expect(document?.info.permissions).toEqual([
+      { action: "shell", resource: "*", effect: "ask" },
+      { action: "shell", resource: "git status", effect: "allow" },
+    ])
+    expect(document?.path).toBe(AbsolutePath.make(config))
+    if (!Array.isArray(body)) throw new Error("Expected a config entry array")
+    const raw = body.find((entry) => isRecord(entry) && entry["type"] === "document" && entry["path"] === config)
+    if (!isRecord(raw) || !isRecord(raw["info"])) throw new Error("Expected a config document")
+    expect(raw["info"]).not.toHaveProperty("default_agent")
+    expect(raw["info"]).not.toHaveProperty("model")
+    const mcp = raw["info"]["mcp"]
+    if (!isRecord(mcp) || !isRecord(mcp["servers"]) || !isRecord(mcp["servers"]["docs"]))
+      throw new Error("Expected an MCP server config")
+    expect(mcp["servers"]["docs"]).not.toHaveProperty("headers")
+    expect(mcp["servers"]["docs"]).not.toHaveProperty("oauth")
+  }),
 )
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/server/test/fetch.test.ts
+++ b/packages/server/test/fetch.test.ts
@@ -61,7 +61,7 @@ it.live("serves the HttpApi and enforces Basic auth like the Node server", () =>
     const body: unknown = yield* Effect.promise(() => response.json())
     if (typeof body !== "object" || body === null) throw new Error("Expected a health response object")
     expect((body as Record<string, unknown>)["healthy"]).toBe(true)
-  }).pipe(Effect.scoped),
+  }),
 )
 
 it.live("activates credentials through the HttpApi", () =>
@@ -71,7 +71,7 @@ it.live("activates credentials through the HttpApi", () =>
       handler(new Request("http://opencode.local/api/credential/cred_missing/activate", { method: "POST" })),
     )
     expect(response.status).toBe(204)
-  }).pipe(Effect.scoped),
+  }),
 )
 
 it.live("serves unauthenticated and answers CORS preflight when no password is configured", () =>
@@ -93,7 +93,7 @@ it.live("serves unauthenticated and answers CORS preflight when no password is c
       ),
     )
     expect(preflight.headers.get("access-control-allow-origin")).toBe("http://localhost:3000")
-  }).pipe(Effect.scoped),
+  }),
 )
 
 it.live("cancels a stale OpenAI OAuth callback server before falling back", () =>
@@ -113,7 +113,7 @@ it.live("cancels a stale OpenAI OAuth callback server before falling back", () =
     expect(requests).toContain("/cancel")
     const body = (yield* Effect.promise(() => response.json())) as { data: { url: string } }
     expect(new URL(body.data.url).searchParams.get("redirect_uri")).toBe("http://localhost:1455/auth/callback")
-  }).pipe(Effect.scoped),
+  }),
 )
 
 it.live("falls back to port 1457 when OpenAI OAuth port 1455 remains busy", () =>
@@ -133,7 +133,7 @@ it.live("falls back to port 1457 when OpenAI OAuth port 1455 remains busy", () =
     expect(requests).toContain("/cancel")
     const body = (yield* Effect.promise(() => response.json())) as { data: { url: string } }
     expect(new URL(body.data.url).searchParams.get("redirect_uri")).toBe("http://localhost:1457/auth/callback")
-  }).pipe(Effect.scoped),
+  }),
 )
 
 it.live("explains how to recover when both OpenAI OAuth callback ports are busy", () =>
@@ -155,7 +155,7 @@ it.live("explains how to recover when both OpenAI OAuth callback ports are busy"
         "OpenAI browser login needs local port 1455 or 1457, but both are already in use. Stop the processes using those ports or choose ChatGPT Pro/Plus (headless), then try again.",
       kind: "integration_authorization",
     })
-  }).pipe(Effect.scoped),
+  }),
 )
 
 it.live("treats destroying a missing workspace as success", () =>
@@ -171,7 +171,7 @@ it.live("treats destroying a missing workspace as success", () =>
 
     expect(response.status).toBe(200)
     expect(yield* Effect.promise(() => response.json())).toEqual({ destroyed: false })
-  }).pipe(Effect.scoped),
+  }),
 )
 
 it.live("creates idempotent caller-identified workspaces through the HttpApi", () =>
@@ -213,7 +213,7 @@ it.live("creates idempotent caller-identified workspaces through the HttpApi", (
     const minted = yield* create({ provider: "fake" })
     expect(minted.status).toBe(200)
     expect(yield* Effect.promise(() => minted.json())).toMatchObject({ data: expect.stringMatching(/^wrk_/) })
-  }).pipe(Effect.scoped),
+  }),
 )
 
 it.live("serves the session view operation and missing-session error", () =>
@@ -260,7 +260,7 @@ it.live("serves the session view operation and missing-session error", () =>
       ),
     )
     expect(missing.status).toBe(404)
-  }).pipe(Effect.scoped),
+  }),
 )
 
 // Pins the eager-boot guarantee: the application layer is built before the handler returns, so
@@ -283,5 +283,5 @@ it.live("stays serviceable when the first request aborts", () =>
 
     const second = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/health")))
     expect(second.status).toBe(200)
-  }).pipe(Effect.scoped),
+  }),
 )

--- a/packages/server/test/fixture/server.ts
+++ b/packages/server/test/fixture/server.ts
@@ -1,0 +1,19 @@
+import { Effect } from "effect"
+import { HttpServer } from "effect/unstable/http"
+import { ServerProcess } from "../../src/process"
+
+export const startServer = Effect.fnUntraced(function* (directory: string) {
+  const server = yield* ServerProcess.start<never, never>({
+    hostname: "127.0.0.1",
+    port: 0,
+    password: "secret",
+    app: { version: "test-version" },
+    database: { path: ":memory:" },
+    config: { directory },
+    fs: { filewatcher: false },
+  })
+  return {
+    base: HttpServer.formatAddress(server.address),
+    headers: { authorization: `Basic ${btoa("opencode:secret")}` },
+  }
+})

--- a/packages/server/test/generate.test.ts
+++ b/packages/server/test/generate.test.ts
@@ -31,41 +31,37 @@ const generate = makeLocationNode({
 })
 
 it.live("uses base configuration without depending on process.cwd()", () =>
-  Effect.acquireUseRelease(
-    Effect.promise(() => tmpdir("opencode-generate-endpoint-")),
-    (tmp) =>
-      Effect.gen(function* () {
-        const global = path.join(tmp.path, "global")
-        const project = path.join(tmp.path, "project")
-        yield* Effect.promise(() => Promise.all([fs.mkdir(global), fs.mkdir(project)]))
-        yield* Effect.promise(() =>
-          Promise.all([
-            fs.writeFile(path.join(global, "opencode.json"), JSON.stringify({ model: "base/default" })),
-            fs.writeFile(path.join(project, "opencode.json"), JSON.stringify({ model: "project/default" })),
-          ]),
-        )
-        const handler = yield* ServerFetch.make(
-          {
-            database: { path: ":memory:" },
-            config: { directory: global },
-            fs: { filewatcher: false },
-          },
-          { overrides: [[Generate.node, generate]] },
-        )
+  Effect.gen(function* () {
+    const tmp = yield* Effect.acquireDisposable(Effect.promise(() => tmpdir("opencode-generate-endpoint-")))
+    const global = path.join(tmp.path, "global")
+    const project = path.join(tmp.path, "project")
+    yield* Effect.promise(() => Promise.all([fs.mkdir(global), fs.mkdir(project)]))
+    yield* Effect.promise(() =>
+      Promise.all([
+        fs.writeFile(path.join(global, "opencode.json"), JSON.stringify({ model: "base/default" })),
+        fs.writeFile(path.join(project, "opencode.json"), JSON.stringify({ model: "project/default" })),
+      ]),
+    )
+    const handler = yield* ServerFetch.make(
+      {
+        database: { path: ":memory:" },
+        config: { directory: global },
+        fs: { filewatcher: false },
+      },
+      { overrides: [[Generate.node, generate]] },
+    )
 
-        expect(global).not.toBe(process.cwd())
-        expect(yield* request(handler, new URL("http://opencode.local/api/generate"))).toEqual({
-          model: { providerID: "base", model: "default" },
-        })
+    expect(global).not.toBe(process.cwd())
+    expect(yield* request(handler, new URL("http://opencode.local/api/generate"))).toEqual({
+      model: { providerID: "base", model: "default" },
+    })
 
-        const legacy = new URL("http://opencode.local/api/generate")
-        legacy.searchParams.set("location[directory]", project)
-        expect(yield* request(handler, legacy)).toEqual({
-          model: { providerID: "base", model: "default" },
-        })
-      }),
-    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-  ),
+    const legacy = new URL("http://opencode.local/api/generate")
+    legacy.searchParams.set("location[directory]", project)
+    expect(yield* request(handler, legacy)).toEqual({
+      model: { providerID: "base", model: "default" },
+    })
+  }),
 )
 
 function request(handler: (request: Request) => Promise<Response>, url: URL) {

--- a/packages/server/test/model.test.ts
+++ b/packages/server/test/model.test.ts
@@ -2,54 +2,39 @@ import fs from "node:fs/promises"
 import path from "node:path"
 import { expect } from "bun:test"
 import { Effect } from "effect"
-import { HttpServer } from "effect/unstable/http"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import { it } from "../../core/test/lib/effect"
-import { ServerProcess } from "../src/process"
+import { startServer } from "./fixture/server"
 
 it.live("waits for plugin initialization before listing models", () =>
-  Effect.acquireUseRelease(
-    Effect.promise(() => tmpdir("opencode-model-endpoint-")),
-    (tmp) =>
-      Effect.gen(function* () {
-        yield* Effect.promise(() =>
-          fs.writeFile(
-            path.join(tmp.path, "opencode.json"),
-            JSON.stringify({
-              providers: {
-                custom: {
-                  package: "aisdk:@ai-sdk/openai-compatible",
-                  settings: { apiKey: "secret" },
-                  models: { chat: {} },
-                },
-              },
-            }),
-          ),
-        )
-        const server = yield* ServerProcess.start<never, never>({
-          hostname: "127.0.0.1",
-          port: 0,
-          password: "secret",
-          app: { version: "test-version" },
-          database: { path: ":memory:" },
-          config: { directory: tmp.path },
-          fs: { filewatcher: false },
-        })
-        const url = new URL("/api/model", HttpServer.formatAddress(server.address))
-        url.searchParams.set("location[directory]", tmp.path)
-        const response = yield* Effect.promise(() =>
-          fetch(url, { headers: { authorization: `Basic ${btoa("opencode:secret")}` } }),
-        )
+  Effect.gen(function* () {
+    const tmp = yield* Effect.acquireDisposable(Effect.promise(() => tmpdir("opencode-model-endpoint-")))
+    yield* Effect.promise(() =>
+      fs.writeFile(
+        path.join(tmp.path, "opencode.json"),
+        JSON.stringify({
+          providers: {
+            custom: {
+              package: "aisdk:@ai-sdk/openai-compatible",
+              settings: { apiKey: "secret" },
+              models: { chat: {} },
+            },
+          },
+        }),
+      ),
+    )
+    const server = yield* startServer(tmp.path)
+    const url = new URL("/api/model", server.base)
+    url.searchParams.set("location[directory]", tmp.path)
+    const response = yield* Effect.promise(() => fetch(url, { headers: server.headers }))
 
-        expect(response.status).toBe(200)
-        const body: unknown = yield* Effect.promise(() => response.json())
-        if (!isRecord(body) || !Array.isArray(body["data"])) throw new Error("Expected a model list response")
-        expect(
-          body["data"].some((model) => isRecord(model) && model["providerID"] === "custom" && model["id"] === "chat"),
-        ).toBeTrue()
-      }),
-    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-  ),
+    expect(response.status).toBe(200)
+    const body: unknown = yield* Effect.promise(() => response.json())
+    if (!isRecord(body) || !Array.isArray(body["data"])) throw new Error("Expected a model list response")
+    expect(
+      body["data"].some((model) => isRecord(model) && model["providerID"] === "custom" && model["id"] === "chat"),
+    ).toBeTrue()
+  }),
 )
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/server/test/session-message-update.test.ts
+++ b/packages/server/test/session-message-update.test.ts
@@ -141,5 +141,5 @@ it.live("updates completed assistant message content through the session HTTP AP
       _tag: "ConflictError",
       resource: state.assistant,
     })
-  }).pipe(Effect.scoped),
+  }),
 )

--- a/packages/server/test/workerd.test.ts
+++ b/packages/server/test/workerd.test.ts
@@ -29,5 +29,5 @@ it.live("boots the workerd profile over durable object storage", () =>
 
     const body: unknown = yield* Effect.promise(() => health.json())
     expect(body).toMatchObject({ healthy: true, version: "workerd-test" })
-  }).pipe(Effect.scoped),
+  }),
 )

--- a/packages/server/test/worktree.test.ts
+++ b/packages/server/test/worktree.test.ts
@@ -3,67 +3,58 @@ import path from "node:path"
 import { $ } from "bun"
 import { expect } from "bun:test"
 import { Effect } from "effect"
-import { HttpServer } from "effect/unstable/http"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import { it } from "../../core/test/lib/effect"
-import { ServerProcess } from "../src/process"
+import { startServer } from "./fixture/server"
 
 it.live("lists, creates, and removes worktrees by project ID", () =>
-  Effect.acquireUseRelease(
-    Effect.promise(() => tmpdir("opencode-worktree-endpoint-")),
-    (tmp) =>
-      Effect.gen(function* () {
-        const project = path.join(tmp.path, "project")
-        const destination = path.join(tmp.path, "worktrees")
-        yield* Effect.promise(() => fs.mkdir(project, { recursive: true }))
-        yield* Effect.promise(() => $`git init`.cwd(project).quiet())
-        yield* Effect.promise(() => $`git config user.email test@opencode.test`.cwd(project).quiet())
-        yield* Effect.promise(() => $`git config user.name Test`.cwd(project).quiet())
-        yield* Effect.promise(() => $`git commit --allow-empty -m root`.cwd(project).quiet())
-        const server = yield* ServerProcess.start<never, never>({
-          hostname: "127.0.0.1",
-          port: 0,
-          password: "secret",
-          app: { version: "test-version" },
-          database: { path: ":memory:" },
-          config: { directory: path.join(tmp.path, "config") },
-          fs: { filewatcher: false },
-        })
-        const base = HttpServer.formatAddress(server.address)
-        const headers = { authorization: `Basic ${btoa("opencode:secret")}` }
-        const location = new URL("/api/location", base)
-        location.searchParams.set("location[directory]", project)
-        const resolved = yield* Effect.promise(() => fetch(location, { headers }).then((response) => response.json()))
-        if (!isRecord(resolved) || !isRecord(resolved.project) || typeof resolved.project.id !== "string")
-          throw new Error("Expected resolved project")
-        const url = new URL(`/api/worktree/${resolved.project.id}`, base)
+  Effect.gen(function* () {
+    const tmp = yield* Effect.acquireDisposable(Effect.promise(() => tmpdir("opencode-worktree-endpoint-")))
+    const project = path.join(tmp.path, "project")
+    const destination = path.join(tmp.path, "worktrees")
+    yield* Effect.promise(() => fs.mkdir(project, { recursive: true }))
+    yield* Effect.promise(() => $`git init`.cwd(project).quiet())
+    yield* Effect.promise(() => $`git config user.email test@opencode.test`.cwd(project).quiet())
+    yield* Effect.promise(() => $`git config user.name Test`.cwd(project).quiet())
+    yield* Effect.promise(() => $`git commit --allow-empty -m root`.cwd(project).quiet())
+    const server = yield* startServer(path.join(tmp.path, "config"))
+    const location = new URL("/api/location", server.base)
+    location.searchParams.set("location[directory]", project)
+    const resolved = yield* Effect.promise(() =>
+      fetch(location, { headers: server.headers }).then((response) => response.json()),
+    )
+    if (!isRecord(resolved) || !isRecord(resolved.project) || typeof resolved.project.id !== "string")
+      throw new Error("Expected resolved project")
+    const url = new URL(`/api/worktree/${resolved.project.id}`, server.base)
 
-        const initial = yield* Effect.promise(() => fetch(url, { headers }).then((response) => response.json()))
-        expect(initial).toEqual([{ directory: project }])
+    const initial = yield* Effect.promise(() =>
+      fetch(url, { headers: server.headers }).then((response) => response.json()),
+    )
+    expect(initial).toEqual([{ directory: project }])
 
-        const created = yield* Effect.promise(() =>
-          fetch(url, {
-            method: "POST",
-            headers: { ...headers, "content-type": "application/json" },
-            body: JSON.stringify({ strategy: "git", directory: destination, name: "api" }),
-          }).then((response) => response.json()),
-        )
-        expect(created).toEqual({ directory: path.join(destination, "api") })
+    const created = yield* Effect.promise(() =>
+      fetch(url, {
+        method: "POST",
+        headers: { ...server.headers, "content-type": "application/json" },
+        body: JSON.stringify({ strategy: "git", directory: destination, name: "api" }),
+      }).then((response) => response.json()),
+    )
+    expect(created).toEqual({ directory: path.join(destination, "api") })
 
-        const listed = yield* Effect.promise(() => fetch(url, { headers }).then((response) => response.json()))
-        expect(listed).toContainEqual({ directory: path.join(destination, "api"), strategy: "git" })
+    const listed = yield* Effect.promise(() =>
+      fetch(url, { headers: server.headers }).then((response) => response.json()),
+    )
+    expect(listed).toContainEqual({ directory: path.join(destination, "api"), strategy: "git" })
 
-        const removed = yield* Effect.promise(() =>
-          fetch(url, {
-            method: "DELETE",
-            headers: { ...headers, "content-type": "application/json" },
-            body: JSON.stringify({ directory: path.join(destination, "api"), force: false }),
-          }),
-        )
-        expect(removed.status).toBe(204)
+    const removed = yield* Effect.promise(() =>
+      fetch(url, {
+        method: "DELETE",
+        headers: { ...server.headers, "content-type": "application/json" },
+        body: JSON.stringify({ directory: path.join(destination, "api"), force: false }),
       }),
-    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
-  ),
+    )
+    expect(removed.status).toBe(204)
+  }),
 )
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Why
Four endpoint tests dispose temporary directories before the surrounding test scope shuts down server resources. Twelve other test bodies create scopes already supplied by `it.live`, obscuring the actual lifetime boundary.

## What Changes
Acquire disposable directories in the test scope before starting servers, so LIFO finalization closes server resources before deleting directories. A narrow fixture shares the identical Node-server startup settings, base URL, and auth headers while retaining the caller's scope.

Remove twelve redundant terminal test-body scopes. All sixteen scenarios and 67 static assertion expressions remain. The real Node HTTP tests and the distinct Generate override/config-resolution test keep their existing transports and behavior.

## Scope
Test-only changes across seven Server suites and one startup fixture. Specialized tracing, PTY, compression, and explicitly delimited lifetimes remain explicit. No production, public API, or generated-client changes. Based directly on V2, independently of the other cleanup PRs.

## Verification
Run from `packages/server`. The existing Core test script supplies isolated HOME/XDG/configuration values while running Server's tests:

```sh
bun run ../core/script/test.ts test/config.test.ts test/model.test.ts test/worktree.test.ts test/generate.test.ts test/session-message-update.test.ts test/workerd.test.ts
bun run ../core/script/test.ts test/config.test.ts test/model.test.ts test/worktree.test.ts test/generate.test.ts test/fetch.test.ts test/session-message-update.test.ts test/workerd.test.ts
bun run ../core/script/test.ts
bun typecheck
```

The six non-fetch changed suites pass: six tests and 38 assertions. Isolated focused baseline and candidate both report 13 passed / 3 failed. Isolated full baseline and candidate both report 32 passed / 3 failed / 1 skipped with 116 assertions. Typechecking, formatting, and whitespace checks pass.

The same three OAuth callback-port recovery cases fail before and after: on this macOS/Bun environment, occupying localhost's IPv6 listener does not prevent a second IPv4 listener. The optional persistent-PTY smoke test is skipped because its binary is unavailable. Bare baseline runs also load host configuration and time out, so the verification above uses the isolated runner. The full suite is not green; these pre-existing failures are not changed by this refactor.
