### PR TITLE
test(cli): scope temporary directories to test lifetimes

### DIFF
--- a/packages/cli/test/config.test.ts
+++ b/packages/cli/test/config.test.ts
@@ -6,6 +6,7 @@ import { expect, test } from "bun:test"
 import { parse } from "jsonc-parser"
 import path from "path"
 import { Config } from "../src/config"
+import { tmpdir } from "./fixture/tmpdir"
 
 function run<A, E>(directory: string, effect: Effect.Effect<A, E, Config.Service>) {
   return Effect.runPromise(
@@ -35,53 +36,45 @@ test("generates reusable keybind schemas and preserves descriptions and numeric 
 })
 
 test("includes the published schema when creating cli.json", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
+  await using directory = await tmpdir()
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.update((draft) => {
-          draft.animations = false
-        })
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.update((draft) => {
+        draft.animations = false
+      })
+    }),
+  )
 
-    expect(config).toEqual({ $schema: "https://opencode.ai/v2/cli.json", animations: false })
-    expect(await Bun.file(path.join(directory, "cli.json")).json()).toEqual(config)
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config).toEqual({ $schema: "https://opencode.ai/v2/cli.json", animations: false })
+  expect(await Bun.file(path.join(directory.path, "cli.json")).json()).toEqual(config)
 })
 
 test("preserves the schema in an existing cli.json", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
   await Bun.write(file, JSON.stringify({ $schema: "https://opencode.ai/v2/cli.json", animations: true }))
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.update((draft) => {
-          draft.animations = false
-        })
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.update((draft) => {
+        draft.animations = false
+      })
+    }),
+  )
 
-    expect(config).toEqual({ $schema: "https://opencode.ai/v2/cli.json", animations: false })
-    expect(await Bun.file(file).json()).toEqual(config)
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config).toEqual({ $schema: "https://opencode.ai/v2/cli.json", animations: false })
+  expect(await Bun.file(file).json()).toEqual(config)
 })
 
 test("migrates tui and kv config into cli.json", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
+  await using directory = await tmpdir()
   await Bun.write(
-    path.join(directory, "tui.json"),
+    path.join(directory.path, "tui.json"),
     JSON.stringify({
       theme: "legacy",
       keybinds: {
@@ -102,7 +95,7 @@ test("migrates tui and kv config into cli.json", async () => {
     }),
   )
   await Bun.write(
-    path.join(directory, "kv.json"),
+    path.join(directory.path, "kv.json"),
     JSON.stringify({
       theme_mode_lock: "light",
       attention_sound_pack: "custom.pack",
@@ -124,115 +117,108 @@ test("migrates tui and kv config into cli.json", async () => {
     }),
   )
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.get()
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.get()
+    }),
+  )
 
-    expect(config).toMatchObject({
-      $schema: "https://opencode.ai/v2/cli.json",
-      theme: { name: "legacy", mode: "light" },
-      keybinds: {
-        leader: "ctrl+o",
-        "app.exit": "ctrl+q",
-        "prompt.paste": { key: "ctrl+v", preventDefault: false },
-        "session.delete": false,
-        "dialog.select.next": "ctrl+n",
-      },
-      plugins: [{ package: "example", options: { mode: "safe" } }, "-disabled"],
-      leader: { timeout: 500 },
-      scroll: { speed: 2, acceleration: true },
-      attention: { sound_pack: "custom.pack" },
-      diffs: { wrap: "none", tree: false, single: true, view: "split" },
-      terminal: { title: false },
-      prompt: { editor: false, paste: "full" },
-      session: { sidebar: "hide", scrollbar: true, thinking: "show", grouping: "none" },
-      animations: false,
-      mouse: false,
-    })
-    expect(config).not.toHaveProperty("skipped_version")
-    expect(config).not.toHaveProperty("which_key")
-    expect(config).not.toHaveProperty("hints")
-    expect((await Bun.file(path.join(directory, "cli.json")).json()).keybinds).toEqual({
+  expect(config).toMatchObject({
+    $schema: "https://opencode.ai/v2/cli.json",
+    theme: { name: "legacy", mode: "light" },
+    keybinds: {
       leader: "ctrl+o",
       "app.exit": "ctrl+q",
       "prompt.paste": { key: "ctrl+v", preventDefault: false },
       "session.delete": false,
       "dialog.select.next": "ctrl+n",
-    })
-    expect(await Bun.file(path.join(directory, "cli.json")).exists()).toBe(true)
-    expect(await Bun.file(path.join(directory, "tui.json")).exists()).toBe(true)
-    expect(await Bun.file(path.join(directory, "kv.json")).exists()).toBe(true)
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+    },
+    plugins: [{ package: "example", options: { mode: "safe" } }, "-disabled"],
+    leader: { timeout: 500 },
+    scroll: { speed: 2, acceleration: true },
+    attention: { sound_pack: "custom.pack" },
+    diffs: { wrap: "none", tree: false, single: true, view: "split" },
+    terminal: { title: false },
+    prompt: { editor: false, paste: "full" },
+    session: { sidebar: "hide", scrollbar: true, thinking: "show", grouping: "none" },
+    animations: false,
+    mouse: false,
+  })
+  expect(config).not.toHaveProperty("skipped_version")
+  expect(config).not.toHaveProperty("which_key")
+  expect(config).not.toHaveProperty("hints")
+  expect((await Bun.file(path.join(directory.path, "cli.json")).json()).keybinds).toEqual({
+    leader: "ctrl+o",
+    "app.exit": "ctrl+q",
+    "prompt.paste": { key: "ctrl+v", preventDefault: false },
+    "session.delete": false,
+    "dialog.select.next": "ctrl+n",
+  })
+  expect(await Bun.file(path.join(directory.path, "cli.json")).exists()).toBe(true)
+  expect(await Bun.file(path.join(directory.path, "tui.json")).exists()).toBe(true)
+  expect(await Bun.file(path.join(directory.path, "kv.json")).exists()).toBe(true)
 })
 
 test("migrates before the first update and does not remigrate afterward", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  await Bun.write(path.join(directory, "tui.json"), JSON.stringify({ theme: "legacy" }))
+  await using directory = await tmpdir()
+  await Bun.write(path.join(directory.path, "tui.json"), JSON.stringify({ theme: "legacy" }))
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        yield* service.update((draft) => {
-          draft.animations = false
-          draft.mouse = false
-        })
-        yield* Effect.promise(() => Bun.write(path.join(directory, "tui.json"), JSON.stringify({ theme: "changed" })))
-        return yield* service.get()
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      yield* service.update((draft) => {
+        draft.animations = false
+        draft.mouse = false
+      })
+      yield* Effect.promise(() =>
+        Bun.write(path.join(directory.path, "tui.json"), JSON.stringify({ theme: "changed" })),
+      )
+      return yield* service.get()
+    }),
+  )
 
-    expect(config).toEqual({
-      $schema: "https://opencode.ai/v2/cli.json",
-      theme: { name: "legacy" },
-      animations: false,
-      mouse: false,
-    })
-    expect(await Bun.file(path.join(directory, "cli.json")).json()).toEqual({
-      $schema: "https://opencode.ai/v2/cli.json",
-      theme: { name: "legacy" },
-      animations: false,
-      mouse: false,
-    })
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config).toEqual({
+    $schema: "https://opencode.ai/v2/cli.json",
+    theme: { name: "legacy" },
+    animations: false,
+    mouse: false,
+  })
+  expect(await Bun.file(path.join(directory.path, "cli.json")).json()).toEqual({
+    $schema: "https://opencode.ai/v2/cli.json",
+    theme: { name: "legacy" },
+    animations: false,
+    mouse: false,
+  })
 })
 
 test("preserves legacy cursor settings", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  await Bun.write(path.join(directory, "tui.json"), JSON.stringify({ cursor: { style: "underline", blinking: false } }))
+  await using directory = await tmpdir()
+  await Bun.write(
+    path.join(directory.path, "tui.json"),
+    JSON.stringify({ cursor: { style: "underline", blinking: false } }),
+  )
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.get()
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.get()
+    }),
+  )
 
-    expect(config.cursor).toEqual({ style: "underline", blinking: false })
-    expect((await Bun.file(path.join(directory, "cli.json")).json()).cursor).toEqual({
-      style: "underline",
-      blinking: false,
-    })
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config.cursor).toEqual({ style: "underline", blinking: false })
+  expect((await Bun.file(path.join(directory.path, "cli.json")).json()).cursor).toEqual({
+    style: "underline",
+    blinking: false,
+  })
 })
 
 test("migrates legacy keybind names in an existing cli.json", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
   await Bun.write(
     file,
     `{
@@ -251,31 +237,27 @@ test("migrates legacy keybind names in an existing cli.json", async () => {
 `,
   )
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.get()
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.get()
+    }),
+  )
 
-    expect(config.keybinds).toEqual({
-      "session.list": "ctrl+l",
-      "session.delete": "ctrl+x",
-    })
-    const text = await Bun.file(file).text()
-    expect(text).toContain("// Preserve this comment")
-    expect(text).toContain("// Session list shortcut")
-    expect(text).toContain("// Legacy delete shortcut")
-    expect(text).toContain("// Canonical delete shortcut")
-    expect(parse(text).keybinds).toEqual({
-      "session.list": "ctrl+l",
-      "session.delete": "ctrl+x",
-    })
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config.keybinds).toEqual({
+    "session.list": "ctrl+l",
+    "session.delete": "ctrl+x",
+  })
+  const text = await Bun.file(file).text()
+  expect(text).toContain("// Preserve this comment")
+  expect(text).toContain("// Session list shortcut")
+  expect(text).toContain("// Legacy delete shortcut")
+  expect(text).toContain("// Canonical delete shortcut")
+  expect(parse(text).keybinds).toEqual({
+    "session.list": "ctrl+l",
+    "session.delete": "ctrl+x",
+  })
 })
 
 test("migrates copy_on_select in an existing cli.json", async () => {
@@ -284,8 +266,8 @@ test("migrates copy_on_select in an existing cli.json", async () => {
     { legacy: false, expected: "manual" },
     { legacy: true, copy: "manual", expected: "manual" },
   ] as const) {
-    const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-    const file = path.join(directory, "cli.json")
+    await using directory = await tmpdir()
+    const file = path.join(directory.path, "cli.json")
     await Bun.write(
       file,
       `{
@@ -298,29 +280,25 @@ test("migrates copy_on_select in an existing cli.json", async () => {
 `,
     )
 
-    try {
-      const config = await run(
-        directory,
-        Effect.gen(function* () {
-          const service = yield* Config.Service
-          return yield* service.get()
-        }),
-      )
+    const config = await run(
+      directory.path,
+      Effect.gen(function* () {
+        const service = yield* Config.Service
+        return yield* service.get()
+      }),
+    )
 
-      expect(config.terminal).toEqual({ copy: item.expected })
-      const text = await Bun.file(file).text()
-      expect(text).toContain("// Preserve this comment")
-      expect(text).not.toContain("copy_on_select")
-      expect(parse(text).terminal).toEqual({ copy: item.expected })
-    } finally {
-      await Bun.$`rm -rf ${directory}`
-    }
+    expect(config.terminal).toEqual({ copy: item.expected })
+    const text = await Bun.file(file).text()
+    expect(text).toContain("// Preserve this comment")
+    expect(text).not.toContain("copy_on_select")
+    expect(parse(text).terminal).toEqual({ copy: item.expected })
   }
 })
 
 test("uses migrated keybinds when persistence fails", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
   await Bun.write(file, `{"keybinds":{"session_list":"ctrl+l"}}`)
   const node = await Effect.runPromise(FileSystem.FileSystem.pipe(Effect.provide(NodeFileSystem.layer)))
   const fs = new Proxy(node, {
@@ -330,88 +308,76 @@ test("uses migrated keybinds when persistence fails", async () => {
     },
   })
 
-  try {
-    const config = await Effect.runPromise(
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.get()
-      }).pipe(
-        Effect.provide(Config.layer),
-        Effect.provide(Global.layerWith({ config: directory, state: directory })),
-        Effect.provideService(FileSystem.FileSystem, fs),
-      ),
-    )
+  const config = await Effect.runPromise(
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.get()
+    }).pipe(
+      Effect.provide(Config.layer),
+      Effect.provide(Global.layerWith({ config: directory.path, state: directory.path })),
+      Effect.provideService(FileSystem.FileSystem, fs),
+    ),
+  )
 
-    expect(config.keybinds).toEqual({ "session.list": "ctrl+l" })
-    expect(await Bun.file(file).json()).toEqual({ keybinds: { session_list: "ctrl+l" } })
-    expect(await Array.fromAsync(new Bun.Glob("*.tmp").scan(directory))).toEqual([])
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config.keybinds).toEqual({ "session.list": "ctrl+l" })
+  expect(await Bun.file(file).json()).toEqual({ keybinds: { session_list: "ctrl+l" } })
+  expect(await Array.fromAsync(new Bun.Glob("*.tmp").scan(directory.path))).toEqual([])
 })
 
 test("preserves the effective value when migrating duplicate legacy keybinds", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
   await Bun.write(file, `{"keybinds":{"session_delete":"ctrl+a","session_delete":"ctrl+b"}}`)
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.get()
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.get()
+    }),
+  )
 
-    expect(config.keybinds).toEqual({ "session.delete": "ctrl+b" })
-    expect(parse(await Bun.file(file).text()).keybinds).toEqual({ "session.delete": "ctrl+b" })
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config.keybinds).toEqual({ "session.delete": "ctrl+b" })
+  expect(parse(await Bun.file(file).text()).keybinds).toEqual({ "session.delete": "ctrl+b" })
 })
 
 test("migrates and updates the effective duplicate top-level keybinds", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
   await Bun.write(file, `{"keybinds":{"session_delete":"first"},"keybinds":{"session_delete":"last"}}`)
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        expect((yield* service.get()).keybinds).toEqual({ "session.delete": "last" })
-        return yield* service.update((draft) => {
-          draft.keybinds = { ...draft.keybinds, "session.delete": "changed" }
-        })
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      expect((yield* service.get()).keybinds).toEqual({ "session.delete": "last" })
+      return yield* service.update((draft) => {
+        draft.keybinds = { ...draft.keybinds, "session.delete": "changed" }
+      })
+    }),
+  )
 
-    expect(config.keybinds).toEqual({ "session.delete": "changed" })
-    expect(parse(await Bun.file(file).text()).keybinds).toEqual({ "session.delete": "changed" })
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config.keybinds).toEqual({ "session.delete": "changed" })
+  expect(parse(await Bun.file(file).text()).keybinds).toEqual({ "session.delete": "changed" })
 })
 
 test("serializes migration and updates across processes", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
-  const started = path.join(directory, "started")
-  const release = path.join(directory, "release")
-  const migrateReady = path.join(directory, "migrate-ready")
-  const updateReady = path.join(directory, "update-ready")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
+  const started = path.join(directory.path, "started")
+  const release = path.join(directory.path, "release")
+  const migrateReady = path.join(directory.path, "migrate-ready")
+  const updateReady = path.join(directory.path, "update-ready")
   await Bun.write(file, `{"keybinds":{"session_delete":"ctrl+d"}}`)
   const worker = path.join(import.meta.dir, "fixture/config-concurrency.ts")
-  const migrate = Bun.spawn([process.execPath, worker, "migrate", directory, started, release, migrateReady], {
+  const migrate = Bun.spawn([process.execPath, worker, "migrate", directory.path, started, release, migrateReady], {
     stdout: "ignore",
     stderr: "pipe",
   })
 
   try {
     await waitForFile(started, migrate.exited)
-    const update = Bun.spawn([process.execPath, worker, "update", directory, started, release, updateReady], {
+    const update = Bun.spawn([process.execPath, worker, "update", directory.path, started, release, updateReady], {
       stdout: "ignore",
       stderr: "pipe",
     })
@@ -431,21 +397,20 @@ test("serializes migration and updates across processes", async () => {
     await Bun.write(release, "")
     migrate.kill()
     await migrate.exited
-    await Bun.$`rm -rf ${directory}`
   }
 })
 
 test("config reads remain interruptible while waiting for the file lock", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
-  const locks = path.join(directory, "locks")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
+  const locks = path.join(directory.path, "locks")
   const held = await Flock.acquire(file, { dir: locks })
 
   try {
     const service = await Effect.runPromise(
       Config.Service.pipe(
         Effect.provide(Config.layer),
-        Effect.provide(Global.layerWith({ config: directory, state: directory })),
+        Effect.provide(Global.layerWith({ config: directory.path, state: directory.path })),
         Effect.provide(NodeFileSystem.layer),
       ),
     )
@@ -453,43 +418,38 @@ test("config reads remain interruptible while waiting for the file lock", async 
     expect(await Promise.race([result, Bun.sleep(250).then(() => "blocked" as const)])).toEqual(Option.none())
   } finally {
     await held.release()
-    await Bun.$`rm -rf ${directory}`
   }
 })
 
 test("updates effective duplicate canonical keybinds", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
   await Bun.write(
     file,
     `{"keybinds":{"session.delete":"first","session.delete":"last","permission.mode":"off","permission.mode":"on"}}`,
   )
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        expect((yield* service.get()).keybinds).toEqual({ "session.delete": "last", "permission.mode": "on" })
-        return yield* service.update((draft) => {
-          draft.keybinds = { ...draft.keybinds, "session.delete": "changed", "permission.mode": "changed" }
-        })
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      expect((yield* service.get()).keybinds).toEqual({ "session.delete": "last", "permission.mode": "on" })
+      return yield* service.update((draft) => {
+        draft.keybinds = { ...draft.keybinds, "session.delete": "changed", "permission.mode": "changed" }
+      })
+    }),
+  )
 
-    expect(config.keybinds).toEqual({ "session.delete": "changed", "permission.mode": "changed" })
-    expect(parse(await Bun.file(file).text()).keybinds).toEqual({
-      "session.delete": "changed",
-      "permission.mode": "changed",
-    })
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config.keybinds).toEqual({ "session.delete": "changed", "permission.mode": "changed" })
+  expect(parse(await Bun.file(file).text()).keybinds).toEqual({
+    "session.delete": "changed",
+    "permission.mode": "changed",
+  })
 })
 
 test("removes orphaned keybinds without deleting trailing comments", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "cli.json")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "cli.json")
   await Bun.write(
     file,
     `{
@@ -501,50 +461,42 @@ test("removes orphaned keybinds without deleting trailing comments", async () =>
 `,
   )
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.get()
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.get()
+    }),
+  )
 
-    expect(config.keybinds).toEqual({})
-    const text = await Bun.file(file).text()
-    expect(text).toContain("/* Keep legacy explanation */")
-    expect(text).toContain("/* Keep canonical explanation */")
-    expect(parse(text).keybinds).toEqual({})
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config.keybinds).toEqual({})
+  const text = await Bun.file(file).text()
+  expect(text).toContain("/* Keep legacy explanation */")
+  expect(text).toContain("/* Keep canonical explanation */")
+  expect(parse(text).keybinds).toEqual({})
 })
 
 test("updates a config draft while preserving JSONC comments", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  await Bun.write(path.join(directory, "cli.json"), '{\n  // Keep this comment\n  "animations": true\n}\n')
+  await using directory = await tmpdir()
+  await Bun.write(path.join(directory.path, "cli.json"), '{\n  // Keep this comment\n  "animations": true\n}\n')
 
-  try {
-    const config = await run(
-      directory,
-      Effect.gen(function* () {
-        const service = yield* Config.Service
-        return yield* service.update((draft) => {
-          draft.prompt = { paste: "compact" }
-          draft.mini = { thinking: "hide", shell_output: "hide", turn_summary: "hide", splash: "hide", mono: true }
-        })
-      }),
-    )
+  const config = await run(
+    directory.path,
+    Effect.gen(function* () {
+      const service = yield* Config.Service
+      return yield* service.update((draft) => {
+        draft.prompt = { paste: "compact" }
+        draft.mini = { thinking: "hide", shell_output: "hide", turn_summary: "hide", splash: "hide", mono: true }
+      })
+    }),
+  )
 
-    expect(config).toEqual({
-      animations: true,
-      prompt: { paste: "compact" },
-      mini: { thinking: "hide", shell_output: "hide", turn_summary: "hide", splash: "hide", mono: true },
-    })
-    expect(await Bun.file(path.join(directory, "cli.json")).text()).toContain("// Keep this comment")
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(config).toEqual({
+    animations: true,
+    prompt: { paste: "compact" },
+    mini: { thinking: "hide", shell_output: "hide", turn_summary: "hide", splash: "hide", mono: true },
+  })
+  expect(await Bun.file(path.join(directory.path, "cli.json")).text()).toContain("// Keep this comment")
 })
 
 async function waitForFile(file: string, exited: Promise<number>) {

--- a/packages/cli/test/fixture/tmpdir.ts
+++ b/packages/cli/test/fixture/tmpdir.ts
@@ -1,0 +1,13 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+export async function tmpdir() {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "opencode-cli-test-"))
+  return {
+    path: directory,
+    async [Symbol.asyncDispose]() {
+      await rm(directory, { recursive: true, force: true })
+    },
+  }
+}

--- a/packages/cli/test/mini-host.test.ts
+++ b/packages/cli/test/mini-host.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, rm } from "node:fs/promises"
+import { describe, expect, test } from "bun:test"
 import path from "node:path"
 import { Readable } from "node:stream"
 import { pathToFileURL } from "node:url"
@@ -10,18 +9,12 @@ import {
   type InteractiveStdin,
   usingInteractiveStdin,
 } from "../src/mini-host"
+import { tmpdir } from "./fixture/tmpdir"
 
-const temporary: string[] = []
 const model = { providerID: "openai", modelID: "gpt-5" }
 
 function stream(isTTY: boolean) {
   return Object.assign(new Readable({ read() {} }), { isTTY }) as NodeJS.ReadStream
-}
-
-async function root() {
-  const directory = await mkdtemp(path.join(import.meta.dir, ".mini-host-"))
-  temporary.push(directory)
-  return directory
 }
 
 function host(terminal: InteractiveStdin, directory: string) {
@@ -31,10 +24,6 @@ function host(terminal: InteractiveStdin, directory: string) {
     paths: { home: directory, state: directory, log: directory },
   })
 }
-
-afterEach(async () => {
-  await Promise.all(temporary.splice(0).map((directory) => rm(directory, { recursive: true, force: true })))
-})
 
 describe("Mini CLI host", () => {
   test("reuses tty stdin without taking ownership", () => {
@@ -129,30 +118,36 @@ describe("Mini CLI host", () => {
   })
 
   test("subscribes and unsubscribes process signals through host capabilities", async () => {
-    const input = host({ stdin: stream(true), cleanup() {} }, await root())
+    await using directory = await tmpdir()
+    const input = host({ stdin: stream(true), cleanup() {} }, directory.path)
     const sigint = process.listenerCount("SIGINT")
     const sigusr2 = process.listenerCount("SIGUSR2")
     const offInt = input.signals.sigint.subscribe(() => {})
     const offTheme = input.signals.sigusr2.subscribe(() => {})
 
-    expect(process.listenerCount("SIGINT")).toBe(sigint + 1)
-    expect(process.listenerCount("SIGUSR2")).toBe(sigusr2 + 1)
-    offInt()
-    offInt()
-    offTheme()
-    offTheme()
-    expect(process.listenerCount("SIGINT")).toBe(sigint)
-    expect(process.listenerCount("SIGUSR2")).toBe(sigusr2)
+    try {
+      expect(process.listenerCount("SIGINT")).toBe(sigint + 1)
+      expect(process.listenerCount("SIGUSR2")).toBe(sigusr2 + 1)
+      offInt()
+      offInt()
+      offTheme()
+      offTheme()
+      expect(process.listenerCount("SIGINT")).toBe(sigint)
+      expect(process.listenerCount("SIGUSR2")).toBe(sigusr2)
+    } finally {
+      offInt()
+      offTheme()
+    }
   })
 
   test("passes frontend host capabilities", async () => {
-    const directory = await root()
-    const input = host({ stdin: stream(true), cleanup() {} }, directory)
+    await using directory = await tmpdir()
+    const input = host({ stdin: stream(true), cleanup() {} }, directory.path)
 
-    expect(input.paths).toEqual({ home: directory })
+    expect(input.paths).toEqual({ home: directory.path })
     expect(input.platform).toBe(process.platform)
     expect(typeof input.files.readText).toBe("function")
-    const file = path.join(directory, "attachment.txt")
+    const file = path.join(directory.path, "attachment.txt")
     await Bun.write(file, "attachment contents")
     expect(await input.files.readText(pathToFileURL(file).href)).toBe("attachment contents")
     expect(typeof input.startup.showTiming).toBe("boolean")
@@ -160,9 +155,9 @@ describe("Mini CLI host", () => {
   })
 
   test("delegates model variant preferences", async () => {
-    const directory = await root()
-    const input = host({ stdin: stream(true), cleanup() {} }, directory)
-    const file = path.join(directory, "model.json")
+    await using directory = await tmpdir()
+    const input = host({ stdin: stream(true), cleanup() {} }, directory.path)
+    const file = path.join(directory.path, "model.json")
 
     await input.preferences.saveVariant(model, "high")
     expect(await input.preferences.resolveVariant(model)).toBe("high")

--- a/packages/cli/test/plugin-add.test.ts
+++ b/packages/cli/test/plugin-add.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test"
 import path from "node:path"
 import { parse } from "jsonc-parser"
 import { configurationTarget, writePluginConfig } from "../src/commands/handlers/plugin/add"
+import { tmpdir } from "./fixture/tmpdir"
 
 test("routes packages according to their exported runtimes", () => {
   expect(configurationTarget("server.js", "tui.js")).toBe("server")
@@ -11,20 +12,16 @@ test("routes packages according to their exported runtimes", () => {
 })
 
 test("adds a package to global plugin config without replacing unrelated settings", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "opencode.jsonc")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "opencode.jsonc")
   await Bun.write(file, '{\n  // retained\n  "model": "provider/model",\n  "plugins": ["first"]\n}\n')
 
-  try {
-    expect(await writePluginConfig(file, "second@1.0.0")).toBe(true)
-    expect(await writePluginConfig(file, "second@1.0.0")).toBe(false)
-    const text = await Bun.file(file).text()
-    expect(text).toContain("// retained")
-    expect(parse(text)).toEqual({
-      model: "provider/model",
-      plugins: ["first", "second@1.0.0"],
-    })
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(await writePluginConfig(file, "second@1.0.0")).toBe(true)
+  expect(await writePluginConfig(file, "second@1.0.0")).toBe(false)
+  const text = await Bun.file(file).text()
+  expect(text).toContain("// retained")
+  expect(parse(text)).toEqual({
+    model: "provider/model",
+    plugins: ["first", "second@1.0.0"],
+  })
 })

--- a/packages/cli/test/plugin-remove.test.ts
+++ b/packages/cli/test/plugin-remove.test.ts
@@ -2,22 +2,19 @@ import { expect, test } from "bun:test"
 import path from "node:path"
 import { parse } from "jsonc-parser"
 import { removePluginConfig } from "../src/commands/handlers/plugin/remove"
+import { tmpdir } from "./fixture/tmpdir"
 
 test("removes string and object package entries without replacing unrelated settings", async () => {
-  const directory = await Bun.$`mktemp -d`.text().then((value) => value.trim())
-  const file = path.join(directory, "opencode.jsonc")
+  await using directory = await tmpdir()
+  const file = path.join(directory.path, "opencode.jsonc")
   await Bun.write(
     file,
     '{\n  // retained\n  "model": "provider/model",\n  "plugins": ["remove-me", { "package": "remove-me", "options": {} }, "keep-me"]\n}\n',
   )
 
-  try {
-    expect(await removePluginConfig(file, "remove-me")).toBe(true)
-    expect(await removePluginConfig(file, "remove-me")).toBe(false)
-    const text = await Bun.file(file).text()
-    expect(text).toContain("// retained")
-    expect(parse(text)).toEqual({ model: "provider/model", plugins: ["keep-me"] })
-  } finally {
-    await Bun.$`rm -rf ${directory}`
-  }
+  expect(await removePluginConfig(file, "remove-me")).toBe(true)
+  expect(await removePluginConfig(file, "remove-me")).toBe(false)
+  const text = await Bun.file(file).text()
+  expect(text).toContain("// retained")
+  expect(parse(text)).toEqual({ model: "provider/model", plugins: ["keep-me"] })
 })


### PR DESCRIPTION
## Why
Several CLI tests allocate temporary directories and write setup files before entering their cleanup block, leaving a disposal gap if setup fails. Mini-host tests instead track directories in a module-level array drained by `afterEach`.

## What Changes
Use one CLI-local, platform-only async-disposable directory fixture with `await using`. Replace seventeen shell-based allocation sites and three shared-registry consumers, so cleanup covers both setup and assertion failures without shell commands or global ownership.

All 26 tests remain, including the three migration-loop variants. Subprocess gates, lock release, JSONC inputs, and migration assertions stay explicit. Signal unsubscribers also run on assertion failure, while repeated-unsubscribe checks remain.

## Scope
Test-only changes to configuration, plugin add/remove, and Mini-host tests plus their directory fixture. No production changes, Core imports, or additional Effect runners. Based directly on V2, independently of the other cleanup PRs.

## Verification
Run from `packages/cli`:

```sh
bun run test test/config.test.ts test/plugin-add.test.ts test/plugin-remove.test.ts test/mini-host.test.ts test/import-boundaries.test.ts
bun run test test/config.test.ts test/plugin-add.test.ts test/plugin-remove.test.ts test/mini-host.test.ts test/import-boundaries.test.ts --rerun-each 3
bun typecheck
```

Baseline focused tests passed 26 tests and 95 assertions; import-boundary checks passed four tests and 24 assertions. Refactored tests plus boundaries passed 30 tests and 119 assertions. Repeated verification passed 90 executions and 357 assertions. Typechecking, formatting, and whitespace checks passed, as did a local early-setup-failure disposal smoke check.

The full CLI suite was not run.
