### PR TITLE
fix(websearch): remove provider whitelist - enable websearch for all providers by default

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -127,6 +127,20 @@ export const Info = Schema.Struct({
   layout: Schema.optional(ConfigLayoutV1.Layout).annotate({ description: "@deprecated Always uses stretch layout." }),
   permission: Schema.optional(ConfigPermissionV1.Info),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),
+  websearch: Schema.optional(
+    Schema.Struct({
+      enabled: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Enable the native websearch tool for all model providers (default: true). Set to false to hide the tool entirely",
+      }),
+      provider: Schema.optional(Schema.Literals(["auto", "exa", "parallel"])).annotate({
+        description:
+          "Web search backend. 'auto' picks a backend per session; 'exa' or 'parallel' pins that backend for every call",
+      }),
+    }),
+  ).annotate({
+    description: "Native web search tool configuration, see https://opencode.ai/docs/tools",
+  }),
   attachment: Schema.optional(ConfigAttachmentV1.Info).annotate({
     description: "Attachment processing configuration, including image size limits and resizing behavior",
   }),

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -55,15 +55,6 @@ import { MCP } from "@/mcp"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { McpCatalog } from "@/mcp/catalog"
 
-export function webSearchEnabled(providerID: ProviderV2.ID, flags = { exa: false, parallel: false }) {
-  return (
-    providerID === ProviderV2.ID.opencode ||
-    providerID === ProviderV2.ID.make("opencode-go") ||
-    flags.exa ||
-    flags.parallel
-  )
-}
-
 type TaskDef = Tool.InferDef<typeof TaskTool>
 type ReadDef = Tool.InferDef<typeof ReadTool>
 
@@ -289,10 +280,9 @@ const layer = Layer.effect(
     })
 
     const tools: Interface["tools"] = Effect.fn("ToolRegistry.tools")(function* (input) {
+      const cfg = yield* config.get()
       const filtered = (yield* all()).filter((tool) => {
-        if (tool.id === WebSearchTool.id) {
-          return webSearchEnabled(input.providerID, { exa: flags.enableExa, parallel: flags.enableParallel })
-        }
+        if (tool.id === WebSearchTool.id) return cfg.websearch?.enabled !== false
 
         const usePatch =
           input.modelID.includes("gpt-") && !input.modelID.includes("oss") && !input.modelID.includes("gpt-4")

--- a/packages/opencode/src/tool/websearch.ts
+++ b/packages/opencode/src/tool/websearch.ts
@@ -6,6 +6,7 @@ import DESCRIPTION from "./websearch.txt"
 import { checksum } from "@opencode-ai/core/util/encode"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Config } from "@/config/config"
 
 export const Parameters = Schema.Struct({
   query: Schema.String.annotate({ description: "Websearch query" }),
@@ -27,13 +28,33 @@ export const Parameters = Schema.Struct({
 const WebSearchProviderSchema = Schema.Literals(["exa", "parallel"])
 export type WebSearchProvider = Schema.Schema.Type<typeof WebSearchProviderSchema>
 
-export function selectWebSearchProvider(sessionID: string, flags = { exa: false, parallel: false }): WebSearchProvider {
+// Backend pin priority (decision D3): config.websearch.provider > OPENCODE_WEBSEARCH_PROVIDER
+// > legacy OPENCODE_ENABLE_EXA/_PARALLEL > per-session checksum split.
+export function selectWebSearchProvider(
+  sessionID: string,
+  options: {
+    provider?: "auto" | WebSearchProvider
+    exa?: boolean
+    parallel?: boolean
+  } = {},
+): WebSearchProvider {
+  if (options.provider === "exa" || options.provider === "parallel") return options.provider
   const override = process.env.OPENCODE_WEBSEARCH_PROVIDER
   if (override === "exa" || override === "parallel") return override
-  if (flags.parallel) return "parallel"
-  if (flags.exa) return "exa"
+  if (options.parallel) return "parallel"
+  if (options.exa) return "exa"
 
   return Number.parseInt(checksum(sessionID) ?? "0", 36) % 2 === 0 ? "exa" : "parallel"
+}
+
+let legacyEnvWarned = false
+
+function warnLegacyEnvFlags(flags: { enableExa: boolean; enableParallel: boolean }) {
+  if (legacyEnvWarned || (!flags.enableExa && !flags.enableParallel)) return Effect.void
+  legacyEnvWarned = true
+  return Effect.logWarning(
+    "OPENCODE_ENABLE_EXA / OPENCODE_ENABLE_PARALLEL no longer enable or disable websearch; the tool is available to all providers by default. They now only pin the backend — use the websearch.provider section in opencode.json instead",
+  )
 }
 
 export function webSearchProviderLabel(provider: unknown) {
@@ -101,6 +122,9 @@ export const WebSearchTool = Tool.define(
   Effect.gen(function* () {
     const http = yield* HttpClient.HttpClient
     const flags = yield* RuntimeFlags.Service
+    const config = yield* Config.Service
+
+    yield* warnLegacyEnvFlags(flags)
 
     return {
       get description() {
@@ -109,7 +133,9 @@ export const WebSearchTool = Tool.define(
       parameters: Parameters,
       execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
         Effect.gen(function* () {
+          const cfg = yield* config.get()
           const provider = selectWebSearchProvider(ctx.sessionID, {
+            provider: cfg.websearch?.provider,
             exa: flags.enableExa,
             parallel: flags.enableParallel,
           })

--- a/packages/opencode/test/tool/websearch.test.ts
+++ b/packages/opencode/test/tool/websearch.test.ts
@@ -1,15 +1,105 @@
-import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { afterEach, describe, expect, test } from "bun:test"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { logLines } from "effect/testing/TestConsole"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
 import { parseResponse } from "../../src/tool/mcp-websearch"
 import { selectWebSearchProvider, webSearchModelName, webSearchProviderLabel } from "../../src/tool/websearch"
 
-import { webSearchEnabled } from "../../src/tool/registry"
-import { it } from "../lib/effect"
-import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ToolRegistry } from "@/tool/registry"
+import { Agent } from "@/agent/agent"
+import { Config } from "@/config/config"
+import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { InstanceState } from "@/effect/instance-state"
+import { disposeAllInstances } from "../fixture/fixture"
+import { it, testEffect } from "../lib/effect"
+import { TestConfig } from "../fixture/config"
 
 const SESSION_ID = "ses_0196aabbccddeeff001122334455"
 
-describe("websearch provider", () => {
+const configLayer = (info: Record<string, unknown>) =>
+  TestConfig.layer({
+    directories: () => InstanceState.directory.pipe(Effect.map((dir) => [path.join(dir, ".opencode")])),
+    get: () => Effect.succeed(info as ConfigV1.Info),
+  })
+
+const root = LayerNode.group([ToolRegistry.node, Agent.node])
+
+const runner = (info: Record<string, unknown> = {}, flags: Record<string, unknown> = {}) =>
+  testEffect(
+    LayerNode.compile(root, [
+      [Config.node, configLayer(info)],
+      [RuntimeFlags.node, RuntimeFlags.layer(flags as never)],
+    ] as const),
+  )
+
+const itDefault = runner()
+const itDisabled = runner({ websearch: { enabled: false } })
+const itEnabled = runner({ websearch: { enabled: true } })
+const itLegacyExaFlag = runner({}, { enableExa: true })
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const toolsFor = (providerID: ProviderV2.ID) =>
+  Effect.gen(function* () {
+    const registry = yield* ToolRegistry.Service
+    const agents = yield* Agent.Service
+    const agent = yield* agents.defaultInfo()
+    const tools = yield* registry.tools({ providerID, modelID: ModelV2.ID.make("test"), agent })
+    return tools.map((tool) => tool.id)
+  })
+
+describe("websearch tool availability", () => {
+  // B1 — default-on for every provider, whitelisted or not
+  itDefault.instance("is included for arbitrary providers without any config", () =>
+    Effect.gen(function* () {
+      const ids = yield* toolsFor(ProviderV2.ID.make("ollama-local"))
+      expect(ids).toContain("websearch")
+    }),
+  )
+
+  // B5 — explicit opt-in keeps the tool
+  itEnabled.instance("stays included when websearch.enabled is explicitly true", () =>
+    Effect.gen(function* () {
+      const ids = yield* toolsFor(ProviderV2.ID.openai)
+      expect(ids).toContain("websearch")
+    }),
+  )
+
+  // B2 — opt-out hides the tool for non-managed providers
+  itDisabled.instance("is hidden when websearch.enabled is false", () =>
+    Effect.gen(function* () {
+      const ids = yield* toolsFor(ProviderV2.ID.make("ollama-local"))
+      expect(ids).not.toContain("websearch")
+    }),
+  )
+
+  // B3 — config wins over managed-provider status
+  itDisabled.instance("is hidden even for managed providers when websearch.enabled is false", () =>
+    Effect.gen(function* () {
+      const ids = yield* toolsFor(ProviderV2.ID.opencode)
+      expect(ids).not.toContain("websearch")
+    }),
+  )
+
+  // B7 — legacy OPENCODE_ENABLE_EXA no longer gates inclusion but warns once
+  itLegacyExaFlag.instance("warns once that legacy enablement env vars are deprecated", () =>
+    Effect.gen(function* () {
+      const ids = yield* toolsFor(ProviderV2.ID.make("ollama-local"))
+      expect(ids).toContain("websearch")
+
+      const lines = yield* logLines
+      expect(JSON.stringify(lines)).toContain("OPENCODE_ENABLE_EXA")
+    }),
+  )
+})
+
+describe("websearch backend selection", () => {
   test("selects a stable provider per session", () => {
     expect(selectWebSearchProvider(SESSION_ID)).toBe(selectWebSearchProvider(SESSION_ID))
   })
@@ -29,20 +119,58 @@ describe("websearch provider", () => {
     }
   })
 
-  test("routes to Exa when the Exa flag is enabled", () => {
-    expect(selectWebSearchProvider(SESSION_ID, { exa: true, parallel: false })).toBe("exa")
+  // B4 — config pin is honored
+  test("honors an explicit config pin", () => {
+    expect(selectWebSearchProvider(SESSION_ID, { provider: "exa" })).toBe("exa")
+    expect(selectWebSearchProvider(SESSION_ID, { provider: "parallel" })).toBe("parallel")
   })
 
-  test("routes to Parallel when the Parallel flag is enabled", () => {
-    expect(selectWebSearchProvider(SESSION_ID, { exa: false, parallel: true })).toBe("parallel")
+  // B4/"auto" — the default value must behave like no pin at all
+  test("treats provider 'auto' like no pin", () => {
+    expect(selectWebSearchProvider(SESSION_ID, { provider: "auto" })).toBe(selectWebSearchProvider(SESSION_ID))
   })
 
-  test("is enabled for OpenCode providers or explicit websearch provider flags", () => {
-    expect(webSearchEnabled(ProviderV2.ID.opencode, { exa: false, parallel: false })).toBe(true)
-    expect(webSearchEnabled(ProviderV2.ID.make("opencode-go"), { exa: false, parallel: false })).toBe(true)
-    expect(webSearchEnabled(ProviderV2.ID.openai, { exa: false, parallel: false })).toBe(false)
-    expect(webSearchEnabled(ProviderV2.ID.openai, { exa: true, parallel: false })).toBe(true)
-    expect(webSearchEnabled(ProviderV2.ID.openai, { exa: false, parallel: true })).toBe(true)
+  // B6/#44343 review note — an invalid env pin must not crash and must fall
+  // back to the same result as no pin
+  test("ignores an invalid OPENCODE_WEBSEARCH_PROVIDER value", () => {
+    const original = process.env.OPENCODE_WEBSEARCH_PROVIDER
+
+    try {
+      process.env.OPENCODE_WEBSEARCH_PROVIDER = "bogus"
+      const withBogus = selectWebSearchProvider(SESSION_ID)
+
+      delete process.env.OPENCODE_WEBSEARCH_PROVIDER
+      expect(withBogus).toBe(selectWebSearchProvider(SESSION_ID))
+    } finally {
+      if (original === undefined) delete process.env.OPENCODE_WEBSEARCH_PROVIDER
+      else process.env.OPENCODE_WEBSEARCH_PROVIDER = original
+    }
+  })
+
+  // B8/D3 — config pin beats the env var, which beats legacy flags
+  test("ranks config pin over the env var and legacy flags", () => {
+    const original = process.env.OPENCODE_WEBSEARCH_PROVIDER
+
+    try {
+      process.env.OPENCODE_WEBSEARCH_PROVIDER = "exa"
+      expect(selectWebSearchProvider(SESSION_ID, { provider: "parallel" })).toBe("parallel")
+      expect(selectWebSearchProvider(SESSION_ID, { parallel: true })).toBe("exa")
+
+      delete process.env.OPENCODE_WEBSEARCH_PROVIDER
+      expect(selectWebSearchProvider(SESSION_ID, { exa: true, parallel: true })).toBe("parallel")
+    } finally {
+      if (original === undefined) delete process.env.OPENCODE_WEBSEARCH_PROVIDER
+      else process.env.OPENCODE_WEBSEARCH_PROVIDER = original
+    }
+  })
+
+  // D3 — legacy flags remain pure backend pins
+  test("routes to Exa when the Exa flag is set", () => {
+    expect(selectWebSearchProvider(SESSION_ID, { exa: true })).toBe("exa")
+  })
+
+  test("routes to Parallel when the Parallel flag is set", () => {
+    expect(selectWebSearchProvider(SESSION_ID, { parallel: true })).toBe("parallel")
   })
 
   test("uses branded labels", () => {

--- a/packages/web/src/content/docs/cli.mdx
+++ b/packages/web/src/content/docs/cli.mdx
@@ -700,8 +700,9 @@ OpenCode can be configured using environment variables.
 | `OPENCODE_DISABLE_MOUSE`              | boolean | Disable mouse capture in the TUI                  |
 | `OPENCODE_FAKE_VCS`                   | string  | Fake VCS provider for testing purposes            |
 | `OPENCODE_CLIENT`                     | string  | Client identifier (defaults to `cli`)             |
-| `OPENCODE_ENABLE_EXA`                 | boolean | Enable Exa web search tools                       |
-| `OPENCODE_ENABLE_PARALLEL`            | boolean | Enable Parallel web search tools                  |
+| `OPENCODE_ENABLE_EXA`                 | boolean | Deprecated as an enablement switch: websearch is on by default. Now only pins the Exa backend (prefer `websearch.provider` in config) |
+| `OPENCODE_ENABLE_PARALLEL`            | boolean | Deprecated as an enablement switch: websearch is on by default. Now only pins the Parallel backend (prefer `websearch.provider` in config) |
+| `OPENCODE_WEBSEARCH_PROVIDER`         | string  | Pin the web search backend (`exa` or `parallel`). Precedence: `websearch.provider` config wins over this variable                  |
 | `OPENCODE_SERVER_PASSWORD`            | string  | Enable basic auth for `serve`/`web`               |
 | `OPENCODE_SERVER_USERNAME`            | string  | Override basic auth username (default `opencode`) |
 | `OPENCODE_MODELS_URL`                 | string  | Custom URL for fetching models configuration      |

--- a/packages/web/src/content/docs/tools.mdx
+++ b/packages/web/src/content/docs/tools.mdx
@@ -256,22 +256,15 @@ Allows the LLM to fetch and read web pages. Useful for looking up documentation 
 
 Search the web for information.
 
-:::note
-This tool is only available when using the OpenCode or OpenCode Go provider, or when either the `OPENCODE_ENABLE_EXA` or `OPENCODE_ENABLE_PARALLEL` environment variable is set to any truthy value (e.g., `true` or `1`).
+This tool is available to all model providers by default.
 
-To enable when launching OpenCode:
-
-```bash
-OPENCODE_ENABLE_EXA=1 opencode
-# or
-OPENCODE_ENABLE_PARALLEL=1 opencode
-```
-
-:::
-
-```json title="opencode.json" {4}
+```json title="opencode.json" {4-8}
 {
   "$schema": "https://opencode.ai/config.json",
+  "websearch": {
+    "enabled": true,
+    "provider": "auto"
+  },
   "permission": {
     "websearch": "allow"
   }
@@ -280,7 +273,16 @@ OPENCODE_ENABLE_PARALLEL=1 opencode
 
 Performs web searches using Exa or Parallel to find relevant information online. Useful for researching topics, finding current events, or gathering information beyond the training data cutoff.
 
+The optional `websearch` config section controls the tool:
+
+- `enabled` — set to `false` to remove the tool from every provider (default: `true`)
+- `provider` — `auto` picks a backend per session; `exa` or `parallel` pins that backend for every call
+
 No API key is required — the tool connects directly to the backend's hosted MCP service without authentication.
+
+:::note
+Consent is managed through the `permission.websearch` rule, so air-gapped or privacy-sensitive setups can deny the tool while keeping it visible.
+:::
 
 :::tip
 Use `websearch` when you need to find information (discovery), and `webfetch` when you need to retrieve content from a specific URL (retrieval).


### PR DESCRIPTION
### Issue for this PR

Closes #44307

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`websearch` is a client-side tool backed by the public Exa/Parallel MCP endpoints, so its availability should not depend on the identity of the model provider. Today it is hidden for every provider except `opencode`/`opencode-go` unless undocumented env vars are set.

- Remove the `webSearchEnabled(providerID, ...)` whitelist from `ToolRegistry`. The tool is now included for every provider unless explicitly disabled via config (`websearch.enabled: false`); consent stays on the existing `permission.websearch` layer (ask/deny per call), which is untouched.
- Add a documented config section:

  ```jsonc
  {
    "websearch": {
      "enabled": true,   // default true; false hides the tool everywhere
      "provider": "auto" // "auto" | "exa" | "parallel"
    }
  }
  ```

- Backend selection priority becomes: `websearch.provider` -> `OPENCODE_WEBSEARCH_PROVIDER` -> legacy `OPENCODE_ENABLE_EXA` / `OPENCODE_ENABLE_PARALLEL` pins -> per-session checksum split (unchanged).
- `OPENCODE_ENABLE_EXA` / `_PARALLEL` no longer gate availability; they keep pin semantics and log a one-shot deprecation warning.
- Docs: rewrite the websearch section in `tools.mdx`; mark the env flags deprecated in `cli.mdx`.

Why this instead of #44343: #44343 keeps the hardcoded whitelist, so custom/local providers stay broken out of the box and every new managed provider needs another additive line (#40568, #42378, PR #42630). The whitelist is also not enforcement: the bypass is a client-side env var, and the backends are public keyless endpoints that both vendors offer for free (Parallel explicitly targets OpenCode users). Removing the mechanism removes the bug class, matches `webfetch` (already shipped to all providers unfiltered), and matches the V2 core tool, which registers `websearch` unconditionally (`packages/core/src/tool/builtins.ts`).

Compatibility:

- Zen/Go users: no behavior change.
- Custom-provider users without any config: tool appears (this is the fix; refs #40028, #39121).
- Users with legacy env flags: keep working as backend pins, plus a deprecation warning.
- Air-gapped / privacy-sensitive setups: `websearch.enabled: false` or `permission.websearch: deny`.

### How did you verify your code works?

- Unit matrix in `packages/opencode/test/tool/websearch.test.ts`: **18/18 pass** — default-on for arbitrary providers without config; `websearch.enabled: false` hides the tool (also for managed providers); pin priority config > env > legacy flags; invalid `OPENCODE_WEBSEARCH_PROVIDER` value falls back to the checksum split without crashing; one-shot deprecation warning for legacy flags. Together with `test/tool/registry.test.ts`: **33/33 pass**.
- `bun test test/tool/` in `packages/opencode`: **~392 pass** across runs (391–393, timing-flaky `tool.glob` on slow Windows hosts) / persistent fail only `tool.shell abort > preserves output when aborted`, which reproduces on pristine dev on this machine; pre-existing Windows-only issue, unrelated to this change.
- `tsgo --noEmit`: 0 errors in `packages/core`; `packages/opencode` has 1 pre-existing error in the untouched `test/provider/transform.test.ts` (broken by upstream #46820 on the new base, unrelated to this change); oxlint on changed files: 0 errors. Rebased onto `upstream/dev@c0f09afe` (from `c2eacd72`); merge simulation shows 0 conflicts.
- Manual E2E on a local build against a custom OpenAI-compatible provider and a managed `opencode/*` control (config injected inline via `OPENCODE_CONFIG_CONTENT`, legacy env vars stripped per process): the tool appears with no env vars configured; `enabled: false` removes it; `websearch.provider: "exa"` shows `"exa"` in tool-call metadata and wins over `OPENCODE_WEBSEARCH_PROVIDER=parallel`; a legacy `OPENCODE_ENABLE_EXA=1` run logs the deprecation warning.

### Screenshots / recordings

_N/A - no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
