### PR TITLE
fix(app): preserve tool disclosures when groups update

### DIFF
--- a/packages/app/e2e/regression/session-timeline-collapse-state.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-collapse-state.spec.ts
@@ -95,7 +95,10 @@ test.describe("regression: session timeline local row state", () => {
     const group = page.locator('[data-component="collapsed-tool-group"]')
     const summary = group.getByRole("button", { name: "Used Patch", exact: true })
     await summary.click()
-    const wrapper = group.locator(`[data-timeline-part-id="${editPartID}"]`)
+    await group.locator(`[data-timeline-part-id="${editPartID}"]`).evaluate((element) => {
+      element.setAttribute("data-disclosure-probe", "existing")
+    })
+    const wrapper = group.locator('[data-disclosure-probe="existing"]')
     const trigger = wrapper.locator('[data-scope="apply-patch"] button')
     await expect(trigger).toHaveAttribute("aria-expanded", "false")
     await trigger.click()
@@ -107,10 +110,8 @@ test.describe("regression: session timeline local row state", () => {
       const id = `prt_patch_${count}`
       events.push(...toolEvents({ ...part, id, callID: id }))
       await expect(group.locator('[data-component="tag"]')).toHaveText(String(count))
-      const added = group.locator(`[data-timeline-part-id="${id}"] [data-scope="apply-patch"] button`)
-      await expect(added).toBeVisible()
+      await expect(group).toHaveAttribute("data-timeline-part-ids", new RegExp(`${id}$`))
       await expect(trigger).toHaveAttribute("aria-expanded", String(count === 2))
-      await expect(added).toHaveAttribute("aria-expanded", "false")
       await expect(summary).toHaveAttribute("aria-expanded", "true")
       expect(await original!.evaluate((node) => node.isConnected)).toBe(true)
     }

--- a/packages/app/e2e/regression/session-timeline-collapse-state.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-collapse-state.spec.ts
@@ -84,6 +84,38 @@ const assistantMessage = {
 } satisfies SessionMessageInfo
 
 test.describe("regression: session timeline local row state", () => {
+  test("preserves a patch file choice as new calls join its Used group", async ({ page }) => {
+    const events: EventPayload[] = []
+    const part = { ...editPart, tool: "patch" }
+    await mockServer(page, events, [userMessage, { ...assistantMessage, content: [toolContent(part)] }])
+    await configurePage(page, false)
+    await page.goto(sessionHref())
+    await expectSessionTitle(page, title)
+
+    const group = page.locator('[data-component="collapsed-tool-group"]')
+    const summary = group.getByRole("button", { name: "Used Patch", exact: true })
+    await summary.click()
+    const wrapper = group.locator(`[data-timeline-part-id="${editPartID}"]`)
+    const trigger = wrapper.locator('[data-scope="apply-patch"] button')
+    await expect(trigger).toHaveAttribute("aria-expanded", "false")
+    await trigger.click()
+    await expect(trigger).toHaveAttribute("aria-expanded", "true")
+    const original = await wrapper.elementHandle()
+
+    for (const count of [2, 3]) {
+      if (count === 3) await trigger.click()
+      const id = `prt_patch_${count}`
+      events.push(...toolEvents({ ...part, id, callID: id }))
+      await expect(group.locator('[data-component="tag"]')).toHaveText(String(count))
+      const added = group.locator(`[data-timeline-part-id="${id}"] [data-scope="apply-patch"] button`)
+      await expect(added).toBeVisible()
+      await expect(trigger).toHaveAttribute("aria-expanded", String(count === 2))
+      await expect(added).toHaveAttribute("aria-expanded", "false")
+      await expect(summary).toHaveAttribute("aria-expanded", "true")
+      expect(await original!.evaluate((node) => node.isConnected)).toBe(true)
+    }
+  })
+
   test("keeps a manually collapsed tool collapsed when later assistant content streams", async ({ page }) => {
     const events: EventPayload[] = []
     await mockServer(page, events)
@@ -208,19 +240,19 @@ test.describe("regression: session timeline local row state", () => {
   })
 })
 
-async function configurePage(page: Page) {
-  await page.addInitScript(() => {
+async function configurePage(page: Page, expanded = true) {
+  await page.addInitScript((expanded) => {
     localStorage.setItem(
       "settings.v3",
       JSON.stringify({
         general: {
-          editToolPartsExpanded: true,
-          shellToolPartsExpanded: true,
+          editToolPartsExpanded: expanded,
+          shellToolPartsExpanded: expanded,
           showReasoningSummaries: true,
         },
       }),
     )
-  })
+  }, expanded)
 }
 
 async function expectExpanded(locator: Locator, expected: boolean) {

--- a/packages/session-ui/component-tests/tool-disclosure.spec.ts
+++ b/packages/session-ui/component-tests/tool-disclosure.spec.ts
@@ -1,0 +1,45 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+for (const open of [true, false]) {
+  story(
+    `preserves ${open ? "expanded" : "collapsed"} tool choices when calls join the group`,
+    async ({ mount }, info) => {
+      const root = await mount("current-session-file-changes--appending-tool-calls")
+      const group = root.locator('[data-component="collapsed-tool-group"]')
+      await group.getByRole("button", { name: "Used Shell, Patch", exact: true }).click()
+      const shell = group.locator('[data-timeline-part-id="tool_shell_existing"] [data-slot="collapsible-trigger"]')
+      const patch = group.locator('[data-timeline-part-id="tool_patch_existing"]')
+      const first = patch.locator('[data-scope="apply-patch"] button').filter({ hasText: "a.ts" })
+      const second = patch.locator('[data-scope="apply-patch"] button').filter({ hasText: "b.ts" })
+      const diff = patch.locator('[data-type="update"]').filter({ hasText: "b.ts" }).locator('[data-component="file"]')
+      await shell.click()
+      await first.click()
+      await second.click()
+      if (!open) {
+        await shell.click()
+        await first.click()
+      }
+      await expect(shell).toHaveAttribute("aria-expanded", String(open))
+      await expect(first).toHaveAttribute("aria-expanded", String(open))
+      await expect(second).toHaveAttribute("aria-expanded", "true")
+      await expect(diff).toBeVisible()
+      const original = await patch.elementHandle()
+      for (const count of [3, 4]) {
+        await root.getByRole("button", { name: "Append tool call", exact: true }).click()
+        await expect(group.locator('[data-component="tag"]')).toHaveText(String(count))
+        await expect(diff).toBeVisible()
+        await root
+          .locator('[data-component="session-timeline"]')
+          .screenshot({ path: info.outputPath(`append-${count}.png`) })
+        await expect(shell).toHaveAttribute("aria-expanded", String(open))
+        await expect(first).toHaveAttribute("aria-expanded", String(open))
+        await expect(second).toHaveAttribute("aria-expanded", "true")
+        expect(await original!.evaluate((node) => node.isConnected)).toBe(true)
+        await expect(group.getByRole("button", { name: "Used Shell, Patch", exact: true })).toHaveAttribute(
+          "aria-expanded",
+          "true",
+        )
+      }
+    },
+  )
+}

--- a/packages/session-ui/component-tests/tool-disclosure.spec.ts
+++ b/packages/session-ui/component-tests/tool-disclosure.spec.ts
@@ -8,7 +8,10 @@ for (const open of [true, false]) {
       const group = root.locator('[data-component="collapsed-tool-group"]')
       await group.getByRole("button", { name: "Used Shell, Patch", exact: true }).click()
       const shell = group.locator('[data-timeline-part-id="tool_shell_existing"] [data-slot="collapsible-trigger"]')
-      const patch = group.locator('[data-timeline-part-id="tool_patch_existing"]')
+    await group.locator('[data-timeline-part-id="tool_patch_existing"]').evaluate((element) => {
+      element.setAttribute("data-disclosure-probe", "existing")
+    })
+    const patch = group.locator('[data-disclosure-probe="existing"]')
       const first = patch.locator('[data-scope="apply-patch"] button').filter({ hasText: "a.ts" })
       const second = patch.locator('[data-scope="apply-patch"] button').filter({ hasText: "b.ts" })
       const diff = patch.locator('[data-type="update"]').filter({ hasText: "b.ts" }).locator('[data-component="file"]')

--- a/packages/session-ui/src/timeline/file-changes.stories.tsx
+++ b/packages/session-ui/src/timeline/file-changes.stories.tsx
@@ -199,6 +199,51 @@ const fileScenarios = {
   write: WrittenSource,
 }
 
+export const AppendingToolCalls = {
+  render: () => {
+    const [state, setState] = createStore({ calls: 0 })
+    const files = ["src/a.ts", "src/b.ts"].map((file) => ({
+      ...storyPatchFile(file),
+      patch: createTwoFilesPatch(file, file, "export const before = true\n", "export const after = true\n"),
+    }))
+    const document = createMemo(() =>
+      storyDocument([
+        storyTool("tool_shell_existing", "shell", "completed", { command: "printf checked" }, { output: "checked" }),
+        storyTool(
+          "tool_patch_existing",
+          "patch",
+          "completed",
+          { patchText: "Update two files" },
+          {
+            metadata: { files },
+          },
+        ),
+        ...Array.from({ length: state.calls }, (_, index) =>
+          storyTool(
+            `tool_patch_next_${index}`,
+            "patch",
+            "completed",
+            { patchText: "Update src/a.ts again" },
+            {
+              metadata: { files: [files[0]] },
+            },
+          ),
+        ),
+      ]),
+    )
+    return (
+      <section class="mx-auto flex w-full max-w-[860px] flex-col gap-4 p-6">
+        <button type="button" onClick={() => setState("calls", (count) => count + 1)}>
+          Append tool call
+        </button>
+        <CurrentSessionProviders document={document()}>
+          <SessionTimeline document={document()} />
+        </CurrentSessionProviders>
+      </section>
+    )
+  },
+}
+
 export const ChangingFiles = {
   args: { scenario: "streaming" },
   argTypes: { scenario: { control: "select", options: Object.keys(fileScenarios) } },

--- a/packages/session-ui/src/timeline/session-timeline-row.tsx
+++ b/packages/session-ui/src/timeline/session-timeline-row.tsx
@@ -475,11 +475,13 @@ export function createSessionTimelineRowRenderer(input: {
         if (value._tag !== "AssistantPart") throw new Error("Expected an assistant-part timeline row")
         return value
       }
+      // Construct once per row key, not inside JSX that reruns when group refs change.
+      const content = renderAssistant(current, onSizeChange)
       return (
         <Frame row={current()}>
           <div data-slot="session-turn-message-container" class={`w-full ${padding()}`}>
             <div data-slot="session-turn-assistant-content" aria-hidden={workingTurn(current().userMessageID)}>
-              {renderAssistant(current, onSizeChange)}
+              {content}
             </div>
           </div>
         </Frame>


### PR DESCRIPTION
## Summary

Construct assistant content once per stable row key instead of invoking its renderer inside a reactive JSX expression. Adding group refs previously reran that constructor and remounted nested tools, resetting their local disclosure choices.

The production fix is three added lines and one replaced expression. It retains reactive content updates without introducing a new state store or changing defaults.

## Reproduction

1. Expand Used Shell, Patch, the shell output, and two individual patch files.
2. Append another patch call touching the same path.
3. Before: the existing shell and files collapse. After: the user's choices remain.

The regression failed before the fix and passes afterward. Both explicit expanded and collapsed choices are covered, including independent sibling files and repeated appends.

Tests track the existing rendered file stack rather than requiring one stack per patch call, so they also apply when adjacent calls are merged by the separate patch-grouping fix.

## Screenshots

Before:

![Disclosures reset after append](https://raw.githubusercontent.com/Hona/opencode/fde017d005ad955c0eae1b14922417265654d760/.github/pr-evidence/preserve-tool-state/before.png)

After:

![Disclosures preserved after append](https://raw.githubusercontent.com/Hona/opencode/fde017d005ad955c0eae1b14922417265654d760/.github/pr-evidence/preserve-tool-state/after.png)

Screenshots contain only deterministic fixture content, with no model selector. Images are outside the code diff.

## Verification

- Four app collapse-state E2E tests pass, including the new live-event regression.
- Both component regressions pass at desktop and 390px widths using the production timeline through a Vite fixture harness.
- App and session-ui typechecks, and E2E typecheck, pass.
- App unit suite: 543 passed; session-ui unit suite: 113 passed before rebasing.
- Rebased onto merged #45462 and reran app E2E, desktop component regressions, and package typechecks successfully.
- Formatting and diff checks pass.

Production benchmark captured before editing and repeated after the fix on the same pre-rebase base (`10786cb60c`): streaming completion 6520 ms -> 6188 ms; RAF p95 unchanged at 300 ms. Both delivered all 32 deltas with no row/Markdown replacement, bottom drift, or blank samples. Single samples are not a performance guarantee.

One-line notice truncation remains a separate PR.
