### PR TITLE
fix(core): apply plugin environment to v2 bash

### DIFF
--- a/packages/core/src/shell-environment.ts
+++ b/packages/core/src/shell-environment.ts
@@ -1,0 +1,24 @@
+export * as ShellEnvironment from "./shell-environment"
+
+import { makeLocationNode } from "./effect/app-node"
+import { Context, Effect, Layer } from "effect"
+
+export interface Interface {
+  readonly get: (input: {
+    directory: string
+    cwd: string
+    sessionID?: string
+    callID?: string
+  }) => Effect.Effect<Record<string, string>>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/v2/ShellEnvironment") {}
+
+export const layer = Layer.succeed(
+  Service,
+  Service.of({
+    get: () => Effect.succeed({}),
+  }),
+)
+
+export const node = makeLocationNode({ service: Service, layer, deps: [] })

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -7,10 +7,12 @@ import { ChildProcess } from "effect/unstable/process"
 import { Config } from "../config"
 import { makeLocationNode } from "../effect/app-node"
 import { FSUtil } from "../fs-util"
+import { Location } from "../location"
 import { LocationMutation } from "../location-mutation"
 import { AppProcess } from "../process"
 import { PermissionV2 } from "../permission"
 import { PositiveInt } from "../schema"
+import { ShellEnvironment } from "../shell-environment"
 import { ToolRegistry } from "./registry"
 import { Tool } from "./tool"
 import { Tools } from "./tools"
@@ -67,7 +69,6 @@ const isTimeout = (error: AppProcess.AppProcessError) =>
 // TODO: Port BashArity reusable command-prefix approvals.
 // TODO: Replace token-based command-argument external-directory advisories with parser-based detection.
 // TODO: Restore PowerShell and cmd-specific invocation/path handling on Windows.
-// TODO: Add plugin shell.env environment augmentation once V2 plugin hooks exist.
 // TODO: Add durable/live progress metadata streaming for long-running commands once V2 tool invocation progress context is wired.
 // TODO: Persist background job status and define restart recovery before exposing remote observation.
 // TODO: Re-add model-facing background launch only with owner-bound get/wait/cancel tools and completion delivery.
@@ -98,10 +99,12 @@ const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
     const mutation = yield* LocationMutation.Service
+    const location = yield* Location.Service
     const fs = yield* FSUtil.Service
     const appProcess = yield* AppProcess.Service
     const config = yield* Config.Service
     const permission = yield* PermissionV2.Service
+    const environment = yield* ShellEnvironment.Service
 
     yield* tools
       .register({
@@ -155,9 +158,17 @@ const layer = Layer.effectDiscard(
               const shell =
                 Object.assign({}, ...entries.flatMap((entry) => (entry.type === "document" ? [entry.info] : [])))
                   .shell ?? defaultShell()
+              const extra = yield* environment.get({
+                directory: location.directory,
+                cwd: target.canonical,
+                sessionID: context.sessionID,
+                callID: context.toolCallID,
+              })
               const command = ChildProcess.make(input.command, [], {
                 cwd: target.canonical,
                 shell,
+                env: extra,
+                extendEnv: true,
                 stdin: "ignore",
                 detached: process.platform !== "win32",
                 forceKillAfter: Duration.seconds(3),
@@ -203,5 +214,14 @@ const layer = Layer.effectDiscard(
 export const node = makeLocationNode({
   name: "tool/bash",
   layer,
-  deps: [ToolRegistry.node, LocationMutation.node, FSUtil.node, AppProcess.node, Config.node, PermissionV2.node],
+  deps: [
+    ToolRegistry.node,
+    LocationMutation.node,
+    Location.node,
+    FSUtil.node,
+    AppProcess.node,
+    Config.node,
+    PermissionV2.node,
+    ShellEnvironment.node,
+  ],
 })

--- a/packages/core/test/tool-bash.test.ts
+++ b/packages/core/test/tool-bash.test.ts
@@ -12,6 +12,7 @@ import { Location } from "@opencode-ai/core/location"
 import { LocationMutation } from "@opencode-ai/core/location-mutation"
 import { PermissionV2 } from "@opencode-ai/core/permission"
 import { AppProcess } from "@opencode-ai/core/process"
+import { ShellEnvironment } from "@opencode-ai/core/shell-environment"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { BashTool } from "@opencode-ai/core/tool/bash"
@@ -28,6 +29,8 @@ const runs: Array<{
   readonly command: string
   readonly cwd?: string
   readonly shell?: string | boolean
+  readonly env?: NodeJS.ProcessEnv
+  readonly extendEnv?: boolean
   readonly options?: AppProcess.RunOptions
 }> = []
 let denyAction: string | undefined
@@ -67,7 +70,14 @@ const appProcess = Layer.succeed(
     run: (command: ChildProcess.Command, options?: AppProcess.RunOptions) =>
       Effect.suspend(() => {
         if (command._tag !== "StandardCommand") throw new Error("expected standard command")
-        runs.push({ command: command.command, cwd: command.options.cwd, shell: command.options.shell, options })
+        runs.push({
+          command: command.command,
+          cwd: command.options.cwd,
+          shell: command.options.shell,
+          env: command.options.env,
+          extendEnv: command.options.extendEnv,
+          options,
+        })
         return runFailure ? Effect.fail(runFailure) : Effect.succeed(result)
       }),
   } as unknown as AppProcess.Interface),
@@ -101,6 +111,7 @@ const withTool = <A, E, R>(
   directory: string,
   body: (registry: ToolRegistry.Interface) => Effect.Effect<A, E, R>,
   processLayer: Layer.Layer<AppProcess.Service> = appProcess,
+  environmentLayer: Layer.Layer<ShellEnvironment.Service> = ShellEnvironment.layer,
 ) => {
   const activeLocation = Layer.succeed(
     Location.Service,
@@ -117,6 +128,7 @@ const withTool = <A, E, R>(
           [PermissionV2.node, permission],
           [AppProcess.node, processLayer],
           [Config.node, config],
+          [ShellEnvironment.node, environmentLayer],
           [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
         ],
       ),
@@ -228,6 +240,37 @@ describe("BashTool", () => {
   )
 
   if (process.platform !== "win32") {
+    it.live("applies the location shell environment before spawning", () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          const environment = Layer.succeed(
+            ShellEnvironment.Service,
+            ShellEnvironment.Service.of({
+              get: (input) => Effect.succeed({ SHELL_ENV_PROBE: `${input.sessionID}:${input.callID}` }),
+            }),
+          )
+          return withTool(
+            tmp.path,
+            (registry) => settleTool(registry, call({ command: "printf core-bash" })),
+            appProcess,
+            environment,
+          ).pipe(
+            Effect.andThen(
+              Effect.sync(() => {
+                expect(runs[0]).toMatchObject({
+                  env: { SHELL_ENV_PROBE: `${sessionID}:call-bash` },
+                  extendEnv: true,
+                })
+              }),
+            ),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      ),
+    )
+
     it.live("executes a real shell command through AppProcess", () =>
       Effect.acquireUseRelease(
         Effect.promise(() => tmpdir()),
@@ -425,7 +468,6 @@ test("keeps locked deferred parity TODOs visible", async () => {
     "Port BashArity reusable command-prefix approvals.",
     "Replace token-based command-argument external-directory advisories with parser-based detection.",
     "Restore PowerShell and cmd-specific invocation/path handling on Windows.",
-    "Add plugin shell.env environment augmentation once V2 plugin hooks exist.",
     "Add durable/live progress metadata streaming for long-running commands once V2 tool invocation progress context is wired.",
     "Persist background job status and define restart recovery before exposing remote observation.",
     "Revisit process-group cleanup and platform coverage with shell-specific tests if current AppProcess semantics do not fully cover it.",

--- a/packages/opencode/src/plugin/shell-environment.ts
+++ b/packages/opencode/src/plugin/shell-environment.ts
@@ -1,0 +1,42 @@
+export * as PluginShellEnvironment from "./shell-environment"
+
+import { makeLocationNode } from "@opencode-ai/core/effect/app-node"
+import { ShellEnvironment } from "@opencode-ai/core/shell-environment"
+import { Effect, Layer } from "effect"
+import { InstanceRef } from "@/effect/instance-ref"
+import { Project } from "@/project/project"
+import { Plugin } from "."
+
+export const layer = Layer.effect(
+  ShellEnvironment.Service,
+  Effect.gen(function* () {
+    const plugin = yield* Plugin.Service
+    const project = yield* Project.Service
+    return ShellEnvironment.Service.of({
+      get: Effect.fn("ShellEnvironment.get")(function* (input) {
+        const result = yield* project.fromDirectory(input.directory)
+        const instance = {
+          directory: input.directory,
+          worktree: result.sandbox,
+          project: result.project,
+        }
+        return yield* plugin
+          .trigger(
+            "shell.env",
+            { cwd: input.cwd, sessionID: input.sessionID, callID: input.callID },
+            { env: {} as Record<string, string> },
+          )
+          .pipe(
+            Effect.map((output) => output.env),
+            Effect.provideService(InstanceRef, instance),
+          )
+      }),
+    })
+  }),
+)
+
+export const node = makeLocationNode({
+  service: ShellEnvironment.Service,
+  layer,
+  deps: [Plugin.node, Project.node],
+})

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -22,6 +22,7 @@ import { McpAuth } from "@/mcp/auth"
 import { Permission } from "@/permission"
 import { Plugin } from "@/plugin"
 import { PluginPtyEnvironment } from "@/plugin/pty-environment"
+import { PluginShellEnvironment } from "@/plugin/shell-environment"
 import { InstanceStore } from "@/project/instance-store"
 import { Project } from "@/project/project"
 import { Vcs } from "@/project/vcs"
@@ -66,6 +67,7 @@ import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionV2 } from "@opencode-ai/core/session"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import * as SessionExecutionLocal from "@opencode-ai/core/session/execution/local"
+import { ShellEnvironment } from "@opencode-ai/core/shell-environment"
 import { lazy } from "@/util/lazy"
 import { CorsConfig, isAllowedCorsOrigin, type CorsOptions } from "@opencode-ai/server/cors"
 import { serveUIEffect } from "@/server/shared/ui"
@@ -271,7 +273,7 @@ const app = LayerNode.group([
 export function createRoutes(
   corsOptions?: CorsOptions,
 ): Layer.Layer<never, EffectConfig.ConfigError, RouteRequirements> {
-  const locationServiceMapV2 = buildLocationServiceMap()
+  const locationServiceMapV2 = buildLocationServiceMap([[ShellEnvironment.node, PluginShellEnvironment.node]])
 
   return Layer.mergeAll(
     rootApiRoutes,

--- a/packages/opencode/test/plugin/trigger.test.ts
+++ b/packages/opencode/test/plugin/trigger.test.ts
@@ -8,6 +8,9 @@ import { Account } from "../../src/account/account"
 import { Auth } from "../../src/auth"
 import { RuntimeFlags } from "../../src/effect/runtime-flags"
 import { Plugin } from "../../src/plugin/index"
+import { PluginShellEnvironment } from "../../src/plugin/shell-environment"
+import { Project } from "../../src/project/project"
+import { ShellEnvironment } from "@opencode-ai/core/shell-environment"
 
 import { TestInstance } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -20,7 +23,7 @@ import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 
 const it = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Plugin.node, CrossSpawnSpawner.node]), [
+  AppNodeBuilder.build(LayerNode.group([Plugin.node, Project.node, CrossSpawnSpawner.node]), [
     [Auth.node, AuthTest.empty],
     [Account.node, AccountTest.empty],
     [Npm.node, NpmTest.noop],
@@ -73,6 +76,34 @@ const triggerSystemTransform = Effect.fn("PluginTriggerTest.triggerSystemTransfo
 })
 
 describe("plugin.trigger", () => {
+  it.instance("projects shell.env hooks through the V2 shell environment adapter", () =>
+    withProject(
+      [
+        "export default async () => ({",
+        '  "shell.env": (input, output) => {',
+        '    output.env.SHELL_ENV_PROBE = [input.cwd, input.sessionID, input.callID].join("|")',
+        "  },",
+        "})",
+        "",
+      ].join("\n"),
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const environment = yield* ShellEnvironment.Service.use((service) =>
+          service.get({
+            directory: test.directory,
+            cwd: path.join(test.directory, "child"),
+            sessionID: "ses_adapter_test",
+            callID: "call_adapter_test",
+          }),
+        ).pipe(Effect.provide(PluginShellEnvironment.layer))
+
+        expect(environment).toEqual({
+          SHELL_ENV_PROBE: `${path.join(test.directory, "child")}|ses_adapter_test|call_adapter_test`,
+        })
+      }),
+    ),
+  )
+
   it.instance("runs synchronous hooks without crashing", () =>
     withProject(
       [

--- a/packages/opencode/test/server/httpapi-v2-pty.test.ts
+++ b/packages/opencode/test/server/httpapi-v2-pty.test.ts
@@ -209,7 +209,7 @@ describe("v2 pty HttpApi", () => {
           directoryHeader(dir),
           HttpClientRequest.bodyJson({
             command: "/bin/sh",
-            args: ["-c", 'printf "%s|%s|%s|%s|%s\\n" "$CALLER" "$SHARED" "$PLUGIN" "$TERM" "$HOOK_CWD"; sleep 5'],
+            args: ["-c", 'printf "%s|%s|%s|%s|%s\\n" "$CALLER" "$SHARED" "$PLUGIN" "$TERM" "$HOOK_CWD"; exec /bin/cat'],
             cwd,
             env: { CALLER: "caller", SHARED: "caller", TERM: "caller" },
           }),


### PR DESCRIPTION
### Issue for this PR

Closes #41117

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

V2 Bash runs through Core and did not invoke the existing `shell.env` plugin hook, so plugin-provided environment variables were absent from Bash processes.

This adds a Core `ShellEnvironment` service, connects it to the legacy plugin hook in the OpenCode location graph, and applies the returned environment immediately before process spawn. The hook receives the request `cwd`, `sessionID`, and `callID`; `extendEnv: true` preserves the existing process environment. PTY keeps its existing hook path.

### How did you verify your code works?

- `bun test test/tool-bash.test.ts` in `packages/core` (12 passed)
- `bun test test/plugin/trigger.test.ts` in `packages/opencode` (3 passed)
- `bun test test/server/httpapi-v2-pty.test.ts --timeout 20000` in `packages/opencode` (4 passed)
- `bun run typecheck` in `packages/core` and `packages/opencode`
- repository pre-push typecheck (30 packages)

### Screenshots / recordings

Not applicable; this change has no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR