### PR TITLE
fix(tui): dismiss question prompt when server question already gone

### DIFF
--- a/packages/tui/src/routes/session/question.tsx
+++ b/packages/tui/src/routes/session/question.tsx
@@ -5,6 +5,7 @@ import type { TextareaRenderable } from "@opentui/core"
 import { selectedForeground, tint, useTheme } from "../../context/theme"
 import type { QuestionAnswer, QuestionRequest } from "@opencode-ai/sdk/v2"
 import { useSDK } from "../../context/sdk"
+import { useSync } from "../../context/sync"
 import { SplitBorder } from "../../ui/border"
 import { useTuiConfig } from "../../config"
 import { useBindings, useOpencodeModeStack } from "../../keymap"
@@ -13,6 +14,7 @@ const QUESTION_MODE = "question"
 
 export function QuestionPrompt(props: { request: QuestionRequest; directory?: string }) {
   const sdk = useSDK()
+  const sync = useSync()
   const { theme } = useTheme()
   const renderer = useRenderer()
   const tuiConfig = useTuiConfig()
@@ -45,19 +47,32 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
     return store.answers[store.tab]?.includes(value) ?? false
   })
 
+  function forceDismiss() {
+    sync.set("question", props.request.sessionID, [])
+  }
+
   function submit() {
     const answers = questions().map((_, i) => store.answers[i] ?? [])
-    void sdk.client.question.reply({
+    sdk.client.question.reply({
       requestID: props.request.id,
       directory: props.directory,
       answers,
+    }).then(() => {
+      // server will send question.replied event — sync handles it
+    }).catch(() => {
+      // question already gone server-side; dismiss locally
+      forceDismiss()
     })
   }
 
   function reject() {
-    void sdk.client.question.reject({
+    sdk.client.question.reject({
       requestID: props.request.id,
       directory: props.directory,
+    }).then(() => {
+      // server will send question.rejected event — sync handles it
+    }).catch(() => {
+      forceDismiss()
     })
   }
 
@@ -71,10 +86,14 @@ export function QuestionPrompt(props: { request: QuestionRequest; directory?: st
       setStore("custom", inputs)
     }
     if (single()) {
-      void sdk.client.question.reply({
+      sdk.client.question.reply({
         requestID: props.request.id,
         directory: props.directory,
         answers: [[answer]],
+      }).then(() => {
+        // server will send question.replied event — sync handles it
+      }).catch(() => {
+        forceDismiss()
       })
       return
     }


### PR DESCRIPTION
## PR Information
**Author:** This pull request was written by an AI agent (OpenCode, DeepSeek v4 Flash) based on a bug report from a user of the TUI. The code was reviewed by the user who experienced the issue.

## Original Issue
When a session gets interrupted (e.g. service restart), the server clears its question requests but the TUI never receives the corresponding `question.rejected` event because the server-side question was already removed. The stale question stays in the TUI's sync store, so `QuestionPrompt` keeps rendering — but pressing Escape calls `reject()` which returns a `QuestionNotFoundError` that is silently swallowed by `void`. The user is stuck in a form they can't dismiss.

The only recovery was a service restart (re-sync clears the stale question), which is not acceptable for a dismissible form.

## Root Cause
All three question-dismiss paths (`submit`, `reject`, and the single-select `pick`) use `void` on the API promise. When the server returns a 404 / `QuestionNotFoundError`, the promise rejects silently and the question stays in the sync store, keeping the prompt visible.

## Fix
1. Import `useSync` so the prompt can mutate the sync store directly.
2. Add a `forceDismiss()` helper that clears all questions for this session from the sync store, causing the parent view to unmount `QuestionPrompt`.
3. Chain `.then().catch()` on all three API calls — on success the server sends the normal event (sync handles it); on error (question already gone), `forceDismiss()` removes it locally.

**File changed:** `packages/tui/src/routes/session/question.tsx`