### PR TITLE
fix(app): keep timeline notices on one line

### DIFF
--- a/packages/app/e2e/regression/session-notice-truncation.spec.ts
+++ b/packages/app/e2e/regression/session-notice-truncation.spec.ts
@@ -1,0 +1,89 @@
+import { expect, test } from "@playwright/test"
+import { setupTimeline } from "../performance/timeline-stability/fixture"
+
+for (const width of [1400, 390]) {
+  for (const profile of [
+    { locale: "en", direction: "ltr" },
+    { locale: "en", direction: "rtl" },
+    { locale: "ar", direction: "rtl" },
+  ]) {
+    test(`keeps notices on one line: ${profile.locale} ${profile.direction} ${width}`, async ({ page }, info) => {
+      const command =
+        "bun run inspect --target src/renderer/session-timeline.ts --output artifacts/inspection-report.json ".repeat(5)
+      const descriptions = [
+        `${command}--finished`,
+        `Instructions changed\n${command}--updated`,
+        `\u0645\u0631\u0627\u062c\u0639\u0629 ${command}--reviewed`,
+      ]
+      await setupTimeline(page, {
+        locale: profile.locale,
+        viewport: { width, height: 900 },
+        sessionMessages: [
+          {
+            id: "msg_notice_user",
+            type: "user",
+            text: "Inspect the project and report completion.",
+            time: { created: 1 },
+          },
+          {
+            id: "msg_notice_shell",
+            type: "synthetic",
+            text: "Complete",
+            description: descriptions[0],
+            metadata: { source: "shell", state: "completed" },
+            time: { created: 2 },
+          },
+          { id: "msg_notice_system", type: "system", text: descriptions[1], time: { created: 3 } },
+          {
+            id: "msg_notice_agent",
+            type: "synthetic",
+            text: "Complete",
+            description: descriptions[2],
+            metadata: { source: "subagent", state: "completed", agent: "general" },
+            time: { created: 4 },
+          },
+        ],
+      })
+      await page
+        .locator("html")
+        .evaluate((element, direction) => element.setAttribute("dir", direction), profile.direction)
+      const notices = page.locator('[data-slot="session-timeline-notice"]')
+      await expect(notices).toHaveCount(3)
+      await expect(notices).toContainText(descriptions)
+      await page.locator("[data-timeline-virtual-content]").screenshot({ path: info.outputPath("notices.png") })
+      await expect
+        .poll(() =>
+          notices.evaluateAll((nodes) =>
+            nodes.map((node) => {
+              const style = getComputedStyle(node)
+              const element = node as HTMLElement
+              return {
+                direction: style.direction,
+                whiteSpace: style.whiteSpace,
+                textOverflow: style.textOverflow,
+                overflow: style.overflowX,
+                singleLine:
+                  Math.abs(
+                    element.clientHeight -
+                      parseFloat(style.paddingTop) -
+                      parseFloat(style.paddingBottom) -
+                      parseFloat(style.lineHeight),
+                  ) <= 1,
+                clipped: element.scrollWidth > element.clientWidth,
+              }
+            }),
+          ),
+        )
+        .toEqual(
+          Array.from({ length: 3 }, () => ({
+            direction: profile.direction,
+            whiteSpace: "nowrap",
+            textOverflow: "ellipsis",
+            overflow: "hidden",
+            singleLine: true,
+            clipped: true,
+          })),
+        )
+    })
+  }
+}

--- a/packages/session-ui/src/timeline/session-timeline-row.tsx
+++ b/packages/session-ui/src/timeline/session-timeline-row.tsx
@@ -368,7 +368,7 @@ export function createSessionTimelineRowRenderer(input: {
                         fallback={
                           <div
                             data-slot="session-timeline-notice"
-                            class={`w-full pt-3 pb-1 text-13-regular text-text-weak ${padding()}`}
+                            class={`w-full truncate pt-3 pb-1 text-13-regular text-text-weak ${padding()}`}
                           >
                             <bdi dir="auto" class="text-13-medium">
                               {content().label}


### PR DESCRIPTION
## Summary

Add the existing `truncate` utility to plain timeline notices. Long notices such as Shell finished now stay on one line with an ellipsis, matching tool subtitle treatment instead of wrapping across the transcript.

One production class change. Full text and existing bidi isolation remain in the DOM. Compaction content, model separators, and movement notices are unchanged.

## Screenshots

Before:

![Notices wrap across multiple lines](https://raw.githubusercontent.com/Hona/opencode/38d1bd20206d88613d60153b95de9e1d46e06859/.github/pr-evidence/single-line-notices/before.png)

After:

![Notices stay on one line](https://raw.githubusercontent.com/Hona/opencode/38d1bd20206d88613d60153b95de9e1d46e06859/.github/pr-evidence/single-line-notices/after.png)

Deterministic fixture transcript only; no model selector or private session content. Images are outside the code diff.

## Verification

- The new regression fails before the class change and passes after it.
- Six app E2E cases pass: English LTR, English forced RTL, and Arabic RTL at 1400px and 390px. They check one-line geometry, ellipsis/overflow styles, and retention of the complete text.
- The six cases also pass after rebasing onto merged #45477.
- App unit tests: 543 passed. Session UI unit tests: 122 passed.
- E2E and session-ui typechecks pass. Formatting and diff checks pass.
- Production benchmark captured before edits and repeated on the same pre-rebase base: completion 7648 ms -> 9377 ms, RAF p95 316.6 ms -> 383.4 ms. Both delivered every delta without row/Markdown replacement, bottom drift, or blank samples. The after sample was slower; one sample does not establish performance equivalence or isolate a cause.
