### PR TITLE
fix(tui): ignore startup abort errors

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -559,7 +559,9 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         result.location.command.refresh(),
         result.location.skill.refresh(),
       ]).then((settled) => {
-        for (const failure of settled.filter((item) => item.status === "rejected"))
+        for (const failure of settled.filter(
+          (item): item is PromiseRejectedResult => item.status === "rejected" && item.reason?.name !== "AbortError",
+        ))
           console.error("Failed to refresh default location data", failure.reason)
       })
     })

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -92,6 +92,39 @@ test("refreshes resources into reactive getters", async () => {
   }
 })
 
+test("ignores expected startup cancellation while reporting refresh failures", async () => {
+  const events = createEventSource()
+  const failure = new Error("provider refresh failed")
+  const calls = createFetch((url) => {
+    if (url.pathname === "/api/agent") throw new DOMException("The operation was aborted.", "AbortError")
+    if (url.pathname === "/api/provider") throw failure
+    return undefined
+  }, events)
+  const original = console.error
+  const errors: unknown[][] = []
+  console.error = (...args) => errors.push(args)
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <SDKProvider url="http://test" directory={directory} events={events.source} fetch={calls.fetch}>
+        <ProjectProvider>
+          <DataProvider>
+            <box />
+          </DataProvider>
+        </ProjectProvider>
+      </SDKProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    await wait(() => errors.length > 0)
+    expect(errors).toEqual([["Failed to refresh default location data", failure]])
+  } finally {
+    console.error = original
+    app.renderer.destroy()
+  }
+})
+
 test("refreshes integrations after integration updates", async () => {
   const events = createEventSource()
   const requests = { integration: 0, model: 0, provider: 0 }


### PR DESCRIPTION
### Issue for this PR

Closes #45409

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The initial TUI data refresh now treats AbortError as expected cancellation, so Ctrl+C during startup does not print cancellation stack traces. Other refresh failures are still logged.

### How did you verify your code works?

On base c2eacd72, the provider-mount regression fails because both the AbortError and a real provider error are logged. With this change, only the real error remains.

- TUI data tests: 8 passed
- Full TUI suite: 194 passed, 1 skipped
- TUI typecheck passed
- Prettier and git diff --check passed

### Screenshots / recordings

Not applicable; this changes shutdown stderr behavior.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR