### PR TITLE
fix(opencode): edit tool reports fuzzy matches as exact success

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -85,6 +85,7 @@ export const EditTool = Tool.define(
           let diff = ""
           let contentOld = ""
           let contentNew = ""
+          let matchStrategy = "exact"
           yield* lock(filePath).withPermits(1)(
             Effect.gen(function* () {
               if (params.oldString === "") {
@@ -130,7 +131,9 @@ export const EditTool = Tool.define(
               const old = convertToLineEnding(normalizeLineEndings(params.oldString), ending)
               const replacement = convertToLineEnding(normalizeLineEndings(params.newString), ending)
 
-              const next = Bom.split(replace(contentOld, old, replacement, params.replaceAll))
+              const replaced = replace(contentOld, old, replacement, params.replaceAll)
+              matchStrategy = replaced.strategy
+              const next = Bom.split(replaced.content)
               const desiredBom = source.bom || next.bom
               contentNew = next.text
 
@@ -190,10 +193,13 @@ export const EditTool = Tool.define(
               diff,
               filediff,
               diagnostics: {},
+              matchStrategy,
             },
           })
 
           let output = "Edit applied successfully."
+          if (matchStrategy !== "exact")
+            output += `\n\nNote: oldString did not match the file exactly; the edit was applied via fuzzy matching (${matchStrategy}). Review the diff below to verify the result is what you intended:\n${diff}`
           yield* lsp.touchFile(filePath, "document")
           const diagnostics = yield* lsp.diagnostics()
           const normalizedFilePath = FSUtil.normalizePath(filePath)
@@ -205,6 +211,7 @@ export const EditTool = Tool.define(
               diagnostics,
               diff,
               filediff,
+              matchStrategy,
             },
             title: `${path.relative(instance.worktree, filePath)}`,
             output,
@@ -679,7 +686,12 @@ export function trimDiff(diff: string): string {
   return trimmedLines.join("\n")
 }
 
-export function replace(content: string, oldString: string, newString: string, replaceAll = false): string {
+export function replace(
+  content: string,
+  oldString: string,
+  newString: string,
+  replaceAll = false,
+): { content: string; strategy: string } {
   if (oldString === newString) {
     throw new Error("No changes to apply: oldString and newString are identical.")
   }
@@ -691,17 +703,17 @@ export function replace(content: string, oldString: string, newString: string, r
 
   let notFound = true
 
-  for (const replacer of [
-    SimpleReplacer,
-    LineTrimmedReplacer,
-    BlockAnchorReplacer,
-    WhitespaceNormalizedReplacer,
-    IndentationFlexibleReplacer,
-    EscapeNormalizedReplacer,
-    TrimmedBoundaryReplacer,
-    ContextAwareReplacer,
-    MultiOccurrenceReplacer,
-  ]) {
+  for (const [strategy, replacer] of [
+    ["exact", SimpleReplacer],
+    ["line-trimmed", LineTrimmedReplacer],
+    ["block-anchor", BlockAnchorReplacer],
+    ["whitespace-normalized", WhitespaceNormalizedReplacer],
+    ["indentation-flexible", IndentationFlexibleReplacer],
+    ["escape-normalized", EscapeNormalizedReplacer],
+    ["trimmed-boundary", TrimmedBoundaryReplacer],
+    ["context-aware", ContextAwareReplacer],
+    ["multi-occurrence", MultiOccurrenceReplacer],
+  ] as const) {
     for (const search of replacer(content, oldString)) {
       const index = content.indexOf(search)
       if (index === -1) continue
@@ -712,11 +724,11 @@ export function replace(content: string, oldString: string, newString: string, r
         )
       }
       if (replaceAll) {
-        return content.replaceAll(search, newString)
+        return { content: content.replaceAll(search, newString), strategy }
       }
       const lastIndex = content.lastIndexOf(search)
       if (index !== lastIndex) continue
-      return content.substring(0, index) + newString + content.substring(index + search.length)
+      return { content: content.substring(0, index) + newString + content.substring(index + search.length), strategy }
     }
   }
 

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -151,7 +151,24 @@ describe("tool.edit", () => {
         const result = yield* run({ filePath: filepath, oldString: "old content", newString: "new content" })
 
         expect(result.output).toContain("Edit applied successfully")
+        expect(result.output).not.toContain("fuzzy matching")
+        expect(result.metadata.matchStrategy).toBe("exact")
         expect(yield* load(filepath)).toBe("new content here")
+      }),
+    )
+
+    it.instance("reports fuzzy match strategy when oldString does not match exactly", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "fuzzy.txt")
+        yield* put(filepath, "alpha\n   beta_line\ngamma\n")
+
+        // oldString has 4-space indent, file has 3 — matched via LineTrimmedReplacer
+        const result = yield* run({ filePath: filepath, oldString: "    beta_line", newString: "    beta_edited" })
+
+        expect(result.metadata.matchStrategy).toBe("line-trimmed")
+        expect(result.output).toContain("fuzzy matching (line-trimmed)")
+        expect(result.output).toContain("+    beta_edited")
       }),
     )
 


### PR DESCRIPTION
### Issue for this PR

Closes #34424

This covers points 2 and 3 of that issue. Points 1, 4 and 5 are out of scope here and can be tracked separately.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`edit.txt` tells the model the tool "Performs exact string replacements in files", that it must "preserve the exact indentation (tabs/spaces)", and that "the edit will FAIL if `oldString` is not found in the file". The not-found error says the same thing: *"It must match exactly, including whitespace, indentation, and line endings."*

That is not what happens. `replace()` tries `SimpleReplacer` (byte-exact) first, then eight tolerant fallbacks. When a fallback wins, the tool returns the same plain `"Edit applied successfully."` as an exact match. Given the contract above, the only thing the model can conclude from that is "my `oldString` matched exactly, indentation included" — and it is wrong. A wrong `oldString`, e.g. 4-space indentation where the file has 3, is silently absorbed and the line gets rewritten with the wrong indentation.

The strategy that won was already known inside the loop; it was just being dropped at `return`.

- `replace()` returns `{ content, strategy }` instead of a bare string, and the chain is a list of `[name, replacer]` pairs so the winning matcher comes back with the result.
- On a non-exact hit the tool appends a note naming the strategy and echoes the diff, so the caller sees the actual change instead of being told to go look for it.
- `matchStrategy` is added to the tool metadata.

Three things I deliberately did not do:

- **Reword `edit.txt` instead.** That is the other way to resolve a docs-vs-behaviour mismatch, but a static "sometimes it matches loosely" cannot tell the model whether *this particular call* was loose. The per-call signal is the part that is missing.
- **Tighten the fuzzy chain.** It exists because LLMs drift on whitespace. Making it strict would trade silent corruption for a pile of retry failures. Tolerance is unchanged here; only the reporting changes.
- **Detect it at the tool layer with `contentOld.includes(oldString)`.** Looks cheaper, but it reports `exact` incorrectly when `SimpleReplacer` matches in more than one place: the loop `continue`s past it (`index !== lastIndex`), a fuzzy replacer wins, and `includes` is still true. Changing the signature costs the same and does not lie — `replace()` has exactly one caller in the repo (`edit.ts:133`), and the tests go through `EditTool`, not `replace` directly.

Related: #44996 is the same mismatch on the failure path (the not-found error text). Left alone to keep this focused.

### How did you verify your code works?

- Added a test using the indentation case from the issue: file has `   beta_line` (3 spaces), `oldString` has 4. Asserts `matchStrategy === "line-trimmed"`, that the note names the strategy, and that the diff is echoed.
- Extended the existing exact-match test to assert `matchStrategy === "exact"` and that no note is emitted, so the exact path stays byte-identical to before.
- `bun test test/tool/edit.test.ts` — 30/30 pass. (`rejects empty oldString on existing files` intermittently hits the 5s timeout on my machine, but it does that on a clean `dev` checkout too, with my changes stashed.)
- `bun test test/acp/tool.test.ts` — 9/9 pass. These assert the exact `"Edit applied successfully."` string, so they confirm the exact path is untouched.
- `bun run typecheck` in `packages/opencode` — clean.

To see the original behaviour on `dev`: create a file with a 3-space-indented line, call `edit` with a 4-space-indented `oldString`, and note the output is indistinguishable from an exact match.

### Screenshots / recordings

n/a — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
