### PR TITLE
fix(app): stop shimmer when background shells finish

### DIFF
--- a/packages/app/e2e/regression/session-shell-completion.spec.ts
+++ b/packages/app/e2e/regression/session-shell-completion.spec.ts
@@ -127,3 +127,65 @@ for (const grouped of [false, true]) {
     })
   }
 }
+
+test("shows the authoritative foreground result after streaming shell output", async ({ page }) => {
+  const timeline = await setupTimeline(page, {
+    settings: { shellToolPartsExpanded: true },
+    sessionMessages: [
+      { id: "msg_user", type: "user", text: "Run the check.", time: { created: 1 } },
+      {
+        id: "msg_foreground",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          {
+            type: "tool",
+            id: "call_foreground",
+            name: "shell",
+            state: { status: "running", input: { command: shell.command }, metadata: { shellID: shell.id } },
+            time: { created: 2 },
+          },
+        ],
+        time: { created: 2 },
+      },
+    ],
+  })
+  await page.route("**/api/shell/*/output?*", (route) =>
+    route.fulfill({
+      json: {
+        location: { directory },
+        data: {
+          output: Number(new URL(route.request().url()).searchParams.get("cursor")) === 0 ? "Checking project\n" : "",
+          cursor: 17,
+          size: 17,
+          truncated: false,
+        },
+      },
+    }),
+  )
+  await page.reload()
+  await timeline.transport.waitForConnection()
+  const card = page.locator('[data-timeline-part-id="call_foreground"]')
+  const shimmer = card.locator('[data-component="text-shimmer"]')
+  await expect(shimmer).toHaveAttribute("data-active", "true")
+  await expect(card.locator('[data-slot="bash-result"]')).toHaveText("Checking project")
+  await timeline.transport.send({
+    id: "evt_foreground_complete",
+    created: 3,
+    type: "session.tool.success",
+    durable: { aggregateID: sessionID, seq: 0, version: 2 },
+    data: {
+      sessionID,
+      assistantMessageID: "msg_foreground",
+      id: "call_foreground",
+      executed: true,
+      content: [{ type: "text", text: "Checking project\nCheck finished\nCommand exited with code 0." }],
+      metadata: { status: "completed", exit: 0 },
+    },
+  })
+  await expect(shimmer).toHaveAttribute("data-active", "false")
+  await expect(card.locator('[data-slot="bash-result"]')).toHaveText(
+    "Checking project\nCheck finished\nCommand exited with code 0.",
+  )
+})

--- a/packages/app/e2e/regression/session-shell-completion.spec.ts
+++ b/packages/app/e2e/regression/session-shell-completion.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test"
+import type { SessionMessageAssistant, ShellInfo } from "@opencode-ai/client/promise"
+import { directory, sessionID, setupTimeline } from "../performance/timeline-stability/fixture"
+
+const shell = {
+  id: "sh_background",
+  status: "running",
+  command: "bun run check",
+  cwd: directory,
+  shell: "bash",
+  file: "/tmp/check.out",
+  metadata: { sessionID },
+  time: { started: 2 },
+} satisfies ShellInfo
+
+for (const grouped of [false, true]) {
+  for (const status of ["exited", "killed", "timeout"] as const) {
+    test(`stops ${grouped ? "grouped" : "standalone"} background shell shimmer when ${status}`, async ({
+      page,
+    }, info) => {
+      const message: SessionMessageAssistant = {
+        id: "msg_background",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [shell.id, "sh_other"].map((id) => ({
+          type: "tool",
+          id: `call_${id}`,
+          name: "shell",
+          state: {
+            status: "completed",
+            input: { command: shell.command },
+            content: [{ type: "text", text: "Command moved to the background." }],
+            metadata: { shellID: id, status: "running" },
+          },
+          time: { created: 2, completed: 3 },
+        })),
+        time: { created: 2, completed: 3 },
+      }
+      if (grouped)
+        message.content.unshift({
+          type: "tool",
+          id: "call_read",
+          name: "read",
+          state: {
+            status: "completed",
+            input: { path: "package.json" },
+            content: [{ type: "text", text: "{}" }],
+            metadata: {},
+          },
+          time: { created: 1, completed: 2 },
+        })
+      const timeline = await setupTimeline(page, {
+        viewport: { width: grouped ? 390 : 1400, height: 900 },
+        settings: { shellToolPartsExpanded: !grouped },
+        sessionStatus: { [sessionID]: { type: "busy" } },
+        sessionMessages: [
+          { id: "msg_user", type: "user", text: "Run two independent checks.", time: { created: 1 } },
+          message,
+        ],
+      })
+      const state = { finished: false, requests: 0 }
+      await page.route("**/api/shell?*", (route) =>
+        route.fulfill({
+          json: { location: { directory }, data: [...(state.finished ? [] : [shell]), { ...shell, id: "sh_other" }] },
+        }),
+      )
+      await page.route("**/api/shell/*/output?*", (route) => {
+        const url = new URL(route.request().url())
+        const target = url.pathname.includes(`/${shell.id}/`)
+        if (target) state.requests++
+        const output = target && state.finished ? "Checking project\nCheck finished\n" : "Checking project\n"
+        const cursor = Number(url.searchParams.get("cursor") ?? 0)
+        const end = Math.min(output.length, cursor + 17)
+        return route.fulfill({
+          json: {
+            location: { directory },
+            data: {
+              output: output.slice(cursor, end),
+              cursor: end,
+              size: output.length,
+              truncated: false,
+            },
+          },
+        })
+      })
+      await page.clock.install()
+      await page.reload()
+      await timeline.transport.waitForConnection()
+      const group = page.locator('[data-component="collapsed-tool-group"]')
+      const groupTrigger = group.locator(':scope > [data-component="collapsible"] > [data-slot="collapsible-trigger"]')
+      if (grouped) {
+        await expect(group).toHaveAttribute("data-timeline-part-ids", "call_read,call_sh_background,call_sh_other")
+        await expect(groupTrigger).toHaveAttribute("aria-expanded", "false")
+        await groupTrigger.click()
+      }
+      const card = page.locator(`[data-timeline-part-id="call_${shell.id}"]`)
+      const shimmer = card.locator('[data-component="text-shimmer"]')
+      const other = page.locator('[data-timeline-part-id="call_sh_other"] [data-component="text-shimmer"]')
+      await expect(shimmer).toHaveAttribute("data-active", "true")
+      await expect(other).toHaveAttribute("data-active", "true")
+      if (grouped) await card.locator('[data-slot="collapsible-trigger"]').click()
+      await expect(card.locator('[data-slot="bash-result"]')).toHaveText("Checking project")
+
+      state.finished = true
+      await timeline.transport.send({
+        id: "evt_shell_exited",
+        created: 4,
+        type: "shell.exited",
+        location: { directory },
+        data: { id: shell.id, status, exit: status === "exited" ? 0 : 1 },
+      })
+      await expect(shimmer).toHaveAttribute("data-active", "false")
+      await expect(other).toHaveAttribute("data-active", "true")
+      await expect(card.locator('[data-slot="bash-result"]')).toHaveText("Checking project\nCheck finished")
+      await expect(card.locator('[data-slot="collapsible-trigger"]')).toHaveAttribute("aria-expanded", "true")
+      await page.locator("[data-timeline-virtual-content]").screenshot({ path: info.outputPath("shell-finished.png") })
+
+      const requests = state.requests
+      await page.clock.fastForward(5_000)
+      expect(state.requests).toBe(requests)
+
+      await page.reload()
+      if (grouped) await groupTrigger.click()
+      await expect(shimmer).toHaveAttribute("data-active", "false")
+      await expect(other).toHaveAttribute("data-active", "true")
+    })
+  }
+}

--- a/packages/app/e2e/regression/session-timeline-notices.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-notices.spec.ts
@@ -5,6 +5,7 @@ import {
   compactionEnded,
   compactionFailed,
   compactionStarted,
+  directory,
   event,
   session,
   sessionID,
@@ -348,6 +349,24 @@ test("separates blocking and already-backgrounded work into two rows", async ({ 
     },
   })
 
+  await timeline.transport.send({
+    id: "evt_background_shell_created",
+    created: 3,
+    type: "shell.created",
+    location: { directory },
+    data: {
+      info: {
+        id: "shell_backgrounded",
+        status: "running",
+        command: "sleep 120",
+        cwd: directory,
+        shell: "bash",
+        file: "/tmp/background.out",
+        metadata: { sessionID },
+        time: { started: 2 },
+      },
+    },
+  })
   const backgroundCard = page.locator('[data-timeline-part-id="call_backgrounded"]')
   await expect(page.getByText(/move running work to the background/i)).toBeVisible()
   await page.getByRole("button", { name: "Session details" }).click()

--- a/packages/app/src/shell/routes/session-ui-provider.tsx
+++ b/packages/app/src/shell/routes/session-ui-provider.tsx
@@ -55,6 +55,7 @@ export function SessionUIProvider(
       data={sessionUIData()}
       directory={directory()}
       sessionID={params.id}
+      shellRunning={(id) => !!data.shell.get(id)}
       shellOutput={(input) => serverSDK.api.shell.output(input)}
       onNavigateToSession={navigateToSession}
       onSessionHref={href}

--- a/packages/session-ui/src/context/data.tsx
+++ b/packages/session-ui/src/context/data.tsx
@@ -46,6 +46,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
     data: Data
     directory: string
     sessionID?: string
+    shellRunning?: (id: string) => boolean
     shellOutput?: (input: ShellOutputInput) => Promise<ShellOutputOutput>
     onNavigateToSession?: NavigateToSessionFn
     onSessionHref?: SessionHrefFn
@@ -62,6 +63,7 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       },
       navigateToSession: props.onNavigateToSession,
       sessionHref: props.onSessionHref,
+      shellRunning: props.shellRunning,
       shellOutput: props.shellOutput,
     }
   },

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -1452,7 +1452,12 @@ ToolRegistry.register({
       if (typeof props.metadata.command === "string") return props.metadata.command
       return ""
     }
-    const output = createMemo(() => stripAnsi(streamed() || props.output || "").replace(/\r\n?/g, "\n"))
+    const output = createMemo(() =>
+      stripAnsi((typeof props.metadata.shellID === "string" && streamed()) || props.output || "").replace(
+        /\r\n?/g,
+        "\n",
+      ),
+    )
     return (
       <BasicTool
         {...props}

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -1411,28 +1411,37 @@ ToolRegistry.register({
     const i18n = useI18n()
     const data = useData()
     const streaming = () => props.status === "streaming"
-    const pending = () => streaming() || props.status === "running" || props.metadata.status === "running"
+    const pending = () =>
+      streaming() ||
+      props.status === "running" ||
+      (typeof props.metadata.shellID === "string" && data.shellRunning?.(props.metadata.shellID) === true)
     const sawStreaming = streaming()
     const [streamed, setStreamed] = createSignal("")
     createEffect(() => {
       const id = props.metadata.shellID
       const shellOutput = data.shellOutput
-      if (typeof id !== "string" || !pending() || !shellOutput) return
+      if (typeof id !== "string" || !shellOutput) return
       const directory = data.directory
+      const running = pending()
       let cursor = 0
       let loading = false
       let disposed = false
       const load = async () => {
         if (loading) return
         loading = true
-        const response = await shellOutput({ id, location: { directory }, cursor }).catch(() => undefined)
-        if (disposed) return
-        if (response?.data.output) setStreamed((output) => output + response.data.output)
-        if (response) cursor = response.data.cursor
+        do {
+          const response = await shellOutput({ id, location: { directory }, cursor }).catch(() => undefined)
+          if (disposed || !response) break
+          setStreamed((output) => (cursor === 0 ? response.data.output : output + response.data.output))
+          if (response.data.cursor <= cursor) break
+          cursor = response.data.cursor
+          if (running || cursor >= response.data.size) break
+        } while (!disposed)
         loading = false
       }
       void load()
-      const interval = setInterval(() => void load(), 1_000)
+      // Refresh the final snapshot on exit, but poll only while the shell is live.
+      const interval = running ? setInterval(() => void load(), 1_000) : undefined
       onCleanup(() => {
         disposed = true
         clearInterval(interval)
@@ -1443,7 +1452,7 @@ ToolRegistry.register({
       if (typeof props.metadata.command === "string") return props.metadata.command
       return ""
     }
-    const output = createMemo(() => stripAnsi((pending() && streamed()) || props.output || "").replace(/\r\n?/g, "\n"))
+    const output = createMemo(() => stripAnsi(streamed() || props.output || "").replace(/\r\n?/g, "\n"))
     return (
       <BasicTool
         {...props}


### PR DESCRIPTION
## Summary

Use the live shell registry for background shell progress, matching the TUI's `data.shell.get(id)` check. The original tool result intentionally keeps `metadata.status: "running"` after backgrounding; treating it as live state left the shell title shimmering after completion.

- Stop shimmer and output polling when `shell.exited` removes the shell from the registry. No dependency on the later synthetic completion notice or the parent session becoming idle.
- Keep foreground progress driven by the tool state and use the authoritative tool result when foreground completion removes the live shell ID.
- Fetch the final paginated output snapshot and keep it visible instead of restoring the old "moved to the background" result. Historical shells load their output without starting a polling interval.
- Preserve existing disclosure choices. No protocol, server, or stored-history changes.

## Evidence

Both screenshots show the first shell after its exit event; the second shell and parent session are still running. The fixture deliberately uses the same command twice to verify identity by shell ID, not command text. Screenshots are cropped to deterministic transcript content and stored outside the code diff.

Before: the first title still has active shimmer (the regression observes `data-active="true"`).

![Before: finished shell still has progress treatment](https://raw.githubusercontent.com/Hona/opencode/3576cb64db5a1863e5bb493d014ef64e205af7a7/.github/pr-evidence/shell-completion-shimmer/before.png)

After: the first title is static and final output remains visible; the second still has active shimmer.

![After: only the running shell has progress treatment](https://raw.githubusercontent.com/Hona/opencode/3576cb64db5a1863e5bb493d014ef64e205af7a7/.github/pr-evidence/shell-completion-shimmer/after.png)

## Verification

- Production reproduction fails before the fix: shimmer remains active after `shell.exited`.
- 20 production Chromium E2E cases pass, including six new cases covering exit, kill, and timeout in standalone desktop and grouped 390px layouts. They check reloads, independent same-command shells, complete paginated output without duplication, disclosure preservation, and no further polling using Playwright's virtual clock. A seventh new case checks foreground completion after partial output has streamed, including retention of the final exit notice.
- Existing background/subagent/notice and disclosure regressions pass. The existing background-shell fixture now supplies a live `shell.created` event rather than relying on stale tool metadata.
- App unit tests: 543 passed. Session UI unit tests: 122 passed.
- App, session-ui, and E2E typechecks pass. Prettier and diff checks pass.

Production benchmarks ran serially on base `fa1ab5f8e1`, with 72 history entries, 32 deltas, 6x CPU throttling, one worker, and no retries. Before / final-after: completion 2628 / 3032 ms; RAF p95 83.3 / 66.7 ms. Both delivered all deltas with no row/Markdown replacement, bottom drift, or blank samples. The final completion sample was slower; single samples do not isolate a cause or establish performance equivalence. Raw logs and reports, including intermediate development samples, are retained locally under `C:/tmp/opencode/shell-completion-shimmer/`.
