### PR TITLE
fix(cli): keep the positional message out of -f in run

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -181,7 +181,8 @@ export const RunCommand = effectCmd({
         alias: ["f"],
         type: "string",
         array: true,
-        describe: "file(s) to attach to message",
+        nargs: 1,
+        describe: "file(s) to attach to message, repeat -f for each file",
       })
       .option("title", {
         type: "string",

--- a/packages/opencode/test/cli/run/run-file-args.test.ts
+++ b/packages/opencode/test/cli/run/run-file-args.test.ts
@@ -1,0 +1,26 @@
+// Subprocess tests for how `opencode run` splits `-f/--file` values from the
+// positional message. Yargs array options are greedy by default, so a leading
+// `-f` used to swallow the prompt words into the file list (#40304) and the
+// run died on "File not found: <first prompt word>". The option takes one path
+// per occurrence now, so flag-first order reaches the model.
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../../lib/cli-process"
+
+describe("opencode run file arguments", () => {
+  cliIt.concurrent(
+    "keeps the positional prompt when -f comes first",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        yield* llm.text("flag order ok")
+
+        const result = yield* opencode.run("check the hosts file", {
+          extraArgs: ["-f", "/etc/hosts"],
+        })
+
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toBe("flag order ok\n")
+      }),
+    60_000,
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #40304 (also covers #45501)

### Type of change

- [x] Bug fix

### What does this PR do?

`-f/--file` is declared as an array option, so yargs greedily consumed the positional message when the flag came first: `opencode run -f file "prompt"` died on `File not found: <first prompt word>`. Giving the option `nargs: 1` makes each occurrence take exactly one path (`-f a -f b` for multiple files), so both flag orders deliver the message. Verified locally that yargs 18 still accumulates repeated flags into one array with `nargs: 1`.

The exit-code-0 part of #45501 is already fixed on dev (file-not-found exits 1), nothing to change there.

### How did you verify your code works?

`opencode run -f /etc/hosts "summarize this"` against dev fails before this change and sends the prompt after it. Added a subprocess regression test (`test/cli/run/run-file-args.test.ts`) that fails on unfixed dev and passes with the change; the `run-process.test.ts` suite is still green.

### Screenshots / recordings

CLI change, no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR