### PR TITLE
fix(console): merge duplicate Go usage rows with the same resolved multiplier

### DIFF
--- a/packages/console/app/src/lib/lite-usage.ts
+++ b/packages/console/app/src/lib/lite-usage.ts
@@ -18,7 +18,26 @@ export type LiteUsageBreakdownItem = {
 }
 
 export function buildLiteUsageBreakdown(input: { usage: number; limit: number; sources: LiteUsageBreakdownSource[] }) {
-  const rows: LiteUsageBreakdownItem[] = input.sources
+  // Historical rows store no costMultiplier and form their own query group,
+  // so a model whose fallback resolves to the recorded multiplier would show
+  // two identical rows. Merge by model + resolved multiplier; only genuine
+  // multiplier changes stay separate.
+  const merged = new Map<string, LiteUsageBreakdownSource>()
+  for (const source of input.sources) {
+    const key = `${source.model}\0${source.multiplier ?? "none"}`
+    const existing = merged.get(key)
+    if (!existing) {
+      merged.set(key, source)
+      continue
+    }
+    merged.set(key, {
+      ...existing,
+      cost: existing.cost + source.cost,
+      quotaCost: existing.quotaCost + source.quotaCost,
+      estimated: existing.estimated && source.estimated,
+    })
+  }
+  const rows: LiteUsageBreakdownItem[] = [...merged.values()]
     .filter((item) => item.cost !== 0 || item.quotaCost !== 0)
     .sort((a, b) => b.quotaCost - a.quotaCost)
     .map((item) => ({

--- a/packages/console/app/test/liteUsage.test.ts
+++ b/packages/console/app/test/liteUsage.test.ts
@@ -72,4 +72,25 @@ describe("Go usage breakdown", () => {
     expect(result.rows.map((row) => row.multiplier)).toEqual([2, 1])
     expect(result.rows.map((row) => row.contributionPercent)).toEqual([40, 10])
   })
+
+  test("merges estimated and recorded rows that resolve to the same multiplier", () => {
+    const result = buildLiteUsageBreakdown({
+      usage: 600,
+      limit: 1_000,
+      sources: [
+        { model: "deepseek", name: "DeepSeek V4 Flash", cost: 100, quotaCost: 200, multiplier: 2, estimated: true },
+        { model: "deepseek", name: "DeepSeek V4 Flash", cost: 300, quotaCost: 600, multiplier: 2, estimated: false },
+        { model: "kimi", name: "Kimi", cost: 116, quotaCost: 116, multiplier: 1, estimated: false },
+      ],
+    })
+
+    expect(result.rows).toHaveLength(2)
+    expect(result.rows[0]).toMatchObject({
+      model: "deepseek",
+      cost: 400,
+      quotaCost: 800,
+      multiplier: 2,
+      estimated: false,
+    })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #45502

### Type of change

- [x] Bug fix

### What does this PR do?

The usage breakdown groups by model and the raw stored multiplier. Rows recorded before `enrichment.costMultiplier` exists land in a NULL-multiplier group, so when the catalog fallback resolves to the same multiplier as the recorded rows, the Go page shows two identical rows for one model. `buildLiteUsageBreakdown` now merges sources by model + resolved multiplier (summing cost and quota), and only genuine multiplier changes stay separate. A merged row is no longer `estimated` once any of its parts had the multiplier recorded.

### How did you verify your code works?

Added a unit test in `packages/console/app/test/liteUsage.test.ts` that passes one estimated and one recorded source for the same model with the same resolved multiplier and asserts a single merged row; it fails on unfixed dev. The existing suite (including the multiplier-change separation test) passes, typecheck clean.

### Screenshots / recordings

Aggregation logic, no visual change beyond the duplicate row disappearing.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR