### PR TITLE
fix(cli): summarize agent list output, full rules behind --verbose

### DIFF
--- a/packages/opencode/src/cli/cmd/agent.ts
+++ b/packages/opencode/src/cli/cmd/agent.ts
@@ -234,7 +234,12 @@ const AgentCreateCommand = effectCmd({
 const AgentListCommand = effectCmd({
   command: "list",
   describe: "list all available agents",
-  handler: Effect.fn("Cli.agent.list")(function* () {
+  builder: (yargs) =>
+    yargs.option("verbose", {
+      type: "boolean",
+      describe: "print each agent's full resolved permission rules",
+    }),
+  handler: Effect.fn("Cli.agent.list")(function* (args) {
     const { Agent } = yield* Effect.promise(() => import("../../agent/agent"))
     const agents = yield* Agent.Service.use((svc) => svc.list())
     const sortedAgents = agents.sort((a, b) => {
@@ -245,8 +250,10 @@ const AgentListCommand = effectCmd({
     })
 
     for (const agent of sortedAgents) {
-      process.stdout.write(`${agent.name} (${agent.mode})` + EOL)
-      process.stdout.write(`  ${JSON.stringify(agent.permission, null, 2)}` + EOL)
+      const model = agent.model ? ` ${agent.model.providerID}/${agent.model.modelID}` : ""
+      const description = agent.description ? ` — ${agent.description}` : ""
+      process.stdout.write(`${agent.name} (${agent.mode})${model}${description}` + EOL)
+      if (args.verbose) process.stdout.write(`  ${JSON.stringify(agent.permission, null, 2)}` + EOL)
     }
   }),
 })

--- a/packages/opencode/test/cli/agent-list.test.ts
+++ b/packages/opencode/test/cli/agent-list.test.ts
@@ -1,0 +1,35 @@
+// `opencode agent list` used to pretty-print every agent's full resolved
+// permission ruleset — thousands of lines on configured setups (#45496).
+// The default output is now one summary line per agent; --verbose restores
+// the full ruleset.
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { cliIt } from "../lib/cli-process"
+
+describe("opencode agent list", () => {
+  cliIt.concurrent(
+    "prints one summary line per agent without the resolved rules",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const result = yield* opencode.spawn(["agent", "list"])
+
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("(primary)")
+        expect(result.stdout).not.toContain("{")
+      }),
+    60_000,
+  )
+
+  cliIt.concurrent(
+    "prints the full resolved permission rules with --verbose",
+    ({ opencode }) =>
+      Effect.gen(function* () {
+        const result = yield* opencode.spawn(["agent", "list", "--verbose"])
+
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("(primary)")
+        expect(result.stdout).toContain("{")
+      }),
+    60_000,
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45496

### Type of change

- [x] Bug fix

### What does this PR do?

`agent list` pretty-printed every agent's fully resolved permission ruleset — 8,600+ lines / 222 KB on the reporter's setup. The default output is now one line per agent (`name (mode) model — description`, model/description only when set), and `--verbose` prints the resolved rules under each agent, same as before. Matches the direction proposed in the issue.

### How did you verify your code works?

Ran `opencode agent list` and `agent list --verbose` locally against dev. Added subprocess tests (`test/cli/agent-list.test.ts`) asserting the default output contains no rules JSON while `--verbose` does; they fail on unfixed dev. Typecheck clean.

### Screenshots / recordings

```
build (primary) — The default agent. Executes tools based on configured permissions.
plan (primary) — Plan mode. Disallows all edit tools.
explore (subagent) — Fast agent specialized for exploring codebases. …
```

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR