### PR TITLE
fix(tui): stop printing abort stack traces on Ctrl+C during startup

### DIFF
--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -559,8 +559,12 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
         result.location.command.refresh(),
         result.location.skill.refresh(),
       ]).then((settled) => {
-        for (const failure of settled.filter((item) => item.status === "rejected"))
+        for (const failure of settled.filter((item) => item.status === "rejected")) {
+          // Ctrl+C aborts in-flight refreshes on the way out; that is a normal
+          // shutdown, not a failure worth a stack trace.
+          if (failure.reason instanceof Error && failure.reason.name === "AbortError") continue
           console.error("Failed to refresh default location data", failure.reason)
+        }
       })
     })
 

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -484,3 +484,85 @@ test("projects live context updates with their message ID", async () => {
     app.renderer.destroy()
   }
 })
+
+const locationDataPaths = [
+  "/api/location",
+  "/api/agent",
+  "/api/model",
+  "/api/provider",
+  "/api/integration",
+  "/api/command",
+  "/api/skill",
+  "/api/reference",
+]
+
+async function mountDataApp(fetch: typeof globalThis.fetch) {
+  const events = createEventSource()
+  let ready!: () => void
+  const mounted = new Promise<void>((resolve) => {
+    ready = resolve
+  })
+
+  function Probe() {
+    onMount(ready)
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <SDKProvider url="http://test" directory={directory} events={events.source} fetch={fetch}>
+        <ProjectProvider>
+          <DataProvider>
+            <Probe />
+          </DataProvider>
+        </ProjectProvider>
+      </SDKProvider>
+    </TestTuiContexts>
+  ))
+
+  return { app, mounted }
+}
+
+test("startup refresh treats aborted location requests as a normal shutdown", async () => {
+  const base = createFetch((url) => {
+    if (locationDataPaths.includes(url.pathname)) throw new DOMException("The operation was aborted.", "AbortError")
+    return undefined
+  })
+  const errors: string[] = []
+  const original = console.error
+  console.error = (...args: unknown[]) => {
+    errors.push(args.map(String).join(" "))
+  }
+
+  const { app, mounted } = await mountDataApp(base.fetch)
+  try {
+    await mounted
+    await Bun.sleep(100)
+    expect(errors.filter((line) => line.includes("Failed to refresh default location data"))).toEqual([])
+  } finally {
+    console.error = original
+    app.renderer.destroy()
+  }
+})
+
+test("startup refresh still reports non-abort failures", async () => {
+  const base = createFetch((url) => {
+    if (locationDataPaths.includes(url.pathname)) throw new Error("refresh exploded")
+    return undefined
+  })
+  const errors: string[] = []
+  const original = console.error
+  console.error = (...args: unknown[]) => {
+    errors.push(args.map(String).join(" "))
+  }
+
+  const { app, mounted } = await mountDataApp(base.fetch)
+  try {
+    await mounted
+    await wait(() => errors.some((line) => line.includes("Failed to refresh default location data")))
+    expect(errors.some((line) => line.includes("refresh exploded"))).toBe(true)
+  } finally {
+    console.error = original
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45409

### Type of change

- [x] Bug fix

### What does this PR do?

The startup location refresh in `packages/tui/src/context/data.tsx` logged every rejected promise. When Ctrl+C aborts the in-flight requests on the way out, those AbortError/DOMException rejections printed full stack traces after the TUI had already exited. The handler now skips reasons with `name === "AbortError"` (normal shutdown cancellation) and still logs genuine failures.

### How did you verify your code works?

Added two tests in `packages/tui/test/cli/tui/data.test.tsx`: all location refreshes rejecting with `DOMException AbortError` produce no "Failed to refresh" log, while real errors still do. The abort test fails on unfixed dev. Full `data.test.tsx` suite (9 tests) green, typecheck clean.

### Screenshots / recordings

CLI/TUI noise fix, no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR