### PR TITLE
feat(acp): forward session title updates via session_info_update

### DIFF
--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -3,6 +3,7 @@ import type {
   Event,
   EventMessagePartDelta,
   EventMessagePartUpdated,
+  EventSessionUpdated,
   OpencodeClient,
   Part,
   SessionMessageResponse,
@@ -40,6 +41,7 @@ export class Subscription {
   private readonly abort = new AbortController()
   private readonly shellSnapshots = new Map<string, string>()
   private readonly toolStarts = new Set<string>()
+  private readonly titles = new Map<string, string>()
   private readonly connectionWaiters = new Set<() => void>()
   private readonly idleWaiters = new Map<string, Set<ReturnType<typeof signal>>>()
   private readonly permission: ACPPermission.Handler
@@ -95,6 +97,8 @@ export class Subscription {
       case "session.status":
         if (event.properties.status.type === "idle") this.idle(event.properties.sessionID)
         return
+      case "session.updated":
+        return this.handleSessionUpdated(event)
       case "permission.asked":
         this.permission.handle(event)
         return
@@ -186,6 +190,23 @@ export class Subscription {
     if (!waiters) return
     this.idleWaiters.delete(sessionId)
     for (const waiter of waiters) waiter.resolve()
+  }
+
+  private async handleSessionUpdated(event: EventSessionUpdated) {
+    const title = event.properties.info.title
+    if (!title) return
+    const sessionId = event.properties.sessionID
+    const session = await Effect.runPromise(this.input.session.tryGet(sessionId))
+    if (!session) return
+    if (this.titles.get(session.id) === title) return
+    this.titles.set(session.id, title)
+    await this.input.connection.sessionUpdate({
+      sessionId: session.id,
+      update: {
+        sessionUpdate: "session_info_update",
+        title,
+      },
+    })
   }
 
   private async handlePartUpdated(event: EventMessagePartUpdated) {

--- a/packages/opencode/test/acp/event.test.ts
+++ b/packages/opencode/test/acp/event.test.ts
@@ -301,6 +301,20 @@ function toolUpdates(updates: SessionUpdateParams[]) {
   })
 }
 
+function sessionUpdated(sessionID: string, title?: string): Event {
+  return {
+    id: `evt_${sessionID}_session_${title ?? "untitled"}`,
+    type: "session.updated",
+    properties: {
+      sessionID,
+      info: { id: sessionID, title } as unknown as Extract<
+        Event,
+        { type: "session.updated" }
+      >["properties"]["info"],
+    },
+  }
+}
+
 async function createKnownSession(
   session: ACPSession.Interface,
   sessionId: string,
@@ -319,6 +333,48 @@ async function createKnownSession(
 }
 
 describe("acp event routing", () => {
+  it("forwards session title updates as session_info_update", async () => {
+    const harness = createHarness()
+    await Effect.runPromise(harness.session.create({ id: "ses_a", cwd: "/workspace" }))
+
+    await harness.subscription.handle(sessionUpdated("ses_a", "My session title"))
+
+    expect(harness.updates).toEqual([
+      {
+        sessionId: "ses_a",
+        update: {
+          sessionUpdate: "session_info_update",
+          title: "My session title",
+        },
+      },
+    ])
+  })
+
+  it("only forwards a session title once until it changes", async () => {
+    const harness = createHarness()
+    await Effect.runPromise(harness.session.create({ id: "ses_a", cwd: "/workspace" }))
+
+    await harness.subscription.handle(sessionUpdated("ses_a", "First title"))
+    await harness.subscription.handle(sessionUpdated("ses_a", "First title"))
+    await harness.subscription.handle(sessionUpdated("ses_a", "Second title"))
+
+    expect(harness.updates.map((update) => update.update)).toEqual([
+      { sessionUpdate: "session_info_update", title: "First title" },
+      { sessionUpdate: "session_info_update", title: "Second title" },
+    ])
+  })
+
+  it("ignores session updates for unknown sessions and empty titles", async () => {
+    const harness = createHarness()
+    await Effect.runPromise(harness.session.create({ id: "ses_a", cwd: "/workspace" }))
+
+    await harness.subscription.handle(sessionUpdated("ses_unknown", "Title"))
+    await harness.subscription.handle(sessionUpdated("ses_a"))
+    await harness.subscription.handle(sessionUpdated("ses_a", ""))
+
+    expect(harness.updates).toEqual([])
+  })
+
   it("routes message.part.delta by sessionID without cross-session pollution", async () => {
     const harness = createHarness()
     await createKnownSession(harness.session, "ses_a", { messageId: "msg_a", partId: "part_a", partType: "text" })


### PR DESCRIPTION
### Issue for this PR

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a session title changes (e.g. the title agent generates a title after the first prompt, or a custom `agent.title.prompt` config renames it), ACP clients never learn about it. The ACP event subscription in `packages/opencode/src/acp/event.ts` only handles `session.status`, `permission.asked`, and `message.part.updated/delta` — `session.updated` events are ignored.

Clients like Zed set a provisional title from the truncated first user message and only replace it when the agent sends a `session_info_update` notification (stabilized ACP protocol feature; Zed handles it in `acp_thread.rs` and replaces the provisional title on receipt). Since opencode never sends one, ACP sessions stay mislabeled even though `opencode` CLI/TUI shows the correct title. Titles are only exposed passively via `session/list`.

This PR handles `session.updated` in the ACP event subscription and forwards non-empty title changes for known sessions as `session_info_update` notifications. Repeated `session.updated` events with an unchanged title are deduplicated via a per-session map so we do not spam the notification on every session write.

### How did you verify your code works?

- Added unit tests in `packages/opencode/test/acp/event.test.ts` covering: title forwarded as `session_info_update`, dedup of unchanged titles, and ignoring unknown sessions / empty titles.
- `bun test test/acp/event.test.ts` — 19 pass, 0 fail.
- `bun run typecheck` (tsgo) — clean.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR