### PR TITLE
feat(telegram): add bi-directional telegram tui session bridge

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -882,6 +882,9 @@ export const RunCommand = effectCmd({
         try {
           await runInteractiveMode({
             sdk: client,
+            sdkOptions: args.attach
+              ? { baseUrl: args.attach, headers: attachHeaders }
+              : { baseUrl: "http://opencode.internal", fetch: fetchFn },
             directory: cwd,
             sessionID,
             sessionTitle: sess.title,

--- a/packages/opencode/src/cli/cmd/run/prompt.shared.ts
+++ b/packages/opencode/src/cli/cmd/run/prompt.shared.ts
@@ -52,6 +52,11 @@ export function isNewCommand(input: string): boolean {
   return input.trim().toLowerCase() === "/new"
 }
 
+export function isTelegramCommand(input: string): boolean {
+  const text = input.trim().toLowerCase()
+  return text === "/telegram" || text.startsWith("/telegram ") || text === "/tg" || text.startsWith("/tg ")
+}
+
 export function createPromptHistory(items?: RunPrompt[]): PromptHistoryState {
   const list = (items ?? []).filter((item) => item.text.trim().length > 0).map(promptCopy)
   const next: RunPrompt[] = []

--- a/packages/opencode/src/cli/cmd/run/runtime.queue.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.queue.ts
@@ -10,7 +10,7 @@
 // Resolves when the footer closes and all in-flight work finishes.
 import * as Locale from "@/util/locale"
 import { MessageID, PartID } from "@/session/schema"
-import { isExitCommand, isNewCommand } from "./prompt.shared"
+import { isExitCommand, isNewCommand, isTelegramCommand } from "./prompt.shared"
 import type { FooterApi, FooterEvent, FooterQueuedPrompt, RunPrompt } from "./types"
 
 type Trace = {
@@ -27,6 +27,8 @@ export type QueueInput = {
   footer: FooterApi
   initialInput?: string
   trace?: Trace
+  getSessionID?: () => string | undefined
+  getTelegramServer?: () => { baseUrl: string; fetch?: typeof fetch; headers?: RequestInit["headers"] } | undefined
   onSend?: (prompt: RunPrompt) => void
   onNewSession?: () => void | Promise<void>
   run: (prompt: RunPrompt, signal: AbortSignal) => Promise<void>
@@ -159,6 +161,23 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
               },
             )
             await input.onNewSession()
+            continue
+          }
+
+          if (prompt.mode !== "shell" && isTelegramCommand(prompt.text)) {
+            syncQueue()
+            const parts = prompt.text.trim().split(/\s+/)
+            const sub = parts[1] ?? "link"
+            const sessionID = input.getSessionID?.()
+            const server = input.getTelegramServer?.()
+            const { dispatchTelegramCommand } = await import("@/telegram/bridge")
+            const result = await dispatchTelegramCommand(sub, sessionID, server)
+            input.footer.append({
+              kind: result.kind,
+              text: result.text,
+              phase: "final",
+              source: "system",
+            })
             continue
           }
 

--- a/packages/opencode/src/cli/cmd/run/runtime.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.ts
@@ -31,7 +31,9 @@ export { runPromptQueue } from "./runtime.queue"
 type BootContext = Pick<
   RunInput,
   "sdk" | "directory" | "sessionID" | "sessionTitle" | "resume" | "agent" | "model" | "variant"
->
+> & {
+  server?: { baseUrl: string; fetch?: typeof fetch; headers?: RequestInit["headers"] }
+}
 
 type CreateSessionInput = {
   agent: string | undefined
@@ -545,6 +547,8 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
     await mod.runPromptQueue({
       footer,
       initialInput: input.initialInput,
+      getSessionID: () => state.sessionID,
+      getTelegramServer: () => ctx.server,
       trace: log,
       onSend: (prompt) => {
         state.shown = true
@@ -772,6 +776,7 @@ export async function runInteractiveLocalMode(input: RunLocalInput): Promise<voi
       return {
         sdk,
         directory: input.directory,
+        server: { baseUrl: "http://opencode.internal", fetch: input.fetch },
         sessionID: "",
         sessionTitle: undefined,
         resume: false,
@@ -800,6 +805,9 @@ export async function runInteractiveMode(
       boot: async () => ({
         sdk: input.sdk,
         directory: input.directory,
+        server: input.sdkOptions
+          ? { baseUrl: input.sdkOptions.baseUrl, fetch: input.sdkOptions.fetch, headers: input.sdkOptions.headers }
+          : undefined,
         sessionID: input.sessionID,
         sessionTitle: input.sessionTitle,
         resume: input.resume,

--- a/packages/opencode/src/cli/cmd/run/types.ts
+++ b/packages/opencode/src/cli/cmd/run/types.ts
@@ -56,6 +56,7 @@ export type RunResource = RunResourceMap[string]
 
 export type RunInput = {
   sdk: OpencodeClient
+  sdkOptions?: { baseUrl: string; fetch?: typeof fetch; headers?: RequestInit["headers"] }
   directory: string
   sessionID: string
   sessionTitle?: string

--- a/packages/opencode/src/cli/cmd/set-tg-token.ts
+++ b/packages/opencode/src/cli/cmd/set-tg-token.ts
@@ -1,0 +1,28 @@
+import type { Argv } from "yargs"
+import { Effect } from "effect"
+import path from "path"
+import { Global } from "@opencode-ai/core/global"
+import { effectCmd, fail } from "../effect-cmd"
+
+export const SetTelegramTokenCommand = effectCmd({
+  command: "set-tg-token <token>",
+  describe: "save a Telegram bot token for the telegram bridge",
+  instance: false,
+  builder: (yargs: Argv) => {
+    return yargs.positional("token", {
+      type: "string",
+      demandOption: true,
+      describe: "bot token from @BotFather",
+    })
+  },
+  handler: Effect.fn("Cli.setTelegramToken")(function* (args: { token: string }) {
+    const token = args.token.trim()
+    if (!token) return yield* fail("Bot token is required")
+    const tokenPath = path.join(Global.Path.data, "telegram-token")
+    yield* Effect.promise(async () => {
+      await Bun.write(tokenPath, token, { createPath: true })
+      await import("fs/promises").then((fs) => fs.chmod(tokenPath, 0o600)).catch(() => {})
+    }).pipe(Effect.catch((error) => fail(String(error))))
+    console.log("Telegram bot token saved. Run `opencode telegram` or use `/telegram` in TUI to start the bridge.")
+  }),
+})

--- a/packages/opencode/src/cli/cmd/telegram.ts
+++ b/packages/opencode/src/cli/cmd/telegram.ts
@@ -1,0 +1,39 @@
+import type { Argv } from "yargs"
+import { Effect } from "effect"
+import { ServerAuth } from "@/server/auth"
+import { SessionID } from "@/session/schema"
+import { TelegramBridge } from "@/telegram/bridge"
+import { effectCmd, fail } from "../effect-cmd"
+
+export const TelegramCommand = effectCmd({
+  command: "telegram",
+  describe: "link a Telegram chat to an opencode session",
+  instance: true,
+  builder: (yargs: Argv) => {
+    return yargs.option("session", {
+      type: "string",
+      alias: ["s"],
+      describe: "session id to link with Telegram",
+    })
+  },
+  handler: Effect.fn("Cli.telegram")(function* (args: { session?: string }) {
+    const bridge = yield* TelegramBridge.Service
+    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const { Server } = await import("@/server/server")
+      const request = new Request(input, init)
+      const headers = new Headers(request.headers)
+      const auth = ServerAuth.header()
+      if (auth) headers.set("Authorization", auth)
+      return Server.Default().app.fetch(new Request(request, { headers }))
+    }) as typeof globalThis.fetch
+
+    bridge.configure({ baseUrl: "http://opencode.internal", fetch: fetchFn })
+    const sessionID = args.session ? SessionID.make(args.session) : undefined
+    const link = yield* bridge.link({ sessionID }).pipe(
+      Effect.catch((error) => fail(error.message)),
+    )
+    console.log(`Open this link in Telegram to connect a chat (valid for 10 minutes):\n${link.url}`)
+    console.log("Telegram bridge running. Press Ctrl+C to stop.")
+    yield* Effect.never
+  }),
+})

--- a/packages/opencode/src/command/index.ts
+++ b/packages/opencode/src/command/index.ts
@@ -46,6 +46,8 @@ export function hints(template: string) {
 export const Default = {
   INIT: "init",
   REVIEW: "review",
+  TELEGRAM: "telegram",
+  TG: "tg",
 } as const
 
 export interface Interface {
@@ -85,6 +87,24 @@ const layer = Layer.effect(
         },
         subtask: true,
         hints: hints(PROMPT_REVIEW),
+      }
+      commands[Default.TELEGRAM] = {
+        name: Default.TELEGRAM,
+        description: "Telegram bridge: link, status, or unlink",
+        source: "command",
+        get template() {
+          return ""
+        },
+        hints: [],
+      }
+      commands[Default.TG] = {
+        name: Default.TG,
+        description: "Telegram bridge (alias for /telegram)",
+        source: "command",
+        get template() {
+          return ""
+        },
+        hints: [],
       }
 
       for (const [name, command] of Object.entries(cfg.command ?? {})) {

--- a/packages/opencode/src/effect/app-runtime.ts
+++ b/packages/opencode/src/effect/app-runtime.ts
@@ -45,6 +45,7 @@ import { Workspace } from "@/control-plane/workspace"
 import { Worktree } from "@/worktree"
 import { Installation } from "@/installation"
 import { ShareNext } from "@/share/share-next"
+import { TelegramBridge } from "@/telegram/bridge"
 import { SessionShare } from "@/share/session"
 import { Npm } from "@opencode-ai/core/npm"
 import { memoMap } from "@opencode-ai/core/effect/memo-map"
@@ -105,6 +106,7 @@ export const AppLayer = AppNodeBuilderV1.build(
     Installation.node,
     ShareNext.node,
     SessionShare.node,
+    TelegramBridge.node,
   ]),
 ).pipe(Layer.provideMerge(AppNodeBuilderV1.build(Ripgrep.node)), Layer.provideMerge(Observability.layer))
 

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -28,6 +28,8 @@ import { SessionCommand } from "./cli/cmd/session"
 import { DbCommand } from "./cli/cmd/db"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
+import { TelegramCommand } from "./cli/cmd/telegram"
+import { SetTelegramTokenCommand } from "./cli/cmd/set-tg-token"
 import { Heap } from "./cli/heap"
 
 const args = hideBin(process.argv)
@@ -101,6 +103,8 @@ const cli = yargs(args)
   .command(SessionCommand)
   .command(PluginCommand)
   .command(DbCommand)
+  .command(TelegramCommand)
+  .command(SetTelegramTokenCommand)
   .fail((msg, err) => {
     if (
       msg?.startsWith("Unknown argument") ||

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1359,6 +1359,74 @@ const layer = Layer.effect(
         command: input.command,
         agent: input.agent,
       })
+
+      // Command reply messages published here convey ephemeral UI status and are not persisted to storage.
+      if (input.command === "telegram" || input.command === "tg") {
+        const { dispatchTelegramCommand } = yield* Effect.promise(() => import("@/telegram/bridge"))
+        const res = yield* Effect.promise(() => dispatchTelegramCommand(input.arguments, input.sessionID))
+        const responseText = res.text
+
+        const now = Date.now()
+        const userMsgID = input.messageID ?? MessageID.ascending()
+        const currentMdl = yield* currentModel(input.sessionID)
+        const userMsgInfo: SessionV1.User = {
+          id: userMsgID,
+          role: "user",
+          sessionID: input.sessionID,
+          time: { created: now },
+          agent: input.agent ?? "build",
+          model: currentMdl,
+        }
+        const userPartID = PartID.ascending()
+        const userPart: SessionV1.TextPart = {
+          id: userPartID,
+          sessionID: input.sessionID,
+          messageID: userMsgID,
+          type: "text",
+          text: `/${input.command} ${input.arguments}`.trim(),
+        }
+
+        const replyMsgID = MessageID.ascending()
+        const replyMsgInfo: SessionV1.Assistant = {
+          id: replyMsgID,
+          role: "assistant",
+          sessionID: input.sessionID,
+          time: { created: now, completed: now },
+          parentID: userMsgID,
+          modelID: currentMdl.modelID,
+          providerID: currentMdl.providerID,
+          mode: userMsgInfo.agent,
+          agent: userMsgInfo.agent,
+          path: { cwd: (yield* InstanceState.context).directory, root: (yield* InstanceState.context).worktree },
+          cost: 0,
+          tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        }
+        const replyPartID = PartID.ascending()
+        const replyPart: SessionV1.TextPart = {
+          id: replyPartID,
+          sessionID: input.sessionID,
+          messageID: replyMsgID,
+          type: "text",
+          text: responseText,
+        }
+
+        yield* events.publish(SessionV1.Event.MessageUpdated, { sessionID: input.sessionID, info: userMsgInfo })
+        yield* events.publish(SessionV1.Event.PartUpdated, { sessionID: input.sessionID, part: userPart, time: now })
+        yield* events.publish(SessionV1.Event.MessageUpdated, { sessionID: input.sessionID, info: replyMsgInfo })
+        yield* events.publish(SessionV1.Event.PartUpdated, { sessionID: input.sessionID, part: replyPart, time: now })
+        yield* events.publish(Command.Event.Executed, {
+          name: input.command,
+          sessionID: input.sessionID,
+          arguments: input.arguments,
+          messageID: replyMsgID,
+        })
+
+        return {
+          info: replyMsgInfo,
+          parts: [replyPart],
+        }
+      }
+
       const cmd = yield* commands.get(input.command)
       if (!cmd) {
         const available = (yield* commands.list()).map((c) => c.name)

--- a/packages/opencode/src/telegram/api.ts
+++ b/packages/opencode/src/telegram/api.ts
@@ -1,0 +1,108 @@
+export interface TelegramUser {
+  id: number
+  username?: string
+  first_name?: string
+  last_name?: string
+}
+
+export interface TelegramChat {
+  id: number
+  type: string
+  title?: string
+  username?: string
+  first_name?: string
+  last_name?: string
+}
+
+export interface TelegramMessage {
+  message_id: number
+  text?: string
+  caption?: string
+  from?: TelegramUser
+  chat: TelegramChat
+}
+
+export interface TelegramUpdate {
+  update_id: number
+  message?: TelegramMessage
+}
+
+interface ApiResponse<T> {
+  ok: boolean
+  result: T
+}
+
+interface RateLimitBody {
+  parameters?: { retry_after?: number }
+}
+
+export interface ApiOptions {
+  botToken: string
+  baseUrl?: string
+}
+
+export interface SendOptions {
+  parseMode?: "HTML"
+}
+
+export class ApiError extends Error {}
+
+const RATE_LIMIT_MAX_WAIT_SECONDS = 30
+
+export class TelegramApi {
+  private readonly token: string
+  readonly baseUrl: string
+
+  constructor(opts: ApiOptions) {
+    this.token = opts.botToken
+    this.baseUrl = opts.baseUrl ?? "https://api.telegram.org"
+  }
+
+  async getMe(): Promise<TelegramUser> {
+    return this.call("getMe")
+  }
+
+  async getUpdates(input: { timeout: number; offset: number }): Promise<TelegramUpdate[]> {
+    return this.call("getUpdates", {
+      timeout: input.timeout,
+      offset: input.offset,
+      allowed_updates: ["message"],
+    })
+  }
+
+  async sendMessage(chatId: number, text: string, opts?: SendOptions): Promise<{ message_id: number }> {
+    return this.call("sendMessage", serializeText({ chat_id: chatId, text }, opts))
+  }
+
+  async editMessageText(
+    chatId: number,
+    messageId: number,
+    text: string,
+    opts?: SendOptions,
+  ): Promise<{ message_id: number }> {
+    return this.call("editMessageText", serializeText({ chat_id: chatId, message_id: messageId, text }, opts))
+  }
+
+  private async call<T>(method: string, payload?: Record<string, unknown>, allowRetry = true): Promise<T> {
+    const res = await fetch(`${this.baseUrl}/bot${this.token}/${method}`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: payload ? JSON.stringify(payload) : "{}",
+    })
+    if (res.status === 429 && allowRetry) {
+      const body = (await res.json().catch(() => undefined)) as RateLimitBody | undefined
+      const seconds = Math.min(body?.parameters?.retry_after ?? 1, RATE_LIMIT_MAX_WAIT_SECONDS)
+      await Bun.sleep(seconds * 1000)
+      return this.call(method, payload, false)
+    }
+    if (!res.ok) throw new ApiError(`Telegram API ${method} failed: HTTP ${res.status}`)
+    const data = (await res.json()) as ApiResponse<T>
+    if (!data.ok) throw new ApiError(`Telegram API ${method} failed`)
+    return data.result
+  }
+}
+
+function serializeText(payload: Record<string, unknown>, opts?: SendOptions): Record<string, unknown> {
+  if (!opts?.parseMode) return payload
+  return { ...payload, parse_mode: opts.parseMode }
+}

--- a/packages/opencode/src/telegram/bridge.ts
+++ b/packages/opencode/src/telegram/bridge.ts
@@ -1,0 +1,726 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Global } from "@opencode-ai/core/global"
+import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/v2"
+import { Context, Effect, Layer, Schema, Scope } from "effect"
+import path from "path"
+import { SessionID, MessageID } from "@/session/schema"
+import { TelegramApi, type TelegramMessage } from "./api"
+
+import type { GlobalEvent } from "@opencode-ai/sdk/v2"
+
+const LINK_TTL_MS = 10 * 60_000
+const POLL_ERROR_DELAY_MS = 2000
+const REPLY_MAX_CHARS = 4000
+const MIRROR_DEBOUNCE_MS = 1500
+
+export type BridgeEventSource = {
+  subscribe: (handler: (event: GlobalEvent) => void) => Promise<() => void> | (() => void)
+}
+
+export interface Options {
+  apiBaseUrl?: string
+  pollTimeoutSeconds?: number
+  botToken?: string
+  linksPath?: string
+  server?: {
+    baseUrl: string
+    fetch?: typeof fetch
+    headers?: RequestInit["headers"]
+    events?: BridgeEventSource
+  }
+}
+
+export interface LinkResult {
+  url: string
+  token: string
+}
+
+export interface ChatLink {
+  chatId: number
+  chatLabel: string
+  sessionID: SessionID
+  directory?: string
+}
+
+export interface Status {
+  linked: ChatLink[]
+}
+
+export class LinkError extends Schema.TaggedErrorClass<LinkError>()("TelegramBridgeLinkError", {
+  message: Schema.String,
+}) {}
+
+interface Interface {
+  readonly link: (input?: { sessionID?: SessionID; botToken?: string }) => Effect.Effect<LinkResult, LinkError>
+  readonly status: Effect.Effect<Status>
+  readonly unlinkSession: (sessionID: SessionID) => Effect.Effect<void>
+  readonly configure: (server: Options["server"]) => void
+}
+
+export class Settings extends Context.Service<Settings, Options>()("@opencode/TelegramBridge/Settings") {}
+export class Service extends Context.Service<Service, Interface>()("@opencode/TelegramBridge") {}
+
+function randomToken(bytes = 18): string {
+  const arr = new Uint8Array(bytes)
+  crypto.getRandomValues(arr)
+  return Buffer.from(arr).toString("base64url")
+}
+
+function chatLabel(chat: { title?: string; username?: string; first_name?: string; last_name?: string }): string {
+  return (chat.title ?? chat.username ?? [chat.first_name, chat.last_name].filter(Boolean).join(" ")) || "unknown"
+}
+
+export function splitChunks(text: string, size = REPLY_MAX_CHARS): string[] {
+  if (text.length <= size) return [text]
+  const chunks: string[] = []
+  let rest = text
+  while (rest.length > size) {
+    let cut = rest.lastIndexOf("\n\n", size)
+    if (cut < size / 2) cut = rest.lastIndexOf("\n", size)
+    if (cut < size / 2) cut = size
+    chunks.push(rest.slice(0, cut))
+    rest = rest.slice(cut).replace(/^\n+/, "")
+  }
+  if (rest.length > 0) chunks.push(rest)
+  return chunks
+}
+
+/** Escapes HTML and renders fenced code blocks + inline code as Telegram HTML entities. */
+export function formatReplyHtml(text: string): string {
+  const escaped = text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
+  const parts = escaped.split(/```(\w*)\n?([\s\S]*?)```/)
+  let out = ""
+  for (let i = 0; i < parts.length; i += 3) {
+    out += (parts[i] ?? "").replace(/`([^`\n]+)`/g, "<code>$1</code>")
+    const lang = parts[i + 1]
+    if (lang === undefined) continue
+    out += `<pre><code${lang ? ` class="language-${lang}"` : ""}>${parts[i + 2]?.trimEnd() ?? ""}</code></pre>`
+  }
+  return out
+}
+
+interface PendingLink {
+  expiresAt: number
+  sessionID?: SessionID
+}
+
+interface MirrorState {
+  messageID: string
+  parts: Map<string, string>
+  telegramMessageId?: number
+  timer?: ReturnType<typeof setTimeout>
+  done: boolean
+  sending?: Promise<void>
+  pending?: boolean
+}
+
+const tokenFilePath = path.join(Global.Path.data, "telegram-token")
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const opts = yield* Settings
+    const scope = yield* Scope.Scope
+
+    let serverConfig: Options["server"] | undefined = opts.server
+    let api: TelegramApi | undefined
+    let botUsername: string | undefined
+
+    const clients = new Map<string | undefined, OpencodeClient>()
+    function clientFor(directory?: string): OpencodeClient {
+      const key = directory ?? ""
+      let c = clients.get(key)
+      if (!c) {
+        const cfg =
+          serverConfig ??
+          opts.server ?? {
+            baseUrl: "http://opencode.internal",
+            fetch: (async (rin: RequestInfo | URL, rini?: RequestInit) => {
+              const { Server } = await import("@/server/server")
+              const { ServerAuth } = await import("@/server/auth")
+              const req = new Request(rin, rini)
+              const h = new Headers(req.headers)
+              const auth = ServerAuth.header()
+              if (auth) h.set("Authorization", auth)
+              return Server.Default().app.fetch(new Request(req, { headers: h }))
+            }) as typeof fetch,
+          }
+        c = createOpencodeClient({
+          baseUrl: cfg.baseUrl,
+          fetch: cfg.fetch,
+          headers: cfg.headers,
+          directory,
+        })
+        clients.set(key, c)
+      }
+      return c
+    }
+
+    const router = new Map<number, ChatLink>()
+    const pendingLinks = new Map<string, PendingLink>()
+    const mirrors = new Map<SessionID, MirrorState>()
+
+    let started = false
+    let linksLoaded = false
+    let offset = 0
+
+    const resolveToken = async (explicit?: string): Promise<string | undefined> => {
+      if (explicit) return explicit
+      if (opts.botToken) return opts.botToken
+      if (process.env.TELEGRAM_BOT_TOKEN) return process.env.TELEGRAM_BOT_TOKEN
+      try {
+        const saved = await Bun.file(tokenFilePath).text()
+        if (saved.trim()) return saved.trim()
+      } catch {}
+      return undefined
+    }
+
+    const getApi = Effect.fn("TelegramBridge.getApi")(function* (token: string) {
+      if (!api) api = new TelegramApi({ botToken: token, baseUrl: opts.apiBaseUrl })
+      return api
+    })
+
+    const sendText = Effect.fn("TelegramBridge.sendText")(function* (chatId: number, text: string) {
+      if (!api) return
+      yield* Effect.tryPromise(() => api!.sendMessage(chatId, text, { parseMode: "HTML" })).pipe(
+        Effect.catch(() => Effect.tryPromise(() => api!.sendMessage(chatId, text))),
+        Effect.catch((cause) => Effect.logWarning("telegram send failed", { chatId, cause })),
+      )
+    })
+
+    const buildText = (state: MirrorState) =>
+      [...state.parts.values()].join("\n\n").trim() || (state.done ? "Done." : "…")
+
+    const sendChunks = async (chatId: number, state: MirrorState) => {
+      if (!api) return
+      const chunks = splitChunks(buildText(state))
+      for (let i = 0; i < chunks.length; i++) {
+        const editExisting = i === 0 && state.telegramMessageId !== undefined
+        try {
+          if (editExisting) await api.editMessageText(chatId, state.telegramMessageId!, formatReplyHtml(chunks[i]), { parseMode: "HTML" })
+          else {
+            const sent = await api.sendMessage(chatId, formatReplyHtml(chunks[i]), { parseMode: "HTML" })
+            state.telegramMessageId = sent.message_id
+          }
+        } catch {
+          // Telegram rejects malformed HTML entities — fall back to plain text for this chunk.
+          try {
+            if (editExisting) await api.editMessageText(chatId, state.telegramMessageId!, chunks[i])
+            else {
+              const sent = await api.sendMessage(chatId, chunks[i])
+              state.telegramMessageId = sent.message_id
+            }
+          } catch {}
+        }
+      }
+    }
+
+    const flushMirror = (sessionID: SessionID) => {
+      const state = mirrors.get(sessionID)
+      const link = [...router.values()].find((entry) => entry.sessionID === sessionID)
+      if (!state || !link || !api) return
+      delete state.timer
+      // Serialize sends so overlapping debounces can't post duplicate chunks.
+      if (state.sending) {
+        state.pending = true
+        return
+      }
+      state.sending = sendChunks(link.chatId, state).finally(() => {
+        state.sending = undefined
+        if (state.pending) {
+          state.pending = false
+          scheduleMirror(sessionID)
+        }
+      })
+    }
+
+    const scheduleMirror = (sessionID: SessionID) => {
+      const state = mirrors.get(sessionID)
+      if (!state) return
+      if (state.timer) clearTimeout(state.timer)
+      state.timer = setTimeout(() => flushMirror(sessionID), MIRROR_DEBOUNCE_MS)
+    }
+
+    const messageRole = new Map<string, "user" | "assistant">()
+    const botSubmitted = new Set<string>()
+    const userMirrored = new Set<string>()
+
+    const onStreamEvent = (evt: { type: string; properties: any }) => {
+      if (evt.type === "message.updated") {
+        const info = evt.properties.info
+        if (!info) return
+        const sessionID = info.sessionID as SessionID
+        if (![...router.values()].some((l) => l.sessionID === sessionID)) return
+        messageRole.set(info.id, info.role)
+        if (messageRole.size > 500) {
+          messageRole.clear()
+          userMirrored.clear()
+        }
+        if (info.role !== "assistant") return
+        let state = mirrors.get(sessionID)
+        if (!state || state.messageID !== info.id) {
+          state = { messageID: info.id, parts: new Map(), done: false }
+          mirrors.set(sessionID, state)
+        }
+        if (info.time?.completed) {
+          state.done = true
+          scheduleMirror(sessionID)
+        }
+        return
+      }
+      if (evt.type === "message.part.updated") {
+        const part = evt.properties.part
+        if (!part) return
+        const sessionID = part.sessionID as SessionID
+        const link = [...router.values()].find((l) => l.sessionID === sessionID)
+        if (!link) return
+
+        if (messageRole.get(part.messageID) === "user") {
+          if (botSubmitted.has(part.messageID) || userMirrored.has(part.messageID)) return
+          if (part.type === "text" && !part.synthetic && part.text.trim()) {
+            userMirrored.add(part.messageID)
+            void api?.sendMessage(link.chatId, `👤 ${part.text}`).catch(() => {})
+          }
+          return
+        }
+
+        const state = mirrors.get(sessionID)
+        if (!state || state.messageID !== part.messageID) return
+        if (part.type !== "text" || part.synthetic) return
+        state.parts.set(part.id, part.text)
+        scheduleMirror(sessionID)
+      }
+    }
+
+    const startMirroring = Effect.gen(function* () {
+      const injected = (serverConfig ?? opts.server)?.events
+      if (injected) {
+        yield* Effect.promise(async () => {
+          await injected.subscribe((e) => {
+            const p = (e as any)?.payload
+            if (p && typeof p.type === "string" && p.properties) onStreamEvent(p)
+          })
+        })
+        return
+      }
+
+      yield* Effect.forkIn(scope)(
+        Effect.promise(async () => {
+          while (started) {
+            try {
+              const client = clientFor(undefined)
+              const events = await client.global.event()
+              for await (const event of events.stream) {
+                const payload = (event as any)?.payload ?? event
+                onStreamEvent(payload as any)
+              }
+            } catch (err) {
+              console.error("[telegram] mirror stream error", err)
+              await Bun.sleep(POLL_ERROR_DELAY_MS)
+            }
+          }
+        }),
+      )
+    })
+
+    const startPolling = Effect.fn("TelegramBridge.startPolling")(function* () {
+      if (started) return
+      started = true
+      yield* startMirroring
+      const tick = Effect.gen(function* () {
+        if (!api) return
+        const updates = yield* Effect.tryPromise(() =>
+          api!.getUpdates({ timeout: opts.pollTimeoutSeconds ?? 25, offset }),
+        ).pipe(Effect.catch(() => Effect.succeed([])))
+        for (const upd of updates) {
+          offset = Math.max(offset, upd.update_id + 1)
+          if (!upd.message) continue
+          yield* handleMessage(upd.message).pipe(
+            Effect.catchCause((cause) => Effect.logWarning("telegram handleMessage failed", { cause })),
+          )
+        }
+      }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("telegram polling failed", { cause }).pipe(
+            Effect.andThen(() => Effect.sleep(POLL_ERROR_DELAY_MS)),
+          ),
+        ),
+      )
+      yield* Effect.forever(tick).pipe(Effect.forkIn(scope))
+    })
+
+    const handleMessage = Effect.fn("TelegramBridge.handleMessage")(function* (msg: TelegramMessage) {
+      const text = msg.text?.trim() ?? ""
+      const chatId = msg.chat.id
+      yield* Effect.logInfo("Telegram message received", { chatId, text, from: msg.from?.username })
+
+      if (text.startsWith("/start")) {
+        const token = text.split(/\s+/)[1] ?? ""
+        const pending = pendingLinks.get(token)
+        if (!pending || Date.now() > pending.expiresAt) {
+          pendingLinks.delete(token)
+          yield* sendText(chatId, "Link token invalid or expired. Run /telegram in opencode again.")
+          return
+        }
+        pendingLinks.delete(token)
+        const label = chatLabel(msg.chat)
+        let sessionID = pending.sessionID
+        let directory: string | undefined
+        if (!sessionID) {
+          const res = yield* Effect.promise(() =>
+            clientFor(undefined).session.create({ title: `telegram ${label}` }),
+          ).pipe(Effect.catchCause((cause) => Effect.succeed({ error: cause, data: undefined })))
+          if (res.error || !res.data?.id) {
+            yield* sendText(chatId, `Could not create session: ${String(res.error ?? "unknown error")}`)
+            return
+          }
+          sessionID = res.data.id as SessionID
+          directory = res.data.directory
+        }
+        router.set(chatId, { chatId, chatLabel: label, sessionID, directory })
+        yield* persistLinks()
+        yield* Effect.logInfo("Telegram chat linked to session", { chatId, sessionID })
+        yield* sendText(chatId, `Linked to opencode session ${sessionID}. Send /stop to interrupt generation.`)
+        return
+      }
+
+      if (text === "/telegram") {
+        if (!api || !botUsername) {
+          yield* sendText(chatId, "Telegram bridge is still starting; try again shortly.")
+          return
+        }
+        const { url } = yield* issueLink()
+        yield* sendText(chatId, `Tap this link within 10 minutes to connect this chat to opencode:\n${url}`)
+        return
+      }
+
+      if (text === "/stop") {
+        const link = router.get(chatId)
+        if (!link) return
+        yield* Effect.promise(() => clientFor(link.directory).session.abort({ sessionID: link.sessionID })).pipe(
+          Effect.ignore,
+        )
+        yield* sendText(chatId, "Stop signal sent.")
+        return
+      }
+
+      if (text === "/status") {
+        const link = router.get(chatId)
+        if (!link) {
+          yield* sendText(chatId, "This chat is not linked to any opencode session.")
+          return
+        }
+        yield* sendText(chatId, `Currently linked to opencode session: ${link.sessionID}`)
+        return
+      }
+
+      if (text === "/unlink") {
+        const link = router.get(chatId)
+        if (!link) {
+          yield* sendText(chatId, "This chat is not linked to any opencode session.")
+          return
+        }
+        router.delete(chatId)
+        yield* persistLinks()
+        yield* sendText(chatId, `Unlinked from opencode session ${link.sessionID}.`)
+        return
+      }
+
+      const link = router.get(chatId)
+      if (!link) {
+        yield* Effect.logInfo("Telegram message received for unlinked chat", { chatId, text })
+        return
+      }
+      if (text.length === 0) return
+
+      if (!link.directory) {
+        const res = yield* Effect.promise(() =>
+          clientFor(undefined).session.get({ sessionID: link.sessionID }),
+        ).pipe(Effect.catchCause(() => Effect.succeed(undefined)))
+        if (res?.data?.directory) {
+          link.directory = res.data.directory
+          router.set(chatId, link)
+        }
+      }
+
+      const messageID = MessageID.ascending()
+      botSubmitted.add(messageID)
+      if (botSubmitted.size > 500) botSubmitted.clear()
+
+      const res = yield* Effect.promise(() =>
+        clientFor(link.directory).session.promptAsync({
+          sessionID: link.sessionID,
+          messageID,
+          parts: [{ type: "text", text }],
+        }),
+      ).pipe(
+        Effect.catchCause((cause) =>
+          sendText(
+            chatId,
+            `⚠️ OpenCode prompt error for session <code>${link.sessionID}</code>: ${String(cause)}.`,
+          ),
+        ),
+      )
+      if (res && typeof res === "object" && "error" in res && (res as any).error) {
+        yield* sendText(
+          chatId,
+          `⚠️ OpenCode prompt error for session <code>${link.sessionID}</code>: ${String((res as any).error?.message ?? (res as any).error)}.`,
+        )
+      }
+    })
+
+    const issueLink = Effect.fn("TelegramBridge.issueLink")(function* (sessionID?: SessionID) {
+      const token = randomToken()
+      pendingLinks.set(token, { expiresAt: Date.now() + LINK_TTL_MS, sessionID })
+      return { url: `https://t.me/${botUsername}?start=${token}`, token }
+    })
+
+    const loadLinks = async (): Promise<ChatLink[]> => {
+      if (!opts.linksPath) return []
+      try {
+        return await Bun.file(opts.linksPath).json()
+      } catch {}
+      return []
+    }
+
+    const ensureLinksLoaded = Effect.fn("TelegramBridge.ensureLinksLoaded")(function* () {
+      if (linksLoaded) return
+      linksLoaded = true
+      for (const entry of yield* Effect.promise(loadLinks)) {
+        router.set(entry.chatId, entry)
+      }
+    })
+
+    const persistLinks = Effect.fn("TelegramBridge.persistLinks")(function* () {
+      if (!opts.linksPath) return
+      yield* Effect.promise(() => Bun.write(opts.linksPath!, JSON.stringify([...router.values()], null, 2), { createPath: true })).pipe(
+        Effect.catch((cause) => Effect.logWarning("telegram links save failed", { cause })),
+      )
+    })
+
+    yield* Effect.addFinalizer(() =>
+      Effect.sync(() => {
+        for (const state of mirrors.values()) {
+          if (state.timer) clearTimeout(state.timer)
+        }
+      }),
+    )
+
+    yield* Effect.gen(function* () {
+      yield* ensureLinksLoaded()
+      if (!(serverConfig ?? opts.server)?.baseUrl) return
+      const token = yield* Effect.promise(() => resolveToken())
+      if (!token) return
+      const currentApi = yield* getApi(token)
+      if (!botUsername) {
+        const me = yield* Effect.tryPromise(() => currentApi.getMe()).pipe(Effect.catch(() => Effect.succeed(undefined)))
+        if (me) botUsername = me.username
+      }
+      if (botUsername) {
+        yield* startPolling()
+        yield* Effect.logInfo("Telegram bridge autostarted on boot", { botUsername })
+      }
+    }).pipe(Effect.ignore, Effect.forkIn(scope))
+
+    return Service.of({
+      configure: (server) => {
+        if (server) {
+          serverConfig = server
+          clients.clear()
+          router.clear()
+          mirrors.clear()
+          pendingLinks.clear()
+          botSubmitted.clear()
+          userMirrored.clear()
+          messageRole.clear()
+          linksLoaded = false
+        }
+      },
+      link: (input) =>
+        Effect.gen(function* () {
+          yield* ensureLinksLoaded()
+          const token = yield* Effect.promise(() => resolveToken(input?.botToken))
+          if (!token) {
+            return yield* new LinkError({ message: "No Telegram bot token configured. Save one first: opencode set-tg-token <token>." })
+          }
+          if (input?.botToken && input.botToken !== token) {
+            yield* Effect.promise(async () => {
+              await Bun.write(tokenFilePath, input.botToken!, { createPath: true })
+              await import("fs/promises").then((fs) => fs.chmod(tokenFilePath, 0o600)).catch(() => {})
+            }).pipe(Effect.ignore)
+          }
+          const currentApi = yield* getApi(token)
+          if (!botUsername) {
+            const me = yield* Effect.tryPromise(() => currentApi.getMe()).pipe(
+              Effect.catch((cause) => Effect.fail(new LinkError({ message: `getMe failed: ${String(cause)}` }))),
+            )
+            botUsername = me.username
+          }
+          if (!botUsername) {
+            return yield* new LinkError({ message: "Bot username is missing" })
+          }
+          yield* startPolling()
+          return yield* issueLink(input?.sessionID)
+        }),
+      status: Effect.gen(function* () {
+        yield* ensureLinksLoaded()
+        return { linked: [...router.values()] }
+      }),
+      unlinkSession: (sessionID: SessionID) =>
+        Effect.gen(function* () {
+          yield* ensureLinksLoaded()
+          for (const [chatId, entry] of router.entries()) {
+            if (entry.sessionID === sessionID) {
+              router.delete(chatId)
+            }
+          }
+          yield* persistLinks()
+        }),
+    })
+  }),
+)
+
+const envLayer = Layer.effect(
+  Settings,
+  Effect.sync(() => ({
+    apiBaseUrl: process.env["OPENCODE_TELEGRAM_API_BASE_URL"],
+    botToken: process.env["TELEGRAM_BOT_TOKEN"],
+    linksPath: process.env["OPENCODE_TELEGRAM_LINKS_PATH"] ?? path.join(Global.Path.data, "telegram-links.json"),
+  })),
+)
+
+export const node = LayerNode.make({
+  service: Service,
+  layer: layer.pipe(Layer.provideMerge(envLayer)),
+  deps: [],
+})
+
+export async function setupTelegramRemote(input?: {
+  sessionID?: string
+  server?: Options["server"]
+}): Promise<{ token: string; url: string } | undefined> {
+  try {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    const { SessionID } = await import("@/session/schema")
+
+    const result = await AppRuntime.runPromise(
+      Effect.gen(function* () {
+        const bridge = yield* Service
+        if (input?.server) bridge.configure(input.server)
+        const id = input?.sessionID ? SessionID.make(input.sessionID) : undefined
+        return yield* bridge.link({ sessionID: id })
+      }),
+    )
+
+    return result
+  } catch (cause) {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    await AppRuntime.runPromise(Effect.logWarning("telegram setup failed", { cause })).catch(() => {})
+    return undefined
+  }
+}
+
+export async function getTelegramStatus(server?: Options["server"]): Promise<{ linked: { chatId: number; chatLabel: string; sessionID: string }[] } | undefined> {
+  try {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    return await AppRuntime.runPromise(
+      Effect.gen(function* () {
+        const bridge = yield* Service
+        if (server) bridge.configure(server)
+        return yield* bridge.status
+      }),
+    )
+  } catch (cause) {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    await AppRuntime.runPromise(Effect.logWarning("telegram status check failed", { cause })).catch(() => {})
+    return undefined
+  }
+}
+
+export async function unlinkTelegramSession(sessionID: string, server?: Options["server"]): Promise<void> {
+  try {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    const { SessionID } = await import("@/session/schema")
+    await AppRuntime.runPromise(
+      Effect.gen(function* () {
+        const bridge = yield* Service
+        if (server) bridge.configure(server)
+        yield* bridge.unlinkSession(SessionID.make(sessionID))
+      }),
+    )
+  } catch (cause) {
+    const { AppRuntime } = await import("@/effect/app-runtime")
+    await AppRuntime.runPromise(Effect.logWarning("telegram unlink failed", { cause })).catch(() => {})
+  }
+}
+
+export async function dispatchTelegramCommand(
+  rawSubCommand: string,
+  sessionID?: string,
+  server?: Options["server"],
+): Promise<{ text: string; kind: "assistant" | "error" }> {
+  const sub = rawSubCommand.trim().split(/\s+/)[0]?.toLowerCase() ?? "link"
+  if (sub === "link" || sub === "") {
+    if (!sessionID) {
+      return {
+        text: "No active session to link. Start a session or run a prompt first.",
+        kind: "error",
+      }
+    }
+    const link = await setupTelegramRemote({ sessionID, server })
+    if (link) {
+      return {
+        text: `**Telegram Remote Mode**\n\n[Open link in Telegram](${link.url})\n\n*(Valid for 10 minutes. Tap "Start" in Telegram to pair)*`,
+        kind: "assistant",
+      }
+    }
+    return {
+      text: "Telegram bot token is not configured. Save one first: `opencode set-tg-token <token>`.",
+      kind: "error",
+    }
+  }
+
+  if (sub === "status") {
+    const status = await getTelegramStatus(server)
+    const linked = status?.linked.filter((x) => Boolean(sessionID) && x.sessionID === sessionID) ?? []
+    if (linked.length > 0) {
+      return {
+        text: `Telegram bridge active. Linked to chat ${linked[0].chatId} (${linked[0].chatLabel ?? "chat"}).`,
+        kind: "assistant",
+      }
+    }
+    return {
+      text: "Telegram bridge is ready, but not linked to this session. Run `/tg link` or `/telegram` to link.",
+      kind: "assistant",
+    }
+  }
+
+  if (sub === "unlink") {
+    if (!sessionID) {
+      return {
+        text: "Telegram bridge is not linked to this session; nothing to unlink.",
+        kind: "error",
+      }
+    }
+    const status = await getTelegramStatus(server)
+    const linked = status?.linked.filter((x) => x.sessionID === sessionID) ?? []
+    if (linked.length === 0) {
+      return {
+        text: "Telegram bridge is not linked to this session; nothing to unlink.",
+        kind: "error",
+      }
+    }
+    await unlinkTelegramSession(sessionID, server)
+    return {
+      text: "Unlinked Telegram chat from this session.",
+      kind: "assistant",
+    }
+  }
+
+  return {
+    text: "Usage: `/telegram` or `/tg link` | `/tg status` | `/tg unlink`",
+    kind: "error",
+  }
+}
+
+export * as TelegramBridge from "./bridge"

--- a/packages/opencode/test/telegram/bridge.test.ts
+++ b/packages/opencode/test/telegram/bridge.test.ts
@@ -1,0 +1,656 @@
+import { beforeEach, describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import fs from "fs"
+import path from "path"
+import type { TelegramMessage, TelegramUpdate } from "@/telegram/api"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { SessionID } from "@/session/schema"
+import { testEffect } from "../lib/effect"
+import { TelegramBridge } from "@/telegram/bridge"
+
+const BOT_USERNAME = "test_bot"
+
+interface SentMessage {
+  chat_id: number
+  text: string
+}
+
+function startBotApi() {
+  const sent: SentMessage[] = []
+  let queue: TelegramUpdate[][] = []
+  let updateID = 0
+  let messageID = 100
+
+  const server = Bun.serve({
+    port: 0,
+    fetch: async (req) => {
+      const url = new URL(req.url)
+      const method = url.pathname.split("/").at(-1)
+      if (method === "getMe") {
+        return Response.json({ ok: true, result: { id: 1, username: BOT_USERNAME } })
+      }
+      if (method === "getUpdates") {
+        const batch = queue.shift()
+        if (batch) return Response.json({ ok: true, result: batch })
+        await Bun.sleep(25)
+        return Response.json({ ok: true, result: [] })
+      }
+      if (method === "sendMessage") {
+        const payload = (await req.json()) as SentMessage
+        sent.push(payload)
+        return Response.json({ ok: true, result: { message_id: ++messageID } })
+      }
+      if (method === "editMessageText") {
+        const payload = (await req.json()) as SentMessage
+        sent.push(payload)
+        return Response.json({ ok: true, result: { message_id: messageID } })
+      }
+      return Response.json({ ok: false }, { status: 400 })
+    },
+  })
+
+  return {
+    sent,
+    server,
+    push(message: Partial<TelegramMessage>) {
+      updateID += 1
+      queue.push([
+        {
+          update_id: updateID,
+          message: {
+            message_id: updateID,
+            chat: { id: 1, type: "private" },
+            ...message,
+          } as TelegramMessage,
+        },
+      ])
+    },
+    reset() {
+      sent.length = 0
+      queue = []
+    },
+    stop: () => server.stop(true),
+  }
+}
+
+interface RecordedPrompt {
+  sessionID: SessionID
+  text: string
+}
+
+function startFakeServer() {
+  const prompts: RecordedPrompt[] = []
+  const cancelled: SessionID[] = []
+  const createdSessions: SessionID[] = []
+  let sessionCounter = 0
+  const clients = new Set<ReadableStreamDefaultController>()
+
+  const server = Bun.serve({
+    port: 0,
+    fetch: async (req) => {
+      const url = new URL(req.url)
+      if (url.pathname === "/event" || url.pathname === "/global/event") {
+        const body = new ReadableStream({
+          start(controller) {
+            clients.add(controller)
+          },
+          cancel(controller) {
+            clients.delete(controller)
+          },
+        })
+        return new Response(body, {
+          headers: {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            Connection: "keep-alive",
+          },
+        })
+      }
+      if (url.pathname === "/session" && req.method === "POST") {
+        if (fakeServer.shouldFailCreate) {
+          return Response.json({ error: { message: "boom" } }, { status: 500 })
+        }
+        sessionCounter += 1
+        const id = SessionID.make(`ses-telegram-test-${sessionCounter}`)
+        createdSessions.push(id)
+        const body = (await req.json()) as { title?: string }
+        return Response.json({ id, title: body.title, directory: "/tmp" })
+      }
+      if (url.pathname.startsWith("/session/") && req.method === "GET") {
+        const id = url.pathname.split("/")[2] as SessionID
+        return Response.json({ id, title: "test", directory: "/tmp" })
+      }
+      if (url.pathname.includes("/prompt_async") && req.method === "POST") {
+        if (fakeServer.shouldFailPrompt) {
+          fakeServer.shouldFailPrompt = false
+          return Response.json({ error: "prompt failed" }, { status: 500 })
+        }
+        const parts = url.pathname.split("/")
+        const sessionID = parts[2] as SessionID
+        const body = (await req.json()) as { parts: { type: string; text: string }[] }
+        const text = body.parts.find((p) => p.type === "text")?.text ?? ""
+        prompts.push({ sessionID, text })
+        return Response.json({ status: "ok" })
+      }
+      if (url.pathname.includes("/abort") && req.method === "POST") {
+        const parts = url.pathname.split("/")
+        const sessionID = parts[2] as SessionID
+        cancelled.push(sessionID)
+        return Response.json({ status: "ok" })
+      }
+      return Response.json({ ok: false }, { status: 404 })
+    },
+  })
+
+  function emitSSE(event: { type: string; properties: any }) {
+    const data = `data: ${JSON.stringify({ payload: event })}\n\n`
+    const enc = new TextEncoder().encode(data)
+    for (const client of clients) {
+      try {
+        client.enqueue(enc)
+      } catch {}
+    }
+  }
+
+  return {
+    server,
+    url: `http://localhost:${server.port}`,
+    prompts,
+    cancelled,
+    createdSessions,
+    shouldFailCreate: false,
+    shouldFailPrompt: false,
+    emitSSE,
+    reset() {
+      prompts.length = 0
+      cancelled.length = 0
+      createdSessions.length = 0
+      sessionCounter = 0
+      this.shouldFailCreate = false
+      this.shouldFailPrompt = false
+    },
+    stop() {
+      server.stop(true)
+    },
+  }
+}
+
+const bot = startBotApi()
+const fakeServer = startFakeServer()
+const linksDir = path.join("/tmp", `opencode-telegram-test-${process.pid}`)
+const linksPath = path.join(linksDir, "links.json")
+fs.mkdirSync(linksDir, { recursive: true })
+process.env["OPENCODE_TELEGRAM_API_BASE_URL"] = `http://localhost:${bot.server.port}`
+process.env["OPENCODE_TELEGRAM_LINKS_PATH"] = linksPath
+
+let messageCounter = 0
+
+function publishReply(sessionID: SessionID, replyText = "assistant reply") {
+  messageCounter += 1
+  const messageID = `msg_telegram_${messageCounter}`
+  fakeServer.emitSSE({
+    type: "message.updated",
+    properties: {
+      info: {
+        id: messageID,
+        role: "assistant",
+        sessionID,
+        time: {},
+      },
+    },
+  })
+  fakeServer.emitSSE({
+    type: "message.part.updated",
+    properties: {
+      part: {
+        id: `prt_telegram_${messageCounter}`,
+        sessionID,
+        messageID,
+        type: "text",
+        text: replyText,
+      },
+    },
+  })
+  fakeServer.emitSSE({
+    type: "message.updated",
+    properties: {
+      info: {
+        id: messageID,
+        role: "assistant",
+        sessionID,
+        time: { completed: Date.now() },
+      },
+    },
+  })
+}
+
+const env = LayerNode.compile(TelegramBridge.node, [])
+const it = testEffect(env)
+
+beforeEach(() => {
+  bot.reset()
+  fakeServer.reset()
+  fs.rmSync(linksPath, { force: true })
+})
+
+async function waitUntil(predicate: () => boolean, message: string) {
+  const deadline = Date.now() + 5000
+  while (!predicate()) {
+    if (Date.now() > deadline) throw new Error(`timeout: ${message}`)
+    await Bun.sleep(10)
+  }
+}
+
+describe("TelegramBridge", () => {
+  it.live("link returns a t.me URL and starts empty", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      expect(link.url).toContain(`https://t.me/${BOT_USERNAME}?start=`)
+      const status = yield* bridge.status
+      expect(status.linked).toEqual([])
+    }),
+  )
+
+  it.live("links a chat via /start token", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 111, type: "private", first_name: "Ada" } })
+
+      yield* Effect.promise(() => waitUntil(() => bot.sent.length > 0, "link confirmation"))
+
+      expect(bot.sent[0]?.chat_id).toBe(111)
+      expect(bot.sent[0]?.text).toContain("Linked to opencode session")
+      expect(fakeServer.createdSessions).toEqual([SessionID.make("ses-telegram-test-1")])
+
+      const status = yield* bridge.status
+      expect(status.linked).toEqual([{ chatId: 111, chatLabel: "Ada", sessionID: fakeServer.createdSessions[0], directory: "/tmp" }])
+    }),
+  )
+
+  it.live("links an existing sessionID when specified in link()", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const customID = SessionID.make("ses-telegram-custom-999")
+      const link = yield* bridge.link({ sessionID: customID, botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 333, type: "private", first_name: "Bob" } })
+
+      yield* Effect.promise(() => waitUntil(() => bot.sent.length > 0, "link confirmation"))
+
+      expect(bot.sent[0]?.chat_id).toBe(333)
+      expect(bot.sent[0]?.text).toContain(`Linked to opencode session ${customID}`)
+      expect(fakeServer.createdSessions).toEqual([])
+
+      const status = yield* bridge.status
+      expect(status.linked).toEqual([{ chatId: 333, chatLabel: "Bob", sessionID: customID }])
+    }),
+  )
+
+  it.live("handles /status and /unlink commands", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const customID = SessionID.make("ses-telegram-custom-888")
+      const link = yield* bridge.link({ sessionID: customID, botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 444, type: "private", first_name: "Carol" } })
+      yield* Effect.promise(() => waitUntil(() => bot.sent.length > 0, "linked"))
+
+      bot.push({ text: "/status", chat: { id: 444, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => Boolean(bot.sent.at(-1)?.text.includes("Currently linked")), "status reply"))
+      expect(bot.sent.at(-1)?.text).toContain(customID)
+
+      bot.push({ text: "/unlink", chat: { id: 444, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => Boolean(bot.sent.at(-1)?.text.includes("Unlinked from")), "unlink reply"))
+
+      const status = yield* bridge.status
+      expect(status.linked).toEqual([])
+    }),
+  )
+
+  it.live("rejects an invalid link token", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: "/start wrong-token", chat: { id: 222, type: "private" } })
+
+      yield* Effect.promise(() => waitUntil(() => bot.sent.length > 0, "rejection message"))
+
+      expect(bot.sent[0]?.text).toContain("invalid or expired")
+      expect(fakeServer.createdSessions).toEqual([])
+    }),
+  )
+
+  it.live("routes chat messages into session prompts and mirrors replies", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 111, type: "private", first_name: "Ada" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked session"))
+      const linkedSession = fakeServer.createdSessions[0]
+
+      bot.push({ text: "hello opencode", chat: { id: 111, type: "private" } })
+      yield* Effect.promise(() =>
+        waitUntil(() => fakeServer.prompts.some((p) => p.sessionID === linkedSession), "prompt recorded"),
+      )
+      expect(fakeServer.prompts[0]?.text).toBe("hello opencode")
+
+      publishReply(linkedSession)
+      yield* Effect.promise(() => waitUntil(() => bot.sent.some((m) => m.text === "assistant reply"), "reply sent"))
+      expect(bot.sent.at(-1)?.chat_id).toBe(111)
+    }),
+  )
+
+  it.live("runs chats in parallel without head-of-line blocking", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const firstLink = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${firstLink.token}`, chat: { id: 111, type: "private", first_name: "Ada" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "first chat linked"))
+      const firstSession = fakeServer.createdSessions[0]
+
+      const secondLink = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${secondLink.token}`, chat: { id: 222, type: "private", username: "grace" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 2, "second chat linked"))
+      const secondSession = fakeServer.createdSessions[1]
+
+      bot.push({ text: "slow question", chat: { id: 111, type: "private" } })
+      bot.push({ text: "fast question", chat: { id: 222, type: "private" } })
+
+      yield* Effect.promise(() =>
+        waitUntil(
+          () => fakeServer.prompts.some((p) => p.sessionID === secondSession && p.text === "fast question"),
+          "second prompt recorded",
+        ),
+      )
+      expect(fakeServer.prompts.length).toBe(2)
+    }),
+  )
+
+  it.live("/stop cancels the mapped session", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 111, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked"))
+
+      bot.push({ text: "/stop", chat: { id: 111, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.cancelled.length > 0, "cancel recorded"))
+
+      expect(fakeServer.cancelled).toEqual([fakeServer.createdSessions[0]])
+      yield* Effect.promise(() => waitUntil(() => bot.sent.at(-1)?.text === "Stop signal sent.", "stop confirmation"))
+    }),
+  )
+
+  it.live("ignores messages from unlinked chats", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: "who is this?", chat: { id: 999, type: "private" } })
+      yield* Effect.sleep(150)
+      expect(fakeServer.prompts).toEqual([])
+      expect(bot.sent).toEqual([])
+    }),
+  )
+
+  it.live("/telegram in a chat issues a link that completes pairing", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      yield* bridge.link({ botToken: "test-token" })
+
+      bot.push({ text: "/telegram", chat: { id: 555, type: "private", first_name: "Linus" } })
+      yield* Effect.promise(() =>
+        waitUntil(() => bot.sent.some((m) => m.chat_id === 555 && m.text.includes("t.me/")), "link reply"),
+      )
+      const reply = bot.sent.find((m) => m.chat_id === 555)!
+      const token = reply.text.match(/\?start=(\S+)/)![1]
+      expect(fakeServer.createdSessions).toEqual([])
+
+      bot.push({ text: `/start ${token}`, chat: { id: 555, type: "private", first_name: "Linus" } })
+      yield* Effect.promise(() => waitUntil(() => bot.sent.some((m) => m.text.includes("Linked to opencode session")), "paired session confirmation"))
+      expect(bot.sent.at(-1)?.text).toContain("Linked to opencode session")
+
+      const status = yield* bridge.status
+      expect(status.linked).toEqual([{ chatId: 555, chatLabel: "Linus", sessionID: fakeServer.createdSessions[0], directory: "/tmp" }])
+    }),
+  )
+
+  it.live("splits long replies into multiple messages", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 111, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked"))
+      const linkedSession = fakeServer.createdSessions[0]
+
+      bot.push({ text: "long answer please", chat: { id: 111, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.prompts.length === 1, "prompt recorded"))
+
+      const paragraph = `para-${"x".repeat(900)}\n\n`
+      const longText = paragraph.repeat(12)
+      publishReply(linkedSession, longText)
+
+      yield* Effect.promise(() =>
+        waitUntil(() => bot.sent.filter((m) => m.chat_id === 111 && m.text.includes("para-")).length >= 3, "chunks sent"),
+      )
+      const joined = bot.sent
+        .filter((m) => m.chat_id === 111 && m.text.includes("para-"))
+        .map((m) => m.text)
+        .join("\n")
+      expect(joined.startsWith("para-")).toBe(true)
+      for (const chunk of bot.sent.filter((m) => m.text.includes("para-"))) {
+        expect(chunk.text!.length).toBeLessThanOrEqual(4100)
+      }
+    }),
+  )
+
+  it.live("formats fenced code blocks and inline code as HTML", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 111, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked"))
+      const linkedSession = fakeServer.createdSessions[0]
+
+      bot.push({ text: "show code", chat: { id: 111, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.prompts.length === 1, "prompt recorded"))
+
+      publishReply(linkedSession, 'Look: `a < b` then\n```ts\nconst x = a < b && c > d\n```\ndone')
+      yield* Effect.promise(() =>
+        waitUntil(
+          () => bot.sent.some((m) => m.chat_id === 111 && m.text.includes("<pre>")),
+          "html reply sent",
+        ),
+      )
+      const reply = bot.sent.find((m) => m.text.includes("<pre>"))!
+      expect(reply.text).toContain('<code class="language-ts">const x = a &lt; b &amp;&amp; c &gt; d</code>')
+      expect(reply.text).toContain("<code>a &lt; b</code>")
+    }),
+  )
+
+  it.live("persists links to disk on link and restores them later", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 111, type: "private", first_name: "Ada" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked"))
+      yield* Effect.promise(() => waitUntil(() => fs.existsSync(linksPath), "links persisted"))
+
+      const persisted = JSON.parse(yield* Effect.promise(() => Bun.file(linksPath).text()))
+      expect(persisted).toEqual([{ chatId: 111, chatLabel: "Ada", sessionID: fakeServer.createdSessions[0], directory: "/tmp" }])
+
+      const status = yield* bridge.status
+      expect(status.linked).toEqual(persisted)
+    }),
+  )
+
+  it.live("restores previous run's links from disk without relinking", () =>
+    Effect.gen(function* () {
+      const restored = SessionID.make("ses-telegram-restored-1")
+      yield* Effect.promise(() =>
+        Bun.write(linksPath, JSON.stringify([{ chatId: 777, chatLabel: "Grace", sessionID: restored }])),
+      )
+
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const status = yield* bridge.status
+      expect(status.linked).toEqual([{ chatId: 777, chatLabel: "Grace", sessionID: restored }])
+    }),
+  )
+
+  it.live("mirrors events delivered via injected event source (Fix 1)", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      let handler!: (event: any) => void
+      bridge.configure({
+        baseUrl: fakeServer.url,
+        events: {
+          subscribe: (h) => {
+            handler = h
+            return () => {}
+          },
+        },
+      })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 888, type: "private", first_name: "Injected" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked session"))
+      const linkedSession = fakeServer.createdSessions[0]
+
+      handler({
+        payload: {
+          type: "message.updated",
+          properties: {
+            info: {
+              id: "msg_injected_1",
+              role: "assistant",
+              sessionID: linkedSession,
+              time: {},
+            },
+          },
+        },
+      })
+      handler({
+        payload: {
+          type: "message.part.updated",
+          properties: {
+            part: {
+              id: "prt_injected_1",
+              sessionID: linkedSession,
+              messageID: "msg_injected_1",
+              type: "text",
+              text: "injected stream reply",
+            },
+          },
+        },
+      })
+      handler({
+        payload: {
+          type: "message.updated",
+          properties: {
+            info: {
+              id: "msg_injected_1",
+              role: "assistant",
+              sessionID: linkedSession,
+              time: { completed: Date.now() },
+            },
+          },
+        },
+      })
+
+      yield* Effect.promise(() =>
+        waitUntil(() => bot.sent.some((m) => m.chat_id === 888 && m.text === "injected stream reply"), "injected reply sent"),
+      )
+      expect(bot.sent.at(-1)?.chat_id).toBe(888)
+    }),
+  )
+
+  it.live("handles session creation error cleanly (Fix 5)", () =>
+    Effect.gen(function* () {
+      fakeServer.shouldFailCreate = true
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 999, type: "private" } })
+
+      yield* Effect.promise(() =>
+        waitUntil(() => bot.sent.some((m) => m.chat_id === 999 && m.text.includes("Could not create session")), "error reported"),
+      )
+      expect(fakeServer.createdSessions).toEqual([])
+    }),
+  )
+
+  it.live("uses fallback server config when unconfigured (Fix 7)", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 101, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked session"))
+
+      bot.push({ text: "hello fallback", chat: { id: 101, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.prompts.length === 1, "prompt recorded"))
+      expect(fakeServer.prompts[0].text).toBe("hello fallback")
+    }),
+  )
+
+  it.live("poll fiber survives a failing promptAsync call (Fix 7)", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 202, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked session"))
+
+      fakeServer.shouldFailPrompt = true
+      bot.push({ text: "failing message", chat: { id: 202, type: "private" } })
+      yield* Effect.promise(() =>
+        waitUntil(() => bot.sent.some((m) => m.chat_id === 202 && m.text.includes("OpenCode prompt error")), "error sent"),
+      )
+
+      bot.push({ text: "subsequent working message", chat: { id: 202, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.prompts.some((p) => p.text === "subsequent working message"), "poll fiber survived"))
+      expect(fakeServer.prompts.at(-1)?.text).toBe("subsequent working message")
+    }),
+  )
+
+  it.live("mirrors user prompts typed in opencode TUI to Telegram (Fix 13)", () =>
+    Effect.gen(function* () {
+      const bridge = yield* TelegramBridge.Service
+      bridge.configure({ baseUrl: fakeServer.url })
+      const link = yield* bridge.link({ botToken: "test-token" })
+      bot.push({ text: `/start ${link.token}`, chat: { id: 303, type: "private" } })
+      yield* Effect.promise(() => waitUntil(() => fakeServer.createdSessions.length === 1, "linked session"))
+      const linkedSession = fakeServer.createdSessions[0]
+
+      fakeServer.emitSSE({
+        type: "message.updated",
+        properties: {
+          info: { id: "msg_user_tui_1", role: "user", sessionID: linkedSession, time: {} },
+        },
+      })
+      fakeServer.emitSSE({
+        type: "message.part.updated",
+        properties: {
+          part: { id: "prt_user_tui_1", sessionID: linkedSession, messageID: "msg_user_tui_1", type: "text", text: "tui user prompt" },
+        },
+      })
+
+      yield* Effect.promise(() =>
+        waitUntil(() => bot.sent.some((m) => m.chat_id === 303 && m.text === "👤 tui user prompt"), "user prompt mirrored"),
+      )
+      expect(bot.sent.some((m) => m.chat_id === 303 && m.text === "👤 tui user prompt")).toBe(true)
+    }),
+  )
+})

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1070,7 +1070,8 @@ export function Prompt(props: PromptProps) {
       setStore("mode", "normal")
     } else if (
       inputText.startsWith("/") &&
-      sync.data.command.some((x) => x.name === inputText.split("\n")[0].split(" ")[0].slice(1))
+      (sync.data.command.some((x) => x.name === inputText.split("\n")[0].split(" ")[0].slice(1)) ||
+        ["telegram", "tg"].includes(inputText.split("\n")[0].split(" ")[0].slice(1)))
     ) {
       move.startSubmit()
       // Parse command from first line, preserve multi-line content in arguments


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Refactors the Telegram bridge to use `@opencode-ai/sdk/v2` `OpencodeClient` and enables bi-directional session mirroring with OpenCode TUI.

- Refactors `packages/opencode/src/telegram/bridge.ts` to use `@opencode-ai/sdk/v2` `OpencodeClient` instead of internal module bindings.
- Adds `/telegram` and `/tg` session pairing commands in TUI prompt bar and runtime queue handler.
- Subscribes to `/global/event` to mirror assistant replies across directories to Telegram.
- Mirrors user prompts typed inside OpenCode TUI (`👤 <prompt>`) to Telegram chat while tracking `botSubmitted` messages to avoid duplicate echoes.
- Adds `opencode set-tg-token <token>` and `opencode telegram` CLI commands.
- Removes obsolete `-t / --telegram` CLI flags from `tui` and `attach` commands.
- Unifies command dispatch via `dispatchTelegramCommand`.

### How did you verify your code works?

- Ran unit tests in `packages/opencode`: `bun test test/telegram/bridge.test.ts` (19/19 pass).
- Ran TypeScript typecheck in `packages/opencode`: `bun typecheck`.
- Rebuilt single binary `bun run script/build.ts --single` and tested `/telegram` pairing.

### Screenshots / recordings

N/A (CLI / TUI integration)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
