### PR TITLE
feat(tui): jump to background tool starts

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -90,6 +90,7 @@ import {
   createSessionRows,
   messageBoundaryIDs,
   resolvePart,
+  sessionRowID,
   turnDuration,
   turnTokensPerSecond,
   type CacheUsage,
@@ -140,6 +141,7 @@ const context = createContext<{
   config: ReturnType<typeof useConfig>["data"]
   mutatePending: (action: PendingAction, inboxID: string) => Promise<boolean>
   pendingDelivery: (inboxID: string) => SessionInbox.Delivery | undefined
+  jumpToShell: (jobID: string) => void
 }>()
 
 function use() {
@@ -653,6 +655,24 @@ export function Session(props: {
       const message = data.session.message.get(route.sessionID, messageID)
       alignMessage(messageID, Math.max(0, y - (message?.type === "assistant" ? 1 : 0)))
     })
+
+  const jumpToShell = (jobID: string) => {
+    const jump = () => {
+      const index = rows.findIndex((row) => row.type === "part" && row.ref.partID === jobID)
+      if (index === -1) {
+        if (data.session.message.more(route.sessionID)) prependHistory(0, jump)
+        return
+      }
+      const id = sessionRowID(rows[index]!, boundaries()[index])
+      if (!id) return
+      ensureAllRows(() => {
+        const child = scroll.getRenderable(id)
+        if (!child) return
+        alignMessage(id, Math.max(0, scroll.scrollTop + child.y - scroll.viewport.y))
+      })
+    }
+    jump()
+  }
 
   function toBottom() {
     clearMessageNavigation()
@@ -1267,6 +1287,7 @@ export function Session(props: {
         config,
         mutatePending,
         pendingDelivery: (inboxID) => pendingDeliveries().get(inboxID),
+        jumpToShell,
       }}
     >
       <box flexDirection="row" flexGrow={1} minHeight={0}>
@@ -1429,7 +1450,7 @@ type SessionRowViewProps = {
 
 function SessionRowView(props: SessionRowViewProps) {
   return (
-    <box id={props.boundaryID} marginTop={1} flexShrink={0}>
+    <box id={sessionRowID(props.row, props.boundaryID)} marginTop={1} flexShrink={0}>
       <Switch>
         <Match when={props.row.type === "message" ? props.row : undefined}>
           {(row) => (
@@ -2008,8 +2029,11 @@ function SessionSwitchMessageV2(props: { message: SessionMessageInfo }) {
 function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
   const ctx = use()
   const theme = useTheme()
+  const renderer = useRenderer()
+  const [hover, setHover] = createSignal(false)
   const metadata = () => (props.message.type === "synthetic" ? props.message.metadata : undefined)
   const source = () => stringValue(metadata()?.source)
+  const jobID = () => (source() === "shell" ? stringValue(metadata()?.jobID) : undefined)
   const completion = () => source() === "subagent" || source() === "shell"
   const state = () => stringValue(metadata()?.state)
   const actor = () => (source() === "shell" ? "Shell" : Locale.titlecase(stringValue(metadata()?.agent) ?? "Subagent"))
@@ -2027,6 +2051,7 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
   const heading = () => `${state() === "completed" ? "↳" : "!"} ${actor()} ${status()}`
   const suffix = () => Locale.truncateWidth(` · ${description()}`, Math.max(0, ctx.width - 3 - stringWidth(heading())))
   const color = () => {
+    if (hover()) return theme.text.action.secondary.hovered
     if (state() === "error") return theme.text.feedback.error.default
     if (state() === "cancelled") return theme.text.feedback.warning.default
     return theme.text.feedback.info.default
@@ -2040,7 +2065,19 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
         </InlineToolRow>
       }
     >
-      <box marginLeft={3}>
+      <box
+        id={jobID() ? `shell-completion:${jobID()}` : undefined}
+        marginLeft={3}
+        onMouseOver={() => {
+          if (jobID()) setHover(true)
+        }}
+        onMouseOut={() => setHover(false)}
+        onMouseUp={() => {
+          const id = jobID()
+          if (!id || renderer.getSelection()?.getSelectedText()) return
+          ctx.jumpToShell(id)
+        }}
+      >
         <text wrapMode="none">
           <span style={{ fg: color() }}>{heading()}</span>
           <span style={{ fg: theme.text.subdued }}>{suffix()}</span>

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -86,6 +86,7 @@ import { useLocation } from "../../context/location"
 import { Slot } from "../../plugin/render"
 import { usePlugin } from "../../plugin/context"
 import {
+  backgroundToolRowIndex,
   cacheReuseDrop,
   createSessionRows,
   messageBoundaryIDs,
@@ -93,6 +94,7 @@ import {
   sessionRowID,
   turnDuration,
   turnTokensPerSecond,
+  type BackgroundToolTarget,
   type CacheUsage,
   type PartRef,
   type SessionRow,
@@ -141,7 +143,7 @@ const context = createContext<{
   config: ReturnType<typeof useConfig>["data"]
   mutatePending: (action: PendingAction, inboxID: string) => Promise<boolean>
   pendingDelivery: (inboxID: string) => SessionInbox.Delivery | undefined
-  jumpToShell: (jobID: string) => void
+  jumpToBackgroundTool: (target: BackgroundToolTarget, beforeMessageID: string) => void
 }>()
 
 function use() {
@@ -656,9 +658,9 @@ export function Session(props: {
       alignMessage(messageID, Math.max(0, y - (message?.type === "assistant" ? 1 : 0)))
     })
 
-  const jumpToShell = (jobID: string) => {
+  const jumpToBackgroundTool = (target: BackgroundToolTarget, beforeMessageID: string) => {
     const jump = () => {
-      const index = rows.findIndex((row) => row.type === "part" && row.ref.partID === jobID)
+      const index = backgroundToolRowIndex(rows, messages(), target, beforeMessageID)
       if (index === -1) {
         if (data.session.message.more(route.sessionID)) prependHistory(0, jump)
         return
@@ -1287,7 +1289,7 @@ export function Session(props: {
         config,
         mutatePending,
         pendingDelivery: (inboxID) => pendingDeliveries().get(inboxID),
-        jumpToShell,
+        jumpToBackgroundTool,
       }}
     >
       <box flexDirection="row" flexGrow={1} minHeight={0}>
@@ -2033,7 +2035,16 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
   const [hover, setHover] = createSignal(false)
   const metadata = () => (props.message.type === "synthetic" ? props.message.metadata : undefined)
   const source = () => stringValue(metadata()?.source)
-  const jobID = () => (source() === "shell" ? stringValue(metadata()?.jobID) : undefined)
+  const target = createMemo<BackgroundToolTarget | undefined>(() => {
+    if (source() === "shell") {
+      const id = stringValue(metadata()?.jobID)
+      return id ? { source: "shell", id } : undefined
+    }
+    if (source() === "subagent") {
+      const id = stringValue(metadata()?.childID)
+      return id ? { source: "subagent", id } : undefined
+    }
+  })
   const completion = () => source() === "subagent" || source() === "shell"
   const state = () => stringValue(metadata()?.state)
   const actor = () => (source() === "shell" ? "Shell" : Locale.titlecase(stringValue(metadata()?.agent) ?? "Subagent"))
@@ -2066,16 +2077,16 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
       }
     >
       <box
-        id={jobID() ? `shell-completion:${jobID()}` : undefined}
+        id={target() ? `${target()!.source}-completion:${target()!.id}` : undefined}
         marginLeft={3}
         onMouseOver={() => {
-          if (jobID()) setHover(true)
+          if (target()) setHover(true)
         }}
         onMouseOut={() => setHover(false)}
         onMouseUp={() => {
-          const id = jobID()
-          if (!id || renderer.getSelection()?.getSelectedText()) return
-          ctx.jumpToShell(id)
+          const item = target()
+          if (!item || renderer.getSelection()?.getSelectedText()) return
+          ctx.jumpToBackgroundTool(item, props.message.id)
         }}
       >
         <text wrapMode="none">

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -670,7 +670,7 @@ export function Session(props: {
       ensureAllRows(() => {
         const child = scroll.getRenderable(id)
         if (!child) return
-        alignMessage(id, Math.max(0, scroll.scrollTop + child.y - scroll.viewport.y))
+        alignMessage(id, Math.max(0, scroll.scrollTop + child.y - scroll.viewport.y - 1))
       })
     }
     jump()

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -393,6 +393,11 @@ export function messageBoundaryIDs(rows: SessionRow[], messages: SessionMessageI
   })
 }
 
+export function sessionRowID(row: SessionRow, boundaryID?: string) {
+  if (boundaryID) return boundaryID
+  if (row.type === "part") return `session-part:${row.ref.messageID}:${row.ref.partID}`
+}
+
 function rowBoundaryMessageID(row: SessionRow, messages: Map<string, SessionMessageInfo>) {
   if (row.type === "message") {
     const message = messages.get(row.messageID)

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -35,6 +35,8 @@ export type SessionRow =
   | { type: "assistant-footer"; messageID: string }
   | { type: "turn-usage"; messageIDs: string[]; previousCache?: CacheUsage }
 
+export type BackgroundToolTarget = { source: "shell" | "subagent"; id: string }
+
 export function createSessionRows(sessionID: Accessor<string>, onSynced?: (sessionID: string) => void) {
   const data = useData()
   const client = useClient()
@@ -396,6 +398,30 @@ export function messageBoundaryIDs(rows: SessionRow[], messages: SessionMessageI
 export function sessionRowID(row: SessionRow, boundaryID?: string) {
   if (boundaryID) return boundaryID
   if (row.type === "part") return `session-part:${row.ref.messageID}:${row.ref.partID}`
+}
+
+export function backgroundToolRowIndex(
+  rows: SessionRow[],
+  messages: SessionMessageInfo[],
+  target: BackgroundToolTarget,
+  beforeMessageID: string,
+) {
+  const byID = new Map(messages.map((message) => [message.id, message]))
+  const end = rows.findIndex((row) => row.type === "message" && row.messageID === beforeMessageID)
+  return rows.slice(0, end === -1 ? rows.length : end).findLastIndex((row) => {
+    if (row.type !== "part") return false
+    if (target.source === "shell") return row.ref.partID === target.id
+    const message = byID.get(row.ref.messageID)
+    if (message?.type !== "assistant") return false
+    const part = resolvePart(message, row.ref.partID)
+    return (
+      part?.type === "tool" &&
+      part.name.toLowerCase() === "subagent" &&
+      part.state.status === "completed" &&
+      part.state.metadata?.status === "running" &&
+      part.state.metadata.sessionID === target.id
+    )
+  })
 }
 
 function rowBoundaryMessageID(row: SessionRow, messages: Map<string, SessionMessageInfo>) {

--- a/packages/tui/test/cli/tui/session-rows.test.ts
+++ b/packages/tui/test/cli/tui/session-rows.test.ts
@@ -4,6 +4,7 @@ import {
   cacheReuseDrop,
   messageBoundaryIDs,
   reduceSessionRows,
+  sessionRowID,
   turnDuration,
   turnTokensPerSecond,
 } from "../../../src/routes/session/rows"
@@ -142,6 +143,26 @@ test("assigns assistant boundaries to the first rendered row instead of the firs
   const rows = reduceSessionRows(messages)
 
   expect(messageBoundaryIDs(rows, messages)).toEqual(["user-1", "assistant-1", undefined, undefined])
+})
+
+test("assigns stable IDs to tool rows for direct navigation", () => {
+  const messages: SessionMessageInfo[] = [
+    assistant("assistant-1", [
+      { type: "text", text: "Starting a shell" },
+      { type: "tool", id: "shell-1", name: "shell", state: pending(), time: { created: 2 } },
+    ]),
+    assistant("assistant-2", [
+      { type: "tool", id: "shell-2", name: "shell", state: pending(), time: { created: 3 } },
+    ]),
+  ]
+  const rows = reduceSessionRows(messages)
+  const boundaries = messageBoundaryIDs(rows, messages)
+
+  expect(rows.map((row, index) => sessionRowID(row, boundaries[index]))).toEqual([
+    "assistant-1",
+    "session-part:assistant-1:shell-1",
+    "assistant-2",
+  ])
 })
 
 test("groups exploration parts across assistant messages until a delimiter", () => {

--- a/packages/tui/test/cli/tui/session-rows.test.ts
+++ b/packages/tui/test/cli/tui/session-rows.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test"
-import type { SessionMessageAssistant, SessionMessageInfo } from "@opencode-ai/client"
+import type { SessionMessageAssistant, SessionMessageAssistantTool, SessionMessageInfo } from "@opencode-ai/client"
 import {
+  backgroundToolRowIndex,
   cacheReuseDrop,
   messageBoundaryIDs,
   reduceSessionRows,
@@ -163,6 +164,58 @@ test("assigns stable IDs to tool rows for direct navigation", () => {
     "session-part:assistant-1:shell-1",
     "assistant-2",
   ])
+})
+
+test("finds background tool launch rows for completion navigation", () => {
+  const messages: SessionMessageInfo[] = [
+    assistant("assistant-1", [
+      { type: "tool", id: "shell-1", name: "shell", state: pending(), time: { created: 1 } },
+    ]),
+    assistant("assistant-2", [
+      {
+        type: "tool",
+        id: "subagent-1",
+        name: "subagent",
+        state: completed({ sessionID: "child-1", status: "running" }),
+        time: { created: 2 },
+      },
+    ]),
+    {
+      type: "synthetic",
+      id: "completion-1",
+      text: "First background run completed",
+      description: "First run",
+      time: { created: 3 },
+    },
+    assistant("assistant-3", [
+      {
+        type: "tool",
+        id: "subagent-2",
+        name: "subagent",
+        state: completed({ sessionID: "child-1", status: "running" }),
+        time: { created: 4 },
+      },
+      {
+        type: "tool",
+        id: "subagent-foreground",
+        name: "subagent",
+        state: completed({ sessionID: "child-1", status: "completed" }),
+        time: { created: 5 },
+      },
+    ]),
+    {
+      type: "synthetic",
+      id: "completion-2",
+      text: "Second background run completed",
+      description: "Second run",
+      time: { created: 6 },
+    },
+  ]
+  const rows = reduceSessionRows(messages)
+
+  expect(backgroundToolRowIndex(rows, messages, { source: "shell", id: "shell-1" }, "completion-2")).toBe(0)
+  expect(backgroundToolRowIndex(rows, messages, { source: "subagent", id: "child-1" }, "completion-1")).toBe(1)
+  expect(backgroundToolRowIndex(rows, messages, { source: "subagent", id: "child-1" }, "completion-2")).toBe(3)
 })
 
 test("groups exploration parts across assistant messages until a delimiter", () => {
@@ -456,4 +509,15 @@ function assistant(id: string, content: SessionMessageAssistant["content"]): Ses
 
 function pending() {
   return { status: "streaming" as const, input: "" }
+}
+
+function completed(
+  metadata: Record<string, string>,
+): Extract<SessionMessageAssistantTool["state"], { status: "completed" }> {
+  return {
+    status: "completed",
+    input: {},
+    content: [{ type: "text", text: "Background" }],
+    metadata,
+  }
 }


### PR DESCRIPTION
## Summary
- make correlated Shell and Subagent completion notices clickable
- jump to the exact originating background tool row, loading older history when needed
- select the correct launch when the same child subagent session runs in the background multiple times
- preserve text selection and show action hover feedback

## Demo
[Watch the OpenCode Drive recording (MP4)](https://gist.githubusercontent.com/jlongster/8931cd754d740f36ee4108a9609313e4/raw/e519f891e11d422d3e30a33893d4bd26a897d012/shell-jump-demo.mp4)

The deterministic [Drive script](https://gist.github.com/jlongster/8931cd754d740f36ee4108a9609313e4) starts a real background shell, pushes its start offscreen, clicks the completion notice, and verifies that the original shell card is visible.

## Test plan
- `bun test test/cli/tui/session-rows.test.ts`
- `bun typecheck`
- `opencode-drive check /tmp/opencode/shell-jump-drive.ts`
- recorded the script against this development checkout with `opencode-drive start --script ... --dev ... --record`