### PR TITLE
fix(opencode): serialize and atomically write auth.json

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -4,10 +4,12 @@ import { Effect, Layer, Record, Result, Schema, Context } from "effect"
 import { NonNegativeInt } from "@opencode-ai/core/schema"
 import { Global } from "@opencode-ai/core/global"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
 const file = path.join(Global.Path.data, "auth.json")
+const lockKey = `auth:${file}`
 
 const fail = (message: string) => (cause: unknown) => new AuthError({ message, cause })
 
@@ -53,9 +55,10 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fsys = yield* FSUtil.Service
+    const flock = yield* EffectFlock.Service
     const decode = Schema.decodeUnknownOption(Info)
 
-    const all = Effect.fn("Auth.all")(function* () {
+    const read = Effect.fn("Auth.read")(function* () {
       if (process.env.OPENCODE_AUTH_CONTENT) {
         try {
           return JSON.parse(process.env.OPENCODE_AUTH_CONTENT)
@@ -66,32 +69,51 @@ const layer = Layer.effect(
       return Record.filterMap(data, (value) => Result.fromOption(decode(value), () => undefined))
     })
 
+    const all = Effect.fn("Auth.all")(function* () {
+      return yield* read().pipe(flock.withLock(lockKey), Effect.mapError(fail("Failed to read auth data")))
+    })
+
+    const mutate = Effect.fn("Auth.mutate")(function* (update: (data: Record<string, Info>) => Record<string, Info>) {
+      yield* Effect.gen(function* () {
+        const tempfile = `${file}.${process.pid}.${Date.now()}.tmp`
+        const data = update(yield* read())
+        yield* fsys.writeJson(tempfile, data, 0o600).pipe(
+          Effect.andThen(fsys.rename(tempfile, file)),
+          Effect.catch((error) =>
+            fsys.remove(tempfile, { force: true }).pipe(Effect.ignore, Effect.andThen(Effect.fail(error))),
+          ),
+        )
+      }).pipe(flock.withLock(lockKey), Effect.mapError(fail("Failed to write auth data")))
+    })
+
     const get = Effect.fn("Auth.get")(function* (providerID: string) {
       return (yield* all())[providerID]
     })
 
     const set = Effect.fn("Auth.set")(function* (key: string, info: Info) {
       const norm = key.replace(/\/+$/, "")
-      const data = yield* all()
-      if (norm !== key) delete data[key]
-      delete data[norm + "/"]
-      yield* fsys
-        .writeJson(file, { ...data, [norm]: info }, 0o600)
-        .pipe(Effect.mapError(fail("Failed to write auth data")))
+      yield* mutate((data) => {
+        const next = { ...data }
+        if (norm !== key) delete next[key]
+        delete next[norm + "/"]
+        return { ...next, [norm]: info }
+      })
     })
 
     const remove = Effect.fn("Auth.remove")(function* (key: string) {
       const norm = key.replace(/\/+$/, "")
-      const data = yield* all()
-      delete data[key]
-      delete data[norm]
-      yield* fsys.writeJson(file, data, 0o600).pipe(Effect.mapError(fail("Failed to write auth data")))
+      yield* mutate((data) => {
+        const next = { ...data }
+        delete next[key]
+        delete next[norm]
+        return next
+      })
     })
 
     return Service.of({ get, all, set, remove })
   }),
 )
 
-export const node = LayerNode.make({ service: Service, layer: layer, deps: [FSUtil.node] })
+export const node = LayerNode.make({ service: Service, layer: layer, deps: [FSUtil.node, EffectFlock.node] })
 
 export * as Auth from "."


### PR DESCRIPTION
Fixes #37059

Automatisierter Upstream-PR für mQorva-Kandidat #1.

Fix: fix(opencode): serialize and atomically write auth.json

Betroffene Dateien:
- packages/opencode/src/auth/index.ts
- packages/opencode/test/auth/auth.test.ts (Concurrency-Regression)