### PR TITLE
docs: add opencode-caelestia-notify to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -37,6 +37,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible             |
 | [opencode-notificator](https://github.com/panta82/opencode-notificator)                            | Desktop notifications and sound alerts for OpenCode sessions                                       |
 | [opencode-notifier](https://github.com/mohak34/opencode-notifier)                                  | Desktop notifications and sound alerts for permission, completion, and error events                |
+| [opencode-caelestia-notify](https://github.com/Shanu-Kumawat/opencode-caelestia-notify)            | Sends a notification when opencode finishes, errors or waits for permission                        |
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |


### PR DESCRIPTION
### Issue for this PR

No linked issue - adds community plugin to ecosystem list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-caelestia-notify` to the Plugins table in `ecosystem.mdx`.

It is a single-file plugin that sends a desktop notification when opencode finishes responding, errors, or waits for permission/input. It shows the session name, dedupes repeated idle events, and skips the done notification when the terminal is focused. I built and tested it on Arch + Hyprland with Caelestia shell. It works on any Hyprland/Wayland desktop with a notification daemon and needs no dependencies. The icon self-installs to the hicolor theme on first run.

Repo: https://github.com/Shanu-Kumawat/opencode-caelestia-notify

### How did you verify your code works?

Tested locally with `opencode run` using OPENCODE_NOTIFY_DEBUG, verified the icon writes to `~/.local/share/icons/hicolor/scalable/apps/opencode.svg` and the cache path, and confirmed notifications appear with `notify-send`. Also checked the SVG renders correctly with rsvg-convert and qt6-svg.

### Screenshots / recordings

Not a UI code change in this repo, docs only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR