### PR TITLE
fix(core): preserve imported session parents

### DIFF
--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -526,7 +526,7 @@ export function make(options: ClientOptions) {
             path: `/api/session/import`,
             body: { info: input["info"], messages: input["messages"], location: input["location"] },
             successStatus: 200,
-            declaredStatuses: [409, 401, 400],
+            declaredStatuses: [409, 404, 401, 400],
             empty: false,
           },
           requestOptions,

--- a/packages/core/src/session/transfer.ts
+++ b/packages/core/src/session/transfer.ts
@@ -34,7 +34,10 @@ export interface Interface {
     sessionID: Session.ID
     sanitize?: boolean
   }) => Effect.Effect<Data, Session.NotFoundError | Session.MessageDecodeError>
-  readonly import: (input: { data: Data; location: Location.Ref }) => Effect.Effect<Session.Info, ImportConflictError>
+  readonly import: (input: {
+    data: Data
+    location: Location.Ref
+  }) => Effect.Effect<Session.Info, ImportConflictError | Session.NotFoundError>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionTransfer") {}
@@ -66,6 +69,7 @@ const layer = Layer.effect(
           .get()
           .pipe(Effect.orDie)
         if (recorded) return yield* new ImportConflictError({ sessionID })
+        if (input.data.info.parentID) yield* sessions.get(input.data.info.parentID)
         const project = yield* projects.resolve(input.location.directory)
         yield* upsertProject(db, project).pipe(Effect.orDie)
         const messages = input.data.messages.filter(isSettled).map((message, index) => {
@@ -85,6 +89,7 @@ const layer = Layer.effect(
             SessionEvent.Created,
             {
               sessionID,
+              parentID: input.data.info.parentID,
               slug: Slug.create(),
               version: app.version,
               projectID: project.id,

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -191,12 +191,13 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           location: Location.Ref.pipe(Schema.optional),
         }),
         success: Schema.Struct({ data: Session.Info }),
-        error: ConflictError,
+        error: [ConflictError, SessionNotFoundError],
       }).annotateMerge(
         OpenApi.annotations({
           identifier: "v2.session.import",
           summary: "Import session",
-          description: "Import a projected session transcript at the requested location.",
+          description:
+            "Import a projected session transcript at the requested location. If parentID is supplied, the parent session must already exist; import parents before children.",
         }),
       ),
     )

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -135,6 +135,7 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
                 location: ctx.payload.location ?? { directory: AbsolutePath.make(process.cwd()) },
               })
               .pipe(
+                Effect.catchTag("Session.NotFoundError", missingSession),
                 Effect.catchTag(
                   "SessionTransfer.ImportConflictError",
                   (error) =>

--- a/packages/server/test/session-import.test.ts
+++ b/packages/server/test/session-import.test.ts
@@ -1,0 +1,72 @@
+import { expect } from "bun:test"
+import { Session } from "@opencode-ai/schema/session"
+import { Effect, Schema } from "effect"
+import { it } from "../../core/test/lib/effect"
+import { ServerFetch } from "../src/fetch"
+
+const SessionResponse = Schema.Struct({ data: Schema.toEncoded(Session.Info) })
+const SessionsResponse = Schema.Struct({ data: Schema.Array(Schema.toEncoded(Session.Info)) })
+
+const setup = Effect.gen(function* () {
+  const handler = yield* ServerFetch.make({
+    app: { version: "test" },
+    database: { path: ":memory:" },
+    fs: { filewatcher: false },
+  })
+  return (path: string, body?: unknown, status = 200) =>
+    Effect.promise(async () => {
+      const response = await handler(
+        new Request(`http://opencode.local${path}`, {
+          method: body === undefined ? "GET" : "POST",
+          headers: { "content-type": "application/json" },
+          body: body === undefined ? undefined : JSON.stringify(body),
+        }),
+      )
+      const json: unknown = await response.json()
+      expect(response.status).toBe(status)
+      return json
+    })
+})
+
+it.live("preserves imported parentID through HTTP import, read, and parent filter", () =>
+  Effect.gen(function* () {
+    const request = yield* setup
+    const parent = Schema.decodeUnknownSync(SessionResponse)(yield* request("/api/session", { title: "Parent" }))
+    const id = Session.ID.create()
+    const imported = Schema.decodeUnknownSync(SessionResponse)(
+      yield* request("/api/session/import", {
+        info: { ...parent.data, id, parentID: parent.data.id, title: "Imported child" },
+        messages: [],
+      }),
+    )
+    const read = Schema.decodeUnknownSync(SessionResponse)(yield* request(`/api/session/${id}`))
+    const children = Schema.decodeUnknownSync(SessionsResponse)(
+      yield* request(`/api/session?parentID=${parent.data.id}`),
+    )
+    expect({
+      imported: imported.data.parentID,
+      read: read.data.parentID,
+      children: children.data.map((child) => child.id),
+    }).toEqual({ imported: parent.data.id, read: parent.data.id, children: [id] })
+  }).pipe(Effect.scoped),
+)
+;["missing", "self"].forEach((parent) => {
+  it.live(`rejects a ${parent} parent without creating the imported session`, () =>
+    Effect.gen(function* () {
+      const request = yield* setup
+      const template = Schema.decodeUnknownSync(SessionResponse)(yield* request("/api/session", {}))
+      const id = Session.ID.create()
+      const parentID = parent === "self" ? id : Session.ID.create()
+      const error = yield* request(
+        "/api/session/import",
+        { info: { ...template.data, id, parentID }, messages: [] },
+        404,
+      )
+      expect(error).toMatchObject({ _tag: "SessionNotFoundError", sessionID: parentID })
+      expect(yield* request(`/api/session/${id}`, undefined, 404)).toMatchObject({
+        _tag: "SessionNotFoundError",
+        sessionID: id,
+      })
+    }).pipe(Effect.scoped),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45555

### Type of change

- [x] Bug fix

### What does this PR do?

Pass imported `parentID` into `SessionEvent.Created`, so the existing projector preserves it in import responses, subsequent reads, and parent-filtered listings.

Require the parent to exist before any import writes. Missing parents and self-parenting return `SessionNotFoundError` (404); imports must be parent-first. Document this policy and regenerate the client for the additional declared error.

### How did you verify your code works?

- Confirmed the HTTP regression fails before the mapping change, and missing/self-parent rejection tests fail before validation.
- 41 core session-create/transfer tests passed.
- 7 focused server tests, 8 protocol tests, and 41 focused client tests passed.
- Core, server, protocol, and client typechecks passed; the pre-push repository typecheck also passed all 33 tasks.
- Client generation, formatting, and diff checks passed.

### Screenshots / recordings

Not applicable; backend-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR