### PR TITLE
fix(tui): resolve explicitly selected hidden agents

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -48,6 +48,14 @@ export function recentModels(
     .map((item) => ({ providerID: item.providerID, modelID: item.modelID }))
 }
 
+export function visiblePrimaryAgents<T extends { mode: string; hidden?: boolean }>(agents: T[]) {
+  return agents.filter((agent) => agent.mode !== "subagent" && !agent.hidden)
+}
+
+export function resolvePrimaryAgent<T extends { name: string; mode: string }>(agents: T[], name: string) {
+  return agents.find((agent) => agent.mode !== "subagent" && agent.name === name)
+}
+
 export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
   name: "Local",
   init: () => {
@@ -75,7 +83,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     }
 
     function createAgent() {
-      const agents = createMemo(() => sync.data.agent.filter((agent) => agent.mode !== "subagent" && !agent.hidden))
+      const primaryAgents = createMemo(() => sync.data.agent.filter((agent) => agent.mode !== "subagent"))
+      const agents = createMemo(() => visiblePrimaryAgents(sync.data.agent))
       const visibleAgents = createMemo(() => sync.data.agent.filter((agent) => !agent.hidden))
       const [agentStore, setAgentStore] = createStore({
         current: undefined as string | undefined,
@@ -94,10 +103,10 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           return agents()
         },
         current() {
-          return agents().find((x) => x.name === agentStore.current) ?? agents().at(0)
+          return resolvePrimaryAgent(primaryAgents(), agentStore.current ?? "") ?? agents().at(0)
         },
         set(name: string) {
-          if (!agents().some((x) => x.name === name))
+          if (!resolvePrimaryAgent(primaryAgents(), name))
             return toast.show({
               variant: "warning",
               message: `Agent not found: ${name}`,

--- a/packages/tui/test/context/local.test.ts
+++ b/packages/tui/test/context/local.test.ts
@@ -1,5 +1,20 @@
 import { expect, test } from "bun:test"
-import { parseModel, recentModels } from "../../src/context/local"
+import { parseModel, recentModels, resolvePrimaryAgent, visiblePrimaryAgents } from "../../src/context/local"
+
+const agents = [
+  { name: "visible", mode: "primary", hidden: false },
+  { name: "hidden", mode: "primary", hidden: true },
+  { name: "hidden-subagent", mode: "subagent", hidden: true },
+] as const
+
+test("resolves hidden primary agents without including them in visible agents", () => {
+  expect(visiblePrimaryAgents([...agents]).map((agent) => agent.name)).toEqual(["visible"])
+  expect(resolvePrimaryAgent([...agents], "hidden")?.name).toBe("hidden")
+})
+
+test("does not resolve hidden subagents as primary agents", () => {
+  expect(resolvePrimaryAgent([...agents], "hidden-subagent")).toBeUndefined()
+})
 
 test("parses model IDs containing slashes", () => {
   expect(parseModel("provider/family/model")).toEqual({


### PR DESCRIPTION
### Issue for this PR

Fixes #45573

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Keeps hidden primary agents out of the TUI picker and cycle while allowing an explicitly supplied `--agent` to select one. Subagents remain invalid as primary agents.

This complements #45254 and the behavior documented in #44751.

### How did you verify your code works?

- `bun test test/context/local.test.ts` in `packages/tui`: 4 pass
- Repository pre-push typecheck: 30/30 packages passed
- `git diff --check`

### Screenshots / recordings

Not applicable; this changes startup agent resolution without changing the picker UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR