### PR TITLE
fix(lsp): parse RHEL four-component JDK versions in jdtls activation

### DIFF
--- a/packages/opencode/src/lsp/jdtls-version.ts
+++ b/packages/opencode/src/lsp/jdtls-version.ts
@@ -1,0 +1,7 @@
+// JDKs print the version inside quotes, and the component count varies: vanilla
+// builds use three ("21.0.3") while RHEL's OpenJDK 25 patches print four
+// ("25.0.4.1"). Match the major and ignore the rest (#45569).
+export function javaVersion(stderr: string): number | undefined {
+  const m = /"(\d+)(?:\.\d+)*"/.exec(stderr)
+  return m ? parseInt(m[1]) : undefined
+}

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -11,6 +11,7 @@ import { Process } from "@/util/process"
 import { which } from "@opencode-ai/core/util/which"
 import { Module } from "@opencode-ai/core/util/module"
 import { spawn } from "./launch"
+import { javaVersion } from "./jdtls-version"
 import { Npm } from "@opencode-ai/core/npm"
 import type { RuntimeFlags } from "@/effect/runtime-flags"
 
@@ -1190,10 +1191,7 @@ export const JDTLS: Info = {
     if (!java) {
       return
     }
-    const javaMajorVersion = await run(["java", "-version"]).then((result) => {
-      const m = /"(\d+)\.\d+\.\d+"/.exec(result.stderr.toString())
-      return !m ? undefined : parseInt(m[1])
-    })
+    const javaMajorVersion = await run(["java", "-version"]).then((result) => javaVersion(result.stderr.toString()))
     if (javaMajorVersion == null || javaMajorVersion < 21) {
       return
     }

--- a/packages/opencode/test/lsp/jdtls-version.test.ts
+++ b/packages/opencode/test/lsp/jdtls-version.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { javaVersion } from "../../src/lsp/jdtls-version"
+
+describe("lsp.jdtls java version parsing", () => {
+  test("parses vanilla three-component versions", () => {
+    expect(javaVersion('openjdk version "21.0.3" 2024-04-16')).toBe(21)
+  })
+
+  test("parses RHEL four-component build strings (#45569)", () => {
+    const stderr = [
+      'openjdk version "25.0.4.1" 2026-08-18 LTS',
+      "OpenJDK Runtime Environment (Red_Hat-25.0.4.1.1-1) (build 25.0.4.1+1-LTS)",
+      "OpenJDK 64-Bit Server VM (Red_Hat-25.0.4.1.1-1) (build 25.0.4.1+1-LTS, mixed mode, sharing)",
+    ].join("\n")
+    expect(javaVersion(stderr)).toBe(25)
+  })
+
+  test("parses bare major versions", () => {
+    expect(javaVersion('openjdk version "21" 2023-09-19')).toBe(21)
+  })
+
+  test("returns undefined without a quoted version", () => {
+    expect(javaVersion("command not found: java")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45569

### Type of change

- [x] Bug fix

### What does this PR do?

The JDTLS activation regex (`"(\d+)\.\d+\.\d+"`) required exactly three version components, but RHEL 10.2's patched OpenJDK 25 prints a four-component string (`"25.0.4.1"`), so version parsing failed and the Java LSP silently never spawned. The parsing now extracts the major version regardless of component count, moved into a small exported helper so it can be tested.

### How did you verify your code works?

New unit tests (`test/lsp/jdtls-version.test.ts`) cover the RHEL four-component string, vanilla three-component, bare-major, and no-version cases; they fail against the old regex. `tsgo --noEmit` clean.

### Screenshots / recordings

No UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR