### PR TITLE
fix(opencode): preserve provider tool calls

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -6,7 +6,7 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { Context, Effect, Layer } from "effect"
 import * as Stream from "effect/Stream"
-import { streamText, wrapLanguageModel, type ModelMessage, type Tool } from "ai"
+import { streamText, wrapLanguageModel, type ModelMessage, type Tool, type ToolCallRepairFunction } from "ai"
 import type { LLMEvent } from "@opencode-ai/llm"
 import { LLMClient } from "@opencode-ai/llm/route"
 import type { LLMClientService } from "@opencode-ai/llm/route"
@@ -58,6 +58,28 @@ export interface Interface {
 export class Service extends Context.Service<Service, Interface>()("@opencode/LLM") {}
 
 export const use = serviceUse(Service)
+
+export function repairToolCall(tools: Record<string, Tool>): ToolCallRepairFunction<Record<string, Tool>> {
+  return async (failed) => {
+    if (failed.toolCall.providerExecuted) return null
+
+    const lower = failed.toolCall.toolName.toLowerCase()
+    if (lower !== failed.toolCall.toolName && tools[lower]) {
+      return {
+        ...failed.toolCall,
+        toolName: lower,
+      }
+    }
+    return {
+      ...failed.toolCall,
+      input: JSON.stringify({
+        tool: failed.toolCall.toolName,
+        error: failed.error.message,
+      }),
+      toolName: "invalid",
+    }
+  }
+}
 
 const live: Layer.Layer<
   Service,
@@ -293,23 +315,7 @@ const live: Layer.Layer<
           },
           // Copilot returns the authoritative billed amount only in provider-specific response fields.
           includeRawChunks: input.model.providerID.includes("github-copilot"),
-          async experimental_repairToolCall(failed) {
-            const lower = failed.toolCall.toolName.toLowerCase()
-            if (lower !== failed.toolCall.toolName && prepared.tools[lower]) {
-              return {
-                ...failed.toolCall,
-                toolName: lower,
-              }
-            }
-            return {
-              ...failed.toolCall,
-              input: JSON.stringify({
-                tool: failed.toolCall.toolName,
-                error: failed.error.message,
-              }),
-              toolName: "invalid",
-            }
-          },
+          experimental_repairToolCall: repairToolCall(prepared.tools),
           temperature: prepared.params.temperature,
           topP: prepared.params.topP,
           topK: prepared.params.topK,

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -3,7 +3,7 @@ import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import path from "path"
-import { tool, type ModelMessage } from "ai"
+import { NoSuchToolError, tool, type ModelMessage } from "ai"
 import { Cause, Effect, Exit, Fiber, Layer, Stream } from "effect"
 import { InstanceRef } from "../../src/effect/instance-ref"
 import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
@@ -170,6 +170,53 @@ describe("session.llm.hasToolCalls", () => {
       },
     ] as ModelMessage[]
     expect(LLM.hasToolCalls(messages)).toBe(true)
+  })
+})
+
+describe("session.llm.repairToolCall", () => {
+  const tools = {
+    bash: tool({
+      inputSchema: z.object({ command: z.string() }),
+    }),
+    invalid: tool({
+      inputSchema: z.object({ tool: z.string(), error: z.string() }),
+    }),
+  }
+
+  const failure = (toolName: string, providerExecuted = false) => ({
+    system: undefined,
+    messages: [],
+    toolCall: {
+      type: "tool-call" as const,
+      toolCallId: "call-1",
+      toolName,
+      input: "{}",
+      providerExecuted,
+    },
+    tools,
+    inputSchema: async () => ({ type: "object" as const }),
+    error: new NoSuchToolError({ toolName, availableTools: Object.keys(tools) }),
+  })
+
+  test("declines to rewrite provider-executed calls", async () => {
+    expect(await LLM.repairToolCall(tools)(failure("tool_search_tool_1", true))).toBeNull()
+  })
+
+  test("repairs case-only tool name mismatches", async () => {
+    expect(await LLM.repairToolCall(tools)(failure("BASH"))).toMatchObject({
+      toolName: "bash",
+      input: "{}",
+    })
+  })
+
+  test("routes unknown client tool calls through invalid", async () => {
+    expect(await LLM.repairToolCall(tools)(failure("missing"))).toMatchObject({
+      toolName: "invalid",
+      input: JSON.stringify({
+        tool: "missing",
+        error: "Model tried to call unavailable tool 'missing'. Available tools: bash, invalid.",
+      }),
+    })
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

Closes #45261

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Provider-executed tool calls are not client-side tool-name errors and must not be rewritten to the `invalid` tool. This change declines repair for those calls while retaining the existing case-insensitive name repair and invalid-tool fallback for client-executed calls.

### How did you verify your code works?

- `bun test test/session/llm.test.ts --test-name-pattern repairToolCall`
- `bun typecheck`

The focused regression tests cover provider-executed calls, case-only repairs, and unknown client tools.

### Screenshots / recordings

Not applicable; this change has no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR