### PR TITLE
fix(llm): use GPT-5 completion limit

### DIFF
--- a/packages/llm/src/protocols/openai-chat.ts
+++ b/packages/llm/src/protocols/openai-chat.ts
@@ -28,6 +28,11 @@ const IMAGE_MIMES = new Set<string>(ProviderShared.IMAGE_MIMES)
 export const DEFAULT_BASE_URL = "https://api.openai.com/v1"
 export const PATH = "/chat/completions"
 
+export const usesMaxCompletionTokens = (modelID: string) => {
+  const id = modelID.toLowerCase()
+  return /(?:^|[/_-])gpt-5(?:[._-]|$)/.test(id)
+}
+
 // =============================================================================
 // Request Body Schema
 // =============================================================================
@@ -98,6 +103,7 @@ export const bodyFields = {
   store: Schema.optional(Schema.Boolean),
   reasoning_effort: Schema.optional(OpenAIOptions.OpenAIReasoningEffort),
   max_tokens: Schema.optional(Schema.Number),
+  max_completion_tokens: Schema.optional(Schema.Number),
   temperature: Schema.optional(Schema.Number),
   top_p: Schema.optional(Schema.Number),
   frequency_penalty: Schema.optional(Schema.Number),
@@ -346,6 +352,7 @@ const fromRequest = Effect.fn("OpenAIChat.fromRequest")(function* (request: LLMR
   // validation, and HTTP execution are composed by `Route.make`.
   const generation = request.generation
   const toolSchemaCompatibility = request.model.compatibility?.toolSchema
+  const completionTokenLimit = usesMaxCompletionTokens(request.model.id)
   return {
     model: request.model.id,
     messages: yield* lowerMessages(request),
@@ -358,7 +365,8 @@ const fromRequest = Effect.fn("OpenAIChat.fromRequest")(function* (request: LLMR
     tool_choice: request.toolChoice ? yield* lowerToolChoice(request.toolChoice) : undefined,
     stream: true as const,
     stream_options: { include_usage: true },
-    max_tokens: generation?.maxTokens,
+    max_tokens: completionTokenLimit ? undefined : generation?.maxTokens,
+    max_completion_tokens: completionTokenLimit ? generation?.maxTokens : undefined,
     temperature: generation?.temperature,
     top_p: generation?.topP,
     frequency_penalty: generation?.frequencyPenalty,

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -51,6 +51,21 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("uses max_completion_tokens for prefixed GPT-5 model ids", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          model: model.route.model({ id: "azure/gpt-5.4" }),
+          prompt: "Say hello.",
+          generation: { maxTokens: 20 },
+        }),
+      )
+
+      expect(prepared.body.max_tokens).toBeUndefined()
+      expect(prepared.body.max_completion_tokens).toBe(20)
+    }),
+  )
+
   it.effect("lowers chronological system updates to escaped user wrappers in order", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -31,8 +31,27 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { OpenAIChat } from "@opencode-ai/llm/protocols/openai-chat"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 300_000
+const OPENAI_CHAT_PACKAGES = new Set(["@ai-sdk/openai", "@ai-sdk/azure", "@ai-sdk/openai-compatible"])
+
+export function normalizeOpenAIChatTokenLimit(npm: string, init: BunFetchRequestInit) {
+  if (!OPENAI_CHAT_PACKAGES.has(npm) || typeof init.body !== "string") return init
+  const body = JSON.parse(init.body)
+  if (
+    !isRecord(body) ||
+    typeof body.model !== "string" ||
+    !OpenAIChat.usesMaxCompletionTokens(body.model) ||
+    typeof body.max_tokens !== "number" ||
+    body.max_completion_tokens !== undefined
+  )
+    return init
+
+  const normalized: Record<string, unknown> = { ...body, max_completion_tokens: body.max_tokens }
+  delete normalized.max_tokens
+  return { ...init, body: JSON.stringify(normalized) }
+}
 
 function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (typeof ms !== "number" || ms <= 0) return res
@@ -1798,7 +1817,7 @@ const layer = Layer.effect(
 
         options["fetch"] = async (input: any, init?: BunFetchRequestInit) => {
           const fetchFn = customFetch ?? fetch
-          const opts = init ?? {}
+          const opts = normalizeOpenAIChatTokenLimit(model.api.npm, init ?? {})
           const chunkAbortCtl = typeof chunkTimeout === "number" && chunkTimeout > 0 ? new AbortController() : undefined
           const headerTimeoutMs = headerTimeout === false ? undefined : headerTimeout
           const headerTimeoutCtl = typeof headerTimeoutMs === "number" ? timeoutController(headerTimeoutMs) : undefined

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -76,6 +76,29 @@ const providerLayer = (flags: Partial<RuntimeFlags.Info> = {}) =>
 
 const list = Provider.use.list()
 
+test("normalizes GPT-5 chat token limits for OpenAI-compatible SDKs", () => {
+  const init = {
+    method: "POST",
+    body: JSON.stringify({ model: "azure/gpt-5.4", max_tokens: 32_000, stream: true }),
+  }
+  const result = Provider.normalizeOpenAIChatTokenLimit("@ai-sdk/openai-compatible", init)
+
+  expect(JSON.parse(String(result.body))).toEqual({
+    model: "azure/gpt-5.4",
+    max_completion_tokens: 32_000,
+    stream: true,
+  })
+})
+
+test("preserves legacy token limits for non-GPT-5 models", () => {
+  const init = {
+    method: "POST",
+    body: JSON.stringify({ model: "gpt-4o-mini", max_tokens: 16_000, stream: true }),
+  }
+
+  expect(Provider.normalizeOpenAIChatTokenLimit("@ai-sdk/openai-compatible", init)).toBe(init)
+})
+
 const paid = (providers: Record<string, { models: Record<string, { cost: { input: number } }> }>) => {
   const item = providers[ProviderV2.ID.make("opencode")]
   expect(item).toBeDefined()


### PR DESCRIPTION
### Issue for this PR

Closes #45439

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

GPT-5 chat requests require `max_completion_tokens` instead of `max_tokens`. This change selects the correct field in the native OpenAI chat protocol and normalizes the default OpenAI, Azure, and OpenAI-compatible AI SDK request paths, while retaining `max_tokens` for other model families.

### How did you verify your code works?

- `bun test test/provider/openai-chat.test.ts --test-name-pattern max_completion_tokens` in `packages/llm`
- `bun test test/provider/provider.test.ts --test-name-pattern "token limits"` in `packages/opencode`
- `bun typecheck` in `packages/llm`
- `bun typecheck` in `packages/opencode`

### Screenshots / recordings

Not applicable; this change has no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR