### PR TITLE
fix(enterprise): revoke shared session data

### DIFF
--- a/packages/enterprise/src/core/share.ts
+++ b/packages/enterprise/src/core/share.ts
@@ -137,14 +137,14 @@ export namespace Share {
     if (share.secret !== body.secret) throw new Errors.InvalidSecret(body.id)
     await Storage.remove(["share", body.id])
     const groups = await Promise.all([
-      Storage.list({ prefix: ["share_snapshot", body.id] }),
-      Storage.list({ prefix: ["share_compaction", body.id] }),
       Storage.list({ prefix: ["share_event", body.id] }),
       Storage.list({ prefix: ["share_data", body.id] }),
     ])
-    for (const item of groups.flat()) {
-      await Storage.remove(item)
-    }
+    await Promise.all([
+      Storage.remove(["share_snapshot", body.id]),
+      Storage.remove(["share_compaction", body.id]),
+      ...groups.flat().map((item) => Storage.remove(item)),
+    ])
   })
 
   export const removeAdmin = fn(Info.pick({ id: true }), async (body) => {
@@ -168,6 +168,7 @@ export namespace Share {
   )
 
   export async function data(shareID: string) {
+    if (!(await get(shareID))) throw new Errors.NotFound(shareID)
     return (await readSnapshot(shareID)) ?? legacy(shareID)
   }
 

--- a/packages/enterprise/src/routes/api/[...path].ts
+++ b/packages/enterprise/src/routes/api/[...path].ts
@@ -8,7 +8,7 @@ import { Share } from "~/core/share"
 import { Resource } from "sst"
 import { timingSafeEqual } from "node:crypto"
 
-const app = new Hono()
+export const app = new Hono()
 
 app
   .basePath("/api")
@@ -105,13 +105,26 @@ app
             },
           },
         },
+        404: {
+          description: "Share not found",
+          content: {
+            "application/json": {
+              schema: resolver(z.object({ error: z.string() })),
+            },
+          },
+        },
       },
     }),
     validator("param", z.object({ shareID: z.string() })),
     async (c) => {
       const { shareID } = c.req.valid("param")
-      c.header("Cache-Control", "public, max-age=30, s-maxage=300, stale-while-revalidate=86400")
-      return c.json(await Share.data(shareID))
+      c.header("Cache-Control", "private, no-store")
+      const data = await Share.data(shareID).catch((error) => {
+        if (error instanceof Share.Errors.NotFound) return undefined
+        throw error
+      })
+      if (!data) return c.json({ error: `Share not found: ${shareID}` }, 404)
+      return c.json(data)
     },
   )
   .delete(

--- a/packages/enterprise/src/routes/share/[shareID].tsx
+++ b/packages/enterprise/src/routes/share/[shareID].tsx
@@ -122,10 +122,7 @@ const getData = query(async (shareID) => {
 }, "getShareData")
 
 export default function () {
-  getRequestEvent()?.response.headers.set(
-    "Cache-Control",
-    "public, max-age=30, s-maxage=300, stale-while-revalidate=86400",
-  )
+  getRequestEvent()?.response.headers.set("Cache-Control", "private, no-store")
 
   const params = useParams()
   const data = createAsync(async () => {

--- a/packages/enterprise/test/core/share.test.ts
+++ b/packages/enterprise/test/core/share.test.ts
@@ -22,6 +22,31 @@ describe.concurrent("core.share", () => {
     expect(await Share.get(share.id)).toBeUndefined()
   })
 
+  test("should revoke data access and remove all persisted share data", async () => {
+    const sessionID = Identifier.descending()
+    const share = await Share.create({ sessionID })
+    const data: Share.Data[] = [
+      {
+        type: "part",
+        data: { id: "part1", sessionID, messageID: "msg1", type: "text", text: "Private" },
+      },
+    ]
+
+    await Share.sync({ share: { id: share.id, secret: share.secret }, data })
+    await Storage.write(["share_compaction", share.id], { data })
+    await Storage.write(["share_event", share.id, Identifier.descending()], data)
+    await Storage.write(["share_data", share.id, "part", "msg1", "part1"], data[0].data)
+
+    await Share.remove({ id: share.id, secret: share.secret })
+
+    expect(await Share.get(share.id)).toBeUndefined()
+    expect(await Storage.read(["share_snapshot", share.id])).toBeUndefined()
+    expect(await Storage.read(["share_compaction", share.id])).toBeUndefined()
+    expect(await Storage.list({ prefix: ["share_event", share.id] })).toEqual([])
+    expect(await Storage.list({ prefix: ["share_data", share.id] })).toEqual([])
+    await expect(Share.data(share.id)).rejects.toBeInstanceOf(Share.Errors.NotFound)
+  })
+
   test("should sync data to a share", async () => {
     const sessionID = Identifier.descending()
     const share = await Share.create({ sessionID })

--- a/packages/enterprise/test/routes/share-api.test.ts
+++ b/packages/enterprise/test/routes/share-api.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test"
+import { Identifier } from "@opencode-ai/core/util/identifier"
+import { Share } from "../../src/core/share"
+import { app } from "../../src/routes/api/[...path]"
+
+test("share data responses are not cached and disappear after unshare", async () => {
+  const sessionID = Identifier.descending()
+  const share = await Share.create({ sessionID })
+  await Share.sync({
+    share: { id: share.id, secret: share.secret },
+    data: [
+      {
+        type: "part",
+        data: { id: "part1", sessionID, messageID: "msg1", type: "text", text: "Private" },
+      },
+    ],
+  })
+
+  const before = await app.fetch(new Request(`https://enterprise.test/api/share/${share.id}/data`))
+  expect(before.status).toBe(200)
+  expect(before.headers.get("Cache-Control")).toBe("private, no-store")
+
+  await Share.remove({ id: share.id, secret: share.secret })
+
+  const after = await app.fetch(new Request(`https://enterprise.test/api/share/${share.id}/data`))
+  expect(after.status).toBe(404)
+  expect(after.headers.get("Cache-Control")).toBe("private, no-store")
+  expect(await after.text()).toBe(JSON.stringify({ error: `Share not found: ${share.id}` }))
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45525

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Unsharing removed the share metadata but attempted to delete snapshot and compaction objects through directory-prefix listings, even though those objects use exact keys. This change removes the exact objects and legacy data, rejects data reads after revocation, returns `404` for revoked shares, and marks share responses `private, no-store` so new responses are not retained by shared caches.

### How did you verify your code works?

- Enterprise package typecheck passed with the Windows checkout's symlink placeholder excluded.
- Added core coverage for exact object removal and rejected reads after unshare.
- Added API coverage for `no-store` responses and `404` after unshare.
- The storage integration tests require a configured S3 or R2 adapter and could not run in the current local environment without those credentials.

### Screenshots / recordings

Not applicable; this change has no UI impact.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR