### PR TITLE
fix(ui): remount kobalte select after selection

### DIFF
--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -1,5 +1,5 @@
 import { Select as Kobalte } from "@kobalte/core/select"
-import { createMemo, onCleanup, splitProps, type ComponentProps, type JSX } from "solid-js"
+import { Show, createMemo, createSignal, onCleanup, splitProps, type ComponentProps, type JSX } from "solid-js"
 import { pipe, groupBy, entries, map } from "remeda"
 import { Button, ButtonProps } from "./button"
 import { Icon } from "./icon"
@@ -82,93 +82,107 @@ export function Select<T>(props: SelectProps<T> & Omit<ButtonProps, "children">)
     return result
   })
 
+  // Kobalte's <Portal> enters a broken state after the first item selection: the
+  // next open fires onOpenChange(true) but the content never mounts to the DOM,
+  // so dropdowns (theme, color scheme, language, shell, ...) stop reopening until
+  // the component is recreated. Remounting a fresh instance after every selection
+  // gives the portal a clean state so the next open always renders.
+  const [mounted, setMounted] = createSignal(true)
+  const remount = () => {
+    setMounted(false)
+    setTimeout(() => setMounted(true), 0)
+  }
+
   return (
-    // @ts-ignore
-    <Kobalte<T, { category: string; options: T[] }>
-      {...others}
-      data-component="select"
-      data-trigger-style={local.triggerVariant}
-      placement={local.triggerVariant === "settings" ? "bottom-end" : "bottom-start"}
-      gutter={4}
-      value={local.current}
-      options={grouped()}
-      optionValue={(x) => (local.value ? local.value(x) : (x as string))}
-      optionTextValue={(x) => (local.label ? local.label(x) : (x as string))}
-      optionGroupChildren="options"
-      placeholder={local.placeholder}
-      sectionComponent={(local) => (
-        <Kobalte.Section data-slot="select-section">{local.section.rawValue.category}</Kobalte.Section>
-      )}
-      itemComponent={(itemProps) => (
-        <Kobalte.Item
-          {...itemProps}
-          data-slot="select-select-item"
-          classList={{
-            ...local.classList,
-            [local.class ?? ""]: !!local.class,
-          }}
-          onPointerEnter={() => move(itemProps.item.rawValue)}
-          onPointerMove={() => move(itemProps.item.rawValue)}
-          onFocus={() => move(itemProps.item.rawValue)}
-        >
-          <Kobalte.ItemLabel data-slot="select-select-item-label">
-            {local.children
-              ? local.children(itemProps.item.rawValue)
-              : local.label
-                ? local.label(itemProps.item.rawValue)
-                : (itemProps.item.rawValue as string)}
-          </Kobalte.ItemLabel>
-          <Kobalte.ItemIndicator data-slot="select-select-item-indicator">
-            <Icon name="check-small" size="small" />
-          </Kobalte.ItemIndicator>
-        </Kobalte.Item>
-      )}
-      onChange={(v) => {
-        local.onSelect?.(v ?? undefined)
-        stop()
-      }}
-      onOpenChange={(open) => {
-        local.onOpenChange?.(open)
-        if (!open) stop()
-      }}
-    >
-      <Kobalte.Trigger
-        {...local.triggerProps}
-        disabled={props.disabled}
-        data-slot="select-select-trigger"
-        as={Button}
-        size={props.size}
-        variant={props.variant}
-        style={local.triggerStyle}
-        classList={{
-          ...local.classList,
-          [local.class ?? ""]: !!local.class,
+    <Show when={mounted()}>
+      {/* @ts-ignore */}
+      <Kobalte<T, { category: string; options: T[] }>
+        {...others}
+        data-component="select"
+        data-trigger-style={local.triggerVariant}
+        placement={local.triggerVariant === "settings" ? "bottom-end" : "bottom-start"}
+        gutter={4}
+        value={local.current}
+        options={grouped()}
+        optionValue={(x) => (local.value ? local.value(x) : (x as string))}
+        optionTextValue={(x) => (local.label ? local.label(x) : (x as string))}
+        optionGroupChildren="options"
+        placeholder={local.placeholder}
+        sectionComponent={(local) => (
+          <Kobalte.Section data-slot="select-section">{local.section.rawValue.category}</Kobalte.Section>
+        )}
+        itemComponent={(itemProps) => (
+          <Kobalte.Item
+            {...itemProps}
+            data-slot="select-select-item"
+            classList={{
+              ...local.classList,
+              [local.class ?? ""]: !!local.class,
+            }}
+            onPointerEnter={() => move(itemProps.item.rawValue)}
+            onPointerMove={() => move(itemProps.item.rawValue)}
+            onFocus={() => move(itemProps.item.rawValue)}
+          >
+            <Kobalte.ItemLabel data-slot="select-select-item-label">
+              {local.children
+                ? local.children(itemProps.item.rawValue)
+                : local.label
+                  ? local.label(itemProps.item.rawValue)
+                  : (itemProps.item.rawValue as string)}
+            </Kobalte.ItemLabel>
+            <Kobalte.ItemIndicator data-slot="select-select-item-indicator">
+              <Icon name="check-small" size="small" />
+            </Kobalte.ItemIndicator>
+          </Kobalte.Item>
+        )}
+        onChange={(v) => {
+          local.onSelect?.(v ?? undefined)
+          stop()
+          remount()
+        }}
+        onOpenChange={(open) => {
+          local.onOpenChange?.(open)
+          if (!open) stop()
         }}
       >
-        <Kobalte.Value<T> data-slot="select-select-trigger-value" class={local.valueClass}>
-          {(state) => {
-            const selected = state.selectedOption() ?? local.current
-            if (!selected) return local.placeholder || ""
-            if (local.label) return local.label(selected)
-            return selected as string
-          }}
-        </Kobalte.Value>
-        <Kobalte.Icon data-slot="select-select-trigger-icon">
-          <Icon name={local.triggerVariant === "settings" ? "selector" : "chevron-down"} size="small" />
-        </Kobalte.Icon>
-      </Kobalte.Trigger>
-      <Kobalte.Portal>
-        <Kobalte.Content
+        <Kobalte.Trigger
+          {...local.triggerProps}
+          disabled={props.disabled}
+          data-slot="select-select-trigger"
+          as={Button}
+          size={props.size}
+          variant={props.variant}
+          style={local.triggerStyle}
           classList={{
             ...local.classList,
             [local.class ?? ""]: !!local.class,
           }}
-          data-component="select-content"
-          data-trigger-style={local.triggerVariant}
         >
-          <Kobalte.Listbox data-slot="select-select-content-list" />
-        </Kobalte.Content>
-      </Kobalte.Portal>
-    </Kobalte>
+          <Kobalte.Value<T> data-slot="select-select-trigger-value" class={local.valueClass}>
+            {(state) => {
+              const selected = state.selectedOption() ?? local.current
+              if (!selected) return local.placeholder || ""
+              if (local.label) return local.label(selected)
+              return selected as string
+            }}
+          </Kobalte.Value>
+          <Kobalte.Icon data-slot="select-select-trigger-icon">
+            <Icon name={local.triggerVariant === "settings" ? "selector" : "chevron-down"} size="small" />
+          </Kobalte.Icon>
+        </Kobalte.Trigger>
+        <Kobalte.Portal>
+          <Kobalte.Content
+            classList={{
+              ...local.classList,
+              [local.class ?? ""]: !!local.class,
+            }}
+            data-component="select-content"
+            data-trigger-style={local.triggerVariant}
+          >
+            <Kobalte.Listbox data-slot="select-select-content-list" />
+          </Kobalte.Content>
+        </Kobalte.Portal>
+      </Kobalte>
+    </Show>
   )
 }

--- a/packages/ui/src/v2/components/select-v2.tsx
+++ b/packages/ui/src/v2/components/select-v2.tsx
@@ -1,5 +1,5 @@
 import { Select as Kobalte } from "@kobalte/core/select"
-import { Show, createMemo, onCleanup, splitProps, type ComponentProps, type JSX } from "solid-js"
+import { Show, createMemo, createSignal, onCleanup, splitProps, type ComponentProps, type JSX } from "solid-js"
 import "./select-v2.css"
 
 function groupOptions<T>(options: T[], groupBy?: (x: T) => string): { category: string; options: T[] }[] {
@@ -117,93 +117,107 @@ export function SelectV2<T>(props: SelectV2Props<T>) {
 
   const grouped = createMemo(() => groupOptions(local.options, local.groupBy))
 
+  // Kobalte's <Portal> enters a broken state after the first item selection: the
+  // next open fires onOpenChange(true) but the content never mounts to the DOM,
+  // so dropdowns (theme, color scheme, language, shell, ...) stop reopening until
+  // the component is recreated. Remounting a fresh instance after every selection
+  // gives the portal a clean state so the next open always renders.
+  const [mounted, setMounted] = createSignal(true)
+  const remount = () => {
+    setMounted(false)
+    setTimeout(() => setMounted(true), 0)
+  }
+
   return (
-    <Kobalte<T, { category: string; options: T[] }>
-      {...others}
-      multiple={false}
-      allowDuplicateSelectionEvents={false}
-      disabled={local.disabled}
-      data-component="select-v2-root"
-      placement={local.placement ?? (inline() ? "bottom-end" : "bottom-start")}
-      gutter={local.gutter ?? 4}
-      sameWidth={local.sameWidth ?? !inline()}
-      flip={local.flip ?? true}
-      slide={local.slide ?? true}
-      fitViewport={local.fitViewport ?? false}
-      value={local.current}
-      options={grouped()}
-      optionValue={(x) => (local.value ? local.value(x) : String(x as string))}
-      optionTextValue={(x) => (local.label ? local.label(x) : String(x as string))}
-      optionGroupChildren="options"
-      placeholder={local.placeholder}
-      sectionComponent={(sectionProps) => (
-        <Kobalte.Section>
-          <Show when={sectionProps.section.rawValue.category}>
-            <div data-slot="menu-v2-group-label">{sectionProps.section.rawValue.category}</div>
-          </Show>
-        </Kobalte.Section>
-      )}
-      itemComponent={(itemProps) => (
-        <Kobalte.Item
-          {...itemProps}
-          data-component="menu-v2-item"
-          onPointerEnter={() => move(itemProps.item.rawValue)}
-          onPointerMove={() => move(itemProps.item.rawValue)}
-          onFocus={() => move(itemProps.item.rawValue)}
-        >
-          <Kobalte.ItemLabel data-slot="menu-v2-item-content" as="span">
-            {local.children
-              ? local.children(itemProps.item.rawValue)
-              : local.label
-                ? local.label(itemProps.item.rawValue)
-                : String(itemProps.item.rawValue as string)}
-          </Kobalte.ItemLabel>
-          <Kobalte.ItemIndicator data-slot="menu-v2-item-indicator" forceMount>
-            <CheckSmall />
-          </Kobalte.ItemIndicator>
-        </Kobalte.Item>
-      )}
-      onChange={(next) => {
-        const v = next == null ? null : Array.isArray(next) ? ((next[0] as T) ?? null) : (next as T)
-        local.onSelect?.(v)
-        stop()
-      }}
-      onOpenChange={(open) => {
-        local.onOpenChange?.(open)
-        if (!open) stop()
-      }}
-    >
-      <Kobalte.Trigger
-        as="div"
-        data-component="select-v2"
-        data-appearance={local.appearance ?? "base"}
-        data-invalid={local.invalid ? "" : undefined}
-        data-numeric={local.numeric ? "" : undefined}
+    <Show when={mounted()}>
+      <Kobalte<T, { category: string; options: T[] }>
+        {...others}
+        multiple={false}
+        allowDuplicateSelectionEvents={false}
         disabled={local.disabled}
-        data-disabled={local.disabled ? "" : undefined}
-        classList={{
-          ...local.classList,
-          [local.class ?? ""]: !!local.class,
+        data-component="select-v2-root"
+        placement={local.placement ?? (inline() ? "bottom-end" : "bottom-start")}
+        gutter={local.gutter ?? 4}
+        sameWidth={local.sameWidth ?? !inline()}
+        flip={local.flip ?? true}
+        slide={local.slide ?? true}
+        fitViewport={local.fitViewport ?? false}
+        value={local.current}
+        options={grouped()}
+        optionValue={(x) => (local.value ? local.value(x) : String(x as string))}
+        optionTextValue={(x) => (local.label ? local.label(x) : String(x as string))}
+        optionGroupChildren="options"
+        placeholder={local.placeholder}
+        sectionComponent={(sectionProps) => (
+          <Kobalte.Section>
+            <Show when={sectionProps.section.rawValue.category}>
+              <div data-slot="menu-v2-group-label">{sectionProps.section.rawValue.category}</div>
+            </Show>
+          </Kobalte.Section>
+        )}
+        itemComponent={(itemProps) => (
+          <Kobalte.Item
+            {...itemProps}
+            data-component="menu-v2-item"
+            onPointerEnter={() => move(itemProps.item.rawValue)}
+            onPointerMove={() => move(itemProps.item.rawValue)}
+            onFocus={() => move(itemProps.item.rawValue)}
+          >
+            <Kobalte.ItemLabel data-slot="menu-v2-item-content" as="span">
+              {local.children
+                ? local.children(itemProps.item.rawValue)
+                : local.label
+                  ? local.label(itemProps.item.rawValue)
+                  : String(itemProps.item.rawValue as string)}
+            </Kobalte.ItemLabel>
+            <Kobalte.ItemIndicator data-slot="menu-v2-item-indicator" forceMount>
+              <CheckSmall />
+            </Kobalte.ItemIndicator>
+          </Kobalte.Item>
+        )}
+        onChange={(next) => {
+          const v = next == null ? null : Array.isArray(next) ? ((next[0] as T) ?? null) : (next as T)
+          local.onSelect?.(v)
+          stop()
+          remount()
+        }}
+        onOpenChange={(open) => {
+          local.onOpenChange?.(open)
+          if (!open) stop()
         }}
       >
-        <div data-slot="select-v2-value">
-          <Kobalte.Value<T> data-slot="select-v2-value-text" class={local.valueClass}>
-            {(st) => {
-              const selected = st.selectedOption()
-              if (local.label && selected != null) return local.label(selected)
-              return selected != null ? (selected as string) : ""
-            }}
-          </Kobalte.Value>
-        </div>
-        <span data-slot="select-v2-chevron" aria-hidden="true">
-          <ChevronDown />
-        </span>
-      </Kobalte.Trigger>
-      <Kobalte.Portal>
-        <Kobalte.Content data-component="menu-v2-content" data-slot="select-v2-content">
-          <Kobalte.Listbox data-slot="select-v2-listbox" />
-        </Kobalte.Content>
-      </Kobalte.Portal>
-    </Kobalte>
+        <Kobalte.Trigger
+          as="div"
+          data-component="select-v2"
+          data-appearance={local.appearance ?? "base"}
+          data-invalid={local.invalid ? "" : undefined}
+          data-numeric={local.numeric ? "" : undefined}
+          disabled={local.disabled}
+          data-disabled={local.disabled ? "" : undefined}
+          classList={{
+            ...local.classList,
+            [local.class ?? ""]: !!local.class,
+          }}
+        >
+          <div data-slot="select-v2-value">
+            <Kobalte.Value<T> data-slot="select-v2-value-text" class={local.valueClass}>
+              {(st) => {
+                const selected = st.selectedOption()
+                if (local.label && selected != null) return local.label(selected)
+                return selected != null ? (selected as string) : ""
+              }}
+            </Kobalte.Value>
+          </div>
+          <span data-slot="select-v2-chevron" aria-hidden="true">
+            <ChevronDown />
+          </span>
+        </Kobalte.Trigger>
+        <Kobalte.Portal>
+          <Kobalte.Content data-component="menu-v2-content" data-slot="select-v2-content">
+            <Kobalte.Listbox data-slot="select-v2-listbox" />
+          </Kobalte.Content>
+        </Kobalte.Portal>
+      </Kobalte>
+    </Show>
   )
 }


### PR DESCRIPTION
### Issue for this PR

Closes #40047

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the settings, the dropdowns (theme, color scheme, language, ...) stop reopening after the first item selection: changing the theme again requires closing and reopening the settings window.

Root cause: the Kobalte `<Portal>` enters a broken state after the first item selection — the next open fires `onOpenChange(true)` but the content is never mounted to the DOM. This is the same root cause reported in #38621 and #39455.

The fix remounts a fresh `Select` instance after every selection: it wraps the Kobalte tree in `<Show when={mounted()}>` backed by a `createSignal`, and calls `remount()` inside `onChange`. Recreating the component gives the portal a clean state so the next open always renders. Applied to:
- `packages/ui/src/v2/components/select-v2.tsx` (used by the current settings)
- `packages/ui/src/components/select.tsx` (legacy component)

### How did you verify your code works?

Ran the local toolchain on this branch for `packages/ui`:
- `bun run typecheck` (`tsgo --noEmit`) — passes (exit 0)
- `bun run build` (`rm -rf dist && tsc -p tsconfig.build.json`) — passes (exit 0)

Runtime behavior was verified at code level: the change only adds a remount wrapper around the existing Kobalte tree plus a `remount()` call in `onChange`; no existing props, callbacks or styling are touched. I could not launch the desktop app in this environment to record a screenshot.

### Screenshots / recordings

_Not provided — could not launch the desktop app in this environment to record it._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR