### PR TITLE
refactor(core): simplify WebFetch error narrowing

### DIFF
--- a/packages/core/src/tool/plugin/webfetch.ts
+++ b/packages/core/src/tool/plugin/webfetch.ts
@@ -3,7 +3,7 @@ export * as WebFetchTool from "./webfetch.js"
 import type { Context as PluginContext } from "@opencode-ai/plugin/effect/plugin"
 import { ToolFailure } from "@opencode-ai/ai"
 import { Duration, Effect, Schema } from "effect"
-import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { HttpClient, type HttpClientError, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { Parser } from "htmlparser2"
 import { Permission } from "../../permission.js"
 import { convertHTMLToMarkdown, MAX_MARKDOWN_BYTES } from "../html-markdown.js"
@@ -58,18 +58,9 @@ const headers = (format: Format, userAgent: string) => ({
 const openCodeUserAgent =
   "Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; OpenCode-User/1.0; +https://opencode.ai"
 
-const isCloudflareChallenge = (error: unknown) => {
-  if (!error || typeof error !== "object" || !("reason" in error)) return false
-  const reason = error.reason
-  if (
-    !reason ||
-    typeof reason !== "object" ||
-    !("_tag" in reason) ||
-    reason._tag !== "StatusCodeError" ||
-    !("response" in reason)
-  )
-    return false
-  const response = reason.response as HttpClientResponse.HttpClientResponse
+const isCloudflareChallenge = (error: HttpClientError.HttpClientError) => {
+  if (error.reason._tag !== "StatusCodeError") return false
+  const response = error.reason.response
   return response.status === 403 && response.headers["cf-mitigated"] === "challenge"
 }
 

--- a/packages/core/test/tool-webfetch.test.ts
+++ b/packages/core/test/tool-webfetch.test.ts
@@ -573,6 +573,22 @@ describe("WebFetchTool registration", () => {
     }),
   )
 
+  it.effect("does not retry ordinary 403 responses", () =>
+    Effect.gen(function* () {
+      reset()
+      respond = () => Effect.succeed(new Response("forbidden", { status: 403 }))
+      const registry = yield* Tool.Service
+      const url = "https://example.com/forbidden"
+
+      expect(yield* executeTool(registry, call({ url, format: "text" }))).toEqual({
+        status: "error",
+        error: { type: "unknown", message: `StatusCode: non 2xx status code (403 GET ${url})` },
+      })
+      expect(requests).toHaveLength(1)
+      expect(requests[0]?.headers["user-agent"]).toBe(webFetchUserAgent)
+    }),
+  )
+
   it.effect("times out stalled requests", () =>
     Effect.gen(function* () {
       reset()


### PR DESCRIPTION
## Why

WebFetch manually probes HTTP failures as unknown objects and casts their responses, even though its only caller already exposes `HttpClientError`. Using that contract removes unchecked narrowing from the challenge-retry policy.

## What Changes

Type the private predicate with `HttpClientError` and narrow its reason using the `StatusCodeError` discriminant. The retry behavior stays unchanged:

| Response | Behavior |
| --- | --- |
| Status-code error with HTTP 403 and `cf-mitigated: challenge` | Retry once with the `opencode` user agent. |
| Ordinary HTTP 403 without the challenge header | Fail after one request, preserving the initial user agent and status-error message. |

The new regression exercises the registered tool through the existing `HttpClient.make` / `HttpClientResponse.fromWeb` fixture. Existing positive assertions still check both user agents.

## Scope

Only the private WebFetch predicate and its existing test file. Request construction, public schemas, and typed-error/defect/interruption boundaries are unchanged.

## Verification

```sh
# From packages/core
bun run test ./test/tool-webfetch.test.ts ./test/tool-execute.test.ts ./test/tool-schema.test.ts ./test/session-runner-tool-registry.test.ts
bun typecheck
bunx --no-install prettier --check ./src/tool/plugin/webfetch.ts ./test/tool-webfetch.test.ts

# From the repository root
git diff origin/v2...HEAD --check
git push -u origin webfetch-error-types
```

- 108 tests passed across four files; Core typecheck and formatting passed.
- The normal pre-push hook passed all 33 workspace typecheck tasks.
- Mutation check: temporarily matching every 403 made the new regression fail with two requests instead of one. Restored the exact header condition before the final passing run.
- HTTP verification used injected responses and the existing local redirect server, not live websites.
