### PR TITLE
refactor(core): centralize full-prefix KV scans

### DIFF
--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -402,14 +402,7 @@ export const make = Effect.gen(function* () {
   })
 
   const pendingBackground: Interface["pendingBackground"] = Effect.gen(function* () {
-    const recovered: Background[] = []
-    let after: string | undefined
-    do {
-      const page = yield* kv.scan({ prefix: backgroundPrefix, after })
-      recovered.push(...Array.filterMap(page.entries, (entry) => decodeBackground(entry.value)))
-      after = page.next
-    } while (after)
-    return recovered
+    return Array.filterMap(yield* kv.scanAll(backgroundPrefix), (entry) => decodeBackground(entry.value))
   }).pipe(Effect.withSpan("Job.pendingBackground"))
 
   const completeBackground: Interface["completeBackground"] = Effect.fn("Job.completeBackground")((notificationID) =>

--- a/packages/core/src/kv.ts
+++ b/packages/core/src/kv.ts
@@ -29,6 +29,7 @@ export interface Interface {
   readonly set: (key: string, value: Value) => Effect.Effect<void>
   readonly remove: (key: string) => Effect.Effect<void>
   readonly scan: (options: ScanOptions) => Effect.Effect<ScanResult>
+  readonly scanAll: (prefix: string) => Effect.Effect<readonly Entry[]>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/KV") {}
@@ -37,6 +38,28 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const db = (yield* Database.Service).db
+    const scan: Interface["scan"] = Effect.fn("KV.scan")(function* (options) {
+      const limit = Number.isNaN(options.limit) ? 100 : Math.min(Math.max(Math.floor(options.limit ?? 100), 1), 1000)
+      const end = prefixEnd(options.prefix)
+      const rows = yield* db
+        .select({ key: KVTable.key, value: KVTable.value })
+        .from(KVTable)
+        .where(
+          and(
+            options.prefix === "" ? undefined : gte(KVTable.key, options.prefix),
+            end === undefined ? undefined : lt(KVTable.key, end),
+            options.after === undefined ? undefined : gt(KVTable.key, options.after),
+          ),
+        )
+        .orderBy(asc(KVTable.key))
+        .limit(limit + 1)
+        .all()
+        .pipe(Effect.orDie)
+      const entries = rows.slice(0, limit)
+      if (rows.length <= limit) return { entries }
+      return { entries, next: entries[entries.length - 1].key }
+    })
+
     return Service.of({
       get: Effect.fn("KV.get")(function* (key) {
         return (yield* db
@@ -57,26 +80,16 @@ const layer = Layer.effect(
       remove: Effect.fn("KV.remove")(function* (key) {
         yield* db.delete(KVTable).where(eq(KVTable.key, key)).run().pipe(Effect.orDie)
       }),
-      scan: Effect.fn("KV.scan")(function* (options) {
-        const limit = Number.isNaN(options.limit) ? 100 : Math.min(Math.max(Math.floor(options.limit ?? 100), 1), 1000)
-        const end = prefixEnd(options.prefix)
-        const rows = yield* db
-          .select({ key: KVTable.key, value: KVTable.value })
-          .from(KVTable)
-          .where(
-            and(
-              options.prefix === "" ? undefined : gte(KVTable.key, options.prefix),
-              end === undefined ? undefined : lt(KVTable.key, end),
-              options.after === undefined ? undefined : gt(KVTable.key, options.after),
-            ),
-          )
-          .orderBy(asc(KVTable.key))
-          .limit(limit + 1)
-          .all()
-          .pipe(Effect.orDie)
-        const entries = rows.slice(0, limit)
-        if (rows.length <= limit) return { entries }
-        return { entries, next: entries[entries.length - 1].key }
+      scan,
+      scanAll: Effect.fn("KV.scanAll")(function* (prefix) {
+        const entries: Entry[] = []
+        let after: string | undefined
+        do {
+          const page = yield* scan({ prefix, after, limit: 1000 })
+          entries.push(...page.entries)
+          after = page.next
+        } while (after !== undefined)
+        return entries
       }),
     })
   }),

--- a/packages/core/test/kv.test.ts
+++ b/packages/core/test/kv.test.ts
@@ -51,6 +51,8 @@ describe("KV", () => {
         entries: [{ key: `${prefix}éclair`, value: { order: 3 } }],
       })
       expect(yield* kv.scan({ prefix: `${prefix}%_` })).toEqual({ entries: [] })
+      expect(yield* kv.scanAll(`${prefix}%_`)).toEqual([])
+      expect(yield* kv.scanAll(prefix)).toEqual([...first.entries, { key: `${prefix}éclair`, value: { order: 3 } }])
     }),
   )
 
@@ -76,6 +78,15 @@ describe("KV", () => {
       expect((yield* kv.scan({ prefix, limit: 0 })).entries).toHaveLength(1)
       expect((yield* kv.scan({ prefix, limit: -10 })).entries).toHaveLength(1)
       expect((yield* kv.scan({ prefix, limit: Number.NaN })).entries).toHaveLength(100)
+
+      const all = kv.scanAll(prefix)
+      const entries = Array.from({ length: 1001 }, (_, index) => {
+        const key = `${prefix}${index.toString().padStart(4, "0")}`
+        return { key, value: key }
+      })
+      expect(yield* all).toEqual(entries)
+      yield* kv.remove(`${prefix}0000`)
+      expect(yield* all).toEqual(entries.slice(1))
     }),
   )
 })


### PR DESCRIPTION
## Why

Background-job recovery currently has to manage KV pagination itself, mixing storage cursor handling with recovery-record decoding. It also uses the default 100-entry page size even though it needs every matching record.

## What Changes

Add `KV.scanAll(prefix)` to collect matching entries in key order using the existing paginated scan with 1,000-entry pages. `Job.pendingBackground` uses it and keeps the same recovery-record decoding and invalid-record filtering.

| Case | Result |
| --- | --- |
| No matching keys | An empty array |
| 1,001 matching keys | All entries in key order across two pages |
| Evaluate the same scan effect after deleting a key | A fresh result without the deleted entry or accumulated duplicates |

The existing `scan` limits and cursor contract remain unchanged. Focused assertions cover literal special-character prefixes, ordering, pagination, and repeated evaluation.

## Verification

```sh
# Repository root
bun install --frozen-lockfile
bunx prettier --check packages/core/src/kv.ts packages/core/src/job.ts packages/core/test/kv.test.ts
git diff --check
git diff --cached --check
git push -u origin kv-scan-all

# packages/core
bun typecheck
bun run test test/kv.test.ts test/job.test.ts
bun run test test/session-execution.test.ts test/tool-shell.test.ts
```

- Dependency installation, formatting, whitespace checks, and core typechecking passed.
- Focused KV/job tests: 15 passed, 0 failed, 147 assertions.
- Recovery and shell tests: 98 passed, 19 skipped, 0 failed, 552 assertions. The skipped tests require PowerShell, which is unavailable locally.
- The normal push hook ran the repository typecheck: 33 successful tasks, including 27 cache hits. Hooks were not bypassed.
- The full core test suite and live application workflows were not run.
