### PR TITLE
chore(core): narrow websocket platform import

### DIFF
--- a/packages/core/src/effect/websocket-constructor.ts
+++ b/packages/core/src/effect/websocket-constructor.ts
@@ -1,4 +1,5 @@
-import { NodeSocket } from "@effect/platform-node"
+// The platform barrel also exposes Redis and its optional native hash loader, which workerd cannot resolve.
+import { NodeWS } from "@effect/platform-node/NodeSocket"
 import { HttpProxyAgent } from "http-proxy-agent"
 import { HttpsProxyAgent } from "https-proxy-agent"
 import { Layer } from "effect"
@@ -80,8 +81,8 @@ const layer = Layer.succeed(Socket.WebSocketConstructor, (url, input) => {
     followRedirects: false,
   }
   const socket = config.protocols
-    ? new NodeSocket.NodeWS.WebSocket(url, config.protocols, native)
-    : new NodeSocket.NodeWS.WebSocket(url, native)
+    ? new NodeWS.WebSocket(url, config.protocols, native)
+    : new NodeWS.WebSocket(url, native)
   // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion -- ws implements the WebSocket surface consumed by the AI transport.
   return socket as unknown as globalThis.WebSocket
 })


### PR DESCRIPTION
## Why

The WebSocket constructor imports the Node platform barrel even though it only needs the WebSocket implementation. That barrel also exports `NodeRedis`, whose `redis` dependency exposes an optional native `@node-rs/xxhash` loader that workerd cannot resolve if retained in a bundle. Untouched `v2` package verification already passes at `5fb30405059dc69f9b5df18d4fb7d859030a5a69`, so this is preventive import-graph hygiene, not a fix for failing mainline packaging.

## What Changes

- **Before:** Reach `NodeWS.WebSocket` through the `@effect/platform-node` barrel.
- **After:** Import the same `NodeWS` export directly from `@effect/platform-node/NodeSocket`, avoiding the barrel's unrelated Redis dependency path.
- Keep both constructor overloads, headers, proxy selection, redirect rejection, and the Bun-native path unchanged. Add a comment explaining the subpath import.

## Scope

One core source file; no runtime behavior or public API changes.

## Verification

```sh
# Worktree root
bun install --frozen-lockfile

# packages/core, before and after the source change
bun typecheck
bun run test test/effect-app-node-platform.test.ts test/session-model-transport-live.test.ts

# packages/sdk, before any source edit and after the source change
bun run verify:package

# Worktree root, after the source change
bunx prettier --check packages/core/src/effect/websocket-constructor.ts
bunx oxlint packages/core/src/effect/websocket-constructor.ts
git diff --check

# Normal push, including the repository typecheck hook
git push -u origin websocket-subpath
```

Core typechecking passes before and after, and the focused WebSocket suite passes all 10 tests in both runs. Package verification passes before and after with `packed SDK consumer OK`, including clean tarball installation, entrypoint imports, Wrangler dry-run bundling, and a Miniflare health request. The initial fresh-worktree attempt stopped at missing `tsc`; installing the frozen dependencies resolved it without tracked changes.

In these local clean-consumer runs, Wrangler's dry-run upload size decreased from 22,069.79 KiB to 20,930.05 KiB (gzip: 3,886.43 KiB to 3,658.78 KiB). Formatting, linting, and diff checks pass. The normal pre-push typecheck hook also passes: 33 successful tasks, 27 cached.
