### PR TITLE
test(core): make websocket overflow fixture deterministic

### DIFF
--- a/packages/core/test/session-model-transport.test.ts
+++ b/packages/core/test/session-model-transport.test.ts
@@ -698,16 +698,22 @@ describe("SessionModelTransport", () => {
 
   test("poisons instead of dropping data when the inbound queue overflows", async () => {
     const messages = queue<string | Uint8Array, AIError>()
+    const poisoned = Deferred.makeUnsafe<void>()
     let closed = 0
     const connector: WebSocketConnector = {
       open: () =>
         Effect.succeed({
           sendText: () =>
+            // Hold consumption at the send boundary until the reader fills and poisons the inbound queue.
             Effect.sync(() => {
               for (let index = 0; index <= 129; index++) Queue.offerUnsafe(messages, `frame:${index}`)
-            }),
-          messages: Stream.fromQueue(messages),
-          close: Effect.sync(() => closed++).pipe(Effect.andThen(Queue.shutdown(messages)), Effect.asVoid),
+            }).pipe(Effect.andThen(Deferred.await(poisoned))),
+          messages: Stream.fromQueue(messages).pipe(Stream.tap(() => Effect.yieldNow)),
+          close: Effect.sync(() => closed++).pipe(
+            Effect.andThen(Deferred.succeed(poisoned, undefined)),
+            Effect.andThen(Queue.shutdown(messages)),
+            Effect.asVoid,
+          ),
         }),
     }
 
@@ -721,7 +727,7 @@ describe("SessionModelTransport", () => {
             ...item,
             driver: {
               create: item.driver.create,
-              observe: (_create, frame) => Effect.sleep("1 millis").pipe(Effect.as({ type: "frame" as const, frame })),
+              observe: (_create, frame) => Effect.succeed({ type: "frame" as const, frame }),
             },
           }),
         )


### PR DESCRIPTION
## Why

The inbound-overflow test depends on scheduler interleaving: `Stream.fromQueue` can dequeue a batch before the fixture fills the bounded queue. Delaying provider observation does not prevent that dequeue, so the test can miss the overflow and fail only by timing out on slow CI runners.

## What Changes

Hold fixture send completion on a `Deferred` until the production overflow path closes the connection. The reader yields between frames while the consumer remains at the send boundary, making queue saturation independent of the observation delay.

Remove that delay and retain the existing assertions: an accepted `queue-overflow` transport failure and exactly one connection close. Only this test fixture changes; production transport behavior is unchanged.

## Verification

```sh
# Worktree root
bun install --frozen-lockfile
bunx prettier --check packages/core/test/session-model-transport.test.ts
git diff --check origin/v2...HEAD

# packages/core
bun typecheck
bun run test test/session-model-transport.test.ts
for run in $(seq 1 25); do printf 'Transport stress run %s/25\n' "$run"; bun run test test/session-model-transport.test.ts || exit 1; done

# Worktree root, with normal hooks
git push -u origin overflow-fixture
```

The focused file passes all 23 tests. All 25 additional full-file runs pass, totaling 575 stress-test passes with no failures. Core typechecking, formatting, and whitespace checks pass. The normal pre-push hook also passes all 33 repository typecheck tasks, with 27 cache hits. The full core suite was not run locally.
