### PR TITLE
refactor(core): share patch write path

### DIFF
--- a/packages/core/src/tool/plugin/patch.ts
+++ b/packages/core/src/tool/plugin/patch.ts
@@ -215,17 +215,6 @@ export const Plugin = {
                 prepared,
                 (change) =>
                   Effect.gen(function* () {
-                    if (change.type === "add") {
-                      yield* environment.files
-                        .write(change.target.absolute, new TextEncoder().encode(change.content))
-                        .pipe(Effect.mapError((error) => fail(`Failed to write ${change.target.resource}`, error)))
-                      applied.push({
-                        type: change.type,
-                        resource: change.target.resource,
-                        target: change.target.absolute,
-                      })
-                      return
-                    }
                     if (change.type === "delete") {
                       yield* environment.files
                         .remove(change.target.absolute)
@@ -237,7 +226,7 @@ export const Plugin = {
                       })
                       return
                     }
-                    if (change.moveTarget) {
+                    if (change.type === "update" && change.moveTarget) {
                       const moveTarget = change.moveTarget
                       yield* environment.files
                         .write(moveTarget.absolute, new TextEncoder().encode(change.content))


### PR DESCRIPTION
**Why**
Patch adds and non-moving updates duplicate the same file write, failure message, and applied-result recording. Keeping two copies obscures their identical behavior after preparation.

**What Changes**
Keep delete and moving-update cases explicit, then let adds and non-moving updates use the existing final write-and-record path. Check the update discriminant before accessing `moveTarget`.

Behavior is unchanged: adds still overwrite existing targets, operations apply sequentially, and moves are recorded only after source removal succeeds. The special destination-written/source-removal-failed error and successful-prefix reporting remain intact.

**Scope**
Only `packages/core/src/tool/plugin/patch.ts`, with no new helper. Preparation, permissions, locking, formatting, and BOM handling are unchanged. Reuse existing tests rather than duplicate their coverage.

**Verification**
```sh
# From packages/core
bun run test test/tool-patch.test.ts
bun run test test/tool-execute.test.ts test/tool-schema.test.ts
bun typecheck

# From the repository root
bunx prettier --check packages/core/src/tool/plugin/patch.ts
bunx oxlint packages/core/src/tool/plugin/patch.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/tool/plugin/patch.ts
git diff --check

# Run automatically by the normal pre-push hook
bun typecheck
```

39 patch tests and 19 execution/schema tests passed. Core typecheck and all formatting/lint checks passed. The normal pre-push hook also passed all 33 workspace typecheck tasks. The Effect-pattern scan exited successfully with only a runtime binary-resolution setup warning.
