### PR TITLE
fix(core): refresh cached references safely

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -397,6 +397,7 @@ export type ReferenceGitSource = {
   type: "git"
   repository: string
   branch?: string
+  refresh?: string
   description?: string
   hidden?: boolean
 }
@@ -1958,7 +1959,7 @@ export type ConfigEntry =
         references?: {
           [x: string]:
             | string
-            | { repository: string; branch?: string; description?: string; hidden?: boolean }
+            | { repository: string; branch?: string; refresh?: string; description?: string; hidden?: boolean }
             | { path: string; description?: string; hidden?: boolean }
         }
         websearch?: false | { provider: "random" | (string & {}) }

--- a/packages/core/src/config/plugin/reference.ts
+++ b/packages/core/src/config/plugin/reference.ts
@@ -4,7 +4,7 @@ import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Document } from "@opencode-ai/schema/config"
 import { ConfigReference } from "@opencode-ai/schema/config/reference"
 import path from "path"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { Config } from "../../config.js"
 import { Reference } from "../../reference.js"
 import { AbsolutePath } from "../../schema.js"
@@ -20,7 +20,7 @@ export const Plugin = define({
     const global = yield* Global.Service
     const loaded = yield* ConfigEntryObserver.observe(config, ctx.event, ctx.reference.reload())
     yield* ctx.reference.transform((draft) => {
-      const entries = new Map<string, Reference.Source>()
+      const entries = new Map<string, Parameters<typeof draft.add>[1]>()
       for (const doc of loaded.entries.filter((entry): entry is Document => entry.type === "document")) {
         const directory = doc.path ? path.dirname(doc.path) : location.directory
         for (const [name, entry] of Object.entries(doc.info.references ?? {})) {
@@ -38,13 +38,16 @@ export const Plugin = define({
                   ...(description === undefined ? {} : { description }),
                   ...(hidden === undefined ? {} : { hidden }),
                 })
-              : Reference.GitSource.make({
-                  type: "git",
-                  repository: typeof entry === "string" ? entry : entry.repository,
-                  ...(entry.branch === undefined ? {} : { branch: entry.branch }),
-                  ...(description === undefined ? {} : { description }),
-                  ...(hidden === undefined ? {} : { hidden }),
-                }),
+              : Schema.encodeSync(Reference.GitSource)(
+                  Reference.GitSource.make({
+                    type: "git",
+                    repository: entry.repository,
+                    ...(entry.branch === undefined ? {} : { branch: entry.branch }),
+                    ...(entry.refresh === undefined ? {} : { refresh: entry.refresh }),
+                    ...(description === undefined ? {} : { description }),
+                    ...(hidden === undefined ? {} : { hidden }),
+                  }),
+                ),
           )
         }
       }

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -77,6 +77,7 @@ export interface Interface {
       directory: AbsolutePath
       branch?: string
       depth?: number
+      nonInteractive?: boolean
     }) => Effect.Effect<Repository, OperationError>
     readonly create: (input: {
       worktree: AbsolutePath
@@ -95,9 +96,13 @@ export interface Interface {
   }
   readonly sync: {
     readonly fetchRemotes: (repository: Repository, input?: { prune?: boolean }) => Effect.Effect<void, OperationError>
+    readonly fetchOrigin: (
+      repository: Repository,
+      input?: { prune?: boolean; nonInteractive?: boolean },
+    ) => Effect.Effect<void, OperationError>
     readonly fetchBranch: (
       repository: Repository,
-      input: { remote?: string; branch: string; force?: boolean },
+      input: { remote?: string; branch: string; force?: boolean; nonInteractive?: boolean },
     ) => Effect.Effect<void, OperationError>
     readonly checkoutRemoteBranch: (
       repository: Repository,
@@ -229,11 +234,12 @@ const layer = Layer.effect(
       operation: OperationError["operation"],
       directory: AbsolutePath,
       args: string[],
+      options?: { nonInteractive?: boolean },
     ) {
       const result = yield* execute(
         directory,
         proc,
-      )(args).pipe(
+      )(args, options).pipe(
         Effect.mapError((cause) => new OperationError({ operation, directory, message: cause.message, cause })),
       )
       if (result.exitCode === 0) return
@@ -249,16 +255,23 @@ const layer = Layer.effect(
       directory: AbsolutePath
       branch?: string
       depth?: number
+      nonInteractive?: boolean
     }) {
-      yield* operation("clone", AbsolutePath.make(path.dirname(input.directory)), [
+      yield* operation(
         "clone",
-        "--depth",
-        String(input.depth ?? 100),
-        ...(input.branch ? ["--branch", input.branch] : []),
-        "--",
-        input.remote,
-        input.directory,
-      ])
+        AbsolutePath.make(path.dirname(input.directory)),
+        [
+          ...(input.nonInteractive ? ["-c", "credential.interactive=false"] : []),
+          "clone",
+          "--depth",
+          String(input.depth ?? 100),
+          ...(input.branch ? ["--branch", input.branch] : []),
+          "--",
+          input.remote,
+          input.directory,
+        ],
+        { nonInteractive: input.nonInteractive },
+      )
       const repository = yield* discover(input.directory)
       if (repository) return repository
       return yield* new OperationError({
@@ -268,20 +281,41 @@ const layer = Layer.effect(
       })
     })
 
-    const fetch = Effect.fn("Git.sync.fetchRemotes")(function* (
-      repository: Repository,
-      input: { prune?: boolean } = {},
-    ) {
+    const fetch = Effect.fn("Git.sync.fetchRemotes")(function* (repository: Repository, input = {}) {
       yield* operation("fetch", repository.worktree, ["fetch", "--all", ...(input.prune === false ? [] : ["--prune"])])
+    })
+
+    const fetchOrigin = Effect.fn("Git.sync.fetchOrigin")(function* (repository: Repository, input = {}) {
+      yield* operation(
+        "fetch",
+        repository.worktree,
+        [
+          ...(input.nonInteractive ? ["-c", "credential.interactive=false"] : []),
+          "fetch",
+          "origin",
+          ...(input.prune === false ? [] : ["--prune"]),
+        ],
+        { nonInteractive: input.nonInteractive },
+      )
     })
 
     const fetchBranch = Effect.fn("Git.sync.fetchBranch")(function* (
       repository: Repository,
-      input: { remote?: string; branch: string; force?: boolean },
+      input: { remote?: string; branch: string; force?: boolean; nonInteractive?: boolean },
     ) {
       const remoteName = input.remote ?? "origin"
       const spec = `refs/heads/${input.branch}:refs/remotes/${remoteName}/${input.branch}`
-      yield* operation("fetch", repository.worktree, ["fetch", remoteName, input.force === false ? spec : `+${spec}`])
+      yield* operation(
+        "fetch",
+        repository.worktree,
+        [
+          ...(input.nonInteractive ? ["-c", "credential.interactive=false"] : []),
+          "fetch",
+          remoteName,
+          input.force === false ? spec : `+${spec}`,
+        ],
+        { nonInteractive: input.nonInteractive },
+      )
     })
 
     const checkout = Effect.fn("Git.sync.checkoutRemoteBranch")(function* (
@@ -689,7 +723,7 @@ const layer = Layer.effect(
       repo: { discover, clone, create },
       remote: { get: remote },
       history: { head, branch, defaultRemoteBranch: remoteHead, rootCommits: roots },
-      sync: { fetchRemotes: fetch, fetchBranch, checkoutRemoteBranch: checkout, resetHard: reset },
+      sync: { fetchRemotes: fetch, fetchOrigin, fetchBranch, checkoutRemoteBranch: checkout, resetHard: reset },
       worktree: { create: worktreeCreate, remove: worktreeRemove, list: worktreeList },
       index: { refresh, ignored },
       tree: {
@@ -717,13 +751,14 @@ function run(cwd: string, proc: AppProcess.Interface) {
 }
 
 function execute(cwd: string, proc: AppProcess.Interface) {
-  return (args: string[]) =>
+  return (args: string[], options?: { nonInteractive?: boolean }) =>
     proc
       .run(
         ChildProcess.make("git", args, {
           cwd,
           extendEnv: true,
           stdin: "ignore",
+          ...(options?.nonInteractive ? { env: { GIT_TERMINAL_PROMPT: "0" } } : {}),
         }),
       )
       .pipe(

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -336,7 +336,8 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: Interface, p
           callback({
             add: (name, source) => draft.add(name, Schema.decodeUnknownSync(Reference.Source)(source)),
             remove: draft.remove,
-            list: draft.list,
+            list: () =>
+              draft.list().map(([name, source]) => [name, Schema.encodeSync(Reference.Source)(source)]),
           })
         }),
     },

--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -1,7 +1,7 @@
 export * as Reference from "./reference.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import { Context, Effect, Layer, Scope, Types } from "effect"
+import { Context, Duration, Effect, Layer, Scope, Types } from "effect"
 import { Reference } from "@opencode-ai/schema/reference"
 import { Global } from "@opencode-ai/util/global"
 import { Bus } from "./bus.js"
@@ -48,6 +48,20 @@ const layer = Layer.effect(
     const cache = yield* RepositoryCache.Service
     const scope = yield* Scope.Scope
     const materialized = new Map<string, Info>()
+    const materialize = (name: string, source: GitSource) => {
+      const repository = Repository.parse(source.repository)
+      if (!repository || !Repository.isRemote(repository)) return Effect.void
+      return cache.ensure({ reference: repository, branch: source.branch, refresh: source.refresh }).pipe(
+        Effect.catchCause((cause) =>
+          Effect.logWarning("failed to materialize reference", {
+            name,
+            repository: source.repository,
+            cause,
+          }),
+        ),
+        Effect.forkIn(scope),
+      )
+    }
     const state = State.create<Data, Draft>({
       name: "reference",
       initial: () => ({ sources: new Map() }),
@@ -75,6 +89,13 @@ const layer = Layer.effect(
             }
             const repository = Repository.parse(source.repository)
             if (!repository || !Repository.isRemote(repository)) continue
+            if (source.refresh !== undefined) {
+              const refresh = Duration.toMillis(source.refresh)
+              if (!Number.isFinite(refresh) || refresh <= 0) {
+                yield* Effect.logWarning("reference refresh must be a finite positive duration", { name })
+                continue
+              }
+            }
             if (source.branch) {
               try {
                 Repository.validateBranch(source.branch)
@@ -92,16 +113,7 @@ const layer = Layer.effect(
                 source,
               }),
             )
-            yield* cache.ensure({ reference: repository, branch: source.branch, refresh: true }).pipe(
-              Effect.catchCause((cause) =>
-                Effect.logWarning("failed to materialize reference", {
-                  name,
-                  repository: source.repository,
-                  cause,
-                }),
-              ),
-              Effect.forkIn(scope),
-            )
+            yield* materialize(name, source)
           }
           yield* bus.publish(Reference.Event.Updated, {})
         }),
@@ -111,6 +123,10 @@ const layer = Layer.effect(
       transform: state.transform,
       reload: state.reload,
       list: Effect.fn("Reference.list")(function* () {
+        yield* Effect.forEach(materialized.entries(), ([name, reference]) => {
+          if (reference.source.type === "local") return Effect.void
+          return materialize(name, reference.source)
+        })
         return Array.from(materialized.values())
       }),
     })

--- a/packages/core/src/repository-cache.ts
+++ b/packages/core/src/repository-cache.ts
@@ -2,11 +2,11 @@
  * Local tracking checkouts for remote Git references, one per remote and
  * branch. Each checkout permanently tracks a single ref: the requested branch
  * when the cache key has one, otherwise the remote default branch. Content
- * follows "newest wins": refresh fetches and hard-resets, so readers may
- * observe the checkout move underneath them.
+ * follows "newest wins": stale checkouts fetch and hard-reset, so
+ * readers may observe the checkout move underneath them.
  */
 import path from "path"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Duration, Effect, Layer, Schema } from "effect"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Git } from "./git.js"
 import { Global } from "@opencode-ai/util/global"
@@ -27,9 +27,12 @@ export type Result = {
 
 export type EnsureInput = {
   readonly reference: Repository.RemoteReference
-  readonly refresh?: boolean
   readonly branch?: string
+  readonly refresh?: Duration.Duration
 }
+
+const refreshAttemptFile = "opencode-reference-refresh-attempt"
+const defaultRefresh = Duration.hours(1)
 
 export class InvalidBranchError extends Schema.TaggedError<InvalidBranchError>()("RepositoryCacheInvalidBranchError", {
   branch: Schema.String,
@@ -121,12 +124,22 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | EffectFl
           const repository = input.reference.label
           const localPath = Repository.cachePath(global.repos, input.reference, input.branch)
           const cloneTarget = Repository.parse(input.reference.remote) ?? input.reference
+          const describe = (status: Result["status"], checkout: Git.Repository) =>
+            Effect.gen(function* () {
+              return {
+                repository,
+                host: input.reference.host,
+                remote: input.reference.remote,
+                localPath,
+                status,
+                head: yield* git.history.head(checkout),
+                branch: yield* git.history.branch(checkout),
+              } satisfies Result
+            })
 
           return yield* flock
             .withLock(
               Effect.gen(function* () {
-                yield* cacheOperation(fs.ensureDir(path.dirname(localPath)), "ensure cache directory", localPath)
-
                 const existing = yield* git.repo.discover(AbsolutePath.make(localPath))
                 const origin = existing ? yield* git.remote.get(existing) : undefined
                 const originReference = origin ? Repository.parse(origin) : undefined
@@ -140,70 +153,55 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | Git.Service | EffectFl
                     originReference &&
                     Repository.same(originReference, cloneTarget),
                 )
+                yield* cacheOperation(fs.ensureDir(path.dirname(localPath)), "ensure cache directory", localPath)
                 if (!reuse && (yield* fs.existsSafe(localPath))) {
                   yield* cacheOperation(fs.remove(localPath, { recursive: true }), "remove stale cache", localPath)
                 }
 
-                const status = !reuse
-                  ? ("cloned" as const)
-                  : input.refresh
-                    ? ("refreshed" as const)
-                    : ("cached" as const)
-
-                if (status === "cloned") {
-                  yield* git.repo
+                if (!reuse) {
+                  const checkout = yield* git.repo
                     .clone({
                       remote: input.reference.remote,
                       directory: AbsolutePath.make(localPath),
                       branch: input.branch,
+                      nonInteractive: true,
                     })
                     .pipe(Effect.mapError((error) => new CloneFailedError({ repository, message: error.message })))
+                  // A successful clone is current, so it starts the refresh interval.
+                  yield* writeRefreshAttempt(fs, checkout.gitDirectory, localPath)
+                  return yield* describe("cloned", checkout)
                 }
 
-                if (status === "refreshed") {
-                  if (!existing)
-                    return yield* new FetchFailedError({ repository, message: "Repository is unavailable" })
+                if (!existing) return yield* new FetchFailedError({ repository, message: "Repository is unavailable" })
+                if (!(yield* isRefreshDue(fs, existing.gitDirectory, input.refresh ?? defaultRefresh)))
+                  return yield* describe("cached", existing)
+
+                // Rate-limit failed background fetches as well as successful ones.
+                yield* writeRefreshAttempt(fs, existing.gitDirectory, localPath)
+                yield* (input.branch
+                  ? git.sync.fetchBranch(existing, { branch: input.branch, nonInteractive: true })
+                  : git.sync.fetchOrigin(existing, { nonInteractive: true })
+                ).pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: error.message })))
+
+                // Checking out the tracked ref before resetting keeps the
+                // checkout self-healing even if it was left on another
+                // branch.
+                const branch = input.branch ?? (yield* git.history.defaultRemoteBranch(existing))
+                if (branch) {
                   yield* git.sync
-                    .fetchRemotes(existing)
-                    .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: error.message })))
-
-                  if (input.branch) {
-                    yield* git.sync
-                      .fetchBranch(existing, { branch: input.branch })
-                      .pipe(Effect.mapError((error) => new FetchFailedError({ repository, message: error.message })))
-                  }
-
-                  // Checking out the tracked ref before resetting keeps the
-                  // checkout self-healing even if it was left on another
-                  // branch.
-                  const branch = input.branch ?? (yield* git.history.defaultRemoteBranch(existing))
-                  if (branch) {
-                    yield* git.sync
-                      .checkoutRemoteBranch(existing, { branch })
-                      .pipe(
-                        Effect.mapError(
-                          (error) => new CheckoutFailedError({ repository, branch, message: error.message }),
-                        ),
-                      )
-                  }
-
-                  const target = branch ?? (yield* git.history.branch(existing))
-                  yield* git.sync
-                    .resetHard(existing, target ? `origin/${target}` : "HEAD")
-                    .pipe(Effect.mapError((error) => new ResetFailedError({ repository, message: error.message })))
+                    .checkoutRemoteBranch(existing, { branch })
+                    .pipe(
+                      Effect.mapError(
+                        (error) => new CheckoutFailedError({ repository, branch, message: error.message }),
+                      ),
+                    )
                 }
 
-                const checkout = yield* git.repo.discover(AbsolutePath.make(localPath))
-
-                return {
-                  repository,
-                  host: input.reference.host,
-                  remote: input.reference.remote,
-                  localPath,
-                  status,
-                  head: checkout ? yield* git.history.head(checkout) : undefined,
-                  branch: checkout ? yield* git.history.branch(checkout) : undefined,
-                } satisfies Result
+                const target = branch ?? (yield* git.history.branch(existing))
+                yield* git.sync
+                  .resetHard(existing, target ? `origin/${target}` : "HEAD")
+                  .pipe(Effect.mapError((error) => new ResetFailedError({ repository, message: error.message })))
+                return yield* describe("refreshed", existing)
               }),
               `repository-cache:${localPath}`,
             )
@@ -230,6 +228,24 @@ function errorMessage(error: unknown) {
 function cacheOperation<A, E, R>(effect: Effect.Effect<A, E, R>, operation: string, target: string) {
   return effect.pipe(
     Effect.mapError((error) => new CacheOperationError({ operation, path: target, message: errorMessage(error) })),
+  )
+}
+
+function isRefreshDue(fs: FSUtil.Interface, gitDirectory: string, refresh: Duration.Duration) {
+  return fs.readFileStringSafe(path.join(gitDirectory, refreshAttemptFile)).pipe(
+    Effect.orElseSucceed(() => undefined),
+    Effect.map((value) => {
+      const refreshed = Number(value)
+      return !Number.isFinite(refreshed) || Date.now() - refreshed >= Duration.toMillis(refresh)
+    }),
+  )
+}
+
+function writeRefreshAttempt(fs: FSUtil.Interface, gitDirectory: string, localPath: string) {
+  return cacheOperation(
+    fs.writeFileString(path.join(gitDirectory, refreshAttemptFile), String(Date.now())),
+    "write refresh attempt",
+    localPath,
   )
 }
 

--- a/packages/core/src/repository.ts
+++ b/packages/core/src/repository.ts
@@ -67,7 +67,7 @@ export function parse(input: string): Reference | undefined {
     return buildRemote({
       host: url.host,
       segments,
-      remote: url.host === "github.com" ? githubRemote(segments.join("/")) : cleaned,
+      remote: url.host === "github.com" && url.protocol !== "ssh:" ? githubRemote(segments.join("/")) : cleaned,
       protocol: url.protocol,
     })
   } catch {

--- a/packages/core/src/v1/config/migrate.ts
+++ b/packages/core/src/v1/config/migrate.ts
@@ -2,6 +2,7 @@ export * as ConfigMigrateV1 from "./migrate.js"
 
 import { Info } from "@opencode-ai/schema/config"
 import { ConfigAgent } from "@opencode-ai/schema/config/agent"
+import { ConfigReference } from "@opencode-ai/schema/config/reference"
 import { Schema } from "effect"
 import { ConfigV1 } from "./config.js"
 import { ConfigAgentV1 } from "./agent.js"
@@ -18,6 +19,7 @@ const decodeInfo = Schema.decodeUnknownSync(Schema.fromJsonString(Info), decodeO
 const encodeInfo = Schema.encodeSync(Info)
 const decodeAgent = Schema.decodeUnknownSync(Schema.fromJsonString(ConfigAgent.Info), decodeOptions)
 const encodeAgent = Schema.encodeSync(ConfigAgent.Info)
+const encodeReference = Schema.encodeSync(ConfigReference.Info)
 export function migrate(info: typeof ConfigV1.Info.Type) {
   return encodeInfo(
     decodeInfo(
@@ -50,7 +52,7 @@ export function migrate(info: typeof ConfigV1.Info.Type) {
         skills: info.skills && [...(info.skills.paths ?? []), ...(info.skills.urls ?? [])],
         commands: commands(info.command),
         instructions: info.instructions,
-        references: info.references ?? info.reference,
+        references: info.references ? encodeReference(info.references) : info.reference ? encodeReference(info.reference) : undefined,
         experimental: experimental(info),
         plugins: info.plugin?.map((plugin) =>
           typeof plugin === "string" ? plugin : { package: plugin[0], options: plugin[1] },

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -1,7 +1,7 @@
 import path from "path"
 import fs from "fs/promises"
 import { describe, expect } from "bun:test"
-import { Effect, Fiber, Layer, Logger, PubSub, Schema, Stream } from "effect"
+import { Effect, Fiber, Layer, Logger, Option, PubSub, Schema, Stream } from "effect"
 import { FastCheck } from "effect/testing"
 import { Config } from "@opencode-ai/core/config"
 import { AgentsDirectory, Directory, Document, Event, Info } from "@opencode-ai/schema/config"
@@ -552,16 +552,31 @@ describe("Config", () => {
   it.effect("migrates arbitrary v1 configuration into valid v2 configuration", () =>
     Effect.sync(() => {
       FastCheck.assert(
-        FastCheck.property(Schema.toArbitrary(ConfigV1.Info)(FastCheck), (info) => {
-          const parsed = Schema.decodeUnknownSync(ConfigV1.Info)(
-            Schema.decodeUnknownSync(Schema.fromJsonString(Schema.Unknown))(
-              Schema.encodeUnknownSync(Schema.fromJsonString(Schema.Unknown))(info),
-            ),
-          )
-          Schema.decodeUnknownSync(Info)(ConfigMigrateV1.migrate(parsed), { errors: "all" })
-        }),
+        FastCheck.property(
+          Schema.toArbitrary(ConfigV1.Info)(FastCheck).filter((info) =>
+            Option.isSome(Schema.encodeUnknownOption(ConfigV1.Info)(info)),
+          ),
+          (info) => {
+            const parsed = Schema.decodeUnknownSync(ConfigV1.Info)(
+              JSON.parse(JSON.stringify(Schema.encodeSync(ConfigV1.Info)(info))),
+            )
+            Schema.decodeUnknownSync(Info)(ConfigMigrateV1.migrate(parsed), { errors: "all" })
+          },
+        ),
         { numRuns: 100 },
       )
+    }),
+  )
+
+  it.effect("migrates v1 Git reference refresh intervals as configuration strings", () =>
+    Effect.sync(() => {
+      const v1 = Schema.decodeUnknownSync(ConfigV1.Info)({
+        references: { effect: { repository: "Effect-TS/effect", refresh: "15 minutes" } },
+      })
+      const migrated = ConfigMigrateV1.migrate(v1)
+
+      expect(Schema.decodeUnknownSync(Info)(migrated).references?.effect).toBeDefined()
+      expect(migrated.references?.effect).toEqual({ repository: "Effect-TS/effect", refresh: "900000 millis" })
     }),
   )
 

--- a/packages/core/test/config/reference.test.ts
+++ b/packages/core/test/config/reference.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test"
+import { Duration, Effect, Layer, Schema } from "effect"
+import { Config } from "@opencode-ai/core/config"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { ConfigReferencePlugin } from "@opencode-ai/core/config/plugin/reference"
+import { Plugin } from "@opencode-ai/core/plugin"
+import { PluginHost } from "@opencode-ai/core/plugin/host"
+import { Reference } from "@opencode-ai/core/reference"
+import { RepositoryCache } from "@opencode-ai/core/repository-cache"
+import { Document, Info } from "@opencode-ai/schema/config"
+import { Global } from "@opencode-ai/util/global"
+import { testEffect } from "../lib/effect"
+import { PluginTestLayer } from "../plugin/fixture"
+
+const decode = Schema.decodeUnknownSync(Info)
+const it = testEffect(PluginTestLayer)
+const referenceLayer = AppNodeBuilder.build(Reference.node, [
+  [RepositoryCache.node, Layer.mock(RepositoryCache.Service, { ensure: () => Effect.never })],
+])
+
+describe("config references", () => {
+  test("decodes Git refresh intervals as durations", () => {
+    const reference = decode({
+      references: { effect: { repository: "Effect-TS/effect", refresh: "15 minutes" } },
+    }).references?.effect
+
+    expect(typeof reference).toBe("object")
+    if (typeof reference !== "object" || !reference || !("repository" in reference)) return
+    expect(reference.refresh).toEqual(Duration.minutes(15))
+  })
+
+  it.effect("converts Git refresh intervals across config and plugin boundaries", () =>
+    Effect.gen(function* () {
+      const plugin = yield* Plugin.Service
+      const references = yield* Reference.Service
+      const host = yield* PluginHost.make(plugin)
+      yield* ConfigReferencePlugin.Plugin.effect(host)
+
+      const reference = (yield* references.list()).find((entry) => entry.name === "effect")
+      if (!reference || reference.source.type !== "git") throw new Error("expected configured Git reference")
+      expect(reference.source.refresh).toEqual(Duration.minutes(15))
+
+      yield* host.reference.transform((draft) => {
+        expect(draft.list()).toContainEqual([
+          "effect",
+          { type: "git", repository: "Effect-TS/effect", refresh: "900000 millis" },
+        ])
+      })
+    }).pipe(
+      Effect.provide(referenceLayer),
+      Effect.provide(
+        Config.testLayer([
+          new Document({
+            type: "document",
+            info: decode({
+              references: { effect: { repository: "Effect-TS/effect", refresh: "15 minutes" } },
+            }),
+          }),
+        ]),
+      ),
+      Effect.provideService(Global.Service, Global.Service.of(Global.make())),
+    ),
+  )
+})

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -6,7 +6,7 @@ import { Effect } from "effect"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Git } from "@opencode-ai/core/git"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
-import { branch, commit, gitRemote } from "./fixture/git"
+import { branch, commit, git, gitRemote } from "./fixture/git"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
@@ -70,6 +70,34 @@ describe("Git", () => {
         yield* git.sync.resetHard(repository, "origin/feature/docs")
         expect(yield* git.history.branch(repository)).toBe("feature/docs")
         expect(yield* read(path.join(target, "README.md"))).toBe("feature\n")
+      }),
+    ),
+  )
+
+  it.live("fetches all remotes by default", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        const service = yield* Git.Service
+        const target = AbsolutePath.make(path.join(fixture.root, "checkout"))
+        const repository = yield* service.repo.clone({ remote: fixture.remote, directory: target })
+        yield* Effect.promise(() => git(target, "remote", "add", "other", path.join(fixture.root, "missing.git")))
+
+        const error = yield* Effect.flip(service.sync.fetchRemotes(repository))
+
+        expect(error.operation).toBe("fetch")
+      }),
+    ),
+  )
+
+  it.live("fetches only origin when requested", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        const service = yield* Git.Service
+        const target = AbsolutePath.make(path.join(fixture.root, "checkout"))
+        const repository = yield* service.repo.clone({ remote: fixture.remote, directory: target })
+        yield* Effect.promise(() => git(target, "remote", "add", "other", path.join(fixture.root, "missing.git")))
+
+        yield* service.sync.fetchOrigin(repository)
       }),
     ),
   )

--- a/packages/core/test/reference.test.ts
+++ b/packages/core/test/reference.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Effect, Exit, Layer, Scope } from "effect"
+import { Duration, Effect, Exit, Layer, Scope } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -10,7 +10,7 @@ import { RepositoryCache } from "@opencode-ai/core/repository-cache"
 import { it } from "./lib/effect"
 
 const cache = Layer.mock(RepositoryCache.Service, {
-  ensure: () => Effect.die("unexpected Git materialization"),
+  ensure: () => Effect.never,
 })
 const referenceLayer = AppNodeBuilder.build(Reference.node, [[RepositoryCache.node, cache]])
 
@@ -37,11 +37,16 @@ describe("Reference", () => {
     }).pipe(Effect.provide(referenceLayer)),
   )
 
-  it.effect("derives Git paths without exposing cache operations", () =>
+  it.effect("derives Git paths while materializing asynchronously", () =>
     Effect.gen(function* () {
       const references = yield* Reference.Service
       const repository = Repository.parseRemote("owner/repo")
-      const source = Reference.GitSource.make({ type: "git", repository: "owner/repo", branch: "main" })
+      const source = Reference.GitSource.make({
+        type: "git",
+        repository: "owner/repo",
+        branch: "main",
+        refresh: Duration.minutes(15),
+      })
       yield* references.transform((editor) => editor.add("sdk", source))
 
       expect(yield* references.list()).toEqual([
@@ -73,6 +78,22 @@ describe("Reference", () => {
           source,
         }),
       ])
+    }).pipe(Effect.scoped, Effect.provide(referenceLayer)),
+  )
+
+  it.effect("rejects non-finite or non-positive Git refresh intervals", () =>
+    Effect.gen(function* () {
+      const references = yield* Reference.Service
+      yield* Effect.forEach([Duration.zero, Duration.infinity], (refresh, index) =>
+        references.transform((editor) =>
+          editor.add(
+            `sdk-${index}`,
+            Reference.GitSource.make({ type: "git", repository: "owner/repo", refresh }),
+          ),
+        ),
+      )
+
+      expect(yield* references.list()).toEqual([])
     }).pipe(Effect.scoped, Effect.provide(referenceLayer)),
   )
 })

--- a/packages/core/test/repository-cache.test.ts
+++ b/packages/core/test/repository-cache.test.ts
@@ -2,13 +2,14 @@ import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
-import { Effect, Layer } from "effect"
+import { Duration, Effect, Layer } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
-import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Git } from "@opencode-ai/core/git"
+import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Global } from "@opencode-ai/util/global"
 import { Repository } from "@opencode-ai/core/repository"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
-import { branch, git, gitRemote } from "./fixture/git"
+import { branch, commit, git, gitRemote } from "./fixture/git"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
@@ -77,13 +78,112 @@ describe("RepositoryCache", () => {
         expect(featured.localPath.endsWith("repo@feature")).toBe(true)
         expect(yield* read(path.join(featured.localPath, "README.md"))).toBe("two\n")
 
-        const refreshed = yield* cache.ensure({ reference: fixture.reference, refresh: true })
+        const refreshed = yield* cache.ensure({ reference: fixture.reference })
         expect(refreshed.localPath).not.toBe(featured.localPath)
         expect(yield* read(path.join(refreshed.localPath, "README.md"))).toBe("one\n")
 
         const cached = yield* cache.ensure({ reference: fixture.reference, branch: "feature" })
         expect(cached.status).toBe("cached")
         expect(yield* read(path.join(cached.localPath, "README.md"))).toBe("two\n")
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("does not refresh a checkout with fresh metadata", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        const cache = yield* RepositoryCache.Service
+        const initial = yield* cache.ensure({ reference: fixture.reference })
+        yield* Effect.promise(() => commit(fixture.source, "two\n", "second"))
+
+        const cached = yield* cache.ensure({ reference: fixture.reference })
+
+        expect(cached.status).toBe("cached")
+        expect(yield* read(path.join(initial.localPath, "README.md"))).toBe("one\n")
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("refreshes an expired checkout from origin", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        const cache = yield* RepositoryCache.Service
+        const initial = yield* cache.ensure({ reference: fixture.reference })
+        yield* Effect.promise(() => commit(fixture.source, "two\n", "second"))
+        yield* Effect.promise(async () => {
+          await git(initial.localPath, "remote", "add", "other", path.join(fixture.root, "missing.git"))
+          await fs.writeFile(refreshAttemptFile(initial.localPath), "0")
+        })
+
+        const refreshed = yield* cache.ensure({ reference: fixture.reference })
+
+        expect(refreshed.status).toBe("refreshed")
+        expect(yield* read(path.join(initial.localPath, "README.md"))).toBe("two\n")
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("uses the configured refresh interval", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        const cache = yield* RepositoryCache.Service
+        const initial = yield* cache.ensure({ reference: fixture.reference })
+        yield* Effect.promise(() => commit(fixture.source, "two\n", "second"))
+        yield* Effect.promise(() => fs.writeFile(refreshAttemptFile(initial.localPath), String(Date.now() - 120_000)))
+
+        const refreshed = yield* cache.ensure({ reference: fixture.reference, refresh: Duration.minutes(1) })
+        expect(refreshed.status).toBe("refreshed")
+        expect(yield* read(path.join(initial.localPath, "README.md"))).toBe("two\n")
+
+        yield* Effect.promise(() => commit(fixture.source, "three\n", "third"))
+        const cached = yield* cache.ensure({ reference: fixture.reference, refresh: Duration.hours(1) })
+        expect(cached.status).toBe("cached")
+        expect(yield* read(path.join(initial.localPath, "README.md"))).toBe("two\n")
+      }).pipe(Effect.provide(cacheLayer(fixture.root))),
+    ),
+  )
+
+  it.live("clones and refreshes SSH remotes with the standard cache policy", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(async () => {
+        const root = await tmpdir()
+        return { root, ...sshCache(root.path) }
+      }),
+      (fixture) =>
+        Effect.gen(function* () {
+          const cache = yield* RepositoryCache.Service
+          expect(fixture.reference.remote).toBe("ssh://git@github.com/owner/repo.git")
+          const cloned = yield* cache.ensure({ reference: fixture.reference })
+          yield* Effect.promise(() => fs.writeFile(refreshAttemptFile(fixture.localPath), "0"))
+
+          const refreshed = yield* cache.ensure({ reference: fixture.reference })
+
+          expect(cloned.status).toBe("cloned")
+          expect(refreshed.status).toBe("refreshed")
+          expect(fixture.cloneRemotes).toEqual([fixture.reference.remote])
+          expect(fixture.fetchRemotes).toEqual([fixture.reference.remote])
+        }).pipe(Effect.provide(fixture.layer)),
+      (fixture) => Effect.promise(() => fixture.root[Symbol.asyncDispose]()),
+    ),
+  )
+
+  it.live("preserves a checkout and rate limits failed refreshes", () =>
+    withRemote((fixture) =>
+      Effect.gen(function* () {
+        const cache = yield* RepositoryCache.Service
+        const initial = yield* cache.ensure({ reference: fixture.reference })
+        const remote = pathToFileURL(path.join(fixture.root, "missing.git")).href
+        yield* Effect.promise(async () => {
+          await git(initial.localPath, "config", "remote.origin.url", remote)
+          await fs.writeFile(refreshAttemptFile(initial.localPath), "0")
+        })
+
+        const error = yield* Effect.flip(cache.ensure({ reference: { ...fixture.reference, remote } }))
+        const cached = yield* cache.ensure({ reference: { ...fixture.reference, remote } })
+
+        expect(error).toBeInstanceOf(RepositoryCache.FetchFailedError)
+        expect(cached.status).toBe("cached")
+        expect(yield* read(path.join(initial.localPath, "README.md"))).toBe("one\n")
       }).pipe(Effect.provide(cacheLayer(fixture.root))),
     ),
   )
@@ -117,6 +217,7 @@ describe("RepositoryCache", () => {
       }).pipe(Effect.provide(cacheLayer(fixture.root))),
     ),
   )
+
 })
 
 function cacheLayer(root: string) {
@@ -147,4 +248,82 @@ function exists(file: string) {
       () => false,
     ),
   )
+}
+
+function refreshAttemptFile(checkout: string) {
+  return path.join(checkout, ".git", "opencode-reference-refresh-attempt")
+}
+
+function sshCache(root: string) {
+  const reference = Repository.parseRemote("ssh://git@github.com/owner/repo.git")
+  const localPath = Repository.cachePath(path.join(root, "repos"), reference)
+  const state: {
+    checkout?: Git.Repository
+    cloneRemotes: string[]
+    fetchRemotes: string[]
+  } = {
+    checkout: undefined,
+    cloneRemotes: [],
+    fetchRemotes: [],
+  }
+  const layer = AppNodeBuilder.build(RepositoryCache.node, [
+    [Global.node, Global.layerWith({ state: path.join(root, "state"), repos: path.join(root, "repos") })],
+    [
+      Git.node,
+      Layer.mock(Git.Service, {
+        repo: {
+          discover: () => Effect.succeed(state.checkout),
+          clone: (input) =>
+            Effect.promise(async () => {
+              expect(input.nonInteractive).toBe(true)
+              state.cloneRemotes.push(input.remote)
+              const checkout = new Git.Repository({
+                worktree: input.directory,
+                gitDirectory: AbsolutePath.make(path.join(input.directory, ".git")),
+                commonDirectory: AbsolutePath.make(path.join(input.directory, ".git")),
+              })
+              await fs.mkdir(checkout.gitDirectory, { recursive: true })
+              state.checkout = checkout
+              return checkout
+            }),
+          create: () => Effect.die("Unexpected repository creation"),
+        },
+        remote: { get: () => Effect.succeed(reference.remote) },
+        history: {
+          head: () => Effect.succeed("head"),
+          branch: () => Effect.succeed("main"),
+          defaultRemoteBranch: () => Effect.succeed("main"),
+          rootCommits: () => Effect.succeed([]),
+        },
+        sync: {
+          fetchRemotes: () => Effect.die("Unexpected fetch all"),
+          fetchOrigin: (_, input) => Effect.sync(() => {
+            expect(input?.nonInteractive).toBe(true)
+            state.fetchRemotes.push(reference.remote)
+          }),
+          fetchBranch: () => Effect.die("Unexpected branch fetch"),
+          checkoutRemoteBranch: () => Effect.void,
+          resetHard: () => Effect.void,
+        },
+        worktree: {
+          create: () => Effect.die("Unexpected worktree creation"),
+          remove: () => Effect.die("Unexpected worktree removal"),
+          list: () => Effect.die("Unexpected worktree listing"),
+        },
+        index: {
+          refresh: () => Effect.die("Unexpected index refresh"),
+          ignored: () => Effect.die("Unexpected index lookup"),
+        },
+        tree: {
+          capture: () => Effect.die("Unexpected tree capture"),
+          write: () => Effect.die("Unexpected tree write"),
+          files: () => Effect.die("Unexpected tree file listing"),
+          diff: () => Effect.die("Unexpected tree diff"),
+          restore: () => Effect.die("Unexpected tree restore"),
+        },
+      }),
+    ],
+  ])
+
+  return { reference, localPath, layer, cloneRemotes: state.cloneRemotes, fetchRemotes: state.fetchRemotes }
 }

--- a/packages/core/test/repository.test.ts
+++ b/packages/core/test/repository.test.ts
@@ -41,6 +41,19 @@ describe("Repository", () => {
     })
   })
 
+  test("preserves SSH GitHub remotes", () => {
+    expect(Repository.parseRemote("ssh://git@github.com/owner/repo.git")).toMatchObject({
+      host: "github.com",
+      path: "owner/repo",
+      remote: "ssh://git@github.com/owner/repo.git",
+    })
+    expect(Repository.parseRemote("git+ssh://git@github.com/owner/repo.git")).toMatchObject({
+      host: "github.com",
+      path: "owner/repo",
+      remote: "ssh://git@github.com/owner/repo.git",
+    })
+  })
+
   test("keeps local file repositories distinct from remote repositories", () => {
     const localPath = path.resolve("repo.git")
     const reference = Repository.parse(pathToFileURL(localPath).href)

--- a/packages/schema/src/config/reference.ts
+++ b/packages/schema/src/config/reference.ts
@@ -6,6 +6,9 @@ import { optional } from "../schema.js"
 export class Git extends Schema.Class<Git>("Config.Reference.Git")({
   repository: Schema.String,
   branch: Schema.String.pipe(optional),
+  refresh: Schema.DurationFromString.pipe(optional).annotate({
+    description: 'Interval between refresh attempts (default: "1 hour")',
+  }),
   description: Schema.String.pipe(optional),
   hidden: Schema.Boolean.pipe(optional),
 }) {}

--- a/packages/schema/src/reference.ts
+++ b/packages/schema/src/reference.ts
@@ -21,6 +21,7 @@ export const GitSource = Schema.Struct({
   type: Schema.Literal("git"),
   repository: Schema.String,
   branch: Schema.String.pipe(optional),
+  refresh: Schema.DurationFromString.pipe(optional),
   description: Schema.String.pipe(optional),
   hidden: Schema.Boolean.pipe(optional),
 }).annotate({ identifier: "Reference.GitSource" })

--- a/packages/www/src/docs/content/config.mdx
+++ b/packages/www/src/docs/content/config.mdx
@@ -408,11 +408,14 @@ context.
     "effect": {
       "repository": "Effect-TS/effect",
       "branch": "main",
+      "refresh": "15 minutes",
     },
   },
 }
 ```
 
+Git references refresh once per hour by default.
+Set `refresh` to a finite positive duration such as `"15 minutes"` to change the interval.
 See the [references guide](/references) for shorthand, visibility, and path resolution.
 
 ### Plugins

--- a/packages/www/src/docs/content/references.mdx
+++ b/packages/www/src/docs/content/references.mdx
@@ -19,6 +19,7 @@ Configure references by alias in `opencode.json` or `opencode.jsonc`:
     "effect": {
       "repository": "Effect-TS/effect",
       "branch": "main",
+      "refresh": "15 minutes",
       "description": "Use for Effect implementation details",
     },
   },
@@ -71,6 +72,7 @@ Git URLs, host/path forms, and SCP-style remotes are supported.
     "effect": {
       "repository": "Effect-TS/effect",
       "branch": "main",
+      "refresh": "15 minutes",
     },
     "internal-sdk": {
       "repository": "git@gitlab.example.com:platform/sdk.git",
@@ -106,15 +108,18 @@ installation, for example, `Effect-TS/effect` is stored at:
 ~/.local/share/opencode/repos/github.com/Effect-TS/effect
 ```
 
-Missing repositories are cloned. Existing checkouts are fetched and reset to
-the requested branch, or to the remote default branch when `branch` is omitted.
-Materialization runs asynchronously when references load or reload, so a new
-reference can appear before its checkout is ready. Clone and refresh failures
-are logged and do not stop other references from loading.
+Missing repositories are cloned. Existing checkouts are refreshed in the
+background at the configured `refresh` interval, which defaults to one hour,
+then reset to the requested branch, or to the remote default branch when
+`branch` is omitted. Failed refresh attempts retain the existing checkout and
+are not retried until the next interval.
+Materialization runs asynchronously when references load, reload, or attach,
+so a new reference can appear before its checkout is ready. Clone and refresh
+failures are logged and do not stop other references from loading.
 
 <Callout type="warning">
-  The cache has one checkout per normalized remote, not one per branch. Do not configure the same repository at multiple
-  branches; only one branch can be exposed. Avoid editing cached checkouts because a refresh resets them.
+  The cache has one checkout per normalized remote and branch. Avoid editing automatically refreshed checkouts because a
+  refresh resets them.
 </Callout>
 
 ## Description and visibility
@@ -160,6 +165,7 @@ applicable edit permission.
 | `path`        | Required | No       | Local directory path                          |
 | `repository`  | No       | Required | Remote Git repository                         |
 | `branch`      | No       | Optional | Branch to fetch and check out                 |
+| `refresh`     | No       | Optional | Interval between refresh attempts (default: 1 hour) |
 | `description` | Optional | Optional | Guidance describing when agents should use it |
 | `hidden`      | Optional | Optional | Hide it from interactive client selectors     |
 


### PR DESCRIPTION
### Issue for this PR

Closes #45562

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Refresh cached remote Git references in the background without blocking reference discovery.
SSH and HTTPS remotes use the same non-interactive system Git path.
Git references can configure a finite positive refresh interval, such as `refresh: "15 minutes"`.
The default remains one hour when `refresh` is omitted.

```text
Configured Git reference
  repository: "owner/repo"
  refresh: "15 minutes"  (optional)
          |
          v
Decode configuration duration
          |
          +-- Zero, negative, or infinite?
          |      |
          |      +-- Log warning and skip reference
          |
          +-- Valid duration
                 |
                 v
        Background RepositoryCache.ensure()
                 |
                 +-- Missing or mismatched checkout
                 |      |
                 |      +-- Clone remote
                 |      +-- Record refresh attempt
                 |
                 +-- Matching checkout, interval not elapsed
                 |      |
                 |      +-- Return cached checkout
                 |
                 +-- Matching checkout, interval elapsed
                        |
                        +-- Fetch remote
                        +-- Checkout tracked branch
                        +-- Hard-reset to origin branch
                        +-- Record refresh attempt
```

Failed clone and refresh attempts are logged and do not block other references.
Failed refreshes use the same per-reference interval before retrying.

### How did you verify your code works?

- `bun test test/config/config.test.ts test/config/reload.test.ts test/config/reference.test.ts test/reference.test.ts test/repository.test.ts test/repository-cache.test.ts` from `packages/core` (60 passing)
- `bun typecheck` from `packages/core`
- Commit hook: `bun turbo typecheck --concurrency=3` (33 packages passing)
- `bun run generate` from `packages/client`

### Screenshots / recordings

N/A, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
