### PR TITLE
test(core): stabilize Windows live I/O fixtures

### DIFF
--- a/packages/core/test/repository-cache.test.ts
+++ b/packages/core/test/repository-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, setDefaultTimeout } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { pathToFileURL } from "url"
@@ -13,6 +13,9 @@ import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(Layer.empty)
+
+// Cold Git setup and cloning can exceed Bun's five-second default on Windows.
+setDefaultTimeout(15_000)
 
 describe("RepositoryCache", () => {
   it.live("replaces a stale cache directory before cloning", () =>

--- a/packages/core/test/session-prompt-hooks.test.ts
+++ b/packages/core/test/session-prompt-hooks.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, setDefaultTimeout } from "bun:test"
 import path from "path"
 import { Deferred, Effect, Fiber, Stream } from "effect"
 import { Bus } from "@opencode-ai/core/bus"
 import { Database } from "@opencode-ai/core/database/database"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
 import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
 import { PluginRuntime } from "@opencode-ai/core/plugin/runtime"
@@ -22,6 +23,9 @@ import { tempGlobalLayer } from "./fixture/global"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
+// These tests include real Location and plugin startup, not just hook callbacks.
+setDefaultTimeout(15_000)
+
 const runtime = PluginRuntime.makeCell()
 const it = testEffect(
   AppNodeBuilder.build(
@@ -36,6 +40,7 @@ const it = testEffect(
     [
       [Bus.node, Bus.configured({ persist: true })],
       [Global.node, tempGlobalLayer],
+      [Watcher.node, Watcher.configured({ enabled: false })],
       [SessionExecution.node, SessionExecution.noopLayer],
       [PluginRuntime.node, PluginRuntime.layerWithCell(runtime)],
     ],


### PR DESCRIPTION
## Why

Windows CI for #45440 exceeded Bun's default five-second watchdog while doing cold local-plugin setup and real Git checkout setup. These tests exercise behavior, not a five-second startup guarantee. Once the watchdog kills a Git subprocess, unfinished Effect work can produce misleading late errors.

## What Changes

- Set a file-local 15-second watchdog for the RepositoryCache and Session prompt-hook integration suites. No global timeout, retry, or skip changes.
- Disable native filesystem watchers only in the prompt-hook fixture. Its plugin files are written before Location initialization, so real initial config discovery, plugin setup, supervisor readiness, and prompt transformation remain exercised without irrelevant native watch subscriptions.
- Preserve every existing assertion, test action, gate, and concurrency check. The cache test still requires one `cloned` result and one `cached` result.

## Scope

Two test files only. No production cache, Git, locking, test-helper, CI configuration, or package changes. Native watcher and config-reload suites remain enabled where they were before.

A broader test-fiber cleanup prototype was discarded because Bun's `onTestFinished` rejects concurrent tests. This patch does not claim to solve that existing test-runner limitation or prove which metadata command failed during Windows CI.

## Verification

```sh
# packages/core
bun run test test/session-prompt-hooks.test.ts test/repository-cache.test.ts --rerun-each 10
bun run test test/repository-cache.test.ts --concurrent --max-concurrency 4 --rerun-each 5
env -u CI bun run test test/filesystem/watcher.test.ts test/config/command.test.ts
CI=true bun run test test/config/config.test.ts --test-name-pattern 'keeps watching a deleted config file'
bun run test
bun typecheck

# worktree root
bun install --frozen-lockfile
bunx prettier --check packages/core/test/repository-cache.test.ts packages/core/test/session-prompt-hooks.test.ts
bunx oxlint packages/core/test/repository-cache.test.ts packages/core/test/session-prompt-hooks.test.ts
git diff --check
git push -u origin windows-test-reliability
```

- Repeated live-I/O suites: 130 passed, 530 assertions; all original behavior assertions retained.
- Concurrent cache suite: 30 passed, 90 assertions across five repetitions with four-way concurrency.
- Native watcher/command coverage: 20 passed, 38 assertions with `CI` unset.
- Config deletion/recreation coverage: 1 passed, 3 assertions with `CI=true`.
- Full Core: 3,697 passed, 39 skipped, 0 failed; 78,516 assertions across 219 files.
- Core typecheck, frozen install, formatting, and whitespace checks passed. Lint reports no errors and one existing unused import warning.
- Normal pre-push checks: all 33 workspace typecheck tasks passed (27 cached); no hooks bypassed.

Local verification is macOS; the Windows CI result is still required. #45440 remains blocked with auto-merge disabled while this separate fix is validated.
