### PR TITLE
refactor(core): share read media types

### DIFF
--- a/packages/core/src/tool/plugin/read.ts
+++ b/packages/core/src/tool/plugin/read.ts
@@ -15,7 +15,6 @@ import { Environment } from "../../environment/index.js"
 
 export const name = "read"
 const FILENAME = "AGENTS.md"
-const SUPPORTED_MEDIA_MIMES = new Set(["image/jpeg", "image/png", "image/gif", "image/webp", "application/pdf"])
 const LocationInput = Schema.Struct({
   path: Schema.String.annotate({ description: "File or directory to read" }),
   offset: ReadToolFileSystem.PageInput.fields.offset.annotate({
@@ -104,7 +103,11 @@ export const Plugin = {
                 Effect.catch(() => Effect.void),
                 Effect.catchDefect(() => Effect.void),
               )
-              if (content.type === "file" && content.encoding === "base64" && !SUPPORTED_MEDIA_MIMES.has(content.mime))
+              if (
+                content.type === "file" &&
+                content.encoding === "base64" &&
+                !ReadToolFileSystem.MEDIA_MIMES.has(content.mime)
+              )
                 return yield* Effect.fail(new ReadToolFileSystem.BinaryFileError({ resource }))
               return content
             }).pipe(

--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -18,7 +18,7 @@ const FIRST_CHUNK = 256 * 1024
 const MAX_LINE_LENGTH = 2_000
 const TREE_BASE = 6
 const MAX_LINE_SUFFIX = `... (line truncated to ${MAX_LINE_LENGTH} chars)`
-const MEDIA_MIMES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf"])
+export const MEDIA_MIMES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf"])
 
 export class BinaryFileError extends Schema.TaggedError<BinaryFileError>()("ReadTool.BinaryFileError", {
   resource: Schema.String,


### PR DESCRIPTION
**Why**

The filesystem reader and read-tool leaf independently declared the same five supported media MIME types. That duplicated policy could drift even though the two validation boundaries intentionally enforce the same media contract.

**What Changes**

- Export the reader's existing `MEDIA_MIMES` policy containing PNG, JPEG, GIF, WebP, and PDF.
- Reuse that set from the read-tool leaf through `ReadToolFileSystem`.
- Keep both checks: the reader still decides which bytes to ingest as media, and the leaf still rejects unsupported base64 results from replacement readers.

**Scope**

This is a behavior-preserving Core refactor. It does not change MIME detection, ingestion limits, media delivery, schemas, Protocol, or generated clients.

**Verification**

```sh
cd packages/core && bun run test test/tool-read-filesystem.test.ts test/tool-read.test.ts
cd packages/core && bun typecheck
bunx prettier --check packages/core/src/tool/read-filesystem.ts packages/core/src/tool/plugin/read.ts
bunx oxlint packages/core/src/tool/read-filesystem.ts packages/core/src/tool/plugin/read.ts
bun run lint:effect-patterns
bun run lint:effect-simplifications
git diff --check origin/v2...HEAD
git push -u origin read-media-types
```

- 37 focused tests passed across both read suites.
- Core typecheck passed; the push hook also passed all 33 workspace typecheck tasks.
- Prettier, Effect simplification checks, and diff whitespace checks passed.
- Oxlint reported 0 errors and 2 pre-existing `consistent-return` warnings in untouched reader functions.
- The repository-wide Effect-pattern scan reports 31 existing findings, including an unchanged `Effect.die` in the reader; this PR adds no matching pattern.
