### PR TITLE
fix(server): reset session status to idle when async prompt fails

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -321,6 +321,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
               sessionID: ctx.params.sessionID,
               error: new NamedError.Unknown({ message: Cause.pretty(cause) }).toObject(),
             })
+            yield* statusSvc.set(ctx.params.sessionID, { type: "idle" }).pipe(Effect.ignore)
           }),
         ),
         Effect.forkIn(scope, { startImmediately: true }),


### PR DESCRIPTION
Fixes #45610

Related to:
- #35472 (status busy after prompt stream closes)
- #45384 (async prompt silent failure)

This PR addresses a specific code path: the error handler in the async prompt handler in packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts. It resets session status to idle when an async prompt fails, complementing the fixes for the related issues above.

## Description
When an async prompt fails, the session status remains stuck in a running state instead of being reset to idle.

## Changes
- Added session status reset to idle in the error handler of the async prompt handler in packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts

## Testing
- Typecheck passes
- Existing tests pass
