### PR TITLE
refactor(core): reuse formatter executable helper

### DIFF
--- a/packages/core/src/formatter/builtins.ts
+++ b/packages/core/src/formatter/builtins.ts
@@ -35,23 +35,14 @@ export function make(input: {
       )
       .pipe(Effect.option)
 
-  const gofmt: Info = {
-    name: "gofmt",
-    extensions: [".go"],
-    enabled: Effect.sync(() => {
-      const match = findExecutable("gofmt")
-      return match ? [match, "-w", "$FILE"] : disabled
-    }),
-  }
+  const gofmt = executable("gofmt", [".go"], ["-w", "$FILE"], findExecutable)
 
-  const mix: Info = {
-    name: "mix",
-    extensions: [".ex", ".exs", ".eex", ".heex", ".leex", ".neex", ".sface"],
-    enabled: Effect.sync(() => {
-      const match = findExecutable("mix")
-      return match ? [match, "format", "$FILE"] : disabled
-    }),
-  }
+  const mix = executable(
+    "mix",
+    [".ex", ".exs", ".eex", ".heex", ".leex", ".neex", ".sface"],
+    ["format", "$FILE"],
+    findExecutable,
+  )
 
   const prettier: Info = {
     name: "prettier",
@@ -147,14 +138,7 @@ export function make(input: {
     }).pipe(Effect.orElseSucceed(() => disabled)),
   }
 
-  const zig: Info = {
-    name: "zig",
-    extensions: [".zig", ".zon"],
-    enabled: Effect.sync(() => {
-      const match = findExecutable("zig")
-      return match ? [match, "fmt", "$FILE"] : disabled
-    }),
-  }
+  const zig = executable("zig", [".zig", ".zon"], ["fmt", "$FILE"], findExecutable)
 
   const clang: Info = {
     name: "clang-format",
@@ -166,14 +150,7 @@ export function make(input: {
     }).pipe(Effect.orElseSucceed(() => disabled)),
   }
 
-  const ktlint: Info = {
-    name: "ktlint",
-    extensions: [".kt", ".kts"],
-    enabled: Effect.sync(() => {
-      const match = findExecutable("ktlint")
-      return match ? [match, "-F", "$FILE"] : disabled
-    }),
-  }
+  const ktlint = executable("ktlint", [".kt", ".kts"], ["-F", "$FILE"], findExecutable)
 
   const ruff: Info = {
     name: "ruff",


### PR DESCRIPTION
**Why**

Four builtin formatter definitions duplicated the same deferred executable lookup and command construction already owned by the private `executable` helper. Reusing that helper keeps the definitions aligned without changing formatter behavior.

**What Changes**

Route `gofmt`, `mix`, `zig`, and `ktlint` through `executable`, preserving their names, extension lists, arguments, registration order, managed binary lookup, and lazy resolution.

**Scope**

This is limited to those four formatter definitions. Config-aware and command-probing formatters remain unchanged.

**Verification**

```sh
cd packages/core
bun run test test/formatter.test.ts
bun typecheck

cd ../..
bun run lint -- packages/core/src/formatter/builtins.ts
bunx prettier --check packages/core/src/formatter/builtins.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/formatter/builtins.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/formatter/builtins.ts
git diff --check origin/v2...HEAD
```

The formatter suite passed 7 tests, Core typecheck passed, and all scoped static checks passed. The normal push hook also completed the repository typecheck with 33/33 tasks successful. A repository-wide effect-pattern scan reports 31 existing diagnostics outside the changed file; the scoped scan above is clean.