### PR TITLE
refactor(core): reuse read newline locator

### DIFF
--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -361,12 +361,8 @@ const textOffset = (tree: TextNode, newline: number) => {
     if (!child) return tree.summary.bytes
     node = child
   }
-  for (const [index, byte] of node.bytes.entries()) {
-    if (byte !== 10) continue
-    remaining--
-    if (remaining === 0) return offset + index + 1
-  }
-  return tree.summary.bytes
+  const end = nthNewline(node.bytes, remaining)
+  return end === undefined ? tree.summary.bytes : offset + end
 }
 
 const nthNewline = (bytes: Uint8Array, count: number) => {

--- a/packages/core/test/tool-read-filesystem.test.ts
+++ b/packages/core/test/tool-read-filesystem.test.ts
@@ -257,6 +257,21 @@ describe("ReadToolFileSystem", () => {
     }),
   )
 
+  it.effect("reads after a newline at the first chunk boundary", () =>
+    Effect.gen(function* () {
+      const { environment, files, directory } = yield* fixture
+      const file = path.join(directory, "boundary.txt")
+      yield* files.writeFileString(file, `${"a".repeat(256 * 1024 - 1)}\nsecond\n`)
+
+      const result = yield* ReadToolFileSystem.read(environment, absolute(file), "boundary.txt", {
+        offset: 2,
+        limit: 1,
+      })
+
+      expect(result).toMatchObject({ type: "text-page", content: "second", offset: 2, truncated: false })
+    }),
+  )
+
   it.effect("preserves the media ingestion limit message", () =>
     Effect.gen(function* () {
       const { environment, files, directory } = yield* fixture


### PR DESCRIPTION
**Why**

The multi-chunk text reader duplicated the adjacent helper’s logic for locating the nth LF within a selected leaf. Reusing the existing locator keeps the private byte-offset policy in one place without changing paging behavior.

**What Changes**

- Delegate the terminal leaf scan in `textOffset` to `nthNewline`.
- Preserve the accumulated subtree offset for found newlines and the whole-tree byte fallback when none is found.
- Cover an LF exactly at the 256 KiB chunk boundary through the real filesystem reader.

**Scope**

This is a private Core reader refactor. Input schemas, paging defaults and budgets, UTF-8/CRLF handling, NUL/media handling, spans, and public contracts are unchanged.

**Verification**

```sh
(cd packages/core && bun run test test/tool-read-filesystem.test.ts test/tool-read.test.ts)
(cd packages/core && bun typecheck)
bunx prettier --check packages/core/src/tool/read-filesystem.ts packages/core/test/tool-read-filesystem.test.ts
bunx oxlint packages/core/src/tool/read-filesystem.ts packages/core/test/tool-read-filesystem.test.ts
bun run lint:effect-simplifications
./.husky/pre-push
git diff --check
```

The two reader suites pass with 38 tests, package and pre-push typechecks pass, formatting and Effect simplification checks pass, and oxlint reports zero errors with two pre-existing `consistent-return` warnings. The broader `lint:effect-patterns` scan remains blocked by 31 baseline diagnostics; its focused reader scan reports only the pre-existing `Effect.die(string)` at line 165.