### PR TITLE
refactor(core): remove unreachable permission branch

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -170,7 +170,7 @@ const layer = Layer.effect(
       if (denied(input, rules)) return { effect: "deny" as const, rules }
       const all = [...rules, ...(yield* savedRules())]
       const effects = input.resources.map((resource) => evaluate(input.action, resource, all).effect)
-      const effect: Permission.Effect = effects.includes("deny") ? "deny" : effects.includes("ask") ? "ask" : "allow"
+      const effect: Permission.Effect = effects.includes("ask") ? "ask" : "allow"
       const event = yield* hooks.trigger("permission", "evaluate", {
         sessionID: input.sessionID,
         agent: input.agent,


### PR DESCRIPTION
**Why**
Permission evaluation already returns immediately when configured rules deny any requested resource, and saved rules can only add allows. Rechecking for deny in the later pre-hook aggregate is therefore dead code that obscures the two-stage permission flow. This is a readability cleanup, not a repaired authorization bug.

**What Changes**
- Derive the pre-hook aggregate from its only reachable outcomes: `ask` or `allow`.
- Preserve the configured-deny gate and the post-hook deny handling unchanged.

**Scope**
This PR changes one expression in Core permission evaluation. Permission policy, saved grants, hook dispatch, public effect types, and assertion behavior are unchanged.

**Verification**
```sh
cd packages/core
bun run test test/permission.test.ts  # 104 pass
bun typecheck

cd ../..
bunx prettier --check packages/core/src/permission.ts
bunx oxlint packages/core/src/permission.ts  # 0 errors; 3 warnings on unchanged lines
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/permission.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/permission.ts
git diff --check
git push -u origin permission-deny-branch  # pre-push typecheck: 33/33 successful
```
