### PR TITLE
refactor(core): use word casing for MCP namespaces

### DIFF
--- a/.changeset/mcp-word-case.md
+++ b/.changeset/mcp-word-case.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": major
+---
+
+Treat MCP as a word in current Core namespace exports: rename `MCP` to `Mcp`, `MCPClient` to `McpClient`, `MCPStdio` to `McpStdio`, `MCPOAuth` to `McpOAuth`, `ConfigMCPPlugin` to `ConfigMcpPlugin`, and `MCPCodeModeExclusionPlugin` to `McpCodeModeExclusionPlugin`. Direct consumers must update their imports. Module paths, Schema contracts, runtime service keys, error tags, and behavior are unchanged.

--- a/packages/core/src/config/plugin/mcp.ts
+++ b/packages/core/src/config/plugin/mcp.ts
@@ -1,11 +1,11 @@
-export * as ConfigMCPPlugin from "./mcp.js"
+export * as ConfigMcpPlugin from "./mcp.js"
 
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Document, type Entry } from "@opencode-ai/schema/config"
-import { Mcp } from "@opencode-ai/schema/mcp"
+import type { ServerConfig } from "@opencode-ai/schema/mcp"
 import { Effect, Stream } from "effect"
 import { Config } from "../../config.js"
-import { MCP } from "../../mcp/index.js"
+import { Mcp } from "../../mcp/index.js"
 
 export const Plugin = define({
   id: "opencode.config.mcp",
@@ -18,7 +18,7 @@ export const register = Effect.fn("ConfigMCPPlugin.register")(function* (
   events: Stream.Stream<{ readonly type: string }, unknown>,
 ) {
   const config = yield* Config.Service
-  const mcp = yield* MCP.Service
+  const mcp = yield* Mcp.Service
   const loaded = { entries: [] as Entry[] }
 
   yield* events.pipe(
@@ -43,7 +43,7 @@ export const register = Effect.fn("ConfigMCPPlugin.register")(function* (
       {},
       ...documents.flatMap((entry) => (entry.info.mcp?.timeout ? [entry.info.mcp.timeout] : [])),
     )
-    const servers = new Map<string, Mcp.ServerConfig>()
+    const servers = new Map<string, ServerConfig>()
     for (const document of documents) {
       for (const [name, server] of Object.entries(document.info.mcp?.servers ?? {})) {
         servers.set(name, { ...server, timeout: { ...timeout, ...server.timeout } })

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -23,7 +23,7 @@ import { Location } from "./location.js"
 import { LocationMutation } from "./location-mutation.js"
 import { LocationServiceMap } from "./location-service-map.js"
 import { ModelResolver } from "./model-resolver.js"
-import { MCP } from "./mcp/index.js"
+import { Mcp } from "./mcp/index.js"
 import { Permission } from "./permission.js"
 import { Plugin } from "./plugin.js"
 import { PluginHooks } from "./plugin/hooks.js"
@@ -84,7 +84,7 @@ const locationServiceNodes = [
   LocationMutation.node,
   FileMutation.node,
   Formatter.node,
-  MCP.node,
+  Mcp.node,
   Permission.node,
   Tool.node,
   ToolOutput.node,

--- a/packages/core/src/mcp/client.ts
+++ b/packages/core/src/mcp/client.ts
@@ -1,4 +1,4 @@
-export * as MCPClient from "./client.js"
+export * as McpClient from "./client.js"
 
 import path from "node:path"
 import { pathToFileURL } from "node:url"
@@ -29,7 +29,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js"
 import { Cause, Effect, Exit, Schema } from "effect"
 import { ConfigMCP } from "@opencode-ai/schema/config/mcp"
-import { MCPStdio } from "./stdio.js"
+import { McpStdio } from "./stdio.js"
 
 const DEFAULT_STARTUP_TIMEOUT = 30_000
 const DEFAULT_CATALOG_TIMEOUT = 30_000
@@ -222,7 +222,7 @@ export const connect = Effect.fnUntraced(function* (
   const exit = yield* Effect.gen(function* () {
     if (config.type === "local") {
       const [command, ...args] = config.command
-      const transport = yield* MCPStdio.make({
+      const transport = yield* McpStdio.make({
         server,
         command,
         args,

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,4 +1,4 @@
-export * as MCP from "./index.js"
+export * as Mcp from "./index.js"
 
 import { Mcp } from "@opencode-ai/schema/mcp"
 import { McpEvent } from "@opencode-ai/schema/mcp-event"
@@ -16,7 +16,7 @@ import { KeyedMutex } from "../effect/keyed-mutex.js"
 import { Location } from "../location.js"
 import { waitForAbort } from "@opencode-ai/util/process"
 import { State } from "../state.js"
-import type { MCPClient } from "./client.js"
+import type { McpClient } from "./client.js"
 
 export const ServerName = Schema.String.pipe(Schema.brand("MCP.ServerName"))
 export const PromptsChanged = ephemeral({ type: "mcp.prompts.changed", schema: { server: Schema.String } })
@@ -114,7 +114,7 @@ type ServerEntry = {
   status: Status
   readonly startup: Latch.Latch
   scope?: Scope.Closeable
-  client?: MCPClient.Connection
+  client?: McpClient.Connection
   tools?: ReadonlyArray<Tool>
   prompts?: ReadonlyArray<Prompt>
   // Set when a remote server is registered as an OAuth integration; the credential lives in the global store.
@@ -235,8 +235,8 @@ export const layer = (options?: Options) =>
               method: { id: methodID, type: "oauth", label: name },
               authorize: () =>
                 Effect.gen(function* () {
-                  const { MCPOAuth } = yield* Effect.promise(() => import("./oauth.js"))
-                  return yield* MCPOAuth.authorize({ name, config: remote, methodID })
+                  const { McpOAuth } = yield* Effect.promise(() => import("./oauth.js"))
+                  return yield* McpOAuth.authorize({ name, config: remote, methodID })
                 }),
             })
           })
@@ -254,7 +254,7 @@ export const layer = (options?: Options) =>
       // opens a browser, so an auth-gated connect ends in UnauthorizedError -> needs_auth rather than a redirect.
       const connectProvider = Effect.fnUntraced(function* (entry: ServerEntry) {
         if (entry.config.type !== "remote" || !entry.integrationID) return undefined
-        const { MCPOAuth } = yield* Effect.promise(() => import("./oauth.js"))
+        const { McpOAuth } = yield* Effect.promise(() => import("./oauth.js"))
         const remote = entry.config
         const oauth = remote.oauth || undefined
         const base = {
@@ -270,7 +270,7 @@ export const layer = (options?: Options) =>
           // ends in UnauthorizedError -> needs_auth. Returning no provider instead would let the transport throw
           // a raw HTTP error, hiding the auth requirement behind a generic failed status. Anonymous servers are
           // unaffected: tokens() returns undefined, so no auth header is sent and the SDK never calls auth().
-          return MCPOAuth.provider({ ...base, store: MCPOAuth.memoryStore() })
+          return McpOAuth.provider({ ...base, store: McpOAuth.memoryStore() })
         const credentialID = found.id
         const methodID = found.value.methodID
         const integrationID = entry.integrationID
@@ -282,7 +282,7 @@ export const layer = (options?: Options) =>
           const match = stored.find((credential) => credential.id === credentialID)
           return match && match.value.type === "oauth" ? match.value : undefined
         }
-        return MCPOAuth.provider({
+        return McpOAuth.provider({
           ...base,
           // Drop a credential the SDK rejected so the next connect cleanly reports needs_auth — but only if it is
           // still the stored one. Rotating servers hand out a fresh refresh token per use, so a concurrent
@@ -303,22 +303,22 @@ export const layer = (options?: Options) =>
               const oauth = await readOAuthCredential()
               if (!oauth) return undefined
               presented = oauth.refresh
-              return MCPOAuth.toTokens(oauth)
+              return McpOAuth.toTokens(oauth)
             },
             saveTokens: async (tokens) => {
               const previous = await readOAuthCredential()
-              const value = MCPOAuth.toCredential({
+              const value = McpOAuth.toCredential({
                 methodID,
                 serverUrl: remote.url,
                 tokens,
-                client: previous ? MCPOAuth.clientFromCredential(previous) : undefined,
+                client: previous ? McpOAuth.clientFromCredential(previous) : undefined,
               })
               presented = value.refresh
               await Effect.runPromise(credentials.update(credentialID, { value }))
             },
             clientInformation: async () => {
               const oauth = await readOAuthCredential()
-              return oauth ? MCPOAuth.clientFromCredential(oauth) : undefined
+              return oauth ? McpOAuth.clientFromCredential(oauth) : undefined
             },
             saveClientInformation: async () => {},
             codeVerifier: async () => undefined,
@@ -330,7 +330,7 @@ export const layer = (options?: Options) =>
       const elicitation = {
         create: (input: {
           readonly server: string
-          readonly params: MCPClient.ElicitationParams
+          readonly params: McpClient.ElicitationParams
           readonly signal: AbortSignal
         }) =>
           Effect.gen(function* () {
@@ -355,7 +355,7 @@ export const layer = (options?: Options) =>
                   Effect.raceFirst(waitForAbort(input.signal)),
                   Effect.ensuring(Effect.sync(() => urlElicitations.delete(key))),
                   Effect.map(
-                    (state): MCPClient.ElicitationResult => ({
+                    (state): McpClient.ElicitationResult => ({
                       action: state.status === "answered" ? "accept" : "cancel",
                     }),
                   ),
@@ -375,13 +375,13 @@ export const layer = (options?: Options) =>
               })
               .pipe(
                 Effect.raceFirst(waitForAbort(input.signal)),
-                Effect.map((state): MCPClient.ElicitationResult => {
+                Effect.map((state): McpClient.ElicitationResult => {
                   if (state.status !== "answered") return { action: "cancel" }
                   return {
                     action: "accept",
                     content: Object.fromEntries(
                       Object.entries(state.answer).map(
-                        ([key, value]): [string, NonNullable<MCPClient.ElicitationResult["content"]>[string]] =>
+                        ([key, value]): [string, NonNullable<McpClient.ElicitationResult["content"]>[string]] =>
                           typeof value === "object" ? [key, Array.from(value)] : [key, value],
                       ),
                     ),
@@ -395,9 +395,9 @@ export const layer = (options?: Options) =>
             if (!formID) return
             yield* forms.reply({ id: formID, answer: { [URL_ELICITATION_FIELD_KEY]: true } }).pipe(Effect.ignore)
           }),
-      } satisfies MCPClient.ElicitationHandler
+      } satisfies McpClient.ElicitationHandler
 
-      const toTool = (server: ServerName, entry: ServerEntry, def: MCPClient.ToolDefinition) =>
+      const toTool = (server: ServerName, entry: ServerEntry, def: McpClient.ToolDefinition) =>
         new Tool({
           server,
           name: def.name,
@@ -407,7 +407,7 @@ export const layer = (options?: Options) =>
           outputSchema: def.outputSchema,
         })
 
-      const toPrompt = (server: ServerName, def: MCPClient.PromptDefinition) =>
+      const toPrompt = (server: ServerName, def: McpClient.PromptDefinition) =>
         new Prompt({
           server,
           name: def.name,
@@ -422,7 +422,7 @@ export const layer = (options?: Options) =>
           ),
         })
 
-      const toResource = (server: ServerName, def: MCPClient.ResourceDefinition) =>
+      const toResource = (server: ServerName, def: McpClient.ResourceDefinition) =>
         Resource.make({
           server,
           name: def.name,
@@ -431,7 +431,7 @@ export const layer = (options?: Options) =>
           mimeType: def.mimeType,
         })
 
-      const toResourceTemplate = (server: ServerName, def: MCPClient.ResourceTemplateDefinition) =>
+      const toResourceTemplate = (server: ServerName, def: McpClient.ResourceTemplateDefinition) =>
         ResourceTemplate.make({
           server,
           name: def.name,
@@ -440,14 +440,14 @@ export const layer = (options?: Options) =>
           mimeType: def.mimeType,
         })
 
-      const refreshTools = (name: ServerName, entry: ServerEntry, connection: MCPClient.Connection) =>
+      const refreshTools = (name: ServerName, entry: ServerEntry, connection: McpClient.Connection) =>
         connection.tools().pipe(
           Effect.map((defs) => {
             entry.tools = defs.map((def) => toTool(name, entry, def))
           }),
         )
 
-      const refreshPrompts = (name: ServerName, entry: ServerEntry, connection: MCPClient.Connection) =>
+      const refreshPrompts = (name: ServerName, entry: ServerEntry, connection: McpClient.Connection) =>
         connection.prompts().pipe(
           Effect.orElseSucceed(() => []),
           Effect.map((defs) => {
@@ -459,7 +459,7 @@ export const layer = (options?: Options) =>
       // Runs a connection callback under the server lock, dropping it if the connection is no longer
       // the entry's live client, so late SDK callbacks cannot commit obsolete state.
       const whenLive =
-        (name: ServerName, entry: ServerEntry, connection: MCPClient.Connection) =>
+        (name: ServerName, entry: ServerEntry, connection: McpClient.Connection) =>
         <E>(effect: Effect.Effect<void, E>) =>
           fork(
             Effect.suspend(() => (entry.client === connection ? effect : Effect.void)).pipe(
@@ -468,7 +468,7 @@ export const layer = (options?: Options) =>
             ),
           )
 
-      const watch = (name: ServerName, entry: ServerEntry, connection: MCPClient.Connection) => {
+      const watch = (name: ServerName, entry: ServerEntry, connection: McpClient.Connection) => {
         const live = whenLive(name, entry, connection)
         connection.onClose(() =>
           live(
@@ -491,7 +491,7 @@ export const layer = (options?: Options) =>
         connection.onResourcesChanged(() => live(bus.publish(McpEvent.ResourcesChanged, { server: name })))
       }
 
-      const serverLog = (server: ServerName, message: MCPClient.LogMessage) => {
+      const serverLog = (server: ServerName, message: McpClient.LogMessage) => {
         const fields = { server, logger: message.logger, level: message.level, data: message.data }
         switch (message.level) {
           case "debug":
@@ -518,10 +518,10 @@ export const layer = (options?: Options) =>
           const scope = yield* Scope.fork(root)
           entry.scope = scope
           const authProvider = yield* connectProvider(entry)
-          const { MCPClient } = yield* Effect.promise(() => import("./client.js"))
+          const { McpClient } = yield* Effect.promise(() => import("./client.js"))
           // List tools as part of connect so a failure here marks the server failed rather than
           // leaving it connected with a silently empty tool list and no path to recover.
-          const result = yield* MCPClient.connect(
+          const result = yield* McpClient.connect(
             name,
             entry.config,
             location.directory,
@@ -555,7 +555,7 @@ export const layer = (options?: Options) =>
           entry.scope = undefined
           const error = Cause.squash(result.cause)
           entry.status =
-            error instanceof MCPClient.NeedsAuthError
+            error instanceof McpClient.NeedsAuthError
               ? { status: "needs_auth" }
               : { status: "failed", error: error instanceof Error ? error.message : String(error) }
           yield* Effect.logWarning("mcp connect failed", { server: name, status: entry.status })
@@ -938,4 +938,4 @@ function toElicitationField(key: string, property: ElicitationProperty, required
   }
 }
 
-type ElicitationProperty = MCPClient.ElicitationFormParams["requestedSchema"]["properties"][string]
+type ElicitationProperty = McpClient.ElicitationFormParams["requestedSchema"]["properties"][string]

--- a/packages/core/src/mcp/instructions.ts
+++ b/packages/core/src/mcp/instructions.ts
@@ -5,7 +5,7 @@ import { Context, Effect, Layer, Schema } from "effect"
 import { Agent } from "../agent.js"
 import { Permission } from "../permission.js"
 import { McpTool } from "../tool/mcp.js"
-import { MCP } from "./index.js"
+import { Mcp } from "./index.js"
 import { Instructions } from "../instructions/index.js"
 
 const Summary = Schema.Struct({
@@ -63,7 +63,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Mc
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const mcp = yield* MCP.Service
+    const mcp = yield* Mcp.Service
 
     return Service.of({
       load: Effect.fn("McpInstructions.load")(function* (selection) {
@@ -110,4 +110,4 @@ export const layer = Layer.effect(
   }),
 )
 
-export const node = makeLocationNode({ service: Service, layer, deps: [MCP.node] })
+export const node = makeLocationNode({ service: Service, layer, deps: [Mcp.node] })

--- a/packages/core/src/mcp/oauth.ts
+++ b/packages/core/src/mcp/oauth.ts
@@ -1,4 +1,4 @@
-export * as MCPOAuth from "./oauth.js"
+export * as McpOAuth from "./oauth.js"
 
 import { auth, type OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"

--- a/packages/core/src/mcp/stdio.ts
+++ b/packages/core/src/mcp/stdio.ts
@@ -1,4 +1,4 @@
-export * as MCPStdio from "./stdio.js"
+export * as McpStdio from "./stdio.js"
 
 import { ReadBuffer, serializeMessage } from "@modelcontextprotocol/sdk/shared/stdio.js"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -13,7 +13,7 @@ import { Command } from "./command.js"
 import { Bus } from "./bus.js"
 import { Integration } from "./integration.js"
 import { KV } from "./kv.js"
-import { MCP } from "./mcp/index.js"
+import { Mcp } from "./mcp/index.js"
 import { Location } from "./location.js"
 import { PluginHost } from "./plugin/host.js"
 import { PluginRuntime } from "./plugin/runtime.js"
@@ -197,7 +197,7 @@ export const node = makeLocationNode({
     Command.node,
     Integration.node,
     KV.node,
-    MCP.node,
+    Mcp.node,
     Location.node,
     Reference.node,
     Skill.node,

--- a/packages/core/src/plugin/command.ts
+++ b/packages/core/src/plugin/command.ts
@@ -4,7 +4,7 @@ import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect, Stream } from "effect"
 import { Bus } from "../bus.js"
 import { Location } from "../location.js"
-import { MCP } from "../mcp/index.js"
+import { Mcp } from "../mcp/index.js"
 import PROMPT_INITIALIZE from "./command/initialize.txt"
 import PROMPT_REVIEW from "./command/review.txt"
 
@@ -12,20 +12,18 @@ export const Plugin = define({
   id: "opencode.command",
   effect: Effect.fn(function* (ctx) {
     const location = yield* Location.Service
-    const mcp = yield* MCP.Service
+    const mcp = yield* Mcp.Service
     const bus = yield* Bus.Service
-    const loaded = { prompts: [] as MCP.Prompt[] }
-    yield* bus
-      .subscribe(MCP.PromptsChanged)
-      .pipe(
-        Stream.runForEach(() =>
-          mcp.prompts().pipe(
-            Effect.tap((prompts) => Effect.sync(() => (loaded.prompts = prompts))),
-            Effect.andThen(ctx.command.reload()),
-          ),
+    const loaded = { prompts: [] as Mcp.Prompt[] }
+    yield* bus.subscribe(Mcp.PromptsChanged).pipe(
+      Stream.runForEach(() =>
+        mcp.prompts().pipe(
+          Effect.tap((prompts) => Effect.sync(() => (loaded.prompts = prompts))),
+          Effect.andThen(ctx.command.reload()),
         ),
-        Effect.forkScoped({ startImmediately: true }),
-      )
+      ),
+      Effect.forkScoped({ startImmediately: true }),
+    )
     loaded.prompts = yield* mcp.prompts()
     yield* ctx.command.transform((draft) => {
       draft.add({

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -3,7 +3,7 @@ export * as PluginHost from "./host.js"
 import { Plugin } from "@opencode-ai/plugin/effect"
 import type { IntegrationMethodRegistration } from "@opencode-ai/plugin/effect/integration"
 import { EventManifest } from "@opencode-ai/schema/event-manifest"
-import { Mcp } from "@opencode-ai/schema/mcp"
+import { ServerConfig } from "@opencode-ai/schema/mcp"
 import { App } from "../app.js"
 import { Effect, Schema, Stream } from "effect"
 import { Agent } from "../agent.js"
@@ -16,7 +16,7 @@ import { Integration } from "../integration.js"
 import { KV } from "../kv.js"
 import { Location } from "../location.js"
 import { Model } from "../model.js"
-import { MCP } from "../mcp/index.js"
+import { Mcp } from "../mcp/index.js"
 import { PluginRuntime } from "./runtime.js"
 import { Provider } from "../provider.js"
 import { Reference } from "../reference.js"
@@ -41,7 +41,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: Interface, p
   const bus = yield* Bus.Service
   const integration = yield* Integration.Service
   const kv = yield* KV.Service
-  const mcp = yield* MCP.Service
+  const mcp = yield* Mcp.Service
   const location = yield* Location.Service
   const reference = yield* Reference.Service
   const skill = yield* Skill.Service
@@ -295,7 +295,7 @@ export const make = Effect.fn("PluginHost.make")(function* (plugin: Interface, p
           callback({
             list: () => draft.list().map(([name, config]) => [name, mutable(config)]),
             get: (name) => mutable(draft.get(name)),
-            set: (name, config) => draft.set(name, Schema.decodeUnknownSync(Mcp.ServerConfig)(config)),
+            set: (name, config) => draft.set(name, Schema.decodeUnknownSync(ServerConfig)(config)),
             update: draft.update,
             remove: draft.remove,
           })

--- a/packages/core/src/plugin/internal.ts
+++ b/packages/core/src/plugin/internal.ts
@@ -18,7 +18,7 @@ import { ConfigFormatterPlugin } from "../config/plugin/formatter.js"
 import { ConfigImagePlugin } from "../config/plugin/image.js"
 import { ConfigInstructionPlugin } from "../config/plugin/instruction.js"
 import { ConfigLocationWatcherPlugin } from "../config/plugin/location-watcher.js"
-import { ConfigMCPPlugin } from "../config/plugin/mcp.js"
+import { ConfigMcpPlugin } from "../config/plugin/mcp.js"
 import { ConfigProviderPlugin } from "../config/plugin/provider.js"
 import { ConfigPolicyPlugin } from "../config/plugin/policy.js"
 import { ConfigReferencePlugin } from "../config/plugin/reference.js"
@@ -44,7 +44,7 @@ import { KV } from "../kv.js"
 import { Location } from "../location.js"
 import { LocationMutation } from "../location-mutation.js"
 import { ModelsDev } from "../models-dev.js"
-import { MCP } from "../mcp/index.js"
+import { Mcp } from "../mcp/index.js"
 import { Npm } from "@opencode-ai/util/npm"
 import { Permission } from "../permission.js"
 import { Reference } from "../reference.js"
@@ -78,7 +78,7 @@ import { AgentPlugin } from "./agent.js"
 import { CommandPlugin } from "./command.js"
 import { PlanPlugin } from "./plan.js"
 import { ModelsDevPlugin } from "./models-dev.js"
-import { MCPCodeModeExclusionPlugin } from "./mcp-codemode-exclusion.js"
+import { McpCodeModeExclusionPlugin } from "./mcp-codemode-exclusion.js"
 import { ProviderPlugins } from "./provider.js"
 import { WebSearchPlugins } from "./websearch/index.js"
 import { PluginRuntime } from "./runtime.js"
@@ -114,7 +114,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
   const location = yield* Location.Service
   const locationMutation = yield* LocationMutation.Service
   const models = yield* ModelsDev.Service
-  const mcp = yield* MCP.Service
+  const mcp = yield* Mcp.Service
   const npm = yield* Npm.Service
   const permission = yield* Permission.Service
   const runtime = yield* PluginRuntime.Service
@@ -158,7 +158,7 @@ const services = Effect.fn("PluginInternal.services")(function* () {
     Context.make(Location.Service, location),
     Context.make(LocationMutation.Service, locationMutation),
     Context.make(ModelsDev.Service, models),
-    Context.make(MCP.Service, mcp),
+    Context.make(Mcp.Service, mcp),
     Context.make(Npm.Service, npm),
     Context.make(Permission.Service, permission),
     Context.make(PluginRuntime.Service, runtime),
@@ -209,7 +209,7 @@ export const requirements = LayerNode.group([
   Location.node,
   LocationMutation.node,
   ModelsDev.node,
-  MCP.node,
+  Mcp.node,
   Npm.node,
   Permission.node,
   PluginRuntime.node,
@@ -234,8 +234,8 @@ export const requirements = LayerNode.group([
 export type InternalPlugin = Plugin<Requirements | Scope.Scope>
 
 const pre = [
-  ConfigMCPPlugin.Plugin,
-  MCPCodeModeExclusionPlugin.Plugin,
+  ConfigMcpPlugin.Plugin,
+  McpCodeModeExclusionPlugin.Plugin,
   WellKnownPlugin.Plugin,
   VcsGitPlugin.Plugin,
   AgentPlugin.Plugin,

--- a/packages/core/src/plugin/mcp-codemode-exclusion.ts
+++ b/packages/core/src/plugin/mcp-codemode-exclusion.ts
@@ -1,4 +1,4 @@
-export * as MCPCodeModeExclusionPlugin from "./mcp-codemode-exclusion.js"
+export * as McpCodeModeExclusionPlugin from "./mcp-codemode-exclusion.js"
 
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Effect } from "effect"

--- a/packages/core/src/plugin/runtime.ts
+++ b/packages/core/src/plugin/runtime.ts
@@ -6,7 +6,7 @@ import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { Job } from "../job.js"
 import { Location } from "../location.js"
 import { LocationServiceMap } from "../location-service-map.js"
-import { MCP } from "../mcp/index.js"
+import { Mcp } from "../mcp/index.js"
 import { Session } from "../session.js"
 
 export interface Interface {
@@ -38,7 +38,7 @@ export interface Interface {
     readonly mcp: {
       readonly list: (
         ref: Location.Ref,
-      ) => Effect.Effect<{ readonly location: Location.Info; readonly data: MCP.ServerInfo[] }, unknown>
+      ) => Effect.Effect<{ readonly location: Location.Info; readonly data: Mcp.ServerInfo[] }, unknown>
     }
   }
 }
@@ -130,7 +130,7 @@ export const providerLayerWithCell = (cell: Cell) =>
             list: (ref) =>
               Effect.gen(function* () {
                 const location = yield* Location.Service
-                const mcp = yield* MCP.Service
+                const mcp = yield* Mcp.Service
                 return {
                   location: new Location.Info({
                     directory: location.directory,

--- a/packages/core/src/tool/mcp.ts
+++ b/packages/core/src/tool/mcp.ts
@@ -6,7 +6,7 @@ import { Context, Effect, Fiber, type JsonSchema, Layer, Semaphore, Stream } fro
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Bus } from "../bus.js"
 
-import { MCP } from "../mcp/index.js"
+import { Mcp } from "../mcp/index.js"
 import { Permission } from "../permission.js"
 import { Tool } from "../tool.js"
 
@@ -26,12 +26,12 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Mc
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    const mcp = yield* MCP.Service
+    const mcp = yield* Mcp.Service
     const tools = yield* Tool.Service
     const bus = yield* Bus.Service
     const permission = yield* Permission.Service
     const lock = Semaphore.makeUnsafe(1)
-    let discovered: MCP.Tool[] = []
+    let discovered: Mcp.Tool[] = []
 
     // Register once after initial discovery; only subsequent updates need a debounced reload.
     const initial = yield* lock
@@ -134,5 +134,5 @@ export const layer = Layer.effect(
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [Tool.node, MCP.node, Bus.node, Permission.node],
+  deps: [Tool.node, Mcp.node, Bus.node, Permission.node],
 })

--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -19,7 +19,7 @@ import { WellKnown } from "@opencode-ai/core/wellknown"
 import { Global } from "@opencode-ai/util/global"
 import { AppProcess } from "@opencode-ai/util/process"
 import { Location } from "@opencode-ai/core/location"
-import { MCP } from "@opencode-ai/core/mcp/index"
+import { Mcp } from "@opencode-ai/core/mcp/index"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { ShellSelect } from "@opencode-ai/core/shell/select"
 import { Watcher } from "@opencode-ai/core/filesystem/watcher"
@@ -43,7 +43,7 @@ const it = testEffect(
   AppNodeBuilder.build(
     LayerNode.group([Command.node, Bus.node, FSUtil.node, AppProcess.node, Location.node, ShellSelect.node]),
     [
-      [MCP.node, emptyMcpLayer],
+      [Mcp.node, emptyMcpLayer],
       [Config.node, emptyConfigLayer],
       [Location.node, testLocationLayer],
       [ShellSelect.node, shellLayer],
@@ -431,9 +431,7 @@ function sourceCases() {
     {
       name: "updated",
       prepare: (directory: string) =>
-        Effect.promise(() =>
-          fs.writeFile(path.join(directory, "review.md"), markdown("Review first", "Review first")),
-        ),
+        Effect.promise(() => fs.writeFile(path.join(directory, "review.md"), markdown("Review first", "Review first"))),
       mutate: (directory: string) =>
         Effect.promise(async () => {
           const file = path.join(directory, "review.md")

--- a/packages/core/test/fixture/mcp.ts
+++ b/packages/core/test/fixture/mcp.ts
@@ -1,13 +1,13 @@
 import { Effect, Layer, Stream } from "effect"
 import { Config } from "@opencode-ai/core/config"
 import { Location } from "@opencode-ai/core/location"
-import { MCP } from "@opencode-ai/core/mcp/index"
+import { Mcp } from "@opencode-ai/core/mcp/index"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { location } from "./location"
 
 export const emptyMcpLayer = Layer.succeed(
-  MCP.Service,
-  MCP.Service.of({
+  Mcp.Service,
+  Mcp.Service.of({
     transform: () => Effect.die("unused mcp.transform"),
     reload: () => Effect.die("unused mcp.reload"),
     servers: () => Effect.succeed([]),
@@ -20,7 +20,7 @@ export const emptyMcpLayer = Layer.succeed(
     instructions: () => Effect.succeed([]),
     prompts: () => Effect.succeed([]),
     prompt: () => Effect.undefined,
-    resourceCatalog: () => Effect.succeed(MCP.ResourceCatalog.make({ resources: [], templates: [] })),
+    resourceCatalog: () => Effect.succeed(Mcp.ResourceCatalog.make({ resources: [], templates: [] })),
     readResource: () => Effect.undefined,
   }),
 )

--- a/packages/core/test/location-layer.test.ts
+++ b/packages/core/test/location-layer.test.ts
@@ -31,7 +31,7 @@ import { Plugin } from "@opencode-ai/core/plugin"
 import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Model } from "@opencode-ai/core/model"
-import { MCP } from "@opencode-ai/core/mcp/index"
+import { Mcp } from "@opencode-ai/core/mcp/index"
 import { Project } from "@opencode-ai/core/project"
 import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
@@ -998,7 +998,7 @@ describe("LocationServiceMap", () => {
 
           yield* Effect.gen(function* () {
             const supervisor = yield* PluginSupervisor.Service
-            const mcp = yield* MCP.Service
+            const mcp = yield* Mcp.Service
             yield* supervisor.flush
             expect(observed.example).toBe(false)
             yield* mcp.add("dynamic", {

--- a/packages/core/test/mcp-instructions.test.ts
+++ b/packages/core/test/mcp-instructions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from "bun:test"
 import { Effect, Layer } from "effect"
 import { Agent } from "@opencode-ai/core/agent"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
-import { MCP } from "@opencode-ai/core/mcp/index"
+import { Mcp } from "@opencode-ai/core/mcp/index"
 import { McpInstructions } from "@opencode-ai/core/mcp/instructions"
 import { Permission } from "@opencode-ai/core/permission"
 import { McpTool } from "@opencode-ai/core/tool/mcp"
@@ -17,15 +17,15 @@ const selection = (permissions: Permission.Ruleset = []) => {
 }
 
 const instructions = (server: string, text: string) =>
-  new MCP.ServerInstructions({ server: MCP.ServerName.make(server), instructions: text })
+  new Mcp.ServerInstructions({ server: Mcp.ServerName.make(server), instructions: text })
 
-const tool = (server: string, name = "search") => new MCP.Tool({ server: MCP.ServerName.make(server), name })
+const tool = (server: string, name = "search") => new Mcp.Tool({ server: Mcp.ServerName.make(server), name })
 
-const layer = (catalog: () => MCP.ServerInstructions[], tools: () => MCP.Tool[]) =>
+const layer = (catalog: () => Mcp.ServerInstructions[], tools: () => Mcp.Tool[]) =>
   AppNodeBuilder.build(McpInstructions.node, [
     [
-      MCP.node,
-      Layer.mock(MCP.Service, {
+      Mcp.node,
+      Layer.mock(Mcp.Service, {
         instructions: () => Effect.succeed(catalog()),
         tools: () => Effect.succeed(tools()),
       }),
@@ -113,7 +113,7 @@ describe("McpInstructions", () => {
       Effect.provide(
         layer(
           () => [instructions("alpha", "Alpha instructions")],
-          () => [new MCP.Tool({ server: MCP.ServerName.make("alpha"), name: "search", codemode: false })],
+          () => [new Mcp.Tool({ server: Mcp.ServerName.make("alpha"), name: "search", codemode: false })],
         ),
       ),
     ),
@@ -125,7 +125,7 @@ describe("McpInstructions", () => {
       const service = yield* McpInstructions.Service
       const initialized = yield* service.load(selection()).pipe(Effect.flatMap(readInitial))
 
-      tools = [new MCP.Tool({ server: MCP.ServerName.make("alpha"), name: "search", codemode: false })]
+      tools = [new Mcp.Tool({ server: Mcp.ServerName.make("alpha"), name: "search", codemode: false })]
       const changed = yield* readUpdate(yield* service.load(selection()), initialized)
       expect(changed.text).toBe(
         [

--- a/packages/core/test/mcp-oauth.test.ts
+++ b/packages/core/test/mcp-oauth.test.ts
@@ -2,7 +2,7 @@ import { afterAll, describe, expect, test } from "bun:test"
 import { refreshAuthorization } from "@modelcontextprotocol/sdk/client/auth.js"
 import { ConfigMCP } from "@opencode-ai/schema/config/mcp"
 import { Integration } from "@opencode-ai/core/integration"
-import { MCPOAuth } from "@opencode-ai/core/mcp/oauth"
+import { McpOAuth } from "@opencode-ai/core/mcp/oauth"
 import { Effect } from "effect"
 
 const authServer = Bun.serve({ port: 0, fetch: () => new Response(null, { status: 404 }) })
@@ -12,7 +12,7 @@ const authorize = (redirect_uri?: string) =>
   Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const authorization = yield* MCPOAuth.authorize({
+        const authorization = yield* McpOAuth.authorize({
           name: "test",
           config: new ConfigMCP.Remote({
             type: "remote",

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -16,7 +16,7 @@ import { Document, Event, Info } from "@opencode-ai/schema/config"
 import { ConfigMCP } from "@opencode-ai/schema/config/mcp"
 import { McpEvent } from "@opencode-ai/schema/mcp-event"
 import { Config } from "@opencode-ai/core/config"
-import { ConfigMCPPlugin } from "@opencode-ai/core/config/plugin/mcp"
+import { ConfigMcpPlugin } from "@opencode-ai/core/config/plugin/mcp"
 import { Credential } from "@opencode-ai/core/credential"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
@@ -27,9 +27,9 @@ import { Integration } from "@opencode-ai/core/integration"
 import { Environment } from "@opencode-ai/core/environment/index"
 import { EnvironmentUnavailable } from "@opencode-ai/core/environment/unavailable"
 import { Location } from "@opencode-ai/core/location"
-import { MCP } from "@opencode-ai/core/mcp/index"
-import { MCPClient } from "@opencode-ai/core/mcp/client"
-import { MCPStdio } from "@opencode-ai/core/mcp/stdio"
+import { Mcp } from "@opencode-ai/core/mcp/index"
+import { McpClient } from "@opencode-ai/core/mcp/client"
+import { McpStdio } from "@opencode-ai/core/mcp/stdio"
 import { Permission } from "@opencode-ai/core/permission"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
@@ -180,7 +180,7 @@ function resourceServer(
 function resourceMcpLayer(
   server: string | typeof ConfigMCP.Server.Type,
   onFormCreated?: (form: Form.Info) => Effect.Effect<void>,
-  options?: MCP.Options,
+  options?: Mcp.Options,
   overrides?: {
     entries?: Config.Interface["entries"]
     subscribe?: Bus.Interface["subscribe"]
@@ -193,10 +193,10 @@ function resourceMcpLayer(
   return Layer.effectDiscard(
     Effect.gen(function* () {
       const bus = yield* Bus.Service
-      yield* ConfigMCPPlugin.register(bus.subscribe())
+      yield* ConfigMcpPlugin.register(bus.subscribe())
     }),
   ).pipe(
-    Layer.provideMerge(MCP.layer(options)),
+    Layer.provideMerge(Mcp.layer(options)),
     Layer.provideMerge(Form.layer),
     Layer.provide(
       Layer.mergeAll(
@@ -267,13 +267,13 @@ function resourceMcpLayer(
 }
 
 const connect = (server: string, config: typeof ConfigMCP.Server.Type, directory: string) =>
-  MCPClient.connect(server, config, directory).pipe(Effect.provide(hostEnvironmentLayer))
+  McpClient.connect(server, config, directory).pipe(Effect.provide(hostEnvironmentLayer))
 
-const mcp = Layer.mock(MCP.Service, {
+const mcp = Layer.mock(Mcp.Service, {
   tools: () =>
     Effect.succeed([
-      new MCP.Tool({
-        server: MCP.ServerName.make("demo"),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make("demo"),
         name: "search",
         description: "Search",
         inputSchema: { type: "object", properties: {} },
@@ -283,28 +283,28 @@ const mcp = Layer.mock(MCP.Service, {
           required: ["ok"],
         },
       }),
-      new MCP.Tool({
-        server: MCP.ServerName.make("demo"),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make("demo"),
         name: "status",
         description: "Status",
         inputSchema: { type: "object", properties: {} },
       }),
-      new MCP.Tool({
-        server: MCP.ServerName.make("direct"),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make("direct"),
         name: "lookup",
         codemode: false,
         description: "Lookup",
         inputSchema: { type: "object", properties: {} },
       }),
-      new MCP.Tool({
-        server: MCP.ServerName.make("direct"),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make("direct"),
         name: "fail",
         codemode: false,
         description: "Always fails",
         inputSchema: { type: "object", properties: {} },
       }),
-      new MCP.Tool({
-        server: MCP.ServerName.make("direct"),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make("direct"),
         name: "media",
         codemode: false,
         description: "Returns text and an image",
@@ -315,15 +315,15 @@ const mcp = Layer.mock(MCP.Service, {
     Effect.sync(() => {
       calls += 1
       if (input.name === "fail")
-        return new MCP.ToolResult({
-          server: MCP.ServerName.make(input.server),
+        return new Mcp.ToolResult({
+          server: Mcp.ServerName.make(input.server),
           tool: input.name,
           isError: true,
           content: [{ type: "text", text: "search index unavailable" }],
         })
       if (input.name === "media")
-        return new MCP.ToolResult({
-          server: MCP.ServerName.make(input.server),
+        return new Mcp.ToolResult({
+          server: Mcp.ServerName.make(input.server),
           tool: input.name,
           isError: false,
           content: [
@@ -332,14 +332,14 @@ const mcp = Layer.mock(MCP.Service, {
           ],
         })
       if (input.name === "status")
-        return new MCP.ToolResult({
-          server: MCP.ServerName.make(input.server),
+        return new Mcp.ToolResult({
+          server: Mcp.ServerName.make(input.server),
           tool: input.name,
           isError: false,
           content: [{ type: "text", text: "hello" }],
         })
-      return new MCP.ToolResult({
-        server: MCP.ServerName.make(input.server),
+      return new Mcp.ToolResult({
+        server: Mcp.ServerName.make(input.server),
         tool: input.name,
         isError: false,
         structured: { ok: true },
@@ -358,7 +358,7 @@ const permissions = Layer.mock(Permission.Service, {
 const events = Layer.mock(Bus.Service, { subscribe: () => Stream.never })
 const it = testEffect(
   AppNodeBuilder.build(LayerNode.group([Tool.node, McpTool.node]), [
-    [MCP.node, mcp],
+    [Mcp.node, mcp],
     [Permission.node, permissions],
     [Bus.node, events],
     [Image.node, imagePassthrough],
@@ -367,12 +367,12 @@ const it = testEffect(
 
 describe("MCP errors", () => {
   test("expose useful messages", () => {
-    expect(new MCP.NotFoundError({ server: MCP.ServerName.make("demo") }).message).toBe("MCP server not found: demo")
+    expect(new Mcp.NotFoundError({ server: Mcp.ServerName.make("demo") }).message).toBe("MCP server not found: demo")
     expect(
-      new MCP.ToolCallError({ server: MCP.ServerName.make("demo"), tool: "search", message: "failed" }).message,
+      new Mcp.ToolCallError({ server: Mcp.ServerName.make("demo"), tool: "search", message: "failed" }).message,
     ).toBe("failed")
-    expect(new MCPClient.NeedsAuthError({ server: "demo" }).message).toBe("MCP server requires authentication: demo")
-    expect(new MCPClient.ConnectError({ server: "demo", message: "offline" }).message).toBe("offline")
+    expect(new McpClient.NeedsAuthError({ server: "demo" }).message).toBe("MCP server requires authentication: demo")
+    expect(new McpClient.ConnectError({ server: "demo", message: "offline" }).message).toBe("offline")
   })
 })
 
@@ -488,7 +488,7 @@ test("spawns local MCP servers through the location environment", async () => {
   await Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const connection = yield* MCPClient.connect("environment", config, import.meta.dir)
+        const connection = yield* McpClient.connect("environment", config, import.meta.dir)
         yield* connection.tools()
       }),
     ).pipe(Effect.provide(recordingEnvironmentLayer(spawns))),
@@ -513,7 +513,7 @@ test("reports a local MCP server as failed when the location has no execution pl
 
   await Effect.runPromise(
     Effect.gen(function* () {
-      const service = yield* MCP.Service
+      const service = yield* Mcp.Service
       yield* service.tools()
       const status = (yield* service.servers()).find((server) => server.name === "resources")?.status
       expect(status).toEqual({
@@ -528,7 +528,7 @@ test("rejects sends before the stdio transport is started", async () => {
   await Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const transport = yield* MCPStdio.make({
+        const transport = yield* McpStdio.make({
           server: "not-started",
           command: process.execPath,
           args: [path.join(import.meta.dir, "fixture/mcp-output-schema.ts")],
@@ -551,7 +551,7 @@ test("joins concurrent stdio transport closes", async () => {
   await Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const transport = yield* MCPStdio.make({
+        const transport = yield* McpStdio.make({
           server: "concurrent-close",
           command: "unused",
           args: [],
@@ -605,7 +605,7 @@ test("closes a stdio process that finishes spawning after close", async () => {
   await Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const transport = yield* MCPStdio.make({
+        const transport = yield* McpStdio.make({
           server: "close-during-spawn",
           command: "unused",
           args: [],
@@ -816,7 +816,7 @@ for (const entry of [
       })
       const error = yield* connect("resources", config, import.meta.dir).pipe(Effect.flip)
 
-      expect(error).toBeInstanceOf(MCPClient.ConnectError)
+      expect(error).toBeInstanceOf(McpClient.ConnectError)
       expect(server.state.initializations).toBe(entry.attempts)
       expect(server.state.urls).toHaveLength(entry.attempts)
       if (entry.query || entry.codemode === false) expect(server.state.urls).toEqual([config.url])
@@ -956,7 +956,7 @@ test("accepts empty MCP elicitations without creating forms", async () => {
       Effect.gen(function* () {
         const server = yield* resourceServer({ resources: false, emptyElicitation: true })
         const result = yield* Effect.gen(function* () {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           const forms = yield* Form.Service
           const result = yield* service.callTool({ server: "resources", name: "empty-elicitation" })
           expect(yield* forms.list()).toEqual([])
@@ -976,7 +976,7 @@ test("acknowledges completed MCP URL elicitations without returning internal con
         const server = yield* resourceServer({ resources: false, urlElicitation: true })
         const created = yield* Deferred.make<Form.Info>()
         const result = yield* Effect.gen(function* () {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           const forms = yield* Form.Service
           const call = yield* service.callTool({ server: "resources", name: "url-elicitation" }).pipe(Effect.forkScoped)
 
@@ -1006,7 +1006,7 @@ test("loads and reads MCP resources", async () => {
         server.state.templates = [{ name: "File", uriTemplate: "docs://{path}" }]
 
         yield* Effect.gen(function* () {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           expect(yield* service.resourceCatalog()).toEqual({
             resources: [
               {
@@ -1053,12 +1053,12 @@ test("adds, disconnects, and reconnects MCP servers at runtime", async () => {
     Effect.scoped(
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
 
           expect((yield* service.servers())[0]?.status).toEqual({ status: "disabled" })
           expect(published).toContain(McpEvent.StatusChanged.type)
-          expect(yield* service.connect("missing").pipe(Effect.flip)).toBeInstanceOf(MCP.NotFoundError)
-          expect(yield* service.disconnect("missing").pipe(Effect.flip)).toBeInstanceOf(MCP.NotFoundError)
+          expect(yield* service.connect("missing").pipe(Effect.flip)).toBeInstanceOf(Mcp.NotFoundError)
+          expect(yield* service.disconnect("missing").pipe(Effect.flip)).toBeInstanceOf(Mcp.NotFoundError)
           yield* service.add(
             "dynamic",
             new ConfigMCP.Local({
@@ -1101,7 +1101,7 @@ test("adds, disconnects, and reconnects MCP servers at runtime", async () => {
           yield* service.remove("dynamic")
           expect((yield* service.servers()).some((server) => server.name === "dynamic")).toBe(false)
           expect(yield* service.tools()).toEqual([])
-          expect(yield* service.remove("dynamic").pipe(Effect.flip)).toBeInstanceOf(MCP.NotFoundError)
+          expect(yield* service.remove("dynamic").pipe(Effect.flip)).toBeInstanceOf(Mcp.NotFoundError)
         }).pipe(
           Effect.provide(
             resourceMcpLayer(
@@ -1125,7 +1125,7 @@ testEffect(resourceMcpLayer(new ConfigMCP.Local({ type: "local", command: ["unus
   "manages live MCP servers entirely through scoped transforms",
   () =>
     Effect.gen(function* () {
-      const service = yield* MCP.Service
+      const service = yield* Mcp.Service
 
       yield* Effect.scoped(
         Effect.gen(function* () {
@@ -1168,7 +1168,7 @@ testEffect(resourceMcpLayer(new ConfigMCP.Local({ type: "local", command: ["unus
         }),
       )
 
-      expect((yield* service.servers()).map((server) => server.name)).toEqual([MCP.ServerName.make("resources")])
+      expect((yield* service.servers()).map((server) => server.name)).toEqual([Mcp.ServerName.make("resources")])
       expect(yield* service.tools()).toEqual([])
     }),
 )
@@ -1177,7 +1177,7 @@ test("restores runtime MCP config when a transform is disposed", async () => {
   await Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const service = yield* MCP.Service
+        const service = yield* Mcp.Service
         const config = new ConfigMCP.Remote({
           type: "remote",
           url: "https://example.com/mcp",
@@ -1220,7 +1220,7 @@ test("isolates nested configured MCP mutations and reconciles them", async () =>
   await Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const service = yield* MCP.Service
+        const service = yield* Mcp.Service
         expect(published.filter((type) => type === McpEvent.StatusChanged.type)).toHaveLength(1)
         yield* service.transform((draft) =>
           draft.update("resources", (server) => {
@@ -1263,7 +1263,7 @@ test("reconciles only changed MCP server config", async () => {
           } satisfies Payload<typeof Event.Updated>)
 
         yield* Effect.gen(function* () {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           yield* service.tools()
           expect(server.state.toolLists).toBe(1)
           expect(server.state.initializations).toBe(1)
@@ -1330,7 +1330,7 @@ test("serializes concurrent MCP lifecycle operations", async () => {
     Effect.scoped(
       Effect.gen(function* () {
         yield* Effect.gen(function* () {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
 
           // Whatever order the racing operations land in, the resulting state must be consistent.
           yield* Effect.all(
@@ -1373,8 +1373,8 @@ test("serializes concurrent MCP lifecycle operations", async () => {
 testEffect(Layer.empty).live("isolates invalid MCP tools and preserves plugin transforms through catalog updates", () =>
   Effect.gen(function* () {
     const tool = (server: string, name: string, description = name) =>
-      new MCP.Tool({
-        server: MCP.ServerName.make(server),
+      new Mcp.Tool({
+        server: Mcp.ServerName.make(server),
         name,
         description,
         codemode: false,
@@ -1498,13 +1498,13 @@ testEffect(Layer.empty).live("isolates invalid MCP tools and preserves plugin tr
         Layer.fresh(
           AppNodeBuilder.build(LayerNode.group([Tool.node, McpTool.node, Bus.node]), [
             [
-              MCP.node,
-              Layer.mock(MCP.Service, {
+              Mcp.node,
+              Layer.mock(Mcp.Service, {
                 tools: () => Ref.get(catalog),
                 callTool: (input) =>
                   Effect.succeed(
-                    new MCP.ToolResult({
-                      server: MCP.ServerName.make(input.server),
+                    new Mcp.ToolResult({
+                      server: Mcp.ServerName.make(input.server),
                       tool: input.name,
                       isError: false,
                       content: [{ type: "text", text: "healthy" }],
@@ -1541,12 +1541,12 @@ testEffect(Layer.empty).effect("coalesces queued MCP tool notifications after in
     Effect.provide(
       AppNodeBuilder.build(LayerNode.group([Tool.node, McpTool.node, Bus.node]), [
         [
-          MCP.node,
-          Layer.mock(MCP.Service, {
+          Mcp.node,
+          Layer.mock(Mcp.Service, {
             tools: () =>
               Effect.sync(() => [
-                new MCP.Tool({
-                  server: MCP.ServerName.make("demo"),
+                new Mcp.Tool({
+                  server: Mcp.ServerName.make("demo"),
                   name: `read_${++reads}`,
                   codemode: false,
                   inputSchema: { type: "object", properties: {} },

--- a/packages/core/test/plugin/command.test.ts
+++ b/packages/core/test/plugin/command.test.ts
@@ -4,7 +4,7 @@ import { Command } from "@opencode-ai/core/command"
 import { Bus } from "@opencode-ai/core/bus"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Location } from "@opencode-ai/core/location"
-import { MCP } from "@opencode-ai/core/mcp/index"
+import { Mcp } from "@opencode-ai/core/mcp/index"
 import { CommandPlugin } from "@opencode-ai/core/plugin/command"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/schema/session"
@@ -24,8 +24,8 @@ const locationLayer = Layer.succeed(
   Location.Service.of(location({ directory }, { projectDirectory: project })),
 )
 const it = testEffect(
-  AppNodeBuilder.build(LayerNode.group([Command.node, MCP.node, Bus.node]), [
-    [MCP.node, emptyMcpLayer],
+  AppNodeBuilder.build(LayerNode.group([Command.node, Mcp.node, Bus.node]), [
+    [Mcp.node, emptyMcpLayer],
     [Location.node, locationLayer],
   ]),
 )

--- a/packages/core/test/plugin/fixture.ts
+++ b/packages/core/test/plugin/fixture.ts
@@ -14,7 +14,7 @@ import { Generate } from "@opencode-ai/core/generate"
 import { Integration } from "@opencode-ai/core/integration"
 import { KV } from "@opencode-ai/core/kv"
 import { Location } from "@opencode-ai/core/location"
-import { MCP } from "@opencode-ai/core/mcp/index"
+import { Mcp } from "@opencode-ai/core/mcp/index"
 import { Npm } from "@opencode-ai/util/npm"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
@@ -72,7 +72,7 @@ export const PluginTestLayer = LayerNode.compile(
     Command.node,
     Integration.node,
     KV.node,
-    MCP.node,
+    Mcp.node,
     PluginRuntime.node,
     Permission.node,
     PluginHooks.node,
@@ -89,7 +89,7 @@ export const PluginTestLayer = LayerNode.compile(
     [Location.node, tempLocationLayer],
     [Npm.node, npmLayer],
     [Config.node, Config.testLayer()],
-    [MCP.node, emptyMcpLayer],
+    [Mcp.node, emptyMcpLayer],
     [Generate.node, generateLayer],
     [Permission.node, permissionLayer],
   ],

--- a/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
+++ b/packages/core/test/plugin/mcp-codemode-exclusion.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "bun:test"
-import { MCPCodeModeExclusionPlugin } from "@opencode-ai/core/plugin/mcp-codemode-exclusion"
+import { McpCodeModeExclusionPlugin } from "@opencode-ai/core/plugin/mcp-codemode-exclusion"
 import type { Mcp } from "@opencode-ai/schema/mcp"
 import { Effect, type Types } from "effect"
 import { it } from "../lib/effect"
@@ -51,7 +51,7 @@ it.effect("defaults only known Code Mode MCP servers to direct tools", () =>
     )
     const base = host()
 
-    yield* MCPCodeModeExclusionPlugin.Plugin.effect(
+    yield* McpCodeModeExclusionPlugin.Plugin.effect(
       host({
         mcp: {
           ...base.mcp,

--- a/packages/server/src/handlers/mcp.ts
+++ b/packages/server/src/handlers/mcp.ts
@@ -1,11 +1,11 @@
-import { MCP } from "@opencode-ai/core/mcp/index"
+import { Mcp } from "@opencode-ai/core/mcp/index"
 import { McpServerNotFoundError } from "@opencode-ai/protocol/errors"
 import { Effect } from "effect"
 import { HttpApiBuilder, HttpApiSchema } from "effect/unstable/httpapi"
 import { Api } from "../api"
 import { response } from "../location"
 
-const notFound = <A, R>(effect: Effect.Effect<A, MCP.NotFoundError, R>) =>
+const notFound = <A, R>(effect: Effect.Effect<A, Mcp.NotFoundError, R>) =>
   effect.pipe(Effect.mapError((error) => new McpServerNotFoundError({ server: error.server, message: error.message })))
 
 export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
@@ -14,7 +14,7 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
       .handle(
         "mcp.list",
         Effect.fn(function* () {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           return yield* response(
             service
               .servers()
@@ -29,7 +29,7 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
       .handle(
         "mcp.add",
         Effect.fn(function* (ctx) {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           yield* service.add(ctx.params.server, ctx.payload.config)
           return HttpApiSchema.NoContent.make()
         }),
@@ -37,7 +37,7 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
       .handle(
         "mcp.remove",
         Effect.fn(function* (ctx) {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           yield* notFound(service.remove(ctx.params.server))
           return HttpApiSchema.NoContent.make()
         }),
@@ -45,7 +45,7 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
       .handle(
         "mcp.connect",
         Effect.fn(function* (ctx) {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           yield* notFound(service.connect(ctx.params.server))
           return HttpApiSchema.NoContent.make()
         }),
@@ -53,7 +53,7 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
       .handle(
         "mcp.disconnect",
         Effect.fn(function* (ctx) {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           yield* notFound(service.disconnect(ctx.params.server))
           return HttpApiSchema.NoContent.make()
         }),
@@ -61,7 +61,7 @@ export const McpHandler = HttpApiBuilder.group(Api, "server.mcp", (handlers) =>
       .handle(
         "mcp.resource.catalog",
         Effect.fn(function* () {
-          const service = yield* MCP.Service
+          const service = yield* Mcp.Service
           return yield* response(service.resourceCatalog())
         }),
       )

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -17,7 +17,7 @@ import { Session } from "@opencode-ai/core/session"
 import { SessionTransfer } from "@opencode-ai/core/session/transfer"
 import { ShellSelect } from "@opencode-ai/core/shell/select"
 import { Job } from "@opencode-ai/core/job"
-import { MCP } from "@opencode-ai/core/mcp/index"
+import { Mcp } from "@opencode-ai/core/mcp/index"
 import { Global } from "@opencode-ai/util/global"
 import { InstructionDiscovery } from "@opencode-ai/core/instruction-discovery"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
@@ -118,8 +118,8 @@ function makeRoutes<AuthError, AuthServices>(
     [InstructionDiscovery.node, InstructionDiscovery.configured({ project: options.config?.project })],
     [ShellSelect.node, ShellSelect.configured({ gitbash: options.windows?.gitbash })],
     [
-      MCP.node,
-      MCP.configured({
+      Mcp.node,
+      Mcp.configured({
         clientInfo: {
           name: options.app?.name ?? "opencode",
           version: options.app?.version ?? "unknown",


### PR DESCRIPTION
## Why

Current Core MCP modules mix uppercase acronym blocks with word casing: `MCPClient` sits beside `McpTool`, `McpInstructions`, and `WebSearchMcp`. Use `Mcp` consistently for Core-owned namespace identifiers, matching Schema's `Mcp` and `McpEvent` without renaming those contracts.

Supersedes #45460, which proposed the opposite casing for only two namespaces.

## What Changes

| Previous Core export | New Core export |
| --- | --- |
| `MCP` | `Mcp` |
| `MCPClient` | `McpClient` |
| `MCPStdio` | `McpStdio` |
| `MCPOAuth` | `McpOAuth` |
| `ConfigMCPPlugin` | `ConfigMcpPlugin` |
| `MCPCodeModeExclusionPlugin` | `McpCodeModeExclusionPlugin` |

Update static imports, lazy import destructuring, namespace references, tests, and the two Server consumers. Existing `McpTool`, `McpInstructions`, and `WebSearchMcp` exports keep their names. Where Core and Schema namespaces would collide, import the canonical `ServerConfig` contract directly instead of adding aliases or wrapper schemas.

Direct consumers of the renamed exports must update their imports. A major Core changeset documents that migration; module paths remain unchanged.

## Scope

Current Core-owned namespace casing only. Schema exports, including `ConfigMCP`, legacy V1 names, runtime service keys, schema identifiers, error tags, trace labels, protocol strings, and user-visible content are unchanged. No behavior or HTTP contract changes.

## Verification

```sh
# Repository root
bun install --frozen-lockfile
bunx prettier --check $(git diff HEAD^ --name-only)
git diff HEAD^ --check
git push -u origin mcp-word-case

# packages/core
bun run test test/mcp.test.ts test/mcp-oauth.test.ts test/mcp-instructions.test.ts test/plugin/mcp-codemode-exclusion.test.ts test/plugin/command.test.ts test/config/command.test.ts test/location-layer.test.ts test/session-generate.test.ts
bun typecheck

# packages/server
bun run test test/config.test.ts
bun typecheck
```

The fresh base and renamed branch both pass 97 focused Core tests, with 322 assertions. The Server config test passes, with 8 assertions. Core and Server typechecking, formatting, and whitespace checks pass. The normal pre-push hook passes all 33 workspace typecheck tasks, including 27 cache hits.

A TypeScript AST check of the 25 changed source/test files confirmed that all string and template literals are preserved and no old renamed identifiers remain in those files. Repository-wide consumer inspection found no missed static or lazy references. The full Core suite and CI were not run as part of this local verification.
