### PR TITLE
fix(provider): drop Bedrock assistant messages left with only unsigned reasoning

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -356,6 +356,29 @@ function normalizeMessages(
   return msgs
 }
 
+// The @ai-sdk/amazon-bedrock converter intentionally drops reasoning parts that
+// carry no signature (an aborted thinking stream never receives one, since the
+// signature arrives at the end of the block). An assistant message whose only
+// content is unsigned reasoning therefore reaches Bedrock as an empty content
+// array — rejected with "The content field in the Message object is empty" —
+// or, when applyCaching attached a cachePoint to it, as a lone cachePoint
+// block — rejected with "There is nothing available to cache". Both 400s are
+// non-retryable and repeat on every request while the message sits in the
+// last-2 cache window, wedging the session. Drop such messages before caching
+// and conversion: the converter discards their content anyway, so the model
+// sees no difference. Must run before applyCaching so cache points land on
+// messages that survive.
+function dropUnsignedReasoningOnlyMessages(msgs: ModelMessage[]): ModelMessage[] {
+  return msgs.filter((msg) => {
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) return true
+    return msg.content.some((part) => {
+      if (part.type !== "reasoning") return true
+      const metadata = part.providerOptions?.["bedrock"] ?? part.providerOptions?.["amazonBedrock"]
+      return metadata?.["signature"] != null || metadata?.["redactedData"] != null
+    })
+  })
+}
+
 function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
   const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
   const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
@@ -465,6 +488,9 @@ function mapProviderOptions(
 
 export function message(msgs: ModelMessage[], model: Provider.Model, options: Record<string, unknown>) {
   msgs = unsupportedParts(msgs, model)
+  if (model.api.npm === "@ai-sdk/amazon-bedrock") {
+    msgs = dropUnsignedReasoningOnlyMessages(msgs)
+  }
   msgs = normalizeMessages(msgs, model, options)
   const usesAnthropicAutomaticCaching =
     options.cacheControl !== undefined &&

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -5680,3 +5680,113 @@ describe("ProviderTransform.options - kimi family adaptive thinking", () => {
     expect(result.thinking).toBeUndefined()
   })
 })
+
+describe("ProviderTransform.message - Bedrock unsigned reasoning-only messages", () => {
+  const createBedrockModel = () =>
+    ({
+      id: "amazon-bedrock/global.anthropic.claude-sonnet-4-5",
+      providerID: "amazon-bedrock",
+      api: {
+        id: "global.anthropic.claude-sonnet-4-5",
+        url: "https://bedrock-runtime.eu-west-1.amazonaws.com",
+        npm: "@ai-sdk/amazon-bedrock",
+      },
+      name: "Claude Sonnet 4.5",
+      capabilities: {
+        temperature: true,
+        reasoning: true,
+        attachment: true,
+        toolcall: true,
+        input: { text: true, audio: false, image: true, video: false, pdf: true },
+        output: { text: true, audio: false, image: false, video: false, pdf: false },
+        interleaved: false,
+      },
+      cost: { input: 0.003, output: 0.015, cache: { read: 0.0003, write: 0.00375 } },
+      limit: { context: 200000, output: 8192 },
+      status: "active",
+      options: {},
+      headers: {},
+    }) as any
+
+  const unsignedReasoningOnly = {
+    role: "assistant",
+    // aborted mid-thinking: no signature ever arrived, so no providerOptions
+    content: [{ type: "reasoning", text: "Let me consider the options" }],
+  }
+
+  test("drops an assistant message whose only content is unsigned reasoning", () => {
+    const result = ProviderTransform.message(
+      [
+        { role: "user", content: "think hard then answer" },
+        unsignedReasoningOnly,
+        { role: "user", content: "hello?" },
+      ] as any[],
+      createBedrockModel(),
+      {},
+    )
+    expect(result.map((msg: any) => msg.role)).toEqual(["user", "user"])
+  })
+
+  test("cache points land on surviving messages, not the dropped one", () => {
+    const result = ProviderTransform.message(
+      [
+        { role: "user", content: "think hard then answer" },
+        { role: "assistant", content: [{ type: "text", text: "thinking done, answering" }] },
+        unsignedReasoningOnly,
+      ] as any[],
+      createBedrockModel(),
+      {},
+    )
+    expect(result).toHaveLength(2)
+    for (const msg of result as any[]) {
+      expect(msg.providerOptions?.bedrock?.cachePoint).toEqual({ type: "default" })
+    }
+  })
+
+  test("keeps a signed reasoning-only assistant message", () => {
+    const result = ProviderTransform.message(
+      [
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "reasoning",
+              text: "Let me consider the options",
+              providerOptions: { bedrock: { signature: "sig-123" } },
+            },
+          ],
+        },
+      ] as any[],
+      createBedrockModel(),
+      {},
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  test("keeps an assistant message where unsigned reasoning sits next to real content", () => {
+    const result = ProviderTransform.message(
+      [
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", text: "Let me consider the options" },
+            { type: "text", text: "The answer is 42." },
+          ],
+        },
+      ] as any[],
+      createBedrockModel(),
+      {},
+    )
+    expect(result).toHaveLength(1)
+  })
+
+  test("does not touch other providers", () => {
+    const result = ProviderTransform.message([unsignedReasoningOnly] as any[], {
+      ...createBedrockModel(),
+      id: "anthropic/claude-sonnet-4-5",
+      providerID: "anthropic",
+      api: { id: "claude-sonnet-4-5", url: "https://api.anthropic.com", npm: "@ai-sdk/anthropic" },
+    } as any, {})
+    expect(result).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45620

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a thinking stream dies mid-turn on Bedrock, the saved reasoning part has no signature (it arrives at the end of the block, so it never came). On replay the AI SDK drops unsigned reasoning, so the assistant message goes out with empty content — or as a lone cachePoint once `applyCaching` has stamped the last two messages. Bedrock rejects both with a non-retryable 400 ("There is nothing available to cache" / "content field is empty") and the session is wedged until the message drifts out of the cache window.

The fix drops those messages in `ProviderTransform.message` — scoped to `@ai-sdk/amazon-bedrock`, before `applyCaching` so cache points land on messages that survive. It works because the converter was discarding their content anyway... the model sees an identical request, just without the guaranteed 400. Same shape as the #14586 filters.

The root-cause fix is upstream (vercel/ai#19852), but that's on the `@ai-sdk/amazon-bedrock` 5.x line and opencode vendors 4.0.x, so this covers the gap. When the vendored package catches up this becomes harmless belt-and-braces.

### How did you verify your code works?

Five new cases in `transform.test.ts` — the two drop behaviours fail without the fix; signed reasoning, mixed content, and other providers are untouched. 416/416 passing. Also ran dev from source against a real poisoned session (isolated XDG dirs): the exact 400 before the change, normal completion after, on `global.anthropic.claude-fable-5`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR