### PR TITLE
refactor(core): remove identity schema pipes

### DIFF
--- a/packages/core/src/v1/config/lsp.ts
+++ b/packages/core/src/v1/config/lsp.ts
@@ -4,7 +4,7 @@ import { Schema } from "effect"
 
 export const Disabled = Schema.Struct({
   disabled: Schema.Literal(true),
-}).pipe((schema) => schema)
+})
 
 export const Entry = Schema.Union([
   Disabled,
@@ -15,7 +15,7 @@ export const Entry = Schema.Union([
     env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
     initialization: Schema.optional(Schema.Record(Schema.String, Schema.Unknown)),
   }),
-]).pipe((schema) => schema)
+])
 
 // Keep this list aligned with the builtin servers in opencode's LSP runtime.
 // Custom servers must declare extensions because the runtime cannot infer them.
@@ -73,8 +73,8 @@ export const requiresExtensionsForCustomServers = Schema.makeFilter<
   return ok ? undefined : "For custom LSP servers, 'extensions' array is required."
 })
 
-export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)])
-  .check(requiresExtensionsForCustomServers)
-  .pipe((schema) => schema)
+export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)]).check(
+  requiresExtensionsForCustomServers,
+)
 
 export type Info = Schema.Schema.Type<typeof Info>


### PR DESCRIPTION
**Why**

The V1 LSP schemas pass through identity `pipe` callbacks that do not transform their schemas. These no-op operations add noise to compatibility-sensitive schema definitions without affecting their contract.

**What Changes**

Remove the identity pipes from `Disabled`, `Entry`, and `Info`. Their fields, checks, mutable array decoding, built-in server IDs, and exports remain unchanged.

**Scope**

This PR only simplifies the V1 LSP schema expressions; it does not change configuration migration or validation behavior.

**Verification**

```sh
cd packages/core
bun run test test/config/config.test.ts test/config/normalization.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/v1/config/lsp.ts
bunx oxlint packages/core/src/v1/config/lsp.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/v1/config/lsp.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/v1/config/lsp.ts
git diff --check origin/v2...HEAD
```

The focused suites pass 61 tests. Typechecking, formatting, linting, both pattern scans, and the diff check pass.
