### PR TITLE
refactor(core): remove duplicate config failure

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -81,8 +81,6 @@ export const testLayer = (initial: Entry[] = []) =>
           Effect.gen(function* () {
             const current = yield* Ref.get(entries)
             const index = current.findIndex((entry) => entry.type === "document" && entry.path !== undefined)
-            if (index === -1)
-              return yield* Effect.fail(new UpdateError({ message: "No editable config document found" }))
             const entry = current[index]
             if (!entry || entry.type !== "document")
               return yield* Effect.fail(new UpdateError({ message: "No editable config document found" }))


### PR DESCRIPTION
**Why**

The in-memory config test layer checks the failed editable-document lookup twice and emits the same `UpdateError` from both branches. The second guard already handles the missing indexed entry and provides the required narrowing.

**What Changes**

Remove the duplicate `index === -1` failure branch. Missing or non-document entries still fail with the exact `No editable config document found` message before update logic runs.

**Scope**

This only simplifies the test-layer update path; the index lookup, immutable replacement, production update path, and error contract remain unchanged.

**Verification**

```sh
cd packages/core
bun run test test/config/config.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/config.ts
bunx oxlint packages/core/src/config.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/config.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/config.ts
git diff --check origin/v2...HEAD
```

The focused suite passes 35 tests, including the direct no-editable-document assertion. Typechecking, formatting, both pattern scans, and the diff check pass; oxlint exits successfully with two pre-existing warnings outside the changed lines.
