### PR TITLE
test(schema): target config color contract

### DIFF
--- a/packages/schema/test/contract-hygiene.test.ts
+++ b/packages/schema/test/contract-hygiene.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { DateTime, Schema } from "effect"
 import { Agent } from "../src/agent.js"
+import { ConfigAgent } from "../src/config/agent.js"
 import { FileSystem } from "../src/filesystem.js"
 import { Form } from "../src/form.js"
 import { Mcp } from "../src/mcp.js"
@@ -23,7 +24,7 @@ import { AbsolutePath, optional } from "../src/schema.js"
 
 describe("contract hygiene", () => {
   test("restricts agent colors to six-digit hex values", () => {
-    const decode = Schema.decodeUnknownSync(Agent.Color)
+    const decode = Schema.decodeUnknownSync(ConfigAgent.Color)
     expect(decode("#ff6b6b")).toBe("#ff6b6b")
     expect(() => decode("warning")).toThrow()
   })


### PR DESCRIPTION
## Why
The contract hygiene suite expects agent configuration colors to reject non-hex strings, but it runs that assertion against the permissive public `Agent.Color` contract. This makes the test contradict the public schema and its dedicated permissive-color coverage.

## What Changes
The hex restriction assertion now decodes `ConfigAgent.Color`, where the six-digit hex rule is defined. Public `Agent.Color` behavior remains unchanged.

## Scope
This is a test-only correction to the schema contract target.

## Verification
Run from `packages/schema`:

```sh
bun run test test/contract-hygiene.test.ts
bun typecheck
```

The focused contract suite and package typecheck passed. Formatting and diff checks also passed.
