### PR TITLE
fix(core): forward plugin interrupt options

### DIFF
--- a/.changeset/plugin-interrupt-options.md
+++ b/.changeset/plugin-interrupt-options.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Forward plugin Session interrupt options so continuation requests reach the Session service.

--- a/packages/core/src/plugin/runtime.ts
+++ b/packages/core/src/plugin/runtime.ts
@@ -76,7 +76,7 @@ export const layerWithCell = (cell: Cell) =>
         resume: (sessionID) => require(cell, (runtime) => runtime.session.resume(sessionID)),
         switchAgent: (input) => require(cell, (runtime) => runtime.session.switchAgent(input)),
         switchModel: (input) => require(cell, (runtime) => runtime.session.switchModel(input)),
-        interrupt: (sessionID) => require(cell, (runtime) => runtime.session.interrupt(sessionID)),
+        interrupt: (sessionID, options) => require(cell, (runtime) => runtime.session.interrupt(sessionID, options)),
         synthetic: (input) => require(cell, (runtime) => runtime.session.synthetic(input)),
         wait: (sessionID) => require(cell, (runtime) => runtime.session.wait(sessionID)),
         context: (sessionID) => require(cell, (runtime) => runtime.session.context(sessionID)),

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -113,6 +113,36 @@ describe("Plugin", () => {
     }),
   )
 
+  it.effect("forwards session interrupt options through the runtime cell", () =>
+    Effect.gen(function* () {
+      const plugins = yield* Plugin.Service
+      const fallback = yield* PluginRuntime.Service
+      const cell = PluginRuntime.makeCell()
+      const sessionID = Session.ID.create()
+      const calls: Array<{ sessionID: Session.ID; options: { continue?: boolean } | undefined }> = []
+      cell.runtime = {
+        ...fallback,
+        session: {
+          ...fallback.session,
+          interrupt: (id, options) =>
+            Effect.sync(() => {
+              calls.push({ sessionID: id, options })
+              return true
+            }),
+        },
+      }
+      const runtime = yield* PluginRuntime.Service.pipe(Effect.provide(PluginRuntime.layerWithCell(cell)))
+      const host = yield* PluginHost.make(plugins).pipe(Effect.provideService(PluginRuntime.Service, runtime))
+
+      expect(yield* runtime.session.interrupt(sessionID)).toBe(true)
+      expect(yield* host.session.interrupt({ sessionID, continue: true })).toEqual({ interrupted: true })
+      expect(calls).toEqual([
+        { sessionID, options: undefined },
+        { sessionID, options: { continue: true } },
+      ])
+    }),
+  )
+
   it.effect("registers and removes scoped VCS providers", () =>
     Effect.gen(function* () {
       const plugins = yield* Plugin.Service


### PR DESCRIPTION
**Why**
The cell-backed plugin runtime accepted the public Session interrupt method type but dropped its optional continuation argument. Plugin-host calls requesting continuation therefore reached Session interruption without the requested option.

**What Changes**
The runtime adapter now forwards both the Session ID and interrupt options through the deferred cell lookup. A focused test covers an omitted option at the cell boundary and `continue: true` through the production plugin-host call shape. A patch changeset records the behavior fix for `@opencode-ai/core`.

**Scope**
This only restores the existing interrupt contract; Session ownership, interruption behavior, and continuation policy are unchanged. PR #45618 also edits this file for MCP namespace casing but does not touch the interrupt adapter.

**Verification**
```sh
cd packages/core
bun run test test/plugin.test.ts
bun typecheck
cd ../..
bun run prettier --check .changeset/plugin-interrupt-options.md
bun run oxlint packages/core/src/plugin/runtime.ts packages/core/test/plugin.test.ts
git diff --check
git push  # pre-push hook: full workspace typecheck
```

Focused tests: 19 passed, 0 failed. Changeset formatting, Core typecheck, and full-workspace typecheck passed; oxlint reported 0 warnings and 0 errors.