### PR TITLE
fix(core): preserve benchmark directory argument

### DIFF
--- a/packages/core/script/benchmark-location.ts
+++ b/packages/core/script/benchmark-location.ts
@@ -12,7 +12,9 @@ import { AbsolutePath } from "../src/schema"
 const args = process.argv.slice(2)
 const iterationsIndex = args.indexOf("--iterations")
 const iterations = iterationsIndex === -1 ? 10 : Number(args[iterationsIndex + 1])
-const directory = args.find((arg, index) => !arg.startsWith("--") && index !== iterationsIndex + 1) ?? process.cwd()
+const directory =
+  args.find((arg, index) => !arg.startsWith("--") && (iterationsIndex === -1 || index !== iterationsIndex + 1)) ??
+  process.cwd()
 
 if (!Number.isInteger(iterations) || iterations < 1) {
   console.error("--iterations must be a positive integer")


### PR DESCRIPTION
**Why**

Running `benchmark:location /workspace` without `--iterations` discarded `/workspace` because the missing flag index (`-1`) made positional index zero look like the flag value. The benchmark then silently targeted the current directory instead.

**What Changes**

The positional-directory predicate now excludes the value after `--iterations` only when that flag is present. The ten-iteration default, explicit iteration parsing and validation, directory resolution, measurements, and output remain unchanged.

**Scope**

This only corrects argument selection in the internal Location benchmark script. There is no existing parser seam; the change stays local rather than adding production structure solely for a unit test, and no package changeset is needed for this development script.

**Verification**

```sh
bun -e <focused parser matrix: no args, directory only, directory before/after --iterations>
bun typecheck # packages/core
bunx prettier --check packages/core/script/benchmark-location.ts
git diff --check
# push hook: bun turbo typecheck --concurrency=3
```

The focused four-case argument matrix passed, Core typechecking passed, formatting and diff checks passed, and the push hook completed all 33 repository typecheck tasks.