### PR TITLE
refactor(core): reuse shared record guard

### DIFF
--- a/packages/core/src/config/normalize.ts
+++ b/packages/core/src/config/normalize.ts
@@ -1,6 +1,7 @@
 export * as ConfigNormalize from "./normalize.js"
 
 import { isDeepStrictEqual } from "node:util"
+import { isRecord } from "@opencode-ai/ai/utils/record"
 import { Option, Schema } from "effect"
 import { Info } from "@opencode-ai/schema/config"
 import { ConfigAgent } from "@opencode-ai/schema/config/agent"
@@ -780,10 +781,6 @@ function isDirectLegacyMcp(value: unknown) {
 
 function isEnabledOnlyMcp(value: unknown) {
   return isRecord(value) && !own(value, "type") && typeof value.enabled === "boolean"
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
**Why**

Config normalization carried an exact copy of the AI package record guard. Keeping both predicates invites accidental divergence at a boundary that intentionally accepts non-null, non-array objects.

**What Changes**

Normalization imports the existing `isRecord` helper and removes its local copy. The stricter prototype-aware `isPlainRecord`, own-property writes, and arbitrary-key safeguards remain unchanged.

**Scope**

This PR changes only helper ownership; accepted configuration inputs and diagnostics remain the same.

**Verification**

```sh
cd packages/core
bun typecheck
bun run test test/config/normalization.test.ts
cd ../..
bunx prettier --write packages/core/src/config/normalize.ts
bunx oxlint packages/core/src/config/normalize.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/config/normalize.ts
git diff --check
```

Typecheck passed and 26 focused tests passed. Oxlint reported only existing warnings.