### PR TITLE
refactor(core): reuse tool name normalization

### DIFF
--- a/packages/core/src/codemode/tool.ts
+++ b/packages/core/src/codemode/tool.ts
@@ -3,7 +3,7 @@ export * as CodeModeTool from "./tool.js"
 import { CodeMode, Tool, toolError } from "@opencode-ai/codemode"
 import type { Content, Context, Error, Info, Metadata, Result } from "@opencode-ai/schema/tool"
 import { Effect, Ref, Schema, Semaphore } from "effect"
-import { definition } from "../tool/runtime.js"
+import { definition, normalizedName } from "../tool/runtime.js"
 
 const ExecuteFile = Schema.Struct({
   data: Schema.String,
@@ -165,7 +165,7 @@ function runtime(
 }
 
 function qualifiedName(registration: Info) {
-  const normalized = registration.name.replace(/[^a-zA-Z0-9_-]/g, "_")
+  const normalized = normalizedName(registration)
   if (registration.options?.namespace === undefined) return normalized
   return `${registration.options.namespace}.${normalized}`
 }

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -15,7 +15,7 @@ import { PluginHooks } from "./plugin/hooks.js"
 import { SessionMessage } from "./session/message.js"
 import { SessionSchema } from "./session/schema.js"
 import { State } from "./state.js"
-import { definition, execute, normalizeContent } from "./tool/runtime.js"
+import { definition, effectiveName, execute, normalizedName, normalizeContent } from "./tool/runtime.js"
 import { Wildcard } from "./util/wildcard.js"
 
 export class RegistrationError extends Schema.TaggedError<RegistrationError>()("Tool.RegistrationError", {
@@ -284,13 +284,6 @@ function registrationError(tool: Tool.Info) {
   })
   return Result.isFailure(result) ? result.failure : undefined
 }
-
-const normalizedName = (tool: Tool.Info) => tool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
-
-const effectiveName = (tool: Tool.Info) =>
-  tool.options?.namespace === undefined
-    ? normalizedName(tool)
-    : `${tool.options.namespace.replaceAll(".", "_")}_${normalizedName(tool)}`
 
 export const node = makeLocationNode({
   service: Service,

--- a/packages/core/src/tool/runtime.ts
+++ b/packages/core/src/tool/runtime.ts
@@ -270,9 +270,9 @@ const stringify = (value: unknown) => {
   }
 }
 
-const normalizedName = (tool: Tool.Info) => tool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
+export const normalizedName = (tool: Tool.Info) => tool.name.replace(/[^a-zA-Z0-9_-]/g, "_")
 
-const effectiveName = (tool: Tool.Info) =>
+export const effectiveName = (tool: Tool.Info) =>
   tool.options?.namespace === undefined
     ? normalizedName(tool)
     : `${tool.options.namespace.replaceAll(".", "_")}_${normalizedName(tool)}`


### PR DESCRIPTION
**Why**

Tool registration and runtime definition building maintained separate copies of the same normalized and effective name rules. Code Mode also repeated the normalization portion, increasing the chance that registered, advertised, and callable names drift.

**What Changes**

The registry now imports the runtime naming functions, and Code Mode reuses normalization while retaining its dotted namespace composition. Public tool names, flattened native names, dotted Code Mode paths, validation, and collision precedence are unchanged.

**Scope**

This PR only consolidates existing naming logic. MCP sanitization and Code Mode namespace policy remain separate.

**Verification**

```sh
cd packages/core
bun typecheck
bun run test test/session-runner-tool-registry.test.ts test/tool-execute.test.ts
cd ../..
bunx prettier --write packages/core/src/tool.ts packages/core/src/tool/runtime.ts packages/core/src/codemode/tool.ts
bunx oxlint packages/core/src/tool.ts packages/core/src/tool/runtime.ts packages/core/src/codemode/tool.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/tool.ts packages/core/src/tool/runtime.ts packages/core/src/codemode/tool.ts
git diff --check
```

Typecheck passed and 40 focused tests passed. Oxlint reported only existing warnings; the house scan reported the existing string-valued `Effect.die` in `tool/runtime.ts`, outside this change.