### PR TITLE
refactor(core): share local provider settings fold

### DIFF
--- a/packages/core/src/plugin/provider/configured.ts
+++ b/packages/core/src/plugin/provider/configured.ts
@@ -1,5 +1,5 @@
 import { Effect, Option } from "effect"
-import type { Document } from "@opencode-ai/schema/config"
+import type { Document, Entry } from "@opencode-ai/schema/config"
 import { Catalog } from "../../catalog.js"
 import { Config } from "../../config.js"
 import { Provider } from "../../provider.js"
@@ -9,7 +9,11 @@ export const configuredSettings = Effect.fn("ProviderPlugin.configuredSettings")
   const current = (yield* catalog.provider.get(id))?.settings
   const service = yield* Effect.serviceOption(Config.Service)
   const entries = Option.isSome(service) ? yield* service.value.entries() : []
+  return foldSettings(entries, id, current)
+})
+
+export function foldSettings(entries: readonly Entry[], id: string, initial: Provider.Settings | undefined) {
   return entries
     .filter((entry): entry is Document => entry.type === "document")
-    .reduce((settings, entry) => Provider.mergeOverlay(settings, entry.info.providers?.[id]?.settings), current)
-})
+    .reduce((settings, entry) => Provider.mergeOverlay(settings, entry.info.providers?.[id]?.settings), initial)
+}

--- a/packages/core/src/plugin/provider/lmstudio.ts
+++ b/packages/core/src/plugin/provider/lmstudio.ts
@@ -1,11 +1,11 @@
 import { define } from "@opencode-ai/plugin/effect/plugin"
-import { Document, type Entry } from "@opencode-ai/schema/config"
+import type { Entry } from "@opencode-ai/schema/config"
 import { Duration, Effect, Schedule, Schema, Semaphore, Stream } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { Config } from "../../config.js"
 import { Model } from "../../model.js"
-import { Provider } from "../../provider.js"
 import type { PluginInternal } from "../internal.js"
+import { foldSettings } from "./configured.js"
 
 const providerID = "lmstudio"
 
@@ -150,13 +150,7 @@ export function make(origin = "http://127.0.0.1:1234", interval: Duration.Input 
 export const LMStudioPlugin = make()
 
 function configured(entries: readonly Entry[], origin: string) {
-  const settings = entries
-    .filter((entry): entry is Document => entry.type === "document")
-    .flatMap((entry) => {
-      const settings = entry.info.providers?.[providerID]?.settings
-      return settings ? [settings] : []
-    })
-    .reduce<Provider.Settings | undefined>((result, item) => Provider.mergeOverlay(result, item), undefined)
+  const settings = foldSettings(entries, providerID, undefined)
   const baseURL = (
     typeof settings?.baseURL === "string" ? settings.baseURL : `${origin.replace(/\/+$/, "")}/v1`
   ).replace(/\/+$/, "")

--- a/packages/core/src/plugin/provider/ollama.ts
+++ b/packages/core/src/plugin/provider/ollama.ts
@@ -1,11 +1,11 @@
 import { define } from "@opencode-ai/plugin/effect/plugin"
-import { Document, type Entry } from "@opencode-ai/schema/config"
+import type { Entry } from "@opencode-ai/schema/config"
 import { Duration, Effect, Schedule, Schema, Semaphore, Stream } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { Config } from "../../config.js"
 import { Model } from "../../model.js"
-import { Provider } from "../../provider.js"
 import type { PluginInternal } from "../internal.js"
+import { foldSettings } from "./configured.js"
 
 const providerID = "ollama"
 
@@ -206,13 +206,7 @@ export function make(origin = "http://127.0.0.1:11434", interval: Duration.Input
 export const OllamaPlugin = make()
 
 function configured(entries: readonly Entry[], origin: string) {
-  const settings = entries
-    .filter((entry): entry is Document => entry.type === "document")
-    .flatMap((entry) => {
-      const settings = entry.info.providers?.[providerID]?.settings
-      return settings ? [settings] : []
-    })
-    .reduce<Provider.Settings | undefined>((result, item) => Provider.mergeOverlay(result, item), undefined)
+  const settings = foldSettings(entries, providerID, undefined)
   const baseURL = (
     typeof settings?.baseURL === "string" ? settings.baseURL : `${origin.replace(/\/+$/, "")}/v1`
   ).replace(/\/+$/, "")

--- a/packages/core/src/plugin/provider/vllm.ts
+++ b/packages/core/src/plugin/provider/vllm.ts
@@ -1,11 +1,11 @@
 import { define } from "@opencode-ai/plugin/effect/plugin"
-import { Document, type Entry } from "@opencode-ai/schema/config"
+import type { Entry } from "@opencode-ai/schema/config"
 import { Duration, Effect, Schedule, Schema, Semaphore, Stream } from "effect"
 import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { Config } from "../../config.js"
 import { Model } from "../../model.js"
-import { Provider } from "../../provider.js"
 import type { PluginInternal } from "../internal.js"
+import { foldSettings } from "./configured.js"
 
 const providerID = "vllm"
 
@@ -136,13 +136,7 @@ export function make(origin = "http://127.0.0.1:8000", interval: Duration.Input 
 export const VLLMPlugin = make()
 
 function configured(entries: readonly Entry[], origin: string) {
-  const settings = entries
-    .filter((entry): entry is Document => entry.type === "document")
-    .flatMap((entry) => {
-      const settings = entry.info.providers?.[providerID]?.settings
-      return settings ? [settings] : []
-    })
-    .reduce<Provider.Settings | undefined>((result, item) => Provider.mergeOverlay(result, item), undefined)
+  const settings = foldSettings(entries, providerID, undefined)
   const baseURL = (
     typeof settings?.baseURL === "string" ? settings.baseURL : `${origin.replace(/\/+$/, "")}/v1`
   ).replace(/\/+$/, "")


### PR DESCRIPTION
**Why**

LM Studio, Ollama, and vLLM each repeated the same ordered config-document settings fold. Keeping three copies risks drift in deep overlay and explicit clearing behavior.

**What Changes**

The existing configured-provider module now exposes a synchronous fold with an explicit initial value. Local discovery providers call it with `undefined`; the configured provider path continues to seed from current catalog settings.

**Scope**

Only pure settings folding is shared. Discovery inventories, refresh lifecycles, URL construction, endpoint policies, and catalog/config service acquisition remain provider-owned.

**Verification**

```sh
cd packages/core
bun typecheck
bun run test test/plugin/provider-lmstudio.test.ts test/plugin/provider-ollama.test.ts test/plugin/provider-vllm.test.ts
cd ../..
bunx prettier --write packages/core/src/plugin/provider/configured.ts packages/core/src/plugin/provider/lmstudio.ts packages/core/src/plugin/provider/ollama.ts packages/core/src/plugin/provider/vllm.ts
bunx oxlint packages/core/src/plugin/provider/configured.ts packages/core/src/plugin/provider/lmstudio.ts packages/core/src/plugin/provider/ollama.ts packages/core/src/plugin/provider/vllm.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/plugin/provider/configured.ts packages/core/src/plugin/provider/lmstudio.ts packages/core/src/plugin/provider/ollama.ts packages/core/src/plugin/provider/vllm.ts
git diff --check
```

Typecheck passed and all 14 focused provider tests passed. Lint and house scans passed without diagnostics.