### PR TITLE
refactor(core): parse MCP prompt arguments once

### DIFF
--- a/packages/core/src/plugin/command.ts
+++ b/packages/core/src/plugin/command.ts
@@ -60,14 +60,12 @@ export const Plugin = define({
           description: prompt.description,
           execute: (input) =>
             Effect.gen(function* () {
+              const args = parseArguments(input.prompt.text)
               const result = yield* mcp.prompt({
                 server: prompt.server,
                 name: prompt.name,
                 args: Object.fromEntries(
-                  (prompt.arguments ?? []).map((argument, index) => [
-                    argument.name,
-                    parseArguments(input.prompt.text)[index] ?? "",
-                  ]),
+                  (prompt.arguments ?? []).map((argument, index) => [argument.name, args[index] ?? ""]),
                 ),
               })
               if (!result) return yield* Effect.fail(new Error(`MCP prompt not found: ${prompt.server}:${prompt.name}`))


### PR DESCRIPTION
**Why**

MCP command execution tokenized the same prompt once for every declared argument. This repeated identical parsing work and made the positional mapping harder to read.

**What Changes**

The executor parses the prompt once and reuses the resulting positional array. Quoted tokens, image markers, argument order, and empty-string fallback behavior are unchanged.

**Scope**

This PR stays inside the built-in MCP command executor and does not introduce a tokenizer abstraction or change MCP transport behavior.

**Verification**

```sh
cd packages/core
bun typecheck
bun run test test/plugin/command.test.ts
cd ../..
bunx prettier --write packages/core/src/plugin/command.ts
bunx oxlint packages/core/src/plugin/command.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/plugin/command.ts
git diff --check
```

Typecheck passed and the existing command plugin test passed. The current fixture exposes an empty MCP service and does not provide a focused prompt invocation boundary; adding one would require duplicating the full MCP service fixture for this two-line behavior-preserving change.