### PR TITLE
refactor(core): consolidate HTML inline handling

### DIFF
--- a/packages/core/src/tool/html-markdown.ts
+++ b/packages/core/src/tool/html-markdown.ts
@@ -197,6 +197,12 @@ export function convertHTMLToMarkdown(html: string) {
           .trim()
           .replace(/([\\"])/g, "\\$1")}"`
       : ""
+  const inlineMarker = (name: string) => {
+    if (name === "strong" || name === "b") return "**"
+    if (name === "em" || name === "i") return "*"
+    if (name === "s" || name === "strike" || name === "del") return "~~"
+    return undefined
+  }
   const finishCode = (code: NonNullable<Frame["code"]>) => {
     if (code.inline && !code.text) return
     let backticks = 0
@@ -321,20 +327,9 @@ export function convertHTMLToMarkdown(html: string) {
         block()
         return
       }
-      if (name === "strong" || name === "b") {
-        inline("**", true)
-        frame.marker = { index: output.length - 1, block: blockCount, previous: activeMarker }
-        activeMarker = frame.marker
-        return
-      }
-      if (name === "em" || name === "i") {
-        inline("*", true)
-        frame.marker = { index: output.length - 1, block: blockCount, previous: activeMarker }
-        activeMarker = frame.marker
-        return
-      }
-      if (name === "s" || name === "strike" || name === "del") {
-        inline("~~", true)
+      const marker = inlineMarker(name)
+      if (marker) {
+        inline(marker, true)
         frame.marker = { index: output.length - 1, block: blockCount, previous: activeMarker }
         activeMarker = frame.marker
         return
@@ -509,16 +504,8 @@ export function convertHTMLToMarkdown(html: string) {
         return
       }
       if (name === "dd") return block()
-      if (
-        name === "strong" ||
-        name === "b" ||
-        name === "em" ||
-        name === "i" ||
-        name === "s" ||
-        name === "strike" ||
-        name === "del"
-      ) {
-        const value = name === "strong" || name === "b" ? "**" : name === "em" || name === "i" ? "*" : "~~"
+      const marker = inlineMarker(name)
+      if (marker) {
         const trailingSpace = pendingSpace
         pendingSpace = false
         if (frame.marker) activeMarker = frame.marker.previous
@@ -527,15 +514,15 @@ export function convertHTMLToMarkdown(html: string) {
           pendingSpace = trailingSpace || frame.marker.leadingSpace === true
           return
         }
-        inline(value)
+        inline(marker)
         pendingSpace = trailingSpace || frame.marker?.leadingSpace === true
         return
       }
       if (name === "a") {
         if (frame.link && (activeLink === frame.link || !activeLink)) {
           activeLink = frame.link
-          if (linkOpen) append(`](${destination(frame.link?.href ?? "")}${title(frame.link?.title)})`)
-          else if (last && last !== "\n") append(`](${destination(frame.link?.href ?? "")}${title(frame.link?.title)})`)
+          if (linkOpen || (last && last !== "\n"))
+            append(`](${destination(frame.link.href)}${title(frame.link.title)})`)
           linkOpen = false
           activeLink = undefined
         }


### PR DESCRIPTION
**Why**

HTML conversion repeated the same inline marker inventory and frame setup for strong, emphasis, and strike tags. Anchor closing also carried two identical append branches.

**What Changes**

Open and close handlers share one local tag-to-marker decision, and identical anchor append conditions are combined. Preformatted checks, marker frames, active-link identity, link-code handling, parser state, and byte accounting remain in their existing order.

**Scope**

This PR only consolidates local parser branches; it does not introduce a parser abstraction or alter Markdown policy.

**Verification**

```sh
cd packages/core
bun typecheck
bun run test test/tool-webfetch.test.ts
cd ../..
bunx prettier --write packages/core/src/tool/html-markdown.ts
bunx oxlint packages/core/src/tool/html-markdown.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/tool/html-markdown.ts
git diff --check
```

Typecheck passed and all 54 WebFetch/HTML tests passed. Oxlint reported one existing assertion warning outside the changed branches.