### PR TITLE
fix(core): preserve assistant text metadata

### DIFF
--- a/.changeset/assistant-text-metadata.md
+++ b/.changeset/assistant-text-metadata.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Preserve provider metadata on assistant text when replaying conversation history through AI SDK providers.

--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -514,7 +514,7 @@ function userPart(part: ContentPart): UserContent {
 function assistantPart(part: ContentPart): AssistantContent {
   switch (part.type) {
     case "text":
-      return [{ type: "text", text: part.text }]
+      return [{ type: "text", text: part.text, providerOptions: metadataProviderOptions(part.providerMetadata) }]
     case "media":
       return [{ type: "file", mediaType: part.mediaType, data: part.data, filename: part.filename }]
     case "reasoning":

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -326,6 +326,8 @@ it.effect("projects replay metadata onto AI SDK prompt parts", () =>
         model: resolved,
         messages: [
           Message.assistant([
+            { type: "text", text: "Answer", providerMetadata: { anthropic: { cacheControl: { type: "ephemeral" } } } },
+            { type: "text", text: " without metadata" },
             { type: "reasoning", text: "Think", providerMetadata: { anthropic: { signature: "signed" } } },
             {
               type: "tool-call",
@@ -344,6 +346,16 @@ it.effect("projects replay metadata onto AI SDK prompt parts", () =>
       {
         role: "assistant",
         content: [
+          {
+            type: "text",
+            text: "Answer",
+            providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+          },
+          {
+            type: "text",
+            text: " without metadata",
+            providerOptions: undefined,
+          },
           {
             type: "reasoning",
             text: "Think",


### PR DESCRIPTION
**Why**

Canonical assistant text parts can retain provider metadata for later same-model replay, but the AI SDK lowering path discarded that metadata while preserving it for neighboring reasoning and tool parts. Providers that understand text-part options therefore could not receive previously captured text state.

**What Changes**

| Assistant text input | AI SDK prompt part |
| --- | --- |
| Text with JSON-safe provider metadata | Text with matching `providerOptions` |
| Text without provider metadata | Text with no provider options |

The change uses the existing metadata conversion boundary, preserving its JSON-safe projection and the Session layer's existing model, provider, and error filtering.

**Scope**

This only changes live assistant-text replay. It does not assume every provider interprets text metadata, change provider storage defaults, normalize file data, or remove the adjacent unused `text` helper.

Open PR overlap was inspected before publishing. #45002 adds a later, unrelated test hunk in `aisdk.test.ts`; no open `v2` PR changes this source hunk. The separate dead-helper cleanup remains untouched.

**Verification**

```sh
cd packages/core
bun run test test/aisdk.test.ts
bun typecheck

cd ../..
bunx prettier --check packages/core/src/aisdk.ts packages/core/test/aisdk.test.ts .changeset/assistant-text-metadata.md
bunx oxlint packages/core/src/aisdk.ts packages/core/test/aisdk.test.ts
git diff --check
git push -u origin assistant-text-metadata
```

- Focused AI SDK suite: 31 passed, 0 failed.
- Core source and test typecheck passed.
- Push hook repository typecheck: 33 tasks passed.
- Prettier and diff checks passed.
- Scoped oxlint completed with 0 errors and 11 pre-existing warnings in the touched files, including the intentionally untouched unused helper.
