### PR TITLE
refactor(core): reuse Mercurial diff preparation

### DIFF
--- a/packages/core/src/plugin/vcs/hg.ts
+++ b/packages/core/src/plugin/vcs/hg.ts
@@ -109,25 +109,14 @@ function make(
       return []
     }),
     status: Effect.fn("VcsHg.status")(function* () {
-      const [items, batch] = yield* Effect.all(
-        // Zero-context patches are enough to count changed lines.
-        [hg.status(undefined, scope), hg.diff(undefined, scope, { context: 0 })],
-        { concurrency: 2 },
-      )
-      const chunks = chunksByFile(batch, () => undefined)
-      return yield* Effect.forEach(
-        items.toSorted((a, b) => a.file.localeCompare(b.file)),
+      return (yield* diffAgainst(undefined, { context: 0 })).map(
         (item) =>
-          Effect.gen(function* () {
-            const patch = yield* patchFor(item, undefined, chunks.get(item.file))
-            const counts = countPatch(patch)
-            return {
-              file: item.file,
-              additions: counts.additions,
-              deletions: counts.deletions,
-              status: item.status,
-            } satisfies FileStatus
-          }),
+          ({
+            file: item.file,
+            additions: item.additions,
+            deletions: item.deletions,
+            status: item.status,
+          }) satisfies FileStatus,
       )
     }),
     diff: Effect.fn("VcsHg.diff")(function* (mode: Mode, options?: DiffOptions) {


### PR DESCRIPTION
**Why**

Mercurial status duplicated the adapter diff workflow for status retrieval, patch splitting, sorting, synthetic patches, and line counts. Both paths therefore had to keep the same preparation behavior in sync.

**What Changes**

Status reuses the private diff preparation with zero context, then projects away the patch. Sorting, synthetic missing/untracked patches, counts, error behavior, and command concurrency remain unchanged.

**Scope**

This PR stays inside the Mercurial adapter and does not route through the public VCS diff service.

**Verification**

```sh
cd packages/core
bun typecheck
bun run test test/vcs-hg.test.ts
cd ../..
bunx prettier --write packages/core/src/plugin/vcs/hg.ts
bunx oxlint packages/core/src/plugin/vcs/hg.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/plugin/vcs/hg.ts
git diff --check
```

Typecheck, formatting, lint, house scan, and diff check passed. The six Mercurial tests were discovered but skipped because `hg` is unavailable in the isolated environment.