### PR TITLE
refactor(core): remove unused responses state

### DIFF
--- a/packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
+++ b/packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
@@ -1,9 +1,4 @@
-import {
-  type LanguageModelV3Prompt,
-  type LanguageModelV3ToolCallPart,
-  type SharedV3Warning,
-  UnsupportedFunctionalityError,
-} from "@ai-sdk/provider"
+import { type LanguageModelV3Prompt, type SharedV3Warning, UnsupportedFunctionalityError } from "@ai-sdk/provider"
 import { convertToBase64, parseProviderOptions } from "@ai-sdk/provider-utils"
 import { z } from "zod/v4"
 import type { OpenAIResponsesInput, OpenAIResponsesReasoning } from "./openai-responses-api-types.js"
@@ -116,7 +111,6 @@ export async function convertToOpenAIResponsesInput({
 
       case "assistant": {
         const reasoningMessages: Record<string, OpenAIResponsesReasoning> = {}
-        const toolCallParts: Record<string, LanguageModelV3ToolCallPart> = {}
 
         for (const part of content) {
           switch (part.type) {
@@ -129,8 +123,6 @@ export async function convertToOpenAIResponsesInput({
               break
             }
             case "tool-call": {
-              toolCallParts[part.toolCallId] = part
-
               if (part.providerExecuted) {
                 break
               }


### PR DESCRIPTION
**Why**
The Copilot Responses converter allocated and populated a tool-call lookup for every assistant message but never read or returned it. The apparent correlation state obscured that conversion uses each part directly.

**What Changes**
Remove the private `toolCallParts` record, its writes, and its now-unused SDK type import. The live reasoning-message and approval-ID state, provider-executed behavior, emitted function calls, and wire discriminants are unchanged.

**Scope**
This is a private converter-state deletion with no public, persisted, or request/response shape change.

**Verification**
```sh
cd packages/core
bun run test test/github-copilot/openai-responses-language-model.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
bunx oxlint packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/github-copilot/responses/convert-to-openai-responses-input.ts
# pre-push hook
bun turbo typecheck --concurrency=3
```

The focused suite passed 10 tests with 31 expectations. Core and full-workspace typechecks, Prettier, and the scoped AST scan passed. Oxlint reported five existing warnings and no errors.