### PR TITLE
fix(core): preserve Responses tool strictness

### DIFF
--- a/.changeset/responses-tool-strictness.md
+++ b/.changeset/responses-tool-strictness.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Preserve explicit function tool strictness in Copilot Responses requests.

--- a/packages/core/src/github-copilot/responses/openai-responses-prepare-tools.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-prepare-tools.ts
@@ -47,7 +47,7 @@ export function prepareResponsesTools({
           name: tool.name,
           description: tool.description,
           parameters: tool.inputSchema,
-          strict: strictJsonSchema,
+          strict: tool.strict ?? strictJsonSchema,
         })
         break
       case "provider": {

--- a/packages/core/test/github-copilot/openai-responses-prepare-tools.test.ts
+++ b/packages/core/test/github-copilot/openai-responses-prepare-tools.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider"
+import { prepareResponsesTools } from "@opencode-ai/core/github-copilot/responses/openai-responses-prepare-tools"
+
+function prepare(strict: boolean | undefined, strictJsonSchema: boolean) {
+  const tool: LanguageModelV3FunctionTool = {
+    type: "function",
+    name: "lookup",
+    inputSchema: { type: "object", properties: {} },
+    strict,
+  }
+  return prepareResponsesTools({ tools: [tool], strictJsonSchema }).tools?.[0]
+}
+
+test("function tools prefer explicit strictness over the global fallback", () => {
+  expect(prepare(true, false)).toMatchObject({ type: "function", strict: true })
+  expect(prepare(false, true)).toMatchObject({ type: "function", strict: false })
+  expect(prepare(undefined, true)).toMatchObject({ type: "function", strict: true })
+  expect(prepare(undefined, false)).toMatchObject({ type: "function", strict: false })
+})


### PR DESCRIPTION
**Why**

Copilot Responses accepted the SDK function tool `strict` field but overwrote every tool with the request-wide `strictJsonSchema` value. Explicit `true` became false under defaults, and explicit `false` became true under a global strict request.

**What Changes**

Function-tool lowering now uses `tool.strict ?? strictJsonSchema`. Explicit booleans survive, while omitted strictness retains the existing request-wide fallback and false default.

| Tool strict | Global fallback | Wire strict |
| --- | --- | --- |
| `true` | `false` | `true` |
| `false` | `true` | `false` |
| omitted | `true` | `true` |
| omitted | `false` | `false` |

**Scope**

This is limited to the existing Copilot Responses function-tool wire field. Response-format strictness, hosted tools, tool choice, warnings, Session contracts, and native providers are unchanged.

**Verification**

```sh
bun run test test/github-copilot/openai-responses-prepare-tools.test.ts # packages/core: 1 pass, 4 assertions
bun typecheck # packages/core
bunx prettier --check packages/core/src/github-copilot/responses/openai-responses-prepare-tools.ts packages/core/test/github-copilot/openai-responses-prepare-tools.test.ts
git diff --check
# push hook: bun turbo typecheck --concurrency=3
```

The focused strictness matrix, Core typechecking, formatting, diff checks, and all 33 push-hook typecheck tasks passed.