### PR TITLE
refactor(core): remove unused chat state

### DIFF
--- a/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
+++ b/packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
@@ -330,7 +330,6 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
     const toolCalls: Array<{
       id: string
-      type: "function"
       function: {
         name: string
         arguments: string
@@ -560,7 +559,6 @@ export class OpenAICompatibleChatLanguageModel implements LanguageModelV3 {
 
                   toolCalls[index] = {
                     id: toolCallDelta.id,
-                    type: "function",
                     function: {
                       name: toolCallDelta.function.name,
                       arguments: toolCallDelta.function.arguments ?? "",


### PR DESCRIPTION
**Why**
The Copilot Chat stream accumulator stored a private `type: "function"` discriminator that no parser, flush path, or emitted event reads. Keeping it suggests the accumulator itself is serialized even though output events construct their own wire discriminants.

**What Changes**
Remove only the unread private discriminator and initializer. Tool-call IDs, names, argument accumulation, completion tracking, event ordering, flush behavior, and emitted `tool-call` discriminants remain unchanged.

**Scope**
This does not change request-wire function tool types or any public/provider event shape.

**Verification**
```sh
cd packages/core
bun run test test/github-copilot/copilot-chat-model.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
bunx oxlint packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/github-copilot/chat/openai-compatible-chat-language-model.ts
# pre-push hook
bun turbo typecheck --concurrency=3
```

The focused suite passed 11 tests with 62 expectations. Core and full-workspace typechecks, Prettier, and the scoped AST scan passed. Oxlint reported three existing warnings and no errors.