### PR TITLE
test(core): exercise fsutil passthroughs

### DIFF
--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -361,29 +361,29 @@ describe("FSUtil", () => {
     it(
       "exists works",
       Effect.gen(function* () {
-        yield* FSUtil.Service
+        const fs = yield* FSUtil.Service
         const filesys = yield* FileSystem.FileSystem
         const tmp = yield* filesys.makeTempDirectoryScoped()
         const file = path.join(tmp, "exists.txt")
         yield* filesys.writeFileString(file, "yes")
 
-        expect(yield* filesys.exists(file)).toBe(true)
-        expect(yield* filesys.exists(file + ".nope")).toBe(false)
+        expect(yield* fs.exists(file)).toBe(true)
+        expect(yield* fs.exists(file + ".nope")).toBe(false)
       }),
     )
 
     it(
       "remove works",
       Effect.gen(function* () {
-        yield* FSUtil.Service
+        const fs = yield* FSUtil.Service
         const filesys = yield* FileSystem.FileSystem
         const tmp = yield* filesys.makeTempDirectoryScoped()
         const file = path.join(tmp, "delete-me.txt")
         yield* filesys.writeFileString(file, "bye")
 
-        yield* filesys.remove(file)
+        yield* fs.remove(file)
 
-        expect(yield* filesys.exists(file)).toBe(false)
+        expect(yield* fs.exists(file)).toBe(false)
       }),
     )
   })


### PR DESCRIPTION
## Why
The FSUtil passthrough tests acquire `FSUtil.Service` but discard it, then run every operation through the underlying platform filesystem. As written, the named tests can pass without exercising FSUtil's inherited wrapper methods.

## What Changes
Fixture creation still uses the platform filesystem. The existing `exists` and `remove` scenarios now invoke those methods through `FSUtil.Service`, including the post-removal assertion.

## Scope
This is a test-only subject correction for the two existing passthrough cases.

## Verification
Run from `packages/core`:

```sh
bun run test test/filesystem/filesystem.test.ts
bun typecheck
```

All 28 filesystem tests passed with 43 assertions. Core typechecking, repository pre-push typechecking, formatting, lint, and diff checks passed.
