### PR TITLE
refactor(core): preserve Copilot handler inference

### DIFF
--- a/packages/core/src/github-copilot/responses/openai-error.ts
+++ b/packages/core/src/github-copilot/responses/openai-error.ts
@@ -16,7 +16,7 @@ export const openaiErrorDataSchema = z.object({
 
 export type OpenAIErrorData = z.infer<typeof openaiErrorDataSchema>
 
-export const openaiFailedResponseHandler: any = createJsonErrorResponseHandler({
+export const openaiFailedResponseHandler = createJsonErrorResponseHandler({
   errorSchema: openaiErrorDataSchema,
   errorToMessage: (data) => data.error.message,
 })


### PR DESCRIPTION
**Why**
The Copilot Responses error handler erased the SDK factory return type with an explicit `any`, hiding the typed `ResponseHandler` contract from its consumers.

**What Changes**
The unnecessary annotation is removed so `createJsonErrorResponseHandler` supplies the handler type. Runtime schema, error mapping, and exports are unchanged.

**Scope**
This is a one-line inference cleanup in the Responses adapter; independent error schemas and handler behavior are untouched.

**Verification**
```sh
cd packages/core
bun run test test/github-copilot/openai-responses-language-model.test.ts
bun typecheck
cd ../..
bun run prettier --check packages/core/src/github-copilot/responses/openai-error.ts
bun run oxlint packages/core/src/github-copilot/responses/openai-error.ts
git diff --check
git push -u origin copilot-handler-type  # pre-push hook: full workspace typecheck
```

Copilot Responses tests: 10 passed, 0 failed. Package and full-workspace typechecks passed; oxlint reported 0 warnings and 0 errors.