### PR TITLE
test(core): remove dead test setup

### DIFF
--- a/packages/core/test/config/policy.test.ts
+++ b/packages/core/test/config/policy.test.ts
@@ -7,7 +7,7 @@ import { Bus } from "@opencode-ai/core/bus"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
 import { Provider } from "@opencode-ai/core/provider"
-import { Effect, Schema, Stream } from "effect"
+import { Effect, Schema } from "effect"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "../plugin/fixture"
 

--- a/packages/core/test/plugin/fixture.ts
+++ b/packages/core/test/plugin/fixture.ts
@@ -79,7 +79,6 @@ export const PluginTestLayer = LayerNode.compile(
     Reference.node,
     Skill.node,
     SkillDiscovery.node,
-    PluginHooks.node,
     Tool.node,
     Vcs.node,
     Watcher.node,

--- a/packages/core/test/plugin/host.ts
+++ b/packages/core/test/plugin/host.ts
@@ -1,5 +1,5 @@
 import { Plugin } from "@opencode-ai/plugin/effect"
-import type { IntegrationMethod, IntegrationMethodRegistration } from "@opencode-ai/plugin/effect/integration"
+import type { IntegrationMethod } from "@opencode-ai/plugin/effect/integration"
 import { Agent } from "@opencode-ai/core/agent"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Credential } from "@opencode-ai/core/credential"
@@ -439,10 +439,6 @@ export function webSearchHost(websearch: WebSearch.Interface): Plugin.Context["w
         })
       }),
   }
-}
-
-function oauthCredential(value: Credential.OAuth) {
-  return Credential.OAuth.make({ ...value, methodID: Integration.MethodID.make(value.methodID) })
 }
 
 function internalMethod(value: IntegrationMethod): Integration.Method {

--- a/packages/core/test/plugin/variant.test.ts
+++ b/packages/core/test/plugin/variant.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
-import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Location } from "@opencode-ai/core/location"
 import { Model } from "@opencode-ai/core/model"
 import { VariantPlugin } from "@opencode-ai/core/plugin/variant"

--- a/packages/core/test/plugin/websearch-fixture.ts
+++ b/packages/core/test/plugin/websearch-fixture.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Stream } from "effect"
+import { Effect, Layer } from "effect"
 import { HttpClient, HttpClientResponse } from "effect/unstable/http"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"

--- a/packages/core/test/session-tool-progress.test.ts
+++ b/packages/core/test/session-tool-progress.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { asc, eq } from "drizzle-orm"
-import { DateTime, Effect, Schema } from "effect"
+import { Effect, Schema } from "effect"
 import { Database } from "@opencode-ai/core/database/database"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
@@ -24,7 +24,6 @@ const it = testEffect(
     [Bus.node, Bus.configured({ persist: true })],
   ]),
 )
-const timestamp = DateTime.makeUnsafe(1)
 const model = { id: Model.ID.make("model"), providerID: Provider.ID.make("provider") }
 
 const content = (text: string) => [{ type: "text" as const, text }] as const


### PR DESCRIPTION
**Why**
Several tests retained setup that was never consumed: unused imports, a fixed timestamp that configured no clock or event, a duplicate plugin hook node, and an uncalled credential adapter. These fixtures implied dependencies or lifecycle behavior they did not have.

**What Changes**
- Removes unused `Stream`, `DateTime`, and `LayerNode` setup from focused Config, websearch, session progress, and Variant tests.
- Removes the duplicate `PluginHooks.node` entry from the plugin test graph.
- Removes the uncalled `oauthCredential` helper and its now-unused type import from the test host.

**Scope**
Only dead test scaffolding is removed. Service layers, event construction, projected-state assertions, websearch request capture, policy reload behavior, and variant generation are unchanged. MCP/AppProcess fixture edits in #45618/#45086 and host behavior additions in #43681/#43556 are outside these hunks.

**Verification**
```sh
cd packages/core
bun run test test/config/policy.test.ts test/plugin/websearch.test.ts test/session-tool-progress.test.ts
bun run test test/plugin/variant.test.ts test/plugin/promise.test.ts
bun typecheck

cd ../..
bun turbo typecheck --concurrency=3
bun prettier --check packages/core/test/config/policy.test.ts packages/core/test/plugin/websearch-fixture.ts packages/core/test/session-tool-progress.test.ts packages/core/test/plugin/fixture.ts packages/core/test/plugin/host.ts packages/core/test/plugin/variant.test.ts
bun oxlint packages/core/test/plugin/fixture.ts packages/core/test/plugin/host.ts packages/core/test/plugin/variant.test.ts
git diff --check origin/v2...HEAD
```

9 original focused tests and 23 plugin fixture consumer tests passed. Core and workspace typechecks passed. Formatting and diff checks passed; scoped lint reported zero errors with pre-existing fixture/host warnings only.
