### PR TITLE
refactor(core): remove infallible layer conversion

### DIFF
--- a/packages/core/src/location-mutation.ts
+++ b/packages/core/src/location-mutation.ts
@@ -120,6 +120,6 @@ const layer = Layer.effect(
 
 export const node = makeLocationNode({
   service: Service,
-  layer: layer.pipe(Layer.orDie),
+  layer,
   deps: [FSUtil.node, Location.node, ProjectMarkers.node],
 })

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1209,7 +1209,7 @@ const SHELL_MAX_CAPTURE_BYTES = 1024 * 1024
 
 export const node = makeGlobalNode({
   service: Service,
-  layer: layer.pipe(Layer.orDie),
+  layer,
   deps: [
     Job.node,
     SessionEnvironment.node,


### PR DESCRIPTION
**Why**
Session and LocationMutation wrap their implementation layers in typed-error conversion even though layer acquisition only reads services, allocates local state, and constructs methods. Their actual database, filesystem, admission, and move failures occur later inside those methods, outside the conversion boundary.

**What Changes**
Passes both implementation layers directly to their app nodes. Node dependencies, service identity, per-build state, scopes, and method-level error policies are unchanged.

**Scope**
This removes only the build-time `Layer.orDie` wrappers. It does not change dependency-layer construction or convert any Session/LocationMutation operation errors.

**Verification**
```sh
cd packages/core
bun typecheck
bun run test test/location-mutation.test.ts test/session-create.test.ts
cd ../..
bunx oxlint packages/core/src/location-mutation.ts packages/core/src/session.ts
```

Core typecheck passed and all 55 focused tests passed. Oxlint completed with no errors and eight pre-existing warnings in `session.ts`. The push hook completed the 33-package workspace typecheck.