### PR TITLE
refactor(core): delegate credential activation

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -719,16 +719,7 @@ const layer = Layer.effect(
             }),
           })
         }),
-        activate: Effect.fn("Integration.connection.activate")(function* (credentialID) {
-          const credential = yield* credentials.get(credentialID)
-          if (!credential) return
-          const active = resolveConnections(
-            state.get().integrations.get(credential.integrationID),
-            yield* credentials.list(credential.integrationID),
-          )[0]
-          if (active?.type === "credential" && active.id === credentialID) return
-          yield* credentials.activate(credentialID)
-        }),
+        activate: Effect.fn("Integration.connection.activate")((credentialID) => credentials.activate(credentialID)),
         update: Effect.fn("Integration.connection.update")((credentialID, updates) =>
           credentials.update(credentialID, updates),
         ),


### PR DESCRIPTION
**Why**
Integration credential activation currently duplicates credential lookup and active-selection reconstruction before calling the credential service. That creates a second implementation of missing-ID and idempotence behavior outside the transaction that owns activation ordering and switch events.

**What Changes**
`Integration.connection.activate` remains the named Integration facade but now delegates directly to `Credential.activate`.

| Case | Result |
| --- | --- |
| Missing credential ID | No-op |
| Already active credential | No-op |
| Inactive credential | Transactionally activates it and publishes one switch event |

Environment precedence, connection projection, credential ordering, event publication, and the HTTP-facing Integration contract remain unchanged.

**Scope**
This PR only removes redundant activation logic from the Integration facade. It does not change credential persistence, Integration locking/state reads, events, or API schemas.

**Verification**
```sh
cd packages/core
bun run test test/credential.test.ts
bun run test test/integration.test.ts -t "projects credential and env connections"
bun typecheck
cd ../..
bunx prettier --check packages/core/src/integration.ts
bunx oxlint packages/core/src/integration.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/integration.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/integration.ts
git diff --check origin/v2...HEAD
```

All four credential tests and the focused Integration projection/activation test pass. Core typechecking and the pre-push workspace typecheck pass; formatting and both scoped scans are clean. Oxlint completes with existing warnings outside the changed line.

A broader combined credential/Integration run completed 16 tests and timed out only in the unrelated command-authentication polling test; that path was not retried or changed here.
