### PR TITLE
fix(core): correct compaction history direction

### DIFF
--- a/.changeset/compaction-history-direction.md
+++ b/.changeset/compaction-history-direction.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Correct the compaction prompt to point existing summaries at the conversation history that follows them.

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -215,7 +215,7 @@ const select = (
 export const buildPrompt = (input: { readonly previousSummary?: string; readonly context: readonly string[] }) =>
   [
     input.previousSummary
-      ? `Update the anchored summary below using the conversation history above.\nPreserve still-true details, remove stale details, and merge in the new facts.\n<previous-summary>\n${input.previousSummary}\n</previous-summary>`
+      ? `Update the anchored summary below using the conversation history below.\nPreserve still-true details, remove stale details, and merge in the new facts.\n<previous-summary>\n${input.previousSummary}\n</previous-summary>`
       : "Create a new anchored summary from the conversation history.",
     SUMMARY_TEMPLATE,
     "The following is the conversation history:",

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -143,6 +143,13 @@ test("compaction prompt requires the checkpoint headings in order", () => {
   expect(prompt).toContain("Keep every section, even when empty.")
 })
 
+test("compaction points an existing summary to the following history", () => {
+  const prompt = SessionCompaction.buildPrompt({ previousSummary: "Previous summary", context: ["Recent history"] })
+
+  expect(prompt.split("\n", 1)[0]).toBe("Update the anchored summary below using the conversation history below.")
+  expect(prompt).not.toContain("conversation history above")
+})
+
 it.effect("auto compaction reserves a buffer below the prompt ceiling", () =>
   Effect.gen(function* () {
     const compaction = yield* SessionCompaction.Service


### PR DESCRIPTION
**Why**

When updating an existing compaction summary, the prompt told the model to use conversation history "above" even though the history follows the summary and template. That directional instruction contradicted the actual prompt layout.

**What Changes**

The existing-summary sentence now points to the conversation history "below." Prompt ordering, retained-history selection, summary structure, and new-summary wording remain unchanged.

The regression pins the exact first sentence and rejects the stale directional phrase. The patch includes a changeset for future compaction requests.

**Scope**

This corrects one positional word only. It does not rewrite the compaction prompt or change persisted summaries.

**Verification**

From `packages/core`:

```sh
bun run test test/session-compaction.test.ts
bun typecheck
```

From the repository root:

```sh
bunx oxlint packages/core/src/session/compaction.ts packages/core/test/session-compaction.test.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/session/compaction.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/session/compaction.ts
git diff --check
sh .husky/pre-push
```

The focused suite passed (9 tests), Core typecheck passed, both structural scans passed, diff-check passed, and the full 39-package pre-push typecheck passed. Scoped oxlint completed with one pre-existing warning in unchanged compaction control flow and no errors.
