### PR TITLE
refactor(core): reuse execute visibility predicate

### DIFF
--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -211,8 +211,7 @@ const layer = Layer.effect(
           }
           const direct = new Map(Array.from(active).filter(([, tool]) => tool.options?.codemode === false))
           const codemode = new Map(Array.from(active).filter(([, tool]) => tool.options?.codemode !== false))
-          const executeRule = rules.findLast((rule) => Wildcard.match("execute", rule.action))
-          const codemodeEnabled = executeRule?.resource !== "*" || executeRule.effect !== "deny"
+          const codemodeEnabled = !whollyDisabled("execute", rules)
           const codemodeTool = codemodeEnabled
             ? CodeModeTool.create(codemode, (name, tool, input, context) =>
                 beforeExecute(name, input, context).pipe(


### PR DESCRIPTION
**Why**

Code Mode visibility repeated the exact negation of the registry's existing whole-resource disabled predicate. Keeping two spellings for the same last-match policy risks future drift between ordinary-tool and `execute` catalog filtering.

**What Changes**

The snapshot now computes Code Mode visibility with `!whollyDisabled("execute", rules)`. This preserves absent rules, last-match precedence, `resource === "*"`, empty versus disabled catalogs, and the separation between catalog visibility and leaf execution authorization.

**Scope**

This is predicate reuse only. No permission evaluation boundary or tool execution behavior changes.

**Verification**

From `packages/core`:

```sh
bun run test test/session-runner-tool-registry.test.ts
bun typecheck
```

From the repository root:

```sh
bunx oxlint packages/core/src/tool.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/tool.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/tool.ts
git diff --check
sh .husky/pre-push
```

The full registry suite passed (35 tests), Core typecheck passed, lint and both structural scans passed, diff-check passed, and the full 39-package pre-push typecheck passed.
