### PR TITLE
refactor(core): simplify instruction preview blobs

### DIFF
--- a/packages/core/src/session/instruction-state.ts
+++ b/packages/core/src/session/instruction-state.ts
@@ -202,7 +202,7 @@ export const preview = Effect.fn("InstructionState.preview")(function* (
     update: Instructions.renderUpdate(
       instructions,
       dereference(state.current_values, stored),
-      dereferenceDelta(result.delta, new Map([...stored, ...observedBlobs])),
+      dereferenceDelta(result.delta, observedBlobs),
     ),
   }
 })

--- a/packages/core/test/instruction-state.test.ts
+++ b/packages/core/test/instruction-state.test.ts
@@ -322,6 +322,35 @@ describe("InstructionState", () => {
     }),
   )
 
+  it.effect("previews changed and removed instructions from observed blobs", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionSchema.ID.make("ses_instruction_generate_delta")
+      const { db, events } = yield* setup(sessionID)
+      let current = "Initial context"
+      let retired: string | Instructions.Removed = "Retired context"
+      const instructions = Instructions.combine([
+        source(
+          "test/current",
+          Effect.sync(() => current),
+        ),
+        source(
+          "test/retired",
+          Effect.sync(() => retired),
+        ),
+      ])
+      yield* InstructionState.prepare(db, events, instructions, sessionID)
+      current = "Changed context"
+      retired = Instructions.removed
+
+      const assembled = yield* preview(db, sessionID, instructions)
+
+      expect(assembled.initial).toContain("Initial context")
+      expect(assembled.initial).toContain("Retired context")
+      expect(assembled.update).toContain("Changed context")
+      expect(assembled.update).toContain("Removed Retired context")
+    }),
+  )
+
   it.effect("persists chronological updates as system messages", () =>
     Effect.gen(function* () {
       const sessionID = SessionSchema.ID.make("ses_instruction_messages")


### PR DESCRIPTION
**Why**

Instruction preview merged stored blobs into the map used to dereference a fresh delta. Every non-removal delta value is already admitted together with its observed blob, while removals need no blob, so the merge obscured that invariant and allocated an unnecessary map.

**What Changes**

Preview now passes the complete observed blob map directly to delta dereferencing. Stored blob reads remain unchanged for the epoch baseline and previous values, including missing-blob integrity checks and the distinction between missing values and JSON null.

A focused regression combines one changed source with one removed source and verifies both the persisted baseline rendering and fresh update rendering.

**Scope**

This is a private preview-path cleanup. It does not change persistence, commit behavior, instruction epochs, or public result fields.

**Verification**

From `packages/core`:

```sh
bun run test test/instruction-state.test.ts
bun typecheck
```

From the repository root:

```sh
bunx oxlint packages/core/src/session/instruction-state.ts packages/core/test/instruction-state.test.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/session/instruction-state.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/session/instruction-state.ts
git diff --check
sh .husky/pre-push
```

The focused suite passed (11 tests), Core typecheck passed, lint and both structural scans passed, diff-check passed, and the full 39-package pre-push typecheck passed.
