### PR TITLE
test(core): use partial service mocks

### DIFF
--- a/packages/core/test/tool-question.test.ts
+++ b/packages/core/test/tool-question.test.ts
@@ -45,28 +45,19 @@ const permission = permissionLayer({
       ),
     ),
 })
-const form = Layer.succeed(
-  Form.Service,
-  Form.Service.of({
-    ask: (input: Form.CreateInput) =>
-      Effect.sync(() => {
-        captured = input
-      }).pipe(
-        Effect.andThen(
-          Effect.sync(
-            (): Form.TerminalState =>
-              reject ? { status: "cancelled" } : { status: "answered", answer: { q0: "Build", q1: ["Dev"] } },
-          ),
+const form = Layer.mock(Form.Service, {
+  ask: (input: Form.CreateInput) =>
+    Effect.sync(() => {
+      captured = input
+    }).pipe(
+      Effect.andThen(
+        Effect.sync(
+          (): Form.TerminalState =>
+            reject ? { status: "cancelled" } : { status: "answered", answer: { q0: "Build", q1: ["Dev"] } },
         ),
       ),
-    create: () => Effect.die("unused"),
-    get: () => Effect.die("unused"),
-    list: () => Effect.die("unused"),
-    state: () => Effect.die("unused"),
-    reply: () => Effect.die("unused"),
-    cancel: () => Effect.die("unused"),
-  }),
-)
+    ),
+})
 const questionToolNode = makeLocationNode({
   name: "test/question-tool-plugin",
   layer: Layer.effectDiscard(registerToolPlugin(QuestionTool.Plugin)),
@@ -114,6 +105,7 @@ describe("QuestionTool", () => {
     Effect.gen(function* () {
       captured = undefined
       deny = true
+      yield* Effect.addFinalizer(() => Effect.sync(() => (deny = false)))
       const registry = yield* Tool.Service
 
       expect(
@@ -135,7 +127,6 @@ describe("QuestionTool", () => {
         },
       })
       expect(capturedInput()).toBeUndefined()
-      deny = false
     }),
   )
 

--- a/packages/core/test/tool-skill.test.ts
+++ b/packages/core/test/tool-skill.test.ts
@@ -69,15 +69,10 @@ describe("SkillTool", () => {
                 ),
               ),
           })
-          const skills = Layer.succeed(
-            Skill.Service,
-            Skill.Service.of({
-              transform: (_transform) => Effect.die("unused"),
-              reload: () => Effect.die("unused"),
-              get: (id) => Effect.succeed(current.find((skill) => skill.id === id)),
-              list: () => Effect.succeed(current),
-            }),
-          )
+          const skills = Layer.mock(Skill.Service, {
+            get: (id) => Effect.succeed(current.find((skill) => skill.id === id)),
+            list: () => Effect.succeed(current),
+          })
           const skillToolLayer = AppNodeBuilder.build(LayerNode.group([Tool.node, skillToolNode]), [
             [Permission.node, permission],
             [Skill.node, skills],


### PR DESCRIPTION
## Why
Focused Form and Skill doubles repeat every unused effectful method as `Effect.die("unused")`. This makes the tests track unrelated interface additions while obscuring the one or two behaviors each fixture actually controls; the question denial flag also resets only after successful assertions.

## What Changes
- QuestionTool's Form layer uses the existing `Layer.mock` convention and implements only `ask`.
- SkillTool's Skill layer uses `Layer.mock` and retains its stateful `get` and `list` behavior.
- The question denial case registers immediate scoped restoration, so permission state resets on failure as well as success.
- Nested service objects and exercised fixture state remain explicit; omitted methods still fail if unexpectedly executed.

## Scope
This handles the Form and Skill partial mocks. The WebSearch occurrence remains with the separate controlled-websearch fixture PR.

## Verification
Run from `packages/core`:

```sh
bun run test test/tool-question.test.ts test/tool-skill.test.ts
bun typecheck
```

All 6 focused tests passed with 25 assertions. Core typechecking, repository pre-push typechecking, formatting, lint, and diff checks passed.
