### PR TITLE
fix(core): keep vertex settings serializable

### DIFF
--- a/.changeset/vertex-settings-serialization.md
+++ b/.changeset/vertex-settings-serialization.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Keep Google Vertex catalog settings serializable during model projection.

--- a/packages/core/src/plugin/provider/google-vertex.ts
+++ b/packages/core/src/plugin/provider/google-vertex.ts
@@ -81,9 +81,6 @@ export const GoogleVertexPlugin = define({
             ...(typeof provider.settings?.baseURL === "string"
               ? { baseURL: replaceVertexVars(provider.settings.baseURL, project, location) }
               : {}),
-            ...(Provider.packageName(provider.package)?.includes("@ai-sdk/openai-compatible")
-              ? { fetch: authFetch(provider.settings?.fetch) }
-              : {}),
           }
         })
       }

--- a/packages/core/test/plugin/provider-google-vertex.test.ts
+++ b/packages/core/test/plugin/provider-google-vertex.test.ts
@@ -253,7 +253,7 @@ describe("GoogleVertexPlugin", () => {
       () =>
         Effect.gen(function* () {
           const catalog = yield* Catalog.Service
-          yield* catalog.transform((catalog) =>
+          yield* catalog.transform((catalog) => {
             catalog.provider.update(Provider.ID.make("google-vertex"), (provider) => {
               provider.package = Provider.aisdk("@ai-sdk/openai-compatible")
               provider.settings = {
@@ -262,16 +262,19 @@ describe("GoogleVertexPlugin", () => {
                   "https://${GOOGLE_VERTEX_ENDPOINT}/v1/projects/${GOOGLE_VERTEX_PROJECT}/locations/${GOOGLE_VERTEX_LOCATION}",
               }
               provider.settings = { ...provider.settings, project: "config-project", location: "global" }
-            }),
-          )
+            })
+            catalog.model.update(Provider.ID.make("google-vertex"), Model.ID.make("gemini"), () => {})
+          })
           yield* addPlugin()
           const provider = required(yield* catalog.provider.get(Provider.ID.make("google-vertex")))
+          const model = required(yield* catalog.model.get(Provider.ID.make("google-vertex"), Model.ID.make("gemini")))
           expect(provider.settings?.project).toBe("config-project")
           expect(provider.settings?.location).toBe("global")
           expect(provider).toMatchObject({
             package: "aisdk:@ai-sdk/openai-compatible",
             settings: { baseURL: "https://aiplatform.googleapis.com/v1/projects/config-project/locations/global" },
           })
+          expect(model.settings).toEqual(provider.settings)
         }),
     ),
   )


### PR DESCRIPTION
**Why**

The Google Vertex catalog transform stored a runtime `fetch` function in provider settings. Catalog model projection JSON-merges provider and model settings, so reading a compatible Vertex model could fail schema validation before execution.

**What Changes**

The catalog transform now retains only serializable project, location, and endpoint settings. Google authentication fetch injection remains in the existing AI SDK runtime hook.

The regression adds a model to the existing compatible-Vertex catalog case and reads its projected settings through the real Catalog service.

**Scope**

This fixes the catalog/settings boundary only. It does not change native provider selection or claim to add ADC authentication to the native OpenAI-compatible route.

**Verification**

```sh
cd packages/core
bun run test test/plugin/provider-google-vertex.test.ts
bun typecheck

cd ../..
bunx prettier --check packages/core/src/plugin/provider/google-vertex.ts packages/core/test/plugin/provider-google-vertex.test.ts
bunx oxlint packages/core/src/plugin/provider/google-vertex.ts packages/core/test/plugin/provider-google-vertex.test.ts
git diff --check
git push -u origin vertex-settings # repository hook: full workspace typecheck
```

Focused result: 12 tests passed. Core typecheck, formatting, diff validation, and the full 39-package push-hook typecheck passed. Oxlint completed with only pre-existing warnings in the test file.
