### PR TITLE
test(core): make test sentinels effective

### DIFF
--- a/packages/core/test/shared-schema.test.ts
+++ b/packages/core/test/shared-schema.test.ts
@@ -162,7 +162,6 @@ test("Core reuses the canonical shared schemas", async () => {
   ]
   for (const [core, shared] of schemas) expect(core).toBe(shared)
 
-  expect(Agent.Info.default(Agent.ID.make("test"))).toEqual(Agent.Info.default(Agent.ID.make("test")))
   expect(coreModel.Info.default(coreProvider.ID.make("test"), coreModel.ID.make("model"))).toEqual(
     Model.Info.default(Provider.ID.make("test"), Model.ID.make("model")),
   )

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -45,7 +45,9 @@ describe("Skill", () => {
           value.description = "Updated"
           value.id = Skill.ID.make("ignored")
         })
-        draft.update("missing", () => Effect.die("unreachable"))
+        draft.update("missing", () => {
+          throw new Error("unreachable")
+        })
         draft.add(info("deploy", "Deploy"))
         draft.remove("deploy")
       })


### PR DESCRIPTION
**Why**
The missing-skill updater returns a lazy `Effect.die`, but the updater contract is synchronous and discards return values, so the impossible-path sentinel would not execute. The shared-schema suite also compares the Core Agent default constructor with itself, adding no assertion beyond the schema identity check already present.

**What Changes**
- Throw synchronously if the missing-skill updater is unexpectedly called.
- Remove the redundant Agent default self-comparison.

**Scope**
This preserves the existing test intent without adding coverage or changing production behavior.

**Verification**
```sh
bun install --frozen-lockfile
cd packages/core && bun typecheck
cd packages/core && bun run test test/skill.test.ts test/shared-schema.test.ts
bunx prettier --check packages/core/test/skill.test.ts packages/core/test/shared-schema.test.ts
git push -u origin executable-checks
```

The focused run passed 7 tests. Package typecheck, formatting, and the push-hook repository typecheck passed.