### PR TITLE
refactor(core): use environment driver namespace

### DIFF
--- a/packages/core/src/workspace.ts
+++ b/packages/core/src/workspace.ts
@@ -6,7 +6,7 @@ import { eq } from "drizzle-orm"
 import { Clock, Context, Deferred, Duration, Effect, Exit, FiberSet, Layer, Ref, Schedule, Schema, Scope } from "effect"
 import { systemError } from "effect/PlatformError"
 import { make } from "effect/unstable/process/ChildProcessSpawner"
-import type { Driver as EnvironmentDriver } from "./environment/driver.js"
+import type { EnvironmentDriver } from "./environment/driver.js"
 import { Database } from "./database/database.js"
 import { KeyedMutex } from "./effect/keyed-mutex.js"
 import { WorkspaceDriver } from "./workspace/driver.js"
@@ -43,12 +43,11 @@ export interface Interface {
   ) => Effect.Effect<Info, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
   readonly connect: (
     workspaceID: ID,
-  ) => Effect.Effect<EnvironmentDriver, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
+  ) => Effect.Effect<EnvironmentDriver.Driver, NotFound | WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
   /** Makes the workspace absent; reports whether this call destroyed an existing workspace. */
-  readonly destroy: (workspaceID: ID) => Effect.Effect<
-    Workspace.DestroyResult,
-    WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound
-  >
+  readonly destroy: (
+    workspaceID: ID,
+  ) => Effect.Effect<Workspace.DestroyResult, WorkspaceDriver.Error | WorkspaceDriver.ProviderNotFound>
 }
 
 export interface Options {
@@ -60,7 +59,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Wo
 
 interface Connection {
   readonly driver: WorkspaceDriver.Interface
-  readonly environment: EnvironmentDriver
+  readonly environment: EnvironmentDriver.Driver
   readonly saveBinding: (binding: WorkspaceDriver.Binding) => Effect.Effect<void>
   readonly lastActivity: Ref.Ref<number>
   readonly active: Ref.Ref<number>
@@ -91,12 +90,7 @@ const layer = (options: Options) =>
       const idleThreshold = Duration.toMillis(options.idleThreshold ?? Duration.minutes(20))
 
       const find = (workspaceID: ID) =>
-        db
-          .select()
-          .from(WorkspaceTable)
-          .where(eq(WorkspaceTable.id, workspaceID))
-          .get()
-          .pipe(Effect.orDie)
+        db.select().from(WorkspaceTable).where(eq(WorkspaceTable.id, workspaceID)).get().pipe(Effect.orDie)
 
       const load = Effect.fn("Workspace.load")(function* (workspaceID: ID) {
         const row = yield* find(workspaceID)

--- a/packages/core/src/workspace/driver.ts
+++ b/packages/core/src/workspace/driver.ts
@@ -4,7 +4,7 @@ import { Workspace } from "@opencode-ai/schema/workspace"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { Context, Effect, Layer, Schema } from "effect"
 import type { Scope } from "effect"
-import type { Driver as EnvironmentDriver } from "../environment/driver.js"
+import type { EnvironmentDriver } from "../environment/driver.js"
 
 /**
  * Smallest provider-owned JSON value required to reconnect to the same
@@ -41,7 +41,7 @@ export interface Interface {
     readonly workspaceID: Workspace.ID
     readonly binding: Binding
     readonly saveBinding: (binding: Binding) => Effect.Effect<void>
-  }) => Effect.Effect<EnvironmentDriver, Error, Scope.Scope>
+  }) => Effect.Effect<EnvironmentDriver.Driver, Error, Scope.Scope>
   readonly suspendForIdle: (input: {
     readonly workspaceID: Workspace.ID
     readonly binding: Binding


### PR DESCRIPTION
**Why**
Workspace modules renamed the environment `Driver` import even though that module already exports the contextual `EnvironmentDriver` namespace. The aliases violated the repository import policy and obscured the source namespace.

**What Changes**
Both workspace modules now import the type-only `EnvironmentDriver` namespace and refer to `EnvironmentDriver.Driver` at contract boundaries.

**Scope**
This changes only type import spelling. Workspace return shapes, provider contracts, registry behavior, provisioning, connection, and idle lifecycle are unchanged.

**Verification**
```sh
cd packages/core
bun run test test/workspace.test.ts
bun typecheck
cd ../..
bun run prettier --write packages/core/src/workspace.ts packages/core/src/workspace/driver.ts
bun run oxlint packages/core/src/workspace.ts packages/core/src/workspace/driver.ts
git diff --check
git push -u origin workspace-driver-import  # pre-push hook: full workspace typecheck
```

Workspace tests: 17 passed, 0 failed. Package and full-workspace typechecks passed; oxlint reported 0 warnings and 0 errors.