### PR TITLE
refactor(core): use keyed MCP credential reads

### DIFF
--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -273,14 +273,12 @@ export const layer = (options?: Options) =>
           return MCPOAuth.provider({ ...base, store: MCPOAuth.memoryStore() })
         const credentialID = found.id
         const methodID = found.value.methodID
-        const integrationID = entry.integrationID
         // Tracks the refresh token this provider last presented, so invalidate can tell whether the SDK
         // rejected the currently-stored credential or a snapshot another connection has already rotated past.
         let presented = found.value.refresh
         const readOAuthCredential = async () => {
-          const stored = await Effect.runPromise(credentials.list(integrationID))
-          const match = stored.find((credential) => credential.id === credentialID)
-          return match && match.value.type === "oauth" ? match.value : undefined
+          const stored = await Effect.runPromise(credentials.get(credentialID))
+          return stored?.value.type === "oauth" ? stored.value : undefined
         }
         return MCPOAuth.provider({
           ...base,


### PR DESCRIPTION
**Why**
The Promise-facing MCP OAuth store knows the credential ID it must track, but each read currently loads every credential for the integration and searches that list. This obscures the row-identity invariant used by token refresh, invalidation, and client-information reads.

**What Changes**
Fresh OAuth store reads now call `Credential.get(credentialID)` and retain the OAuth discriminant before exposing the value.

| Stored row state | Store result |
| --- | --- |
| Same ID updated | Latest OAuth value |
| Same ID removed | `undefined` |
| Same ID changed to another credential type | `undefined` |
| Another integration credential exists | Never substituted |

Presented-refresh tracking, invalidation, token conversion, client information, writes, and the Promise contract remain unchanged.

**Scope**
This PR only replaces integration-wide credential reads in the connect-time MCP OAuth store. It does not change MCP publication recovery, OAuth protocol behavior, integration selection, or credential persistence.

**Verification**
```sh
cd packages/core
bun run test test/mcp.test.ts test/mcp-oauth.test.ts test/credential.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/mcp/index.ts
bunx oxlint packages/core/src/mcp/index.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/mcp/index.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/mcp/index.ts
git diff --check origin/v2...HEAD
```

All 61 focused MCP, OAuth, and credential tests pass. Core typechecking and the pre-push workspace typecheck pass; formatting and both scoped scans are clean. Oxlint completes with only existing warnings outside the changed helper.

No new provider-store test was added: the closure is private to connect-time SDK wiring, and isolating it would require exporting implementation detail or introducing a synthetic OAuth server that is disproportionate to this keyed-read refactor.
