### PR TITLE
refactor(core): type native PTY import explicitly

### DIFF
--- a/packages/core/src/pty/pty.node.ts
+++ b/packages/core/src/pty/pty.node.ts
@@ -1,14 +1,15 @@
 import { createRequire } from "node:module"
 import { isSea } from "node:sea"
+import type { spawn } from "@lydell/node-pty"
 import type { Opts, Proc } from "./pty.js"
 
 export type { Disp, Exit, Opts, Proc } from "./pty.js"
 
-const pty = createRequire(import.meta.url)(
-  process.env.OPENCODE_NODE_PTY_PATH ?? "@lydell/node-pty",
-) as typeof import("@lydell/node-pty")
+const pty = createRequire(import.meta.url)(process.env.OPENCODE_NODE_PTY_PATH ?? "@lydell/node-pty") as {
+  spawn: typeof spawn
+}
 
-export function spawn(file: string, args: string[], opts: Opts): Proc {
+function spawnPty(file: string, args: string[], opts: Opts): Proc {
   const proc = pty.spawn(file, args, process.platform === "win32" && isSea() ? { ...opts, useConptyDll: true } : opts)
   return {
     pid: proc.pid,
@@ -29,3 +30,5 @@ export function spawn(file: string, args: string[], opts: Opts): Proc {
     },
   }
 }
+
+export { spawnPty as spawn }


### PR DESCRIPTION
**Why**
The Node PTY adapter used a prohibited type-position import to type its dynamically required native module.

**What Changes**
The native `spawn` signature is now imported with an ordinary type-only import, and the required module is narrowed to that member. The wrapper follows the Bun adapter pattern by using a local `spawnPty` name and re-exporting it as the existing public `spawn`.

**Scope**
`createRequire`, the injected native path, lazy runtime loading, process forwarding, and Windows SEA `useConptyDll` behavior are unchanged.

**Verification**
```sh
cd packages/core
bun run test test/pty/pty-session.test.ts
bun typecheck
cd ../..
bun run prettier --write packages/core/src/pty/pty.node.ts
bun run oxlint packages/core/src/pty/pty.node.ts
git diff --check
git push -u origin pty-native-import  # pre-push hook: full workspace typecheck
```

PTY session tests: 7 passed, 0 failed. Package and full-workspace typechecks passed. Oxlint reported 0 errors and 1 existing-category warning for narrowing the dynamically required `any` value.