### PR TITLE
test(core): bind acquired test services

### DIFF
--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -22,7 +22,8 @@ describe("Ripgrep", () => {
           yield* Effect.promise(() => fs.mkdir(path.join(tmp.path, "src")))
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "match.ts"), "needle\n"))
 
-          const result = yield* (yield* Ripgrep.Service).glob({ cwd: tmp.path, pattern: "**/*.ts", limit: 10 })
+          const ripgrep = yield* Ripgrep.Service
+          const result = yield* ripgrep.glob({ cwd: tmp.path, pattern: "**/*.ts", limit: 10 })
           expect(result.map((item) => item.path)).toEqual([RelativePath.make("src/match.ts")])
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
@@ -38,7 +39,8 @@ describe("Ripgrep", () => {
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "match.ts"), "needle\n"))
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "skip.txt"), "needle\n"))
 
-          const result = yield* (yield* Ripgrep.Service).grep({
+          const ripgrep = yield* Ripgrep.Service
+          const result = yield* ripgrep.grep({
             cwd: tmp.path,
             pattern: "needle",
             include: "*.ts",
@@ -64,7 +66,8 @@ describe("Ripgrep", () => {
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "node_modules", "pkg", "index.js"), "ignored\n"))
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "src", "index.js"), "included\n"))
 
-          const files = yield* (yield* Ripgrep.Service).find({ cwd: tmp.path, pattern: "*", limit: 10 })
+          const ripgrep = yield* Ripgrep.Service
+          const files = yield* ripgrep.find({ cwd: tmp.path, pattern: "*", limit: 10 })
           expect(files.map((item) => item.path)).toContain(RelativePath.make("src/index.js"))
           expect(files.map((item) => item.path)).not.toContain(RelativePath.make("node_modules/pkg/index.js"))
         }),
@@ -113,7 +116,8 @@ describe("Ripgrep", () => {
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "Pictures", "private.jpg"), "private\n"))
           yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "visible.txt"), "visible\n"))
 
-          const files = yield* (yield* Ripgrep.Service).find({
+          const ripgrep = yield* Ripgrep.Service
+          const files = yield* ripgrep.find({
             cwd: tmp.path,
             pattern: "*",
             limit: 10,
@@ -136,7 +140,8 @@ describe("Ripgrep", () => {
             fs.writeFile(path.join(tmp.path, "generated.ts"), `Cloudflare${"x".repeat(70 * 1024)}\n`),
           )
 
-          const matches = yield* (yield* Ripgrep.Service).grep({
+          const ripgrep = yield* Ripgrep.Service
+          const matches = yield* ripgrep.grep({
             cwd: tmp.path,
             pattern: "Cloudflare",
             limit: 10,

--- a/packages/core/test/tool-output.test.ts
+++ b/packages/core/test/tool-output.test.ts
@@ -22,8 +22,9 @@ const withStore = <A, E, R>(
       ])
       return Effect.gen(function* () {
         const output = yield* ToolOutput.Service
+        const fs = yield* FSUtil.Service
         if (limits) yield* output.transform((draft) => draft.configure(limits))
-        return yield* body(output, yield* FSUtil.Service, tmp.path)
+        return yield* body(output, fs, tmp.path)
       }).pipe(Effect.provide(layer))
     },
     (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),

--- a/packages/core/test/tool-search.test.ts
+++ b/packages/core/test/tool-search.test.ts
@@ -18,7 +18,7 @@ import { GrepTool } from "@opencode-ai/core/tool/plugin/grep"
 import { Tool } from "@opencode-ai/core/tool"
 import { location } from "./fixture/location"
 import { tmpdir } from "./fixture/tmpdir"
-import { testEffect } from "./lib/effect"
+import { it } from "./lib/effect"
 import { permissionLayer } from "./lib/permission"
 import { executeTool, registerToolPlugin, toolIdentity } from "./lib/tool"
 
@@ -40,7 +40,8 @@ const withTools = <A, E, R>(
   assertions?: Permission.AssertInput[],
 ) =>
   Effect.gen(function* () {
-    return yield* body(yield* Tool.Service)
+    const registry = yield* Tool.Service
+    return yield* body(registry)
   }).pipe(
     Effect.provide(
       AppNodeBuilder.build(LayerNode.group([Tool.node, globToolNode, grepToolNode]), [
@@ -66,8 +67,6 @@ const call = (name: "glob" | "grep", input: unknown) => ({
   ...toolIdentity,
   call: { type: "tool-call" as const, id: `call-${name}`, name, input },
 })
-
-const it = testEffect(Layer.empty)
 
 describe("search tools", () => {
   it.live("bounds omitted glob and grep limits", () =>

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -215,7 +215,8 @@ const withSession = <A, E, R>(directory: string, body: (registry: Tool.Interface
     const locations = yield* LocationServiceMap.Service
     const locationLayer = locations.get(location)
     return yield* Effect.gen(function* () {
-      yield* (yield* PluginSupervisor.Service).flush
+      const plugins = yield* PluginSupervisor.Service
+      yield* plugins.flush
       const registry = yield* Tool.Service
       return yield* body(registry)
     }).pipe(Effect.provide(locationLayer), Effect.ensuring(locations.invalidate(location)))


### PR DESCRIPTION
## Why
Several test generators acquire a service inside the same expression that invokes it or passes it to a callback. This hides the dependency boundary and conflicts with the repository's named-service style; `tool-search` also wraps the already-exported zero-service test harness in an empty layer.

## What Changes
- Ripgrep, PluginSupervisor, FSUtil, and Tool services are bound inside their existing generators before use.
- Service bindings remain inside their existing Location and layer scopes, preserving ownership and call order.
- Search-tool tests import the shared `it` harness directly instead of rebuilding it with `Layer.empty`.

## Scope
This covers the unowned `TESTF-09/10` occurrences in ripgrep, shell, output, and search tests. Edit, write, patch, and file-mutation occurrences remain with the already-active fixture cleanup PR.

## Verification
```sh
cd packages/core
bun run test test/ripgrep.test.ts test/tool-shell.test.ts test/tool-output.test.ts test/tool-search.test.ts
bun typecheck
cd ../..
bunx oxlint packages/core/test/ripgrep.test.ts packages/core/test/tool-shell.test.ts packages/core/test/tool-output.test.ts packages/core/test/tool-search.test.ts
bunx prettier --check packages/core/test/ripgrep.test.ts packages/core/test/tool-shell.test.ts packages/core/test/tool-output.test.ts packages/core/test/tool-search.test.ts
git diff --check
```

The focused run passed 94 tests, skipped 19 platform-specific cases, and completed 507 assertions. Core and pre-push repository typechecking passed. Formatting and diff checks passed. Oxlint completed with the pre-existing unused `LayerNode` import tracked separately under `TESTF-16`; it reported no errors.
