### PR TITLE
docs(tui): complete session tabs story guidance

### DIFF
--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -329,8 +329,8 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         },
       },
       {
-        // Random runs stay off the selected tab, so this is the way to watch the edge flash
-        // and running sweep under the cursor.
+        // Random runs may select any eligible tab; this command guarantees the edge flash
+        // and running sweep can be watched under the cursor.
         bind: "s",
         title: "Run selected tab",
         group: "Storybook",
@@ -448,10 +448,13 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         message={lastEvent()}
         controls={[
           { shortcut: "s", label: "work" },
+          { shortcut: "space/e", label: "random work" },
+          { shortcut: "p", label: "prompt" },
           { shortcut: "q", label: "question" },
           { shortcut: "a", label: "permission" },
           { shortcut: "i", label: "idle" },
           { shortcut: "f/x", label: "complete/fail" },
+          { shortcut: "t/d", label: "add/close" },
           { shortcut: "c", label: "spinner" },
           { shortcut: "u", label: "unread marker" },
           { shortcut: "m", label: "motion" },


### PR DESCRIPTION
**Why**

The session tabs story exposes prompt, random-work, and tab-lifecycle fixture states, but its footer does not tell reviewers how to reach them. A nearby comment also claims random work excludes the selected tab even though selection includes every eligible tab.

**What Changes**

| Control | Fixture state exposed |
| --- | --- |
| `space` / `e` | Start or finish work on a random eligible tab |
| `p` | Prompt the selected tab, including while it is busy |
| `t` / `d` | Add or close tabs to exercise untitled and overflow states |

The random-work comment now describes the actual selection behavior. The random selector itself is unchanged.

**Demo**

Matched `session-tabs` story captures at 110x30. Left: `origin/v2` (`0c77f6ed5`). Right: this PR (`30de876f9`).

![Session tabs story footer before and after](https://github.com/user-attachments/assets/95e57709-123a-4ae9-8347-f5fbb58e1f8b)

These are real OpenCode Drive captures with identical fixture state and viewport. Drive's recording exporter failed after saving the base frame, so the comparison uses inspected static frames for this static footer change.

**Scope**

This implements TUI-05 in the fixture-driven story only. It does not change production tabs, keybindings, random selection, or navigation aliases.

**Verification**

```sh
cd packages/tui
bun typecheck
bun run test test/component/session-tabs-status.test.tsx test/component/session-tabs-mouse.test.tsx test/component/session-tabs-marquee.test.ts

cd ../..
bunx prettier --check packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
bun run typecheck
git diff --check
```

The TUI and repository-wide typechecks passed, as did formatting and `git diff --check`. The focused run passed 11 of 12 unchanged production component tests; `horizontal tabs replace ordinals with status without moving titles` timed out waiting for a frame predicate after 20 passes. This PR changes only story guidance and does not touch that component or test.

The `session-tabs` story was also exercised through OpenCode Drive at 110x30 against both revisions; the new footer controls rendered as expected.
