### PR TITLE
refactor(core): clarify PTY binary validation

### DIFF
--- a/packages/core/src/persistent-pty/binary.bun.ts
+++ b/packages/core/src/persistent-pty/binary.bun.ts
@@ -19,7 +19,7 @@ async function install(
   const directory = path.join(root, `${input.version}-${input.sha256.slice(0, 16)}`)
   await privateDirectory(directory)
   const destination = path.join(directory, "opencode-pty")
-  if (await exists(destination, input.sha256)) return destination
+  if (await validateIfPresent(destination, input.sha256)) return destination
 
   const bytes = new Uint8Array(await Bun.file(input.path).arrayBuffer())
   if (sha256(bytes) !== input.sha256) throw new Error("Embedded opencode-pty checksum mismatch")
@@ -34,7 +34,7 @@ async function install(
     }
     await chmod(temporary, 0o755)
     await rename(temporary, destination).catch(async (error) => {
-      if (!(await exists(destination, input.sha256))) throw error
+      if (!(await validateIfPresent(destination, input.sha256))) throw error
     })
   } finally {
     await rm(temporary, { force: true })
@@ -52,7 +52,7 @@ async function privateDirectory(directory: string) {
   await chmod(directory, 0o700)
 }
 
-async function exists(file: string, expected: string) {
+async function validateIfPresent(file: string, expected: string) {
   try {
     await validate(file, expected)
     return true
@@ -62,14 +62,13 @@ async function exists(file: string, expected: string) {
   }
 }
 
-async function validate(file: string, expected?: string) {
+async function validate(file: string, expected: string) {
   const info = await lstat(file)
   if (!info.isFile() || info.isSymbolicLink()) throw new Error(`Unsafe opencode-pty executable: ${file}`)
   const uid = typeof process.getuid === "function" ? process.getuid() : undefined
   if (uid !== undefined && info.uid !== uid)
     throw new Error(`opencode-pty executable is owned by another user: ${file}`)
-  if (expected && sha256(await readFile(file)) !== expected)
-    throw new Error(`Cached opencode-pty checksum mismatch: ${file}`)
+  if (sha256(await readFile(file)) !== expected) throw new Error(`Cached opencode-pty checksum mismatch: ${file}`)
   await chmod(file, 0o755)
   return file
 }


### PR DESCRIPTION
**Why**
The cached PTY helper was named `exists` even though it validates file kind, ownership, digest, and permissions and propagates invalid-cache failures. Its validator also exposed an unused checksum-skip branch despite every caller supplying the build-produced SHA-256.

**What Changes**
The helper is renamed `validateIfPresent`, the expected digest is required, and the dead optional checksum branch is removed.

**Scope**
Ownership, symlink, digest, exclusive-write, sync, rename-race, chmod, and cleanup checks are unchanged. There is no direct installer test in the existing suite, so verification is compile/static.

**Verification**
```sh
cd packages/core
bun typecheck
cd ../..
bun run prettier --check packages/core/src/persistent-pty/binary.bun.ts
bun run oxlint packages/core/src/persistent-pty/binary.bun.ts
git diff --check
git push -u origin pty-binary-validate  # pre-push hook: full workspace typecheck
```

Package and full-workspace typechecks passed; oxlint reported 0 warnings and 0 errors.