### PR TITLE
chore: remove duplicate oxlint options

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -41,11 +41,5 @@
     // Warn when spreading non-plain objects (Headers, class instances, etc.)
     "typescript/no-misused-spread": "warn"
   },
-  "options": {
-    "typeAware": true
-  },
-  "options": {
-    "typeAware": true
-  },
   "ignorePatterns": ["**/node_modules", "**/dist", "**/.build", "**/.sst", "**/*.d.ts", "**/sdk.gen.ts"]
 }


### PR DESCRIPTION
**Why**
The oxlint configuration repeated the identical top-level `options.typeAware` key three times. Duplicate JSON-with-comments keys are misleading and make future edits ambiguous.

**What Changes**
The two trailing duplicate `options` objects are removed, leaving the original `typeAware: true` configuration.

**Scope**
Rules, categories, exclusions, and effective lint behavior are unchanged.

**Verification**
```sh
bun run prettier --check .oxlintrc.json
bun run oxlint packages/plugin/src/effect/websearch.ts
rg -n options .oxlintrc.json
git diff --check
git push -u origin oxlint-plugin-keys  # pre-push hook: full workspace typecheck
```

The cleaned config loaded successfully, linted the source with 0 warnings and 0 errors, and contains exactly one top-level `options` key. Full-workspace typecheck passed.