### PR TITLE
refactor(core): consolidate model error mapping

### DIFF
--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -37,20 +37,19 @@ export const layer = Layer.effect(
 
     const runText = Effect.fn("Generate.text")(function* (input: TextInput) {
       const resolved = yield* resolver.resolve(input.model).pipe(
-        Effect.catchTags({
-          "SessionRunnerModel.VariantUnavailableError": (error) =>
-            input.model
+        Effect.catchTag(
+          [
+            "SessionRunnerModel.VariantUnavailableError",
+            "SessionRunnerModel.UnsupportedPackageError",
+            "SessionRunnerModel.UnresolvedProviderVariablesError",
+          ],
+          (error) => {
+            const mapped: Error = input.model
               ? new ModelSelectionError({ message: error.message })
-              : new UnavailableError({ message: error.message, service: error.providerID }),
-          "SessionRunnerModel.UnsupportedPackageError": (error) =>
-            input.model
-              ? new ModelSelectionError({ message: error.message })
-              : new UnavailableError({ message: error.message, service: error.providerID }),
-          "SessionRunnerModel.UnresolvedProviderVariablesError": (error) =>
-            input.model
-              ? new ModelSelectionError({ message: error.message })
-              : new UnavailableError({ message: error.message, service: error.providerID }),
-        }),
+              : new UnavailableError({ message: error.message, service: error.providerID })
+            return Effect.fail(mapped)
+          },
+        ),
       )
       if (!resolved)
         return yield* new ModelSelectionError({


### PR DESCRIPTION
**Why**
Generate maps three ModelResolver failure tags through identical explicit-versus-implicit selection logic. Effect supports catching a non-empty tag list with one narrowed handler.

**What Changes**
Replaces the three duplicate handlers with one multi-tag `catchTag` handler. Explicit model requests still fail with `ModelSelectionError`; implicit resolution still fails with `UnavailableError` carrying the resolver provider ID.

**Scope**
The no-model fallback, AI generation error mapping, and separate Integration authorization message remain unchanged. PR #45398 also touches `generate.ts` for Bedrock region behavior but does not consolidate these resolver handlers.

**Verification**
```sh
cd packages/core
bun typecheck
bun run test test/generate.test.ts test/model-resolver.test.ts
cd ../..
bunx oxlint packages/core/src/generate.ts
```

Core typecheck passed, all 41 focused tests passed, and oxlint reported no warnings or errors. The push hook completed the 33-package workspace typecheck.