### PR TITLE
fix(tui): show configured diff close shortcut

### DIFF
--- a/.changeset/diff-close-help.md
+++ b/.changeset/diff-close-help.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/tui": patch
+---
+
+Show the configured close shortcut in the diff viewer help dialog.

--- a/packages/tui/src/feature-plugins/system/diff-viewer.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer.tsx
@@ -949,7 +949,7 @@ function DiffViewerHelpDialog(props: { context: Plugin.Context }) {
   const shortcut = (id: string) => () => props.context.keymap.shortcuts(id)[0]
   const rows = [
     {
-      shortcut: () => "q",
+      shortcut: shortcut("diff.close"),
       action: "Close viewer",
       description: "Quit the diff viewer",
     },

--- a/packages/tui/test/cli/tui/diff-viewer.test.tsx
+++ b/packages/tui/test/cli/tui/diff-viewer.test.tsx
@@ -5,6 +5,7 @@ import { testRender } from "@opentui/solid"
 import type {
   Context,
   Destination,
+  DialogOptions,
   KeymapCommand,
   KeymapLayer,
   Page,
@@ -20,7 +21,7 @@ import diffViewerPlugin from "../../../src/feature-plugins/system/diff-viewer"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 import { TestTuiContexts } from "../../fixture/tui-environment"
 import { createApi, createEventStream, createFetch, json } from "../../fixture/tui-client"
-import { DialogProvider } from "../../../src/ui/dialog"
+import { DialogProvider, useDialog } from "../../../src/ui/dialog"
 import { ToastProvider } from "../../../src/ui/toast"
 import { createSignal } from "solid-js"
 
@@ -56,6 +57,43 @@ test("ctrl+c closes the diff viewer without exiting the application", async () =
     viewer.app.mockInput.pressKey("c", { ctrl: true })
     await viewer.app.waitFor(() => viewer.current().type !== "plugin")
     expect(viewer.current()).toEqual(startRoute)
+  } finally {
+    viewer.app.renderer.destroy()
+  }
+})
+
+test("diff help advertises and runs the configured close shortcut", async () => {
+  const viewer = await renderDiffViewer([], { keybinds: { "diff.close": "x" } })
+
+  try {
+    viewer.commands.get("diff.help")!.run()
+    await viewer.app.waitForFrame((frame) => frame.includes("Diff shortcuts"))
+    expect(viewer.app.captureCharFrame()).toContain("x    Close viewer")
+
+    viewer.clearDialog()
+    await viewer.app.waitForFrame((frame) => !frame.includes("Diff shortcuts"))
+    expect(viewer.current().type).toBe("plugin")
+
+    viewer.app.mockInput.pressKey("x")
+    await viewer.app.waitFor(() => viewer.current().type !== "plugin")
+    expect(viewer.current()).toEqual(startRoute)
+  } finally {
+    viewer.app.renderer.destroy()
+  }
+})
+
+test.each([
+  [undefined, "escapClose viewer"],
+  ["none" as const, "-    Close viewer"],
+])("diff help preserves the default and unbound close display", async (binding, expected) => {
+  const viewer = await renderDiffViewer([], {
+    keybinds: binding === undefined ? undefined : { "diff.close": binding },
+  })
+
+  try {
+    viewer.commands.get("diff.help")!.run()
+    await viewer.app.waitForFrame((frame) => frame.includes("Diff shortcuts"))
+    expect(viewer.app.captureCharFrame()).toContain(expected)
   } finally {
     viewer.app.renderer.destroy()
   }
@@ -163,6 +201,7 @@ async function renderDiffViewer(
   let renderCommands: SlotClaim<"app">["render"] | undefined
   let vcsDiffInput: unknown
   let shortcut: (command: string) => string | undefined = () => undefined
+  let clearDialog = () => {}
   const config = createTuiResolvedConfig({ keybinds: options.keybinds })
   const transport = createFetch((url) => {
     if (url.pathname !== "/api/vcs/diff") return
@@ -182,6 +221,8 @@ async function renderDiffViewer(
     function Content() {
       const keymap = Keymap.use()
       const shortcuts = Keymap.useShortcuts()
+      const dialog = useDialog()
+      clearDialog = dialog.clear
       shortcut = shortcuts.get
       theme = useThemes().currentTokens()
       const context = {
@@ -207,9 +248,12 @@ async function renderDiffViewer(
         },
         ui: {
           dialog: {
-            show: () => () => {},
-            set() {},
-            clear() {},
+            show: dialog.replace,
+            set(options: DialogOptions) {
+              dialog.setSize(options.size ?? "medium")
+              dialog.setCentered(options.centered ?? false)
+            },
+            clear: dialog.clear,
           },
           router: {
             register(page: Page) {
@@ -272,6 +316,7 @@ async function renderDiffViewer(
     app,
     commands,
     current,
+    clearDialog: () => clearDialog(),
     shortcut: (command: string) => shortcut(command),
     vcsDiffInput: () => vcsDiffInput,
   }


### PR DESCRIPTION
**Why**
When `diff.close` is rebound, the diff viewer help dialog still advertises a hardcoded `q`. The displayed instruction can therefore disagree with the key that actually closes the viewer.

**What Changes**

| `diff.close` setting | Help dialog | Result |
| --- | --- | --- |
| `x` | `x` | Pressing `x` closes the viewer |
| default | first configured default shortcut | Help follows the maintained keymap default |
| `none` | `-` | Help shows that no close shortcut is bound |

The Close row now uses the same keymap shortcut resolver as every other row. A focused production-component test opens the real dialog, checks custom/default/unbound displays, and exercises the custom close action.

**Demo**

Matched production TUI comparison using the same deterministic fixture at `110x34` with `diff.close: x`: before is `origin/v2` at `0c77f6ed5b`, after is `80e5c0cba8`. The provider is simulated; the stable comparison is trimmed from the full Drive recordings and presented side by side.

https://github.com/user-attachments/assets/2b7e0e9e-dc1c-4ca7-be06-135d1806f06e

Narrow `88x28` after run: Escape dismisses help, then the configured `x` closes the viewer and returns home. The provider is simulated.

https://github.com/user-attachments/assets/6061fc78-c704-4996-b822-432abab1ed52

**Scope**
This only changes the diff help row and its focused test coverage; keybind defaults, schema, and command registration are unchanged. #45687 also touches `diff-viewer.tsx`, but a combined merge-tree check is clean because its setup cleanup does not overlap this help row.

**Verification**

```sh
cd packages/tui
bun run test test/cli/tui/diff-viewer.test.tsx
bun typecheck
cd ../..
bunx prettier --check packages/tui/src/feature-plugins/system/diff-viewer.tsx packages/tui/test/cli/tui/diff-viewer.test.tsx
git diff --check origin/v2...HEAD
```

The focused suite passed 10 tests with 27 assertions. TUI typechecking, Prettier, and diff whitespace checks passed. The matched Drive fixture was also exercised at `110x34` and `88x28`, including Escape dialog dismissal and the configured `x` close action.
