### PR TITLE
refactor(util): share process stop policy

### DIFF
--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -244,11 +244,11 @@ describe("cross-spawn spawner", () => {
     )
 
     fx.effect(
-      "kills a child when scope exits",
+      "uses the configured kill signal when scope exits",
       Effect.gen(function* () {
         const pid = yield* Effect.scoped(
           Effect.gen(function* () {
-            const handle = yield* js("setInterval(() => {}, 10_000)")
+            const handle = yield* js("setInterval(() => {}, 10_000)", { killSignal: "SIGKILL" })
             return Number(handle.pid)
           }),
         )

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -323,6 +323,22 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
       return Effect.fail(toPlatformError("kill", new Error("Failed to kill child process"), command))
     })
 
+  const stop = (
+    command: ChildProcess.StandardCommand,
+    proc: NodeChildProcess.ChildProcess,
+    exit: ExitSignal,
+    opts: ChildProcess.KillOptions | undefined,
+  ) => {
+    const send = (signal: NodeJS.Signals) =>
+      Effect.catch(killGroup(command, proc, signal), () => killOne(command, proc, signal))
+    const attempt = send(opts?.killSignal ?? "SIGTERM").pipe(Effect.andThen(Deferred.await(exit)), Effect.asVoid)
+    if (!opts?.forceKillAfter) return attempt
+    return Effect.timeoutOrElse(attempt, {
+      duration: opts.forceKillAfter,
+      orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(exit)), Effect.asVoid),
+    })
+  }
+
   const timeout =
     (
       proc: NodeChildProcess.ChildProcess,
@@ -390,17 +406,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
                 if (code !== 0 && Predicate.isNotNull(code)) return yield* Effect.ignore(kill(killGroup))
                 return yield* Effect.void
               }
-              const send = (s: NodeJS.Signals) =>
-                Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
-              const sig = command.options.killSignal ?? "SIGTERM"
-              const attempt = send(sig).pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid)
-              const escalated = command.options.forceKillAfter
-                ? Effect.timeoutOrElse(attempt, {
-                    duration: command.options.forceKillAfter,
-                    orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid),
-                  })
-                : attempt
-              return yield* Effect.ignore(escalated)
+              return yield* Effect.ignore(stop(command, proc, signal, command.options))
             }),
           )
 
@@ -426,17 +432,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
                 ),
               )
             }),
-            kill: (opts?: ChildProcess.KillOptions) => {
-              const sig = opts?.killSignal ?? "SIGTERM"
-              const send = (s: NodeJS.Signals) =>
-                Effect.catch(killGroup(command, proc, s), () => killOne(command, proc, s))
-              const attempt = send(sig).pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid)
-              if (!opts?.forceKillAfter) return attempt
-              return Effect.timeoutOrElse(attempt, {
-                duration: opts.forceKillAfter,
-                orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(signal)), Effect.asVoid),
-              })
-            },
+            kill: (opts?: ChildProcess.KillOptions) => stop(command, proc, signal, opts),
             unref: Effect.sync(() => {
               if (ref) {
                 proc.unref()


### PR DESCRIPTION
**Why**

Running-process scope disposal and the public `kill` handle duplicated the same group/single signal fallback, close-Deferred wait, and optional escalation policy. Changes to that stop protocol therefore required two synchronized edits.

**What Changes**

A private `stop` operation now owns only that shared send-and-wait workflow. Scope disposal passes command options and retains its outer `Effect.ignore`; public `kill` passes per-call options and retains typed failures.

The disposal regression now supplies an explicit `SIGKILL` command option, while the existing public-handle test continues to cover `forceKillAfter`.

**Scope**

The already-exited finalizer branch, timeout truthiness, default signal, process-group fallback, close-event wait, and escalation placement remain unchanged. Open PR #45526 extracts process infrastructure and overlaps this area broadly, so this PR may need rebasing or reapplication after it lands.

**Verification**

```sh
cd packages/core
bun run test test/effect/cross-spawn-spawner.test.ts
bun typecheck

cd ../util
bun typecheck

cd ../..
bunx prettier --check packages/util/src/cross-spawn-spawner.ts packages/core/test/effect/cross-spawn-spawner.test.ts
bunx oxlint packages/util/src/cross-spawn-spawner.ts packages/core/test/effect/cross-spawn-spawner.test.ts
git diff --check
git push -u origin process-stop-policy # repository hook: full workspace typecheck
```

Focused result: all 24 live spawner tests passed. Core/Util typechecks, formatting, diff validation, and the full 39-package push-hook typecheck passed. Oxlint completed with pre-existing warnings in `cross-spawn-spawner.ts`.
