### PR TITLE
refactor(core): use nonthrowing URL parsing

### DIFF
--- a/packages/core/src/form.ts
+++ b/packages/core/src/form.ts
@@ -311,7 +311,7 @@ function validateField(field: InputField, value: Form.Value): string | undefined
     }
     if (field.format === "email" && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
       return `Expected email for form field: ${field.key}`
-    if (field.format === "uri" && !isUri(value)) return `Expected URI for form field: ${field.key}`
+    if (field.format === "uri" && !URL.canParse(value)) return `Expected URI for form field: ${field.key}`
     if (field.format === "date" && !isDate(value)) return `Expected date for form field: ${field.key}`
     if (field.format === "date-time" && !isDateTime(value)) return `Expected date-time for form field: ${field.key}`
     if (field.options && !field.custom && !field.options.some((option) => option.value === value)) {
@@ -345,15 +345,6 @@ function validateField(field: InputField, value: Form.Value): string | undefined
 
 function isStringArray(value: Form.Value): value is ReadonlyArray<string> {
   return Array.isArray(value) && value.every((item): item is string => typeof item === "string")
-}
-
-function isUri(value: string) {
-  try {
-    new URL(value)
-    return true
-  } catch {
-    return false
-  }
 }
 
 function isDate(value: string) {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -249,15 +249,14 @@ const layer = Layer.effect(
       const value = input.trim()
       if (!value) return undefined
 
-      try {
-        const parsed = new URL(value)
+      const parsed = URL.parse(value)
+      if (parsed) {
         if (parsed.protocol === "file:") return undefined
         return parts(parsed.hostname, parsed.pathname)
-      } catch {
-        const scp = value.match(/^([^@/:]+@)?([^/:]+):(.+)$/)
-        if (scp) return parts(scp[2], scp[3])
-        return undefined
       }
+      const scp = value.match(/^([^@/:]+@)?([^/:]+):(.+)$/)
+      if (scp) return parts(scp[2], scp[3])
+      return undefined
     }
 
     function parts(host: string, name: string) {

--- a/packages/core/test/form.test.ts
+++ b/packages/core/test/form.test.ts
@@ -19,6 +19,17 @@ const input = {
 } satisfies Form.CreateInput
 
 describe("Form", () => {
+  it.effect("validates absolute URI formats without restricting schemes", () =>
+    Effect.sync(() => {
+      const fields = [{ key: "uri", type: "string", format: "uri" }] satisfies ReadonlyArray<Form.Field>
+
+      expect(Form.validateAnswer(fields, { uri: "https://example.com/path" })).toBeUndefined()
+      expect(Form.validateAnswer(fields, { uri: "mailto:user@example.com" })).toBeUndefined()
+      expect(Form.validateAnswer(fields, { uri: "relative/path" })).toBe("Expected URI for form field: uri")
+      expect(Form.validateAnswer(fields, { uri: "://invalid" })).toBe("Expected URI for form field: uri")
+    }),
+  )
+
   it.effect("returns a terminal cancelled state from ask", () =>
     Effect.gen(function* () {
       const service = yield* Form.Service


### PR DESCRIPTION
**Why**
Form URI validation and Project remote normalization use exceptions only to express ordinary parse failure. The runtime exposes non-throwing URL predicates for both cases.

**What Changes**
Uses `URL.canParse` directly for URI-formatted string fields and `URL.parse` before Project remote normalization. Project falls through to SCP-style parsing only when URL parsing returns null. Adds validator coverage for HTTP, non-HTTP, relative, and malformed URI strings.

**Scope**
Form validation remains scheme-agnostic and requires an absolute URL. Project still rejects file remotes, preserves host/path normalization, and does not reinterpret successfully parsed but unusable URLs as SCP remotes. RegExp validation and Repository file-URL conversion retain their real exception boundaries. PR #45009 also touches `project.ts` for Jujutsu support but does not change this Git remote parsing hunk.

**Verification**
```sh
cd packages/core
bun typecheck
bun run test test/form.test.ts test/project.test.ts
cd ../..
bunx oxlint packages/core/src/form.ts packages/core/src/project.ts packages/core/test/form.test.ts
```

Core typecheck passed; 35 focused tests passed and one platform-gated test skipped. Oxlint completed with no errors and ten pre-existing warnings. The push hook completed the 33-package workspace typecheck.