### PR TITLE
refactor(core): compare plugin generations directly

### DIFF
--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -91,16 +91,11 @@ const layer = Layer.effect(
 
       yield* lock.withPermit(
         Effect.gen(function* () {
-          const next = definitions.map((definition) => ({ id: definition.id, version: definition.version }))
-          const current = Array.from(active.values(), (entry) => ({
-            id: entry.plugin.id,
-            version: entry.plugin.version,
-          }))
           if (
-            current.length === next.length &&
-            current.every((definition, index) => {
-              const candidate = next[index]
-              return definition.id === candidate?.id && definition.version === candidate.version
+            active.size === definitions.length &&
+            Array.from(active.values()).every((entry, index) => {
+              const definition = definitions[index]
+              return entry.plugin.id === definition?.id && entry.plugin.version === definition.version
             })
           ) {
             const nextInventory = [...Array.from(active.values(), (entry) => activeInfo(entry.plugin)), ...failures]


### PR DESCRIPTION
**Why**
Plugin activation projected both the requested generation and active generation into temporary `{ id, version }` arrays solely to compare fields already present on the retained records.

**What Changes**
Compares the ordered active plugin entries directly against the normalized definitions, using the active map size for the existing length check.

**Scope**
Ordered ID/version equality, duplicate-ID rejection, unchanged-version suppression, inventory-only updates, activation order, and publication behavior are unchanged. Open PRs #45618 and #45631 touch other `plugin.ts` hunks but not this generation comparison.

**Verification**
```sh
cd packages/core
bun typecheck
bun run test test/plugin.test.ts test/config/plugin.test.ts
cd ../..
bunx oxlint packages/core/src/plugin.ts
```

Core typecheck passed, all 34 focused tests passed, and oxlint reported no warnings or errors. The push hook completed the 33-package workspace typecheck.