### PR TITLE
refactor(core): simplify skill discovery validation

### DIFF
--- a/packages/core/src/skill/discovery.ts
+++ b/packages/core/src/skill/discovery.ts
@@ -2,7 +2,7 @@ export * as SkillDiscovery from "./discovery.js"
 
 import path from "path"
 import { Context, Effect, Layer, Schedule, Schema } from "effect"
-import { FetchHttpClient, HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
@@ -37,15 +37,7 @@ function isSafeRelativePath(value: string) {
     !path.win32.isAbsolute(value) &&
     segments.every((segment) => {
       try {
-        const decoded = decodeURIComponent(segment)
-        return (
-          decoded.length > 0 &&
-          decoded !== "." &&
-          decoded !== ".." &&
-          !decoded.includes("/") &&
-          !decoded.includes("\\") &&
-          !decoded.includes("\0")
-        )
+        return isSafeSegment(decodeURIComponent(segment))
       } catch {
         return false
       }
@@ -146,10 +138,9 @@ const layer = Layer.effect(
                 file,
               }
             })
-            if (files.some((file) => file === undefined)) {
+            if (!files.every((file): file is { url: string; destination: string; file: string } => file !== undefined))
               return []
-            }
-            return [{ skill, root, versionFile, files: files as { url: string; destination: string; file: string }[] }]
+            return [{ skill, root, versionFile, files }]
           }),
           ({ skill, root, versionFile, files }) =>
             Effect.gen(function* () {


### PR DESCRIPTION
**Why**
Skill discovery duplicated its safe path-segment predicate, retained an unused HTTP import, and asserted the complete file descriptor array after already rejecting undefined members.

**What Changes**
Reuses `isSafeSegment` after URI decoding, narrows the all-or-nothing file list with `every`, and removes the unused `FetchHttpClient` import.

**Scope**
Whole-skill rejection, URI/origin and containment checks, staging, backup behavior, download concurrency, and cached-version behavior are unchanged. Invalid file members are still rejected as a group rather than filtered.

**Verification**
```sh
cd packages/core
bun typecheck
bun run test test/skill-discovery.test.ts
cd ../..
bunx prettier --check packages/core/src/skill/discovery.ts
bunx oxlint packages/core/src/skill/discovery.ts
```

Core typecheck passed, all seven focused tests passed, and oxlint reported no warnings or errors. The push hook completed the 33-package workspace typecheck.