### PR TITLE
refactor: normalize filesystem boundary imports

### DIFF
--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -7,16 +7,16 @@ import { FileSystem } from "@opencode-ai/schema/filesystem"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { Cause, Context, Effect, Layer, PubSub, RcMap, Schema, Stream } from "effect"
 import { lazy } from "../util/lazy.js"
-import { watch as watchFileSystem } from "node:fs"
+import { watch } from "node:fs"
 import path from "path"
 import loadBinding from "./watcher-binding.js"
 
 const SUBSCRIBE_TIMEOUT_MS = 10_000
 export const Event = { Updated: FileSystem.Event.Changed }
 
-const watcher = lazy((): typeof import("@parcel/watcher") | undefined => {
+const watcher = lazy((): typeof ParcelWatcher | undefined => {
   try {
-    return createWrapper(loadBinding()) as typeof import("@parcel/watcher")
+    return createWrapper(loadBinding()) as typeof ParcelWatcher
   } catch {
     return
   }
@@ -192,7 +192,7 @@ export const nativeLayer = Layer.succeed(
       if (input.type === "file") {
         return Effect.sync(() => {
           const directory = path.dirname(input.target)
-          const subscription = watchFileSystem(directory, { recursive: false }, (_event, file) => {
+          const subscription = watch(directory, { recursive: false }, (_event, file) => {
             if (file && path.resolve(directory, file.toString()) !== input.target) return
             input.publish({ path: input.target, type: "update" } satisfies Update)
           })
@@ -218,7 +218,7 @@ export function configured(options?: Options) {
 export const node = configured()
 
 function subscribeDirectory(
-  native: typeof import("@parcel/watcher") | undefined,
+  native: typeof ParcelWatcher | undefined,
   backend: ParcelWatcher.BackendType | undefined,
   directory: string,
   ignore: readonly string[],

--- a/packages/core/src/ripgrep/binary.ts
+++ b/packages/core/src/ripgrep/binary.ts
@@ -1,6 +1,6 @@
 import path from "path"
 import { Context, Effect, Layer, Stream } from "effect"
-import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { CrossSpawnSpawner } from "@opencode-ai/util/cross-spawn-spawner"

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -1,6 +1,4 @@
 import type { NonEmptyReadonlyArray } from "effect/Array"
-import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem"
-import * as NodePath from "@effect/platform-node/NodePath"
 import * as NodeSink from "@effect/platform-node/NodeSink"
 import * as NodeStream from "@effect/platform-node/NodeStream"
 import { Deferred, Effect, Exit, FileSystem, Layer, Path, PlatformError, Predicate, Sink, Stream } from "effect"

--- a/packages/util/src/fs-util.ts
+++ b/packages/util/src/fs-util.ts
@@ -1,4 +1,3 @@
-import * as NodeFileSystem from "@effect/platform-node/NodeFileSystem"
 import path, { dirname, isAbsolute, join, relative, sep } from "path"
 import { realpathSync } from "fs"
 import { readdir } from "fs/promises"


### PR DESCRIPTION
**Why**
Filesystem boundaries retained an unnecessary Node watch alias, repeated type-position Parcel module imports, one unused HTTP client import, and three unused Node platform namespace imports.

**What Changes**
Uses the existing type-only Parcel binding for watcher signatures and the native `watch` name directly, then removes the unused Ripgrep and Util platform imports.

**Scope**
Parcel loading remains lazy, `createWrapper` and the native binding boundary are unchanged, and NodeSink/NodeStream plus application-node platform composition remain intact. This is import/type spelling only. PRs #45718, #45725, #45407, #45526, and #45526 touch broader process or ripgrep behavior and may overlap imports; none removes this complete set.

**Verification**
```sh
cd packages/core
bun typecheck
bun run test test/filesystem/watcher.test.ts test/ripgrep-binary.test.ts test/filesystem/filesystem.test.ts test/effect/cross-spawn-spawner.test.ts
cd ../util
bun typecheck
cd ../..
bunx prettier --check packages/core/src/filesystem/watcher.ts packages/core/src/ripgrep/binary.ts packages/util/src/fs-util.ts packages/util/src/cross-spawn-spawner.ts
bunx oxlint packages/core/src/filesystem/watcher.ts packages/core/src/ripgrep/binary.ts packages/util/src/fs-util.ts packages/util/src/cross-spawn-spawner.ts
```

Core and Util typechecks passed, and 64 focused tests passed across the discovered suites. Oxlint completed with no errors and ten pre-existing warnings. The push hook completed the 33-package workspace typecheck.