### PR TITLE
feat(core): per-instance plugin input

### DIFF
--- a/packages/core/src/instance.ts
+++ b/packages/core/src/instance.ts
@@ -23,6 +23,7 @@ import { Mcp } from "./mcp/index.js"
 import { Permission } from "./permission.js"
 import { Plugin } from "./plugin.js"
 import { PluginHooks } from "./plugin/hooks.js"
+import { InstancePlugins } from "./plugin/instance.js"
 import { PluginSupervisor } from "./plugin/supervisor.js"
 import { Worktree } from "./worktree.js"
 import { Pty } from "./pty.js"
@@ -66,6 +67,7 @@ const nodes = [
   AISDK.node,
   Plugin.node,
   PluginHooks.node,
+  InstancePlugins.node,
   PluginSupervisor.node,
   Worktree.refreshNode,
   FileSystemSearch.node,
@@ -109,10 +111,20 @@ export const graph = LayerNode.group<typeof nodes>(nodes)
 export type Services = LayerNode.Output<typeof graph>
 export type Error = LayerNode.Error<typeof graph>
 
+export interface Options {
+  // Plugins this instance is born with; empty and absent are equivalent.
+  readonly plugins?: InstancePlugins.List
+  readonly replacements?: LayerNode.Replacements
+}
+
 // One instance is one compiled, fresh copy of the graph standing on a directory.
-export function layer(ref: Location.Ref, replacements: LayerNode.Replacements = []) {
+export function layer(ref: Location.Ref, options: Options = {}) {
   const startedAt = performance.now()
-  const allReplacements = replacements.concat([[Location.node, Location.boundNode(ref)]])
+  // Bound pairs come last, so they win over caller replacements of the same nodes.
+  const allReplacements = (options.replacements ?? []).concat([
+    [Location.node, Location.boundNode(ref)],
+    [InstancePlugins.node, InstancePlugins.bound(options.plugins ?? [])],
+  ])
   // Apply replacements during hoist, not afterward: replacements can
   // introduce new tagged dependencies (Location.boundNode depends on
   // Project), and the hoist walk is the only pass that can still slice

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -25,7 +25,7 @@ export function buildLocationServiceMap(
   return Layer.effect(
     LocationServiceMap.Service,
     Effect.map(
-      LayerMap.make((ref: Location.Ref) => Instance.layer(ref, replacements), {
+      LayerMap.make((ref: Location.Ref) => Instance.layer(ref, { replacements }), {
         // Workspace-placed directories exist only inside the workspace, so a
         // local stat consults the wrong filesystem. Workspace liveness is
         // owned by placement; do not probe the sandbox here, which would

--- a/packages/core/src/plugin/instance.ts
+++ b/packages/core/src/plugin/instance.ts
@@ -1,0 +1,49 @@
+export * as InstancePlugins from "./instance.js"
+
+import type { Plugin } from "@opencode-ai/plugin/effect/plugin"
+import { Context, Layer } from "effect"
+import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import type { Versioned } from "../plugin.js"
+
+/**
+ * Holds the plugins one instance is born with. Unlike the host-global
+ * `SdkPlugins` store, this list is a birth argument of a single instance:
+ * `Instance.layer` binds it through the replacement mechanism, so two
+ * instances in one process can carry different plugins. The list is immutable
+ * for the instance's lifetime; runtime dynamism lives inside plugins through
+ * the container transform/reload APIs.
+ *
+ * Limitations, both shared with `SdkPlugins`: `vcs` marker declarations are
+ * not seen by `ProjectMarkers` (it is global and runs during project
+ * resolution, before the instance exists), and config plugin operations may
+ * disable instance plugins by id.
+ */
+export type List = readonly Plugin[]
+
+export interface Interface {
+  readonly all: () => readonly Versioned[]
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/InstancePlugins") {}
+
+export const node = makeLocationNode({
+  service: Service,
+  layer: Layer.succeed(Service, Service.of({ all: () => [] })),
+  deps: [],
+})
+
+// The constant version is load-bearing: the plugin registry treats an
+// unchanged (id, version) pair as the same plugin across activations, which
+// is only correct because a bound list never changes after creation.
+// `source: "sdk"` means host-contributed; an instance list is the
+// per-instance form of the same channel.
+export function bound(plugins: List) {
+  const duplicates = plugins.filter((plugin, index) => plugins.findIndex((other) => other.id === plugin.id) !== index)
+  if (duplicates.length > 0) {
+    throw new Error(`duplicate instance plugin ids: ${duplicates.map((plugin) => plugin.id).join(", ")}`)
+  }
+  const stamped = plugins.map(
+    (plugin): Versioned => ({ ...plugin, version: "instance", source: { type: "sdk" } }),
+  )
+  return Layer.succeed(Service, Service.of({ all: () => stamped }))
+}

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -9,6 +9,7 @@ import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Bus } from "../bus.js"
 import { Npm } from "@opencode-ai/util/npm"
 import { Plugin } from "../plugin.js"
+import { InstancePlugins } from "./instance.js"
 import { PluginInternal } from "./internal.js"
 import { PluginModule } from "./module.js"
 import { SdkPlugins } from "./sdk.js"
@@ -85,6 +86,7 @@ export const layer = Layer.effect(
   Effect.gen(function* () {
     const registry = yield* Plugin.Service
     const sdk = yield* SdkPlugins.Service
+    const instance = yield* InstancePlugins.Service
     const sources = yield* ConfigPluginSource.Service
     const bus = yield* Bus.Service
     const ready = yield* Latch.make()
@@ -93,10 +95,13 @@ export const layer = Layer.effect(
     const activate = Effect.fn("PluginSupervisor.activate")(function* () {
       // Resolve OpenCode's internal plugins with their privileged Location services.
       const internal = yield* PluginInternal.list()
-      // Combine internal plugins with host-contributed SDK plugins in boot order.
+      // Combine internal plugins with host-contributed plugins in boot order.
+      // Instance-bound plugins come last: later activation can override earlier
+      // container writes, so the instance's explicit choices win over globals.
       const pre = [
         ...internal.pre.map((plugin) => ({ ...plugin, version: "internal", source: { type: "builtin" as const } })),
         ...sdk.all(),
+        ...instance.all(),
       ]
       const post = internal.post.map((plugin) => ({
         ...plugin,
@@ -138,6 +143,7 @@ export const layer = Layer.effect(
 const nodeDeps = [
   Plugin.node,
   SdkPlugins.node,
+  InstancePlugins.node,
   ConfigPluginSource.node,
   Bus.node,
   Npm.node,

--- a/packages/core/test/instance-plugins.test.ts
+++ b/packages/core/test/instance-plugins.test.ts
@@ -1,0 +1,104 @@
+import fs from "fs/promises"
+import path from "path"
+import { describe, expect, test } from "bun:test"
+import { Duration, Effect, Layer, LayerMap } from "effect"
+import { Plugin } from "@opencode-ai/plugin/effect"
+import { Agent } from "@opencode-ai/core/agent"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Global } from "@opencode-ai/util/global"
+import { Instance } from "@opencode-ai/core/instance"
+import { InstancePlugins } from "@opencode-ai/core/plugin/instance"
+import { LocationServiceMap } from "@opencode-ai/core/location-services"
+import { Location } from "@opencode-ai/core/location"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
+import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { tmpdir } from "./fixture/tmpdir"
+import { tempGlobalLayer } from "./fixture/global"
+import { testEffect } from "./lib/effect"
+import { Database } from "../src/database/database"
+import { Bus } from "../src/bus"
+
+const agentPlugin = (pluginID: string, agentID: string) =>
+  Plugin.define({
+    id: pluginID,
+    effect: (ctx) => ctx.agent.transform((agents) => agents.update(Agent.ID.make(agentID), () => {})),
+  })
+
+// A host-owned assignment in miniature: the map decides per ref which plugins
+// an instance is born with, the way an embedder will per Slack thread.
+const instances = Layer.effect(
+  LocationServiceMap.Service,
+  LayerMap.make(
+    (ref: Location.Ref) =>
+      Instance.layer(ref, {
+        plugins: path.basename(ref.directory) === "thread-a" ? [agentPlugin("thread-a-plugin", "thread-a-agent")] : [],
+        replacements: [[Global.node, tempGlobalLayer]],
+      }),
+    { idleTimeToLive: Duration.infinity },
+  ),
+)
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
+    [Global.node, tempGlobalLayer],
+    [LocationServiceMap.node, instances],
+  ]),
+)
+
+describe("InstancePlugins", () => {
+  it.live("binds plugins to one instance without leaking to siblings", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const locations = yield* LocationServiceMap.Service
+          const sdk = yield* SdkPlugins.Service
+          yield* sdk.register(agentPlugin("global-plugin", "global-agent"))
+
+          const dirA = path.join(dir.path, "thread-a")
+          const dirB = path.join(dir.path, "thread-b")
+          yield* Effect.promise(() => fs.mkdir(dirA))
+          yield* Effect.promise(() => fs.mkdir(dirB))
+          const refA = Location.Ref.make({ directory: AbsolutePath.make(dirA) })
+          const refB = Location.Ref.make({ directory: AbsolutePath.make(dirB) })
+
+          const agents = (ref: Location.Ref) =>
+            Effect.gen(function* () {
+              const supervisor = yield* PluginSupervisor.Service
+              yield* supervisor.flush
+              const service = yield* Agent.Service
+              return {
+                bound: yield* service.get(Agent.ID.make("thread-a-agent")),
+                global: yield* service.get(Agent.ID.make("global-agent")),
+              }
+            }).pipe(Effect.scoped, Effect.provide(locations.get(ref)))
+
+          const a = yield* agents(refA)
+          expect(a.bound).toBeDefined()
+          expect(a.global).toBeDefined()
+
+          const b = yield* agents(refB)
+          expect(b.bound).toBeUndefined()
+          expect(b.global).toBeDefined()
+
+          // Eviction and rebuild re-bind the same list.
+          yield* locations.invalidate(refA)
+          const rebuilt = yield* agents(refA)
+          expect(rebuilt.bound).toBeDefined()
+          expect(rebuilt.global).toBeDefined()
+        }),
+      ),
+    ),
+  )
+})
+
+describe("InstancePlugins.bound", () => {
+  test("rejects duplicate ids in one list", () => {
+    const plugin = Plugin.define({ id: "dup", effect: () => Effect.void })
+    expect(() => InstancePlugins.bound([plugin, plugin])).toThrow("duplicate instance plugin ids: dup")
+  })
+})


### PR DESCRIPTION
Stacked on #45705 (`instance-module`); will retarget to `v2` when that merges.

## Why

An embedder creating instances (one per Slack thread, for example) has no way to give a specific instance its own plugins. The only host-facing channel is the global `SdkPlugins` registry, which delivers every registered plugin to every instance in the process — per-thread tools require fencing everything apart with per-channel agents and permissions instead of just handing each instance what it should have.

## What Changes

`Instance.layer` gains an options object with a `plugins` birth argument. Plugins bound there exist only in that instance:

```ts
Instance.layer(ref, { plugins: [slackTools(thread)] })
```

| Source | Scope | When |
|---|---|---|
| built-ins (`PluginInternal`) | every instance | unchanged |
| config discovery | per directory | unchanged |
| `SdkPlugins.register` | every instance (global) | unchanged |
| `Instance.Options.plugins` | **one instance** | new |

The supervisor splices the new source last — `[...internal.pre, ...sdk.all(), ...instance.all()]` — so an instance's explicit plugins activate after ambient globals and can override their container writes.

## Binding Mechanism

A new location-tagged `InstancePlugins` node holds the list (default empty). `Instance.layer` binds it unconditionally through the same replacement mechanism that binds the directory (`Location.boundNode`), so `plugins: []` and absent are equivalent and there is exactly one code path. The bound list is immutable and stamped with a constant version — load-bearing, since the plugin registry treats an unchanged `(id, version)` pair as the same plugin across activations. `source: { type: "sdk" }` is reused deliberately: it means host-contributed, and an instance list is the per-instance form of that channel.

Documented limitations (both shared with SDK plugins): config plugin operations may disable instance plugins by id, and `vcs` marker declarations are not seen by `ProjectMarkers`, which runs during project resolution before the instance exists. `InstancePlugins.bound` rejects duplicate ids within one list up front, because a duplicate id at activation time fails the whole plugin generation.

## Scope

This PR makes the recipe accept per-instance plugins; reaching that per instance from the public API (host-owned session-to-instance assignment) is the next step in the plan. The default path (`buildLocationServiceMap`) passes no plugins and behaves identically.

## Verification

```sh
cd packages/core
bun typecheck
bun run test test/instance-plugins.test.ts                       # 2 pass
bun run test test/location-layer.test.ts test/config/plugin.test.ts  # 39 pass
```

The new test installs a `LocationServiceMap` whose assignment gives instance A a plugin and instance B none — a miniature of the host-owned assignment pattern — and asserts: the bound plugin's agent exists only in A, a globally registered SDK plugin appears in both, and invalidation plus rebuild re-binds the list. A unit test pins duplicate-id rejection.