### PR TITLE
refactor(util): narrow layer visitor options

### DIFF
--- a/packages/util/src/effect/layer-node.ts
+++ b/packages/util/src/effect/layer-node.ts
@@ -164,7 +164,6 @@ function isNode(input: Layer.Any | AnyNode): input is AnyNode {
 type Visit<Result> = (node: AnyNode, context: VisitContext<Result>) => Result
 
 type VisitContext<Result> = {
-  readonly cache: Map<AnyNode, Result>
   readonly visit: (node: AnyNode) => Result
 }
 
@@ -174,7 +173,6 @@ function walk<Result>(
   options: {
     readonly cache?: Map<AnyNode, Result>
     readonly resolve?: (node: AnyNode) => AnyNode
-    readonly detectCycles?: boolean
   } = {},
 ) {
   const cache = options.cache ?? new Map<AnyNode, Result>()
@@ -186,7 +184,7 @@ function walk<Result>(
     const cached = cache.get(target)
     if (cached !== undefined || cache.has(target)) return cached!
 
-    if (options.detectCycles !== false && visiting.has(target)) {
+    if (visiting.has(target)) {
       const start = stack.indexOf(target)
       throw new Error(
         `Cycle detected in layer tree: ${[...stack.slice(start), target].map((item) => item.name).join(" -> ")}`,
@@ -196,7 +194,7 @@ function walk<Result>(
     visiting.add(target)
     stack.push(target)
     try {
-      const result = visit(target, { cache, visit: recur })
+      const result = visit(target, { visit: recur })
       if (!cache.has(target)) cache.set(target, result)
       return result
     } finally {


### PR DESCRIPTION
**Why**
LayerNode exposed its internal traversal cache to visit callbacks even though no callback read it, and offered a cycle-detection switch that no caller disabled.

**What Changes**
Removes the unused visitor cache field and option switch, leaving cycle detection unconditional.

**Scope**
The internal cache remains available through the existing caller-supplied `cache` option, including compile-time sharing across roots. Replacement resolution, graph rewriting, cache writes, and cycle diagnostics are unchanged.

**Verification**
```sh
cd packages/util
bun typecheck
cd ../core
bun typecheck
bun run test test/effect/layer-node/layer-node.test.ts test/effect/layer-node/node-build.test.ts
cd ../..
bunx prettier --check packages/util/src/effect/layer-node.ts
bunx oxlint packages/util/src/effect/layer-node.ts
```

Core and Util typechecks passed, all 17 focused tests passed, and oxlint completed with no errors and 11 pre-existing warnings. The push hook completed the 33-package workspace typecheck.