### PR TITLE
docs(core): correct newtype decoding guidance

### DIFF
--- a/.changeset/correct-newtype-decoding.md
+++ b/.changeset/correct-newtype-decoding.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Correct the published Newtype documentation to recommend `Schema.decodeUnknownSync` for schema-based synchronous decoding.

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -41,7 +41,7 @@ export type DeepMutable<T> = T extends string | number | boolean | bigint | symb
 
 /**
  * Nominal wrapper for scalar types. The class itself is a valid schema —
- * pass it directly to `Schema.decode`, `Schema.decodeEffect`, etc.
+ * pass it directly to `Schema.decodeUnknownSync`, `Schema.decodeEffect`, etc.
  *
  * The runtime value remains an unwrapped primitive. `Schema.brand` supplies
  * the primitive schema behavior and constructor validation, while the class


### PR DESCRIPTION
**Why**
The Newtype documentation said a schema could be passed directly to `Schema.decode`, but that operation accepts an encode/decode transformation rather than a schema.

**What Changes**
Names the schema-taking `Schema.decodeUnknownSync` operation instead. The existing example continues to demonstrate `Schema.decodeUnknownEffect`.

**Scope**
This is a documentation-only correction. Newtype construction, branding, decoding, encoding, and runtime representation are unchanged.

**Verification**
```sh
cd packages/core
bun typecheck
bun run test test/newtype.test.ts
cd ../..
bunx prettier --check packages/core/src/schema.ts
bunx oxlint packages/core/src/schema.ts
```

Core typecheck passed, all five focused tests passed, and oxlint completed with no errors and one pre-existing warning. The push hook completed the 33-package workspace typecheck.