### PR TITLE
refactor(core): flatten session title factory

### DIFF
--- a/packages/core/src/session/title.ts
+++ b/packages/core/src/session/title.ts
@@ -1,8 +1,7 @@
 export * as SessionTitle from "./title.js"
 
 import { isDeepStrictEqual } from "node:util"
-import { LLMClient, AIError, LLMEvent, Message, SystemPart, type LLMRequest } from "@opencode-ai/ai"
-import type { StreamOptions } from "@opencode-ai/ai/route"
+import { LLMClient, LLMEvent, Message, SystemPart } from "@opencode-ai/ai"
 import { Context, DateTime, Effect, Layer, Stream } from "effect"
 import type { Agent } from "../agent.js"
 import { Database } from "../database/database.js"
@@ -23,15 +22,6 @@ const MAX_CONTEXT_LENGTH = 8_000
 const MAX_FIRST_MESSAGE_LENGTH = 2_000
 const titleChanged = Symbol("Session title changed")
 
-type Dependencies = {
-  readonly bus: Bus.Interface
-  readonly llm: {
-    readonly stream: (request: LLMRequest, options?: StreamOptions) => Stream.Stream<LLMEvent, AIError>
-  }
-  readonly context: SessionContext.Interface
-  readonly store: SessionStore.Interface
-}
-
 export interface Interface {
   /** Generates an initial title or regenerates one from bounded conversation history. */
   readonly generate: (sessionID: SessionSchema.ID) => Effect.Effect<void>
@@ -46,117 +36,6 @@ export const isUntitled = (session: SessionSchema.Info) =>
     time: { created: DateTime.toEpochMillis(session.time.created) },
   })
 
-const attempt = Effect.fn("SessionTitle.attempt")(function* (
-  dependencies: Dependencies,
-  input: {
-    readonly session: SessionSchema.Info
-    readonly agent: Agent.Info
-    readonly text: string
-    readonly model: SessionRunnerModel.Resolved
-  },
-) {
-  const chunks: string[] = []
-  let failed = false
-  let usage: SessionUsage.Recorded | undefined
-  const recordUsage = Effect.suspend(() =>
-    usage
-      ? dependencies.bus.publish(SessionEvent.UsageRecorded, {
-          sessionID: input.session.id,
-          source: "title",
-          ...usage,
-        })
-      : Effect.void,
-  )
-  const prepared = yield* dependencies.context.prepare({
-    scope: { session: input.session, agentID: input.agent.id, model: input.model },
-    transcript: {
-      system: input.agent.system ? [SystemPart.make(input.agent.system)] : [],
-      messages: [Message.user(input.text)],
-    },
-    contextHooks: false,
-  })
-  yield* dependencies.llm.stream(prepared.request, prepared.options).pipe(
-    Stream.runForEach((event) => {
-      if (LLMEvent.is.providerError(event)) failed = true
-      if (LLMEvent.is.textDelta(event)) chunks.push(event.text)
-      if (LLMEvent.is.stepFinish(event)) {
-        const step = SessionUsage.record(event.usage, input.model.cost)
-        usage = usage ? SessionUsage.add(usage, step) : step
-      }
-      return Effect.void
-    }),
-    Effect.catchTag("AI.Error", () =>
-      Effect.sync(() => {
-        failed = true
-      }),
-    ),
-    Effect.onInterrupt(() => recordUsage.pipe(Effect.asVoid)),
-  )
-  yield* recordUsage
-  if (failed) return
-  return chunks
-    .join("")
-    .split("\n")
-    .map((line) => line.trim())
-    .find((line) => line.length > 0)
-})
-
-const make = (dependencies: Dependencies) => {
-  const generate = Effect.fn("SessionTitle.generate")(function* (
-    db: Database.Interface["db"],
-    sessionID: SessionSchema.ID,
-  ) {
-    const session = yield* dependencies.store.get(sessionID)
-    if (!session) return
-    const firstUser = yield* SessionHistory.firstUserMessage(db, session.id)
-    if (!firstUser) return
-    const text = !isUntitled(session)
-      ? yield* dependencies.store.context(session.id).pipe(
-          Effect.map((messages) => {
-            const original = `Original request:\n${firstUser.text.slice(0, MAX_FIRST_MESSAGE_LENGTH)}`
-            const recent = messages
-              .flatMap((message) => {
-                if (message.type === "user" && message.id !== firstUser.id) return [`User: ${message.text.trim()}`]
-                if (message.type !== "assistant") return []
-                const text = message.content
-                  .flatMap((part) => (part.type === "text" ? [part.text.trim()] : []))
-                  .filter(Boolean)
-                  .join("\n")
-                return text ? [`Assistant: ${text}`] : []
-              })
-              .join("\n\n")
-            if (!recent) return original
-            const prefix = `${original}\n\nRecent conversation:\n`
-            return `${prefix}${recent.slice(-(MAX_CONTEXT_LENGTH - prefix.length))}`
-          }),
-          Effect.orElseSucceed(() => firstUser.text),
-        )
-      : firstUser.text
-    const selection = yield* dependencies.context.selectTitle(session)
-    if (!selection) return
-    const title =
-      (yield* attempt(dependencies, { session, agent: selection.agent, text, model: selection.selected })) ??
-      (selection.primary && !isDeepStrictEqual(selection.selected.ref, selection.primary.ref)
-        ? yield* attempt(dependencies, { session, agent: selection.agent, text, model: selection.primary })
-        : undefined)
-    if (!title) return
-    const expectedSequence = (yield* Bus.latestSequence(db, sessionID)) + 1
-    const current = yield* dependencies.store.get(sessionID)
-    if (!current || current.title !== session.title || current.title === truncate(title)) return
-    yield* dependencies.bus
-      .publish(
-        SessionEvent.Renamed,
-        {
-          sessionID: session.id,
-          title: truncate(title),
-        },
-        { commit: (sequence) => (sequence === expectedSequence ? Effect.void : Effect.die(titleChanged)) },
-      )
-      .pipe(Effect.catchDefect((defect) => (defect === titleChanged ? Effect.void : Effect.die(defect))))
-  })
-  return { generate }
-}
-
 export const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -165,10 +44,107 @@ export const layer = Layer.effect(
     const context = yield* SessionContext.Service
     const store = yield* SessionStore.Service
     const database = yield* Database.Service
-    const title = make({ bus, llm, context, store })
-    return Service.of({
-      generate: (sessionID) => title.generate(database.db, sessionID),
+    const attempt = Effect.fn("SessionTitle.attempt")(function* (input: {
+      readonly session: SessionSchema.Info
+      readonly agent: Agent.Info
+      readonly text: string
+      readonly model: SessionRunnerModel.Resolved
+    }) {
+      const chunks: string[] = []
+      let failed = false
+      let usage: SessionUsage.Recorded | undefined
+      const recordUsage = Effect.suspend(() =>
+        usage
+          ? bus.publish(SessionEvent.UsageRecorded, {
+              sessionID: input.session.id,
+              source: "title",
+              ...usage,
+            })
+          : Effect.void,
+      )
+      const prepared = yield* context.prepare({
+        scope: { session: input.session, agentID: input.agent.id, model: input.model },
+        transcript: {
+          system: input.agent.system ? [SystemPart.make(input.agent.system)] : [],
+          messages: [Message.user(input.text)],
+        },
+        contextHooks: false,
+      })
+      yield* llm.stream(prepared.request, prepared.options).pipe(
+        Stream.runForEach((event) => {
+          if (LLMEvent.is.providerError(event)) failed = true
+          if (LLMEvent.is.textDelta(event)) chunks.push(event.text)
+          if (LLMEvent.is.stepFinish(event)) {
+            const step = SessionUsage.record(event.usage, input.model.cost)
+            usage = usage ? SessionUsage.add(usage, step) : step
+          }
+          return Effect.void
+        }),
+        Effect.catchTag("AI.Error", () =>
+          Effect.sync(() => {
+            failed = true
+          }),
+        ),
+        Effect.onInterrupt(() => recordUsage.pipe(Effect.asVoid)),
+      )
+      yield* recordUsage
+      if (failed) return
+      return chunks
+        .join("")
+        .split("\n")
+        .map((line) => line.trim())
+        .find((line) => line.length > 0)
     })
+    const generate = Effect.fn("SessionTitle.generate")(function* (sessionID: SessionSchema.ID) {
+      const session = yield* store.get(sessionID)
+      if (!session) return
+      const firstUser = yield* SessionHistory.firstUserMessage(database.db, session.id)
+      if (!firstUser) return
+      const text = !isUntitled(session)
+        ? yield* store.context(session.id).pipe(
+            Effect.map((messages) => {
+              const original = `Original request:\n${firstUser.text.slice(0, MAX_FIRST_MESSAGE_LENGTH)}`
+              const recent = messages
+                .flatMap((message) => {
+                  if (message.type === "user" && message.id !== firstUser.id) return [`User: ${message.text.trim()}`]
+                  if (message.type !== "assistant") return []
+                  const text = message.content
+                    .flatMap((part) => (part.type === "text" ? [part.text.trim()] : []))
+                    .filter(Boolean)
+                    .join("\n")
+                  return text ? [`Assistant: ${text}`] : []
+                })
+                .join("\n\n")
+              if (!recent) return original
+              const prefix = `${original}\n\nRecent conversation:\n`
+              return `${prefix}${recent.slice(-(MAX_CONTEXT_LENGTH - prefix.length))}`
+            }),
+            Effect.orElseSucceed(() => firstUser.text),
+          )
+        : firstUser.text
+      const selection = yield* context.selectTitle(session)
+      if (!selection) return
+      const title =
+        (yield* attempt({ session, agent: selection.agent, text, model: selection.selected })) ??
+        (selection.primary && !isDeepStrictEqual(selection.selected.ref, selection.primary.ref)
+          ? yield* attempt({ session, agent: selection.agent, text, model: selection.primary })
+          : undefined)
+      if (!title) return
+      const expectedSequence = (yield* Bus.latestSequence(database.db, sessionID)) + 1
+      const current = yield* store.get(sessionID)
+      if (!current || current.title !== session.title || current.title === truncate(title)) return
+      yield* bus
+        .publish(
+          SessionEvent.Renamed,
+          {
+            sessionID: session.id,
+            title: truncate(title),
+          },
+          { commit: (sequence) => (sequence === expectedSequence ? Effect.void : Effect.die(titleChanged)) },
+        )
+        .pipe(Effect.catchDefect((defect) => (defect === titleChanged ? Effect.void : Effect.die(defect))))
+    })
+    return Service.of({ generate })
   }),
 )
 


### PR DESCRIPTION
**Why**
The title layer currently builds a private dependency record, then wraps its only generated method solely to pass the database back into each call. This duplicates the layer wiring and maintains a handwritten subset of the LLM client contract without providing an independent seam.

**What Changes**
- Construct the named `SessionTitle.attempt` and `SessionTitle.generate` effects directly inside the layer.
- Close over the layer-acquired database, bus, LLM client, context, and store instead of forwarding a private dependency record.
- Preserve title model fallback order, usage settlement, regeneration context, sequence-checked rename protection, layer substitution, and per-attempt mutable state.

**Scope**
This is a behavior-preserving refactor of the private title service wiring only. It does not change the public service, title generation behavior, runner integration, or published package behavior, so no changeset is included.

**Verification**
```sh
cd packages/core && bun run test test/session-title.test.ts
cd packages/core && bun typecheck
bunx prettier --check packages/core/src/session/title.ts
bun run lint -- packages/core/src/session/title.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/session/title.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/session/title.ts
git diff --check
git push -u origin flatten-title-factory
```

The focused suite passed 14 tests. Core typecheck, formatting, both focused Effect rule scans, and diff checks passed. The repository linter completed with 0 errors (baseline warnings remain), and the normal push hook completed all 33 workspace typecheck tasks.