### PR TITLE
test(core): guarantee execution scope cleanup

### DIFF
--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -85,6 +85,7 @@ describe("SessionExecution lifecycle", () => {
       const completedRunning = yield* Deferred.make<void>()
       const release = yield* Deferred.make<void>()
       const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
       const context = yield* buildExecution(scope, ({ sessionID }) =>
         sessionID === completed
           ? Deferred.succeed(completedRunning, undefined).pipe(Effect.andThen(Deferred.await(release)))
@@ -245,6 +246,7 @@ describe("SessionExecution lifecycle", () => {
       const bothDraining = yield* Deferred.make<void>()
       const continued: SessionEvent.Synthetic[] = []
       const scope = yield* Scope.make()
+      yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void))
       const context = yield* buildExecution(scope, ({ sessionID }) =>
         Effect.sync(() => {
           drained.push(sessionID)


### PR DESCRIPTION
## Why
Two execution lifecycle tests build layers in independent scopes but close those scopes only after successful assertions. An assertion failure can therefore leave the execution coordinator layer alive, including one never-ending drain.

## What Changes
Register the existing `Scope.close(scope, Exit.void)` operation as an ambient test finalizer immediately after each independent scope is created. Both explicit closes remain in place, including the first case's post-close claim assertion; closing an already closed scope remains a no-op.

## Scope
Test-only cleanup for the two residual TESTF-01 occurrences in `session-execution.test.ts`. This has no dependency on #45636, #45682, or merged #45464, which own other TESTF-01 fixture boundaries in different files. Open #45413 also touches `session-execution.test.ts`, but only its execution-builder wiring near the end of the file; its hunks and behavior do not overlap these two scope acquisitions.

## Verification
```sh
# packages/core
bun run test test/session-execution.test.ts
bun typecheck

# repository root
bunx prettier --check packages/core/test/session-execution.test.ts
bunx oxlint packages/core/test/session-execution.test.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/test/session-execution.test.ts
git diff --check
git push -u origin execution-test-cleanup
```

The focused suite passed 29 tests with 107 assertions. Core typecheck, formatting, structural scan, whitespace checks, and the normal pre-push 33-package workspace typecheck passed. Oxlint reported no errors and one existing warning in an unrelated generator.