### PR TITLE
fix(tui): unify attention indicators with unread accent

### DIFF
--- a/.changeset/attention-accent-color.md
+++ b/.changeset/attention-accent-color.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/theme": patch
+---
+
+Use the unread accent color by default for question and permission status indicators, while preserving explicit theme overrides.

--- a/.changeset/primary-question-color.md
+++ b/.changeset/primary-question-color.md
@@ -1,5 +1,0 @@
----
-"@opencode-ai/theme": patch
----
-
-Use the primary theme color for question status indicators instead of the informational feedback color.

--- a/.changeset/primary-question-color.md
+++ b/.changeset/primary-question-color.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/theme": patch
+---
+
+Use the primary theme color for question status indicators instead of the informational feedback color.

--- a/packages/theme/src/tui/defaults.ts
+++ b/packages/theme/src/tui/defaults.ts
@@ -123,8 +123,8 @@ export const DEFAULT_THEME = {
       },
       status: {
         running: "$hue.interactive.800",
-        question: "$hue.interactive.800",
-        permission: "$text.feedback.warning.default",
+        question: "$text.status.unread",
+        permission: "$text.status.unread",
         unread: "$hue.accent.800",
       },
       feedback: {
@@ -344,8 +344,8 @@ export const DEFAULT_THEME = {
       },
       status: {
         running: "$hue.interactive.200",
-        question: "$hue.interactive.200",
-        permission: "$text.feedback.warning.default",
+        question: "$text.status.unread",
+        permission: "$text.status.unread",
         unread: "$hue.accent.200",
       },
       feedback: {

--- a/packages/theme/src/tui/defaults.ts
+++ b/packages/theme/src/tui/defaults.ts
@@ -123,7 +123,7 @@ export const DEFAULT_THEME = {
       },
       status: {
         running: "$hue.interactive.800",
-        question: "$text.feedback.info.default",
+        question: "$hue.interactive.800",
         permission: "$text.feedback.warning.default",
         unread: "$hue.accent.800",
       },
@@ -344,7 +344,7 @@ export const DEFAULT_THEME = {
       },
       status: {
         running: "$hue.interactive.200",
-        question: "$text.feedback.info.default",
+        question: "$hue.interactive.200",
         permission: "$text.feedback.warning.default",
         unread: "$hue.accent.200",
       },

--- a/packages/theme/test/status.test.ts
+++ b/packages/theme/test/status.test.ts
@@ -11,10 +11,25 @@ test.each(["light", "dark"] as const)("built-in %s themes resolve status colors"
   for (const document of [DEFAULT_THEME, migrateV1(source)]) {
     const theme = resolveThemeDocument(document, mode)
     expect(theme.text.status.running.equals(theme.hue.interactive[mode === "light" ? 800 : 200])).toBeTrue()
-    expect(theme.text.status.question.equals(theme.text.feedback.info.default)).toBeTrue()
+    expect(theme.text.status.question.equals(theme.hue.interactive[mode === "light" ? 800 : 200])).toBeTrue()
     expect(theme.text.status.permission.equals(theme.text.feedback.warning.default)).toBeTrue()
     expect(theme.text.status.unread.equals(theme.hue.accent[mode === "light" ? 800 : 200])).toBeTrue()
     expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
+  }
+})
+
+test.each(["light", "dark"] as const)("custom %s themes inherit the primary question color", (mode) => {
+  for (const standalone of [false, true]) {
+    const theme = resolveThemeDocument(
+      Schema.decodeUnknownSync(ThemeDocument)({
+        version: 2,
+        standalone,
+        [mode]: { hue: { ...DEFAULT_THEME[mode].hue, interactive: "$hue.purple" } },
+      }),
+      mode,
+    )
+    expect(theme.text.status.question.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
+    expect(theme.contextual.elevated.text.status.question).toEqual(theme.text.status.question)
   }
 })
 

--- a/packages/theme/test/status.test.ts
+++ b/packages/theme/test/status.test.ts
@@ -11,25 +11,30 @@ test.each(["light", "dark"] as const)("built-in %s themes resolve status colors"
   for (const document of [DEFAULT_THEME, migrateV1(source)]) {
     const theme = resolveThemeDocument(document, mode)
     expect(theme.text.status.running.equals(theme.hue.interactive[mode === "light" ? 800 : 200])).toBeTrue()
-    expect(theme.text.status.question.equals(theme.hue.interactive[mode === "light" ? 800 : 200])).toBeTrue()
-    expect(theme.text.status.permission.equals(theme.text.feedback.warning.default)).toBeTrue()
+    expect(theme.text.status.question.equals(theme.text.status.unread)).toBeTrue()
+    expect(theme.text.status.permission.equals(theme.text.status.unread)).toBeTrue()
     expect(theme.text.status.unread.equals(theme.hue.accent[mode === "light" ? 800 : 200])).toBeTrue()
     expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
   }
 })
 
-test.each(["light", "dark"] as const)("custom %s themes inherit the primary question color", (mode) => {
+test.each(["light", "dark"] as const)("custom %s themes inherit the unread attention color", (mode) => {
   for (const standalone of [false, true]) {
     const theme = resolveThemeDocument(
       Schema.decodeUnknownSync(ThemeDocument)({
         version: 2,
         standalone,
-        [mode]: { hue: { ...DEFAULT_THEME[mode].hue, interactive: "$hue.purple" } },
+        [mode]: {
+          hue: { ...DEFAULT_THEME[mode].hue, accent: "$hue.purple" },
+          text: { status: { unread: "#abcdef" } },
+        },
       }),
       mode,
     )
-    expect(theme.text.status.question.equals(theme.hue.purple[mode === "light" ? 800 : 200])).toBeTrue()
-    expect(theme.contextual.elevated.text.status.question).toEqual(theme.text.status.question)
+    expect(theme.text.status.unread.equals(RGBA.fromHex("#abcdef"))).toBeTrue()
+    expect(theme.text.status.question.equals(theme.text.status.unread)).toBeTrue()
+    expect(theme.text.status.permission.equals(theme.text.status.unread)).toBeTrue()
+    expect(theme.contextual.elevated.text.status).toEqual(theme.text.status)
   }
 })
 
@@ -42,8 +47,7 @@ test.each(["light", "dark"] as const)("custom %s themes inherit and override sta
         [mode]: {
           hue: { ...DEFAULT_THEME[mode].hue, interactive: "$hue.purple", accent: "$hue.orange" },
           text: {
-            feedback: { warning: { default: "#654321" } },
-            status: { question: "#123456" },
+            status: { question: "#123456", permission: "#654321" },
           },
         },
       }),

--- a/packages/tui/test/component/session-tabs-status.test.tsx
+++ b/packages/tui/test/component/session-tabs-status.test.tsx
@@ -124,6 +124,12 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         setActive("second")
         setStatus({ ...EMPTY_SESSION_TAB_STATUS, busy: true, attention })
         await app.renderOnce()
+        const indicatorColor = () =>
+          app
+            .captureSpans()
+            .lines.flatMap((line) => line.spans)
+            .find((span) => span.text.trim() === (attention === "question" ? "?" : "!"))?.fg
+        expect(indicatorColor()?.toInts()).toEqual(theme.text.status[attention].toInts())
         const glow = () => {
           const colors = app
             .captureSpans()
@@ -140,6 +146,7 @@ for (const orientation of ["horizontal", "vertical"] as const) {
         expect(full).toBeGreaterThan(0)
         setActive("first")
         await app.renderOnce()
+        expect(indicatorColor()?.toInts()).toEqual(theme.text.status[attention].toInts())
         const dim = glow()
         expect(dim).toBeGreaterThan(0)
         expect(dim).toBeLessThan(full)


### PR DESCRIPTION
**Why**
Question, permission, and unread indicators currently use three different colors. Give them one consistent attention color and let the glyph communicate what needs attention.

**What Changes**
Default both `text.status.question` and `text.status.permission` to `$text.status.unread`, the theme's unread accent color.

| State | Before | After |
| --- | --- | --- |
| Question `?` | Informational feedback | Unread accent |
| Permission `!` | Warning | Unread accent |
| Unread | Accent | Unchanged |
| Running | Primary/interactive | Unchanged |

Changing a theme's unread color now updates question and permission indicators too, unless the theme explicitly overrides those status tokens. This applies to both light and dark modes, including standalone themes.

**Demo**
Left: base `0c77f6ed5b`. Right: `99d57e01b3`.

OpenCode dark, Catppuccin dark, Gruvbox dark, then Catppuccin light. Each pair shows real running, question, permission, and unread sessions, with the question selected.

https://github.com/user-attachments/assets/b5fbb977-cdf6-45be-be7b-77b74f23c099

Recorded from the production TUI using an isolated OpenCode Drive scenario with simulated LLM responses. Live frames are sampled at 10 fps and encoded with Drive's recording renderer. The video reuses the base-revision footage, crops to the tab rail, and joins equal-length theme checkpoints. Setup and theme-picker transitions are omitted.

**Scope**
Only the default question and permission colors change. Their glyphs and semantic tokens remain distinct, explicit theme overrides are preserved, and error feedback stays unchanged. Includes a theme changeset and regression coverage for theme resolution and selected/unselected tab indicators.

**Verification**
```sh
(cd packages/theme && bun run test)
(cd packages/theme && bun typecheck)
(cd packages/tui && bun run test test/component/session-tabs-status.test.tsx test/component/session-tabs-mouse.test.tsx)
(cd packages/tui && bun typecheck)
git diff --check 0c77f6ed5b...HEAD
```

All passed: 6 theme tests and 8 tab tests. The push hook also passed all 33 workspace typecheck tasks. All four updated Drive runs completed successfully; inspected narrow 60x26 and wide 120x32 captures as well as the recorded 96x26 viewport.
