### PR TITLE
refactor(core): remove unused response stream state

### DIFF
--- a/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
+++ b/packages/core/src/github-copilot/responses/openai-responses-language-model.ts
@@ -792,7 +792,6 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
     const ongoingToolCalls: Record<
       number,
       | {
-          toolName: string
           toolCallId: string
           codeInterpreter?: {
             containerId: string
@@ -851,7 +850,6 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
             if (isResponseOutputItemAddedChunk(value)) {
               if (value.item.type === "function_call") {
                 ongoingToolCalls[value.output_index] = {
-                  toolName: value.item.name,
                   toolCallId: value.item.call_id,
                 }
 
@@ -862,7 +860,6 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 })
               } else if (value.item.type === "web_search_call") {
                 ongoingToolCalls[value.output_index] = {
-                  toolName: webSearchToolName ?? "web_search",
                   toolCallId: value.item.id,
                 }
 
@@ -873,7 +870,6 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 })
               } else if (value.item.type === "computer_call") {
                 ongoingToolCalls[value.output_index] = {
-                  toolName: "computer_use",
                   toolCallId: value.item.id,
                 }
 
@@ -884,7 +880,6 @@ export class OpenAIResponsesLanguageModel implements LanguageModelV3 {
                 })
               } else if (value.item.type === "code_interpreter_call") {
                 ongoingToolCalls[value.output_index] = {
-                  toolName: "code_interpreter",
                   toolCallId: value.item.id,
                   codeInterpreter: {
                     containerId: value.item.container_id,


### PR DESCRIPTION
**Why**

The Copilot Responses stream map stored a tool name for every tracked function, web-search, computer, and code-interpreter call, but no map consumer reads that field. The apparent bookkeeping suggests completion events depend on the stored name even though they construct their names directly from each event branch.

**What Changes**

Remove the private `toolName` member and its four initializers. Keep the map's tool-call IDs and code-interpreter container data, along with all emitted tool names, inputs, results, ordering, and cleanup behavior.

**Scope**

This PR owns only the accepted ADAPT-03 Responses-stream occurrence. PR #45659 owns the separate Responses input-converter occurrence and PR #45664 owns the Chat occurrence. PR #45658 changes hosted-tool identity in this same model file, but its get-args, completion-event, model-config, and test hunks do not overlap these private map-state deletions. This behavior-preserving refactor has no changeset.

**Verification**

```sh
cd packages/core
bun run test test/github-copilot/openai-responses-language-model.test.ts
bun typecheck
bun run build
cd ../..
bunx prettier --check packages/core/src/github-copilot/responses/openai-responses-language-model.ts
bun run lint -- packages/core/src/github-copilot/responses/openai-responses-language-model.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/github-copilot/responses/openai-responses-language-model.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/github-copilot/responses/openai-responses-language-model.ts
git diff --check origin/v2...HEAD
git push -u origin response-stream-state
```

The focused suite passed 10 tests with 31 expectations. Core typecheck, Core build, Prettier, both AST scans, diff validation, and the pre-push 39-package typecheck passed. Oxlint reported five pre-existing warnings outside the edited lines and no errors.
