### PR TITLE
feat(core): vanilla instance discovery option

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -224,38 +224,38 @@ export const layer = (options?: Options) =>
                 .pipe(Effect.orDie)
 
         const globalEnabled = options?.global !== false
-        // The upward walk can reach the user's home directory. Home-level
-        // .claude/.agents are global config however they are found, so a
-        // global: false caller excludes them from the walk's results too.
-        const excludedGlobals = new Set(
-          globalEnabled ? [] : [globalClaudeDirectory, globalAgentsDirectory].map((item) => path.resolve(item)),
+        // A walked path that resolves into a global root is global config
+        // however the walk reached it (home above the project, or a location
+        // beneath the global config dir), so global: false excludes it
+        // uniformly — classified once here, not per consumer below.
+        const globalRoots = [globalDirectory, globalClaudeDirectory, globalAgentsDirectory].map((item) =>
+          path.resolve(item),
         )
+        const visible = globalEnabled
+          ? discovered
+          : discovered.filter((item) => {
+              const resolved = path.resolve(item)
+              return !globalRoots.some((root) => resolved === root || resolved.startsWith(root + path.sep))
+            })
         // We load certain files from a few other folders in the ecosystem
         const claude = [
           ...new Set([
             ...(globalEnabled && (yield* fs.isDir(globalClaudeDirectory)) ? [globalClaudeDirectory] : []),
-            ...discovered
-              .filter((item) => path.basename(item) === ".claude" && !excludedGlobals.has(path.resolve(item)))
-              .toReversed(),
+            ...visible.filter((item) => path.basename(item) === ".claude").toReversed(),
           ]),
         ].map((directory) => new ClaudeDirectory({ type: "claude", path: AbsolutePath.make(directory) }))
         const agents = [
           ...new Set([
             ...(globalEnabled && (yield* fs.isDir(globalAgentsDirectory)) ? [globalAgentsDirectory] : []),
-            ...discovered
-              .filter((item) => path.basename(item) === ".agents" && !excludedGlobals.has(path.resolve(item)))
-              .toReversed(),
+            ...visible.filter((item) => path.basename(item) === ".agents").toReversed(),
           ]),
         ].map((directory) => new AgentsDirectory({ type: "agents", path: AbsolutePath.make(directory) }))
 
-        const directories = [
-          ...(globalEnabled ? [globalDirectory] : []),
-          ...discovered
-            .filter((item) => path.basename(item) === ".opencode")
-            .toReversed()
-            .map((directory) => AbsolutePath.make(directory)),
-        ]
-        const directPaths = discovered
+        const projectDirectories = visible
+          .filter((item) => path.basename(item) === ".opencode")
+          .toReversed()
+          .map((directory) => AbsolutePath.make(directory))
+        const directPaths = visible
           .filter((item) => ![".agents", ".claude", ".opencode"].includes(path.basename(item)))
           .toReversed()
         fileTargets.clear()
@@ -287,12 +287,13 @@ export const layer = (options?: Options) =>
               )
             : []
 
-        const supplementary = yield* Effect.forEach(directories, loadDirectory).pipe(Effect.orDie)
-        // The global config dir, when enabled, is directories[0]: its entries
-        // sit below explicit and direct files, while project directories rank
-        // above them.
-        const globalSupplementary = globalEnabled ? (supplementary[0] ?? []) : []
-        const projectSupplementary = globalEnabled ? supplementary.slice(1).flat() : supplementary.flat()
+        // Global entries sit below explicit and direct files; project
+        // directories rank above them.
+        const globalSupplementary = globalEnabled ? yield* loadDirectory(globalDirectory).pipe(Effect.orDie) : []
+        const projectSupplementary = yield* Effect.forEach(projectDirectories, loadDirectory).pipe(
+          Effect.orDie,
+          Effect.map((entries) => entries.flat()),
+        )
         return [
           ...(yield* loadWellknown().pipe(Effect.orDie)),
           ...claude,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -224,17 +224,27 @@ export const layer = (options?: Options) =>
                 .pipe(Effect.orDie)
 
         const globalEnabled = options?.global !== false
+        // The upward walk can reach the user's home directory. Home-level
+        // .claude/.agents are global config however they are found, so a
+        // global: false caller excludes them from the walk's results too.
+        const excludedGlobals = new Set(
+          globalEnabled ? [] : [globalClaudeDirectory, globalAgentsDirectory].map((item) => path.resolve(item)),
+        )
         // We load certain files from a few other folders in the ecosystem
         const claude = [
           ...new Set([
             ...(globalEnabled && (yield* fs.isDir(globalClaudeDirectory)) ? [globalClaudeDirectory] : []),
-            ...discovered.filter((item) => path.basename(item) === ".claude").toReversed(),
+            ...discovered
+              .filter((item) => path.basename(item) === ".claude" && !excludedGlobals.has(path.resolve(item)))
+              .toReversed(),
           ]),
         ].map((directory) => new ClaudeDirectory({ type: "claude", path: AbsolutePath.make(directory) }))
         const agents = [
           ...new Set([
             ...(globalEnabled && (yield* fs.isDir(globalAgentsDirectory)) ? [globalAgentsDirectory] : []),
-            ...discovered.filter((item) => path.basename(item) === ".agents").toReversed(),
+            ...discovered
+              .filter((item) => path.basename(item) === ".agents" && !excludedGlobals.has(path.resolve(item)))
+              .toReversed(),
           ]),
         ].map((directory) => new AgentsDirectory({ type: "agents", path: AbsolutePath.make(directory) }))
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -53,6 +53,9 @@ export class UpdateError extends Schema.TaggedError<UpdateError>()("Config.Updat
 
 export const Options = Schema.Struct({
   project: Schema.optional(Schema.Boolean),
+  // false skips the global config dir, ~/.claude, and ~/.agents; wellknown,
+  // file, and content entries still load.
+  global: Schema.optional(Schema.Boolean),
   file: Schema.optional(Schema.String),
   content: Schema.optional(Schema.String),
 })
@@ -220,22 +223,23 @@ export const layer = (options?: Options) =>
                 })
                 .pipe(Effect.orDie)
 
+        const globalEnabled = options?.global !== false
         // We load certain files from a few other folders in the ecosystem
         const claude = [
           ...new Set([
-            ...((yield* fs.isDir(globalClaudeDirectory)) ? [globalClaudeDirectory] : []),
+            ...(globalEnabled && (yield* fs.isDir(globalClaudeDirectory)) ? [globalClaudeDirectory] : []),
             ...discovered.filter((item) => path.basename(item) === ".claude").toReversed(),
           ]),
         ].map((directory) => new ClaudeDirectory({ type: "claude", path: AbsolutePath.make(directory) }))
         const agents = [
           ...new Set([
-            ...((yield* fs.isDir(globalAgentsDirectory)) ? [globalAgentsDirectory] : []),
+            ...(globalEnabled && (yield* fs.isDir(globalAgentsDirectory)) ? [globalAgentsDirectory] : []),
             ...discovered.filter((item) => path.basename(item) === ".agents").toReversed(),
           ]),
         ].map((directory) => new AgentsDirectory({ type: "agents", path: AbsolutePath.make(directory) }))
 
         const directories = [
-          globalDirectory,
+          ...(globalEnabled ? [globalDirectory] : []),
           ...discovered
             .filter((item) => path.basename(item) === ".opencode")
             .toReversed()
@@ -274,14 +278,19 @@ export const layer = (options?: Options) =>
             : []
 
         const supplementary = yield* Effect.forEach(directories, loadDirectory).pipe(Effect.orDie)
+        // The global config dir, when enabled, is directories[0]: its entries
+        // sit below explicit and direct files, while project directories rank
+        // above them.
+        const globalSupplementary = globalEnabled ? (supplementary[0] ?? []) : []
+        const projectSupplementary = globalEnabled ? supplementary.slice(1).flat() : supplementary.flat()
         return [
           ...(yield* loadWellknown().pipe(Effect.orDie)),
           ...claude,
           ...agents,
-          ...(supplementary[0] ?? []),
+          ...globalSupplementary,
           ...explicit,
           ...direct,
-          ...supplementary.slice(1).flat(),
+          ...projectSupplementary,
           ...content,
         ]
       })

--- a/packages/core/src/config/plugin/instruction.ts
+++ b/packages/core/src/config/plugin/instruction.ts
@@ -36,7 +36,7 @@ export const Plugin = define({
 
       const publish = (update: Watcher.Update) => PubSub.publish(changes, update.path).pipe(Effect.asVoid)
       const candidates = [
-        globalFile,
+        ...(discovery.global ? [globalFile] : []),
         ...(project ? ancestorDirectories(start, stop).map((directory) => join(directory, "AGENTS.md")) : []),
       ]
       for (const path of new Set(candidates)) {
@@ -51,6 +51,7 @@ export const Plugin = define({
       })
 
       const globalSource = Effect.fn("ConfigInstructionPlugin.globalSource")(function* () {
+        if (!discovery.global) return []
         const file = yield* read(globalFile)
         return file ? [file] : []
       })

--- a/packages/core/src/config/plugin/instruction.ts
+++ b/packages/core/src/config/plugin/instruction.ts
@@ -19,6 +19,9 @@ export const Plugin = define({
   id: "opencode.config.instruction",
   effect: Effect.fn(function* () {
     const discovery = yield* InstructionDiscovery.Service
+    // Nothing this plugin watches or loads can contribute when both scopes
+    // are disabled; skip the resolves, the watcher fiber, and the transform.
+    if (!discovery.project && !discovery.global) return
     yield* Effect.gen(function* () {
       const fs = yield* FSUtil.Service
       const global = yield* Global.Service
@@ -35,9 +38,15 @@ export const Plugin = define({
       const loaded: { current: Loaded } = { current: { type: "available", files: [] } }
 
       const publish = (update: Watcher.Update) => PubSub.publish(changes, update.path).pipe(Effect.asVoid)
+      // The ancestor walk can reach the global file when the location sits
+      // beneath the global config dir; global: false excludes it there too.
       const candidates = [
         ...(discovery.global ? [globalFile] : []),
-        ...(project ? ancestorDirectories(start, stop).map((directory) => join(directory, "AGENTS.md")) : []),
+        ...(project
+          ? ancestorDirectories(start, stop)
+              .map((directory) => join(directory, "AGENTS.md"))
+              .filter((file) => discovery.global || file !== globalFile)
+          : []),
       ]
       for (const path of new Set(candidates)) {
         const updates = yield* watcher.subscribe({ path, type: "file" })
@@ -58,9 +67,8 @@ export const Plugin = define({
 
       const projectSource = Effect.fn("ConfigInstructionPlugin.projectSource")(function* () {
         if (!project) return []
-        const discovered = new Set(
-          yield* Effect.forEach(yield* fs.up({ targets: ["AGENTS.md"], start, stop }), fs.resolve),
-        )
+        const walked = yield* Effect.forEach(yield* fs.up({ targets: ["AGENTS.md"], start, stop }), fs.resolve)
+        const discovered = new Set(walked.filter((file) => discovery.global || file !== globalFile))
         const files = yield* Effect.forEach(discovered, read, { concurrency: "unbounded" })
         if (files.some((file) => file === undefined)) return Instructions.unavailable
         return files.filter((file): file is InstructionDiscovery.File => file !== undefined)

--- a/packages/core/src/instance.ts
+++ b/packages/core/src/instance.ts
@@ -4,7 +4,6 @@ import { AISDK } from "./aisdk.js"
 import { Catalog } from "./catalog.js"
 import { Command } from "./command.js"
 import { Config } from "./config.js"
-import { ConfigPluginSource } from "./config/plugin/source.js"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Node } from "@opencode-ai/util/effect/app-node"
 import { FileMutation } from "./file-mutation.js"
@@ -117,31 +116,39 @@ export interface Options {
   readonly plugins?: InstancePlugins.List
   // Filesystem config discovery; true (default) is today's behavior. When
   // false the instance boots vanilla: no upward config scan, no global config
-  // dir, no plugin-dir loading, no AGENTS.md discovery. Wellknown integration
-  // config and host-injected values still apply, and a config value that
-  // explicitly names something file-backed (a skill path, an MCP command) is
-  // a request, not discovery.
+  // dir, no plugin-dir loading or ambient plugin module imports, no boot-time
+  // AGENTS.md discovery. Wellknown integration config and host-injected values
+  // still apply, and a config value that explicitly names something
+  // file-backed (a skill path, an MCP command) is a request, not discovery.
+  // Use-triggered behavior also stays: reading a file still injects nested
+  // AGENTS.md instructions — that is session-time context, not boot-time
+  // population.
   readonly discovery?: boolean
   readonly replacements?: LayerNode.Replacements
 }
 
 // Vanilla neutralizes the discovery inputs; the plugin list stays untouched.
+// These are defaults ahead of caller replacements: a host that replaces a
+// gated node itself owns that node's discovery flags. Plugin-directory
+// discovery needs no swap here — implicit scanning only triggers on Directory
+// config entries, which a no-scan Config never produces, and the default
+// source still honors explicit plugin operations from wellknown and
+// host-injected config.
 const vanillaReplacements: LayerNode.Replacements = [
   [Config.node, Config.configured({ project: false, global: false })],
-  [ConfigPluginSource.node, ConfigPluginSource.empty],
   [InstructionDiscovery.node, InstructionDiscovery.configured({ project: false, global: false })],
 ]
 
 // One instance is one compiled, fresh copy of the graph standing on a directory.
 export function layer(ref: Location.Ref, options: Options = {}) {
   const startedAt = performance.now()
+  const defaults: LayerNode.Replacements = options.discovery === false ? vanillaReplacements : []
   // Bound pairs come last, so they win over caller replacements of the same nodes.
   const bound: LayerNode.Replacements = [
-    ...(options.discovery === false ? vanillaReplacements : []),
-    [Location.node, Location.boundNode(ref)],
+    [Location.node, Location.boundNode(ref, { discovery: options.discovery })],
     [InstancePlugins.node, InstancePlugins.bound(options.plugins ?? [])],
   ]
-  const allReplacements = (options.replacements ?? []).concat(bound)
+  const allReplacements = defaults.concat(options.replacements ?? [], bound)
   // Apply replacements during hoist, not afterward: replacements can
   // introduce new tagged dependencies (Location.boundNode depends on
   // Project), and the hoist walk is the only pass that can still slice

--- a/packages/core/src/instance.ts
+++ b/packages/core/src/instance.ts
@@ -4,6 +4,7 @@ import { AISDK } from "./aisdk.js"
 import { Catalog } from "./catalog.js"
 import { Command } from "./command.js"
 import { Config } from "./config.js"
+import { ConfigPluginSource } from "./config/plugin/source.js"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Node } from "@opencode-ai/util/effect/app-node"
 import { FileMutation } from "./file-mutation.js"
@@ -114,17 +115,33 @@ export type Error = LayerNode.Error<typeof graph>
 export interface Options {
   // Plugins this instance is born with; empty and absent are equivalent.
   readonly plugins?: InstancePlugins.List
+  // Filesystem config discovery; true (default) is today's behavior. When
+  // false the instance boots vanilla: no upward config scan, no global config
+  // dir, no plugin-dir loading, no AGENTS.md discovery. Wellknown integration
+  // config and host-injected values still apply, and a config value that
+  // explicitly names something file-backed (a skill path, an MCP command) is
+  // a request, not discovery.
+  readonly discovery?: boolean
   readonly replacements?: LayerNode.Replacements
 }
+
+// Vanilla neutralizes the discovery inputs; the plugin list stays untouched.
+const vanillaReplacements: LayerNode.Replacements = [
+  [Config.node, Config.configured({ project: false, global: false })],
+  [ConfigPluginSource.node, ConfigPluginSource.empty],
+  [InstructionDiscovery.node, InstructionDiscovery.configured({ project: false, global: false })],
+]
 
 // One instance is one compiled, fresh copy of the graph standing on a directory.
 export function layer(ref: Location.Ref, options: Options = {}) {
   const startedAt = performance.now()
   // Bound pairs come last, so they win over caller replacements of the same nodes.
-  const allReplacements = (options.replacements ?? []).concat([
+  const bound: LayerNode.Replacements = [
+    ...(options.discovery === false ? vanillaReplacements : []),
     [Location.node, Location.boundNode(ref)],
     [InstancePlugins.node, InstancePlugins.bound(options.plugins ?? [])],
-  ])
+  ]
+  const allReplacements = (options.replacements ?? []).concat(bound)
   // Apply replacements during hoist, not afterward: replacements can
   // introduce new tagged dependencies (Location.boundNode depends on
   // Project), and the hoist walk is the only pass that can still slice

--- a/packages/core/src/instance.ts
+++ b/packages/core/src/instance.ts
@@ -142,13 +142,14 @@ const vanillaReplacements: LayerNode.Replacements = [
 // One instance is one compiled, fresh copy of the graph standing on a directory.
 export function layer(ref: Location.Ref, options: Options = {}) {
   const startedAt = performance.now()
-  const defaults: LayerNode.Replacements = options.discovery === false ? vanillaReplacements : []
-  // Bound pairs come last, so they win over caller replacements of the same nodes.
-  const bound: LayerNode.Replacements = [
+  // Ordered: vanilla defaults, then caller replacements (which win over the
+  // defaults), then bound pairs (which win over everything).
+  const allReplacements: LayerNode.Replacements = [
+    ...(options.discovery === false ? vanillaReplacements : []),
+    ...(options.replacements ?? []),
     [Location.node, Location.boundNode(ref, { discovery: options.discovery })],
     [InstancePlugins.node, InstancePlugins.bound(options.plugins ?? [])],
   ]
-  const allReplacements = defaults.concat(options.replacements ?? [], bound)
   // Apply replacements during hoist, not afterward: replacements can
   // introduce new tagged dependencies (Location.boundNode depends on
   // Project), and the hoist walk is the only pass that can still slice

--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -39,12 +39,14 @@ export interface Interface extends State.Transformable<Draft> {
   // Discovery policy lives here because internal plugins have no per-composition options channel.
   // Move it into plugin config once plugins can consume their own options.
   readonly project: boolean
+  readonly global: boolean
   readonly list: () => Effect.Effect<File[] | Instructions.Unavailable>
   readonly load: () => Effect.Effect<Instructions.List>
 }
 
 export const Options = Schema.Struct({
   project: Schema.optional(Schema.Boolean),
+  global: Schema.optional(Schema.Boolean),
 })
 export type Options = typeof Options.Type
 
@@ -95,6 +97,7 @@ export const layer = (options?: Options) =>
 
       return Service.of({
         project: options?.project !== false,
+        global: options?.global !== false,
         transform: state.transform,
         reload: state.reload,
         list,

--- a/packages/core/src/location.ts
+++ b/packages/core/src/location.ts
@@ -17,12 +17,12 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Lo
 
 export const node = LayerNode.unbound(Service, tags.values.location)
 
-const layer = (ref: Ref) =>
+const layer = (ref: Ref, options?: { readonly discovery?: boolean }) =>
   Layer.effect(
     Service,
     Effect.gen(function* () {
       const project = yield* Project.Service
-      const resolved = yield* project.resolve(ref.directory)
+      const resolved = yield* project.resolve(ref.directory, options)
       return Service.of({
         directory: ref.directory,
         workspaceID: ref.workspaceID,
@@ -33,9 +33,9 @@ const layer = (ref: Ref) =>
     }),
   )
 
-export const boundNode = (ref: Ref) =>
+export const boundNode = (ref: Ref, options?: { readonly discovery?: boolean }) =>
   makeLocationNode({
     service: Service,
-    layer: layer(ref),
+    layer: layer(ref, options),
     deps: [Project.node],
   })

--- a/packages/core/src/plugin/instance.ts
+++ b/packages/core/src/plugin/instance.ts
@@ -13,10 +13,11 @@ import type { Versioned } from "../plugin.js"
  * for the instance's lifetime; runtime dynamism lives inside plugins through
  * the container transform/reload APIs.
  *
- * Limitations, both shared with `SdkPlugins`: `vcs` marker declarations are
- * not seen by `ProjectMarkers` (it is global and runs during project
- * resolution, before the instance exists), and config plugin operations may
- * disable instance plugins by id.
+ * Limitations: `vcs` marker declarations in an instance list are not seen by
+ * `ProjectMarkers` (it is global and runs during project resolution, before
+ * the instance exists — unlike `SdkPlugins`, whose declarations it consumes
+ * directly), and config plugin operations may disable instance plugins by id,
+ * matching `SdkPlugins` behavior.
  */
 export type List = readonly Plugin[]
 
@@ -28,7 +29,7 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/In
 
 export const node = makeLocationNode({
   service: Service,
-  layer: Layer.succeed(Service, Service.of({ all: () => [] })),
+  layer: bound([]),
   deps: [],
 })
 

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -62,7 +62,7 @@ export const root = Effect.fn("Project.root")(function* (
 export interface Interface {
   readonly list: () => Effect.Effect<ReadonlyArray<Info>>
   readonly update: (input: UpdateInput) => Effect.Effect<Info, NotFoundError>
-  readonly resolve: (input: AbsolutePath) => Effect.Effect<Resolved>
+  readonly resolve: (input: AbsolutePath, options?: { readonly discovery?: boolean }) => Effect.Effect<Resolved>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Project") {}
@@ -317,9 +317,12 @@ const layer = Layer.effect(
       }
     })
 
-    const resolve = Effect.fn("Project.resolve")(function* (input: AbsolutePath) {
+    const resolve = Effect.fn("Project.resolve")(function* (
+      input: AbsolutePath,
+      options?: { readonly discovery?: boolean },
+    ) {
       const directory = AbsolutePath.make(yield* fs.resolve(input))
-      const marker = yield* markers.discover(directory)
+      const marker = yield* markers.discover(directory, options)
       const native = yield* fs.up({ targets: [".git", ".hg"], start: directory, mode: "first" }).pipe(
         Effect.map((matches) => matches[0]),
         Effect.orElseSucceed(() => undefined),

--- a/packages/core/src/project/markers.ts
+++ b/packages/core/src/project/markers.ts
@@ -22,7 +22,10 @@ export interface Match {
 }
 
 export interface Interface {
-  readonly discover: (directory: AbsolutePath) => Effect.Effect<Match | undefined>
+  readonly discover: (
+    directory: AbsolutePath,
+    options?: { readonly discovery?: boolean },
+  ) => Effect.Effect<Match | undefined>
   readonly targets: () => readonly string[]
 }
 
@@ -38,7 +41,10 @@ const layer = Layer.effect(
     const known = new Set([".git", ".hg"])
     const loaded = new Map<string, Versioned | undefined>()
 
-    const discover = Effect.fn("ProjectMarkers.discover")(function* (directory: AbsolutePath) {
+    // The filesystem half of discovery: walk up for config, scan plugin
+    // directories, and read configured plugin operations. This is the part a
+    // no-discovery caller must skip — it imports plugin modules.
+    const scanOperations = Effect.fnUntraced(function* (directory: AbsolutePath) {
       const found = yield* fs
         .up({ targets: [".opencode", "opencode.json", "opencode.jsonc"], start: directory })
         .pipe(Effect.orElseSucceed(() => []))
@@ -54,7 +60,7 @@ const layer = Layer.effect(
       const configured = yield* Effect.forEach([...new Set(files)], (file) => read(fs, file)).pipe(
         Effect.map((entries) => entries.flat()),
       )
-      const operations = yield* Effect.forEach(
+      return yield* Effect.forEach(
         [
           ...automatic.map((target): ConfigPluginSource.Operation => ({ type: "add", target, options: {} })),
           ...configured,
@@ -70,6 +76,15 @@ const layer = Layer.effect(
           )
         },
       )
+    })
+
+    const discover = Effect.fn("ProjectMarkers.discover")(function* (
+      directory: AbsolutePath,
+      options?: { readonly discovery?: boolean },
+    ) {
+      // discovery: false skips the config scan and its plugin module loading;
+      // sdk-declared vcs markers are host-explicit, not ambient, so they stay.
+      const operations = options?.discovery === false ? [] : yield* scanOperations(directory)
       const declarations = new Map<string, { readonly id: string; readonly markers: readonly string[] }>()
 
       for (const plugin of sdk.all()) {

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -128,6 +128,49 @@ describe("Config", () => {
     ),
   )
 
+  it.live("excludes home-level claude and agents directories when global is disabled", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) => {
+        const global = path.join(tmp.path, "global")
+        const home = path.join(global, "home")
+        const project = path.join(home, "project")
+        const ambient = (entries: readonly { type: string }[]) =>
+          entries.filter((entry) => entry.type === "claude" || entry.type === "agents")
+        return Effect.promise(() =>
+          Promise.all([
+            fs.mkdir(project, { recursive: true }),
+            fs.mkdir(path.join(home, ".claude"), { recursive: true }),
+            fs.mkdir(path.join(home, ".agents"), { recursive: true }),
+          ]),
+        ).pipe(
+          Effect.andThen(
+            Effect.gen(function* () {
+              // The fixture is real: with global enabled the walk finds both.
+              const config = yield* Config.Service
+              expect(ambient(yield* config.entries()).length).toBe(2)
+            }).pipe(Effect.provide(testLayer(project, global))),
+          ),
+          Effect.andThen(
+            // Home-level directories are global config however the walk
+            // reaches them, so global: false excludes them even with the
+            // project walk enabled.
+            Effect.gen(function* () {
+              const config = yield* Config.Service
+              expect(ambient(yield* config.entries())).toEqual([])
+            }).pipe(
+              Effect.provide(
+                testLayer(project, global, project, undefined, undefined, undefined, undefined, { global: false }),
+              ),
+            ),
+          ),
+        )
+      }),
+    ),
+  )
+
   it.effect("fails updates when no file-backed document exists", () =>
     Effect.gen(function* () {
       const config = yield* Config.Service

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -171,6 +171,42 @@ describe("Config", () => {
     ),
   )
 
+  it.live("excludes global config reached through the project walk when global is disabled", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) => {
+        // The location sits BENEATH the global config dir, so the upward walk
+        // reaches the global opencode.json as a direct file.
+        const global = path.join(tmp.path, "global")
+        const project = path.join(global, "plugins", "demo")
+        return Effect.promise(async () => {
+          await fs.mkdir(project, { recursive: true })
+          await fs.writeFile(path.join(global, "opencode.json"), JSON.stringify({ shell: "global-sentinel" }))
+        }).pipe(
+          Effect.andThen(
+            // Fixture control: with global enabled the file loads.
+            Effect.gen(function* () {
+              const config = yield* Config.Service
+              expect(Config.latest(yield* config.entries(), "shell")).toBe("global-sentinel")
+            }).pipe(Effect.provide(testLayer(project, global))),
+          ),
+          Effect.andThen(
+            Effect.gen(function* () {
+              const config = yield* Config.Service
+              expect(Config.latest(yield* config.entries(), "shell")).toBeUndefined()
+            }).pipe(
+              Effect.provide(
+                testLayer(project, global, project, undefined, undefined, undefined, undefined, { global: false }),
+              ),
+            ),
+          ),
+        )
+      }),
+    ),
+  )
+
   it.effect("fails updates when no file-backed document exists", () =>
     Effect.gen(function* () {
       const config = yield* Config.Service

--- a/packages/core/test/instance-vanilla.test.ts
+++ b/packages/core/test/instance-vanilla.test.ts
@@ -13,21 +13,38 @@ import { Location } from "@opencode-ai/core/location"
 import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Tool } from "@opencode-ai/core/tool"
 import { tmpdir } from "./fixture/tmpdir"
 import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
 import { Database } from "../src/database/database"
 import { Bus } from "../src/bus"
 
+// Config the host hands the vanilla instance explicitly: a value and an
+// explicit plugin removal, both of which must survive discovery: false.
+const hostConfig: LayerNode.Replacements = [
+  [
+    Config.node,
+    Config.configured({
+      project: false,
+      global: false,
+      content: JSON.stringify({ shell: "vanilla-host", plugins: ["-opencode.tool.shell"] }),
+    }),
+  ],
+]
+
 // Same directory contents, two instances: one vanilla, one with discovery.
 const instances = Layer.effect(
   LocationServiceMap.Service,
   LayerMap.make(
-    (ref: Location.Ref) =>
-      Instance.layer(ref, {
-        discovery: path.basename(ref.directory) !== "vanilla",
-        replacements: [[Global.node, tempGlobalLayer]],
-      }),
+    (ref: Location.Ref) => {
+      const vanilla = path.basename(ref.directory) === "vanilla"
+      return Instance.layer(ref, {
+        discovery: !vanilla,
+        // Caller replacements win over the vanilla defaults.
+        replacements: [[Global.node, tempGlobalLayer], ...(vanilla ? hostConfig : [])],
+      })
+    },
     { idleTimeToLive: Duration.infinity },
   ),
 )
@@ -63,18 +80,25 @@ describe("Instance vanilla", () => {
               yield* supervisor.flush
               const config = yield* Config.Service
               const discovery = yield* InstructionDiscovery.Service
+              const tools = yield* Tool.Service
               const entries = yield* config.entries()
               return {
                 documents: entries.filter(
                   (entry) => "path" in entry && typeof entry.path === "string" && entry.path.startsWith(ref.directory),
                 ),
                 instructions: yield* discovery.list(),
+                shell: Config.latest(entries, "shell"),
+                toolNames: (yield* tools.snapshot()).definitions.map((definition) => definition.name),
               }
             }).pipe(Effect.scoped, Effect.provide(locations.get(ref)))
 
           const vanilla = yield* read(yield* plant("vanilla"))
           expect(vanilla.documents).toEqual([])
           expect(vanilla.instructions).toEqual([])
+          // Host-injected content survives discovery: false, including its
+          // explicit plugin operations.
+          expect(vanilla.shell).toBe("vanilla-host")
+          expect(vanilla.toolNames).not.toContain("shell")
 
           const discovery = yield* read(yield* plant("discovery"))
           expect(discovery.documents.length).toBeGreaterThan(0)
@@ -82,6 +106,45 @@ describe("Instance vanilla", () => {
             Array.isArray(discovery.instructions) &&
               discovery.instructions.some((file) => file.path.endsWith("AGENTS.md")),
           ).toBe(true)
+          expect(discovery.toolNames).toContain("shell")
+        }),
+      ),
+    ),
+  )
+
+  it.live("does not execute ambient plugin modules", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const locations = yield* LocationServiceMap.Service
+          const directory = path.join(dir.path, "vanilla")
+          const marker = path.join(directory, "ambient-loaded.txt")
+          // A plugin module whose import writes a sentinel: project-marker
+          // discovery used to import it during vanilla boot.
+          yield* Effect.promise(async () => {
+            await fs.mkdir(path.join(directory, ".opencode", "plugins"), { recursive: true })
+            await fs.writeFile(
+              path.join(directory, ".opencode", "plugins", "ambient.ts"),
+              [
+                'import { writeFile } from "node:fs/promises"',
+                `await writeFile(${JSON.stringify(marker)}, "loaded")`,
+                'export default { id: "ambient-plugin", setup() {} }',
+              ].join("\n"),
+            )
+          })
+          const ref = Location.Ref.make({ directory: AbsolutePath.make(directory) })
+          yield* Effect.gen(function* () {
+            const supervisor = yield* PluginSupervisor.Service
+            yield* supervisor.flush
+            const config = yield* Config.Service
+            // Only the pathless host-injected document; nothing file-backed.
+            const entries = yield* config.entries()
+            expect(entries.filter((entry) => "path" in entry && typeof entry.path === "string")).toEqual([])
+          }).pipe(Effect.scoped, Effect.provide(locations.get(ref)))
+          expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
         }),
       ),
     ),

--- a/packages/core/test/instance-vanilla.test.ts
+++ b/packages/core/test/instance-vanilla.test.ts
@@ -1,0 +1,89 @@
+import fs from "fs/promises"
+import path from "path"
+import { describe, expect } from "bun:test"
+import { Duration, Effect, Layer, LayerMap } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Global } from "@opencode-ai/util/global"
+import { Config } from "@opencode-ai/core/config"
+import { Instance } from "@opencode-ai/core/instance"
+import { InstructionDiscovery } from "@opencode-ai/core/instruction-discovery"
+import { LocationServiceMap } from "@opencode-ai/core/location-services"
+import { Location } from "@opencode-ai/core/location"
+import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
+import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { tmpdir } from "./fixture/tmpdir"
+import { tempGlobalLayer } from "./fixture/global"
+import { testEffect } from "./lib/effect"
+import { Database } from "../src/database/database"
+import { Bus } from "../src/bus"
+
+// Same directory contents, two instances: one vanilla, one with discovery.
+const instances = Layer.effect(
+  LocationServiceMap.Service,
+  LayerMap.make(
+    (ref: Location.Ref) =>
+      Instance.layer(ref, {
+        discovery: path.basename(ref.directory) !== "vanilla",
+        replacements: [[Global.node, tempGlobalLayer]],
+      }),
+    { idleTimeToLive: Duration.infinity },
+  ),
+)
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
+    [Global.node, tempGlobalLayer],
+    [LocationServiceMap.node, instances],
+  ]),
+)
+
+describe("Instance vanilla", () => {
+  it.live("boots without filesystem config discovery", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((dir) =>
+        Effect.gen(function* () {
+          const locations = yield* LocationServiceMap.Service
+          const plant = (name: string) =>
+            Effect.promise(async () => {
+              const directory = path.join(dir.path, name)
+              await fs.mkdir(directory)
+              await fs.writeFile(path.join(directory, "opencode.json"), "{}")
+              await fs.writeFile(path.join(directory, "AGENTS.md"), "planted instructions")
+              return Location.Ref.make({ directory: AbsolutePath.make(directory) })
+            })
+
+          const read = (ref: Location.Ref) =>
+            Effect.gen(function* () {
+              const supervisor = yield* PluginSupervisor.Service
+              yield* supervisor.flush
+              const config = yield* Config.Service
+              const discovery = yield* InstructionDiscovery.Service
+              const entries = yield* config.entries()
+              return {
+                documents: entries.filter(
+                  (entry) => "path" in entry && typeof entry.path === "string" && entry.path.startsWith(ref.directory),
+                ),
+                instructions: yield* discovery.list(),
+              }
+            }).pipe(Effect.scoped, Effect.provide(locations.get(ref)))
+
+          const vanilla = yield* read(yield* plant("vanilla"))
+          expect(vanilla.documents).toEqual([])
+          expect(vanilla.instructions).toEqual([])
+
+          const discovery = yield* read(yield* plant("discovery"))
+          expect(discovery.documents.length).toBeGreaterThan(0)
+          expect(
+            Array.isArray(discovery.instructions) &&
+              discovery.instructions.some((file) => file.path.endsWith("AGENTS.md")),
+          ).toBe(true)
+        }),
+      ),
+    ),
+  )
+})

--- a/packages/core/test/instance-vanilla.test.ts
+++ b/packages/core/test/instance-vanilla.test.ts
@@ -38,11 +38,12 @@ const instances = Layer.effect(
   LocationServiceMap.Service,
   LayerMap.make(
     (ref: Location.Ref) => {
-      const vanilla = path.basename(ref.directory) === "vanilla"
+      const name = path.basename(ref.directory)
       return Instance.layer(ref, {
-        discovery: !vanilla,
+        // "bare" exercises the vanilla defaults themselves: no caller Config.
+        discovery: name !== "vanilla" && name !== "bare",
         // Caller replacements win over the vanilla defaults.
-        replacements: [[Global.node, tempGlobalLayer], ...(vanilla ? hostConfig : [])],
+        replacements: [[Global.node, tempGlobalLayer], ...(name === "vanilla" ? hostConfig : [])],
       })
     },
     { idleTimeToLive: Duration.infinity },
@@ -99,6 +100,13 @@ describe("Instance vanilla", () => {
           // explicit plugin operations.
           expect(vanilla.shell).toBe("vanilla-host")
           expect(vanilla.toolNames).not.toContain("shell")
+
+          // Bare vanilla: the defaults themselves, with no caller Config.
+          const bare = yield* read(yield* plant("bare"))
+          expect(bare.documents).toEqual([])
+          expect(bare.instructions).toEqual([])
+          expect(bare.shell).toBeUndefined()
+          expect(bare.toolNames).toContain("shell")
 
           const discovery = yield* read(yield* plant("discovery"))
           expect(discovery.documents.length).toBeGreaterThan(0)

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -105,6 +105,7 @@ const builtins = Layer.mock(InstructionBuiltIns.Service, {
 })
 const discovery = Layer.mock(InstructionDiscovery.Service, {
   project: true,
+  global: true,
   load: () => Effect.succeed(Instructions.empty),
 })
 const skills = Layer.mock(SkillInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })

--- a/packages/core/test/session-runner-recorded.test.ts
+++ b/packages/core/test/session-runner-recorded.test.ts
@@ -79,6 +79,7 @@ const models = Layer.mock(SessionRunnerModel.Service)({
 const systemContext = Layer.mock(InstructionBuiltIns.Service, { load: () => Effect.succeed(Instructions.empty) })
 const instructionContext = Layer.mock(InstructionDiscovery.Service, {
   project: true,
+  global: true,
   load: () => Effect.succeed(Instructions.empty),
 })
 const skillInstructions = Layer.mock(SkillInstructions.Service, { load: () => Effect.succeed(Instructions.empty) })

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -351,6 +351,7 @@ const layer = Layer.unwrap(
     })
     const instructionContext = Layer.mock(InstructionDiscovery.Service, {
       project: true,
+      global: true,
       load: () => Effect.succeed(Instructions.empty),
     })
     const skillInstructions = Layer.mock(SkillInstructions.Service, {


### PR DESCRIPTION
Stacked on #45732 (`instance-plugins`), which stacks on #45705 (`instance-module`); will retarget as the stack merges.

## Why

Every instance that boots runs filesystem config discovery: the upward `opencode.json`/`.opencode`/`.claude`/`.agents` scan, the global config dir, plugin-directory loading, ambient plugin module imports during project-marker resolution, and the AGENTS.md ancestor walk. Right for the TUI standing in a repo; wrong for an embedder-created instance (one per Slack thread), which should start empty except for what the host hands it — and today has no way to opt out.

## What Changes

```ts
Instance.layer(ref, { discovery: false })   // vanilla; default true = today, byte-identical
```

Vanilla is **neutralized discovery inputs, not fewer plugins**. Classification of all ~40 built-ins showed 12 of the 16 `Config*` plugins are appliers — they read already-loaded config values and write containers — and must stay so host-injected config keeps working. `discovery: false` turns off each discovery input:

| Discovery input | Mechanism |
|---|---|
| `Config` upward scan + global config dir + `~/.claude` + `~/.agents` | `Config.configured({ project: false, global: false })` — `global` is a new `Config.Options` flag; it also excludes home-level `.claude`/`.agents` reached through the upward walk |
| ambient plugin module imports during project resolution | `{ discovery: false }` threaded `Location.boundNode → Project.resolve → ProjectMarkers.discover`: skips the config walk and `PluginModule.load`, keeps sdk-declared vcs markers (host-explicit) and native `.git`/`.hg` detection |
| plugin-directory loading | no swap needed — implicit scanning only triggers on `Directory` config entries, which a no-scan `Config` never produces; explicit plugin operations from wellknown and host content still apply |
| AGENTS.md ancestor walk | `InstructionDiscovery.configured({ project: false, global: false })` — `global` is new, gating the global-config AGENTS.md the plugin previously always read and watched |
| — | plugin lists untouched |

## Composition Order

Replacements apply as `[...vanillaDefaults, ...callerReplacements, ...boundPairs]`. Vanilla entries are per-node *defaults*: a host that passes its own `Config.configured({ content, ... })` keeps it, and then owns that node's discovery flags. The bound pairs (directory, instance plugin list) always win. Workerd already proves the vanilla shape in production: full plugin list, neutralized inputs.

What still works in vanilla: wellknown integration config (DB/HTTP, not filesystem discovery), `content`/`file` config options including their explicit plugin add/remove operations, and host-injected config values applied through the `Config*` applier plugins. A config value that explicitly names something file-backed (a skill path, an MCP command) is a request, not discovery.

**Deliberately kept:** the read tool's nested AGENTS.md injection. `discovery` gates boot-time ambient population; reading a file is use-triggered, per-session, within-location behavior — clone a repo into a sandbox, read its files, its instructions apply. If a host needs to disable that, it is a future instruction-policy knob, not `discovery`.

## Entry Priority

The global config dir was positionally `supplementary[0]` in `Config.discover`; the gate preserves the priority order (global below explicit and direct files, project directories above) instead of letting a project directory slide into the global slot when `global: false`.

## Scope

This completes the instance recipe: construct (`Instance.layer`), populate explicitly (`plugins`), and opt out of filesystem population (`discovery: false`). Host-owned session-to-instance assignment is the next step. Virtual (non-file-backed) skills are a noted future improvement. Session create/move/transfer resolve projects through the ungated process-global path (pre-existing behavior); carrying instance discovery policy into those resolutions belongs to the assignment seam work.

## Verification

```sh
cd packages/core
bun typecheck
bun run test test/instance-vanilla.test.ts     # 2 pass
bun run test test/config/ test/instance-plugins.test.ts test/instance-vanilla.test.ts test/location-layer.test.ts test/session-generate.test.ts test/project.test.ts
# 187 pass, 1 skip (pre-existing), 0 fail
```

The vanilla test plants identical `opencode.json` + `AGENTS.md` in two directories and boots one vanilla and one discovery instance from the same map: the vanilla instance sees no file-backed config documents and no boot instructions while keeping host-injected content (a config value and an explicit `-opencode.tool.shell` removal both take effect); the discovery instance sees everything. A second test plants a `.opencode/plugins` module whose import writes a sentinel and proves a vanilla boot never executes it. A config-level test proves `global: false` excludes home-level `.claude`/`.agents` even when the project walk reaches them.

An independent review of the initial commit surfaced the ambient-module execution, composition-order, explicit-plugin-ops, and home-level-walk issues fixed in the follow-up commit; its fourth finding (nested read-triggered instructions) is retained by design as described above.