### PR TITLE
fix(tui): keep recent models in provider groups

### DIFF
--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -36,7 +36,8 @@ export function DialogModel(props: { providerID?: string }) {
         return [
           {
             key: item,
-            value: { providerID: provider.id, modelID: model.id },
+            // `section` keeps this row distinct from the same model under its provider group
+            value: { providerID: provider.id, modelID: model.id, section: category },
             title: model.name ?? item.modelID,
             description: provider.name,
             category,
@@ -84,22 +85,6 @@ export function DialogModel(props: { providerID?: string }) {
               onSelect(provider.id, model)
             },
           })),
-          filter((option) => {
-            if (!showSections) return true
-            if (
-              favorites.some(
-                (item) => item.providerID === option.value.providerID && item.modelID === option.value.modelID,
-              )
-            )
-              return false
-            if (
-              recents.some(
-                (item) => item.providerID === option.value.providerID && item.modelID === option.value.modelID,
-              )
-            )
-              return false
-            return true
-          }),
           (options) => sortModelOptions(options, props.providerID !== undefined),
         ),
       ),


### PR DESCRIPTION
### Issue for this PR

Closes #40592

### Type of change

- [x] Bug fix

### What does this PR do?

In the model picker, models that were in Favorites or Recent were filtered out of their provider group. Once a model was used it only appeared under Recent and disappeared from its provider section. This removes that filter so the same model appears in Recent/Favorites and also under its provider. Section rows now include the section in their value so the two rows remain distinct for hover and selection.

### How did you verify your code works?

* bun test and tsgo in packages/tui pass on latest dev
* Walked Home through favorites, recents and OpenCode Go on stock 1.18.21 and on the fixed build

### Screenshots / recordings

Before:
![before](https://files.catbox.moe/8slrzm.gif)

After:
![after](https://files.catbox.moe/tdt4mx.gif)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR