### PR TITLE
fix(desktop): minify production bundles

### DIFF
--- a/packages/desktop/electron.vite.config.test.ts
+++ b/packages/desktop/electron.vite.config.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test"
+import { loadConfigFromFile } from "electron-vite"
+
+test.each(["build", "serve"] as const)("configures minification for %s", async (command) => {
+  const result = await loadConfigFromFile(
+    { command, mode: command === "build" ? "production" : "development" },
+    `${import.meta.dirname}/electron.vite.config.ts`,
+  )
+
+  expect(result?.config.main?.build?.minify).toBe(command === "build")
+  expect(result?.config.preload?.build?.minify).toBe(command === "build")
+  expect(result?.config.renderer?.build?.minify).toBe(command === "build")
+  expect(result?.config.renderer?.build?.sourcemap).toBe(true)
+})

--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -28,12 +28,13 @@ const sentry =
       })
     : false
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   main: {
     define: {
       "import.meta.env.OPENCODE_CHANNEL": JSON.stringify(channel),
     },
     build: {
+      minify: command === "build",
       rolldownOptions: {
         input: { index: "src/main/index.ts" },
         // Keep this identical to electron-vite's Node 20.11+ shim. Its regex insertion can
@@ -64,6 +65,7 @@ const require = __cjs_mod__.createRequire(import.meta.url);
   },
   preload: {
     build: {
+      minify: command === "build",
       rolldownOptions: {
         input: { index: "src/preload/index.ts" },
         output: {
@@ -85,6 +87,7 @@ const require = __cjs_mod__.createRequire(import.meta.url);
     publicDir: "../../../app/public",
     root: "src/renderer",
     build: {
+      minify: command === "build",
       sourcemap: true,
       rolldownOptions: {
         input: {
@@ -93,4 +96,4 @@ const require = __cjs_mod__.createRequire(import.meta.url);
       },
     },
   },
-})
+}))


### PR DESCRIPTION
### Issue for this PR

Found during a local Desktop bundle audit; no existing issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Electron Vite defaults to unminified output. Enable minification for main, preload, and renderer builds, while keeping `electron-vite dev` unminified. Preserve renderer source maps and existing packaging rules.

Add a regression test for build and serve configuration.

### How did you verify your code works?

- `bun test` from `packages/desktop`: 84 passed, including the new regression tests.
- `bun typecheck` from `packages/desktop`: passed.
- `OPENCODE_CHANNEL=prod bun run build --logLevel warn`: passed on Windows x64 with Bun 1.4.0; Sentry upload disabled.
- Prettier, Oxlint, and Node syntax checks for generated main/preload output: passed.

Local before/after measurements, decimal MB, excluding source maps:

| Output | Before | After |
| --- | ---: | ---: |
| Generated app output, including assets and lazy chunks | 41.60 MB | 33.23 MB |
| HTML-linked startup JS/CSS | 3.12 MB | 1.54 MB |
| HTML-linked startup JS/CSS, gzip | 699 KB | 431 KB |

These measure emitted bytes, not startup latency or installer size. No app/server was launched or restarted for verification. Build warnings remain for large lazy chunks.

### Screenshots / recordings

Not applicable: build configuration only, with no intended visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
