### PR TITLE
chore: lint identity pipe callbacks

### DIFF
--- a/script/ast-grep/effect-simplifications/rule-tests/__snapshots__/no-identity-pipe-snapshot.yml
+++ b/script/ast-grep/effect-simplifications/rule-tests/__snapshots__/no-identity-pipe-snapshot.yml
@@ -1,0 +1,38 @@
+id: no-identity-pipe
+snapshots:
+  schema.pipe((value) => value):
+    labels:
+      - source: schema.pipe((value) => value)
+        style: primary
+        start: 0
+        end: 29
+  schema.pipe((value) => { return value }):
+    labels:
+      - source: schema.pipe((value) => { return value })
+        style: primary
+        start: 0
+        end: 40
+  "schema.pipe((value: Schema) => value)":
+    labels:
+      - source: "schema.pipe((value: Schema) => value)"
+        style: primary
+        start: 0
+        end: 37
+  "schema.pipe((value: Schema) => { return value })":
+    labels:
+      - source: "schema.pipe((value: Schema) => { return value })"
+        style: primary
+        start: 0
+        end: 48
+  schema.pipe(value => value):
+    labels:
+      - source: schema.pipe(value => value)
+        style: primary
+        start: 0
+        end: 27
+  schema.pipe(value => { return value }):
+    labels:
+      - source: schema.pipe(value => { return value })
+        style: primary
+        start: 0
+        end: 38

--- a/script/ast-grep/effect-simplifications/rule-tests/__snapshots__/no-identity-pipe-tsx-snapshot.yml
+++ b/script/ast-grep/effect-simplifications/rule-tests/__snapshots__/no-identity-pipe-tsx-snapshot.yml
@@ -1,0 +1,38 @@
+id: no-identity-pipe-tsx
+snapshots:
+  const view = <Widget value={schema.pipe((value) => value)} />:
+    labels:
+      - source: schema.pipe((value) => value)
+        style: primary
+        start: 28
+        end: 57
+  const view = <Widget value={schema.pipe((value) => { return value })} />:
+    labels:
+      - source: schema.pipe((value) => { return value })
+        style: primary
+        start: 28
+        end: 68
+  "const view = <Widget value={schema.pipe((value: Schema) => value)} />":
+    labels:
+      - source: "schema.pipe((value: Schema) => value)"
+        style: primary
+        start: 28
+        end: 65
+  "const view = <Widget value={schema.pipe((value: Schema) => { return value })} />":
+    labels:
+      - source: "schema.pipe((value: Schema) => { return value })"
+        style: primary
+        start: 28
+        end: 76
+  const view = <Widget value={schema.pipe(value => value)} />:
+    labels:
+      - source: schema.pipe(value => value)
+        style: primary
+        start: 28
+        end: 55
+  const view = <Widget value={schema.pipe(value => { return value })} />:
+    labels:
+      - source: schema.pipe(value => { return value })
+        style: primary
+        start: 28
+        end: 66

--- a/script/ast-grep/effect-simplifications/rule-tests/no-identity-pipe-test.yml
+++ b/script/ast-grep/effect-simplifications/rule-tests/no-identity-pipe-test.yml
@@ -1,0 +1,18 @@
+id: no-identity-pipe
+valid:
+  - schema
+  - schema.pipe(transform)
+  - schema.pipe((value) => transform(value))
+  - schema.pipe((value) => other)
+  - schema.pipe((value) => { log(value); return value })
+  - schema.pipe((value = fallback) => value)
+  - schema.pipe(({ value }) => value)
+  - schema.pipe((value) => value, transform)
+  - other.call((value) => value)
+invalid:
+  - schema.pipe((value) => value)
+  - schema.pipe(value => value)
+  - "schema.pipe((value: Schema) => value)"
+  - schema.pipe((value) => { return value })
+  - schema.pipe(value => { return value })
+  - "schema.pipe((value: Schema) => { return value })"

--- a/script/ast-grep/effect-simplifications/rule-tests/no-identity-pipe-tsx-test.yml
+++ b/script/ast-grep/effect-simplifications/rule-tests/no-identity-pipe-tsx-test.yml
@@ -1,0 +1,17 @@
+id: no-identity-pipe-tsx
+valid:
+  - const view = <Widget value={schema} />
+  - const view = <Widget value={schema.pipe(transform)} />
+  - const view = <Widget value={schema.pipe((value) => transform(value))} />
+  - const view = <Widget value={schema.pipe((value) => other)} />
+  - const view = <Widget value={schema.pipe((value) => { log(value); return value })} />
+  - const view = <Widget value={schema.pipe((value = fallback) => value)} />
+  - const view = <Widget value={schema.pipe(({ value }) => value)} />
+  - const view = <Widget value={schema.pipe((value) => value, transform)} />
+invalid:
+  - const view = <Widget value={schema.pipe((value) => value)} />
+  - const view = <Widget value={schema.pipe(value => value)} />
+  - "const view = <Widget value={schema.pipe((value: Schema) => value)} />"
+  - const view = <Widget value={schema.pipe((value) => { return value })} />
+  - const view = <Widget value={schema.pipe(value => { return value })} />
+  - "const view = <Widget value={schema.pipe((value: Schema) => { return value })} />"

--- a/script/ast-grep/effect-simplifications/rules/no-identity-pipe-tsx.yml
+++ b/script/ast-grep/effect-simplifications/rules/no-identity-pipe-tsx.yml
@@ -1,0 +1,12 @@
+id: no-identity-pipe-tsx
+language: Tsx
+message: Remove identity callbacks from pipe calls.
+severity: error
+rule:
+  any:
+    - pattern: $RECEIVER.pipe(($VALUE) => $VALUE)
+    - pattern: $RECEIVER.pipe($VALUE => $VALUE)
+    - pattern: "$RECEIVER.pipe(($VALUE: $TYPE) => $VALUE)"
+    - pattern: $RECEIVER.pipe(($VALUE) => { return $VALUE })
+    - pattern: $RECEIVER.pipe($VALUE => { return $VALUE })
+    - pattern: "$RECEIVER.pipe(($VALUE: $TYPE) => { return $VALUE })"

--- a/script/ast-grep/effect-simplifications/rules/no-identity-pipe.yml
+++ b/script/ast-grep/effect-simplifications/rules/no-identity-pipe.yml
@@ -1,0 +1,12 @@
+id: no-identity-pipe
+language: TypeScript
+message: Remove identity callbacks from pipe calls.
+severity: error
+rule:
+  any:
+    - pattern: $RECEIVER.pipe(($VALUE) => $VALUE)
+    - pattern: $RECEIVER.pipe($VALUE => $VALUE)
+    - pattern: "$RECEIVER.pipe(($VALUE: $TYPE) => $VALUE)"
+    - pattern: $RECEIVER.pipe(($VALUE) => { return $VALUE })
+    - pattern: $RECEIVER.pipe($VALUE => { return $VALUE })
+    - pattern: "$RECEIVER.pipe(($VALUE: $TYPE) => { return $VALUE })"


### PR DESCRIPTION
**Why**

Identity callbacks such as `schema.pipe((value) => value)` add a pipeline stage without changing the value. The Core style audit removed three instances, but the existing simplification scan did not prevent them from returning.

**What Changes**

| Pattern | Result |
|---|---|
| `value.pipe((item) => item)` | Lint error |
| `value.pipe((item: Type) => item)` | Lint error |
| `value.pipe((item) => transform(item))` | Allowed |
| `value.pipe((item) => { log(item); return item })` | Allowed |

Add TypeScript and TSX ast-grep rules for expression-bodied and single-return-block identity callbacks. Rule tests cover typed and untyped callbacks while excluding transforms, side effects, defaults, destructuring, and additional pipe stages.

**Scope**

This only extends the existing Effect simplification lint pass; production code and runtime behavior are unchanged.

**Verification**

```sh
bun run test:effect-simplification-rules
bun run lint:effect-simplifications
bunx prettier --check script/ast-grep/effect-simplifications/rules/no-identity-pipe.yml script/ast-grep/effect-simplifications/rules/no-identity-pipe-tsx.yml script/ast-grep/effect-simplifications/rule-tests/no-identity-pipe-test.yml script/ast-grep/effect-simplifications/rule-tests/no-identity-pipe-tsx-test.yml script/ast-grep/effect-simplifications/rule-tests/__snapshots__/no-identity-pipe-snapshot.yml script/ast-grep/effect-simplifications/rule-tests/__snapshots__/no-identity-pipe-tsx-snapshot.yml
git diff --check origin/v2...HEAD
```

All eight rule suites pass, the repository-wide simplification scan reports no violations, formatting passes, and the diff is clean.