### PR TITLE
fix(deps): upgrade diff to 8.0.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1134,7 +1134,7 @@
     "@typescript/native-preview": "7.0.0-dev.20251207.1",
     "ai": "6.0.168",
     "cross-spawn": "7.0.6",
-    "diff": "8.0.2",
+    "diff": "8.0.4",
     "dompurify": "3.3.1",
     "drizzle-kit": "1.0.0-rc.5-ab785fc",
     "drizzle-orm": "1.0.0-rc.5-169397b",
@@ -3831,7 +3831,7 @@
 
     "didyoumean": ["didyoumean@1.2.2", "", {}, "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw=="],
 
-    "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+    "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "dir-compare": ["dir-compare@4.2.0", "", { "dependencies": { "minimatch": "^3.0.5", "p-limit": "^3.1.0 " } }, "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ=="],
 

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
       "opentui-spinner": "0.0.7",
       "@solid-primitives/storage": "4.3.3",
       "@tailwindcss/vite": "4.1.11",
-      "diff": "8.0.2",
+      "diff": "8.0.4",
       "dompurify": "3.3.1",
       "drizzle-kit": "1.0.0-rc.5-ab785fc",
       "drizzle-orm": "1.0.0-rc.5-169397b",

--- a/packages/session-ui/src/components/session-diff.test.ts
+++ b/packages/session-ui/src/components/session-diff.test.ts
@@ -2,6 +2,43 @@ import { describe, expect, test } from "bun:test"
 import { normalize, resolveFileDiff, text } from "./session-diff"
 
 describe("session diff", () => {
+  test.each([
+    ["carriage return", "\r"],
+    ["line separator", "\u2028"],
+    ["paragraph separator", "\u2029"],
+  ])(
+    "parses adversarial patch headers containing a %s",
+    (_, separator) => {
+      // GHSA-73rr-hh4g-fpgx: isolate synchronous hangs and memory growth from the test runner.
+      const name = `a${separator}b.ts`
+      const padding = " ".repeat(10_000)
+      const patches = [
+        `--- ${name}\t\n+++ b.ts\t\n`,
+        `--- a.ts\t\n+++ ${name}\t\n`,
+        `--- ${padding}${name}\t\n+++ b.ts\t\n`,
+        `--- a.ts\t\n+++ ${padding}${name}\t\n`,
+        `Index: ${padding}${name}\n--- a.ts\t\n+++ b.ts\t\n`,
+        `diff -r abc -r def ${padding}${name}\n--- a.ts\t\n+++ b.ts\t\n`,
+      ].map((header) => `${header}@@ -1 +1 @@\n-old\n+new\n`)
+      const result = Bun.spawnSync({
+        cmd: [
+          process.execPath,
+          "--eval",
+          `import { completePatchContents } from "./session-diff.ts"
+         console.log(JSON.stringify((await Bun.stdin.json()).map(completePatchContents)))`,
+        ],
+        cwd: import.meta.dir,
+        stdin: Buffer.from(JSON.stringify(patches)),
+        timeout: 5_000,
+        killSignal: "SIGKILL",
+      })
+
+      expect(result.exitCode, result.stderr.toString()).toBe(0)
+      expect(JSON.parse(result.stdout.toString())).toEqual(patches.map(() => ({ before: "old\n", after: "new\n" })))
+    },
+    10_000,
+  )
+
   test("renders whole-file unified patches as complete diffs", () => {
     const diff = {
       file: "a.ts",


### PR DESCRIPTION
### Issue for this PR

Addresses [GHSA-73rr-hh4g-fpgx / CVE-2026-24001](https://github.com/kpdecker/jsdiff/security/advisories/GHSA-73rr-hh4g-fpgx).

### Type of change

- [x] Bug fix

### What does this PR do?

Upgrades the shared diff catalog from 8.0.2 to 8.0.4 and regenerates the lockfile. The new version includes the advisory fix introduced in 8.0.3.

Adds regression coverage through the production session diff parser for filename and leading headers containing carriage returns, line separators, and paragraph separators. Covers both filename markers, Index headers, and Mercurial headers, including long whitespace prefixes. Each case runs in a child process with a timeout so a regression cannot hang the test runner.

### How did you verify your code works?

- Confirmed the line-separator regression fails at the child-process timeout with diff 8.0.2, then passes with 8.0.4.
- Session UI: all 134 tests passed; package typecheck passed.
- Core: all 49 tool-patch and instruction-discovery tests passed.
- Pre-push workspace typechecks passed (33 tasks, including cached results).
- Prettier and git diff --check passed.
- Local verification used Bun 1.4.0.

### Screenshots / recordings

Not applicable: dependency and test changes only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR