### PR TITLE
fix(desktop): preserve lazy Sentry loading

### DIFF
--- a/packages/app/src/shell/errors/error.tsx
+++ b/packages/app/src/shell/errors/error.tsx
@@ -1,5 +1,5 @@
 import { TextField } from "@opencode-ai/ui/text-field"
-import { captureException, isEnabled } from "@sentry/solid"
+import type { captureException } from "@sentry/solid"
 import { Logo } from "@opencode-ai/ui/logo"
 import { Button } from "@opencode-ai/ui/button"
 import { Component, createSignal, onMount, Show } from "solid-js"
@@ -227,6 +227,7 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
   let recordedFatalError: Promise<void> | undefined
   const [store, setStore] = createStore({
     actionError: undefined as string | undefined,
+    captureException: undefined as typeof captureException | undefined,
   })
 
   function ensureFatalErrorRecorded() {
@@ -243,6 +244,11 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
 
   onMount(() => {
     void ensureFatalErrorRecorded().catch(() => undefined)
+    void import("@sentry/solid")
+      .then(({ captureException, isEnabled }) => {
+        if (isEnabled()) setStore("captureException", () => captureException)
+      })
+      .catch(() => undefined)
   })
 
   async function checkForUpdates() {
@@ -311,15 +317,15 @@ export const ErrorPage: Component<ErrorPageProps> = (props) => {
               {language.t("error.page.action.exportLogs")}
             </Button>
           </Show>
-          <Show when={isEnabled}>
-            {(_) => {
+          <Show when={store.captureException}>
+            {(capture) => {
               const [reported, setReported] = createSignal(false)
               return (
                 <Button
                   size="large"
                   disabled={reported()}
                   onClick={() => {
-                    captureException(props.error)
+                    capture()(props.error)
                     setReported(true)
                   }}
                 >


### PR DESCRIPTION
### Issue for this PR

Fixes eager Sentry loading in the desktop renderer. No linked issue.

### Type of change

- [x] Bug fix

### What does this PR do?

The shared error page statically imported Sentry, defeating the desktop startup module's dynamic import. Load the reporting controls when the error page mounts instead, and show Report Error only when Sentry is enabled. A failed import leaves the recovery controls usable.

Keep Sentry initialization before rendering and automatic error-boundary capture unchanged, so startup errors are still reported.

### How did you verify your code works?

- App and desktop `bun typecheck`; all 33 pre-push typecheck tasks passed.
- Desktop production build; inspected the static chunk graph and source maps: zero eagerly loaded Sentry modules.
- 14 focused tests passed for desktop configuration, startup errors, and error descriptions.
- Direct Playwright checks with the real error page and Sentry SDK: healthy startup, automatic startup-error capture, manual reporting, disabled Sentry, and failed SDK loading. Test events went only to a local fixture endpoint.
- Prettier and `git diff --check` passed.

### Screenshots / recordings

No visual design changes. Startup-error fixture after the fix, with reporting available:

![Startup error with reporting available](https://github.com/user-attachments/assets/a17b7412-a500-494b-9739-3e1b9bc68df4)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
