### PR TITLE
fix(core): preserve typed config test-layer errors

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -84,7 +84,10 @@ export const testLayer = (initial: Entry[] = []) =>
             const entry = current[index]
             if (!entry || entry.type !== "document")
               return yield* Effect.fail(new UpdateError({ message: "No editable config document found" }))
-            const info = produce(entry.info, update)
+            const info = yield* Effect.try({
+              try: () => produce(entry.info, update),
+              catch: (cause) => new UpdateError({ message: "Config update failed", cause }),
+            })
             yield* Ref.set(entries, current.with(index, new Document({ type: "document", path: entry.path, info })))
             return info
           }),

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -97,6 +97,20 @@ describe("Config", () => {
           Effect.andThen(
             Effect.gen(function* () {
               const config = yield* Config.Service
+              const content = yield* Effect.promise(() => fs.readFile(globalFile, "utf8"))
+              const cause = new Error("Rejected config update")
+              const error = yield* config
+                .update((draft) => {
+                  draft.shell = "discarded"
+                  throw cause
+                })
+                .pipe(Effect.flip)
+
+              expect(error).toBeInstanceOf(Config.UpdateError)
+              expect(error.message).toBe("Config update failed")
+              expect(error.cause).toBe(cause)
+              expect(yield* Effect.promise(() => fs.readFile(globalFile, "utf8"))).toBe(content)
+
               const updated = yield* config.update((draft) => {
                 draft.shell = "updated"
               })
@@ -335,6 +349,38 @@ describe("Config", () => {
       yield* Effect.yieldNow
       yield* test.emitChange({ type: "create", path: "/root/commands/review.md" })
       expect(Array.from(yield* Fiber.join(received))).toEqual([{ type: "create", path: "/root/commands/review.md" }])
+    }).pipe(Effect.provide(Config.testLayer())),
+  )
+
+  it.effect("keeps test config unchanged after an update callback fails", () =>
+    Effect.gen(function* () {
+      const config = yield* Config.Service
+      const test = yield* Config.Test
+      const entry = new Document({
+        type: "document",
+        path: AbsolutePath.make(path.join(import.meta.dir, "opencode.json")),
+        info: new Info({ shell: "initial" }),
+      })
+      yield* test.setEntries([entry])
+      const cause = new Error("Rejected config update")
+      const error = yield* config
+        .update((draft) => {
+          draft.shell = "discarded"
+          throw cause
+        })
+        .pipe(Effect.flip)
+
+      expect(error).toBeInstanceOf(Config.UpdateError)
+      expect(error.message).toBe("Config update failed")
+      expect(error.cause).toBe(cause)
+      expect(yield* config.entries()).toEqual([entry])
+      expect(entry.info.shell).toBe("initial")
+
+      const updated = yield* config.update((draft) => {
+        draft.shell = "recovered"
+      })
+      expect(updated.shell).toBe("recovered")
+      expect(Config.latest(yield* test.entries(), "shell")).toBe("recovered")
     }).pipe(Effect.provide(Config.testLayer())),
   )
 


### PR DESCRIPTION
## Why

A throwing configuration-update callback fails differently with `Config.testLayer()` than with the production implementation: the test layer emits an Effect defect, while production returns typed `Config.UpdateError`. Consumers tested with the first-class stub can therefore miss their normal error-handling path.

## What Changes

Wrap the test layer's Immer mutation in the same `Effect.try` error mapping used by production.

| Scenario | Before | After |
| --- | --- | --- |
| Callback mutates its draft, then throws | Defect escapes the test layer | Typed `Config.UpdateError`, message `Config update failed`, original cause preserved |
| Read entries after the failure | No explicit regression coverage | Entries and the original document remain unchanged |
| Submit a valid update afterward | No explicit recovery coverage | Update succeeds and both normal/test interfaces observe the recovered value |

The new stub regression failed before the fix. The existing real-file update test now checks the same error class/message/cause and unchanged file contents before performing its original successful update.

## Scope

Only the test implementation in `packages/core/src/config.ts` and its config tests. Production behavior, public signatures, service tags, layer shape, and scope ownership are unchanged. No broader test-driver or simulation migration is included.

## Verification

Run from `packages/core`:

```bash
bun run test test/config/config.test.ts
bun run test test/config
bun run test test/config/config.test.ts --test-name-pattern 'updates the first file-backed document|keeps test config unchanged after an update callback fails' --concurrent --rerun-each 10
bun run test
bun typecheck
```

- Before the fix, the config file had 35 passed and 1 failed, solely the new stub regression's uncaught callback exception. The production comparison passed.
- After the fix, the config file passed 36 tests / 136 assertions.
- Config suite: 135 passed / 629 assertions, no failures.
- Focused repetitions: 20 passed / 150 assertions, no failures.
- Full Core suite: 3,739 passed, 39 skipped, 0 failed / 78,706 assertions.
- Core typechecking, including runtime tests, passed. Prettier and diff whitespace checks passed.
