### PR TITLE
fix(core): complete supervisor flush when plugin activation fails

### DIFF
--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -125,9 +125,9 @@ export const layer = Layer.effect(
       Stream.debounce("100 millis"),
       Stream.runForEach((target) =>
         Effect.gen(function* () {
-          yield* activate()
+          yield* activate().pipe(Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause })))
           if (observed === target) yield* ready.open
-        }).pipe(Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause }))),
+        }),
       ),
       Effect.forkScoped({ startImmediately: true }),
     )

--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -427,6 +427,20 @@ describe("PluginSupervisor config", () => {
       }),
     ),
   )
+
+  it.live("unblocks flush when plugin activation fails", () =>
+    Effect.gen(function* () {
+      const sdk = yield* SdkPlugins.Service
+      yield* sdk.register(EffectPlugin.define({ id: "duplicate-id", effect: () => Effect.void }))
+      yield* sdk.register(EffectPlugin.define({ id: "duplicate-id", effect: () => Effect.void }))
+      yield* withLocation(
+        undefined,
+        Effect.gen(function* () {
+          yield* ready().pipe(Effect.timeout("2 seconds"))
+        }),
+      )
+    }),
+  )
 })
 
 const ready = Effect.fnUntraced(function* () {


### PR DESCRIPTION
### Why
When `PluginSupervisor.activate` fails (such as when duplicate plugin IDs are registered or a plugin fails to activate), the supervisor reload stream caught the defect and logged an error, but aborted before reaching `ready.open`. Because the `ready` latch is initialized closed, subsequent calls to `supervisor.flush` (such as at session creation, prompt handling, and step execution) blocked on `ready.await` forever.

### What Changes
- Catch activation errors within `activate().pipe(Effect.catchCause(...))` in `PluginSupervisor` so that `if (observed === target) yield* ready.open` always runs once the current batch finishes processing, allowing `supervisor.flush` to unblock and complete.
- Failures continue to be logged and tracked in plugin status without silent swallow or ordering changes.
- Add a timeout-bounded reproduction test in `packages/core/test/config/plugin.test.ts` verifying that `supervisor.flush` completes when plugin activation fails due to duplicate plugin IDs.

### Scope
`packages/core` plugin supervisor failure path.

### Verification
```bash
bun run test test/config/plugin.test.ts test/plugin.test.ts test/plugin-hooks.test.ts
bun typecheck
```