### PR TITLE
fix(core): cap provider retry-after delays at fifteen minutes

### DIFF
--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -40,9 +40,14 @@ export function isRetryable(error: AIError) {
   }
 }
 
+/** Bound provider-requested delays so a hostile or buggy retry-after cannot stall a session for hours. */
+const RETRY_AFTER_MAX = Duration.toMillis("15 minutes")
+
 const retryAfter = (input: Input) => {
   if (input.cause.reason._tag === "RateLimit" || input.cause.reason._tag === "ProviderInternal")
-    return input.cause.reason.retryAfterMs
+    return input.cause.reason.retryAfterMs === undefined
+      ? undefined
+      : Math.min(input.cause.reason.retryAfterMs, RETRY_AFTER_MAX)
   return undefined
 }
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -4874,6 +4874,23 @@ describe("SessionRunnerLLM", () => {
     }),
   )
 
+  it.effect("caps an excessive provider retry-after delay at fifteen minutes", () =>
+    Effect.gen(function* () {
+      const session = yield* setup
+      yield* admit(session, "Retry capped rate limit")
+      yield* TestLLM.push(Stream.fail(rateLimited(3_600_000)))
+      yield* TestLLM.push(TestLLM.text("Recovered", "retry-cap-success"))
+
+      const run = yield* session.resume(sessionID).pipe(Effect.forkChild)
+      yield* TestLLM.wait(1)
+      yield* TestClock.adjust("899999 millis")
+      expect(requests).toHaveLength(1)
+      yield* TestClock.adjust("1 millis")
+      yield* Fiber.join(run)
+      expect(requests).toHaveLength(2)
+    }),
+  )
+
   it.effect("continues an incomplete stream after observable text", () =>
     Effect.gen(function* () {
       const session = yield* setup


### PR DESCRIPTION
## Summary
- Session retries take the larger of the scheduled backoff and a provider-requested `retry-after` delay. That minimum was unbounded, so a buggy or hostile `retry-after` header (for example one hour) silently stalled the session for that entire duration.
- Cap the provider-requested minimum at fifteen minutes before it raises the scheduled delay. Ordinary backoff behavior is unchanged, and requested delays at or below the cap are still honored exactly.

## Verification
- New runner test: a 60-minute `retryAfterMs` waits exactly fifteen minutes before the next attempt.
- `bun run test test/session-runner.test.ts`: 174 pass, 0 fail.
- `bun typecheck` passes in `packages/core`; formatting and diff checks pass.