### PR TITLE
chore(desktop): trim external dependency archives

### DIFF
--- a/packages/desktop/electron-builder.config.test.ts
+++ b/packages/desktop/electron-builder.config.test.ts
@@ -1,7 +1,15 @@
 import { expect, test } from "bun:test"
+import { statSync } from "node:fs"
+import { cp, mkdtemp, rm } from "node:fs/promises"
+import { createRequire } from "node:module"
+import os from "node:os"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
 import type { Configuration } from "electron-builder"
 
 const legacyDesktopEntry = "resources/linux/opencode-desktop.desktop"
+// Use electron-builder's matcher so the tests also cover its glob and directory traversal semantics.
+const { FileMatcher } = createRequire(import.meta.resolve("electron-builder"))("app-builder-lib/out/fileMatcher")
 
 const channels = [
   { channel: "dev", appId: "ai.opencode.desktop.dev" },
@@ -27,7 +35,104 @@ for (const channel of channels) {
     expect(config.deb?.fpm).toContainEqual(expect.stringContaining(`/usr/share/metainfo/${channel.appId}.metainfo.xml`))
     expect(config.rpm?.fpm).toContainEqual(expect.stringContaining(`/usr/share/metainfo/${channel.appId}.metainfo.xml`))
   })
+
+  test(`trims external dependencies without excluding runtime files for ${channel.channel}`, async () => {
+    const config = (await import(`./electron-builder.config.ts?channel=${channel.channel}`)).default as Configuration
+    const filter = new FileMatcher(import.meta.dirname, "", (value: string) => value, [
+      "**/*",
+      ...(Array.isArray(config.files) ? config.files : []).filter(
+        (value): value is string => typeof value === "string" && value.startsWith("!"),
+      ),
+    ]).createFilter()
+    for (const prefix of ["node_modules/", "node_modules/parent/node_modules/"]) {
+      for (const file of [
+        "@zip.js/zip.js/dist/zip.js",
+        "@zip.js/zip.js/dist/z-worker.js",
+        "@zip.js/zip.js/index.cjs",
+        "@zip.js/zip.js/index.min.js",
+        "@zip.js/zip.js/index-fflate.js",
+        "@zip.js/zip.js/deno.json",
+        "@zip.js/zip.js/eslint.config.mjs",
+        "electron-updater/out/main.js.map",
+        "electron-updater/out/providers/GitHubProvider.js.map",
+        "builder-util-runtime/out/httpExecutor.js.map",
+        "lazy-val/out/main.js.map",
+        "ajv/lib/core.ts",
+        "ajv/dist/compile/index.js.map",
+        "ajv-formats/src/formats.ts",
+        "ajv-formats/dist/formats.js.map",
+        "js-yaml/dist/js-yaml.js",
+        "js-yaml/dist/js-yaml.min.js",
+        "js-yaml/dist/js-yaml.mjs.map",
+        "js-yaml/bin/js-yaml.js",
+      ]) {
+        expect(filter(path.join(import.meta.dirname, prefix, file), statSync(import.meta.filename))).toBe(false)
+      }
+      for (const file of [
+        "@zip.js/zip.js/index.js",
+        "@zip.js/zip.js/lib/zip-fs.js",
+        "@zip.js/zip.js/lib/z-worker-inline.js",
+        "@zip.js/zip.js/lib/core/streams/codecs/deflate.js",
+        "electron-updater/out/main.js",
+        "electron-updater/out/MacUpdater.js",
+        "electron-updater/out/NsisUpdater.js",
+        "electron-updater/out/providers/GitHubProvider.js",
+        "builder-util-runtime/out/httpExecutor.js",
+        "lazy-val/out/main.js",
+        "ajv/dist/ajv.js",
+        "ajv/dist/refs/json-schema-draft-07.json",
+        "ajv-formats/dist/formats.js",
+        "js-yaml/index.js",
+        "js-yaml/lib/loader.js",
+        "js-yaml/dist/js-yaml.mjs",
+        "debug/src/index.js",
+        "unrelated/dist/index.js.map",
+        ...["@zip.js/zip.js", "electron-updater", "builder-util-runtime", "ajv", "ajv-formats", "js-yaml"].flatMap(
+          (name) => [`${name}/package.json`, `${name}/LICENSE`],
+        ),
+      ]) {
+        expect(filter(path.join(import.meta.dirname, prefix, file), statSync(import.meta.filename))).toBe(true)
+      }
+      expect(filter(path.join(import.meta.dirname, prefix, "@zip.js/zip.js/dist"), statSync(import.meta.dirname))).toBe(
+        false,
+      )
+      expect(filter(path.join(import.meta.dirname, prefix, "@zip.js/zip.js/lib"), statSync(import.meta.dirname))).toBe(
+        true,
+      )
+    }
+  })
 }
+
+test("the trimmed Zip.js package can still export compressed logs", async () => {
+  const config = (await import("./electron-builder.config.ts")).default
+  const dir = await mkdtemp(path.join(os.tmpdir(), "opencode-zip-package-"))
+  const source = path.dirname(fileURLToPath(import.meta.resolve("@zip.js/zip.js/package.json")))
+  const filter = new FileMatcher(dir, "", (value: string) => value, [
+    "**/*",
+    ...(Array.isArray(config.files) ? config.files : []).filter(
+      (value): value is string => typeof value === "string" && value.startsWith("!"),
+    ),
+  ]).createFilter()
+  try {
+    await cp(source, dir, {
+      recursive: true,
+      filter: (file) =>
+        filter(path.join(dir, "node_modules/@zip.js/zip.js", path.relative(source, file)), statSync(file)),
+    })
+    const zip = await import(pathToFileURL(path.join(dir, "index.js")).href)
+    const writer = new zip.ZipWriter(new zip.BlobWriter("application/zip"))
+    await writer.add("desktop.log", new zip.BlobReader(new Blob(["diagnostic log\n".repeat(100)])))
+    const reader = new zip.ZipReader(new zip.BlobReader(await writer.close()))
+    const entries = await reader.getEntries()
+    expect(entries.map((entry: { filename: string }) => entry.filename)).toEqual(["desktop.log"])
+    expect(entries[0].compressionMethod).toBe(8)
+    expect(await entries[0].getData(new zip.TextWriter())).toBe("diagnostic log\n".repeat(100))
+    await reader.close()
+    await zip.terminateWorkers()
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+})
 
 test("keeps a hidden prod launcher for old Linux pins", async () => {
   const previous = process.env.OPENCODE_CHANNEL

--- a/packages/desktop/electron-builder.config.ts
+++ b/packages/desktop/electron-builder.config.ts
@@ -55,7 +55,22 @@ const getBase = (appId: string): Configuration => ({
   extraMetadata: {
     desktopName: `${appId}.desktop`,
   },
-  files: ["out/**/*", "resources/**/*", "!resources/opencode-cli*"],
+  files: [
+    "out/**/*",
+    "resources/**/*",
+    "!resources/opencode-cli*",
+    // Log export imports Zip.js as ESM. Keep index.js and lib, including its inline worker.
+    "!**/node_modules/@zip.js/zip.js/dist{,/**/*}",
+    "!**/node_modules/@zip.js/zip.js/{index.cjs,index.min.js,index-fflate.js,deno.json,eslint.config.mjs}",
+    // These packages execute compiled JavaScript, not their sources or source maps.
+    "!**/node_modules/{electron-updater,builder-util-runtime,lazy-val}/out/**/*.js.map",
+    "!**/node_modules/ajv/lib{,/**/*}",
+    "!**/node_modules/ajv-formats/src{,/**/*}",
+    "!**/node_modules/{ajv,ajv-formats}/dist/**/*.js.map",
+    // Keep js-yaml's CommonJS sources and dist/js-yaml.mjs ESM entry, not browser bundles or its CLI.
+    "!**/node_modules/js-yaml/dist/{js-yaml.js,js-yaml.min.js,*.map}",
+    "!**/node_modules/js-yaml/bin{,/**/*}",
+  ],
   extraResources:
     channel !== "prod"
       ? [

--- a/packages/desktop/electron.vite.config.test.ts
+++ b/packages/desktop/electron.vite.config.test.ts
@@ -72,6 +72,7 @@ test("bundles one Effect runtime and Drizzle while keeping native dependencies e
   expect(new Set(effect).size).toBe(effect.length)
   expect(imports).toContain("electron")
   expect(imports).toContain("node:sqlite")
+  expect(chunks.some((chunk) => chunk.dynamicImports.includes("@zip.js/zip.js"))).toBe(true)
   expect(imports).toContain(`@lydell/node-pty-${process.platform}-${process.arch}`)
   expect(modules.some((id) => id.includes("/node_modules/msgpackr-extract/"))).toBe(false)
   expect(chunks.some((chunk) => chunk.code.includes("msgpackr-extract"))).toBe(true)


### PR DESCRIPTION
## Summary

- Add package-specific Electron Builder exclusions for remaining external dependencies. The Effect and Drizzle distributions were already removed; this does not change their bundling.
- Remove Zip.js browser/alternate distributions, Ajv TypeScript sources, and updater/validation/YAML source maps. Remove js-yaml's unused browser bundles and CLI.
- Retain Zip.js's ESM entry, runtime `lib` sources and inline worker; js-yaml's CommonJS sources and ESM entry; all updater platform/provider implementations; package manifests and licenses.
- Add regression coverage using Electron Builder's actual file matcher, a compressed ZIP round-trip with the filtered package, and a build assertion that Zip.js remains a dynamic ESM import.

## Measured Savings

Local Windows x64, Electron 42.10.1, Electron Builder 26.15.7, Bun 1.4.0 (the repository pins 1.3.14). Baseline: `b92b84f33d`. Both packages use the same `electron-vite build` output and installed dependency tree, with `OPENCODE_CHANNEL=prod` for packaging. Renderer source maps remain in both artifacts because no Sentry upload was run. These are local unsigned builds, not published release-size estimates.

| Artifact | Before (bytes) | After (bytes) | Saved |
| --- | ---: | ---: | ---: |
| External dependency payload | 9,154,433 | 4,716,250 | 4,438,183 (48.5%) |
| `app.asar`, including header | 98,160,541 | 93,641,714 | 4,518,827 (4.6%) |
| Windows NSIS installer | 126,500,986 | 126,040,465 | 460,521 (0.36%) |

310 files removed. All 2,620 retained files have identical SHA-256 integrity hashes in the before/after ASARs.

| Dependency | Files removed | Payload bytes saved |
| --- | ---: | ---: |
| `@zip.js/zip.js` | 20 | 2,623,542 |
| `js-yaml` | 6 | 730,807 |
| `ajv` | 231 | 615,928 |
| `electron-updater` | 32 | 327,521 |
| `builder-util-runtime` | 14 | 109,962 |
| `ajv-formats` | 6 | 29,267 |
| `lazy-val` | 1 | 1,156 |

Measurements use actual Electron Builder ASARs and NSIS installers, not the installed `node_modules` directory sizes. From `packages/desktop`, package each config with:

```sh
bunx electron-builder --dir --win --x64 --config electron-builder.config.ts --config.directories.output=C:/tmp/opencode/archive-before --config.win.signAndEditExecutable=false --publish never
bunx electron-builder --win nsis --x64 --prepackaged C:/tmp/opencode/archive-before/win-unpacked --config electron-builder.config.ts --config.directories.output=C:/tmp/opencode/installer-before --config.win.signAndEditExecutable=false --publish never
```

Repeat with the new config and separate `archive-after` / `installer-after` output directories. Set `OPENCODE_CHANNEL=prod` for both runs. Prepare the installer icons with `bun ./scripts/copy-icons.ts prod` before creating NSIS installers.

## Validation

- `bunx electron-vite build`: passed.
- `bun test electron-builder.config.test.ts electron.vite.config.test.ts`: 16 passed.
- `bun typecheck` from `packages/desktop`: passed.
- Pre-push workspace typecheck: all 33 tasks passed (25 cached).
- Prettier checks and `git diff --check`: passed.
- Before/after Windows x64 directory packages and NSIS installers: built successfully.
- Smoke-tested dependencies extracted from the new ASAR under Electron 42.10.1 / Node 24.18.1: compressed ZIP creation/readback, NSIS updater initialization and GitHub feed setup without network requests, YAML parsing through both CommonJS and ESM entries, and Conf persistence/schema validation including Ajv formats.
- macOS/Linux packaging and live update download/install were not exercised. Updater platform modules remain intact.

No visual changes; the size tables provide the before/after evidence. Build artifacts are not committed.
