### PR TITLE
fix(core): recover reads with non-breaking spaces

### DIFF
--- a/packages/core/src/tool/plugin/read.ts
+++ b/packages/core/src/tool/plugin/read.ts
@@ -53,29 +53,58 @@ export const Plugin = {
                 messageID: context.messageID,
                 id: context.id,
               }
-              const target = yield* mutation.resolve({ path: input.path })
-              const external = target.externalDirectory
-              if (external)
-                yield* permission.assert({
-                  ...LocationMutation.externalDirectoryPermission(external),
-                  sessionID: context.sessionID,
-                  agent: context.agent,
-                  source,
+              const authorize = (target: LocationMutation.Target, authorizeExternal = true) =>
+                Effect.gen(function* () {
+                  if (target.externalDirectory && authorizeExternal)
+                    yield* permission.assert({
+                      ...LocationMutation.externalDirectoryPermission(target.externalDirectory),
+                      sessionID: context.sessionID,
+                      agent: context.agent,
+                      source,
+                    })
+                  yield* permission.assert({
+                    action: name,
+                    resources: [target.resource],
+                    save: ["*"],
+                    sessionID: context.sessionID,
+                    agent: context.agent,
+                    source,
+                  })
                 })
-              const resource = target.resource
-              const absolute = AbsolutePath.make(target.absolute)
-              yield* permission.assert({
-                action: name,
-                resources: [resource],
-                save: ["*"],
-                sessionID: context.sessionID,
-                agent: context.agent,
-                source,
-              })
-              const content = yield* reader.read(absolute, resource, { offset: input.offset, limit: input.limit }).pipe(
+              const read = (target: LocationMutation.Target) =>
+                reader.read(AbsolutePath.make(target.absolute), target.resource, {
+                  offset: input.offset,
+                  limit: input.limit,
+                })
+
+              const requested = yield* mutation.resolve({ path: input.path })
+              yield* authorize(requested)
+              const result = yield* read(requested).pipe(
+                Effect.map((content) => ({ content, target: requested, path: input.path })),
                 Effect.catchIf(
                   (error) => error instanceof Environment.NotFound,
-                  () => missing(input.path, target.absolute),
+                  () =>
+                    Effect.gen(function* () {
+                      const alternate = yield* alternatePath(requested.absolute).pipe(
+                        Effect.orElseSucceed(() => undefined),
+                      )
+                      if (!alternate) return yield* missing(input.path, requested.absolute)
+                      const target = yield* mutation.resolve({ path: alternate, kind: "file" })
+                      // The candidate is a sibling under the external directory already approved above.
+                      yield* authorize(target, false)
+                      const content = yield* read(target).pipe(
+                        Effect.catchIf(
+                          (error) => error instanceof Environment.NotFound,
+                          () => missing(input.path, requested.absolute),
+                        ),
+                      )
+                      if (content.type === "list-page") return yield* missing(input.path, requested.absolute)
+                      return {
+                        content,
+                        target,
+                        path: join(dirname(input.path), basename(alternate)),
+                      }
+                    }),
                 ),
               )
               // After a successful read, discover nearby AGENTS.md walking up to the Location
@@ -84,14 +113,14 @@ export const Plugin = {
               // is discovered); for a file it starts at the file's dirname. External reads are
               // skipped, and discovery failures never fail the read.
               yield* Effect.gen(function* () {
-                if (target.externalDirectory !== undefined) return
-                const resolved = yield* fs.resolve(target.absolute)
+                if (result.target.externalDirectory !== undefined) return
+                const resolved = yield* fs.resolve(result.target.absolute)
                 const root = yield* fs.resolve(location.directory)
                 // up() searches its stop directory, so the Location-root AGENTS.md (already
                 // supplied by core initial instructions) is dropped by the dirname filter.
                 const discovered = yield* fs.up({
                   targets: [FILENAME],
-                  start: content.type === "list-page" ? resolved : dirname(resolved),
+                  start: result.content.type === "list-page" ? resolved : dirname(resolved),
                   stop: root,
                 })
                 const candidates = (yield* Effect.forEach(discovered, fs.resolve)).filter(
@@ -104,17 +133,17 @@ export const Plugin = {
                 Effect.catchDefect(() => Effect.void),
               )
               if (
-                content.type === "file" &&
-                content.encoding === "base64" &&
-                !ReadToolFileSystem.MEDIA_MIMES.has(content.mime)
+                result.content.type === "file" &&
+                result.content.encoding === "base64" &&
+                !ReadToolFileSystem.MEDIA_MIMES.has(result.content.mime)
               )
-                return yield* Effect.fail(new ReadToolFileSystem.BinaryFileError({ resource }))
-              return content
+                return yield* Effect.fail(new ReadToolFileSystem.BinaryFileError({ resource: result.target.resource }))
+              return { output: result.content, path: result.path }
             }).pipe(
-              Effect.map((output) => ({
-                output,
-                content: toModelContent(input.path, input.offset, output),
-                metadata: { truncated: output.type === "file" ? false : output.truncated },
+              Effect.map((result) => ({
+                output: result.output,
+                content: toModelContent(result.path, input.offset, result.output),
+                metadata: { truncated: result.output.type === "file" ? false : result.output.truncated },
               })),
               Effect.mapError((error) => {
                 if (error instanceof ToolFailure) return error
@@ -132,6 +161,15 @@ export const Plugin = {
         }),
       )
       .pipe(Effect.orDie)
+
+    const alternatePath = Effect.fn("ReadTool.alternatePath")(function* (absolute: string) {
+      const base = basename(absolute).replace(/[\u00a0\u202f]/g, " ")
+      const matches = (yield* reader.list(AbsolutePath.make(dirname(absolute)))).filter(
+        (entry) => entry.type === "file" && entry.name.replace(/[\u00a0\u202f]/g, " ") === base,
+      )
+      if (matches.length !== 1) return
+      return join(dirname(absolute), matches[0].name)
+    })
 
     const missing = Effect.fn("ReadTool.missing")(function* (input: string, absolute: string) {
       const base = basename(input).toLowerCase()

--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -101,6 +101,7 @@ export class ListPage extends Schema.Class<ListPage>("ReadTool.ListPage")({
 }) {}
 
 export interface Interface {
+  readonly list: (path: AbsolutePath) => ReturnType<Files["list"]>
   readonly read: (
     path: AbsolutePath,
     resource: string,
@@ -378,7 +379,10 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const environment = yield* Environment.Service
-    return Service.of({ read: (path, resource, page) => read(environment.files, path, resource, page) })
+    return Service.of({
+      list: environment.files.list,
+      read: (path, resource, page) => read(environment.files, path, resource, page),
+    })
   }),
 )
 

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -46,8 +46,10 @@ const readCalls: {
   input: AbsolutePath
   page: ReadToolFileSystem.PageInput
 }[] = []
+const listCalls: AbsolutePath[] = []
 let resolveFailure: unknown
 let directoryEntries: string[] = []
+let directoryEntryDetails: Environment.DirEntry[] = []
 let readResult: ReadToolFileSystem.FileContent | ReadToolFileSystem.TextPage | ReadToolFileSystem.ListPage = {
   type: "file",
   uri: "file:///README.md",
@@ -57,12 +59,18 @@ let readResult: ReadToolFileSystem.FileContent | ReadToolFileSystem.TextPage | R
   mime: "text/plain",
 }
 let readFailure: ReadToolFileSystem.ReadError | undefined
+let readOverride: ReadToolFileSystem.Interface["read"] | undefined
 const reader = Layer.succeed(
   ReadToolFileSystem.Service,
   ReadToolFileSystem.Service.of({
-    read: (input, _resource, page = {}) => {
+    list: (input) => {
+      listCalls.push(input)
+      return Effect.succeed(directoryEntryDetails)
+    },
+    read: (input, resource, page = {}) => {
       readCalls.push({ input, page })
       if (resolveFailure !== undefined) return Effect.die(resolveFailure)
+      if (readOverride) return readOverride(input, resource, page)
       if (readFailure !== undefined) return Effect.fail(readFailure)
       return Effect.succeed(readResult)
     },
@@ -155,9 +163,11 @@ describe("ReadTool", () => {
   beforeEach(() => {
     assertions.length = 0
     readCalls.length = 0
+    listCalls.length = 0
     allow = true
     resolveFailure = undefined
     directoryEntries = []
+    directoryEntryDetails = []
     readResult = {
       type: "file",
       uri: "file:///README.md",
@@ -167,6 +177,7 @@ describe("ReadTool", () => {
       mime: "text/plain",
     }
     readFailure = undefined
+    readOverride = undefined
   })
 
   it.effect("registers, authorizes, and reads through the location filesystem", () =>
@@ -202,6 +213,7 @@ describe("ReadTool", () => {
           page: { offset: undefined, limit: undefined },
         },
       ])
+      expect(listCalls).toEqual([])
     }),
   )
 
@@ -633,6 +645,88 @@ describe("ReadTool", () => {
           page: { offset: undefined, limit: undefined },
         },
       ])
+    }),
+  )
+
+  it.effect("recovers a unique file whose non-breaking spaces differ", () =>
+    Effect.gen(function* () {
+      const requested = "Screenshot 2026-08-27 3.15 PM.png"
+      const recovered = "Screenshot 2026-08-27 3.15\u202fPM.png"
+      const requestedAbsolute = path.join(process.cwd(), requested)
+      const recoveredAbsolute = path.join(process.cwd(), recovered)
+      directoryEntryDetails = [{ name: recovered, type: "file" }]
+      readOverride = (input) =>
+        input === requestedAbsolute
+          ? Effect.fail(new Environment.NotFound({ path: requestedAbsolute }))
+          : Effect.succeed(readResult)
+      const registry = yield* Tool.Service
+
+      const result = yield* executeTool(registry, {
+        sessionID,
+        ...toolIdentity,
+        call: { type: "tool-call", id: "call-recovered-path", name: "read", input: { path: requested } },
+      })
+
+      expect(result).toMatchObject({
+        status: "completed",
+        content: [{ type: "text", text: `Read file ${recovered}, lines 1-1\n1: hello` }],
+      })
+      expect(assertions).toMatchObject([
+        { action: "read", resources: [requested] },
+        { action: "read", resources: [recovered] },
+      ])
+      expect(readCalls.map((call) => call.input)).toEqual([
+        AbsolutePath.make(requestedAbsolute),
+        AbsolutePath.make(recoveredAbsolute),
+      ])
+      expect(listCalls).toEqual([AbsolutePath.make(process.cwd())])
+    }),
+  )
+
+  it.effect("does not recover ambiguous files", () =>
+    Effect.gen(function* () {
+      const requested = "report final.txt"
+      const requestedAbsolute = path.join(process.cwd(), requested)
+      readFailure = new Environment.NotFound({ path: requestedAbsolute })
+      directoryEntryDetails = [
+        { name: "report\u00a0final.txt", type: "file" },
+        { name: "report\u202ffinal.txt", type: "file" },
+      ]
+      const registry = yield* Tool.Service
+
+      expect(
+        yield* executeTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: { type: "tool-call", id: "call-ambiguous-path", name: "read", input: { path: requested } },
+        }),
+      ).toMatchObject({ status: "error", error: { message: `File not found: ${requested}` } })
+      expect(assertions).toHaveLength(1)
+      expect(readCalls).toHaveLength(1)
+    }),
+  )
+
+  it.effect("does not recover a directory", () =>
+    Effect.gen(function* () {
+      const requested = "report final"
+      const recovered = "report\u00a0final"
+      const requestedAbsolute = path.join(process.cwd(), requested)
+      directoryEntryDetails = [{ name: recovered, type: "directory" }]
+      readOverride = (input) =>
+        input === requestedAbsolute
+          ? Effect.fail(new Environment.NotFound({ path: requestedAbsolute }))
+          : Effect.succeed(new ReadToolFileSystem.ListPage({ type: "list-page", entries: [], truncated: false }))
+      const registry = yield* Tool.Service
+
+      expect(
+        yield* executeTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: { type: "tool-call", id: "call-directory-recovery", name: "read", input: { path: requested } },
+        }),
+      ).toMatchObject({ status: "error", error: { message: `File not found: ${requested}` } })
+      expect(assertions).toHaveLength(1)
+      expect(readCalls).toHaveLength(1)
     }),
   )
 


### PR DESCRIPTION
## Summary
- retry missing reads when exactly one sibling file differs only by non-breaking space variants
- keep literal paths first and reject ambiguous or directory matches
- authorize the recovered file and report its actual filename in tool output
- perform candidate discovery through the active location environment

## Testing
- `bun test test/tool-read.test.ts test/tool-read-filesystem.test.ts`
- `bun typecheck`
- Prettier and `git diff --check`