### PR TITLE
fix(core): resolve coherent state before OAuth refresh

### DIFF
--- a/.changeset/state-flush.md
+++ b/.changeset/state-flush.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Refresh expired OAuth credentials resolved during batched plugin activation. Integration connection resolution now materializes registrations deferred by the activation batch before consulting refresh implementations, so a just-registered OAuth method is no longer skipped and an expired token no longer used as-is.

--- a/.changeset/state-flush.md
+++ b/.changeset/state-flush.md
@@ -1,5 +1,0 @@
----
-"@opencode-ai/core": patch
----
-
-Refresh expired OAuth credentials resolved during batched plugin activation. Integration connection resolution now materializes registrations deferred by the activation batch before consulting refresh implementations, so a just-registered OAuth method is no longer skipped and an expired token no longer used as-is.

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -676,6 +676,10 @@ const layer = Layer.effect(
           const credential = yield* credentials.get(connection.id)
           if (!credential) return undefined
           if (credential.value.type === "key") return credential.value
+          // Plugin activation batches registrations: a plugin resolving during its own
+          // setup must see the refresh implementation it just registered, or an expired
+          // credential is silently returned without refreshing.
+          yield* state.flush()
           const implementation = state
             .get()
             .integrations.get(credential.integrationID)

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -679,10 +679,9 @@ const layer = Layer.effect(
           // Plugin activation batches registrations: a plugin resolving during its own
           // setup must see the refresh implementation it just registered, or an expired
           // credential is silently returned without refreshing.
-          yield* state.flush()
-          const implementation = state
-            .get()
-            .integrations.get(credential.integrationID)
+          const current = yield* state.resolve()
+          const implementation = current.integrations
+            .get(credential.integrationID)
             ?.implementations.get(credential.value.methodID)
           if (!implementation?.refresh) return credential.value
           const now = yield* Clock.currentTimeMillis

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -75,6 +75,12 @@ export interface Options<State, DraftApi> {
 
 export interface Interface<State, DraftApi> extends Transformable<DraftApi> {
   readonly get: () => State
+  /**
+   * Materializes registrations and disposals deferred by an active batch so
+   * subsequent reads observe them. No-op when nothing is pending; never waits
+   * out the reload debounce.
+   */
+  readonly flush: () => Effect.Effect<void>
 }
 
 export function create<State, DraftApi>(options: Options<State, DraftApi>): Interface<State, DraftApi> {
@@ -84,6 +90,7 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
   let requestedAt = 0
   let running = false
   let closed = false
+  let dirty = false
   let waiters: { generation: number; done: Deferred.Deferred<void> }[] = []
   const semaphore = Semaphore.makeUnsafe(1)
 
@@ -93,6 +100,7 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
   })
 
   const materialize = Effect.fnUntraced(function* () {
+    dirty = false
     if (closed) return
     const next = options.initial()
     const api = options.draft(next)
@@ -162,6 +170,7 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
                       closed = true
                       return
                     }
+                    dirty = true
                     batch.reloads.add(materializeReload)
                     return
                   }
@@ -177,12 +186,21 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
           )
           yield* Scope.addFinalizer(scope, dispose)
           const batch = yield* CurrentBatch
-          if (batch?.active) batch.reloads.add(materializeReload)
-          else yield* materializeReload()
+          if (batch?.active) {
+            dirty = true
+            batch.reloads.add(materializeReload)
+          } else yield* materializeReload()
           return { dispose }
         }),
       )
     }),
     reload,
+    flush: Effect.fnUntraced(function* () {
+      if (!dirty) return
+      // Flushing from inside the deferring batch replaces its queued rebuild.
+      const batch = yield* CurrentBatch
+      batch?.reloads.delete(materializeReload)
+      yield* materializeReload()
+    }),
   }
 }

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -74,13 +74,14 @@ export interface Options<State, DraftApi> {
 }
 
 export interface Interface<State, DraftApi> extends Transformable<DraftApi> {
+  /** Returns the last published value without rebuilding or waiting. */
   readonly get: () => State
   /**
-   * Materializes registrations and disposals deferred by an active batch so
-   * subsequent reads observe them. No-op when nothing is pending; never waits
-   * out the reload debounce.
+   * Resolves completed registration changes, joining an in-progress rebuild or
+   * materializing batched changes before returning the published value. Does not
+   * wait for future registrations or a scheduled reload's debounce.
    */
-  readonly flush: () => Effect.Effect<void>
+  readonly resolve: () => Effect.Effect<State>
 }
 
 export function create<State, DraftApi>(options: Options<State, DraftApi>): Interface<State, DraftApi> {
@@ -96,11 +97,11 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
 
   const commit = Effect.fn("State.commit")(function* (next: State) {
     state = next
+    dirty = false
     if (options.finalize) yield* options.finalize(options.draft(next))
   })
 
   const materialize = Effect.fnUntraced(function* () {
-    dirty = false
     if (closed) return
     const next = options.initial()
     const api = options.draft(next)
@@ -195,12 +196,16 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
       )
     }),
     reload,
-    flush: Effect.fnUntraced(function* () {
-      if (!dirty) return
-      // Flushing from inside the deferring batch replaces its queued rebuild.
-      const batch = yield* CurrentBatch
-      batch?.reloads.delete(materializeReload)
-      yield* materializeReload()
-    }),
+    resolve: Effect.fnUntraced(
+      function* () {
+        const batch = yield* CurrentBatch
+        if (dirty) yield* materialize()
+        // Resolution replaces this batch's queued rebuild only after publication succeeds.
+        batch?.reloads.delete(materializeReload)
+        return state
+      },
+      // Wait interruptibly for the owner, then finish publication and notification together.
+      (effect) => semaphore.withPermit(Effect.uninterruptible(effect)),
+    ),
   }
 }

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -7,6 +7,7 @@ import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Bus } from "@opencode-ai/core/bus"
 import { Integration } from "@opencode-ai/core/integration"
+import { State } from "@opencode-ai/core/state"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(AppNodeBuilder.build(LayerNode.group([Integration.node, Credential.node, Bus.node])))
@@ -259,6 +260,41 @@ describe("Integration", () => {
           value: Credential.Key.make({ type: "key", key: "secret" }),
         }),
       ])
+    }),
+  )
+
+  it.effect("refreshes an expired OAuth credential registered in the same batch", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const credentials = yield* Credential.Service
+      const integrationID = Integration.ID.make("opencode")
+      const methodID = Integration.MethodID.make("device")
+      const stored = yield* credentials.create({
+        integrationID,
+        label: "Work",
+        value: Credential.OAuth.make({ type: "oauth", methodID, access: "expired", refresh: "refresh", expires: 1 }),
+      })
+
+      // Plugin activation batches setup, deferring method registration until
+      // every plugin finishes. A plugin resolving its connection during setup
+      // must still reach the refresh implementation it just registered.
+      const resolved = yield* State.batch(
+        Effect.gen(function* () {
+          yield* integrations.transform((editor) =>
+            editor.method.update({
+              integrationID,
+              method: { id: methodID, type: "oauth", label: "Device" },
+              authorize: () => Effect.die(new Error("unused authorize")),
+              refresh: (credential) =>
+                Effect.succeed({ ...credential, access: "fresh", expires: Number.MAX_SAFE_INTEGER }),
+            }),
+          )
+          return yield* integrations.connection.resolve({ type: "credential", id: stored.id, label: "Work" })
+        }),
+      )
+
+      expect(resolved).toMatchObject({ type: "oauth", access: "fresh" })
+      expect((yield* credentials.get(stored.id))?.value).toMatchObject({ access: "fresh" })
     }),
   )
 

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -133,6 +133,65 @@ describe("State", () => {
     }),
   )
 
+  it.effect("flushes registrations deferred by a batch", () =>
+    Effect.gen(function* () {
+      let finalized = 0
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        finalize: () => Effect.sync(() => finalized++),
+      })
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* state.transform((draft) => {
+            draft.add("first")
+          })
+          expect(state.get().values).toEqual([])
+
+          yield* state.flush()
+          expect(state.get().values).toEqual(["first"])
+          expect(finalized).toBe(1)
+
+          // Nothing pending: flush does not rebuild again.
+          yield* state.flush()
+          expect(finalized).toBe(1)
+
+          yield* state.transform((draft) => {
+            draft.add("second")
+          })
+        }),
+      )
+
+      // Flushing absorbed the queued batch rebuild; only the later registration
+      // rebuilds at batch completion.
+      expect(state.get().values).toEqual(["first", "second"])
+      expect(finalized).toBe(2)
+    }),
+  )
+
+  it.effect("flushes disposals deferred by a batch", () =>
+    Effect.gen(function* () {
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      })
+      const scope = yield* Scope.make()
+      yield* state.transform((draft) => draft.add("value")).pipe(Scope.provide(scope))
+      expect(state.get().values).toEqual(["value"])
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* Scope.close(scope, Exit.void)
+          expect(state.get().values).toEqual(["value"])
+
+          yield* state.flush()
+          expect(state.get().values).toEqual([])
+        }),
+      )
+    }),
+  )
+
   it.effect("discards teardown rebuilds and pending reloads while still running cleanup", () =>
     Effect.gen(function* () {
       let finalized = 0

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { State } from "@opencode-ai/core/state"
-import { Deferred, Effect, Exit, Fiber, Layer, Scope } from "effect"
+import { Deferred, Effect, Exit, Fiber, Layer, Scheduler, Scope } from "effect"
 import { TestClock } from "effect/testing"
 import { testEffect } from "./lib/effect"
 
@@ -55,12 +55,18 @@ describe("State", () => {
     }),
   )
 
-  it.effect("runs transforms during every reload", () =>
+  it.effect("skips a reload's debounce when resolving but joins an in-progress reload", () =>
     Effect.gen(function* () {
+      const rebuilding = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
       let value = "first"
       const state = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        finalize: () =>
+          value === "first"
+            ? Effect.void
+            : Deferred.succeed(rebuilding, undefined).pipe(Effect.andThen(Deferred.await(release))),
       })
 
       yield* state.transform((editor) => {
@@ -70,8 +76,15 @@ describe("State", () => {
 
       value = "second"
       const reload = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* Effect.addFinalizer(() => Deferred.succeed(release, undefined))
+      expect((yield* state.resolve()).values).toEqual(["first"])
       yield* TestClock.adjust("500 millis")
+      yield* Deferred.await(rebuilding)
+      const reader = yield* state.resolve().pipe(Effect.forkChild({ startImmediately: true }))
+      expect(reader.pollUnsafe()).toBeUndefined()
+      yield* Deferred.succeed(release, undefined)
       yield* Fiber.join(reload)
+      expect((yield* Fiber.join(reader)).values).toEqual(["second"])
       expect(state.get().values).toEqual(["second"])
     }),
   )
@@ -133,7 +146,7 @@ describe("State", () => {
     }),
   )
 
-  it.effect("flushes registrations deferred by a batch", () =>
+  it.effect("resolves registrations deferred by a batch without rebuilding twice", () =>
     Effect.gen(function* () {
       let finalized = 0
       const state = State.create({
@@ -142,6 +155,9 @@ describe("State", () => {
         finalize: () => Effect.sync(() => finalized++),
       })
 
+      expect(yield* state.resolve()).toBe(state.get())
+      expect(finalized).toBe(0)
+
       yield* State.batch(
         Effect.gen(function* () {
           yield* state.transform((draft) => {
@@ -149,12 +165,11 @@ describe("State", () => {
           })
           expect(state.get().values).toEqual([])
 
-          yield* state.flush()
+          expect((yield* state.resolve()).values).toEqual(["first"])
           expect(state.get().values).toEqual(["first"])
           expect(finalized).toBe(1)
 
-          // Nothing pending: flush does not rebuild again.
-          yield* state.flush()
+          expect(yield* state.resolve()).toBe(state.get())
           expect(finalized).toBe(1)
 
           yield* state.transform((draft) => {
@@ -163,14 +178,14 @@ describe("State", () => {
         }),
       )
 
-      // Flushing absorbed the queued batch rebuild; only the later registration
+      // Resolution absorbed the queued batch rebuild; only the later registration
       // rebuilds at batch completion.
       expect(state.get().values).toEqual(["first", "second"])
       expect(finalized).toBe(2)
     }),
   )
 
-  it.effect("flushes disposals deferred by a batch", () =>
+  it.effect("resolves disposals deferred by a batch", () =>
     Effect.gen(function* () {
       const state = State.create({
         initial: () => ({ values: [] as string[] }),
@@ -185,8 +200,109 @@ describe("State", () => {
           yield* Scope.close(scope, Exit.void)
           expect(state.get().values).toEqual(["value"])
 
-          yield* state.flush()
+          expect((yield* state.resolve()).values).toEqual([])
+        }),
+      )
+    }),
+  )
+
+  it.effect("joins a concurrent resolution instead of returning the previous publication", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>()
+      const values = Array.from({ length: 128 }, (_, index) => index)
+      let finalized = 0
+      const state = State.create({
+        initial: () => ({ values: [] as number[] }),
+        draft: (draft) => draft,
+        finalize: () => Effect.sync(() => finalized++),
+      })
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* Effect.forEach(values, (value) =>
+            state.transform((draft) => {
+              draft.values.push(value)
+              if (value === 0) Deferred.doneUnsafe(started, Effect.void)
+            }),
+          )
+          const reader = yield* Deferred.await(started).pipe(
+            Effect.andThen(
+              Effect.gen(function* () {
+                expect(state.get().values).toEqual([])
+                return yield* state.resolve()
+              }),
+            ),
+            Effect.forkChild({ startImmediately: true }),
+          )
+          // Yield during synchronous transform replay, before the next value is published.
+          const writer = yield* state
+            .resolve()
+            .pipe(Effect.provideService(Scheduler.MaxOpsBeforeYield, 64), Effect.forkChild({ startImmediately: true }))
+          const observed = yield* Fiber.join(reader)
+          const published = yield* Fiber.join(writer)
+          expect(observed.values).toEqual(values)
+          expect(observed).toBe(published)
+        }),
+      )
+      expect(finalized).toBe(1)
+    }),
+  )
+
+  it.effect("keeps queued resolution cancellable but finishes a rebuild once started", () =>
+    Effect.gen(function* () {
+      const started = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      let finalized = 0
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => draft,
+        finalize: () =>
+          Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Deferred.await(release)),
+            Effect.andThen(Effect.sync(() => finalized++)),
+          ),
+      })
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* state.transform((draft) => draft.values.push("value"))
+          const writer = yield* state.resolve().pipe(Effect.forkChild({ startImmediately: true }))
+          yield* Effect.addFinalizer(() => Deferred.succeed(release, undefined))
+          yield* Deferred.await(started)
+          const reader = yield* state.resolve().pipe(Effect.forkChild({ startImmediately: true }))
+          expect(reader.pollUnsafe()).toBeUndefined()
+          yield* Fiber.interrupt(reader)
+          expect(writer.pollUnsafe()).toBeUndefined()
+
+          const interruption = yield* Fiber.interrupt(writer).pipe(Effect.forkChild({ startImmediately: true }))
+          expect(interruption.pollUnsafe()).toBeUndefined()
+          yield* Deferred.succeed(release, undefined)
+          yield* Fiber.join(interruption)
+          expect((yield* state.resolve()).values).toEqual(["value"])
+        }),
+      )
+      expect(finalized).toBe(1)
+    }),
+  )
+
+  it.effect("can resolve again after transform replay fails", () =>
+    Effect.gen(function* () {
+      let fail = true
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => draft,
+      })
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* state.transform((draft) => {
+            if (fail) throw new Error("replay failed")
+            draft.values.push("value")
+          })
+          expect(Exit.isFailure(yield* Effect.exit(state.resolve()))).toBeTrue()
           expect(state.get().values).toEqual([])
+          fail = false
+          expect((yield* state.resolve()).values).toEqual(["value"])
         }),
       )
     }),
@@ -219,6 +335,7 @@ describe("State", () => {
       yield* Fiber.join(pending)
       yield* registration.dispose
       yield* state.reload()
+      expect(yield* state.resolve()).toBe(state.get())
       expect(finalized).toBe(1)
     }),
   )


### PR DESCRIPTION
## Why

Plugin setup runs inside `State.batch`, which defers registration publication. Console registers its OAuth refresh implementation and then resolves its connection during that same setup. The resolver can therefore miss the handler and return an expired token unchanged.

The earlier version of this PR added `State.flush()`, but its pending-work check could return while another fiber was still rebuilding. This revision makes obtaining the coherent value one synchronized operation instead.

## What Changes

| Operation | Contract |
| --- | --- |
| `state.get()` | Return the last published value immediately, without rebuilding or waiting. Unchanged. |
| `state.resolve()` | Materialize completed registration/disposal changes or join an in-progress rebuild, then return the published value. |
| `state.reload()` | Keep the existing debounced replay behavior. Resolution does not wait out a scheduled reload's debounce. |

`Integration.connection.resolve` uses the returned value to find its OAuth refresh implementation:

```ts
const current = yield* state.resolve()
const implementation = current.integrations
  .get(credential.integrationID)
  ?.implementations.get(credential.value.methodID)
```

Other State reads remain unchanged. There is no caller-visible `State.flush()` or plugin-activation wait on this path.

## Publication Ordering

The existing State semaphore owns the pending-work decision, rebuild, and returned value. Pending registrations become clean only when the replacement value is published, so a failed replay remains resolvable. Successful resolution absorbs the current batch's queued rebuild.

Waiting for the semaphore remains interruptible. Once resolution starts rebuilding, publication and notification finish together before interruption propagates. OAuth network refresh runs after State resolution has released the semaphore.

```mermaid
sequenceDiagram
    participant P as Plugin setup
    participant I as Integration resolver
    participant S as State
    participant O as OAuth provider
    P->>S: Register refresh implementation inside batch
    P->>I: Resolve stored connection
    I->>S: resolve()
    S->>S: Join or rebuild under semaphore
    S-->>I: Published registry; semaphore released
    I->>O: Refresh expired credential
    O-->>I: Fresh credential
    I-->>P: Persisted fresh credential
```

## Scope

This owns State registration visibility and the OAuth refresh-handler lookup, not plugin installation, cross-registry transactions, or Console inventory recovery. It retains nonblocking discovery reads and does not change the broader activation policy. #45759 can remove its plugin-side registration-visibility workaround after this lands.

## Verification

Run with Bun 1.4.0 from `packages/core`:

```sh
bun run test test/state.test.ts test/integration.test.ts
bun run test test/state.test.ts \
  --test-name-pattern 'concurrent resolution|queued resolution|replay fails' \
  --rerun-each 100
bun typecheck
bun run test
```

- Focused State/Integration suites: **27 passed**.
- Full Core suite: **4,071 passed, 40 skipped, 0 failed** across 230 files. The focused suites passed again after strengthening the existing reload test.
- New concurrency, cancellation, and failed-replay regressions: **300 passed** across 100 repetitions each. All three failed against the previous synchronization before the fix.
- Coverage retains same-batch expired OAuth refresh and persistence, registration/disposal visibility, no duplicate batch rebuild, nonblocking published reads, reload debounce, and teardown suppression.
- Core typechecking, changed-file formatting, and whitespace checks passed.
- The unmodified pre-push hook passed all **33 repository typecheck tasks**.
