### PR TITLE
chore(deps): upgrade Effect to rc.112

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -185,7 +185,7 @@
         "solid-js": "catalog:",
       },
       "peerDependencies": {
-        "effect": "4.0.0-rc.111",
+        "effect": "4.0.0-rc.112",
         "solid-js": ">=1.9.0",
       },
       "optionalPeers": [
@@ -506,7 +506,7 @@
       "name": "@opencode-ai/http-recorder",
       "version": "1.18.15",
       "dependencies": {
-        "@effect/platform-node-shared": "4.0.0-rc.111",
+        "@effect/platform-node-shared": "4.0.0-rc.112",
       },
       "devDependencies": {
         "@effect/platform-node": "catalog:",
@@ -1062,10 +1062,10 @@
   "catalog": {
     "@cloudflare/workers-types": "4.20251008.0",
     "@corvu/drawer": "0.2.4",
-    "@effect/opentelemetry": "4.0.0-rc.111",
-    "@effect/platform-node": "4.0.0-rc.111",
-    "@effect/platform-node-shared": "4.0.0-rc.111",
-    "@effect/sql-sqlite-bun": "4.0.0-rc.111",
+    "@effect/opentelemetry": "4.0.0-rc.112",
+    "@effect/platform-node": "4.0.0-rc.112",
+    "@effect/platform-node-shared": "4.0.0-rc.112",
+    "@effect/sql-sqlite-bun": "4.0.0-rc.112",
     "@hono/standard-validator": "0.2.0",
     "@hono/zod-validator": "0.4.2",
     "@kobalte/core": "0.13.13",
@@ -1105,7 +1105,7 @@
     "dompurify": "3.4.14",
     "drizzle-kit": "1.0.0-rc.5-ab785fc",
     "drizzle-orm": "1.0.0-rc.5-169397b",
-    "effect": "4.0.0-rc.111",
+    "effect": "4.0.0-rc.112",
     "fuzzysort": "3.1.0",
     "get-east-asian-width": "1.6.0",
     "hono": "4.10.7",
@@ -1664,13 +1664,13 @@
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.12.0", "", {}, "sha512-mlUE+rZ8CatQekLhnaiN91Iemdd+e2gFKooGlnRB3oPTL3VghLfX24dx7HrzMNeC1JrIB/0kpsfyty3f5HNfxQ=="],
 
-    "@effect/opentelemetry": ["@effect/opentelemetry@4.0.0-rc.111", "", { "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <2.0.0", "@opentelemetry/api-logs": ">=0.203.0 <0.300.0", "@opentelemetry/resources": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-trace-node": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-trace-web": ">=2.0.0 <3.0.0", "@opentelemetry/semantic-conventions": ">=1.33.0 <2.0.0", "effect": "^4.0.0-rc.111" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/api-logs", "@opentelemetry/resources", "@opentelemetry/sdk-logs", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-trace-base", "@opentelemetry/sdk-trace-node", "@opentelemetry/sdk-trace-web"] }, "sha512-bztAYpWoipn/a4tFjECMNvtWLkf2TS+Qn23PBI+f4q5DP9cBKfV00uhX8cwEVcfAtZd+lflSbGURHa4xlSewOA=="],
+    "@effect/opentelemetry": ["@effect/opentelemetry@4.0.0-rc.112", "", { "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <2.0.0", "@opentelemetry/api-logs": ">=0.203.0 <0.300.0", "@opentelemetry/resources": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-logs": ">=0.203.0 <0.300.0", "@opentelemetry/sdk-metrics": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-trace-base": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-trace-node": ">=2.0.0 <3.0.0", "@opentelemetry/sdk-trace-web": ">=2.0.0 <3.0.0", "@opentelemetry/semantic-conventions": ">=1.33.0 <2.0.0", "effect": "^4.0.0-rc.112" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/api-logs", "@opentelemetry/resources", "@opentelemetry/sdk-logs", "@opentelemetry/sdk-metrics", "@opentelemetry/sdk-trace-base", "@opentelemetry/sdk-trace-node", "@opentelemetry/sdk-trace-web"] }, "sha512-OTRv1DxTHUmnakgJ6XVM8wVgF1KgZH4UXnOemwSLUwUjXO+RCikzF8oR/rlVmOGq81KtQzj1URM4M4nchlQOuQ=="],
 
-    "@effect/platform-node": ["@effect/platform-node@4.0.0-rc.111", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.111", "mime": "^4.1.0", "undici": "^8.10.0" }, "peerDependencies": { "effect": "^4.0.0-rc.111", "redis": ">=5.0.0 <7.0.0" } }, "sha512-oy1i7HsOGg/5r+DuBe5+ddmnUhnXmyZFPFPXZCBdO/RQpHK3PIFe1/2UMGxZE+ngDymrSksuQTSgQLF6P+MLqw=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-rc.112", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-rc.112", "mime": "^4.1.0", "undici": "^8.10.0" }, "peerDependencies": { "effect": "^4.0.0-rc.112", "redis": ">=5.0.0 <7.0.0" } }, "sha512-/BMAcdNGQQskLmI0Zoa95KfTZkr9HV9N4NSxaSrusG6GeW6Ulp9KvZ+Rlaiw8lnOt43CXjFLdfll5/k5rxL4hQ=="],
 
-    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.111", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.111" } }, "sha512-iES0Q9vmjhaUKqeW9ceonuD45MUg/Ouk08LzRSptZ+B5qB0w9WlRjDmUz5TJmY2betNop5FRI5k4AD4mtQt3Bw=="],
+    "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-rc.112", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.3" }, "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ=="],
 
-    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-rc.111", "", { "peerDependencies": { "effect": "^4.0.0-rc.111" } }, "sha512-u5HqWLYISTH5ydsCr45nOGmkspmAeNzK4q+plMrJntDoG8sQttwizC4akGfbQDgoSxyYfyBzi3YyVW/NvhvSQQ=="],
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-rc.112", "", { "peerDependencies": { "effect": "^4.0.0-rc.112" } }, "sha512-EqR8pWZo3VzedRvP6qo5HcfqNmFvSa+sQLWQl3oBMx2KY1FCc8NYjep79wYjNkW0qABnffrPUXCMTOncd1A+5g=="],
 
     "@electron-internal/extract-zip": ["@electron-internal/extract-zip@1.0.5", "", {}, "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA=="],
 
@@ -3834,7 +3834,7 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
+    "effect": ["effect@4.0.0-rc.112", "", { "dependencies": { "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A=="],
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
@@ -6316,6 +6316,10 @@
 
     "@solidjs/start/vite": ["vite@7.1.10", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA=="],
 
+    "@standard-community/standard-json/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
+
+    "@standard-community/standard-openapi/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
+
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
@@ -6895,6 +6899,8 @@
     "@brendonovich/vite-plugin-opencode/@opencode-ai/client/@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-beta-18050", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-beta-18050", "effect": "4.0.0-rc.111" } }, "sha512-HDQMnvGp8IU0MdBRbEuydX1WQm09BZ4HJm9iSMQwzweJuQ2HNscgzHJPIH6P02BsbbtfJ8J7sZGPItrz1tWSgw=="],
 
     "@brendonovich/vite-plugin-opencode/@opencode-ai/client/@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-beta-18050", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-rc.111" } }, "sha512-/D6VXaWlytTXR3IOiMLIKuPcfp7FQNUzRPm9z3K7UBFd1Bw4q/WZksaf5RVcBGz+0YRxYMc1V4D7MFlceSgtyg=="],
+
+    "@brendonovich/vite-plugin-opencode/@opencode-ai/client/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
 
     "@bruits/satteri-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 

--- a/package.json
+++ b/package.json
@@ -39,10 +39,10 @@
       "packages/stats/*"
     ],
     "catalog": {
-      "@effect/opentelemetry": "4.0.0-rc.111",
-      "@effect/platform-node": "4.0.0-rc.111",
-      "@effect/platform-node-shared": "4.0.0-rc.111",
-      "@effect/sql-sqlite-bun": "4.0.0-rc.111",
+      "@effect/opentelemetry": "4.0.0-rc.112",
+      "@effect/platform-node": "4.0.0-rc.112",
+      "@effect/platform-node-shared": "4.0.0-rc.112",
+      "@effect/sql-sqlite-bun": "4.0.0-rc.112",
       "@npmcli/arborist": "9.4.0",
       "@types/bun": "1.3.13",
       "@types/cross-spawn": "6.0.6",
@@ -76,7 +76,7 @@
       "dompurify": "3.4.14",
       "drizzle-kit": "1.0.0-rc.5-ab785fc",
       "drizzle-orm": "1.0.0-rc.5-169397b",
-      "effect": "4.0.0-rc.111",
+      "effect": "4.0.0-rc.112",
       "ai": "6.0.168",
       "cross-spawn": "7.0.6",
       "hono": "4.10.7",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,7 +37,7 @@
     "@opencode-ai/protocol": "workspace:*"
   },
   "peerDependencies": {
-    "effect": "4.0.0-rc.111",
+    "effect": "4.0.0-rc.112",
     "solid-js": ">=1.9.0"
   },
   "peerDependenciesMeta": {

--- a/packages/desktop/src/main/ipc-transport.test.ts
+++ b/packages/desktop/src/main/ipc-transport.test.ts
@@ -131,6 +131,7 @@ function clientProtocol(port: MessagePort) {
           Effect.forkScoped,
         )
         return {
+          codecFor: serialization.codecFor,
           send: (_clientId: number, request: RpcMessage.FromClientEncoded) =>
             Effect.sync(() => {
               const encoded = parser.encode(request)

--- a/packages/desktop/src/main/ipc-transport.ts
+++ b/packages/desktop/src/main/ipc-transport.ts
@@ -92,6 +92,7 @@ export const IpcServerProtocolLive = Layer.unwrap(
           yield* Effect.addFinalizer(() => Effect.forEach([...bindings.keys()], disconnect, { discard: true }))
 
           return {
+            codecFor: serialization.codecFor,
             disconnects,
             send: (clientId, response) =>
               Effect.sync(() => {

--- a/packages/desktop/src/renderer/ipc-client.ts
+++ b/packages/desktop/src/renderer/ipc-client.ts
@@ -100,6 +100,7 @@ function clientProtocol(value: MessagePort) {
           Effect.forkScoped,
         )
         return {
+          codecFor: serialization.codecFor,
           send: (_clientId, request) =>
             Effect.sync(() => {
               const encoded = parser.encode(request)

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -52,7 +52,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
-    "@effect/platform-node-shared": "4.0.0-rc.111"
+    "@effect/platform-node-shared": "4.0.0-rc.112"
   },
   "peerDependencies": {
     "effect": "catalog:"


### PR DESCRIPTION
## Why

OpenCode V2 still pins Effect `4.0.0-rc.111`. Upgrade the shared runtime and related packages together so the workspace and published Client peer requirement target `rc.112`.

A version-only bump breaks desktop's custom RPC transports: `rc.112` requires protocols to expose the serialization codec used for RPC payloads and results.

## What Changes

| Surface | Before | After |
| --- | --- | --- |
| Effect, OpenTelemetry, Node platform, shared Node platform, Bun SQLite catalog | `4.0.0-rc.111` | `4.0.0-rc.112` |
| Client optional Effect peer | Exact `rc.111` | Exact `rc.112` |
| HTTP Recorder shared-platform dependency | Exact `rc.111` | Exact `rc.112` |
| Desktop IPC client/server protocols and test client | No codec selector | Forward `serialization.codecFor` |

Desktop retains its existing MessagePack serialization. The existing transport regression verifies independent renderer ports, binary arguments/results, streamed tagged classes, renderer reload, and disposal.

## Scope

Dependency manifests, the regenerated Bun lockfile, and three codec-forwarding lines. No public OpenCode endpoints, RPC message schemas, TestLLM behavior, or simulation orchestration change. No release, installed-client update, or live-service replacement is included.

## Verification

Commands run from their package directories:

```bash
# packages/core
RECORD=false bun run test
bun typecheck

# packages/desktop
bun typecheck
bun run ../core/script/test.ts src/main/ipc-transport.test.ts --timeout 30000

# packages/ai
bun typecheck
RECORD=false bun run test
RECORD=false bun run ../core/script/test.ts --timeout 30000

# packages/http-recorder
bun typecheck
bun run test
bun run script/pack.ts

# packages/client
bun run check:generated

# packages/cli
bun run test

# packages/sdk
bun run verify:package
```

- Core: 3,776 passed, 39 skipped, 0 failed; 78,829 assertions.
- Desktop typechecking and IPC transport regression passed. Before the codec-forwarding migration, desktop typechecking failed because both production protocols lacked `codecFor`.
- HTTP Recorder: 48 passed, no failures.
- HTTP Recorder packed artifact: inspected all six files and verified exact `rc.112` peer/shared-platform pins. A fresh consumer passed strict exported-API typechecking, public imports, and an Effect runtime smoke; consumer, recorder, and Node platform resolve one `rc.112` runtime. The existing `verify:package` script hardcodes `beta.83`, so this used a current-version consumer rather than claiming that stale verifier passed.
- Client generated-output check passed with no generated-file changes.
- Client: 84 passed; SDK: 26 passed; Simulation: 42 passed; Util: 21 passed. Assigned backend-package typechecks passed.
- CLI: 225 passed across 41 files, no failures, with the configured 30-second per-test timeout. An initial 120-second outer shell deadline terminated the suite before its summary; the complete rerun used no outer deadline and finished in 151 seconds without changing test limits.
- Packed SDK verification passed: all 11 package builds/packs, a fresh npm consumer with one Effect runtime, all four SDK entry points under default/workerd conditions, Wrangler dry-run and import-boundary checks, and a local Miniflare health boot. All temporarily rewritten package manifests were restored; consumers and tarballs were cleaned up.
- A temporary isolated ServerFetch smoke test requested `/openapi.json` and verified the generated document and health operation. This exercises the newly lazy OpenAPI generation; the temporary probe was removed.
- Normal pre-push workspace typechecking passed all 33 tasks. Formatting and diff whitespace checks passed; frozen-lockfile install passed.
- Core, Client, Server, SDK, Schema, Protocol, AI, Simulation, Util, CLI, Desktop, and HTTP Recorder all resolve the same installed `effect@4.0.0-rc.112` path. Third-party peer resolutions retain isolated `rc.111` entries in the generated lockfile.

### Confirmed Baseline Failures

These failures were reproduced in a separate clean checkout of the unchanged base `a065ad4ba76abf98e1836f61934d14c2a5aa3429`, with its own installed `effect@4.0.0-rc.111`:

- AI: 791 passed, 25 skipped, 15 failed. Both configured and HOME/credential-isolated baseline runs match all 15 candidate failure names and assertion/fixture-mismatch output, excluding timestamps and stack frames.
- HTTP API Codegen: 93 passed, 1 failed. The shared-anonymous-type assertion expects redundant parentheses; baseline `rc.111` and candidate `rc.112` produce identical unparenthesized output.
- Server: three OAuth callback-port tests fail with identical status/request assertions on baseline and candidate. Candidate full suite had 36 passed and 2 skipped, including the temporary OpenAPI smoke. The two skips require an unavailable persistent PTY binary.

These unrelated baseline failures are not changed or hidden by this PR. Local upgrade validation is complete; GitHub CI is tracked separately.
