### PR TITLE
fix(core): pull pending registry changes on read

### DIFF
--- a/.changeset/state-pull.md
+++ b/.changeset/state-pull.md
@@ -1,0 +1,5 @@
+---
+"@opencode-ai/core": patch
+---
+
+Make registry reads synchronously replay pending transform changes, including during plugin activation and before reload notifications finish debouncing. Separate derived-state preparation from change observers so reads do not publish events or reconcile background resources. Preserve resource coordination and report OAuth persistence failures when fresh registration replay fails.

--- a/.changeset/state-pull.md
+++ b/.changeset/state-pull.md
@@ -1,5 +1,0 @@
----
-"@opencode-ai/core": patch
----
-
-Make registry reads synchronously replay pending transform changes, including during plugin activation and before reload notifications finish debouncing. Separate derived-state preparation from change observers so reads do not publish events or reconcile background resources. Preserve resource coordination and report OAuth persistence failures when fresh registration replay fails.

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -87,7 +87,7 @@ const layer = Layer.effect(
           draft.agents.delete(id)
         },
       }),
-      finalize: () => bus.publish(Agent.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(Agent.Event.Updated, {}).pipe(Effect.asVoid),
     })
     const selectable = (agent: Info | undefined) =>
       agent && agent.mode !== "subagent" && !agent.hidden ? agent : undefined

--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -134,7 +134,7 @@ const layer = Layer.effect(
         }
         return result
       },
-      finalize: Effect.fn("Catalog.finalize")(function* () {
+      notify: Effect.fn("Catalog.notify")(function* () {
         yield* bus.publish(Catalog.Event.Updated, {})
       }),
     })

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -60,7 +60,7 @@ export const layer = Layer.effect(
       draft: (draft) => ({
         add: (definition) => draft.set(definition.name, definition),
       }),
-      finalize: () => bus.publish(Command.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(Command.Event.Updated, {}).pipe(Effect.asVoid),
     })
     const info = (definition: Definition) =>
       Info.make({

--- a/packages/core/src/filesystem/location-watcher-policy.ts
+++ b/packages/core/src/filesystem/location-watcher-policy.ts
@@ -25,19 +25,15 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Lo
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
-    let current: readonly string[] = []
     const listeners = new Set<(ignore: readonly string[]) => Effect.Effect<void>>()
-    const state = State.create<Data, Draft>({
+    const state: State.Interface<Data, Draft> = State.create<Data, Draft>({
       name: "location-watcher-policy",
       initial: () => ({ ignore: [] }),
       draft: (draft) => ({
         add: (ignore) => draft.ignore.push(...ignore),
         list: () => draft.ignore,
       }),
-      finalize: (draft) =>
-        Effect.sync(() => {
-          current = [...draft.list()]
-        }).pipe(Effect.andThen(Effect.forEach(listeners, (listener) => listener(current), { discard: true }))),
+      notify: () => Effect.forEach(listeners, (listener) => listener(state.get().ignore), { discard: true }),
     })
     const observe = Effect.fn("LocationWatcherPolicy.observe")(function* (
       listener: (ignore: readonly string[]) => Effect.Effect<void>,
@@ -56,7 +52,7 @@ const layer = Layer.effect(
     return Service.of({
       transform: state.transform,
       reload: state.reload,
-      current: () => current,
+      current: () => state.get().ignore,
       observe,
     })
   }),

--- a/packages/core/src/instruction-discovery.ts
+++ b/packages/core/src/instruction-discovery.ts
@@ -74,7 +74,7 @@ export const layer = (options?: Options) =>
             draft.available = false
           },
         }),
-        finalize: () => bus.publish(Event.Updated, {}).pipe(Effect.asVoid),
+        notify: () => bus.publish(Event.Updated, {}).pipe(Effect.asVoid),
       })
 
       const source = (value: ReadonlyArray<File> | Instructions.Unavailable | Instructions.Removed) =>

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -328,7 +328,7 @@ const layer = Layer.effect(
           },
         },
       }),
-      finalize: () => bus.publish(Integration.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(Integration.Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     const createCredential = Effect.fnUntraced(function* (input: Parameters<Credential.Interface["create"]>[0]) {
@@ -400,11 +400,13 @@ const layer = Layer.effect(
       }
 
       yield* Effect.gen(function* () {
-        const implementation = state
-          .get()
-          .integrations.get(attempt.integrationID)
-          ?.implementations.get(attempt.methodID)
-        const persistence = yield* Effect.sync(() => attempt.label ?? implementation?.label?.(exit.value)).pipe(
+        const persistence = yield* Effect.sync(() => {
+          const implementation = state
+            .get()
+            .integrations.get(attempt.integrationID)
+            ?.implementations.get(attempt.methodID)
+          return attempt.label ?? implementation?.label?.(exit.value)
+        }).pipe(
           Effect.flatMap((label) =>
             createCredential({
               integrationID: attempt.integrationID,

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -6,7 +6,21 @@ import { ephemeral } from "@opencode-ai/schema/event"
 import type { Session } from "@opencode-ai/schema/session"
 import { createHash } from "node:crypto"
 import { isDeepStrictEqual } from "node:util"
-import { Cause, Context, Effect, Exit, FiberSet, Latch, Layer, Schema, Scope, Semaphore, Stream, Types } from "effect"
+import {
+  Cause,
+  Context,
+  Effect,
+  Exit,
+  Fiber,
+  FiberSet,
+  Latch,
+  Layer,
+  Schema,
+  Scope,
+  Semaphore,
+  Stream,
+  Types,
+} from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Credential } from "../credential.js"
 import { Bus } from "../bus.js"
@@ -617,8 +631,7 @@ export const layer = (options?: Options) =>
       const overrides = new Map<ServerName, Mcp.ServerConfig | false>()
       const reconcileLock = Semaphore.makeUnsafe(1)
       const reconcile = Effect.fnUntraced(function* () {
-        if (root.state._tag === "Closed") return
-        const servers = new Map(state.get().servers)
+        const servers = state.get().servers
         if (!applied && entries.size === 0) {
           for (const [name, server] of servers) {
             entries.set(name, {
@@ -704,7 +717,12 @@ export const layer = (options?: Options) =>
           },
           remove: (server) => draft.servers.delete(ServerName.make(server)),
         }),
-        notify: () => reconcileLock.withPermit(reconcile()),
+        notify: () =>
+          Effect.gen(function* () {
+            const exit = yield* Fiber.await(fork(reconcileLock.withPermit(reconcile())))
+            if (Exit.isFailure(exit) && root.state._tag === "Closed" && Cause.hasInterruptsOnly(exit.cause)) return
+            yield* exit
+          }),
       })
 
       // Suspend so each await sees current entries; a bare Map iterator is exhausted after one run.

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -617,6 +617,7 @@ export const layer = (options?: Options) =>
       const overrides = new Map<ServerName, Mcp.ServerConfig | false>()
       const reconcileLock = Semaphore.makeUnsafe(1)
       const reconcile = Effect.fnUntraced(function* () {
+        if (root.state._tag === "Closed") return
         const servers = new Map(state.get().servers)
         if (!applied && entries.size === 0) {
           for (const [name, server] of servers) {

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -6,7 +6,7 @@ import { ephemeral } from "@opencode-ai/schema/event"
 import type { Session } from "@opencode-ai/schema/session"
 import { createHash } from "node:crypto"
 import { isDeepStrictEqual } from "node:util"
-import { Cause, Context, Effect, Exit, FiberSet, Latch, Layer, Schema, Scope, Stream, Types } from "effect"
+import { Cause, Context, Effect, Exit, FiberSet, Latch, Layer, Schema, Scope, Semaphore, Stream, Types } from "effect"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { Credential } from "../credential.js"
 import { Bus } from "../bus.js"
@@ -615,8 +615,9 @@ export const layer = (options?: Options) =>
 
       let applied: Map<ServerName, Mcp.ServerConfig> | undefined
       const overrides = new Map<ServerName, Mcp.ServerConfig | false>()
-      const reconcile = Effect.fnUntraced(function* (next: Draft) {
-        const servers = new Map(next.list())
+      const reconcileLock = Semaphore.makeUnsafe(1)
+      const reconcile = Effect.fnUntraced(function* () {
+        const servers = new Map(state.get().servers)
         if (!applied && entries.size === 0) {
           for (const [name, server] of servers) {
             entries.set(name, {
@@ -677,7 +678,7 @@ export const layer = (options?: Options) =>
           Stream.runForEach((event) => Effect.sync(() => fork(reconnect(event.data.integrationID)))),
         ),
       )
-      const state = State.create<Data, Draft>({
+      const state: State.Interface<Data, Draft> = State.create<Data, Draft>({
         name: "mcp",
         initial: () => ({
           servers: new Map(
@@ -702,7 +703,7 @@ export const layer = (options?: Options) =>
           },
           remove: (server) => draft.servers.delete(ServerName.make(server)),
         }),
-        finalize: reconcile,
+        notify: () => reconcileLock.withPermit(reconcile()),
       })
 
       // Suspend so each await sees current entries; a bare Map iterator is exhausted after one run.

--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -26,6 +26,7 @@ export type Info = Reference.Info
 
 type Data = {
   sources: Map<string, Types.DeepMutable<Source>>
+  materialized: Map<string, Info>
 }
 
 type Draft = {
@@ -47,61 +48,71 @@ const layer = Layer.effect(
     const bus = yield* Bus.Service
     const cache = yield* RepositoryCache.Service
     const scope = yield* Scope.Scope
-    const materialized = new Map<string, Info>()
-    const state = State.create<Data, Draft>({
+    const state: State.Interface<Data, Draft> = State.create<Data, Draft>({
       name: "reference",
-      initial: () => ({ sources: new Map() }),
+      initial: () => ({ sources: new Map(), materialized: new Map() }),
       draft: (draft) => ({
         add: (name, source) => draft.sources.set(name, source as Types.DeepMutable<Source>),
         remove: (name) => draft.sources.delete(name),
         list: () => Array.from(draft.sources.entries()) as [string, Source][],
       }),
-      finalize: (draft) =>
-        Effect.gen(function* () {
-          materialized.clear()
-          for (const [name, source] of draft.list()) {
-            if (source.type === "local") {
-              materialized.set(
-                name,
-                Info.make({
-                  name,
-                  path: source.path,
-                  ...(source.description === undefined ? {} : { description: source.description }),
-                  ...(source.hidden === undefined ? {} : { hidden: source.hidden }),
-                  source,
-                }),
-              )
-              continue
-            }
-            const repository = Repository.parse(source.repository)
-            if (!repository || !Repository.isRemote(repository)) continue
-            if (source.branch) {
-              try {
-                Repository.validateBranch(source.branch)
-              } catch {
-                continue
-              }
-            }
-            materialized.set(
+      prepare: (data) => {
+        for (const [name, source] of data.sources) {
+          if (source.type === "local") {
+            data.materialized.set(
               name,
               Info.make({
                 name,
-                path: AbsolutePath.make(Repository.cachePath(global.repos, repository, source.branch)),
+                path: source.path,
                 ...(source.description === undefined ? {} : { description: source.description }),
                 ...(source.hidden === undefined ? {} : { hidden: source.hidden }),
                 source,
               }),
             )
-            yield* cache.ensure({ reference: repository, branch: source.branch, refresh: true }).pipe(
-              Effect.catchCause((cause) =>
-                Effect.logWarning("failed to materialize reference", {
-                  name,
-                  repository: source.repository,
-                  cause,
-                }),
-              ),
-              Effect.forkIn(scope),
-            )
+            continue
+          }
+          const repository = Repository.parse(source.repository)
+          if (!repository || !Repository.isRemote(repository)) continue
+          if (source.branch) {
+            try {
+              Repository.validateBranch(source.branch)
+            } catch {
+              continue
+            }
+          }
+          data.materialized.set(
+            name,
+            Info.make({
+              name,
+              path: AbsolutePath.make(Repository.cachePath(global.repos, repository, source.branch)),
+              ...(source.description === undefined ? {} : { description: source.description }),
+              ...(source.hidden === undefined ? {} : { hidden: source.hidden }),
+              source,
+            }),
+          )
+        }
+      },
+      notify: () =>
+        Effect.gen(function* () {
+          for (const info of state.get().materialized.values()) {
+            const source = info.source
+            if (source.type !== "git") continue
+            yield* cache
+              .ensure({
+                reference: Repository.parseRemote(source.repository),
+                branch: source.branch,
+                refresh: true,
+              })
+              .pipe(
+                Effect.catchCause((cause) =>
+                  Effect.logWarning("failed to materialize reference", {
+                    name: info.name,
+                    repository: source.repository,
+                    cause,
+                  }),
+                ),
+                Effect.forkIn(scope),
+              )
           }
           yield* bus.publish(Reference.Event.Updated, {})
         }),
@@ -111,7 +122,7 @@ const layer = Layer.effect(
       transform: state.transform,
       reload: state.reload,
       list: Effect.fn("Reference.list")(function* () {
-        return Array.from(materialized.values())
+        return Array.from(state.get().materialized.values())
       }),
     })
   }),

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -109,7 +109,7 @@ const layer = Layer.effect(
           draft.skills.delete(ID.make(id))
         },
       }),
-      finalize: () => bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(Skill.Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     return Service.of({

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -3,7 +3,7 @@ export * as State from "./state.js"
 import { Clock, Context, Deferred, Effect, Exit, Scope } from "effect"
 
 /**
- * A replayable transform applied to a draft during reload.
+ * A replayable transform applied to a draft while deriving state.
  *
  * Domain drafts expose readable and writable state while preserving concise
  * plugin/config code. Transforms synchronously rebuild derived state.
@@ -23,7 +23,7 @@ export type Transform<DraftApi> = (
   transform: TransformCallback<DraftApi>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
-/** Invalidates captured inputs immediately and coalesces change notifications. */
+/** Invalidates the snapshot after captured inputs change and coalesces notifications. */
 export type Reload = () => Effect.Effect<void>
 
 export interface Transformable<DraftApi> {
@@ -78,7 +78,7 @@ export interface Options<State, DraftApi> {
   /**
    * Observes accepted changes outside the read path. Batched writes notify at
    * batch completion; reloads debounce notifications. Reads never run this hook.
-   * Resource reconciliation owns any coordination it requires.
+   * Resource reconciliation owns its execution scope and coordination.
    */
   readonly notify?: () => Effect.Effect<void>
 }
@@ -93,9 +93,8 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
   const transforms = new Set<{ run: TransformCallback<DraftApi> }>()
   let dirty = false
   let requestedAt = 0
-  let running = false
   let closed = false
-  let waiters: Deferred.Deferred<void>[] = []
+  let pending: Deferred.Deferred<void> | undefined
 
   const get = () => {
     if (!dirty || closed) return state
@@ -114,23 +113,17 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
     if (options.notify) yield* options.notify()
   })
 
-  const publish = (): Effect.Effect<void> =>
+  const publish = (done: Deferred.Deferred<void>): Effect.Effect<void> =>
     Effect.gen(function* () {
       const clock = yield* Clock.Clock
       const remaining = requestedAt + reloadDebounce - clock.currentTimeMillisUnsafe()
       if (remaining > 0) yield* Effect.sleep(remaining)
-      if (clock.currentTimeMillisUnsafe() < requestedAt + reloadDebounce) return yield* publish()
+      if (clock.currentTimeMillisUnsafe() < requestedAt + reloadDebounce) return yield* publish(done)
 
       // Release scheduling ownership before observers run: an observer may
       // request and await another reload without joining this notification.
-      const completed = waiters
-      waiters = []
-      running = false
-      const exit = yield* notify().pipe(Effect.exit)
-      yield* Effect.forEach(completed, (done) => Deferred.done(done, exit), {
-        concurrency: "unbounded",
-        discard: true,
-      })
+      pending = undefined
+      yield* notify().pipe(Deferred.into(done))
     })
 
   const changed = (debounce: boolean) =>
@@ -149,13 +142,13 @@ export function create<State, DraftApi>(options: Options<State, DraftApi>): Inte
         }
         if (!debounce) return yield* restore(notify())
 
-        const done = Deferred.makeUnsafe<void>()
         const clock = yield* Clock.Clock
         requestedAt = clock.currentTimeMillisUnsafe()
-        waiters.push(done)
-        if (!running) {
-          running = true
-          yield* publish().pipe(Effect.forkDetach)
+        // No yields between choosing the burst's completion and claiming it.
+        const done = pending ?? Deferred.makeUnsafe<void>()
+        if (!pending) {
+          pending = done
+          yield* publish(done).pipe(Effect.forkDetach)
         }
         yield* restore(Deferred.await(done))
       }),

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -1,6 +1,6 @@
 export * as State from "./state.js"
 
-import { Clock, Context, Deferred, Effect, Scope, Semaphore } from "effect"
+import { Clock, Context, Deferred, Effect, Exit, Scope } from "effect"
 
 /**
  * A replayable transform applied to a draft during reload.
@@ -16,13 +16,14 @@ export interface Registration {
 }
 
 /**
- * Registers and applies a scoped transform. Closing the owning Scope removes
- * the transform and reloads the materialized state.
+ * Registers a scoped transform and invalidates the derived state. Closing the
+ * owning Scope removes the transform. Reads synchronously replay pending changes.
  */
 export type Transform<DraftApi> = (
   transform: TransformCallback<DraftApi>,
 ) => Effect.Effect<Registration, never, Scope.Scope>
 
+/** Invalidates captured inputs immediately and coalesces change notifications. */
 export type Reload = () => Effect.Effect<void>
 
 export interface Transformable<DraftApi> {
@@ -33,7 +34,7 @@ export interface Transformable<DraftApi> {
 type Batch = {
   active: boolean
   readonly flush: boolean
-  readonly reloads: Set<Reload>
+  readonly notifications: Set<Reload>
 }
 
 const CurrentBatch = Context.Reference<Batch | undefined>("@opencode/State/CurrentBatch", {
@@ -41,17 +42,24 @@ const CurrentBatch = Context.Reference<Batch | undefined>("@opencode/State/Curre
 })
 const reloadDebounce = 500
 
-/** flush: false is terminal teardown: states whose transforms are removed stop rebuilding, including pending reloads. */
+/** Batches notifications, not read visibility. flush: false is terminal teardown. */
 export function batch<A, E, R>(effect: Effect.Effect<A, E, R>, options: { readonly flush?: boolean } = {}) {
-  return Effect.gen(function* () {
-    const current = yield* CurrentBatch
-    if (current?.active && options.flush !== false) return yield* effect
-    const batch: Batch = { active: true, flush: options.flush !== false, reloads: new Set() }
-    const exit = yield* effect.pipe(Effect.provideService(CurrentBatch, batch), Effect.exit)
-    batch.active = false
-    if (batch.flush) yield* Effect.forEach(batch.reloads, (reload) => reload(), { discard: true })
-    return yield* exit
-  })
+  return Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      const current = yield* CurrentBatch
+      if (current?.active && options.flush !== false) return yield* restore(effect)
+      const batch: Batch = { active: true, flush: options.flush !== false, notifications: new Set() }
+      const exit = yield* restore(effect.pipe(Effect.provideService(CurrentBatch, batch))).pipe(Effect.exit)
+      batch.active = false
+      const notifications = batch.flush
+        ? yield* Effect.forEach(batch.notifications, (notify) => notify().pipe(Effect.exit))
+        : []
+      // Accepted writes are not rolled back: one failed observer must not hide
+      // the other states' changes, or replace the batch body's failure.
+      yield* Exit.asVoidAll([exit, ...notifications])
+      return yield* exit
+    }),
+  )
 }
 
 export const inherit = Effect.fnUntraced(function* () {
@@ -65,124 +73,117 @@ export interface Options<State, DraftApi> {
   readonly initial: () => State
   /** Wraps mutable state in a domain-specific draft API. */
   readonly draft: MakeDraft<State, DraftApi>
+  /** Synchronously completes derived data after ordered transform replay. */
+  readonly prepare?: (state: State) => void
   /**
-   * Runs after the rebuilt state becomes visible. Update events published here
-   * act as read barriers: subscribers refetching on the event observe the
-   * committed state.
+   * Observes accepted changes outside the read path. Batched writes notify at
+   * batch completion; reloads debounce notifications. Reads never run this hook.
+   * Resource reconciliation owns any coordination it requires.
    */
-  readonly finalize?: (draft: DraftApi) => Effect.Effect<void>
+  readonly notify?: () => Effect.Effect<void>
 }
 
 export interface Interface<State, DraftApi> extends Transformable<DraftApi> {
+  /** Returns the latest accepted state, replaying stale inputs synchronously. */
   readonly get: () => State
 }
 
 export function create<State, DraftApi>(options: Options<State, DraftApi>): Interface<State, DraftApi> {
   let state = options.initial()
-  let transforms: { run: TransformCallback<DraftApi> }[] = []
-  let generation = 0
+  const transforms = new Set<{ run: TransformCallback<DraftApi> }>()
+  let dirty = false
   let requestedAt = 0
   let running = false
   let closed = false
-  let waiters: { generation: number; done: Deferred.Deferred<void> }[] = []
-  const semaphore = Semaphore.makeUnsafe(1)
+  let waiters: Deferred.Deferred<void>[] = []
 
-  const commit = Effect.fn("State.commit")(function* (next: State) {
-    state = next
-    if (options.finalize) yield* options.finalize(options.draft(next))
-  })
-
-  const materialize = Effect.fnUntraced(function* () {
-    if (closed) return
+  const get = () => {
+    if (!dirty || closed) return state
     const next = options.initial()
     const api = options.draft(next)
-    for (const transform of transforms) {
-      yield* Effect.sync(() => {
-        transform.run(api)
-      })
-    }
-    yield* commit(next)
+    transforms.forEach((transform) => transform.run(api))
+    options.prepare?.(next)
+    state = next
+    dirty = false
+    return state
+  }
+
+  const notify = Effect.fn("State.notify")(function* () {
+    if (closed) return
+    get()
+    if (options.notify) yield* options.notify()
   })
 
-  const materializeReload = () => semaphore.withPermit(materialize())
-
-  const rebuild = (): Effect.Effect<void> =>
+  const publish = (): Effect.Effect<void> =>
     Effect.gen(function* () {
       const clock = yield* Clock.Clock
       const remaining = requestedAt + reloadDebounce - clock.currentTimeMillisUnsafe()
       if (remaining > 0) yield* Effect.sleep(remaining)
-      if (clock.currentTimeMillisUnsafe() < requestedAt + reloadDebounce) return yield* rebuild()
+      if (clock.currentTimeMillisUnsafe() < requestedAt + reloadDebounce) return yield* publish()
 
-      const target = generation
-      const exit = yield* materializeReload().pipe(Effect.exit)
-      const completed = waiters.filter((waiter) => waiter.generation <= target)
-      waiters = waiters.filter((waiter) => waiter.generation > target)
-      yield* Effect.forEach(completed, (waiter) => Deferred.done(waiter.done, exit), {
+      // Release scheduling ownership before observers run: an observer may
+      // request and await another reload without joining this notification.
+      const completed = waiters
+      waiters = []
+      running = false
+      const exit = yield* notify().pipe(Effect.exit)
+      yield* Effect.forEach(completed, (done) => Deferred.done(done, exit), {
         concurrency: "unbounded",
         discard: true,
       })
-      if (generation > target) return yield* rebuild()
-      running = false
     })
 
-  const reload = Effect.fnUntraced(function* () {
-    if (closed) return
-    const done = Deferred.makeUnsafe<void>()
-    const clock = yield* Clock.Clock
-    generation++
-    requestedAt = clock.currentTimeMillisUnsafe()
-    waiters.push({ generation, done })
-    if (!running) {
-      running = true
-      yield* rebuild().pipe(Effect.forkDetach)
-    }
-    yield* Deferred.await(done)
-  })
+  const changed = (debounce: boolean) =>
+    Effect.uninterruptibleMask((restore) =>
+      Effect.gen(function* () {
+        if (closed) return
+        if (debounce) dirty = true
+        const batch = yield* CurrentBatch
+        if (batch?.active) {
+          if (!batch.flush) {
+            closed = true
+            return
+          }
+          batch.notifications.add(notify)
+          return
+        }
+        if (!debounce) return yield* restore(notify())
+
+        const done = Deferred.makeUnsafe<void>()
+        const clock = yield* Clock.Clock
+        requestedAt = clock.currentTimeMillisUnsafe()
+        waiters.push(done)
+        if (!running) {
+          running = true
+          yield* publish().pipe(Effect.forkDetach)
+        }
+        yield* restore(Deferred.await(done))
+      }),
+    )
 
   return {
-    get: () => state,
+    get,
     transform: Effect.fn("State.transform")(function* (update) {
       yield* Effect.annotateCurrentSpan("state", options.name ?? "anonymous")
       const scope = yield* Scope.Scope
       return yield* Effect.uninterruptible(
         Effect.gen(function* () {
           const transform = { run: update }
-          let active = true
           const dispose = Effect.uninterruptible(
-            semaphore.withPermit(
-              Effect.suspend(() => {
-                if (!active) return Effect.void
-                active = false
-                transforms = transforms.filter((item) => item !== transform)
-                return Effect.gen(function* () {
-                  const batch = yield* CurrentBatch
-                  if (batch?.active) {
-                    // Detached debounced reloads must also stay quiet after teardown.
-                    if (!batch.flush) {
-                      closed = true
-                      return
-                    }
-                    batch.reloads.add(materializeReload)
-                    return
-                  }
-                  yield* materialize()
-                })
-              }),
-            ),
-          )
-          yield* semaphore.withPermit(
-            Effect.sync(() => {
-              transforms = [...transforms, transform]
+            Effect.suspend(() => {
+              if (!transforms.delete(transform)) return Effect.void
+              dirty = true
+              return changed(false)
             }),
           )
+          transforms.add(transform)
+          dirty = true
           yield* Scope.addFinalizer(scope, dispose)
-          const batch = yield* CurrentBatch
-          if (batch?.active) batch.reloads.add(materializeReload)
-          else yield* materializeReload()
+          yield* changed(false)
           return { dispose }
         }),
       )
     }),
-    reload,
+    reload: () => changed(true),
   }
 }

--- a/packages/core/src/state.ts
+++ b/packages/core/src/state.ts
@@ -52,7 +52,7 @@ export function batch<A, E, R>(effect: Effect.Effect<A, E, R>, options: { readon
       const exit = yield* restore(effect.pipe(Effect.provideService(CurrentBatch, batch))).pipe(Effect.exit)
       batch.active = false
       const notifications = batch.flush
-        ? yield* Effect.forEach(batch.notifications, (notify) => notify().pipe(Effect.exit))
+        ? yield* Effect.forEach(batch.notifications, (notify) => restore(notify()).pipe(Effect.exit))
         : []
       // Accepted writes are not rolled back: one failed observer must not hide
       // the other states' changes, or replace the batch body's failure.

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -185,7 +185,7 @@ const layer = Layer.effect(
           draft.tools.delete(id)
         },
       }),
-      finalize: () =>
+      notify: () =>
         Effect.forEach(
           state.get().errors,
           ({ tool, error }) =>

--- a/packages/core/src/vcs.ts
+++ b/packages/core/src/vcs.ts
@@ -1,7 +1,7 @@
 export * as Vcs from "./vcs.js"
 
 import path from "path"
-import { Cause, Context, Effect, Layer, Schema, Stream } from "effect"
+import { Cause, Context, Effect, Layer, Schema, Semaphore, Stream } from "effect"
 import type { VcsDefinition, VcsDraft } from "@opencode-ai/plugin/effect/vcs"
 import { FileDiff } from "@opencode-ai/schema/file-diff"
 import { FileSystem } from "@opencode-ai/schema/filesystem"
@@ -49,6 +49,7 @@ const layer = Layer.effect(
     const bus = yield* Bus.Service
     const vcs = location.vcs
     const current: { info: Info } = { info: { branch: {} } }
+    const refreshLock = Semaphore.makeUnsafe(1)
     const scope = {
       directory: location.directory,
       worktree: location.project.directory,
@@ -69,7 +70,7 @@ const layer = Layer.effect(
           set: (selection) => (draft.selection = selection),
         },
       }),
-      finalize: () => refresh(),
+      notify: () => refresh(),
     })
     const selected = () => {
       const value = state.get()
@@ -87,13 +88,17 @@ const layer = Layer.effect(
         ),
       )
     const refresh = Effect.fn("Vcs.refresh")(function* () {
-      const provider = selected()
-      const next: Info = provider
-        ? yield* protect(provider, "info", provider.info(scope).pipe(Effect.flatMap(decodeInfo)), { branch: {} })
-        : { branch: {} }
-      const changed = current.info.branch.current !== next.branch.current
-      current.info = next
-      if (changed) yield* bus.publish(VcsEvent.BranchUpdated, { branch: next.branch.current })
+      const changed = yield* Effect.gen(function* () {
+        const provider = selected()
+        const next: Info = provider
+          ? yield* protect(provider, "info", provider.info(scope).pipe(Effect.flatMap(decodeInfo)), { branch: {} })
+          : { branch: {} }
+        const changed = current.info.branch.current !== next.branch.current
+        current.info = next
+        return changed
+      }).pipe(refreshLock.withPermit)
+      // Listeners may refresh again; publish outside the permit using the latest committed branch.
+      if (changed) yield* bus.publish(VcsEvent.BranchUpdated, { branch: current.info.branch.current })
     })
 
     if (vcs) {

--- a/packages/core/src/vcs.ts
+++ b/packages/core/src/vcs.ts
@@ -97,8 +97,14 @@ const layer = Layer.effect(
         current.info = next
         return changed
       }).pipe(refreshLock.withPermit)
-      // Listeners may refresh again; publish outside the permit using the latest committed branch.
-      if (changed) yield* bus.publish(VcsEvent.BranchUpdated, { branch: current.info.branch.current })
+      if (!changed) return
+      // Legacy listeners can publish nested updates before streams and SSE receive
+      // this event. Re-announce the latest branch if publication was overtaken.
+      while (true) {
+        const branch = current.info.branch.current
+        yield* bus.publish(VcsEvent.BranchUpdated, { branch })
+        if (branch === current.info.branch.current) return
+      }
     })
 
     if (vcs) {

--- a/packages/core/src/vcs.ts
+++ b/packages/core/src/vcs.ts
@@ -1,7 +1,7 @@
 export * as Vcs from "./vcs.js"
 
 import path from "path"
-import { Cause, Context, Effect, Layer, Schema, Semaphore, Stream } from "effect"
+import { Cause, Context, Effect, Exit, Fiber, FiberSet, Layer, Schema, Semaphore, Stream } from "effect"
 import type { VcsDefinition, VcsDraft } from "@opencode-ai/plugin/effect/vcs"
 import { FileDiff } from "@opencode-ai/schema/file-diff"
 import { FileSystem } from "@opencode-ai/schema/filesystem"
@@ -47,6 +47,8 @@ const layer = Layer.effect(
     const fs = yield* FSUtil.Service
     const location = yield* Location.Service
     const bus = yield* Bus.Service
+    const root = yield* Effect.scope
+    const fork = yield* FiberSet.makeRuntime<never, void, never>()
     const vcs = location.vcs
     const current: { info: Info } = { info: { branch: {} } }
     const refreshLock = Semaphore.makeUnsafe(1)
@@ -70,7 +72,12 @@ const layer = Layer.effect(
           set: (selection) => (draft.selection = selection),
         },
       }),
-      notify: () => refresh(),
+      notify: () =>
+        Effect.gen(function* () {
+          const exit = yield* Fiber.await(fork(refresh()))
+          if (Exit.isFailure(exit) && root.state._tag === "Closed" && Cause.hasInterruptsOnly(exit.cause)) return
+          yield* exit
+        }),
     })
     const selected = () => {
       const value = state.get()
@@ -116,7 +123,13 @@ const layer = Layer.effect(
       yield* bus.subscribe(FileSystem.Event.Changed).pipe(
         Stream.filter((event) => isBranchMetadata(event.data.file)),
         Stream.runForEach((event) =>
-          refresh().pipe(Effect.withSpan("Vcs.refreshBranch", { attributes: { file: event.data.file } })),
+          refresh().pipe(
+            Effect.catchCauseIf(
+              (cause) => !Cause.hasInterrupts(cause),
+              (cause) => Effect.logWarning("vcs refresh failed", { file: event.data.file, cause }),
+            ),
+            Effect.withSpan("Vcs.refreshBranch", { attributes: { file: event.data.file } }),
+          ),
         ),
         Effect.forkScoped({ startImmediately: true }),
       )

--- a/packages/core/src/websearch.ts
+++ b/packages/core/src/websearch.ts
@@ -88,7 +88,7 @@ const layer = Layer.effect(
           set: (selection) => (draft.selection = selection),
         },
       }),
-      finalize: () => bus.publish(WebSearch.Event.Updated, {}).pipe(Effect.asVoid),
+      notify: () => bus.publish(WebSearch.Event.Updated, {}).pipe(Effect.asVoid),
     })
 
     const requireProvider = (providers: Map<ID, ProviderImplementation>, providerID: ID) => {

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -11,6 +11,7 @@ import { Location } from "@opencode-ai/core/location"
 import { Model } from "@opencode-ai/core/model"
 import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { State } from "@opencode-ai/core/state"
 import { location } from "./fixture/location"
 import { testEffect } from "./lib/effect"
 
@@ -30,6 +31,57 @@ const catalogLayer = AppNodeBuilder.build(
 const it = testEffect(catalogLayer)
 
 describe("Catalog", () => {
+  it.effect("reads available and default models inside a batch before publishing", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const bus = yield* Bus.Service
+      const observed: string[] = []
+      const unsubscribe = yield* bus.listen((event) =>
+        event.type === Catalog.Event.Updated.type
+          ? catalog.model.default().pipe(
+              Effect.map((model) => {
+                observed.push(model?.id ?? "none")
+              }),
+            )
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+      const providerID = Provider.ID.make("test")
+      const old = Model.ID.make("old")
+      const newest = Model.ID.make("new")
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* catalog.transform((draft) => {
+            draft.provider.update(providerID, () => {})
+            draft.model.update(providerID, old, (model) => {
+              model.time.released = 1000
+            })
+            draft.model.update(providerID, newest, (model) => {
+              model.time.released = 2000
+            })
+            draft.model.default.set(providerID, old)
+          })
+          expect((yield* catalog.model.available()).map((model) => model.id)).toEqual([newest, old])
+          expect((yield* catalog.model.default())?.id).toBe(old)
+
+          const overlay = yield* catalog.transform((draft) =>
+            draft.model.update(providerID, old, (model) => {
+              model.enabled = false
+            }),
+          )
+          expect((yield* catalog.model.available()).map((model) => model.id)).toEqual([newest])
+          expect((yield* catalog.model.default())?.id).toBe(newest)
+          yield* overlay.dispose
+          expect((yield* catalog.model.default())?.id).toBe(old)
+          expect(observed).toEqual([])
+        }),
+      )
+
+      expect(observed).toEqual([old])
+    }),
+  )
+
   it.effect("publishes an updated event after catalog changes", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service
@@ -294,6 +346,7 @@ describe("Catalog", () => {
 
       configured = false
       const reload = yield* catalog.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      expect((yield* catalog.model.default())?.id).toBe(newest)
       yield* TestClock.adjust("500 millis")
       yield* Fiber.join(reload)
       expect((yield* catalog.model.default())?.id).toBe(newest)

--- a/packages/core/test/filesystem/location-watcher-policy.test.ts
+++ b/packages/core/test/filesystem/location-watcher-policy.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect } from "bun:test"
+import { Effect, Fiber, Scope } from "effect"
+import { TestClock } from "effect/testing"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LocationWatcherPolicy } from "@opencode-ai/core/filesystem/location-watcher-policy"
+import { State } from "@opencode-ai/core/state"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(AppNodeBuilder.build(LocationWatcherPolicy.node))
+
+describe("LocationWatcherPolicy", () => {
+  it.effect("reads batched registrations and disposals without notifying observers", () =>
+    Effect.gen(function* () {
+      const policy = yield* LocationWatcherPolicy.Service
+      const observed: string[][] = []
+      yield* policy.observe((ignore) =>
+        Effect.sync(() => {
+          observed.push([...ignore])
+        }),
+      )
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* policy.transform((draft) => draft.add(["base"]))
+          const overlay = yield* policy.transform((draft) => draft.add(["overlay"]))
+          const snapshot = policy.current()
+          expect(snapshot).toEqual(["base", "overlay"])
+          expect(observed).toEqual([])
+
+          yield* overlay.dispose
+          expect(policy.current()).toEqual(["base"])
+          expect(snapshot).toEqual(["base", "overlay"])
+          expect(observed).toEqual([])
+        }),
+      )
+
+      expect(observed).toEqual([["base"]])
+    }),
+  )
+
+  it.effect("reads reloaded patterns before debounced observer reconciliation", () =>
+    Effect.gen(function* () {
+      const policy = yield* LocationWatcherPolicy.Service
+      const observed: string[][] = []
+      let ignore = ["first"]
+      yield* policy.observe((ignore) =>
+        Effect.sync(() => {
+          observed.push([...ignore])
+        }),
+      )
+      yield* policy.transform((draft) => draft.add(ignore))
+      const snapshot = policy.current()
+      observed.length = 0
+
+      ignore = ["second"]
+      const reload = yield* policy.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      expect(policy.current()).toEqual(["second"])
+      expect(snapshot).toEqual(["first"])
+      expect(observed).toEqual([])
+
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(reload)
+      expect(observed).toEqual([["second"]])
+    }),
+  )
+
+  it.effect("passes the latest policy to later observers after a reentrant registration", () =>
+    Effect.gen(function* () {
+      const policy = yield* LocationWatcherPolicy.Service
+      const scope = yield* Scope.Scope
+      const observed: string[][] = []
+      let reentered = false
+      yield* policy.observe(() =>
+        Effect.gen(function* () {
+          if (reentered) return
+          reentered = true
+          yield* policy.transform((draft) => draft.add(["inner"])).pipe(Scope.provide(scope))
+        }),
+      )
+      yield* policy.observe((ignore) =>
+        Effect.sync(() => {
+          observed.push([...ignore])
+        }),
+      )
+
+      yield* policy.transform((draft) => draft.add(["outer"]))
+
+      expect(policy.current()).toEqual(["outer", "inner"])
+      expect(observed).toEqual([
+        ["outer", "inner"],
+        ["outer", "inner"],
+      ])
+    }),
+  )
+
+  it.effect("allows an observer to await a reload and keeps later observers current", () =>
+    Effect.gen(function* () {
+      const policy = yield* LocationWatcherPolicy.Service
+      const observed: string[][] = []
+      let ignore = ["first"]
+      let reentered = false
+      yield* policy.observe(() =>
+        Effect.gen(function* () {
+          if (reentered) return
+          reentered = true
+          ignore = ["second"]
+          yield* policy.reload()
+        }),
+      )
+      yield* policy.observe((ignore) =>
+        Effect.sync(() => {
+          observed.push([...ignore])
+        }),
+      )
+
+      const writer = yield* policy
+        .transform((draft) => draft.add(ignore))
+        .pipe(Effect.forkChild({ startImmediately: true }))
+      expect(policy.current()).toEqual(["second"])
+      expect(observed).toEqual([])
+
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(writer)
+      expect(observed).toEqual([["second"], ["second"]])
+    }),
+  )
+})

--- a/packages/core/test/fixture/location.ts
+++ b/packages/core/test/fixture/location.ts
@@ -14,6 +14,10 @@ export function location(ref: Location.Ref, input: { projectDirectory?: Absolute
   } satisfies Location.Interface
 }
 
+export function locationLayer(ref: Location.Ref, input: { projectDirectory?: AbsolutePath; vcs?: Project.Vcs } = {}) {
+  return Layer.succeed(Location.Service, Location.Service.of(location(ref, input)))
+}
+
 export const tempLocationLayer = Layer.unwrap(
   Effect.acquireRelease(
     Effect.promise(() => tmpdir()),
@@ -21,7 +25,7 @@ export const tempLocationLayer = Layer.unwrap(
   ).pipe(
     Effect.map((tmp) => {
       const ref = Location.Ref.make({ directory: AbsolutePath.make(tmp.path) })
-      return Layer.succeed(Location.Service, Location.Service.of(location(ref)))
+      return locationLayer(ref)
     }),
   ),
 )

--- a/packages/core/test/integration-replay.test.ts
+++ b/packages/core/test/integration-replay.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect } from "bun:test"
+import { Cause, Effect, Exit, Fiber } from "effect"
+import { TestClock } from "effect/testing"
+import { Credential } from "@opencode-ai/core/credential"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Integration } from "@opencode-ai/core/integration"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { testEffect } from "./lib/effect"
+
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([Integration.node, Credential.node])))
+
+describe("Integration replay", () => {
+  it.effect("fails and closes an OAuth attempt when fresh implementation replay throws", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const credentials = yield* Credential.Service
+      const integrationID = Integration.ID.make("replay-test")
+      const methodID = Integration.MethodID.make("code")
+      const source = { fail: false, closed: false }
+      const failure = new Error("integration transform replay failed")
+      yield* integrations.transform((editor) => {
+        if (source.fail) throw failure
+        editor.method.update({
+          integrationID,
+          method: { id: methodID, type: "oauth", label: "Fixture" },
+          authorize: () =>
+            Effect.addFinalizer(() => Effect.sync(() => (source.closed = true))).pipe(
+              Effect.as({
+                mode: "code" as const,
+                url: "https://example.com/authorize",
+                instructions: "Enter the fixture code",
+                callback: () =>
+                  Effect.succeed(
+                    Credential.OAuth.make({
+                      type: "oauth",
+                      methodID,
+                      access: "dummy-access",
+                      refresh: "dummy-refresh",
+                      expires: Number.MAX_SAFE_INTEGER,
+                    }),
+                  ),
+              }),
+            ),
+        })
+      })
+
+      const attempt = yield* integrations.oauth.connect({ integrationID, methodID, label: "Fixture" })
+      source.fail = true
+      const reload = yield* integrations.reload().pipe(Effect.exit, Effect.forkChild({ startImmediately: true }))
+      yield* Effect.addFinalizer(() =>
+        Effect.gen(function* () {
+          source.fail = false
+          yield* TestClock.adjust("500 millis")
+          yield* Fiber.join(reload)
+        }),
+      )
+
+      const exit = yield* integrations.oauth
+        .complete({ integrationID, attemptID: attempt.attemptID, code: "dummy-code" })
+        .pipe(Effect.exit)
+
+      expect(Exit.isFailure(exit) && Cause.hasDies(exit.cause)).toBe(true)
+      expect(Exit.isFailure(exit) && Cause.squash(exit.cause)).toBe(failure)
+      expect(yield* integrations.oauth.status({ integrationID, attemptID: attempt.attemptID })).toEqual({
+        status: "failed",
+        message: failure.message,
+        time: attempt.time,
+      })
+      expect(source.closed).toBe(true)
+      expect(yield* credentials.list(integrationID)).toEqual([])
+    }),
+  )
+})

--- a/packages/core/test/integration-replay.test.ts
+++ b/packages/core/test/integration-replay.test.ts
@@ -59,7 +59,7 @@ describe("Integration replay", () => {
         .complete({ integrationID, attemptID: attempt.attemptID, code: "dummy-code" })
         .pipe(Effect.exit)
 
-      expect(Exit.isFailure(exit) && Cause.hasDies(exit.cause)).toBe(true)
+      expect(exit).toMatchObject(Exit.die(failure))
       expect(Exit.isFailure(exit) && Cause.squash(exit.cause)).toBe(failure)
       expect(yield* integrations.oauth.status({ integrationID, attemptID: attempt.attemptID })).toEqual({
         status: "failed",

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -7,6 +7,7 @@ import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Bus } from "@opencode-ai/core/bus"
 import { Integration } from "@opencode-ai/core/integration"
+import { State } from "@opencode-ai/core/state"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(AppNodeBuilder.build(LayerNode.group([Integration.node, Credential.node, Bus.node])))
@@ -259,6 +260,102 @@ describe("Integration", () => {
           value: Credential.Key.make({ type: "key", key: "secret" }),
         }),
       ])
+    }),
+  )
+
+  it.effect("resolves stored OAuth with refresh registrations made inside a batch", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const credentials = yield* Credential.Service
+      const integrationID = Integration.ID.make("acme")
+      const method = Integration.OAuthMethod.make({
+        id: Integration.MethodID.make("browser"),
+        type: "oauth",
+        label: "Browser",
+      })
+      const expired = Credential.OAuth.make({
+        type: "oauth",
+        methodID: method.id,
+        access: "expired",
+        refresh: "refresh",
+        expires: 0,
+      })
+      const fresh = Credential.OAuth.make({
+        ...expired,
+        access: "fresh",
+        refresh: "fresh-refresh",
+        expires: (yield* Clock.currentTimeMillis) + Duration.toMillis(Duration.hours(1)),
+      })
+      const stored = yield* credentials.create({ integrationID, label: "Personal", value: expired })
+      const connection = { type: "credential" as const, id: stored.id, label: stored.label }
+      const calls: string[] = []
+      const implementation = {
+        integrationID,
+        method,
+        authorize: () => Effect.die("unexpected authorization"),
+        refresh: (value: Credential.OAuth) =>
+          Effect.sync(() => {
+            expect(value).toEqual(expired)
+            calls.push("original")
+            return fresh
+          }),
+      }
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* integrations.transform((editor) => editor.method.update(implementation))
+          expect(yield* integrations.connection.resolve(connection)).toEqual(fresh)
+          expect((yield* credentials.get(stored.id))?.value).toEqual(fresh)
+          expect(calls).toEqual(["original"])
+
+          expect(yield* integrations.connection.resolve(connection)).toEqual(fresh)
+          expect(calls).toEqual(["original"])
+
+          yield* credentials.update(stored.id, { value: expired })
+          const overridden = Credential.OAuth.make({ ...fresh, access: "override" })
+          const override = yield* integrations.transform((editor) =>
+            editor.method.update({
+              ...implementation,
+              refresh: (value) =>
+                Effect.sync(() => {
+                  expect(value).toEqual(expired)
+                  calls.push("override")
+                  return overridden
+                }),
+            }),
+          )
+          expect(yield* integrations.connection.resolve(connection)).toEqual(overridden)
+          expect((yield* credentials.get(stored.id))?.value).toEqual(overridden)
+
+          yield* override.dispose
+          yield* credentials.update(stored.id, { value: expired })
+          expect(yield* integrations.connection.resolve(connection)).toEqual(fresh)
+          expect(calls).toEqual(["original", "override", "original"])
+
+          yield* credentials.update(stored.id, { value: expired })
+          const removal = yield* integrations.transform((editor) => editor.method.remove(integrationID, method))
+          expect(yield* integrations.connection.resolve(connection)).toEqual(expired)
+          expect((yield* credentials.get(stored.id))?.value).toEqual(expired)
+          expect(calls).toEqual(["original", "override", "original"])
+
+          yield* removal.dispose
+          expect(yield* integrations.connection.resolve(connection)).toEqual(fresh)
+          yield* credentials.update(stored.id, { value: expired })
+          yield* integrations.transform((editor) => editor.method.update({ ...implementation, refresh: undefined }))
+          expect(yield* integrations.connection.resolve(connection)).toEqual(expired)
+          expect((yield* credentials.get(stored.id))?.value).toEqual(expired)
+          expect(calls).toEqual(["original", "override", "original", "original"])
+
+          const failure = new Error("refresh failed")
+          yield* integrations.transform((editor) =>
+            editor.method.update({ ...implementation, refresh: () => Effect.fail(failure) }),
+          )
+          expect(yield* integrations.connection.resolve(connection).pipe(Effect.flip)).toEqual(
+            new Integration.AuthorizationError({ cause: failure }),
+          )
+          expect((yield* credentials.get(stored.id))?.value).toEqual(expired)
+        }),
+      )
     }),
   )
 

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -1471,74 +1471,84 @@ testEffect(Layer.empty).live("serializes MCP config restoration behind an in-fli
     )
   }),
 )
-
-testEffect(
-  AppNodeBuilder.build(
-    LayerNode.group([Bus.node, Integration.node, Credential.node, Form.node, Environment.node, Location.node]),
-    [
+;["active", "queued"].forEach((phase) =>
+  testEffect(
+    AppNodeBuilder.build(
+      LayerNode.group([Bus.node, Integration.node, Credential.node, Form.node, Environment.node, Location.node]),
       [
-        Location.node,
-        Layer.succeed(
-          Location.Service,
-          Location.Service.of(location({ directory: AbsolutePath.make(import.meta.dir) })),
-        ),
+        [
+          Location.node,
+          Layer.succeed(
+            Location.Service,
+            Location.Service.of(location({ directory: AbsolutePath.make(import.meta.dir) })),
+          ),
+        ],
+        [Environment.node, hostEnvironmentLayer],
       ],
-      [Environment.node, hostEnvironmentLayer],
-    ],
+    ),
+  ).effect(`discards ${phase} MCP notifications after its layer closes`, () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const root = yield* Scope.make()
+      yield* Effect.addFinalizer(() =>
+        Deferred.succeed(release, undefined).pipe(
+          Effect.andThen(State.batch(Scope.close(root, Exit.void), { flush: false })),
+          Effect.andThen(TestClock.adjust("500 millis")),
+        ),
+      )
+      const context = yield* Layer.build(Mcp.layer()).pipe(Scope.provide(root))
+      const service = Context.get(context, Mcp.Service)
+      const observed: string[] = []
+      let block = false
+      const unsubscribe = yield* bus.listen((event) =>
+        Effect.gen(function* () {
+          if (event.type !== McpEvent.StatusChanged.type) return
+          observed.push(Schema.decodeUnknownSync(McpEvent.StatusChanged.data)(event.data).server)
+          if (!block) return
+          block = false
+          yield* Deferred.succeed(entered, undefined)
+          yield* Deferred.await(release)
+        }),
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+      const source = { url: "https://example.com/initial", added: false }
+      yield* service
+        .transform((draft) => {
+          draft.set("fixture", { type: "remote", url: source.url, oauth: false, disabled: true })
+          if (source.added) draft.set("queued", { type: "local", command: ["unused"], disabled: true })
+        })
+        .pipe(Scope.provide(root))
+
+      block = true
+      source.url = "https://example.com/first"
+      source.added = phase === "active"
+      const first = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Deferred.await(entered)
+      source.url = "https://example.com/second"
+      source.added = true
+      const second = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+
+      const shutdown = yield* State.batch(Scope.close(root, Exit.void), { flush: false }).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      )
+      yield* TestClock.adjust("1 millis")
+      expect(shutdown.pollUnsafe()).toBeDefined()
+      expect(first.pollUnsafe()).toBeDefined()
+      expect(second.pollUnsafe()).toBeDefined()
+      expect(yield* Deferred.isDone(release)).toBe(false)
+      yield* Fiber.join(shutdown)
+      observed.length = 0
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(first)
+      yield* Fiber.join(second)
+      expect(observed).toEqual([])
+      expect((yield* service.servers()).map((server) => server.name)).toEqual([Mcp.ServerName.make("fixture")])
+    }),
   ),
-).effect("discards queued MCP notifications after its layer closes", () =>
-  Effect.gen(function* () {
-    const bus = yield* Bus.Service
-    const entered = yield* Deferred.make<void>()
-    const release = yield* Deferred.make<void>()
-    const root = yield* Scope.make()
-    yield* Effect.addFinalizer(() =>
-      Deferred.succeed(release, undefined).pipe(
-        Effect.andThen(State.batch(Scope.close(root, Exit.void), { flush: false })),
-        Effect.andThen(TestClock.adjust("500 millis")),
-      ),
-    )
-    const context = yield* Layer.build(Mcp.layer()).pipe(Scope.provide(root))
-    const service = Context.get(context, Mcp.Service)
-    const observed: string[] = []
-    let block = false
-    const unsubscribe = yield* bus.listen((event) =>
-      Effect.gen(function* () {
-        if (event.type !== McpEvent.StatusChanged.type) return
-        observed.push(Schema.decodeUnknownSync(McpEvent.StatusChanged.data)(event.data).server)
-        if (!block) return
-        block = false
-        yield* Deferred.succeed(entered, undefined)
-        yield* Deferred.await(release)
-      }),
-    )
-    yield* Effect.addFinalizer(() => unsubscribe)
-    const source = { url: "https://example.com/initial", added: false }
-    yield* service
-      .transform((draft) => {
-        draft.set("fixture", { type: "remote", url: source.url, oauth: false, disabled: true })
-        if (source.added) draft.set("queued", { type: "local", command: ["unused"], disabled: true })
-      })
-      .pipe(Scope.provide(root))
-
-    block = true
-    source.url = "https://example.com/first"
-    const first = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
-    yield* TestClock.adjust("500 millis")
-    yield* Deferred.await(entered)
-    source.url = "https://example.com/second"
-    source.added = true
-    const second = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
-    yield* TestClock.adjust("500 millis")
-
-    yield* State.batch(Scope.close(root, Exit.void), { flush: false })
-    observed.length = 0
-    yield* Deferred.succeed(release, undefined)
-    yield* Fiber.join(first)
-    yield* Fiber.join(second)
-    expect(observed).toEqual([])
-    expect((yield* service.servers()).map((server) => server.name)).toEqual([Mcp.ServerName.make("fixture")])
-  }),
 )
 
 test("serializes concurrent MCP lifecycle operations", async () => {

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -57,7 +57,7 @@ import { ExitCode, makeHandle, ProcessId } from "effect/unstable/process/ChildPr
 import { Image } from "@opencode-ai/core/image"
 import { testEffect } from "./lib/effect"
 import { imagePassthrough } from "./lib/image"
-import { location } from "./fixture/location"
+import { location, locationLayer } from "./fixture/location"
 import { hostEnvironmentLayer, recordingEnvironmentLayer } from "./fixture/environment"
 import { executeTool, toolDefinitions, toolIdentity, waitForTool } from "./lib/tool"
 
@@ -1471,22 +1471,17 @@ testEffect(Layer.empty).live("serializes MCP config restoration behind an in-fli
     )
   }),
 )
+const shutdownIt = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Bus.node, Integration.node, Credential.node, Form.node, Environment.node, Location.node]),
+    [
+      [Location.node, locationLayer({ directory: AbsolutePath.make(import.meta.dir) })],
+      [Environment.node, hostEnvironmentLayer],
+    ],
+  ),
+)
 ;["active", "queued"].forEach((phase) =>
-  testEffect(
-    AppNodeBuilder.build(
-      LayerNode.group([Bus.node, Integration.node, Credential.node, Form.node, Environment.node, Location.node]),
-      [
-        [
-          Location.node,
-          Layer.succeed(
-            Location.Service,
-            Location.Service.of(location({ directory: AbsolutePath.make(import.meta.dir) })),
-          ),
-        ],
-        [Environment.node, hostEnvironmentLayer],
-      ],
-    ),
-  ).effect(`discards ${phase} MCP notifications after its layer closes`, () =>
+  shutdownIt.effect(`discards ${phase} MCP notifications after its layer closes`, () =>
     Effect.gen(function* () {
       const bus = yield* Bus.Service
       const entered = yield* Deferred.make<void>()
@@ -1498,7 +1493,7 @@ testEffect(Layer.empty).live("serializes MCP config restoration behind an in-fli
           Effect.andThen(TestClock.adjust("500 millis")),
         ),
       )
-      const context = yield* Layer.build(Mcp.layer()).pipe(Scope.provide(root))
+      const context = yield* Layer.buildWithScope(Mcp.layer(), root)
       const service = Context.get(context, Mcp.Service)
       const observed: string[] = []
       let block = false

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -33,6 +33,7 @@ import { McpStdio } from "@opencode-ai/core/mcp/stdio"
 import { Permission } from "@opencode-ai/core/permission"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
+import { State } from "@opencode-ai/core/state"
 import { McpTool } from "@opencode-ai/core/tool/mcp"
 import { Tool } from "@opencode-ai/core/tool"
 import { Deferred, Effect, Exit, Fiber, Layer, PubSub, Ref, Schedule, Schema, Sink, Stream } from "effect"
@@ -67,7 +68,7 @@ function resourceServer(
     listChanged?: boolean
     emptyElicitation?: boolean
     urlElicitation?: boolean
-    respond?: (request: Request) => Response | undefined
+    respond?: (request: Request) => Response | undefined | Promise<Response | undefined>
   } = {},
 ) {
   return Effect.acquireRelease(
@@ -176,7 +177,7 @@ function resourceServer(
           if (typeof body === "object" && body !== null && "method" in body && body.method === "initialize") {
             state.initializations += 1
           }
-          return input.respond?.(request) ?? transport.handleRequest(request)
+          return (await input.respond?.(request)) ?? transport.handleRequest(request)
         },
       })
       return {
@@ -1410,6 +1411,52 @@ test("reconciles only changed MCP server config", async () => {
     ),
   )
 })
+
+testEffect(Layer.empty).live("serializes MCP config restoration behind an in-flight replacement", () =>
+  Effect.gen(function* () {
+    const started = yield* Deferred.make<void>()
+    const release = yield* Deferred.make<void>()
+    const accepted = yield* Deferred.make<void>()
+    const server = yield* resourceServer({
+      respond: (request) =>
+        request.method !== "POST"
+          ? undefined
+          : Effect.runPromise(
+              Deferred.succeed(started, undefined).pipe(Effect.andThen(Deferred.await(release)), Effect.as(undefined)),
+            ),
+    })
+
+    yield* Effect.gen(function* () {
+      const service = yield* Mcp.Service
+      expect((yield* service.servers())[0]?.status).toEqual({ status: "disabled" })
+      const replacing = yield* service
+        .transform((draft) => draft.update("resources", (config) => (config.disabled = false)))
+        .pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* Deferred.await(started)
+
+      const restoring = yield* State.batch(
+        Effect.gen(function* () {
+          yield* service.transform((draft) => draft.update("resources", (config) => (config.disabled = true)))
+          yield* Deferred.succeed(accepted, undefined)
+        }),
+      ).pipe(Effect.forkScoped({ startImmediately: true }))
+      yield* Deferred.await(accepted)
+      expect((yield* service.servers())[0]?.status).toEqual({ status: "pending" })
+
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(replacing)
+      yield* Fiber.join(restoring)
+      expect((yield* service.servers())[0]?.status).toEqual({ status: "disabled" })
+      expect(yield* service.tools()).toEqual([])
+      expect(server.state.initializations).toBe(1)
+    }).pipe(
+      Effect.ensuring(Deferred.succeed(release, undefined)),
+      Effect.provide(
+        resourceMcpLayer(new ConfigMCP.Remote({ type: "remote", url: server.url, oauth: false, disabled: true })),
+      ),
+    )
+  }),
+)
 
 test("serializes concurrent MCP lifecycle operations", async () => {
   await Effect.runPromise(

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -36,7 +36,21 @@ import { Session } from "@opencode-ai/core/session"
 import { State } from "@opencode-ai/core/state"
 import { McpTool } from "@opencode-ai/core/tool/mcp"
 import { Tool } from "@opencode-ai/core/tool"
-import { Deferred, Effect, Exit, Fiber, Layer, PubSub, Ref, Schedule, Schema, Sink, Stream } from "effect"
+import {
+  Context,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  PubSub,
+  Ref,
+  Schedule,
+  Schema,
+  Scope,
+  Sink,
+  Stream,
+} from "effect"
 import { TestClock } from "effect/testing"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { ExitCode, makeHandle, ProcessId } from "effect/unstable/process/ChildProcessSpawner"
@@ -1455,6 +1469,75 @@ testEffect(Layer.empty).live("serializes MCP config restoration behind an in-fli
         resourceMcpLayer(new ConfigMCP.Remote({ type: "remote", url: server.url, oauth: false, disabled: true })),
       ),
     )
+  }),
+)
+
+testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Bus.node, Integration.node, Credential.node, Form.node, Environment.node, Location.node]),
+    [
+      [
+        Location.node,
+        Layer.succeed(
+          Location.Service,
+          Location.Service.of(location({ directory: AbsolutePath.make(import.meta.dir) })),
+        ),
+      ],
+      [Environment.node, hostEnvironmentLayer],
+    ],
+  ),
+).effect("discards queued MCP notifications after its layer closes", () =>
+  Effect.gen(function* () {
+    const bus = yield* Bus.Service
+    const entered = yield* Deferred.make<void>()
+    const release = yield* Deferred.make<void>()
+    const root = yield* Scope.make()
+    yield* Effect.addFinalizer(() =>
+      Deferred.succeed(release, undefined).pipe(
+        Effect.andThen(State.batch(Scope.close(root, Exit.void), { flush: false })),
+        Effect.andThen(TestClock.adjust("500 millis")),
+      ),
+    )
+    const context = yield* Layer.build(Mcp.layer()).pipe(Scope.provide(root))
+    const service = Context.get(context, Mcp.Service)
+    const observed: string[] = []
+    let block = false
+    const unsubscribe = yield* bus.listen((event) =>
+      Effect.gen(function* () {
+        if (event.type !== McpEvent.StatusChanged.type) return
+        observed.push(Schema.decodeUnknownSync(McpEvent.StatusChanged.data)(event.data).server)
+        if (!block) return
+        block = false
+        yield* Deferred.succeed(entered, undefined)
+        yield* Deferred.await(release)
+      }),
+    )
+    yield* Effect.addFinalizer(() => unsubscribe)
+    const source = { url: "https://example.com/initial", added: false }
+    yield* service
+      .transform((draft) => {
+        draft.set("fixture", { type: "remote", url: source.url, oauth: false, disabled: true })
+        if (source.added) draft.set("queued", { type: "local", command: ["unused"], disabled: true })
+      })
+      .pipe(Scope.provide(root))
+
+    block = true
+    source.url = "https://example.com/first"
+    const first = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
+    yield* TestClock.adjust("500 millis")
+    yield* Deferred.await(entered)
+    source.url = "https://example.com/second"
+    source.added = true
+    const second = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
+    yield* TestClock.adjust("500 millis")
+
+    yield* State.batch(Scope.close(root, Exit.void), { flush: false })
+    observed.length = 0
+    yield* Deferred.succeed(release, undefined)
+    yield* Fiber.join(first)
+    yield* Fiber.join(second)
+    expect(observed).toEqual([])
+    expect((yield* service.servers()).map((server) => server.name)).toEqual([Mcp.ServerName.make("fixture")])
   }),
 )
 

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -105,7 +105,7 @@ describe("Plugin", () => {
     }),
   )
 
-  it.effect("refreshes its own stored OAuth connection during plugin activation", () =>
+  it.live("refreshes its own stored OAuth connection during plugin activation", () =>
     Effect.gen(function* () {
       const plugins = yield* Plugin.Service
       const credentials = yield* Credential.Service

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect } from "bun:test"
 import { ToolFailure } from "@opencode-ai/ai"
-import { Context, Effect, Exit, Fiber, Schema, Stream } from "effect"
+import { Clock, Context, Duration, Effect, Exit, Fiber, Schema, Stream } from "effect"
 import { Plugin as EffectPlugin } from "@opencode-ai/plugin/effect"
 import { Config as ConfigSchema } from "@opencode-ai/schema/config"
 import { Agent } from "@opencode-ai/core/agent"
 import { Bus } from "@opencode-ai/core/bus"
+import { Credential } from "@opencode-ai/core/credential"
+import { Integration } from "@opencode-ai/core/integration"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
 import { PluginRuntime } from "@opencode-ai/core/plugin/runtime"
@@ -99,6 +101,64 @@ describe("Plugin", () => {
           workspaceID: location.workspaceID,
           project: location.project,
         }),
+      ])
+    }),
+  )
+
+  it.effect("refreshes its own stored OAuth connection during plugin activation", () =>
+    Effect.gen(function* () {
+      const plugins = yield* Plugin.Service
+      const credentials = yield* Credential.Service
+      const integrationID = Integration.ID.make("acme")
+      const methodID = Integration.MethodID.make("browser")
+      const expired = Credential.OAuth.make({
+        type: "oauth",
+        methodID,
+        access: "expired",
+        refresh: "refresh",
+        expires: 0,
+      })
+      const fresh = Credential.OAuth.make({
+        ...expired,
+        access: "fresh",
+        refresh: "fresh-refresh",
+        expires: (yield* Clock.currentTimeMillis) + Duration.toMillis(Duration.hours(1)),
+      })
+      const stored = yield* credentials.create({ integrationID, label: "Personal", value: expired })
+      const resolved: (Credential.Value | undefined)[] = []
+      const refreshed: Credential.OAuth[] = []
+
+      yield* plugins.activate([
+        versioned(
+          EffectPlugin.define({
+            id: "oauth-refresh",
+            effect: (ctx) =>
+              Effect.gen(function* () {
+                yield* ctx.integration.transform((editor) =>
+                  editor.method.update({
+                    integrationID,
+                    method: { id: methodID, type: "oauth", label: "Browser" },
+                    authorize: () => Effect.die("unexpected authorization"),
+                    refresh: (value) =>
+                      Effect.sync(() => {
+                        refreshed.push(value)
+                        return fresh
+                      }),
+                  }),
+                )
+                const connection = yield* ctx.integration.connection.active(integrationID)
+                if (!connection) return yield* Effect.die("stored connection missing")
+                resolved.push(yield* ctx.integration.connection.resolve(connection).pipe(Effect.orDie))
+              }),
+          }),
+        ),
+      ])
+
+      expect(resolved).toEqual([fresh])
+      expect(refreshed).toEqual([expired])
+      expect((yield* credentials.get(stored.id))?.value).toEqual(fresh)
+      expect(yield* plugins.list()).toEqual([
+        { id: Plugin.ID.make("oauth-refresh"), source: { type: "builtin" }, status: "active", tui: false },
       ])
     }),
   )

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -112,7 +112,7 @@ describe("fromPromise", () => {
     }),
   )
 
-  it.effect("refreshes its own stored OAuth connection during plugin activation", () =>
+  it.live("refreshes its own stored OAuth connection during plugin activation", () =>
     Effect.gen(function* () {
       const plugins = yield* Plugin.Service
       const credentials = yield* Credential.Service

--- a/packages/core/test/plugin/promise.test.ts
+++ b/packages/core/test/plugin/promise.test.ts
@@ -3,6 +3,8 @@ import { Message, SystemPart } from "@opencode-ai/ai"
 import { DateTime, Effect, Schema } from "effect"
 import { Agent } from "@opencode-ai/core/agent"
 import { Catalog } from "@opencode-ai/core/catalog"
+import { Credential } from "@opencode-ai/core/credential"
+import { Integration } from "@opencode-ai/core/integration"
 import { Model } from "@opencode-ai/core/model"
 import { Location } from "@opencode-ai/core/location"
 import { Plugin } from "@opencode-ai/core/plugin"
@@ -107,6 +109,59 @@ describe("fromPromise", () => {
           },
         }),
       ).effect(host)
+    }),
+  )
+
+  it.effect("refreshes its own stored OAuth connection during plugin activation", () =>
+    Effect.gen(function* () {
+      const plugins = yield* Plugin.Service
+      const credentials = yield* Credential.Service
+      const integrationID = Integration.ID.make("acme")
+      const methodID = Integration.MethodID.make("browser")
+      const expired = Credential.OAuth.make({
+        type: "oauth",
+        methodID,
+        access: "expired",
+        refresh: "dummy",
+        expires: 0,
+      })
+      const fresh = Credential.OAuth.make({ ...expired, access: "fresh", expires: Number.MAX_SAFE_INTEGER })
+      const stored = yield* credentials.create({ integrationID, label: "Fixture", value: expired })
+      const resolved: string[] = []
+      const refreshed: string[] = []
+      const adapted = PluginPromise.fromPromise(
+        define({
+          id: "promise-oauth-refresh",
+          setup: async (ctx) => {
+            await ctx.integration.transform((editor) =>
+              editor.method.update({
+                integrationID,
+                method: { id: methodID, type: "oauth", label: "Browser" },
+                authorize: async () => {
+                  throw new Error("unexpected authorization")
+                },
+                refresh: async (value) => {
+                  refreshed.push(value.access)
+                  return fresh
+                },
+              }),
+            )
+            const connection = await ctx.integration.connection.active(integrationID)
+            if (!connection) throw new Error("stored connection missing")
+            const value = await ctx.integration.connection.resolve(connection)
+            resolved.push(value?.type === "oauth" ? value.access : "missing")
+          },
+        }),
+      )
+
+      yield* plugins.activate([{ ...adapted, version: "1" }])
+
+      expect(resolved).toEqual(["fresh"])
+      expect(refreshed).toEqual(["expired"])
+      expect((yield* credentials.get(stored.id))?.value).toEqual(fresh)
+      expect(yield* plugins.list()).toEqual([
+        { id: Plugin.ID.make("promise-oauth-refresh"), source: { type: "builtin" }, status: "active", tui: false },
+      ])
     }),
   )
 

--- a/packages/core/test/reference.test.ts
+++ b/packages/core/test/reference.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect } from "bun:test"
 import { Effect, Exit, Layer, Scope } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Bus } from "@opencode-ai/core/bus"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { State } from "@opencode-ai/core/state"
 import { Global } from "@opencode-ai/util/global"
 import { Reference } from "@opencode-ai/core/reference"
 import { Repository } from "@opencode-ai/core/repository"
@@ -11,9 +14,128 @@ import { it } from "./lib/effect"
 const cache = Layer.mock(RepositoryCache.Service, {
   ensure: () => Effect.die("unexpected Git materialization"),
 })
-const referenceLayer = AppNodeBuilder.build(Reference.node, [[RepositoryCache.node, cache]])
+const referenceLayer = AppNodeBuilder.build(LayerNode.group([Reference.node, Bus.node]), [
+  [RepositoryCache.node, cache],
+])
 
 describe("Reference", () => {
+  it.effect("prepares batched references before cache work or update events", () => {
+    const operations: RepositoryCache.EnsureInput[] = []
+    const cache = Layer.mock(RepositoryCache.Service, {
+      ensure: (input) =>
+        Effect.sync(() => {
+          operations.push(input)
+          return {
+            repository: input.reference.label,
+            host: input.reference.host,
+            remote: input.reference.remote,
+            localPath: Repository.cachePath(Global.Path.repos, input.reference, input.branch),
+            status: "cached",
+          } satisfies RepositoryCache.Result
+        }),
+    })
+    const referenceLayer = AppNodeBuilder.build(LayerNode.group([Reference.node, Bus.node]), [
+      [RepositoryCache.node, cache],
+    ])
+
+    return Effect.gen(function* () {
+      const references = yield* Reference.Service
+      const bus = yield* Bus.Service
+      const observed: string[][] = []
+      const unsubscribe = yield* bus.listen((event) =>
+        event.type === Reference.Event.Updated.type
+          ? references.list().pipe(
+              Effect.map((infos) => {
+                observed.push(infos.map((info) => info.name))
+              }),
+            )
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* references.transform((draft) => {
+            draft.add("docs", Reference.LocalSource.make({ type: "local", path: AbsolutePath.make("/docs") }))
+            draft.add(
+              "sdk",
+              Reference.GitSource.make({
+                type: "git",
+                repository: "owner/repo",
+                branch: "feature/docs",
+                description: "SDK documentation",
+                hidden: true,
+              }),
+            )
+            draft.add("invalid", Reference.GitSource.make({ type: "git", repository: "invalid" }))
+            draft.add(
+              "invalid-branch",
+              Reference.GitSource.make({ type: "git", repository: "owner/repo", branch: "../escape" }),
+            )
+            draft.add("file", Reference.GitSource.make({ type: "git", repository: "file:///docs" }))
+          })
+          const infos = yield* references.list()
+          expect(infos.map((info) => info.name)).toEqual(["docs", "sdk"])
+          expect(infos[1]).toMatchObject({
+            path: Repository.cachePath(Global.Path.repos, Repository.parseRemote("owner/repo"), "feature/docs"),
+            description: "SDK documentation",
+            hidden: true,
+          })
+          expect(operations).toEqual([])
+          expect(observed).toEqual([])
+        }),
+      )
+
+      expect(observed).toEqual([["docs", "sdk"]])
+      yield* Effect.yieldNow
+      expect(
+        operations.map((input) => ({
+          repository: input.reference.label,
+          branch: input.branch,
+          refresh: input.refresh,
+        })),
+      ).toEqual([{ repository: "owner/repo", branch: "feature/docs", refresh: true }])
+    }).pipe(Effect.provide(referenceLayer))
+  })
+
+  it.effect("lets update listeners replace references and refetch the latest projection", () =>
+    Effect.gen(function* () {
+      const references = yield* Reference.Service
+      const bus = yield* Bus.Service
+      const scope = yield* Scope.Scope
+      const observed: string[][] = []
+      let reentered = false
+      const first = yield* bus.listen((event) =>
+        Effect.gen(function* () {
+          if (event.type !== Reference.Event.Updated.type || reentered) return
+          reentered = true
+          yield* references
+            .transform((draft) =>
+              draft.add("docs", Reference.LocalSource.make({ type: "local", path: AbsolutePath.make("/new") })),
+            )
+            .pipe(Scope.provide(scope))
+        }),
+      )
+      const second = yield* bus.listen((event) =>
+        event.type === Reference.Event.Updated.type
+          ? references.list().pipe(
+              Effect.map((infos) => {
+                observed.push(infos.map((info) => info.path))
+              }),
+            )
+          : Effect.void,
+      )
+      yield* Effect.addFinalizer(() => first.pipe(Effect.andThen(second)))
+
+      yield* references.transform((draft) =>
+        draft.add("docs", Reference.LocalSource.make({ type: "local", path: AbsolutePath.make("/old") })),
+      )
+
+      expect((yield* references.list()).map((info) => info.path)).toEqual([AbsolutePath.make("/new")])
+      expect(observed).toEqual([["/new"], ["/new"]])
+    }).pipe(Effect.provide(referenceLayer)),
+  )
+
   it.effect("registers normalized sources for the owning scope", () =>
     Effect.gen(function* () {
       const references = yield* Reference.Service

--- a/packages/core/test/reference.test.ts
+++ b/packages/core/test/reference.test.ts
@@ -9,7 +9,7 @@ import { Global } from "@opencode-ai/util/global"
 import { Reference } from "@opencode-ai/core/reference"
 import { Repository } from "@opencode-ai/core/repository"
 import { RepositoryCache } from "@opencode-ai/core/repository-cache"
-import { it } from "./lib/effect"
+import { it, testEffect } from "./lib/effect"
 
 const cache = Layer.mock(RepositoryCache.Service, {
   ensure: () => Effect.die("unexpected Git materialization"),
@@ -17,6 +17,7 @@ const cache = Layer.mock(RepositoryCache.Service, {
 const referenceLayer = AppNodeBuilder.build(LayerNode.group([Reference.node, Bus.node]), [
   [RepositoryCache.node, cache],
 ])
+const referenceIt = testEffect(referenceLayer)
 
 describe("Reference", () => {
   it.effect("prepares batched references before cache work or update events", () => {
@@ -95,10 +96,10 @@ describe("Reference", () => {
           refresh: input.refresh,
         })),
       ).toEqual([{ repository: "owner/repo", branch: "feature/docs", refresh: true }])
-    }).pipe(Effect.provide(referenceLayer))
+    }).pipe(Effect.scoped, Effect.provide(referenceLayer))
   })
 
-  it.effect("lets update listeners replace references and refetch the latest projection", () =>
+  referenceIt.effect("lets update listeners replace references and refetch the latest projection", () =>
     Effect.gen(function* () {
       const references = yield* Reference.Service
       const bus = yield* Bus.Service
@@ -133,13 +134,14 @@ describe("Reference", () => {
 
       expect((yield* references.list()).map((info) => info.path)).toEqual([AbsolutePath.make("/new")])
       expect(observed).toEqual([["/new"], ["/new"]])
-    }).pipe(Effect.provide(referenceLayer)),
+    }),
   )
 
-  it.effect("registers normalized sources for the owning scope", () =>
+  referenceIt.effect("registers normalized sources for the owning scope", () =>
     Effect.gen(function* () {
       const references = yield* Reference.Service
-      const scope = yield* Scope.make()
+      const parent = yield* Effect.scope
+      const scope = yield* Scope.fork(parent)
       const path = AbsolutePath.make("/docs")
       const source = Reference.LocalSource.make({
         type: "local",
@@ -155,10 +157,10 @@ describe("Reference", () => {
 
       yield* Scope.close(scope, Exit.void)
       expect(yield* references.list()).toEqual([])
-    }).pipe(Effect.provide(referenceLayer)),
+    }),
   )
 
-  it.effect("derives Git paths without exposing cache operations", () =>
+  referenceIt.effect("derives Git paths without exposing cache operations", () =>
     Effect.gen(function* () {
       const references = yield* Reference.Service
       const repository = Repository.parseRemote("owner/repo")
@@ -172,10 +174,10 @@ describe("Reference", () => {
           source,
         }),
       ])
-    }).pipe(Effect.scoped, Effect.provide(referenceLayer)),
+    }),
   )
 
-  it.effect("preserves configured Git descriptions", () =>
+  referenceIt.effect("preserves configured Git descriptions", () =>
     Effect.gen(function* () {
       const references = yield* Reference.Service
       const repository = Repository.parseRemote("owner/repo")
@@ -194,6 +196,6 @@ describe("Reference", () => {
           source,
         }),
       ])
-    }).pipe(Effect.scoped, Effect.provide(referenceLayer)),
+    }),
   )
 })

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -430,6 +430,38 @@ describe("State", () => {
     }),
   )
 
+  it.effect("closes a batched observer's owning scope without losing the body's failure", () =>
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const registrations = yield* Scope.make()
+      const owner = yield* Scope.make()
+      yield* Effect.addFinalizer(() =>
+        Deferred.succeed(release, undefined).pipe(
+          Effect.andThen(Scope.close(owner, Exit.void)),
+          Effect.andThen(State.batch(Scope.close(registrations, Exit.void), { flush: false })),
+        ),
+      )
+      const state = State.create({
+        initial: () => ({}),
+        draft: (draft) => draft,
+        notify: () => Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(release))),
+      })
+      const writer = yield* State.batch(
+        state.transform(() => {}).pipe(Scope.provide(registrations), Effect.andThen(Effect.fail("batch body failed"))),
+      ).pipe(Effect.forkIn(owner, { startImmediately: true }))
+      yield* Deferred.await(entered)
+
+      const shutdown = yield* Scope.close(owner, Exit.void).pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("1 millis")
+      expect(shutdown.pollUnsafe()).toBeDefined()
+      expect(yield* Deferred.isDone(release)).toBe(false)
+      const exit = yield* Fiber.await(writer)
+      expect(Exit.hasInterrupts(exit)).toBe(true)
+      if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain("batch body failed")
+    }),
+  )
+
   it.effect("lets batch observers read the other states' accepted changes", () =>
     Effect.gen(function* () {
       const observed: string[][] = []

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -321,6 +321,43 @@ describe("State", () => {
     }),
   )
 
+  it.effect("keeps coalesced reload callers independent of cancellation and shares their notification failure", () =>
+    Effect.gen(function* () {
+      let fail = false
+      let notifications = 0
+      const failure = new Error("notification failed")
+      const state = State.create({
+        initial: () => ({}),
+        draft: (draft) => draft,
+        notify: () =>
+          Effect.sync(() => {
+            notifications++
+            if (fail) throw failure
+          }),
+      })
+      yield* state.transform(() => {})
+      notifications = 0
+      fail = true
+
+      const cancelled = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      const first = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      const second = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* Fiber.interrupt(cancelled)
+      yield* TestClock.adjust("500 millis")
+      const exits = yield* Effect.all([Fiber.await(first), Fiber.await(second)])
+      fail = false
+
+      expect(Exit.hasInterrupts(yield* Fiber.await(cancelled))).toBe(true)
+      expect(exits.map((exit) => Exit.isFailure(exit) && Cause.squash(exit.cause))).toEqual([failure, failure])
+      expect(notifications).toBe(1)
+
+      const recovered = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(recovered)
+      expect(notifications).toBe(2)
+    }),
+  )
+
   it.effect("continues publishing when a reload caller is cancelled while scheduling its worker", () =>
     Effect.gen(function* () {
       let value = "first"

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect } from "bun:test"
 import { State } from "@opencode-ai/core/state"
-import { Deferred, Effect, Exit, Fiber, Layer, Scope } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Scheduler, Scope } from "effect"
 import { TestClock } from "effect/testing"
 import { testEffect } from "./lib/effect"
 
@@ -15,7 +15,7 @@ describe("State", () => {
       const state = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (value: string) => draft.values.push(value) }),
-        finalize: () =>
+        notify: () =>
           block ? Deferred.succeed(rebuilding, undefined).pipe(Effect.andThen(Deferred.await(release))) : Effect.void,
       })
       const scope = yield* Scope.make()
@@ -36,20 +36,20 @@ describe("State", () => {
     }),
   )
 
-  it.effect("commits rebuilt state before finalize runs", () =>
+  it.effect("makes rebuilt state visible before notifying", () =>
     Effect.gen(function* () {
       const observed: string[][] = []
       const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        finalize: () => Effect.sync(() => observed.push([...state.get().values])),
+        notify: () => Effect.sync(() => observed.push([...state.get().values])),
       })
 
       yield* state.transform((draft) => {
         draft.add("value")
       })
 
-      // Update events publish from finalize, so consumers reading on the event
+      // Update events publish from notify, so consumers reading on the event
       // must observe the rebuilt state, not the previous one.
       expect(observed).toEqual([["value"]])
     }),
@@ -76,6 +76,303 @@ describe("State", () => {
     }),
   )
 
+  it.effect("reads registrations and disposals inside a batch without publishing", () =>
+    Effect.gen(function* () {
+      const observed: string[][] = []
+      let replays = 0
+      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () => Effect.sync(() => observed.push([...state.get().values])),
+      })
+      const scope = yield* Scope.make()
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* state
+            .transform((draft) => {
+              replays++
+              draft.add("value")
+            })
+            .pipe(Scope.provide(scope))
+
+          const snapshot = state.get()
+          expect(snapshot.values).toEqual(["value"])
+          expect(state.get()).toBe(snapshot)
+          expect(replays).toBe(1)
+          expect(observed).toEqual([])
+
+          yield* Scope.close(scope, Exit.void)
+          expect(state.get().values).toEqual([])
+          expect(snapshot.values).toEqual(["value"])
+          expect(observed).toEqual([])
+        }),
+      )
+
+      expect(observed).toEqual([[]])
+    }),
+  )
+
+  it.effect("reads a requested reload without waiting for its notification debounce", () =>
+    Effect.gen(function* () {
+      let value = "first"
+      let replays = 0
+      const observed: string[][] = []
+      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () => Effect.sync(() => observed.push([...state.get().values])),
+      })
+      yield* state.transform((draft) => {
+        replays++
+        draft.add(value)
+      })
+      const snapshot = state.get()
+      observed.length = 0
+
+      value = "second"
+      const reload = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("50 millis")
+
+      expect(state.get().values).toEqual(["second"])
+      expect(snapshot.values).toEqual(["first"])
+      expect(replays).toBe(2)
+      expect(observed).toEqual([])
+
+      yield* TestClock.adjust("450 millis")
+      yield* Fiber.join(reload)
+      expect(observed).toEqual([["second"]])
+      expect(replays).toBe(2)
+    }),
+  )
+
+  it.effect("can await reload inside a batch while deferring its notification", () =>
+    Effect.gen(function* () {
+      let value = "first"
+      let notifications = 0
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () => Effect.sync(() => notifications++),
+      })
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* state.transform((draft) => draft.add(value))
+          expect(state.get().values).toEqual(["first"])
+          value = "second"
+          yield* state.reload()
+          expect(state.get().values).toEqual(["second"])
+          expect(notifications).toBe(0)
+        }),
+      )
+
+      expect(notifications).toBe(1)
+    }),
+  )
+
+  it.effect("prepares derived data during reads without running observers", () =>
+    Effect.gen(function* () {
+      let notifications = 0
+      const state = State.create({
+        initial: () => ({ values: [] as string[], joined: "" }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        prepare: (data) => {
+          data.joined = data.values.join(",")
+        },
+        notify: () => Effect.sync(() => notifications++),
+      })
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* state.transform((draft) => draft.add("first"))
+          yield* state.transform((draft) => draft.add("second"))
+          expect(state.get().joined).toBe("first,second")
+          expect(notifications).toBe(0)
+        }),
+      )
+
+      expect(notifications).toBe(1)
+    }),
+  )
+
+  it.effect("keeps replay failures observable without replacing the previous snapshot", () =>
+    Effect.gen(function* () {
+      let fail = false
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        prepare: () => {
+          if (fail) throw new Error("preparation failed")
+        },
+      })
+      yield* state.transform((draft) => draft.add("first"))
+      const snapshot = state.get()
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* state.transform((draft) => draft.add("second"))
+          fail = true
+          expect(() => state.get()).toThrow("preparation failed")
+          expect(() => state.get()).toThrow("preparation failed")
+          expect(snapshot.values).toEqual(["first"])
+          fail = false
+          expect(state.get().values).toEqual(["first", "second"])
+        }),
+      )
+    }),
+  )
+
+  it.effect("allows an observer to await a registration on the same state", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.Scope
+      let added = false
+      const observed: string[][] = []
+      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () =>
+          Effect.gen(function* () {
+            observed.push([...state.get().values])
+            if (added) return
+            added = true
+            yield* state.transform((draft) => draft.add("second")).pipe(Scope.provide(scope))
+          }),
+      })
+
+      yield* state.transform((draft) => draft.add("first"))
+      expect(observed).toEqual([["first"], ["first", "second"]])
+      expect(state.get().values).toEqual(["first", "second"])
+    }),
+  )
+
+  it.effect("allows a debounced observer to await another reload", () =>
+    Effect.gen(function* () {
+      let value = "first"
+      let reloadAgain = false
+      const observed: string[][] = []
+      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () =>
+          Effect.gen(function* () {
+            observed.push([...state.get().values])
+            if (!reloadAgain) return
+            reloadAgain = false
+            value = "third"
+            yield* state.reload()
+          }),
+      })
+      yield* state.transform((draft) => draft.add(value))
+      observed.length = 0
+
+      value = "second"
+      reloadAgain = true
+      const reload = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("1 second")
+      yield* Fiber.join(reload)
+
+      expect(observed).toEqual([["second"], ["third"]])
+      expect(state.get().values).toEqual(["third"])
+    }),
+  )
+
+  it.effect("keeps reload waiters associated with their own notification results", () =>
+    Effect.gen(function* () {
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      let value = "first"
+      let block = false
+      const observed: string[][] = []
+      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () =>
+          Effect.gen(function* () {
+            observed.push([...state.get().values])
+            if (!block) return
+            block = false
+            yield* Deferred.succeed(entered, undefined)
+            yield* Deferred.await(release)
+            return yield* Effect.die(new Error("first notification failed"))
+          }),
+      })
+      yield* state.transform((draft) => draft.add(value))
+      observed.length = 0
+
+      value = "second"
+      block = true
+      const first = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Deferred.await(entered)
+
+      value = "third"
+      const second = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      expect(state.get().values).toEqual(["third"])
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(second)
+      expect(first.pollUnsafe()).toBeUndefined()
+      expect(observed).toEqual([["second"], ["third"]])
+
+      yield* Deferred.succeed(release, undefined)
+      const exit = yield* Fiber.await(first)
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) expect(Cause.pretty(exit.cause)).toContain("first notification failed")
+    }),
+  )
+
+  it.effect("continues publishing when a reload caller is cancelled while scheduling its worker", () =>
+    Effect.gen(function* () {
+      let value = "first"
+      let notifications = 0
+      let interrupted = false
+      const state = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () => Effect.sync(() => notifications++),
+      })
+      yield* state.transform((draft) => draft.add(value))
+      notifications = 0
+
+      value = "second"
+      const cancelled = yield* Effect.withFiber((fiber) => {
+        const base = new Scheduler.MixedScheduler("sync")
+        const scheduler: Scheduler.Scheduler = {
+          executionMode: base.executionMode,
+          // Keep the first scheduled task at the detached worker handoff.
+          shouldYield: () => false,
+          makeDispatcher: () => {
+            const dispatcher = base.makeDispatcher()
+            return {
+              scheduleTask: (task, priority) => {
+                if (!interrupted) {
+                  interrupted = true
+                  fiber.interruptUnsafe()
+                }
+                dispatcher.scheduleTask(task, priority)
+              },
+              flush: () => dispatcher.flush(),
+            }
+          },
+        }
+        return state.reload().pipe(Effect.provideService(Scheduler.Scheduler, scheduler))
+      }).pipe(Effect.forkChild({ startImmediately: true }))
+      const exit = yield* Fiber.await(cancelled)
+      expect(interrupted).toBe(true)
+      expect(Exit.hasInterrupts(exit)).toBe(true)
+      expect(state.get().values).toEqual(["second"])
+      yield* TestClock.adjust("500 millis")
+      expect(notifications).toBe(1)
+
+      value = "third"
+      const reload = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(reload)
+      expect(state.get().values).toEqual(["third"])
+      expect(notifications).toBe(2)
+    }),
+  )
+
   it.effect("disposes a transform once and rebuilds remaining state", () =>
     Effect.gen(function* () {
       const state = State.create({
@@ -98,18 +395,18 @@ describe("State", () => {
     }),
   )
 
-  it.effect("batches automatic rebuilds", () =>
+  it.effect("batches notifications", () =>
     Effect.gen(function* () {
       let finalized = 0
       const first = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        finalize: () => Effect.sync(() => finalized++),
+        notify: () => Effect.sync(() => finalized++),
       })
       const second = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        finalize: () => Effect.sync(() => finalized++),
+        notify: () => Effect.sync(() => finalized++),
       })
 
       yield* State.batch(
@@ -133,14 +430,91 @@ describe("State", () => {
     }),
   )
 
+  it.effect("lets batch observers read the other states' accepted changes", () =>
+    Effect.gen(function* () {
+      const observed: string[][] = []
+      const first = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+        notify: () => Effect.sync(() => observed.push([...second.get().values])),
+      })
+      const second = State.create({
+        initial: () => ({ values: [] as string[] }),
+        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      })
+
+      yield* State.batch(
+        Effect.gen(function* () {
+          yield* first.transform((draft) => draft.add("first"))
+          yield* second.transform((draft) => draft.add("second"))
+        }),
+      )
+
+      expect(observed).toEqual([["second"]])
+    }),
+  )
+  ;["replay", "notification"].forEach((failure) =>
+    it.effect(`notifies the other states when a batch ${failure} fails`, () =>
+      Effect.gen(function* () {
+        let fail = true
+        const observed: string[] = []
+        const first = State.create({
+          initial: () => ({}),
+          draft: (draft) => draft,
+          notify: () => Effect.sync(() => observed.push("first")),
+        })
+        const failing = State.create({
+          initial: () => ({}),
+          draft: (draft) => draft,
+          prepare: () => {
+            if (fail && failure === "replay") throw new Error("replay failed")
+          },
+          notify: () =>
+            fail ? Effect.die(new Error("notification failed")) : Effect.sync(() => observed.push("failing")),
+        })
+        const last = State.create({
+          initial: () => ({}),
+          draft: (draft) => draft,
+          notify: () => Effect.sync(() => observed.push("last")),
+        })
+
+        const exit = yield* State.batch(
+          Effect.gen(function* () {
+            yield* first.transform(() => {})
+            yield* failing.transform(() => {})
+            yield* last.transform(() => {})
+            return yield* Effect.die(new Error("batch failed"))
+          }),
+        ).pipe(Effect.exit)
+        fail = false
+
+        expect(observed).toEqual(["first", "last"])
+        expect(Exit.isFailure(exit)).toBe(true)
+        if (Exit.isFailure(exit)) {
+          expect(Cause.pretty(exit.cause)).toContain("batch failed")
+          expect(Cause.pretty(exit.cause)).toContain(`${failure} failed`)
+        }
+
+        const reload = yield* failing.reload().pipe(Effect.forkChild({ startImmediately: true }))
+        yield* TestClock.adjust("500 millis")
+        yield* Fiber.join(reload)
+        expect(observed).toEqual(["first", "last", "failing"])
+      }),
+    ),
+  )
+
   it.effect("discards teardown rebuilds and pending reloads while still running cleanup", () =>
     Effect.gen(function* () {
       let finalized = 0
+      let prepared = 0
       let disposed = 0
       const state = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        finalize: () => Effect.sync(() => finalized++),
+        prepare: () => {
+          prepared++
+        },
+        notify: () => Effect.sync(() => finalized++),
       })
       const scope = yield* Scope.make()
       yield* Scope.addFinalizer(
@@ -148,19 +522,25 @@ describe("State", () => {
         Effect.sync(() => disposed++),
       )
       const registration = yield* state.transform((draft) => draft.add("value")).pipe(Scope.provide(scope))
+      const snapshot = state.get()
       expect(finalized).toBe(1)
+      expect(prepared).toBe(1)
 
       const pending = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
       yield* TestClock.adjust("250 millis")
       yield* State.batch(Scope.close(scope, Exit.void), { flush: false })
       expect(disposed).toBe(1)
       expect(finalized).toBe(1)
+      expect(state.get()).toBe(snapshot)
+      expect(prepared).toBe(1)
 
       yield* TestClock.adjust("500 millis")
       yield* Fiber.join(pending)
       yield* registration.dispose
       yield* state.reload()
       expect(finalized).toBe(1)
+      expect(state.get()).toBe(snapshot)
+      expect(prepared).toBe(1)
     }),
   )
 
@@ -170,12 +550,12 @@ describe("State", () => {
       const closing = State.create({
         initial: () => ({}),
         draft: (draft) => draft,
-        finalize: () => Effect.sync(() => finalized.push("closing")),
+        notify: () => Effect.sync(() => finalized.push("closing")),
       })
       const live = State.create({
         initial: () => ({}),
         draft: (draft) => draft,
-        finalize: () => Effect.sync(() => finalized.push("live")),
+        notify: () => Effect.sync(() => finalized.push("live")),
       })
       const scope = yield* Scope.make()
       yield* closing.transform(() => {}).pipe(Scope.provide(scope))
@@ -197,7 +577,7 @@ describe("State", () => {
       const state = State.create({
         initial: () => ({ values: [] as string[] }),
         draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        finalize: () => Effect.sync(() => finalized++),
+        notify: () => Effect.sync(() => finalized++),
       })
       yield* state.transform((draft) => {
         draft.add("value")

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -1,10 +1,18 @@
 import { describe, expect } from "bun:test"
 import { State } from "@opencode-ai/core/state"
-import { Cause, Deferred, Effect, Exit, Fiber, Layer, Scheduler, Scope } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Scheduler, Scope } from "effect"
 import { TestClock } from "effect/testing"
-import { testEffect } from "./lib/effect"
+import { it } from "./lib/effect"
 
-const it = testEffect(Layer.empty)
+function valuesState(
+  hooks: Pick<State.Options<{ values: string[] }, { add: (item: string) => void }>, "prepare" | "notify"> = {},
+) {
+  return State.create({
+    initial: () => ({ values: new Array<string>() }),
+    draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+    ...hooks,
+  })
+}
 
 describe("State", () => {
   it.effect("commits a transform atomically when its updater is interrupted", () =>
@@ -12,17 +20,13 @@ describe("State", () => {
       const rebuilding = yield* Deferred.make<void>()
       const release = yield* Deferred.make<void>()
       let block = true
-      const state = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (value: string) => draft.values.push(value) }),
+      const state = valuesState({
         notify: () =>
           block ? Deferred.succeed(rebuilding, undefined).pipe(Effect.andThen(Deferred.await(release))) : Effect.void,
       })
       const scope = yield* Scope.make()
       const fiber = yield* state
-        .transform((editor) => {
-          editor.add("registered")
-        })
+        .transform((editor) => editor.add("registered"))
         .pipe(Scope.provide(scope), Effect.forkChild)
       yield* Deferred.await(rebuilding)
       const interruption = yield* Fiber.interrupt(fiber).pipe(Effect.forkChild)
@@ -39,15 +43,11 @@ describe("State", () => {
   it.effect("makes rebuilt state visible before notifying", () =>
     Effect.gen(function* () {
       const observed: string[][] = []
-      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const state: ReturnType<typeof valuesState> = valuesState({
         notify: () => Effect.sync(() => observed.push([...state.get().values])),
       })
 
-      yield* state.transform((draft) => {
-        draft.add("value")
-      })
+      yield* state.transform((draft) => draft.add("value"))
 
       // Update events publish from notify, so consumers reading on the event
       // must observe the rebuilt state, not the previous one.
@@ -58,14 +58,9 @@ describe("State", () => {
   it.effect("runs transforms during every reload", () =>
     Effect.gen(function* () {
       let value = "first"
-      const state = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-      })
+      const state = valuesState()
 
-      yield* state.transform((editor) => {
-        editor.add(value)
-      })
+      yield* state.transform((editor) => editor.add(value))
       expect(state.get().values).toEqual(["first"])
 
       value = "second"
@@ -80,9 +75,7 @@ describe("State", () => {
     Effect.gen(function* () {
       const observed: string[][] = []
       let replays = 0
-      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const state: ReturnType<typeof valuesState> = valuesState({
         notify: () => Effect.sync(() => observed.push([...state.get().values])),
       })
       const scope = yield* Scope.make()
@@ -118,9 +111,7 @@ describe("State", () => {
       let value = "first"
       let replays = 0
       const observed: string[][] = []
-      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const state: ReturnType<typeof valuesState> = valuesState({
         notify: () => Effect.sync(() => observed.push([...state.get().values])),
       })
       yield* state.transform((draft) => {
@@ -150,11 +141,7 @@ describe("State", () => {
     Effect.gen(function* () {
       let value = "first"
       let notifications = 0
-      const state = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        notify: () => Effect.sync(() => notifications++),
-      })
+      const state = valuesState({ notify: () => Effect.sync(() => notifications++) })
 
       yield* State.batch(
         Effect.gen(function* () {
@@ -199,9 +186,7 @@ describe("State", () => {
   it.effect("keeps replay failures observable without replacing the previous snapshot", () =>
     Effect.gen(function* () {
       let fail = false
-      const state = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const state = valuesState({
         prepare: () => {
           if (fail) throw new Error("preparation failed")
         },
@@ -228,9 +213,7 @@ describe("State", () => {
       const scope = yield* Scope.Scope
       let added = false
       const observed: string[][] = []
-      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const state: ReturnType<typeof valuesState> = valuesState({
         notify: () =>
           Effect.gen(function* () {
             observed.push([...state.get().values])
@@ -251,9 +234,7 @@ describe("State", () => {
       let value = "first"
       let reloadAgain = false
       const observed: string[][] = []
-      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const state: ReturnType<typeof valuesState> = valuesState({
         notify: () =>
           Effect.gen(function* () {
             observed.push([...state.get().values])
@@ -284,9 +265,7 @@ describe("State", () => {
       let value = "first"
       let block = false
       const observed: string[][] = []
-      const state: State.Interface<{ values: string[] }, { add: (item: string) => void }> = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const state: ReturnType<typeof valuesState> = valuesState({
         notify: () =>
           Effect.gen(function* () {
             observed.push([...state.get().values])
@@ -298,6 +277,8 @@ describe("State", () => {
           }),
       })
       yield* state.transform((draft) => draft.add(value))
+      // Release the detached worker before the earlier registration finalizer runs.
+      yield* Effect.addFinalizer(() => Deferred.succeed(release, undefined))
       observed.length = 0
 
       value = "second"
@@ -344,7 +325,7 @@ describe("State", () => {
       const second = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
       yield* Fiber.interrupt(cancelled)
       yield* TestClock.adjust("500 millis")
-      const exits = yield* Effect.all([Fiber.await(first), Fiber.await(second)])
+      const exits = yield* Fiber.awaitAll([first, second])
       fail = false
 
       expect(Exit.hasInterrupts(yield* Fiber.await(cancelled))).toBe(true)
@@ -363,11 +344,7 @@ describe("State", () => {
       let value = "first"
       let notifications = 0
       let interrupted = false
-      const state = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        notify: () => Effect.sync(() => notifications++),
-      })
+      const state = valuesState({ notify: () => Effect.sync(() => notifications++) })
       yield* state.transform((draft) => draft.add(value))
       notifications = 0
 
@@ -412,16 +389,9 @@ describe("State", () => {
 
   it.effect("disposes a transform once and rebuilds remaining state", () =>
     Effect.gen(function* () {
-      const state = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-      })
-      yield* state.transform((editor) => {
-        editor.add("first")
-      })
-      const registration = yield* state.transform((editor) => {
-        editor.add("second")
-      })
+      const state = valuesState()
+      yield* state.transform((editor) => editor.add("first"))
+      const registration = yield* state.transform((editor) => editor.add("second"))
       expect(state.get().values).toEqual(["first", "second"])
 
       yield* registration.dispose
@@ -434,36 +404,22 @@ describe("State", () => {
 
   it.effect("batches notifications", () =>
     Effect.gen(function* () {
-      let finalized = 0
-      const first = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        notify: () => Effect.sync(() => finalized++),
-      })
-      const second = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        notify: () => Effect.sync(() => finalized++),
-      })
+      let notifications = 0
+      const first = valuesState({ notify: () => Effect.sync(() => notifications++) })
+      const second = valuesState({ notify: () => Effect.sync(() => notifications++) })
 
       yield* State.batch(
         Effect.gen(function* () {
-          yield* first.transform((draft) => {
-            draft.add("first")
-          })
-          yield* first.transform((draft) => {
-            draft.add("second")
-          })
-          yield* second.transform((draft) => {
-            draft.add("third")
-          })
-          expect(finalized).toBe(0)
+          yield* first.transform((draft) => draft.add("first"))
+          yield* first.transform((draft) => draft.add("second"))
+          yield* second.transform((draft) => draft.add("third"))
+          expect(notifications).toBe(0)
         }),
       )
 
       expect(first.get().values).toEqual(["first", "second"])
       expect(second.get().values).toEqual(["third"])
-      expect(finalized).toBe(2)
+      expect(notifications).toBe(2)
     }),
   )
 
@@ -502,15 +458,10 @@ describe("State", () => {
   it.effect("lets batch observers read the other states' accepted changes", () =>
     Effect.gen(function* () {
       const observed: string[][] = []
-      const first = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const first = valuesState({
         notify: () => Effect.sync(() => observed.push([...second.get().values])),
       })
-      const second = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-      })
+      const second = valuesState()
 
       yield* State.batch(
         Effect.gen(function* () {
@@ -574,16 +525,14 @@ describe("State", () => {
 
   it.effect("discards teardown rebuilds and pending reloads while still running cleanup", () =>
     Effect.gen(function* () {
-      let finalized = 0
+      let notifications = 0
       let prepared = 0
       let disposed = 0
-      const state = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
+      const state = valuesState({
         prepare: () => {
           prepared++
         },
-        notify: () => Effect.sync(() => finalized++),
+        notify: () => Effect.sync(() => notifications++),
       })
       const scope = yield* Scope.make()
       yield* Scope.addFinalizer(
@@ -592,14 +541,14 @@ describe("State", () => {
       )
       const registration = yield* state.transform((draft) => draft.add("value")).pipe(Scope.provide(scope))
       const snapshot = state.get()
-      expect(finalized).toBe(1)
+      expect(notifications).toBe(1)
       expect(prepared).toBe(1)
 
       const pending = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
       yield* TestClock.adjust("250 millis")
       yield* State.batch(Scope.close(scope, Exit.void), { flush: false })
       expect(disposed).toBe(1)
-      expect(finalized).toBe(1)
+      expect(notifications).toBe(1)
       expect(state.get()).toBe(snapshot)
       expect(prepared).toBe(1)
 
@@ -607,7 +556,7 @@ describe("State", () => {
       yield* Fiber.join(pending)
       yield* registration.dispose
       yield* state.reload()
-      expect(finalized).toBe(1)
+      expect(notifications).toBe(1)
       expect(state.get()).toBe(snapshot)
       expect(prepared).toBe(1)
     }),
@@ -615,20 +564,20 @@ describe("State", () => {
 
   it.effect("keeps teardown suppression separate from an enclosing live batch", () =>
     Effect.gen(function* () {
-      const finalized: string[] = []
+      const notifications: string[] = []
       const closing = State.create({
         initial: () => ({}),
         draft: (draft) => draft,
-        notify: () => Effect.sync(() => finalized.push("closing")),
+        notify: () => Effect.sync(() => notifications.push("closing")),
       })
       const live = State.create({
         initial: () => ({}),
         draft: (draft) => draft,
-        notify: () => Effect.sync(() => finalized.push("live")),
+        notify: () => Effect.sync(() => notifications.push("live")),
       })
       const scope = yield* Scope.make()
       yield* closing.transform(() => {}).pipe(Scope.provide(scope))
-      finalized.length = 0
+      notifications.length = 0
 
       yield* State.batch(
         Effect.gen(function* () {
@@ -636,33 +585,27 @@ describe("State", () => {
           yield* State.batch(Scope.close(scope, Exit.void), { flush: false })
         }),
       )
-      expect(finalized).toEqual(["live"])
+      expect(notifications).toEqual(["live"])
     }),
   )
 
   it.effect("debounces reload bursts", () =>
     Effect.gen(function* () {
-      let finalized = 0
-      const state = State.create({
-        initial: () => ({ values: [] as string[] }),
-        draft: (draft) => ({ add: (item: string) => draft.values.push(item) }),
-        notify: () => Effect.sync(() => finalized++),
-      })
-      yield* state.transform((draft) => {
-        draft.add("value")
-      })
-      finalized = 0
+      let notifications = 0
+      const state = valuesState({ notify: () => Effect.sync(() => notifications++) })
+      yield* state.transform((draft) => draft.add("value"))
+      notifications = 0
 
       const first = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
       yield* TestClock.adjust("250 millis")
       const second = yield* state.reload().pipe(Effect.forkChild({ startImmediately: true }))
       yield* TestClock.adjust("499 millis")
-      expect(finalized).toBe(0)
+      expect(notifications).toBe(0)
       yield* TestClock.adjust("1 millis")
       yield* Fiber.join(first)
       yield* Fiber.join(second)
 
-      expect(finalized).toBe(1)
+      expect(notifications).toBe(1)
     }),
   )
 })

--- a/packages/core/test/tool-registry.test.ts
+++ b/packages/core/test/tool-registry.test.ts
@@ -311,7 +311,7 @@ describe("Tool", () => {
     }),
   )
 
-  it.effect("replays empty sources on reload and keeps advertised snapshots", () =>
+  it.effect("reads refreshed sources before notifications and keeps advertised snapshots", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
       let source: Info[] = []
@@ -321,24 +321,24 @@ describe("Tool", () => {
       const tool = { ...constant("first"), name: "echo", options: { codemode: false } }
       source = [tool]
       const first = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
-      yield* TestClock.adjust("500 millis")
-      yield* Fiber.join(first)
       const advertised = yield* service.snapshot()
       expect((yield* advertised.execute(call("echo"))).output).toEqual({ text: "first" })
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(first)
 
       tool.execute = constant("second").execute
       expect((yield* advertised.execute(call("echo"))).output).toEqual({ text: "first" })
       const second = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      expect((yield* executeTool(service, call("echo"))).output).toEqual({ text: "second" })
       yield* TestClock.adjust("500 millis")
       yield* Fiber.join(second)
-      expect((yield* executeTool(service, call("echo"))).output).toEqual({ text: "second" })
       expect((yield* advertised.execute(call("echo"))).output).toEqual({ text: "first" })
 
       source = []
       const removed = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      expect((yield* service.snapshot()).definitions.map((tool) => tool.name)).toEqual(["execute"])
       yield* TestClock.adjust("500 millis")
       yield* Fiber.join(removed)
-      expect((yield* service.snapshot()).definitions.map((tool) => tool.name)).toEqual(["execute"])
       expect((yield* advertised.execute(call("echo"))).output).toEqual({ text: "first" })
     }),
   )
@@ -370,7 +370,7 @@ describe("Tool", () => {
     }),
   )
 
-  it.effect("batches tool publication and suppresses terminal teardown replay", () =>
+  it.effect("batches tool notifications with fresh snapshots and suppresses terminal teardown replay", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
       const runs: string[] = []
@@ -386,7 +386,8 @@ describe("Tool", () => {
             draft.add({ ...constant("overlay"), name: "echo", options: { codemode: false } })
           })
           expect(runs).toEqual([])
-          expect((yield* service.snapshot()).definitions.map((tool) => tool.name)).toEqual(["execute"])
+          expect((yield* service.snapshot()).definitions.map((tool) => tool.name)).toEqual(["echo", "execute"])
+          expect(runs).toEqual(["base", "overlay"])
         }).pipe(Scope.provide(scope)),
       )
 
@@ -545,23 +546,32 @@ describe("Tool", () => {
     }),
   )
 
-  it.effect("logs invalid tool definitions without dropping healthy tools", () => {
+  it.effect("compiles healthy tools before notifying invalid definition diagnostics", () => {
     const output: unknown[] = []
     const logger = Logger.map(Logger.formatStructured, (entry) => {
       output.push(entry.message)
     })
     return Effect.gen(function* () {
       const service = yield* Tool.Service
-      yield* service.transform((draft) => {
-        draft.add({ ...make(), name: "healthy", options: { codemode: false } })
-        draft.add({
-          name: "phone_type",
-          input: Schema.Struct({}),
-          execute: () => Effect.succeed({ content: "ok" }),
-          options: { codemode: false },
-        } as unknown as Info)
-        draft.add({ ...make(), name: "codemode" })
-      })
+      const snapshot = yield* State.batch(
+        Effect.gen(function* () {
+          yield* service.transform((draft) => {
+            draft.add({ ...make(), name: "healthy", options: { codemode: false } })
+            draft.add({
+              name: "phone_type",
+              input: Schema.Struct({}),
+              execute: () => Effect.succeed({ content: "ok" }),
+              options: { codemode: false },
+            } as unknown as Info)
+            draft.add({ ...make(), name: "codemode" })
+          })
+          const snapshot = yield* service.snapshot()
+          expect(snapshot.definitions.map((tool) => tool.name)).toEqual(["healthy", "execute"])
+          expect(snapshot.codeModeCatalog?.map((tool) => tool.path)).toEqual(["codemode"])
+          expect(output).toEqual([])
+          return snapshot
+        }),
+      )
 
       expect(output).toEqual([
         [
@@ -573,9 +583,6 @@ describe("Tool", () => {
           },
         ],
       ])
-      const snapshot = yield* service.snapshot()
-      expect(snapshot.definitions.map((tool) => tool.name)).toEqual(["healthy", "execute"])
-      expect(snapshot.codeModeCatalog?.map((tool) => tool.path)).toEqual(["codemode"])
       expect((yield* snapshot.execute(call("phone_type")).pipe(Effect.flip)).message).toBe("Unknown tool: phone_type")
     }).pipe(Effect.provide(Logger.layer([logger])))
   })

--- a/packages/core/test/vcs.test.ts
+++ b/packages/core/test/vcs.test.ts
@@ -2,12 +2,13 @@ import { $ } from "bun"
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Cause, Effect, Exit, Fiber, Layer, Stream } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Schema, Scope, Stream } from "effect"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { AppProcess } from "@opencode-ai/util/process"
 import { Bus } from "@opencode-ai/core/bus"
 import { Location } from "@opencode-ai/core/location"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { State } from "@opencode-ai/core/state"
 import { Vcs } from "@opencode-ai/core/vcs"
 import { VcsGitPlugin } from "@opencode-ai/core/plugin/vcs/git"
 import type { VcsDefinition, VcsDiffInput } from "@opencode-ai/plugin/effect/vcs"
@@ -205,6 +206,98 @@ describe("Vcs", () => {
         yield* Fiber.interrupt(fiber)
         const exit = yield* Fiber.await(fiber)
         expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBeTrue()
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("serializes filesystem and config refreshes while reading the latest desired provider", () =>
+    withGit((directory) =>
+      Effect.gen(function* () {
+        const vcs = yield* Vcs.Service
+        const bus = yield* Bus.Service
+        const started = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        const accepted = yield* Deferred.make<void>()
+        const reads: string[] = []
+        yield* vcs.transform((draft) =>
+          draft.add(
+            provider({
+              id: "git",
+              info: () =>
+                Effect.gen(function* () {
+                  reads.push(reads.length === 0 ? "initial" : "filesystem")
+                  if (reads.length === 1) return { branch: { current: "initial" } }
+                  yield* Deferred.succeed(started, undefined)
+                  yield* Deferred.await(release)
+                  return { branch: { current: "filesystem" } }
+                }),
+            }),
+          ),
+        )
+        const updates = yield* bus
+          .subscribe(VcsEvent.BranchUpdated)
+          .pipe(Stream.take(2), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+
+        yield* Effect.gen(function* () {
+          yield* bus.publish(FileSystem.Event.Changed, { file: path.join(directory, ".git", "HEAD"), event: "change" })
+          yield* Deferred.await(started)
+          const configured = yield* State.batch(
+            Effect.gen(function* () {
+              yield* vcs.transform((draft) =>
+                draft.add(
+                  provider({
+                    id: "git",
+                    info: () =>
+                      Effect.sync(() => {
+                        reads.push("config")
+                        return { branch: { current: "config" } }
+                      }),
+                    status: () => Effect.succeed([{ file: "config.txt", additions: 1, deletions: 0, status: "added" }]),
+                  }),
+                ),
+              )
+              expect((yield* vcs.status())[0]?.file).toBe("config.txt")
+              expect(yield* vcs.info()).toEqual({ branch: { current: "initial" } })
+              yield* Deferred.succeed(accepted, undefined)
+            }),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Deferred.await(accepted)
+          expect(reads).toEqual(["initial", "filesystem"])
+
+          yield* Deferred.succeed(release, undefined)
+          yield* Fiber.join(configured)
+          expect((yield* Fiber.join(updates)).at(-1)?.data.branch).toBe("config")
+          expect(yield* vcs.info()).toEqual({ branch: { current: "config" } })
+          expect(reads).toEqual(["initial", "filesystem", "config"])
+        }).pipe(Effect.ensuring(Deferred.succeed(release, undefined)))
+      }),
+    ),
+  )
+
+  it.live("allows branch listeners to change the selected provider", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const vcs = yield* Vcs.Service
+        const bus = yield* Bus.Service
+        const scope = yield* Effect.scope
+        const unsubscribe = yield* bus.listen((event) => {
+          if (
+            event.type !== VcsEvent.BranchUpdated.type ||
+            Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch !== "feature"
+          )
+            return Effect.void
+          return vcs
+            .transform((draft) =>
+              draft.add(provider({ info: () => Effect.succeed({ branch: { current: "listener" } }) })),
+            )
+            .pipe(Scope.provide(scope), Effect.asVoid)
+        })
+        yield* vcs.transform((draft) => {
+          draft.add(provider())
+          draft.default.set("custom")
+        })
+        expect(yield* vcs.info()).toEqual({ branch: { current: "listener" } })
+        yield* unsubscribe
       }).pipe(provide(directory)),
     ),
   )

--- a/packages/core/test/vcs.test.ts
+++ b/packages/core/test/vcs.test.ts
@@ -19,6 +19,8 @@ import { tmpdir } from "./fixture/tmpdir"
 import { it } from "./lib/effect"
 import { host } from "./plugin/host"
 
+const Done = Bus.ephemeral({ type: "test.vcs.done", schema: {} })
+
 const provide = (directory: string, input: { git?: boolean } = {}) =>
   Effect.provide(
     LayerNode.compile(LayerNode.group([Vcs.node, Bus.node, Location.node, AppProcess.node]), [
@@ -274,12 +276,17 @@ describe("Vcs", () => {
     ),
   )
 
-  it.live("allows branch listeners to change the selected provider", () =>
+  it.live("keeps branch streams current when listeners change the selected provider", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
         const vcs = yield* Vcs.Service
         const bus = yield* Bus.Service
         const scope = yield* Effect.scope
+        const updates = yield* bus.subscribe([VcsEvent.BranchUpdated, Done]).pipe(
+          Stream.takeUntil((event) => event.type === Done.type),
+          Stream.runCollect,
+          Effect.forkScoped({ startImmediately: true }),
+        )
         const unsubscribe = yield* bus.listen((event) => {
           if (
             event.type !== VcsEvent.BranchUpdated.type ||
@@ -292,12 +299,61 @@ describe("Vcs", () => {
             )
             .pipe(Scope.provide(scope), Effect.asVoid)
         })
-        yield* vcs.transform((draft) => {
-          draft.add(provider())
-          draft.default.set("custom")
-        })
-        expect(yield* vcs.info()).toEqual({ branch: { current: "listener" } })
-        yield* unsubscribe
+        yield* Effect.gen(function* () {
+          yield* vcs.transform((draft) => {
+            draft.add(provider())
+            draft.default.set("custom")
+          })
+          yield* bus.publish(Done, {})
+          const events = (yield* Fiber.join(updates)).filter((event) => event.type === VcsEvent.BranchUpdated.type)
+          expect(yield* vcs.info()).toEqual({ branch: { current: "listener" } })
+          expect(events.length).toBeGreaterThanOrEqual(2)
+          expect(events.at(-1)?.data.branch).toBe((yield* vcs.info()).branch.current)
+        }).pipe(Effect.ensuring(unsubscribe))
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("does not roll back branch streams when an older listener finishes late", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const vcs = yield* Vcs.Service
+        const bus = yield* Bus.Service
+        const entered = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        const updates = yield* bus.subscribe([VcsEvent.BranchUpdated, Done]).pipe(
+          Stream.takeUntil((event) => event.type === Done.type),
+          Stream.runCollect,
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        const unsubscribe = yield* bus.listen((event) =>
+          event.type === VcsEvent.BranchUpdated.type &&
+          Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch === "older"
+            ? Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(release)))
+            : Effect.void,
+        )
+
+        yield* Effect.gen(function* () {
+          const older = yield* vcs
+            .transform((draft) => {
+              draft.add(provider({ info: () => Effect.succeed({ branch: { current: "older" } }) }))
+              draft.default.set("custom")
+            })
+            .pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Deferred.await(entered)
+          yield* vcs.transform((draft) =>
+            draft.add(provider({ info: () => Effect.succeed({ branch: { current: "newer" } }) })),
+          )
+          expect(older.pollUnsafe()).toBeUndefined()
+          expect((yield* vcs.info()).branch.current).toBe("newer")
+
+          yield* Deferred.succeed(release, undefined)
+          yield* Fiber.join(older)
+          yield* bus.publish(Done, {})
+          const events = (yield* Fiber.join(updates)).filter((event) => event.type === VcsEvent.BranchUpdated.type)
+          expect(events.length).toBeGreaterThanOrEqual(2)
+          expect(events.at(-1)?.data.branch).toBe((yield* vcs.info()).branch.current)
+        }).pipe(Effect.ensuring(Deferred.succeed(release, undefined).pipe(Effect.andThen(unsubscribe))))
       }).pipe(provide(directory)),
     ),
   )

--- a/packages/core/test/vcs.test.ts
+++ b/packages/core/test/vcs.test.ts
@@ -2,7 +2,7 @@ import { $ } from "bun"
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Cause, Context, Deferred, Effect, Exit, Fiber, Layer, Schema, Scope, Stream } from "effect"
+import { Cause, Context, Deferred, Effect, Exit, Fiber, Layer, Option, Schema, Scope, Stream } from "effect"
 import { TestClock } from "effect/testing"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { AppProcess } from "@opencode-ai/util/process"
@@ -15,26 +15,27 @@ import { VcsGitPlugin } from "@opencode-ai/core/plugin/vcs/git"
 import type { VcsDefinition, VcsDiffInput } from "@opencode-ai/plugin/effect/vcs"
 import { FileSystem } from "@opencode-ai/schema/filesystem"
 import { VcsEvent } from "@opencode-ai/schema/vcs-event"
-import { location } from "./fixture/location"
+import { locationLayer } from "./fixture/location"
 import { tmpdir } from "./fixture/tmpdir"
-import { it } from "./lib/effect"
+import { it, testEffect } from "./lib/effect"
 import { host } from "./plugin/host"
 
 const Done = Bus.ephemeral({ type: "test.vcs.done", schema: {} })
+
+const synthetic = testEffect(
+  LayerNode.compile(LayerNode.group([Vcs.node, Bus.node, Location.node]), [
+    [Location.node, locationLayer({ directory: AbsolutePath.make(import.meta.dir) })],
+  ]),
+)
 
 const provide = (directory: string, input: { git?: boolean } = {}) =>
   Effect.provide(
     LayerNode.compile(LayerNode.group([Vcs.node, Bus.node, Location.node, AppProcess.node]), [
       [
         Location.node,
-        Layer.succeed(
-          Location.Service,
-          Location.Service.of(
-            location(
-              { directory: AbsolutePath.make(directory) },
-              input.git ? { vcs: { type: "git", store: AbsolutePath.make(path.join(directory, ".git")) } } : {},
-            ),
-          ),
+        locationLayer(
+          { directory: AbsolutePath.make(directory) },
+          input.git ? { vcs: { type: "git", store: AbsolutePath.make(path.join(directory, ".git")) } } : {},
         ),
       ],
     ]),
@@ -88,40 +89,36 @@ const provider = (input: Partial<VcsDefinition> = {}) =>
   }) satisfies VcsDefinition
 
 describe("Vcs", () => {
-  it.live("returns empty results outside version control", () =>
-    withTmp((directory) =>
-      Effect.gen(function* () {
-        const vcs = yield* Vcs.Service
-        expect(yield* vcs.info()).toEqual({ branch: {} })
-        expect(yield* vcs.branches()).toEqual([])
-        expect(yield* vcs.status()).toEqual([])
-        expect(yield* vcs.diff("working")).toEqual([])
-        expect(yield* vcs.diff("branch")).toEqual([])
-      }).pipe(provide(directory)),
-    ),
+  synthetic.effect("returns empty results outside version control", () =>
+    Effect.gen(function* () {
+      const vcs = yield* Vcs.Service
+      expect(yield* vcs.info()).toEqual({ branch: {} })
+      expect(yield* vcs.branches()).toEqual([])
+      expect(yield* vcs.status()).toEqual([])
+      expect(yield* vcs.diff("working")).toEqual([])
+      expect(yield* vcs.diff("branch")).toEqual([])
+    }),
   )
 
-  it.live("serves scoped providers and restores the fallback after disposal", () =>
-    withTmp((directory) =>
-      Effect.gen(function* () {
-        const vcs = yield* Vcs.Service
-        const registration = yield* vcs.transform((draft) => {
-          draft.add(provider())
-          draft.default.set("custom")
-        })
+  synthetic.effect("serves scoped providers and restores the fallback after disposal", () =>
+    Effect.gen(function* () {
+      const vcs = yield* Vcs.Service
+      const registration = yield* vcs.transform((draft) => {
+        draft.add(provider())
+        draft.default.set("custom")
+      })
 
-        expect(yield* vcs.info()).toEqual({ branch: { current: "feature", default: "main" } })
-        expect(yield* vcs.branches()).toEqual(["feature", "main"])
-        expect(yield* vcs.status()).toEqual([{ file: "file.txt", additions: 1, deletions: 0, status: "added" }])
-        expect(yield* vcs.diff("working")).toEqual([
-          { file: "file.txt", patch: "+hello", additions: 1, deletions: 0, status: "added" },
-        ])
+      expect(yield* vcs.info()).toEqual({ branch: { current: "feature", default: "main" } })
+      expect(yield* vcs.branches()).toEqual(["feature", "main"])
+      expect(yield* vcs.status()).toEqual([{ file: "file.txt", additions: 1, deletions: 0, status: "added" }])
+      expect(yield* vcs.diff("working")).toEqual([
+        { file: "file.txt", patch: "+hello", additions: 1, deletions: 0, status: "added" },
+      ])
 
-        yield* registration.dispose
-        expect(yield* vcs.info()).toEqual({ branch: {} })
-        expect(yield* vcs.status()).toEqual([])
-      }).pipe(provide(directory)),
-    ),
+      yield* registration.dispose
+      expect(yield* vcs.info()).toEqual({ branch: {} })
+      expect(yield* vcs.status()).toEqual([])
+    }),
   )
 
   it.live("automatically selects a provider matching the resolved repository", () =>
@@ -137,91 +134,88 @@ describe("Vcs", () => {
     ),
   )
 
-  it.live("passes location scope and bounded diff options to providers", () =>
-    withTmp((directory) =>
-      Effect.gen(function* () {
-        const observed: VcsDiffInput[] = []
-        const vcs = yield* Vcs.Service
-        yield* vcs.transform((draft) => {
-          draft.add(
-            provider({
-              diff: (input) =>
-                Effect.sync(() => {
-                  observed.push(input)
-                  return [{ file: "file.txt", patch: "+hello", additions: 1, deletions: 0, status: "added" }]
-                }),
-            }),
-          )
-          draft.default.set("custom")
-        })
+  synthetic.effect("passes location scope and bounded diff options to providers", () =>
+    Effect.gen(function* () {
+      const observed: VcsDiffInput[] = []
+      const vcs = yield* Vcs.Service
+      const location = yield* Location.Service
+      yield* vcs.transform((draft) => {
+        draft.add(
+          provider({
+            diff: (input) =>
+              Effect.sync(() => {
+                observed.push(input)
+                return [{ file: "file.txt", patch: "+hello", additions: 1, deletions: 0, status: "added" }]
+              }),
+          }),
+        )
+        draft.default.set("custom")
+      })
 
-        yield* vcs.diff("branch", { context: 3 })
-        expect(observed).toEqual([
-          {
-            directory,
-            worktree: directory,
-            canonical: directory,
-            mode: "branch",
-            context: 3,
-            maxOutputBytes: 10_000_000,
-          },
-        ])
-      }).pipe(provide(directory)),
-    ),
+      yield* vcs.diff("branch", { context: 3 })
+      expect(observed).toEqual([
+        {
+          directory: location.directory,
+          worktree: location.directory,
+          canonical: location.directory,
+          mode: "branch",
+          context: 3,
+          maxOutputBytes: 10_000_000,
+        },
+      ])
+    }),
   )
 
-  it.live("validates provider results and bounds oversized patches", () =>
-    withTmp((directory) =>
-      Effect.gen(function* () {
-        const vcs = yield* Vcs.Service
-        yield* vcs.transform((draft) => {
-          draft.add(
-            provider({
-              status: () => Effect.succeed([{ file: "file.txt", additions: -1, deletions: 0, status: "added" }]),
-              diff: () =>
-                Effect.succeed([
-                  { file: "file.txt", patch: "x".repeat(10_000_001), additions: 1, deletions: 0, status: "added" },
-                ]),
-            }),
-          )
-          draft.default.set("custom")
-        })
+  synthetic.effect("validates provider results and bounds oversized patches", () =>
+    Effect.gen(function* () {
+      const vcs = yield* Vcs.Service
+      yield* vcs.transform((draft) => {
+        draft.add(
+          provider({
+            status: () => Effect.succeed([{ file: "file.txt", additions: -1, deletions: 0, status: "added" }]),
+            diff: () =>
+              Effect.succeed([
+                { file: "file.txt", patch: "x".repeat(10_000_001), additions: 1, deletions: 0, status: "added" },
+              ]),
+          }),
+        )
+        draft.default.set("custom")
+      })
 
-        expect(yield* vcs.status()).toEqual([])
-        const rows = yield* vcs.diff("working")
-        expect(rows).toHaveLength(1)
-        expect(Buffer.byteLength(rows[0].patch)).toBeLessThan(1000)
-        expect(rows[0].additions).toBe(1)
-      }).pipe(provide(directory)),
-    ),
+      expect(yield* vcs.status()).toEqual([])
+      const rows = yield* vcs.diff("working")
+      expect(rows).toHaveLength(1)
+      expect(Buffer.byteLength(rows[0].patch)).toBeLessThan(1000)
+      expect(rows[0].additions).toBe(1)
+    }),
   )
 
-  it.live("preserves provider interruption", () =>
-    withTmp((directory) =>
-      Effect.gen(function* () {
-        const vcs = yield* Vcs.Service
-        let interrupt = false
-        yield* vcs.transform((draft) => {
-          draft.add(
-            provider({
-              info: () =>
-                interrupt ? Effect.interrupt : Effect.succeed({ branch: { current: "feature", default: "main" } }),
-              status: () => Effect.never,
-            }),
-          )
-          draft.default.set("custom")
-        })
+  synthetic.effect("preserves provider interruption", () =>
+    Effect.gen(function* () {
+      const vcs = yield* Vcs.Service
+      let interrupt = false
+      yield* vcs.transform((draft) => {
+        draft.add(
+          provider({
+            info: () =>
+              interrupt ? Effect.interrupt : Effect.succeed({ branch: { current: "feature", default: "main" } }),
+            status: () => Effect.never,
+          }),
+        )
+        draft.default.set("custom")
+      })
 
-        const fiber = yield* Effect.forkChild(vcs.status())
-        yield* Fiber.interrupt(fiber)
-        const exit = yield* Fiber.await(fiber)
-        expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBeTrue()
+      const fiber = yield* Effect.forkChild(vcs.status())
+      yield* Fiber.interrupt(fiber)
+      const exit = yield* Fiber.await(fiber)
+      expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBeTrue()
 
-        interrupt = true
-        const reload = yield* vcs.reload().pipe(Effect.timeout("1 second"), Effect.exit)
-        expect(Exit.isFailure(reload) && Cause.hasInterruptsOnly(reload.cause)).toBeTrue()
-      }).pipe(provide(directory)),
-    ),
+      interrupt = true
+      const reload = yield* vcs.reload().pipe(Effect.timeout("1 second"), Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("1 second")
+      const reloaded = yield* Fiber.await(reload)
+      expect(Exit.isFailure(reloaded) && Cause.hasInterruptsOnly(reloaded.cause)).toBeTrue()
+    }),
   )
 
   it.live("keeps watching HEAD changes after a transform replay failure", () =>
@@ -258,15 +252,12 @@ describe("Vcs", () => {
         expect((yield* vcs.info()).branch.current).toBe("recovered")
         const updated = yield* bus
           .subscribe(VcsEvent.BranchUpdated)
-          .pipe(Stream.runHead, Effect.timeout("1 second"), Effect.exit, Effect.forkScoped({ startImmediately: true }))
+          .pipe(Stream.runHead, Effect.timeout("1 second"), Effect.forkScoped({ startImmediately: true }))
         branch = "after-recovery"
         yield* bus.publish(FileSystem.Event.Changed, { file: path.join(directory, ".git", "HEAD"), event: "change" })
         const event = yield* Fiber.join(updated)
         expect((yield* vcs.info()).branch.current).toBe("after-recovery")
-        expect(event).toMatchObject({
-          _tag: "Success",
-          value: { _tag: "Some", value: { data: { branch: "after-recovery" } } },
-        })
+        expect(Option.getOrUndefined(event)).toMatchObject({ data: { branch: "after-recovery" } })
       }),
     ),
   )
@@ -283,28 +274,25 @@ describe("Vcs", () => {
           Effect.andThen(TestClock.adjust("500 millis")),
         ),
       )
-      const context = yield* Layer.build(
+      const context = yield* Layer.buildWithScope(
         LayerNode.compile(Vcs.node, [
           [Bus.node, Layer.succeed(Bus.Service, bus)],
-          [
-            Location.node,
-            Layer.succeed(
-              Location.Service,
-              Location.Service.of(location({ directory: AbsolutePath.make(import.meta.dir) })),
-            ),
-          ],
+          [Location.node, locationLayer({ directory: AbsolutePath.make(import.meta.dir) })],
         ]),
-      ).pipe(Scope.provide(root))
+        root,
+      )
       const vcs = Context.get(context, Vcs.Service)
       const reads: string[] = []
       const observed: (string | undefined)[] = []
-      const unsubscribe = yield* bus.listen((event) =>
-        Effect.sync(() => {
-          if (event.type !== VcsEvent.BranchUpdated.type) return
-          observed.push(Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch)
-        }),
+      yield* Effect.acquireRelease(
+        bus.listen((event) =>
+          Effect.sync(() => {
+            if (event.type !== VcsEvent.BranchUpdated.type) return
+            observed.push(Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch)
+          }),
+        ),
+        (unsubscribe) => unsubscribe,
       )
-      yield* Effect.addFinalizer(() => unsubscribe)
       let branch = "initial"
       let block = false
       yield* vcs
@@ -352,8 +340,8 @@ describe("Vcs", () => {
       expect(yield* Deferred.isDone(release)).toBe(false)
       yield* Fiber.join(shutdown)
       yield* Deferred.succeed(release, undefined)
-      yield* Fiber.join(first).pipe(Effect.timeout("1 second"), TestClock.withLive)
-      yield* Fiber.join(second).pipe(Effect.timeout("1 second"), TestClock.withLive)
+      yield* Fiber.join(first)
+      yield* Fiber.join(second)
       expect(reads).toEqual(["initial", "initial"])
       expect(observed).toEqual([])
       expect(yield* vcs.info()).toBe(snapshot)
@@ -386,7 +374,7 @@ describe("Vcs", () => {
         )
         const updates = yield* bus
           .subscribe(VcsEvent.BranchUpdated)
-          .pipe(Stream.take(2), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+          .pipe(Stream.take(2), Stream.runLast, Effect.forkScoped({ startImmediately: true }))
 
         yield* Effect.gen(function* () {
           yield* bus.publish(FileSystem.Event.Changed, { file: path.join(directory, ".git", "HEAD"), event: "change" })
@@ -416,7 +404,7 @@ describe("Vcs", () => {
 
           yield* Deferred.succeed(release, undefined)
           yield* Fiber.join(configured)
-          expect((yield* Fiber.join(updates)).at(-1)?.data.branch).toBe("config")
+          expect(Option.getOrUndefined(yield* Fiber.join(updates))?.data.branch).toBe("config")
           expect(yield* vcs.info()).toEqual({ branch: { current: "config" } })
           expect(reads).toEqual(["initial", "filesystem", "config"])
         }).pipe(Effect.ensuring(Deferred.succeed(release, undefined)))
@@ -424,86 +412,82 @@ describe("Vcs", () => {
     ),
   )
 
-  it.live("keeps branch streams current when listeners change the selected provider", () =>
-    withTmp((directory) =>
-      Effect.gen(function* () {
-        const vcs = yield* Vcs.Service
-        const bus = yield* Bus.Service
-        const scope = yield* Effect.scope
-        const updates = yield* bus.subscribe([VcsEvent.BranchUpdated, Done]).pipe(
-          Stream.takeUntil((event) => event.type === Done.type),
-          Stream.runCollect,
-          Effect.forkScoped({ startImmediately: true }),
+  synthetic.effect("keeps branch streams current when listeners change the selected provider", () =>
+    Effect.gen(function* () {
+      const vcs = yield* Vcs.Service
+      const bus = yield* Bus.Service
+      const scope = yield* Effect.scope
+      const updates = yield* bus.subscribe([VcsEvent.BranchUpdated, Done]).pipe(
+        Stream.takeUntil((event) => event.type === Done.type),
+        Stream.runCollect,
+        Effect.forkScoped({ startImmediately: true }),
+      )
+      const unsubscribe = yield* bus.listen((event) => {
+        if (
+          event.type !== VcsEvent.BranchUpdated.type ||
+          Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch !== "feature"
         )
-        const unsubscribe = yield* bus.listen((event) => {
-          if (
-            event.type !== VcsEvent.BranchUpdated.type ||
-            Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch !== "feature"
+          return Effect.void
+        return vcs
+          .transform((draft) =>
+            draft.add(provider({ info: () => Effect.succeed({ branch: { current: "listener" } }) })),
           )
-            return Effect.void
-          return vcs
-            .transform((draft) =>
-              draft.add(provider({ info: () => Effect.succeed({ branch: { current: "listener" } }) })),
-            )
-            .pipe(Scope.provide(scope), Effect.asVoid)
+          .pipe(Scope.provide(scope), Effect.asVoid)
+      })
+      yield* Effect.gen(function* () {
+        yield* vcs.transform((draft) => {
+          draft.add(provider())
+          draft.default.set("custom")
         })
-        yield* Effect.gen(function* () {
-          yield* vcs.transform((draft) => {
-            draft.add(provider())
-            draft.default.set("custom")
-          })
-          yield* bus.publish(Done, {})
-          const events = (yield* Fiber.join(updates)).filter((event) => event.type === VcsEvent.BranchUpdated.type)
-          expect(yield* vcs.info()).toEqual({ branch: { current: "listener" } })
-          expect(events.length).toBeGreaterThanOrEqual(2)
-          expect(events.at(-1)?.data.branch).toBe((yield* vcs.info()).branch.current)
-        }).pipe(Effect.ensuring(unsubscribe))
-      }).pipe(provide(directory)),
-    ),
+        yield* bus.publish(Done, {})
+        const events = (yield* Fiber.join(updates)).filter((event) => event.type === VcsEvent.BranchUpdated.type)
+        expect(yield* vcs.info()).toEqual({ branch: { current: "listener" } })
+        expect(events.length).toBeGreaterThanOrEqual(2)
+        expect(events.at(-1)?.data.branch).toBe((yield* vcs.info()).branch.current)
+      }).pipe(Effect.ensuring(unsubscribe))
+    }),
   )
 
-  it.live("does not roll back branch streams when an older listener finishes late", () =>
-    withTmp((directory) =>
-      Effect.gen(function* () {
-        const vcs = yield* Vcs.Service
-        const bus = yield* Bus.Service
-        const entered = yield* Deferred.make<void>()
-        const release = yield* Deferred.make<void>()
-        const updates = yield* bus.subscribe([VcsEvent.BranchUpdated, Done]).pipe(
-          Stream.takeUntil((event) => event.type === Done.type),
-          Stream.runCollect,
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        const unsubscribe = yield* bus.listen((event) =>
-          event.type === VcsEvent.BranchUpdated.type &&
-          Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch === "older"
-            ? Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(release)))
-            : Effect.void,
-        )
+  synthetic.effect("does not roll back branch streams when an older listener finishes late", () =>
+    Effect.gen(function* () {
+      const vcs = yield* Vcs.Service
+      const bus = yield* Bus.Service
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const updates = yield* bus.subscribe([VcsEvent.BranchUpdated, Done]).pipe(
+        Stream.takeUntil((event) => event.type === Done.type),
+        Stream.runCollect,
+        Effect.forkScoped({ startImmediately: true }),
+      )
+      const unsubscribe = yield* bus.listen((event) =>
+        event.type === VcsEvent.BranchUpdated.type &&
+        Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch === "older"
+          ? Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(release)))
+          : Effect.void,
+      )
 
-        yield* Effect.gen(function* () {
-          const older = yield* vcs
-            .transform((draft) => {
-              draft.add(provider({ info: () => Effect.succeed({ branch: { current: "older" } }) }))
-              draft.default.set("custom")
-            })
-            .pipe(Effect.forkScoped({ startImmediately: true }))
-          yield* Deferred.await(entered)
-          yield* vcs.transform((draft) =>
-            draft.add(provider({ info: () => Effect.succeed({ branch: { current: "newer" } }) })),
-          )
-          expect(older.pollUnsafe()).toBeUndefined()
-          expect((yield* vcs.info()).branch.current).toBe("newer")
+      yield* Effect.gen(function* () {
+        const older = yield* vcs
+          .transform((draft) => {
+            draft.add(provider({ info: () => Effect.succeed({ branch: { current: "older" } }) }))
+            draft.default.set("custom")
+          })
+          .pipe(Effect.forkScoped({ startImmediately: true }))
+        yield* Deferred.await(entered)
+        yield* vcs.transform((draft) =>
+          draft.add(provider({ info: () => Effect.succeed({ branch: { current: "newer" } }) })),
+        )
+        expect(older.pollUnsafe()).toBeUndefined()
+        expect((yield* vcs.info()).branch.current).toBe("newer")
 
-          yield* Deferred.succeed(release, undefined)
-          yield* Fiber.join(older)
-          yield* bus.publish(Done, {})
-          const events = (yield* Fiber.join(updates)).filter((event) => event.type === VcsEvent.BranchUpdated.type)
-          expect(events.length).toBeGreaterThanOrEqual(2)
-          expect(events.at(-1)?.data.branch).toBe((yield* vcs.info()).branch.current)
-        }).pipe(Effect.ensuring(Deferred.succeed(release, undefined).pipe(Effect.andThen(unsubscribe))))
-      }).pipe(provide(directory)),
-    ),
+        yield* Deferred.succeed(release, undefined)
+        yield* Fiber.join(older)
+        yield* bus.publish(Done, {})
+        const events = (yield* Fiber.join(updates)).filter((event) => event.type === VcsEvent.BranchUpdated.type)
+        expect(events.length).toBeGreaterThanOrEqual(2)
+        expect(events.at(-1)?.data.branch).toBe((yield* vcs.info()).branch.current)
+      }).pipe(Effect.ensuring(Deferred.succeed(release, undefined).pipe(Effect.andThen(unsubscribe))))
+    }),
   )
 
   it.live("lists local branches by recent activity", () =>

--- a/packages/core/test/vcs.test.ts
+++ b/packages/core/test/vcs.test.ts
@@ -2,7 +2,8 @@ import { $ } from "bun"
 import { describe, expect } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Cause, Deferred, Effect, Exit, Fiber, Layer, Schema, Scope, Stream } from "effect"
+import { Cause, Context, Deferred, Effect, Exit, Fiber, Layer, Schema, Scope, Stream } from "effect"
+import { TestClock } from "effect/testing"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { AppProcess } from "@opencode-ai/util/process"
 import { Bus } from "@opencode-ai/core/bus"
@@ -199,8 +200,15 @@ describe("Vcs", () => {
     withTmp((directory) =>
       Effect.gen(function* () {
         const vcs = yield* Vcs.Service
+        let interrupt = false
         yield* vcs.transform((draft) => {
-          draft.add(provider({ status: () => Effect.never }))
+          draft.add(
+            provider({
+              info: () =>
+                interrupt ? Effect.interrupt : Effect.succeed({ branch: { current: "feature", default: "main" } }),
+              status: () => Effect.never,
+            }),
+          )
           draft.default.set("custom")
         })
 
@@ -208,8 +216,148 @@ describe("Vcs", () => {
         yield* Fiber.interrupt(fiber)
         const exit = yield* Fiber.await(fiber)
         expect(Exit.isFailure(exit) && Cause.hasInterrupts(exit.cause)).toBeTrue()
+
+        interrupt = true
+        const reload = yield* vcs.reload().pipe(Effect.timeout("1 second"), Effect.exit)
+        expect(Exit.isFailure(reload) && Cause.hasInterruptsOnly(reload.cause)).toBeTrue()
       }).pipe(provide(directory)),
     ),
+  )
+
+  it.live("keeps watching HEAD changes after a transform replay failure", () =>
+    withGit((directory) =>
+      Effect.gen(function* () {
+        const vcs = yield* Vcs.Service
+        const bus = yield* Bus.Service
+        const replayed = yield* Deferred.make<void>()
+        const faulty = yield* Scope.make()
+        yield* Effect.addFinalizer(() => Scope.close(faulty, Exit.void))
+        let branch = "initial"
+        yield* vcs.transform((draft) =>
+          draft.add(provider({ id: "git", info: () => Effect.sync(() => ({ branch: { current: branch } })) })),
+        )
+        const failure = new Error("fixture replay failed")
+        let replays = 0
+        const failed = yield* vcs
+          .transform(() => {
+            if (++replays === 2) Deferred.doneUnsafe(replayed, Exit.void)
+            throw failure
+          })
+          .pipe(Scope.provide(faulty), Effect.exit)
+        expect(Exit.isFailure(failed) && Cause.squash(failed.cause)).toBe(failure)
+
+        yield* bus.publish(FileSystem.Event.Changed, { file: path.join(directory, ".git", "HEAD"), event: "change" })
+        yield* Deferred.await(replayed).pipe(Effect.timeout("1 second"))
+        yield* Effect.yieldNow
+        const status = yield* vcs.status().pipe(Effect.exit)
+        expect(Exit.isFailure(status) && Cause.squash(status.cause)).toBe(failure)
+        expect((yield* vcs.info()).branch.current).toBe("initial")
+
+        branch = "recovered"
+        yield* Scope.close(faulty, Exit.void)
+        expect((yield* vcs.info()).branch.current).toBe("recovered")
+        const updated = yield* bus
+          .subscribe(VcsEvent.BranchUpdated)
+          .pipe(Stream.runHead, Effect.timeout("1 second"), Effect.exit, Effect.forkScoped({ startImmediately: true }))
+        branch = "after-recovery"
+        yield* bus.publish(FileSystem.Event.Changed, { file: path.join(directory, ".git", "HEAD"), event: "change" })
+        const event = yield* Fiber.join(updated)
+        expect((yield* vcs.info()).branch.current).toBe("after-recovery")
+        expect(event).toMatchObject({
+          _tag: "Success",
+          value: { _tag: "Some", value: { data: { branch: "after-recovery" } } },
+        })
+      }),
+    ),
+  )
+
+  it.effect("stops in-flight and queued reloads when its layer closes", () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const entered = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const root = yield* Scope.make()
+      yield* Effect.addFinalizer(() =>
+        Deferred.succeed(release, undefined).pipe(
+          Effect.andThen(State.batch(Scope.close(root, Exit.void), { flush: false })),
+          Effect.andThen(TestClock.adjust("500 millis")),
+        ),
+      )
+      const context = yield* Layer.build(
+        LayerNode.compile(Vcs.node, [
+          [Bus.node, Layer.succeed(Bus.Service, bus)],
+          [
+            Location.node,
+            Layer.succeed(
+              Location.Service,
+              Location.Service.of(location({ directory: AbsolutePath.make(import.meta.dir) })),
+            ),
+          ],
+        ]),
+      ).pipe(Scope.provide(root))
+      const vcs = Context.get(context, Vcs.Service)
+      const reads: string[] = []
+      const observed: (string | undefined)[] = []
+      const unsubscribe = yield* bus.listen((event) =>
+        Effect.sync(() => {
+          if (event.type !== VcsEvent.BranchUpdated.type) return
+          observed.push(Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch)
+        }),
+      )
+      yield* Effect.addFinalizer(() => unsubscribe)
+      let branch = "initial"
+      let block = false
+      yield* vcs
+        .transform((draft) => {
+          draft.add(
+            provider({
+              info: () =>
+                Effect.gen(function* () {
+                  const value = branch
+                  reads.push(value)
+                  if (block) {
+                    block = false
+                    yield* Deferred.succeed(entered, undefined)
+                    yield* Deferred.await(release)
+                  }
+                  return { branch: { current: value } }
+                }),
+            }),
+          )
+          draft.default.set("custom")
+        })
+        .pipe(Scope.provide(root))
+      observed.length = 0
+
+      block = true
+      const first = yield* vcs.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Deferred.await(entered).pipe(Effect.timeout("1 second"), TestClock.withLive)
+      branch = "late"
+      const second = yield* vcs.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Effect.yieldNow
+      expect(reads).toEqual(["initial", "initial"])
+      expect(first.pollUnsafe()).toBeUndefined()
+      expect(second.pollUnsafe()).toBeUndefined()
+      const snapshot = yield* vcs.info()
+
+      const shutdown = yield* State.batch(Scope.close(root, Exit.void), { flush: false }).pipe(
+        Effect.forkChild({ startImmediately: true }),
+      )
+      yield* TestClock.adjust("1 millis")
+      expect(shutdown.pollUnsafe()).toBeDefined()
+      expect(first.pollUnsafe()).toBeDefined()
+      expect(second.pollUnsafe()).toBeDefined()
+      expect(yield* Deferred.isDone(release)).toBe(false)
+      yield* Fiber.join(shutdown)
+      yield* Deferred.succeed(release, undefined)
+      yield* Fiber.join(first).pipe(Effect.timeout("1 second"), TestClock.withLive)
+      yield* Fiber.join(second).pipe(Effect.timeout("1 second"), TestClock.withLive)
+      expect(reads).toEqual(["initial", "initial"])
+      expect(observed).toEqual([])
+      expect(yield* vcs.info()).toBe(snapshot)
+    }).pipe(Effect.provide(LayerNode.compile(Bus.node))),
   )
 
   it.live("serializes filesystem and config refreshes while reading the latest desired provider", () =>

--- a/packages/server/test/event-feed.test.ts
+++ b/packages/server/test/event-feed.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, test } from "bun:test"
 import { Agent } from "@opencode-ai/core/agent"
 import { Bus } from "@opencode-ai/core/bus"
+import { Database } from "@opencode-ai/core/database/database"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Location } from "@opencode-ai/core/location"
+import { Vcs } from "@opencode-ai/core/vcs"
 import { Credential } from "@opencode-ai/schema/credential"
 import { Event } from "@opencode-ai/schema/event"
 import { IntegrationID } from "@opencode-ai/schema/integration-id"
-import { Deferred, Effect, Exit, Fiber, Option, Schema, Stream } from "effect"
+import { VcsEvent } from "@opencode-ai/schema/vcs-event"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Deferred, Effect, Exit, Fiber, Option, Schema, Scope, Stream } from "effect"
+import { tempLocationLayer } from "../../core/test/fixture/location"
 import { it } from "../../core/test/lib/effect"
 import { EventFeed } from "../src/event-feed"
 
@@ -43,6 +50,59 @@ describe("EventFeed", () => {
     const payload = event("wire")
     expect(EventFeed.frame(payload)).toBe(`data: ${JSON.stringify(payload)}\n\n`)
   })
+
+  it.effect("delivers the latest VCS branch after an earlier legacy listener reenters", () =>
+    Effect.gen(function* () {
+      const bus = yield* Bus.Service
+      const vcs = yield* Vcs.Service
+      const scope = yield* Scope.Scope
+      const provider = {
+        id: "fixture",
+        name: "Fixture",
+        info: () => Effect.succeed({ branch: { current: "outer" } }),
+        branches: () => Effect.succeed([]),
+        status: () => Effect.succeed([]),
+        diff: () => Effect.succeed([]),
+      }
+      const unsubscribe = yield* bus.listen((event) =>
+        event.type === VcsEvent.BranchUpdated.type &&
+        Schema.decodeUnknownSync(VcsEvent.BranchUpdated.data)(event.data).branch === "outer"
+          ? vcs
+              .transform((draft) =>
+                draft.add({ ...provider, info: () => Effect.succeed({ branch: { current: "inner" } }) }),
+              )
+              .pipe(Scope.provide(scope), Effect.asVoid)
+          : Effect.void,
+      )
+      const feed = yield* EventFeed.make(bus.listen, {
+        encode: (event) => (event.type === VcsEvent.BranchUpdated.type ? (event.data.branch ?? "none") : event.type),
+      })
+      const stream = yield* feed.subscribe
+      const received = yield* stream.pipe(
+        Stream.takeUntil((frame) => frame === Agent.Event.Updated.type, { excludeLast: true }),
+        Stream.runLast,
+        Effect.forkScoped({ startImmediately: true }),
+      )
+
+      yield* vcs.transform((draft) => {
+        draft.add(provider)
+        draft.default.set(provider.id)
+      })
+      yield* unsubscribe
+      yield* bus.publish(Agent.Event.Updated, {})
+
+      const info = yield* vcs.info()
+      expect(info.branch.current).toBe("inner")
+      expect(Option.getOrUndefined(yield* Fiber.join(received))).toBe(info.branch.current)
+    }).pipe(
+      Effect.provide(
+        AppNodeBuilder.build(LayerNode.group([Vcs.node, Bus.node]), [
+          [Location.node, tempLocationLayer],
+          [Database.node, Database.configured({ path: ":memory:" })],
+        ]),
+      ),
+    ),
+  )
 
   it.effect("encodes once and delivers the same frame to every subscriber", () =>
     Effect.gen(function* () {

--- a/packages/server/test/event-feed.test.ts
+++ b/packages/server/test/event-feed.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, test } from "bun:test"
 import { Agent } from "@opencode-ai/core/agent"
 import { Bus } from "@opencode-ai/core/bus"
 import { Database } from "@opencode-ai/core/database/database"
-import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Location } from "@opencode-ai/core/location"
+import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Vcs } from "@opencode-ai/core/vcs"
 import { Credential } from "@opencode-ai/schema/credential"
 import { Event } from "@opencode-ai/schema/event"
@@ -11,11 +11,17 @@ import { IntegrationID } from "@opencode-ai/schema/integration-id"
 import { VcsEvent } from "@opencode-ai/schema/vcs-event"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Deferred, Effect, Exit, Fiber, Option, Schema, Scope, Stream } from "effect"
-import { tempLocationLayer } from "../../core/test/fixture/location"
-import { it } from "../../core/test/lib/effect"
+import { locationLayer } from "../../core/test/fixture/location"
+import { it, testEffect } from "../../core/test/lib/effect"
 import { EventFeed } from "../src/event-feed"
 
 const Internal = Bus.ephemeral({ type: "test.internal", schema: { value: Schema.String } })
+const vcsIt = testEffect(
+  LayerNode.compile(LayerNode.group([Vcs.node, Bus.node]), [
+    [Location.node, locationLayer({ directory: AbsolutePath.make(import.meta.dir) })],
+    [Database.node, Database.configured({ path: ":memory:" })],
+  ]),
+)
 
 const event = (id: string): Event.Payload<typeof Agent.Event.Updated> => ({
   id: Event.ID.make(`evt_${id}`),
@@ -51,7 +57,7 @@ describe("EventFeed", () => {
     expect(EventFeed.frame(payload)).toBe(`data: ${JSON.stringify(payload)}\n\n`)
   })
 
-  it.effect("delivers the latest VCS branch after an earlier legacy listener reenters", () =>
+  vcsIt.effect("delivers the latest VCS branch after an earlier legacy listener reenters", () =>
     Effect.gen(function* () {
       const bus = yield* Bus.Service
       const vcs = yield* Vcs.Service
@@ -74,34 +80,30 @@ describe("EventFeed", () => {
               .pipe(Scope.provide(scope), Effect.asVoid)
           : Effect.void,
       )
-      const feed = yield* EventFeed.make(bus.listen, {
-        encode: (event) => (event.type === VcsEvent.BranchUpdated.type ? (event.data.branch ?? "none") : event.type),
-      })
-      const stream = yield* feed.subscribe
-      const received = yield* stream.pipe(
-        Stream.takeUntil((frame) => frame === Agent.Event.Updated.type, { excludeLast: true }),
-        Stream.runLast,
-        Effect.forkScoped({ startImmediately: true }),
-      )
+      // Unsubscribe before registration teardown can restore "outer" and reenter the listener.
+      yield* Effect.gen(function* () {
+        const feed = yield* EventFeed.make(bus.listen, {
+          encode: (event) => (event.type === VcsEvent.BranchUpdated.type ? (event.data.branch ?? "none") : event.type),
+        })
+        const stream = yield* feed.subscribe
+        const received = yield* stream.pipe(
+          Stream.takeUntil((frame) => frame === Agent.Event.Updated.type, { excludeLast: true }),
+          Stream.runLast,
+          Effect.forkScoped({ startImmediately: true }),
+        )
 
-      yield* vcs.transform((draft) => {
-        draft.add(provider)
-        draft.default.set(provider.id)
-      })
-      yield* unsubscribe
-      yield* bus.publish(Agent.Event.Updated, {})
+        yield* vcs.transform((draft) => {
+          draft.add(provider)
+          draft.default.set(provider.id)
+        })
+        yield* unsubscribe
+        yield* bus.publish(Agent.Event.Updated, {})
 
-      const info = yield* vcs.info()
-      expect(info.branch.current).toBe("inner")
-      expect(Option.getOrUndefined(yield* Fiber.join(received))).toBe(info.branch.current)
-    }).pipe(
-      Effect.provide(
-        AppNodeBuilder.build(LayerNode.group([Vcs.node, Bus.node]), [
-          [Location.node, tempLocationLayer],
-          [Database.node, Database.configured({ path: ":memory:" })],
-        ]),
-      ),
-    ),
+        const info = yield* vcs.info()
+        expect(info.branch.current).toBe("inner")
+        expect(Option.getOrUndefined(yield* Fiber.join(received))).toBe(info.branch.current)
+      }).pipe(Effect.ensuring(unsubscribe))
+    }),
   )
 
   it.effect("encodes once and delivers the same frame to every subscriber", () =>

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -95,10 +95,10 @@ Pass plugin options with the object form in `opencode.json(c)`.
     {
       "package": "./plugins/company.ts",
       "options": {
-        "strict": true
-      }
-    }
-  ]
+        "strict": true,
+      },
+    },
+  ],
 }
 ```
 
@@ -119,6 +119,10 @@ export default Plugin.define({
 
 Transforms are a central pattern in the plugin API and modify how OpenCode works. Plugins register
 transforms and each builds on the changes made before it.
+
+Transform callbacks are synchronous and should only edit their draft. Load external data before registering or
+reloading a transform. Registry reads replay pending changes when needed, so definitions registered earlier in
+setup are readable without waiting for all plugins to finish setup. Update notifications are batched separately.
 
 Say we have a plugin that adds one model to the catalog.
 
@@ -159,8 +163,7 @@ export default Plugin.define({
 })
 ```
 
-Now say the first plugin dynamically fetches can fetch its model list from a
-dynamic source. It can call `reload` when that list changes.
+Now say the first plugin fetches its model list from a dynamic source. It can call `reload` when that list changes.
 
 ```ts title="plugins/models.ts"
 import { Plugin } from "@opencode-ai/plugin"
@@ -190,7 +193,12 @@ export default Plugin.define({
 })
 ```
 
-`reload` replays every catalog transform in order, so the output-price policy still filters the refreshed models.
+`reload` invalidates the catalog without changing transform order, so the output-price policy still filters the
+refreshed models. Reads replay those changes immediately rather than waiting for the update notification's
+500 ms debounce. If nothing reads the catalog, it is rebuilt before the notification instead.
+
+Reading definitions does not start or await background resource work. MCP connections, Git reference checkouts,
+and cached VCS information retain their own lifecycle and readiness behavior.
 
 ## API
 
@@ -468,14 +476,23 @@ interface IntegrationContext {
     key(input: IntegrationConnectKeyInput, requestOptions?: RequestOptions): Promise<void>
   }
   oauth: {
-    connect(input: IntegrationOauthConnectInput, requestOptions?: RequestOptions): Promise<IntegrationOauthConnectOutput>
+    connect(
+      input: IntegrationOauthConnectInput,
+      requestOptions?: RequestOptions,
+    ): Promise<IntegrationOauthConnectOutput>
     status(input: IntegrationOauthStatusInput, requestOptions?: RequestOptions): Promise<IntegrationOauthStatusOutput>
     complete(input: IntegrationOauthCompleteInput, requestOptions?: RequestOptions): Promise<void>
     cancel(input: IntegrationOauthCancelInput, requestOptions?: RequestOptions): Promise<void>
   }
   command: {
-    connect(input: IntegrationCommandConnectInput, requestOptions?: RequestOptions): Promise<IntegrationCommandConnectOutput>
-    status(input: IntegrationCommandStatusInput, requestOptions?: RequestOptions): Promise<IntegrationCommandStatusOutput>
+    connect(
+      input: IntegrationCommandConnectInput,
+      requestOptions?: RequestOptions,
+    ): Promise<IntegrationCommandConnectOutput>
+    status(
+      input: IntegrationCommandStatusInput,
+      requestOptions?: RequestOptions,
+    ): Promise<IntegrationCommandStatusOutput>
     cancel(input: IntegrationCommandCancelInput, requestOptions?: RequestOptions): Promise<void>
   }
   transform(callback: (draft: IntegrationDraft) => void): Promise<Registration>
@@ -1237,10 +1254,7 @@ await ctx.shell.hook("create.before", (event) => {
 
 ```ts
 interface ShellHookContext {
-  hook(
-    name: "create.before",
-    callback: (event: ShellCreateBefore) => Promise<void> | void,
-  ): Promise<Registration>
+  hook(name: "create.before", callback: (event: ShellCreateBefore) => Promise<void> | void): Promise<Registration>
 }
 
 interface ShellCreateBefore {


### PR DESCRIPTION
## Why

During plugin startup, an OAuth refresh method can be registered but still absent from the readable Integration state until the activation batch finishes. Resolving a connection during setup then returns an expired credential unchanged. Registry reads can also miss already-requested source updates during the 500 ms reload debounce.

Both failures come from making read visibility wait for effectful publication. This change makes reads pull pending definitions synchronously and keeps publication separate.

## What Changes

| Operation | Before | After |
| --- | --- | --- |
| Read after an awaited transform inside a batch | Previous snapshot | Latest accepted definitions |
| Read after reload is requested, before 500 ms elapses | Previous snapshot | Synchronous ordered replay |
| Repeated reads without another change | Cached snapshot | Cached snapshot, without another replay |
| Observer awaits another registration or reload | Can wait on the replay it is observing | No State replay lock or shared read flight |
| One batch observer or replay fails | Later states can lose their notifications | All pending notifications are attempted; failures remain observable |

The existing `transform`, `Registration.dispose`, and `reload` interfaces remain intact. Changing captured source data still requires `reload`; this is not automatic dependency tracking or a new contribution API.

## Demo

The same OpenCode Drive fixture cold-starts with an expired, stored OAuth credential. The config endpoint stays healthy: it returns `401` for the expired token and `200` after refresh. This reproduces a startup ordering bug, not a DNS outage or a cache-recovery scenario.

https://github.com/user-attachments/assets/c917936e-5275-44c8-aff8-1ffdf559fa15

**Left:** recorded base `f6992059be`. **Right:** recorded pre-rebase PR head `be8f5a5242`. The first three seconds show the same model-picker search; the next three show a prompt using the same saved model selection. The same after-scenario was rerun successfully on rebased head `57a079b874`; this existing video retains its original, accurate revision labels.

| Verified observation | Before | After |
| --- | --- | --- |
| OAuth refresh before the first cold-start config request | Skipped | Refresh completes first |
| Config response | `401` | `200` |
| Search for `Orbit Fixture` | `No results found` | `Orbit Fixture Model` is listed |
| Stored credential | Remains expired | Refreshed credential is persisted |
| Prompt with the saved model | `ModelUnavailableError`; zero LLM requests | One LLM request and a response |

The TUI, server, Console plugin, registration/lookup, OAuth refresh, and database persistence are real production code. The device-login, account, token, and inventory endpoint responses use a loopback fixture with dummy data; the LLM response is canned Drive output. Request order, the model-list API, and persisted credential expiry independently verify the result; the canned response is not evidence of OAuth behavior. Before's error is in the server log; the visible composer labels the saved model unavailable rather than displaying that error message.

Both runs use a fresh isolated database, a naturally expiring token, and the same loopback-only simulation transport adapter. No real provider account, live service, manual credential edit, or post-restart account/model switch is involved. The Console plugin and TUI source are identical between these revisions. Playback is side-by-side at normal speed, with setup and navigation omitted between matched checkpoints.

## Startup Ordering

**Precondition:** the account is already connected, its stored access token has expired, and its refresh token is valid. Plugin activation runs setup inside `State.batch`. The HTTP endpoint can successfully refresh the token throughout both sequences.

### Before: Registration Is Accepted but Not Readable

```mermaid
sequenceDiagram
    autonumber
    participant P as Console plugin setup
    participant I as Integration
    participant H as OAuth/config endpoint
    participant C as Catalog
    participant U as TUI / Session

    Note over P,C: Plugin.activate opens State.batch
    P->>I: transform(register OAuth refresh handler)
    I-->>P: Registration accepted, replay deferred
    P->>I: connection.active("opencode")
    I->>I: state.get() returns old snapshot
    I-->>P: Stored connection still found in credentials
    P->>I: connection.resolve(connection)
    I->>I: Old snapshot has no refresh implementation
    I-->>P: Fallback returns expired stored token
    P->>H: GET /api/config with expired token
    H-->>P: 401 Unauthorized
    P->>P: Catch fetch failure<br/>providers = undefined
    P->>C: Register transform reading captured providers
    Note over P,C: All plugin setup finishes, activation batch closes
    I->>I: Replay registrations<br/>refresh handler now visible
    C->>C: Replay transform over providers ?? empty object
    Note over P,C: No automatic rerun of load(), token resolution, or HTTP fetch
    U->>C: List models
    C-->>U: Orbit model absent
    U->>U: Saved-model prompt fails with ModelUnavailableError
```

The Integration snapshot eventually catches up. **The lasting failure is the plugin's captured result:** making the handler visible later does not retry the earlier request, and replaying the catalog transform only reuses `providers = undefined`.

### After: The First Read Pulls Accepted Definitions

```mermaid
sequenceDiagram
    autonumber
    participant P as Console plugin setup
    participant I as Integration
    participant H as OAuth/config endpoint
    participant C as Catalog
    participant U as TUI / Session

    Note over P,C: Plugin.activate opens State.batch
    P->>I: transform(register OAuth refresh handler)
    I-->>P: Registration accepted, snapshot marked dirty
    P->>I: connection.active("opencode")
    I->>I: state.get() synchronously replays pending transforms
    Note over I: Refresh handler is now readable<br/>notifications remain batched
    I-->>P: Stored OAuth connection
    P->>I: connection.resolve(connection)
    I->>I: Read cached implementation<br/>detect expired token
    I->>H: POST /auth/device/token using refresh token
    H-->>I: Fresh access token
    I->>I: Persist refreshed credential
    I-->>P: Fresh credential
    P->>H: GET /api/config with fresh token
    H-->>P: 200 OK with Orbit inventory
    P->>P: Capture providers containing Orbit
    P->>C: Register transform reading captured providers
    Note over P,C: All plugin setup finishes, activation batch closes
    I->>I: Publish deferred Integration update
    C->>C: Rebuild if dirty<br/>publish Catalog update
    U->>C: List models
    C-->>U: Orbit model is listed
    U->>U: Saved-model prompt reaches simulated LLM and responds
```

In this concrete path, `connection.active()` is the first read and performs the replay; `connection.resolve()` then sees the cached fresh implementation. The read itself does not perform HTTP: the subsequent explicit `resolve()` invokes refresh. Catalog reads can likewise pull accepted definitions before notification, without waiting for the batch to close.

## Pull Reads

Accepted registration, disposal, and reload operations invalidate the derived snapshot. `State.get()` rebuilds it with `initial`, ordered synchronous transforms, and optional synchronous `prepare`, then caches the result. A failed replay does not mark the previous snapshot fresh.

`notify` observes changes outside the read path. Batches coalesce notifications, not visibility; directly awaiting reload inside a batch accepts the invalidation without waiting for that batch to finish. Outside a batch, reload retains its trailing-edge notification debounce. Reading early does not consume the pending notification, and a state with no readers is rebuilt before notifying.

Reload callers in one debounce window share one `Deferred`, rather than a waiter array and completion fan-out. The cell is claimed before scheduling and cleared before observers run: cancelling one caller does not cancel the notification, and reentrant reloads get a separate completion window.

## Side Effects

The old `finalize` hook mixed derived metadata with effects. Its consumers now make the distinction explicit:

- Registry update events and Tool diagnostics use `notify` only.
- Reference normalization lives in the State snapshot and runs in `prepare`; scoped repository cache work stays in `notify`.
- Watcher policy reads pull the current ignore list. Each observer receives the latest policy, including after another observer performs a nested update.
- MCP reconciliation and VCS refresh retain local resource permits and acquire the latest desired state inside them. Their State-driven notification work runs in layer-owned fiber runtimes, so teardown cancels both active and permit-queued operations, not just work that has not started. Only pure owner-close interruption settles quietly; normal failures and interruption while the owner is live remain observable.
- Filesystem-triggered VCS refresh contains non-interruption failures per event. A faulty transform can fail a refresh without permanently stopping the HEAD watcher; API read/reload replay failures remain observable.
- VCS publishes branch changes after releasing its refresh permit. If a legacy callback or concurrent refresh overtakes publication, it re-announces the latest branch before returning. This leaves both Bus streams and the bounded SSE feed on the current branch without changing their delivery contracts.
- Batch bookkeeping stays interruption-safe, but observer work runs with the caller's interruptibility restored. Scoped shutdown can cancel an observer that is awaiting resource I/O; the batch-body failure and observer exits remain aggregated.
- OAuth settlement includes the fresh implementation lookup inside its existing persistence failure boundary, so a replay defect closes the attempt with terminal failed status rather than leaving it pending forever.

## Test Structure

The test-only follow-up replaces repeated State and Location construction with two small fixture helpers, uses explicit layers and virtual time for synthetic VCS/SSE cases, keeps real platform fixtures live, and makes cleanup ordering explicit. It removes 70 net lines across nine test/fixture files without dropping cases or assertions. Un-nesting existing cases adds Git diff churn; this is shorter test code, not a smaller additions/deletions counter or new production machinery.

## Scope

This is a fresh `v2` alternative to the pending read/flush fixes in #44813 and #45810, with regression coverage for the notification failures documented in #44843. It does not introduce another plugin lifecycle phase or change resource readiness: an available definition does not imply that an MCP handshake, Git checkout, or VCS refresh has finished. Bus-wide nested-event ordering, bounded SSE capacity/overflow behavior, and outside-batch atomic registration/disposal semantics remain unchanged.

Corrective VCS notifications converge after successful publication; transient older and duplicate notifications can still appear. This PR remains draft for independent review.

## Verification

Rebased onto `origin/v2` at `d837ffe70f`, producing head `57a079b874`, on Effect `4.0.0-rc.112`. All four commits are retained. The only manual conflict preserves upstream's `Effect.fnUntraced(..., Effect.uninterruptible)` wrapper while retaining the fresh OAuth implementation lookup inside `Effect.sync(...).pipe(..., Effect.exit)`, so replay failure still settles the attempt. `range-diff` shows only the expected wrapper indentation and upstream MCP import context changes.

Current rebased-head verification: **279 Core tests passed**, 990 assertions across 13 files, including State, OAuth activation/settlement, MCP/VCS ownership, Bus, and models.dev; **8 focused Server tests passed**, including the actual bounded EventFeed. Full Core with the disclosed `--timeout 30000` passed **3,837 tests, 40 skips, 0 failures**, with 79,154 assertions across 225 files in 147.07 seconds. The full Server suite passed **40 tests, 3 existing skips, 0 failures**, with 159 assertions. Core, Server, and WWW typechecks, formatting, and Effect structural checks passed. Normal pre-push typechecking passed all **33 tasks**. No test deadline or skip was changed by this rebase.

The unchanged isolated Drive fixture also passed on `57a079b874`: naturally expired stored OAuth, refresh before the first cold config `200`, the fixture model visible in the real picker, one simulated LLM request with the same saved selection, and refreshed expiry persisted under the same credential identity. No live service or real provider account was used.

For `57a079b874`, [typecheck](https://github.com/anomalyco/opencode/actions/runs/33212488190) and [normal PR Linux/Windows unit and e2e CI](https://github.com/anomalyco/opencode/actions/runs/33212487637/attempts/2) are now green. The [first test attempt](https://github.com/anomalyco/opencode/actions/runs/33212487637/attempts/1) failed Linux's TUI assertion `closing a tab is not undone by another TUI viewing the same session`: persisted tabs still contained `shared` instead of `[]`. This was an assertion failure, not a timeout. The test uses a fake HTTP client rather than Core State; TUI sources are unchanged by this PR. The first attempt checked out GitHub merge commit `dc130469f6` against then-current `v2` `d0baff184b`, not the standalone head tree. Windows freshly executed Core: **3,590 passed, 293 skipped, 0 failed**. Locally on the head, the tab case passed **10 targeted repetitions**, and its full file passed **96 cases / 207 assertions** across three repetitions. The requested Linux unit-job rerun passed without any branch code or deadline change. The original Linux failure's cause remains unestablished; a successful rerun is not a claimed fix. The remaining CI history below belongs to earlier revisions.

For pre-rebase `be8f5a5242`, the normal [PR Linux/Windows unit and e2e workflow](https://github.com/anomalyco/opencode/actions/runs/33199909442) and [typecheck](https://github.com/anomalyco/opencode/actions/runs/33199939764) passed. A separate, expanded full-repository workflow still has a failed Windows result: its [first attempt](https://github.com/anomalyco/opencode/actions/runs/33199939435/attempts/1) hit five-second deadlines in Linux's failing-shell-command test and Windows's Session UI source-import scan; both cleared on rerun. [Attempt 2](https://github.com/anomalyco/opencode/actions/runs/33199939435/attempts/2) passed Linux unit and both e2e jobs but hit the same deadline in Windows's project-identity-after-creation integration test. Those test files were unchanged from that base. Local normal-timeout repetitions passed **10 shell cases, 40 import-boundary checks, and 5 project-identity cases**, but this does not prove the Windows CI cause. No code, skip, or deadline was changed in this branch, and a third automatic rerun was not requested.

The separate project-adoption fixture cleanup, #46009, is merged into `v2` and included in this new base, retaining the same assertions and deadline. Its Linux/Windows unit and e2e workflow passed for `6ce6d92199`, including fresh Windows Core execution with zero failures. The Session UI scan cleanup is owned by #45970. These separate results do not replace fresh CI for the rebased State-pull head.

```sh
# packages/core
RECORD=false bun run test --timeout 30000
bun typecheck

# packages/server, using Core's environment-isolating test wrapper
RECORD=false bun run ../core/script/test.ts
bun typecheck

# packages/www
bun typecheck
bun run check:generated
bun run build
```

- Baseline negative controls reproduced stale in-batch reads, stale reads during reload debounce, and expired OAuth credentials in both Integration and real plugin activation fixtures.
- A full-diff simplify review reproduced three regressions in `73423fd3e2`: blocked batch-observer shutdown, queued MCP work after owner closure, and stale final VCS delivery. Each new regression was verified failing before its fix. VCS coverage includes the real bounded `EventFeed.make(bus.listen)` SSE path, not only Bus subscriptions.
- The second full-diff review found three more failure cases in `07b5d00fb0`: active MCP reconciliation surviving teardown, queued VCS refresh touching a closed layer, and a VCS replay exception permanently stopping filesystem refresh. Actual-service regressions reproduced all three before the fixes. Stronger teardown checks also prove shutdown and both reload callers settle before the fixture releases blocked I/O; the guard-only/direct-notify negative control failed all four boundary tests, and scoped execution plus per-event failure containment passed them.
- Effect and Promise plugins both refresh and persist their own expired OAuth connection during actual `Plugin.activate`. Coalesced reload coverage cancels one caller, verifies the surviving callers receive the same notification failure, and verifies a later reload recovers.
- At pre-rebase `be8f5a5242`, affected Core suites on Effect `rc.112`: **216 passed, 0 failed**, 837 assertions across 11 files, including upstream's additional plugin/MCP coverage. Bounded SSE feed and Server models: **8 passed, 0 failed**, including existing encoding and overflow behavior. Earlier, the four new boundary regressions also passed **40/40** runs with `--rerun-each 10`.
- Focused domain suites and dependent config tests passed. They cover executable snapshot preservation, Reference read purity, watcher reentrancy, and overlapping MCP/VCS resource changes.
- At pre-rebase `be8f5a5242`, full Core suite with `--timeout 30000`: **3,839 passed, 39 skipped, 0 failed**, 79,174 assertions across 225 files.
- Default-timeout full-suite attempts hit different unchanged Git fixtures: the npm-install test first, then Project canonical-directory resolution on the serial rerun. The first also reported the cancelled clone's `SIGTERM` as an inter-test error. Isolated npm passed **12/12**; isolated Project passed **24, with 1 skip**. Full-suite validation uses the explicitly disclosed `--timeout 30000` CLI override; no fixture timeout was edited and no skip was added. The changed-area suites and 40 repeated boundary checks passed with the normal timeout.
- One full-suite attempt after the final rebase hit Config file-recreation's internal five-second timeout and LM Studio discovery's internal polling deadline. Both files passed in isolation (**41 tests / 148 assertions**), and the two cases passed all **10 repeated runs / 35 assertions** without changing code or deadlines. This attempt is distinct from the final full-suite result above.
- Core and Server typechecks, Prettier, and Effect-pattern/simplification checks passed. The unchanged documentation surface also passed its earlier typecheck/build/generated checks.
- A final source-level audit of the seven-file follow-up delta found no further demonstrated correctness or minimality issue. Explicitly uninterruptible backend/plugin work retains its existing ability to delay shutdown.
- A third full-diff reuse, correctness, and efficiency/lifecycle review of `a629943c8e` found no actionable change. Bounded probes covered replay/disposal recovery, debounce result isolation, caller cancellation, active/queued MCP and VCS teardown, and mixed interruption/defect causes. The implementation was left unchanged; 212 focused Core tests, 8 Server tests, both package typechecks, and the full Core suite were rerun successfully with the timeout policy above.
- The pre-rebase test-structure follow-up preserved **212 Core cases / 807 assertions** and **7 EventFeed cases / 13 assertions**. Repeatability checks passed **90 Core runs and 10 SSE runs** with normal timeouts. Negative controls still failed four stale-read cases, four teardown/recovery cases, two VCS stream cases, and the actual bounded SSE case; restoring production made the suites pass. That test-only commit left production byte-for-byte unchanged from its parent; the rebase also retains upstream's MCP recovery cleanup.
- A bounded test-delta audit found no lost regression proof or cleanup-order issue. The converted provider-interruption case retains an explicit one-second timeout, driven by virtual time rather than wall-clock waiting.
- Normal pre-push repository typechecking passed: **33 successful tasks**, including Server, TUI, SDK, and the generated Client surface.
- GitHub [typecheck](https://github.com/anomalyco/opencode/actions/runs/33188977506) and [Linux/Windows unit and e2e verification](https://github.com/anomalyco/opencode/actions/runs/33188976482) passed for `a629943c8e` via explicit workflow dispatch.
- GitHub [typecheck](https://github.com/anomalyco/opencode/actions/runs/33197266923) passed for pre-rebase `e43f58d973`. Its [unit/e2e workflow](https://github.com/anomalyco/opencode/actions/runs/33197266956) failed in Linux's TUI tab-rendering test, not a changed file in this PR; Core's parallel test task was interrupted. On the rebased branch, the focused tab-status and session-row suites passed **22 tests / 139 assertions**. Current-head CI is reported separately above.
- At pre-rebase `be8f5a5242`, the full Server suite after upstream baseline repairs had **39 passed, 3 skipped, 0 failed**, 136 assertions across 16 files. Upstream #45826 occupies both IPv4/IPv6 callback addresses, resolving the three previously documented baseline port-fixture failures. The three skips require an optional PTY binary. No Server runtime or callback-fixture repair is added by this PR.

OAuth credentials and resource endpoints in tests are dummy or loopback fixtures. Verification did not restart a live service or use a real provider account.
