### PR TITLE
refactor(ai): default unrecognized provider failures to retry

### DIFF
--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -58,23 +58,26 @@ export const isContextOverflowFailure = (failure: unknown) =>
     : Schema.is(ProviderErrorEvent)(failure) && failure.classification === "context-overflow"
 
 const decodeJson = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown))
-const QUOTA_CODES = new Set(["insufficient_quota", "usage_not_included", "billing_error"])
+const QUOTA_CODES = new Set(["insufficient_quota", "usage_not_included", "usage_limit_reached", "billing_error"])
+const AUTH_CODES = new Set(["authentication_error", "permission_error"])
 const SERVER_CODES = new Set([
   "api_error",
   "internal_error",
   "internalserverexception",
   "modelstreamerrorexception",
   "overloaded_error",
+  "resource_exhausted",
   "server_error",
   "server_is_overloaded",
-  "slow_down",
+  "service_unavailable",
   "serviceunavailableexception",
+  "slow_down",
 ])
 const INVALID_REQUEST_CODES = new Set(["invalid_prompt", "invalid_request_error", "validationexception"])
 const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
-const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
+const QUOTA_TEXT =
+  /insufficient[-_\s]?quota|quota[-_\s]?exceeded|usage[-_\s]?limit|available balance|out of budget|billing/i
 const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
-const NETWORK_ERROR_TEXT = /network[-_\s]error/i
 
 export interface ProviderFailure {
   readonly message: string
@@ -90,8 +93,12 @@ export interface ProviderFailure {
   readonly rateLimit?: HttpRateLimitDetails | undefined
 }
 
-// Keep HTTP failures and provider-reported stream failures on one typed path so
-// session retry policy never needs provider-specific string matching.
+// Classification records affirmative evidence about a failure. Deterministic
+// failures need positive identification (a 4xx status, quota/auth/policy
+// signals); anything unrecognized stays UnknownProvider, which the session
+// retry policy treats as retry-eligible because transient failures arrive in
+// unpredictable shapes while deterministic rejections almost always carry a
+// status or known code.
 export function classifyProviderFailure(input: ProviderFailure): AIError["reason"] {
   const details = { message: input.message, body: input.rawBody, http: input.http, cause: input.cause }
   const body = input.rawBody ?? ""
@@ -114,48 +121,35 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
   if (input.status === 413 || isPayloadTooLarge(text))
     return new InvalidRequestError({ ...details, classification: "payload-too-large" })
   if (CONTENT_POLICY_TEXT.test(text)) return new ContentPolicyError(details)
-  if (codes.some((code) => QUOTA_CODES.has(code)) || (input.status === 429 && QUOTA_TEXT.test(text)))
+  if (codes.some((code) => QUOTA_CODES.has(code)) || (clientScoped && QUOTA_TEXT.test(text)))
     return new QuotaExceededError(details)
-  if (input.status === 401) return new AuthenticationError({ ...details, kind: "invalid" })
-  if (input.status === 403) return new AuthenticationError({ ...details, kind: "insufficient-permissions" })
-  if (codes.includes("authentication_error")) return new AuthenticationError({ ...details, kind: "invalid" })
-  if (codes.includes("permission_error"))
-    return new AuthenticationError({ ...details, kind: "insufficient-permissions" })
+  if (input.status === 401 || input.status === 403 || codes.some((code) => AUTH_CODES.has(code)))
+    return new AuthenticationError(details)
   if (
-    codes.some((code) => code.includes("rate_limit") || code === "too_many_requests" || code === "throttlingexception")
+    input.status === 429 ||
+    codes.some(
+      (code) => code.includes("rate_limit") || code === "too_many_requests" || code === "throttlingexception",
+    ) ||
+    RATE_LIMIT_TEXT.test(text)
   )
     return new RateLimitError({
       ...details,
       retryAfterMs: input.retryAfterMs,
       rateLimit: input.rateLimit,
     })
-  if (RATE_LIMIT_TEXT.test(text))
-    return new RateLimitError({
-      ...details,
-      retryAfterMs: input.retryAfterMs,
-      rateLimit: input.rateLimit,
-    })
-  if (NETWORK_ERROR_TEXT.test(text)) return new ProviderInternalError(details)
-  if (codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable")))
-    return new ProviderInternalError({
-      ...details,
-      retryAfterMs: input.retryAfterMs,
-    })
-  if (input.status === 429) {
-    return new RateLimitError({
-      ...details,
-      retryAfterMs: input.retryAfterMs,
-      rateLimit: input.rateLimit,
-    })
-  }
-  if (input.status === 408 || input.status === 409 || (input.status !== undefined && input.status >= 500))
+  if (
+    input.status === 408 ||
+    input.status === 409 ||
+    (input.status !== undefined && input.status >= 500) ||
+    codes.some((code) => SERVER_CODES.has(code))
+  )
     return new ProviderInternalError({
       ...details,
       retryAfterMs: input.retryAfterMs,
     })
   if (codes.some((code) => INVALID_REQUEST_CODES.has(code))) return new InvalidRequestError(details)
-  if (input.status === 400 || input.status === 404 || input.status === 413 || input.status === 422)
-    return new InvalidRequestError(details)
+  // Any remaining 4xx is a deterministic rejection of this request.
+  if (input.status !== undefined && input.status >= 400 && input.status < 500) return new InvalidRequestError(details)
   return new UnknownProviderError(details)
 }
 

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -66,12 +66,10 @@ const SERVER_CODES = new Set([
   "internalserverexception",
   "modelstreamerrorexception",
   "overloaded_error",
-  "resource_exhausted",
   "server_error",
   "server_is_overloaded",
-  "service_unavailable",
-  "serviceunavailableexception",
   "slow_down",
+  "serviceunavailableexception",
 ])
 const INVALID_REQUEST_CODES = new Set(["invalid_prompt", "invalid_request_error", "validationexception"])
 const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
@@ -140,7 +138,7 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
     input.status === 408 ||
     input.status === 409 ||
     (input.status !== undefined && input.status >= 500) ||
-    codes.some((code) => SERVER_CODES.has(code))
+    codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable"))
   )
     return new ProviderInternalError({
       ...details,

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -58,7 +58,7 @@ export const isContextOverflowFailure = (failure: unknown) =>
     : Schema.is(ProviderErrorEvent)(failure) && failure.classification === "context-overflow"
 
 const decodeJson = Schema.decodeUnknownOption(Schema.fromJsonString(Schema.Unknown))
-const QUOTA_CODES = new Set(["insufficient_quota", "usage_not_included", "usage_limit_reached", "billing_error"])
+const QUOTA_CODES = new Set(["insufficient_quota", "usage_not_included", "billing_error"])
 const AUTH_CODES = new Set(["authentication_error", "permission_error"])
 const SERVER_CODES = new Set([
   "api_error",
@@ -75,8 +75,7 @@ const SERVER_CODES = new Set([
 ])
 const INVALID_REQUEST_CODES = new Set(["invalid_prompt", "invalid_request_error", "validationexception"])
 const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
-const QUOTA_TEXT =
-  /insufficient[-_\s]?quota|quota[-_\s]?exceeded|usage[-_\s]?limit|available balance|out of budget|billing/i
+const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
 const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
 
 export interface ProviderFailure {
@@ -121,7 +120,7 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
   if (input.status === 413 || isPayloadTooLarge(text))
     return new InvalidRequestError({ ...details, classification: "payload-too-large" })
   if (CONTENT_POLICY_TEXT.test(text)) return new ContentPolicyError(details)
-  if (codes.some((code) => QUOTA_CODES.has(code)) || (clientScoped && QUOTA_TEXT.test(text)))
+  if (codes.some((code) => QUOTA_CODES.has(code)) || (input.status === 429 && QUOTA_TEXT.test(text)))
     return new QuotaExceededError(details)
   if (input.status === 401 || input.status === 403 || codes.some((code) => AUTH_CODES.has(code)))
     return new AuthenticationError(details)

--- a/packages/ai/src/route/auth.ts
+++ b/packages/ai/src/route/auth.ts
@@ -139,7 +139,7 @@ const toAIError = (error: AuthError): AIError => {
     return new AIError({
       reason:
         error instanceof MissingCredentialError
-          ? new AuthenticationError({ message: error.message, cause: error, kind: "missing" })
+          ? new AuthenticationError({ message: error.message, cause: error })
           : new InvalidRequestError({ message: `Failed to resolve auth config: ${error.message}`, cause: error }),
     })
   }

--- a/packages/ai/src/schema/errors.ts
+++ b/packages/ai/src/schema/errors.ts
@@ -44,10 +44,7 @@ export class NoRouteError extends Schema.TaggedError<NoRouteError>("AI.Error.NoR
 
 export class AuthenticationError extends Schema.TaggedError<AuthenticationError>("AI.Error.Authentication")(
   "Authentication",
-  {
-    ...ReasonFields,
-    kind: Schema.Literals(["missing", "invalid", "expired", "insufficient-permissions", "unknown"]),
-  },
+  ReasonFields,
 ) {}
 
 export class RateLimitError extends Schema.TaggedError<RateLimitError>("AI.Error.RateLimit")("RateLimit", {

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -87,23 +87,6 @@ describe("provider error classification", () => {
     ])
   })
 
-  test("classifies subscription and usage limit failures as quota exhaustion", () => {
-    expect(
-      [
-        classifyProviderFailure({ message: "Monthly usage limit reached", status: 429 }),
-        classifyProviderFailure({ message: "You are out of budget" }),
-        classifyProviderFailure({ message: '{"error":{"code":"usage_limit_reached"}}' }),
-        classifyProviderFailure({ message: "Enable available balance usage to continue", status: 429 }),
-      ].map((reason) => reason._tag),
-    ).toEqual(["QuotaExceeded", "QuotaExceeded", "QuotaExceeded", "QuotaExceeded"])
-  })
-
-  test("keeps quota wording on server failures classified as provider internal", () => {
-    expect(classifyProviderFailure({ message: "billing service unavailable", status: 503 })._tag).toBe(
-      "ProviderInternal",
-    )
-  })
-
   test("classifies any remaining 4xx status as an invalid request", () => {
     expect(
       [400, 402, 404, 418, 422, 451].map(

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -87,10 +87,29 @@ describe("provider error classification", () => {
     ])
   })
 
-  test("classifies network error text as provider internal", () => {
+  test("classifies subscription and usage limit failures as quota exhaustion", () => {
     expect(
-      ["network error", "network-error", "network_error"].map((message) => classifyProviderFailure({ message })._tag),
-    ).toEqual(["ProviderInternal", "ProviderInternal", "ProviderInternal"])
+      [
+        classifyProviderFailure({ message: "Monthly usage limit reached", status: 429 }),
+        classifyProviderFailure({ message: "You are out of budget" }),
+        classifyProviderFailure({ message: '{"error":{"code":"usage_limit_reached"}}' }),
+        classifyProviderFailure({ message: "Enable available balance usage to continue", status: 429 }),
+      ].map((reason) => reason._tag),
+    ).toEqual(["QuotaExceeded", "QuotaExceeded", "QuotaExceeded", "QuotaExceeded"])
+  })
+
+  test("keeps quota wording on server failures classified as provider internal", () => {
+    expect(classifyProviderFailure({ message: "billing service unavailable", status: 503 })._tag).toBe(
+      "ProviderInternal",
+    )
+  })
+
+  test("classifies any remaining 4xx status as an invalid request", () => {
+    expect(
+      [400, 402, 404, 418, 422, 451].map(
+        (status) => classifyProviderFailure({ message: `HTTP ${status}`, status })._tag,
+      ),
+    ).toEqual(Array(6).fill("InvalidRequest"))
   })
 
   test("classifies nested provider codes when a top-level code is also present", () => {
@@ -103,10 +122,12 @@ describe("provider error classification", () => {
     ).toEqual(["QuotaExceeded", "ProviderInternal", "InvalidRequest"])
   })
 
-  test("keeps unknown and malformed provider payloads non-retryable", () => {
+  test("leaves unrecognized failures unclassified for the retry default", () => {
     expect(classifyProviderFailure({ message: '{"error":{"message":"no_kv_space"}}' })._tag).toBe("UnknownProvider")
     expect(classifyProviderFailure({ message: '{"type":"error","error":{"code":123}}' })._tag).toBe("UnknownProvider")
     expect(classifyProviderFailure({ message: "not-json" })._tag).toBe("UnknownProvider")
+    expect(classifyProviderFailure({ message: "network error" })._tag).toBe("UnknownProvider")
+    expect(classifyProviderFailure({ message: "Provider returned error" })._tag).toBe("UnknownProvider")
   })
 })
 

--- a/packages/ai/test/provider/error-retention.test.ts
+++ b/packages/ai/test/provider/error-retention.test.ts
@@ -52,7 +52,7 @@ describe("provider error retention", () => {
           Effect.flip,
         )
         expect(error.message).toContain("Slow down")
-        expect(error.reason._tag).toBe(entry.name === "Gemini" ? "ProviderInternal" : "RateLimit")
+        expect(error.reason._tag).toBe("RateLimit")
         expect(error.reason.body).toBe(body)
         expect(error.reason.http).toMatchObject({ status: 200, headers: { "x-provider-trace": "trace-1" } })
         expect(error.reason.http?.url).toStartWith("https://provider.test/")

--- a/packages/ai/test/schema.test.ts
+++ b/packages/ai/test/schema.test.ts
@@ -250,7 +250,7 @@ test("AI error reasons are tagged Errors with required messages", () => {
       provider: model.provider,
       model: model.id,
     }),
-    new AuthenticationError({ message: "Missing credentials", kind: "missing" }),
+    new AuthenticationError({ message: "Missing credentials" }),
     new RateLimitError({ message: "Rate limited" }),
     new QuotaExceededError({ message: "Quota exceeded" }),
     new ContentPolicyError({ message: "Content blocked" }),

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -26,12 +26,16 @@ export function isRetryable(error: AIError) {
       return error.reason.delivery === undefined || error.reason.delivery === "not-sent"
     case "InvalidProviderOutput":
       return error.reason.classification === "incomplete-stream"
+    // Unrecognized failures retry: classification records affirmative
+    // deterministic evidence, and transient failures are exactly the ones
+    // that arrive in shapes no classifier anticipates.
+    case "UnknownProvider":
+      return true
     case "Authentication":
     case "QuotaExceeded":
     case "ContentPolicy":
     case "InvalidRequest":
     case "NoRoute":
-    case "UnknownProvider":
       return false
     default: {
       const exhaustive: never = error.reason

--- a/packages/core/test/aisdk.test.ts
+++ b/packages/core/test/aisdk.test.ts
@@ -757,7 +757,7 @@ it.effect("classifies data-only AI SDK authentication errors", () =>
         data: { error: { code: "authentication_error" } },
       }),
     )
-    expect(error.reason).toMatchObject({ _tag: "Authentication", kind: "invalid" })
+    expect(error.reason).toMatchObject({ _tag: "Authentication" })
     expect(SessionRunnerRetry.isRetryable(error)).toBeFalse()
   }),
 )
@@ -776,7 +776,7 @@ Object.entries({
         responseBody,
       })
       const error = yield* streamFailure(cause)
-      expect(error.reason).toMatchObject({ _tag: "Authentication", kind: "invalid" })
+      expect(error.reason).toMatchObject({ _tag: "Authentication" })
       expect(SessionRunnerRetry.isRetryable(error)).toBeFalse()
       expect(error.reason.body).toBe(responseBody)
       expect(error.reason.cause).toBe(cause)

--- a/packages/core/test/session-error.test.ts
+++ b/packages/core/test/session-error.test.ts
@@ -32,9 +32,7 @@ describe("toSessionError", () => {
       type: "provider.rate-limit",
       message: "rate",
     })
-    expect(toSessionError(llm(new AuthenticationError({ message: "auth", kind: "invalid" }))).type).toBe(
-      "provider.auth",
-    )
+    expect(toSessionError(llm(new AuthenticationError({ message: "auth" }))).type).toBe("provider.auth")
     expect(toSessionError(llm(new QuotaExceededError({ message: "quota" }))).type).toBe("provider.quota")
     expect(toSessionError(llm(new ContentPolicyError({ message: "blocked" }))).type).toBe("provider.content-filter")
     expect(
@@ -129,14 +127,15 @@ describe("toSessionError", () => {
     })
   })
 
-  test("retries only rate limits, provider-internal failures, and transport failures", () => {
+  test("retries rate limits, provider-internal, transport, and unrecognized failures", () => {
     const eligible = [
       llm(new RateLimitError({ message: "rate" })),
       llm(new ProviderInternalError({ message: "internal" })),
       llm(new TransportError({ message: "transport", transport: "http", operation: "request" })),
+      llm(new UnknownProviderError({ message: "unknown" })),
     ]
     const ineligible = [
-      llm(new AuthenticationError({ message: "auth", kind: "invalid" })),
+      llm(new AuthenticationError({ message: "auth" })),
       llm(new QuotaExceededError({ message: "quota" })),
       llm(new ContentPolicyError({ message: "blocked" })),
       llm(new InvalidProviderOutputError({ message: "output" })),
@@ -149,11 +148,10 @@ describe("toSessionError", () => {
           model: ModelID.make("model"),
         }),
       ),
-      llm(new UnknownProviderError({ message: "unknown" })),
     ]
 
-    expect(eligible.map(SessionRunnerRetry.isRetryable)).toEqual([true, true, true])
-    expect(ineligible.map(SessionRunnerRetry.isRetryable)).toEqual([false, false, false, false, false, false, false])
+    expect(eligible.map(SessionRunnerRetry.isRetryable)).toEqual([true, true, true, true])
+    expect(ineligible.map(SessionRunnerRetry.isRetryable)).toEqual([false, false, false, false, false, false])
   })
 
   test("retries transport failures only when delivery is absent or not sent", () => {


### PR DESCRIPTION
## Summary
Session retry eligibility previously required affirmatively recognizing a failure as transient: anything the classifier could not identify became `UnknownProviderError`, which never retried. Transient failures are exactly the ones that arrive in unpredictable shapes (gateway wrappers, proxy phrasings, gRPC-style text), so every new wording silently killed turns that would have succeeded on retry, and each fix required another classifier rule.

This inverts the default: classification now records affirmative evidence that a failure is deterministic, and anything unrecognized retries under the existing bounded policy (4 retries, jittered backoff, 15-minute cap).

- `UnknownProviderError` is now retry-eligible in the session retry policy.
- Any remaining 4xx status classifies as `InvalidRequest`, replacing the enumerated 400/404/413/422 list. The flip requires this: a 4xx without a matching rule must keep failing fast rather than inherit the new retry default.
- Removed the network-error text promotion rule; code-field substring matching for `exhausted`/`unavailable` server conditions is retained. Status 429 now uniformly classifies as `RateLimit`.
- Removed `AuthenticationError.kind`, which was written at four construction sites and never read.

Quota classification is intentionally unchanged; broader subscription/usage-limit wording is deferred to a follow-up so its non-retry semantics get their own review.

## Behavior notes
- A deterministic failure with no status and no recognized signal now costs at most the bounded retry budget before surfacing; previously it failed fast. The reverse error (dropping a recoverable turn) is permanent, so the asymmetry favors retrying.
- Gemini 429 `RESOURCE_EXHAUSTED` now classifies as `RateLimit` instead of `ProviderInternal`; both retry, and the rate-limit category is the accurate one.

## Verification
- AI: 793 pass, 15 fail — identical failures on a clean `v2` baseline worktree (recording/fixture drift, none touched by this change).
- Core: full isolated `bun run test`, 3770 pass / 0 fail; classification, retry, runner, and AISDK suites rerun after the quota revert.
- `bun typecheck` passes in `packages/ai` and `packages/core`; formatting and diff checks pass.
