### PR TITLE
fix(session-ui): enable word diffs in unified view

### DIFF
--- a/packages/session-ui/component-tests/file.spec.ts
+++ b/packages/session-ui/component-tests/file.spec.ts
@@ -1,0 +1,35 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+for (const split of [false, true]) {
+  for (const theme of ["light", "dark"]) {
+    story(`highlights changed words in ${split ? "split" : "unified"} ${theme} diffs`, async ({ mount }) => {
+      const root = await mount("components-session-review--inline-changes", { args: { split }, globals: { theme } })
+      const diffs = root.locator("diffs-container")
+      await expect(diffs).toHaveCount(2)
+      for (const diff of await diffs.all()) {
+        await expect(diff.locator('[data-line] [style*="--syntax-"]')).not.toHaveCount(0)
+      }
+      const additions = root.locator('[data-line-type="change-addition"] [data-diff-span]')
+      await expect(additions).toHaveText(["select-text"])
+      await expect(root.locator('[data-line-type="context"] [data-diff-span]')).toHaveCount(0)
+      await expect(root.locator('[data-line-type="change-deletion"] [data-diff-span]')).toHaveText([
+        '"http" in',
+        "? error.reason.",
+        "response?.",
+        ": undefined",
+      ])
+      await expect(additions).not.toHaveCSS("background-color", "rgba(0, 0, 0, 0)")
+    })
+  }
+
+  for (const source of ["files", "metadata"]) {
+    story(`skips word diffs for large ${split ? "split" : "unified"} ${source}`, async ({ mount }) => {
+      const root = await mount("components-session-review--large-file", { args: { split, source } })
+      const line = root.locator('[data-line][data-line-type="change-addition"]')
+      await expect(line).toHaveText("export const value = 'after'")
+      // Plain first paint is not proof that the worker kept inline diffs disabled.
+      await expect(line.locator('[style*="--syntax-"]')).not.toHaveCount(0)
+      await expect(root.locator("[data-diff-span]")).toHaveCount(0)
+    })
+  }
+}

--- a/packages/session-ui/component-tests/session-review-comments.spec.ts
+++ b/packages/session-ui/component-tests/session-review-comments.spec.ts
@@ -4,7 +4,7 @@ import { expect, story } from "../../storybook/playwright/story"
 story("opens the comment editor when code is clicked", async ({ mount }) => {
   const root = await mount("components-session-review--interactive-comments")
   const review = root.locator('[data-component="session-review"]')
-  await review.getByText("export const value = 'after'", { exact: true }).click()
+  await review.locator('[data-line-type="change-addition"] [data-diff-span]').click()
   await expect(review.getByRole("textbox")).toBeVisible()
   await expect(review.locator('[data-slot="line-comment-editor-label"]')).toHaveText("Commenting on line 2")
 })

--- a/packages/session-ui/src/components/file.tsx
+++ b/packages/session-ui/src/components/file.tsx
@@ -906,7 +906,7 @@ function TextViewer<T>(props: TextFileProps<T>) {
 
   createEffect(() => {
     const opts = options()
-    const workerPool = getWorkerPool("unified")
+    const workerPool = getWorkerPool()
     const virtualizer = virtuals.get()
 
     renderViewer({
@@ -1111,7 +1111,8 @@ function DiffViewer<T>(props: DiffFileProps<T>) {
 
   createEffect(() => {
     const opts = options()
-    const workerPool = large() ? getWorkerPool("unified") : getWorkerPool(props.diffStyle)
+    // Worker render options override per-viewer options, including the large-file fallback.
+    const workerPool = getWorkerPool(large() ? "none" : "word-alt")
     const virtualizer = virtuals.get()
     const beforeContents = typeof local.before?.contents === "string" ? local.before.contents : ""
     const afterContents = typeof local.after?.contents === "string" ? local.after.contents : ""

--- a/packages/session-ui/src/components/session-review.stories.tsx
+++ b/packages/session-ui/src/components/session-review.stories.tsx
@@ -1,6 +1,8 @@
 import { createStore } from "solid-js/store"
+import { parseDiffFromFile } from "@pierre/diffs"
 import { CurrentSessionProviders } from "../storybook/current-session-story"
 import { editThenTestDocument, reviewDiffs } from "../storybook/current-session-fixtures"
+import { File } from "./file"
 import { SessionReview, type SessionReviewComment } from "./session-review"
 
 function ReviewStory(props: { split?: boolean }) {
@@ -77,3 +79,79 @@ function InteractiveCommentsStory() {
 }
 
 export const InteractiveComments = { render: () => <InteractiveCommentsStory /> }
+
+const gitDiffs = [
+  {
+    // OpenCode 93e1f383dd79683af4fc5ad139cea0516603c838, unchanged git-show output.
+    file: "packages/session-ui/src/components/file.tsx",
+    additions: 1,
+    deletions: 1,
+    patch: `diff --git a/packages/session-ui/src/components/file.tsx b/packages/session-ui/src/components/file.tsx
+index 704971b014..4876731cbd 100644
+--- a/packages/session-ui/src/components/file.tsx
++++ b/packages/session-ui/src/components/file.tsx
+@@ -702,7 +702,7 @@ function ViewerShell(props: {
+       data-mode={props.mode}
+       dir="ltr"
+       style={styleVariables}
+-      class="relative outline-none"
++      class="relative select-text outline-none"
+       classList={{
+         ...props.classList,
+         [props.class ?? ""]: !!props.class,
+`,
+  },
+  {
+    // OpenCode 497a24c17d, unchanged git-show output.
+    file: "packages/core/src/session/runner/retry.ts",
+    additions: 1,
+    deletions: 1,
+    patch: `diff --git a/packages/core/src/session/runner/retry.ts b/packages/core/src/session/runner/retry.ts
+index 10f6680097..ef26792ffe 100644
+--- a/packages/core/src/session/runner/retry.ts
++++ b/packages/core/src/session/runner/retry.ts
+@@ -15,7 +15,7 @@ export interface Input {
+ }
+\x20
+ export function isRetryable(error: AIError) {
+-  const override = "http" in error.reason ? error.reason.http?.response?.headers["x-should-retry"] : undefined
++  const override = error.reason.http?.headers["x-should-retry"]
+   if (override === "true") return true
+   if (override === "false") return false
+   switch (error.reason._tag) {
+`,
+  },
+]
+
+export const InlineChanges = {
+  args: { split: false },
+  render: (args: { split: boolean }) => (
+    <CurrentSessionProviders document={editThenTestDocument}>
+      <div class="mx-auto h-screen min-h-[620px] w-full max-w-[1100px] overflow-hidden bg-background-base">
+        <SessionReview
+          title="OpenCode Git history"
+          diffs={gitDiffs}
+          open={gitDiffs.map((diff) => diff.file)}
+          split={args.split}
+        />
+      </div>
+    </CurrentSessionProviders>
+  ),
+}
+
+export const LargeFile = {
+  args: { split: false, source: "files" },
+  argTypes: { source: { control: "select", options: ["files", "metadata"] } },
+  render: (args: { split: boolean; source: string }) => {
+    // Cross the viewer's 500,000-character limit without long changed lines or 1,000 total lines.
+    const padding = `// ${"unchanged ".repeat(70)}\n`.repeat(800)
+    const before = { name: "large.ts", contents: `export const value = 'before'\n${padding}` }
+    const after = { name: "large.ts", contents: `export const value = 'after'\n${padding}` }
+    const input = args.source === "metadata" ? { fileDiff: parseDiffFromFile(before, after) } : { before, after }
+    return (
+      <div class="h-screen overflow-auto bg-background-base">
+        <File mode="diff" {...input} diffStyle={args.split ? "split" : "unified"} />
+      </div>
+    )
+  },
+}

--- a/packages/session-ui/src/pierre/index.ts
+++ b/packages/session-ui/src/pierre/index.ts
@@ -197,7 +197,7 @@ export function createDefaultOptions<T>(style: FileDiffOptions<T>["diffStyle"]) 
     disableBackground: false,
     expansionLineCount: 20,
     hunkSeparators: "line-info-basic",
-    lineDiffType: style === "split" ? "word-alt" : "none",
+    lineDiffType: "word-alt",
     maxLineDiffLength: 1000,
     maxLineLengthForHighlighting: 1000,
     disableFileHeader: true,

--- a/packages/session-ui/src/pierre/worker.ts
+++ b/packages/session-ui/src/pierre/worker.ts
@@ -4,8 +4,6 @@ import { registerOpenCodeTheme } from "@opencode-ai/ui/context/marked-theme-regi
 
 registerOpenCodeTheme()
 
-export type WorkerPoolStyle = "unified" | "split"
-
 export function workerFactory(): Worker {
   return new Worker(ShikiWorkerUrl, { type: "module" })
 }
@@ -32,24 +30,25 @@ function createPool(lineDiffType: "none" | "word-alt") {
   return pool
 }
 
-let unified: WorkerPoolManager | undefined
-let split: WorkerPoolManager | undefined
+let plain: WorkerPoolManager | undefined
+let diff: WorkerPoolManager | undefined
 
-export function getWorkerPool(style: WorkerPoolStyle | undefined): WorkerPoolManager | undefined {
+export function getWorkerPool(lineDiffType: "none" | "word-alt" = "word-alt"): WorkerPoolManager | undefined {
   if (typeof window === "undefined") return
 
-  if (style === "split") {
-    if (!split) split = createPool("word-alt")
-    return split
+  if (lineDiffType === "none") {
+    if (!plain) plain = createPool("none")
+    return plain
   }
 
-  if (!unified) unified = createPool("none")
-  return unified
+  if (!diff) diff = createPool("word-alt")
+  return diff
 }
 
 export function getWorkerPools() {
+  const pool = getWorkerPool()
   return {
-    unified: getWorkerPool("unified"),
-    split: getWorkerPool("split"),
+    unified: pool,
+    split: pool,
   }
 }

--- a/packages/session-ui/src/v2/components/session-review-v2.tsx
+++ b/packages/session-ui/src/v2/components/session-review-v2.tsx
@@ -152,7 +152,7 @@ export function SessionReviewV2(props: SessionReviewV2Props) {
   const locale = useLocale()
 
   createEffect(() => {
-    getWorkerPool(props.diffStyle)
+    getWorkerPool()
   })
 
   const fileIndex = () => {


### PR DESCRIPTION
**Summary**
- Enable Pierre's built-in `word-alt` highlighting in unified diffs, matching split view. Keep the existing line tint and emphasize only changed words within each row.
- Share the normal word-diff worker pool across layouts. Keep a separate no-word-diff pool for files above 500,000 characters and retain the 1,000-character inline-diff limit. No dependency upgrade or additional workers.
- Add real Git-history fixtures and browser coverage for both layouts and themes, both large-file input paths, and clicking highlighted words to comment.

**Verification**
- `packages/session-ui`: `bun typecheck` and `bun run test` (164 passed).
- `packages/session-ui`: `bun run test:components -- component-tests/file.spec.ts component-tests/session-review-comments.spec.ts --workers=1` (12 passed).
- `packages/app`: `bun run build` passed.
- Repository pre-push typechecks passed (33 tasks).
- Verified the non-worker renderer with the production default options in default, unified, and split modes.
- Verified the large-file test fails if its no-word-diff worker guard is removed, then restored the guard.
- Captured the production viewer at 1100px and 390px widths in light and dark themes. Images are attachments, not committed files.

**Screenshots**
These are real OpenCode patches, rendered by the production `SessionReview` and `File` components in Storybook. Both fixture patches were checked byte-for-byte against `git show`:

- [`93e1f383dd`](https://github.com/anomalyco/opencode/commit/93e1f383dd79683af4fc5ad139cea0516603c838): adds `select-text` in `packages/session-ui/src/components/file.tsx`.
- [`497a24c17d`](https://github.com/anomalyco/opencode/commit/497a24c17df148ce11bffeb1e01a05aff215d718): simplifies the retry-header expression in `packages/core/src/session/runner/retry.ts`.

The file contents, theme, and viewport are identical within each before/after pair. Only the viewer implementation changes.

**Light: Before**
![Unified diff before word highlighting, light theme](https://github.com/user-attachments/assets/4cbebfc7-059c-486f-b811-878f2dab69ed)

**Light: After**
![Unified diff with changed-word highlighting, light theme](https://github.com/user-attachments/assets/fa276ee0-8003-4503-99ca-f220c3eee24f)

<details>
<summary>Dark theme and narrow layouts</summary>

**Dark: Before**
![Unified diff before word highlighting, dark theme](https://github.com/user-attachments/assets/7048f146-d425-4e9e-8a92-e7268568a90e)

**Dark: After**
![Unified diff with changed-word highlighting, dark theme](https://github.com/user-attachments/assets/196bc248-1d6d-4eea-ab97-e49d4542fc86)

**Narrow Light**
| Before | After |
| --- | --- |
| ![Narrow light before](https://github.com/user-attachments/assets/3cc549e0-66ff-42a4-8520-f4c5cda2b879) | ![Narrow light after](https://github.com/user-attachments/assets/e6a80dd0-9c77-45c9-b1a5-e5a94496dbd4) |

**Narrow Dark**
| Before | After |
| --- | --- |
| ![Narrow dark before](https://github.com/user-attachments/assets/22fd8c45-b47f-4405-b714-535ad00995be) | ![Narrow dark after](https://github.com/user-attachments/assets/5e6d3f49-4372-4774-ae4a-351cf97324ee) |

</details>

**Performance Check**
One cold run of the minified production `File` component per revision: 100 changed lines, unified layout, 1366 x 768 viewport, two workers.

| Measurement | Before | After |
| --- | ---: | ---: |
| Render callback | 167.1 ms | 185.9 ms |
| Content and worker readiness observed | 266.9 ms | 250.9 ms |
| Rendered lines | 100 | 100 |
| Inline highlight spans | 0 | 100 |

These are diagnostic samples, not a statistical performance claim. The existing review-pane scaling benchmark is blocked by its stale VCS fixture response: it returns a raw array where the current client expects `{ location, data }`. This PR leaves that unrelated fixture unchanged and uses the direct production-renderer comparison above.
