### PR TITLE
fix(ai): detect DashScope input length overflow errors

### DIFF
--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -37,6 +37,7 @@ const patterns = [
   /too large for model with \d+ maximum context length/i,
   /prompt has [\d,]+ tokens?, but the configured context size is [\d,]+ tokens?/i,
   /model_context_window_exceeded/i,
+  /range of input length should be/i,
   /too many tokens/i,
   /token limit exceeded/i,
   /request_too_large/i,

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -11,6 +11,7 @@ describe("provider error classification", () => {
       "Input length 131393 exceeds the maximum allowed input length of 131040 tokens.",
       "The input (516368 tokens) is longer than the model's context length (262144 tokens).",
       "Prompt has 5,958,968 tokens, but the configured context size is 256,000 tokens",
+      "Range of input length should be [1, 129024]",
       "Too many tokens",
       "Token limit exceeded",
     ]


### PR DESCRIPTION
## Summary
- DashScope/Qwen reports context overflow as an HTTP 400 `invalid_parameter_error` with the message `Range of input length should be [1, X]`. No existing overflow pattern matched it, so the failure classified as a plain `InvalidRequest` and the session surfaced an error instead of compacting and rebuilding.
- Add the message pattern to the context-overflow list so these failures classify as `InvalidRequest` with `classification: "context-overflow"` and trigger the existing compaction recovery.

## Verification
- Pattern covered by the overflow classification test alongside the other provider wordings.
- `bun test test/provider-error.test.ts`: 15 pass, 0 fail. `bun typecheck` and formatting pass in `packages/ai`.