### PR TITLE
fix(provider): skip Bedrock cache point below minimum cacheable size

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -4,6 +4,7 @@ import type { JSONSchema7 } from "@ai-sdk/provider"
 import type * as Provider from "./provider"
 import type * as ModelsDev from "@opencode-ai/core/models-dev"
 import { iife } from "@/util/iife"
+import { Token } from "@/util/token"
 
 type Modality = NonNullable<ModelsDev.Model["modalities"]>["input"][number]
 
@@ -356,6 +357,24 @@ function normalizeMessages(
 }
 
 function applyCaching(msgs: ModelMessage[], model: Provider.Model): ModelMessage[] {
+  // AWS Bedrock hard-rejects a cache point when the cached prefix is below the
+  // model's minimum cacheable size (~1024 tokens for Claude) with HTTP 400
+  // "nothing available to cache" — unlike the Anthropic API, which silently
+  // ignores an undersized cache_control. A short context (e.g. the first turn of
+  // a freshly forked session) would otherwise fail outright, so skip caching for
+  // Bedrock until the prompt is large enough to be cacheable.
+  const isBedrock = model.providerID.includes("bedrock") || model.api.npm === "@ai-sdk/amazon-bedrock"
+  if (isBedrock) {
+    const text = msgs
+      .flatMap((msg) =>
+        typeof msg.content === "string"
+          ? [msg.content]
+          : msg.content.map((part) => ("text" in part && typeof part.text === "string" ? part.text : "")),
+      )
+      .join("")
+    if (Token.estimate(text) < 1024) return msgs
+  }
+
   const system = msgs.filter((msg) => msg.role === "system").slice(0, 2)
   const final = msgs.filter((msg) => msg.role !== "system").slice(-2)
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2397,7 +2397,10 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
           {},
         )
         expect(messages.map((message) => message.role)).toEqual(["user", "assistant", "user"])
-        expect(messages[1].providerOptions?.bedrock?.cachePoint).toEqual(cached ? { type: "default" } : undefined)
+        // This prompt is tiny (well under Bedrock's ~1024-token minimum), so the
+        // cache point is skipped regardless of model — see the dedicated
+        // "bedrock minimum cacheable size" suite for the caching-wiring coverage.
+        expect(messages[1].providerOptions?.bedrock?.cachePoint).toBeUndefined()
         const provider = createAmazonBedrock({
           apiKey: "test-key",
           region: "us-east-1",
@@ -2408,11 +2411,12 @@ describe("ProviderTransform.message - anthropic empty content filtering", () => 
                 { role: "user", content: [{ text: "Think" }] },
                 {
                   role: "assistant",
-                  content: [{ text: "Earlier answer" }, ...(cached ? [{ cachePoint: { type: "default" } }] : [])],
+                  // Tiny prompt (< Bedrock's ~1024-token minimum) → no cache point.
+                  content: [{ text: "Earlier answer" }],
                 },
                 {
                   role: "user",
-                  content: [{ text: "Continue" }, ...(cached ? [{ cachePoint: { type: "default" } }] : [])],
+                  content: [{ text: "Continue" }],
                 },
               ])
               return Response.json({
@@ -3106,7 +3110,10 @@ describe("ProviderTransform.message - claude w/bedrock custom inference profile"
     const msgs = [
       {
         role: "user",
-        content: "Hello",
+        // Large enough to exceed Bedrock's minimum cacheable size (~1024 tokens);
+        // undersized prompts intentionally skip the cache point (see the
+        // "minimum cacheable size" suite below).
+        content: "Hello ".repeat(1200),
       },
     ] as any[]
 
@@ -3141,7 +3148,8 @@ describe("ProviderTransform.message - bedrock caching with non-bedrock providerI
     const msgs = [
       {
         role: "system",
-        content: "You are a helpful assistant",
+        // Large enough to clear Bedrock's minimum cacheable size (~1024 tokens).
+        content: "You are a helpful assistant. ".repeat(300),
       },
       {
         role: "user",
@@ -3155,7 +3163,49 @@ describe("ProviderTransform.message - bedrock caching with non-bedrock providerI
     expect(result[0].providerOptions?.bedrock).toEqual({
       cachePoint: { type: "default" },
     })
-    expect(result[0].content).toBe("You are a helpful assistant")
+    expect(result[0].content).toBe("You are a helpful assistant. ".repeat(300))
+  })
+})
+
+describe("ProviderTransform.message - bedrock minimum cacheable size", () => {
+  const bedrockModel = {
+    id: "amazon-bedrock/global.anthropic.claude-opus-4",
+    providerID: "amazon-bedrock",
+    api: {
+      id: "global.anthropic.claude-opus-4",
+      url: "https://bedrock-runtime.us-east-1.amazonaws.com",
+      npm: "@ai-sdk/amazon-bedrock",
+    },
+    name: "Claude Opus 4",
+    capabilities: {},
+    options: {},
+    headers: {},
+  } as any
+
+  test("skips the cache point when the prompt is below the minimum (~1024 tokens)", () => {
+    // A tiny prompt — e.g. the first turn of a freshly forked session. Bedrock
+    // would reject a cache point here with HTTP 400 "nothing available to cache".
+    const msgs = [
+      { role: "system", content: "You are helpful" },
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, bedrockModel, {}) as any[]
+
+    for (const msg of result) {
+      expect(msg.providerOptions?.bedrock?.cachePoint).toBeUndefined()
+    }
+  })
+
+  test("adds the cache point once the prompt clears the minimum", () => {
+    const msgs = [
+      { role: "system", content: "You are a helpful assistant. ".repeat(300) },
+      { role: "user", content: [{ type: "text", text: "hi" }] },
+    ] as any[]
+
+    const result = ProviderTransform.message(msgs, bedrockModel, {}) as any[]
+
+    expect(result.some((msg) => msg.providerOptions?.bedrock?.cachePoint?.type === "default")).toBe(true)
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

Closes #45855

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`applyCaching()` always adds a Bedrock `cachePoint`. Bedrock rejects a cache point when the cached prefix is under the model's minimum (~1024 tokens for Claude) with a 400, so a short prompt — like the first turn of a freshly forked session — fails outright instead of just running uncached. (The Anthropic API tolerates this; Bedrock doesn't.)

The fix guards the Bedrock branch: estimate the prompt size with the existing `Token.estimate`, and skip the cache point below ~1024 tokens. Other providers are untouched.

### How did you verify your code works?

`bun test test/provider/transform.test.ts` → 427 pass, 0 fail.

I updated the existing Bedrock caching tests to use prompts above the minimum (they assert the caching wiring), fixed one reasoning-replay test that used a tiny prompt, and added a small suite asserting: undersized prompt → no cache point, large enough prompt → cache point present.

Note: repo-wide `typecheck` fails on a pre-existing error in `src/bus/global.ts` that this PR doesn't touch; `transform.ts` typechecks clean.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
