### PR TITLE
fix: use x64 build on Windows ARM64 (native build lacks bun:ffi)

### DIFF
--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -23,7 +23,16 @@ const archMap = {
 }
 
 const platform = platformMap[os.platform()] ?? os.platform()
-const arch = archMap[os.arch()] ?? os.arch()
+let arch = archMap[os.arch()] ?? os.arch()
+
+// Windows on ARM: the native arm64 build cannot load OpenTUI because bun:ffi
+// (dlopen/TinyCC) is disabled in bun's windows-arm64 runtime. Use the x64 build,
+// which runs under Windows' x64 emulation and has full bun:ffi support.
+if (platform === "windows" && arch === "arm64") {
+  console.log("opencode: using the x64 build on Windows ARM64 (native build lacks bun:ffi support required by OpenTUI)")
+  arch = "x64"
+}
+
 const base = `opencode-${platform}-${arch}`
 const sourceBinary = platform === "windows" ? "opencode.exe" : "opencode"
 const targetBinary = path.join(__dirname, "bin", "opencode.exe")


### PR DESCRIPTION
The native windows-arm64 build cannot initialize OpenTUI because bun:ffi (dlopen/TinyCC) is disabled in bun's windows-arm64 runtime. This makes interactive startup crash with "Failed to initialize OpenTUI render library: bun:ffi dlopen() is not available in this build".

This PR falls back to the windows-x64 build on Windows on ARM (Snapdragon X Elite/Plus). The x64 binary runs under Windows' built-in x64 emulation and has full bun:ffi support; it is already published as opencode-windows-x64 and opencode-windows-x64-baseline (used automatically since emulated CPUs report no AVX2).

Tested on a Windows 11 ARM64 machine: after the patch, in/opencode.exe is the x64 PE build (machine type 0x8664) and opencode --version succeeds.