### PR TITLE
fix(tui): support slash-containing channels

### DIFF
--- a/packages/tui/src/context/storage.tsx
+++ b/packages/tui/src/context/storage.tsx
@@ -44,12 +44,18 @@ function segment(value: string) {
   return value
 }
 
+function channelSegment(value: string) {
+  if (/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(value) && value !== "." && value !== "..") return value
+  return `encoded-${Buffer.from(value).toString("base64url")}`
+}
+
 function createStorage(root: string, channel: string) {
   const entries = new Map<string, { readonly value: Entry<object>; readonly reload: () => void }>()
   const memories = new Map<string, MemoryEntry<object>>()
   const pending = new Set<Promise<void>>()
-  const directory = path.join(root, segment(channel), "tui")
-  const locks = path.join(root, segment(channel), "locks")
+  const namespace = channelSegment(channel)
+  const directory = path.join(root, namespace, "tui")
+  const locks = path.join(root, namespace, "locks")
   mkdirSync(directory, { recursive: true })
 
   const storage: Storage = {

--- a/packages/tui/test/context/storage.test.tsx
+++ b/packages/tui/test/context/storage.test.tsx
@@ -1,0 +1,29 @@
+/** @jsxImportSource @opentui/solid */
+import { expect, test } from "bun:test"
+import { testRender } from "@opentui/solid"
+import path from "path"
+import { readdir } from "fs/promises"
+import { TuiAppProvider } from "../../src/context/runtime"
+import { StorageProvider } from "../../src/context/storage"
+import { tmpdir } from "../fixture/fixture"
+import { TestTuiContexts } from "../fixture/tui-environment"
+
+test("supports channels containing slashes", async () => {
+  await using temporary = await tmpdir()
+  const app = await testRender(() => (
+    <TestTuiContexts paths={{ state: temporary.path }}>
+      <TuiAppProvider value={{ name: "test", version: "test", channel: "fix/repro" }}>
+        <StorageProvider>
+          <box />
+        </StorageProvider>
+      </TuiAppProvider>
+    </TestTuiContexts>
+  ))
+
+  try {
+    expect(await readdir(temporary.path)).toEqual(["encoded-Zml4L3JlcHJv"])
+    expect(await readdir(path.join(temporary.path, "encoded-Zml4L3JlcHJv"))).toEqual(["tui"])
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45493

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

TUI storage previously treated the build channel as an already-valid path segment. Channels derived from branch names such as `fix/repro` therefore crashed `StorageProvider` before the TUI rendered.

This keeps existing valid channel directories unchanged and encodes invalid channels as a stable base64url path segment. The encoding keeps the namespace inside one directory and avoids collisions from simply replacing `/` with `-`.

### How did you verify your code works?

- Reproduced the original `TypeError: Invalid storage segment: fix/repro` against the unmodified V2 base.
- Added a regression test that mounts `StorageProvider` with `fix/repro` and verifies the resulting single-segment storage directory.
- Ran `bun test` from `packages/tui`: 900 passed, 4 skipped, 0 failed.
- Ran the repository changed-file lint and full `bun typecheck`.

### Screenshots / recordings

Not applicable; the failure happened before the TUI rendered.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
