### PR TITLE
fix(ai): respect completed response item text

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -855,6 +855,11 @@ const decodeReasoningPart = Schema.decodeUnknownOption(
   Schema.Struct({ type: Schema.tag("reasoning_text"), text: Schema.String }),
 )
 
+const joinReasoningText = (parts: ReadonlyArray<string | undefined>) => {
+  if (!parts.some((part) => part !== undefined && part.length > 0)) return undefined
+  return parts.filter((part) => part !== undefined).join("\n\n")
+}
+
 export const outputItemID = (state: ParserState, event: Event) =>
   event.output_index === undefined ? event.item_id : (state.outputItems[event.output_index] ?? event.item_id)
 
@@ -1085,12 +1090,13 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
     const message = state.message?.id === item.id ? state.message : undefined
     const itemPhase = messagePhase(item.phase)
     const phase = itemPhase === undefined ? message?.phase : itemPhase
-    const content = Array.isArray(item.content)
-      ? item.content.flatMap((part: unknown) => {
-          const decoded = Option.getOrUndefined(decodeMessagePart(part))
-          return decoded ? [decoded.type === "output_text" ? decoded.text : decoded.refusal] : []
-        })
-      : []
+    const parts: ReadonlyArray<unknown> = Array.isArray(item.content) ? item.content : []
+    const content: string[] = []
+    for (const part of parts) {
+      const decoded = Option.getOrUndefined(decodeMessagePart(part))
+      if (!decoded) continue
+      content.push(decoded.type === "output_text" ? decoded.text : decoded.refusal)
+    }
     const text = content.length > 0 ? content.join("") : undefined
     const metadata = providerMetadata(state, { itemId: item.id, ...(phase === undefined ? {} : { phase }) })
     const events: LLMEvent[] = []
@@ -1157,35 +1163,30 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   if (isReasoningItem(item)) {
     if (state.reasoningItems[item.id]?.open === false) return [state, NO_EVENTS] satisfies StepResult
     const metadata = reasoningMetadata(state, item)
-    const summary = Array.isArray(item.summary)
-      ? item.summary.map((part: unknown) => Option.getOrUndefined(decodeSummaryPart(part))?.text)
-      : []
-    const content = Array.isArray(item.content)
-      ? item.content.flatMap((part: unknown) => {
-          const decoded = Option.getOrUndefined(decodeReasoningPart(part))
-          return decoded ? [decoded.text] : []
-        })
-      : []
-    const text = summary.some(Boolean)
-      ? summary.filter((part) => part !== undefined).join("\n\n")
-      : content.some(Boolean)
-        ? content.join("\n\n")
-        : undefined
+    const summaryParts: ReadonlyArray<unknown> = Array.isArray(item.summary) ? item.summary : []
+    const summary: Array<string | undefined> = []
+    for (const part of summaryParts) {
+      const decoded = Option.getOrUndefined(decodeSummaryPart(part))
+      // Keep missing entries so the array still matches the provider's summary indexes.
+      summary.push(decoded?.text)
+    }
+    const reasoningParts: ReadonlyArray<unknown> = Array.isArray(item.content) ? item.content : []
+    const content: string[] = []
+    for (const part of reasoningParts) {
+      const decoded = Option.getOrUndefined(decodeReasoningPart(part))
+      if (decoded) content.push(decoded.text)
+    }
+    const itemText = joinReasoningText(summary) ?? joinReasoningText(content)
     const events: LLMEvent[] = []
     const reasoningItem = state.reasoningItems[item.id]
     if (reasoningItem) {
-      const parts = Object.entries(reasoningItem.summaryParts)
+      const fragments = Object.entries(reasoningItem.summaryParts)
       let lifecycle = state.lifecycle
-      // Once earlier summaries have closed, the whole item cannot replace the remaining fragment.
-      for (const [index, status] of parts) {
+      for (const [index, status] of fragments) {
         if (status === "concluded") continue
-        lifecycle = Lifecycle.reasoningEnd(
-          lifecycle,
-          events,
-          `${item.id}:${index}`,
-          metadata,
-          parts.length === 1 ? text : summary[Number(index)] || undefined,
-        )
+        // Do not repeat earlier summaries that were already emitted as separate fragments.
+        const finalText = fragments.length === 1 ? itemText : summary[Number(index)]
+        lifecycle = Lifecycle.reasoningEnd(lifecycle, events, `${item.id}:${index}`, metadata, finalText || undefined)
       }
       return [
         {
@@ -1210,7 +1211,7 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
         LLMEvent.reasoningEnd({
           id: item.id,
           providerMetadata: metadata,
-          text,
+          text: itemText,
         }),
       )
       return [

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -346,7 +346,6 @@ export const Event = Schema.StructWithRest(
     item_id: Schema.optional(Schema.String),
     output_index: Schema.optional(Schema.Number),
     summary_index: Schema.optional(Schema.Number),
-    content_index: Schema.optional(Schema.Number),
     // OutputItemAdded/Done permit a null item in the Open Responses OpenAPI schema.
     item: optionalNull(StreamItem),
     response: Schema.optional(
@@ -397,13 +396,7 @@ export interface ParserState {
   readonly hasFunctionCall: boolean
   readonly lifecycle: Lifecycle.State
   readonly outputItems: Readonly<Record<number, string>>
-  readonly message:
-    | {
-        readonly id: string
-        readonly phase: MessagePhase | null | undefined
-        readonly parts: Readonly<Record<number, { readonly text: string; readonly done: boolean }>>
-      }
-    | undefined
+  readonly message: { readonly id: string; readonly phase: MessagePhase | null | undefined } | undefined
   readonly reasoningItems: Readonly<Record<string, ReasoningStreamItem>>
 }
 
@@ -420,7 +413,6 @@ interface ReasoningStreamItem {
   // is started eagerly when the item opens, so block existence cannot tell
   // whether a `.done` final would duplicate streamed text.
   readonly deltaIndexes: ReadonlySet<number>
-  readonly finalTexts: Readonly<Record<number, string>>
 }
 
 // =============================================================================
@@ -837,63 +829,30 @@ export const terminal = (event: Event) => TERMINAL_TYPES.has(event.type)
 
 const onOutputTextDelta = (state: ParserState, event: Event, id: string): StepResult => {
   if (!event.delta || state.message?.id !== id) return [state, NO_EVENTS]
-  const index = event.content_index ?? 0
-  const part = state.message.parts[index]
-  if (part?.done) return [state, NO_EVENTS]
   const events: LLMEvent[] = []
   const phase = state.message.phase
   const metadata = providerMetadata(state, { itemId: id, ...(phase === undefined ? {} : { phase }) })
   const lifecycle = Lifecycle.textStart(state.lifecycle, events, id, metadata)
-  return [
-    {
-      ...state,
-      lifecycle: Lifecycle.textDelta(lifecycle, events, id, event.delta),
-      message: {
-        ...state.message,
-        parts: { ...state.message.parts, [index]: { text: (part?.text ?? "") + event.delta, done: false } },
-      },
-    },
-    events,
-  ]
+  return [{ ...state, lifecycle: Lifecycle.textDelta(lifecycle, events, id, event.delta) }, events]
 }
 
 const onOutputTextDone = (state: ParserState, event: Event, id: string): StepResult => {
   if (state.message?.id === id) {
-    const index = event.content_index ?? 0
-    if (event.text === undefined || (state.message.parts[index]?.done && event.type !== "response.content_part.done"))
-      return [state, NO_EVENTS]
-    const [current, emitted] = state.message.parts[index]
-      ? [state, NO_EVENTS]
-      : onOutputTextDelta(state, { ...event, delta: event.text }, id)
-    return [
-      {
-        ...current,
-        message: {
-          ...state.message,
-          parts: { ...state.message.parts, [index]: { text: event.text, done: true } },
-        },
-      },
-      emitted,
-    ]
+    if (state.lifecycle.text.has(id) || event.text === undefined) return [state, NO_EVENTS]
+    return onOutputTextDelta(state, { ...event, delta: event.text }, id)
   }
   const events: LLMEvent[] = []
   return [{ ...state, lifecycle: Lifecycle.textEnd(state.lifecycle, events, id) }, events]
 }
 
-const messageFinalText = (message: ParserState["message"]) => {
-  const parts = Object.values(message?.parts ?? {})
-  return parts.some((part) => part.done) ? parts.map((part) => part.text).join("") : undefined
-}
-
 const decodeMessagePart = Schema.decodeUnknownOption(
-  Schema.Union([
-    Schema.Struct({ type: Schema.tag("output_text"), text: Schema.String }),
-    Schema.Struct({ type: Schema.tag("refusal"), refusal: Schema.String }),
-  ]),
+  Schema.Union([OpenResponsesOutputText, Schema.Struct({ type: Schema.tag("refusal"), refusal: Schema.String })]),
 )
 
-const decodeSummaryPart = Schema.decodeUnknownOption(
-  Schema.Struct({ type: Schema.tag("summary_text"), text: Schema.String }),
+const decodeSummaryPart = Schema.decodeUnknownOption(OpenResponsesReasoningSummaryText)
+
+const decodeReasoningPart = Schema.decodeUnknownOption(
+  Schema.Struct({ type: Schema.tag("reasoning_text"), text: Schema.String }),
 )
 
 export const outputItemID = (state: ParserState, event: Event) =>
@@ -908,13 +867,7 @@ const startReasoningSummaryPart = (state: ParserState, itemID: string, index: nu
     .filter((entry) => entry[1] !== "concluded")
     .reduce(
       (lifecycle, entry) =>
-        Lifecycle.reasoningEnd(
-          lifecycle,
-          events,
-          `${itemID}:${entry[0]}`,
-          providerMetadata(state, { itemId: itemID }),
-          item.finalTexts[Number(entry[0])],
-        ),
+        Lifecycle.reasoningEnd(lifecycle, events, `${itemID}:${entry[0]}`, providerMetadata(state, { itemId: itemID })),
       state.lifecycle,
     )
   return [
@@ -967,39 +920,15 @@ export const onReasoningDelta = (state: ParserState, event: Event, itemID: strin
   ]
 }
 
-// Keep the final until the existing boundary closes the fragment, so encrypted
-// item metadata can still be attached to its single reasoning-end event.
-export const onReasoningDone = (
-  state: ParserState,
-  itemID: string,
-  index: number,
-  text: string | undefined,
-): StepResult => {
+// Some compatible gateways emit a reasoning final without streaming any
+// deltas, mirroring `response.output_text.done`. Reconcile the complete text
+// as a single delta unless that summary index already streamed one.
+export const onReasoningDone = (state: ParserState, event: Event, itemID: string): StepResult => {
   const item = state.reasoningItems[itemID]
-  if (!item?.open || text === undefined) return [state, NO_EVENTS]
-  if (item.summaryParts[index] === "concluded") return [state, NO_EVENTS]
-  const [started, emitted] = startReasoningSummaryPart(state, itemID, index)
-  const current = started.reasoningItems[itemID]
-  if (!current) return [started, emitted]
-  const events = [...emitted]
-  const append = text.length > 0 && !current.deltaIndexes.has(index)
-  return [
-    {
-      ...started,
-      lifecycle: append
-        ? Lifecycle.reasoningDelta(started.lifecycle, events, `${itemID}:${index}`, text)
-        : started.lifecycle,
-      reasoningItems: {
-        ...started.reasoningItems,
-        [itemID]: {
-          ...current,
-          deltaIndexes: append ? new Set([...current.deltaIndexes, index]) : current.deltaIndexes,
-          finalTexts: { ...current.finalTexts, [index]: text },
-        },
-      },
-    },
-    events,
-  ]
+  if (!item?.open || typeof event.text !== "string") return [state, NO_EVENTS]
+  const index = event.summary_index ?? 0
+  if (item.deltaIndexes.has(index)) return [state, NO_EVENTS]
+  return onReasoningDelta(state, { ...event, delta: event.text }, itemID)
 }
 
 const reasoningMetadata = (state: ParserState, item: StreamItem & { id: string }) =>
@@ -1031,7 +960,6 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
           events,
           id,
           providerMetadata(state, { itemId: id, ...(openPhase === undefined ? {} : { phase: openPhase }) }),
-          messageFinalText(state.message),
         )
       }, state.lifecycle)
     return [
@@ -1041,7 +969,6 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
         message: {
           id: itemID,
           phase: phase === undefined && state.message?.id === itemID ? state.message.phase : phase,
-          parts: state.message?.id === itemID ? state.message.parts : {},
         },
       },
       events,
@@ -1061,7 +988,6 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
             encryptedContent: item.encrypted_content,
             summaryParts: { 0: "active" },
             deltaIndexes: new Set(),
-            finalTexts: {},
           },
         },
       },
@@ -1097,18 +1023,14 @@ const onReasoningSummaryPartAdded = (state: ParserState, event: Event): StepResu
 
 const onReasoningSummaryPartDone = (state: ParserState, event: Event): StepResult => {
   if (event.item_id === undefined || event.summary_index === undefined) return [state, NO_EVENTS]
-  const part = Option.getOrUndefined(decodeSummaryPart(event.part))
-  const [current, events] = part
-    ? onReasoningDone(state, event.item_id, event.summary_index, part.text)
-    : [state, NO_EVENTS]
-  const item = current.reasoningItems[event.item_id]
+  const item = state.reasoningItems[event.item_id]
   if (!item?.open) return [state, NO_EVENTS]
-  if (item.summaryParts[event.summary_index] !== "active") return [current, events]
+  if (item.summaryParts[event.summary_index] !== "active") return [state, NO_EVENTS]
   return [
     {
-      ...current,
+      ...state,
       reasoningItems: {
-        ...current.reasoningItems,
+        ...state.reasoningItems,
         [event.item_id]: {
           ...item,
           summaryParts: {
@@ -1118,7 +1040,7 @@ const onReasoningSummaryPartDone = (state: ParserState, event: Event): StepResul
         },
       },
     },
-    events,
+    NO_EVENTS,
   ]
 }
 
@@ -1169,7 +1091,7 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
           return decoded ? [decoded.type === "output_text" ? decoded.text : decoded.refusal] : []
         })
       : []
-    const text = content.length > 0 ? content.join("") : messageFinalText(message)
+    const text = content.length > 0 ? content.join("") : undefined
     const metadata = providerMetadata(state, { itemId: item.id, ...(phase === undefined ? {} : { phase }) })
     const events: LLMEvent[] = []
     const lifecycle =
@@ -1235,40 +1157,42 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   if (isReasoningItem(item)) {
     if (state.reasoningItems[item.id]?.open === false) return [state, NO_EVENTS] satisfies StepResult
     const metadata = reasoningMetadata(state, item)
-    const parts: ReadonlyArray<unknown> = Array.isArray(item.summary) ? item.summary : []
-    const summary: string[] = []
+    const summary = Array.isArray(item.summary)
+      ? item.summary.map((part: unknown) => Option.getOrUndefined(decodeSummaryPart(part))?.text)
+      : []
+    const content = Array.isArray(item.content)
+      ? item.content.flatMap((part: unknown) => {
+          const decoded = Option.getOrUndefined(decodeReasoningPart(part))
+          return decoded ? [decoded.text] : []
+        })
+      : []
+    const text = summary.some(Boolean)
+      ? summary.filter((part) => part !== undefined).join("\n\n")
+      : content.some(Boolean)
+        ? content.join("\n\n")
+        : undefined
     const events: LLMEvent[] = []
-    let current = state
-    const lastIndex = Math.max(-1, ...Object.keys(state.reasoningItems[item.id]?.summaryParts ?? {}).map(Number))
-    for (const [index, part] of parts.entries()) {
-      const decoded = Option.getOrUndefined(decodeSummaryPart(part))
-      if (!decoded) continue
-      summary.push(decoded.text)
-      // Backfilling an earlier gap would close the current fragment before its final arrives.
-      if (index < lastIndex) continue
-      const [next, emitted] = onReasoningDone(current, item.id, index, decoded.text)
-      current = next
-      events.push(...emitted)
-    }
-    const reasoningItem = current.reasoningItems[item.id]
+    const reasoningItem = state.reasoningItems[item.id]
     if (reasoningItem) {
-      let lifecycle = current.lifecycle
-      for (const [index, status] of Object.entries(reasoningItem.summaryParts)) {
+      const parts = Object.entries(reasoningItem.summaryParts)
+      let lifecycle = state.lifecycle
+      // Once earlier summaries have closed, the whole item cannot replace the remaining fragment.
+      for (const [index, status] of parts) {
         if (status === "concluded") continue
         lifecycle = Lifecycle.reasoningEnd(
           lifecycle,
           events,
           `${item.id}:${index}`,
           metadata,
-          reasoningItem.finalTexts[Number(index)],
+          parts.length === 1 ? text : summary[Number(index)] || undefined,
         )
       }
       return [
         {
-          ...current,
+          ...state,
           lifecycle,
           reasoningItems: {
-            ...current.reasoningItems,
+            ...state.reasoningItems,
             [item.id]: {
               ...reasoningItem,
               open: false,
@@ -1286,7 +1210,7 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
         LLMEvent.reasoningEnd({
           id: item.id,
           providerMetadata: metadata,
-          text: summary.length > 0 ? summary.join("\n\n") : undefined,
+          text,
         }),
       )
       return [
@@ -1300,7 +1224,6 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
               encryptedContent: item.encrypted_content,
               summaryParts: { 0: "concluded" },
               deltaIndexes: new Set(),
-              finalTexts: {},
             },
           },
         },
@@ -1325,7 +1248,6 @@ const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (
       if (id === undefined) continue
       const tracked =
         (item.type === "function_call" && current.tools[id]) ||
-        (item.type === "message" && current.message?.id === id) ||
         (item.type === "reasoning" && current.reasoningItems[id]?.open)
       if (!tracked) continue
       const [next, emitted] = yield* onOutputItemDone(current, item)
@@ -1342,23 +1264,7 @@ const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (
   const hasFunctionCall =
     pending.events.some((event) => LLMEvent.is.toolCall(event) || LLMEvent.is.toolInputError(event)) ||
     current.hasFunctionCall
-  // Generic terminal closure must also carry finals received before a missing item boundary.
-  let lifecycle = current.lifecycle
-  for (const [id, item] of Object.entries(current.reasoningItems)) {
-    for (const index of Object.keys(item.summaryParts)) {
-      lifecycle = Lifecycle.reasoningEnd(lifecycle, events, `${id}:${index}`, undefined, item.finalTexts[Number(index)])
-    }
-  }
-  for (const id of lifecycle.text) {
-    lifecycle = Lifecycle.textEnd(
-      lifecycle,
-      events,
-      id,
-      undefined,
-      current.message?.id === id ? messageFinalText(current.message) : undefined,
-    )
-  }
-  lifecycle = Lifecycle.finish(lifecycle, events, {
+  const lifecycle = Lifecycle.finish(current.lifecycle, events, {
     reason: {
       normalized: mapFinishReason(event, hasFunctionCall),
       raw: event.response?.incomplete_details?.reason,
@@ -1433,18 +1339,6 @@ export const step = (state: ParserState, input: Event) => {
         : onOutputTextDone(state, { ...event, text: value }, event.item_id),
     )
   }
-  if (event.type === "response.content_part.done" && event.item_id !== undefined) {
-    const part = Option.getOrUndefined(decodeMessagePart(event.part))
-    return Effect.succeed<StepResult>(
-      part
-        ? onOutputTextDone(
-            state,
-            { ...event, text: part.type === "output_text" ? part.text : part.refusal },
-            event.item_id,
-          )
-        : [state, NO_EVENTS],
-    )
-  }
   if (event.type === "response.reasoning.delta" || event.type === "response.reasoning_summary_text.delta") {
     if (event.item_id === undefined) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
     return Effect.succeed(onReasoningDelta(state, event, event.item_id))
@@ -1455,7 +1349,7 @@ export const step = (state: ParserState, input: Event) => {
     event.type === "response.reasoning_text.done"
   ) {
     if (event.item_id === undefined) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
-    return Effect.succeed(onReasoningDone(state, event.item_id, event.summary_index ?? 0, event.text))
+    return Effect.succeed(onReasoningDone(state, event, event.item_id))
   }
   if (event.type === "response.reasoning_summary_part.added")
     return event.item_id !== undefined

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -969,26 +969,36 @@ export const onReasoningDelta = (state: ParserState, event: Event, itemID: strin
 
 // Keep the final until the existing boundary closes the fragment, so encrypted
 // item metadata can still be attached to its single reasoning-end event.
-export const onReasoningDone = (state: ParserState, event: Event, itemID: string): StepResult => {
+export const onReasoningDone = (
+  state: ParserState,
+  itemID: string,
+  index: number,
+  text: string | undefined,
+): StepResult => {
   const item = state.reasoningItems[itemID]
-  if (!item?.open || typeof event.text !== "string") return [state, NO_EVENTS]
-  const index = event.summary_index ?? 0
+  if (!item?.open || text === undefined) return [state, NO_EVENTS]
   if (item.summaryParts[index] === "concluded") return [state, NO_EVENTS]
-  const [started, opened] = startReasoningSummaryPart(state, itemID, index)
-  const [current, emitted] = item.deltaIndexes.has(index)
-    ? [started, NO_EVENTS]
-    : onReasoningDelta(started, { ...event, delta: event.text }, itemID)
-  const reasoningItem = current.reasoningItems[itemID]
-  if (!reasoningItem) return [current, [...opened, ...emitted]]
+  const [started, emitted] = startReasoningSummaryPart(state, itemID, index)
+  const current = started.reasoningItems[itemID]
+  if (!current) return [started, emitted]
+  const events = [...emitted]
+  const append = text.length > 0 && !current.deltaIndexes.has(index)
   return [
     {
-      ...current,
+      ...started,
+      lifecycle: append
+        ? Lifecycle.reasoningDelta(started.lifecycle, events, `${itemID}:${index}`, text)
+        : started.lifecycle,
       reasoningItems: {
-        ...current.reasoningItems,
-        [itemID]: { ...reasoningItem, finalTexts: { ...reasoningItem.finalTexts, [index]: event.text } },
+        ...started.reasoningItems,
+        [itemID]: {
+          ...current,
+          deltaIndexes: append ? new Set([...current.deltaIndexes, index]) : current.deltaIndexes,
+          finalTexts: { ...current.finalTexts, [index]: text },
+        },
       },
     },
-    [...opened, ...emitted],
+    events,
   ]
 }
 
@@ -1089,7 +1099,7 @@ const onReasoningSummaryPartDone = (state: ParserState, event: Event): StepResul
   if (event.item_id === undefined || event.summary_index === undefined) return [state, NO_EVENTS]
   const part = Option.getOrUndefined(decodeSummaryPart(event.part))
   const [current, events] = part
-    ? onReasoningDone(state, { ...event, text: part.text }, event.item_id)
+    ? onReasoningDone(state, event.item_id, event.summary_index, part.text)
     : [state, NO_EVENTS]
   const item = current.reasoningItems[event.item_id]
   if (!item?.open) return [state, NO_EVENTS]
@@ -1143,36 +1153,32 @@ const onFunctionCallArgumentsDelta = Effect.fn("OpenResponses.onFunctionCallArgu
   return [{ ...state, lifecycle, tools: result.tools }, events] satisfies StepResult
 })
 
-const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (state: ParserState, event: Event) {
-  const item = event.item
+const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
+  state: ParserState,
+  item: Event["item"],
+) {
   if (!item) return [state, NO_EVENTS] satisfies StepResult
 
   if (item.type === "message" && item.id !== undefined) {
+    const message = state.message?.id === item.id ? state.message : undefined
     const itemPhase = messagePhase(item.phase)
-    const phase = itemPhase === undefined && state.message?.id === item.id ? state.message.phase : itemPhase
+    const phase = itemPhase === undefined ? message?.phase : itemPhase
     const content = Array.isArray(item.content)
       ? item.content.flatMap((part: unknown) => {
           const decoded = Option.getOrUndefined(decodeMessagePart(part))
           return decoded ? [decoded.type === "output_text" ? decoded.text : decoded.refusal] : []
         })
       : []
-    const text =
-      content.length > 0
-        ? content.join("")
-        : state.message?.id === item.id
-          ? messageFinalText(state.message)
-          : undefined
+    const text = content.length > 0 ? content.join("") : messageFinalText(message)
     const metadata = providerMetadata(state, { itemId: item.id, ...(phase === undefined ? {} : { phase }) })
     const events: LLMEvent[] = []
     const lifecycle =
-      state.message?.id === item.id && text !== undefined && text.length > 0
-        ? Lifecycle.textStart(state.lifecycle, events, item.id, metadata)
-        : state.lifecycle
+      message && text ? Lifecycle.textStart(state.lifecycle, events, item.id, metadata) : state.lifecycle
     return [
       {
         ...state,
         lifecycle: Lifecycle.textEnd(lifecycle, events, item.id, metadata, text),
-        message: state.message?.id === item.id ? undefined : state.message,
+        message: message ? undefined : state.message,
       },
       events,
     ] satisfies StepResult
@@ -1227,44 +1233,36 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   }
 
   if (isReasoningItem(item)) {
+    if (state.reasoningItems[item.id]?.open === false) return [state, NO_EVENTS] satisfies StepResult
     const metadata = reasoningMetadata(state, item)
-    const summary = Array.isArray(item.summary)
-      ? item.summary.flatMap((part: unknown, index) => {
-          const decoded = Option.getOrUndefined(decodeSummaryPart(part))
-          return decoded ? [{ index, text: decoded.text }] : []
-        })
-      : []
+    const parts: ReadonlyArray<unknown> = Array.isArray(item.summary) ? item.summary : []
+    const summary: string[] = []
+    const events: LLMEvent[] = []
+    let current = state
     const lastIndex = Math.max(-1, ...Object.keys(state.reasoningItems[item.id]?.summaryParts ?? {}).map(Number))
-    const [current, emitted] = summary.reduce<StepResult>(
-      ([current, events], part) => {
-        // Backfilling an earlier gap would close the current fragment before its final arrives.
-        if (part.index < lastIndex) return [current, events]
-        const [next, emitted] = onReasoningDone(
-          current,
-          { type: "response.reasoning_summary_text.done", summary_index: part.index, text: part.text },
-          item.id,
-        )
-        return [next, [...events, ...emitted]]
-      },
-      [state, NO_EVENTS],
-    )
-    const events: LLMEvent[] = [...emitted]
+    for (const [index, part] of parts.entries()) {
+      const decoded = Option.getOrUndefined(decodeSummaryPart(part))
+      if (!decoded) continue
+      summary.push(decoded.text)
+      // Backfilling an earlier gap would close the current fragment before its final arrives.
+      if (index < lastIndex) continue
+      const [next, emitted] = onReasoningDone(current, item.id, index, decoded.text)
+      current = next
+      events.push(...emitted)
+    }
     const reasoningItem = current.reasoningItems[item.id]
     if (reasoningItem) {
-      if (!reasoningItem.open) return [state, NO_EVENTS] satisfies StepResult
-      const lifecycle = Object.entries(reasoningItem.summaryParts)
-        .filter((entry) => entry[1] === "active" || entry[1] === "can-conclude")
-        .reduce(
-          (lifecycle, entry) =>
-            Lifecycle.reasoningEnd(
-              lifecycle,
-              events,
-              `${item.id}:${entry[0]}`,
-              metadata,
-              reasoningItem.finalTexts[Number(entry[0])],
-            ),
-          current.lifecycle,
+      let lifecycle = current.lifecycle
+      for (const [index, status] of Object.entries(reasoningItem.summaryParts)) {
+        if (status === "concluded") continue
+        lifecycle = Lifecycle.reasoningEnd(
+          lifecycle,
+          events,
+          `${item.id}:${index}`,
+          metadata,
+          reasoningItem.finalTexts[Number(index)],
         )
+      }
       return [
         {
           ...current,
@@ -1288,7 +1286,7 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
         LLMEvent.reasoningEnd({
           id: item.id,
           providerMetadata: metadata,
-          text: summary.length > 0 ? summary.map((part) => part.text).join("\n\n") : undefined,
+          text: summary.length > 0 ? summary.join("\n\n") : undefined,
         }),
       )
       return [
@@ -1319,58 +1317,48 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
 })
 
 const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (state: ParserState, event: Event) {
-  const reconciled =
-    event.type === "response.completed"
-      ? yield* Effect.reduce(
-          event.response?.output ?? [],
-          () => [state, NO_EVENTS] satisfies StepResult,
-          ([current, events], item) => {
-            const id = item.id ?? (item.type === "function_call" ? item.call_id : undefined)
-            if (
-              id === undefined ||
-              ((item.type !== "function_call" || !current.tools[id]) &&
-                (item.type !== "message" || current.message?.id !== id) &&
-                (item.type !== "reasoning" || !current.reasoningItems[id]?.open))
-            )
-              return Effect.succeed([current, events] satisfies StepResult)
-            return onOutputItemDone(current, { type: "response.output_item.done", item }).pipe(
-              Effect.map(([next, emitted]) => [next, [...events, ...emitted]] satisfies StepResult),
-            )
-          },
-        )
-      : ([state, NO_EVENTS] satisfies StepResult)
-  const current = reconciled[0]
+  let current = state
+  const events: LLMEvent[] = []
+  if (event.type === "response.completed") {
+    for (const item of event.response?.output ?? []) {
+      const id = item.id ?? (item.type === "function_call" ? item.call_id : undefined)
+      if (id === undefined) continue
+      const tracked =
+        (item.type === "function_call" && current.tools[id]) ||
+        (item.type === "message" && current.message?.id === id) ||
+        (item.type === "reasoning" && current.reasoningItems[id]?.open)
+      if (!tracked) continue
+      const [next, emitted] = yield* onOutputItemDone(current, item)
+      current = next
+      events.push(...emitted)
+    }
+  }
   // Some compatible providers omit output_item.done even after completing the response.
   const pending =
     event.type === "response.completed"
       ? yield* ToolStream.finishAll(current.id, current.tools)
       : { tools: current.tools, events: NO_EVENTS }
-  const events: LLMEvent[] = [...reconciled[1], ...pending.events]
+  events.push(...pending.events)
   const hasFunctionCall =
     pending.events.some((event) => LLMEvent.is.toolCall(event) || LLMEvent.is.toolInputError(event)) ||
     current.hasFunctionCall
   // Generic terminal closure must also carry finals received before a missing item boundary.
-  const reasoningClosed = Object.entries(current.reasoningItems).reduce(
-    (lifecycle, [id, item]) =>
-      Object.entries(item.summaryParts).reduce(
-        (lifecycle, [index]) =>
-          Lifecycle.reasoningEnd(lifecycle, events, `${id}:${index}`, undefined, item.finalTexts[Number(index)]),
-        lifecycle,
-      ),
-    current.lifecycle,
-  )
-  const closed = [...reasoningClosed.text].reduce(
-    (lifecycle, id) =>
-      Lifecycle.textEnd(
-        lifecycle,
-        events,
-        id,
-        undefined,
-        current.message?.id === id ? messageFinalText(current.message) : undefined,
-      ),
-    reasoningClosed,
-  )
-  const lifecycle = Lifecycle.finish(closed, events, {
+  let lifecycle = current.lifecycle
+  for (const [id, item] of Object.entries(current.reasoningItems)) {
+    for (const index of Object.keys(item.summaryParts)) {
+      lifecycle = Lifecycle.reasoningEnd(lifecycle, events, `${id}:${index}`, undefined, item.finalTexts[Number(index)])
+    }
+  }
+  for (const id of lifecycle.text) {
+    lifecycle = Lifecycle.textEnd(
+      lifecycle,
+      events,
+      id,
+      undefined,
+      current.message?.id === id ? messageFinalText(current.message) : undefined,
+    )
+  }
+  lifecycle = Lifecycle.finish(lifecycle, events, {
     reason: {
       normalized: mapFinishReason(event, hasFunctionCall),
       raw: event.response?.incomplete_details?.reason,
@@ -1467,7 +1455,7 @@ export const step = (state: ParserState, input: Event) => {
     event.type === "response.reasoning_text.done"
   ) {
     if (event.item_id === undefined) return ProviderShared.eventError(state.id, `${event.type} is missing item_id`)
-    return Effect.succeed(onReasoningDone(state, event, event.item_id))
+    return Effect.succeed(onReasoningDone(state, event.item_id, event.summary_index ?? 0, event.text))
   }
   if (event.type === "response.reasoning_summary_part.added")
     return event.item_id !== undefined
@@ -1504,7 +1492,7 @@ export const step = (state: ParserState, input: Event) => {
   if (event.type === "response.output_item.done") {
     if (event.item?.type === "message" && event.item.id === undefined)
       return ProviderShared.eventError(state.id, `${event.type} message is missing id`)
-    return onOutputItemDone(state, event)
+    return onOutputItemDone(state, event.item)
   }
   if (event.type === "response.completed" || event.type === "response.incomplete") return onResponseFinish(state, event)
   if (event.type === "response.failed") return providerFailure(event, `${state.name} response failed`)

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -1247,10 +1247,7 @@ const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (
     for (const item of event.response?.output ?? []) {
       const id = item.id ?? (item.type === "function_call" ? item.call_id : undefined)
       if (id === undefined) continue
-      const tracked =
-        (item.type === "function_call" && current.tools[id]) ||
-        (item.type === "reasoning" && current.reasoningItems[id]?.open)
-      if (!tracked) continue
+      if (item.type !== "function_call" || !current.tools[id]) continue
       const [next, emitted] = yield* onOutputItemDone(current, item)
       current = next
       events.push(...emitted)

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -1,4 +1,4 @@
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
 import type { Content } from "@opencode-ai/schema/tool"
 import { HttpTransport } from "../route/transport/index.js"
 import { Protocol } from "../route/protocol.js"
@@ -346,6 +346,7 @@ export const Event = Schema.StructWithRest(
     item_id: Schema.optional(Schema.String),
     output_index: Schema.optional(Schema.Number),
     summary_index: Schema.optional(Schema.Number),
+    content_index: Schema.optional(Schema.Number),
     // OutputItemAdded/Done permit a null item in the Open Responses OpenAPI schema.
     item: optionalNull(StreamItem),
     response: Schema.optional(
@@ -396,7 +397,13 @@ export interface ParserState {
   readonly hasFunctionCall: boolean
   readonly lifecycle: Lifecycle.State
   readonly outputItems: Readonly<Record<number, string>>
-  readonly message: { readonly id: string; readonly phase: MessagePhase | null | undefined } | undefined
+  readonly message:
+    | {
+        readonly id: string
+        readonly phase: MessagePhase | null | undefined
+        readonly parts: Readonly<Record<number, { readonly text: string; readonly done: boolean }>>
+      }
+    | undefined
   readonly reasoningItems: Readonly<Record<string, ReasoningStreamItem>>
 }
 
@@ -413,6 +420,7 @@ interface ReasoningStreamItem {
   // is started eagerly when the item opens, so block existence cannot tell
   // whether a `.done` final would duplicate streamed text.
   readonly deltaIndexes: ReadonlySet<number>
+  readonly finalTexts: Readonly<Record<number, string>>
 }
 
 // =============================================================================
@@ -829,21 +837,64 @@ export const terminal = (event: Event) => TERMINAL_TYPES.has(event.type)
 
 const onOutputTextDelta = (state: ParserState, event: Event, id: string): StepResult => {
   if (!event.delta || state.message?.id !== id) return [state, NO_EVENTS]
+  const index = event.content_index ?? 0
+  const part = state.message.parts[index]
+  if (part?.done) return [state, NO_EVENTS]
   const events: LLMEvent[] = []
   const phase = state.message.phase
   const metadata = providerMetadata(state, { itemId: id, ...(phase === undefined ? {} : { phase }) })
   const lifecycle = Lifecycle.textStart(state.lifecycle, events, id, metadata)
-  return [{ ...state, lifecycle: Lifecycle.textDelta(lifecycle, events, id, event.delta) }, events]
+  return [
+    {
+      ...state,
+      lifecycle: Lifecycle.textDelta(lifecycle, events, id, event.delta),
+      message: {
+        ...state.message,
+        parts: { ...state.message.parts, [index]: { text: (part?.text ?? "") + event.delta, done: false } },
+      },
+    },
+    events,
+  ]
 }
 
 const onOutputTextDone = (state: ParserState, event: Event, id: string): StepResult => {
   if (state.message?.id === id) {
-    if (state.lifecycle.text.has(id) || event.text === undefined) return [state, NO_EVENTS]
-    return onOutputTextDelta(state, { ...event, delta: event.text }, id)
+    const index = event.content_index ?? 0
+    if (event.text === undefined || (state.message.parts[index]?.done && event.type !== "response.content_part.done"))
+      return [state, NO_EVENTS]
+    const [current, emitted] = state.message.parts[index]
+      ? [state, NO_EVENTS]
+      : onOutputTextDelta(state, { ...event, delta: event.text }, id)
+    return [
+      {
+        ...current,
+        message: {
+          ...state.message,
+          parts: { ...state.message.parts, [index]: { text: event.text, done: true } },
+        },
+      },
+      emitted,
+    ]
   }
   const events: LLMEvent[] = []
   return [{ ...state, lifecycle: Lifecycle.textEnd(state.lifecycle, events, id) }, events]
 }
+
+const messageFinalText = (message: ParserState["message"]) => {
+  const parts = Object.values(message?.parts ?? {})
+  return parts.some((part) => part.done) ? parts.map((part) => part.text).join("") : undefined
+}
+
+const decodeMessagePart = Schema.decodeUnknownOption(
+  Schema.Union([
+    Schema.Struct({ type: Schema.tag("output_text"), text: Schema.String }),
+    Schema.Struct({ type: Schema.tag("refusal"), refusal: Schema.String }),
+  ]),
+)
+
+const decodeSummaryPart = Schema.decodeUnknownOption(
+  Schema.Struct({ type: Schema.tag("summary_text"), text: Schema.String }),
+)
 
 export const outputItemID = (state: ParserState, event: Event) =>
   event.output_index === undefined ? event.item_id : (state.outputItems[event.output_index] ?? event.item_id)
@@ -857,7 +908,13 @@ const startReasoningSummaryPart = (state: ParserState, itemID: string, index: nu
     .filter((entry) => entry[1] !== "concluded")
     .reduce(
       (lifecycle, entry) =>
-        Lifecycle.reasoningEnd(lifecycle, events, `${itemID}:${entry[0]}`, providerMetadata(state, { itemId: itemID })),
+        Lifecycle.reasoningEnd(
+          lifecycle,
+          events,
+          `${itemID}:${entry[0]}`,
+          providerMetadata(state, { itemId: itemID }),
+          item.finalTexts[Number(entry[0])],
+        ),
       state.lifecycle,
     )
   return [
@@ -910,15 +967,29 @@ export const onReasoningDelta = (state: ParserState, event: Event, itemID: strin
   ]
 }
 
-// Some compatible gateways emit a reasoning final without streaming any
-// deltas, mirroring `response.output_text.done`. Reconcile the complete text
-// as a single delta unless that summary index already streamed one.
+// Keep the final until the existing boundary closes the fragment, so encrypted
+// item metadata can still be attached to its single reasoning-end event.
 export const onReasoningDone = (state: ParserState, event: Event, itemID: string): StepResult => {
   const item = state.reasoningItems[itemID]
   if (!item?.open || typeof event.text !== "string") return [state, NO_EVENTS]
   const index = event.summary_index ?? 0
-  if (item.deltaIndexes.has(index)) return [state, NO_EVENTS]
-  return onReasoningDelta(state, { ...event, delta: event.text }, itemID)
+  if (item.summaryParts[index] === "concluded") return [state, NO_EVENTS]
+  const [started, opened] = startReasoningSummaryPart(state, itemID, index)
+  const [current, emitted] = item.deltaIndexes.has(index)
+    ? [started, NO_EVENTS]
+    : onReasoningDelta(started, { ...event, delta: event.text }, itemID)
+  const reasoningItem = current.reasoningItems[itemID]
+  if (!reasoningItem) return [current, [...opened, ...emitted]]
+  return [
+    {
+      ...current,
+      reasoningItems: {
+        ...current.reasoningItems,
+        [itemID]: { ...reasoningItem, finalTexts: { ...reasoningItem.finalTexts, [index]: event.text } },
+      },
+    },
+    [...opened, ...emitted],
+  ]
 }
 
 const reasoningMetadata = (state: ParserState, item: StreamItem & { id: string }) =>
@@ -950,6 +1021,7 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
           events,
           id,
           providerMetadata(state, { itemId: id, ...(openPhase === undefined ? {} : { phase: openPhase }) }),
+          messageFinalText(state.message),
         )
       }, state.lifecycle)
     return [
@@ -959,6 +1031,7 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
         message: {
           id: itemID,
           phase: phase === undefined && state.message?.id === itemID ? state.message.phase : phase,
+          parts: state.message?.id === itemID ? state.message.parts : {},
         },
       },
       events,
@@ -978,6 +1051,7 @@ const onOutputItemAdded = (state: ParserState, event: Event): StepResult => {
             encryptedContent: item.encrypted_content,
             summaryParts: { 0: "active" },
             deltaIndexes: new Set(),
+            finalTexts: {},
           },
         },
       },
@@ -1013,14 +1087,18 @@ const onReasoningSummaryPartAdded = (state: ParserState, event: Event): StepResu
 
 const onReasoningSummaryPartDone = (state: ParserState, event: Event): StepResult => {
   if (event.item_id === undefined || event.summary_index === undefined) return [state, NO_EVENTS]
-  const item = state.reasoningItems[event.item_id]
+  const part = Option.getOrUndefined(decodeSummaryPart(event.part))
+  const [current, events] = part
+    ? onReasoningDone(state, { ...event, text: part.text }, event.item_id)
+    : [state, NO_EVENTS]
+  const item = current.reasoningItems[event.item_id]
   if (!item?.open) return [state, NO_EVENTS]
-  if (item.summaryParts[event.summary_index] !== "active") return [state, NO_EVENTS]
+  if (item.summaryParts[event.summary_index] !== "active") return [current, events]
   return [
     {
-      ...state,
+      ...current,
       reasoningItems: {
-        ...state.reasoningItems,
+        ...current.reasoningItems,
         [event.item_id]: {
           ...item,
           summaryParts: {
@@ -1030,7 +1108,7 @@ const onReasoningSummaryPartDone = (state: ParserState, event: Event): StepResul
         },
       },
     },
-    NO_EVENTS,
+    events,
   ]
 }
 
@@ -1072,16 +1150,28 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   if (item.type === "message" && item.id !== undefined) {
     const itemPhase = messagePhase(item.phase)
     const phase = itemPhase === undefined && state.message?.id === item.id ? state.message.phase : itemPhase
+    const content = Array.isArray(item.content)
+      ? item.content.flatMap((part: unknown) => {
+          const decoded = Option.getOrUndefined(decodeMessagePart(part))
+          return decoded ? [decoded.type === "output_text" ? decoded.text : decoded.refusal] : []
+        })
+      : []
+    const text =
+      content.length > 0
+        ? content.join("")
+        : state.message?.id === item.id
+          ? messageFinalText(state.message)
+          : undefined
+    const metadata = providerMetadata(state, { itemId: item.id, ...(phase === undefined ? {} : { phase }) })
     const events: LLMEvent[] = []
+    const lifecycle =
+      state.message?.id === item.id && text !== undefined && text.length > 0
+        ? Lifecycle.textStart(state.lifecycle, events, item.id, metadata)
+        : state.lifecycle
     return [
       {
         ...state,
-        lifecycle: Lifecycle.textEnd(
-          state.lifecycle,
-          events,
-          item.id,
-          providerMetadata(state, { itemId: item.id, ...(phase === undefined ? {} : { phase }) }),
-        ),
+        lifecycle: Lifecycle.textEnd(lifecycle, events, item.id, metadata, text),
         message: state.message?.id === item.id ? undefined : state.message,
       },
       events,
@@ -1137,23 +1227,50 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
   }
 
   if (isReasoningItem(item)) {
-    const events: LLMEvent[] = []
     const metadata = reasoningMetadata(state, item)
-    const reasoningItem = state.reasoningItems[item.id]
+    const summary = Array.isArray(item.summary)
+      ? item.summary.flatMap((part: unknown, index) => {
+          const decoded = Option.getOrUndefined(decodeSummaryPart(part))
+          return decoded ? [{ index, text: decoded.text }] : []
+        })
+      : []
+    const lastIndex = Math.max(-1, ...Object.keys(state.reasoningItems[item.id]?.summaryParts ?? {}).map(Number))
+    const [current, emitted] = summary.reduce<StepResult>(
+      ([current, events], part) => {
+        // Backfilling an earlier gap would close the current fragment before its final arrives.
+        if (part.index < lastIndex) return [current, events]
+        const [next, emitted] = onReasoningDone(
+          current,
+          { type: "response.reasoning_summary_text.done", summary_index: part.index, text: part.text },
+          item.id,
+        )
+        return [next, [...events, ...emitted]]
+      },
+      [state, NO_EVENTS],
+    )
+    const events: LLMEvent[] = [...emitted]
+    const reasoningItem = current.reasoningItems[item.id]
     if (reasoningItem) {
       if (!reasoningItem.open) return [state, NO_EVENTS] satisfies StepResult
       const lifecycle = Object.entries(reasoningItem.summaryParts)
         .filter((entry) => entry[1] === "active" || entry[1] === "can-conclude")
         .reduce(
-          (lifecycle, entry) => Lifecycle.reasoningEnd(lifecycle, events, `${item.id}:${entry[0]}`, metadata),
-          state.lifecycle,
+          (lifecycle, entry) =>
+            Lifecycle.reasoningEnd(
+              lifecycle,
+              events,
+              `${item.id}:${entry[0]}`,
+              metadata,
+              reasoningItem.finalTexts[Number(entry[0])],
+            ),
+          current.lifecycle,
         )
       return [
         {
-          ...state,
+          ...current,
           lifecycle,
           reasoningItems: {
-            ...state.reasoningItems,
+            ...current.reasoningItems,
             [item.id]: {
               ...reasoningItem,
               open: false,
@@ -1167,7 +1284,13 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
     if (!state.lifecycle.reasoning.has(item.id)) {
       const lifecycle = Lifecycle.stepStart(state.lifecycle, events)
       events.push(LLMEvent.reasoningStart({ id: item.id, providerMetadata: metadata }))
-      events.push(LLMEvent.reasoningEnd({ id: item.id, providerMetadata: metadata }))
+      events.push(
+        LLMEvent.reasoningEnd({
+          id: item.id,
+          providerMetadata: metadata,
+          text: summary.length > 0 ? summary.map((part) => part.text).join("\n\n") : undefined,
+        }),
+      )
       return [
         {
           ...state,
@@ -1179,6 +1302,7 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
               encryptedContent: item.encrypted_content,
               summaryParts: { 0: "concluded" },
               deltaIndexes: new Set(),
+              finalTexts: {},
             },
           },
         },
@@ -1205,6 +1329,7 @@ const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (
             if (
               id === undefined ||
               ((item.type !== "function_call" || !current.tools[id]) &&
+                (item.type !== "message" || current.message?.id !== id) &&
                 (item.type !== "reasoning" || !current.reasoningItems[id]?.open))
             )
               return Effect.succeed([current, events] satisfies StepResult)
@@ -1224,7 +1349,28 @@ const onResponseFinish = Effect.fn("OpenResponses.onResponseFinish")(function* (
   const hasFunctionCall =
     pending.events.some((event) => LLMEvent.is.toolCall(event) || LLMEvent.is.toolInputError(event)) ||
     current.hasFunctionCall
-  const lifecycle = Lifecycle.finish(current.lifecycle, events, {
+  // Generic terminal closure must also carry finals received before a missing item boundary.
+  const reasoningClosed = Object.entries(current.reasoningItems).reduce(
+    (lifecycle, [id, item]) =>
+      Object.entries(item.summaryParts).reduce(
+        (lifecycle, [index]) =>
+          Lifecycle.reasoningEnd(lifecycle, events, `${id}:${index}`, undefined, item.finalTexts[Number(index)]),
+        lifecycle,
+      ),
+    current.lifecycle,
+  )
+  const closed = [...reasoningClosed.text].reduce(
+    (lifecycle, id) =>
+      Lifecycle.textEnd(
+        lifecycle,
+        events,
+        id,
+        undefined,
+        current.message?.id === id ? messageFinalText(current.message) : undefined,
+      ),
+    reasoningClosed,
+  )
+  const lifecycle = Lifecycle.finish(closed, events, {
     reason: {
       normalized: mapFinishReason(event, hasFunctionCall),
       raw: event.response?.incomplete_details?.reason,
@@ -1297,6 +1443,18 @@ export const step = (state: ParserState, input: Event) => {
       event.type === "response.refusal.delta"
         ? onOutputTextDelta(state, event, event.item_id)
         : onOutputTextDone(state, { ...event, text: value }, event.item_id),
+    )
+  }
+  if (event.type === "response.content_part.done" && event.item_id !== undefined) {
+    const part = Option.getOrUndefined(decodeMessagePart(event.part))
+    return Effect.succeed<StepResult>(
+      part
+        ? onOutputTextDone(
+            state,
+            { ...event, text: part.type === "output_text" ? part.text : part.refusal },
+            event.item_id,
+          )
+        : [state, NO_EVENTS],
     )
   }
   if (event.type === "response.reasoning.delta" || event.type === "response.reasoning_summary_text.delta") {

--- a/packages/ai/test/provider/open-responses-finals.test.ts
+++ b/packages/ai/test/provider/open-responses-finals.test.ts
@@ -1,0 +1,723 @@
+import { describe, expect } from "bun:test"
+import { Effect, Stream } from "effect"
+import { LLM, LLMEvent } from "../../src/index.js"
+import { OpenResponses } from "../../src/protocols/open-responses.js"
+import { configure } from "../../src/providers/openai-compatible-responses.js"
+import { OpenAI, XAI } from "../../src/providers.js"
+import { LLMClient } from "../../src/route.js"
+import { it } from "../lib/effect.js"
+import { fixedResponse } from "../lib/http.js"
+import { sseEvents } from "../lib/sse.js"
+
+const model = configure({ apiKey: "test-key", baseURL: "https://responses.example.test/v1" }).model("example-model")
+const completed = { type: "response.completed", response: { id: "resp_1" } }
+
+const collect = (input: ReadonlyArray<OpenResponses.Event>, selected = model) =>
+  Effect.gen(function* () {
+    const request = LLM.request({ model: selected, prompt: "Respond." })
+    const response = yield* LLMClient.generate(request)
+    const events = yield* LLMClient.stream(request).pipe(Stream.runCollect)
+    expect(events).toEqual(response.events)
+    const active = { text: new Set<string>(), reasoning: new Set<string>() }
+    const closed = { text: new Set<string>(), reasoning: new Set<string>() }
+    events.forEach((event) => {
+      if (event.type === "text-start" || event.type === "reasoning-start") {
+        const kind = event.type === "text-start" ? "text" : "reasoning"
+        expect(active[kind].size).toBe(0)
+        expect(closed[kind].has(event.id)).toBe(false)
+        active[kind].add(event.id)
+      }
+      if (event.type === "text-delta" || event.type === "reasoning-delta") {
+        expect(active[event.type === "text-delta" ? "text" : "reasoning"].has(event.id)).toBe(true)
+      }
+      if (event.type === "text-end" || event.type === "reasoning-end") {
+        const kind = event.type === "text-end" ? "text" : "reasoning"
+        expect(active[kind].delete(event.id)).toBe(true)
+        expect(closed[kind].has(event.id)).toBe(false)
+        closed[kind].add(event.id)
+      }
+      if (event.type === "step-finish" || event.type === "finish") {
+        expect(active.text.size).toBe(0)
+        expect(active.reasoning.size).toBe(0)
+      }
+    })
+    expect(events[0]?.type).toBe("step-start")
+    expect(events.filter(LLMEvent.is.stepStart)).toHaveLength(1)
+    expect(events.filter(LLMEvent.is.stepFinish)).toHaveLength(1)
+    expect(events.filter(LLMEvent.is.finish)).toHaveLength(1)
+    expect(events.slice(-2).map((event) => event.type)).toEqual(["step-finish", "finish"])
+    return response
+  }).pipe(Effect.provide(fixedResponse(sseEvents(...input))))
+
+describe("Open Responses final text", () => {
+  ;["output_text", "refusal"].forEach((kind) => {
+    ;[
+      { name: "longer", text: "Draft answer expanded" },
+      { name: "shorter", text: "Draft" },
+      { name: "non-prefix", text: "Replacement" },
+      { name: "empty", text: "" },
+    ].forEach((final) => {
+      it.effect(`replaces ${kind} deltas with a ${final.name} final at item close`, () =>
+        Effect.gen(function* () {
+          const response = yield* collect([
+            { type: "response.output_item.added", item: { type: "message", id: "msg_1", phase: "commentary" } },
+            { type: `response.${kind}.delta`, item_id: "msg_1", content_index: 0, delta: "Draft answer" },
+            {
+              type: `response.${kind}.done`,
+              item_id: "msg_1",
+              content_index: 0,
+              ...(kind === "refusal" ? { refusal: final.text } : { text: final.text }),
+            },
+            { type: "response.output_item.done", item: { type: "message", id: "msg_1", phase: "final_answer" } },
+            completed,
+          ])
+          expect(response.text).toBe(final.text)
+          expect(response.events.filter(LLMEvent.is.textDelta).map((event) => event.text)).toEqual(["Draft answer"])
+          expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
+            {
+              type: "text-end",
+              id: "msg_1",
+              text: final.text,
+              providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "final_answer" } },
+            },
+          ])
+          expect(response.message.content.find((part) => part.type === "text")).toMatchObject({
+            text: final.text,
+            providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "final_answer" } },
+          })
+        }),
+      )
+    })
+  })
+
+  it.effect("aggregates content indexes independently and retains deltas for parts without finals", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+        { type: "response.output_text.delta", item_id: "msg_1", content_index: 0, delta: "first draft" },
+        { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "First " },
+        { type: "response.output_text.delta", item_id: "msg_1", content_index: 1, delta: "discard" },
+        { type: "response.output_text.done", item_id: "msg_1", content_index: 1, text: "" },
+        { type: "response.output_text.delta", item_id: "msg_1", content_index: 2, delta: "fallback " },
+        { type: "response.refusal.delta", item_id: "msg_1", content_index: 3, delta: "last draft" },
+        { type: "response.refusal.done", item_id: "msg_1", content_index: 3, refusal: "last" },
+        { type: "response.output_item.done", item: { type: "message", id: "msg_1" } },
+        completed,
+      ])
+      expect(response.text).toBe("First fallback last")
+      expect(response.events.filter(LLMEvent.is.textStart)).toHaveLength(1)
+      expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1", text: "First fallback last" }])
+    }),
+  )
+  ;[false, true].forEach((streamed) => {
+    it.effect(`uses item content over cached part finals ${streamed ? "with" : "without"} deltas`, () =>
+      Effect.gen(function* () {
+        const response = yield* collect([
+          { type: "response.output_item.added", item: { type: "message", id: "msg_1", phase: "commentary" } },
+          ...(streamed ? [{ type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" }] : []),
+          { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "Cached" },
+          {
+            type: "response.output_item.done",
+            item: {
+              type: "message",
+              id: "msg_1",
+              phase: "final_answer",
+              content: [
+                { type: "output_text", text: "Final " },
+                { type: "refusal", refusal: "refusal" },
+              ],
+            },
+          },
+          completed,
+        ])
+        expect(response.text).toBe("Final refusal")
+        expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
+          {
+            type: "text-end",
+            id: "msg_1",
+            text: "Final refusal",
+            providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "final_answer" } },
+          },
+        ])
+      }),
+    )
+  })
+
+  it.effect("uses a tracked message item snapshot without text deltas or part finals", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+        {
+          type: "response.output_item.done",
+          item: { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Snapshot only" }] },
+        },
+        completed,
+      ])
+      expect(response.text).toBe("Snapshot only")
+      expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1", text: "Snapshot only" }])
+    }),
+  )
+
+  it.effect("uses a content-part snapshot over an earlier scalar final when item content is absent", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+        { type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" },
+        { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "Cached" },
+        {
+          type: "response.content_part.done",
+          item_id: "msg_1",
+          content_index: 0,
+          part: { type: "output_text", text: "Corrected" },
+        },
+        { type: "response.output_item.done", item: { type: "message", id: "msg_1" } },
+        completed,
+      ])
+      expect(response.text).toBe("Corrected")
+      expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
+        {
+          type: "text-end",
+          id: "msg_1",
+          text: "Corrected",
+          providerMetadata: { "openai-compatible": { itemId: "msg_1" } },
+        },
+      ])
+    }),
+  )
+  ;[false, true].forEach((streamed) => {
+    it.effect(`empty item content ${streamed ? "preserves streamed text" : "does not create a text fragment"}`, () =>
+      Effect.gen(function* () {
+        const response = yield* collect([
+          { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+          ...(streamed ? [{ type: "response.output_text.delta", item_id: "msg_1", delta: "Keep" }] : []),
+          { type: "response.output_item.done", item: { type: "message", id: "msg_1", content: [] } },
+          completed,
+        ])
+        expect(response.text).toBe(streamed ? "Keep" : "")
+        expect(response.message.content.filter((part) => part.type === "text")).toHaveLength(streamed ? 1 : 0)
+        if (!streamed) {
+          expect(response.events.filter((event) => event.type.startsWith("text-"))).toEqual([])
+          return
+        }
+        expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1" }])
+        expect(response.events.filter(LLMEvent.is.textEnd).map((event) => event.text)).toEqual([undefined])
+      }),
+    )
+
+    it.effect(`empty scalar and item finals ${streamed ? "clear active text" : "do not create a text fragment"}`, () =>
+      Effect.gen(function* () {
+        const response = yield* collect([
+          { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+          ...(streamed ? [{ type: "response.output_text.delta", item_id: "msg_1", delta: "Discard" }] : []),
+          { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "" },
+          {
+            type: "response.content_part.done",
+            item_id: "msg_1",
+            content_index: 0,
+            part: { type: "output_text", text: "" },
+          },
+          {
+            type: "response.output_item.done",
+            item: { type: "message", id: "msg_1", content: [{ type: "output_text", text: "" }] },
+          },
+          completed,
+        ])
+        expect(response.text).toBe("")
+        expect(response.message.content.filter((part) => part.type === "text")).toHaveLength(streamed ? 1 : 0)
+        if (!streamed) {
+          expect(response.events.filter((event) => event.type.startsWith("text-"))).toEqual([])
+          return
+        }
+        expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1", text: "" }])
+      }),
+    )
+  })
+  ;[
+    {
+      name: "readable text beside an unfamiliar part",
+      content: [
+        { type: "output_text", text: "Readable final" },
+        { type: "other", text: { value: "unfamiliar" } },
+      ],
+      text: "Readable final",
+    },
+    {
+      name: "unknown-only content",
+      content: [{ type: "other", text: { value: "unfamiliar" } }],
+      text: "Cached final",
+    },
+    {
+      name: "malformed known text content",
+      content: [
+        { type: "output_text", text: { value: "unfamiliar" } },
+        { type: "refusal", refusal: null },
+      ],
+      text: "Cached final",
+    },
+    { name: "empty content", content: [], text: "Cached final" },
+  ].forEach((fixture) => {
+    it.effect(`decodes ${fixture.name} without treating absent text as an empty final`, () =>
+      Effect.gen(function* () {
+        const response = yield* collect([
+          { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+          { type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" },
+          { type: "response.output_text.done", item_id: "msg_1", text: "Cached final" },
+          { type: "response.output_item.done", item: { type: "message", id: "msg_1", content: fixture.content } },
+          completed,
+        ])
+        expect(response.text).toBe(fixture.text)
+        expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
+          {
+            type: "text-end",
+            id: "msg_1",
+            text: fixture.text,
+            providerMetadata: { "openai-compatible": { itemId: "msg_1" } },
+          },
+        ])
+      }),
+    )
+  })
+
+  it.effect("defers cached finals until the next message and ignores late edits to closed text", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "message", id: "msg_1", phase: "commentary" } },
+        { type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" },
+        { type: "response.output_text.done", item_id: "msg_1", text: "First " },
+        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Thinking" },
+        { type: "response.output_item.added", item: { type: "message", id: "msg_2" } },
+        { type: "response.output_text.delta", item_id: "msg_2", delta: "second" },
+        { type: "response.output_text.done", item_id: "msg_1", text: "Late final" },
+        {
+          type: "response.output_item.done",
+          item: { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Late snapshot" }] },
+        },
+        { type: "response.output_text.delta", item_id: "msg_1", delta: "Late delta" },
+        { type: "response.output_item.done", item: { type: "message", id: "msg_2" } },
+        { type: "response.output_item.done", item: { type: "reasoning", id: "rs_1" } },
+        completed,
+      ])
+      expect(response.text).toBe("First second")
+      expect(response.reasoning).toBe("Thinking")
+      expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([
+        {
+          id: "msg_1",
+          text: "First ",
+          providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "commentary" } },
+        },
+        { id: "msg_2" },
+      ])
+      expect(
+        response.events
+          .filter((event) => event.type.endsWith("-start") || event.type.endsWith("-end"))
+          .map((event) => event.type),
+      ).toEqual(["step-start", "text-start", "reasoning-start", "text-end", "text-start", "text-end", "reasoning-end"])
+    }),
+  )
+})
+
+describe("Open Responses final reasoning", () => {
+  ;["reasoning_summary_text.done", "reasoning_summary_part.done"].forEach((kind) => {
+    ;[
+      { name: "longer", text: "Draft reasoning expanded" },
+      { name: "shorter", text: "Draft" },
+      { name: "non-prefix", text: "Replacement" },
+      { name: "empty", text: "" },
+    ].forEach((final) => {
+      it.effect(`replaces reasoning with a ${final.name} ${kind} snapshot at item close`, () =>
+        Effect.gen(function* () {
+          const response = yield* collect([
+            { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1", encrypted_content: null } },
+            {
+              type: "response.reasoning_summary_text.delta",
+              item_id: "rs_1",
+              summary_index: 0,
+              delta: "Draft reasoning",
+            },
+            {
+              type: `response.${kind}`,
+              item_id: "rs_1",
+              summary_index: 0,
+              ...(kind === "reasoning_summary_part.done"
+                ? { part: { type: "summary_text", text: final.text } }
+                : { text: final.text }),
+            },
+            {
+              type: "response.output_item.done",
+              item: { type: "reasoning", id: "rs_1", encrypted_content: "final-state" },
+            },
+            completed,
+          ])
+          expect(response.reasoning).toBe(final.text)
+          expect(response.events.filter(LLMEvent.is.reasoningDelta).map((event) => event.text)).toEqual([
+            "Draft reasoning",
+          ])
+          expect(response.events.filter(LLMEvent.is.reasoningEnd)).toEqual([
+            {
+              type: "reasoning-end",
+              id: "rs_1:0",
+              text: final.text,
+              providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
+            },
+          ])
+          expect(response.message.content.find((part) => part.type === "reasoning")).toMatchObject({
+            text: final.text,
+            providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
+          })
+        }),
+      )
+    })
+  })
+
+  it.effect("closes per-index finals at the next summary and only reconciles still-open item summaries", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "Draft zero" },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "Zero" },
+        { type: "response.reasoning_summary_part.added", item_id: "rs_1", summary_index: 1 },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 1, delta: "Draft one" },
+        {
+          type: "response.reasoning_summary_part.done",
+          item_id: "rs_1",
+          summary_index: 1,
+          part: { type: "summary_text", text: "Cached one" },
+        },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "Late final" },
+        {
+          type: "response.reasoning_summary_part.done",
+          item_id: "rs_1",
+          summary_index: 0,
+          part: { type: "summary_text", text: "Late part" },
+        },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "final-state",
+            summary: [
+              { type: "summary_text", text: "Late item edit" },
+              { type: "summary_text", text: "One" },
+              { type: "summary_text", text: "Two" },
+            ],
+          },
+        },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 2, text: "Late closed item" },
+        completed,
+      ])
+      expect(response.reasoning).toBe("ZeroOneTwo")
+      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toMatchObject([
+        { id: "rs_1:0", text: "Zero", providerMetadata: { "openai-compatible": { itemId: "rs_1" } } },
+        { id: "rs_1:1", text: "One" },
+        {
+          id: "rs_1:2",
+          text: "Two",
+          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
+        },
+      ])
+    }),
+  )
+
+  it.effect("uses done-only reasoning summary text and ignores duplicate item finals", () =>
+    Effect.gen(function* () {
+      const item = {
+        type: "reasoning",
+        id: "rs_1",
+        encrypted_content: "final-state",
+        summary: [{ type: "summary_text", text: "Only summary" }],
+      }
+      const response = yield* collect([
+        { type: "response.output_item.done", item },
+        {
+          type: "response.output_item.done",
+          item: { ...item, summary: [{ type: "summary_text", text: "Late edit" }] },
+        },
+        completed,
+      ])
+      expect(response.reasoning).toBe("Only summary")
+      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toMatchObject([
+        {
+          text: "Only summary",
+          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
+        },
+      ])
+    }),
+  )
+
+  it.effect("ignores earlier summary gaps without closing or reopening the active later index", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "Draft zero" },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "Closed zero " },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 2, delta: "Draft two" },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 2, text: "Cached two" },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "final-state",
+            summary: [
+              { type: "summary_text", text: "Late zero" },
+              { type: "summary_text", text: "Earlier gap" },
+              { type: "summary_text", text: "Final two" },
+            ],
+          },
+        },
+        completed,
+      ])
+      expect(response.reasoning).toBe("Closed zero Final two")
+      expect(response.events.filter(LLMEvent.is.reasoningStart).map((event) => event.id)).toEqual(["rs_1:0", "rs_1:2"])
+      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toEqual([
+        {
+          type: "reasoning-end",
+          id: "rs_1:0",
+          text: "Closed zero ",
+          providerMetadata: { "openai-compatible": { itemId: "rs_1" } },
+        },
+        {
+          type: "reasoning-end",
+          id: "rs_1:2",
+          text: "Final two",
+          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
+        },
+      ])
+    }),
+  )
+
+  it.effect("retains summary indexes and neighboring finals around an unfamiliar summary part", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "Draft" },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "Cached zero" },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "reasoning",
+            id: "rs_1",
+            encrypted_content: "final-state",
+            summary: [
+              { type: "summary_text", text: "Final zero " },
+              { type: "other", text: { value: "unfamiliar" } },
+              { type: "summary_text", text: "Final two" },
+            ],
+          },
+        },
+        completed,
+      ])
+      expect(response.reasoning).toBe("Final zero Final two")
+      expect(response.events.filter(LLMEvent.is.reasoningStart).map((event) => event.id)).toEqual(["rs_1:0", "rs_1:2"])
+      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toMatchObject([
+        { id: "rs_1:0", text: "Final zero " },
+        {
+          id: "rs_1:2",
+          text: "Final two",
+          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
+        },
+      ])
+    }),
+  )
+
+  it.effect("uses a part-only summary final without any streamed reasoning deltas", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+        {
+          type: "response.reasoning_summary_part.done",
+          item_id: "rs_1",
+          summary_index: 0,
+          part: { type: "summary_text", text: "Only final" },
+        },
+        completed,
+      ])
+      expect(response.reasoning).toBe("Only final")
+      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toMatchObject([{ id: "rs_1:0", text: "Only final" }])
+    }),
+  )
+
+  it.effect("closes cached summary finals at implicit boundaries while retaining unsnapshotted indexes", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "Draft" },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "First " },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 1, text: "second " },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 2, delta: "fallback" },
+        {
+          type: "response.output_item.done",
+          item: { type: "reasoning", id: "rs_1", encrypted_content: "final-state" },
+        },
+        completed,
+      ])
+      expect(response.reasoning).toBe("First second fallback")
+      expect(
+        response.events.filter(LLMEvent.is.reasoningEnd).map((event) => ({ id: event.id, text: event.text })),
+      ).toEqual([
+        { id: "rs_1:0", text: "First " },
+        { id: "rs_1:1", text: "second " },
+        { id: "rs_1:2", text: undefined },
+      ])
+    }),
+  )
+})
+
+describe("Open Responses terminal finals", () => {
+  it.effect("recovers tracked messages with no deltas from completed output", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+        {
+          type: "response.completed",
+          response: {
+            output: [{ type: "message", id: "msg_1", content: [{ type: "output_text", text: "Terminal only" }] }],
+          },
+        },
+      ])
+      expect(response.text).toBe("Terminal only")
+      expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1", text: "Terminal only" }])
+    }),
+  )
+  ;[
+    { name: "compatible", model, key: "openai-compatible" },
+    { name: "OpenAI", model: OpenAI.configure({ apiKey: "test-key" }).responses("gpt-5"), key: "openai" },
+    { name: "xAI", model: XAI.configure({ apiKey: "test-key" }).responses("grok-4.6"), key: "xai" },
+  ].forEach((provider) => {
+    it.effect(`reconciles tracked text and reasoning from ${provider.name} completed output`, () =>
+      Effect.gen(function* () {
+        const response = yield* collect(
+          [
+            { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1", encrypted_content: null } },
+            { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Reasoning draft" },
+            { type: "response.reasoning_summary_text.done", item_id: "rs_1", text: "Cached reasoning" },
+            { type: "response.output_item.added", item: { type: "message", id: "msg_1", phase: "commentary" } },
+            { type: "response.output_text.delta", item_id: "msg_1", delta: "Text draft" },
+            { type: "response.output_text.done", item_id: "msg_1", text: "Cached text" },
+            {
+              type: "response.completed",
+              response: {
+                id: "resp_1",
+                output: [
+                  { type: "reasoning", id: "rs_unknown", summary: [{ type: "summary_text", text: "Untracked" }] },
+                  { type: "message", id: "msg_unknown", content: [{ type: "output_text", text: "Untracked" }] },
+                  {
+                    type: "reasoning",
+                    id: "rs_1",
+                    encrypted_content: "terminal-state",
+                    summary: [{ type: "summary_text", text: "Final reasoning" }],
+                  },
+                  {
+                    type: "message",
+                    id: "msg_1",
+                    phase: "final_answer",
+                    content: [{ type: "output_text", text: "Final text" }],
+                  },
+                ],
+              },
+            },
+          ],
+          provider.model,
+        )
+        expect(response.text).toBe("Final text")
+        expect(response.reasoning).toBe("Final reasoning")
+        expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
+          {
+            type: "text-end",
+            id: "msg_1",
+            text: "Final text",
+            providerMetadata: { [provider.key]: { itemId: "msg_1", phase: "final_answer" } },
+          },
+        ])
+        expect(response.events.filter(LLMEvent.is.reasoningEnd)).toEqual([
+          {
+            type: "reasoning-end",
+            id: "rs_1:0",
+            text: "Final reasoning",
+            providerMetadata: { [provider.key]: { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" } },
+          },
+        ])
+        expect(response.message.content.find((part) => part.type === "reasoning")?.providerMetadata).toEqual({
+          [provider.key]: { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" },
+        })
+        expect(response.message.content.find((part) => part.type === "text")?.providerMetadata).toEqual({
+          [provider.key]: { itemId: "msg_1", phase: "final_answer" },
+        })
+      }),
+    )
+  })
+  ;["response.completed", "response.incomplete"].forEach((terminal) => {
+    ;[false, true].forEach((finals) => {
+      it.effect(`flushes ${finals ? "cached finals" : "delta fallback"} on ${terminal}`, () =>
+        Effect.gen(function* () {
+          const response = yield* collect([
+            { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+            { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Reasoning draft" },
+            { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+            { type: "response.output_text.delta", item_id: "msg_1", delta: "Text draft" },
+            ...(finals
+              ? [
+                  { type: "response.reasoning_summary_text.done", item_id: "rs_1", text: "Reasoning final" },
+                  { type: "response.output_text.done", item_id: "msg_1", text: "Text final" },
+                ]
+              : []),
+            {
+              type: terminal,
+              response: {
+                id: "resp_1",
+                ...(terminal === "response.incomplete"
+                  ? {
+                      incomplete_details: { reason: "max_output_tokens" },
+                      output: [
+                        { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "Not reconciled" }] },
+                        { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Not reconciled" }] },
+                      ],
+                    }
+                  : {}),
+              },
+            },
+          ])
+          expect(response.text).toBe(finals ? "Text final" : "Text draft")
+          expect(response.reasoning).toBe(finals ? "Reasoning final" : "Reasoning draft")
+          expect(response.events.filter(LLMEvent.is.textEnd).map((event) => event.text)).toEqual([
+            finals ? "Text final" : undefined,
+          ])
+          expect(response.events.filter(LLMEvent.is.reasoningEnd).map((event) => event.text)).toEqual([
+            finals ? "Reasoning final" : undefined,
+          ])
+          expect(response.events.filter(LLMEvent.is.finish).map((event) => event.reason.normalized)).toEqual([
+            terminal === "response.incomplete" ? "length" : "stop",
+          ])
+        }),
+      )
+    })
+  })
+
+  it.effect("does not reopen closed text or reasoning from completed output", () =>
+    Effect.gen(function* () {
+      const response = yield* collect([
+        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Original reasoning" },
+        { type: "response.output_item.done", item: { type: "reasoning", id: "rs_1" } },
+        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+        { type: "response.output_text.delta", item_id: "msg_1", delta: "Original text" },
+        { type: "response.output_item.done", item: { type: "message", id: "msg_1" } },
+        {
+          type: "response.completed",
+          response: {
+            output: [
+              { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "Late reasoning" }] },
+              { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Late text" }] },
+            ],
+          },
+        },
+      ])
+      expect(response.text).toBe("Original text")
+      expect(response.reasoning).toBe("Original reasoning")
+      expect(response.events.filter(LLMEvent.is.textEnd)).toHaveLength(1)
+      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toHaveLength(1)
+    }),
+  )
+})

--- a/packages/ai/test/provider/open-responses-finals.test.ts
+++ b/packages/ai/test/provider/open-responses-finals.test.ts
@@ -1,141 +1,42 @@
 import { describe, expect } from "bun:test"
-import { Effect, Stream } from "effect"
+import { Effect } from "effect"
 import { LLM, LLMEvent } from "../../src/index.js"
 import { OpenResponses } from "../../src/protocols/open-responses.js"
 import { configure } from "../../src/providers/openai-compatible-responses.js"
-import { OpenAI, XAI } from "../../src/providers.js"
 import { LLMClient } from "../../src/route.js"
 import { it } from "../lib/effect.js"
 import { fixedResponse } from "../lib/http.js"
 import { sseEvents } from "../lib/sse.js"
 
-const model = configure({ apiKey: "test-key", baseURL: "https://responses.example.test/v1" }).model("example-model")
+const request = LLM.request({
+  model: configure({ apiKey: "test-key", baseURL: "https://responses.example.test/v1" }).model("example-model"),
+  prompt: "Respond.",
+})
 const completed = { type: "response.completed", response: { id: "resp_1" } }
+const generate = (...events: OpenResponses.Event[]) =>
+  LLMClient.generate(request).pipe(Effect.provide(fixedResponse(sseEvents(...events))))
 
-const collect = (input: ReadonlyArray<OpenResponses.Event>, selected = model) =>
-  Effect.gen(function* () {
-    const request = LLM.request({ model: selected, prompt: "Respond." })
-    const response = yield* LLMClient.generate(request)
-    const events = yield* LLMClient.stream(request).pipe(Stream.runCollect)
-    expect(events).toEqual(response.events)
-    const active = { text: new Set<string>(), reasoning: new Set<string>() }
-    const closed = { text: new Set<string>(), reasoning: new Set<string>() }
-    events.forEach((event) => {
-      if (event.type === "text-start" || event.type === "reasoning-start") {
-        const kind = event.type === "text-start" ? "text" : "reasoning"
-        expect(active[kind].size).toBe(0)
-        expect(closed[kind].has(event.id)).toBe(false)
-        active[kind].add(event.id)
-      }
-      if (event.type === "text-delta" || event.type === "reasoning-delta") {
-        expect(active[event.type === "text-delta" ? "text" : "reasoning"].has(event.id)).toBe(true)
-      }
-      if (event.type === "text-end" || event.type === "reasoning-end") {
-        const kind = event.type === "text-end" ? "text" : "reasoning"
-        expect(active[kind].delete(event.id)).toBe(true)
-        expect(closed[kind].has(event.id)).toBe(false)
-        closed[kind].add(event.id)
-      }
-      if (event.type === "step-finish" || event.type === "finish") {
-        expect(active.text.size).toBe(0)
-        expect(active.reasoning.size).toBe(0)
-      }
-    })
-    expect(events[0]?.type).toBe("step-start")
-    expect(events.filter(LLMEvent.is.stepStart)).toHaveLength(1)
-    expect(events.filter(LLMEvent.is.stepFinish)).toHaveLength(1)
-    expect(events.filter(LLMEvent.is.finish)).toHaveLength(1)
-    expect(events.slice(-2).map((event) => event.type)).toEqual(["step-finish", "finish"])
-    return response
-  }).pipe(Effect.provide(fixedResponse(sseEvents(...input))))
-
-describe("Open Responses final text", () => {
-  ;["output_text", "refusal"].forEach((kind) => {
-    ;[
-      { name: "longer", text: "Draft answer expanded" },
-      { name: "shorter", text: "Draft" },
-      { name: "non-prefix", text: "Replacement" },
-      { name: "empty", text: "" },
-    ].forEach((final) => {
-      it.effect(`replaces ${kind} deltas with a ${final.name} final at item close`, () =>
-        Effect.gen(function* () {
-          const response = yield* collect([
-            { type: "response.output_item.added", item: { type: "message", id: "msg_1", phase: "commentary" } },
-            { type: `response.${kind}.delta`, item_id: "msg_1", content_index: 0, delta: "Draft answer" },
-            {
-              type: `response.${kind}.done`,
-              item_id: "msg_1",
-              content_index: 0,
-              ...(kind === "refusal" ? { refusal: final.text } : { text: final.text }),
-            },
-            { type: "response.output_item.done", item: { type: "message", id: "msg_1", phase: "final_answer" } },
-            completed,
-          ])
-          expect(response.text).toBe(final.text)
-          expect(response.events.filter(LLMEvent.is.textDelta).map((event) => event.text)).toEqual(["Draft answer"])
-          expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
-            {
-              type: "text-end",
-              id: "msg_1",
-              text: final.text,
-              providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "final_answer" } },
-            },
-          ])
-          expect(response.message.content.find((part) => part.type === "text")).toMatchObject({
-            text: final.text,
-            providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "final_answer" } },
-          })
-        }),
-      )
-    })
-  })
-
-  it.effect("aggregates content indexes independently and retains deltas for parts without finals", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
-        { type: "response.output_text.delta", item_id: "msg_1", content_index: 0, delta: "first draft" },
-        { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "First " },
-        { type: "response.output_text.delta", item_id: "msg_1", content_index: 1, delta: "discard" },
-        { type: "response.output_text.done", item_id: "msg_1", content_index: 1, text: "" },
-        { type: "response.output_text.delta", item_id: "msg_1", content_index: 2, delta: "fallback " },
-        { type: "response.refusal.delta", item_id: "msg_1", content_index: 3, delta: "last draft" },
-        { type: "response.refusal.done", item_id: "msg_1", content_index: 3, refusal: "last" },
-        { type: "response.output_item.done", item: { type: "message", id: "msg_1" } },
-        completed,
-      ])
-      expect(response.text).toBe("First fallback last")
-      expect(response.events.filter(LLMEvent.is.textStart)).toHaveLength(1)
-      expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1", text: "First fallback last" }])
-    }),
-  )
-  ;[false, true].forEach((streamed) => {
-    it.effect(`uses item content over cached part finals ${streamed ? "with" : "without"} deltas`, () =>
+describe("Open Responses completed item text", () => {
+  ;["Draft expanded", "D", "Replacement", ""].forEach((text) => {
+    it.effect(`replaces streamed text with completed item text ${JSON.stringify(text)}`, () =>
       Effect.gen(function* () {
-        const response = yield* collect([
+        const response = yield* generate(
           { type: "response.output_item.added", item: { type: "message", id: "msg_1", phase: "commentary" } },
-          ...(streamed ? [{ type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" }] : []),
-          { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "Cached" },
+          { type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" },
+          { type: "response.output_text.done", item_id: "msg_1", text: "Part final" },
           {
             type: "response.output_item.done",
-            item: {
-              type: "message",
-              id: "msg_1",
-              phase: "final_answer",
-              content: [
-                { type: "output_text", text: "Final " },
-                { type: "refusal", refusal: "refusal" },
-              ],
-            },
+            item: { type: "message", id: "msg_1", phase: "final_answer", content: [{ type: "output_text", text }] },
           },
           completed,
-        ])
-        expect(response.text).toBe("Final refusal")
+        )
+        expect(response.text).toBe(text)
+        expect(response.events.filter(LLMEvent.is.textDelta).map((event) => event.text)).toEqual(["Draft"])
         expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
           {
             type: "text-end",
             id: "msg_1",
-            text: "Final refusal",
+            text,
             providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "final_answer" } },
           },
         ])
@@ -143,581 +44,166 @@ describe("Open Responses final text", () => {
     )
   })
 
-  it.effect("uses a tracked message item snapshot without text deltas or part finals", () =>
+  it.effect("joins completed text and refusal parts without streamed text", () =>
     Effect.gen(function* () {
-      const response = yield* collect([
+      const response = yield* generate(
         { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
         {
           type: "response.output_item.done",
-          item: { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Snapshot only" }] },
+          item: {
+            type: "message",
+            id: "msg_1",
+            content: [
+              { type: "output_text", text: "Answer. " },
+              { type: "refusal", refusal: "Cannot help." },
+            ],
+          },
         },
         completed,
-      ])
-      expect(response.text).toBe("Snapshot only")
-      expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1", text: "Snapshot only" }])
+      )
+      expect(response.text).toBe("Answer. Cannot help.")
+      expect(response.events.filter(LLMEvent.is.textStart)).toHaveLength(1)
+      expect(response.events.filter(LLMEvent.is.textEnd)).toHaveLength(1)
     }),
   )
 
-  it.effect("uses a content-part snapshot over an earlier scalar final when item content is absent", () =>
+  it.effect("does not create an empty text fragment for an empty completed message", () =>
     Effect.gen(function* () {
-      const response = yield* collect([
+      const response = yield* generate(
         { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
-        { type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" },
-        { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "Cached" },
+        { type: "response.output_text.done", item_id: "msg_1", text: "" },
+        {
+          type: "response.output_item.done",
+          item: { type: "message", id: "msg_1", content: [{ type: "output_text", text: "" }] },
+        },
+        completed,
+      )
+      expect(response.message.content).toEqual([])
+      expect(response.events.filter(LLMEvent.is.textStart)).toEqual([])
+    }),
+  )
+})
+
+describe("Open Responses completed item reasoning", () => {
+  ;[
+    {
+      name: "summary",
+      summary: [
+        { type: "summary_text", text: "Final" },
+        { type: "summary_text", text: "summary" },
+      ],
+      content: [{ type: "reasoning_text", text: "Raw" }],
+      text: "Final\n\nsummary",
+    },
+    {
+      name: "raw text",
+      summary: [
+        { type: "summary_text", text: "" },
+        { type: "summary_text", text: "" },
+      ],
+      content: [{ type: "reasoning_text", text: "Raw" }],
+      text: "Raw",
+    },
+    {
+      name: "streamed fallback",
+      summary: [
+        { type: "summary_text", text: "" },
+        { type: "summary_text", text: "" },
+      ],
+      content: [
+        { type: "reasoning_text", text: "" },
+        { type: "reasoning_text", text: "" },
+      ],
+      text: "Draft",
+    },
+  ].forEach((fixture) => {
+    it.effect(`uses ${fixture.name} at item completion`, () =>
+      Effect.gen(function* () {
+        const response = yield* generate(
+          { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+          { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Draft" },
+          { type: "response.reasoning_summary_text.done", item_id: "rs_1", text: "Part final" },
+          {
+            type: "response.output_item.done",
+            item: {
+              type: "reasoning",
+              id: "rs_1",
+              summary: fixture.summary,
+              content: fixture.content,
+              encrypted_content: "encrypted",
+            },
+          },
+          completed,
+        )
+        expect(response.reasoning).toBe(fixture.text)
+        expect(response.events.filter(LLMEvent.is.reasoningEnd)).toHaveLength(1)
+        expect(response.message.content.find((part) => part.type === "reasoning")?.providerMetadata).toEqual({
+          "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "encrypted" },
+        })
+      }),
+    )
+  })
+
+  it.effect("replaces only the still-open summary without repeating earlier text", () =>
+    Effect.gen(function* () {
+      const response = yield* generate(
+        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "First " },
+        { type: "response.reasoning_summary_part.added", item_id: "rs_1", summary_index: 1 },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 1, delta: "draft" },
+        {
+          type: "response.output_item.done",
+          item: {
+            type: "reasoning",
+            id: "rs_1",
+            summary: [
+              { type: "summary_text", text: "First " },
+              { type: "summary_text", text: "final" },
+            ],
+          },
+        },
+        completed,
+      )
+      expect(response.reasoning).toBe("First final")
+      expect(response.events.filter(LLMEvent.is.reasoningEnd).map((event) => event.text)).toEqual([undefined, "final"])
+    }),
+  )
+})
+;["response.completed", "response.incomplete"].forEach((type) => {
+  it.effect(`keeps streamed text when part finals are followed by ${type} without item completion`, () =>
+    Effect.gen(function* () {
+      const response = yield* generate(
+        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
+        { type: "response.output_text.delta", item_id: "msg_1", content_index: 0, delta: "Hel" },
+        { type: "response.output_text.delta", item_id: "msg_1", content_index: 1, delta: "world" },
+        { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "Hello " },
         {
           type: "response.content_part.done",
           item_id: "msg_1",
           content_index: 0,
-          part: { type: "output_text", text: "Corrected" },
+          part: { type: "output_text", text: "Hello " },
         },
-        { type: "response.output_item.done", item: { type: "message", id: "msg_1" } },
-        completed,
-      ])
-      expect(response.text).toBe("Corrected")
-      expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
-        {
-          type: "text-end",
-          id: "msg_1",
-          text: "Corrected",
-          providerMetadata: { "openai-compatible": { itemId: "msg_1" } },
-        },
-      ])
-    }),
-  )
-  ;[false, true].forEach((streamed) => {
-    it.effect(`empty item content ${streamed ? "preserves streamed text" : "does not create a text fragment"}`, () =>
-      Effect.gen(function* () {
-        const response = yield* collect([
-          { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
-          ...(streamed ? [{ type: "response.output_text.delta", item_id: "msg_1", delta: "Keep" }] : []),
-          { type: "response.output_item.done", item: { type: "message", id: "msg_1", content: [] } },
-          completed,
-        ])
-        expect(response.text).toBe(streamed ? "Keep" : "")
-        expect(response.message.content.filter((part) => part.type === "text")).toHaveLength(streamed ? 1 : 0)
-        if (!streamed) {
-          expect(response.events.filter((event) => event.type.startsWith("text-"))).toEqual([])
-          return
-        }
-        expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1" }])
-        expect(response.events.filter(LLMEvent.is.textEnd).map((event) => event.text)).toEqual([undefined])
-      }),
-    )
-
-    it.effect(`empty scalar and item finals ${streamed ? "clear active text" : "do not create a text fragment"}`, () =>
-      Effect.gen(function* () {
-        const response = yield* collect([
-          { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
-          ...(streamed ? [{ type: "response.output_text.delta", item_id: "msg_1", delta: "Discard" }] : []),
-          { type: "response.output_text.done", item_id: "msg_1", content_index: 0, text: "" },
-          {
-            type: "response.content_part.done",
-            item_id: "msg_1",
-            content_index: 0,
-            part: { type: "output_text", text: "" },
-          },
-          {
-            type: "response.output_item.done",
-            item: { type: "message", id: "msg_1", content: [{ type: "output_text", text: "" }] },
-          },
-          completed,
-        ])
-        expect(response.text).toBe("")
-        expect(response.message.content.filter((part) => part.type === "text")).toHaveLength(streamed ? 1 : 0)
-        if (!streamed) {
-          expect(response.events.filter((event) => event.type.startsWith("text-"))).toEqual([])
-          return
-        }
-        expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1", text: "" }])
-      }),
-    )
-  })
-  ;[
-    {
-      name: "readable text beside an unfamiliar part",
-      content: [
-        { type: "output_text", text: "Readable final" },
-        { type: "other", text: { value: "unfamiliar" } },
-      ],
-      text: "Readable final",
-    },
-    {
-      name: "unknown-only content",
-      content: [{ type: "other", text: { value: "unfamiliar" } }],
-      text: "Cached final",
-    },
-    {
-      name: "malformed known text content",
-      content: [
-        { type: "output_text", text: { value: "unfamiliar" } },
-        { type: "refusal", refusal: null },
-      ],
-      text: "Cached final",
-    },
-    { name: "empty content", content: [], text: "Cached final" },
-  ].forEach((fixture) => {
-    it.effect(`decodes ${fixture.name} without treating absent text as an empty final`, () =>
-      Effect.gen(function* () {
-        const response = yield* collect([
-          { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
-          { type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" },
-          { type: "response.output_text.done", item_id: "msg_1", text: "Cached final" },
-          { type: "response.output_item.done", item: { type: "message", id: "msg_1", content: fixture.content } },
-          completed,
-        ])
-        expect(response.text).toBe(fixture.text)
-        expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
-          {
-            type: "text-end",
-            id: "msg_1",
-            text: fixture.text,
-            providerMetadata: { "openai-compatible": { itemId: "msg_1" } },
-          },
-        ])
-      }),
-    )
-  })
-
-  it.effect("defers cached finals until the next message and ignores late edits to closed text", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "message", id: "msg_1", phase: "commentary" } },
-        { type: "response.output_text.delta", item_id: "msg_1", delta: "Draft" },
-        { type: "response.output_text.done", item_id: "msg_1", text: "First " },
         { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Thinking" },
-        { type: "response.output_item.added", item: { type: "message", id: "msg_2" } },
-        { type: "response.output_text.delta", item_id: "msg_2", delta: "second" },
-        { type: "response.output_text.done", item_id: "msg_1", text: "Late final" },
-        {
-          type: "response.output_item.done",
-          item: { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Late snapshot" }] },
-        },
-        { type: "response.output_text.delta", item_id: "msg_1", delta: "Late delta" },
-        { type: "response.output_item.done", item: { type: "message", id: "msg_2" } },
-        { type: "response.output_item.done", item: { type: "reasoning", id: "rs_1" } },
-        completed,
-      ])
-      expect(response.text).toBe("First second")
-      expect(response.reasoning).toBe("Thinking")
-      expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([
-        {
-          id: "msg_1",
-          text: "First ",
-          providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "commentary" } },
-        },
-        { id: "msg_2" },
-      ])
-      expect(
-        response.events
-          .filter((event) => event.type.endsWith("-start") || event.type.endsWith("-end"))
-          .map((event) => event.type),
-      ).toEqual(["step-start", "text-start", "reasoning-start", "text-end", "text-start", "text-end", "reasoning-end"])
-    }),
-  )
-})
-
-describe("Open Responses final reasoning", () => {
-  ;["reasoning_summary_text.done", "reasoning_summary_part.done"].forEach((kind) => {
-    ;[
-      { name: "longer", text: "Draft reasoning expanded" },
-      { name: "shorter", text: "Draft" },
-      { name: "non-prefix", text: "Replacement" },
-      { name: "empty", text: "" },
-    ].forEach((final) => {
-      it.effect(`replaces reasoning with a ${final.name} ${kind} snapshot at item close`, () =>
-        Effect.gen(function* () {
-          const response = yield* collect([
-            { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1", encrypted_content: null } },
-            {
-              type: "response.reasoning_summary_text.delta",
-              item_id: "rs_1",
-              summary_index: 0,
-              delta: "Draft reasoning",
-            },
-            {
-              type: `response.${kind}`,
-              item_id: "rs_1",
-              summary_index: 0,
-              ...(kind === "reasoning_summary_part.done"
-                ? { part: { type: "summary_text", text: final.text } }
-                : { text: final.text }),
-            },
-            {
-              type: "response.output_item.done",
-              item: { type: "reasoning", id: "rs_1", encrypted_content: "final-state" },
-            },
-            completed,
-          ])
-          expect(response.reasoning).toBe(final.text)
-          expect(response.events.filter(LLMEvent.is.reasoningDelta).map((event) => event.text)).toEqual([
-            "Draft reasoning",
-          ])
-          expect(response.events.filter(LLMEvent.is.reasoningEnd)).toEqual([
-            {
-              type: "reasoning-end",
-              id: "rs_1:0",
-              text: final.text,
-              providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
-            },
-          ])
-          expect(response.message.content.find((part) => part.type === "reasoning")).toMatchObject({
-            text: final.text,
-            providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
-          })
-        }),
-      )
-    })
-  })
-
-  it.effect("closes per-index finals at the next summary and only reconciles still-open item summaries", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "Draft zero" },
-        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "Zero" },
-        { type: "response.reasoning_summary_part.added", item_id: "rs_1", summary_index: 1 },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 1, delta: "Draft one" },
-        {
-          type: "response.reasoning_summary_part.done",
-          item_id: "rs_1",
-          summary_index: 1,
-          part: { type: "summary_text", text: "Cached one" },
-        },
-        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "Late final" },
+        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Draft" },
+        { type: "response.reasoning_summary_text.done", item_id: "rs_1", text: "Part final" },
         {
           type: "response.reasoning_summary_part.done",
           item_id: "rs_1",
           summary_index: 0,
-          part: { type: "summary_text", text: "Late part" },
+          part: { type: "summary_text", text: "Part final" },
         },
         {
-          type: "response.output_item.done",
-          item: {
-            type: "reasoning",
-            id: "rs_1",
-            encrypted_content: "final-state",
-            summary: [
-              { type: "summary_text", text: "Late item edit" },
-              { type: "summary_text", text: "One" },
-              { type: "summary_text", text: "Two" },
-            ],
-          },
-        },
-        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 2, text: "Late closed item" },
-        completed,
-      ])
-      expect(response.reasoning).toBe("ZeroOneTwo")
-      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toMatchObject([
-        { id: "rs_1:0", text: "Zero", providerMetadata: { "openai-compatible": { itemId: "rs_1" } } },
-        { id: "rs_1:1", text: "One" },
-        {
-          id: "rs_1:2",
-          text: "Two",
-          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
-        },
-      ])
-    }),
-  )
-
-  it.effect("uses done-only reasoning summary text and ignores duplicate item finals", () =>
-    Effect.gen(function* () {
-      const item = {
-        type: "reasoning",
-        id: "rs_1",
-        encrypted_content: "final-state",
-        summary: [{ type: "summary_text", text: "Only summary" }],
-      }
-      const response = yield* collect([
-        { type: "response.output_item.done", item },
-        {
-          type: "response.output_item.done",
-          item: { ...item, summary: [{ type: "summary_text", text: "Late edit" }] },
-        },
-        completed,
-      ])
-      expect(response.reasoning).toBe("Only summary")
-      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toMatchObject([
-        {
-          text: "Only summary",
-          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
-        },
-      ])
-    }),
-  )
-
-  it.effect("ignores earlier summary gaps without closing or reopening the active later index", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "Draft zero" },
-        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "Closed zero " },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 2, delta: "Draft two" },
-        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 2, text: "Cached two" },
-        {
-          type: "response.output_item.done",
-          item: {
-            type: "reasoning",
-            id: "rs_1",
-            encrypted_content: "final-state",
-            summary: [
-              { type: "summary_text", text: "Late zero" },
-              { type: "summary_text", text: "Earlier gap" },
-              { type: "summary_text", text: "Final two" },
-            ],
-          },
-        },
-        completed,
-      ])
-      expect(response.reasoning).toBe("Closed zero Final two")
-      expect(response.events.filter(LLMEvent.is.reasoningStart).map((event) => event.id)).toEqual(["rs_1:0", "rs_1:2"])
-      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toEqual([
-        {
-          type: "reasoning-end",
-          id: "rs_1:0",
-          text: "Closed zero ",
-          providerMetadata: { "openai-compatible": { itemId: "rs_1" } },
-        },
-        {
-          type: "reasoning-end",
-          id: "rs_1:2",
-          text: "Final two",
-          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
-        },
-      ])
-    }),
-  )
-
-  it.effect("retains summary indexes and neighboring finals around an unfamiliar summary part", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "Draft" },
-        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "Cached zero" },
-        {
-          type: "response.output_item.done",
-          item: {
-            type: "reasoning",
-            id: "rs_1",
-            encrypted_content: "final-state",
-            summary: [
-              { type: "summary_text", text: "Final zero " },
-              { type: "other", text: { value: "unfamiliar" } },
-              { type: "summary_text", text: "Final two" },
-            ],
-          },
-        },
-        completed,
-      ])
-      expect(response.reasoning).toBe("Final zero Final two")
-      expect(response.events.filter(LLMEvent.is.reasoningStart).map((event) => event.id)).toEqual(["rs_1:0", "rs_1:2"])
-      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toMatchObject([
-        { id: "rs_1:0", text: "Final zero " },
-        {
-          id: "rs_1:2",
-          text: "Final two",
-          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "final-state" } },
-        },
-      ])
-    }),
-  )
-
-  it.effect("uses a part-only summary final without any streamed reasoning deltas", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
-        {
-          type: "response.reasoning_summary_part.done",
-          item_id: "rs_1",
-          summary_index: 0,
-          part: { type: "summary_text", text: "Only final" },
-        },
-        completed,
-      ])
-      expect(response.reasoning).toBe("Only final")
-      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toMatchObject([{ id: "rs_1:0", text: "Only final" }])
-    }),
-  )
-
-  it.effect("closes cached summary finals at implicit boundaries while retaining unsnapshotted indexes", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 0, delta: "Draft" },
-        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 0, text: "First " },
-        { type: "response.reasoning_summary_text.done", item_id: "rs_1", summary_index: 1, text: "second " },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", summary_index: 2, delta: "fallback" },
-        {
-          type: "response.output_item.done",
-          item: { type: "reasoning", id: "rs_1", encrypted_content: "final-state" },
-        },
-        completed,
-      ])
-      expect(response.reasoning).toBe("First second fallback")
-      expect(
-        response.events.filter(LLMEvent.is.reasoningEnd).map((event) => ({ id: event.id, text: event.text })),
-      ).toEqual([
-        { id: "rs_1:0", text: "First " },
-        { id: "rs_1:1", text: "second " },
-        { id: "rs_1:2", text: undefined },
-      ])
-    }),
-  )
-})
-
-describe("Open Responses terminal finals", () => {
-  it.effect("recovers tracked messages with no deltas from completed output", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
-        {
-          type: "response.completed",
+          type,
           response: {
-            output: [{ type: "message", id: "msg_1", content: [{ type: "output_text", text: "Terminal only" }] }],
+            id: "resp_1",
+            incomplete_details: type === "response.incomplete" ? { reason: "max_output_tokens" } : undefined,
           },
         },
-      ])
-      expect(response.text).toBe("Terminal only")
-      expect(response.events.filter(LLMEvent.is.textEnd)).toMatchObject([{ id: "msg_1", text: "Terminal only" }])
-    }),
-  )
-  ;[
-    { name: "compatible", model, key: "openai-compatible" },
-    { name: "OpenAI", model: OpenAI.configure({ apiKey: "test-key" }).responses("gpt-5"), key: "openai" },
-    { name: "xAI", model: XAI.configure({ apiKey: "test-key" }).responses("grok-4.6"), key: "xai" },
-  ].forEach((provider) => {
-    it.effect(`reconciles tracked text and reasoning from ${provider.name} completed output`, () =>
-      Effect.gen(function* () {
-        const response = yield* collect(
-          [
-            { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1", encrypted_content: null } },
-            { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Reasoning draft" },
-            { type: "response.reasoning_summary_text.done", item_id: "rs_1", text: "Cached reasoning" },
-            { type: "response.output_item.added", item: { type: "message", id: "msg_1", phase: "commentary" } },
-            { type: "response.output_text.delta", item_id: "msg_1", delta: "Text draft" },
-            { type: "response.output_text.done", item_id: "msg_1", text: "Cached text" },
-            {
-              type: "response.completed",
-              response: {
-                id: "resp_1",
-                output: [
-                  { type: "reasoning", id: "rs_unknown", summary: [{ type: "summary_text", text: "Untracked" }] },
-                  { type: "message", id: "msg_unknown", content: [{ type: "output_text", text: "Untracked" }] },
-                  {
-                    type: "reasoning",
-                    id: "rs_1",
-                    encrypted_content: "terminal-state",
-                    summary: [{ type: "summary_text", text: "Final reasoning" }],
-                  },
-                  {
-                    type: "message",
-                    id: "msg_1",
-                    phase: "final_answer",
-                    content: [{ type: "output_text", text: "Final text" }],
-                  },
-                ],
-              },
-            },
-          ],
-          provider.model,
-        )
-        expect(response.text).toBe("Final text")
-        expect(response.reasoning).toBe("Final reasoning")
-        expect(response.events.filter(LLMEvent.is.textEnd)).toEqual([
-          {
-            type: "text-end",
-            id: "msg_1",
-            text: "Final text",
-            providerMetadata: { [provider.key]: { itemId: "msg_1", phase: "final_answer" } },
-          },
-        ])
-        expect(response.events.filter(LLMEvent.is.reasoningEnd)).toEqual([
-          {
-            type: "reasoning-end",
-            id: "rs_1:0",
-            text: "Final reasoning",
-            providerMetadata: { [provider.key]: { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" } },
-          },
-        ])
-        expect(response.message.content.find((part) => part.type === "reasoning")?.providerMetadata).toEqual({
-          [provider.key]: { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" },
-        })
-        expect(response.message.content.find((part) => part.type === "text")?.providerMetadata).toEqual({
-          [provider.key]: { itemId: "msg_1", phase: "final_answer" },
-        })
-      }),
-    )
-  })
-  ;["response.completed", "response.incomplete"].forEach((terminal) => {
-    ;[false, true].forEach((finals) => {
-      it.effect(`flushes ${finals ? "cached finals" : "delta fallback"} on ${terminal}`, () =>
-        Effect.gen(function* () {
-          const response = yield* collect([
-            { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
-            { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Reasoning draft" },
-            { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
-            { type: "response.output_text.delta", item_id: "msg_1", delta: "Text draft" },
-            ...(finals
-              ? [
-                  { type: "response.reasoning_summary_text.done", item_id: "rs_1", text: "Reasoning final" },
-                  { type: "response.output_text.done", item_id: "msg_1", text: "Text final" },
-                ]
-              : []),
-            {
-              type: terminal,
-              response: {
-                id: "resp_1",
-                ...(terminal === "response.incomplete"
-                  ? {
-                      incomplete_details: { reason: "max_output_tokens" },
-                      output: [
-                        { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "Not reconciled" }] },
-                        { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Not reconciled" }] },
-                      ],
-                    }
-                  : {}),
-              },
-            },
-          ])
-          expect(response.text).toBe(finals ? "Text final" : "Text draft")
-          expect(response.reasoning).toBe(finals ? "Reasoning final" : "Reasoning draft")
-          expect(response.events.filter(LLMEvent.is.textEnd).map((event) => event.text)).toEqual([
-            finals ? "Text final" : undefined,
-          ])
-          expect(response.events.filter(LLMEvent.is.reasoningEnd).map((event) => event.text)).toEqual([
-            finals ? "Reasoning final" : undefined,
-          ])
-          expect(response.events.filter(LLMEvent.is.finish).map((event) => event.reason.normalized)).toEqual([
-            terminal === "response.incomplete" ? "length" : "stop",
-          ])
-        }),
       )
-    })
-  })
-
-  it.effect("does not reopen closed text or reasoning from completed output", () =>
-    Effect.gen(function* () {
-      const response = yield* collect([
-        { type: "response.output_item.added", item: { type: "reasoning", id: "rs_1" } },
-        { type: "response.reasoning_summary_text.delta", item_id: "rs_1", delta: "Original reasoning" },
-        { type: "response.output_item.done", item: { type: "reasoning", id: "rs_1" } },
-        { type: "response.output_item.added", item: { type: "message", id: "msg_1" } },
-        { type: "response.output_text.delta", item_id: "msg_1", delta: "Original text" },
-        { type: "response.output_item.done", item: { type: "message", id: "msg_1" } },
-        {
-          type: "response.completed",
-          response: {
-            output: [
-              { type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "Late reasoning" }] },
-              { type: "message", id: "msg_1", content: [{ type: "output_text", text: "Late text" }] },
-            ],
-          },
-        },
-      ])
-      expect(response.text).toBe("Original text")
-      expect(response.reasoning).toBe("Original reasoning")
-      expect(response.events.filter(LLMEvent.is.textEnd)).toHaveLength(1)
-      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toHaveLength(1)
+      expect(response.text).toBe("Helworld")
+      expect(response.reasoning).toBe("Draft")
+      expect(response.events.filter(LLMEvent.is.textEnd).map((event) => event.text)).toEqual([undefined])
+      expect(response.events.filter(LLMEvent.is.reasoningEnd).map((event) => event.text)).toEqual([undefined])
     }),
   )
 })

--- a/packages/ai/test/provider/open-responses-lifecycle.test.ts
+++ b/packages/ai/test/provider/open-responses-lifecycle.test.ts
@@ -302,7 +302,7 @@ describe("Open Responses basic-item lifecycles", () => {
     )
   })
 
-  it.effect("recovers pending items in completed output order with terminal encrypted metadata", () =>
+  it.effect("recovers pending calls without reconciling terminal reasoning", () =>
     Effect.gen(function* () {
       const events = yield* collect(
         {
@@ -327,11 +327,6 @@ describe("Open Responses basic-item lifecycles", () => {
       )
       expect(events.slice(5, -2)).toEqual([
         {
-          type: "reasoning-end",
-          id: "rs_1:0",
-          providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" } },
-        },
-        {
           type: "tool-input-end",
           id: "call_1",
           name: "lookup",
@@ -342,8 +337,10 @@ describe("Open Responses basic-item lifecycles", () => {
           id: "call_1",
           name: "lookup",
           input: { query: "final" },
+          providerExecuted: undefined,
           providerMetadata: { "openai-compatible": { itemId: "fc_1" } },
         },
+        { type: "reasoning-end", id: "rs_1:0" },
       ])
     }),
   )

--- a/packages/ai/test/provider/open-responses-lifecycle.test.ts
+++ b/packages/ai/test/provider/open-responses-lifecycle.test.ts
@@ -113,12 +113,7 @@ describe("Open Responses basic-item lifecycles", () => {
           providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: null } },
         },
         { type: "reasoning-delta", id: "rs_1:1", text: "Second" },
-        {
-          type: "reasoning-end",
-          id: "rs_1:1",
-          text: "Second",
-          providerMetadata: { "openai-compatible": { itemId: "rs_1" } },
-        },
+        { type: "reasoning-end", id: "rs_1:1", providerMetadata: { "openai-compatible": { itemId: "rs_1" } } },
         {
           type: "reasoning-start",
           id: "rs_1:2",
@@ -198,7 +193,6 @@ describe("Open Responses basic-item lifecycles", () => {
         {
           type: "text-end",
           id: "msg_1",
-          text: "Checking",
           providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "commentary" } },
         },
         {
@@ -210,7 +204,6 @@ describe("Open Responses basic-item lifecycles", () => {
         {
           type: "text-end",
           id: "msg_2",
-          text: "Cannot help.",
           providerMetadata: { "openai-compatible": { itemId: "msg_2", phase: "final_answer" } },
         },
         {
@@ -219,12 +212,7 @@ describe("Open Responses basic-item lifecycles", () => {
           providerMetadata: { "openai-compatible": { itemId: "msg_3", phase: null } },
         },
         { type: "text-delta", id: "msg_3", text: "Done-only refusal." },
-        {
-          type: "text-end",
-          id: "msg_3",
-          text: "Done-only refusal.",
-          providerMetadata: { "openai-compatible": { itemId: "msg_3", phase: null } },
-        },
+        { type: "text-end", id: "msg_3", providerMetadata: { "openai-compatible": { itemId: "msg_3", phase: null } } },
       ])
     }),
   )

--- a/packages/ai/test/provider/open-responses-lifecycle.test.ts
+++ b/packages/ai/test/provider/open-responses-lifecycle.test.ts
@@ -113,7 +113,12 @@ describe("Open Responses basic-item lifecycles", () => {
           providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: null } },
         },
         { type: "reasoning-delta", id: "rs_1:1", text: "Second" },
-        { type: "reasoning-end", id: "rs_1:1", providerMetadata: { "openai-compatible": { itemId: "rs_1" } } },
+        {
+          type: "reasoning-end",
+          id: "rs_1:1",
+          text: "Second",
+          providerMetadata: { "openai-compatible": { itemId: "rs_1" } },
+        },
         {
           type: "reasoning-start",
           id: "rs_1:2",
@@ -129,7 +134,7 @@ describe("Open Responses basic-item lifecycles", () => {
     }),
   )
 
-  it.effect("preserves done-only encrypted reasoning without replaying its summary or late events", () =>
+  it.effect("preserves done-only reasoning text and encryption without replaying late events", () =>
     Effect.gen(function* () {
       const item = {
         type: "reasoning",
@@ -157,6 +162,7 @@ describe("Open Responses basic-item lifecycles", () => {
         {
           type: "reasoning-end",
           id: "rs_1",
+          text: "Not streamed",
           providerMetadata: { "openai-compatible": { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
         },
       ])
@@ -192,6 +198,7 @@ describe("Open Responses basic-item lifecycles", () => {
         {
           type: "text-end",
           id: "msg_1",
+          text: "Checking",
           providerMetadata: { "openai-compatible": { itemId: "msg_1", phase: "commentary" } },
         },
         {
@@ -203,6 +210,7 @@ describe("Open Responses basic-item lifecycles", () => {
         {
           type: "text-end",
           id: "msg_2",
+          text: "Cannot help.",
           providerMetadata: { "openai-compatible": { itemId: "msg_2", phase: "final_answer" } },
         },
         {
@@ -211,7 +219,12 @@ describe("Open Responses basic-item lifecycles", () => {
           providerMetadata: { "openai-compatible": { itemId: "msg_3", phase: null } },
         },
         { type: "text-delta", id: "msg_3", text: "Done-only refusal." },
-        { type: "text-end", id: "msg_3", providerMetadata: { "openai-compatible": { itemId: "msg_3", phase: null } } },
+        {
+          type: "text-end",
+          id: "msg_3",
+          text: "Done-only refusal.",
+          providerMetadata: { "openai-compatible": { itemId: "msg_3", phase: null } },
+        },
       ])
     }),
   )

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -406,7 +406,7 @@ describe("Open Responses-compatible route", () => {
     })
 
     routings.forEach((routing) => {
-      it.effect(`preserves reasoning summary boundaries and terminal metadata with ${routing.name}`, () =>
+      it.effect(`preserves reasoning summary boundaries without terminal reconciliation with ${routing.name}`, () =>
         Effect.gen(function* () {
           const address = { item_id: routing.item_id, output_index: routing.output_index }
           const response = yield* LLMClient.generate(request).pipe(
@@ -444,21 +444,18 @@ describe("Open Responses-compatible route", () => {
               type: "reasoning",
               text: "Second.",
               providerMetadata: {
-                "openai-compatible": { itemId: routing.id, reasoningEncryptedContent: "final-state" },
+                "openai-compatible": { itemId: routing.id, reasoningEncryptedContent: null },
               },
             },
           ])
           expect(response.events.filter(LLMEvent.is.reasoningEnd)).toEqual([
-            expect.objectContaining({
+            {
+              type: "reasoning-end",
               id: `${routing.id}:0`,
+              text: undefined,
               providerMetadata: { "openai-compatible": { itemId: routing.id } },
-            }),
-            expect.objectContaining({
-              id: `${routing.id}:1`,
-              providerMetadata: {
-                "openai-compatible": { itemId: routing.id, reasoningEncryptedContent: "final-state" },
-              },
-            }),
+            },
+            { type: "reasoning-end", id: `${routing.id}:1` },
           ])
         }),
       )
@@ -671,7 +668,7 @@ describe("Open Responses-compatible route", () => {
     }),
   )
 
-  it.effect("preserves terminal reasoning metadata when item completion is missing", () =>
+  it.effect("ignores terminal reasoning output when item completion is missing", () =>
     Effect.gen(function* () {
       const model = configure({
         apiKey: "test-key",
@@ -697,8 +694,9 @@ describe("Open Responses-compatible route", () => {
         ),
       )
 
-      expect(response.events.find((event) => event.type === "reasoning-end")).toMatchObject({
-        providerMetadata: { "openai-compatible": { itemId: "rs_raw", reasoningEncryptedContent: "raw-state" } },
+      expect(response.events.find((event) => event.type === "reasoning-end")).toEqual({
+        type: "reasoning-end",
+        id: "rs_raw:0",
       })
     }),
   )

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -2554,7 +2554,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("preserves terminal reasoning metadata when output item completion is missing", () =>
+  it.effect("ignores terminal reasoning output when item completion is missing", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(
         LLMRequest.update(request, { providerOptions: { store: false } }),
@@ -2595,30 +2595,13 @@ describe("OpenAI Responses route", () => {
 
       expect(response.reasoning).toBe("Checked the diff.")
       expect(response.events.filter((event) => event.type === "reasoning-end")).toEqual([
-        {
-          type: "reasoning-end",
-          id: "rs_1:0",
-          providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" } },
-          text: "Checked the diff.",
-        },
+        { type: "reasoning-end", id: "rs_1:0" },
       ])
       expect(response.message.content).toContainEqual({
         type: "reasoning",
         text: "Checked the diff.",
-        providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" } },
+        providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: null } },
       })
-
-      const prepared = yield* compileRequest(
-        LLM.request({ model, messages: [response.message], providerOptions: { store: false } }),
-      )
-      expect(prepared.body.input).toEqual([
-        {
-          type: "reasoning",
-          id: "rs_1",
-          summary: [{ type: "summary_text", text: "Checked the diff." }],
-          encrypted_content: "terminal-state",
-        },
-      ])
     }),
   )
 
@@ -2645,7 +2628,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("reconciles pending reasoning and function calls in completed output order", () =>
+  it.effect("recovers pending function calls without reconciling terminal reasoning", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(
         LLMRequest.update(request, { providerOptions: { store: false } }),
@@ -2683,14 +2666,15 @@ describe("OpenAI Responses route", () => {
         ),
       )
 
-      expect(response.events.find((event) => event.type === "reasoning-end")).toMatchObject({
-        providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" } },
+      expect(response.events.find((event) => event.type === "reasoning-end")).toEqual({
+        type: "reasoning-end",
+        id: "rs_1:0",
       })
       expect(response.events.filter(LLMEvent.is.toolCall)).toEqual([
         expect.objectContaining({ id: "call_1", input: { query: "weather" } }),
       ])
-      expect(response.events.findIndex((event) => event.type === "reasoning-end")).toBeLessThan(
-        response.events.findIndex(LLMEvent.is.toolCall),
+      expect(response.events.findIndex(LLMEvent.is.toolCall)).toBeLessThan(
+        response.events.findIndex((event) => event.type === "reasoning-end"),
       )
       expect(response.finishReason.normalized).toBe("tool-calls")
     }),

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -2599,6 +2599,7 @@ describe("OpenAI Responses route", () => {
           type: "reasoning-end",
           id: "rs_1:0",
           providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "terminal-state" } },
+          text: "Checked the diff.",
         },
       ])
       expect(response.message.content).toContainEqual({
@@ -3019,6 +3020,7 @@ describe("OpenAI Responses route", () => {
         {
           type: "reasoning-end",
           id: "rs_1:0",
+          text: "Checked the diff.",
           providerMetadata: { openai: { itemId: "rs_1", reasoningEncryptedContent: "encrypted-state" } },
         },
       ])


### PR DESCRIPTION
## Before

The Responses adapter could keep streamed text even when a completed item supplied a different final value.

```text
streamed:       "Draft answer"
completed item: "Corrected answer"
saved:          "Draft answer"
```

## After

Read text and refusal content from completed message items and pass it through `text-end.text`. For reasoning, prefer the completed summary, then raw reasoning text, and otherwise retain the streamed value. Preserve phase and encrypted metadata supplied by the completed item.

```text
streamed:       "Draft answer"
completed item: "Corrected answer"
saved:          "Corrected answer"
```

There is no extra delta buffer, per-part final cache, or merging of partial corrections. Existing handling for providers that send text without deltas remains unchanged. Final content and reasoning metadata require `response.output_item.done`; terminal `response.completed.output` is not used to reconstruct missing reasoning items.

Already-closed reasoning fragments are not rewritten, and split summaries only replace their still-open matching fragment. Tool completion policy, raw-reasoning/summary channel separation, and common event schemas are unchanged. No Core or client changes.