### PR TITLE
fix(core): continue retryable failures after durable output

### DIFF
--- a/packages/core/src/session/runner/step.ts
+++ b/packages/core/src/session/runner/step.ts
@@ -224,10 +224,15 @@ export const make = Effect.gen(function* () {
             })
         }
 
+        // After durable output, recovery continues instead of replaying: the
+        // partial assistant message is already persisted history. Any failure
+        // the pre-output gate would retry is continued here, plus interrupted
+        // streams, whose read failures may carry delivery states the retry
+        // policy rejects for full resends.
         if (
           llmFailure &&
           llmError &&
-          isInterruptedStream(llmFailure) &&
+          (isInterruptedStream(llmFailure) || SessionRunnerRetry.isRetryable(llmFailure)) &&
           record.outputStarted &&
           tools.declines.length === 0 &&
           !tools.interrupted

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -11,6 +11,7 @@ import {
   InvalidProviderOutputError,
   InvalidRequestError,
   RateLimitError,
+  UnknownProviderError,
 } from "@opencode-ai/ai"
 import * as OpenAIChat from "@opencode-ai/ai/protocols/openai-chat"
 import { TestLLM } from "@opencode-ai/ai/testing"
@@ -848,18 +849,19 @@ function* verifyEphemeralDeltas(s: Scenario, kind: FragmentKind) {
 function* verifyPartialFlushOnFailure(s: Scenario, kind: FragmentKind) {
   const prompt = `Fail after ${kind}`
   const fixture = fragmentFixture(kind, fragmentID(kind, "partial"), ["Partial"])
-  const failure = providerUnavailable()
+  // A non-retryable failure keeps the step terminal so the flushed fragments settle durably.
+  const failure = invalidRequest()
   yield* s.admit(prompt)
   yield* s.llm.push(TestLLM.failAfter(failure, ...fixture.partialEvents))
 
   expect(yield* s.resume.pipe(Effect.flip)).toBe(failure)
   expect(yield* s.context).toMatchObject([
     Expected.user(prompt),
-    Expected.assistant({ finish: "error", error: { type: "provider.transport", message: "Provider unavailable" } }, [
+    Expected.assistant({ finish: "error", error: { type: "provider.invalid-request", message: "Invalid request" } }, [
       kind === "tool input"
         ? Expected.failedTool(
             { id: fragmentID(kind, "partial") },
-            { error: { type: "provider.transport", message: "Provider unavailable" } },
+            { error: { type: "provider.invalid-request", message: "Invalid request" } },
           )
         : fixture.expectedContent,
     ]),
@@ -3942,7 +3944,8 @@ describe("SessionRunnerLLM", () => {
 
   scenario("awaits started local tools before surfacing provider stream failure", function* (s) {
     yield* s.admit("Settle before failing")
-    const failure = providerUnavailable()
+    // Non-retryable so the step settles terminally instead of continuing after tool output.
+    const failure = invalidRequest()
     const tools = yield* s.blockTools()
     yield* s.llm.push(
       TestLLM.failAfter(
@@ -4492,6 +4495,74 @@ describe("SessionRunnerLLM", () => {
     expect(yield* s.context).toMatchObject([
       { type: "user" },
       Expected.assistant({ finish: "error" }, [Expected.text("Partial")]),
+      { type: "synthetic", text: INCOMPLETE_STREAM_CONTINUATION },
+      Expected.assistant({ finish: "stop" }, [Expected.text(" continuation")]),
+    ])
+  })
+
+  scenario("continues after a mid-stream rate limit honoring retry-after", function* (s) {
+    yield* s.admit("Continue after rate limit")
+    yield* s.llm.push(
+      TestLLM.failAfter(
+        rateLimited(5_000),
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.textStart({ id: "rate-limited-partial" }),
+        LLMEvent.textDelta({ id: "rate-limited-partial", text: "Partial" }),
+      ),
+    )
+    yield* s.llm.push(TestLLM.text(" continuation", "rate-limit-continuation"))
+
+    const run = yield* s.resume.pipe(Effect.forkChild)
+    yield* s.llm.wait(1)
+    yield* TestClock.adjust("4999 millis")
+    expect(s.requests).toHaveLength(1)
+    yield* TestClock.adjust("1 millis")
+    yield* Fiber.join(run)
+
+    expect(s.requests).toHaveLength(2)
+    expect(s.requests[1]?.messages.at(-2)).toMatchObject({
+      role: "assistant",
+      content: [{ type: "text", text: "Partial" }],
+    })
+    expect(s.requests[1]?.messages.at(-1)).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: INCOMPLETE_STREAM_CONTINUATION }],
+    })
+    expect(yield* recordedEventTypes(sessionID)).toContain("session.retry.scheduled.1")
+    expect(yield* s.context).toMatchObject([
+      Expected.user("Continue after rate limit"),
+      Expected.assistant({ finish: "error", error: { type: "provider.rate-limit" } }, [Expected.text("Partial")]),
+      { type: "synthetic", text: INCOMPLETE_STREAM_CONTINUATION },
+      Expected.assistant({ finish: "stop" }, [Expected.text(" continuation")]),
+    ])
+  })
+
+  scenario("continues after an unrecognized mid-stream provider failure", function* (s) {
+    const failure = new AIError({ reason: new UnknownProviderError({ message: "Provider returned error" }) })
+    yield* s.admit("Continue after unknown failure")
+    yield* s.llm.push(
+      TestLLM.failAfter(
+        failure,
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.textStart({ id: "unknown-failure-partial" }),
+        LLMEvent.textDelta({ id: "unknown-failure-partial", text: "Partial" }),
+      ),
+    )
+    yield* s.llm.push(TestLLM.text(" continuation", "unknown-failure-continuation"))
+
+    const run = yield* s.resume.pipe(Effect.forkChild)
+    yield* s.llm.wait(1)
+    yield* TestClock.adjust("2400 millis")
+    yield* Fiber.join(run)
+
+    expect(s.requests).toHaveLength(2)
+    expect(s.requests[1]?.messages.at(-1)).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: INCOMPLETE_STREAM_CONTINUATION }],
+    })
+    expect(yield* s.context).toMatchObject([
+      Expected.user("Continue after unknown failure"),
+      Expected.assistant({ finish: "error", error: { type: "provider.unknown" } }, [Expected.text("Partial")]),
       { type: "synthetic", text: INCOMPLETE_STREAM_CONTINUATION },
       Expected.assistant({ finish: "stop" }, [Expected.text(" continuation")]),
     ])
@@ -5254,7 +5325,8 @@ describe("SessionRunnerLLM", () => {
   })
 
   scenario("durably fails a hosted tool left unresolved by a raw provider stream failure", function* (s) {
-    const failure = providerUnavailable()
+    // Non-retryable so the step settles terminally instead of continuing after tool output.
+    const failure = invalidRequest()
     yield* s.llm.push(
       Stream.concat(
         Stream.fromIterable([LLMEvent.stepStart({ index: 0 }), hostedCall("call-hosted-raw-failure", "effect")]),
@@ -5278,7 +5350,7 @@ describe("SessionRunnerLLM", () => {
     yield* replaySessionProjection(sessionID)
     expect(yield* s.context).toMatchObject([
       Expected.user("Fail hosted tool on raw failure"),
-      Expected.assistant({ finish: "error", error: { type: "provider.transport", message: "Provider unavailable" } }, [
+      Expected.assistant({ finish: "error", error: { type: "provider.invalid-request", message: "Invalid request" } }, [
         Expected.failedTool({ id: "call-hosted-raw-failure" }, {}),
       ]),
     ])


### PR DESCRIPTION
## Summary
A retryable failure arriving after the assistant produced durable output had no recovery path. The pre-output retry gate requires `!outputStarted`, and the continuation gate only matched interrupted-stream shapes (`Transport` read failures, incomplete streams). A provider that streams partial output and then reports a retryable error — an overloaded/rate-limit/server error event inside the stream, or any unrecognized failure — matched neither gate and durably failed the turn, even though the same failure before output would have retried.

The continuation gate now also accepts any failure the retry policy considers retry-eligible:

- Before: continue when `isInterruptedStream(failure)` and output started.
- After: continue when `isInterruptedStream(failure) || isRetryable(failure)` and output started.

`isInterruptedStream` stays in the condition rather than being replaced: WebSocket read failures can carry `delivery: "accepted"` or `"rejected"`, which the retry policy rejects for full resends but which must keep taking the continuation path after durable output.

## Behavior notes
- Continuations already run through the same retry schedule as pre-output retries, so the new cases inherit jittered exponential backoff, provider `retry-after` floors, the 15-minute cap, and the shared five-attempt budget with no policy changes. A mid-stream rate limit now waits out its `retry-after` before continuing.
- The recovery keeps the persisted partial assistant message, publishes the durable step failure, and continues with the existing synthetic continuation prompt — identical mechanics to incomplete-stream continuation.
- Non-retryable failures after output (invalid request, auth, quota, content policy, context overflow) still settle terminally, unchanged.

## Verification
- New scenarios: mid-stream rate limit continues after honoring `retry-after` exactly; unrecognized mid-stream provider failure continues with backoff.
- Three existing scenarios asserted durable settlement using a retryable transport fixture after output; their intent is fragment flushing and tool settlement, so they now use a non-retryable `InvalidRequest` fixture.
- Full isolated Core suite: 3783 pass / 39 skip / 0 fail. `bun typecheck` and formatting pass in `packages/core`.