### PR TITLE
fix(ai): keep chat reasoning in one lifecycle

### DIFF
--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -1000,33 +1000,12 @@ const step = (state: ParserState, event: OpenAIChatEvent) =>
       lifecycle = Lifecycle.reasoningStart(lifecycle, events, "reasoning-0", deltaMetadata)
     const reasoningEmitted = state.reasoningEmitted || lifecycle.reasoning.has("reasoning-0")
 
-    if (delta?.content) {
-      lifecycle = Lifecycle.reasoningEnd(
-        lifecycle,
-        events,
-        "reasoning-0",
-        reasoningMetadata(
-          state.providerMetadataKey,
-          reasoningField,
-          reasoningDetailsObserved ? state.reasoningDetails : undefined,
-        ),
-      )
-      lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
-    }
+    // Reasoning is one response-wide channel: it stays open alongside text and
+    // refusal output so late reasoning deltas and details join the same block,
+    // and `finishEvents` closes it once with the complete metadata.
+    if (delta?.content) lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.content)
 
-    if (delta?.refusal) {
-      lifecycle = Lifecycle.reasoningEnd(
-        lifecycle,
-        events,
-        "reasoning-0",
-        reasoningMetadata(
-          state.providerMetadataKey,
-          reasoningField,
-          reasoningDetailsObserved ? state.reasoningDetails : undefined,
-        ),
-      )
-      lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.refusal)
-    }
+    if (delta?.refusal) lifecycle = Lifecycle.textDelta(lifecycle, events, "text-0", delta.refusal)
 
     // Compatible providers may omit indexes. Prefer durable identity, then use
     // batch position for parallel deltas or the latest call for sparse chunks.
@@ -1132,10 +1111,12 @@ const finishEvents = Effect.fn("OpenAIChat.finishEvents")(function* (state: Pars
           state.finishReason.normalized === "stop" && hasToolCalls ? "tool-calls" : state.finishReason.normalized,
       }
     : { normalized: hasToolCalls ? ("tool-calls" as const) : ("stop" as const) }
+  // Snapshot details at publish time so the emitted event never observes later
+  // mutation of the accumulated `reasoningDetails` array.
   const metadata = reasoningMetadata(
     state.providerMetadataKey,
     state.reasoningField,
-    state.reasoningDetailsObserved ? state.reasoningDetails : undefined,
+    state.reasoningDetailsObserved ? [...state.reasoningDetails] : undefined,
   )
   const started =
     state.reasoningDetailsObserved && !state.reasoningEmitted

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -7,6 +7,7 @@ import {
   AIError,
   LLMEvent,
   LLMRequest,
+  LLMResponse,
   Message,
   LanguageModel,
   ToolCallPart,
@@ -1149,7 +1150,7 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
-  it.effect("preserves scalar reasoning after content starts", () =>
+  it.effect("preserves scalar reasoning after content starts in one lifecycle", () =>
     Effect.gen(function* () {
       const details = [{ type: "reasoning.text", text: "detail", format: "unknown", index: 0 }]
       const response = yield* LLMClient.generate(request).pipe(
@@ -1166,8 +1167,35 @@ describe("OpenAI Chat route", () => {
       )
 
       expect(response.reasoning).toBe("detailscalar")
-      expect(response.events.filter(LLMEvent.is.reasoningStart)).toHaveLength(2)
-      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toHaveLength(2)
+      expect(response.events.filter(LLMEvent.is.reasoningStart)).toHaveLength(1)
+      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toHaveLength(1)
+      expect(response.message.content.filter((part) => part.type === "reasoning")).toHaveLength(1)
+      expect(response.message.content.find((part) => part.type === "reasoning")?.providerMetadata).toEqual({
+        openai: { reasoningField: "reasoning", reasoningDetails: details },
+      })
+    }),
+  )
+
+  it.effect("keeps one reasoning lifecycle across many content chunks", () =>
+    Effect.gen(function* () {
+      const details = [{ type: "reasoning.text", text: "thinking", format: "anthropic-claude-v1", index: 0 }]
+      const response = yield* LLMClient.generate(request).pipe(
+        Effect.provide(
+          fixedResponse(
+            sseEvents(
+              { choices: [{ delta: { reasoning: "thinking", reasoning_details: details } }] },
+              ...Array.from({ length: 25 }, (_, index) => deltaChunk({ content: `chunk-${index} ` })),
+              deltaChunk({}, "stop"),
+            ),
+          ),
+        ),
+      )
+
+      expect(response.reasoning).toBe("thinking")
+      expect(response.text).toBe(Array.from({ length: 25 }, (_, index) => `chunk-${index} `).join(""))
+      expect(response.events.filter(LLMEvent.is.reasoningStart)).toHaveLength(1)
+      expect(response.events.filter(LLMEvent.is.reasoningEnd)).toHaveLength(1)
+      expect(response.message.content.filter((part) => part.type === "reasoning")).toHaveLength(1)
       expect(response.message.content.find((part) => part.type === "reasoning")?.providerMetadata).toEqual({
         openai: { reasoningField: "reasoning", reasoningDetails: details },
       })
@@ -1213,7 +1241,18 @@ describe("OpenAI Chat route", () => {
           index: 0,
         },
       ]
-      const response = yield* LLMClient.generate(request).pipe(
+      // Snapshot reasoning-end metadata as each event is published so the
+      // assertion cannot pass through later mutation of a shared array.
+      const publishedEndMetadata: unknown[] = []
+      const response = yield* LLMClient.stream(request).pipe(
+        Stream.tap((event) =>
+          Effect.sync(() => {
+            if (LLMEvent.is.reasoningEnd(event))
+              publishedEndMetadata.push(decodeJson(encodeJson(event.providerMetadata)))
+          }),
+        ),
+        Stream.runFold(LLMResponse.empty, LLMResponse.reduce),
+        Effect.map((state) => LLMResponse.complete(state)!),
         Effect.provide(
           fixedResponse(
             sseEvents(
@@ -1234,10 +1273,12 @@ describe("OpenAI Chat route", () => {
       expect(response.events.filter(LLMEvent.is.reasoningStart)).toHaveLength(1)
       expect(response.events.filter(LLMEvent.is.reasoningDelta)).toHaveLength(1)
       expect(response.events.filter(LLMEvent.is.reasoningEnd)).toHaveLength(1)
-      expect(response.events.filter(LLMEvent.is.reasoningEnd).at(-1)?.providerMetadata).toEqual({
-        openai: { reasoningField: "reasoning", reasoningDetails: merged },
-      })
-      expect(response.events.findIndex(LLMEvent.is.reasoningEnd)).toBeLessThan(
+      expect(publishedEndMetadata).toEqual([{ openai: { reasoningField: "reasoning", reasoningDetails: merged } }])
+      expect(response.events.findIndex(LLMEvent.is.reasoningStart)).toBeLessThan(
+        response.events.findIndex(LLMEvent.is.textStart),
+      )
+      // Reasoning stays open alongside text and closes once during finalization.
+      expect(response.events.findIndex(LLMEvent.is.reasoningEnd)).toBeGreaterThan(
         response.events.findIndex(LLMEvent.is.textStart),
       )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2897,6 +2897,54 @@ describe("SessionRunnerLLM", () => {
     ])
   })
 
+  scenario("keeps one durable reasoning part when reasoning closes after text", function* (s) {
+    yield* s.admit("Think and answer")
+
+    const details = [{ type: "reasoning.text", text: "thinking", signature: "signed", index: 0 }]
+    yield* s.llm.push(
+      TestLLM.stop(
+        LLMEvent.reasoningStart({ id: "reasoning-0" }),
+        LLMEvent.reasoningDelta({ id: "reasoning-0", text: "thinking" }),
+        LLMEvent.textStart({ id: "text-0" }),
+        LLMEvent.textDelta({ id: "text-0", text: "Hello" }),
+        LLMEvent.textDelta({ id: "text-0", text: " world" }),
+        LLMEvent.reasoningEnd({
+          id: "reasoning-0",
+          providerMetadata: { openai: { reasoningField: "reasoning", reasoningDetails: details } },
+        }),
+        LLMEvent.textEnd({ id: "text-0" }),
+      ),
+    )
+    yield* s.resume
+    yield* replaySessionProjection(sessionID)
+
+    const assistant = requireAssistant(yield* s.context)
+    expect(assistant.content.filter((part) => part.type === "reasoning")).toHaveLength(1)
+    expect(yield* s.context).toMatchObject([
+      Expected.user("Think and answer"),
+      Expected.assistant({}, [
+        {
+          type: "reasoning",
+          text: "thinking",
+          state: { reasoningField: "reasoning", reasoningDetails: details },
+        },
+        { type: "text", text: "Hello world" },
+      ]),
+    ])
+
+    yield* s.admit("Continue")
+    yield* s.llm.push([])
+    yield* s.resume
+
+    expect(s.requests[1]?.messages[1]?.content.filter((part) => part.type === "reasoning")).toEqual([
+      {
+        type: "reasoning",
+        text: "thinking",
+        providerMetadata: { openai: { reasoningField: "reasoning", reasoningDetails: details } },
+      },
+    ])
+  })
+
   scenario("restores durable text provider metadata in the next request", function* (s) {
     yield* s.admit("Check first")
 


### PR DESCRIPTION
Fixes #45791

## Problem

`openai-chat` eagerly ended the reasoning block whenever visible content or refusal arrived. Because `reasoningDetailsObserved` stayed true, every later content chunk re-opened an empty `reasoning-0` block that was immediately ended again. Core assigns each reopened block a new ordinal and persists a new reasoning part, each carrying the accumulated `reasoningDetails`, which are flat-mapped on replay — quadratic storage and context growth.

## Fix

Treat Chat Completions reasoning as one response-wide channel:

- Removed the eager `Lifecycle.reasoningEnd(...)` calls from the content and refusal branches; text/refusal and reasoning are now independently active.
- `reasoning-0` starts once and stays open, so late reasoning deltas and details (including signatures arriving after text starts) join the same block.
- `finishEvents` performs the single final `reasoning-end`, attaching the complete metadata with a publish-time snapshot of the accumulated details so emitted events never observe later mutation.
- The recently added `[DONE]` terminal behavior is preserved.

The change is protocol-local; no replay deduplication or migration for already-corrupted sessions.

## Tests

- Structured reasoning followed by many content chunks emits exactly one `reasoning-start`/`reasoning-end` and one reasoning part.
- Signature-only details arriving after text appear on the final `reasoning-end`, asserted against publisher-time metadata snapshots taken as events stream.
- Scalar reasoning arriving after content stays in the same lifecycle (updated from the previous 2-start/2-end expectation).
- Session integration test in `packages/core`: a streamed response whose reasoning closes after text produces one durable reasoning part and one replayed `reasoning_details` block in the next request.

## Verification

- `bun test test/provider/openai-chat.test.ts` in `packages/ai` (61 pass); full ai suite matches base-branch failures only.
- `bun run test test/session-runner.test.ts` in `packages/core` (175 pass).
- `bun typecheck` in `packages/ai` and `packages/core`.