### PR TITLE
fix: allow windows-arm64 in install script

### DIFF
--- a/install
+++ b/install
@@ -101,7 +101,7 @@ else
 
     combo="$os-$arch"
     case "$combo" in
-      linux-x64|linux-arm64|darwin-x64|darwin-arm64|windows-x64)
+      linux-x64|linux-arm64|darwin-x64|darwin-arm64|windows-x64|windows-arm64)
         ;;
       *)
         echo -e "${RED}Unsupported OS/Arch: $os/$arch${NC}"


### PR DESCRIPTION
The `install` script arch allowlist omits `windows-arm64`, so the installer rejects ARM64 Windows with `Unsupported OS/Arch: windows/arm64` even though detection already maps `aarch64` to `arm64` and every release publishes `opencode-windows-arm64.zip`.

Fixes #44664.