### PR TITLE
chore: bump Bun pin to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "AI-powered development tool",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "scripts": {
     "dev": "bun run --cwd packages/opencode --conditions=browser src/index.ts",
     "dev:desktop": "bun --cwd packages/desktop dev",


### PR DESCRIPTION
The root `package.json` pins `packageManager` to `bun@1.3.14`, which CI uses and `bun build --compile` embeds into releases. Bun 1.3.14 ships `bun:ffi` compiled out on `windows-aarch64` (TinyCC has no ARM64 backend), and the TUI loads OpenTUI's native library through `bun:ffi` — so **every native Windows ARM64 build fails at TUI startup**:

```
Failed to initialize OpenTUI render library: bun:ffi dlopen() is not available in this build (TinyCC is disabled)
```

Bun 1.4.0 (released 2026-08-20) ships engine-native FFI that works on Windows ARM64 (oven-sh/bun#28055, #33696). Community rebuilds of the official source with Bun 1.4.0 (e.g. https://github.com/airtaxi/opencode-windows-arm64) confirm the error disappears and the TUI runs natively on ARM64.

Related: #19130, #38520, #44945, #45875.

Known follow-up (not addressed here): `bun-pty` ships only an x64 Windows DLL, so `#pty` shell sessions may still need a win32-arm64 build upstream (github.com/sursaone/bun-pty).