### PR TITLE
fix(core): strip trailing newlines from grep line previews

### DIFF
--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -19,6 +19,12 @@ const ERROR_BYTES = 8 * 1024
 const MAX_RECORD_BYTES = 64 * 1024
 const MAX_SUBMATCHES = 100
 
+/** Strip the trailing newline ripgrep includes in line previews, then bound the preview length. */
+const previewLine = (raw: string) => {
+  const line = raw.replace(/\r?\n$/, "")
+  return line.length > 2_000 ? line.slice(0, 2_000).replace(/[\uD800-\uDBFF]$/, "") + "..." : line
+}
+
 const RawMatch = Schema.Struct({
   type: Schema.Literal("match"),
   data: Schema.Struct({
@@ -264,10 +270,7 @@ const layer = Layer.effect(
                 }),
                 line: match.line_number,
                 offset: match.absolute_offset,
-                text:
-                  match.lines.text.length > 2_000
-                    ? match.lines.text.slice(0, 2_000).replace(/[\uD800-\uDBFF]$/, "") + "..."
-                    : match.lines.text,
+                text: previewLine(match.lines.text),
                 submatches: match.submatches.map((submatch) => ({
                   text: submatch.match.text,
                   start: submatch.start,

--- a/packages/core/test/ripgrep.test.ts
+++ b/packages/core/test/ripgrep.test.ts
@@ -82,4 +82,27 @@ describe("Ripgrep", () => {
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
     ),
   )
+  it.live("strips trailing newlines from line previews", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) =>
+        Effect.gen(function* () {
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "lf.txt"), "needle\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "crlf.txt"), "needle\r\n"))
+          yield* Effect.promise(() => fs.writeFile(path.join(tmp.path, "no-newline.txt"), "needle"))
+
+          const matches = yield* (yield* Ripgrep.Service).grep({
+            cwd: tmp.path,
+            pattern: "needle",
+            limit: 10,
+          })
+          const textByPath = new Map(matches.map((match) => [String(match.entry.path), match.text]))
+
+          expect(textByPath.get("lf.txt")).toBe("needle")
+          expect(textByPath.get("crlf.txt")).toBe("needle")
+          expect(textByPath.get("no-newline.txt")).toBe("needle")
+        }),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #45879

### Type of change

- [x] Bug fix

### What does this PR do?

ripgrep's `--json` output includes the line's trailing newline in `lines.text` (`\r\n` for CRLF files). That newline survived into `Match.text` and from there into the grep tool output, so every match rendered with an extra blank line after it (in both the model-facing text and the structured output), even though blank lines are only meant to separate file groups.

The fix strips the trailing newline in `previewLine` before the existing length truncation runs, in the same place the preview is already shaped. This covers both the V2 and V1 grep tools since they share the ripgrep layer.

### How did you verify your code works?

Added a regression test in `packages/core/test/ripgrep.test.ts` covering LF, CRLF, and no-trailing-newline files. `bun test test/ripgrep.test.ts` (4 pass), `bun test test/tool/grep.test.ts` (6 pass), and `bun run typecheck` all clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR