### PR TITLE
fix(core): normalize unprefixed AI SDK packages in provider config

### DIFF
--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -74,7 +74,9 @@ const layer = Layer.effect(
     const projectModel = (model: Model.Info, provider: Provider.Info) => {
       return {
         ...model,
-        package: model.package ?? provider.package,
+        // Normalize here too so catalog entries injected without config parsing (tests, plugins)
+        // still resolve through the AI SDK loader instead of the native one.
+        package: Provider.normalizeAISDK(model.package ?? provider.package),
         settings: Provider.mergeOverlay(provider.settings, model.settings),
         headers: Provider.mergeHeaders(provider.headers, model.headers),
         body: Provider.mergeOverlay(provider.body, model.body),

--- a/packages/core/src/config/normalize.ts
+++ b/packages/core/src/config/normalize.ts
@@ -25,10 +25,11 @@ import { ConfigPermissionV1 } from "../v1/config/permission.js"
 import { ConfigPluginV1 } from "../v1/config/plugin.js"
 import { ConfigProviderV1 } from "../v1/config/provider.js"
 import { ConfigMigrateV1 } from "../v1/config/migrate.js"
+import { Provider } from "../provider.js"
 import { PositiveInt } from "../schema.js"
 
 export interface Diagnostic {
-  readonly kind: "conflict" | "invalid" | "unsupported"
+  readonly kind: "conflict" | "invalid" | "unsupported" | "normalized"
   readonly path: readonly string[]
   readonly message: string
 }
@@ -164,6 +165,7 @@ export function normalize(input: unknown): Result {
     isRecord(input.provider) || isRecord(input.providers),
     diagnostics,
   )
+  normalizeProviderPackages(encoded, diagnostics)
 
   const toolRules = migrateTools(input.tools, diagnostics)
   const permissionRules = migratePermissions(input.permission, diagnostics)
@@ -773,6 +775,33 @@ function invalid(path: string[], diagnostics: Diagnostic[]) {
 
 function conflict(path: string[], diagnostics: Diagnostic[]) {
   diagnostics.push({ kind: "conflict", path, message: "retained native value over legacy value" })
+}
+
+function normalizeProviderPackages(encoded: Record<string, unknown>, diagnostics: Diagnostic[]) {
+  const providers = encoded.providers
+  if (!isRecord(providers)) return
+  Object.entries(providers).forEach(([id, value]) => {
+    if (!isRecord(value)) return
+    const path = ["providers", id]
+    normalizePackageField(value, path, diagnostics)
+    if (!isRecord(value.models)) return
+    Object.entries(value.models).forEach(([modelID, model]) => {
+      if (!isRecord(model)) return
+      normalizePackageField(model, [...path, "models", modelID], diagnostics)
+    })
+  })
+}
+
+function normalizePackageField(entry: Record<string, unknown>, path: string[], diagnostics: Diagnostic[]) {
+  const pkg = entry.package
+  if (typeof pkg !== "string" || pkg.startsWith(Provider.AISDK_PREFIX) || !Provider.looksLikeAISDK(pkg)) return
+  const normalized = Provider.aisdk(pkg)
+  entry.package = normalized
+  diagnostics.push({
+    kind: "normalized",
+    path,
+    message: `normalized AI SDK package "${pkg}" to "${normalized}" (the "aisdk:" prefix selects the AI SDK loader)`,
+  })
 }
 
 function isDirectLegacyMcp(value: unknown) {

--- a/packages/core/src/provider.ts
+++ b/packages/core/src/provider.ts
@@ -14,6 +14,11 @@ export type ID = typeof ID.Type
 export const AISDK_PREFIX = "aisdk:"
 export const isAISDK = (value: string | undefined): value is string => value?.startsWith(AISDK_PREFIX) ?? false
 export const aisdk = (value: string) => (isAISDK(value) ? value : `${AISDK_PREFIX}${value}`)
+// Only `@ai-sdk/*` is unambiguous enough to auto-prefix; other AI SDK-compatible packages still
+// require the explicit "aisdk:" discriminator so native modules are never misclassified.
+export const looksLikeAISDK = (value: string | undefined): boolean => value?.startsWith("@ai-sdk/") ?? false
+export const normalizeAISDK = (value: string | undefined) =>
+  value !== undefined && looksLikeAISDK(value) ? aisdk(value) : value
 export function packageName(value: string): string
 export function packageName(value: undefined): undefined
 export function packageName(value: string | undefined): string | undefined

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -223,6 +223,31 @@ describe("Catalog", () => {
     }),
   )
 
+  it.effect("normalizes unprefixed AI SDK packages when projecting models", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const providerID = Provider.ID.make("test")
+      const modelID = Model.ID.make("model")
+      const fallbackID = Model.ID.make("fallback")
+      yield* catalog.transform((catalog) => {
+        catalog.provider.update(providerID, (provider) => {
+          provider.package = "@ai-sdk/openai-compatible"
+        })
+        catalog.model.update(providerID, modelID, (model) => {
+          model.package = "@ai-sdk/openai"
+        })
+        catalog.model.update(providerID, fallbackID, () => {})
+      })
+
+      expect(required(yield* catalog.model.get(providerID, modelID))).toMatchObject({
+        package: Provider.aisdk("@ai-sdk/openai"),
+      })
+      expect(required(yield* catalog.model.get(providerID, fallbackID))).toMatchObject({
+        package: Provider.aisdk("@ai-sdk/openai-compatible"),
+      })
+    }),
+  )
+
   it.effect("resolves provider and model overlay merges", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service

--- a/packages/core/test/config/normalization.test.ts
+++ b/packages/core/test/config/normalization.test.ts
@@ -111,19 +111,28 @@ describe("ConfigNormalize", () => {
   })
 
   test("leaves prefixed, native, and non-ai-sdk package values untouched", () => {
-    const result = normalized({
+    const input = {
       providers: {
         prefixed: { package: "aisdk:@ai-sdk/openai-compatible", models: { chat: {} } },
         native: { package: "@opencode-ai/ai/providers/openai", models: { chat: {} } },
+        mixed: {
+          package: "aisdk:@ai-sdk/anthropic",
+          models: { chat: { package: "@opencode-ai/ai/providers/openai-compatible" } },
+        },
         file: { package: "file:///some/provider", models: { chat: {} } },
         thirdparty: { package: "@scope/ai-sdk-provider", models: { chat: {} } },
         missing: { models: { chat: {} } },
       },
-    })
+    }
+    const snapshot = structuredClone(input)
+    const result = normalized(input)
     expect(result.diagnostics.filter((item) => item.kind === "normalized")).toEqual([])
+    expect(input).toEqual(snapshot)
     const info = Schema.decodeUnknownSync(Info, options)(result.encoded)
     expect(info.providers?.prefixed?.package).toBe("aisdk:@ai-sdk/openai-compatible")
     expect(info.providers?.native?.package).toBe("@opencode-ai/ai/providers/openai")
+    expect(info.providers?.mixed?.package).toBe("aisdk:@ai-sdk/anthropic")
+    expect(info.providers?.mixed?.models?.chat?.package).toBe("@opencode-ai/ai/providers/openai-compatible")
     expect(info.providers?.file?.package).toBe("file:///some/provider")
     expect(info.providers?.thirdparty?.package).toBe("@scope/ai-sdk-provider")
     expect(info.providers?.missing?.package).toBeUndefined()

--- a/packages/core/test/config/normalization.test.ts
+++ b/packages/core/test/config/normalization.test.ts
@@ -92,6 +92,43 @@ describe("ConfigNormalize", () => {
     )
   })
 
+  test("normalizes unprefixed AI SDK packages at provider and model level", () => {
+    const result = normalized({
+      providers: {
+        custom: {
+          package: "@ai-sdk/openai-compatible",
+          models: { chat: { package: "@ai-sdk/anthropic" } },
+        },
+      },
+    })
+    expect(result.diagnostics.filter((item) => item.kind === "normalized").map((item) => item.path)).toEqual([
+      ["providers", "custom"],
+      ["providers", "custom", "models", "chat"],
+    ])
+    const info = Schema.decodeUnknownSync(Info, options)(result.encoded)
+    expect(info.providers?.custom?.package).toBe("aisdk:@ai-sdk/openai-compatible")
+    expect(info.providers?.custom?.models?.chat?.package).toBe("aisdk:@ai-sdk/anthropic")
+  })
+
+  test("leaves prefixed, native, and non-ai-sdk package values untouched", () => {
+    const result = normalized({
+      providers: {
+        prefixed: { package: "aisdk:@ai-sdk/openai-compatible", models: { chat: {} } },
+        native: { package: "@opencode-ai/ai/providers/openai", models: { chat: {} } },
+        file: { package: "file:///some/provider", models: { chat: {} } },
+        thirdparty: { package: "@scope/ai-sdk-provider", models: { chat: {} } },
+        missing: { models: { chat: {} } },
+      },
+    })
+    expect(result.diagnostics.filter((item) => item.kind === "normalized")).toEqual([])
+    const info = Schema.decodeUnknownSync(Info, options)(result.encoded)
+    expect(info.providers?.prefixed?.package).toBe("aisdk:@ai-sdk/openai-compatible")
+    expect(info.providers?.native?.package).toBe("@opencode-ai/ai/providers/openai")
+    expect(info.providers?.file?.package).toBe("file:///some/provider")
+    expect(info.providers?.thirdparty?.package).toBe("@scope/ai-sdk-provider")
+    expect(info.providers?.missing?.package).toBeUndefined()
+  })
+
   test("merges named maps by entry and gives valid native entries precedence", () => {
     const result = normalized({
       reference: { legacy: { path: "../legacy" }, duplicate: { path: "../old" } },

--- a/packages/core/test/provider.test.ts
+++ b/packages/core/test/provider.test.ts
@@ -21,4 +21,25 @@ describe("Provider", () => {
       expect(loaded.model).toBeFunction()
     }
   })
+
+  test("detects unprefixed @ai-sdk packages only", () => {
+    expect(Provider.looksLikeAISDK("@ai-sdk/openai")).toBe(true)
+    expect(Provider.looksLikeAISDK("@ai-sdk/openai-compatible")).toBe(true)
+    expect(Provider.looksLikeAISDK("aisdk:@ai-sdk/openai")).toBe(false)
+    expect(Provider.looksLikeAISDK("@opencode-ai/ai/providers/openai")).toBe(false)
+    expect(Provider.looksLikeAISDK("file:///provider")).toBe(false)
+    expect(Provider.looksLikeAISDK("@scope/ai-sdk-provider")).toBe(false)
+    expect(Provider.looksLikeAISDK("openai")).toBe(false)
+    expect(Provider.looksLikeAISDK("")).toBe(false)
+    expect(Provider.looksLikeAISDK(undefined)).toBe(false)
+  })
+
+  test("normalizes unprefixed @ai-sdk packages and leaves others alone", () => {
+    expect(Provider.normalizeAISDK("@ai-sdk/openai-compatible")).toBe("aisdk:@ai-sdk/openai-compatible")
+    expect(Provider.normalizeAISDK("aisdk:@ai-sdk/openai")).toBe("aisdk:@ai-sdk/openai")
+    expect(Provider.normalizeAISDK("@opencode-ai/ai/providers/openai")).toBe("@opencode-ai/ai/providers/openai")
+    expect(Provider.normalizeAISDK("file:///provider")).toBe("file:///provider")
+    expect(Provider.normalizeAISDK("")).toBe("")
+    expect(Provider.normalizeAISDK(undefined)).toBeUndefined()
+  })
 })

--- a/packages/www/src/docs/content/providers.mdx
+++ b/packages/www/src/docs/content/providers.mdx
@@ -196,6 +196,30 @@ Native package options:
 
 You can also use an npm package such as `@acme/opencode-provider` or an absolute `file://` URL for a local package.
 
+To use an [AI SDK](https://ai-sdk.dev) provider package instead of a native one, prefix the package name with `aisdk:`.
+The prefix is what selects the AI SDK runtime — an unprefixed name is always loaded as a native OpenCode package:
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "providers": {
+    "custom": {
+      "package": "aisdk:@ai-sdk/openai-compatible",
+      "settings": {
+        "baseURL": "https://llm.acme.example/v1",
+      },
+      "models": {
+        "chat": {},
+      },
+    },
+  },
+}
+```
+
+Unprefixed `@ai-sdk/*` package names are normalized to the `aisdk:` form automatically when config is loaded. Other
+AI SDK-compatible packages (for example `@openrouter/ai-sdk-provider`) must spell out the `aisdk:` prefix
+explicitly, since a bare name cannot distinguish them from native packages.
+
 Use `settings` for options supported by the selected package.
 
 ## Models

--- a/packages/www/src/docs/content/providers.mdx
+++ b/packages/www/src/docs/content/providers.mdx
@@ -197,7 +197,8 @@ Native package options:
 You can also use an npm package such as `@acme/opencode-provider` or an absolute `file://` URL for a local package.
 
 To use an [AI SDK](https://ai-sdk.dev) provider package instead of a native one, prefix the package name with `aisdk:`.
-The prefix is what selects the AI SDK runtime — an unprefixed name is always loaded as a native OpenCode package:
+The prefix is what selects the AI SDK runtime — a name without it is treated as a native OpenCode package unless it is
+an obvious `@ai-sdk/*` package:
 
 ```jsonc title="opencode.jsonc"
 {


### PR DESCRIPTION
### Issue for this PR

Closes #44881

### Type of change

- [x] Bug fix
- [x] Documentation

### What does this PR do?

A provider configured with an unprefixed AI SDK package like `@ai-sdk/openai-compatible` silently loads through the native OpenCode loader and only fails when a prompt is sent. The v1 migration and the models.dev feed already prefix these names; hand-written v2 config was the one source that didn't.

Config normalization now rewrites obvious `@ai-sdk/*` package names — provider-level and model-level — to the `aisdk:` form and logs a diagnostic naming the prefix, so the config fixes itself at load time instead of failing mid-session. Model projection applies the same rewrite so catalog entries injected without config parsing behave the same. Other AI SDK-compatible packages such as `@openrouter/ai-sdk-provider` still need the explicit prefix deliberately, which keeps native modules and `file://` packages impossible to misclassify. providers.mdx now documents native versus AI SDK package selection.

I picked normalize over reject (the issue allowed either) because v2's rejected entries are silently skipped, which is worse than auto-correcting an unambiguous name, and both other config sources already normalize.

### How did you verify your code works?

New tests: a detector/normalizer unit table in provider.test.ts, normalization cases in normalization.test.ts (provider-level, model-level, untouched prefixed/native/third-party values, input not mutated), and projection normalization in catalog.test.ts. bun typecheck and the core suite pass; oxlint clean.

### Screenshots / recordings

Not a visual change; the docs change is in providers.mdx.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
