### PR TITLE
refactor(tui): use semantic feedback pairs

### DIFF
--- a/packages/theme/src/tui/defaults.ts
+++ b/packages/theme/src/tui/defaults.ts
@@ -168,8 +168,8 @@ export const DEFAULT_THEME = {
         $selected: "$background.formfield.default",
       },
       feedback: {
-        error: { default: "$background.default" },
-        warning: { default: "$background.default" },
+        error: { default: "$hue.red.100" },
+        warning: { default: "$hue.yellow.100" },
         success: { default: "$background.default" },
         info: { default: "$background.default" },
       },
@@ -389,8 +389,8 @@ export const DEFAULT_THEME = {
         $selected: "$background.formfield.default",
       },
       feedback: {
-        error: { default: "$background.default" },
-        warning: { default: "$background.default" },
+        error: { default: "$hue.red.900" },
+        warning: { default: "$hue.yellow.900" },
         success: { default: "$background.default" },
         info: { default: "$background.default" },
       },

--- a/packages/theme/src/tui/syntax.ts
+++ b/packages/theme/src/tui/syntax.ts
@@ -13,9 +13,8 @@ export function generateSyntax(theme: ResolvedThemeTokens, mode: Mode) {
     rule(["extmark.file"], feedback.warning.default, { bold: true }),
     rule(["extmark.agent"], theme.categorical[0][step], { bold: true }),
     rule(["extmark.skill"], (theme.categorical[1] ?? theme.categorical[0])[step], { bold: true }),
-    // V1 migration preserves its selected/inverse foreground in this action state.
-    rule(["extmark.paste"], theme.text.action.primary.focused, {
-      background: feedback.warning.default,
+    rule(["extmark.paste"], feedback.warning.default, {
+      background: theme.background.feedback.warning.default,
       bold: true,
     }),
     rule(["comment", "comment.documentation"], syntax.comment, { italic: true }),

--- a/packages/tui/test/theme/v2/resolve.test.ts
+++ b/packages/tui/test/theme/v2/resolve.test.ts
@@ -24,6 +24,12 @@ test("resolves one-mode documents with defaults for the available mode", () => {
 
   expect(resolvedLight.background.default.equals(resolveTheme(light).background.default)).toBeTrue()
   expect(resolvedDark.background.default.equals(resolveTheme(dark).background.default)).toBeTrue()
+  expect(
+    resolvedLight.background.feedback.warning.default.equals(resolveTheme(light).background.feedback.warning.default),
+  ).toBeTrue()
+  expect(
+    resolvedDark.background.feedback.warning.default.equals(resolveTheme(dark).background.feedback.warning.default),
+  ).toBeTrue()
   expect(resolvedLight.categorical.length).toBeGreaterThan(0)
   expect(resolvedDark.categorical.length).toBeGreaterThan(0)
 })
@@ -48,6 +54,8 @@ test("generates syntax with one categorical hue", () => {
   const syntax = generateSyntax(theme, "light")
 
   expect(syntax.getStyleId("extmark.skill")).not.toBeNull()
+  expect(syntax.getStyle("extmark.paste")?.fg).toBe(theme.text.feedback.warning.default)
+  expect(syntax.getStyle("extmark.paste")?.bg).toBe(theme.background.feedback.warning.default)
   syntax.destroy()
 })
 
@@ -79,6 +87,10 @@ test("resolves independent definitions and hue aliases", () => {
   expect(darkTheme.background.default).toBeInstanceOf(RGBA)
   expect(lightTheme.background.surface.offset).toBe(lightTheme.hue.neutral[300])
   expect(lightTheme.background.surface.overlay).toBe(lightTheme.hue.neutral[400])
+  expect(lightTheme.background.feedback.error.default).toBe(lightTheme.hue.red[100])
+  expect(lightTheme.background.feedback.warning.default).toBe(lightTheme.hue.yellow[100])
+  expect(darkTheme.background.feedback.error.default).toBe(darkTheme.hue.red[900])
+  expect(darkTheme.background.feedback.warning.default).toBe(darkTheme.hue.yellow[900])
   expect(lightTheme.syntax.keyword).toBeInstanceOf(RGBA)
   expect(lightTheme.text.action.primary.default).toBe(lightTheme.hue.neutral[200])
   expect(lightTheme.contextual.elevated.background.action.primary.default).toBe(lightTheme.hue.interactive[500])


### PR DESCRIPTION
### Issue for this PR

Refs #42704

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds distinct warning and error backgrounds for the built-in light and dark TUI themes, then makes pasted-text extmarks use the semantic warning foreground/background pair. This is a focused first slice; removing the remaining V1 compatibility proxy stays separate.

### How did you verify your code works?

- `bun test test/theme/v2/resolve.test.ts` from `packages/tui` (20 passed)
- `bun typecheck` from `packages/theme`
- `git diff --check origin/v2...HEAD`
- `packages/tui` typecheck currently fails in unchanged `packages/core/src/session/message-updater.ts`; the same errors reproduce on a detached `origin/v2` baseline without this patch

### Screenshots / recordings

Not included: this changes theme token wiring rather than component layout. The focused test asserts the resolved foreground/background style pair.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR