### PR TITLE
fix(core): keep captured output in bash timeout settlement

### DIFF
--- a/packages/core/src/process.ts
+++ b/packages/core/src/process.ts
@@ -1,4 +1,4 @@
-import { Context, Duration, Effect, Fiber, Layer, Schema, Stream } from "effect"
+import { Context, Duration, Effect, Fiber, Layer, Ref, Schema, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
@@ -44,6 +44,8 @@ export interface RunResult {
   readonly outputTruncated?: boolean
   readonly stdoutTruncated: boolean
   readonly stderrTruncated: boolean
+  /** Set when the run settled because the timeout elapsed; buffers then hold whatever was captured before it. */
+  readonly timedOut?: boolean
 }
 
 export type Interface = ChildProcessSpawner["Service"] & {
@@ -136,6 +138,24 @@ export const collectStream = (stream: Stream.Stream<Uint8Array, PlatformError>, 
     },
   ).pipe(Effect.map((x) => ({ buffer: Buffer.concat(x.chunks), truncated: x.truncated })))
 
+const recordChunk = (
+  state: { chunks: Uint8Array[]; bytes: number; truncated: boolean },
+  chunk: Uint8Array,
+  maxOutputBytes: number | undefined,
+) => {
+  const chunks = [...state.chunks]
+  let bytes = state.bytes
+  if (maxOutputBytes === undefined) {
+    chunks.push(chunk)
+    bytes += chunk.length
+    return { chunks, bytes, truncated: state.truncated }
+  }
+  const remaining = maxOutputBytes - bytes
+  if (remaining > 0) chunks.push(remaining >= chunk.length ? chunk : chunk.slice(0, remaining))
+  bytes += chunk.length
+  return { chunks, bytes, truncated: state.truncated || bytes > maxOutputBytes }
+}
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -147,20 +167,53 @@ const layer = Layer.effect(
         Effect.gen(function* () {
           const handle = yield* spawner.spawn(command)
           if (options?.combineOutput) {
-            const [output, exitCode] = yield* Effect.all(
-              [collectStream(handle.all, options.maxOutputBytes), handle.exitCode],
+            // Mirror every captured chunk into a ref so a timeout settlement can
+            // still report the output produced before the deadline.
+            const partial = yield* Ref.make({ chunks: [] as Uint8Array[], bytes: 0, truncated: false })
+            const finish = Effect.all(
+              [
+                collectStream(
+                  Stream.tap(handle.all, (chunk) =>
+                    Ref.update(partial, (state) => recordChunk(state, chunk, options.maxOutputBytes)),
+                  ),
+                  options.maxOutputBytes,
+                ),
+                handle.exitCode,
+              ],
               { concurrency: "unbounded" },
+            ).pipe(
+              Effect.map(
+                ([output, exitCode]) =>
+                  ({
+                    command: description,
+                    exitCode,
+                    output: output.buffer,
+                    stdout: Buffer.alloc(0),
+                    stderr: Buffer.alloc(0),
+                    outputTruncated: output.truncated,
+                    stdoutTruncated: false,
+                    stderrTruncated: false,
+                  }) satisfies RunResult,
+              ),
             )
-            return {
-              command: description,
-              exitCode,
-              output: output.buffer,
-              stdout: Buffer.alloc(0),
-              stderr: Buffer.alloc(0),
-              outputTruncated: output.truncated,
-              stdoutTruncated: false,
-              stderrTruncated: false,
-            } satisfies RunResult
+            if (!options.timeout) return yield* finish
+            const expired = Effect.andThen(Effect.sleep(options.timeout), () =>
+              Effect.map(Ref.get(partial), (state) => {
+                const output = Buffer.concat(state.chunks)
+                return {
+                  command: description,
+                  exitCode: -1,
+                  output,
+                  stdout: Buffer.alloc(0),
+                  stderr: Buffer.alloc(0),
+                  outputTruncated: state.truncated,
+                  stdoutTruncated: false,
+                  stderrTruncated: false,
+                  timedOut: true,
+                } satisfies RunResult
+              }),
+            )
+            return yield* Effect.raceFirst(finish, expired)
           }
           const [stdout, stderr, exitCode] = yield* Effect.all(
             [
@@ -180,12 +233,13 @@ const layer = Layer.effect(
           } satisfies RunResult
         }),
       )
-      const timed = options?.timeout
-        ? Effect.timeoutOrElse(collect, {
-            duration: options.timeout,
-            orElse: () => Effect.fail(new AppProcessError({ command: description, cause: new Error("Timed out") })),
-          })
-        : collect
+      const timed =
+        options?.timeout && !options.combineOutput
+          ? Effect.timeoutOrElse(collect, {
+              duration: options.timeout,
+              orElse: () => Effect.fail(new AppProcessError({ command: description, cause: new Error("Timed out") })),
+            })
+          : collect
       const aborted = options?.signal
         ? timed.pipe(
             Effect.raceFirst(

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -174,9 +174,11 @@ const layer = Layer.effectDiscard(
                     isTimeout(error) ? Effect.succeed(undefined) : Effect.fail(error),
                   ),
                 )
-              if (!result) {
+              if (!result || result.timedOut) {
+                const captured = result?.output?.toString("utf8").trimEnd()
+                const capturedBlock = captured ? `\n\nOutput captured before timeout:\n${captured}` : ""
                 return {
-                  output: `Command exceeded timeout of ${timeout} ms. Retry with a larger timeout if the command is expected to take longer.`,
+                  output: `Command exceeded timeout of ${timeout} ms.${capturedBlock}\n\nRetry with a larger timeout if the command is expected to take longer.`,
                   truncated: false,
                   timeout: true,
                   ...(warnings.length ? { warnings } : {}),

--- a/packages/core/test/process/process.test.ts
+++ b/packages/core/test/process/process.test.ts
@@ -174,6 +174,20 @@ describe("AppProcess", () => {
       )
 
       it.live(
+        "timeout with combined output settles with the output captured before the deadline",
+        Effect.gen(function* () {
+          const svc = yield* AppProcess.Service
+          const result = yield* svc.run(cmd("-e", "process.stdout.write('partial-marker');setInterval(()=>{},60000)"), {
+            combineOutput: true,
+            timeout: "500 millis",
+          })
+          expect(result.timedOut).toBe(true)
+          expect(result.output?.toString("utf8")).toBe("partial-marker")
+        }),
+        5_000,
+      )
+
+      it.live(
         "fiber interruption cleans up the scoped child process after readiness",
         Effect.acquireUseRelease(
           Effect.promise(() => fs.mkdtemp(path.join(tmpdir(), "opencode-process-interrupt-"))),

--- a/packages/core/test/tool-bash.test.ts
+++ b/packages/core/test/tool-bash.test.ts
@@ -258,6 +258,31 @@ describe("BashTool", () => {
         (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
       ),
     )
+
+    it.live("keeps captured output in the timeout settlement", () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => {
+          reset()
+          return withTool(
+            tmp.path,
+            (registry) => settleTool(registry, call({ command: "echo bash-timeout-marker; sleep 30", timeout: 1_000 })),
+            LayerNode.compile(AppProcess.node),
+          ).pipe(
+            Effect.andThen((settled) =>
+              Effect.sync(() => {
+                expect(settled.output?.structured).toMatchObject({ timeout: true })
+                const text = settled.output?.content[0]?.type === "text" ? settled.output.content[0].text : ""
+                expect(text).toContain("Command exceeded timeout")
+                expect(text).toContain("Output captured before timeout:")
+                expect(text).toContain("bash-timeout-marker")
+              }),
+            ),
+          )
+        },
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      ),
+    )
   }
 
   it.live("approves an explicit external workdir before bash execution", () =>


### PR DESCRIPTION
### Issue for this PR

Closes #45881

### Type of change

- [x] Bug fix

### What does this PR do?

When a command hit its timeout, the tool returned only the static "Command exceeded timeout" notice. The partial output captured before the deadline was lost, because the timeout interrupted the collect fiber whose fold held the buffer — so the model lost exactly the output (test progress, build logs) that explains why the command hung.

Changes:

- `process.ts`: while collecting combined output, mirror each chunk into a ref. When the timeout elapses, the run now settles successfully with whatever was captured so far, marked by a new optional `timedOut` flag on `RunResult` (`exitCode: -1`, since no exit code exists). The previous timeout-failure behavior is kept for non-combined-output runs, and the child process is still cleaned up by the existing scope finalizer.
- `bash.ts`: the timeout settlement now appends the captured output under "Output captured before timeout:" so the model can act on it.

### How did you verify your code works?

- New process-level test: a node process that prints a marker and hangs, with a 500ms timeout — settles with `timedOut: true` and the marker in `output`.
- New bash tool test: `echo bash-timeout-marker; sleep 30` with a 1000ms timeout — the model-facing text contains both the timeout notice and the marker.
- Both run under the existing real-process test group (POSIX only, like the neighboring tests). `bun test ./test/tool-bash.test.ts ./test/process/process.test.ts`: 41 pass. Full packages/core suite: 1098 pass with one pre-existing network-dependent failure in ModelsDev refresh (unrelated to this change). `bun run typecheck` clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR