### PR TITLE
fix(core): match LF regions of mixed-ending files in edit

### DIFF
--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -40,7 +40,9 @@ export const Output = Schema.Struct({
 export type Output = typeof Output.Type
 
 const normalizeLineEndings = (text: string) => text.replaceAll("\r\n", "\n")
-const detectLineEnding = (text: string): "\n" | "\r\n" => (text.includes("\r\n") ? "\r\n" : "\n")
+/** Treat a file as CRLF only when every newline is a CRLF; mixed-ending files are matched as LF. */
+const detectLineEnding = (text: string): "\n" | "\r\n" =>
+  text.includes("\r\n") && !text.replace(/\r\n/g, "").includes("\n") ? "\r\n" : "\n"
 const convertToLineEnding = (text: string, ending: "\n" | "\r\n") =>
   ending === "\n" ? normalizeLineEndings(text) : normalizeLineEndings(text).replaceAll("\n", "\r\n")
 

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -381,6 +381,26 @@ describe("EditTool", () => {
     ),
   )
 
+  it.live("matches LF regions in a mixed-ending file and keeps other lines untouched", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        const target = path.join(tmp.path, "mixed.txt")
+        return Effect.promise(() => fs.writeFile(target, "alpha\nbeta\r\ngamma\n")).pipe(
+          Effect.andThen(
+            withTool(tmp.path, (registry) =>
+              executeTool(registry, call({ path: "mixed.txt", oldString: "alpha\nbeta", newString: "ALPHA" })),
+            ),
+          ),
+          Effect.andThen(() => Effect.promise(() => fs.readFile(target, "utf8"))),
+          Effect.tap((content) => Effect.sync(() => expect(content).toBe("ALPHA\r\ngamma\n"))),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("rejects an in-place content change after matching but before conditional commit", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
### Issue for this PR

Closes #45880

### Type of change

- [x] Bug fix

### What does this PR do?

The read tool strips a trailing `\r` from each line, so the model always sees pure LF content. But `detectLineEnding` in the edit tool classified any file containing a single CRLF as a CRLF file, and then rewrote the model's entire `oldString` to CRLF. On a file with mixed endings (one commit from a Windows colleague is enough), oldStrings targeting LF regions could never match and the edit failed with a misleading "Could not find oldString".

This is the conservative first step discussed in the issue: treat a file as CRLF only when **every** newline is a CRLF. Consistently CRLF files behave exactly as before (covered by the existing "preserves BOM and CRLF line endings" test). Mixed-ending files now match as LF, so their LF regions become editable, and untouched CRLF lines keep their original endings byte-for-byte.

Known limitation left open in #45880: editing the CRLF region of a mixed file still won't match. Fixing that properly needs a policy decision (preserve mixed endings vs. normalize to the dominant ending) plus normalized-search span mapping, so I kept it out of this PR.

### How did you verify your code works?

New test: editing the LF region of `alpha\nbeta\r\ngamma\n` succeeds and leaves the CRLF line untouched (`ALPHA\r\ngamma\n`). `bun test ./test/tool-edit.test.ts ./test/tool-write.test.ts`: 18 pass. `bun run typecheck` clean, prettier clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR