### PR TITLE
fix(edit): write newString literally instead of expanding $ replacement patterns

### DIFF
--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -178,8 +178,8 @@ const layer = Layer.effectDiscard(
 
                 const replaced =
                   input.replaceAll === true
-                    ? source.text.replaceAll(oldString, newString)
-                    : source.text.replace(oldString, newString)
+                    ? source.text.replaceAll(oldString, () => newString)
+                    : source.text.replace(oldString, () => newString)
                 const counts = diffLines(source.text, replaced).reduce(
                   (result, item) => ({
                     additions: result.additions + (item.added ? (item.count ?? 0) : 0),

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -381,6 +381,29 @@ describe("EditTool", () => {
     ),
   )
 
+  it.live("writes newString literally without expanding $ patterns", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        const target = path.join(tmp.path, "dollar.txt")
+        return Effect.promise(() => fs.writeFile(target, 'log("done");\n')).pipe(
+          Effect.andThen(
+            withTool(tmp.path, (registry) =>
+              executeTool(
+                registry,
+                call({ path: "dollar.txt", oldString: 'log("done");', newString: 'log("$& $1 $` ok");' }),
+              ),
+            ),
+          ),
+          Effect.andThen(() => Effect.promise(() => fs.readFile(target, "utf8"))),
+          Effect.tap((content) => Effect.sync(() => expect(content).toBe('log("$& $1 $` ok");\n'))),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("rejects an in-place content change after matching but before conditional commit", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -712,7 +712,7 @@ export function replace(content: string, oldString: string, newString: string, r
         )
       }
       if (replaceAll) {
-        return content.replaceAll(search, newString)
+        return content.replaceAll(search, () => newString)
       }
       const lastIndex = content.lastIndexOf(search)
       if (index !== lastIndex) continue

--- a/packages/opencode/test/tool/edit.test.ts
+++ b/packages/opencode/test/tool/edit.test.ts
@@ -263,6 +263,18 @@ describe("tool.edit", () => {
       }),
     )
 
+    it.instance("writes newString literally without expanding $ patterns", () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "file.txt")
+        yield* put(filepath, 'log("done");')
+
+        yield* run({ filePath: filepath, oldString: 'log("done");', newString: 'log("$& $1 $` ok");' })
+
+        expect(yield* load(filepath)).toBe('log("$& $1 $` ok");')
+      }),
+    )
+
     it.instance("emits change event for existing files", () =>
       Effect.gen(function* () {
         const test = yield* TestInstance


### PR DESCRIPTION
### Issue for this PR

Closes #45892

### Type of change

- [x] Bug fix

### What does this PR do?

`String.prototype.replace`/`replaceAll` interpret `$\&`, `$```, `$'`, `$n`, and `$$` when given a string replacement. The edit tools passed the model's `newString` straight through, so any replacement containing a dollar pattern silently corrupted the file: `$\&` expanded to the matched text, `$1` to a (missing) capture group, etc. This is common in shell (positional params, `sed`/`awk`), JS template literals, and regex callbacks.

Because the success patch is computed as `source` vs `result`, the corruption was invisible to the model and landed on disk as content it never wrote.

The fix switches to a function replacer (`() => newString`), inserting the replacement verbatim.

- V2 `packages/core/src/tool/edit.ts`: both the `replaceAll` and `replace` paths.
- V1 `packages/opencode/src/tool/edit.ts`: the `replaceAll` path (the non-replaceAll path already used `substring` concatenation).

### How did you verify your code works?

Added regression tests in both suites asserting a `newString` containing `$& $1 $\`` is written literally:

- `packages/core`: `bun test ./test/tool-edit.test.ts` (11 pass)
- `packages/opencode`: `bun test ./test/tool/edit.test.ts` (30 pass)

`bun run typecheck` clean in both packages, prettier clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR