### PR TITLE
fix(app): normalize terminal websocket path

### DIFF
--- a/packages/app/src/utils/terminal-websocket-url.test.ts
+++ b/packages/app/src/utils/terminal-websocket-url.test.ts
@@ -21,6 +21,18 @@ describe("terminalWebSocketURL", () => {
     expect(url.searchParams.has("auth_token")).toBe(false)
   })
 
+  test("normalizes a trailing slash in the server URL", () => {
+    const url = terminalWebSocketURL({
+      url: "https://app.example.test/",
+      id: "pty_test",
+      directory: "/tmp/project",
+      cursor: 0,
+      ticket: "connect-ticket",
+    })
+
+    expect(url.pathname).toBe("/api/pty/pty_test/connect")
+  })
+
   test("uses query auth without embedding credentials in websocket URL for v1", () => {
     const url = terminalWebSocketURL({
       protocol: "v1",

--- a/packages/app/src/utils/terminal-websocket-url.ts
+++ b/packages/app/src/utils/terminal-websocket-url.ts
@@ -13,7 +13,10 @@ export function terminalWebSocketURL(input: {
   authToken?: boolean
 }) {
   const isV1 = input.protocol === "v1"
-  const next = new URL(`${input.url}${isV1 ? `/pty/${input.id}/connect` : `/api/pty/${input.id}/connect`}`)
+  const next = new URL(input.url)
+  next.pathname = `${next.pathname.replace(/\/+$/, "")}${
+    isV1 ? `/pty/${input.id}/connect` : `/api/pty/${input.id}/connect`
+  }`
   if (isV1) {
     next.searchParams.set("directory", input.directory)
   } else {


### PR DESCRIPTION
### Issue for this PR

Closes #45891

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Terminal WebSocket routes were appended to the complete server URL as strings, so a server URL ending in `/` produced a pathname beginning with `//api`. This change parses the server URL first and joins the PTY route onto its normalized pathname, preserving any base path while removing duplicate boundary slashes. A regression test covers the reported trailing-slash input.

### How did you verify your code works?

From `packages/app`:

- `bun test src/utils/terminal-websocket-url.test.ts` — 5 tests passed
- `bun typecheck` — passed

### Screenshots / recordings

Not applicable. This changes URL construction logic without changing the rendered UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR