### PR TITLE
feat(cli): support additional server URLs

### DIFF
--- a/packages/cli/src/commands/commands.ts
+++ b/packages/cli/src/commands/commands.ts
@@ -391,6 +391,24 @@ const Root = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCODE_CLI_NAME
             ),
           },
         }),
+        Spec.make("url", {
+          description: "Manage additional client connection URLs",
+          commands: [
+            Spec.make("add", {
+              description: "Add a client connection URL",
+              params: {
+                url: Argument.string("url").pipe(Argument.withDescription("Client connection URL")),
+              },
+            }),
+            Spec.make("remove", {
+              description: "Remove a client connection URL",
+              params: {
+                url: Argument.string("url").pipe(Argument.withDescription("Client connection URL")),
+              },
+            }),
+            Spec.make("list", { description: "List additional client connection URLs" }),
+          ],
+        }),
         Spec.make("unset", {
           description: "Unset service configuration",
           params: {
@@ -413,6 +431,10 @@ const Root = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCODE_CLI_NAME
           Flag.withSchema(Schema.NonEmptyString),
           Flag.withDescription("Additional allowed CORS origin (repeat for multiple origins)"),
           Flag.atLeast(0),
+        ),
+        url: Flag.string("url").pipe(
+          Flag.withDescription("Additional client connection URL"),
+          Flag.atMost(100),
         ),
         service: Flag.boolean("service").pipe(Flag.withDefault(false)),
         stdio: Flag.boolean("stdio").pipe(Flag.withDefault(false)),

--- a/packages/cli/src/commands/handlers/serve.ts
+++ b/packages/cli/src/commands/handlers/serve.ts
@@ -2,6 +2,7 @@ import { Effect, Option } from "effect"
 import { Commands } from "../commands"
 import { Runtime } from "../../framework/runtime"
 import { ServerProcess } from "../../server-process"
+import { ServiceConfig } from "../../services/service-config"
 
 export default Runtime.handler(
   Commands.commands.serve,
@@ -12,6 +13,7 @@ export default Runtime.handler(
       hostname: Option.getOrUndefined(input.hostname),
       port: Option.getOrUndefined(input.port),
       cors: input.cors.length > 0 ? input.cors : undefined,
+      additionalUrls: input.url.map((url) => ServiceConfig.normalizeUrl(url)),
     })
   }),
 )

--- a/packages/cli/src/commands/handlers/service/url/add.ts
+++ b/packages/cli/src/commands/handlers/service/url/add.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect"
+import { Commands } from "../../../commands"
+import { Runtime } from "../../../../framework/runtime"
+import { ServiceConfig } from "../../../../services/service-config"
+
+export default Runtime.handler(
+  Commands.commands.service.commands.url.commands.add,
+  Effect.fn("cli.service.url.add")(function* (input) {
+    yield* ServiceConfig.addUrl(input.url)
+  }),
+)

--- a/packages/cli/src/commands/handlers/service/url/list.ts
+++ b/packages/cli/src/commands/handlers/service/url/list.ts
@@ -1,0 +1,12 @@
+import { EOL } from "os"
+import { Effect } from "effect"
+import { Commands } from "../../../commands"
+import { Runtime } from "../../../../framework/runtime"
+import { ServiceConfig } from "../../../../services/service-config"
+
+export default Runtime.handler(
+  Commands.commands.service.commands.url.commands.list,
+  Effect.fn("cli.service.url.list")(function* () {
+    process.stdout.write(JSON.stringify(yield* ServiceConfig.listUrls(), null, 2) + EOL)
+  }),
+)

--- a/packages/cli/src/commands/handlers/service/url/remove.ts
+++ b/packages/cli/src/commands/handlers/service/url/remove.ts
@@ -1,0 +1,11 @@
+import { Effect } from "effect"
+import { Commands } from "../../../commands"
+import { Runtime } from "../../../../framework/runtime"
+import { ServiceConfig } from "../../../../services/service-config"
+
+export default Runtime.handler(
+  Commands.commands.service.commands.url.commands.remove,
+  Effect.fn("cli.service.url.remove")(function* (input) {
+    yield* ServiceConfig.removeUrl(input.url)
+  }),
+)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -60,6 +60,11 @@ const Handlers = Runtime.handlers(Commands, {
     stop: () => import("./commands/handlers/service/stop"),
     get: () => import("./commands/handlers/service/get"),
     set: () => import("./commands/handlers/service/set"),
+    url: {
+      add: () => import("./commands/handlers/service/url/add"),
+      remove: () => import("./commands/handlers/service/url/remove"),
+      list: () => import("./commands/handlers/service/url/list"),
+    },
     unset: () => import("./commands/handlers/service/unset"),
   },
   serve: () => import("./commands/handlers/serve"),

--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -23,6 +23,7 @@ export type Options = {
   readonly hostname?: string
   readonly port?: number
   readonly cors?: readonly string[]
+  readonly additionalUrls?: ReadonlyArray<string>
 }
 
 // The process effect lives until server shutdown; tracing it would parent every request to one process-lifetime trace.
@@ -90,6 +91,7 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
           hostname,
           port,
           cors: options.cors ?? config.cors,
+          additionalUrls: [...(options.additionalUrls ?? []), ...(config.urls ?? [])],
           password,
           pty: { handoff },
           simulation: truthy(process.env.OPENCODE_SIMULATE),

--- a/packages/cli/src/services/service-config.ts
+++ b/packages/cli/src/services/service-config.ts
@@ -2,6 +2,7 @@ import { Global } from "@opencode-ai/util/global"
 import { OPENCODE_CHANNEL, OPENCODE_VERSION } from "../version"
 import { Hash } from "@opencode-ai/util/hash"
 import { Service } from "@opencode-ai/client/effect/service"
+import { normalizeConnectionUrl } from "@opencode-ai/server/connection-url"
 import { Effect, FileSystem, Option, Schema } from "effect"
 import { randomBytes } from "crypto"
 import path from "path"
@@ -223,7 +224,9 @@ export const addUrl = Effect.fn("cli.service-config.add-url")(function* (value: 
   const existing = yield* read()
   if (existing.urls?.includes(url)) return
   yield* Service.stop(yield* options())
-  yield* write({ ...existing, urls: [...(existing.urls ?? []), url] })
+  const current = yield* read()
+  if (current.urls?.includes(url)) return
+  yield* write({ ...current, urls: [...(current.urls ?? []), url] })
 })
 
 export const listUrls = Effect.fn("cli.service-config.list-urls")(function* () {
@@ -236,8 +239,10 @@ export const removeUrl = Effect.fn("cli.service-config.remove-url")(function* (v
   const urls = existing.urls?.filter((item) => item !== url) ?? []
   if (urls.length === (existing.urls?.length ?? 0)) return
   yield* Service.stop(yield* options())
-  const { urls: _urls, ...rest } = existing
-  yield* write(urls.length === 0 ? rest : { ...rest, urls })
+  const current = yield* read()
+  const next = current.urls?.filter((item) => item !== url) ?? []
+  const { urls: _urls, ...rest } = current
+  yield* write(next.length === 0 ? rest : { ...rest, urls: next })
 })
 
 export const unset = Effect.fn("cli.service-config.unset")(function* (key: string, name?: string) {
@@ -281,12 +286,7 @@ export const unset = Effect.fn("cli.service-config.unset")(function* (key: strin
 })
 
 export function normalizeUrl(value: string) {
-  if (!URL.canParse(value)) throw new Error(`Invalid URL: ${value}`)
-  const url = new URL(value)
-  if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("URL must use http:// or https://")
-  if (url.username || url.password) throw new Error("URL must not include credentials")
-  if (url.pathname !== "/" || url.search || url.hash) throw new Error("URL must not include a path, query, or fragment")
-  return url.origin
+  return normalizeConnectionUrl(value)
 }
 
 export * as ServiceConfig from "./service-config"

--- a/packages/cli/src/services/service-config.ts
+++ b/packages/cli/src/services/service-config.ts
@@ -14,6 +14,7 @@ import { selfCommand } from "../util/process"
 export const Info = Schema.Struct({
   hostname: Schema.optional(Schema.String),
   port: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(1), Schema.isLessThanOrEqualTo(65_535))),
+  urls: Schema.optional(Schema.Array(Schema.String)),
   password: Schema.optional(Schema.String),
   cors: Schema.optional(Schema.Array(Schema.String)),
   env: Schema.optional(Schema.Record(Schema.String, Schema.String)),
@@ -217,6 +218,28 @@ export const set = Effect.fn("cli.service-config.set")(function* (key: string, v
   }
 })
 
+export const addUrl = Effect.fn("cli.service-config.add-url")(function* (value: string) {
+  const url = normalizeUrl(value)
+  const existing = yield* read()
+  if (existing.urls?.includes(url)) return
+  yield* Service.stop(yield* options())
+  yield* write({ ...existing, urls: [...(existing.urls ?? []), url] })
+})
+
+export const listUrls = Effect.fn("cli.service-config.list-urls")(function* () {
+  return (yield* read()).urls ?? []
+})
+
+export const removeUrl = Effect.fn("cli.service-config.remove-url")(function* (value: string) {
+  const url = normalizeUrl(value)
+  const existing = yield* read()
+  const urls = existing.urls?.filter((item) => item !== url) ?? []
+  if (urls.length === (existing.urls?.length ?? 0)) return
+  yield* Service.stop(yield* options())
+  const { urls: _urls, ...rest } = existing
+  yield* write(urls.length === 0 ? rest : { ...rest, urls })
+})
+
 export const unset = Effect.fn("cli.service-config.unset")(function* (key: string, name?: string) {
   const selected = configKey(key)
   if (selected !== "env" && name !== undefined) throw new Error(`Usage: opencode service unset ${selected}`)
@@ -256,5 +279,14 @@ export const unset = Effect.fn("cli.service-config.unset")(function* (key: strin
     }
   }
 })
+
+export function normalizeUrl(value: string) {
+  if (!URL.canParse(value)) throw new Error(`Invalid URL: ${value}`)
+  const url = new URL(value)
+  if (url.protocol !== "http:" && url.protocol !== "https:") throw new Error("URL must use http:// or https://")
+  if (url.username || url.password) throw new Error("URL must not include credentials")
+  if (url.pathname !== "/" || url.search || url.hash) throw new Error("URL must not include a path, query, or fragment")
+  return url.origin
+}
 
 export * as ServiceConfig from "./service-config"

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -3,7 +3,7 @@ import { Service, type Info } from "@opencode-ai/client/effect/service"
 import { Global } from "@opencode-ai/util/global"
 import { OPENCODE_VERSION } from "../src/version"
 import { expect, test } from "bun:test"
-import { Effect, Schema } from "effect"
+import { Effect, FileSystem, Schema } from "effect"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
@@ -71,6 +71,30 @@ test("service config manages environment variables", async () => {
         Effect.provide(NodeFileSystem.layer),
       ),
     )
+    expect(await Bun.file(path.join(root, "config", "service-local.json")).json()).toEqual({})
+  } finally {
+    await fs.rm(root, { recursive: true, force: true })
+  }
+})
+
+test("service config manages additional URLs", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-urls-"))
+  const layer = Global.layerWith({ config: path.join(root, "config"), state: path.join(root, "state") })
+  try {
+    const run = <A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem | Global.Service>) =>
+      Effect.runPromise(effect.pipe(Effect.provide(layer), Effect.provide(NodeFileSystem.layer)))
+
+    await run(ServiceConfig.addUrl("https://primary.example.com/"))
+    await run(ServiceConfig.addUrl("https://secondary.example.com"))
+    await run(ServiceConfig.addUrl("https://primary.example.com"))
+    expect(await run(ServiceConfig.listUrls())).toEqual([
+      "https://primary.example.com",
+      "https://secondary.example.com",
+    ])
+
+    await run(ServiceConfig.removeUrl("https://primary.example.com/"))
+    expect(await run(ServiceConfig.listUrls())).toEqual(["https://secondary.example.com"])
+    await run(ServiceConfig.removeUrl("https://secondary.example.com"))
     expect(await Bun.file(path.join(root, "config", "service-local.json")).json()).toEqual({})
   } finally {
     await fs.rm(root, { recursive: true, force: true })
@@ -287,14 +311,17 @@ test("concurrent service processes elect one server", async () => {
   }
 }, 120_000)
 
-test("configured managed service port overrides the channel default", async () => {
+test("configured managed service settings reach the server", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "opencode-service-port-"))
   const port = await availablePort()
   const env = serviceEnv(root)
   const registration = path.join(root, "state", "opencode", "service-local.json")
   const config = path.join(root, "config", "opencode", "service-local.json")
   await fs.mkdir(path.join(root, "config", "opencode"), { recursive: true })
-  await fs.writeFile(config, JSON.stringify({ port, password: "" }))
+  await fs.writeFile(
+    config,
+    JSON.stringify({ port, password: "", urls: ["https://primary.example.com", "https://secondary.example.com"] }),
+  )
   const owner = Bun.spawn([process.execPath, path.join(import.meta.dir, "../src/index.ts"), "serve", "--service"], {
     env,
     stderr: "pipe",
@@ -305,6 +332,11 @@ test("configured managed service port overrides the channel default", async () =
     expect(new URL(info.url).port).toBe(String(port))
     expect(info.password).not.toBe("")
     expect((await Bun.file(config).json()).password).toBe(info.password)
+    expect(
+      await fetch(new URL("/api/server", info.url), {
+        headers: { authorization: "Basic " + btoa(`opencode:${info.password}`) },
+      }).then((response) => response.json()),
+    ).toEqual({ urls: ["https://primary.example.com", "https://secondary.example.com", info.url] })
     await Effect.runPromise(Service.stop({ file: registration }).pipe(Effect.provide(NodeFileSystem.layer)))
     await owner.exited
   } finally {

--- a/packages/cli/test/service.test.ts
+++ b/packages/cli/test/service.test.ts
@@ -101,6 +101,14 @@ test("service config manages additional URLs", async () => {
   }
 })
 
+test("service config rejects invalid additional URLs", () => {
+  expect(() => ServiceConfig.normalizeUrl("ftp://example.com")).toThrow()
+  expect(() => ServiceConfig.normalizeUrl("https://user:password@example.com")).toThrow()
+  expect(() => ServiceConfig.normalizeUrl("https://example.com/path")).toThrow()
+  expect(() => ServiceConfig.normalizeUrl("https://example.com?query=true")).toThrow()
+  expect(() => ServiceConfig.normalizeUrl("https://example.com#fragment")).toThrow()
+})
+
 test("service filenames share release channels and identify preview channels", () => {
   expect(ServiceConfig.filename("latest")).toBe("service.json")
   expect(ServiceConfig.filename("dev")).toBe("service.json")

--- a/packages/server/src/connection-url.ts
+++ b/packages/server/src/connection-url.ts
@@ -1,0 +1,17 @@
+import { Schema } from "effect"
+
+export const ConnectionUrl = Schema.String.check(
+  Schema.makeFilter((value) => (isConnectionUrl(value) ? undefined : "an HTTP(S) origin URL")),
+)
+
+export function normalizeConnectionUrl(value: string) {
+  if (!isConnectionUrl(value)) throw new Error(`Invalid connection URL: ${value}`)
+  return new URL(value).origin
+}
+
+function isConnectionUrl(value: string) {
+  if (!URL.canParse(value)) return false
+  const url = new URL(value)
+  if (url.protocol !== "http:" && url.protocol !== "https:") return false
+  return !url.username && !url.password && url.pathname === "/" && !url.search && !url.hash
+}

--- a/packages/server/src/options.ts
+++ b/packages/server/src/options.ts
@@ -2,6 +2,7 @@ import { Database } from "@opencode-ai/core/database/database"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { PersistentPty } from "@opencode-ai/core/persistent-pty"
 import { Schema } from "effect"
+import { ConnectionUrl } from "./connection-url"
 
 export const ServerOptions = Schema.Struct({
   app: Schema.optional(
@@ -13,7 +14,7 @@ export const ServerOptions = Schema.Struct({
   ),
   hostname: Schema.optional(Schema.String),
   port: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0), Schema.isLessThanOrEqualTo(65_535))),
-  additionalUrls: Schema.optional(Schema.Array(Schema.String)),
+  additionalUrls: Schema.optional(Schema.Array(ConnectionUrl)),
   password: Schema.optional(Schema.String),
   cors: Schema.optional(Schema.Array(Schema.String)),
   simulation: Schema.optional(Schema.Boolean),

--- a/packages/server/src/options.ts
+++ b/packages/server/src/options.ts
@@ -13,6 +13,7 @@ export const ServerOptions = Schema.Struct({
   ),
   hostname: Schema.optional(Schema.String),
   port: Schema.optional(Schema.Int.check(Schema.isGreaterThanOrEqualTo(0), Schema.isLessThanOrEqualTo(65_535))),
+  additionalUrls: Schema.optional(Schema.Array(Schema.String)),
   password: Schema.optional(Schema.String),
   cors: Schema.optional(Schema.Array(Schema.String)),
   simulation: Schema.optional(Schema.Boolean),

--- a/packages/server/src/process.ts
+++ b/packages/server/src/process.ts
@@ -98,7 +98,12 @@ export const start = Effect.fn("ServerProcess.start")(function* <E, R>(
           const address = bound.server.address()
           if (address === null || typeof address === "string") return []
           const host = address.family === "IPv6" ? `[${address.address}]` : address.address
-          return ServerInfo.connectionURLs(`http://${host}:${address.port}`, hostname)
+          return [
+            ...new Set([
+              ...(options.additionalUrls ?? []),
+              ...ServerInfo.connectionURLs(`http://${host}:${address.port}`, hostname),
+            ]),
+          ]
         },
       ).pipe(Layer.provideMerge(NodeHttpServer.layerHttpServices)),
       applicationScope,

--- a/packages/server/src/process.ts
+++ b/packages/server/src/process.ts
@@ -17,6 +17,7 @@ import {
 } from "effect/unstable/http"
 import { createServer } from "node:http"
 import { ServerAuth } from "./auth"
+import { normalizeConnectionUrl } from "./connection-url"
 import { isAllowedCorsOrigin } from "./cors"
 import { authorizedRequest } from "./middleware/authorization"
 import { withoutParentSpan } from "./request-tracing"
@@ -100,7 +101,7 @@ export const start = Effect.fn("ServerProcess.start")(function* <E, R>(
           const host = address.family === "IPv6" ? `[${address.address}]` : address.address
           return [
             ...new Set([
-              ...(options.additionalUrls ?? []),
+              ...(options.additionalUrls ?? []).map((url) => normalizeConnectionUrl(url)),
               ...ServerInfo.connectionURLs(`http://${host}:${address.port}`, hostname),
             ]),
           ]

--- a/packages/server/test/options.test.ts
+++ b/packages/server/test/options.test.ts
@@ -27,6 +27,8 @@ test("accepts additional server URLs", () => {
       decode({ additionalUrls: ["https://primary.example.com", "https://secondary.example.com"] }),
     ).additionalUrls,
   ).toEqual(["https://primary.example.com", "https://secondary.example.com"])
+  expect(Option.isNone(decode({ additionalUrls: ["ftp://example.com"] }))).toBe(true)
+  expect(Option.isNone(decode({ additionalUrls: ["https://example.com/path"] }))).toBe(true)
 })
 
 test("accepts durable event persistence configuration", () => {

--- a/packages/server/test/options.test.ts
+++ b/packages/server/test/options.test.ts
@@ -21,6 +21,14 @@ test("accepts optional app metadata", () => {
   })
 })
 
+test("accepts additional server URLs", () => {
+  expect(
+    Option.getOrThrow(
+      decode({ additionalUrls: ["https://primary.example.com", "https://secondary.example.com"] }),
+    ).additionalUrls,
+  ).toEqual(["https://primary.example.com", "https://secondary.example.com"])
+})
+
 test("accepts durable event persistence configuration", () => {
   expect(Option.getOrThrow(decode({ events: { persist: true } })).events).toEqual({ persist: true })
 })

--- a/packages/server/test/process.test.ts
+++ b/packages/server/test/process.test.ts
@@ -133,6 +133,29 @@ it.live("allows browser preflight requests without credentials", () =>
   }),
 )
 
+it.live("reports additional URLs before automatically discovered URLs", () =>
+  Effect.gen(function* () {
+    const server = yield* ServerProcess.start<never, never>({
+      hostname: "127.0.0.1",
+      port: 0,
+      additionalUrls: ["https://primary.example.com", "https://secondary.example.com"],
+      password: "secret",
+      app: { version: "test-version" },
+      database: { path: ":memory:" },
+    })
+    const base = HttpServer.formatAddress(server.address)
+    const response = yield* Effect.promise(() =>
+      fetch(new URL("/api/server", base), {
+        headers: { authorization: `Basic ${btoa("opencode:secret")}` },
+      }).then((response) => response.json()),
+    )
+
+    expect(response).toEqual({
+      urls: ["https://primary.example.com", "https://secondary.example.com", base],
+    })
+  }),
+)
+
 async function readUntil(reader: ReadableStreamDefaultReader<Uint8Array>, expected: string) {
   while (true) {
     const next = await reader.read()

--- a/packages/server/test/process.test.ts
+++ b/packages/server/test/process.test.ts
@@ -138,7 +138,11 @@ it.live("reports additional URLs before automatically discovered URLs", () =>
     const server = yield* ServerProcess.start<never, never>({
       hostname: "127.0.0.1",
       port: 0,
-      additionalUrls: ["https://primary.example.com", "https://secondary.example.com"],
+      additionalUrls: [
+        "https://primary.example.com/",
+        "https://PRIMARY.example.com:443",
+        "https://secondary.example.com",
+      ],
       password: "secret",
       app: { version: "test-version" },
       database: { path: ":memory:" },


### PR DESCRIPTION
### Issue for this PR

N/A (feature PR)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds optional client connection URLs without replacing automatically discovered addresses. `serve --url` accepts repeatable URLs, while `service url add`, `remove`, and `list` manage persisted URLs. Configured URLs are normalized, deduplicated, and returned first by `/api/server`, so `pair` includes reverse proxies and private tunnel endpoints.

### How did you verify your code works?

Ran focused server and CLI tests, package typechecks, CLI help smoke tests, the full pre-push typecheck, and a live Tailscale Serve pairing test from a physical device.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR