### PR TITLE
fix(webfetch): decode responses using the declared charset

### DIFF
--- a/packages/core/src/tool/webfetch.ts
+++ b/packages/core/src/tool/webfetch.ts
@@ -115,6 +115,25 @@ const convert = (content: string, contentType: string, format: Format) => {
   return content
 }
 
+export const charsetFromContentType = (contentType: string): string | undefined => {
+  const match = contentType.match(/charset\s*=\s*["']?([^;"'\s]+)/i)
+  return match?.[1]
+}
+
+export const charsetFromMeta = (bytes: Uint8Array): string | undefined => {
+  const head = new TextDecoder("windows-1252").decode(bytes.subarray(0, 4096))
+  return head.match(/<meta\b[^>]*charset\s*=\s*["']?\s*([^"'\s;>]+)/i)?.[1]
+}
+
+export const decodeBody = (body: Uint8Array, contentType: string): string => {
+  const charset = charsetFromContentType(contentType) ?? charsetFromMeta(body) ?? "utf-8"
+  try {
+    return new TextDecoder(charset as Bun.Encoding).decode(body)
+  } catch {
+    return new TextDecoder().decode(body)
+  }
+}
+
 const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
@@ -162,7 +181,7 @@ const layer = Layer.effectDiscard(
                   orElse: () => Effect.fail(new Error("Request timed out")),
                 }),
               )
-              const content = new TextDecoder().decode(body)
+              const content = decodeBody(body, contentType)
               const output = yield* Effect.try({
                 try: () => convert(content, contentType, input.format),
                 catch: (error) => error,

--- a/packages/core/test/tool-webfetch.test.ts
+++ b/packages/core/test/tool-webfetch.test.ts
@@ -179,6 +179,44 @@ describe("WebFetchTool registration", () => {
     }),
   )
 
+  it.effect("decodes non-UTF-8 content using the declared charset", () =>
+    Effect.gen(function* () {
+      reset()
+      respond = () =>
+        Effect.succeed(
+          new Response(new Uint8Array([0x4f, 0x4b, 0x20, 0xd6, 0xd0, 0xce, 0xc4]), {
+            headers: { "content-type": "text/plain; charset=gbk" },
+          }),
+        )
+      const registry = yield* ToolRegistry.Service
+
+      expect(yield* executeTool(registry, call({ url: "https://1.1.1.1/gbk", format: "text" }))).toEqual({
+        type: "text",
+        value: "OK \u4e2d\u6587",
+      })
+    }),
+  )
+
+  it.effect("falls back to the HTML meta charset when the header omits it", () =>
+    Effect.gen(function* () {
+      reset()
+      const html = new TextEncoder().encode('<html><head><meta charset="gbk"></head><body>')
+      const body = new Uint8Array([...html, 0xd6, 0xd0, 0xce, 0xc4])
+      respond = () =>
+        Effect.succeed(
+          new Response(body, {
+            headers: { "content-type": "text/html" },
+          }),
+        )
+      const registry = yield* ToolRegistry.Service
+
+      expect(yield* executeTool(registry, call({ url: "https://1.1.1.1/meta-gbk", format: "text" }))).toEqual({
+        type: "text",
+        value: "\u4e2d\u6587",
+      })
+    }),
+  )
+
   it.effect("returns an error result when HTML-to-Markdown conversion throws", () =>
     Effect.gen(function* () {
       reset()


### PR DESCRIPTION
### Issue for this PR

Closes #45902

### Type of change

- [x] Bug fix

### What does this PR do?

`webfetch` decoded every response body as UTF-8, ignoring the `charset` from the `Content-Type` header and any HTML `<meta charset>`. Non-UTF-8 pages (GBK/GB18030, Shift_JIS, ISO-8859-1, etc.) came back as replacement-character mojibake.

The fix adds charset-aware decoding:

1. `charsetFromContentType` parses `charset=` from the response header.
2. `charsetFromMeta` scans the first 4 KB for an HTML `<meta charset>` as a fallback (decoded losslessly as windows-1252).
3. `decodeBody` decodes with the resolved charset, falling back to UTF-8 when no charset is declared or the label is unsupported.

### How did you verify your code works?

Added two integration tests in `tool-webfetch.test.ts`:

- a `charset=gbk` response decodes to the correct characters
- a header-less response decodes via its `<meta charset="gbk">`

`bun test ./test/tool-webfetch.test.ts` (14 pass), `bun run typecheck` clean, prettier clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR