### PR TITLE
fix(webfetch): convert application/xhtml+xml responses

### DIFF
--- a/packages/core/src/tool/webfetch.ts
+++ b/packages/core/src/tool/webfetch.ts
@@ -109,7 +109,7 @@ const isTextualMime = (mime: string) =>
   mime === "application/javascript" ||
   mime === "application/x-javascript"
 const convert = (content: string, contentType: string, format: Format) => {
-  if (!contentType.includes("text/html")) return content
+  if (!contentType.includes("text/html") && !contentType.includes("application/xhtml+xml")) return content
   if (format === "markdown") return convertHTMLToMarkdown(content)
   if (format === "text") return extractTextFromHTML(content)
   return content

--- a/packages/core/test/tool-webfetch.test.ts
+++ b/packages/core/test/tool-webfetch.test.ts
@@ -179,6 +179,28 @@ describe("WebFetchTool registration", () => {
     }),
   )
 
+  it.effect("converts XHTML content instead of returning raw markup", () =>
+    Effect.gen(function* () {
+      reset()
+      respond = () =>
+        Effect.succeed(
+          new Response("<h1>Hello</h1><p>world</p>", {
+            headers: { "content-type": "application/xhtml+xml" },
+          }),
+        )
+      const registry = yield* ToolRegistry.Service
+
+      expect(yield* executeTool(registry, call({ url: "https://1.1.1.1/xhtml", format: "markdown" }))).toEqual({
+        type: "text",
+        value: "# Hello\n\nworld",
+      })
+      expect(yield* executeTool(registry, call({ url: "https://1.1.1.1/xhtml", format: "text" }))).toEqual({
+        type: "text",
+        value: "Helloworld",
+      })
+    }),
+  )
+
   it.effect("returns an error result when HTML-to-Markdown conversion throws", () =>
     Effect.gen(function* () {
       reset()


### PR DESCRIPTION
### Issue for this PR

Closes #45905

### Type of change

- [x] Bug fix

### What does this PR do?

`webfetch` advertises `application/xhtml+xml` in its Accept header and `isTextualMime` accepts it, but `convert()` only recognized `text/html`, so XHTML pages were returned as raw XML tag soup instead of converted markdown/text. This PR broadens `convert()` to treat `application/xhtml+xml` as HTML.

### How did you verify your code works?

Added an integration test asserting an `application/xhtml+xml` response converts to markdown and text instead of raw markup.

`bun test ./test/tool-webfetch.test.ts` (13 pass), `bun run typecheck` clean, prettier clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR