### PR TITLE
fix(format): bound formatter subprocesses with a timeout

### DIFF
--- a/packages/core/src/v1/config/formatter.ts
+++ b/packages/core/src/v1/config/formatter.ts
@@ -7,6 +7,7 @@ export const Entry = Schema.Struct({
   command: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
   environment: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   extensions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))),
+  timeout: Schema.optional(Schema.Number),
 })
 
 export const Info = Schema.Union([Schema.Boolean, Schema.Record(Schema.String, Entry)])

--- a/packages/opencode/src/format/formatter.ts
+++ b/packages/opencode/src/format/formatter.ts
@@ -12,6 +12,7 @@ export interface Info {
   name: string
   environment?: Record<string, string>
   extensions: string[]
+  timeout?: number
   enabled(context: Context): Promise<string[] | false>
 }
 

--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -1,5 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Effect, Layer, Context, Schema } from "effect"
+import { Duration, Effect, Layer, Context, Schema } from "effect"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { ChildProcess } from "effect/unstable/process"
 import { AppProcess } from "@opencode-ai/core/process"
@@ -27,6 +27,8 @@ export interface Interface {
 export class Service extends Context.Service<Service, Interface>()("@opencode/Format") {}
 
 export const use = serviceUse(Service)
+
+const DEFAULT_FORMATTER_TIMEOUT_SECONDS = 120
 
 const layer = Layer.effect(
   Service,
@@ -91,6 +93,7 @@ const layer = Layer.effect(
                     stdout: "ignore",
                     stderr: "ignore",
                   }),
+                  { timeout: Duration.seconds(item.timeout ?? DEFAULT_FORMATTER_TIMEOUT_SECONDS) },
                 )
                 .pipe(
                   Effect.catch((error) =>

--- a/packages/opencode/test/format/format.test.ts
+++ b/packages/opencode/test/format/format.test.ts
@@ -232,4 +232,35 @@ describe("Format", () => {
       },
     },
   )
+
+  it.instance(
+    "times out a formatter that hangs",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const file = `${test.directory}/test.hang`
+        yield* Effect.promise(() => Bun.write(file, "x"))
+
+        const start = Date.now()
+        yield* Format.Service.use((fmt) =>
+          Effect.gen(function* () {
+            yield* fmt.init()
+            expect(yield* fmt.file(file)).toBe(true)
+          }),
+        )
+
+        expect(Date.now() - start).toBeLessThan(10_000)
+      }),
+    {
+      config: {
+        formatter: {
+          hanging: {
+            command: ["sh", "-c", "sleep 60"],
+            extensions: [".hang"],
+            timeout: 1,
+          },
+        },
+      },
+    },
+  )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #45908

### Type of change

- [x] Bug fix

### What does this PR do?

Formatter subprocesses were spawned with no timeout or abort channel, so a formatter that hangs (`mix format` implicitly compiling a cold Elixir project, `ktlint`/`latexindent` on a pathological file, ...) blocked the whole edit/write/apply_patch tool call and stalled the session indefinitely.

The fix runs each formatter through `AppProcess.run` with a bounded `timeout`:

- default `120` seconds
- overridable per formatter via a new `timeout` config field (seconds)

A hung formatter now fails the format step and is logged (the existing `Effect.catch` path) instead of hanging the session. The spawned child is killed on timeout via the scoped handle in `AppProcess.run`.

### How did you verify your code works?

Added a regression test in `format.test.ts` registering a formatter with `command: ["sh", "-c", "sleep 60"]` and `timeout: 1`, asserting the file() call returns in under 10s.

`bun test ./test/format/format.test.ts` (12 pass, including the new timeout test at ~1s), `bun run typecheck` clean in both packages, prettier clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR