### PR TITLE
chore(deps): bump solid-js to 1.9.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       "@solidjs/start": "https://pkg.pr.new/@solidjs/start@dfb2020",
       "@sentry/solid": "10.36.0",
       "@sentry/vite-plugin": "4.6.0",
-      "solid-js": "1.9.10",
+      "solid-js": "1.9.15",
       "solid-sonner": "0.3.1",
       "vite-plugin-solid": "2.11.10",
       "@lydell/node-pty": "1.2.0-beta.12"
@@ -141,7 +141,8 @@
     "@opentui/keymap": "catalog:",
     "@opentui/solid": "catalog:",
     "@types/bun": "catalog:",
-    "@types/node": "catalog:"
+    "@types/node": "catalog:",
+    "solid-js": "catalog:"
   },
   "patchedDependencies": {
     "@dnd-kit/dom@0.5.0": "patches/@dnd-kit%2Fdom@0.5.0.patch",
@@ -149,7 +150,7 @@
     "@npmcli/agent@4.0.2": "patches/@npmcli%2Fagent@4.0.2.patch",
     "@silvia-odwyer/photon-node@0.3.4": "patches/@silvia-odwyer%2Fphoton-node@0.3.4.patch",
     "@standard-community/standard-openapi@0.2.9": "patches/@standard-community%2Fstandard-openapi@0.2.9.patch",
-    "solid-js@1.9.10": "patches/solid-js@1.9.10.patch",
+    "solid-js@1.9.15": "patches/solid-js@1.9.15.patch",
     "@ai-sdk/xai@3.0.102": "patches/@ai-sdk%2Fxai@3.0.102.patch",
     "@ai-sdk/mistral@3.0.51": "patches/@ai-sdk%2Fmistral@3.0.51.patch",
     "gcp-metadata@8.1.2": "patches/gcp-metadata@8.1.2.patch",

--- a/patches/solid-js@1.9.15.patch
+++ b/patches/solid-js@1.9.15.patch
@@ -1,17 +1,8 @@
 diff --git a/dist/dev.cjs b/dist/dev.cjs
-index 7104749..dc3eac9 100644
+index 11f3095..d4fbb2b 100644
 --- a/dist/dev.cjs
 +++ b/dist/dev.cjs
-@@ -764,6 +764,8 @@ function runComputation(node, value, time) {
-     if (node.updatedAt != null && "observers" in node) {
-       writeSignal(node, nextValue, true);
-     } else if (Transition && Transition.running && node.pure) {
-+      // On first computation during transition, also set committed value #2046
-+      if (!Transition.sources.has(node)) node.value = nextValue;
-       Transition.sources.add(node);
-       node.tValue = nextValue;
-     } else node.value = nextValue;
-@@ -987,18 +989,21 @@ function cleanNode(node) {
+@@ -1009,18 +1009,21 @@ function cleanNode(node) {
      }
    }
    if (node.tOwned) {
@@ -37,19 +28,10 @@ index 7104749..dc3eac9 100644
    if (Transition && Transition.running) node.tState = 0;else node.state = 0;
    delete node.sourceMap;
 diff --git a/dist/dev.js b/dist/dev.js
-index ea5e4bc..a2e2d59 100644
+index ea05c50..093bb7c 100644
 --- a/dist/dev.js
 +++ b/dist/dev.js
-@@ -762,6 +762,8 @@ function runComputation(node, value, time) {
-     if (node.updatedAt != null && "observers" in node) {
-       writeSignal(node, nextValue, true);
-     } else if (Transition && Transition.running && node.pure) {
-+      // On first computation during transition, also set committed value #2046
-+      if (!Transition.sources.has(node)) node.value = nextValue;
-       Transition.sources.add(node);
-       node.tValue = nextValue;
-     } else node.value = nextValue;
-@@ -985,18 +987,21 @@ function cleanNode(node) {
+@@ -1007,18 +1007,21 @@ function cleanNode(node) {
      }
    }
    if (node.tOwned) {
@@ -75,7 +57,7 @@ index ea5e4bc..a2e2d59 100644
    if (Transition && Transition.running) node.tState = 0;else node.state = 0;
    delete node.sourceMap;
 diff --git a/dist/server.cjs b/dist/server.cjs
-index e715309..188ba81 100644
+index 989ec19..df19676 100644
 --- a/dist/server.cjs
 +++ b/dist/server.cjs
 @@ -127,12 +127,14 @@ function onCleanup(fn) {
@@ -96,7 +78,7 @@ index e715309..188ba81 100644
  }
  function catchError(fn, handler) {
 diff --git a/dist/server.js b/dist/server.js
-index d5f8803..320d9af 100644
+index 1455ee9..23ff7d2 100644
 --- a/dist/server.js
 +++ b/dist/server.js
 @@ -125,12 +125,14 @@ function onCleanup(fn) {
@@ -117,19 +99,10 @@ index d5f8803..320d9af 100644
  }
  function catchError(fn, handler) {
 diff --git a/dist/solid.cjs b/dist/solid.cjs
-index 7c133a2..5ef1501 100644
+index 5fcf6a7..e1b375f 100644
 --- a/dist/solid.cjs
 +++ b/dist/solid.cjs
-@@ -717,6 +717,8 @@ function runComputation(node, value, time) {
-     if (node.updatedAt != null && "observers" in node) {
-       writeSignal(node, nextValue, true);
-     } else if (Transition && Transition.running && node.pure) {
-+      // On first computation during transition, also set committed value #2046
-+      if (!Transition.sources.has(node)) node.value = nextValue;
-       Transition.sources.add(node);
-       node.tValue = nextValue;
-     } else node.value = nextValue;
-@@ -938,18 +940,21 @@ function cleanNode(node) {
+@@ -964,18 +964,21 @@ function cleanNode(node) {
      }
    }
    if (node.tOwned) {
@@ -155,19 +128,10 @@ index 7c133a2..5ef1501 100644
    if (Transition && Transition.running) node.tState = 0;else node.state = 0;
  }
 diff --git a/dist/solid.js b/dist/solid.js
-index 656fd26..6e0038c 100644
+index 7bf60d4..5f25cc7 100644
 --- a/dist/solid.js
 +++ b/dist/solid.js
-@@ -715,6 +715,8 @@ function runComputation(node, value, time) {
-     if (node.updatedAt != null && "observers" in node) {
-       writeSignal(node, nextValue, true);
-     } else if (Transition && Transition.running && node.pure) {
-+      // On first computation during transition, also set committed value #2046
-+      if (!Transition.sources.has(node)) node.value = nextValue;
-       Transition.sources.add(node);
-       node.tValue = nextValue;
-     } else node.value = nextValue;
-@@ -936,18 +938,21 @@ function cleanNode(node) {
+@@ -962,18 +962,21 @@ function cleanNode(node) {
      }
    }
    if (node.tOwned) {


### PR DESCRIPTION
### Issue for this PR

Closes #45918

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bumps the `solid-js` catalog pin from `1.9.10` to `1.9.15`.

`solid-js@1.9.10` constrains its `seroval` dependency to `~1.3.0`, which resolves to `seroval@1.3.2` — affected by **CVE-2026-59940** (Critical, CVSS 9.8), a type-confusion bug in `seroval.fromJSON()`, fixed upstream in `seroval@1.5.3`. Since `seroval` ships in opencode's production bundle via the Solid.js / `@solidjs/start` stack, this is a real vulnerability in the shipped app today (see #45918 and the linked security advisory `GHSA-vxv8-v7jx-pcgr` for full detail). `solid-js@1.9.15` depends on `seroval ~1.5.4`, which clears the CVE with no manual override needed.

While bumping, I also found and fixed a regression it would otherwise introduce:
- One of the two fixes carried in `patches/solid-js@1.9.10.patch` (the Transition-value fix for solid-js #2046) is already merged upstream as of 1.9.15, so the patch has been regenerated (`patches/solid-js@1.9.15.patch`) to keep only the still-needed `cleanNode` reordering fix.
- Bumping the catalog version alone breaks typechecking in `packages/console/app`, because `@solidjs/start` resolves its own nested `solid-js@1.9.10`, and TypeScript's interface merging for `RequestEvent` stops working across the two instances. Fixed by adding `solid-js` to the root `overrides` block, matching the existing pattern already used there for `@opentui/core`/`@opentui/keymap`/`@opentui/solid`.

### How did you verify your code works?

- `bun install` — clean install, patch applies successfully, `bun.lock` shows `seroval` now resolving to `1.5.6` (well above the patched `1.5.3`).
- `bun turbo typecheck` — 30/30 packages pass.
- `bun run --cwd packages/opencode build -- --single --skip-embed-web-ui` — produces a working `opencode-windows-x64` binary; its own `--version`/`--help` smoke test passes.

### Screenshots / recordings

N/A — dependency bump, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
