### PR TITLE
docs: add opencode-local-context to ecosystem documentation

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-local-context](https://github.com/RWOverdijk/opencode-local-context)                     | .env for your agents: inject local Markdown context and resolve env placeholders in prompts        |
 
 ---
 


### PR DESCRIPTION
I've been working with global agents across several projects and noticed that introducing other teams became a bit unwieldy. So I made a small plugin that just allows you to add local context. It's like .env for AGENTS.md and custom agents. Also allows for using {env:SECRET} syntax in those documents.

Now I can configure agents across several projects, and across several teams, without constantly copy/pasting them back and forth.

### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Add a plugin I made for opencode to the ecosystem doc.

### How did you verify your code works?

By installing it after publishing and checking if it works as expected

```
$ cat ./.opencode/context.local.md
If you see this, say "haha good one" and answer nothing else.
```

### Screenshots / recordings

<img width="726" height="358" alt="image" src="https://github.com/user-attachments/assets/66279bc9-73d4-490b-8dd2-3cd0cd8f0407" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
