### PR TITLE
fix(console): protect legacy auth with turnstile

### DIFF
--- a/infra/console.ts
+++ b/infra/console.ts
@@ -60,11 +60,23 @@ const GITHUB_CLIENT_ID_CONSOLE = new sst.Secret("GITHUB_CLIENT_ID_CONSOLE")
 const GITHUB_CLIENT_SECRET_CONSOLE = new sst.Secret("GITHUB_CLIENT_SECRET_CONSOLE")
 const GOOGLE_CLIENT_ID = new sst.Secret("GOOGLE_CLIENT_ID")
 const authStorage = new sst.cloudflare.Kv("AuthStorage")
+const turnstileWidget = new cloudflare.TurnstileWidget("ConsoleTurnstileWidget", {
+  accountId: sst.cloudflare.DEFAULT_ACCOUNT_ID,
+  domains: [`auth.${domain}`],
+  mode: "managed",
+  name: `OpenCode legacy console auth (${$app.stage})`,
+})
+const turnstile = new sst.Linkable("ConsoleTurnstile", {
+  properties: {
+    secret: turnstileWidget.secret,
+    siteKey: turnstileWidget.sitekey,
+  },
+})
 export const auth = new sst.cloudflare.Worker("AuthApi", {
   domain: `auth.${domain}`,
   handler: "packages/console/function/src/auth.ts",
   url: true,
-  link: [database, authStorage, GITHUB_CLIENT_ID_CONSOLE, GITHUB_CLIENT_SECRET_CONSOLE, GOOGLE_CLIENT_ID],
+  link: [database, authStorage, GITHUB_CLIENT_ID_CONSOLE, GITHUB_CLIENT_SECRET_CONSOLE, GOOGLE_CLIENT_ID, turnstile],
 })
 
 ////////////////

--- a/packages/console/function/src/auth.ts
+++ b/packages/console/function/src/auth.ts
@@ -18,6 +18,7 @@ import { UserTable } from "@opencode-ai/console-core/schema/user.sql.js"
 import { AuthTable } from "@opencode-ai/console-core/schema/auth.sql.js"
 import { Identifier } from "@opencode-ai/console-core/identifier.js"
 import { isAllowedAuthorizationRedirect } from "./auth-redirect.js"
+import { getTurnstileProvider, getTurnstileProviderRequest, renderTurnstilePage, verifyTurnstile } from "./turnstile.js"
 
 type Env = {
   AuthStorage: KVNamespace
@@ -43,6 +44,15 @@ const MY_THEME: Theme = {
 export default {
   async fetch(request: Request, env: Env, ctx: ExecutionContext) {
     const requestURL = new URL(request.url)
+    const turnstile =
+      requestURL.pathname === "/turnstile" && request.method === "POST" ? await handleTurnstile(request) : undefined
+    if (turnstile instanceof Response) return turnstile
+    const turnstileProvider = getTurnstileProvider(requestURL.pathname)
+    if (turnstileProvider) {
+      return renderTurnstilePage(Resource.ConsoleTurnstile.siteKey, [turnstileProvider])
+    }
+    const authRequest = turnstile ?? request
+
     if (requestURL.pathname === "/authorize") {
       const redirectURI = requestURL.searchParams.get("redirect_uri")
       if (
@@ -114,6 +124,14 @@ export default {
         namespace: env.AuthStorage,
       }),
       subjects,
+      select(providers) {
+        return Promise.resolve(
+          renderTurnstilePage(
+            Resource.ConsoleTurnstile.siteKey,
+            Object.keys(providers).filter((provider) => provider === "github" || provider === "google"),
+          ),
+        )
+      },
       allow: ({ clientID, redirectURI }) => Promise.resolve(isAllowedAuthorizationRedirect(clientID, redirectURI)),
       async success(ctx, response) {
         console.log(response)
@@ -233,7 +251,35 @@ export default {
         })
         return ctx.subject("account", accountID, { accountID, email, newAccount })
       },
-    }).fetch(request, env, ctx)
+    }).fetch(authRequest, env, ctx)
     return result
   },
+}
+
+async function handleTurnstile(request: Request) {
+  const form = await request.formData().catch(() => new FormData())
+  const provider = form.get("provider")
+  const token = form.get("cf-turnstile-response")
+  if ((provider !== "github" && provider !== "google") || typeof token !== "string") {
+    return renderTurnstilePage(
+      Resource.ConsoleTurnstile.siteKey,
+      undefined,
+      "Complete the security check and try again",
+    )
+  }
+  const verified = await verifyTurnstile({
+    token,
+    secret: Resource.ConsoleTurnstile.secret,
+    hostname: new URL(request.url).hostname,
+    remoteIP: request.headers.get("CF-Connecting-IP") ?? undefined,
+  })
+  if (!verified) {
+    console.warn("Turnstile auth challenge rejected", { provider })
+    return renderTurnstilePage(
+      Resource.ConsoleTurnstile.siteKey,
+      undefined,
+      "Complete the security check and try again",
+    )
+  }
+  return getTurnstileProviderRequest(request, provider)
 }

--- a/packages/console/function/src/turnstile.test.ts
+++ b/packages/console/function/src/turnstile.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test"
+import { getTurnstileProvider, getTurnstileProviderRequest, renderTurnstilePage, verifyTurnstile } from "./turnstile"
+
+describe("Turnstile verification", () => {
+  test("verifies the action, hostname, and source IP", async () => {
+    const requests: Request[] = []
+    const verified = await verifyTurnstile(
+      {
+        token: "challenge-token",
+        secret: "secret",
+        hostname: "auth.dev.opencode.ai",
+        remoteIP: "203.0.113.10",
+      },
+      (input, init) => {
+        requests.push(new Request(input, init))
+        return Promise.resolve(
+          Response.json({
+            success: true,
+            action: "legacy_console_auth",
+            hostname: "auth.dev.opencode.ai",
+          }),
+        )
+      },
+    )
+
+    expect(verified).toBe(true)
+    const body = await requests[0].formData()
+    expect(body.get("response")).toBe("challenge-token")
+    expect(body.get("secret")).toBe("secret")
+    expect(body.get("remoteip")).toBe("203.0.113.10")
+    expect(body.get("idempotency_key")).toBeString()
+  })
+
+  test("rejects missing tokens and mismatched verification context", async () => {
+    const fetcher = () =>
+      Promise.resolve(
+        Response.json({
+          success: true,
+          action: "other_action",
+          hostname: "auth.dev.opencode.ai",
+        }),
+      )
+
+    expect(
+      await verifyTurnstile({ token: "", secret: "secret", hostname: "auth.dev.opencode.ai" }, () =>
+        Promise.reject(new Error("should not fetch")),
+      ),
+    ).toBe(false)
+    expect(
+      await verifyTurnstile({ token: "challenge-token", secret: "secret", hostname: "auth.dev.opencode.ai" }, fetcher),
+    ).toBe(false)
+  })
+
+  test("fails closed when Cloudflare is unavailable", async () => {
+    expect(
+      await verifyTurnstile({ token: "challenge-token", secret: "secret", hostname: "auth.dev.opencode.ai" }, () =>
+        Promise.reject(new Error("unavailable")),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("Turnstile routing", () => {
+  test("recognizes only provider authorization routes", () => {
+    expect(getTurnstileProvider("/github/authorize")).toBe("github")
+    expect(getTurnstileProvider("/google/authorize/")).toBe("google")
+    expect(getTurnstileProvider("/github/callback")).toBeUndefined()
+    expect(getTurnstileProvider("/authorize")).toBeUndefined()
+  })
+
+  test("routes verified challenges directly to the provider", () => {
+    const request = new Request("https://auth.dev.opencode.ai/turnstile", {
+      method: "POST",
+      headers: {
+        Cookie: "openauth=state",
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    })
+    const routed = getTurnstileProviderRequest(request, "github")
+    expect(routed.method).toBe("GET")
+    expect(routed.url).toBe("https://auth.dev.opencode.ai/github/authorize")
+    expect(routed.headers.get("Cookie")).toBe("openauth=state")
+    expect(routed.headers.has("Content-Type")).toBe(false)
+  })
+
+  test("renders a no-store interaction-only challenge", async () => {
+    const response = renderTurnstilePage("site-key", ["github"])
+    const body = await response.text()
+    expect(response.headers.get("Cache-Control")).toBe("no-store")
+    expect(body).toContain('data-sitekey="site-key"')
+    expect(body).toContain('data-action="legacy_console_auth"')
+    expect(body).toContain('data-appearance="interaction-only"')
+    expect(body).toContain('value="github"')
+    expect(body).not.toContain('value="google"')
+  })
+})

--- a/packages/console/function/src/turnstile.ts
+++ b/packages/console/function/src/turnstile.ts
@@ -1,0 +1,140 @@
+import { z } from "zod"
+
+const ACTION = "legacy_console_auth"
+const ENDPOINT = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
+
+const VerificationResponse = z.object({
+  success: z.boolean(),
+  action: z.string().optional(),
+  hostname: z.string().optional(),
+  "error-codes": z.array(z.string()).optional(),
+})
+
+export type TurnstileProvider = "github" | "google"
+type TurnstileFetch = (...input: Parameters<typeof fetch>) => ReturnType<typeof fetch>
+
+export async function verifyTurnstile(
+  input: {
+    token: string
+    secret: string
+    hostname: string
+    remoteIP?: string
+  },
+  fetcher: TurnstileFetch = fetch,
+) {
+  if (!input.token) return false
+  return fetcher(ENDPOINT, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({
+      secret: input.secret,
+      response: input.token,
+      idempotency_key: crypto.randomUUID(),
+      ...(input.remoteIP ? { remoteip: input.remoteIP } : {}),
+    }),
+    signal: AbortSignal.timeout(5_000),
+  })
+    .then(async (response) => {
+      if (!response.ok) return false
+      const result = VerificationResponse.safeParse(await response.json())
+      if (!result.success) return false
+      return result.data.success && result.data.action === ACTION && result.data.hostname === input.hostname
+    })
+    .catch(() => false)
+}
+
+export function getTurnstileProvider(pathname: string): TurnstileProvider | undefined {
+  const provider = pathname.match(/^\/(github|google)\/authorize\/?$/)?.[1]
+  if (provider === "github" || provider === "google") return provider
+}
+
+export function getTurnstileProviderRequest(request: Request, provider: TurnstileProvider) {
+  const cookie = request.headers.get("Cookie")
+  return new Request(new URL(`/${provider}/authorize`, request.url), {
+    headers: cookie ? { Cookie: cookie } : undefined,
+    method: "GET",
+  })
+}
+
+export function renderTurnstilePage(
+  siteKey: string,
+  providers: TurnstileProvider[] = ["github", "google"],
+  error?: string,
+) {
+  const buttons = providers
+    .map(
+      (provider) =>
+        `<button type="submit" name="provider" value="${provider}" disabled>Continue with ${provider === "github" ? "GitHub" : "Google"}</button>`,
+    )
+    .join("")
+  const message = error ? `<p role="alert">${escapeHTML(error)}</p>` : ""
+  return new Response(
+    `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Sign in to OpenCode</title>
+    <script>
+      window.turnstileReady = function () {
+        document.querySelectorAll("button").forEach(function (button) { button.disabled = false })
+      }
+      window.turnstileReset = function () {
+        document.querySelectorAll("button").forEach(function (button) { button.disabled = true })
+      }
+    </script>
+    <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" defer></script>
+    <style>
+      :root { color-scheme: light dark; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+      * { box-sizing: border-box; }
+      body { min-height: 100vh; margin: 0; display: grid; place-items: center; background: Canvas; color: CanvasText; }
+      main { width: min(100% - 32px, 400px); border: 1px solid color-mix(in srgb, CanvasText 20%, transparent); padding: 32px; }
+      header { display: flex; align-items: center; gap: 12px; margin-bottom: 28px; }
+      img { width: 28px; height: 28px; }
+      h1 { margin: 0; font: inherit; font-weight: 700; font-size: 18px; }
+      form { display: grid; gap: 10px; }
+      .turnstile { min-height: 1px; }
+      button { min-height: 44px; border: 1px solid color-mix(in srgb, CanvasText 24%, transparent); background: Canvas; color: CanvasText; font: inherit; font-weight: 600; cursor: pointer; }
+      button:hover:not(:disabled) { background: color-mix(in srgb, CanvasText 7%, Canvas); }
+      button:focus-visible { outline: 2px solid #4d6bfe; outline-offset: 2px; }
+      button:disabled { cursor: wait; opacity: 0.5; }
+      p { margin: 0 0 18px; color: #d33; font-size: 13px; line-height: 1.5; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header><img src="https://opencode.ai/favicon-v3.svg" alt=""><h1>Sign in to OpenCode</h1></header>
+      ${message}
+      <form method="post" action="/turnstile">
+        <div class="turnstile cf-turnstile" data-sitekey="${escapeHTML(siteKey)}" data-action="${ACTION}" data-appearance="interaction-only" data-size="flexible" data-theme="auto" data-callback="turnstileReady" data-error-callback="turnstileReset" data-expired-callback="turnstileReset" data-timeout-callback="turnstileReset"></div>
+        ${buttons}
+      </form>
+    </main>
+  </body>
+</html>`,
+    {
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Security-Policy":
+          "default-src 'none'; base-uri 'none'; connect-src https://challenges.cloudflare.com; form-action 'self'; frame-src https://challenges.cloudflare.com; img-src https://opencode.ai; script-src 'unsafe-inline' https://challenges.cloudflare.com; style-src 'unsafe-inline'",
+        "Content-Type": "text/html; charset=utf-8",
+        "Referrer-Policy": "no-referrer",
+        "X-Content-Type-Options": "nosniff",
+      },
+      status: error ? 400 : 200,
+    },
+  )
+}
+
+function escapeHTML(value: string) {
+  return value.replace(/[&<>"']/g, (character) => {
+    if (character === "&") return "&amp;"
+    if (character === "<") return "&lt;"
+    if (character === ">") return "&gt;"
+    if (character === '"') return "&quot;"
+    return "&#039;"
+  })
+}


### PR DESCRIPTION
## Summary
- add an infra-managed Cloudflare Turnstile widget for the legacy console auth worker
- verify action, hostname, token, and source IP before starting GitHub or Google OAuth
- prevent direct provider routes from bypassing the challenge

## Verification
- `bun test src/turnstile.test.ts src/auth-redirect.test.ts`
- `bun typecheck` in `packages/console/function`
- repository pre-push typecheck (30 packages)
- `bun sst diff --stage dev`