### PR TITLE
feat(tui): prompt and steer selected subagents from the inspector

### DIFF
--- a/packages/tui/src/mini/footer.prompt.tsx
+++ b/packages/tui/src/mini/footer.prompt.tsx
@@ -49,7 +49,7 @@ const AUTOCOMPLETE_ROWS = FOOTER_MENU_ROWS
 const AUTOCOMPLETE_BOTTOM_ROWS = 1
 
 export const TEXTAREA_MIN_ROWS = 1
-const TEXTAREA_MAX_ROWS = 6
+export const TEXTAREA_MAX_ROWS = 6
 export const PROMPT_MAX_ROWS = TEXTAREA_MAX_ROWS + AUTOCOMPLETE_ROWS - 1 + AUTOCOMPLETE_BOTTOM_ROWS
 
 type Mention = Extract<RunPromptPart, { type: "file" | "agent" | "skill" }>
@@ -180,7 +180,7 @@ export function RunPromptBody(props: {
   cursorStyle: RunTuiConfig["cursor"]
   placeholder: () => StyledText | string
   onSubmit: () => void
-  onKeyDown: (event: KeyEvent) => void
+  onKeyDown?: (event: KeyEvent) => void
   onContentChange: () => void
   bind: (area?: TextareaRenderable) => void
 }) {

--- a/packages/tui/src/mini/footer.subagent.tsx
+++ b/packages/tui/src/mini/footer.subagent.tsx
@@ -53,6 +53,12 @@ export function RunFooterSubagentBody(props: {
   detail: () => FooterSubagentDetail | undefined
   onCycle: (dir: -1 | 1) => void
   onClose: () => void
+  // Returns true when the inspector's composer consumed Esc to clear its
+  // draft, keeping the inspector open for a second Esc.
+  onEscape?: () => boolean
+  // True while the inspector's composer holds text: arrow keys then move the
+  // text cursor instead of scrolling, and letters always type.
+  composerOccupied?: () => boolean
   // Formatted interrupt shortcut from the registered keymap binding; the
   // command itself is dispatched through the keymap in footer.view.
   interrupt?: () => string | undefined
@@ -110,6 +116,10 @@ export function RunFooterSubagentBody(props: {
 
     if (event.name === "escape") {
       event.preventDefault()
+      if (props.onEscape?.()) {
+        return
+      }
+
       props.onClose()
       return
     }
@@ -120,13 +130,20 @@ export function RunFooterSubagentBody(props: {
       return
     }
 
-    if (event.name === "up" || event.name === "k") {
+    // Letters must reach the composer, so k/j are no longer scroll keys and
+    // arrows only scroll while the draft is empty; with text they move the
+    // text cursor instead.
+    if (props.composerOccupied?.()) {
+      return
+    }
+
+    if (event.name === "up") {
       event.preventDefault()
       scroll?.scrollBy(-1)
       return
     }
 
-    if (event.name === "down" || event.name === "j") {
+    if (event.name === "down") {
       event.preventDefault()
       scroll?.scrollBy(1)
     }

--- a/packages/tui/src/mini/footer.ts
+++ b/packages/tui/src/mini/footer.ts
@@ -33,7 +33,7 @@ import { Locale } from "../util/locale"
 import { RUN_COMMAND_PANEL_ROWS, RUN_SUBAGENT_PANEL_ROWS } from "./footer.command"
 import { SUBAGENT_INSPECTOR_ROWS } from "./footer.subagent"
 import { PROMPT_MAX_ROWS, TEXTAREA_MIN_ROWS } from "./footer.prompt"
-import { RunFooterView } from "./footer.view"
+import { SUBAGENT_COMPOSER_ROWS, RunFooterView } from "./footer.view"
 import { RunScrollbackStream } from "./scrollback.surface"
 import { RUN_THEME_FALLBACK, resolveRunTheme, type RunTheme } from "./theme"
 import { modelInfo } from "./variant.shared"
@@ -101,6 +101,7 @@ type RunFooterOptions = {
   onEditorOpen: (input: { value: string }) => Promise<string | undefined>
   onSubagentSelect?: (sessionID: string | undefined) => void
   onSubagentInterrupt?: (sessionID: string) => void
+  onSubagentPrompt?: (sessionID: string, prompt: RunPrompt) => boolean | void | Promise<boolean | void>
   subscribeThemeSignal: (listener: () => void) => () => void
 }
 
@@ -203,6 +204,7 @@ export class RunFooter implements FooterApi {
   private setMiniSettings: Setter<MiniSettings>
   private promptRoute: FooterPromptRoute = { type: "composer" }
   private subagentMenuRows = SUBAGENT_ROWS
+  private subagentComposerRows = TEXTAREA_MIN_ROWS
   private interruptTimeout: NodeJS.Timeout | undefined
   private exitTimeout: NodeJS.Timeout | undefined
   private noticeTimeout: NodeJS.Timeout | undefined
@@ -361,6 +363,7 @@ export class RunFooter implements FooterApi {
               onMiniSettingChange: footer.handleMiniSettingChange,
               onSubagentSelect: options.onSubagentSelect,
               onSubagentInterrupt: options.onSubagentInterrupt,
+              onSubagentPrompt: options.onSubagentPrompt,
             })
           },
         }),
@@ -708,7 +711,7 @@ export class RunFooter implements FooterApi {
             : route === "queued-menu" || route === "subagent-menu"
               ? 1 + this.subagentMenuRows
               : route === "subagent"
-                ? this.base + SUBAGENT_INSPECTOR_ROWS
+                ? this.base + SUBAGENT_INSPECTOR_ROWS + SUBAGENT_COMPOSER_ROWS + this.subagentComposerRows
                 : this.base + Math.max(TEXTAREA_MIN_ROWS, Math.min(PROMPT_MAX_ROWS, this.rows))
 
     if (height !== this.renderer.footerHeight) {
@@ -732,9 +735,14 @@ export class RunFooter implements FooterApi {
     }
   }
 
-  private syncLayout = (next: { route: FooterPromptRoute; subagentRows: number }): void => {
+  private syncLayout = (next: {
+    route: FooterPromptRoute
+    subagentRows: number
+    subagentComposerRows: number
+  }): void => {
     this.promptRoute = next.route
     this.subagentMenuRows = next.subagentRows
+    this.subagentComposerRows = next.subagentComposerRows
     if (this.view().type === "prompt") {
       this.applyHeight()
     }

--- a/packages/tui/src/mini/footer.view.tsx
+++ b/packages/tui/src/mini/footer.view.tsx
@@ -8,6 +8,7 @@
 // All state comes from the parent RunFooter through SolidJS signals.
 // The view itself is stateless except for derived memos.
 /** @jsxImportSource @opentui/solid */
+import type { TextareaRenderable } from "@opentui/core"
 import { useTerminalDimensions } from "@opentui/solid"
 import { For, Match, Show, Switch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 import { registerOpencodeSpinner } from "../component/register-spinner"
@@ -25,7 +26,7 @@ import {
 } from "./footer.command"
 import { FOOTER_MENU_ROWS, RunFooterMenu } from "./footer.menu"
 import { RunFooterSubagentBody } from "./footer.subagent"
-import { RunPromptBody, createPromptState } from "./footer.prompt"
+import { TEXTAREA_MAX_ROWS, TEXTAREA_MIN_ROWS, RunPromptBody, createPromptState } from "./footer.prompt"
 import { RunPermissionBody } from "./footer.permission"
 import { RunFormBody } from "./footer.form"
 import { createFormBodyState, type FormBodyState } from "./form.shared"
@@ -60,6 +61,10 @@ import type {
 import type { RunTheme } from "./theme"
 
 registerOpencodeSpinner()
+
+// Rows the subagent composer reserves besides its textarea: the failure line
+// plus the textarea's vertical padding.
+export const SUBAGENT_COMPOSER_ROWS = 3
 
 const EMPTY_BORDER = {
   topLeft: "",
@@ -114,11 +119,12 @@ type RunFooterViewProps = {
   onModelSelect: (model: NonNullable<RunInput["model"]>) => void
   onVariantSelect: (variant: string | undefined) => void
   onRows: (rows: number) => void
-  onLayout: (input: { route: FooterPromptRoute; subagentRows: number }) => void
+  onLayout: (input: { route: FooterPromptRoute; subagentRows: number; subagentComposerRows: number }) => void
   onStatus: (text: string) => void
   onMiniSettingChange: (change: MiniSettingChange) => void | Promise<void>
   onSubagentSelect?: (sessionID: string | undefined) => void
   onSubagentInterrupt?: (sessionID: string) => void
+  onSubagentPrompt?: (sessionID: string, prompt: RunPrompt) => boolean | void | Promise<boolean | void>
 }
 
 export function RunFooterView(props: RunFooterViewProps) {
@@ -338,9 +344,121 @@ export function RunFooterView(props: RunFooterViewProps) {
     return result ?? false
   }
 
+  const [childError, setChildError] = createSignal<string | undefined>(undefined)
+  const [childRows, setChildRows] = createSignal(TEXTAREA_MIN_ROWS)
+  const childDrafts = new Map<string, string>()
+  let childArea: TextareaRenderable | undefined
+  const childPlaceholder = createMemo(() => `Message ${selectedTab()?.label ?? "subagent"}...`)
+
+  const syncChildRows = () => {
+    if (!childArea || childArea.isDestroyed) {
+      return
+    }
+
+    const rows = Math.max(
+      TEXTAREA_MIN_ROWS,
+      Math.min(TEXTAREA_MAX_ROWS, Math.max(childArea.lineCount, childArea.virtualLineCount)),
+    )
+    setChildRows(rows)
+  }
+
+  const syncChildDraft = () => {
+    const sessionID = selected()
+    if (!sessionID) {
+      return
+    }
+
+    childDrafts.set(sessionID, childArea && !childArea.isDestroyed ? childArea.plainText : "")
+  }
+
+  const restoreChildDraft = (sessionID: string, text: string) => {
+    childDrafts.set(sessionID, text)
+    if (selected() !== sessionID || !childArea || childArea.isDestroyed) {
+      return
+    }
+
+    childArea.setText(text)
+  }
+
+  const bindChildArea = (next?: TextareaRenderable) => {
+    if (childArea && !childArea.isDestroyed) {
+      childArea.off("line-info-change", syncChildRows)
+    }
+
+    childArea = next
+    if (!next || next.isDestroyed) {
+      return
+    }
+
+    next.on("line-info-change", syncChildRows)
+    const sessionID = selected()
+    next.setText(sessionID ? (childDrafts.get(sessionID) ?? "") : "")
+    next.focus()
+  }
+
+  // Esc clears a non-empty child draft first; a second Esc then closes the
+  // inspector. Returning true marks the key as consumed for the inspector's
+  // global key handler.
+  const escapeChildComposer = () => {
+    if (!childArea || childArea.isDestroyed || childArea.plainText.length === 0) {
+      return false
+    }
+
+    childArea.setText("")
+    syncChildDraft()
+    return true
+  }
+
+  const submitChildPrompt = () => {
+    const tab = selectedTab()
+    if (!tab) {
+      return
+    }
+
+    const text = childArea && !childArea.isDestroyed ? childArea.plainText : ""
+    if (!text.trim()) {
+      return
+    }
+
+    const run = props.onSubagentPrompt
+    if (!run) {
+      return
+    }
+
+    const sessionID = tab.sessionID
+    setChildError(undefined)
+    childDrafts.delete(sessionID)
+    if (childArea && !childArea.isDestroyed) {
+      childArea.setText("")
+    }
+
+    Promise.resolve()
+      .then(() => run(sessionID, { text, parts: [] }))
+      .then(
+        (accepted) => {
+          if (accepted !== false) {
+            return
+          }
+
+          restoreChildDraft(sessionID, text)
+        },
+        (error) => {
+          setChildError(errorMessage(error))
+          restoreChildDraft(sessionID, text)
+        },
+      )
+  }
+
   const openTab = (sessionID: string) => {
     setRoute({ type: "subagent", sessionID })
     props.onSubagentSelect?.(sessionID)
+    setChildError(undefined)
+    if (!childArea || childArea.isDestroyed) {
+      return
+    }
+
+    childArea.setText(childDrafts.get(sessionID) ?? "")
+    childArea.focus()
   }
 
   const closeTab = () => {
@@ -679,6 +797,7 @@ export function RunFooterView(props: RunFooterViewProps) {
     props.onLayout({
       route: route(),
       subagentRows: subagentMenuRows(),
+      subagentComposerRows: childRows(),
     })
   })
 
@@ -1076,9 +1195,46 @@ export function RunFooterView(props: RunFooterViewProps) {
             detail={detail}
             onCycle={cycleTab}
             onClose={closeTab}
+            onEscape={escapeChildComposer}
+            composerOccupied={() =>
+              Boolean(childArea && !childArea.isDestroyed && childArea.plainText.length > 0)
+            }
             interrupt={() => subagentInterruptShortcut() || undefined}
             shellOutput={() => props.miniSettings().shell_output === "show"}
             mono={props.mono}
+          />
+        </box>
+        <box
+          width="100%"
+          flexShrink={0}
+          flexDirection="column"
+          border={["left"]}
+          borderColor={theme().highlight}
+          customBorderChars={{
+            ...EMPTY_BORDER,
+            vertical: props.mono ? "|" : "┃",
+          }}
+        >
+          <box width="100%" height={1} flexShrink={0}>
+            <Show when={childError()}>
+              {(error) => (
+                <text fg={theme().error} wrapMode="none" truncate>
+                  {error()}
+                </text>
+              )}
+            </Show>
+          </box>
+          <RunPromptBody
+            theme={theme}
+            cursorStyle={props.tuiConfig.cursor}
+            background={() => runTheme().background}
+            placeholder={childPlaceholder}
+            onSubmit={submitChildPrompt}
+            onContentChange={() => {
+              syncChildDraft()
+              syncChildRows()
+            }}
+            bind={bindChildArea}
           />
         </box>
       </Show>

--- a/packages/tui/src/mini/runtime.lifecycle.ts
+++ b/packages/tui/src/mini/runtime.lifecycle.ts
@@ -74,6 +74,7 @@ export type LifecycleInput = {
   onQueuedPromptAction?: (action: QueuedPromptAction, inboxID: string) => Promise<void>
   onSubagentSelect?: (sessionID: string | undefined) => void
   onSubagentInterrupt?: (sessionID: string) => void
+  onSubagentPrompt?: (sessionID: string, prompt: RunPrompt) => boolean | void | Promise<boolean | void>
 }
 
 export type Lifecycle = {
@@ -269,6 +270,7 @@ export async function createRuntimeLifecycle(input: LifecycleInput): Promise<Lif
     subscribeThemeSignal: input.host.signals.sigusr2.subscribe,
     onSubagentSelect: input.onSubagentSelect,
     onSubagentInterrupt: input.onSubagentInterrupt,
+    onSubagentPrompt: input.onSubagentPrompt,
   })
 
   const sigint = () => {

--- a/packages/tui/src/mini/runtime.ts
+++ b/packages/tui/src/mini/runtime.ts
@@ -161,6 +161,32 @@ function formAlreadySettled(error: unknown) {
   return !!error && typeof error === "object" && Reflect.get(error, "_tag") === "FormAlreadySettledError"
 }
 
+// Builds the session.prompt payload for steering a subagent child Session.
+// The child composer submits plain text today, but RunPrompt parts map onto
+// the prompt API's files/agents/skills fields.
+function subagentPromptInput(sessionID: string, prompt: RunPrompt) {
+  const mention = (source: { start: number; end: number; value: string } | undefined) =>
+    source ? { start: source.start, end: source.end, text: source.value } : undefined
+  const files = prompt.parts.flatMap((part) =>
+    part.type === "file" ? [{ uri: part.url, name: part.filename, mention: mention(part.source?.text) }] : [],
+  )
+  const agents = prompt.parts.flatMap((part) =>
+    part.type === "agent" ? [{ name: part.name, mention: mention(part.source) }] : [],
+  )
+  const skills = prompt.parts.flatMap((part) =>
+    part.type === "skill" ? [{ id: part.id, mention: mention(part.source) }] : [],
+  )
+  return {
+    sessionID,
+    id: SessionMessage.ID.create(),
+    text: prompt.text,
+    ...(files.length ? { files } : {}),
+    ...(agents.length ? { agents } : {}),
+    ...(skills.length ? { skills } : {}),
+    delivery: "steer" as const,
+  }
+}
+
 const RESIZE_DELAY = 250
 const LOCAL_REPLAY_ROW_LIMIT = 100
 
@@ -399,6 +425,10 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
     onSubagentInterrupt: (sessionID) => {
       log?.write("send.subagent.interrupt", { sessionID })
       void state.sdk.session.interrupt({ sessionID }).catch(() => {})
+    },
+    onSubagentPrompt: (sessionID, prompt) => {
+      log?.write("send.subagent.prompt", { sessionID, delivery: "steer" })
+      return state.sdk.session.prompt(subagentPromptInput(sessionID, prompt)).then(() => undefined)
     },
     onSubagentSelect: (sessionID) => {
       state.selectSubagent?.(sessionID)

--- a/packages/tui/test/mini/footer.view.test.tsx
+++ b/packages/tui/test/mini/footer.view.test.tsx
@@ -21,6 +21,7 @@ import { RunFooterView } from "../../src/mini/footer.view"
 import { RunEntryContent } from "../../src/mini/scrollback.writer"
 import { RUN_THEME_FALLBACK, type RunTheme } from "../../src/mini/theme"
 import type {
+  FooterPromptRoute,
   FooterQueuedPrompt,
   FooterState,
   FooterSubagentState,
@@ -130,6 +131,10 @@ async function renderFooter(
     onMiniSettingChange?: (change: MiniSettingChange) => void
     queuedPrompts?: FooterQueuedPrompt[]
     onQueuedPromptAction?: (action: "steer" | "cancel", inboxID: string) => Promise<void>
+    onSubagentSelect?: (sessionID: string | undefined) => void
+    onSubagentInterrupt?: (sessionID: string) => void
+    onSubagentPrompt?: (sessionID: string, prompt: RunPrompt) => boolean | void | Promise<boolean | void>
+    onLayout?: (input: { route: FooterPromptRoute; subagentRows: number; subagentComposerRows: number }) => void
   } = {},
 ) {
   const [view, setView] = createSignal<FooterView>(input.view ?? { type: "prompt" })
@@ -186,9 +191,12 @@ async function renderFooter(
           onModelSelect={() => {}}
           onVariantSelect={() => {}}
           onRows={() => {}}
-          onLayout={() => {}}
+          onLayout={(value) => input.onLayout?.(value)}
           onStatus={(status) => input.onStatus?.(status)}
           onMiniSettingChange={(change) => input.onMiniSettingChange?.(change)}
+          onSubagentSelect={input.onSubagentSelect}
+          onSubagentInterrupt={input.onSubagentInterrupt}
+          onSubagentPrompt={input.onSubagentPrompt}
         />
       </Keymap.Provider>
     )
@@ -916,6 +924,185 @@ test("direct subagent panel closes when moving up from the first item", async ()
     expect(closed).toBe(1)
   } finally {
     app.renderer.destroy()
+  }
+})
+
+function twoSubagents(): FooterSubagentState {
+  return {
+    tabs: [
+      subagent({ sessionID: "s-1", label: "Explore", description: "Inspect auth flow" }),
+      subagent({ sessionID: "s-2", label: "General", description: "Write migration plan" }),
+    ],
+    details: {},
+    permissions: [],
+    forms: [],
+  }
+}
+
+// Opens the subagent picker and selects the first tab, leaving the inspector
+// composer focused.
+async function openInspector(app: Awaited<ReturnType<typeof renderFooter>>) {
+  await app.renderOnce()
+  app.mockInput.pressArrow("down")
+  await app.renderOnce()
+  app.mockInput.pressEnter()
+  await app.renderOnce()
+}
+
+function childText(app: Awaited<ReturnType<typeof renderFooter>>) {
+  return app.renderer.currentFocusedEditor?.plainText
+}
+
+test("direct subagent inspector steers the selected child from its composer", async () => {
+  const prompts: Array<{ sessionID: string; prompt: RunPrompt }> = []
+  const app = await renderFooter({
+    height: 24,
+    subagents: twoSubagents(),
+    onSubagentPrompt: (sessionID, prompt) => {
+      prompts.push({ sessionID, prompt })
+    },
+  })
+
+  try {
+    await openInspector(app)
+    expect(app.captureCharFrame()).toContain("Message Explore...")
+    await app.mockInput.typeText("hello child")
+    app.mockInput.pressEnter()
+    await Bun.sleep(1)
+    expect(prompts).toEqual([{ sessionID: "s-1", prompt: { text: "hello child", parts: [] } }])
+    expect(childText(app)).toBe("")
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct subagent inspector reports composer rows through onLayout", async () => {
+  const layouts: Array<{ route: FooterPromptRoute; subagentRows: number; subagentComposerRows: number }> = []
+  const app = await renderFooter({
+    height: 24,
+    subagents: twoSubagents(),
+    onLayout: (value) => layouts.push(value),
+  })
+
+  try {
+    await openInspector(app)
+    expect(layouts.at(-1)).toMatchObject({ route: { type: "subagent", sessionID: "s-1" }, subagentComposerRows: 1 })
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct subagent inspector keeps the composer targeted after an interrupt", async () => {
+  const interrupted: string[] = []
+  const prompted: string[] = []
+  const app = await renderFooter({
+    height: 24,
+    subagents: twoSubagents(),
+    onSubagentInterrupt: (sessionID) => {
+      interrupted.push(sessionID)
+    },
+    onSubagentPrompt: (sessionID) => {
+      prompted.push(sessionID)
+    },
+  })
+
+  try {
+    await openInspector(app)
+    app.mockInput.pressKey("d", { ctrl: true })
+    expect(interrupted).toEqual(["s-1"])
+    expect(app.captureCharFrame()).toContain("Inspect auth flow")
+    expect(childText(app)).toBe("")
+
+    await app.mockInput.typeText("wake up")
+    app.mockInput.pressEnter()
+    await Bun.sleep(1)
+    expect(prompted).toEqual(["s-1"])
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct subagent inspector keeps drafts per child across cycling", async () => {
+  const prompted: Array<{ sessionID: string; text: string }> = []
+  const app = await renderFooter({
+    height: 24,
+    subagents: twoSubagents(),
+    onSubagentPrompt: (sessionID, prompt) => {
+      prompted.push({ sessionID, text: prompt.text })
+    },
+  })
+
+  try {
+    await openInspector(app)
+    await app.mockInput.typeText("draft a")
+    app.mockInput.pressTab()
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("Message General...")
+    expect(childText(app)).toBe("")
+
+    await app.mockInput.typeText("draft b")
+    app.mockInput.pressEnter()
+    await Bun.sleep(1)
+    expect(prompted).toEqual([{ sessionID: "s-2", text: "draft b" }])
+    expect(childText(app)).toBe("")
+
+    app.mockInput.pressTab()
+    await app.renderOnce()
+    expect(childText(app)).toBe("draft a")
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct subagent inspector surfaces child prompt failures inline", async () => {
+  const app = await renderFooter({
+    height: 24,
+    subagents: twoSubagents(),
+    onSubagentPrompt: () => Promise.reject(new Error("child refused the prompt")),
+  })
+
+  try {
+    await openInspector(app)
+    await app.mockInput.typeText("boom")
+    app.mockInput.pressEnter()
+    await Bun.sleep(1)
+    const frame = app.captureCharFrame()
+    expect(frame).toContain("child refused the prompt")
+    expect(childText(app)).toBe("boom")
+
+    app.mockInput.pressTab()
+    await app.renderOnce()
+    expect(app.captureCharFrame()).not.toContain("child refused the prompt")
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct subagent inspector clears the child draft with escape before closing", async () => {
+  const app = await renderFooter({
+    height: 24,
+    subagents: twoSubagents(),
+  })
+
+  try {
+    await app.renderOnce()
+    await app.mockInput.typeText("parent draft")
+    await openInspector(app)
+    await app.mockInput.typeText("child draft")
+    expect(childText(app)).toBe("child draft")
+
+    app.mockInput.pressEscape()
+    await app.renderOnce()
+    expect(childText(app)).toBe("")
+    expect(app.captureCharFrame()).toContain("Inspect auth flow")
+
+    app.mockInput.pressEscape()
+    await app.renderOnce()
+    expect(app.captureCharFrame()).not.toContain("Inspect auth flow")
+    await Bun.sleep(0)
+    expect(childText(app)).toBe("parent draft")
+  } finally {
+    app.cleanup()
   }
 })
 
@@ -1974,5 +2161,26 @@ test("direct variant panel renders current variant selector", async () => {
     expectPaletteList(list, 1)
   } finally {
     app.renderer.destroy()
+  }
+})
+
+test("direct subagent inspector types letters with the scroll keys present", async () => {
+  const prompts: Array<{ sessionID: string; prompt: RunPrompt }> = []
+  const app = await renderFooter({
+    height: 24,
+    subagents: twoSubagents(),
+    onSubagentPrompt: (sessionID, prompt) => {
+      prompts.push({ sessionID, prompt })
+    },
+  })
+
+  try {
+    await openInspector(app)
+    "just keep it".split("").forEach((key) => app.mockInput.pressKey(key))
+    app.mockInput.pressEnter()
+    await Bun.sleep(1)
+    expect(prompts).toEqual([{ sessionID: "s-1", prompt: { text: "just keep it", parts: [] } }])
+  } finally {
+    app.cleanup()
   }
 })

--- a/packages/tui/test/mini/runtime.test.ts
+++ b/packages/tui/test/mini/runtime.test.ts
@@ -593,4 +593,159 @@ describe("run interactive runtime", () => {
     expect(catalogs.skill).toHaveBeenCalledWith(query, { signal: expect.any(AbortSignal) })
     expect(fileFind).toHaveBeenCalledWith({ query: "index", type: "file", ...query })
   })
+
+  test("steers the selected subagent session through session.prompt with a fresh id", async () => {
+    const sdk = OpenCode.make({ baseUrl: "https://opencode.test" })
+    const painted = defer<void>()
+    const api = footer()
+    api.idle = () => painted.promise
+    let lifecycle!: LifecycleInput
+    stubCatalogLists(sdk)
+    // The generated method has conditional return types for throwOnError; this
+    // mock represents the successful branch.
+    // @ts-expect-error successful SDK response is valid for both modes at runtime
+    const prompted = spyOn(sdk.session, "prompt").mockImplementation(() => ok({ data: undefined }))
+    const interrupted = spyOn(sdk.session, "interrupt").mockImplementation(() => ok({ interrupted: true }))
+
+    const task = runInteractiveDeferredMode(
+      {
+        host: host(),
+        sdk,
+        directory: "/tmp",
+        target: async () => ({
+          sessionID: "ses_root",
+          location: { directory: "/tmp", project: { id: "pro-1", directory: "/tmp", canonical: "/tmp" } },
+          agent: "build",
+          model: undefined,
+          variant: undefined,
+          resume: false,
+        }),
+        agent: "build",
+        model: undefined,
+        variant: undefined,
+        files: [],
+      },
+      {
+        createRuntimeLifecycle: async (input) => {
+          lifecycle = input
+          return {
+            footer: api,
+            onResize: () => () => {},
+            refreshTheme: () => {},
+            setTitle: () => {},
+            resetForReplay: () => Promise.resolve(),
+            close: () => Promise.resolve(),
+          }
+        },
+        streamTransport: Promise.resolve({
+          createSessionTransport: async (input) => {
+            setTimeout(() => input.footer.close(), 0)
+            return {
+              runPromptTurn: async () => {},
+              admitPromptTurn: async () => {},
+              waitForIdle: async () => {},
+              interruptActiveTurn: async () => {},
+              selectSubagent: () => {},
+              replayOnResize: async () => false,
+              close: async () => {},
+            }
+          },
+          formatUnknownError: (error: unknown) => String(error),
+        }),
+      },
+    )
+
+    painted.resolve()
+    await task
+
+    await lifecycle.onSubagentPrompt?.("ses_child_a", { text: "focus on the parser", parts: [] })
+    expect(prompted).toHaveBeenCalledTimes(1)
+    const [request] = prompted.mock.calls[0]
+    expect(request).toMatchObject({
+      sessionID: "ses_child_a",
+      text: "focus on the parser",
+      delivery: "steer",
+    })
+    expect(request.id).toMatch(/^msg_/)
+    expect(interrupted).not.toHaveBeenCalled()
+
+    await lifecycle.onSubagentPrompt?.("ses_child_a", { text: "and the tests", parts: [] })
+    const [retry] = prompted.mock.calls[1]
+    expect(retry.id).not.toBe(request.id)
+  })
+
+  test("keeps sibling subagent sessions out of prompt and interrupt traffic", async () => {
+    const sdk = OpenCode.make({ baseUrl: "https://opencode.test" })
+    const painted = defer<void>()
+    const api = footer()
+    api.idle = () => painted.promise
+    let lifecycle!: LifecycleInput
+    stubCatalogLists(sdk)
+    // The generated method has conditional return types for throwOnError; this
+    // mock represents the successful branch.
+    // @ts-expect-error successful SDK response is valid for both modes at runtime
+    const prompted = spyOn(sdk.session, "prompt").mockImplementation(() => ok({ data: undefined }))
+    const interrupted = spyOn(sdk.session, "interrupt").mockImplementation(() => ok({ interrupted: true }))
+
+    const task = runInteractiveDeferredMode(
+      {
+        host: host(),
+        sdk,
+        directory: "/tmp",
+        target: async () => ({
+          sessionID: "ses_root",
+          location: { directory: "/tmp", project: { id: "pro-1", directory: "/tmp", canonical: "/tmp" } },
+          agent: "build",
+          model: undefined,
+          variant: undefined,
+          resume: false,
+        }),
+        agent: "build",
+        model: undefined,
+        variant: undefined,
+        files: [],
+      },
+      {
+        createRuntimeLifecycle: async (input) => {
+          lifecycle = input
+          return {
+            footer: api,
+            onResize: () => () => {},
+            refreshTheme: () => {},
+            setTitle: () => {},
+            resetForReplay: () => Promise.resolve(),
+            close: () => Promise.resolve(),
+          }
+        },
+        streamTransport: Promise.resolve({
+          createSessionTransport: async (input) => {
+            setTimeout(() => input.footer.close(), 0)
+            return {
+              runPromptTurn: async () => {},
+              admitPromptTurn: async () => {},
+              waitForIdle: async () => {},
+              interruptActiveTurn: async () => {},
+              selectSubagent: () => {},
+              replayOnResize: async () => false,
+              close: async () => {},
+            }
+          },
+          formatUnknownError: (error: unknown) => String(error),
+        }),
+      },
+    )
+
+    painted.resolve()
+    await task
+
+    await lifecycle.onSubagentPrompt?.("ses_child_a", { text: "hello", parts: [] })
+    lifecycle.onSubagentInterrupt?.("ses_child_a")
+
+    const promptedSessions = prompted.mock.calls.map((call) => call[0].sessionID)
+    const interruptedSessions = interrupted.mock.calls.map((call) => call[0].sessionID)
+    expect(promptedSessions).toEqual(["ses_child_a"])
+    expect(interruptedSessions).toEqual(["ses_child_a"])
+    // Child interrupts stay parked: no parent-style continue flag.
+    expect(interrupted.mock.calls[0][0]).toEqual({ sessionID: "ses_child_a" })
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #42670

### Type of change

- [x] New feature

### What does this PR do?

The subagent inspector in the compact TUI was read-only: you could watch, cycle, and interrupt a child session, but the composer stayed owned by the parent, so a drifting subagent could only be abandoned or interrupted, never corrected in place.

While a child is selected, the inspector now mounts a composer bound to that child. Submitting calls `session.prompt` on the child's session id with `delivery: "steer"`, so a running child applies the correction at its next safe step boundary without cancelling its active request, and an idle or completed child resumes with retained history. Drafts are kept per child while cycling with Tab, submit targets the selected child at submit time so a draft can't land on a sibling, prompt failures render inline in the inspector with the draft restored, and the existing ctrl+d interrupt still targets only the selected child. No protocol or server changes.

Two interaction decisions worth calling out: the inspector's k/j scroll keys are gone because those letters must type into the composer now (arrow keys scroll only while the draft is empty), and the child composer is plain text — @/slash completions are parent-session semantics.

### How did you verify your code works?

New tests in packages/tui/test/mini cover target routing, steer delivery, interrupt-then-prompt, per-child drafts across cycling, sibling isolation, inline failure surfacing, and a keystroke-level test typing "just keep it" through the old scroll-key path. bun typecheck passes and the full tui suite is green (912 tests), oxlint clean.

### Screenshots / recordings

TUI change; the tests above assert the rendered footer frames (composer label, error line) via captureCharFrame.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
