### PR TITLE
docs(ecosystem): add opencode-mouth and opencode-global-sessions

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,8 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-mouth](https://github.com/pixincreate/opencode-mouth)                                    | Behavior dashboard measuring profanity and friction in your prompts and the model's replies        |
+| [opencode-global-sessions](https://github.com/pixincreate/opencode-global-sessions)                | Search and open sessions from every project on your machine with a global picker and CLI           |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds two rows to the Plugins table on the Ecosystem page, which invites additions via PR:

- [opencode-mouth](https://github.com/pixincreate/opencode-mouth): a `/behavior` TUI dashboard that measures profanity and friction signals in prompts and model replies, ported from oh-my-pi's Behavior feature.
- [opencode-global-sessions](https://github.com/pixincreate/opencode-global-sessions): global session search across projects with a `/sessions-global` picker and a small CLI.

Both are MIT licensed with tagged releases, install scripts, docs, and CI.

### How did you verify your code works?

Checked the table renders correctly and the column padding matches the existing rows. Both plugins are installed and used daily in my own OpenCode setup.

### Screenshots / recordings

Not a UI change; the diff is two markdown table rows.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR