### PR TITLE
fix(core): reject non-UTF-8 files instead of silently corrupting them

### DIFF
--- a/packages/core/src/tool/apply-patch.ts
+++ b/packages/core/src/tool/apply-patch.ts
@@ -137,7 +137,14 @@ const layer = Layer.effectDiscard(
                     }
                     if ((yield* fs.stat(target.canonical)).type !== "File") yield* fail(hunk.path)
                     const source = yield* fs.readFile(target.canonical)
-                    const original = new TextDecoder("utf-8", { ignoreBOM: true }).decode(source)
+                    let original: string
+                    try {
+                      original = new TextDecoder("utf-8", { ignoreBOM: true, fatal: true }).decode(source)
+                    } catch {
+                      return yield* new ToolFailure({
+                        message: `Unable to apply patch at ${hunk.path}: file is not valid UTF-8`,
+                      })
+                    }
                     const before = original.replace(/^\uFEFF/, "")
                     if (hunk.type === "delete") {
                       prepared.push({ ...hunk, target, before, after: "" })
@@ -152,7 +159,7 @@ const layer = Layer.effectDiscard(
                       before,
                       after: update.content,
                     })
-                  }).pipe(Effect.mapError(() => fail(hunk.path)))
+                  }).pipe(Effect.mapError((error) => (error instanceof ToolFailure ? error : fail(hunk.path))))
                 }
 
                 const patchFiles = prepared.map(patchFile)

--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -49,7 +49,7 @@ const splitBom = (text: string) =>
 const joinBom = (text: string, bom: boolean) => (bom ? `\uFEFF${text}` : text)
 const decodeUtf8 = (content: Uint8Array) => {
   const bom = content[0] === 0xef && content[1] === 0xbb && content[2] === 0xbf
-  return { bom, content, text: new TextDecoder().decode(bom ? content.slice(3) : content) }
+  return { bom, content, text: new TextDecoder("utf-8", { fatal: true }).decode(bom ? content.slice(3) : content) }
 }
 
 const countOccurrences = (content: string, search: string) => {
@@ -158,7 +158,13 @@ const layer = Layer.effectDiscard(
                     source: permissionSource,
                   }),
                 )
-                const source = decodeUtf8(yield* unableToEdit(fs.readFile(target.canonical)))
+                const fileContent = yield* unableToEdit(fs.readFile(target.canonical))
+                let source: ReturnType<typeof decodeUtf8>
+                try {
+                  source = decodeUtf8(fileContent)
+                } catch {
+                  return yield* new ToolFailure({ message: `Unable to edit ${input.path}: file is not valid UTF-8` })
+                }
                 const ending = detectLineEnding(source.text)
                 const oldString = convertToLineEnding(input.oldString, ending)
                 const newString = convertToLineEnding(input.newString, ending)

--- a/packages/core/test/tool-apply-patch.test.ts
+++ b/packages/core/test/tool-apply-patch.test.ts
@@ -202,6 +202,38 @@ describe("ApplyPatchTool", () => {
     ),
   )
 
+  it.live("rejects a non-UTF-8 update target instead of corrupting it", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        const update = path.join(tmp.path, "legacy.txt")
+        const bytes = new Uint8Array([...new TextEncoder().encode("before\n"), 0xd6, 0xd0, 0xce, 0xc4, 0x0a])
+        return Effect.promise(() => fs.writeFile(update, bytes)).pipe(
+          Effect.andThen(
+            withTool(tmp.path, (registry) =>
+              executeTool(
+                registry,
+                call("*** Begin Patch\n*** Update File: legacy.txt\n@@\n-before\n+after\n*** End Patch"),
+              ),
+            ),
+          ),
+          Effect.andThen((result) =>
+            Effect.sync(() =>
+              expect(result).toEqual({
+                type: "error",
+                value: "Unable to apply patch at legacy.txt: file is not valid UTF-8",
+              }),
+            ),
+          ),
+          Effect.andThen(() => Effect.promise(() => fs.readFile(update))),
+          Effect.tap((after) => Effect.sync(() => expect(new Uint8Array(after)).toEqual(bytes))),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("rejects moves before applying any hunk", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -381,6 +381,32 @@ describe("EditTool", () => {
     ),
   )
 
+  it.live("rejects a non-UTF-8 file instead of corrupting it", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        const target = path.join(tmp.path, "legacy.txt")
+        const bytes = new Uint8Array([...new TextEncoder().encode("const x = 1\n"), 0xd6, 0xd0, 0xce, 0xc4, 0x0a])
+        return Effect.promise(() => fs.writeFile(target, bytes)).pipe(
+          Effect.andThen(
+            withTool(tmp.path, (registry) =>
+              executeTool(registry, call({ path: "legacy.txt", oldString: "const x = 1", newString: "const y = 1" })),
+            ),
+          ),
+          Effect.andThen((result) =>
+            Effect.sync(() =>
+              expect(result).toEqual({ type: "error", value: "Unable to edit legacy.txt: file is not valid UTF-8" }),
+            ),
+          ),
+          Effect.andThen(() => Effect.promise(() => fs.readFile(target))),
+          Effect.tap((after) => Effect.sync(() => expect(new Uint8Array(after)).toEqual(bytes))),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("rejects an in-place content change after matching but before conditional commit", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
### Issue for this PR

Closes #45924

### Type of change

- [x] Bug fix

### What does this PR do?

`edit` and `apply_patch` decoded file bytes with a non-fatal UTF-8 decoder, so invalid sequences (GBK/Latin-1 comments, stray bytes) were replaced with U+FFFD and the corrupted text was written back to disk. When `oldString` matched an ASCII region, the tool reported success while destroying every non-UTF-8 byte in the file.

The fix decodes with `{ fatal: true }` and fails with an explicit `file is not valid UTF-8` error, leaving the file untouched — matching the `read` tool's existing `MalformedUtf8Error` behavior.

### How did you verify your code works?

Added regression tests in both suites writing a file with GBK bytes and asserting the tool returns an error and the file bytes are unchanged:

- `packages/core`: `bun test ./test/tool-edit.test.ts ./test/tool-apply-patch.test.ts` (21 pass)
- `bun run typecheck` clean, prettier clean

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR