### PR TITLE
fix(session): trigger auto-compaction at the effective input ceiling (#45168)

### DIFF
--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -11,12 +11,22 @@ export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outpu
   const context = input.model.limit.context
   if (context === 0) return 0
 
-  const reserved =
-    input.cfg.compaction?.reserved ??
-    Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
-  return input.model.limit.input
-    ? Math.max(0, input.model.limit.input - reserved)
-    : Math.max(0, context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
+  const outputBudget = input.model.limit.output
+  // The model's usable input budget is bounded by its explicit input cap
+  // (`limit.input`) when present, otherwise by the context window minus the
+  // output budget. We never let the ceiling exceed what still leaves room for a
+  // full response inside the context window. This is what makes auto-compaction
+  // reachable for models whose real input cap sits well below
+  // `context - reserved` — e.g. opencode-go/hy3, where the provider pins input
+  // at 262144 - 65536 = 196608 while models.dev advertises context 256000 and
+  // output 64000 (issue #45168).
+  const inputCeiling = input.model.limit.input ?? Math.max(0, context - outputBudget)
+  const effectiveCeiling = Math.max(0, Math.min(inputCeiling, context - outputBudget))
+
+  // Reserve headroom for the next response plus the configured compaction buffer.
+  const output = ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax)
+  const reserved = input.cfg.compaction?.reserved ?? Math.min(COMPACTION_BUFFER, output)
+  return Math.max(0, effectiveCeiling - Math.min(reserved, outputBudget))
 }
 
 export function isOverflow(input: {

--- a/packages/opencode/test/session/overflow.test.ts
+++ b/packages/opencode/test/session/overflow.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "bun:test"
+import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Provider } from "@/provider/provider"
+import { isOverflow, usable } from "../../src/session/overflow"
+
+// Minimal model builder focused on the token limits that drive overflow math.
+function model(opts: { context: number; output: number; input?: number }): Provider.Model {
+  return {
+    id: "m",
+    providerID: "p",
+    name: "M",
+    limit: { context: opts.context, input: opts.input, output: opts.output },
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    capabilities: {
+      toolcall: true,
+      attachment: false,
+      reasoning: false,
+      temperature: true,
+      input: { text: true, image: false, audio: false, video: false },
+      output: { text: true, image: false, audio: false, video: false },
+    },
+    api: { npm: "@ai-sdk/anthropic" },
+    options: {},
+    status: "active",
+    headers: {},
+    release_date: "2025-01-01",
+  } as unknown as Provider.Model
+}
+
+const cfg = { compaction: { auto: true } } as unknown as ConfigV1.Info
+
+function tokens(t: {
+  input: number
+  output: number
+  cacheRead?: number
+  cacheWrite?: number
+  total?: number
+}): SessionV1.Assistant["tokens"] {
+  return {
+    input: t.input,
+    output: t.output,
+    reasoning: 0,
+    cache: { read: t.cacheRead ?? 0, write: t.cacheWrite ?? 0 },
+    total: t.total,
+  } as unknown as SessionV1.Assistant["tokens"]
+}
+
+describe("overflow.usable", () => {
+  it("bases the input ceiling on context - output, not context - maxOutputTokens (issue #45168)", () => {
+    // tencent/hy3 (opencode-go): models.dev reports context 256000, output 64000.
+    // maxOutputTokens is capped at OUTPUT_TOKEN_MAX (32000), so the old ceiling
+    // `context - maxOutputTokens` = 224000 is unreachable: the provider pins the
+    // real input at 262144 - 65536 = 196608, so the measured count plateaus there.
+    const hy3 = model({ context: 256_000, output: 64_000 })
+    expect(usable({ cfg, model: hy3 })).toBe(172_000)
+  })
+
+  it("uses the explicit input cap but never above context - output", () => {
+    // A model that advertises an explicit input cap equal to its context. The
+    // usable budget must still reserve room for the output response, so it
+    // collapses to context - output (matching the equivalent no-input model).
+    const withInput = model({ context: 256_000, input: 256_000, output: 64_000 })
+    const withoutInput = model({ context: 256_000, output: 64_000 })
+    expect(usable({ cfg, model: withInput })).toBe(172_000)
+    expect(usable({ cfg, model: withoutInput })).toBe(172_000)
+  })
+
+  it("returns 0 when the model has no context limit", () => {
+    const unlimited = model({ context: 0, output: 32_000 })
+    expect(usable({ cfg, model: unlimited })).toBe(0)
+  })
+})
+
+describe("overflow.isOverflow — issue #45168 (hy3 never compacts)", () => {
+  const hy3 = model({ context: 256_000, output: 64_000 })
+
+  it("triggers compaction once input is pinned at the provider's real ceiling", () => {
+    // Observed in the wild: the provider caps input at 196608 and stops serving
+    // cache hits, so every request re-sends the full ~196k context raw.
+    const pinned = tokens({ input: 196_608, output: 1_500 })
+    expect(isOverflow({ cfg, tokens: pinned, model: hy3 })).toBe(true)
+  })
+
+  it("triggers when the input is fully cached but the cache write reaches the ceiling", () => {
+    const pinned = tokens({ input: 0, output: 1_500, cacheWrite: 196_608 })
+    expect(isOverflow({ cfg, tokens: pinned, model: hy3 })).toBe(true)
+  })
+
+  it("does not trigger early in the session", () => {
+    const early = tokens({ input: 120_000, output: 2_000 })
+    expect(isOverflow({ cfg, tokens: early, model: hy3 })).toBe(false)
+  })
+
+  it("does not trigger when compaction.auto is disabled", () => {
+    const disabled = { compaction: { auto: false } } as unknown as ConfigV1.Info
+    const pinned = tokens({ input: 196_608, output: 1_500 })
+    expect(isOverflow({ cfg: disabled, tokens: pinned, model: hy3 })).toBe(false)
+  })
+})
+
+// Realistic models.dev limits. `ceiling` is the provider's real input cap; the
+// test asserts the algorithm compacts before that cap is hit.
+const models = [
+  {
+    name: "tencent/hy3",
+    model: model({ context: 256_000, output: 64_000 }),
+    ceiling: 196_608,
+    usableExpect: 172_000,
+  },
+  {
+    name: "anthropic/claude-opus (200k input cap)",
+    model: model({ context: 200_000, output: 32_000, input: 200_000 }),
+    ceiling: 200_000,
+    usableExpect: 148_000,
+  },
+  {
+    name: "openai/gpt (400k context, 128k output)",
+    model: model({ context: 400_000, output: 128_000 }),
+    ceiling: 272_000,
+    usableExpect: 252_000,
+  },
+  {
+    name: "google/gemini (1M context, 64k output)",
+    model: model({ context: 1_048_576, output: 65_536 }),
+    ceiling: 983_040,
+    usableExpect: 963_040,
+  },
+  {
+    name: "deepseek (1M context, 384k output)",
+    model: model({ context: 1_048_576, output: 384_000 }),
+    ceiling: 664_576,
+    usableExpect: 644_576,
+  },
+] as const
+
+describe("overflow.isOverflow — multiple models.dev models", () => {
+  for (const c of models) {
+    describe(c.name, () => {
+      it("computes the usable budget from the effective input ceiling", () => {
+        expect(usable({ cfg, model: c.model })).toBe(c.usableExpect)
+      })
+
+      it("does not overflow early in the session", () => {
+        const early = tokens({ input: Math.floor(c.ceiling * 0.4), output: 1_000 })
+        expect(isOverflow({ cfg, tokens: early, model: c.model })).toBe(false)
+      })
+
+      it("overflows once input is pinned near the real ceiling", () => {
+        const pinned = tokens({ input: c.ceiling, output: 1_000 })
+        expect(isOverflow({ cfg, tokens: pinned, model: c.model })).toBe(true)
+      })
+    })
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45168

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Auto-compaction was gated by `usable() = context - maxOutputTokens`. `maxOutputTokens` is capped at `OUTPUT_TOKEN_MAX` (32000), so for `opencode-go/hy3` (models.dev: context 256000, output 64000, no `limit.input`) the threshold came out to 224000. The provider actually pins input at 262144 - 65536 = 196608, so the measured token count plateaus around 198k and `isOverflow()` never returned true — the session kept re-sending the full ~196k context as raw, uncached input.

`usable()` now derives the input ceiling from the model's effective input ceiling and reserves a 20k buffer for the next response:

```
inputCeiling    = limit.input ?? (context - output)
effectiveCeiling = min(inputCeiling, context - output)   // always leaves room for a full response
usable          = effectiveCeiling - min(reserved, output)
```

For `hy3` that is 192000 - 20000 = 172000, which the pinned count (198108) exceeds, so compaction fires *before* the provider caps input. Because this is based on the real input ceiling rather than `context - maxOutputTokens`, it works for any model whose real input cap sits below `context - reserved`. Both the V1 (`processor`/`prompt`) and V2 (`SessionCompaction`) call paths use this same function, so both are covered.

### How did you verify your code works?

- Added `packages/opencode/test/session/overflow.test.ts` (pure unit tests on `usable`/`isOverflow`) reproducing #45168 with `tencent/hy3` pinned at input 196608, plus `anthropic/claude-opus` (200k input cap), `openai/gpt` (400k/128k), `google/gemini` (1M/64k) and `deepseek` (1M/384k).
- Confirmed the new tests **fail** on the original `overflow.ts` (13 failures) and **pass** after the fix (22/22).
- Existing `packages/opencode/test/session/compaction.test.ts` still passes (55/55, no regressions).
- `bun typecheck` is clean.

### Screenshots / recordings

N/A — this is a session/compaction logic change, not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR