### PR TITLE
fix(session): bound shell output to 50 KiB preview for LLM (fixes #45099)

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -133,15 +133,43 @@ function toLLMMessage(message: SessionMessage.Message, model: Model): Message[] 
       return [Message.make({ id: message.id, role: "user", content: message.text, metadata: message.metadata })]
     case "system":
       return [Message.system(message.text)]
-    case "shell":
+    case "shell": {
+      const MAX_SHELL_BYTES = 50 * 1024
+      const output = message.output ?? ""
+      const bytes = Buffer.byteLength(output, "utf-8")
+      let preview = output
+      if (bytes > MAX_SHELL_BYTES) {
+        // Keep head and tail preview, similar to ToolOutputStore boundedPreview
+        const headBytes = Math.ceil(MAX_SHELL_BYTES / 2)
+        const tailBytes = Math.floor(MAX_SHELL_BYTES / 2)
+        let head = ""
+        let headLen = 0
+        for (const ch of output) {
+          const sz = Buffer.byteLength(ch, "utf-8")
+          if (headLen + sz > headBytes) break
+          head += ch
+          headLen += sz
+        }
+        let tail = ""
+        let tailLen = 0
+        for (const ch of Array.from(output).toReversed()) {
+          const sz = Buffer.byteLength(ch, "utf-8")
+          if (tailLen + sz > tailBytes) break
+          tail = ch + tail
+          tailLen += sz
+        }
+        const marker = `\n\n[Preview: shell output truncated from ${bytes} bytes to ${MAX_SHELL_BYTES} bytes — full output retained separately]`
+        preview = tail ? `${head}\n\n${marker}\n\n${tail}` : `${head}\n\n${marker}`
+      }
       return [
         Message.make({
           id: message.id,
           role: "user",
-          content: `Shell command: ${message.command}\n\n${message.output}`,
+          content: `Shell command: ${message.command}\n\n${preview}`,
           metadata: message.metadata,
         }),
       ]
+    }
     case "assistant":
       return assistant(message, model)
     case "compaction":


### PR DESCRIPTION
### Issue for this PR

Closes #45099

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes session shell output bypassing the 50 KiB tool-output limit and stranding sessions.

**Root cause:** `packages/core/src/session/runner/to-llm-message.ts:141` inserted the entire persisted `message.output` (up to ~1 MiB via shell capture) directly into the next model request as `Shell command: ${command}\n\n${output}`. Normal tool output is bounded to `50*1024` via `ToolOutputStore` (`MAX_BYTES`) with preview, but session shell bypassed that. `ToolOutputStore` limits, compaction token estimation (`compaction.ts:86` `TOOL_OUTPUT_MAX_CHARS`), and model context `context - buffer` then used stale token counts from prior model response, not the added 1 MiB shell, so provider could reject as `provider.unknown` and session could not auto-recover.

**Changes (minimal, uses existing contracts):**
- `to-llm-message.ts`: bound shell output to `50*1024` bytes for LLM insertion with head/tail preview and marker `[Preview: shell output truncated from ${bytes} bytes to 51200 bytes — full output retained separately]`, mirroring `ToolOutputStore` `boundedPreview` logic. Full `message.output` remains persisted separately; compaction `truncate` still applies.

**Preserved:** `assertHttpUrl`/`PermissionV2`/security, timeout, content-type, `isImageAttachment`/`isTextualMime`, `ToolOutputStore` limits, `SessionCompaction` token estimation.

### How did you verify your code works?

- Reproduced: `1 MiB` shell output (`"x".repeat(1048576)`) truncated to `~51 KiB` (`51309` bytes) with head/tail preserved and marker, `50 KiB` small stays unchanged (node test).
- Verified `to-llm-message.ts` now produces bounded `Shell command` LLM message, cannot create oversized model-facing shell message.
- `git diff` — 1 file, 30 insertions, 2 deletions, `Buffer.byteLength` UTF-8 aware.
- Real `git clone --depth 1`, `checkout -b optamus/fix-session-shell-45099`, `commit 3507256`, `push` to `optamus-ai/opencode`, `gh pr create` — history `df35e84` preserved.

### Screenshots / recordings

N/A — non-UI shell output truncation.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
