### PR TITLE
fix(app): share model visibility between TUI and web UI

### DIFF
--- a/packages/app/src/context/model-visibility.test.ts
+++ b/packages/app/src/context/model-visibility.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test"
+import { DateTime } from "luxon"
+import { computeFamilyHeads, isModelVisible } from "./model-visibility"
+
+describe("computeFamilyHeads", () => {
+  test("returns model as head of unique family", () => {
+    const models = [
+      {
+        providerID: "opencode",
+        modelID: "big-pickle",
+        id: "big-pickle",
+        provider: { id: "opencode" },
+        family: "big-pickle",
+        release_date: "2025-10-17",
+      },
+    ]
+
+    const heads = computeFamilyHeads(models)
+    expect(heads.has("opencode:big-pickle")).toBe(true)
+  })
+
+  test("returns only the most recent model per family", () => {
+    const models = [
+      {
+        providerID: "opencode",
+        modelID: "nemotron-3-ultra-free",
+        id: "nemotron-3-ultra-free",
+        provider: { id: "opencode" },
+        family: "nemotron-free",
+        release_date: "2026-06-04",
+      },
+      {
+        providerID: "opencode",
+        modelID: "nemotron-3.5-lightning-free",
+        id: "nemotron-3.5-lightning-free",
+        provider: { id: "opencode" },
+        family: "nemotron-free",
+        release_date: "2026-08-11",
+      },
+    ]
+
+    const heads = computeFamilyHeads(models)
+    expect(heads.has("opencode:nemotron-3.5-lightning-free")).toBe(true)
+    expect(heads.has("opencode:nemotron-3-ultra-free")).toBe(false)
+  })
+
+  test("handles multiple independent families", () => {
+    const models = [
+      {
+        providerID: "opencode",
+        modelID: "big-pickle",
+        id: "big-pickle",
+        provider: { id: "opencode" },
+        family: "big-pickle",
+        release_date: "2025-10-17",
+      },
+      {
+        providerID: "opencode",
+        modelID: "hy3-free",
+        id: "hy3-free",
+        provider: { id: "opencode" },
+        family: "hy3-free",
+        release_date: "2026-07-06",
+      },
+    ]
+
+    const heads = computeFamilyHeads(models)
+    expect(heads.has("opencode:big-pickle")).toBe(true)
+    expect(heads.has("opencode:hy3-free")).toBe(true)
+  })
+})
+
+describe("isModelVisible", () => {
+  const emptyMap = new Map<string, "show" | "hide">()
+  const showMap = new Map<string, "show" | "hide">([["opencode:big-pickle", "show"]])
+  const hideMap = new Map<string, "show" | "hide">([["opencode:big-pickle", "hide"]])
+
+  test("hide visibility always returns false", () => {
+    const input = {
+      key: "opencode:big-pickle",
+      visibility: hideMap,
+      release: new Map<string, DateTime>(),
+      familyHeads: new Set(["opencode:big-pickle"]),
+    }
+    expect(isModelVisible(input)).toBe(false)
+  })
+
+  test("show visibility always returns true", () => {
+    const input = {
+      key: "opencode:big-pickle",
+      visibility: showMap,
+      release: new Map<string, DateTime>(),
+      familyHeads: new Set<string>(),
+    }
+    expect(isModelVisible(input)).toBe(true)
+  })
+
+  test("model with no release date is visible", () => {
+    const input = {
+      key: "opencode:some-model",
+      visibility: emptyMap,
+      release: new Map<string, DateTime>(),
+      familyHeads: new Set<string>(),
+    }
+    expect(isModelVisible(input)).toBe(true)
+  })
+
+  test("big-pickle (only model in family, old date) is visible", () => {
+    const release = new Map([["opencode:big-pickle", DateTime.fromISO("2025-10-17")]])
+    const input = {
+      key: "opencode:big-pickle",
+      visibility: emptyMap,
+      release,
+      familyHeads: new Set(["opencode:big-pickle"]),
+    }
+    expect(isModelVisible(input)).toBe(true)
+  })
+
+  test("nemotron-3-ultra (superseded by 3.5) is hidden", () => {
+    const release = new Map([
+      ["opencode:nemotron-3-ultra-free", DateTime.fromISO("2026-06-04")],
+      ["opencode:nemotron-3.5-lightning-free", DateTime.fromISO("2026-08-11")],
+    ])
+    const heads = computeFamilyHeads([
+      {
+        providerID: "opencode",
+        modelID: "nemotron-3-ultra-free",
+        id: "nemotron-3-ultra-free",
+        provider: { id: "opencode" },
+        family: "nemotron-free",
+        release_date: "2026-06-04",
+      },
+      {
+        providerID: "opencode",
+        modelID: "nemotron-3.5-lightning-free",
+        id: "nemotron-3.5-lightning-free",
+        provider: { id: "opencode" },
+        family: "nemotron-free",
+        release_date: "2026-08-11",
+      },
+    ])
+
+    const input = {
+      key: "opencode:nemotron-3-ultra-free",
+      visibility: emptyMap,
+      release,
+      familyHeads: heads,
+    }
+    expect(isModelVisible(input)).toBe(false)
+  })
+
+  test("nemotron-3.5 (family head) is visible", () => {
+    const release = new Map([
+      ["opencode:nemotron-3-ultra-free", DateTime.fromISO("2026-06-04")],
+      ["opencode:nemotron-3.5-lightning-free", DateTime.fromISO("2026-08-11")],
+    ])
+    const heads = computeFamilyHeads([
+      {
+        providerID: "opencode",
+        modelID: "nemotron-3-ultra-free",
+        id: "nemotron-3-ultra-free",
+        provider: { id: "opencode" },
+        family: "nemotron-free",
+        release_date: "2026-06-04",
+      },
+      {
+        providerID: "opencode",
+        modelID: "nemotron-3.5-lightning-free",
+        id: "nemotron-3.5-lightning-free",
+        provider: { id: "opencode" },
+        family: "nemotron-free",
+        release_date: "2026-08-11",
+      },
+    ])
+
+    const input = {
+      key: "opencode:nemotron-3.5-lightning-free",
+      visibility: emptyMap,
+      release,
+      familyHeads: heads,
+    }
+    expect(isModelVisible(input)).toBe(true)
+  })
+
+  test("hy3-free, mimo, muse (unique families) are visible", () => {
+    const release = new Map([
+      ["opencode:hy3-free", DateTime.fromISO("2026-07-06")],
+      ["opencode:mimo-v2.5-free", DateTime.fromISO("2026-04-24")],
+      ["opencode:muse-spark-1.2-contributor-free", DateTime.fromISO("2026-08-05")],
+    ])
+    const input = {
+      key: "opencode:hy3-free",
+      visibility: emptyMap,
+      release,
+      familyHeads: new Set(["opencode:hy3-free", "opencode:mimo-v2.5-free", "opencode:muse-spark-1.2-contributor-free"]),
+    }
+    expect(isModelVisible(input)).toBe(true)
+  })
+
+  test("model with invalid date is visible even if not family head", () => {
+    const release = new Map([["opencode:bad-date", DateTime.invalid("test")]])
+    const input = {
+      key: "opencode:bad-date",
+      visibility: emptyMap,
+      release,
+      familyHeads: new Set<string>(),
+    }
+    expect(isModelVisible(input)).toBe(true)
+  })
+})

--- a/packages/app/src/context/model-visibility.ts
+++ b/packages/app/src/context/model-visibility.ts
@@ -1,0 +1,45 @@
+import { DateTime } from "luxon"
+import { firstBy, groupBy, values } from "remeda"
+
+export function toVisibilityKey(model: { providerID: string; modelID: string }): string {
+  return `${model.providerID}:${model.modelID}`
+}
+
+export type ModelVisibilityEntry = {
+  providerID: string
+  modelID: string
+  id: string
+  provider: { id: string }
+  family?: string
+  release_date?: string
+}
+
+function familyHeadKey(model: ModelVisibilityEntry): string {
+  return `${model.providerID}:${model.family ?? ""}`
+}
+
+export function computeFamilyHeads(models: ModelVisibilityEntry[]): Set<string> {
+  const groups = groupBy(models, familyHeadKey)
+  const heads = values(groups)
+    .flatMap((g) => {
+      const head = firstBy(g, [(x) => x.release_date ?? "", "desc"])
+      return head ? [toVisibilityKey(head)] : []
+    })
+  return new Set(heads)
+}
+
+export type VisibilityDecisionInput = {
+  key: string
+  visibility: ReadonlyMap<string, "show" | "hide">
+  release: ReadonlyMap<string, DateTime>
+  familyHeads: ReadonlySet<string>
+}
+
+export function isModelVisible(input: VisibilityDecisionInput): boolean {
+  const state = input.visibility.get(input.key)
+  if (state === "hide") return false
+  if (state === "show") return true
+  const date = input.release.get(input.key)
+  if (!date?.isValid) return true
+  return input.familyHeads.has(input.key)
+}

--- a/packages/app/src/context/models.tsx
+++ b/packages/app/src/context/models.tsx
@@ -1,7 +1,8 @@
 import { type Accessor, createMemo, createResource } from "solid-js"
 import { createStore } from "solid-js/store"
 import { DateTime } from "luxon"
-import { filter, firstBy, flat, groupBy, mapValues, pipe, uniqueBy, values } from "remeda"
+import { uniqueBy } from "remeda"
+import { computeFamilyHeads, isModelVisible, type ModelVisibilityEntry } from "./model-visibility"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { useProviders } from "@/hooks/use-providers"
 import { Persist, persisted } from "@/utils/persist"
@@ -56,36 +57,18 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
         ),
     )
 
-    const latest = createMemo(() =>
-      pipe(
-        available(),
-        filter(
-          (x) =>
-            Math.abs(
-              (release().get(modelKey({ providerID: x.provider.id, modelID: x.id })) ?? DateTime.invalid("invalid"))
-                .diffNow()
-                .as("months"),
-            ) < 6,
-        ),
-        groupBy((x) => x.provider.id),
-        mapValues((models) =>
-          pipe(
-            models,
-            groupBy((x) => x.family),
-            values(),
-            (groups) =>
-              groups.flatMap((g) => {
-                const first = firstBy(g, [(x) => x.release_date, "desc"])
-                return first ? [{ modelID: first.id, providerID: first.provider.id }] : []
-              }),
-          ),
-        ),
-        values(),
-        flat(),
+    const familyHeads = createMemo(() =>
+      computeFamilyHeads(
+        available().map((m) => ({
+          providerID: m.provider.id,
+          modelID: m.id,
+          id: m.id,
+          provider: m.provider,
+          family: m.family,
+          release_date: m.release_date,
+        } satisfies ModelVisibilityEntry)),
       ),
     )
-
-    const latestSet = createMemo(() => new Set(latest().map((x) => modelKey(x))))
 
     const visibility = createMemo(() => {
       const map = new Map<string, Visibility>()
@@ -114,13 +97,7 @@ export const { use: useModels, provider: ModelsProvider } = createSimpleContext(
 
     const visible = (model: ModelKey) => {
       const key = modelKey(model)
-      const state = visibility().get(key)
-      if (state === "hide") return false
-      if (state === "show") return true
-      if (latestSet().has(key)) return true
-      const date = release().get(key)
-      if (!date?.isValid) return true
-      return false
+      return isModelVisible({ key, visibility: visibility(), release: release(), familyHeads: familyHeads() })
     }
 
     const setVisibility = (model: ModelKey, state: boolean) => {


### PR DESCRIPTION
### Issue for this PR

Closes #45934

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The web UI filtered models by a 6-month recency window, hiding older models like big-pickle that are still visible in the TUI.

This extracts the visibility logic into a shared module (`model-visibility.ts`) with `computeFamilyHeads` and `isModelVisible`, then reuses it in `models.tsx` instead of the duplicated 6-month filter.

### How did you verify your code works?

- `bun test` in `packages/app` passes (11/11)
- `bun typecheck` passes
- Built `opencode-fixe` binary and confirmed big-pickle appears in the web UI model picker

### Screenshots / recordings

Before: Models older than 6 months (like big-pickle) were hidden from the web UI.

After: All family head models are visible regardless of age.

![After](https://github.com/user-attachments/assets/after)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR