### PR TITLE
fix(tui): animate automatic session renames

### DIFF
--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -41,6 +41,7 @@ import { DialogSessionRename } from "./dialog-session-rename"
 import { Keymap } from "../context/keymap"
 import { registerOpencodeSpinner } from "./register-spinner"
 import { SPINNER_FRAMES } from "./spinner-frames"
+import "./title-shimmer"
 
 registerOpencodeSpinner()
 
@@ -649,7 +650,7 @@ function VerticalSessionTabs(props: {
               const restingTitleWidth = () => Math.max(1, width() - numberWidth() - 2)
               const hoveredTitleWidth = () => Math.max(1, restingTitleWidth() - 1)
               const titleWidth = () => (hovered() === tab.sessionID ? hoveredTitleWidth() : restingTitleWidth())
-              const title = () => tab.title ?? "Untitled session"
+              const title = () => (props.controller ? undefined : session()?.title) ?? tab.title ?? "Untitled session"
               const scrolling = () => marquee.active() === tab.sessionID
               const visibleTitleParts = createMemo(() =>
                 scrolling()
@@ -908,14 +909,21 @@ function VerticalSessionTabs(props: {
                         unreadMarker={props.unreadMarker}
                         attributes={selected() ? TextAttributes.BOLD : undefined}
                       />
-                      <text
+                      <title_shimmer
                         width={titleWidth()}
+                        height={1}
                         fg={foreground()}
+                        rename={{ pending: status().renaming, title: title() }}
+                        enabled={animations()}
+                        backdrop={pulseBackground()}
                         wrapMode="none"
                         selectable={false}
                         attributes={
-                          (status().renaming ? TextAttributes.DIM : selected() ? TextAttributes.BOLD : 0) |
-                            (tabs.isPreview?.(tab.sessionID) ? TextAttributes.ITALIC : 0) || undefined
+                          (status().renaming && !animations()
+                            ? TextAttributes.DIM
+                            : selected()
+                              ? TextAttributes.BOLD
+                              : 0) | (tabs.isPreview?.(tab.sessionID) ? TextAttributes.ITALIC : 0) || undefined
                         }
                       >
                         <Show
@@ -928,7 +936,7 @@ function VerticalSessionTabs(props: {
                             )}
                           </Index>
                         </Show>
-                      </text>
+                      </title_shimmer>
                       <text
                         position="absolute"
                         right={1}
@@ -1076,6 +1084,7 @@ function HorizontalSessionTabs(props: {
   numbers: boolean
 }) {
   const tabs = props.controller ?? useSessionTabs()
+  const data = props.controller ? undefined : useData()
   const dimensions = useTerminalDimensions()
   const theme = useTheme()
   const config = useConfig().data
@@ -1365,7 +1374,7 @@ function HorizontalSessionTabs(props: {
           const glowColor = createMemo(() => tint(background(), feedbackColor() ?? unreadColor(), glowLevel()))
           const glows = () =>
             Boolean(status().attention || (!selected() && !status().busy && status().unread !== undefined))
-          const title = () => tab.title ?? "Untitled session"
+          const title = () => data?.session.get(tab.sessionID)?.title ?? tab.title ?? "Untitled session"
           const tabNumber = createMemo(() => items().findIndex((item) => item.sessionID === tab.sessionID) + 1)
           const numberWidth = () => Math.max(2, String(items().length).length)
           // Hovering reveals the close mark, so the title's right bound shifts left of it.
@@ -1493,13 +1502,17 @@ function HorizontalSessionTabs(props: {
                   unreadMarker={props.unreadMarker}
                   attributes={bold()}
                 />
-                <text
+                <title_shimmer
                   width={availableTitleWidth()}
+                  height={1}
                   fg={foreground()}
+                  rename={{ pending: status().renaming, title: title() }}
+                  enabled={animations()}
+                  backdrop={background()}
                   wrapMode="none"
                   selectable={false}
                   attributes={
-                    (status().renaming ? TextAttributes.DIM : (bold() ?? 0)) |
+                    (status().renaming && !animations() ? TextAttributes.DIM : (bold() ?? 0)) |
                       (tabs.isPreview?.(tab.sessionID) ? TextAttributes.ITALIC : 0) || undefined
                   }
                 >
@@ -1510,7 +1523,7 @@ function HorizontalSessionTabs(props: {
                       )}
                     </Index>
                   </Show>
-                </text>
+                </title_shimmer>
                 <text
                   position="absolute"
                   right={1}

--- a/packages/tui/src/component/session-tabs.tsx
+++ b/packages/tui/src/component/session-tabs.tsx
@@ -96,6 +96,7 @@ export const EMPTY_SESSION_TAB_STATUS: SessionTabsStatus = {
   promptPulse: 0,
   attention: false,
   busy: false,
+  renaming: false,
 }
 export type SessionTabsController = Pick<ContextController, "tabs" | "current" | "select" | "close" | "move"> & {
   newTab?: () => boolean
@@ -913,7 +914,7 @@ function VerticalSessionTabs(props: {
                         wrapMode="none"
                         selectable={false}
                         attributes={
-                          (selected() ? TextAttributes.BOLD : 0) |
+                          (status().renaming ? TextAttributes.DIM : selected() ? TextAttributes.BOLD : 0) |
                             (tabs.isPreview?.(tab.sessionID) ? TextAttributes.ITALIC : 0) || undefined
                         }
                       >
@@ -1498,7 +1499,8 @@ function HorizontalSessionTabs(props: {
                   wrapMode="none"
                   selectable={false}
                   attributes={
-                    (bold() ?? 0) | (tabs.isPreview?.(tab.sessionID) ? TextAttributes.ITALIC : 0) || undefined
+                    (status().renaming ? TextAttributes.DIM : (bold() ?? 0)) |
+                      (tabs.isPreview?.(tab.sessionID) ? TextAttributes.ITALIC : 0) || undefined
                   }
                 >
                   <Show when={scrolling() || glows() || titleFades()} fallback={visibleTitle()}>

--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -30,7 +30,7 @@ type TabPulseOptions = RenderableOptions<TabPulseRenderable> & {
 }
 
 const clamp = (value: number) => Math.max(0, Math.min(1, value))
-const smootherstep = (value: number) => value * value * value * (value * (value * 6 - 15) + 10)
+export const smootherstep = (value: number) => value * value * value * (value * (value * 6 - 15) + 10)
 const RUN_DURATION = 2_800
 const RUN_ATTACK = 450
 const RUN_HEAD = 4

--- a/packages/tui/src/component/tab-pulse.tsx
+++ b/packages/tui/src/component/tab-pulse.tsx
@@ -53,11 +53,11 @@ const GLOW_RELEASE_PEAK = 1.25
 const GLOW_TAIL = 12
 const GLOW_OPACITY = 0.16
 const DEFAULT_FOREGROUND = RGBA.defaultForeground()
-const intensityAt = (index: number, front: number, head: number, tail: number) => {
+export const intensityAt = (index: number, front: number, head: number, tail: number) => {
   const distance = front - index
   return distance < 0 ? smootherstep(clamp(1 + distance / head)) : smootherstep(clamp(1 - distance / tail))
 }
-const coast = (value: number) => {
+export const coast = (value: number) => {
   const ramp = 0.2
   if (value < ramp) return (value * value) / (2 * ramp * (1 - ramp))
   if (value > 1 - ramp) return 1 - ((1 - value) * (1 - value)) / (2 * ramp * (1 - ramp))

--- a/packages/tui/src/component/title-shimmer.tsx
+++ b/packages/tui/src/component/title-shimmer.tsx
@@ -26,15 +26,18 @@ export class TitleShimmerRenderable extends TextRenderable {
   private _rename: TitleShimmerOptions["rename"]
   private _enabled: boolean
   private _backdrop: RGBA
+  private pendingTitle: string | undefined
   private elapsed = 0
   private arrival: number | undefined
   private scratch: OptimizedBuffer | undefined
+  private previous: OptimizedBuffer | undefined
   private mask = new Float32Array(0)
   private matrix = new Float32Array(16)
 
   constructor(ctx: RenderContext, options: TitleShimmerOptions) {
     super(ctx, options)
     this._rename = options.rename
+    this.pendingTitle = options.rename?.title
     this._enabled = options.enabled ?? true
     this._backdrop = options.backdrop ?? RGBA.defaultBackground()
     this.matrix[15] = 1
@@ -43,18 +46,25 @@ export class TitleShimmerRenderable extends TextRenderable {
   }
 
   private get animating() {
-    return this._enabled && (this._rename?.pending || this.arrival !== undefined)
+    return this._enabled && (this.shimmering || this.arrival !== undefined)
+  }
+
+  private get shimmering() {
+    return this._rename?.pending && this._rename.title === this.pendingTitle
   }
 
   set rename(value: TitleShimmerOptions["rename"]) {
     if (value?.title === this._rename?.title && value?.pending === this._rename?.pending) return
     if (value?.pending && !this._rename?.pending) {
+      this.pendingTitle = value.title
       this.elapsed = 0
       this.arrival = undefined
+      this.previous?.destroy()
+      this.previous = undefined
     }
-    // Observe the full title, not clipped/marquee text or style changes. Never hold old text back.
+    // Only an automatic rename replaces the last painted title with a wipe.
     if (value?.title !== this._rename?.title) {
-      this.arrival = this._rename?.pending && this._enabled ? 0 : undefined
+      this.arrival = value && this._rename?.pending && this._enabled && this.previous ? 0 : undefined
     }
     this._rename = value
     this.changed()
@@ -82,6 +92,10 @@ export class TitleShimmerRenderable extends TextRenderable {
 
   private changed() {
     this.live = this.animating
+    if (!this.animating) {
+      this.previous?.destroy()
+      this.previous = undefined
+    }
     this.requestRender()
   }
 
@@ -91,6 +105,8 @@ export class TitleShimmerRenderable extends TextRenderable {
       this.arrival += deltaTime
       if (this.arrival >= ARRIVAL_DURATION) {
         this.arrival = undefined
+        this.previous?.destroy()
+        this.previous = undefined
         this.live = this.animating
       }
     }
@@ -99,32 +115,45 @@ export class TitleShimmerRenderable extends TextRenderable {
       this.scratch = OptimizedBuffer.create(this.width, this.height, this._ctx.widthMethod, { respectAlpha: true })
     if (this.scratch.width !== this.width || this.scratch.height !== this.height)
       this.scratch.resize(this.width, this.height)
-    if (this.mask.length !== this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
 
     // Shade locally, then composite: colorMatrix itself does not respect ancestor scissors.
     this.scratch.clear(TRANSPARENT)
     // OpenTUI's framebuffer compositor can paint a cut wide glyph. Clip the native text draw first.
-    this.scratch.pushScissorRect(-this.screenX, -this.screenY, buffer.width, buffer.height)
+    const clip = {
+      left: Math.max(0, -this.screenX),
+      top: Math.max(0, -this.screenY),
+      right: Math.min(this.width, buffer.width - this.screenX),
+      bottom: Math.min(this.height, buffer.height - this.screenY),
+    }
     for (let parent = this.parent; parent; parent = parent.parent) {
       if (parent.overflow === "visible" || parent.width <= 0 || parent.height <= 0) continue
       const border = parent instanceof BoxRenderable ? parent.border : false
       const left = Number(border === true || (Array.isArray(border) && border.includes("left")))
       const top = Number(border === true || (Array.isArray(border) && border.includes("top")))
-      this.scratch.pushScissorRect(
-        parent.screenX - this.screenX + left,
-        parent.screenY - this.screenY + top,
-        Math.max(
-          0,
-          parent.width - left - Number(border === true || (Array.isArray(border) && border.includes("right"))),
-        ),
-        Math.max(
-          0,
-          parent.height - top - Number(border === true || (Array.isArray(border) && border.includes("bottom"))),
-        ),
+      clip.left = Math.max(clip.left, parent.screenX - this.screenX + left)
+      clip.top = Math.max(clip.top, parent.screenY - this.screenY + top)
+      clip.right = Math.min(
+        clip.right,
+        parent.screenX -
+          this.screenX +
+          parent.width -
+          Number(border === true || (Array.isArray(border) && border.includes("right"))),
+      )
+      clip.bottom = Math.min(
+        clip.bottom,
+        parent.screenY -
+          this.screenY +
+          parent.height -
+          Number(border === true || (Array.isArray(border) && border.includes("bottom"))),
       )
     }
+    this.scratch.pushScissorRect(
+      clip.left,
+      clip.top,
+      Math.max(0, clip.right - clip.left),
+      Math.max(0, clip.bottom - clip.top),
+    )
     this.scratch.drawTextBuffer(this.textBufferView, 0, 0)
-    this.scratch.clearScissorRects()
     const characters = this.scratch.buffers.char
     let end = 0
     for (let row = 0; row < this.height; row++) {
@@ -136,18 +165,48 @@ export class TitleShimmerRenderable extends TextRenderable {
         column--
       end = Math.max(end, column)
     }
+    if (this.arrival !== undefined && this.previous) {
+      const cut = Math.round(coast(this.arrival / ARRIVAL_DURATION) * Math.max(end, this.previous.width))
+      this.scratch.clear(TRANSPARENT)
+      this.scratch.pushScissorRect(0, 0, cut, this.height)
+      this.scratch.drawTextBuffer(this.textBufferView, 0, 0)
+      this.scratch.popScissorRect()
+      // Snapshot slices must also end on whole glyphs; framebuffer clipping alone can split them.
+      for (let row = 0; row < Math.min(this.height, this.previous.height); row++) {
+        let left = Math.max(cut, clip.left)
+        let right = Math.min(this.previous.width, clip.right)
+        const offset = row * this.previous.width
+        while (left < right && (this.previous.buffers.char[offset + left] & CONTINUATION) === CONTINUATION) left++
+        while (
+          right > left &&
+          right < this.previous.width &&
+          (this.previous.buffers.char[offset + right] & CONTINUATION) === CONTINUATION
+        )
+          right--
+        if (right > left) this.scratch.drawFrameBuffer(left, row, this.previous, left, row, right - left, 1)
+      }
+      this.scratch.clearScissorRects()
+      buffer.drawFrameBuffer(this.screenX, this.screenY, this.scratch)
+      this.markClean()
+      this._ctx.addToHitGrid(this.screenX, this.screenY, this.width, this.height, this.num)
+      return
+    }
+    this.scratch.clearScissorRects()
+    if (this.mask.length !== this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
+    if (!this.previous)
+      this.previous = OptimizedBuffer.create(Math.max(1, end), this.height, this._ctx.widthMethod, {
+        respectAlpha: true,
+      })
+    if (this.previous.width !== Math.max(1, end) || this.previous.height !== this.height)
+      this.previous.resize(Math.max(1, end), this.height)
+    this.previous.clear(TRANSPARENT)
+    this.previous.drawFrameBuffer(0, 0, this.scratch)
     this.elapsed = (this.elapsed + deltaTime) % SHIMMER_DURATION
-    const arriving = this.arrival !== undefined
-    const progress = this.arrival === undefined ? this.elapsed / SHIMMER_DURATION : this.arrival / ARRIVAL_DURATION
-    const front = -4 + coast(progress) * (end + 4 + (arriving ? 0 : 18))
-    // A completion wipe leaves cells behind its head lit instead of dimming them again.
-    const tail = arriving ? Infinity : 18
+    const front = -4 + coast(this.elapsed / SHIMMER_DURATION) * (end + 4 + 18)
     let strength = 0
     for (let cell = 0; cell < characters.length; cell++) {
       const column = cell % this.width
-      if ((characters[cell] & CONTINUATION) !== CONTINUATION) {
-        strength = 0.6 * (1 - intensityAt(column, front, 4, tail))
-      }
+      if ((characters[cell] & CONTINUATION) !== CONTINUATION) strength = 0.6 * (1 - intensityAt(column, front, 4, 18))
       this.mask[cell * 3] = column
       this.mask[cell * 3 + 1] = Math.floor(cell / this.width)
       this.mask[cell * 3 + 2] = strength
@@ -159,6 +218,8 @@ export class TitleShimmerRenderable extends TextRenderable {
   }
 
   override destroy() {
+    this.previous?.destroy()
+    this.previous = undefined
     this.scratch?.destroy()
     this.scratch = undefined
     super.destroy()

--- a/packages/tui/src/component/title-shimmer.tsx
+++ b/packages/tui/src/component/title-shimmer.tsx
@@ -1,0 +1,174 @@
+import {
+  BoxRenderable,
+  OptimizedBuffer,
+  RGBA,
+  TargetChannel,
+  TextRenderable,
+  type RenderContext,
+  type TextOptions,
+} from "@opentui/core"
+import { extend } from "@opentui/solid"
+import { coast, intensityAt } from "./tab-pulse"
+
+type TitleShimmerOptions = TextOptions & {
+  rename?: { title: string; pending: boolean }
+  enabled?: boolean
+  backdrop?: RGBA
+}
+
+const SHIMMER_DURATION = 1200
+const ARRIVAL_DURATION = 450
+const TRANSPARENT = RGBA.fromValues(0, 0, 0, 0)
+// Native text draws wide glyphs as a head followed by flagged continuation cells.
+const CONTINUATION = 0xc0000000 | 0
+
+export class TitleShimmerRenderable extends TextRenderable {
+  private _rename: TitleShimmerOptions["rename"]
+  private _enabled: boolean
+  private _backdrop: RGBA
+  private elapsed = 0
+  private arrival: number | undefined
+  private scratch: OptimizedBuffer | undefined
+  private mask = new Float32Array(0)
+  private matrix = new Float32Array(16)
+
+  constructor(ctx: RenderContext, options: TitleShimmerOptions) {
+    super(ctx, options)
+    this._rename = options.rename
+    this._enabled = options.enabled ?? true
+    this._backdrop = options.backdrop ?? RGBA.defaultBackground()
+    this.matrix[15] = 1
+    this.updateBackdrop()
+    this.live = this.animating
+  }
+
+  private get animating() {
+    return this._enabled && (this._rename?.pending || this.arrival !== undefined)
+  }
+
+  set rename(value: TitleShimmerOptions["rename"]) {
+    if (value?.title === this._rename?.title && value?.pending === this._rename?.pending) return
+    if (value?.pending && !this._rename?.pending) {
+      this.elapsed = 0
+      this.arrival = undefined
+    }
+    // Observe the full title, not clipped/marquee text or style changes. Never hold old text back.
+    if (value?.title !== this._rename?.title) {
+      this.arrival = this._rename?.pending && this._enabled ? 0 : undefined
+    }
+    this._rename = value
+    this.changed()
+  }
+
+  set enabled(value: boolean) {
+    if (value === this._enabled) return
+    this._enabled = value
+    if (!value) this.arrival = undefined
+    this.changed()
+  }
+
+  set backdrop(value: RGBA) {
+    if (value.equals(this._backdrop)) return
+    this._backdrop = value
+    this.updateBackdrop()
+    this.requestRender()
+  }
+
+  private updateBackdrop() {
+    this.matrix[3] = this._backdrop.r
+    this.matrix[7] = this._backdrop.g
+    this.matrix[11] = this._backdrop.b
+  }
+
+  private changed() {
+    this.live = this.animating
+    this.requestRender()
+  }
+
+  override render(buffer: OptimizedBuffer, deltaTime: number) {
+    if (!this.visible || this.isDestroyed || !Number.isFinite(this.width) || this.width <= 0 || this.height <= 0) return
+    if (this.arrival !== undefined) {
+      this.arrival += deltaTime
+      if (this.arrival >= ARRIVAL_DURATION) {
+        this.arrival = undefined
+        this.live = this.animating
+      }
+    }
+    if (!this.animating) return super.render(buffer, deltaTime)
+    if (!this.scratch)
+      this.scratch = OptimizedBuffer.create(this.width, this.height, this._ctx.widthMethod, { respectAlpha: true })
+    if (this.scratch.width !== this.width || this.scratch.height !== this.height)
+      this.scratch.resize(this.width, this.height)
+    if (this.mask.length !== this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
+
+    // Shade locally, then composite: colorMatrix itself does not respect ancestor scissors.
+    this.scratch.clear(TRANSPARENT)
+    // OpenTUI's framebuffer compositor can paint a cut wide glyph. Clip the native text draw first.
+    this.scratch.pushScissorRect(-this.screenX, -this.screenY, buffer.width, buffer.height)
+    for (let parent = this.parent; parent; parent = parent.parent) {
+      if (parent.overflow === "visible" || parent.width <= 0 || parent.height <= 0) continue
+      const border = parent instanceof BoxRenderable ? parent.border : false
+      const left = Number(border === true || (Array.isArray(border) && border.includes("left")))
+      const top = Number(border === true || (Array.isArray(border) && border.includes("top")))
+      this.scratch.pushScissorRect(
+        parent.screenX - this.screenX + left,
+        parent.screenY - this.screenY + top,
+        Math.max(
+          0,
+          parent.width - left - Number(border === true || (Array.isArray(border) && border.includes("right"))),
+        ),
+        Math.max(
+          0,
+          parent.height - top - Number(border === true || (Array.isArray(border) && border.includes("bottom"))),
+        ),
+      )
+    }
+    this.scratch.drawTextBuffer(this.textBufferView, 0, 0)
+    this.scratch.clearScissorRects()
+    const characters = this.scratch.buffers.char
+    let end = 0
+    for (let row = 0; row < this.height; row++) {
+      let column = this.width
+      while (
+        column > 0 &&
+        (characters[row * this.width + column - 1] === 32 || characters[row * this.width + column - 1] === 0)
+      )
+        column--
+      end = Math.max(end, column)
+    }
+    this.elapsed = (this.elapsed + deltaTime) % SHIMMER_DURATION
+    const arriving = this.arrival !== undefined
+    const progress = this.arrival === undefined ? this.elapsed / SHIMMER_DURATION : this.arrival / ARRIVAL_DURATION
+    const front = -4 + coast(progress) * (end + 4 + (arriving ? 0 : 18))
+    // A completion wipe leaves cells behind its head lit instead of dimming them again.
+    const tail = arriving ? Infinity : 18
+    let strength = 0
+    for (let cell = 0; cell < characters.length; cell++) {
+      const column = cell % this.width
+      if ((characters[cell] & CONTINUATION) !== CONTINUATION) {
+        strength = 0.6 * (1 - intensityAt(column, front, 4, tail))
+      }
+      this.mask[cell * 3] = column
+      this.mask[cell * 3 + 1] = Math.floor(cell / this.width)
+      this.mask[cell * 3 + 2] = strength
+    }
+    this.scratch.colorMatrix(this.matrix, this.mask, 1, TargetChannel.FG)
+    buffer.drawFrameBuffer(this.screenX, this.screenY, this.scratch)
+    this.markClean()
+    this._ctx.addToHitGrid(this.screenX, this.screenY, this.width, this.height, this.num)
+  }
+
+  override destroy() {
+    this.scratch?.destroy()
+    this.scratch = undefined
+    super.destroy()
+  }
+}
+
+extend({ title_shimmer: TitleShimmerRenderable })
+
+declare module "@opentui/solid" {
+  interface OpenTUIComponents {
+    title_shimmer: typeof TitleShimmerRenderable
+  }
+}

--- a/packages/tui/src/component/title-shimmer.tsx
+++ b/packages/tui/src/component/title-shimmer.tsx
@@ -8,7 +8,7 @@ import {
   type TextOptions,
 } from "@opentui/core"
 import { extend } from "@opentui/solid"
-import { coast, intensityAt } from "./tab-pulse"
+import { coast, intensityAt, smootherstep } from "./tab-pulse"
 
 type TitleShimmerOptions = TextOptions & {
   rename?: { title: string; pending: boolean }
@@ -17,7 +17,9 @@ type TitleShimmerOptions = TextOptions & {
 }
 
 const SHIMMER_DURATION = 1200
+const SHIMMER_FADE = 240
 const ARRIVAL_DURATION = 450
+const WIPE_FEATHER = 4
 const TRANSPARENT = RGBA.fromValues(0, 0, 0, 0)
 // Native text draws wide glyphs as a head followed by flagged continuation cells.
 const CONTINUATION = 0xc0000000 | 0
@@ -28,6 +30,8 @@ export class TitleShimmerRenderable extends TextRenderable {
   private _backdrop: RGBA
   private pendingTitle: string | undefined
   private elapsed = 0
+  private blend = 0
+  private fresh = true
   private arrival: number | undefined
   private scratch: OptimizedBuffer | undefined
   private previous: OptimizedBuffer | undefined
@@ -46,7 +50,7 @@ export class TitleShimmerRenderable extends TextRenderable {
   }
 
   private get animating() {
-    return this._enabled && (this.shimmering || this.arrival !== undefined)
+    return this._enabled && (this.shimmering || this.arrival !== undefined || this.blend > 0)
   }
 
   private get shimmering() {
@@ -56,8 +60,9 @@ export class TitleShimmerRenderable extends TextRenderable {
   set rename(value: TitleShimmerOptions["rename"]) {
     if (value?.title === this._rename?.title && value?.pending === this._rename?.pending) return
     if (value?.pending && !this._rename?.pending) {
+      if (this.pendingTitle !== value.title) this.blend = 0
       this.pendingTitle = value.title
-      this.elapsed = 0
+      if (this.blend === 0) this.elapsed = 0
       this.arrival = undefined
       this.previous?.destroy()
       this.previous = undefined
@@ -65,6 +70,7 @@ export class TitleShimmerRenderable extends TextRenderable {
     // Only an automatic rename replaces the last painted title with a wipe.
     if (value?.title !== this._rename?.title) {
       this.arrival = value && this._rename?.pending && this._enabled && this.previous ? 0 : undefined
+      if (this.arrival === undefined) this.blend = 0
     }
     this._rename = value
     this.changed()
@@ -73,7 +79,10 @@ export class TitleShimmerRenderable extends TextRenderable {
   set enabled(value: boolean) {
     if (value === this._enabled) return
     this._enabled = value
-    if (!value) this.arrival = undefined
+    if (!value) {
+      this.arrival = undefined
+      this.blend = 0
+    }
     this.changed()
   }
 
@@ -91,6 +100,7 @@ export class TitleShimmerRenderable extends TextRenderable {
   }
 
   private changed() {
+    if (!this.live && this.animating) this.fresh = true
     this.live = this.animating
     if (!this.animating) {
       this.previous?.destroy()
@@ -101,16 +111,28 @@ export class TitleShimmerRenderable extends TextRenderable {
 
   override render(buffer: OptimizedBuffer, deltaTime: number) {
     if (!this.visible || this.isDestroyed || !Number.isFinite(this.width) || this.width <= 0 || this.height <= 0) return
+    if (!this.animating) return super.render(buffer, deltaTime)
+    // A newly live title must not inherit time spent idle before its fade started.
+    const delta = this.fresh ? 0 : deltaTime
+    this.fresh = false
+    this.elapsed = (this.elapsed + delta) % SHIMMER_DURATION
     if (this.arrival !== undefined) {
-      this.arrival += deltaTime
+      this.arrival += delta
       if (this.arrival >= ARRIVAL_DURATION) {
         this.arrival = undefined
-        this.previous?.destroy()
-        this.previous = undefined
-        this.live = this.animating
+        this.blend = 0
       }
     }
-    if (!this.animating) return super.render(buffer, deltaTime)
+    this.blend = Math.max(
+      0,
+      Math.min(1, this.blend + (this.shimmering || this.arrival !== undefined ? delta : -delta) / SHIMMER_FADE),
+    )
+    this.live = this.animating
+    if (!this.animating) {
+      this.previous?.destroy()
+      this.previous = undefined
+      return super.render(buffer, deltaTime)
+    }
     if (!this.scratch)
       this.scratch = OptimizedBuffer.create(this.width, this.height, this._ctx.widthMethod, { respectAlpha: true })
     if (this.scratch.width !== this.width || this.scratch.height !== this.height)
@@ -165,8 +187,13 @@ export class TitleShimmerRenderable extends TextRenderable {
         column--
       end = Math.max(end, column)
     }
-    if (this.arrival !== undefined && this.previous) {
-      const cut = Math.round(coast(this.arrival / ARRIVAL_DURATION) * Math.max(end, this.previous.width))
+    const wipeFront =
+      this.arrival !== undefined && this.previous
+        ? -WIPE_FEATHER +
+          coast(this.arrival / ARRIVAL_DURATION) * (Math.max(end, this.previous.width) + WIPE_FEATHER * 2)
+        : undefined
+    const cut = Math.max(0, Math.min(this.width, Math.round(wipeFront ?? 0)))
+    if (wipeFront !== undefined && this.previous) {
       this.scratch.clear(TRANSPARENT)
       this.scratch.pushScissorRect(0, 0, cut, this.height)
       this.scratch.drawTextBuffer(this.textBufferView, 0, 0)
@@ -185,28 +212,35 @@ export class TitleShimmerRenderable extends TextRenderable {
           right--
         if (right > left) this.scratch.drawFrameBuffer(left, row, this.previous, left, row, right - left, 1)
       }
-      this.scratch.clearScissorRects()
-      buffer.drawFrameBuffer(this.screenX, this.screenY, this.scratch)
-      this.markClean()
-      this._ctx.addToHitGrid(this.screenX, this.screenY, this.width, this.height, this.num)
-      return
     }
     this.scratch.clearScissorRects()
     if (this.mask.length !== this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
-    if (!this.previous)
-      this.previous = OptimizedBuffer.create(Math.max(1, end), this.height, this._ctx.widthMethod, {
-        respectAlpha: true,
-      })
-    if (this.previous.width !== Math.max(1, end) || this.previous.height !== this.height)
-      this.previous.resize(Math.max(1, end), this.height)
-    this.previous.clear(TRANSPARENT)
-    this.previous.drawFrameBuffer(0, 0, this.scratch)
-    this.elapsed = (this.elapsed + deltaTime) % SHIMMER_DURATION
-    const front = -4 + coast(this.elapsed / SHIMMER_DURATION) * (end + 4 + 18)
+    if (wipeFront === undefined) {
+      if (!this.previous)
+        this.previous = OptimizedBuffer.create(Math.max(1, end), this.height, this._ctx.widthMethod, {
+          respectAlpha: true,
+        })
+      if (this.previous.width !== Math.max(1, end) || this.previous.height !== this.height)
+        this.previous.resize(Math.max(1, end), this.height)
+      this.previous.clear(TRANSPARENT)
+      this.previous.drawFrameBuffer(0, 0, this.scratch)
+    }
+    const front = -4 + coast(this.elapsed / SHIMMER_DURATION) * ((this.previous?.width ?? end) + 4 + 18)
+    const level = smootherstep(this.blend)
     let strength = 0
     for (let cell = 0; cell < characters.length; cell++) {
       const column = cell % this.width
-      if ((characters[cell] & CONTINUATION) !== CONTINUATION) strength = 0.6 * (1 - intensityAt(column, front, 4, 18))
+      if ((characters[cell] & CONTINUATION) !== CONTINUATION) {
+        const old = wipeFront === undefined || column >= cut
+        let visibility = old ? 1 - 0.6 * level * (1 - intensityAt(column, front, 4, 18)) : 1
+        if (wipeFront !== undefined) {
+          let width = 1
+          while (column + width < this.width && (characters[cell + width] & CONTINUATION) === CONTINUATION) width++
+          const distance = old ? column - wipeFront : wipeFront - (column + width)
+          visibility *= smootherstep(Math.max(0, Math.min(1, distance / WIPE_FEATHER)))
+        }
+        strength = 1 - visibility
+      }
       this.mask[cell * 3] = column
       this.mask[cell * 3 + 1] = Math.floor(cell / this.width)
       this.mask[cell * 3 + 2] = strength

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -30,6 +30,11 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
             setGeneratingTitles(sessionID, true)
             await client.api.session
               .rename({ sessionID, title: "" })
+              .then(() => {
+                // The HTTP response can beat the renamed event. Keep pending until the new title is projected locally.
+                data.session.invalidate(sessionID)
+                return data.session.sync(sessionID)
+              })
               .finally(() => setGeneratingTitles(sessionID, undefined))
           },
         },

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -1,5 +1,6 @@
 import { createData } from "@opencode-ai/client/solid"
 import type { Plugin } from "@opencode-ai/plugin/tui"
+import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
 import { useClient } from "./client"
 
@@ -17,6 +18,22 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
       directory: props.directory,
     })
     data satisfies Plugin.Context["data"]
-    return data
+    const [generatingTitles, setGeneratingTitles] = createStore<Record<string, boolean | undefined>>({})
+    return {
+      ...data,
+      session: {
+        ...data.session,
+        title: {
+          pending: (sessionID: string) => generatingTitles[sessionID] === true,
+          async generate(sessionID: string) {
+            if (generatingTitles[sessionID]) return
+            setGeneratingTitles(sessionID, true)
+            await client.api.session
+              .rename({ sessionID, title: "" })
+              .finally(() => setGeneratingTitles(sessionID, undefined))
+          },
+        },
+      },
+    }
   },
 })

--- a/packages/tui/src/context/session-tabs.tsx
+++ b/packages/tui/src/context/session-tabs.tsx
@@ -173,6 +173,7 @@ export const { use: useSessionTabs, provider: SessionTabsProvider } = createSimp
             ? ("question" as const)
             : (false as const),
         busy: members.some((id) => data.session.status(id) === "running" || data.session.pending.list(id).length > 0),
+        renaming: data.session.title.pending(session),
       }
     }
 

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -383,6 +383,24 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         },
       })),
       {
+        bind: "n",
+        title: "Regenerate selected title",
+        group: "Storybook",
+        run() {
+          const current = active()
+          if (!current) return
+          const renaming = !controller.status(current).renaming
+          batch(() => {
+            setStatuses((statuses) => ({
+              ...statuses,
+              [current]: { ...(statuses[current] ?? EMPTY_SESSION_TAB_STATUS), renaming },
+            }))
+            if (!renaming) setTabStore("items", number(current) - 1, "title", "Regenerated session title")
+          })
+          setLastEvent(`tab ${number(current)} ${renaming ? "regenerating title; press n to finish" : "renamed"}`)
+        },
+      },
+      {
         bind: "c",
         title: "Cycle spinner shape",
         group: "Storybook",
@@ -454,6 +472,7 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           { shortcut: "a", label: "permission" },
           { shortcut: "i", label: "idle" },
           { shortcut: "f/x", label: "complete/fail" },
+          { shortcut: "n", label: "rename/finish" },
           { shortcut: "t/d", label: "add/close" },
           { shortcut: "c", label: "spinner" },
           { shortcut: "u", label: "unread marker" },

--- a/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
+++ b/packages/tui/src/feature-plugins/system/storybook/session-tabs.tsx
@@ -383,24 +383,6 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
         },
       })),
       {
-        bind: "n",
-        title: "Regenerate selected title",
-        group: "Storybook",
-        run() {
-          const current = active()
-          if (!current) return
-          const renaming = !controller.status(current).renaming
-          batch(() => {
-            setStatuses((statuses) => ({
-              ...statuses,
-              [current]: { ...(statuses[current] ?? EMPTY_SESSION_TAB_STATUS), renaming },
-            }))
-            if (!renaming) setTabStore("items", number(current) - 1, "title", "Regenerated session title")
-          })
-          setLastEvent(`tab ${number(current)} ${renaming ? "regenerating title; press n to finish" : "renamed"}`)
-        },
-      },
-      {
         bind: "c",
         title: "Cycle spinner shape",
         group: "Storybook",
@@ -472,7 +454,6 @@ function SessionTabsStory(props: { context: Plugin.Context }) {
           { shortcut: "a", label: "permission" },
           { shortcut: "i", label: "idle" },
           { shortcut: "f/x", label: "complete/fail" },
-          { shortcut: "n", label: "rename/finish" },
           { shortcut: "t/d", label: "add/close" },
           { shortcut: "c", label: "spinner" },
           { shortcut: "u", label: "unread marker" },

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -801,9 +801,12 @@ export function Session(props: {
       slash: { name: "rename", arguments: true as const },
       run: (input?: string) => {
         if (input === undefined) return DialogSessionRename.show(dialog, route.sessionID, session()?.title)
-        void client.api.session
-          .rename({ sessionID: route.sessionID, title: input.trim() })
-          .catch((error) => toast.error(error))
+        const title = input.trim()
+        void (
+          title
+            ? client.api.session.rename({ sessionID: route.sessionID, title })
+            : data.session.title.generate(route.sessionID)
+        ).catch((error) => toast.error(error))
       },
     },
     {

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -4,6 +4,7 @@ import { useTheme } from "../../context/theme"
 import { useConfig } from "../../config"
 import { Slot } from "../../plugin/render"
 import { withTimestampedFallback } from "@opencode-ai/util/session-title-fallback"
+import { TextAttributes } from "@opentui/core"
 
 import { getScrollAcceleration } from "../../util/scroll"
 import { SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
@@ -45,8 +46,11 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
         >
           <box flexShrink={0} gap={1} paddingRight={1}>
             <box paddingRight={1}>
-              <text fg={theme.text.default}>
-                <b>{withTimestampedFallback(session()!)}</b>
+              <text
+                fg={theme.text.default}
+                attributes={data.session.title.pending(props.sessionID) ? TextAttributes.DIM : TextAttributes.BOLD}
+              >
+                {withTimestampedFallback(session()!)}
               </text>
               <Show when={session()!.location.workspaceID}>
                 <text fg={theme.text.subdued}>{session()!.location.workspaceID}</text>

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -5,6 +5,7 @@ import { useConfig } from "../../config"
 import { Slot } from "../../plugin/render"
 import { withTimestampedFallback } from "@opencode-ai/util/session-title-fallback"
 import { TextAttributes } from "@opentui/core"
+import "../../component/title-shimmer"
 
 import { getScrollAcceleration } from "../../util/scroll"
 import { SESSION_SIDEBAR_WIDTH } from "../../ui/layout"
@@ -46,14 +47,24 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
         >
           <box flexShrink={0} gap={1} paddingRight={1}>
             <box paddingRight={1}>
-              <text
+              <title_shimmer
                 fg={theme.text.default}
-                attributes={data.session.title.pending(props.sessionID) ? TextAttributes.DIM : TextAttributes.BOLD}
+                rename={{
+                  pending: data.session.title.pending(props.sessionID),
+                  title: withTimestampedFallback(session()),
+                }}
+                enabled={config.animations ?? true}
+                backdrop={theme.background.default}
+                attributes={
+                  data.session.title.pending(props.sessionID) && config.animations === false
+                    ? TextAttributes.DIM
+                    : TextAttributes.BOLD
+                }
               >
-                {withTimestampedFallback(session()!)}
-              </text>
-              <Show when={session()!.location.workspaceID}>
-                <text fg={theme.text.subdued}>{session()!.location.workspaceID}</text>
+                {withTimestampedFallback(session())}
+              </title_shimmer>
+              <Show when={session().location.workspaceID}>
+                <text fg={theme.text.subdued}>{session().location.workspaceID}</text>
               </Show>
             </box>
             <Slot path="sidebar.content" input={{ sessionID: props.sessionID }} />

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { EmbeddedTerminalRenderable, type Renderable, ScrollBoxRenderable } from "@opentui/core"
+import { EmbeddedTerminalRenderable, type Renderable, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
 import { createTestRenderer } from "@opentui/core/testing"
 import { Effect, FileSystem } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -222,6 +222,136 @@ test("session title generated while an untitled session is loading remains visib
     await server.stop()
   }
 })
+
+test.each(["horizontal", "vertical", "sidebar"] as const)(
+  "auto rename dims the %s title until the request settles",
+  async (layout) => {
+    await using state = await tmpdir()
+    const setup = await createTestRenderer({ width: 160, height: 30, useThread: false, kittyKeyboard: true })
+    setup.renderer.start()
+    const events = createEventStream()
+    const responses = Array.from({ length: 4 }, () => Promise.withResolvers<Response>())
+    const bodies: unknown[] = []
+    const location = { directory, project: { id: "project", directory, canonical: directory } }
+    const session = {
+      id: "ses_rename",
+      title: "Demo session",
+      projectID: "project",
+      location: { directory },
+      agent: "build",
+      model: { providerID: "provider", id: "model" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: 0, updated: 0 },
+    }
+    const calls = createFetch(async (url, request) => {
+      if (url.pathname === "/api/location") return json(location)
+      if (url.pathname === "/api/agent")
+        return json({ location, data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }] })
+      if (url.pathname === "/api/model")
+        return json({ location, data: [{ id: "model", providerID: "provider", name: "Model", variants: [] }] })
+      if (url.pathname === "/api/provider") return json({ location, data: [{ id: "provider", name: "Provider" }] })
+      if (url.pathname === "/api/session") return json({ data: [], cursor: {} })
+      if (url.pathname === "/api/session/ses_rename") return json({ data: session })
+      if (/^\/api\/session\/ses_rename\/(message|inbox|permission)$/.test(url.pathname))
+        return json({ data: [], cursor: {} })
+      if (url.pathname === "/api/session/ses_rename/rename") {
+        const response = responses[bodies.length]
+        bodies.push(await request.json())
+        return response.promise
+      }
+      return undefined
+    }, events)
+    const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+    const titleSpans = () =>
+      setup
+        .captureSpans()
+        .lines.flatMap((line) => line.spans)
+        .filter((span) => span.text.includes(session.title))
+
+    try {
+      const { run } = await import("../src/app")
+      const task = Effect.runPromise(
+        run({
+          app: { name: "test", version: "test", channel: "test" },
+          server: { endpoint: { url: server.url.toString() } },
+          config: {
+            get: async () => ({
+              animations: false,
+              tabs: { enabled: layout !== "sidebar", layout: layout === "sidebar" ? "horizontal" : layout },
+              session: { sidebar: layout === "sidebar" ? "auto" : "hide" },
+            }),
+            update: async () => ({}),
+          },
+          packages: { resolve: async () => undefined },
+          terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: () => {} }),
+          args: { sessionID: session.id },
+          log: () => {},
+        }).pipe(Effect.provide(Global.layerWith({ state: state.path })), Effect.provide(FileSystem.layerNoop({}))),
+      )
+
+      await setup.waitForFrame((frame) => frame.includes(session.title) && frame.includes("Build · Model Provider"))
+      expect(titleSpans().every((span) => (span.attributes & TextAttributes.BOLD) !== 0)).toBe(true)
+
+      for (const [index, status] of [204, 204, 503].entries()) {
+        await setup.mockInput.typeText("/rename")
+        setup.mockInput.pressEscape()
+        setup.mockInput.pressEnter()
+        await setup.waitFor(() => bodies.length === index + 1)
+        expect(bodies[index]).toEqual({ title: "" })
+        await setup.waitForFrame(
+          () => titleSpans().length > 0 && titleSpans().every((span) => (span.attributes & TextAttributes.DIM) !== 0),
+        )
+        expect(titleSpans().every((span) => (span.attributes & TextAttributes.BOLD) === 0)).toBe(true)
+
+        if (index === 0) {
+          await setup.mockInput.typeText("/rename")
+          setup.mockInput.pressEscape()
+          setup.mockInput.pressEnter()
+          await setup.renderOnce()
+          expect(bodies).toHaveLength(1)
+          session.title = "Generated session"
+          events.emit({
+            id: "evt_renamed",
+            created: 1,
+            type: "session.renamed",
+            durable: { aggregateID: session.id, seq: 1, version: 1 },
+            data: { sessionID: session.id, title: session.title },
+          })
+          await setup.waitForFrame((frame) => frame.includes(session.title))
+        }
+        // No rename event is emitted for the unchanged-title and failed requests.
+        responses[index].resolve(new Response(null, { status }))
+        if (status === 503) {
+          const rows = (await setup.waitForFrame((frame) => frame.includes("UnexpectedStatus"))).split("\n")
+          const row = rows.findIndex((line) => line.includes("UnexpectedStatus"))
+          await setup.mockMouse.click(rows[row].indexOf("UnexpectedStatus"), row)
+        }
+        await setup.waitForFrame(
+          () =>
+            titleSpans().length > 0 &&
+            titleSpans().every(
+              (span) => (span.attributes & TextAttributes.DIM) === 0 && (span.attributes & TextAttributes.BOLD) !== 0,
+            ),
+        )
+      }
+
+      await setup.mockInput.typeText("/rename Hand picked")
+      setup.mockInput.pressEscape()
+      setup.mockInput.pressEnter()
+      await setup.waitFor(() => bodies.length === 4)
+      expect(bodies[3]).toEqual({ title: "Hand picked" })
+      expect(titleSpans().every((span) => (span.attributes & TextAttributes.DIM) === 0)).toBe(true)
+      responses[3].resolve(new Response(null, { status: 204 }))
+      setup.renderer.destroy()
+      await task
+    } finally {
+      responses.forEach((response) => response.resolve(new Response(null, { status: 204 })))
+      if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+      await server.stop()
+    }
+  },
+)
 
 test("session startup prompt is submitted exactly once", async () => {
   const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { EmbeddedTerminalRenderable, type Renderable, ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import { EmbeddedTerminalRenderable, type Renderable, ScrollBoxRenderable } from "@opentui/core"
 import { createTestRenderer } from "@opentui/core/testing"
 import { Effect, FileSystem } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -223,25 +223,17 @@ test("session title generated while an untitled session is loading remains visib
   }
 })
 
-test.each(
-  (["horizontal", "vertical", "sidebar"] as const).flatMap((layout) =>
-    [undefined, false, true].map((animations) => ({ layout, animations })),
-  ),
-)("auto rename feedback follows request and title updates (%j)", async ({ layout, animations }) => {
-  const animated = animations !== false
+test("automatic rename refreshes the displayed title before settling, even without a renamed event", async () => {
   await using state = await tmpdir()
-  const setup = await createTestRenderer({ width: 160, height: 30, useThread: false, kittyKeyboard: true })
+  const setup = await createTestRenderer({ width: 90, height: 20, useThread: false, kittyKeyboard: true })
   setup.renderer.start()
   const events = createEventStream()
-  const responses = Array.from({ length: 4 }, () => Promise.withResolvers<Response>())
-  const refresh = Promise.withResolvers<Response>()
-  const refreshRequested = Promise.withResolvers<void>()
-  let holdRefresh = false
+  const response = Promise.withResolvers<Response>()
   const bodies: unknown[] = []
   const location = { directory, project: { id: "project", directory, canonical: directory } }
   const session = {
     id: "ses_rename",
-    title: "Demo session",
+    title: "Compiler cleanup",
     projectID: "project",
     location: { directory },
     agent: "build",
@@ -258,32 +250,16 @@ test.each(
       return json({ location, data: [{ id: "model", providerID: "provider", name: "Model", variants: [] }] })
     if (url.pathname === "/api/provider") return json({ location, data: [{ id: "provider", name: "Provider" }] })
     if (url.pathname === "/api/session") return json({ data: [], cursor: {} })
-    if (url.pathname === "/api/session/ses_rename") {
-      if (!holdRefresh) return json({ data: session })
-      refreshRequested.resolve()
-      return refresh.promise
-    }
+    if (url.pathname === "/api/session/ses_rename") return json({ data: session })
     if (/^\/api\/session\/ses_rename\/(message|inbox|permission)$/.test(url.pathname))
       return json({ data: [], cursor: {} })
     if (url.pathname === "/api/session/ses_rename/rename") {
-      const response = responses[bodies.length]
       bodies.push(await request.json())
       return response.promise
     }
     return undefined
   }, events)
   const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
-  const titleSpans = () =>
-    setup.captureSpans().lines.flatMap((line) => {
-      const column = line.spans
-        .map((span) => span.text)
-        .join("")
-        .indexOf(session.title)
-      if (column === -1) return []
-      return line.spans
-        .flatMap((span) => Array.from({ length: span.width }, () => span))
-        .slice(column, column + session.title.length)
-    })
 
   try {
     const { run } = await import("../src/app")
@@ -293,9 +269,8 @@ test.each(
         server: { endpoint: { url: server.url.toString() } },
         config: {
           get: async () => ({
-            animations,
-            tabs: { enabled: layout !== "sidebar", layout: layout === "sidebar" ? "horizontal" : layout },
-            session: { sidebar: layout === "sidebar" ? "auto" : "hide" },
+            tabs: { enabled: true, layout: "vertical" },
+            session: { sidebar: "hide" },
           }),
           update: async () => ({}),
         },
@@ -307,87 +282,23 @@ test.each(
     )
 
     await setup.waitForFrame((frame) => frame.includes(session.title) && frame.includes("Build · Model Provider"))
-    expect(titleSpans().every((span) => (span.attributes & TextAttributes.BOLD) !== 0)).toBe(true)
-    const foreground = titleSpans()[0].fg
-
-    for (const [index, status] of [204, 204, 503].entries()) {
-      await setup.mockInput.typeText("/rename")
-      setup.mockInput.pressEscape()
-      setup.mockInput.pressEnter()
-      await setup.waitFor(() => bodies.length === index + 1)
-      expect(bodies[index]).toEqual({ title: "" })
-      await setup.waitForFrame(
-        () =>
-          titleSpans().length > 0 &&
-          (animated
-            ? titleSpans().some((span) => !span.fg.equals(foreground))
-            : titleSpans().every((span) => (span.attributes & TextAttributes.DIM) !== 0)),
-      )
-      expect(titleSpans().every((span) => Boolean(span.attributes & TextAttributes.BOLD) === animated)).toBe(true)
-
-      if (index === 0) {
-        await setup.mockInput.typeText("/rename")
-        setup.mockInput.pressEscape()
-        setup.mockInput.pressEnter()
-        await setup.renderOnce()
-        expect(bodies).toHaveLength(1)
-        if (animated) {
-          // A successful response can precede the event/read that supplies the new title.
-          holdRefresh = true
-          responses[index].resolve(new Response(null, { status }))
-          await refreshRequested.promise
-          await setup.renderOnce()
-          expect(setup.captureCharFrame()).toContain(session.title)
-          expect(titleSpans().some((span) => !span.fg.equals(foreground))).toBe(true)
-        }
-        session.title = "Generated session"
-        events.emit({
-          id: "evt_renamed",
-          created: 1,
-          type: "session.renamed",
-          durable: { aggregateID: session.id, seq: 1, version: 1 },
-          data: { sessionID: session.id, title: session.title },
-        })
-        holdRefresh = false
-        refresh.resolve(json({ data: session }))
-        await setup.waitForFrame((frame) => frame.includes(session.title))
-        if (animated) {
-          expect(titleSpans().some((span) => !span.fg.equals(foreground))).toBe(true)
-          expect(setup.renderer.root.liveCount).toBeGreaterThan(0)
-        }
-      }
-      // No rename event is emitted for the unchanged-title and failed requests.
-      responses[index].resolve(new Response(null, { status }))
-      if (status === 503) {
-        const rows = (await setup.waitForFrame((frame) => frame.includes("UnexpectedStatus"))).split("\n")
-        const row = rows.findIndex((line) => line.includes("UnexpectedStatus"))
-        await setup.mockMouse.click(rows[row].indexOf("UnexpectedStatus"), row)
-      }
-      await setup.waitForFrame(
-        () =>
-          titleSpans().length > 0 &&
-          titleSpans().every(
-            (span) =>
-              (span.attributes & TextAttributes.DIM) === 0 &&
-              (span.attributes & TextAttributes.BOLD) !== 0 &&
-              span.fg.equals(foreground),
-          ),
-        { maxPasses: 60 },
-      )
-    }
-
-    await setup.mockInput.typeText("/rename Hand picked")
+    await setup.mockInput.typeText("/rename")
     setup.mockInput.pressEscape()
     setup.mockInput.pressEnter()
-    await setup.waitFor(() => bodies.length === 4)
-    expect(bodies[3]).toEqual({ title: "Hand picked" })
-    expect(titleSpans().every((span) => (span.attributes & TextAttributes.DIM) === 0)).toBe(true)
-    responses[3].resolve(new Response(null, { status: 204 }))
+    await setup.waitFor(() => bodies.length === 1)
+    await setup.renderOnce()
+    expect(bodies[0]).toEqual({ title: "" })
+    expect(setup.captureCharFrame()).toContain("Compiler cleanup")
+
+    session.title = "Simplify compiler parsing"
+    response.resolve(new Response(null, { status: 204 }))
+    await setup.waitForFrame((frame) => frame.includes(session.title), { maxPasses: 60 })
+    expect(setup.captureCharFrame()).not.toContain("Compiler cleanup")
+
     setup.renderer.destroy()
     await task
   } finally {
-    responses.forEach((response) => response.resolve(new Response(null, { status: 204 })))
-    refresh.resolve(json({ data: session }))
+    response.resolve(new Response(null, { status: 204 }))
     if (!setup.renderer.isDestroyed) setup.renderer.destroy()
     await server.stop()
   }

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -223,135 +223,175 @@ test("session title generated while an untitled session is loading remains visib
   }
 })
 
-test.each(["horizontal", "vertical", "sidebar"] as const)(
-  "auto rename dims the %s title until the request settles",
-  async (layout) => {
-    await using state = await tmpdir()
-    const setup = await createTestRenderer({ width: 160, height: 30, useThread: false, kittyKeyboard: true })
-    setup.renderer.start()
-    const events = createEventStream()
-    const responses = Array.from({ length: 4 }, () => Promise.withResolvers<Response>())
-    const bodies: unknown[] = []
-    const location = { directory, project: { id: "project", directory, canonical: directory } }
-    const session = {
-      id: "ses_rename",
-      title: "Demo session",
-      projectID: "project",
-      location: { directory },
-      agent: "build",
-      model: { providerID: "provider", id: "model" },
-      cost: 0,
-      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-      time: { created: 0, updated: 0 },
+test.each(
+  (["horizontal", "vertical", "sidebar"] as const).flatMap((layout) =>
+    [undefined, false, true].map((animations) => ({ layout, animations })),
+  ),
+)("auto rename feedback follows request and title updates (%j)", async ({ layout, animations }) => {
+  const animated = animations !== false
+  await using state = await tmpdir()
+  const setup = await createTestRenderer({ width: 160, height: 30, useThread: false, kittyKeyboard: true })
+  setup.renderer.start()
+  const events = createEventStream()
+  const responses = Array.from({ length: 4 }, () => Promise.withResolvers<Response>())
+  const refresh = Promise.withResolvers<Response>()
+  const refreshRequested = Promise.withResolvers<void>()
+  let holdRefresh = false
+  const bodies: unknown[] = []
+  const location = { directory, project: { id: "project", directory, canonical: directory } }
+  const session = {
+    id: "ses_rename",
+    title: "Demo session",
+    projectID: "project",
+    location: { directory },
+    agent: "build",
+    model: { providerID: "provider", id: "model" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 0, updated: 0 },
+  }
+  const calls = createFetch(async (url, request) => {
+    if (url.pathname === "/api/location") return json(location)
+    if (url.pathname === "/api/agent")
+      return json({ location, data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }] })
+    if (url.pathname === "/api/model")
+      return json({ location, data: [{ id: "model", providerID: "provider", name: "Model", variants: [] }] })
+    if (url.pathname === "/api/provider") return json({ location, data: [{ id: "provider", name: "Provider" }] })
+    if (url.pathname === "/api/session") return json({ data: [], cursor: {} })
+    if (url.pathname === "/api/session/ses_rename") {
+      if (!holdRefresh) return json({ data: session })
+      refreshRequested.resolve()
+      return refresh.promise
     }
-    const calls = createFetch(async (url, request) => {
-      if (url.pathname === "/api/location") return json(location)
-      if (url.pathname === "/api/agent")
-        return json({ location, data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }] })
-      if (url.pathname === "/api/model")
-        return json({ location, data: [{ id: "model", providerID: "provider", name: "Model", variants: [] }] })
-      if (url.pathname === "/api/provider") return json({ location, data: [{ id: "provider", name: "Provider" }] })
-      if (url.pathname === "/api/session") return json({ data: [], cursor: {} })
-      if (url.pathname === "/api/session/ses_rename") return json({ data: session })
-      if (/^\/api\/session\/ses_rename\/(message|inbox|permission)$/.test(url.pathname))
-        return json({ data: [], cursor: {} })
-      if (url.pathname === "/api/session/ses_rename/rename") {
-        const response = responses[bodies.length]
-        bodies.push(await request.json())
-        return response.promise
-      }
-      return undefined
-    }, events)
-    const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
-    const titleSpans = () =>
-      setup
-        .captureSpans()
-        .lines.flatMap((line) => line.spans)
-        .filter((span) => span.text.includes(session.title))
+    if (/^\/api\/session\/ses_rename\/(message|inbox|permission)$/.test(url.pathname))
+      return json({ data: [], cursor: {} })
+    if (url.pathname === "/api/session/ses_rename/rename") {
+      const response = responses[bodies.length]
+      bodies.push(await request.json())
+      return response.promise
+    }
+    return undefined
+  }, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+  const titleSpans = () =>
+    setup.captureSpans().lines.flatMap((line) => {
+      const column = line.spans
+        .map((span) => span.text)
+        .join("")
+        .indexOf(session.title)
+      if (column === -1) return []
+      return line.spans
+        .flatMap((span) => Array.from({ length: span.width }, () => span))
+        .slice(column, column + session.title.length)
+    })
 
-    try {
-      const { run } = await import("../src/app")
-      const task = Effect.runPromise(
-        run({
-          app: { name: "test", version: "test", channel: "test" },
-          server: { endpoint: { url: server.url.toString() } },
-          config: {
-            get: async () => ({
-              animations: false,
-              tabs: { enabled: layout !== "sidebar", layout: layout === "sidebar" ? "horizontal" : layout },
-              session: { sidebar: layout === "sidebar" ? "auto" : "hide" },
-            }),
-            update: async () => ({}),
-          },
-          packages: { resolve: async () => undefined },
-          terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: () => {} }),
-          args: { sessionID: session.id },
-          log: () => {},
-        }).pipe(Effect.provide(Global.layerWith({ state: state.path })), Effect.provide(FileSystem.layerNoop({}))),
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: {
+          get: async () => ({
+            animations,
+            tabs: { enabled: layout !== "sidebar", layout: layout === "sidebar" ? "horizontal" : layout },
+            session: { sidebar: layout === "sidebar" ? "auto" : "hide" },
+          }),
+          update: async () => ({}),
+        },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: () => {} }),
+        args: { sessionID: session.id },
+        log: () => {},
+      }).pipe(Effect.provide(Global.layerWith({ state: state.path })), Effect.provide(FileSystem.layerNoop({}))),
+    )
+
+    await setup.waitForFrame((frame) => frame.includes(session.title) && frame.includes("Build · Model Provider"))
+    expect(titleSpans().every((span) => (span.attributes & TextAttributes.BOLD) !== 0)).toBe(true)
+    const foreground = titleSpans()[0].fg
+
+    for (const [index, status] of [204, 204, 503].entries()) {
+      await setup.mockInput.typeText("/rename")
+      setup.mockInput.pressEscape()
+      setup.mockInput.pressEnter()
+      await setup.waitFor(() => bodies.length === index + 1)
+      expect(bodies[index]).toEqual({ title: "" })
+      await setup.waitForFrame(
+        () =>
+          titleSpans().length > 0 &&
+          (animated
+            ? titleSpans().some((span) => !span.fg.equals(foreground))
+            : titleSpans().every((span) => (span.attributes & TextAttributes.DIM) !== 0)),
       )
+      expect(titleSpans().every((span) => Boolean(span.attributes & TextAttributes.BOLD) === animated)).toBe(true)
 
-      await setup.waitForFrame((frame) => frame.includes(session.title) && frame.includes("Build · Model Provider"))
-      expect(titleSpans().every((span) => (span.attributes & TextAttributes.BOLD) !== 0)).toBe(true)
-
-      for (const [index, status] of [204, 204, 503].entries()) {
+      if (index === 0) {
         await setup.mockInput.typeText("/rename")
         setup.mockInput.pressEscape()
         setup.mockInput.pressEnter()
-        await setup.waitFor(() => bodies.length === index + 1)
-        expect(bodies[index]).toEqual({ title: "" })
-        await setup.waitForFrame(
-          () => titleSpans().length > 0 && titleSpans().every((span) => (span.attributes & TextAttributes.DIM) !== 0),
-        )
-        expect(titleSpans().every((span) => (span.attributes & TextAttributes.BOLD) === 0)).toBe(true)
-
-        if (index === 0) {
-          await setup.mockInput.typeText("/rename")
-          setup.mockInput.pressEscape()
-          setup.mockInput.pressEnter()
+        await setup.renderOnce()
+        expect(bodies).toHaveLength(1)
+        if (animated) {
+          // A successful response can precede the event/read that supplies the new title.
+          holdRefresh = true
+          responses[index].resolve(new Response(null, { status }))
+          await refreshRequested.promise
           await setup.renderOnce()
-          expect(bodies).toHaveLength(1)
-          session.title = "Generated session"
-          events.emit({
-            id: "evt_renamed",
-            created: 1,
-            type: "session.renamed",
-            durable: { aggregateID: session.id, seq: 1, version: 1 },
-            data: { sessionID: session.id, title: session.title },
-          })
-          await setup.waitForFrame((frame) => frame.includes(session.title))
+          expect(setup.captureCharFrame()).toContain(session.title)
+          expect(titleSpans().some((span) => !span.fg.equals(foreground))).toBe(true)
         }
-        // No rename event is emitted for the unchanged-title and failed requests.
-        responses[index].resolve(new Response(null, { status }))
-        if (status === 503) {
-          const rows = (await setup.waitForFrame((frame) => frame.includes("UnexpectedStatus"))).split("\n")
-          const row = rows.findIndex((line) => line.includes("UnexpectedStatus"))
-          await setup.mockMouse.click(rows[row].indexOf("UnexpectedStatus"), row)
+        session.title = "Generated session"
+        events.emit({
+          id: "evt_renamed",
+          created: 1,
+          type: "session.renamed",
+          durable: { aggregateID: session.id, seq: 1, version: 1 },
+          data: { sessionID: session.id, title: session.title },
+        })
+        holdRefresh = false
+        refresh.resolve(json({ data: session }))
+        await setup.waitForFrame((frame) => frame.includes(session.title))
+        if (animated) {
+          expect(titleSpans().some((span) => !span.fg.equals(foreground))).toBe(true)
+          expect(setup.renderer.root.liveCount).toBeGreaterThan(0)
         }
-        await setup.waitForFrame(
-          () =>
-            titleSpans().length > 0 &&
-            titleSpans().every(
-              (span) => (span.attributes & TextAttributes.DIM) === 0 && (span.attributes & TextAttributes.BOLD) !== 0,
-            ),
-        )
       }
-
-      await setup.mockInput.typeText("/rename Hand picked")
-      setup.mockInput.pressEscape()
-      setup.mockInput.pressEnter()
-      await setup.waitFor(() => bodies.length === 4)
-      expect(bodies[3]).toEqual({ title: "Hand picked" })
-      expect(titleSpans().every((span) => (span.attributes & TextAttributes.DIM) === 0)).toBe(true)
-      responses[3].resolve(new Response(null, { status: 204 }))
-      setup.renderer.destroy()
-      await task
-    } finally {
-      responses.forEach((response) => response.resolve(new Response(null, { status: 204 })))
-      if (!setup.renderer.isDestroyed) setup.renderer.destroy()
-      await server.stop()
+      // No rename event is emitted for the unchanged-title and failed requests.
+      responses[index].resolve(new Response(null, { status }))
+      if (status === 503) {
+        const rows = (await setup.waitForFrame((frame) => frame.includes("UnexpectedStatus"))).split("\n")
+        const row = rows.findIndex((line) => line.includes("UnexpectedStatus"))
+        await setup.mockMouse.click(rows[row].indexOf("UnexpectedStatus"), row)
+      }
+      await setup.waitForFrame(
+        () =>
+          titleSpans().length > 0 &&
+          titleSpans().every(
+            (span) =>
+              (span.attributes & TextAttributes.DIM) === 0 &&
+              (span.attributes & TextAttributes.BOLD) !== 0 &&
+              span.fg.equals(foreground),
+          ),
+        { maxPasses: 60 },
+      )
     }
-  },
-)
+
+    await setup.mockInput.typeText("/rename Hand picked")
+    setup.mockInput.pressEscape()
+    setup.mockInput.pressEnter()
+    await setup.waitFor(() => bodies.length === 4)
+    expect(bodies[3]).toEqual({ title: "Hand picked" })
+    expect(titleSpans().every((span) => (span.attributes & TextAttributes.DIM) === 0)).toBe(true)
+    responses[3].resolve(new Response(null, { status: 204 }))
+    setup.renderer.destroy()
+    await task
+  } finally {
+    responses.forEach((response) => response.resolve(new Response(null, { status: 204 })))
+    refresh.resolve(json({ data: session }))
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    await server.stop()
+  }
+})
 
 test("session startup prompt is submitted exactly once", async () => {
   const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })

--- a/packages/tui/test/component/title-shimmer.test.ts
+++ b/packages/tui/test/component/title-shimmer.test.ts
@@ -1,0 +1,253 @@
+import { expect, test } from "bun:test"
+import { BoxRenderable, RGBA, TextAttributes, TextRenderable } from "@opentui/core"
+import { createTestRenderer, ManualClock } from "@opentui/core/testing"
+import { TitleShimmerRenderable } from "../../src/component/title-shimmer"
+
+for (const light of [false, true]) {
+  test(`shimmer travels right without changing text or geometry (${light ? "light" : "dark"})`, async () => {
+    const clock = new ManualClock()
+    const app = await createTestRenderer({ width: 32, height: 2, useThread: false, clock })
+    const foreground = RGBA.fromHex(light ? "#111111" : "#eeeeee")
+    const background = RGBA.fromHex(light ? "#eeeeee" : "#111111")
+    const title = new TitleShimmerRenderable(app.renderer, {
+      width: 24,
+      height: 1,
+      wrapMode: "none",
+      content: "abcdefghijklmnopqrstuvwx",
+      fg: foreground,
+      backdrop: background,
+      attributes: TextAttributes.ITALIC,
+      rename: { title: "abcdefghijklmnopqrstuvwx", pending: true },
+    })
+    app.renderer.root.add(title)
+    const colors = () =>
+      app
+        .captureSpans()
+        .lines[0].spans.flatMap((span) => Array.from({ length: span.width }, () => span.fg))
+        .slice(0, 24)
+    const peak = () => {
+      const contrast = colors().map(
+        (color) =>
+          Math.abs(color.r - background.r) + Math.abs(color.g - background.g) + Math.abs(color.b - background.b),
+      )
+      return contrast.indexOf(Math.max(...contrast))
+    }
+
+    try {
+      await app.renderOnce()
+      const frame = app.captureCharFrame()
+      const chunks = title.chunks
+      expect(app.renderer.root.liveCount).toBe(1)
+      expect(title.canReuseRenderCommandList()).toBe(true)
+      clock.advance(300)
+      await app.renderOnce()
+      const first = peak()
+      clock.advance(300)
+      await app.renderOnce()
+      expect(peak()).toBeGreaterThan(first)
+      expect(app.captureCharFrame()).toBe(frame)
+      expect(title.chunks).toBe(chunks)
+      expect([title.width, title.height]).toEqual([24, 1])
+      expect(
+        app
+          .captureSpans()
+          .lines[0].spans.filter((span) => span.text.trim())
+          .every((span) => (span.attributes & TextAttributes.ITALIC) !== 0),
+      ).toBe(true)
+
+      title.rename = { title: "abcdefghijklmnopqrstuvwx", pending: false }
+      await app.renderOnce()
+      expect(app.renderer.root.liveCount).toBe(0)
+      expect(colors().every((color) => color.equals(foreground))).toBe(true)
+      title.enabled = false
+      title.rename = { title: "abcdefghijklmnopqrstuvwx", pending: true }
+      await app.renderOnce()
+      expect(app.renderer.root.liveCount).toBe(0)
+      expect(colors().every((color) => color.equals(foreground))).toBe(true)
+      title.destroy()
+      expect(app.renderer.root.liveCount).toBe(0)
+    } finally {
+      app.renderer.destroy()
+    }
+  })
+}
+
+test("native glyphs, ancestor clipping, and shorter replacement survive shading", async () => {
+  const clock = new ManualClock()
+  const app = await createTestRenderer({ width: 32, height: 3, useThread: false, clock })
+  const content = "A\u65e5B \u{1f680} C cafe\u0301"
+  const title = new TitleShimmerRenderable(app.renderer, {
+    width: 24,
+    height: 1,
+    wrapMode: "none",
+    content,
+    fg: "#eeeeee",
+    backdrop: RGBA.fromHex("#111111"),
+    rename: { title: content, pending: true },
+  })
+  const plain = new TextRenderable(app.renderer, { width: 24, height: 1, content, fg: "#eeeeee", wrapMode: "none" })
+  const shadedBox = new BoxRenderable(app.renderer, { width: 24, height: 1, marginLeft: 2, overflow: "hidden" })
+  const plainBox = new BoxRenderable(app.renderer, { width: 24, height: 1, marginLeft: 2, overflow: "hidden" })
+  shadedBox.add(title)
+  plainBox.add(plain)
+  app.renderer.root.add(shadedBox)
+  app.renderer.root.add(plainBox)
+  app.renderer.root.add(new TextRenderable(app.renderer, { content: "untouched", fg: "#eeeeee" }))
+
+  try {
+    await app.renderOnce()
+    clock.advance(800)
+    await app.renderOnce()
+    const rows = app.captureCharFrame().split("\n")
+    expect(rows[0]).toBe(rows[1])
+    expect(rows[0]).toContain(content)
+    const colors = app
+      .captureSpans()
+      .lines[0].spans.flatMap((span) => Array.from({ length: span.width }, () => span.fg.toInts()))
+    expect(colors[3]).toEqual(colors[4])
+    expect(colors[7]).toEqual(colors[8])
+
+    for (const width of [8, 6, 3]) {
+      for (const offset of [0, -2]) {
+        shadedBox.width = width
+        plainBox.width = width
+        title.translateX = offset
+        plain.translateX = offset
+        clock.advance(200)
+        await app.renderOnce()
+        const clipped = app.captureCharFrame().split("\n")
+        expect(clipped[0]).toBe(clipped[1])
+        expect(clipped[2]).toContain("untouched")
+      }
+    }
+    expect(
+      app
+        .captureSpans()
+        .lines[2].spans.find((span) => span.text.includes("untouched"))
+        ?.fg.toInts(),
+    ).toEqual(RGBA.fromHex("#eeeeee").toInts())
+
+    title.content = "Short"
+    plain.content = "Short"
+    title.rename = { title: "Short", pending: false }
+    await app.renderOnce()
+    expect(app.captureCharFrame().split("\n")[0]).toBe(app.captureCharFrame().split("\n")[1])
+    expect(app.captureCharFrame()).not.toContain("cafe")
+    expect(app.renderer.root.liveCount).toBe(1)
+    clock.advance(450)
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test.each([false, true])("arrival wipes right, settles, and never delays text (%s)", async (light) => {
+  const clock = new ManualClock()
+  const app = await createTestRenderer({ width: 32, height: 2, useThread: false, clock })
+  const foreground = RGBA.fromHex(light ? "#111111" : "#eeeeee")
+  const background = RGBA.fromHex(light ? "#eeeeee" : "#111111")
+  const title = new TitleShimmerRenderable(app.renderer, {
+    width: 24,
+    height: 1,
+    content: "Old title",
+    fg: foreground,
+    backdrop: background,
+    rename: { title: "Old title", pending: true },
+  })
+  app.renderer.root.add(title)
+  const contrast = () =>
+    app
+      .captureSpans()
+      .lines[0].spans.flatMap((span) => Array.from({ length: span.width }, () => Math.abs(span.fg.r - background.r)))
+      .slice(0, 24)
+
+  try {
+    await app.renderOnce()
+    title.content = "abcdefghijklmnopqrstuvwx"
+    title.rename = { title: "abcdefghijklmnopqrstuvwx", pending: true }
+    await app.renderOnce()
+    const chunks = title.chunks
+    expect(app.captureCharFrame()).toContain("abcdefghijklmnopqrstuvwx")
+    expect(app.captureCharFrame()).not.toContain("Old title")
+    expect(app.renderer.root.liveCount).toBe(1)
+    title.rename = { title: "abcdefghijklmnopqrstuvwx", pending: false }
+    clock.advance(225)
+    await app.renderOnce()
+    const halfway = contrast()
+    expect(halfway[0]).toBeGreaterThan(halfway[23])
+    expect(halfway[23]).toBeGreaterThan(0)
+    expect(title.chunks).toBe(chunks)
+    clock.advance(225)
+    await app.renderOnce()
+    expect(contrast().every((value) => Math.abs(value - Math.abs(foreground.r - background.r)) < 0.01)).toBe(true)
+    expect(app.renderer.root.liveCount).toBe(0)
+    expect([title.width, title.height]).toEqual([24, 1])
+
+    title.content = "Manual title"
+    title.rename = { title: "Manual title", pending: false }
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("Manual title")
+    expect(app.renderer.root.liveCount).toBe(0)
+
+    title.rename = { title: "Manual title", pending: true }
+    title.content = "Next title"
+    title.rename = { title: "Next title", pending: false }
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(1)
+    title.enabled = false
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(0)
+    title.enabled = true
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("wrapped sidebar titles retain native layout and styles during shimmer and arrival", async () => {
+  const clock = new ManualClock()
+  const app = await createTestRenderer({ width: 24, height: 10, useThread: false, clock })
+  const content = "Review a long title with multiple wrapped lines"
+  const title = new TitleShimmerRenderable(app.renderer, {
+    width: 16,
+    content,
+    fg: "#eeeeee",
+    attributes: TextAttributes.BOLD,
+    backdrop: RGBA.fromHex("#111111"),
+    rename: { title: content, pending: true },
+  })
+  const plain = new TextRenderable(app.renderer, { width: 16, content, fg: "#eeeeee", attributes: TextAttributes.BOLD })
+  app.renderer.root.add(title)
+  app.renderer.root.add(plain)
+  const rows = () => app.captureCharFrame().split("\n")
+
+  try {
+    await app.renderOnce()
+    clock.advance(300)
+    await app.renderOnce()
+    expect(title.height).toBeGreaterThan(1)
+    expect(title.height).toBe(plain.height)
+    expect(rows().slice(0, title.height)).toEqual(rows().slice(title.height, title.height + plain.height))
+    expect(
+      app
+        .captureSpans()
+        .lines.slice(0, title.height)
+        .every((line) =>
+          line.spans.filter((span) => span.text.trim()).every((span) => (span.attributes & TextAttributes.BOLD) !== 0),
+        ),
+    ).toBe(true)
+    title.content = "Short"
+    plain.content = "Short"
+    title.rename = { title: "Short", pending: false }
+    await app.renderOnce()
+    expect(title.height).toBe(1)
+    expect(rows()[0]).toBe(rows()[1])
+    clock.advance(450)
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})

--- a/packages/tui/test/component/title-shimmer.test.ts
+++ b/packages/tui/test/component/title-shimmer.test.ts
@@ -3,7 +3,7 @@ import { BoxRenderable, RGBA, TextAttributes, TextRenderable } from "@opentui/co
 import { createTestRenderer, ManualClock } from "@opentui/core/testing"
 import { TitleShimmerRenderable } from "../../src/component/title-shimmer"
 
-test("pending shimmer changes colors, not text, and stops on unchanged completion", async () => {
+test("shimmer fades in from idle and fades out on unchanged completion", async () => {
   const clock = new ManualClock()
   const app = await createTestRenderer({ width: 24, height: 1, useThread: false, clock })
   const title = new TitleShimmerRenderable(app.renderer, {
@@ -12,20 +12,33 @@ test("pending shimmer changes colors, not text, and stops on unchanged completio
     content: "Compiler cleanup",
     fg: "#eeeeee",
     backdrop: RGBA.fromHex("#111111"),
-    rename: { title: "Compiler cleanup", pending: true },
+    rename: { title: "Compiler cleanup", pending: false },
   })
   app.renderer.root.add(title)
   try {
     await app.renderOnce()
     const frame = app.captureCharFrame()
     const colors = app.captureSpans()
-    clock.advance(600)
+    clock.advance(2000)
+    title.rename = { title: "Compiler cleanup", pending: true }
     await app.renderOnce()
+    expect(app.captureSpans()).toEqual(colors)
+    clock.advance(120)
+    await app.renderOnce()
+    const middle = app.captureSpans().lines[0].spans.findLast((span) => span.text.trim())?.fg.r ?? 0
+    expect(middle).toBeLessThan(colors.lines[0].spans[0].fg.r)
+    clock.advance(120)
+    await app.renderOnce()
+    expect(app.captureSpans().lines[0].spans.findLast((span) => span.text.trim())?.fg.r ?? 0).toBeLessThan(middle)
     expect(app.captureSpans()).not.toEqual(colors)
     expect(app.captureCharFrame()).toBe(frame)
     title.rename = { title: "Compiler cleanup", pending: false }
     await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(1)
+    clock.advance(240)
+    await app.renderOnce()
     expect(app.renderer.root.liveCount).toBe(0)
+    expect(app.captureSpans()).toEqual(colors)
     title.enabled = false
     title.rename = { title: "Compiler cleanup", pending: true }
     await app.renderOnce()
@@ -35,7 +48,7 @@ test("pending shimmer changes colors, not text, and stops on unchanged completio
   }
 })
 
-test("arrival replaces old text with new text across a clean wipe, without a comet", async () => {
+test("a feathered wipe keeps the old shimmer moving without dimming the revealed new title", async () => {
   const clock = new ManualClock()
   const app = await createTestRenderer({ width: 16, height: 1, useThread: false, clock })
   const title = new TitleShimmerRenderable(app.renderer, {
@@ -50,20 +63,22 @@ test("arrival replaces old text with new text across a clean wipe, without a com
   app.renderer.root.add(title)
   try {
     await app.renderOnce()
+    clock.advance(600)
+    await app.renderOnce()
+    const colors = app.captureSpans()
     title.content = "abcdefghijklmnop"
     title.rename = { title: "abcdefghijklmnop", pending: true }
     await app.renderOnce()
     expect(app.captureCharFrame().trim()).toBe("ABCDEFGHIJKLMNOP")
+    expect(app.captureSpans()).toEqual(colors)
     clock.advance(225)
     await app.renderOnce()
     expect(app.captureCharFrame().trim()).toBe("abcdefghIJKLMNOP")
-    expect(
-      app
-        .captureSpans()
-        .lines[0].spans.every(
-          (span) => span.fg.equals(RGBA.fromHex("#eeeeee")) && Boolean(span.attributes & TextAttributes.ITALIC),
-        ),
-    ).toBe(true)
+    const spans = app.captureSpans().lines[0].spans
+    expect(spans[0].fg.equals(RGBA.fromHex("#eeeeee"))).toBe(true)
+    expect(spans.some((span) => span.fg.equals(RGBA.fromHex("#111111")))).toBe(true)
+    expect(spans.at(-1)?.fg.toInts()).not.toEqual(colors.lines[0].spans.at(-1)?.fg.toInts())
+    expect(spans.every((span) => Boolean(span.attributes & TextAttributes.ITALIC))).toBe(true)
     clock.advance(225)
     await app.renderOnce()
     expect(app.captureCharFrame().trim()).toBe("abcdefghijklmnop")
@@ -116,11 +131,11 @@ test("native Unicode clipping and shorter replacement leave no split glyphs or o
     expect(app.captureCharFrame().split("\n")[0]).toBe(app.captureCharFrame().split("\n")[1])
     title.content = "Short"
     title.rename = { title: "Short", pending: false }
-    clock.advance(180)
+    clock.advance(200)
     await app.renderOnce()
     expect(app.captureCharFrame().split("\n")[0].trim()).toBe("Sh B")
     expect(app.captureCharFrame().split("\n")[2]).toContain("untouched")
-    clock.advance(270)
+    clock.advance(250)
     await app.renderOnce()
     expect(app.captureCharFrame().split("\n")[0].trim()).toBe("Short")
     expect(app.renderer.root.liveCount).toBe(0)

--- a/packages/tui/test/component/title-shimmer.test.ts
+++ b/packages/tui/test/component/title-shimmer.test.ts
@@ -3,249 +3,126 @@ import { BoxRenderable, RGBA, TextAttributes, TextRenderable } from "@opentui/co
 import { createTestRenderer, ManualClock } from "@opentui/core/testing"
 import { TitleShimmerRenderable } from "../../src/component/title-shimmer"
 
-for (const light of [false, true]) {
-  test(`shimmer travels right without changing text or geometry (${light ? "light" : "dark"})`, async () => {
-    const clock = new ManualClock()
-    const app = await createTestRenderer({ width: 32, height: 2, useThread: false, clock })
-    const foreground = RGBA.fromHex(light ? "#111111" : "#eeeeee")
-    const background = RGBA.fromHex(light ? "#eeeeee" : "#111111")
-    const title = new TitleShimmerRenderable(app.renderer, {
-      width: 24,
-      height: 1,
-      wrapMode: "none",
-      content: "abcdefghijklmnopqrstuvwx",
-      fg: foreground,
-      backdrop: background,
-      attributes: TextAttributes.ITALIC,
-      rename: { title: "abcdefghijklmnopqrstuvwx", pending: true },
-    })
-    app.renderer.root.add(title)
-    const colors = () =>
-      app
-        .captureSpans()
-        .lines[0].spans.flatMap((span) => Array.from({ length: span.width }, () => span.fg))
-        .slice(0, 24)
-    const peak = () => {
-      const contrast = colors().map(
-        (color) =>
-          Math.abs(color.r - background.r) + Math.abs(color.g - background.g) + Math.abs(color.b - background.b),
-      )
-      return contrast.indexOf(Math.max(...contrast))
-    }
-
-    try {
-      await app.renderOnce()
-      const frame = app.captureCharFrame()
-      const chunks = title.chunks
-      expect(app.renderer.root.liveCount).toBe(1)
-      expect(title.canReuseRenderCommandList()).toBe(true)
-      clock.advance(300)
-      await app.renderOnce()
-      const first = peak()
-      clock.advance(300)
-      await app.renderOnce()
-      expect(peak()).toBeGreaterThan(first)
-      expect(app.captureCharFrame()).toBe(frame)
-      expect(title.chunks).toBe(chunks)
-      expect([title.width, title.height]).toEqual([24, 1])
-      expect(
-        app
-          .captureSpans()
-          .lines[0].spans.filter((span) => span.text.trim())
-          .every((span) => (span.attributes & TextAttributes.ITALIC) !== 0),
-      ).toBe(true)
-
-      title.rename = { title: "abcdefghijklmnopqrstuvwx", pending: false }
-      await app.renderOnce()
-      expect(app.renderer.root.liveCount).toBe(0)
-      expect(colors().every((color) => color.equals(foreground))).toBe(true)
-      title.enabled = false
-      title.rename = { title: "abcdefghijklmnopqrstuvwx", pending: true }
-      await app.renderOnce()
-      expect(app.renderer.root.liveCount).toBe(0)
-      expect(colors().every((color) => color.equals(foreground))).toBe(true)
-      title.destroy()
-      expect(app.renderer.root.liveCount).toBe(0)
-    } finally {
-      app.renderer.destroy()
-    }
-  })
-}
-
-test("native glyphs, ancestor clipping, and shorter replacement survive shading", async () => {
+test("pending shimmer changes colors, not text, and stops on unchanged completion", async () => {
   const clock = new ManualClock()
-  const app = await createTestRenderer({ width: 32, height: 3, useThread: false, clock })
-  const content = "A\u65e5B \u{1f680} C cafe\u0301"
+  const app = await createTestRenderer({ width: 24, height: 1, useThread: false, clock })
   const title = new TitleShimmerRenderable(app.renderer, {
     width: 24,
     height: 1,
-    wrapMode: "none",
+    content: "Compiler cleanup",
+    fg: "#eeeeee",
+    backdrop: RGBA.fromHex("#111111"),
+    rename: { title: "Compiler cleanup", pending: true },
+  })
+  app.renderer.root.add(title)
+  try {
+    await app.renderOnce()
+    const frame = app.captureCharFrame()
+    const colors = app.captureSpans()
+    clock.advance(600)
+    await app.renderOnce()
+    expect(app.captureSpans()).not.toEqual(colors)
+    expect(app.captureCharFrame()).toBe(frame)
+    title.rename = { title: "Compiler cleanup", pending: false }
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(0)
+    title.enabled = false
+    title.rename = { title: "Compiler cleanup", pending: true }
+    await app.renderOnce()
+    expect(app.renderer.root.liveCount).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("arrival replaces old text with new text across a clean wipe, without a comet", async () => {
+  const clock = new ManualClock()
+  const app = await createTestRenderer({ width: 16, height: 1, useThread: false, clock })
+  const title = new TitleShimmerRenderable(app.renderer, {
+    width: 16,
+    height: 1,
+    content: "ABCDEFGHIJKLMNOP",
+    fg: "#eeeeee",
+    attributes: TextAttributes.ITALIC,
+    backdrop: RGBA.fromHex("#111111"),
+    rename: { title: "ABCDEFGHIJKLMNOP", pending: true },
+  })
+  app.renderer.root.add(title)
+  try {
+    await app.renderOnce()
+    title.content = "abcdefghijklmnop"
+    title.rename = { title: "abcdefghijklmnop", pending: true }
+    await app.renderOnce()
+    expect(app.captureCharFrame().trim()).toBe("ABCDEFGHIJKLMNOP")
+    clock.advance(225)
+    await app.renderOnce()
+    expect(app.captureCharFrame().trim()).toBe("abcdefghIJKLMNOP")
+    expect(
+      app
+        .captureSpans()
+        .lines[0].spans.every(
+          (span) => span.fg.equals(RGBA.fromHex("#eeeeee")) && Boolean(span.attributes & TextAttributes.ITALIC),
+        ),
+    ).toBe(true)
+    clock.advance(225)
+    await app.renderOnce()
+    expect(app.captureCharFrame().trim()).toBe("abcdefghijklmnop")
+    expect(app.renderer.root.liveCount).toBe(0)
+
+    title.rename = { title: "abcdefghijklmnop", pending: false }
+    title.content = "Manual"
+    title.rename = { title: "Manual", pending: false }
+    await app.renderOnce()
+    expect(app.captureCharFrame().trim()).toBe("Manual")
+    expect(app.renderer.root.liveCount).toBe(0)
+
+    title.rename = { title: "Manual", pending: true }
+    await app.renderOnce()
+    title.content = "Next"
+    title.rename = { title: "Next", pending: false }
+    title.enabled = false
+    await app.renderOnce()
+    expect(app.captureCharFrame().trim()).toBe("Next")
+    title.enabled = true
+    expect(app.renderer.root.liveCount).toBe(0)
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("native Unicode clipping and shorter replacement leave no split glyphs or old tail", async () => {
+  const clock = new ManualClock()
+  const app = await createTestRenderer({ width: 24, height: 3, useThread: false, clock })
+  const content = "A\u65e5B \u{1f680} cafe\u0301"
+  const title = new TitleShimmerRenderable(app.renderer, {
+    width: 20,
+    height: 1,
     content,
     fg: "#eeeeee",
+    wrapMode: "none",
     backdrop: RGBA.fromHex("#111111"),
     rename: { title: content, pending: true },
   })
-  const plain = new TextRenderable(app.renderer, { width: 24, height: 1, content, fg: "#eeeeee", wrapMode: "none" })
-  const shadedBox = new BoxRenderable(app.renderer, { width: 24, height: 1, marginLeft: 2, overflow: "hidden" })
-  const plainBox = new BoxRenderable(app.renderer, { width: 24, height: 1, marginLeft: 2, overflow: "hidden" })
+  const plain = new TextRenderable(app.renderer, { width: 20, height: 1, content, wrapMode: "none" })
+  const shadedBox = new BoxRenderable(app.renderer, { width: 6, height: 1, marginLeft: 2, overflow: "hidden" })
+  const plainBox = new BoxRenderable(app.renderer, { width: 6, height: 1, marginLeft: 2, overflow: "hidden" })
   shadedBox.add(title)
   plainBox.add(plain)
   app.renderer.root.add(shadedBox)
   app.renderer.root.add(plainBox)
-  app.renderer.root.add(new TextRenderable(app.renderer, { content: "untouched", fg: "#eeeeee" }))
-
+  app.renderer.root.add(new TextRenderable(app.renderer, { content: "untouched" }))
   try {
-    await app.renderOnce()
-    clock.advance(800)
-    await app.renderOnce()
-    const rows = app.captureCharFrame().split("\n")
-    expect(rows[0]).toBe(rows[1])
-    expect(rows[0]).toContain(content)
-    const colors = app
-      .captureSpans()
-      .lines[0].spans.flatMap((span) => Array.from({ length: span.width }, () => span.fg.toInts()))
-    expect(colors[3]).toEqual(colors[4])
-    expect(colors[7]).toEqual(colors[8])
-
-    for (const width of [8, 6, 3]) {
-      for (const offset of [0, -2]) {
-        shadedBox.width = width
-        plainBox.width = width
-        title.translateX = offset
-        plain.translateX = offset
-        clock.advance(200)
-        await app.renderOnce()
-        const clipped = app.captureCharFrame().split("\n")
-        expect(clipped[0]).toBe(clipped[1])
-        expect(clipped[2]).toContain("untouched")
-      }
-    }
-    expect(
-      app
-        .captureSpans()
-        .lines[2].spans.find((span) => span.text.includes("untouched"))
-        ?.fg.toInts(),
-    ).toEqual(RGBA.fromHex("#eeeeee").toInts())
-
-    title.content = "Short"
-    plain.content = "Short"
-    title.rename = { title: "Short", pending: false }
     await app.renderOnce()
     expect(app.captureCharFrame().split("\n")[0]).toBe(app.captureCharFrame().split("\n")[1])
-    expect(app.captureCharFrame()).not.toContain("cafe")
-    expect(app.renderer.root.liveCount).toBe(1)
-    clock.advance(450)
-    await app.renderOnce()
-    expect(app.renderer.root.liveCount).toBe(0)
-  } finally {
-    app.renderer.destroy()
-  }
-})
-
-test.each([false, true])("arrival wipes right, settles, and never delays text (%s)", async (light) => {
-  const clock = new ManualClock()
-  const app = await createTestRenderer({ width: 32, height: 2, useThread: false, clock })
-  const foreground = RGBA.fromHex(light ? "#111111" : "#eeeeee")
-  const background = RGBA.fromHex(light ? "#eeeeee" : "#111111")
-  const title = new TitleShimmerRenderable(app.renderer, {
-    width: 24,
-    height: 1,
-    content: "Old title",
-    fg: foreground,
-    backdrop: background,
-    rename: { title: "Old title", pending: true },
-  })
-  app.renderer.root.add(title)
-  const contrast = () =>
-    app
-      .captureSpans()
-      .lines[0].spans.flatMap((span) => Array.from({ length: span.width }, () => Math.abs(span.fg.r - background.r)))
-      .slice(0, 24)
-
-  try {
-    await app.renderOnce()
-    title.content = "abcdefghijklmnopqrstuvwx"
-    title.rename = { title: "abcdefghijklmnopqrstuvwx", pending: true }
-    await app.renderOnce()
-    const chunks = title.chunks
-    expect(app.captureCharFrame()).toContain("abcdefghijklmnopqrstuvwx")
-    expect(app.captureCharFrame()).not.toContain("Old title")
-    expect(app.renderer.root.liveCount).toBe(1)
-    title.rename = { title: "abcdefghijklmnopqrstuvwx", pending: false }
-    clock.advance(225)
-    await app.renderOnce()
-    const halfway = contrast()
-    expect(halfway[0]).toBeGreaterThan(halfway[23])
-    expect(halfway[23]).toBeGreaterThan(0)
-    expect(title.chunks).toBe(chunks)
-    clock.advance(225)
-    await app.renderOnce()
-    expect(contrast().every((value) => Math.abs(value - Math.abs(foreground.r - background.r)) < 0.01)).toBe(true)
-    expect(app.renderer.root.liveCount).toBe(0)
-    expect([title.width, title.height]).toEqual([24, 1])
-
-    title.content = "Manual title"
-    title.rename = { title: "Manual title", pending: false }
-    await app.renderOnce()
-    expect(app.captureCharFrame()).toContain("Manual title")
-    expect(app.renderer.root.liveCount).toBe(0)
-
-    title.rename = { title: "Manual title", pending: true }
-    title.content = "Next title"
-    title.rename = { title: "Next title", pending: false }
-    await app.renderOnce()
-    expect(app.renderer.root.liveCount).toBe(1)
-    title.enabled = false
-    await app.renderOnce()
-    expect(app.renderer.root.liveCount).toBe(0)
-    title.enabled = true
-    await app.renderOnce()
-    expect(app.renderer.root.liveCount).toBe(0)
-  } finally {
-    app.renderer.destroy()
-  }
-})
-
-test("wrapped sidebar titles retain native layout and styles during shimmer and arrival", async () => {
-  const clock = new ManualClock()
-  const app = await createTestRenderer({ width: 24, height: 10, useThread: false, clock })
-  const content = "Review a long title with multiple wrapped lines"
-  const title = new TitleShimmerRenderable(app.renderer, {
-    width: 16,
-    content,
-    fg: "#eeeeee",
-    attributes: TextAttributes.BOLD,
-    backdrop: RGBA.fromHex("#111111"),
-    rename: { title: content, pending: true },
-  })
-  const plain = new TextRenderable(app.renderer, { width: 16, content, fg: "#eeeeee", attributes: TextAttributes.BOLD })
-  app.renderer.root.add(title)
-  app.renderer.root.add(plain)
-  const rows = () => app.captureCharFrame().split("\n")
-
-  try {
-    await app.renderOnce()
-    clock.advance(300)
-    await app.renderOnce()
-    expect(title.height).toBeGreaterThan(1)
-    expect(title.height).toBe(plain.height)
-    expect(rows().slice(0, title.height)).toEqual(rows().slice(title.height, title.height + plain.height))
-    expect(
-      app
-        .captureSpans()
-        .lines.slice(0, title.height)
-        .every((line) =>
-          line.spans.filter((span) => span.text.trim()).every((span) => (span.attributes & TextAttributes.BOLD) !== 0),
-        ),
-    ).toBe(true)
     title.content = "Short"
-    plain.content = "Short"
     title.rename = { title: "Short", pending: false }
+    clock.advance(180)
     await app.renderOnce()
-    expect(title.height).toBe(1)
-    expect(rows()[0]).toBe(rows()[1])
-    clock.advance(450)
+    expect(app.captureCharFrame().split("\n")[0].trim()).toBe("Sh B")
+    expect(app.captureCharFrame().split("\n")[2]).toContain("untouched")
+    clock.advance(270)
     await app.renderOnce()
+    expect(app.captureCharFrame().split("\n")[0].trim()).toBe("Short")
     expect(app.renderer.root.liveCount).toBe(0)
   } finally {
     app.renderer.destroy()


### PR DESCRIPTION
## Why

Automatic `/rename` leaves the session title looking unchanged while a new title is being generated. The command looks like it did nothing until a different title eventually appears.

## What Changes

| Action | Behavior |
| --- | --- |
| `/rename` without a title | Ease from normal text into the comet shimmer over 240 ms, rather than snapping opacity. The comet repeats every 1200 ms. |
| A new title arrives | Replace old with new across a feathered left-to-right boundary over 450 ms. The old title keeps shimmering as it is wiped away; the revealed new title has no comet. |
| Animations disabled | Dim the title while pending, then restore normal styling without shimmer or arrival motion. |
| Unchanged title or failure | Ease back to normal text over 240 ms without an arrival wipe. Preserve error reporting. |
| Repeat `/rename` while pending | Do not start another generation request for that session. |
| `/rename My session` or the manual dialog | Keep the existing manual rename behavior, without an arrival animation. |

Feedback applies to horizontal tabs, vertical tabs, and the session sidebar. Successful automatic renames refresh the local session before clearing pending, keeping the new title associated with the request even when its response beats the renamed event. Tabs consume the live title rather than waiting for its asynchronous storage write.

The pending shader and arrival wipe run on the renderer clock with reused buffers. The wipe retains an unshaded snapshot of the previous title and applies its continuing shimmer beneath the soft boundary, without resetting brightness or the shimmer phase. Whole native glyphs fade at the border before replacement. The snapshot is released after the wipe or when motion is disabled, and the revealed new title does not resume the comet.

## Demo

https://github.com/user-attachments/assets/ee1c4296-3452-4b46-8c04-ee9b891453e3

Matched OpenCode Drive recordings of the production TUI and server: **before** `0d42e76006`, **after** `1d6b43eb5f`. Both use the same isolated fixture, vertical tabs, and a 90x20 terminal. Model replies are simulated, with the title response held for three seconds. The comparison plays at real speed. Export: 6 seconds, H.264, 1800x480, 60 FPS.

## Scope

Client-local feedback for user-requested automatic title generation, independent of session execution status. No server API change. The experimental story and standalone-launcher changes are not included.

## Verification

```bash
# From packages/tui
bun run test test/component/title-shimmer.test.ts test/component/tab-pulse.test.tsx test/app-lifecycle.test.tsx test/context/session-tabs.test.tsx test/component/session-tabs-status.test.tsx test/component/session-tabs-mouse.test.tsx test/cli/tui/data.test.tsx
bun typecheck
```

112 tests pass across the affected regression suite. Rename-specific coverage remains four tests: eased entry/exit from idle, a feathered wipe with brightness continuity and a continuing old shimmer, Unicode clipping and shorter replacement, and a production slash-command request that refreshes the displayed title without a renamed event. No layout/theme/animation matrix or full-app color sampling is added. TUI typecheck and the pre-push repository typecheck pass (33 tasks, 32 cached).

An earlier full-app probe of the pending comet, before this true-wipe revision, measured roughly 14% of one CPU core while animating and 0.6% while settled, with zero frames and output after settling. It used one horizontal title, 18 static fixture messages, and a counting ANSI discard sink on an M2 Max. This is an app-activation measurement, not shader-only CPU or real PTY/emulator cost. The revised arrival wipe has not been separately benchmarked.
