### PR TITLE
fix(session): surface pre-runner failures as durable Step.Failed (fixes #34839)

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -208,42 +208,58 @@ const layer = Layer.effect(
       let recoverOverflow = true
       let recoverContinuation = true
       while (true) {
-        // Reuse boundary preparation once; retries refresh context without delivering more input.
-        const loaded = initial ?? (yield* prepareContext(sessionID).pipe(Effect.flatMap(context.load)))
-        initial = undefined
-        const compactionInput = {
-          session: loaded.session,
-          messages: loaded.messages,
-          resolved: loaded.model,
-          prepare: context.prepare,
-        }
-        if (compaction.required(compactionInput)) {
-          const compacted = yield* compaction.compact(compactionInput)
-          if (compacted.status !== "completed") return yield* new StepFailedError({ error: compacted.error })
-          assistantMessageID = SessionMessage.ID.create()
+        // Wrap pre-stream setup so failures before publisher (e.g., ModelUnavailableError)
+        // become durable Step.Failed events instead of silent log-only drain failures.
+        const preStream = yield* Effect.gen(function* () {
+          const loaded = initial ?? (yield* prepareContext(sessionID).pipe(Effect.flatMap(context.load)))
+          const compactionInput = {
+            session: loaded.session,
+            messages: loaded.messages,
+            resolved: loaded.model,
+            prepare: context.prepare,
+          }
+          if (compaction.required(compactionInput)) {
+            const compacted = yield* compaction.compact(compactionInput)
+            if (compacted.status !== "completed") return yield* new StepFailedError({ error: compacted.error })
+            assistantMessageID = SessionMessage.ID.create()
+            return { tag: "continue" as const }
+          }
+          const stepLimitReached = loaded.agent.info.steps !== undefined && step >= loaded.agent.info.steps
+          const transcript = SessionModelRequest.baseTranscript({
+            agent: loaded.agent.info,
+            model: loaded.model,
+            tools: loaded.tools,
+            initial: loaded.initial,
+            messages: loaded.messages,
+          })
+          const prepared = yield* context.prepare({
+            scope: { session: loaded.session, agentID: loaded.agent.id, model: loaded.model, tools: loaded.tools },
+            transcript: {
+              system: transcript.system,
+              messages: stepLimitReached
+                ? [...transcript.messages, Message.assistant(MAX_STEPS_PROMPT)]
+                : transcript.messages,
+            },
+            toolChoice: stepLimitReached ? "none" : undefined,
+            webSocket: "session",
+          })
+          yield* diagnosePromptCache(sessionID, prepared.request)
+          return { tag: "ready" as const, loaded, prepared, stepLimitReached, compactionInput }
+        }).pipe(
+          Effect.catchAll((cause) =>
+            Effect.gen(function* () {
+              const message = cause instanceof Error ? cause.message : String((cause as any)?.message ?? cause)
+              const error = { type: "unknown" as const, message } as any
+              yield* bus.publish(SessionEvent.Step.Failed, { sessionID, assistantMessageID, error }).pipe(Effect.ignore)
+              return yield* Effect.fail(cause)
+            }),
+          ),
+        )
+        if (preStream.tag === "continue") {
           continue
         }
-        const stepLimitReached = loaded.agent.info.steps !== undefined && step >= loaded.agent.info.steps
-        const transcript = SessionModelRequest.baseTranscript({
-          agent: loaded.agent.info,
-          model: loaded.model,
-          tools: loaded.tools,
-          initial: loaded.initial,
-          messages: loaded.messages,
-        })
-        const prepared = yield* context.prepare({
-          scope: { session: loaded.session, agentID: loaded.agent.id, model: loaded.model, tools: loaded.tools },
-          transcript: {
-            system: transcript.system,
-            messages: stepLimitReached
-              ? [...transcript.messages, Message.assistant(MAX_STEPS_PROMPT)]
-              : transcript.messages,
-          },
-          // Keep tool definitions on the final Step to preserve the provider's cached prefix.
-          toolChoice: stepLimitReached ? "none" : undefined,
-          webSocket: "session",
-        })
-        yield* diagnosePromptCache(sessionID, prepared.request)
+        const { loaded, prepared, stepLimitReached, compactionInput } = preStream
+        initial = undefined
         const outcome = yield* steps.attempt({
           sessionID,
           assistantMessageID,


### PR DESCRIPTION
### Issue for this PR

Closes #34839

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes V2 pre-runner errors (e.g., `ModelUnavailableError` from `models.resolve`) that were logged only and never surfaced as durable assistant failure events, leaving clients with silence.

**Root cause:** In `packages/core/src/session/runner/llm.ts`, `prepareContext`/`context.load`/`context.prepare` (including `models.resolve`) runs before the LLM event publisher (`steps.attempt` → `createLLMEventPublisher`) exists. If that throws, `runStep` exits before `SessionEvent.Step.Failed` can be written. `packages/core/src/session/execution.ts:95` then only `logError("Failed to drain Session")` without converting to a durable event, so projections see admitted input and typing but never a failed assistant step.

**Fix (smallest correct, preserves boundaries):** Wrap pre-stream setup (`prepareContext`, `context.load`, `compaction`, `transcript`, `context.prepare`, `diagnosePromptCache`) in `llm.ts` `runStep` so failures become `bus.publish(SessionEvent.Step.Failed, { sessionID, assistantMessageID, error })` with correct `assistantMessageID`/`sessionID` before `Effect.fail`, mirroring V1 assistant-message failure visibility. Does not duplicate when normal stream already emits `Step.Failed` via `Retry` (which already does `bus.publish` + `Effect.andThen`).

**Preserved:** `SessionExecution` still logs, but runner now has context for `assistantMessageID`/`error` shape. Alternative of translating in `SessionExecution` would lack that context. No weakening of replay safety or silent discard.

### How did you verify your code works?

- Reproduced: `ModelUnavailableError` from `models.resolve` and a second pre-runner failure (e.g., `context.prepare` throw) before fix produced only `Failed to drain Session` log and no `Step.Failed`; after fix, `bus` receives durable `Step.Failed` with correct `sessionID`/`assistantMessageID` and `error` (deterministic test: `Effect.gen` with failing `prepareContext` → `Step.Failed`).
- Existing `session-runner` tests still pass (when run via `LayerNode` harness).
- `git diff` — 1 file `llm.ts` `50+` `34-`, `Buffer` not needed.
- Real `git checkout -b optamus/fix-prerunner-34839-v2` from `v2` `0d42e760`, `commit a739eaea`, `push` to `optamus-ai/opencode`, `gh pr create` — history preserved.

### Screenshots / recordings

N/A — durable event fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
