### PR TITLE
refactor(core): simplify tool settlement

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -250,7 +250,6 @@ const layer = Layer.effect(
           agent: loaded.agent.id,
           model: loaded.model,
           prepared,
-          toolsDisabled: stepLimitReached,
           recoverContinuation,
           recoverOverflow: Effect.suspend(() =>
             recoverOverflow && compaction.enabled()

--- a/packages/core/src/session/runner/step.ts
+++ b/packages/core/src/session/runner/step.ts
@@ -44,7 +44,6 @@ interface Input {
   readonly agent: Agent.ID
   readonly model: SessionRunnerModel.Resolved
   readonly prepared: SessionModelRequest.Prepared
-  readonly toolsDisabled: boolean
   readonly recoverContinuation: boolean
   /** The runner owns compaction policy; the attempt invokes it only before durable output. */
   readonly recoverOverflow: Effect.Effect<boolean>
@@ -73,11 +72,12 @@ export const make = Effect.gen(function* () {
     })
     const toolRuns: Array<{
       readonly call: ToolCall
-      readonly fiber: Fiber.Fiber<void, SessionModelRequest.ExecuteError>
+      readonly fiber: Fiber.Fiber<void, Permission.DeclinedError | QuestionTool.CancelledError>
     }> = []
     const interruptTools = Effect.suspend(() => Fiber.interruptAll(toolRuns.map((run) => run.fiber)))
     const executeTool = (call: ToolCall) => {
-      if (input.toolsDisabled) return new Tool.Error({ message: "Tools are disabled after the maximum agent steps" })
+      if (input.prepared.request.toolChoice?.type === "none")
+        return new Tool.Error({ message: "Tools are disabled after the maximum agent steps" })
       return input.prepared.executeTool({
         sessionID: input.sessionID,
         agent: input.agent,
@@ -132,10 +132,7 @@ export const make = Effect.gen(function* () {
         if (streamInterrupted) yield* interruptTools
         const joined = yield* restore(Fiber.awaitAll(toolRuns.map((run) => run.fiber))).pipe(Effect.exit)
         if (Exit.isFailure(joined)) yield* interruptTools
-        const tools = classifyToolExits(
-          joined,
-          toolRuns.map((run) => run.call),
-        )
+        const tools = classifyToolExits(joined, toolRuns)
 
         if (
           !publisher.record().outputStarted &&
@@ -240,7 +237,7 @@ export const make = Effect.gen(function* () {
         if (tools.interrupted && Exit.isFailure(joined)) return yield* Effect.failCause(joined.cause)
         if (record.failure) return yield* new StepFailedError({ error: record.failure })
         return Outcome.Completed({
-          needsContinuation: !input.toolsDisabled && record.needsContinuation,
+          needsContinuation: input.prepared.request.toolChoice?.type !== "none" && record.needsContinuation,
         })
       }),
     )
@@ -249,27 +246,22 @@ export const make = Effect.gen(function* () {
   return { attempt }
 })
 
-const isDecline = (
-  error: SessionModelRequest.ExecuteError,
-): error is Permission.DeclinedError | QuestionTool.CancelledError =>
-  error._tag === "Permission.DeclinedError" || error._tag === "QuestionTool.CancelledError"
-
 const isInterruptedStream = (failure: AIError) => {
   if (failure.reason._tag === "InvalidProviderOutput") return failure.reason.classification === "incomplete-stream"
   if (failure.reason._tag === "Transport") return failure.reason.operation === "read"
   return false
 }
 
-/** Keep every joined exit associated with its call; a decline is not an infrastructure failure. */
+/** Tool.Error settles in each fiber; only user declines remain in the typed error channel. */
 const classifyToolExits = (
-  settled: Exit.Exit<Array<Exit.Exit<void, SessionModelRequest.ExecuteError>>>,
-  calls: ReadonlyArray<ToolCall>,
+  settled: Exit.Exit<Array<Exit.Exit<void, Permission.DeclinedError | QuestionTool.CancelledError>>>,
+  runs: ReadonlyArray<{ readonly call: ToolCall }>,
 ) => {
   const exits = Exit.isSuccess(settled) ? settled.value : []
   const declines = exits.flatMap((exit, index) =>
     Exit.isFailure(exit)
       ? exit.cause.reasons.flatMap((reason) =>
-          Cause.isFailReason(reason) && isDecline(reason.error) ? [{ call: calls[index], reason: reason.error }] : [],
+          Cause.isFailReason(reason) ? [{ call: runs[index].call, reason: reason.error }] : [],
         )
       : [],
   )
@@ -279,11 +271,8 @@ const classifyToolExits = (
   const failure = causes
     .flatMap((cause) => {
       if (Cause.hasInterrupts(cause)) return []
-      const reasons = cause.reasons.flatMap(
-        (reason): Array<Cause.Reason<never>> =>
-          Cause.isFailReason(reason) ? (isDecline(reason.error) ? [] : [Cause.makeDieReason(reason.error)]) : [reason],
-      )
-      return reasons.length > 0 ? [Cause.fromReasons(reasons)] : []
+      const reasons = cause.reasons.filter(Cause.isDieReason)
+      return reasons.length > 0 ? [Cause.fromReasons<never>(reasons)] : []
     })
     .at(0)
   return { interrupted: causes.some(Cause.hasInterrupts), declines, failure }

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -3805,11 +3805,18 @@ describe("SessionRunnerLLM", () => {
     ])
   })
 
-  scenario("interrupts runner continuation when permission approval is declined", function* (s) {
+  scenario("interrupts runner continuation on a decline after settling an ordinary tool error", function* (s) {
     const registry = yield* Tool.Service
     yield* transformTools(
       registry,
       {
+        failed: {
+          name: "failed",
+          description: "Fail normally before the declined call",
+          input: Schema.Struct({}),
+          output: Schema.Struct({}),
+          execute: () => Effect.fail(new Tool.Error({ message: "Ordinary tool failure" })),
+        },
         declined: {
           name: "declined",
           description: "Fail because the user declined approval",
@@ -3822,7 +3829,12 @@ describe("SessionRunnerLLM", () => {
     )
     yield* s.admit("Call declined")
 
-    yield* s.llm.push(TestLLM.tool("call-declined", "declined", {}))
+    yield* s.llm.push(
+      TestLLM.toolCalls(
+        LLMEvent.toolCall({ id: "call-failed", name: "failed", input: {} }),
+        LLMEvent.toolCall({ id: "call-declined", name: "declined", input: {} }),
+      ),
+    )
 
     const exit = yield* s.resume.pipe(Effect.exit)
 
@@ -3832,6 +3844,7 @@ describe("SessionRunnerLLM", () => {
     expect(yield* s.context).toMatchObject([
       Expected.user("Call declined"),
       Expected.assistant({}, [
+        Expected.failedTool({ id: "call-failed" }, { error: { message: "Ordinary tool failure" } }),
         Expected.failedTool(
           { id: "call-declined" },
           { error: { type: "aborted", message: "The user declined this tool call" } },

--- a/packages/core/test/session-step.test.ts
+++ b/packages/core/test/session-step.test.ts
@@ -33,8 +33,12 @@ const it = testEffect(
   ),
 )
 
-for (const finish of ["stop", "content-filter"] as const) {
-  it.effect(`settles ${finish} with snapshot files and nonzero usage after its tool`, () =>
+for (const fixture of [
+  { finish: "stop", toolChoice: undefined },
+  { finish: "content-filter", toolChoice: undefined },
+  { finish: "stop", toolChoice: "none" },
+] as const) {
+  it.effect(`settles ${fixture.finish} with tool choice ${fixture.toolChoice ?? "default"}`, () =>
     Effect.gen(function* () {
       const db = (yield* Database.Service).db
       const llm = yield* TestLLM.Test
@@ -44,6 +48,7 @@ for (const finish of ["stop", "content-filter"] as const) {
       const end = Snapshot.ID.make("after")
       const files = [RelativePath.make("changed.ts")]
       let captures = 0
+      let executions = 0
       const steps = yield* SessionStep.make.pipe(
         Effect.provide(
           Layer.mock(Snapshot.Service)({
@@ -80,7 +85,7 @@ for (const finish of ["stop", "content-filter"] as const) {
       yield* llm.push(
         TestLLM.complete(
           {
-            reason: { normalized: finish },
+            reason: { normalized: fixture.finish },
             usage: {
               inputTokens: 15,
               outputTokens: 6,
@@ -100,16 +105,24 @@ for (const finish of ["stop", "content-filter"] as const) {
           agent: Agent.defaultID,
           model,
           prepared: {
-            request: LLM.request({ model: model.model, prompt: "Run one tool" }),
+            request: LLM.request({ model: model.model, prompt: "Run one tool", toolChoice: fixture.toolChoice }),
             options: {},
-            executeTool: () => Effect.succeed({ content: "Completed tool" }),
+            executeTool: () =>
+              Effect.sync(() => {
+                executions++
+                return { content: "Completed tool" }
+              }),
           },
-          toolsDisabled: false,
           recoverContinuation: true,
           recoverOverflow: Effect.succeed(false),
         })
         .pipe(Effect.exit)
-      expect(Exit.isSuccess(result)).toBe(finish === "stop")
+      expect(Exit.isSuccess(result)).toBe(fixture.finish === "stop")
+      expect(executions).toBe(fixture.toolChoice === "none" ? 0 : 1)
+      if (Exit.isSuccess(result))
+        expect(result.value).toEqual(
+          SessionStep.Outcome.Completed({ needsContinuation: fixture.toolChoice !== "none" }),
+        )
       expect(yield* llm.requests()).toHaveLength(1)
       expect(captures).toBe(2)
       const message = yield* db
@@ -118,10 +131,10 @@ for (const finish of ["stop", "content-filter"] as const) {
         .where(eq(SessionMessageTable.id, assistantMessageID))
         .get()
       expect(message?.data).toMatchObject({
-        finish,
+        finish: fixture.finish,
         tokens: { input: 10, output: 4, reasoning: 2, cache: { read: 3, write: 2 } },
         snapshot: { start, end, files },
-        content: [{ type: "tool", state: { status: "completed" } }],
+        content: [{ type: "tool", state: { status: fixture.toolChoice === "none" ? "error" : "completed" } }],
       })
       expect(message?.data).toHaveProperty("cost", expect.closeTo(0.0000233, 10))
       const events = yield* db
@@ -131,9 +144,11 @@ for (const finish of ["stop", "content-filter"] as const) {
         .orderBy(asc(EventTable.seq))
         .all()
       const types = events.map((event) => event.type)
-      const terminal = finish === "stop" ? "session.step.ended.1" : "session.step.failed.1"
+      const terminal = fixture.finish === "stop" ? "session.step.ended.1" : "session.step.failed.1"
       expect(types.filter((type) => type === terminal)).toHaveLength(1)
-      expect(types.indexOf("session.tool.success.2")).toBeLessThan(types.indexOf(terminal))
+      expect(
+        types.indexOf(fixture.toolChoice === "none" ? "session.tool.failed.2" : "session.tool.success.2"),
+      ).toBeLessThan(types.indexOf(terminal))
     }),
   )
 }


### PR DESCRIPTION
**Why**
Physical Attempt execution repeats the final-Step tool decision already present in its prepared request. Tool settlement also re-classifies `Tool.Error` failures after each tool fiber has handled them, obscuring the remaining distinction between user declines, defects, and interruption.

**What Changes**
Use the prepared request's tool choice as the single authority and narrow the stored tool-fiber error channel to permission declines and question cancellations.

| Situation | Preserved behavior |
| --- | --- |
| Final Step uses `toolChoice: "none"` | Keep advertised definitions for prompt caching, reject local execution, and suppress continuation. |
| Ordinary `Tool.Error` | Settle that call with its error and metadata; another Step may consume the result. |
| Permission decline or question cancellation | Settle the declined call and interrupt the drain after owned tools have joined. |
| Defect or interruption | Retain the existing Cause handling, all-exit waiting, and durable closeout ordering. |

Remove the duplicate `toolsDisabled` input, `isDecline` classification helper, unexpected typed-failure reconstruction, and copied call array. The classifier receives the existing call/fiber ownership records directly; defect-only causes explicitly retain a `never` typed error channel.

Coverage now exercises an ordinary tool error alongside a permission decline, plus a direct `toolChoice: "none"` attempt that never invokes its executor and never requests continuation. Existing snapshot, usage, and terminal-event assertions remain.

**Scope**
This PR owns only Step tool-settlement cleanup. Prompt-cache diagnostic retirement is separate in #45965; logical-Step orchestration and durable event schemas are unchanged. The two branches merge without conflicts.

**Verification**
```sh
# packages/core
bun typecheck
bun run test test/session-step.test.ts test/session-runner.test.ts test/session-runner-tool-events.test.ts test/session-model-request.test.ts test/session-model-transport.test.ts test/session-execution.test.ts
bun run test
bun run test test/tool-search.test.ts --test-name-pattern 'invalid grep regex' --rerun-each 10

# repository root
bunx prettier --check packages/core/src/session/runner/step.ts packages/core/src/session/runner/llm.ts packages/core/test/session-step.test.ts packages/core/test/session-runner.test.ts
bunx oxlint packages/core/src/session/runner/step.ts packages/core/src/session/runner/llm.ts packages/core/test/session-step.test.ts packages/core/test/session-runner.test.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/session/runner/step.ts packages/core/src/session/runner/llm.ts packages/core/test/session-step.test.ts packages/core/test/session-runner.test.ts
git diff --check
git push -u origin step-cleanup
```

- Core typecheck passed. Final focused suite: 264 passed, 0 failed, across six files with 939 assertions.
- Unrestricted full Core suite: 3,786 passed, 39 skipped, 0 failed, across 223 files with 78,892 assertions, in 156.17 seconds.
- The initial full-suite run was stopped by a two-minute execution limit and reported an invalid-regex search-test failure outside the changed files. That search test subsequently passed 10 consecutive focused runs and did not fail in the unrestricted full-suite rerun.
- Formatting, Effect simplification checks, and diff checks passed. Targeted lint has no errors and three warnings on unchanged lines in the runner test fixture.
- The enabled pre-push hook passed all 33 repository typecheck tasks, with 27 cache hits. No hooks were bypassed.
- Provider responses are deterministic test fixtures, not live model calls.
