### PR TITLE
fix(tui): admit compaction requests optimistically

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -286,7 +286,8 @@ export function createData(config: CreateDataInput) {
   // Inbox IDs of optimistic admissions awaiting acknowledgement, so rejection
   // only rolls back unacknowledged rows and a pending re-fetch cannot wipe a
   // row the server does not know about yet. Prompts clear on their durable
-  // echo or rollback; compactions also reconcile the POST's canonical ID.
+  // echo, positive pending read, or rollback; compactions also reconcile the
+  // POST's canonical ID.
   const outbox = new Set<string>()
 
   // Session IDs of optimistic create admissions still awaiting acknowledgement
@@ -305,6 +306,11 @@ export function createData(config: CreateDataInput) {
   // failure does not block the next.
   const sending = new Map<string, Promise<unknown>>()
   const compacting = new Map<string, Promise<SessionInboxCompaction>>()
+  const compactionListeners = new Set<() => void>()
+  onCleanup(() => {
+    compactionListeners.forEach((unsubscribe) => unsubscribe())
+    compactionListeners.clear()
+  })
 
   // Register `promise` under `key` until it settles. A later registration
   // replaces an earlier one; settlement only clears its own entry.
@@ -1254,6 +1260,13 @@ export function createData(config: CreateDataInput) {
         sync(sessionID: string) {
           return sync.run(`session.pending:${sessionID}`, async () => {
             const pending = await api().session.inbox.list({ sessionID })
+            // A positive read acknowledges admission even when its SSE echo is delayed.
+            pending.forEach((item) => outbox.delete(item.id))
+            // Compactions also coalesce by Session, not just by the proposed ID.
+            if (pending.some((item) => item.type === "compaction"))
+              store.session.pending[sessionID]
+                ?.filter((item) => item.type === "compaction")
+                .forEach((item) => outbox.delete(item.id))
             // Keep optimistic rows still awaiting their echo: this fetch may
             // have raced ahead of an in-flight admission the server does not
             // know about yet.
@@ -1337,7 +1350,9 @@ export function createData(config: CreateDataInput) {
         const active = compacting.get(input.sessionID)
         if (active) return active
         const pending = store.session.pending[input.sessionID]?.find((item) => item.type === "compaction")
-        const id = pending?.id ?? SessionMessage.ID.create()
+        // A known pending control ID may be consumed while setup waits. Propose
+        // a fresh ID and let the server coalesce, without duplicating its row.
+        const id = SessionMessage.ID.create()
         if (!pending) {
           outbox.add(id)
           admitLocal({
@@ -1371,9 +1386,11 @@ export function createData(config: CreateDataInput) {
             observed.add(event.data.inputID)
           }
         })
+        compactionListeners.add(unsubscribe)
         const previous = sending.get(input.sessionID)
+        const created = creating.get(input.sessionID)
         const request = Promise.resolve()
-          .then(() => Promise.all([creating.get(input.sessionID), previous]))
+          .then(() => Promise.all([created, previous]))
           .then(() => input.model && api().session.switchModel({ sessionID: input.sessionID, model: input.model }))
           .then(() => api().session.compact({ sessionID: input.sessionID, id }))
           .then((item) => {
@@ -1388,7 +1405,9 @@ export function createData(config: CreateDataInput) {
             if (!pending && outbox.delete(id)) removePending(input.sessionID, id)
             throw error
           })
-          .finally(unsubscribe)
+          .finally(() => {
+            if (compactionListeners.delete(unsubscribe)) unsubscribe()
+          })
         track(compacting, input.sessionID, request)
         track(
           sending,
@@ -1402,8 +1421,8 @@ export function createData(config: CreateDataInput) {
       // upsert that same ID with the server's payload. Server admission is
       // idempotent per ID, so retrying with the identical payload cannot
       // double-admit.
-      prompt(input: SessionPromptInput & { gate?: Promise<unknown> }) {
-        const { gate, ...request } = input
+      prompt(input: SessionPromptInput & { gate?: Promise<unknown>; prepare?: () => Promise<unknown> }) {
+        const { gate, prepare, ...request } = input
         const id = request.id ?? SessionMessage.ID.create()
         // A retry may reuse an ID that is already rendered — and possibly
         // already durable. Admit optimistically only for new IDs so a failed
@@ -1435,8 +1454,11 @@ export function createData(config: CreateDataInput) {
         // admission's POST: the row renders now, the send happens once the
         // session exists server-side and earlier inputs are admitted.
         const previous = sending.get(request.sessionID)
+        const created = creating.get(request.sessionID)
         const send = Promise.resolve()
-          .then(() => Promise.all([gate, creating.get(request.sessionID), previous]))
+          .then(() => Promise.all([gate, created, previous]))
+          // Model preparation must not run ahead of earlier admissions.
+          .then(() => prepare?.())
           .then(() => api().session.prompt({ ...request, id }))
         track(
           sending,
@@ -1447,7 +1469,7 @@ export function createData(config: CreateDataInput) {
           ),
         )
         return send.catch((error) => {
-          // Roll back only rows this call admitted and the echo has not
+          // Roll back only rows this call admitted and the server has not
           // acknowledged: anything else is server state.
           if (fresh && outbox.delete(id)) retractLocal(request.sessionID, id)
           throw error

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -29,6 +29,7 @@ import type {
   SessionMessageAssistantTool,
   SessionInfo,
   SessionInboxInfo,
+  SessionInboxCompaction,
   ShellInfo,
   SkillInfo,
   VcsInfo,
@@ -282,12 +283,10 @@ export function createData(config: CreateDataInput) {
     setStore("session", "pending", sessionID, index, { ...item, delivery })
   }
 
-  // Inbox IDs of optimistic prompt admissions still awaiting their durable
-  // echo. This is the one deliberate piece of in-flight bookkeeping in this
-  // layer: it exists so a rejection only rolls back rows the server never
-  // acknowledged, and so a concurrent pending re-fetch cannot wipe a row the
-  // server does not know about yet. Entries clear on the enqueued echo or on
-  // rollback — not on POST success, which typically precedes the echo.
+  // Inbox IDs of optimistic admissions awaiting acknowledgement, so rejection
+  // only rolls back unacknowledged rows and a pending re-fetch cannot wipe a
+  // row the server does not know about yet. Prompts clear on their durable
+  // echo or rollback; compactions also reconcile the POST's canonical ID.
   const outbox = new Set<string>()
 
   // Session IDs of optimistic create admissions still awaiting acknowledgement
@@ -301,15 +300,15 @@ export function createData(config: CreateDataInput) {
   // to exist server-side instead of failing with "not found".
   const creating = new Map<string, Promise<unknown>>()
 
-  // Per-session send chain: prompts must be admitted in submission order,
-  // and HTTP gives no ordering across concurrent POSTs. Each prompt waits
-  // for the previous prompt's POST (settled, so one failure does not block
-  // the next) before sending its own.
+  // Per-session send chain: prompts and compactions must be admitted in
+  // submission order. Each waits for the previous POST to settle, so one
+  // failure does not block the next.
   const sending = new Map<string, Promise<unknown>>()
+  const compacting = new Map<string, Promise<SessionInboxCompaction>>()
 
   // Register `promise` under `key` until it settles. A later registration
   // replaces an earlier one; settlement only clears its own entry.
-  function track(map: Map<string, Promise<unknown>>, key: string, promise: Promise<unknown>) {
+  function track<Value>(map: Map<string, Promise<Value>>, key: string, promise: Promise<Value>) {
     map.set(key, promise)
     const settle = () => {
       if (map.get(key) === promise) map.delete(key)
@@ -319,7 +318,7 @@ export function createData(config: CreateDataInput) {
 
   // Upsert an admitted inbox item into pending, input, and (for user and
   // synthetic items) the visible transcript. Used by the inbox.enqueued
-  // handler and by optimistic prompt admission; the upsert is what reconciles
+  // handler and by optimistic admission; the upsert is what reconciles
   // the durable echo with an optimistic placeholder — the durable payload and
   // times replace the client's guess.
   function admitLocal(item: SessionInboxInfo) {
@@ -332,6 +331,7 @@ export function createData(config: CreateDataInput) {
         item.sessionID,
         at < 0 ? [...pending, item] : pending.map((entry, index) => (index === at ? item : entry)),
       )
+      if (item.type === "compaction") return
       const input = store.session.input[item.sessionID] ?? []
       if (!input.includes(item.id)) setStore("session", "input", item.sessionID, [...input, item.id])
       materializeInboxMessage(item)
@@ -1333,6 +1333,70 @@ export function createData(config: CreateDataInput) {
         if (fresh) track(creating, id, request)
         return { id, request }
       },
+      compact(input: { sessionID: string; model?: ModelRef }) {
+        const active = compacting.get(input.sessionID)
+        if (active) return active
+        const pending = store.session.pending[input.sessionID]?.find((item) => item.type === "compaction")
+        const id = pending?.id ?? SessionMessage.ID.create()
+        if (!pending) {
+          outbox.add(id)
+          admitLocal({
+            id,
+            sessionID: input.sessionID,
+            timeCreated: Date.now(),
+            type: "compaction",
+            delivery: "steer",
+            payload: {},
+          })
+        }
+        // Compaction admission can coalesce onto a different ID. Retire the
+        // speculative row on an echo, and remember consumed IDs until the POST
+        // settles so its older response cannot resurrect a queued row.
+        const observed = new Set<string>()
+        const unsubscribe = config.event.listen((message) => {
+          const event = message.details
+          if (event.type === "session.inbox.enqueued") {
+            if (event.data.sessionID !== input.sessionID || event.data.item.type !== "compaction") return
+            observed.add(event.data.inboxID)
+            if (event.data.inboxID !== id && outbox.delete(id)) removePending(input.sessionID, id)
+            return
+          }
+          if (event.type === "session.inbox.delivered" || event.type === "session.inbox.cancelled") {
+            if (event.data.sessionID !== input.sessionID) return
+            observed.add(event.data.inboxID)
+            return
+          }
+          if (event.type === "session.compaction.started" || event.type === "session.compaction.failed") {
+            if (event.data.sessionID !== input.sessionID || !event.data.inputID) return
+            observed.add(event.data.inputID)
+          }
+        })
+        const previous = sending.get(input.sessionID)
+        const request = Promise.resolve()
+          .then(() => Promise.all([creating.get(input.sessionID), previous]))
+          .then(() => input.model && api().session.switchModel({ sessionID: input.sessionID, model: input.model }))
+          .then(() => api().session.compact({ sessionID: input.sessionID, id }))
+          .then((item) => {
+            batch(() => {
+              outbox.delete(id)
+              if (item.id !== id && !pending) removePending(input.sessionID, id)
+              if (!observed.has(item.id) && !messageIndex.get(input.sessionID)?.has(item.id)) admitLocal(item)
+            })
+            return item
+          })
+          .catch((error) => {
+            if (!pending && outbox.delete(id)) removePending(input.sessionID, id)
+            throw error
+          })
+          .finally(unsubscribe)
+        track(compacting, input.sessionID, request)
+        track(
+          sending,
+          input.sessionID,
+          request.catch(() => undefined),
+        )
+        return request
+      },
       // Optimistic prompt admission: render the prompt immediately under a
       // client-minted ID, send it, and let the durable inbox.enqueued echo
       // upsert that same ID with the server's payload. Server admission is
@@ -1368,8 +1432,8 @@ export function createData(config: CreateDataInput) {
         // Wrapped so even a synchronous client failure reaches the rollback.
         // The POST additionally waits for the caller's gate, for any
         // in-flight optimistic create of this session, and for the previous
-        // prompt's POST: the row renders now, the send happens once the
-        // session exists server-side and earlier prompts are admitted.
+        // admission's POST: the row renders now, the send happens once the
+        // session exists server-side and earlier inputs are admitted.
         const previous = sending.get(request.sessionID)
         const send = Promise.resolve()
           .then(() => Promise.all([gate, creating.get(request.sessionID), previous]))

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -305,21 +305,32 @@ export function createData(config: CreateDataInput) {
   // submission order. Each waits for the previous POST to settle, so one
   // failure does not block the next.
   const sending = new Map<string, Promise<unknown>>()
-  const compacting = new Map<string, Promise<SessionInboxCompaction>>()
-  const compactionListeners = new Set<() => void>()
-  onCleanup(() => {
-    compactionListeners.forEach((unsubscribe) => unsubscribe())
-    compactionListeners.clear()
-  })
+  const compacting = new Map<string, { id: string; observed: Set<string>; request: Promise<SessionInboxCompaction> }>()
+  onCleanup(() => compacting.clear())
 
   // Register `promise` under `key` until it settles. A later registration
   // replaces an earlier one; settlement only clears its own entry.
-  function track<Value>(map: Map<string, Promise<Value>>, key: string, promise: Promise<Value>) {
+  function track(map: Map<string, Promise<unknown>>, key: string, promise: Promise<unknown>) {
     map.set(key, promise)
     const settle = () => {
       if (map.get(key) === promise) map.delete(key)
     }
     void promise.then(settle, settle)
+  }
+
+  // Capture creation before settlement clears its entry, so dependent RPCs still see a failed create.
+  function sendAdmission<Value>(sessionID: string, send: () => Promise<Value>, gate?: Promise<unknown>) {
+    const created = creating.get(sessionID)
+    const previous = sending.get(sessionID)
+    const request = Promise.resolve()
+      .then(() => Promise.all([gate, created, previous]))
+      .then(send)
+    track(
+      sending,
+      sessionID,
+      request.catch(() => undefined),
+    )
+    return request
   }
 
   // Upsert an admitted inbox item into pending, input, and (for user and
@@ -662,6 +673,7 @@ export function createData(config: CreateDataInput) {
           draft.push(existing)
           message.reindex(draft, index, position)
         })
+        compacting.get(event.data.sessionID)?.observed.add(event.data.inboxID)
         return
       }
       case "session.inbox.delivery.changed":
@@ -669,6 +681,7 @@ export function createData(config: CreateDataInput) {
         return
       case "session.inbox.cancelled": {
         retractLocal(event.data.sessionID, event.data.inboxID)
+        compacting.get(event.data.sessionID)?.observed.add(event.data.inboxID)
         return
       }
       case "session.inbox.enqueued": {
@@ -679,6 +692,12 @@ export function createData(config: CreateDataInput) {
           timeCreated: event.created,
           ...event.data.item,
         })
+        if (event.data.item.type === "compaction") {
+          const active = compacting.get(event.data.sessionID)
+          active?.observed.add(event.data.inboxID)
+          if (active && active.id !== event.data.inboxID && outbox.delete(active.id))
+            removePending(event.data.sessionID, active.id)
+        }
         return
       }
       case "session.instructions.updated":
@@ -977,6 +996,7 @@ export function createData(config: CreateDataInput) {
             time: { created: event.created },
           })
         })
+        if (event.data.inputID) compacting.get(event.data.sessionID)?.observed.add(event.data.inputID)
         return
       case "session.execution.succeeded":
       case "session.execution.failed":
@@ -1074,6 +1094,7 @@ export function createData(config: CreateDataInput) {
           }
           message.append(draft, index, failed)
         })
+        if (event.data.inputID) compacting.get(event.data.sessionID)?.observed.add(event.data.inputID)
         return
       case "permission.asked":
         if (store.session.permission[event.data.sessionID]?.some((request) => request.id === event.data.id)) return
@@ -1270,9 +1291,7 @@ export function createData(config: CreateDataInput) {
             // Keep optimistic rows still awaiting their echo: this fetch may
             // have raced ahead of an in-flight admission the server does not
             // know about yet.
-            const inflight = (store.session.pending[sessionID] ?? []).filter(
-              (item) => outbox.has(item.id) && !pending.some((row) => row.id === item.id),
-            )
+            const inflight = (store.session.pending[sessionID] ?? []).filter((item) => outbox.has(item.id))
             const merged = inflight.length === 0 ? pending : [...pending, ...inflight]
             batch(() => {
               setStore("session", "pending", sessionID, reconcile(merged))
@@ -1348,12 +1367,11 @@ export function createData(config: CreateDataInput) {
       },
       compact(input: { sessionID: string; model?: ModelRef }) {
         const active = compacting.get(input.sessionID)
-        if (active) return active
-        const pending = store.session.pending[input.sessionID]?.find((item) => item.type === "compaction")
+        if (active) return active.request
         // A known pending control ID may be consumed while setup waits. Propose
         // a fresh ID and let the server coalesce, without duplicating its row.
         const id = SessionMessage.ID.create()
-        if (!pending) {
+        if (!store.session.pending[input.sessionID]?.some((item) => item.type === "compaction")) {
           outbox.add(id)
           admitLocal({
             id,
@@ -1368,52 +1386,26 @@ export function createData(config: CreateDataInput) {
         // speculative row on an echo, and remember consumed IDs until the POST
         // settles so its older response cannot resurrect a queued row.
         const observed = new Set<string>()
-        const unsubscribe = config.event.listen((message) => {
-          const event = message.details
-          if (event.type === "session.inbox.enqueued") {
-            if (event.data.sessionID !== input.sessionID || event.data.item.type !== "compaction") return
-            observed.add(event.data.inboxID)
-            if (event.data.inboxID !== id && outbox.delete(id)) removePending(input.sessionID, id)
-            return
-          }
-          if (event.type === "session.inbox.delivered" || event.type === "session.inbox.cancelled") {
-            if (event.data.sessionID !== input.sessionID) return
-            observed.add(event.data.inboxID)
-            return
-          }
-          if (event.type === "session.compaction.started" || event.type === "session.compaction.failed") {
-            if (event.data.sessionID !== input.sessionID || !event.data.inputID) return
-            observed.add(event.data.inputID)
-          }
+        const request = sendAdmission(input.sessionID, async () => {
+          if (input.model) await api().session.switchModel({ sessionID: input.sessionID, model: input.model })
+          return api().session.compact({ sessionID: input.sessionID, id })
         })
-        compactionListeners.add(unsubscribe)
-        const previous = sending.get(input.sessionID)
-        const created = creating.get(input.sessionID)
-        const request = Promise.resolve()
-          .then(() => Promise.all([created, previous]))
-          .then(() => input.model && api().session.switchModel({ sessionID: input.sessionID, model: input.model }))
-          .then(() => api().session.compact({ sessionID: input.sessionID, id }))
           .then((item) => {
             batch(() => {
               outbox.delete(id)
-              if (item.id !== id && !pending) removePending(input.sessionID, id)
+              if (item.id !== id) removePending(input.sessionID, id)
               if (!observed.has(item.id) && !messageIndex.get(input.sessionID)?.has(item.id)) admitLocal(item)
             })
             return item
           })
           .catch((error) => {
-            if (!pending && outbox.delete(id)) removePending(input.sessionID, id)
+            if (outbox.delete(id)) removePending(input.sessionID, id)
             throw error
           })
           .finally(() => {
-            if (compactionListeners.delete(unsubscribe)) unsubscribe()
+            if (compacting.get(input.sessionID)?.request === request) compacting.delete(input.sessionID)
           })
-        track(compacting, input.sessionID, request)
-        track(
-          sending,
-          input.sessionID,
-          request.catch(() => undefined),
-        )
+        compacting.set(input.sessionID, { id, observed, request })
         return request
       },
       // Optimistic prompt admission: render the prompt immediately under a
@@ -1448,27 +1440,14 @@ export function createData(config: CreateDataInput) {
             },
           })
         }
-        // Wrapped so even a synchronous client failure reaches the rollback.
-        // The POST additionally waits for the caller's gate, for any
-        // in-flight optimistic create of this session, and for the previous
-        // admission's POST: the row renders now, the send happens once the
-        // session exists server-side and earlier inputs are admitted.
-        const previous = sending.get(request.sessionID)
-        const created = creating.get(request.sessionID)
-        const send = Promise.resolve()
-          .then(() => Promise.all([gate, created, previous]))
-          // Model preparation must not run ahead of earlier admissions.
-          .then(() => prepare?.())
-          .then(() => api().session.prompt({ ...request, id }))
-        track(
-          sending,
+        return sendAdmission(
           request.sessionID,
-          send.then(
-            () => undefined,
-            () => undefined,
-          ),
-        )
-        return send.catch((error) => {
+          async () => {
+            await prepare?.()
+            return api().session.prompt({ ...request, id })
+          },
+          gate,
+        ).catch((error) => {
           // Roll back only rows this call admitted and the server has not
           // acknowledged: anything else is server state.
           if (fresh && outbox.delete(id)) retractLocal(request.sessionID, id)

--- a/packages/client/test/solid-compaction.test.ts
+++ b/packages/client/test/solid-compaction.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "bun:test"
 import { createRoot } from "solid-js"
 import { createData, type CreateDataInput } from "../src/solid"
-import { OpenCode, type OpenCodeEvent, type SessionInboxCompaction } from "../src/promise"
+import { OpenCode, type OpenCodeEvent, type SessionInboxCompaction, type SessionInboxInfo } from "../src/promise"
 
 test("admits compaction before model setup and serializes the following prompt", async () => {
   using fixture = setup()
@@ -38,6 +38,8 @@ test("coalesces duplicate gestures until the admission request settles", async (
   expect(next).not.toBe(first)
   await next
   expect(fixture.calls).toEqual(["compact", "compact"])
+  expect(new Set(fixture.proposals).size).toBe(2)
+  expect(fixture.proposals).not.toContain("msg_canonical")
 })
 
 test("substitutes the canonical response ID and reconciles its later echo", async () => {
@@ -141,6 +143,147 @@ test.each(["proposed", "canonical", "existing"])(
   },
 )
 
+test("uses a fresh control ID when the known pending compaction starts during model setup", async () => {
+  const proposed = Promise.withResolvers<string>()
+  using fixture = setup(async (request) => {
+    if (!request.url.endsWith("/compact")) return undefined
+    const body = await request.json()
+    proposed.resolve(body.id)
+    if (body.id === "msg_existing") return Response.json({ message: "Control ID already consumed" }, { status: 409 })
+    return Response.json({ data: item(body.id) })
+  })
+  fixture.enqueue("msg_existing")
+  const request = fixture.data.session.compact({ sessionID, model: { providerID: "demo", id: "model" } })
+  const result = request.catch((error: unknown) => error)
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([item("msg_existing")])
+  await wait(() => fixture.calls.includes("model"))
+  fixture.emit({
+    ...event,
+    type: "session.compaction.started",
+    data: { sessionID, inputID: "msg_existing", reason: "manual" },
+  })
+  fixture.model.resolve()
+  expect(await proposed.promise).not.toBe("msg_existing")
+  expect(await result).toEqual(item(await proposed.promise))
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([item(await proposed.promise)])
+  expect(fixture.data.session.message.list(sessionID)).toMatchObject([
+    { id: "msg_existing", type: "compaction", status: "running" },
+  ])
+})
+
+test.each(["compaction", "canonical compaction", "user"])(
+  "preserves a fetched durable %s when SSE is delayed and HTTP fails",
+  async (type) => {
+    using fixture = setup(async (request) => {
+      if (request.url.endsWith("/prompt")) return fixture.response.promise
+      return undefined
+    })
+    const request =
+      type === "user"
+        ? fixture.data.session.prompt({ sessionID, text: "Follow up" })
+        : fixture.data.session.compact({ sessionID })
+    const result = request.catch((error: unknown) => error)
+    const id = type === "canonical compaction" ? "msg_canonical" : fixture.data.session.pending.list(sessionID)[0].id
+    const durable: SessionInboxInfo =
+      type === "user" ? { ...item(id, 20), type: "user", payload: { text: "Follow up" } } : item(id, 20)
+    fixture.pending.push(durable)
+    await fixture.data.session.pending.sync(sessionID)
+    expect(fixture.data.session.pending.list(sessionID)).toEqual([durable])
+    fixture.response.resolve(new Response("Lost response", { status: 500 }))
+    expect(await result).toBeInstanceOf(Error)
+    expect(fixture.data.session.pending.list(sessionID)).toEqual([durable])
+    if (type === "user")
+      expect(fixture.data.session.message.list(sessionID)).toMatchObject([{ id, type: "user", text: "Follow up" }])
+  },
+)
+
+test("removes the compaction listener when the data owner is disposed during a gate", async () => {
+  using fixture = setup()
+  const gate = Promise.withResolvers<void>()
+  const first = fixture.data.session.prompt({ sessionID, text: "First", gate: gate.promise })
+  const compact = fixture.data.session.compact({ sessionID })
+  expect(fixture.listeners.size).toBe(2)
+  fixture.dispose()
+  expect(fixture.listeners.size).toBe(0)
+  gate.resolve()
+  fixture.response.resolve(Response.json({ data: item("msg_canonical") }))
+  await Promise.all([first, compact])
+  expect(fixture.listeners.size).toBe(0)
+})
+
+test.each(["gate", "prepare"])(
+  "a preceding prompt's failed %s does not block compaction or following model preparation",
+  async (kind) => {
+    using fixture = setup()
+    const gate = Promise.withResolvers<void>()
+    const prepared: string[] = []
+    const first = fixture.data.session
+      .prompt({
+        sessionID,
+        id: "msg_first",
+        text: "First",
+        gate: kind === "gate" ? gate.promise : undefined,
+        prepare: () => {
+          prepared.push("first")
+          return gate.promise
+        },
+      })
+      .catch((error: unknown) => error)
+    const compact = fixture.data.session.compact({ sessionID, model: { providerID: "demo", id: "first" } })
+    const following = fixture.data.session.prompt({
+      sessionID,
+      text: "Follow up",
+      prepare: () => {
+        prepared.push("following")
+        return fixture.api.session.switchModel({ sessionID, model: { providerID: "demo", id: "second" } })
+      },
+    })
+    if (kind === "prepare") await wait(() => prepared.includes("first"))
+    gate.reject(new Error("Preparation failed"))
+    expect(await first).toBeInstanceOf(Error)
+    await wait(() => fixture.calls.includes("model"))
+    expect(prepared).toEqual(kind === "prepare" ? ["first"] : [])
+    fixture.model.resolve()
+    fixture.response.resolve(Response.json({ data: item("msg_canonical") }))
+    await Promise.all([compact, following])
+    expect(fixture.calls).toEqual(["model", "compact", "model", "prompt"])
+    expect(prepared.at(-1)).toBe("following")
+    expect(fixture.data.session.message.list(sessionID)).toMatchObject([{ type: "user", text: "Follow up" }])
+  },
+)
+
+test("creation failure rejects gated prompt, compaction, and following preparation without sending their RPCs", async () => {
+  const creation = Promise.withResolvers<Response>()
+  const requested = Promise.withResolvers<void>()
+  using fixture = setup(async (request) => {
+    if (!request.url.endsWith("/api/session")) return undefined
+    requested.resolve()
+    return creation.promise
+  })
+  const gate = Promise.withResolvers<void>()
+  const prepared: string[] = []
+  const created = fixture.data.session.create({ id: sessionID })
+  const first = fixture.data.session.prompt({ sessionID, text: "First", gate: gate.promise })
+  const compact = fixture.data.session.compact({ sessionID, model: { providerID: "demo", id: "model" } })
+  const following = fixture.data.session.prompt({
+    sessionID,
+    text: "Follow up",
+    prepare: async () => {
+      prepared.push("following")
+    },
+  })
+  const results = Promise.allSettled([created.request, first, compact, following])
+  await requested.promise
+  creation.resolve(new Response("Creation failed", { status: 500 }))
+  expect((await results).map((result) => result.status)).toEqual(["rejected", "rejected", "rejected", "rejected"])
+  expect(fixture.calls).toEqual([])
+  expect(prepared).toEqual([])
+  expect(fixture.data.session.get(sessionID)).toBeUndefined()
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([])
+  expect(fixture.listeners.size).toBe(1)
+  gate.resolve()
+})
+
 const sessionID = "ses_compact"
 const event = { id: "evt_compact", created: 10, durable: { aggregateID: sessionID, seq: 1, version: 1 } }
 const item = (id: string, timeCreated = 10): SessionInboxCompaction => ({
@@ -152,18 +295,21 @@ const item = (id: string, timeCreated = 10): SessionInboxCompaction => ({
   payload: {},
 })
 
-function setup() {
+function setup(override?: (request: Request) => Promise<Response | undefined>) {
   const model = Promise.withResolvers<void>()
   const response = Promise.withResolvers<Response>()
   const calls: string[] = []
   const proposals: string[] = []
+  const pending: SessionInboxInfo[] = []
   const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
   const api = OpenCode.make({
     baseUrl: "http://opencode.local",
     fetch: async (input, init) => {
       const request = input instanceof Request ? input : new Request(input, init)
+      const overridden = await override?.(request)
+      if (overridden) return overridden
       const rpc = new URL(request.url).pathname.split("/").at(-1)
-      if (rpc === "inbox") return Response.json({ data: [] })
+      if (rpc === "inbox") return Response.json({ data: pending })
       if (rpc === "model") {
         calls.push(rpc)
         await model.promise
@@ -200,11 +346,14 @@ function setup() {
   const emit = (details: OpenCodeEvent) => listeners.forEach((listener) => listener({ name: details.type, details }))
   return {
     data: root.data,
+    api,
+    dispose: root.dispose,
     [Symbol.dispose]: root.dispose,
     model,
     response,
     calls,
     proposals,
+    pending,
     listeners,
     emit,
     enqueue(id: string, created = 10) {

--- a/packages/client/test/solid-compaction.test.ts
+++ b/packages/client/test/solid-compaction.test.ts
@@ -1,0 +1,227 @@
+import { expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createData, type CreateDataInput } from "../src/solid"
+import { OpenCode, type OpenCodeEvent, type SessionInboxCompaction } from "../src/promise"
+
+test("admits compaction before model setup and serializes the following prompt", async () => {
+  using fixture = setup()
+  const compact = fixture.data.session.compact({ sessionID, model: { providerID: "demo", id: "model" } })
+  const proposed = fixture.data.session.pending.list(sessionID)[0]
+  expect(proposed).toMatchObject({ type: "compaction", sessionID })
+  expect(fixture.calls).toEqual([])
+  expect(fixture.data.session.message.list(sessionID)).toEqual([])
+  expect(fixture.data.session.status(sessionID)).toBe("idle")
+
+  const prompt = fixture.data.session.prompt({ sessionID, text: "Follow up" })
+  expect(fixture.data.session.message.list(sessionID)).toMatchObject([{ type: "user", text: "Follow up" }])
+  await wait(() => fixture.calls.length === 1)
+  expect(fixture.calls).toEqual(["model"])
+  fixture.model.resolve()
+  await wait(() => fixture.calls.length === 2)
+  expect(fixture.calls).toEqual(["model", "compact"])
+  fixture.response.resolve(Response.json({ data: item(proposed.id) }))
+  await Promise.all([compact, prompt])
+  expect(fixture.calls).toEqual(["model", "compact", "prompt"])
+  expect(fixture.proposals).toEqual([proposed.id])
+})
+
+test("coalesces duplicate gestures until the admission request settles", async () => {
+  using fixture = setup()
+  const first = fixture.data.session.compact({ sessionID })
+  expect(fixture.data.session.compact({ sessionID })).toBe(first)
+  expect(fixture.data.session.pending.list(sessionID)).toHaveLength(1)
+  await wait(() => fixture.calls.length === 1)
+  fixture.response.resolve(Response.json({ data: item("msg_canonical") }))
+  await first
+  expect(fixture.calls).toEqual(["compact"])
+  const next = fixture.data.session.compact({ sessionID })
+  expect(next).not.toBe(first)
+  await next
+  expect(fixture.calls).toEqual(["compact", "compact"])
+})
+
+test("substitutes the canonical response ID and reconciles its later echo", async () => {
+  using fixture = setup()
+  const request = fixture.data.session.compact({ sessionID })
+  const proposed = fixture.data.session.pending.list(sessionID)[0].id
+  await fixture.data.session.pending.sync(sessionID)
+  expect(fixture.data.session.pending.list(sessionID).map((row) => row.id)).toEqual([proposed])
+  fixture.response.resolve(Response.json({ data: item("msg_canonical") }))
+  await request
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([item("msg_canonical")])
+  fixture.enqueue("msg_canonical", 20)
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([item("msg_canonical", 20)])
+  expect(fixture.data.session.input.list(sessionID)).toEqual([])
+})
+
+test.each(["proposed", "canonical"])("adopts the %s echo before the response without duplicating it", async (kind) => {
+  using fixture = setup()
+  const request = fixture.data.session.compact({ sessionID })
+  const id = kind === "proposed" ? fixture.data.session.pending.list(sessionID)[0].id : "msg_canonical"
+  fixture.enqueue(id, 20)
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([item(id, 20)])
+  fixture.response.resolve(Response.json({ data: item(id) }))
+  await request
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([item(id, 20)])
+})
+
+test.each(["started", "cancelled", "failed"])(
+  "does not resurrect a canonical item already %s before the response",
+  async (kind) => {
+    using fixture = setup()
+    const request = fixture.data.session.compact({ sessionID })
+    fixture.enqueue("msg_canonical")
+    if (kind === "started")
+      fixture.emit({
+        ...event,
+        type: "session.compaction.started",
+        data: { sessionID, inputID: "msg_canonical", reason: "manual" },
+      })
+    if (kind === "cancelled")
+      fixture.emit({ ...event, type: "session.inbox.cancelled", data: { sessionID, inboxID: "msg_canonical" } })
+    if (kind === "failed")
+      fixture.emit({
+        ...event,
+        type: "session.compaction.failed",
+        data: {
+          sessionID,
+          inputID: "msg_canonical",
+          reason: "manual",
+          error: { type: "aborted", message: "Cancelled" },
+        },
+      })
+    expect(fixture.data.session.pending.list(sessionID)).toEqual([])
+    fixture.response.resolve(Response.json({ data: item("msg_canonical") }))
+    await request
+    expect(fixture.data.session.pending.list(sessionID)).toEqual([])
+    if (kind === "started") {
+      expect(fixture.data.session.message.list(sessionID)).toMatchObject([{ type: "compaction", status: "running" }])
+      fixture.emit({
+        ...event,
+        type: "session.compaction.ended",
+        data: { sessionID, reason: "manual", text: "Summary", recent: "Recent" },
+      })
+      expect(fixture.data.session.message.list(sessionID)).toMatchObject([
+        { type: "compaction", status: "completed", summary: "Summary" },
+      ])
+    }
+  },
+)
+
+test.each(["model", "compact"])("rolls back a rejected %s RPC and releases the following prompt", async (rpc) => {
+  using fixture = setup()
+  const request = fixture.data.session.compact({ sessionID, model: { providerID: "demo", id: "model" } })
+  const failed = request.catch((error: unknown) => error)
+  const prompt = fixture.data.session.prompt({ sessionID, text: "Follow up" })
+  if (rpc === "model") fixture.model.reject(new Error("Model setup failed"))
+  if (rpc === "compact") {
+    fixture.model.resolve()
+    fixture.response.resolve(new Response("Admission failed", { status: 500 }))
+  }
+  expect(await failed).toBeInstanceOf(Error)
+  await prompt
+  expect(fixture.data.session.pending.list(sessionID).map((row) => row.type)).toEqual(["user"])
+  expect(fixture.data.session.message.list(sessionID)).toMatchObject([{ type: "user", text: "Follow up" }])
+})
+
+test.each(["proposed", "canonical", "existing"])(
+  "preserves acknowledged %s compaction after an HTTP error",
+  async (kind) => {
+    using fixture = setup()
+    if (kind === "existing") fixture.enqueue("msg_canonical")
+    const request = fixture.data.session.compact({ sessionID })
+    const failed = request.catch((error: unknown) => error)
+    const id = kind === "proposed" ? fixture.data.session.pending.list(sessionID)[0].id : "msg_canonical"
+    if (kind !== "existing") fixture.enqueue(id)
+    expect(fixture.data.session.pending.list(sessionID)).toEqual([item(id)])
+    fixture.response.resolve(new Response("Lost response", { status: 500 }))
+    expect(await failed).toBeInstanceOf(Error)
+    expect(fixture.data.session.pending.list(sessionID)).toEqual([item(id)])
+    expect(fixture.listeners.size).toBe(1)
+  },
+)
+
+const sessionID = "ses_compact"
+const event = { id: "evt_compact", created: 10, durable: { aggregateID: sessionID, seq: 1, version: 1 } }
+const item = (id: string, timeCreated = 10): SessionInboxCompaction => ({
+  id,
+  sessionID,
+  timeCreated,
+  type: "compaction",
+  delivery: "steer",
+  payload: {},
+})
+
+function setup() {
+  const model = Promise.withResolvers<void>()
+  const response = Promise.withResolvers<Response>()
+  const calls: string[] = []
+  const proposals: string[] = []
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      const rpc = new URL(request.url).pathname.split("/").at(-1)
+      if (rpc === "inbox") return Response.json({ data: [] })
+      if (rpc === "model") {
+        calls.push(rpc)
+        await model.promise
+        return new Response(null, { status: 204 })
+      }
+      if (rpc === "compact") {
+        calls.push(rpc)
+        proposals.push((await request.json()).id)
+        return (await response.promise).clone()
+      }
+      if (rpc === "prompt") {
+        calls.push(rpc)
+        return Response.json({
+          data: { ...item((await request.json()).id), type: "user", payload: { text: "Follow up" } },
+        })
+      }
+      throw new Error(`Unexpected request: ${request.url}`)
+    },
+  })
+  const root = createRoot((dispose) => ({
+    data: createData({
+      api: () => api,
+      directory: "/project",
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
+    }),
+    dispose,
+  }))
+  const emit = (details: OpenCodeEvent) => listeners.forEach((listener) => listener({ name: details.type, details }))
+  return {
+    data: root.data,
+    [Symbol.dispose]: root.dispose,
+    model,
+    response,
+    calls,
+    proposals,
+    listeners,
+    emit,
+    enqueue(id: string, created = 10) {
+      emit({
+        ...event,
+        created,
+        type: "session.inbox.enqueued",
+        data: { sessionID, inboxID: id, item: { type: "compaction", delivery: "steer", payload: {} } },
+      })
+    },
+  }
+}
+
+async function wait(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return
+    await Bun.sleep(5)
+  }
+  throw new Error("Timed out waiting for request")
+}

--- a/packages/client/test/solid-compaction.test.ts
+++ b/packages/client/test/solid-compaction.test.ts
@@ -197,18 +197,42 @@ test.each(["compaction", "canonical compaction", "user"])(
   },
 )
 
-test("removes the compaction listener when the data owner is disposed during a gate", async () => {
+test("keeps one event listener and removes it when the data owner is disposed during a gate", async () => {
   using fixture = setup()
   const gate = Promise.withResolvers<void>()
   const first = fixture.data.session.prompt({ sessionID, text: "First", gate: gate.promise })
   const compact = fixture.data.session.compact({ sessionID })
-  expect(fixture.listeners.size).toBe(2)
+  expect(fixture.listeners.size).toBe(1)
   fixture.dispose()
   expect(fixture.listeners.size).toBe(0)
   gate.resolve()
   fixture.response.resolve(Response.json({ data: item("msg_canonical") }))
   await Promise.all([first, compact])
   expect(fixture.listeners.size).toBe(0)
+})
+
+test("routes concurrent compaction observations by session through one listener", async () => {
+  const firstResponse = Promise.withResolvers<Response>()
+  const secondResponse = Promise.withResolvers<Response>()
+  using fixture = setup(async (request) => {
+    if (!request.url.endsWith("/compact")) return undefined
+    return request.url.includes(`/session/${sessionID}/`) ? firstResponse.promise : secondResponse.promise
+  })
+  const first = fixture.data.session.compact({ sessionID })
+  const second = fixture.data.session.compact({ sessionID: "ses_other" })
+  const firstID = fixture.data.session.pending.list(sessionID)[0].id
+  const secondID = fixture.data.session.pending.list("ses_other")[0].id
+  expect(fixture.listeners.size).toBe(1)
+  fixture.emit({ ...event, type: "session.inbox.cancelled", data: { sessionID, inboxID: firstID } })
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([])
+  expect(fixture.data.session.pending.list("ses_other").map((row) => row.id)).toEqual([secondID])
+
+  firstResponse.resolve(Response.json({ data: item(firstID) }))
+  secondResponse.resolve(Response.json({ data: { ...item(secondID), sessionID: "ses_other" } }))
+  await Promise.all([first, second])
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([])
+  expect(fixture.data.session.pending.list("ses_other")).toEqual([{ ...item(secondID), sessionID: "ses_other" }])
+  expect(fixture.listeners.size).toBe(1)
 })
 
 test.each(["gate", "prepare"])(

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1318,24 +1318,7 @@ export function Prompt(props: PromptProps) {
         restoreEntry()
         return true
       }
-      if (
-        session?.model?.providerID !== selection.providerID ||
-        session.model.id !== selection.modelID ||
-        (session.model.variant ?? "default") !== (variant ?? "default")
-      ) {
-        const model = { providerID: selection.providerID, id: selection.modelID, variant }
-        const cancelCommit = local.model.trackSessionCommit(target, model)
-        const switchError = await client.api.session.switchModel({ sessionID: target, model }).then(
-          () => undefined,
-          (error) => error,
-        )
-        if (switchError) {
-          cancelCommit()
-          toast.show({ title: "Failed to switch model", message: errorMessage(switchError), variant: "error" })
-          restoreEntry()
-          return true
-        }
-      }
+      const model = { providerID: selection.providerID, id: selection.modelID, variant }
       if (session?.revert) {
         const error = await client.api.session.revert.commit({ sessionID: target }).then(
           () => undefined,
@@ -1384,6 +1367,16 @@ export function Prompt(props: PromptProps) {
           skills: entry.skills?.length ? entry.skills : undefined,
           delivery,
           gate: newSession?.gate,
+          prepare: () => {
+            // Commit the captured selection after earlier admissions, including
+            // compaction setup. Cached state may still precede their SSE echoes;
+            // the server makes an unchanged selection a no-op.
+            const cancelCommit = local.model.trackSessionCommit(target, model)
+            return client.api.session.switchModel({ sessionID: target, model }).catch((error) => {
+              cancelCommit()
+              throw new Error(`Failed to switch model: ${errorMessage(error)}`, { cause: error })
+            })
+          },
         })
         .catch((error) => {
           if (newSession) return newSession.recover(error)

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -845,18 +845,20 @@ export function Session(props: {
       slash: {
         name: "compact",
       },
-      run: async () => {
+      run: () => {
         const selection = local.model.current()
-        if (selection)
-          await client.api.session.switchModel({
+        void data.session
+          .compact({
             sessionID: route.sessionID,
-            model: {
-              providerID: selection.providerID,
-              id: selection.modelID,
-              variant: local.model.variant.current(),
-            },
+            model: selection
+              ? {
+                  providerID: selection.providerID,
+                  id: selection.modelID,
+                  variant: local.model.variant.current(),
+                }
+              : undefined,
           })
-        await client.api.session.compact({ sessionID: route.sessionID })
+          .catch((error) => toast.show({ message: errorMessage(error), variant: "error" }))
         dialog.clear()
       },
     },

--- a/packages/tui/test/compact-admission.test.tsx
+++ b/packages/tui/test/compact-admission.test.tsx
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test"
 import { createTestRenderer } from "@opentui/core/testing"
+import { InputRenderable } from "@opentui/core"
 import { Effect, FileSystem } from "effect"
 import { Global } from "@opencode-ai/util/global"
 import { createEventStream, createFetch, directory, json } from "./fixture/tui-client"
@@ -13,6 +14,7 @@ test.each([70, 120])(
     setup.renderer.start()
     const ready = Promise.withResolvers<void>()
     const model = Promise.withResolvers<Response>()
+    const modelRequested = Promise.withResolvers<void>()
     const events = createEventStream()
     const mutations: string[] = []
     const sessionID = "ses_compact"
@@ -41,6 +43,7 @@ test.each([70, 120])(
         return json({ location, data: [{ id: "model", providerID: "demo", name: "Demo Model", variants: [] }] })
       if (url.pathname === `/api/session/${sessionID}/model`) {
         mutations.push("model")
+        modelRequested.resolve()
         return model.promise
       }
       if (url.pathname === `/api/session/${sessionID}/compact`) {
@@ -73,6 +76,7 @@ test.each([70, 120])(
       setup.mockInput.pressEnter()
       await setup.renderOnce()
       expect(setup.captureCharFrame().match(/Compaction queued/g)).toHaveLength(1)
+      await modelRequested.promise
       expect(mutations).toEqual(["model"])
 
       model.resolve(json({ message: "Model setup failed" }, { status: 400 }))
@@ -81,6 +85,148 @@ test.each([70, 120])(
       expect(mutations).toEqual(["model"])
     } finally {
       model.resolve(new Response(null, { status: 204 }))
+      setup.renderer.destroy()
+      await task
+      await server.stop()
+    }
+  },
+)
+
+test.each(["first", "second"])(
+  "a following prompt commits its selected model after prompt and compaction setup (cached: %s)",
+  async (initial) => {
+    await using state = await tmpdir()
+    const setup = await createTestRenderer({ width: 100, height: 30, useThread: false, kittyKeyboard: true })
+    setup.renderer.start()
+    const ready = Promise.withResolvers<void>()
+    const first = Promise.withResolvers<void>()
+    const firstRequested = Promise.withResolvers<void>()
+    const secondRequested = Promise.withResolvers<string>()
+    const events = createEventStream()
+    const sessionID = "ses_model_order"
+    const location = { directory, project: { id: "project", directory, canonical: directory } }
+    const session = {
+      id: sessionID,
+      projectID: "project",
+      title: "Model ordering fixture",
+      agent: "build",
+      model: { providerID: "demo", id: initial },
+      location: { directory },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: 0, updated: 0 },
+    }
+    const mutations: string[] = []
+    const calls = createFetch(async (url, request) => {
+      if (url.pathname === `/api/session/${sessionID}`) return json({ data: session })
+      if (url.pathname === `/api/session/${sessionID}/message`) return json({ data: [], cursor: {} })
+      if (url.pathname === `/api/session/${sessionID}/inbox` || url.pathname === `/api/session/${sessionID}/permission`)
+        return json({ data: [] })
+      if (url.pathname === "/api/agent")
+        return json({ location, data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }] })
+      if (url.pathname === "/api/provider") return json({ location, data: [{ id: "demo", name: "Demo" }] })
+      if (url.pathname === "/api/model")
+        return json({
+          location,
+          data: ["first", "second"].map((id) => ({
+            id,
+            providerID: "demo",
+            name: `${id} model`,
+            variants: [],
+            cost: [],
+            time: { released: 0 },
+          })),
+        })
+      if (url.pathname === `/api/session/${sessionID}/model`) {
+        session.model = (await request.json()).model
+        mutations.push(`model:${session.model.id}`)
+        // Delay SSE so local selection must not rely on the cached server model.
+        return new Response(null, { status: 204 })
+      }
+      if (url.pathname === `/api/session/${sessionID}/compact`) {
+        mutations.push(`compact:${session.model.id}`)
+        return json({
+          data: {
+            id: (await request.json()).id,
+            sessionID,
+            type: "compaction",
+            timeCreated: 10,
+            payload: {},
+            delivery: "steer",
+          },
+        })
+      }
+      if (url.pathname === `/api/session/${sessionID}/prompt`) {
+        const body = await request.json()
+        mutations.push(`prompt:${body.text}:${session.model.id}`)
+        if (body.text === "First prompt") {
+          firstRequested.resolve()
+          await first.promise
+        }
+        if (body.text === "Second prompt") secondRequested.resolve(session.model.id)
+        return json({
+          data: {
+            id: body.id,
+            sessionID,
+            type: "user",
+            timeCreated: 10,
+            payload: { text: body.text },
+            delivery: "steer",
+          },
+        })
+      }
+      return undefined
+    }, events)
+    const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: { get: async () => ({ animations: false }), update: async () => ({}) },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        args: { sessionID },
+        log: () => {},
+      }).pipe(Effect.provide(Global.layerWith({ state: state.path })), Effect.provide(FileSystem.layerNoop({}))),
+    )
+    const selectModel = async (id: string) => {
+      await setup.mockInput.typeText("/models")
+      setup.mockInput.pressEnter()
+      await setup.waitForFrame(
+        (frame) => frame.includes("Select model") && setup.renderer.currentFocusedRenderable instanceof InputRenderable,
+      )
+      await setup.mockInput.typeText(id)
+      await setup.renderOnce()
+      setup.mockInput.pressEnter()
+      await setup.waitForFrame((frame) => frame.includes(`${id} model`) && !frame.includes("Select model"))
+    }
+    try {
+      await ready.promise
+      await setup.waitForFrame((frame) => frame.includes(`${initial} model`))
+      await setup.mockInput.typeText("First prompt")
+      setup.mockInput.pressEnter()
+      await firstRequested.promise
+      const submitted = mutations.length
+      if (initial !== "first") await selectModel("first")
+      await setup.mockInput.typeText("/compact")
+      setup.mockInput.pressEnter()
+      await setup.waitForFrame((frame) => frame.includes("Compaction queued"))
+      await selectModel("second")
+      await setup.mockInput.typeText("Second prompt")
+      setup.mockInput.pressEnter()
+      await setup.waitForFrame((frame) => frame.split("\n").slice(0, 20).join("\n").includes("Second prompt"))
+      expect(mutations).toHaveLength(submitted)
+      first.resolve()
+      expect(await secondRequested.promise).toBe("second")
+      expect(mutations.slice(-4)).toEqual([
+        "model:first",
+        "compact:first",
+        "model:second",
+        "prompt:Second prompt:second",
+      ])
+    } finally {
+      first.resolve()
       setup.renderer.destroy()
       await task
       await server.stop()

--- a/packages/tui/test/compact-admission.test.tsx
+++ b/packages/tui/test/compact-admission.test.tsx
@@ -1,0 +1,89 @@
+import { expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+import { Effect, FileSystem } from "effect"
+import { Global } from "@opencode-ai/util/global"
+import { createEventStream, createFetch, directory, json } from "./fixture/tui-client"
+import { tmpdir } from "./fixture/fixture"
+
+test.each([70, 120])(
+  "/compact renders before model setup, suppresses repeat gestures, and toasts rollback at %i columns",
+  async (width) => {
+    await using state = await tmpdir()
+    const setup = await createTestRenderer({ width, height: 30, useThread: false, kittyKeyboard: true })
+    setup.renderer.start()
+    const ready = Promise.withResolvers<void>()
+    const model = Promise.withResolvers<Response>()
+    const events = createEventStream()
+    const mutations: string[] = []
+    const sessionID = "ses_compact"
+    const location = { directory, project: { id: "project", directory, canonical: directory } }
+    const calls = createFetch(async (url) => {
+      if (url.pathname === `/api/session/${sessionID}`)
+        return json({
+          data: {
+            id: sessionID,
+            projectID: "project",
+            title: "Compact fixture",
+            model: { providerID: "demo", id: "model" },
+            location: { directory },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            time: { created: 0, updated: 0 },
+          },
+        })
+      if (url.pathname === `/api/session/${sessionID}/message`) return json({ data: [], cursor: {} })
+      if (url.pathname === `/api/session/${sessionID}/inbox` || url.pathname === `/api/session/${sessionID}/permission`)
+        return json({ data: [] })
+      if (url.pathname === "/api/agent")
+        return json({ location, data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }] })
+      if (url.pathname === "/api/provider") return json({ location, data: [{ id: "demo", name: "Demo" }] })
+      if (url.pathname === "/api/model")
+        return json({ location, data: [{ id: "model", providerID: "demo", name: "Demo Model", variants: [] }] })
+      if (url.pathname === `/api/session/${sessionID}/model`) {
+        mutations.push("model")
+        return model.promise
+      }
+      if (url.pathname === `/api/session/${sessionID}/compact`) {
+        mutations.push("compact")
+        return json({ data: {} })
+      }
+      return undefined
+    }, events)
+    const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: { get: async () => ({ animations: false }), update: async () => ({}) },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        args: { sessionID },
+        log: () => {},
+      }).pipe(Effect.provide(Global.layerWith({ state: state.path })), Effect.provide(FileSystem.layerNoop({}))),
+    )
+    try {
+      await ready.promise
+      await setup.waitForFrame((frame) => frame.includes("Demo Model"))
+      await setup.mockInput.typeText("/compact")
+      setup.mockInput.pressEnter()
+      const frame = await setup.waitForFrame((frame) => frame.includes("Compaction queued"))
+      expect(frame).not.toContain("/compact")
+      await setup.mockInput.typeText("/compact")
+      setup.mockInput.pressEnter()
+      await setup.renderOnce()
+      expect(setup.captureCharFrame().match(/Compaction queued/g)).toHaveLength(1)
+      expect(mutations).toEqual(["model"])
+
+      model.resolve(json({ message: "Model setup failed" }, { status: 400 }))
+      const rejected = await setup.waitForFrame((frame) => frame.includes("Model setup failed"))
+      expect(rejected).not.toContain("Compaction queued")
+      expect(mutations).toEqual(["model"])
+    } finally {
+      model.resolve(new Response(null, { status: 204 }))
+      setup.renderer.destroy()
+      await task
+      await server.stop()
+    }
+  },
+)

--- a/packages/tui/test/fixture/tui-client.ts
+++ b/packages/tui/test/fixture/tui-client.ts
@@ -135,6 +135,8 @@ export function createFetch(override?: FetchHandler, events?: ReturnType<typeof 
       })
     if (url.pathname === "/api/session") return json({ data: [], cursor: {} })
     if (url.pathname === "/api/session/active") return json({ data: {} })
+    if (request.method === "POST" && /^\/api\/session\/[^/]+\/model$/.test(url.pathname))
+      return new Response(null, { status: 204 })
     if (url.pathname === "/api/permission/request")
       return json({
         location: { directory, project: { id: "proj_test", directory: worktree, canonical: worktree } },


### PR DESCRIPTION
## Why

Submitting `/compact` gives no feedback while model selection and compaction admission are on the wire. Repeating the action starts more requests, and a prompt submitted immediately afterward can overtake the compaction while model selection is still pending. Sequencing only the prompt POSTs also lets compaction overwrite a following prompt's selected model.

## What Changes

| Situation | Behavior |
| --- | --- |
| Submit `/compact` | Show `Compaction queued` immediately, before model setup, and close the command dialog. |
| Repeat the action during admission | Join the existing request instead of issuing another model/compaction RPC. |
| Server coalesces onto a different pending inbox ID | Retire the speculative ID and adopt the canonical item, without a second queued row. |
| A known pending compaction starts while setup waits | Propose a fresh control ID instead of reusing the consumed ID. Keep the known row authoritative rather than adding a duplicate placeholder. |
| Durable echo arrives before the HTTP response | Preserve the echoed state. A late response cannot restore an item already started, cancelled, or failed. |
| An inbox refresh acknowledges admission before SSE arrives | Preserve fetched durable state on POST rejection, including a compaction coalesced onto another ID. |
| Model setup or admission fails | Remove only the unacknowledged speculative row and show the error in a toast. |
| Submit a following prompt | Render the prompt immediately, but prepare its model and admit it after earlier admissions settle. A preceding rejection does not block the prompt. |
| Submit an ordinary TUI prompt | Make one explicit model RPC inside the admission chain, even if the selection is unchanged. The prompt renders before this RPC; Core emits no new durable event for an unchanged selection. |

## Admission Ordering

Compaction and prompt model preparation use the existing per-session send chain. Prompt preparation is a lazy callback, so it cannot run ahead of an earlier prompt or compaction. It commits the captured selection rather than trusting cached model state whose SSE echo may be delayed. The pending row is only an admission placeholder: execution status, the running compaction, and completion still come from server events.

One owner-scoped event subscription updates projections and records observations for in-flight compactions; there are no per-admission subscriptions or a separate unsubscribe registry. Compaction entries clear on request settlement or owner disposal. The shared admission helper captures creation gates synchronously, so creation failure prevents dependent model and prompt RPCs. Positive inbox reads also acknowledge admissions and directly determine which optimistic rows survive merging.

## Demo

Left: immutable base `b9cb4fc36a`. Right: committed revision `7cff6978b5`, captured from a clean `compact-admission` worktree after committing. Both run the real production TUI through the same OpenCode Drive script, deterministic README fixture, simulated model, and 100-column by 30-row viewport. The script applies 1200ms wire latency before triggering `/compact`; the equal-length ten-second clips are synchronized to Enter and are not accelerated.

The base stays blank during admission latency. The changed TUI immediately shows `Compaction queued`; both eventually show the server's completed compaction.

This footage predates follow-up commit `bfc73665b9`, which fixes model/admission sequencing, consumed control IDs, refresh acknowledgements, listener cleanup, and deterministic test waits. The shown queued/completed compaction appearance is unchanged; the footage is not a capture of the new head.

Bookkeeping-only follow-up `6491c4b6f5` reuses the projection subscription and shares admission sequencing without changing those rendered states.

https://github.com/user-attachments/assets/571c8e0f-e54a-4208-82ce-39ce51880405

## Scope

This PR owns manual compaction admission and the necessary prompt-model ordering in the V2 TUI and shared Solid client data layer. Ordinary TUI prompts now incur an explicit model RPC, adding a round trip and server lookup when the selection is unchanged, but no duplicate durable fact; Core's existing no-op behavior is verified rather than changed. Other prompt preparation stays outside this coordination, and the public Protocol is unchanged.

## Verification

```sh
# packages/client
bun run test test/solid-compaction.test.ts test/solid-data.test.ts
bun run test
bun typecheck

# packages/tui
bun run test test/cli/tui/session-rows.test.ts
bun run test test/compact-admission.test.tsx
bun run test test/app-lifecycle.test.tsx
bun run test test/compact-admission.test.tsx test/cli/tui/session-rows.test.ts test/cli/tui/data.test.tsx
bun run test
bun typecheck

# packages/core
bun run test test/session-create.test.ts -t 'ignores a model switch|omitted variant'

# Repository root
bunx prettier --check packages/client/src/solid/data.ts packages/client/test/solid-compaction.test.ts packages/tui/src/routes/session/index.tsx packages/tui/src/component/prompt/index.tsx packages/tui/test/compact-admission.test.tsx packages/tui/test/fixture/tui-client.ts
bunx oxlint packages/client/test/solid-compaction.test.ts packages/tui/test/compact-admission.test.tsx
git diff --check
git push origin compact-admission

# opencode-drive/packages/drive, using the new local probe
# OPENCODE_DEV points to the clean compact-admission worktree
bun run src/cli/index.ts check test/manual/tui-regressions/compact-admission.ts
OPENCODE_DRIVE_COMPACT_CASE=consumed bun run src/cli/index.ts start --daemon --name ca-final-consumed-100 --script test/manual/tui-regressions/compact-admission.ts --dev "$OPENCODE_DEV"
bun run test
bun typecheck
```

After the bookkeeping follow-up: the full client suite passes with 106 tests, the full TUI suite passes with 912 tests and 4 skips, and the focused data/rows/real-app suites pass with 70 tests. Both package typechecks pass. A new regression verifies concurrent compactions in different sessions share one listener without mixing cancellation observations or resurrecting consumed rows.

At the ordering-fix revision, all four focused real-app TUI tests passed across 20 consecutive runs. They cover immediate pending state, repeated gestures, rollback toasts at 70 and 120 columns, and model ordering through the production model picker and prompt handler with delayed SSE. Call-log assertions explicitly wait for HTTP arrival rather than assuming it has happened when the optimistic row appears.

Deferred real-client transport tests cover canonical-ID substitution, both echo/response orders, consumption during model setup, positive refresh acknowledgements for compactions and user prompts, owner disposal during a gate, preceding gate/preparation rejection, and creation failure with compaction and following input. The three reconciliation failures were reproduced before the fixes. Two focused Core tests verify unchanged-model and default-variant switches do not add durable events.

Both package typechecks, formatting, and new-test lint pass. The matched Drive runs at the captioned revisions completed successfully, and frames from both sides were inspected before upload.

The normal pre-push hook completed all 33 workspace typecheck tasks successfully; no hooks were bypassed.

### Drive Gauntlet At `6491c4b6f5`

Added a local, currently uncommitted Drive probe with five cases: ordered admission, unseen canonical coalescing, completion of a known queued control during model setup, cancellation during setup, and transport rollback/retry. These run the production TUI and real isolated server, with a simulated model and a TCP blackhole on TUI traffic; the SDK control plane stays clean. No OpenCode source changes were needed for this verification.

- All five cases passed at 70 and 120 columns across three repetitions each: **30/30**.
- All five also passed before the simplification commit, at `bfc73665b9`: **5/5**.
- Negative controls failed at the intended checkpoints: base `b9cb4fc36a` lacks `Compaction queued` during the partition; initial PR `7cff6978b5` returns HTTP 409 when a known control ID completes during setup.
- Review tightened rollback recovery to verify Session idleness and terminal stability after its recovery reply. The final probe passed all five cases at 100 columns plus rollback at 70 and 120 columns: **7/7**. The earlier matrix was not repeated after that focused assertion change.
- Three generated instance names exceeded the CLI limit and were rejected before launch. Shorter-name replacements passed; those infrastructure errors are separate from E2E results.

The matrix used probe SHA256 `3706255ffc7bc9820d7843e72832aa270cdad60bb23ec38f4cfbc82d2f9eaa05`; final validation used `e21556778d18e47296fb7b64f441daeb8eb5c4c942986559b3c5e05bf95a52e2`. Drive runtime revision was `a8b29b9a`, with pre-existing local lifecycle-probe edits retained. The new probe and its README live locally in the Drive checkout, not in this PR's diff.

The broader existing gauntlet is **not all green**: 25 HEAD runs produced 16 invariant passes, one diagnostic result, six failures, and two 240-second timeouts. All eight failures/timeouts reproduced on the immutable PR base with matching errors and lifecycle traces. They concern short-burst text batching, lifecycle probes expecting terminal failure where the server schedules retry, an unserved restart-recovery model request, and tool interruption waiters/prerequisites. The reconnect diagnostic confirms legitimate rejection with draft restoration, not a liveness pass. No new regression attributable to this refactor was found.

Passing broader coverage includes 20 initial-hydration attempts, file-backed restart, a 20-second outage, optimistic create/failure, mid-submit typing, steer/heal flows, multi-tool interleavings, resize, quiescence/restart, and network seeds 1, 7, 42, and 99 with 24 transitions each. Those network runs exercised two connection kills, nine latency windows, sixteen blackholes, and four steers.

Drive's package suite passed 244 Vitest tests and 58 CLI tests; final package typecheck, script check, and focused lint passed. All GitHub Linux/Windows unit and E2E, typecheck, standards, and compliance checks passed for `6491c4b6f5`. TCP-level probes establish queued checkpoints and settled convergence; deferred client tests cover exact response/event interleavings and listener ownership.
