### PR TITLE
fix(client): preserve live activity during hydration

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -215,8 +215,10 @@ export function createData(config: CreateDataInput) {
   )
   const messageIndex = new Map<string, Map<string, number>>()
   const sync = createSync()
+  let activeUpdates: Map<string, DataSessionStatus | undefined> | undefined
 
   function setSessionActive(sessionID: string, status: DataSessionStatus) {
+    activeUpdates?.set(sessionID, status)
     setStore("session", "active", sessionID, status)
   }
 
@@ -473,6 +475,7 @@ export function createData(config: CreateDataInput) {
   }
 
   function removeSession(sessionID: string) {
+    activeUpdates?.set(sessionID, undefined)
     store.session.pending[sessionID]?.forEach((item) => outbox.delete(item.id))
     messageIndex.delete(sessionID)
     sync.invalidate(`session:${sessionID}`)
@@ -504,17 +507,25 @@ export function createData(config: CreateDataInput) {
 
   function handleEvent(event: OpenCodeEvent) {
     switch (event.type) {
-      case "server.connected":
+      case "server.connected": {
+        const updates = new Map<string, DataSessionStatus | undefined>()
+        activeUpdates = updates
         void api()
           .session.active()
           .then((active) => {
-            setStore(
-              "session",
-              "active",
-              reconcile(Object.fromEntries(Object.keys(active).map((sessionID) => [sessionID, "running" as const]))),
-            )
+            if (activeUpdates !== updates) return
+            // Lifecycle events received during hydration supersede the snapshot.
+            const snapshot = new Map<string, DataSessionStatus>(Object.keys(active).map((id) => [id, "running"]))
+            updates.forEach((status, id) => {
+              if (status === undefined) return snapshot.delete(id)
+              snapshot.set(id, status)
+            })
+            activeUpdates = undefined
+            setStore("session", "active", reconcile(Object.fromEntries(snapshot)))
           })
-          .catch(() => undefined)
+          .catch(() => {
+            if (activeUpdates === updates) activeUpdates = undefined
+          })
         void api()
           .location.get({ location: locationQuery(defaultLocation()) })
           .then((location) => {
@@ -525,6 +536,7 @@ export function createData(config: CreateDataInput) {
         void result.location.vcs.sync().catch((error) => console.error("Failed to preload VCS info", error))
         void result.project.sync().catch((error) => console.error("Failed to preload projects", error))
         return
+      }
       case "project.updated":
         setStore("project", "info", event.data.id, reconcile(event.data))
         return

--- a/packages/client/test/solid-data.test.ts
+++ b/packages/client/test/solid-data.test.ts
@@ -485,6 +485,102 @@ test("preserves assistant content replacement events across an active message re
   }
 })
 
+test.each([
+  "session.execution.succeeded",
+  "session.execution.failed",
+  "session.execution.interrupted",
+  "session.execution.started",
+  "session.deleted",
+] as const)("preserves %s activity when an older snapshot arrives", async (type) => {
+  const release = Promise.withResolvers<void>()
+  const requested = Promise.withResolvers<void>()
+  const setup = activityFixture(async () => {
+    requested.resolve()
+    await release.promise
+    return Response.json({
+      data: {
+        ...(type === "session.execution.started" ? {} : { ses_refresh: { type: "running" } }),
+        ses_hydrated: { type: "running" },
+      },
+    })
+  })
+
+  try {
+    if (type !== "session.execution.started") setup.data.session.setStatus("ses_refresh", "running")
+    setup.emit({ type: "server.connected", data: {} })
+    await requested.promise
+    setup.emit({
+      id: "evt_activity",
+      created: 2,
+      type,
+      durable: { aggregateID: "ses_refresh", seq: 2, version: 1 },
+      data: { sessionID: "ses_refresh", reason: "user" },
+    })
+    expect(setup.data.session.status("ses_refresh")).toBe(type === "session.execution.started" ? "running" : "idle")
+    release.resolve()
+    await wait(() => setup.data.session.status("ses_hydrated") === "running")
+    expect(setup.data.session.status("ses_refresh")).toBe(type === "session.execution.started" ? "running" : "idle")
+  } finally {
+    release.resolve()
+    setup.dispose()
+  }
+})
+
+test("ignores activity snapshots from an older connection", async () => {
+  const reads: ReturnType<typeof Promise.withResolvers<Response>>[] = []
+  const setup = activityFixture(() => {
+    const read = Promise.withResolvers<Response>()
+    reads.push(read)
+    return read.promise
+  })
+
+  try {
+    setup.emit({ type: "server.connected", data: {} })
+    await wait(() => reads.length === 1)
+    setup.emit({ type: "server.connected", data: {} })
+    await wait(() => reads.length === 2)
+    reads[1]?.resolve(Response.json({ data: { ses_new: { type: "running" } } }))
+    await wait(() => setup.data.session.status("ses_new") === "running")
+    reads[0]?.resolve(Response.json({ data: { ses_old: { type: "running" } } }))
+    await Bun.sleep(20)
+    expect(setup.data.session.status("ses_new")).toBe("running")
+    expect(setup.data.session.status("ses_old")).toBe("idle")
+  } finally {
+    reads.forEach((read) => read.resolve(Response.json({ data: {} })))
+    setup.dispose()
+  }
+})
+
+function activityFixture(read: () => Response | Promise<Response>) {
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      const path = new URL(request.url).pathname
+      if (path === "/api/session/active") return read()
+      if (path === "/api/project") return Response.json([])
+      if (path === "/api/location") return Response.json({ directory: "/project" })
+      return Response.json({ location: { directory: "/project" }, data: { branch: "main" } })
+    },
+  })
+  return createRoot((dispose) => ({
+    data: createData({
+      api: () => api,
+      directory: "/project",
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
+    }),
+    emit: (details: OpenCodeEvent) => listeners.forEach((listener) => listener({ name: details.type, details })),
+    dispose,
+  }))
+}
+
 async function wait(check: () => boolean) {
   const started = Date.now()
   while (!check()) {


### PR DESCRIPTION
## Why

An idle session can keep spinning in the TUI's tab strip and Sessions picker after a delayed activity snapshot overwrites its completion event. A response from an older connection can also overwrite a newer connection's snapshot, leaving activity incorrect until another event or reconnect repairs it.

## What Changes

Activity snapshots now provide a baseline rather than replacing status changes received while the request was outstanding.

| Ordering | Result |
| --- | --- |
| Success, failure, or interruption arrives before an older running snapshot | Session remains idle |
| Execution starts before an older empty snapshot arrives | Session remains running |
| Session is deleted while its activity snapshot is outstanding | Deleted activity stays removed |
| An older connection's snapshot arrives after the newer connection's | Older response is ignored |
| Another session has no intervening event | Its activity still hydrates from the snapshot |

```mermaid
sequenceDiagram
    participant TUI
    participant Server
    TUI->>Server: GET /api/session/active
    Note over Server: Snapshot captures session as running
    Server-->>TUI: session.execution.succeeded
    Note over TUI: Set idle immediately and retain the update
    Server-->>TUI: Delayed running snapshot
    Note over TUI: Merge retained update; session stays idle
```

## Demo

Matched OpenCode Drive recording: before `936c73b54d`, after `8aad0dceed`. Both run the production TUI with the same fixture and 80x24 observer viewport. A simulated model and temporary server response gate make the ordering deterministic; the server's active map and inbox are empty before the comparison. The clips show five seconds side by side without acceleration. Diagnostic server instrumentation is not included in this PR.

https://github.com/user-attachments/assets/27874bed-6dd3-414e-8807-00b101b223a4

## Scope

This change owns client activity hydration and its regression tests. Inbox-derived busy indicators and event-stream liveness are separate concerns.

## Verification

```sh
# packages/client
bun run test
bun typecheck

# packages/tui
bun run test test/cli/tui/data.test.tsx test/context/session-tabs.test.tsx

# opencode-drive/packages/drive
bun run drive check .tmp/spinner-demo.ts
```

The client suite passes 90 tests, including six activity-ordering regressions. TUI data and tab tests pass all 78 tests. The repository's pre-push hook also passed all 33 typecheck tasks without bypassing hooks. The Drive scenario reproduces the stale tab and picker spinners on the base revision and verifies their absence on the changed revision. The duplicated regression setup is shared, and the start-event case begins idle so its handler is required for the test to pass.
