### PR TITLE
fix(tui): open recent picker before server reads

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -68,7 +68,7 @@ import { DialogThemeList } from "./component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
 import { DialogSessionList } from "./component/dialog-session-list"
-import { DialogOpen, DialogOpenKey } from "./component/dialog-open"
+import { DialogOpen, DialogOpenKey, moveOpenSession } from "./component/dialog-open"
 import { SessionTabs } from "./component/session-tabs"
 import { clampSessionTabsWidth, sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "./ui/layout"
 import { createPaneResize } from "./ui/pane-resize"
@@ -1209,6 +1209,12 @@ function App(props: { pair?: DialogPairCredentials }) {
       type: "session",
       sessionID: evt.data.sessionID,
     })
+  })
+
+  event.on("session.moved", (evt) => {
+    setOpenSessions((sessions) =>
+      sessions.map((session) => (session.id !== evt.data.sessionID ? session : moveOpenSession(session, evt))),
+    )
   })
 
   event.on("session.deleted", (evt) => {

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -68,7 +68,7 @@ import { DialogThemeList } from "./component/dialog-theme-list"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
 import { DialogSessionList } from "./component/dialog-session-list"
-import { DialogOpen, DialogOpenKey, loadDialogOpen } from "./component/dialog-open"
+import { DialogOpen, DialogOpenKey } from "./component/dialog-open"
 import { SessionTabs } from "./component/session-tabs"
 import { clampSessionTabsWidth, sessionTabsFitVertically, SESSION_SIDEBAR_WIDTH } from "./ui/layout"
 import { createPaneResize } from "./ui/pane-resize"
@@ -507,7 +507,7 @@ function App(props: { pair?: DialogPairCredentials }) {
       }).catch((error) => console.error("Failed to persist TUI layout", error))
     },
   })
-  let openingOpen: Promise<SessionInfo[]> | undefined
+  const [openSessions, setOpenSessions] = createSignal<SessionInfo[]>([])
   // Toast once when an MCP server enters a failed or needs-auth state so the user knows to act,
   // without having to open the status panel. Tracking the last alerted status avoids re-toasting
   // the same problem on every refresh while still re-alerting if the state changes.
@@ -719,14 +719,12 @@ function App(props: { pair?: DialogPairCredentials }) {
         title: "Open session or project",
         category: "Session",
         slash: { name: "open", aliases: ["projects", "project"] },
-        run: async () => {
-          if (dialog.key === DialogOpenKey || openingOpen) return
-          const previous = dialog.stack.at(-1)
-          openingOpen = loadDialogOpen(data, client)
-          const sessions = await openingOpen
-          openingOpen = undefined
-          if (dialog.stack.at(-1) !== previous) return
-          dialog.replace(() => <DialogOpen sessions={sessions} />, undefined, { key: DialogOpenKey, size: "large" })
+        run: () => {
+          if (dialog.key === DialogOpenKey) return
+          dialog.replace(() => <DialogOpen sessions={openSessions()} onLoad={setOpenSessions} />, undefined, {
+            key: DialogOpenKey,
+            size: "large",
+          })
         },
       },
       ...Array.from({ length: 9 }, (_, i) => ({
@@ -1214,6 +1212,7 @@ function App(props: { pair?: DialogPairCredentials }) {
   })
 
   event.on("session.deleted", (evt) => {
+    setOpenSessions((sessions) => sessions.filter((session) => session.id !== evt.data.sessionID))
     if (route.data.type === "session" && route.data.sessionID === evt.data.sessionID) {
       const title = active?.id === evt.data.sessionID ? active.title : undefined
       route.navigate({ type: "home" })

--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -1,5 +1,5 @@
 import { createMemo, createResource, createSignal, onCleanup, Show } from "solid-js"
-import type { SessionInfo } from "@opencode-ai/client"
+import type { OpenCodeEvent, SessionInfo } from "@opencode-ai/client"
 import { useTerminalDimensions } from "@opentui/solid"
 import type { RGBA } from "@opentui/core"
 import { dialogWidth, useDialog } from "../ui/dialog"
@@ -44,15 +44,31 @@ export function DialogOpen(props: { sessions: SessionInfo[]; onLoad: (sessions: 
   onCleanup(() => {
     closed = true
   })
-  const [recent] = createResource(() =>
-    client.api.session
+  const [recent] = createResource(() => {
+    // A late read must not overwrite deletion or placement facts observed in flight.
+    const changed = new Map<string, Extract<OpenCodeEvent, { type: "session.deleted" | "session.moved" }>>()
+    const unsubscribe = client.event.listen((message) => {
+      const event = message.details
+      if (event.type === "session.deleted" || event.type === "session.moved") changed.set(event.data.sessionID, event)
+    })
+    onCleanup(unsubscribe)
+    return client.api.session
       .list({ limit: 50, order: "desc", parentID: null })
       .then((response) => {
-        if (!closed) props.onLoad(response.data)
+        if (!closed)
+          props.onLoad(
+            response.data.flatMap((session) => {
+              const event = changed.get(session.id)
+              if (!event) return [session]
+              if (event.type === "session.deleted") return []
+              return [moveOpenSession(props.sessions.find((entry) => entry.id === session.id) ?? session, event)]
+            }),
+          )
         return true
       })
-      .catch(() => false),
-  )
+      .catch(() => false)
+      .finally(unsubscribe)
+  })
   const [projects] = createResource(() =>
     data.project.sync().then(
       () => true,
@@ -205,6 +221,16 @@ export function DialogOpen(props: { sessions: SessionInfo[]; onLoad: (sessions: 
       }}
     />
   )
+}
+
+export function moveOpenSession(session: SessionInfo, event: Extract<OpenCodeEvent, { type: "session.moved" }>) {
+  return {
+    ...session,
+    location: event.data.location,
+    projectID: event.data.projectID ?? session.projectID,
+    subpath: event.data.subpath,
+    time: { ...session.time, updated: Math.max(session.time.updated, event.created) },
+  }
 }
 
 function timeAgo(timestamp: number) {

--- a/packages/tui/src/component/dialog-open.tsx
+++ b/packages/tui/src/component/dialog-open.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createResource, createSignal } from "solid-js"
+import { createMemo, createResource, createSignal, onCleanup, Show } from "solid-js"
 import type { SessionInfo } from "@opencode-ai/client"
 import { useTerminalDimensions } from "@opentui/solid"
 import type { RGBA } from "@opentui/core"
@@ -25,18 +25,7 @@ export const DialogOpenKey = Symbol("DialogOpen")
 
 type OpenTarget = { type: "session"; sessionID: string } | { type: "project"; directory: string }
 
-export async function loadDialogOpen(data: ReturnType<typeof useData>, client: ReturnType<typeof useClient>) {
-  const [, sessions] = await Promise.all([
-    data.project.sync().catch(() => {}),
-    client.api.session
-      .list({ limit: 50, order: "desc", parentID: null })
-      .then((response) => response.data)
-      .catch(() => [] as SessionInfo[]),
-  ])
-  return sessions
-}
-
-export function DialogOpen(props: { sessions: SessionInfo[] }) {
+export function DialogOpen(props: { sessions: SessionInfo[]; onLoad: (sessions: SessionInfo[]) => void }) {
   const dialog = useDialog()
   const route = useRoute()
   const data = useData()
@@ -51,6 +40,25 @@ export function DialogOpen(props: { sessions: SessionInfo[] }) {
   const shortcuts = Keymap.useShortcuts()
   const [filter, setFilter] = createSignal("")
   const [selectionMoved, setSelectionMoved] = createSignal(false)
+  let closed = false
+  onCleanup(() => {
+    closed = true
+  })
+  const [recent] = createResource(() =>
+    client.api.session
+      .list({ limit: 50, order: "desc", parentID: null })
+      .then((response) => {
+        if (!closed) props.onLoad(response.data)
+        return true
+      })
+      .catch(() => false),
+  )
+  const [projects] = createResource(() =>
+    data.project.sync().then(
+      () => true,
+      () => false,
+    ),
+  )
 
   const [matched] = createResource(
     () => {
@@ -154,12 +162,34 @@ export function DialogOpen(props: { sessions: SessionInfo[] }) {
       preserveSelection={selectionMoved()}
       onMove={() => setSelectionMoved(true)}
       onFilter={setFilter}
+      emptyView={
+        <Show when={!recent.loading && !projects.loading}>
+          <box paddingLeft={4} paddingRight={4}>
+            <text fg={theme.text.subdued}>No recent sessions or projects</text>
+          </box>
+        </Show>
+      }
+      footer={
+        <box>
+          <Show when={recent.loading || projects.loading}>
+            <Spinner color={theme.text.subdued}>Refreshing sessions and projects...</Spinner>
+          </Show>
+          <Show when={recent() === false || projects() === false}>
+            <text fg={theme.text.feedback.error.default}>
+              Could not refresh{" "}
+              {recent() === false ? (projects() === false ? "sessions and projects" : "sessions") : "projects"}.
+            </text>
+          </Show>
+        </box>
+      }
       noMatchView={
         <box paddingLeft={4} paddingRight={4}>
           <text fg={theme.text.subdued}>
-            {shortcuts.get("session.list")
-              ? `No matches · search all sessions with ${shortcuts.get("session.list")}`
-              : "No matches"}
+            {recent.loading || projects.loading || matched.loading
+              ? "Searching sessions and projects..."
+              : shortcuts.get("session.list")
+                ? `No matches · search all sessions with ${shortcuts.get("session.list")}`
+                : "No matches"}
           </text>
         </box>
       }

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -284,8 +284,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           selection = option
           if (!moved) return
           if (
-            (!props.preserveSelection && (props.current === undefined || props.focusCurrent === false)) ||
-            store.filter.length > 0
+            !props.preserveSelection &&
+            (props.current === undefined || props.focusCurrent === false || store.filter.length > 0)
           )
             return
           scrollAfterLayout(false, option.value)

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -9,6 +9,7 @@ import { createEventStream, createFetch, directory, json } from "./fixture/tui-c
 import { tmpdir } from "./fixture/fixture"
 
 test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deletions at width %s", async (width) => {
+  await using state = await tmpdir()
   const setup = await createTestRenderer({ width, height: 30, useThread: false, kittyKeyboard: true })
   setup.renderer.start()
   const ready = Promise.withResolvers<void>()
@@ -58,7 +59,7 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
         terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
         args: {},
         log: () => {},
-      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
+      }).pipe(Effect.provide(Global.layerWith({ state: state.path })), Effect.provide(FileSystem.layerNoop({}))),
     )
     await ready.promise
     await setup.waitForFrame((frame) => frame.includes("commands"))

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -15,6 +15,7 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
   const ready = Promise.withResolvers<void>()
   const requested = Promise.withResolvers<void>()
   const response = Promise.withResolvers<Response>()
+  const projects = Promise.withResolvers<Response>()
   const refresh = Promise.withResolvers<Response>()
   const events = createEventStream()
   const cachedSession = {
@@ -35,16 +36,7 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
       if (requests === 2 || requests > 3) return refresh.promise.then((response) => response.clone())
       return json({ data: [cachedSession], cursor: {} })
     }
-    if (url.pathname === "/api/project")
-      return json([
-        {
-          id: "proj_fixture",
-          canonical: "/fixture",
-          name: "Fixture project",
-          time: { created: 1, updated: 2 },
-          sandboxes: [],
-        },
-      ])
+    if (url.pathname === "/api/project") return projects.promise
     return undefined
   }, events)
   const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
@@ -66,8 +58,20 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
     setup.mockInput.pressKey("o", { ctrl: true })
     await requested.promise
     await setup.renderOnce()
-    expect(setup.captureCharFrame()).toContain("Fixture project")
+    expect(setup.captureCharFrame()).toContain("Search sessions")
     expect(setup.captureCharFrame()).toContain("Refreshing")
+    projects.resolve(
+      json([
+        {
+          id: "proj_fixture",
+          canonical: "/fixture",
+          name: "Fixture project",
+          time: { created: 1, updated: 2 },
+          sandboxes: [],
+        },
+      ]),
+    )
+    await setup.waitForFrame((frame) => frame.includes("Fixture project"))
     setup.mockInput.pressKey("o", { ctrl: true })
     expect(requests).toBe(1)
     setup.mockInput.pressEscape()
@@ -99,6 +103,7 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
     await task
   } finally {
     response.resolve(json({ data: [], cursor: {} }))
+    projects.resolve(json([]))
     refresh.resolve(json({ data: [], cursor: {} }))
     if (!setup.renderer.isDestroyed) setup.renderer.destroy()
     await server.stop()

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -33,7 +33,8 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
       requests++
       requested.resolve()
       if (requests === 1) return response.promise
-      if (requests === 2 || requests > 3) return refresh.promise.then((response) => response.clone())
+      if (requests === 2 || requests === 4) return refresh.promise.then((response) => response.clone())
+      if (requests > 4) return new Response("Unavailable", { status: 503 })
       return json({ data: [cachedSession], cursor: {} })
     }
     if (url.pathname === "/api/project") return projects.promise
@@ -86,6 +87,10 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
     await setup.waitForFrame((frame) => !frame.includes("Fixture project"))
     setup.mockInput.pressKey("o", { ctrl: true })
     await setup.waitForFrame((frame) => frame.includes("Cached"))
+    setup.mockInput.pressEscape()
+    await setup.waitForFrame((frame) => !frame.includes("Fixture project"))
+    setup.mockInput.pressKey("o", { ctrl: true })
+    await setup.waitForFrame((frame) => frame.includes("Cached") && frame.includes("Refreshing"))
     events.emit({
       id: "evt_deleted",
       created: 1,
@@ -94,10 +99,13 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
       data: { sessionID: "ses_cached" },
     })
     await setup.waitForFrame((frame) => !frame.includes("Cached"))
+    refresh.resolve(json({ data: [cachedSession], cursor: {} }))
+    await setup.waitForFrame((frame) => frame.includes("Fixture project") && !frame.includes("Refreshing"))
+    expect(setup.captureCharFrame()).not.toContain("Cached")
     setup.mockInput.pressEscape()
     await setup.waitForFrame((frame) => !frame.includes("Fixture project"))
     setup.mockInput.pressKey("o", { ctrl: true })
-    await setup.waitForFrame((frame) => frame.includes("Refreshing"))
+    await setup.waitForFrame((frame) => frame.includes("Could not refresh sessions"))
     expect(setup.captureCharFrame()).not.toContain("Cached")
     setup.renderer.destroy()
     await task
@@ -109,6 +117,131 @@ test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deleti
     await server.stop()
   }
 })
+
+test.each(["dismissed", "refreshing"])(
+  "Ctrl-O retains committed movement of a cached-only session while %s",
+  async (phase) => {
+    await using state = await tmpdir()
+    const setup = await createTestRenderer({ width: 100, height: 30, useThread: false, kittyKeyboard: true })
+    setup.renderer.start()
+    const ready = Promise.withResolvers<void>()
+    const refresh = Promise.withResolvers<Response>()
+    const metadata = Promise.withResolvers<Response>()
+    const destinationRequested = Promise.withResolvers<void>()
+    const events = createEventStream()
+    const cached = {
+      id: "ses_cached_move",
+      title: "Cached movement",
+      projectID: "proj_old",
+      location: { directory: "/fixture/old" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: 1, updated: 2 },
+    }
+    let requests = 0
+    const locations: string[] = []
+    const calls = createFetch((url) => {
+      if (url.pathname === "/api/session") {
+        if (url.searchParams.has("parentID")) {
+          const parent = url.searchParams.get("parentID")
+          if (parent && parent !== "null") return json({ data: [], cursor: {} })
+        }
+        return requests++ === 0
+          ? json({ data: [cached], cursor: {} })
+          : refresh.promise.then((response) => response.clone())
+      }
+      if (url.pathname === `/api/session/${cached.id}`) return metadata.promise
+      if (url.pathname === `/api/session/${cached.id}/message`) return json({ data: [], cursor: {} })
+      if (url.pathname === `/api/session/${cached.id}/inbox` || url.pathname === `/api/session/${cached.id}/permission`)
+        return json({ data: [] })
+      if (url.pathname === "/api/project")
+        return json(
+          ["old", "new"].map((name) => ({
+            id: `proj_${name}`,
+            canonical: `/fixture/${name}`,
+            name: name === "old" ? "Old" : "New",
+            time: { created: 1, updated: 2 },
+            sandboxes: [],
+          })),
+        )
+      if (url.pathname === "/api/location") {
+        const query = url.searchParams.get("location[directory]") ?? ""
+        locations.push(query)
+        if (query.includes("/fixture/new")) {
+          destinationRequested.resolve()
+          return json({
+            directory: "/fixture/new",
+            project: { id: "proj_new", directory: "/fixture/new", canonical: "/fixture/new" },
+          })
+        }
+      }
+      return undefined
+    }, events)
+    const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: { get: async () => ({ animations: false, tabs: { enabled: false } }), update: async () => ({}) },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        args: {},
+        log: () => {},
+      }).pipe(Effect.provide(Global.layerWith({ state: state.path })), Effect.provide(FileSystem.layerNoop({}))),
+    )
+    try {
+      await ready.promise
+      await setup.waitForFrame((frame) => frame.includes("commands"))
+      setup.mockInput.pressKey("o", { ctrl: true })
+      await setup.waitForFrame((frame) => frame.includes(cached.title) && !frame.includes("Refreshing"))
+      setup.mockInput.pressEscape()
+      await setup.waitForFrame((frame) => !frame.includes("Search sessions"))
+      if (phase === "refreshing") {
+        setup.mockInput.pressKey("o", { ctrl: true })
+        await setup.waitForFrame((frame) => frame.includes(cached.title) && frame.includes("Refreshing"))
+      }
+      events.emit({
+        id: "evt_cached_moved",
+        created: 3,
+        type: "session.moved",
+        durable: { aggregateID: cached.id, seq: 1, version: 1 },
+        data: { sessionID: cached.id, location: { directory: "/fixture/new" }, projectID: "proj_new" },
+      })
+      if (phase === "dismissed") {
+        setup.mockInput.pressKey("o", { ctrl: true })
+        refresh.resolve(new Response("Unavailable", { status: 503 }))
+        await setup.waitForFrame((frame) => frame.includes("Could not refresh sessions"))
+      }
+      if (phase === "refreshing") {
+        await setup.waitForFrame((frame) =>
+          frame.split("\n").some((line) => line.includes(cached.title) && line.includes("New")),
+        )
+        refresh.resolve(json({ data: [cached], cursor: {} }))
+        await setup.waitForFrame((frame) => frame.includes(cached.title) && !frame.includes("Refreshing"))
+      }
+      await setup.waitForFrame((frame) =>
+        frame.split("\n").some((line) => line.includes(cached.title) && line.includes("New")),
+      )
+      expect(
+        setup
+          .captureCharFrame()
+          .split("\n")
+          .find((line) => line.includes(cached.title)),
+      ).toContain("New")
+      locations.length = 0
+      setup.mockInput.pressEnter()
+      await destinationRequested.promise
+      expect(locations.some((query) => query.includes("/fixture/old"))).toBe(false)
+    } finally {
+      refresh.resolve(json({ data: [], cursor: {} }))
+      metadata.resolve(json({ data: { ...cached, projectID: "proj_new", location: { directory: "/fixture/new" } } }))
+      setup.renderer.destroy()
+      await task
+      await server.stop()
+    }
+  },
+)
 
 test("SIGHUP clears title and disposes scoped resources once", async () => {
   const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -8,6 +8,102 @@ import path from "node:path"
 import { createEventStream, createFetch, directory, json } from "./fixture/tui-client"
 import { tmpdir } from "./fixture/fixture"
 
+test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deletions at width %s", async (width) => {
+  const setup = await createTestRenderer({ width, height: 30, useThread: false, kittyKeyboard: true })
+  setup.renderer.start()
+  const ready = Promise.withResolvers<void>()
+  const requested = Promise.withResolvers<void>()
+  const response = Promise.withResolvers<Response>()
+  const refresh = Promise.withResolvers<Response>()
+  const events = createEventStream()
+  const cachedSession = {
+    id: "ses_cached",
+    title: "Cached session",
+    projectID: "proj_fixture",
+    location: { directory: "/fixture" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 1, updated: 2 },
+  }
+  let requests = 0
+  const calls = createFetch((url) => {
+    if (url.pathname === "/api/session") {
+      requests++
+      requested.resolve()
+      if (requests === 1) return response.promise
+      if (requests === 2 || requests > 3) return refresh.promise.then((response) => response.clone())
+      return json({ data: [cachedSession], cursor: {} })
+    }
+    if (url.pathname === "/api/project")
+      return json([
+        {
+          id: "proj_fixture",
+          canonical: "/fixture",
+          name: "Fixture project",
+          time: { created: 1, updated: 2 },
+          sandboxes: [],
+        },
+      ])
+    return undefined
+  }, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+  try {
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: { get: async () => ({ animations: false }), update: async () => ({}) },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        args: {},
+        log: () => {},
+      }).pipe(Effect.provide(AppNodeBuilder.build(Global.node)), Effect.provide(FileSystem.layerNoop({}))),
+    )
+    await ready.promise
+    await setup.waitForFrame((frame) => frame.includes("commands"))
+    setup.mockInput.pressKey("o", { ctrl: true })
+    await requested.promise
+    await setup.renderOnce()
+    expect(setup.captureCharFrame()).toContain("Fixture project")
+    expect(setup.captureCharFrame()).toContain("Refreshing")
+    setup.mockInput.pressKey("o", { ctrl: true })
+    expect(requests).toBe(1)
+    setup.mockInput.pressEscape()
+    await setup.waitForFrame((frame) => !frame.includes("Fixture project"))
+    response.resolve(json({ data: [{ ...cachedSession, id: "ses_disposed", title: "Disposed response" }], cursor: {} }))
+    await setup.renderOnce()
+    expect(setup.captureCharFrame()).not.toContain("Fixture project")
+    setup.mockInput.pressKey("o", { ctrl: true })
+    await setup.waitForFrame((frame) => frame.includes("Refreshing"))
+    expect(setup.captureCharFrame()).not.toContain("Disposed")
+    setup.mockInput.pressEscape()
+    await setup.waitForFrame((frame) => !frame.includes("Fixture project"))
+    setup.mockInput.pressKey("o", { ctrl: true })
+    await setup.waitForFrame((frame) => frame.includes("Cached"))
+    events.emit({
+      id: "evt_deleted",
+      created: 1,
+      type: "session.deleted",
+      durable: { aggregateID: "ses_cached", seq: 1, version: 2 },
+      data: { sessionID: "ses_cached" },
+    })
+    await setup.waitForFrame((frame) => !frame.includes("Cached"))
+    setup.mockInput.pressEscape()
+    await setup.waitForFrame((frame) => !frame.includes("Fixture project"))
+    setup.mockInput.pressKey("o", { ctrl: true })
+    await setup.waitForFrame((frame) => frame.includes("Refreshing"))
+    expect(setup.captureCharFrame()).not.toContain("Cached")
+    setup.renderer.destroy()
+    await task
+  } finally {
+    response.resolve(json({ data: [], cursor: {} }))
+    refresh.resolve(json({ data: [], cursor: {} }))
+    if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+    await server.stop()
+  }
+})
+
 test("SIGHUP clears title and disposes scoped resources once", async () => {
   const setup = await createTestRenderer({ width: 80, height: 24, useThread: false })
   const titles: string[] = []

--- a/packages/tui/test/cli/tui/dialog-open.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-open.test.tsx
@@ -1,10 +1,11 @@
 /** @jsxImportSource @opentui/solid */
 import { expect, test } from "bun:test"
 import { testRender } from "@opentui/solid"
-import { onMount } from "solid-js"
-import { DialogOpen, DialogOpenKey, loadDialogOpen } from "../../../src/component/dialog-open"
+import { createSignal, onMount } from "solid-js"
+import type { SessionInfo } from "@opencode-ai/client"
+import { DialogOpen, DialogOpenKey } from "../../../src/component/dialog-open"
 import { ConfigProvider } from "../../../src/config"
-import { ClientProvider, useClient } from "../../../src/context/client"
+import { ClientProvider } from "../../../src/context/client"
 import { DataProvider, useData } from "../../../src/context/data"
 import { Keymap } from "../../../src/context/keymap"
 import { LocationProvider, useLocation } from "../../../src/context/location"
@@ -131,7 +132,7 @@ test("shows the current project and opens its root", async () => {
   }
 })
 
-test("waits for sessions before showing the populated picker", async () => {
+test("shows projects while sessions refresh and preserves the selected project", async () => {
   let resolveSessions!: (response: Response) => void
   const sessions = new Promise<Response>((resolve) => (resolveSessions = resolve))
   const fixture = await renderOpen((url) => {
@@ -157,8 +158,9 @@ test("waits for sessions before showing the populated picker", async () => {
   })
 
   try {
-    await fixture.app.renderOnce()
-    expect(fixture.app.captureCharFrame()).not.toContain("Search sessions and projects")
+    await fixture.app.waitForFrame((frame) => frame.includes("Second project") && frame.includes("Refreshing"))
+    expect(fixture.app.captureCharFrame()).toContain("Search sessions and projects")
+    fixture.app.mockInput.pressArrow("down")
 
     resolveSessions(
       json({
@@ -177,12 +179,128 @@ test("waits for sessions before showing the populated picker", async () => {
       }),
     )
     await fixture.app.waitForFrame((frame) => frame.includes("Recent session") && frame.includes("Second project"))
-    fixture.app.mockInput.pressArrow("down")
-    fixture.app.mockInput.pressArrow("down")
     fixture.app.mockInput.pressEnter()
     await fixture.app.waitFor(() => fixture.route.data.type === "home")
 
     expect(fixture.route.data).toEqual({ type: "home", location: { directory: "/tmp/opencode/second" } })
+  } finally {
+    await fixture.dispose()
+  }
+})
+
+const recentSession = {
+  id: "ses_recent",
+  projectID: "proj_recent",
+  cost: 0,
+  tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  time: { created: 1, updated: 2 },
+  title: "Recent session",
+  location: { directory: "/fixture" },
+}
+
+test("sessions remain selectable while projects are still loading", async () => {
+  const projects = Promise.withResolvers<Response>()
+  const fixture = await renderOpen((url) => {
+    if (url.pathname === "/api/session") return json({ data: [recentSession], cursor: {} })
+    if (url.pathname === "/api/project") return projects.promise
+    return undefined
+  })
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Recent session") && frame.includes("Refreshing"))
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitFor(() => fixture.route.data.type === "session")
+    expect(fixture.route.data).toEqual({ type: "session", sessionID: recentSession.id })
+  } finally {
+    projects.resolve(json([]))
+    await fixture.dispose()
+  }
+})
+
+test("shows hydrated sessions immediately without waiting for either read", async () => {
+  const sessions = Promise.withResolvers<Response>()
+  const projects = Promise.withResolvers<Response>()
+  const fixture = await renderOpen(
+    (url) => {
+      if (url.pathname === "/api/session") return sessions.promise
+      if (url.pathname === "/api/project") return projects.promise
+      return undefined
+    },
+    ({ data }) => data.session.remember(recentSession),
+  )
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Recent session") && frame.includes("Refreshing"))
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitFor(() => fixture.route.data.type === "session")
+    expect(fixture.route.data).toEqual({ type: "session", sessionID: recentSession.id })
+  } finally {
+    sessions.resolve(json({ data: [], cursor: {} }))
+    projects.resolve(json([]))
+    await fixture.dispose()
+  }
+})
+
+test("keeps the previous recent list usable when reopening fails to refresh", async () => {
+  let requests = 0
+  const fixture = await renderOpen((url) => {
+    if (url.pathname === "/api/session")
+      return requests++ === 0
+        ? json({ data: [recentSession], cursor: {} })
+        : new Response("Unavailable", { status: 503 })
+    return undefined
+  })
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Recent session") && !frame.includes("Refreshing"))
+    fixture.app.mockInput.pressEscape()
+    await fixture.app.waitForFrame((frame) => !frame.includes("Recent session"))
+    fixture.open()
+    await fixture.app.waitForFrame((frame) => frame.includes("Could not refresh sessions"))
+    expect(fixture.app.captureCharFrame()).toContain("Recent session")
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitFor(() => fixture.route.data.type === "session")
+    expect(fixture.route.data).toEqual({ type: "session", sessionID: recentSession.id })
+  } finally {
+    await fixture.dispose()
+  }
+})
+
+test("shows an initial loading shell instead of reporting an empty list", async () => {
+  const sessions = Promise.withResolvers<Response>()
+  const projects = Promise.withResolvers<Response>()
+  const fixture = await renderOpen((url) => {
+    if (url.pathname === "/api/session") return sessions.promise
+    if (url.pathname === "/api/project") return projects.promise
+    return undefined
+  })
+  try {
+    await fixture.app.waitForFrame(
+      (frame) => frame.includes("Search sessions and projects") && frame.includes("Refreshing"),
+    )
+    expect(fixture.app.captureCharFrame()).not.toContain("No items available")
+    await fixture.app.mockInput.typeText("missing")
+    await fixture.app.waitForFrame((frame) => frame.includes("Searching sessions and projects"))
+    expect(fixture.app.captureCharFrame()).not.toContain("No matches")
+    sessions.resolve(json({ data: [], cursor: {} }))
+    projects.resolve(json([]))
+    await fixture.app.waitForFrame((frame) => frame.includes("No matches") && !frame.includes("Refreshing"))
+  } finally {
+    sessions.resolve(json({ data: [], cursor: {} }))
+    projects.resolve(json([]))
+    await fixture.dispose()
+  }
+})
+
+test("reports both refresh failures while keeping hydrated sessions usable", async () => {
+  const fixture = await renderOpen(
+    (url) => {
+      if (url.pathname === "/api/session" || url.pathname === "/api/project")
+        return new Response("Unavailable", { status: 503 })
+      return undefined
+    },
+    ({ data }) => data.session.remember(recentSession),
+  )
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Could not refresh sessions and projects"))
+    expect(fixture.app.captureCharFrame()).toContain("Recent session")
   } finally {
     await fixture.dispose()
   }
@@ -291,20 +409,21 @@ async function renderOpen(
   let location!: ReturnType<typeof useLocation>
   let data!: ReturnType<typeof useData>
   let storage!: ReturnType<typeof useStorage>
+  let open!: () => void
 
   function Probe() {
     const dialog = useDialog()
-    const client = useClient()
+    const [sessions, setSessions] = createSignal<SessionInfo[]>([])
     route = useRoute()
     location = useLocation()
     data = useData()
     storage = useStorage()
-    onMount(
-      () =>
-        void Promise.all([beforeOpen?.({ data, location }), loadDialogOpen(data, client)]).then(([, sessions]) =>
-          dialog.replace(() => <DialogOpen sessions={sessions} />, undefined, { key: DialogOpenKey, size: "large" }),
-        ),
-    )
+    open = () =>
+      dialog.replace(() => <DialogOpen sessions={sessions()} onLoad={setSessions} />, undefined, {
+        key: DialogOpenKey,
+        size: "large",
+      })
+    onMount(() => void Promise.resolve(beforeOpen?.({ data, location })).then(open))
     return null
   }
 
@@ -344,6 +463,7 @@ async function renderOpen(
 
   return {
     app,
+    open: () => open(),
     get route() {
       return route
     },

--- a/packages/tui/test/cli/tui/dialog-open.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-open.test.tsx
@@ -1,5 +1,7 @@
 /** @jsxImportSource @opentui/solid */
 import { expect, test } from "bun:test"
+import { once } from "node:events"
+import { CliRenderEvents, TextAttributes } from "@opentui/core"
 import { testRender } from "@opentui/solid"
 import { createSignal, onMount } from "solid-js"
 import type { SessionInfo } from "@opencode-ai/client"
@@ -86,7 +88,7 @@ test("finds and opens an exact session ID outside the recent list", async () => 
     expect(fixture.route.data).toEqual({ type: "session", sessionID })
     expect(fixture.location.ref).toEqual(remote)
   } finally {
-    fixture.dispose()
+    await fixture.dispose()
   }
 })
 
@@ -188,6 +190,80 @@ test("shows projects while sessions refresh and preserves the selected project",
   }
 })
 
+test.each([false, true])("keeps a filtered selection visible after refresh with query reset %s", async (reset) => {
+  const sessions = Promise.withResolvers<Response>()
+  const fixture = await renderOpen((url) => {
+    if (url.pathname === "/api/session") return sessions.promise
+    if (url.pathname === "/api/project")
+      return json([
+        {
+          id: "proj_first",
+          canonical: "/tmp/opencode/first",
+          name: "First shared project",
+          time: { created: 1, updated: 2 },
+          sandboxes: [],
+        },
+        {
+          id: "proj_second",
+          canonical: "/tmp/opencode/second",
+          name: "Second shared project",
+          time: { created: 1, updated: 1 },
+          sandboxes: [],
+        },
+      ])
+    return undefined
+  })
+  const selectedTitle = () =>
+    fixture.app
+      .captureSpans()
+      .lines.flatMap((line) => line.spans)
+      .filter((span) => span.attributes & TextAttributes.BOLD)
+      .map((span) => span.text)
+      .join("")
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Second shared project") && frame.includes("Refreshing"))
+    await fixture.app.mockInput.typeText("shared")
+    await fixture.app.waitForFrame(() => selectedTitle().includes("First shared project"))
+    fixture.app.mockInput.pressArrow("down")
+    await fixture.app.waitForFrame(() => selectedTitle().includes("Second shared project"))
+
+    sessions.resolve(
+      json({
+        data: Array.from({ length: 12 }, (_, index) => ({
+          ...recentSession,
+          id: `ses_shared_${index}`,
+          title: "shared",
+          time: { created: 1, updated: index + 3 },
+        })),
+        cursor: {},
+      }),
+    )
+    await fixture.app.waitForFrame((frame) => frame.includes("Open") && !frame.includes("Refreshing"))
+    // Selection reveal runs on FRAME; the following paint must show the selected row.
+    const frame = once(fixture.app.renderer, CliRenderEvents.FRAME)
+    fixture.app.renderer.requestRender()
+    await frame
+    expect(fixture.app.captureCharFrame()).toContain("Second shared project")
+    expect(selectedTitle()).toContain("Second shared project")
+
+    if (reset) {
+      await fixture.app.mockInput.typeText(" project")
+      await fixture.app.waitForFrame(() => selectedTitle().includes("First shared project"))
+      expect(fixture.app.captureCharFrame()).toContain("Second shared project")
+      expect(selectedTitle()).not.toContain("Second shared project")
+    }
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitFor(() => fixture.route.data.type === "home")
+    expect(fixture.route.data).toEqual({
+      type: "home",
+      location: { directory: `/tmp/opencode/${reset ? "first" : "second"}` },
+    })
+  } finally {
+    sessions.resolve(json({ data: [], cursor: {} }))
+    await fixture.dispose()
+  }
+})
+
 const recentSession = {
   id: "ses_recent",
   projectID: "proj_recent",
@@ -235,6 +311,48 @@ test("shows hydrated sessions immediately without waiting for either read", asyn
   } finally {
     sessions.resolve(json({ data: [], cursor: {} }))
     projects.resolve(json([]))
+    await fixture.dispose()
+  }
+})
+
+test("keeps an uncached moved session in the first successful refresh", async () => {
+  const response = Promise.withResolvers<Response>()
+  const destination = { directory: "/fixture/destination" }
+  const fixture = await renderOpen((url) => (url.pathname === "/api/session" ? response.promise : undefined))
+  try {
+    await fixture.app.waitForFrame((frame) => frame.includes("Refreshing"))
+    fixture.emit({
+      id: "evt_uncached_move",
+      created: 3,
+      type: "session.moved",
+      durable: { aggregateID: recentSession.id, seq: 1, version: 1 },
+      data: { sessionID: recentSession.id, location: destination, projectID: "proj_destination" },
+    })
+    // The following event supplies an ordered-stream receipt barrier without hydrating metadata.
+    fixture.emit({
+      id: "evt_move_received",
+      created: 4,
+      type: "session.execution.started",
+      durable: { aggregateID: recentSession.id, seq: 2, version: 1 },
+      data: { sessionID: recentSession.id },
+    })
+    await fixture.app.waitFor(() => fixture.data.session.status(recentSession.id) === "running")
+    expect(fixture.data.session.get(recentSession.id)).toBeUndefined()
+    response.resolve(
+      json({
+        data: [
+          { ...recentSession, location: destination, projectID: "proj_destination", time: { created: 1, updated: 3 } },
+        ],
+        cursor: {},
+      }),
+    )
+    await fixture.app.waitForFrame((frame) => frame.includes(recentSession.title) && !frame.includes("Refreshing"))
+    fixture.app.mockInput.pressEnter()
+    await fixture.app.waitFor(() => fixture.route.data.type === "session")
+    expect(fixture.route.data).toEqual({ type: "session", sessionID: recentSession.id })
+    expect(fixture.location.ref).toEqual(destination)
+  } finally {
+    response.resolve(json({ data: [], cursor: {} }))
     await fixture.dispose()
   }
 })
@@ -463,6 +581,7 @@ async function renderOpen(
 
   return {
     app,
+    emit: events.emit,
     open: () => open(),
     get route() {
       return route


### PR DESCRIPTION
## Why

Ctrl-O currently waits for recent-session and project reads before mounting its picker, even when the client already has useful rows. A slow server therefore leaves no visible acknowledgement or menu to dismiss, and an eventual response can open the picker after the user has pressed Escape.

## What Changes

The picker mounts synchronously and refreshes sessions and projects independently. It combines hydrated session metadata with the last successful recent-session list retained by this client.

| Situation | Behavior |
| --- | --- |
| Cached rows and slow reads | Open immediately with selectable rows and a refresh indicator. |
| First opening without cached rows | Show a loading shell, not a misleading empty list. |
| Sessions finish before projects | Make sessions selectable without waiting for project labels. |
| Refresh fails | Keep cached rows usable and report which reads failed. |
| New rows arrive after selection moves | Preserve the selected target and keep it visible, including an active filter with overflowing results. Query changes still reset to the first match. |
| Escape during refresh | Dismiss immediately; the disposed dialog cannot reopen or replace the recent-list cache. |
| A cached session is deleted | Remove it immediately. An older in-flight list response cannot put it back into the retained list. |
| A cached-only session is moved | Apply committed placement while the picker is dismissed or refreshing, before a later session GET can correct the local location. |
| A previously uncached session moves during its first list read | Keep the incoming row with committed placement instead of dropping it from a successful refresh. |

## Live Updates

The app owns one recent-list snapshot. It applies committed Session movement and deletion to that snapshot without changing shared-data hydration or precedence. A list request observes only movement/deletion facts received during that request; before committing its response, it omits deleted rows and applies committed placement to moved rows. Observation stops on request settlement or dialog disposal. This is request-local reconciliation, not a durable cache or a general mutation framework.

The shared selection change is limited to `preserveSelection: true`: reindexed filtered selections are revealed after layout. Non-preserving behavior and query-change resets remain unchanged.

## Demo

Real production OpenCode V2 TUI at clean immutable `732f949a657c` (before) and clean committed `64add1d90fcb` (after), with the same isolated synthetic sessions, 100x30 viewport, and 900ms simulated TUI-only HTTP/SSE wire latency. After a healthy warm-up, Ctrl-O is followed by Down at 350ms and Escape at 1000ms. Both equal-length clips cover six seconds: the first second plays at 0.5x and the remaining five seconds play in real time. Sequential playback keeps terminal text legible.

Before, no picker appears while requests are pending and it opens after Escape. After, cached sessions are immediately selectable with inline refresh feedback, and Escape prevents late reopening. The provider is generic and simulated; no model requests are made and no live user data is used. This footage demonstrates initial Ctrl-O pending/dismissal behavior, not the additional cache-isolation or filtered-overflow fixes. Pending and late frames from both labeled final segments were inspected before upload.

https://github.com/user-attachments/assets/7b6d2c1a-f783-4f9e-9578-8542b0b8c7c1

## Scope

This owns Ctrl-O and `/open` responsiveness, including the necessary preserved-selection scrolling when async filtered results reindex rows. The recent list is client-memory state, not a persisted offline cache; search-all sessions and server-side read dependencies remain separate follow-ups.

## Verification

```sh
# packages/tui
bun run test test/cli/tui/dialog-open.test.tsx test/cli/tui/dialog-select.test.tsx test/app-lifecycle.test.tsx test/context/session-tabs.test.tsx
bun run test test/app-lifecycle.test.tsx -t 'Ctrl-O' --rerun-each 10
bun typecheck
XDG_STATE_HOME=/private/var/folders/dd/5fz89drs5p9_r0fk7rwqqnbr0000gn/T/opencode/picker-final-map-suite-state bun run test

# packages/client
bun run test

# Repository root
git range-diff b9cb4fc36a..4f31fe7d9a 732f949a65..4e8973e65e
bunx prettier --check packages/tui/src/app.tsx packages/tui/src/component/dialog-open.tsx packages/tui/src/ui/dialog-select.tsx packages/tui/test/app-lifecycle.test.tsx packages/tui/test/cli/tui/dialog-open.test.tsx
git diff --check
git push --force-with-lease=refs/heads/open-picker:4f31fe7d9a220381aaa6001427e06c5d0c148942 origin open-picker

# opencode-drive/packages/drive, using the new local probe
bun run src/cli/index.ts check test/manual/tui-regressions/open-picker.ts
bun typecheck
```

- Rebased onto `732f949a65` without conflicts. `git range-diff` confirmed all three original commits were patch-identical after rebase. Follow-up `64add1d90f` fixes the audit findings.
- Final focused picker, shared select, real-app, and tab-location suites: **80 passed**. Repeated real-app cases on the committed head: **40 passed** across ten repetitions.
- Final isolated-state full TUI suite: **924 passed, 4 skipped, 0 failed** across 120 files. Full client suite: **112 passed**. Package typecheck and formatting pass; the normal pre-push hook completed all **33 workspace typecheck tasks** without bypassing hooks.
- Regression tests reproduced deletion resurrection at 44 and 100 columns, obsolete cached-only placement while dismissed and refreshing, and invisible filtered selection after twelve stronger incoming session matches. Follow-up review also reproduced an uncached moved row disappearing from a successful first refresh. All now pass. Movement selection tests hold session metadata so eventual hydration cannot hide an incorrect initial location; query-reset and Enter-target assertions are retained.
- Deferred fixtures wait for actual stream/frame or request arrival rather than assuming HTTP completion means SSE has arrived. The inherited renderer resize-listener warning and deliberately rejected project-preload logs still appear in broad fixture runs; they are not reported as clean logs.
- The new local Drive probe passed **36/36** final runs: six cases at 44 and 100 columns, three fresh-instance repetitions each, on clean `64add1d90f`. Cases cover cold loading/dismissal, retained-row selection and repeat Ctrl-O, committed movement before a correcting GET, disposal/reopen, selection through refresh, deletion eviction, and inline failure/recovery. Real prompt admissions verify the destination Session; a blackholed inherited-location check verifies movement before healing. Probe SHA256: `0784972ac67b9ecfdab23136320f48a02a3a718225c3ef560f1c5457b20e6511`.
- The same cold/warm probes failed on immutable base `732f949a65` at both widths: **4/4 expected negative controls**, at the blocked immediate-open checkpoint. The new probe and its README are currently local and uncommitted in the Drive checkout, not part of this PR's diff.
- The same frozen warm case also failed on pre-audit parent `4e8973e65e` at both widths: **2/2 additional expected controls**. That revision opens immediately but retains the old `archive` location while blackholed, despite the server's committed `archive/zen` placement. These failures isolate the cached-placement bug rather than merely the initial-open delay; the final head passes the same pre-heal location assertion.
- TCP-level tests establish their checkpoints and convergence; they do not force every older/newer GET ordering or independently gate session/project requests. Production-component tests cover those exact interleavings and overflowing filtered results.

### Broader Gauntlet

The first pass is **not all green**. On immutable `64add1d90f`, the 25 existing gauntlet runs produced **15 invariant passes, one diagnostic result, seven failures, and two 240-second deadlines**. All **five merged-compaction integration cases** passed at 100 columns. Fresh immutable base `732f949a65` was used for the nine known-problem comparisons; all eight known nonzero target outcomes matched the base, including identical lifecycle traces at steps 1, 10, 20, and 4.

The known baseline issues concern short-text batching, provider-disconnect probes expecting terminal failure where the server schedules retry, an unqueued restart-recovery model request, and tool-interruption waiters/prerequisites. The reconnect diagnostic confirms legitimate transport rejection with draft restoration, not a liveness pass. These failures truncate lifecycle/tool coverage and remain separate follow-ups.

One additional first-pass `quiescence-restart` failure remains retained: `backend connection closed`. Its server logs show a boot failure (`Is port 55775 in use?`), managed-service registration replacement, and TUI background-service resolution failure. Two subsequent base runs and two target runs each passed both restart scenarios. The original failure was not reproduced on base, so PR attribution is not established; rerun success does not erase this intermittent service-election/port-bind negative. No reproducible new picker-related invariant failure was identified.

All **43 broader/integration/comparison physical runs and their script checks** completed. Network seeds 1, 7, 42, and 99 completed 96 transitions, exercising three connection kills, nine latency windows, fourteen blackholes, and four steers. Lifecycle probes completed 35 transitions per revision before the known failure expectations blocked further coverage; no running-tool transition was reached there. All first-pass failures, reruns, seed traces, frames/events, and projected state are retained separately in the local Drive reports. All owned test processes and artifact descriptors were closed.

Drive runtime was `a8b29b9a`, with the pre-existing lifecycle probe edits preserved and unchanged. The local compaction integration probe used SHA256 `e21556778d18e47296fb7b64f441daeb8eb5c4c942986559b3c5e05bf95a52e2`. Drive's package suite passed **244 Vitest tests and 58 CLI tests**, with typecheck, script check, and focused new-probe lint passing. All GitHub Linux/Windows unit and E2E, typecheck, standards, and compliance checks passed on the pushed head. Drive runs were macOS ARM64; their results are not Windows Drive coverage.
