### PR TITLE
refactor(core): flatten session drain loop

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -65,104 +65,97 @@ const layer = Layer.effect(
       yield* plugins.flush
       yield* settleStaleToolCalls(sessionID)
 
-      const advanceToStep = Effect.fn("SessionRunner.advanceToStep")(() =>
-        Effect.uninterruptibleMask((restore) =>
-          Effect.gen(function* () {
-            while (true) {
-              // Location entry and idle boundaries allow queued controls, not necessarily queued prompts.
-              const pending = yield* SessionInbox.serialized(
-                sessionID,
-                Effect.gen(function* () {
-                  const next = yield* SessionInbox.nextPromotable(
-                    db,
-                    sessionID,
-                    entering || !continuing ? "input" : "steer",
+      return yield* Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function* () {
+          while (true) {
+            // Location entry and idle boundaries allow queued controls, not necessarily queued prompts.
+            const pending = yield* SessionInbox.serialized(
+              sessionID,
+              Effect.gen(function* () {
+                const next = yield* SessionInbox.nextPromotable(
+                  db,
+                  sessionID,
+                  entering || !continuing ? "input" : "steer",
+                )
+                if (next?.type === "compaction")
+                  yield* bus.publishAll([
+                    [SessionEvent.InboxDelivered, { sessionID, inboxID: next.id }],
+                    [SessionEvent.Compaction.Started, { sessionID, reason: "manual", recent: "", inputID: next.id }],
+                  ])
+                if (next?.type === "move")
+                  yield* restore(
+                    Effect.gen(function* () {
+                      yield* modelTransport.close(sessionID)
+                      yield* bus.publishAll([
+                        [SessionEvent.InboxDelivered, { sessionID, inboxID: next.id }],
+                        [SessionEvent.Moved, { sessionID, ...next.payload }],
+                      ])
+                    }),
                   )
-                  if (next?.type === "compaction")
-                    yield* bus.publishAll([
-                      [SessionEvent.InboxDelivered, { sessionID, inboxID: next.id }],
-                      [SessionEvent.Compaction.Started, { sessionID, reason: "manual", recent: "", inputID: next.id }],
-                    ])
-                  if (next?.type === "move")
-                    yield* restore(
-                      Effect.gen(function* () {
-                        yield* modelTransport.close(sessionID)
-                        yield* bus.publishAll([
-                          [SessionEvent.InboxDelivered, { sessionID, inboxID: next.id }],
-                          [SessionEvent.Moved, { sessionID, ...next.payload }],
-                        ])
-                      }),
-                    )
-                  return next
-                }),
-              )
-              if (!continuing && pending?.delivery !== "steer") {
-                entering = true
-                step = 1
-              }
-              if (pending?.type === "move")
-                return DrainResult.Moved({ continuation: !entering && continuing ? { step } : undefined })
-              if (pending?.type === "compaction") {
-                const session = yield* store.get(sessionID)
-                if (!session) return yield* Effect.die(new Error(`Session not found: ${sessionID}`))
-                const compacted = yield* restore(
-                  Effect.gen(function* () {
-                    return yield* compaction.compactManual({
-                      session,
-                      resolveModel: context.resolveModel,
-                      prepare: context.prepare,
-                      messages: yield* store.context(sessionID),
-                      inputID: pending.id,
-                      started: true,
-                    })
-                  }),
-                ).pipe(Effect.exit)
-                if (Exit.isFailure(compacted)) {
-                  yield* bus.publish(SessionEvent.Compaction.Failed, {
-                    sessionID,
-                    reason: "manual",
-                    error: Cause.hasInterruptsOnly(compacted.cause)
-                      ? { type: "aborted", message: "Compaction cancelled" }
-                      : { type: "compaction.failed", message: Cause.pretty(compacted.cause) },
-                    inputID: pending.id,
-                  })
-                  return yield* Effect.failCause(compacted.cause)
-                }
-                force = false
-                continue
-              }
-              if (!force && !continuing && (!pending || (pending.delivery === "queue" && promotable === "steer")))
-                return DrainResult.Complete()
-              return yield* restore(
-                Effect.gen(function* () {
-                  const selected = yield* prepareContext(sessionID)
-                  const promoted = yield* SessionInbox.promote(
-                    db,
-                    bus,
-                    sessionID,
-                    entering && !continuing ? promotable : "steer",
-                  )
-                  if (promoted > 0 && !selected.session.parentID && SessionTitle.isUntitled(selected.session))
-                    yield* FiberMap.run(titles, sessionID, title.generate(sessionID).pipe(Effect.ignore), {
-                      onlyIfMissing: true,
-                    })
-                  if (promoted > 0) step = 1
-                  return { _tag: "Ready" as const, context: yield* context.load(selected) }
-                }),
-              )
+                return next
+              }),
+            )
+            if (!continuing && pending?.delivery !== "steer") {
+              entering = true
+              step = 1
             }
-          }),
-        ),
+            if (pending?.type === "move")
+              return DrainResult.Moved({ continuation: !entering && continuing ? { step } : undefined })
+            if (pending?.type === "compaction") {
+              const session = yield* store.get(sessionID)
+              if (!session) return yield* Effect.die(new Error(`Session not found: ${sessionID}`))
+              const compacted = yield* restore(
+                Effect.gen(function* () {
+                  return yield* compaction.compactManual({
+                    session,
+                    resolveModel: context.resolveModel,
+                    prepare: context.prepare,
+                    messages: yield* store.context(sessionID),
+                    inputID: pending.id,
+                    started: true,
+                  })
+                }),
+              ).pipe(Effect.exit)
+              if (Exit.isFailure(compacted)) {
+                yield* bus.publish(SessionEvent.Compaction.Failed, {
+                  sessionID,
+                  reason: "manual",
+                  error: Cause.hasInterruptsOnly(compacted.cause)
+                    ? { type: "aborted", message: "Compaction cancelled" }
+                    : { type: "compaction.failed", message: Cause.pretty(compacted.cause) },
+                  inputID: pending.id,
+                })
+                return yield* Effect.failCause(compacted.cause)
+              }
+              force = false
+              continue
+            }
+            if (!force && !continuing && (!pending || (pending.delivery === "queue" && promotable === "steer")))
+              return DrainResult.Complete()
+            // Keep model work and cursor advancement outside the control settlement mask.
+            yield* restore(
+              Effect.gen(function* () {
+                const selected = yield* prepareContext(sessionID)
+                const promoted = yield* SessionInbox.promote(
+                  db,
+                  bus,
+                  sessionID,
+                  entering && !continuing ? promotable : "steer",
+                )
+                if (promoted > 0 && !selected.session.parentID && SessionTitle.isUntitled(selected.session))
+                  yield* FiberMap.run(titles, sessionID, title.generate(sessionID).pipe(Effect.ignore), {
+                    onlyIfMissing: true,
+                  })
+                if (promoted > 0) step = 1
+                continuing = yield* runStep(yield* context.load(selected), step)
+                step++
+                force = false
+                entering = false
+              }),
+            )
+          }
+        }),
       )
-
-      while (true) {
-        const next = yield* advanceToStep()
-        if (next._tag !== "Ready") return next
-        continuing = yield* runStep(next.context, step)
-        step++
-        force = false
-        entering = false
-      }
     })
 
     const prepareContext = Effect.fn("SessionRunner.prepareContext")(function* (sessionID: SessionSchema.ID) {


### PR DESCRIPTION
**Why**
Following a Session drain requires tracing two loops and a `Ready` handoff even though both loops share the same mutable cursor. The single-use `advanceToStep` helper mutates that cursor before returning prepared context to its caller, so it does not provide an independent scheduling interface.

**What Changes**
Use one drain loop for control handling, instruction preflight, input promotion, context loading, and logical-Step execution. Remove `advanceToStep`, the `Ready` result, and the caller's intermediate result discrimination.

| Situation | Preserved behavior |
| --- | --- |
| Manual compaction is next | Consume the control and record its start atomically. Returned outcomes continue the loop; failed awaited execution records failure and exits. |
| Movement is next | Close the source transport and return `Moved` with the existing continuation rules. |
| Initial instructions are unavailable | Leave input pending and issue no model request; admitted controls still bypass preflight. |
| Input is eligible | Prepare instructions before promotion, then load history and run one logical Step. Promoted input resets the allowance. |
| No forced Step, eligible input, or continuation remains | Return `Complete`, respecting the drain's promotion scope. |

**Interruption Regions**
Control admission and manual-compaction failure publication remain masked. Movement and compaction retain their existing restored regions. Preparation, model execution, and cursor advancement restore the caller's interruption state; the single loop does not make model work uninterruptible. Physical-attempt scopes and tool settlement are unchanged.

This is seven fewer production lines. Most of the displayed diff is indentation from removing one wrapper. The internal `advanceToStep` trace span disappears with its helper; the public drain result and durable events do not change.

**Scope**
Drain-loop cleanup only, with no new modules or services. Title/compaction factory cleanup is independent in #45974; the two branches merge without conflicts. Existing test assertions are unchanged.

**Verification**
```sh
# packages/core, before and after the edit
bun run test test/session-runner.test.ts test/session-execution.test.ts test/session-compaction.test.ts test/session-move.test.ts test/session-step.test.ts

# packages/core, after the edit
bun typecheck
bun run test test/session-runner.test.ts --test-name-pattern 'queued|steer|move|compaction|interrupt|allowance|instructions' --rerun-each 3
bun run test

# repository root
bunx prettier --check packages/core/src/session/runner/llm.ts
bunx oxlint packages/core/src/session/runner/llm.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/session/runner/llm.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/src/session/runner/llm.ts
git diff --check
git push -u origin flatten-drain
```

- Baseline and post-edit focused suites both passed: 223 tests, 0 failures, 859 assertions across five files.
- Core typecheck, formatting, both Effect-pattern checks, and diff checks passed. Targeted Oxlint reported zero warnings and zero errors.
- Repeated boundary cases passed: 165 tests, 0 failures, 699 assertions across three repetitions.
- Full Core suite passed: 3,798 tests, 39 skipped, 0 failures, 78,961 assertions across 223 files, in 177.27 seconds.
- A separate correctness review found no regressions in interruption regions, control handling, instruction/promotion ordering, or continuation state.
- The enabled pre-push hook passed all 33 repository typecheck tasks, with 27 cache hits. No hooks were bypassed.
- Model responses are deterministic fixtures, not live provider calls.
