### PR TITLE
refactor(core): extract config discovery engine

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,28 +1,15 @@
 export * as Config from "./config.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
-import path from "path"
-import { isDeepStrictEqual } from "node:util"
-import { type ParseError, parse } from "jsonc-parser"
-import { Context, Effect, Layer, Option, PubSub, Ref, Schema, Semaphore, Stream } from "effect"
-import {
-  AgentsDirectory,
-  ClaudeDirectory,
-  Directory,
-  Document,
-  Info,
-  type Entry,
-  Event,
-} from "@opencode-ai/schema/config"
+import { Context, Effect, Layer, PubSub, Ref, Stream } from "effect"
+import type { Document, Entry, Info } from "@opencode-ai/schema/config"
 import { Credential } from "./credential.js"
 import { Bus } from "./bus.js"
 import { Watcher } from "./filesystem/watcher.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
 import { Location } from "./location.js"
-import { AbsolutePath } from "./schema.js"
-import { ConfigVariable } from "./config/variable.js"
-import { ConfigNormalize } from "./config/normalize.js"
+import { ConfigDiscovery } from "./config/discovery.js"
 import { WellKnown } from "./wellknown.js"
 
 export function latest<K extends keyof Info>(entries: readonly Entry[], key: K): Info[K] | undefined {
@@ -34,21 +21,14 @@ export interface Interface {
   /** Returns location config documents and discovery sources from lowest to highest priority. */
   readonly entries: () => Effect.Effect<Entry[]>
   /**
-   * Streams raw filesystem updates under config roots. Config owns root
-   * topology and watch reconciliation; domain owners filter this feed for the
-   * source files they parse and rebuild their own state.
+   * Streams raw filesystem updates under config roots from the discovery engine.
+   * Domain owners filter this feed for the source files they parse and rebuild
+   * their own state.
    */
   readonly changes: () => Stream.Stream<Watcher.Update>
 }
 
-export const Options = Schema.Struct({
-  project: Schema.optional(Schema.Boolean),
-  // false skips the global config dir, ~/.claude, and ~/.agents; wellknown,
-  // file, and content entries still load.
-  global: Schema.optional(Schema.Boolean),
-  file: Schema.optional(Schema.String),
-  content: Schema.optional(Schema.String),
-})
+export const Options = ConfigDiscovery.Options
 export type Options = typeof Options.Type
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/Config") {}
@@ -78,312 +58,7 @@ export const testLayer = (initial: Entry[] = []) =>
     }),
   )
 
-export const layer = (options?: Options) =>
-  Layer.effect(
-    Service,
-    Effect.gen(function* () {
-      const fs = yield* FSUtil.Service
-      const global = yield* Global.Service
-      const location = yield* Location.Service
-      const watcher = yield* Watcher.Service
-      const bus = yield* Bus.Service
-      const credentials = yield* Credential.Service
-      const wellknown = yield* WellKnown.Service
-      const names = ["opencode.json", "opencode.jsonc"]
-      const reloadLock = Semaphore.makeUnsafe(1)
-      const fileTargets = new Set<AbsolutePath>()
-      const decodeOptions = { errors: "all", onExcessProperty: "ignore", propertyOrder: "original" } as const
-      const decodeInfo = Schema.decodeUnknownOption(Info, decodeOptions)
-      const parseInfo = Effect.fn("Config.parseInfo")(function* (text: string, source: string) {
-        const errors: ParseError[] = []
-        const input: unknown = parse(text, errors, { allowTrailingComma: true })
-        if (errors.length) {
-          yield* Effect.logWarning("configuration normalization diagnostic", {
-            source,
-            path: "$",
-            kind: "invalid",
-            action: "rejected malformed JSON or JSONC document",
-          })
-          return
-        }
-        const result = ConfigNormalize.normalize(input)
-        yield* Effect.forEach(result.diagnostics, (diagnostic) =>
-          Effect.logWarning("configuration normalization diagnostic", {
-            source,
-            path: diagnostic.path[0] === "$" ? "$" : `$.${diagnostic.path.join(".")}`,
-            kind: diagnostic.kind,
-            action: diagnostic.message,
-          }),
-        )
-        if (result.type === "rejected") return
-        const info = Option.getOrUndefined(decodeInfo(result.encoded))
-        if (info) return info
-        yield* Effect.logWarning("configuration normalization diagnostic", {
-          source,
-          path: "$",
-          kind: "invalid",
-          action: "rejected canonical configuration after final validation",
-        })
-      })
-
-      const loadFile = Effect.fnUntraced(function* (filepath: string) {
-        const text = yield* fs.readFileStringSafe(filepath)
-        if (text === undefined) return
-        const substituted = yield* ConfigVariable.substitute({ type: "path", path: filepath, text })
-        const info = yield* parseInfo(substituted, filepath)
-        if (!info) return
-        return new Document({ type: "document", path: AbsolutePath.make(filepath), info })
-      })
-
-      const loadWellknownEntry = Effect.fnUntraced(function* (entry: WellKnown.Entry) {
-        const auth = entry.manifest.auth
-        if (!auth) return []
-        const credential = (yield* credentials.list(entry.integrationID)).at(-1)
-        if (!credential || credential.value.type !== "key") return []
-        const variables = { [auth.env]: credential.value.key }
-        const configs = yield* wellknown
-          .resolve(entry, variables)
-          .pipe(
-            Effect.catch(() =>
-              Effect.logWarning("failed to load wellknown config", { source: entry.origin }).pipe(
-                Effect.as([] as const),
-              ),
-            ),
-          )
-        return yield* Effect.forEach(configs, (config) =>
-          ConfigVariable.substitute({
-            type: "virtual",
-            source: entry.origin,
-            dir: entry.origin,
-            text: JSON.stringify(config),
-            env: variables,
-          }).pipe(
-            Effect.flatMap((text) => parseInfo(text, entry.origin)),
-            Effect.map((info) => (info ? new Document({ type: "document", info }) : undefined)),
-          ),
-        ).pipe(Effect.map((documents) => documents.filter((document) => document !== undefined)))
-      })
-
-      const loadWellknown = Effect.fn("Config.loadWellknown")(function* () {
-        const entries = yield* wellknown
-          .entries()
-          .pipe(
-            Effect.catch((error) =>
-              Effect.logWarning("failed to discover wellknown config", { error }).pipe(Effect.as([] as const)),
-            ),
-          )
-        return yield* Effect.forEach(entries, loadWellknownEntry).pipe(Effect.map((documents) => documents.flat()))
-      })
-
-      const loadDirectory = Effect.fnUntraced(function* (directory: AbsolutePath) {
-        return [
-          ...(yield* Effect.forEach(names, (file) => loadFile(path.join(directory, file))).pipe(
-            Effect.map((configs) => configs.filter((config): config is Document => config !== undefined)),
-          )),
-          new Directory({ type: "directory", path: directory }),
-        ]
-      })
-
-      const discover = Effect.fn("Config.discover")(function* () {
-        const globalDirectory = AbsolutePath.make(global.config)
-        const globalAgentsDirectory = AbsolutePath.make(path.join(global.home, ".agents"))
-        const globalClaudeDirectory = AbsolutePath.make(path.join(global.home, ".claude"))
-        const locationIsGlobal = path.resolve(location.directory) === path.resolve(global.config)
-        const discovered =
-          locationIsGlobal || options?.project === false
-            ? []
-            : yield* fs
-                .up({
-                  targets: [".opencode", ".claude", ".agents", ...names.toReversed()],
-                  start: location.directory,
-                })
-                .pipe(Effect.orDie)
-
-        const globalEnabled = options?.global !== false
-        // A walked path that resolves into a global root is global config
-        // however the walk reached it (home above the project, or a location
-        // beneath the global config dir), so global: false excludes it
-        // uniformly — classified once here, not per consumer below.
-        const globalRoots = [globalDirectory, globalClaudeDirectory, globalAgentsDirectory].map((item) =>
-          path.resolve(item),
-        )
-        const visible = globalEnabled
-          ? discovered
-          : discovered.filter((item) => {
-              const resolved = path.resolve(item)
-              return !globalRoots.some((root) => resolved === root || resolved.startsWith(root + path.sep))
-            })
-        // We load certain files from a few other folders in the ecosystem
-        const claude = [
-          ...new Set([
-            ...(globalEnabled && (yield* fs.isDir(globalClaudeDirectory)) ? [globalClaudeDirectory] : []),
-            ...visible.filter((item) => path.basename(item) === ".claude").toReversed(),
-          ]),
-        ].map((directory) => new ClaudeDirectory({ type: "claude", path: AbsolutePath.make(directory) }))
-        const agents = [
-          ...new Set([
-            ...(globalEnabled && (yield* fs.isDir(globalAgentsDirectory)) ? [globalAgentsDirectory] : []),
-            ...visible.filter((item) => path.basename(item) === ".agents").toReversed(),
-          ]),
-        ].map((directory) => new AgentsDirectory({ type: "agents", path: AbsolutePath.make(directory) }))
-
-        const projectDirectories = visible
-          .filter((item) => path.basename(item) === ".opencode")
-          .toReversed()
-          .map((directory) => AbsolutePath.make(directory))
-        const directPaths = visible
-          .filter((item) => ![".agents", ".claude", ".opencode"].includes(path.basename(item)))
-          .toReversed()
-        fileTargets.clear()
-        directPaths.forEach((filepath) => fileTargets.add(AbsolutePath.make(filepath)))
-        const direct = yield* Effect.forEach(directPaths, (filepath) => loadFile(filepath)).pipe(
-          Effect.orDie,
-          Effect.map((entries) => entries.filter((entry): entry is Document => entry !== undefined)),
-        )
-
-        const file = options?.file
-        if (file) fileTargets.add(AbsolutePath.make(path.resolve(file)))
-        const explicit = file
-          ? yield* loadFile(path.resolve(file)).pipe(
-              Effect.map((config) => (config ? [config] : [])),
-              Effect.orDie,
-            )
-          : []
-        const content =
-          options?.content !== undefined
-            ? yield* ConfigVariable.substitute({
-                type: "virtual",
-                source: "OPENCODE_CONFIG_CONTENT",
-                dir: location.directory,
-                text: options.content,
-              }).pipe(
-                Effect.flatMap((text) => parseInfo(text, "OPENCODE_CONFIG_CONTENT")),
-                Effect.map((info) => (info ? [new Document({ type: "document", info })] : [])),
-                Effect.orDie,
-              )
-            : []
-
-        // Global entries sit below explicit and direct files; project
-        // directories rank above them.
-        const globalSupplementary = globalEnabled ? yield* loadDirectory(globalDirectory).pipe(Effect.orDie) : []
-        const projectSupplementary = yield* Effect.forEach(projectDirectories, loadDirectory).pipe(
-          Effect.orDie,
-          Effect.map((entries) => entries.flat()),
-        )
-        return [
-          ...(yield* loadWellknown().pipe(Effect.orDie)),
-          ...claude,
-          ...agents,
-          ...globalSupplementary,
-          ...explicit,
-          ...direct,
-          ...projectSupplementary,
-          ...content,
-        ]
-      })
-
-      const initial = yield* discover()
-      let configs = initial
-      const updates = yield* PubSub.unbounded<Watcher.Update>()
-      // Vendored trees inside config roots (a plugin's node_modules, a nested
-      // .git) produce event blizzards that can never change discovery output.
-      const ignore = ["node_modules", ".git", "**/{node_modules,.git}/**"]
-      // Watch-once: roots leave discovery only by deletion, so a stale watch is
-      // inert, bounded, and dies with this layer — and keeping a deleted root's
-      // watch alive is exactly what makes its recreation observable.
-      const watched = new Set<string>()
-      const reconcile = Effect.fn("Config.reconcileWatches")(function* (entries: readonly Entry[]) {
-        const directories = entries.flatMap((entry) => (entry.type === "directory" ? [entry.path] : []))
-        const files = [
-          ...entries.flatMap((entry) => (entry.type === "document" && entry.path ? [entry.path] : [])),
-          ...fileTargets,
-        ]
-        const targets = [
-          ...directories.map((path) => ({ path, type: "directory" as const, ignore })),
-          ...files
-            .filter((file) => !directories.some((directory) => FSUtil.contains(directory, file)))
-            .map((path) => ({ path, type: "file" as const })),
-        ]
-        for (const target of targets) {
-          const key = JSON.stringify(target)
-          if (watched.has(key)) continue
-          watched.add(key)
-          const stream = yield* watcher.subscribe(target)
-          yield* stream.pipe(
-            Stream.runForEach((update) => PubSub.publish(updates, update)),
-            Effect.forkScoped({ startImmediately: true }),
-          )
-        }
-      })
-
-      const reload = Effect.fn("Config.reload")(() =>
-        reloadLock.withPermit(
-          Effect.gen(function* () {
-            const next = yield* discover()
-            yield* reconcile(next)
-            if (isDeepStrictEqual(configs, next)) return
-            configs = next
-            yield* bus.publish(Event.Updated, {})
-          }),
-        ),
-      )
-
-      yield* Stream.fromPubSub(updates).pipe(
-        Stream.debounce("100 millis"),
-        Stream.runForEach((update) =>
-          reload().pipe(
-            Effect.catchCause((cause) => Effect.logError("failed to reload config", { path: update.path, cause })),
-          ),
-        ),
-        Effect.forkScoped({ startImmediately: true }),
-      )
-      yield* bus.subscribe(Credential.Event.Switched).pipe(
-        Stream.filterEffect((event) =>
-          wellknown.entries().pipe(
-            Effect.map((entries) => entries.some((entry) => entry.integrationID === event.data.integrationID)),
-            Effect.orElseSucceed(() => false),
-          ),
-        ),
-        Stream.runForEach(() =>
-          reload().pipe(Effect.catchCause((cause) => Effect.logError("failed to reload wellknown config", { cause }))),
-        ),
-        Effect.forkScoped({ startImmediately: true }),
-      )
-      yield* bus.subscribe(WellKnown.Event.Updated).pipe(
-        Stream.runForEach(() =>
-          reload().pipe(Effect.catchCause((cause) => Effect.logError("failed to reload wellknown sources", { cause }))),
-        ),
-        Effect.forkScoped({ startImmediately: true }),
-      )
-      yield* Effect.sleep("10 minutes").pipe(
-        Effect.andThen(
-          Effect.suspend(() => {
-            if (!wellknown.snapshot().length) return Effect.void
-            return Effect.gen(function* () {
-              const changed = yield* wellknown
-                .refresh()
-                .pipe(
-                  Effect.catch((error) =>
-                    Effect.logWarning("failed to refresh wellknown manifests", { error }).pipe(Effect.as(false)),
-                  ),
-                )
-              if (!changed) yield* reload()
-            }).pipe(Effect.catchCause((cause) => Effect.logWarning("failed to refresh wellknown config", { cause })))
-          }),
-        ),
-        Effect.forever,
-        Effect.forkScoped({ startImmediately: true }),
-      )
-      yield* reconcile(initial)
-
-      return Service.of({
-        entries: Effect.fnUntraced(function* () {
-          return configs
-        }),
-        changes: () => Stream.fromPubSub(updates),
-      })
-    }),
-  )
+export const layer = (options?: Options) => Layer.effect(Service, ConfigDiscovery.make(options))
 
 export function configured(options?: Options) {
   return makeLocationNode({

--- a/packages/core/src/config/discovery.ts
+++ b/packages/core/src/config/discovery.ts
@@ -1,0 +1,337 @@
+export * as ConfigDiscovery from "./discovery.js"
+
+import path from "path"
+import { isDeepStrictEqual } from "node:util"
+import { type ParseError, parse } from "jsonc-parser"
+import { Effect, Option, PubSub, Schema, Semaphore, Stream } from "effect"
+import {
+  AgentsDirectory,
+  ClaudeDirectory,
+  Directory,
+  Document,
+  Info,
+  type Entry,
+  Event,
+} from "@opencode-ai/schema/config"
+import { Credential } from "../credential.js"
+import { Bus } from "../bus.js"
+import { Watcher } from "../filesystem/watcher.js"
+import { FSUtil } from "@opencode-ai/util/fs-util"
+import { Global } from "@opencode-ai/util/global"
+import { Location } from "../location.js"
+import { AbsolutePath } from "../schema.js"
+import { ConfigVariable } from "./variable.js"
+import { ConfigNormalize } from "./normalize.js"
+import { WellKnown } from "../wellknown.js"
+
+export const Options = Schema.Struct({
+  project: Schema.optional(Schema.Boolean),
+  // false skips the global config dir, ~/.claude, and ~/.agents; wellknown,
+  // file, and content entries still load.
+  global: Schema.optional(Schema.Boolean),
+  file: Schema.optional(Schema.String),
+  content: Schema.optional(Schema.String),
+})
+export type Options = typeof Options.Type
+
+/** Builds the scoped discovery engine without requiring the Config service. */
+export const make = Effect.fn("ConfigDiscovery.make")(function* (options?: Options) {
+  const fs = yield* FSUtil.Service
+  const global = yield* Global.Service
+  const location = yield* Location.Service
+  const watcher = yield* Watcher.Service
+  const bus = yield* Bus.Service
+  const credentials = yield* Credential.Service
+  const wellknown = yield* WellKnown.Service
+  const names = ["opencode.json", "opencode.jsonc"]
+  const reloadLock = Semaphore.makeUnsafe(1)
+  const fileTargets = new Set<AbsolutePath>()
+  const decodeOptions = { errors: "all", onExcessProperty: "ignore", propertyOrder: "original" } as const
+  const decodeInfo = Schema.decodeUnknownOption(Info, decodeOptions)
+  const parseInfo = Effect.fn("Config.parseInfo")(function* (text: string, source: string) {
+    const errors: ParseError[] = []
+    const input: unknown = parse(text, errors, { allowTrailingComma: true })
+    if (errors.length) {
+      yield* Effect.logWarning("configuration normalization diagnostic", {
+        source,
+        path: "$",
+        kind: "invalid",
+        action: "rejected malformed JSON or JSONC document",
+      })
+      return
+    }
+    const result = ConfigNormalize.normalize(input)
+    yield* Effect.forEach(result.diagnostics, (diagnostic) =>
+      Effect.logWarning("configuration normalization diagnostic", {
+        source,
+        path: diagnostic.path[0] === "$" ? "$" : `$.${diagnostic.path.join(".")}`,
+        kind: diagnostic.kind,
+        action: diagnostic.message,
+      }),
+    )
+    if (result.type === "rejected") return
+    const info = Option.getOrUndefined(decodeInfo(result.encoded))
+    if (info) return info
+    yield* Effect.logWarning("configuration normalization diagnostic", {
+      source,
+      path: "$",
+      kind: "invalid",
+      action: "rejected canonical configuration after final validation",
+    })
+  })
+
+  const loadFile = Effect.fnUntraced(function* (filepath: string) {
+    const text = yield* fs.readFileStringSafe(filepath)
+    if (text === undefined) return
+    const substituted = yield* ConfigVariable.substitute({ type: "path", path: filepath, text })
+    const info = yield* parseInfo(substituted, filepath)
+    if (!info) return
+    return new Document({ type: "document", path: AbsolutePath.make(filepath), info })
+  })
+
+  const loadWellknownEntry = Effect.fnUntraced(function* (entry: WellKnown.Entry) {
+    const auth = entry.manifest.auth
+    if (!auth) return []
+    const credential = (yield* credentials.list(entry.integrationID)).at(-1)
+    if (!credential || credential.value.type !== "key") return []
+    const variables = { [auth.env]: credential.value.key }
+    const configs = yield* wellknown
+      .resolve(entry, variables)
+      .pipe(
+        Effect.catch(() =>
+          Effect.logWarning("failed to load wellknown config", { source: entry.origin }).pipe(Effect.as([] as const)),
+        ),
+      )
+    return yield* Effect.forEach(configs, (config) =>
+      ConfigVariable.substitute({
+        type: "virtual",
+        source: entry.origin,
+        dir: entry.origin,
+        text: JSON.stringify(config),
+        env: variables,
+      }).pipe(
+        Effect.flatMap((text) => parseInfo(text, entry.origin)),
+        Effect.map((info) => (info ? new Document({ type: "document", info }) : undefined)),
+      ),
+    ).pipe(Effect.map((documents) => documents.filter((document) => document !== undefined)))
+  })
+
+  const loadWellknown = Effect.fn("Config.loadWellknown")(function* () {
+    const entries = yield* wellknown
+      .entries()
+      .pipe(
+        Effect.catch((error) =>
+          Effect.logWarning("failed to discover wellknown config", { error }).pipe(Effect.as([] as const)),
+        ),
+      )
+    return yield* Effect.forEach(entries, loadWellknownEntry).pipe(Effect.map((documents) => documents.flat()))
+  })
+
+  const loadDirectory = Effect.fnUntraced(function* (directory: AbsolutePath) {
+    return [
+      ...(yield* Effect.forEach(names, (file) => loadFile(path.join(directory, file))).pipe(
+        Effect.map((configs) => configs.filter((config): config is Document => config !== undefined)),
+      )),
+      new Directory({ type: "directory", path: directory }),
+    ]
+  })
+
+  const discover = Effect.fn("Config.discover")(function* () {
+    const globalDirectory = AbsolutePath.make(global.config)
+    const globalAgentsDirectory = AbsolutePath.make(path.join(global.home, ".agents"))
+    const globalClaudeDirectory = AbsolutePath.make(path.join(global.home, ".claude"))
+    const locationIsGlobal = path.resolve(location.directory) === path.resolve(global.config)
+    const discovered =
+      locationIsGlobal || options?.project === false
+        ? []
+        : yield* fs
+            .up({
+              targets: [".opencode", ".claude", ".agents", ...names.toReversed()],
+              start: location.directory,
+            })
+            .pipe(Effect.orDie)
+
+    const globalEnabled = options?.global !== false
+    // A walked path that resolves into a global root is global config
+    // however the walk reached it (home above the project, or a location
+    // beneath the global config dir), so global: false excludes it
+    // uniformly — classified once here, not per consumer below.
+    const globalRoots = [globalDirectory, globalClaudeDirectory, globalAgentsDirectory].map((item) =>
+      path.resolve(item),
+    )
+    const visible = globalEnabled
+      ? discovered
+      : discovered.filter((item) => {
+          const resolved = path.resolve(item)
+          return !globalRoots.some((root) => resolved === root || resolved.startsWith(root + path.sep))
+        })
+    // We load certain files from a few other folders in the ecosystem
+    const claude = [
+      ...new Set([
+        ...(globalEnabled && (yield* fs.isDir(globalClaudeDirectory)) ? [globalClaudeDirectory] : []),
+        ...visible.filter((item) => path.basename(item) === ".claude").toReversed(),
+      ]),
+    ].map((directory) => new ClaudeDirectory({ type: "claude", path: AbsolutePath.make(directory) }))
+    const agents = [
+      ...new Set([
+        ...(globalEnabled && (yield* fs.isDir(globalAgentsDirectory)) ? [globalAgentsDirectory] : []),
+        ...visible.filter((item) => path.basename(item) === ".agents").toReversed(),
+      ]),
+    ].map((directory) => new AgentsDirectory({ type: "agents", path: AbsolutePath.make(directory) }))
+
+    const projectDirectories = visible
+      .filter((item) => path.basename(item) === ".opencode")
+      .toReversed()
+      .map((directory) => AbsolutePath.make(directory))
+    const directPaths = visible
+      .filter((item) => ![".agents", ".claude", ".opencode"].includes(path.basename(item)))
+      .toReversed()
+    fileTargets.clear()
+    directPaths.forEach((filepath) => fileTargets.add(AbsolutePath.make(filepath)))
+    const direct = yield* Effect.forEach(directPaths, (filepath) => loadFile(filepath)).pipe(
+      Effect.orDie,
+      Effect.map((entries) => entries.filter((entry): entry is Document => entry !== undefined)),
+    )
+
+    const file = options?.file
+    if (file) fileTargets.add(AbsolutePath.make(path.resolve(file)))
+    const explicit = file
+      ? yield* loadFile(path.resolve(file)).pipe(
+          Effect.map((config) => (config ? [config] : [])),
+          Effect.orDie,
+        )
+      : []
+    const content =
+      options?.content !== undefined
+        ? yield* ConfigVariable.substitute({
+            type: "virtual",
+            source: "OPENCODE_CONFIG_CONTENT",
+            dir: location.directory,
+            text: options.content,
+          }).pipe(
+            Effect.flatMap((text) => parseInfo(text, "OPENCODE_CONFIG_CONTENT")),
+            Effect.map((info) => (info ? [new Document({ type: "document", info })] : [])),
+            Effect.orDie,
+          )
+        : []
+
+    // Global entries sit below explicit and direct files; project
+    // directories rank above them.
+    const globalSupplementary = globalEnabled ? yield* loadDirectory(globalDirectory).pipe(Effect.orDie) : []
+    const projectSupplementary = yield* Effect.forEach(projectDirectories, loadDirectory).pipe(
+      Effect.orDie,
+      Effect.map((entries) => entries.flat()),
+    )
+    return [
+      ...(yield* loadWellknown().pipe(Effect.orDie)),
+      ...claude,
+      ...agents,
+      ...globalSupplementary,
+      ...explicit,
+      ...direct,
+      ...projectSupplementary,
+      ...content,
+    ]
+  })
+
+  const initial = yield* discover()
+  let configs = initial
+  const updates = yield* PubSub.unbounded<Watcher.Update>()
+  // Vendored trees inside config roots (a plugin's node_modules, a nested
+  // .git) produce event blizzards that can never change discovery output.
+  const ignore = ["node_modules", ".git", "**/{node_modules,.git}/**"]
+  // Watch-once: roots leave discovery only by deletion, so a stale watch is
+  // inert, bounded, and dies with this layer — and keeping a deleted root's
+  // watch alive is exactly what makes its recreation observable.
+  const watched = new Set<string>()
+  const reconcile = Effect.fn("Config.reconcileWatches")(function* (entries: readonly Entry[]) {
+    const directories = entries.flatMap((entry) => (entry.type === "directory" ? [entry.path] : []))
+    const files = [
+      ...entries.flatMap((entry) => (entry.type === "document" && entry.path ? [entry.path] : [])),
+      ...fileTargets,
+    ]
+    const targets = [
+      ...directories.map((path) => ({ path, type: "directory" as const, ignore })),
+      ...files
+        .filter((file) => !directories.some((directory) => FSUtil.contains(directory, file)))
+        .map((path) => ({ path, type: "file" as const })),
+    ]
+    for (const target of targets) {
+      const key = JSON.stringify(target)
+      if (watched.has(key)) continue
+      watched.add(key)
+      const stream = yield* watcher.subscribe(target)
+      yield* stream.pipe(
+        Stream.runForEach((update) => PubSub.publish(updates, update)),
+        Effect.forkScoped({ startImmediately: true }),
+      )
+    }
+  })
+
+  const reload = Effect.fn("Config.reload")(() =>
+    reloadLock.withPermit(
+      Effect.gen(function* () {
+        const next = yield* discover()
+        yield* reconcile(next)
+        if (isDeepStrictEqual(configs, next)) return
+        configs = next
+        yield* bus.publish(Event.Updated, {})
+      }),
+    ),
+  )
+
+  yield* Stream.fromPubSub(updates).pipe(
+    Stream.debounce("100 millis"),
+    Stream.runForEach((update) =>
+      reload().pipe(
+        Effect.catchCause((cause) => Effect.logError("failed to reload config", { path: update.path, cause })),
+      ),
+    ),
+    Effect.forkScoped({ startImmediately: true }),
+  )
+  yield* bus.subscribe(Credential.Event.Switched).pipe(
+    Stream.filterEffect((event) =>
+      wellknown.entries().pipe(
+        Effect.map((entries) => entries.some((entry) => entry.integrationID === event.data.integrationID)),
+        Effect.orElseSucceed(() => false),
+      ),
+    ),
+    Stream.runForEach(() =>
+      reload().pipe(Effect.catchCause((cause) => Effect.logError("failed to reload wellknown config", { cause }))),
+    ),
+    Effect.forkScoped({ startImmediately: true }),
+  )
+  yield* bus.subscribe(WellKnown.Event.Updated).pipe(
+    Stream.runForEach(() =>
+      reload().pipe(Effect.catchCause((cause) => Effect.logError("failed to reload wellknown sources", { cause }))),
+    ),
+    Effect.forkScoped({ startImmediately: true }),
+  )
+  yield* Effect.sleep("10 minutes").pipe(
+    Effect.andThen(
+      Effect.suspend(() => {
+        if (!wellknown.snapshot().length) return Effect.void
+        return Effect.gen(function* () {
+          const changed = yield* wellknown
+            .refresh()
+            .pipe(
+              Effect.catch((error) =>
+                Effect.logWarning("failed to refresh wellknown manifests", { error }).pipe(Effect.as(false)),
+              ),
+            )
+          if (!changed) yield* reload()
+        }).pipe(Effect.catchCause((cause) => Effect.logWarning("failed to refresh wellknown config", { cause })))
+      }),
+    ),
+    Effect.forever,
+    Effect.forkScoped({ startImmediately: true }),
+  )
+  yield* reconcile(initial)
+
+  return {
+    entries: Effect.fnUntraced(function* () {
+      return configs
+    }),
+    changes: () => Stream.fromPubSub(updates),
+  }
+})

--- a/packages/core/test/config/discovery.test.ts
+++ b/packages/core/test/config/discovery.test.ts
@@ -1,0 +1,78 @@
+import path from "path"
+import { describe, expect } from "bun:test"
+import { Config } from "@opencode-ai/core/config"
+import { ConfigDiscovery } from "@opencode-ai/core/config/discovery"
+import { Bus } from "@opencode-ai/core/bus"
+import { Credential } from "@opencode-ai/core/credential"
+import { Location } from "@opencode-ai/core/location"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
+import { WellKnown } from "@opencode-ai/core/wellknown"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Event } from "@opencode-ai/schema/config"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { FSUtil } from "@opencode-ai/util/fs-util"
+import { Global } from "@opencode-ai/util/global"
+import { Effect, Fiber, Layer, Stream } from "effect"
+import { emptyCredentialNode, emptyWellknownNode } from "../fixture/config-nodes"
+import { location } from "../fixture/location"
+import { tmpdirScoped } from "../fixture/tmpdir"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([FSUtil.node, Bus.node, Watcher.node, Credential.node, WellKnown.node]), [
+    [Watcher.node, Watcher.testLayer],
+    [Credential.node, emptyCredentialNode],
+    [WellKnown.node, emptyWellknownNode],
+  ]).pipe(Layer.merge(Watcher.testLayer)),
+)
+
+describe("ConfigDiscovery", () => {
+  it.live("discovers and refreshes ordered entries without the Config service", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      const fs = yield* FSUtil.Service
+      const target = path.join(tmp.path, "custom.jsonc")
+      yield* fs.writeFileString(target, '{ "shell": "before" }')
+      yield* Effect.gen(function* () {
+        const watcher = yield* Watcher.Test
+        const bus = yield* Bus.Service
+        const discovery: Config.Interface = yield* ConfigDiscovery.make({
+          project: false,
+          global: false,
+          file: target,
+          content: '{ "shell": "inline" }',
+        })
+        expect(Config.Options).toBe(ConfigDiscovery.Options)
+        expect(yield* discovery.entries()).toMatchObject([
+          { type: "document", path: target, info: { shell: "before" } },
+          { type: "document", info: { shell: "inline" } },
+        ])
+        expect(yield* watcher.subscriptions()).toEqual([{ path: target, type: "file" }])
+        const updated = yield* bus.subscribe(Event.Updated).pipe(
+          Stream.take(1),
+          Stream.mapEffect(() => discovery.entries()),
+          Stream.runCollect,
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        const changed = yield* discovery
+          .changes()
+          .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+        yield* fs.writeFileString(target, '{ "shell": "after" }')
+        expect((yield* discovery.entries())[0]).toMatchObject({ info: { shell: "before" } })
+        yield* watcher.emit({ path: target, type: "update" })
+        expect(yield* Fiber.join(changed)).toEqual([{ path: target, type: "update" }])
+        // The update event is a read barrier: its subscriber sees refreshed entries.
+        expect(yield* Fiber.join(updated)).toMatchObject([
+          [
+            { type: "document", path: target, info: { shell: "after" } },
+            { type: "document", info: { shell: "inline" } },
+          ],
+        ])
+      }).pipe(
+        Effect.provideService(Location.Service, location({ directory: AbsolutePath.make(tmp.path) })),
+        Effect.provideService(Global.Service, Global.make({ config: path.join(tmp.path, "global"), home: tmp.path })),
+      )
+    }),
+  )
+})


### PR DESCRIPTION
## Why

Core Config combines its public entries interface and test adapter with the built-in discovery engine: filesystem loading, normalization/substitution, precedence, watch topology, and credential/wellknown refresh. The discovery mechanism cannot be acquired or tested independently of providing `Config.Service`.

This preparatory extraction names that mechanism without changing the Config interface or moving plugin bootstrap behind plugin activation.

## What Changes

**Before:** `Config.layer(options)` directly contains the discovery engine.

**After:** it acquires the same engine through a scoped internal effect:

```ts
export const layer = (options?: Options) =>
  Layer.effect(Service, ConfigDiscovery.make(options))
```

`ConfigDiscovery.make(options)` returns the initialized `entries()` reader and raw `changes()` stream without requiring `Config.Service`. Config retains its service identity, interface, `latest`, test adapter, configured node, and dependency list. `Config.Options` is the same schema value owned by ConfigDiscovery.

| Situation | Preserved behavior |
| --- | --- |
| Acquiring Config at startup | Initial discovery finishes before Config.Service is provided |
| Global/project/explicit/virtual sources | Existing normalization, substitution, and precedence |
| Reading entries | Read the current cached snapshot, not a new discovery scan |
| Relevant discovery update | Replace the snapshot before publishing config.updated |
| Agent/command/plugin source file update | Raw changes remain available to the existing consumers |
| Replacing Config.node or disabling ambient discovery | The existing graph replacement still controls the whole acquisition engine |

## Bootstrap Ownership

```mermaid
flowchart TD
  N[Config.node: existing identity and dependencies] --> L[Config.layer]
  L --> D[ConfigDiscovery.make]
  D --> I[Await initial discovery]
  I --> W[Start existing scoped observation]
  W --> C[Provide Config.Service]
  C --> P[Existing plugin-source resolution and activation]
```

Discovery remains in the enclosing layer's Scope. There is no new service, graph node, standalone runtime, second cache, or reverse dependency on Config. Existing observation/reload effects retain their trace names; the new acquisition effect adds a `ConfigDiscovery.make` span.

## Scope

This can land before #45968. It intentionally preserves `Config.changes()` and the current consumers; source-watch ownership migration and the final source-neutral Config read model remain follow-ups. It does not change the HTTP API, generated client, plugin API, or UI layout.

## Verification

```sh
# packages/core
bun run test test/config test/filesystem/watcher.test.ts test/mcp.test.ts test/instance-vanilla.test.ts test/location-layer.test.ts
bun typecheck
bun run build

# packages/sdk, isolated HOME/environment via Core's runner
bun run ../core/script/test.ts test/embedded.test.ts

# packages/server
bun run test test/config.test.ts

# repository root
bunx prettier --check packages/core/src/config.ts packages/core/src/config/discovery.ts packages/core/test/config/discovery.test.ts
bunx oxlint packages/core/src/config.ts packages/core/src/config/discovery.ts packages/core/test/config/discovery.test.ts
git diff --check
```

- Core: 257 tests passed across 25 files; typecheck and build passed. Existing Config suites were retained unchanged.
- SDK: 17 embedded tests passed. Server: one Config HTTP test passed.
- The new direct-engine test provides no Config.Service and verifies ordered explicit/virtual entries, option schema identity, cached reads, raw change delivery, and commit-before-update-event visibility.
- Formatting and diff checks passed. Lint reported no errors and two existing consistent-return warnings in mechanically moved discovery code.
- Local verification ran on macOS; it does not claim cross-platform native watcher verification.
- The normal pre-push hook passed all 33 repository typecheck tasks (27 cached); no hooks were bypassed.
