### PR TITLE
docs: add Volcengine Ark to the provider directory

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2372,6 +2372,46 @@ Some useful routing options:
 
 ---
 
+### Volcengine Ark
+
+[Volcengine Ark](https://www.volcengine.com/product/ark) is ByteDance's model
+platform, serving the Doubao Seed models alongside third-party ones like DeepSeek
+and GLM.
+
+1. Head over to the [Ark console](https://console.volcengine.com/ark), create an
+   account, and generate an API key.
+
+2. Run the `/connect` command and search for **Volcengine Ark**.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter your Ark API key.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select a model like _Seed 2.1 Pro_.
+
+   ```txt
+   /models
+   ```
+
+Model IDs on Ark carry a version date — `doubao-seed-2-1-pro-260628` rather than
+`doubao-seed-2.1-pro`. The unversioned form returns a 404, so use the IDs as
+listed by `/models`.
+
+Outside mainland China the same models are served by
+[BytePlus](https://www.byteplus.com/) at
+`https://ark.ap-southeast.bytepluses.com/api/v3`, which uses a separate account.
+
+---
+
 ### xAI
 
 Two ways to authenticate: a SuperGrok subscription via device-code OAuth or a pay-as-you-go API key from the xAI console.


### PR DESCRIPTION
### Issue for this PR

Relates to #40203 (Volcengine Ark Coding Plan request). Docs only, so it doesn't
close that issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a `### Volcengine Ark` section to the provider directory, between Vercel AI
Gateway and xAI.

opencode already works with Ark — the `volcengine` provider comes from models.dev,
and `volcengine-coding-plan` was added there on 2026-08-28. But `providers.mdx`
never mentions it, so there's nothing to find if you go looking. Grepping the file
for `volcengine`, `doubao` or `ark` returns zero hits. This just fills that in,
using the same shape as the entries around it (console link → `/connect` →
`/models`).

Two things I put in the section because I hit them myself:

- Ark model ids include a version date. `doubao-seed-2-1-pro-260628` works;
  `doubao-seed-2.1-pro` returns 404. The console shows the short form, so it's
  easy to copy the wrong thing.
- BytePlus serves the same models outside mainland China, on a separate account.

I left out a Coding Plan section on purpose: none of the other `*-coding-plan`
providers are documented here either, so adding one only for Ark would look odd.
Happy to do all of them separately if that's useful.

### How did you verify your code works?

No code changed, so I verified the instructions rather than the build:

- Sent requests using the base URL from the catalog entry itself
  (`https://ark.cn-beijing.volces.com/api/v3`) with a real key:
  `doubao-seed-2-1-pro-260628` → 200, `doubao-seed-2-0-lite-260428` → 200.
- Confirmed the 404 claim: `doubao-seed-2.1-pro` → 404
  `InvalidEndpointOrModel.NotFound` on that same endpoint.
- Confirmed the BytePlus claim: a mainland key returns 401 against
  `ark.ap-southeast.bytepluses.com` and 200 against `ark.cn-beijing.volces.com`,
  so they are separate accounts.
- Checked the catalog's `name` is exactly `Volcengine Ark`, which is what step 2
  tells you to search for in `/connect`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_On the first box: I verified every factual claim in the section against the live
API as described above. I did not build the docs site locally — the change is a
markdown section using the same structure as its neighbours, so if you'd like me
to confirm it renders, say so and I will._
