### PR TITLE
fix(core): refresh plugins in background

### DIFF
--- a/packages/cli/src/commands/handlers/plugin/add.ts
+++ b/packages/cli/src/commands/handlers/plugin/add.ts
@@ -16,7 +16,7 @@ export default Runtime.handler(
     if (!(yield* Effect.promise(() => Npm.isInstallablePackage(input.package))))
       return yield* Effect.fail(new Error("Plugin target must be an npm registry package or Git package specifier"))
     const npm = yield* Npm.Service
-    const installed = yield* npm.add(input.package, { subpaths: ["server", ""], refresh: true })
+    const installed = yield* npm.add(input.package, { subpaths: ["server", ""] })
     const tui = yield* npm.resolve(input.package, { subpaths: ["tui"] })
     const target = configurationTarget(installed.entrypoint, tui.entrypoint)
     if (!target)

--- a/packages/cli/src/commands/handlers/plugin/add.ts
+++ b/packages/cli/src/commands/handlers/plugin/add.ts
@@ -16,7 +16,7 @@ export default Runtime.handler(
     if (!(yield* Effect.promise(() => Npm.isInstallablePackage(input.package))))
       return yield* Effect.fail(new Error("Plugin target must be an npm registry package or Git package specifier"))
     const npm = yield* Npm.Service
-    const installed = yield* npm.add(input.package, { subpaths: ["server", ""] })
+    const installed = yield* npm.add(input.package, { subpaths: ["server", ""], refresh: true })
     const tui = yield* npm.resolve(input.package, { subpaths: ["tui"] })
     const target = configurationTarget(installed.entrypoint, tui.entrypoint)
     if (!target)

--- a/packages/core/src/plugin/module.ts
+++ b/packages/core/src/plugin/module.ts
@@ -40,7 +40,7 @@ export const load = Effect.fn("PluginModule.load")(function* (
   const npm = yield* Npm.Service
   const entrypoint = path.isAbsolute(operation.target)
     ? pathToFileURL(operation.target).href
-    : (yield* npm.add(operation.target, { subpaths: ["server", ""], refresh: true })).entrypoint
+    : (yield* npm.add(operation.target, { subpaths: ["server", ""] })).entrypoint
   if (!entrypoint) return yield* Effect.fail(new Error(`Plugin entrypoint not found: ${operation.target}`))
   // Bun currently ignores query parameters when caching file:// imports.
   const target = typeof Bun !== "undefined" ? operation.target.replaceAll("\\", "/") : entrypoint

--- a/packages/core/src/plugin/module.ts
+++ b/packages/core/src/plugin/module.ts
@@ -36,9 +36,11 @@ const Definition = Schema.Struct({
 
 export const load = Effect.fn("PluginModule.load")(function* (
   operation: Extract<ConfigPluginSource.Operation, { type: "add" }>,
+  options?: { readonly refresh?: boolean },
 ) {
   const npm = yield* Npm.Service
-  const entrypoint = path.isAbsolute(operation.target)
+  const local = path.isAbsolute(operation.target)
+  const entrypoint = local
     ? pathToFileURL(operation.target).href
     : (yield* npm.add(operation.target, { subpaths: ["server", ""] })).entrypoint
   if (!entrypoint) return yield* Effect.fail(new Error(`Plugin entrypoint not found: ${operation.target}`))
@@ -49,6 +51,14 @@ export const load = Effect.fn("PluginModule.load")(function* (
   const mod = yield* Effect.promise(() => importModule(source))
   const value = (yield* Schema.decodeUnknownEffect(Definition)(mod)).default
   const plugin = "effect" in value ? value : PluginPromise.fromPromise(value)
+  if (!local && options?.refresh) {
+    yield* npm.add(operation.target, { subpaths: ["server", ""], refresh: true }).pipe(
+      Effect.catchCause((cause) =>
+        Effect.logWarning("failed to refresh package plugin", { target: operation.target, cause }),
+      ),
+      Effect.forkDetach,
+    )
+  }
   return {
     id: plugin.id,
     tui: plugin.tui,

--- a/packages/core/src/plugin/module.ts
+++ b/packages/core/src/plugin/module.ts
@@ -36,11 +36,9 @@ const Definition = Schema.Struct({
 
 export const load = Effect.fn("PluginModule.load")(function* (
   operation: Extract<ConfigPluginSource.Operation, { type: "add" }>,
-  options?: { readonly refresh?: boolean },
 ) {
   const npm = yield* Npm.Service
-  const local = path.isAbsolute(operation.target)
-  const entrypoint = local
+  const entrypoint = path.isAbsolute(operation.target)
     ? pathToFileURL(operation.target).href
     : (yield* npm.add(operation.target, { subpaths: ["server", ""] })).entrypoint
   if (!entrypoint) return yield* Effect.fail(new Error(`Plugin entrypoint not found: ${operation.target}`))
@@ -51,14 +49,6 @@ export const load = Effect.fn("PluginModule.load")(function* (
   const mod = yield* Effect.promise(() => importModule(source))
   const value = (yield* Schema.decodeUnknownEffect(Definition)(mod)).default
   const plugin = "effect" in value ? value : PluginPromise.fromPromise(value)
-  if (!local && options?.refresh) {
-    yield* npm.add(operation.target, { subpaths: ["server", ""], refresh: true }).pipe(
-      Effect.catchCause((cause) =>
-        Effect.logWarning("failed to refresh package plugin", { target: operation.target, cause }),
-      ),
-      Effect.forkDetach,
-    )
-  }
   return {
     id: plugin.id,
     tui: plugin.tui,

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -48,7 +48,7 @@ const resolve = Effect.fn("PluginSupervisor.resolve")(function* (
       continue
     }
 
-    const plugin = yield* PluginModule.load(operation).pipe(
+    const plugin = yield* PluginModule.load(operation, { refresh: true }).pipe(
       Effect.catchCause((cause) =>
         Effect.logWarning("failed to load plugin", { target: operation.target, cause }).pipe(
           Effect.as({ error: Cause.pretty(cause) }),

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -48,7 +48,7 @@ const resolve = Effect.fn("PluginSupervisor.resolve")(function* (
       continue
     }
 
-    const plugin = yield* PluginModule.load(operation, { refresh: true }).pipe(
+    const plugin = yield* PluginModule.load(operation).pipe(
       Effect.catchCause((cause) =>
         Effect.logWarning("failed to load plugin", { target: operation.target, cause }).pipe(
           Effect.as({ error: Cause.pretty(cause) }),
@@ -78,6 +78,9 @@ const resolve = Effect.fn("PluginSupervisor.resolve")(function* (
       ...post.filter((plugin) => enabled.has(plugin.id)),
     ],
     failures: [...failures.values()],
+    refreshes: [...packages.entries()].flatMap(([target, plugin]) =>
+      !path.isAbsolute(target) && enabled.has(plugin.id) ? [target] : [],
+    ),
   }
 })
 
@@ -89,6 +92,7 @@ export const layer = Layer.effect(
     const instance = yield* InstancePlugins.Service
     const sources = yield* ConfigPluginSource.Service
     const bus = yield* Bus.Service
+    const npm = yield* Npm.Service
     const ready = yield* Latch.make()
     let observed = 0
 
@@ -113,6 +117,18 @@ export const layer = Layer.effect(
       const resolved = yield* resolve(pre, post, operations)
       // Replace the active generation in one scoped, batched activation.
       yield* registry.activate(resolved.plugins, resolved.failures)
+      if (resolved.refreshes.length) {
+        yield* Effect.forEach(
+          resolved.refreshes,
+          (target) =>
+            npm
+              .add(target, { subpaths: ["server", ""], refresh: true })
+              .pipe(
+                Effect.catchCause((cause) => Effect.logWarning("failed to refresh package plugin", { target, cause })),
+              ),
+          { concurrency: "unbounded", discard: true },
+        ).pipe(Effect.forkDetach)
+      }
     })
     const updates = Stream.merge(sources.changes(), bus.subscribe([Event.Updated, SdkPlugins.Updated])).pipe(
       // Make accepted work visible to flush before coalescing the burst.

--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -7,8 +7,10 @@ import { Agent } from "@opencode-ai/core/agent"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { ConfigPluginSource } from "@opencode-ai/core/config/plugin/source"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Global } from "@opencode-ai/util/global"
+import { Npm } from "@opencode-ai/util/npm"
 import { Bus } from "@opencode-ai/core/bus"
 import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
@@ -18,7 +20,7 @@ import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Model } from "@opencode-ai/core/model"
 import { Provider } from "@opencode-ai/core/provider"
 import { AbsolutePath } from "@opencode-ai/core/schema"
-import { Effect, Fiber, Logger, Stream } from "effect"
+import { Effect, Fiber, Layer, Logger, Schedule, Stream } from "effect"
 import { Database } from "../../src/database/database"
 import { tmpdir } from "../fixture/tmpdir"
 import { tempGlobalLayer } from "../fixture/global"
@@ -34,6 +36,35 @@ const staticIt = testEffect(
     [ConfigPluginSource.node, ConfigPluginSource.empty],
     [Global.node, tempGlobalLayer],
   ]),
+)
+const refreshNpm = makeGlobalNode({
+  service: Npm.Service,
+  layer: Layer.effect(
+    Npm.Service,
+    Effect.gen(function* () {
+      const global = yield* Global.Service
+      const directory = path.join(global.tmp, "background-refresh-plugin")
+      const installed = { directory, entrypoint: pathToFileURL(path.join(directory, "index.js")).href }
+      return Npm.Service.of({
+        add: (_pkg, options) =>
+          options?.refresh
+            ? Effect.promise(() => Bun.write(path.join(directory, "refresh-requested"), "")).pipe(Effect.as(installed))
+            : Effect.succeed(installed),
+        resolve: () => Effect.succeed(installed),
+        which: () => Effect.succeed(undefined),
+      })
+    }),
+  ),
+  deps: [Global.node],
+})
+const refreshIt = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node, Global.node]),
+    [
+      [Global.node, tempGlobalLayer],
+      [Npm.node, refreshNpm],
+    ],
+  ),
 )
 
 describe("PluginSupervisor config", () => {
@@ -51,7 +82,6 @@ describe("PluginSupervisor config", () => {
       }),
     ),
   )
-
   it.live("allows the built-in Plan agent to be disabled", () =>
     withLocation(
       { agents: { plan: { disabled: true } } },
@@ -441,12 +471,56 @@ describe("PluginSupervisor config", () => {
       )
     }),
   )
+
+  refreshIt.live("unblocks flush before refreshing an active package plugin", () =>
+    Effect.gen(function* () {
+      const global = yield* Global.Service
+      const directory = path.join(global.tmp, "background-refresh-plugin")
+      const activated = path.join(directory, "activated")
+      const release = path.join(directory, "release")
+      const refreshed = path.join(directory, "refresh-requested")
+      yield* Effect.promise(async () => {
+        await fs.mkdir(directory, { recursive: true })
+        await fs.writeFile(
+          path.join(directory, "index.js"),
+          `export default {
+            id: "background-refresh-plugin",
+            async setup() {
+              await Bun.write(${JSON.stringify(activated)}, "")
+              while (!(await Bun.file(${JSON.stringify(release)}).exists())) await Bun.sleep(10)
+            },
+          }`,
+        )
+      })
+
+      yield* withLocation(
+        { plugins: ["background-refresh-plugin"] },
+        Effect.gen(function* () {
+          yield* waitForFile(activated)
+          yield* Effect.sleep("100 millis")
+          expect(yield* Effect.promise(() => Bun.file(refreshed).exists())).toBeFalse()
+          yield* Effect.promise(() => Bun.write(release, ""))
+          yield* ready().pipe(Effect.timeout("2 seconds"))
+          yield* waitForFile(refreshed)
+          const plugins = yield* Plugin.Service
+          expect((yield* plugins.list()).map((plugin) => String(plugin.id))).toContain("background-refresh-plugin")
+        }),
+      )
+    }),
+  )
 })
 
 const ready = Effect.fnUntraced(function* () {
   const supervisor = yield* PluginSupervisor.Service
   yield* supervisor.flush
 })
+
+const waitForFile = (file: string) =>
+  Effect.promise(() => Bun.file(file).exists()).pipe(
+    Effect.filterOrFail((exists) => exists),
+    Effect.retry({ times: 200, schedule: Schedule.spaced("10 millis") }),
+    Effect.timeout("2 seconds"),
+  )
 
 function withLocation<A, E, R>(
   config: unknown,

--- a/packages/core/test/config/plugin.test.ts
+++ b/packages/core/test/config/plugin.test.ts
@@ -48,7 +48,12 @@ const refreshNpm = makeGlobalNode({
       return Npm.Service.of({
         add: (_pkg, options) =>
           options?.refresh
-            ? Effect.promise(() => Bun.write(path.join(directory, "refresh-requested"), "")).pipe(Effect.as(installed))
+            ? Effect.gen(function* () {
+                yield* Effect.promise(() => Bun.write(path.join(directory, "refresh-requested"), ""))
+                yield* waitForFile(path.join(directory, "refresh-release")).pipe(Effect.orDie)
+                yield* Effect.promise(() => Bun.write(path.join(directory, "refresh-finished"), ""))
+                return installed
+              })
             : Effect.succeed(installed),
         resolve: () => Effect.succeed(installed),
         which: () => Effect.succeed(undefined),
@@ -472,13 +477,15 @@ describe("PluginSupervisor config", () => {
     }),
   )
 
-  refreshIt.live("unblocks flush before refreshing an active package plugin", () =>
+  refreshIt.live("refreshes active package plugins after setup without blocking flush", () =>
     Effect.gen(function* () {
       const global = yield* Global.Service
       const directory = path.join(global.tmp, "background-refresh-plugin")
       const activated = path.join(directory, "activated")
       const release = path.join(directory, "release")
       const refreshed = path.join(directory, "refresh-requested")
+      const refreshRelease = path.join(directory, "refresh-release")
+      const refreshFinished = path.join(directory, "refresh-finished")
       yield* Effect.promise(async () => {
         await fs.mkdir(directory, { recursive: true })
         await fs.writeFile(
@@ -500,8 +507,10 @@ describe("PluginSupervisor config", () => {
           yield* Effect.sleep("100 millis")
           expect(yield* Effect.promise(() => Bun.file(refreshed).exists())).toBeFalse()
           yield* Effect.promise(() => Bun.write(release, ""))
-          yield* ready().pipe(Effect.timeout("2 seconds"))
           yield* waitForFile(refreshed)
+          yield* ready().pipe(Effect.timeout("2 seconds"))
+          yield* Effect.promise(() => Bun.write(refreshRelease, ""))
+          yield* waitForFile(refreshFinished)
           const plugins = yield* Plugin.Service
           expect((yield* plugins.list()).map((plugin) => String(plugin.id))).toContain("background-refresh-plugin")
         }),

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -234,7 +234,7 @@ describe("Npm.add", () => {
 
     const first = await Effect.gen(function* () {
       const npm = yield* Npm.Service
-      const mutableEntry = yield* npm.add(mutable, { refresh: true })
+      const mutableEntry = yield* npm.add(mutable)
       const pinnedEntry = yield* npm.add(pinned, { refresh: true })
       yield* Effect.promise(async () => {
         await Bun.write(path.join(fixture.repository, "index.js"), 'export default { root: "second" }\n')

--- a/packages/core/test/plugin/module.test.ts
+++ b/packages/core/test/plugin/module.test.ts
@@ -1,0 +1,29 @@
+import path from "path"
+import { pathToFileURL } from "url"
+import { expect, test } from "bun:test"
+import { PluginModule } from "@opencode-ai/core/plugin/module"
+import { Npm } from "@opencode-ai/util/npm"
+import { Effect } from "effect"
+
+test("loads cached plugin packages without requesting a refresh", async () => {
+  const calls: unknown[] = []
+  const entrypoint = path.join(import.meta.dir, "fixtures", "config-effect-plugin.ts")
+  const plugin = await PluginModule.load({ type: "add", target: "fixture-plugin", options: {} }).pipe(
+    Effect.provideService(
+      Npm.Service,
+      Npm.Service.of({
+        add: (_pkg, options) =>
+          Effect.sync(() => {
+            calls.push(options)
+            return { directory: path.dirname(entrypoint), entrypoint: pathToFileURL(entrypoint).href }
+          }),
+        resolve: () => Effect.die(new Error("Unexpected resolve")),
+        which: () => Effect.die(new Error("Unexpected which")),
+      }),
+    ),
+    Effect.runPromise,
+  )
+
+  expect(plugin.id).toBe("config-effect-plugin")
+  expect(calls).toEqual([{ subpaths: ["server", ""] }])
+})

--- a/packages/core/test/plugin/module.test.ts
+++ b/packages/core/test/plugin/module.test.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from "url"
 import { expect, test } from "bun:test"
 import { PluginModule } from "@opencode-ai/core/plugin/module"
 import { Npm } from "@opencode-ai/util/npm"
-import { Effect } from "effect"
+import { Effect, Latch } from "effect"
 
 test("loads cached plugin packages without requesting a refresh", async () => {
   const calls: unknown[] = []
@@ -26,4 +26,31 @@ test("loads cached plugin packages without requesting a refresh", async () => {
 
   expect(plugin.id).toBe("config-effect-plugin")
   expect(calls).toEqual([{ subpaths: ["server", ""] }])
+})
+
+test("refreshes package plugins in the background after importing them", async () => {
+  const result = await Effect.gen(function* () {
+    const started = yield* Latch.make()
+    const calls: unknown[] = []
+    const entrypoint = path.join(import.meta.dir, "fixtures", "config-effect-plugin.ts")
+    const installed = { directory: path.dirname(entrypoint), entrypoint: pathToFileURL(entrypoint).href }
+    const npm = Npm.Service.of({
+      add: (_pkg, options) => {
+        calls.push(options)
+        if (options?.refresh) return started.open.pipe(Effect.andThen(Effect.never))
+        return Effect.succeed(installed)
+      },
+      resolve: () => Effect.die(new Error("Unexpected resolve")),
+      which: () => Effect.die(new Error("Unexpected which")),
+    })
+    const plugin = yield* PluginModule.load(
+      { type: "add", target: "fixture-plugin", options: {} },
+      { refresh: true },
+    ).pipe(Effect.provideService(Npm.Service, npm))
+    yield* started.await
+    return { calls, plugin }
+  }).pipe(Effect.runPromise)
+
+  expect(result.plugin.id).toBe("config-effect-plugin")
+  expect(result.calls).toEqual([{ subpaths: ["server", ""] }, { subpaths: ["server", ""], refresh: true }])
 })

--- a/packages/core/test/plugin/module.test.ts
+++ b/packages/core/test/plugin/module.test.ts
@@ -3,7 +3,7 @@ import { pathToFileURL } from "url"
 import { expect, test } from "bun:test"
 import { PluginModule } from "@opencode-ai/core/plugin/module"
 import { Npm } from "@opencode-ai/util/npm"
-import { Effect, Latch } from "effect"
+import { Effect } from "effect"
 
 test("loads cached plugin packages without requesting a refresh", async () => {
   const calls: unknown[] = []
@@ -26,31 +26,4 @@ test("loads cached plugin packages without requesting a refresh", async () => {
 
   expect(plugin.id).toBe("config-effect-plugin")
   expect(calls).toEqual([{ subpaths: ["server", ""] }])
-})
-
-test("refreshes package plugins in the background after importing them", async () => {
-  const result = await Effect.gen(function* () {
-    const started = yield* Latch.make()
-    const calls: unknown[] = []
-    const entrypoint = path.join(import.meta.dir, "fixtures", "config-effect-plugin.ts")
-    const installed = { directory: path.dirname(entrypoint), entrypoint: pathToFileURL(entrypoint).href }
-    const npm = Npm.Service.of({
-      add: (_pkg, options) => {
-        calls.push(options)
-        if (options?.refresh) return started.open.pipe(Effect.andThen(Effect.never))
-        return Effect.succeed(installed)
-      },
-      resolve: () => Effect.die(new Error("Unexpected resolve")),
-      which: () => Effect.die(new Error("Unexpected which")),
-    })
-    const plugin = yield* PluginModule.load(
-      { type: "add", target: "fixture-plugin", options: {} },
-      { refresh: true },
-    ).pipe(Effect.provideService(Npm.Service, npm))
-    yield* started.await
-    return { calls, plugin }
-  }).pipe(Effect.runPromise)
-
-  expect(result.plugin.id).toBe("config-effect-plugin")
-  expect(result.calls).toEqual([{ subpaths: ["server", ""] }, { subpaths: ["server", ""], refresh: true }])
 })

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -193,6 +193,7 @@ const layer = Layer.effect(
       }
 
       const tree = yield* reify({ dir, add: [pkg] })
+      if (isMutable(parsed)) refreshed.add(pkg)
       const first = tree.edgesOut.values().next().value?.to
       if (!first) {
         const installed = yield* installedName(pkg, dir, parsedName)

--- a/packages/www/src/docs/content/plugins.mdx
+++ b/packages/www/src/docs/content/plugins.mdx
@@ -57,7 +57,7 @@ explicitly or move it under `.opencode/`.
 
 ```jsonc title="opencode.jsonc"
 {
-  "plugins": ["./plugins/local.ts"],
+  "plugins": ["./plugins/local.ts"]
 }
 ```
 
@@ -66,7 +66,7 @@ use `.*` to match an ID prefix. A later ID re-enables a plugin.
 
 ```jsonc title="opencode.jsonc"
 {
-  "plugins": ["*", "-opencode.provider.*", "opencode.provider.openai", "-acme.reviewer"],
+  "plugins": ["*", "-opencode.provider.*", "opencode.provider.openai", "-acme.reviewer"]
 }
 ```
 

--- a/packages/www/src/docs/content/plugins.mdx
+++ b/packages/www/src/docs/content/plugins.mdx
@@ -57,7 +57,7 @@ explicitly or move it under `.opencode/`.
 
 ```jsonc title="opencode.jsonc"
 {
-  "plugins": ["./plugins/local.ts"]
+  "plugins": ["./plugins/local.ts"],
 }
 ```
 
@@ -66,7 +66,7 @@ use `.*` to match an ID prefix. A later ID re-enables a plugin.
 
 ```jsonc title="opencode.jsonc"
 {
-  "plugins": ["*", "-opencode.provider.*", "opencode.provider.openai", "-acme.reviewer"]
+  "plugins": ["*", "-opencode.provider.*", "opencode.provider.openai", "-acme.reviewer"],
 }
 ```
 
@@ -93,9 +93,10 @@ opencode2 plugin add 'github:acme/plugins#main::path:packages/opencode-plugin'
 Branches, tags, complete commit hashes, and npm's `::path:` repository-subdirectory selectors are supported. Configure
 local paths directly; tarball and npm alias targets are not accepted by `plugin add`.
 
-Changes under watched config directories reload automatically. On server startup, OpenCode refreshes unpinned package and
-Git plugins once, then uses that result for the lifetime of the server. Exact npm versions and full Git commit hashes stay
-pinned. Changes to unwatched local dependencies may still require restarting OpenCode.
+Changes under watched config directories reload automatically. Server startup uses cached package plugins without checking
+the network. Run `opencode2 plugin add <package>` again to refresh an unpinned npm or Git plugin explicitly, then restart a
+running OpenCode server to load it. Exact npm versions and full Git commit hashes stay pinned. Changes to unwatched local
+dependencies may also require restarting OpenCode.
 
 ```sh
 touch .opencode/plugins/concise.ts

--- a/packages/www/src/docs/content/plugins.mdx
+++ b/packages/www/src/docs/content/plugins.mdx
@@ -93,10 +93,10 @@ opencode2 plugin add 'github:acme/plugins#main::path:packages/opencode-plugin'
 Branches, tags, complete commit hashes, and npm's `::path:` repository-subdirectory selectors are supported. Configure
 local paths directly; tarball and npm alias targets are not accepted by `plugin add`.
 
-Changes under watched config directories reload automatically. Server startup uses cached package plugins without checking
-the network. Run `opencode2 plugin add <package>` again to refresh an unpinned npm or Git plugin explicitly, then restart a
-running OpenCode server to load it. Exact npm versions and full Git commit hashes stay pinned. Changes to unwatched local
-dependencies may also require restarting OpenCode.
+Changes under watched config directories reload automatically. Server startup loads cached package plugins immediately,
+then refreshes unpinned npm and Git plugins in the background. A refreshed package becomes active the next time the server
+starts. Exact npm versions and full Git commit hashes stay pinned. Changes to unwatched local dependencies may still require
+restarting OpenCode.
 
 ```sh
 touch .opencode/plugins/concise.ts


### PR DESCRIPTION
## Why

A fresh server can spend several seconds checking the network before it imports an already-cached plugin. Mutable package refresh runs during repository-marker discovery, so registry or Git latency blocks the initial Location graph and prompt even when a usable installation is available.

## What Changes

| Plugin source | Startup behavior |
| --- | --- |
| Cached mutable npm or Git spec | Import immediately, then refresh once in the background |
| Uncached package | Install before first import as before |
| Exact npm version or full Git commit | Reuse the pinned installation without refreshing |
| Failed background refresh | Keep the cached plugin active |

Automatic updates remain enabled. The already-imported plugin definition stays active in the current process; the next server process imports the refreshed package.

## Refresh Boundary

```mermaid
sequenceDiagram
    participant Startup as Location startup
    participant Supervisor as Plugin supervisor
    participant Loader as PluginModule
    participant Cache as Package cache
    participant Refresh as Background refresh

    Startup->>Supervisor: load configured plugins
    Supervisor->>Loader: load configured plugin
    Loader->>Cache: resolve cached package
    Cache-->>Loader: cached entrypoint
    Loader->>Loader: import and decode plugin
    Loader-->>Supervisor: plugin definition
    Supervisor->>Supervisor: activate all plugins
    Supervisor-)Refresh: start detached refresh
    Supervisor-->>Startup: open readiness
    Refresh->>Cache: update cached package
    Note over Startup,Cache: Next server process imports the update
```

Repository-marker discovery stays cache-only. The supervisor starts the detached refresh only after all plugin setup has completed, so imports, activation, and readiness do not wait for Arborist or the network.

The regression test blocks plugin setup and verifies that no refresh starts, then blocks the refresh itself and verifies that supervisor flush still completes. It releases both barriers before teardown so no detached test work remains.

## Scope

This changes refresh scheduling and treats a successful first install as the service's refresh attempt. It adds no command, configuration, protocol, generated-client surface, or package-cache format.

## Verification

```sh
# packages/core
bun run test test/npm.test.ts test/plugin/module.test.ts test/config/plugin.test.ts test/project.test.ts
bun run test
bun typecheck
bun run build

# packages/cli
bun run test test/plugin-add.test.ts
bun typecheck

# packages/www
bun typecheck
bun run check:generated
bun run build

# repository pre-push hook
bun turbo typecheck --concurrency=3
```

The focused Core run passed 55 tests with one existing skip. The complete Core suite passed 3,794 tests with 40 skips and no failures. CLI tests, affected package builds/checks, the documentation build, and all 33 pre-push typecheck tasks passed.

A matched standalone benchmark used the same rebased source and warm package cache, toggling only whether the first package refresh was synchronous or detached:

| Measurement | Synchronous refresh | Background refresh |
| --- | ---: | ---: |
| Prompt visible | 13.89 s | 5.14 s |
| Initial Location graph | 9.730 s | 0.941 s |
