### PR TITLE
feat(plugin): add session retry hook

### DIFF
--- a/packages/core/src/session/model-request.ts
+++ b/packages/core/src/session/model-request.ts
@@ -48,6 +48,7 @@ const declineDefect = (cause: Cause.Cause<Tool.Error>) => {
 export interface Prepared {
   readonly request: LLMRequest
   readonly options: StreamOptions
+  readonly retry: (event: PluginHooks.Domains["session"]["retry"]) => Effect.Effect<void>
   /**
    * One request-scoped execution operation. Unknown and hook-removed calls
    * fail individually through the same seam.
@@ -364,9 +365,11 @@ export const layer = Layer.effect(
         tools
           .execute({ ...input, definitions: hooked })
           .pipe(Effect.catchCauseFilter(declineDefect, (decline) => Effect.fail(decline)))
+      const retry: Prepared["retry"] = (event) => hooks.trigger("session", "retry", event).pipe(Effect.asVoid)
       return {
         request,
         options,
+        retry,
         executeTool,
       }
     })

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -24,7 +24,6 @@ import { SessionRunnerRetry } from "./retry.js"
 import { SessionStep } from "./step.js"
 import { ToolOutput } from "../../tool-output.js"
 import { PluginSupervisor } from "../../plugin/supervisor.js"
-import { PluginHooks } from "../../plugin/hooks.js"
 import { MAX_STEPS_PROMPT } from "./max-steps.js"
 
 const CONTINUE_AFTER_INCOMPLETE_STREAM =
@@ -40,7 +39,6 @@ const layer = Layer.effect(
     const db = (yield* Database.Service).db
     const compaction = yield* SessionCompaction.Service
     const plugins = yield* PluginSupervisor.Service
-    const hooks = yield* PluginHooks.Service
     const title = yield* SessionTitle.Service
     const steps = yield* SessionStep.make
     // Title generation starts once input is visible and must not delay model execution.
@@ -178,7 +176,7 @@ const layer = Layer.effect(
     const runStep = Effect.fn("SessionRunner.runStep")(function* (first: SessionContext.Loaded, step: number) {
       const sessionID = first.session.id
       let assistantMessageID = SessionMessage.ID.create()
-      const retry = yield* SessionRunnerRetry.make(bus, hooks, sessionID)
+      const retry = yield* SessionRunnerRetry.make(bus, sessionID)
       let initial: SessionContext.Loaded | undefined = first
       let recoverOverflow = true
       let recoverContinuation = true
@@ -240,6 +238,7 @@ const layer = Layer.effect(
               assistantMessageID,
               agent: loaded.agent.id,
               model: loaded.model.ref,
+              hook: prepared.retry,
             }).pipe(
               Pull.catchDone(() =>
                 bus
@@ -255,6 +254,7 @@ const layer = Layer.effect(
               assistantMessageID,
               agent: loaded.agent.id,
               model: loaded.model.ref,
+              hook: prepared.retry,
             }).pipe(Pull.catchDone(() => outcome.cause))
             yield* bus.publish(SessionEvent.Synthetic, { sessionID, text: CONTINUE_AFTER_INCOMPLETE_STREAM })
             assistantMessageID = SessionMessage.ID.create()
@@ -311,7 +311,6 @@ export const node = makeLocationNode({
     SessionStore.node,
     SessionCompaction.node,
     PluginSupervisor.node,
-    PluginHooks.node,
     SessionTitle.node,
     Snapshot.node,
     ToolOutput.node,

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -1,7 +1,7 @@
 export * as SessionRunnerLLM from "./llm.js"
 
 import { Message } from "@opencode-ai/ai"
-import { Cause, Effect, Exit, FiberMap, Layer, Pull, Schedule } from "effect"
+import { Cause, Effect, Exit, FiberMap, Layer, Pull } from "effect"
 import { Database } from "../../database/database.js"
 import { Bus } from "../../bus.js"
 import { InstructionState } from "../instruction-state.js"
@@ -24,6 +24,7 @@ import { SessionRunnerRetry } from "./retry.js"
 import { SessionStep } from "./step.js"
 import { ToolOutput } from "../../tool-output.js"
 import { PluginSupervisor } from "../../plugin/supervisor.js"
+import { PluginHooks } from "../../plugin/hooks.js"
 import { MAX_STEPS_PROMPT } from "./max-steps.js"
 
 const CONTINUE_AFTER_INCOMPLETE_STREAM =
@@ -39,6 +40,7 @@ const layer = Layer.effect(
     const db = (yield* Database.Service).db
     const compaction = yield* SessionCompaction.Service
     const plugins = yield* PluginSupervisor.Service
+    const hooks = yield* PluginHooks.Service
     const title = yield* SessionTitle.Service
     const steps = yield* SessionStep.make
     // Title generation starts once input is visible and must not delay model execution.
@@ -176,7 +178,7 @@ const layer = Layer.effect(
     const runStep = Effect.fn("SessionRunner.runStep")(function* (first: SessionContext.Loaded, step: number) {
       const sessionID = first.session.id
       let assistantMessageID = SessionMessage.ID.create()
-      const retry = yield* Schedule.toStepWithSleep(SessionRunnerRetry.schedule(bus, sessionID))
+      const retry = yield* SessionRunnerRetry.make(bus, hooks, sessionID)
       let initial: SessionContext.Loaded | undefined = first
       let recoverOverflow = true
       let recoverContinuation = true
@@ -232,7 +234,13 @@ const layer = Layer.effect(
         const completed = yield* SessionStep.Outcome.$match(outcome, {
           Completed: (outcome) => Effect.succeed(outcome.needsContinuation),
           Retry: (outcome) =>
-            retry({ cause: outcome.cause, error: outcome.error, assistantMessageID }).pipe(
+            retry({
+              cause: outcome.cause,
+              error: outcome.error,
+              assistantMessageID,
+              agent: loaded.agent.id,
+              model: loaded.model.ref,
+            }).pipe(
               Pull.catchDone(() =>
                 bus
                   .publish(SessionEvent.Step.Failed, { sessionID, assistantMessageID, error: outcome.error })
@@ -241,9 +249,13 @@ const layer = Layer.effect(
               Effect.asVoid,
             ),
           Continue: Effect.fnUntraced(function* (outcome) {
-            yield* retry({ cause: outcome.cause, error: outcome.error, assistantMessageID }).pipe(
-              Pull.catchDone(() => outcome.cause),
-            )
+            yield* retry({
+              cause: outcome.cause,
+              error: outcome.error,
+              assistantMessageID,
+              agent: loaded.agent.id,
+              model: loaded.model.ref,
+            }).pipe(Pull.catchDone(() => outcome.cause))
             yield* bus.publish(SessionEvent.Synthetic, { sessionID, text: CONTINUE_AFTER_INCOMPLETE_STREAM })
             assistantMessageID = SessionMessage.ID.create()
           }),
@@ -299,6 +311,7 @@ export const node = makeLocationNode({
     SessionStore.node,
     SessionCompaction.node,
     PluginSupervisor.node,
+    PluginHooks.node,
     SessionTitle.node,
     Snapshot.node,
     ToolOutput.node,

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -1,7 +1,7 @@
 export * as SessionRunnerLLM from "./llm.js"
 
 import { Message } from "@opencode-ai/ai"
-import { Cause, Effect, Exit, FiberMap, Layer, Pull } from "effect"
+import { Cause, Effect, Exit, FiberMap, Layer } from "effect"
 import { Database } from "../../database/database.js"
 import { Bus } from "../../bus.js"
 import { InstructionState } from "../instruction-state.js"
@@ -222,6 +222,15 @@ const layer = Layer.effect(
           agent: loaded.agent.id,
           model: loaded.model,
           prepared,
+          retry: (cause, error, proposed) =>
+            retry.decide({
+              cause,
+              error,
+              agent: loaded.agent.id,
+              model: loaded.model.ref,
+              hook: prepared.retry,
+              retry: proposed,
+            }),
           recoverContinuation,
           recoverOverflow: Effect.suspend(() =>
             recoverOverflow && compaction.enabled()
@@ -232,30 +241,17 @@ const layer = Layer.effect(
         const completed = yield* SessionStep.Outcome.$match(outcome, {
           Completed: (outcome) => Effect.succeed(outcome.needsContinuation),
           Retry: (outcome) =>
-            retry({
-              cause: outcome.cause,
+            retry.wait({
+              decision: outcome.decision,
               error: outcome.error,
               assistantMessageID,
-              agent: loaded.agent.id,
-              model: loaded.model.ref,
-              hook: prepared.retry,
-            }).pipe(
-              Pull.catchDone(() =>
-                bus
-                  .publish(SessionEvent.Step.Failed, { sessionID, assistantMessageID, error: outcome.error })
-                  .pipe(Effect.andThen(outcome.cause)),
-              ),
-              Effect.asVoid,
-            ),
+            }),
           Continue: Effect.fnUntraced(function* (outcome) {
-            yield* retry({
-              cause: outcome.cause,
+            yield* retry.wait({
+              decision: outcome.decision,
               error: outcome.error,
               assistantMessageID,
-              agent: loaded.agent.id,
-              model: loaded.model.ref,
-              hook: prepared.retry,
-            }).pipe(Pull.catchDone(() => outcome.cause))
+            })
             yield* bus.publish(SessionEvent.Synthetic, { sessionID, text: CONTINUE_AFTER_INCOMPLETE_STREAM })
             assistantMessageID = SessionMessage.ID.create()
           }),

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -6,7 +6,7 @@ import { Model } from "@opencode-ai/schema/model"
 import { SessionError } from "@opencode-ai/schema/session-error"
 import { Cause, Clock, Duration, Effect, Schedule } from "effect"
 import { Bus } from "../../bus.js"
-import { PluginHooks } from "../../plugin/hooks.js"
+import type { PluginHooks } from "../../plugin/hooks.js"
 import { SessionEvent } from "../event.js"
 import { SessionMessage } from "../message.js"
 import { SessionSchema } from "../schema.js"
@@ -17,6 +17,7 @@ export interface Input {
   readonly assistantMessageID: SessionMessage.ID
   readonly agent: Agent.ID
   readonly model: Model.Ref
+  readonly hook: (event: PluginHooks.Domains["session"]["retry"]) => Effect.Effect<void>
 }
 
 export function isRetryable(error: AIError) {
@@ -70,10 +71,10 @@ const schedule = Schedule.max([Schedule.exponential("2 seconds"), Schedule.recur
   }),
 )
 
-export const make = (bus: Bus.Interface, hooks: PluginHooks.Interface, sessionID: SessionSchema.ID) =>
+export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
   Effect.gen(function* () {
     const step = yield* Schedule.toStep(schedule)
-    let attempt = 0
+    let attempt = 1
     return (input: Input) =>
       Effect.gen(function* () {
         const now = yield* Clock.currentTimeMillis
@@ -88,7 +89,7 @@ export const make = (bus: Bus.Interface, hooks: PluginHooks.Interface, sessionID
           attempt,
           decision: { retry: true, delay },
         }
-        yield* hooks.trigger("session", "retry", event)
+        yield* input.hook(event)
         if (!event.decision.retry) return yield* Cause.done()
         const normalized =
           Number.isFinite(event.decision.delay) && event.decision.delay >= 0 ? Math.ceil(event.decision.delay) : delay
@@ -100,6 +101,7 @@ export const make = (bus: Bus.Interface, hooks: PluginHooks.Interface, sessionID
           at: scheduled + normalized,
           error: input.error,
         })
-        yield* Effect.sleep(Duration.millis(normalized))
+        const remaining = Math.max(0, scheduled + normalized - (yield* Clock.currentTimeMillis))
+        yield* Effect.sleep(Duration.millis(remaining))
       })
   })

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -4,20 +4,26 @@ import { AIError } from "@opencode-ai/ai"
 import { Agent } from "@opencode-ai/schema/agent"
 import { Model } from "@opencode-ai/schema/model"
 import { SessionError } from "@opencode-ai/schema/session-error"
-import { Cause, Clock, Duration, Effect, Schedule } from "effect"
+import { Clock, Duration, Effect, Pull, Schedule } from "effect"
 import { Bus } from "../../bus.js"
 import type { PluginHooks } from "../../plugin/hooks.js"
 import { SessionEvent } from "../event.js"
 import { SessionMessage } from "../message.js"
 import { SessionSchema } from "../schema.js"
 
-export interface Input {
+interface Input {
   readonly cause: AIError
   readonly error: SessionError.Error
-  readonly assistantMessageID: SessionMessage.ID
   readonly agent: Agent.ID
   readonly model: Model.Ref
   readonly hook: (event: PluginHooks.Domains["session"]["retry"]) => Effect.Effect<void>
+  readonly retry: boolean
+}
+
+export interface Decision {
+  readonly retry: true
+  readonly attempt: number
+  readonly delay: number
 }
 
 export function isRetryable(error: AIError) {
@@ -75,10 +81,12 @@ export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
   Effect.gen(function* () {
     const step = yield* Schedule.toStep(schedule)
     let attempt = 1
-    return (input: Input) =>
+    const decide = (input: Input) =>
       Effect.gen(function* () {
         const now = yield* Clock.currentTimeMillis
-        const [, duration] = yield* step(now, input)
+        const next = yield* step(now, input).pipe(Pull.catchDone(() => Effect.succeed(undefined)))
+        if (!next) return { retry: false as const }
+        const [, duration] = next
         attempt++
         const delay = Math.ceil(Duration.toMillis(duration))
         const event: PluginHooks.Domains["session"]["retry"] = {
@@ -87,21 +95,30 @@ export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
           model: input.model,
           error: input.error,
           attempt,
-          decision: { retry: true, delay },
+          decision: input.retry ? { retry: true, delay } : { retry: false },
         }
         yield* input.hook(event)
-        if (!event.decision.retry) return yield* Cause.done()
+        if (!event.decision.retry) return event.decision
         const normalized =
           Number.isFinite(event.decision.delay) && event.decision.delay >= 0 ? Math.ceil(event.decision.delay) : delay
+        return { retry: true as const, attempt, delay: normalized }
+      })
+    const wait = (input: {
+      readonly decision: Decision
+      readonly assistantMessageID: SessionMessage.ID
+      readonly error: SessionError.Error
+    }) =>
+      Effect.gen(function* () {
         const scheduled = yield* Clock.currentTimeMillis
         yield* bus.publish(SessionEvent.RetryScheduled, {
           sessionID,
           assistantMessageID: input.assistantMessageID,
-          attempt,
-          at: scheduled + normalized,
+          attempt: input.decision.attempt,
+          at: scheduled + input.decision.delay,
           error: input.error,
         })
-        const remaining = Math.max(0, scheduled + normalized - (yield* Clock.currentTimeMillis))
+        const remaining = Math.max(0, scheduled + input.decision.delay - (yield* Clock.currentTimeMillis))
         yield* Effect.sleep(Duration.millis(remaining))
       })
+    return { decide, wait }
   })

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -1,9 +1,12 @@
 export * as SessionRunnerRetry from "./retry.js"
 
 import { AIError } from "@opencode-ai/ai"
+import { Agent } from "@opencode-ai/schema/agent"
+import { Model } from "@opencode-ai/schema/model"
 import { SessionError } from "@opencode-ai/schema/session-error"
-import { Duration, Effect, Schedule } from "effect"
+import { Cause, Clock, Duration, Effect, Schedule } from "effect"
 import { Bus } from "../../bus.js"
+import { PluginHooks } from "../../plugin/hooks.js"
 import { SessionEvent } from "../event.js"
 import { SessionMessage } from "../message.js"
 import { SessionSchema } from "../schema.js"
@@ -12,6 +15,8 @@ export interface Input {
   readonly cause: AIError
   readonly error: SessionError.Error
   readonly assistantMessageID: SessionMessage.ID
+  readonly agent: Agent.ID
+  readonly model: Model.Ref
 }
 
 export function isRetryable(error: AIError) {
@@ -55,22 +60,46 @@ const retryAfter = (input: Input) => {
   return undefined
 }
 
-export const schedule = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
-  Schedule.max([Schedule.exponential("2 seconds"), Schedule.recurs(4)]).pipe(
-    Schedule.jittered,
-    Schedule.setInputType<Input>(),
-    Schedule.modifyDelay(({ input, duration: delay }) => {
-      const minimum = retryAfter(input)
-      const duration = minimum === undefined ? delay : Duration.max(delay, Duration.millis(minimum))
-      return Effect.succeed(Duration.millis(Math.ceil(Duration.toMillis(duration))))
-    }),
-    Schedule.tap((metadata) =>
-      bus.publish(SessionEvent.RetryScheduled, {
-        sessionID,
-        assistantMessageID: metadata.input.assistantMessageID,
-        attempt: metadata.attempt + 1,
-        at: metadata.now + Duration.toMillis(metadata.duration),
-        error: metadata.input.error,
-      }),
-    ),
-  )
+const schedule = Schedule.max([Schedule.exponential("2 seconds"), Schedule.recurs(4)]).pipe(
+  Schedule.jittered,
+  Schedule.setInputType<Input>(),
+  Schedule.modifyDelay(({ input, duration: delay }) => {
+    const minimum = retryAfter(input)
+    const duration = minimum === undefined ? delay : Duration.max(delay, Duration.millis(minimum))
+    return Effect.succeed(Duration.millis(Math.ceil(Duration.toMillis(duration))))
+  }),
+)
+
+export const make = (bus: Bus.Interface, hooks: PluginHooks.Interface, sessionID: SessionSchema.ID) =>
+  Effect.gen(function* () {
+    const step = yield* Schedule.toStep(schedule)
+    let attempt = 0
+    return (input: Input) =>
+      Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis
+        const [, duration] = yield* step(now, input)
+        attempt++
+        const delay = Math.ceil(Duration.toMillis(duration))
+        const event: PluginHooks.Domains["session"]["retry"] = {
+          sessionID,
+          agent: input.agent,
+          model: input.model,
+          error: input.error,
+          attempt,
+          decision: { retry: true, delay },
+        }
+        yield* hooks.trigger("session", "retry", event)
+        if (!event.decision.retry) return yield* Cause.done()
+        const normalized =
+          Number.isFinite(event.decision.delay) && event.decision.delay >= 0 ? Math.ceil(event.decision.delay) : delay
+        const scheduled = yield* Clock.currentTimeMillis
+        yield* bus.publish(SessionEvent.RetryScheduled, {
+          sessionID,
+          assistantMessageID: input.assistantMessageID,
+          attempt,
+          at: scheduled + normalized,
+          error: input.error,
+        })
+        yield* Effect.sleep(Duration.millis(normalized))
+      })
+  })

--- a/packages/core/src/session/runner/step.ts
+++ b/packages/core/src/session/runner/step.ts
@@ -31,8 +31,11 @@ import { SessionRunnerRetry } from "./retry.js"
 
 export type Outcome = Data.TaggedEnum<{
   Completed: { readonly needsContinuation: boolean }
-  Retry: { readonly cause: AIError; readonly error: SessionError.Error }
-  Continue: { readonly cause: AIError; readonly error: SessionError.Error }
+  Retry: { readonly error: SessionError.Error; readonly decision: SessionRunnerRetry.Decision }
+  Continue: {
+    readonly error: SessionError.Error
+    readonly decision: SessionRunnerRetry.Decision
+  }
   RecoverFull: {}
   Compacted: {}
 }>
@@ -44,6 +47,11 @@ interface Input {
   readonly agent: Agent.ID
   readonly model: SessionRunnerModel.Resolved
   readonly prepared: SessionModelRequest.Prepared
+  readonly retry: (
+    cause: AIError,
+    error: SessionError.Error,
+    retry: boolean,
+  ) => Effect.Effect<{ readonly retry: false } | SessionRunnerRetry.Decision>
   readonly recoverContinuation: boolean
   /** The runner owns compaction policy; the attempt invokes it only before durable output. */
   readonly recoverOverflow: Effect.Effect<boolean>
@@ -161,10 +169,21 @@ export const make = Effect.gen(function* () {
           !recorded.outputStarted
         )
           return Outcome.RecoverFull()
-        if (llmFailure && llmError && SessionRunnerRetry.isRetryable(llmFailure) && !recorded.outputStarted) {
+        const retry =
+          llmFailure && llmError && !isContextOverflowFailure(llmFailure)
+            ? yield* restore(
+                input.retry(
+                  llmFailure,
+                  llmError,
+                  SessionRunnerRetry.isRetryable(llmFailure) ||
+                    (recorded.outputStarted && isInterruptedStream(llmFailure)),
+                ),
+              )
+            : undefined
+        if (llmFailure && llmError && retry?.retry && !recorded.outputStarted) {
           // Retry state projects onto the existing assistant, even before it has produced output.
           yield* publisher.startAssistant()
-          return Outcome.Retry({ cause: llmFailure, error: llmError })
+          return Outcome.Retry({ error: llmError, decision: retry })
         }
         if (llmError) yield* publisher.failAssistant(llmError)
 
@@ -221,20 +240,15 @@ export const make = Effect.gen(function* () {
             })
         }
 
-        // After durable output, recovery continues instead of replaying: the
-        // partial assistant message is already persisted history. Any failure
-        // the pre-output gate would retry is continued here, plus interrupted
-        // streams, whose read failures may carry delivery states the retry
-        // policy rejects for full resends.
         if (
           llmFailure &&
           llmError &&
-          (isInterruptedStream(llmFailure) || SessionRunnerRetry.isRetryable(llmFailure)) &&
+          retry?.retry &&
           record.outputStarted &&
           tools.declines.length === 0 &&
           !tools.interrupted
         )
-          return Outcome.Continue({ cause: llmFailure, error: llmError })
+          return Outcome.Continue({ error: llmError, decision: retry })
 
         if (Exit.isFailure(stream)) return yield* Effect.failCause(stream.cause)
         if (tools.declines.length > 0) return yield* Effect.interrupt

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -4357,9 +4357,14 @@ describe("SessionRunnerLLM", () => {
     yield* s.admit("Retry transport")
     yield* s.llm.push(Stream.fail(providerUnavailable()))
     yield* s.llm.push(TestLLM.text("Recovered", "retry-success"))
+    const scheduled = yield* s.bus.subscribe(SessionEvent.RetryScheduled).pipe(
+      Stream.filter((event) => event.data.sessionID === sessionID),
+      Stream.runHead,
+      Effect.forkScoped({ startImmediately: true }),
+    )
 
     const run = yield* s.resume.pipe(Effect.forkChild)
-    yield* s.llm.wait(1)
+    yield* Fiber.join(scheduled)
     yield* TestClock.adjust("1599 millis")
     expect(s.requests).toHaveLength(1)
     yield* TestClock.adjust("801 millis")
@@ -4395,7 +4400,7 @@ describe("SessionRunnerLLM", () => {
       agent: "build",
       model: { providerID: "fake", id: "fake-model" },
       error: { type: "provider.transport", message: "Provider unavailable" },
-      attempt: 1,
+      attempt: 2,
       decision: { retry: false },
     })
     expect(yield* recordedEventTypes(sessionID)).not.toContain("session.retry.scheduled.1")
@@ -4415,9 +4420,14 @@ describe("SessionRunnerLLM", () => {
     )
     yield* s.admit("Use custom retry delay")
     yield* s.llm.push(Stream.fail(providerUnavailable()), TestLLM.text("Recovered", "hook-delay-success"))
+    const scheduled = yield* s.bus.subscribe(SessionEvent.RetryScheduled).pipe(
+      Stream.filter((event) => event.data.sessionID === sessionID),
+      Stream.runHead,
+      Effect.forkScoped({ startImmediately: true }),
+    )
 
     const run = yield* s.resume.pipe(Effect.forkChild)
-    yield* s.llm.wait(1)
+    yield* Fiber.join(scheduled)
     yield* TestClock.adjust("4999 millis")
     expect(s.requests).toHaveLength(1)
     yield* TestClock.adjust("1 millis")

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -552,6 +552,7 @@ const setup = Effect.gen(function* () {
     admit,
     resume,
     context: session.context(sessionID),
+    hooks,
     messages: session.messages({ sessionID }),
     inbox: session.inbox(sessionID),
     runPrompt: Effect.fnUntraced(function* (text: string) {
@@ -4374,6 +4375,57 @@ describe("SessionRunnerLLM", () => {
     ])
     yield* replaySessionProjection(sessionID)
     expect((yield* s.context).filter((message) => message.type === "assistant")).toHaveLength(1)
+  })
+
+  scenario("allows session retry hooks to veto a proposed retry", function* (s) {
+    const failure = providerUnavailable()
+    let observed: PluginHooks.Domains["session"]["retry"] | undefined
+    yield* s.hooks.register("session", "retry", (event) =>
+      Effect.sync(() => {
+        observed = event
+        event.decision = { retry: false }
+      }),
+    )
+    yield* s.llm.push(Stream.fail(failure))
+
+    expect(yield* s.runPrompt("Do not retry transport").pipe(Effect.flip)).toBe(failure)
+    expect(s.requests).toHaveLength(1)
+    expect(observed).toMatchObject({
+      sessionID,
+      agent: "build",
+      model: { providerID: "fake", id: "fake-model" },
+      error: { type: "provider.transport", message: "Provider unavailable" },
+      attempt: 1,
+      decision: { retry: false },
+    })
+    expect(yield* recordedEventTypes(sessionID)).not.toContain("session.retry.scheduled.1")
+  })
+
+  scenario("uses the final session retry hook delay", function* (s) {
+    yield* s.hooks.register("session", "retry", (event) =>
+      Effect.sync(() => {
+        event.decision = { retry: true, delay: 10_000 }
+      }),
+    )
+    yield* s.hooks.register("session", "retry", (event) =>
+      Effect.sync(() => {
+        expect(event.decision).toEqual({ retry: true, delay: 10_000 })
+        event.decision = { retry: true, delay: 5_000 }
+      }),
+    )
+    yield* s.admit("Use custom retry delay")
+    yield* s.llm.push(Stream.fail(providerUnavailable()), TestLLM.text("Recovered", "hook-delay-success"))
+
+    const run = yield* s.resume.pipe(Effect.forkChild)
+    yield* s.llm.wait(1)
+    yield* TestClock.adjust("4999 millis")
+    expect(s.requests).toHaveLength(1)
+    yield* TestClock.adjust("1 millis")
+    yield* Fiber.join(run)
+
+    expect(s.requests).toHaveLength(2)
+    const assistant = requireAssistant(yield* s.context)
+    expect(assistant.retry).toBeUndefined()
   })
 
   scenario("does not start another physical attempt after interruption during retry backoff", function* (s) {

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -4406,6 +4406,25 @@ describe("SessionRunnerLLM", () => {
     expect(yield* recordedEventTypes(sessionID)).not.toContain("session.retry.scheduled.1")
   })
 
+  scenario("allows session retry hooks to retry a terminal provider failure", function* (s) {
+    yield* s.hooks.register("session", "retry", (event) =>
+      Effect.sync(() => {
+        expect(event.decision).toEqual({ retry: false })
+        event.decision = { retry: true, delay: 0 }
+      }),
+    )
+    yield* s.admit("Retry invalid request")
+    yield* s.llm.push(Stream.fail(invalidRequest()), TestLLM.text("Recovered", "forced-retry-success"))
+
+    yield* s.resume
+
+    expect(s.requests).toHaveLength(2)
+    expect(yield* s.context).toMatchObject([
+      Expected.user("Retry invalid request"),
+      Expected.assistant({ finish: "stop" }, [Expected.text("Recovered")]),
+    ])
+  })
+
   scenario("uses the final session retry hook delay", function* (s) {
     yield* s.hooks.register("session", "retry", (event) =>
       Effect.sync(() => {

--- a/packages/core/test/session-step.test.ts
+++ b/packages/core/test/session-step.test.ts
@@ -114,6 +114,8 @@ for (const fixture of [
                 return { content: "Completed tool" }
               }),
           },
+          retry: (_cause, _error, retry) =>
+            Effect.succeed(retry ? { retry: true, attempt: 2, delay: 0 } : { retry: false }),
           recoverContinuation: true,
           recoverOverflow: Effect.succeed(false),
         })

--- a/packages/core/test/session-step.test.ts
+++ b/packages/core/test/session-step.test.ts
@@ -105,6 +105,7 @@ for (const fixture of [
           agent: Agent.defaultID,
           model,
           prepared: {
+            retry: () => Effect.void,
             request: LLM.request({ model: model.model, prompt: "Run one tool", toolChoice: fixture.toolChoice }),
             options: {},
             executeTool: () =>

--- a/packages/plugin/src/README.md
+++ b/packages/plugin/src/README.md
@@ -103,7 +103,7 @@ await ctx.session.hook("context", (event) => {
 })
 
 await ctx.session.hook("retry", (event) => {
-  if (event.attempt >= 2) event.decision = { retry: false }
+  if (event.attempt >= 3) event.decision = { retry: false }
 })
 ```
 

--- a/packages/plugin/src/README.md
+++ b/packages/plugin/src/README.md
@@ -101,6 +101,10 @@ await ctx.session.hook("context", (event) => {
   event.tools.read.description = "Read a file using narrow line ranges."
   delete event.tools.write
 })
+
+await ctx.session.hook("retry", (event) => {
+  if (event.attempt >= 2) event.decision = { retry: false }
+})
 ```
 
 Promise tools use complete executable tool values with async executors:

--- a/packages/plugin/src/effect/README.md
+++ b/packages/plugin/src/effect/README.md
@@ -102,7 +102,7 @@ yield *
 yield *
   ctx.session.hook("retry", (event) =>
     Effect.sync(() => {
-      if (event.attempt >= 2) event.decision = { retry: false }
+      if (event.attempt >= 3) event.decision = { retry: false }
     }),
   )
 ```

--- a/packages/plugin/src/effect/README.md
+++ b/packages/plugin/src/effect/README.md
@@ -98,6 +98,13 @@ yield *
       delete event.tools.write
     }),
   )
+
+yield *
+  ctx.session.hook("retry", (event) =>
+    Effect.sync(() => {
+      if (event.attempt >= 2) event.decision = { retry: false }
+    }),
+  )
 ```
 
 ## Reloading A Domain

--- a/packages/plugin/src/effect/session.ts
+++ b/packages/plugin/src/effect/session.ts
@@ -5,6 +5,7 @@ import type { Model } from "@opencode-ai/schema/model"
 import type { PromptInput } from "@opencode-ai/schema/prompt-input"
 import type { Session } from "@opencode-ai/schema/session"
 import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
+import type { SessionError } from "@opencode-ai/schema/session-error"
 import type { SessionMessage } from "@opencode-ai/schema/session-message"
 import type { JsonSchema, Types } from "effect"
 import type { ModelHooks } from "./registration.js"
@@ -52,12 +53,24 @@ export interface SessionHttpResponse {
   response: Response
 }
 
+export type SessionRetryDecision = { retry: false } | { retry: true; delay: number }
+
+export interface SessionRetry {
+  readonly sessionID: Session.ID
+  readonly agent: Agent.ID
+  readonly model: Model.Ref
+  readonly error: SessionError.Error
+  readonly attempt: number
+  decision: SessionRetryDecision
+}
+
 export interface SessionHooks {
   readonly prompt: SessionPrompt
   readonly context: SessionContext
   readonly "model.request": SessionModelRequest
   readonly "http.request": SessionHttpRequest
   readonly "http.response": SessionHttpResponse
+  readonly retry: SessionRetry
 }
 
 export type SessionDomain = Pick<

--- a/packages/plugin/src/promise/session.ts
+++ b/packages/plugin/src/promise/session.ts
@@ -5,6 +5,7 @@ import type { Model } from "@opencode-ai/schema/model"
 import type { PromptInput } from "@opencode-ai/schema/prompt-input"
 import type { Session } from "@opencode-ai/schema/session"
 import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
+import type { SessionError } from "@opencode-ai/schema/session-error"
 import type { SessionMessage } from "@opencode-ai/schema/session-message"
 import type { JsonSchema, Types } from "effect"
 import type { ModelHooks } from "./registration.js"
@@ -52,12 +53,24 @@ export interface SessionHttpResponse {
   response: Response
 }
 
+export type SessionRetryDecision = { retry: false } | { retry: true; delay: number }
+
+export interface SessionRetry {
+  readonly sessionID: Session.ID
+  readonly agent: Agent.ID
+  readonly model: Model.Ref
+  readonly error: SessionError.Error
+  readonly attempt: number
+  decision: SessionRetryDecision
+}
+
 export interface SessionHooks {
   readonly prompt: SessionPrompt
   readonly context: SessionContext
   readonly "model.request": SessionModelRequest
   readonly "http.request": SessionHttpRequest
   readonly "http.response": SessionHttpResponse
+  readonly retry: SessionRetry
 }
 
 export type SessionDomain = Pick<

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -1128,9 +1128,9 @@ effect: (ctx) =>
   }),
 ```
 
-Veto a proposed Session retry or replace its delay in milliseconds. The hook runs after OpenCode classifies the failure
-and computes its backoff, but before the retry is scheduled. It does not expose whether OpenCode internally replays or
-continues the request.
+Override the retry decision for a provider failure or replace its delay in milliseconds. The hook runs after OpenCode
+classifies the failure and proposes its policy, but before any retry is scheduled. It does not expose how OpenCode
+internally performs the next attempt.
 
 ```ts
 effect: (ctx) =>
@@ -1141,16 +1141,21 @@ effect: (ctx) =>
           event.decision = { retry: true, delay: 10_000 }
           return
         }
+        if (event.error.type === "provider.invalid-request" && event.attempt === 2) {
+          event.decision = { retry: true, delay: 0 }
+          return
+        }
         if (event.attempt >= 3) event.decision = { retry: false }
       }),
     )
   }),
 ```
 
-The hook runs only for retries proposed by OpenCode; it cannot make a normally terminal failure retryable. Multiple hooks
-run in registration order and later hooks see the current `decision`. The built-in maximum attempt count remains a hard
-limit. `attempt` is the physical attempt being proposed; the initial request is attempt `1`, so the first retry is attempt
-`2`. Invalid delays (`NaN`, infinity, or negative values) fall back to the computed delay.
+The initial `decision` is OpenCode's policy, so hooks may make a normally terminal provider failure retryable or veto a
+proposed retry. Multiple hooks run in registration order and later hooks see the current decision. The built-in maximum
+attempt count remains a hard limit. `attempt` is the physical attempt being proposed; the initial request is attempt `1`,
+so the first retry is attempt `2`. Invalid delays (`NaN`, infinity, or negative values) fall back to the computed delay.
+Context-overflow recovery remains separate because it compacts the conversation instead of retrying the same request.
 
 #### Reference
 

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -1141,7 +1141,7 @@ effect: (ctx) =>
           event.decision = { retry: true, delay: 10_000 }
           return
         }
-        if (event.attempt >= 2) event.decision = { retry: false }
+        if (event.attempt >= 3) event.decision = { retry: false }
       }),
     )
   }),
@@ -1149,8 +1149,8 @@ effect: (ctx) =>
 
 The hook runs only for retries proposed by OpenCode; it cannot make a normally terminal failure retryable. Multiple hooks
 run in registration order and later hooks see the current `decision`. The built-in maximum attempt count remains a hard
-limit. `attempt` is the proposed retry number, starting at `1`. Invalid delays (`NaN`, infinity, or negative values) fall
-back to the computed delay.
+limit. `attempt` is the physical attempt being proposed; the initial request is attempt `1`, so the first retry is attempt
+`2`. Invalid delays (`NaN`, infinity, or negative values) fall back to the computed delay.
 
 #### Reference
 

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -1128,6 +1128,30 @@ effect: (ctx) =>
   }),
 ```
 
+Veto a proposed Session retry or replace its delay in milliseconds. The hook runs after OpenCode classifies the failure
+and computes its backoff, but before the retry is scheduled. It does not expose whether OpenCode internally replays or
+continues the request.
+
+```ts
+effect: (ctx) =>
+  Effect.gen(function* () {
+    yield* ctx.session.hook("retry", (event) =>
+      Effect.sync(() => {
+        if (event.error.status === 429) {
+          event.decision = { retry: true, delay: 10_000 }
+          return
+        }
+        if (event.attempt >= 2) event.decision = { retry: false }
+      }),
+    )
+  }),
+```
+
+The hook runs only for retries proposed by OpenCode; it cannot make a normally terminal failure retryable. Multiple hooks
+run in registration order and later hooks see the current `decision`. The built-in maximum attempt count remains a hard
+limit. `attempt` is the proposed retry number, starting at `1`. Invalid delays (`NaN`, infinity, or negative values) fall
+back to the computed delay.
+
 #### Reference
 
 ```ts
@@ -1136,6 +1160,18 @@ interface SessionHooks {
   readonly "model.request": SessionModelRequest
   readonly "http.request": SessionHttpRequest
   readonly "http.response": SessionHttpResponse
+  readonly retry: SessionRetry
+}
+
+type RetryDecision = { retry: false } | { retry: true; delay: number }
+
+interface SessionRetry {
+  readonly sessionID: string
+  readonly agent: string
+  readonly model: { providerID: string; id: string; variant?: string }
+  readonly error: { type: string; message: string; status?: number }
+  readonly attempt: number
+  decision: RetryDecision
 }
 
 interface SessionHookDomain {

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -1114,14 +1114,14 @@ await ctx.session.hook("retry", (event) => {
     event.decision = { retry: true, delay: 10_000 }
     return
   }
-  if (event.attempt >= 2) event.decision = { retry: false }
+  if (event.attempt >= 3) event.decision = { retry: false }
 })
 ```
 
 The hook runs only for retries proposed by OpenCode; it cannot make a normally terminal failure retryable. Multiple hooks
 run in registration order and later hooks see the current `decision`. The built-in maximum attempt count remains a hard
-limit. `attempt` is the proposed retry number, starting at `1`. Invalid delays (`NaN`, infinity, or negative values) fall
-back to the computed delay.
+limit. `attempt` is the physical attempt being proposed; the initial request is attempt `1`, so the first retry is attempt
+`2`. Invalid delays (`NaN`, infinity, or negative values) fall back to the computed delay.
 
 #### Reference
 

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -1104,9 +1104,9 @@ await ctx.session.hook("http.response", (event) => {
 })
 ```
 
-Veto a proposed Session retry or replace its delay in milliseconds. The hook runs after OpenCode classifies the failure
-and computes its backoff, but before the retry is scheduled. It does not expose whether OpenCode internally replays or
-continues the request.
+Override the retry decision for a provider failure or replace its delay in milliseconds. The hook runs after OpenCode
+classifies the failure and proposes its policy, but before any retry is scheduled. It does not expose how OpenCode
+internally performs the next attempt.
 
 ```ts
 await ctx.session.hook("retry", (event) => {
@@ -1114,14 +1114,19 @@ await ctx.session.hook("retry", (event) => {
     event.decision = { retry: true, delay: 10_000 }
     return
   }
+  if (event.error.type === "provider.invalid-request" && event.attempt === 2) {
+    event.decision = { retry: true, delay: 0 }
+    return
+  }
   if (event.attempt >= 3) event.decision = { retry: false }
 })
 ```
 
-The hook runs only for retries proposed by OpenCode; it cannot make a normally terminal failure retryable. Multiple hooks
-run in registration order and later hooks see the current `decision`. The built-in maximum attempt count remains a hard
-limit. `attempt` is the physical attempt being proposed; the initial request is attempt `1`, so the first retry is attempt
-`2`. Invalid delays (`NaN`, infinity, or negative values) fall back to the computed delay.
+The initial `decision` is OpenCode's policy, so hooks may make a normally terminal provider failure retryable or veto a
+proposed retry. Multiple hooks run in registration order and later hooks see the current decision. The built-in maximum
+attempt count remains a hard limit. `attempt` is the physical attempt being proposed; the initial request is attempt `1`,
+so the first retry is attempt `2`. Invalid delays (`NaN`, infinity, or negative values) fall back to the computed delay.
+Context-overflow recovery remains separate because it compacts the conversation instead of retrying the same request.
 
 #### Reference
 

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -1104,6 +1104,25 @@ await ctx.session.hook("http.response", (event) => {
 })
 ```
 
+Veto a proposed Session retry or replace its delay in milliseconds. The hook runs after OpenCode classifies the failure
+and computes its backoff, but before the retry is scheduled. It does not expose whether OpenCode internally replays or
+continues the request.
+
+```ts
+await ctx.session.hook("retry", (event) => {
+  if (event.error.status === 429) {
+    event.decision = { retry: true, delay: 10_000 }
+    return
+  }
+  if (event.attempt >= 2) event.decision = { retry: false }
+})
+```
+
+The hook runs only for retries proposed by OpenCode; it cannot make a normally terminal failure retryable. Multiple hooks
+run in registration order and later hooks see the current `decision`. The built-in maximum attempt count remains a hard
+limit. `attempt` is the proposed retry number, starting at `1`. Invalid delays (`NaN`, infinity, or negative values) fall
+back to the computed delay.
+
 #### Reference
 
 ```ts
@@ -1115,6 +1134,18 @@ interface SessionHooks {
   "model.request": SessionModelRequestHook
   "http.request": SessionHttpRequestHook
   "http.response": SessionHttpResponseHook
+  retry: SessionRetryHook
+}
+
+type RetryDecision = { retry: false } | { retry: true; delay: number }
+
+interface SessionRetryHook {
+  readonly sessionID: string
+  readonly agent: string
+  readonly model: { providerID: string; id: string; variant?: string }
+  readonly error: { type: string; message: string; status?: number }
+  readonly attempt: number
+  decision: RetryDecision
 }
 
 interface SessionContextHook {


### PR DESCRIPTION
## Summary
Add a public `session.retry` plugin hook as the final policy decision for provider failures, without exposing the runner's internal recovery mechanism.

```ts
await ctx.session.hook("retry", (event) => {
  if (event.error.status === 429) {
    event.decision = { retry: true, delay: 10_000 }
    return
  }
  if (event.error.type === "provider.invalid-request" && event.attempt === 2) {
    event.decision = { retry: true, delay: 0 }
    return
  }
  if (event.attempt >= 3) event.decision = { retry: false }
})
```

The hook receives stable Session context (`sessionID`, agent, model, projected Session error, and the physical attempt being proposed) plus a discriminated decision:

```ts
type SessionRetryDecision =
  | { retry: false }
  | { retry: true; delay: number }
```

- Core initializes `decision` from its built-in retry classification and backoff. Plugins can veto a proposed retry or force a normally terminal provider failure to retry.
- The hook runs before `session.retry.scheduled`; the final delay drives both the durable `at` deadline/UI countdown and actual sleep.
- Hooks run sequentially, so later hooks see and may replace the current decision. Provider scoping uses the event's model reference.
- The initial request is attempt 1 and the first retry is attempt 2, preserving existing durable event semantics.
- The existing five-attempt ceiling is outside plugin control and remains a hard safety bound. Context-overflow compaction remains separate.
- Invalid delays (negative or non-finite) fall back to Core's computed delay.
- The hook does not expose replay/continuation mechanics, so its contract remains valid if recovery implementation changes.

## Verification
- Runner scenarios cover vetoing a transient retry, forcing a terminal failure to retry, sequential delay overrides, durable deadlines, and the existing retry ceiling.
- Full isolated Core suite: 3789 pass / 39 skip / 0 fail.
- Core and plugin typechecks pass; plugin tests: 5 pass / 0 fail.
- Documentation Astro check reports 0 errors/warnings/hints; formatting and diff checks pass.
