### PR TITLE
feat(tui): add annotation-mode overlay with entrance roll and live tuner

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -46,6 +46,14 @@ import { DialogProvider, useDialog } from "./ui/dialog"
 import { DialogIntegration } from "./component/dialog-integration"
 import { ErrorComponent } from "./component/error-component"
 import { PluginRouteMissing } from "./component/plugin-route-missing"
+import {
+  SHIMMER_CONTROLS,
+  SHIMMER_DEFAULTS,
+  ShimmerOverlay,
+  ShimmerTuner,
+  type ShimmerOverlayRenderable,
+  type ShimmerParams,
+} from "./component/shimmer-overlay"
 import { EditorContextProvider } from "./context/editor"
 import { useEvent } from "./context/event"
 import { ClientProvider, useClient } from "./context/client"
@@ -571,6 +579,50 @@ function App(props: { pair?: DialogPairCredentials }) {
   )
   onCleanup(() => {
     offSelectionKeys()
+  })
+
+  // Shimmer tuner: Ctrl+R toggles the panel; while it is open, ↑/↓ select a control and
+  // ←/→ adjust it (shift = ×5 steps), esc closes. All other keys pass through untouched.
+  const offRippleKey = keymap.intercept(
+    "key",
+    ({ event }) => {
+      const consume = () => {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+      if (event.ctrl && (event.name === "r" || event.name === "R")) {
+        setShimmerPanel((open) => !open)
+        consume()
+        return true
+      }
+      if (!shimmerPanel()) return false
+      if (event.name === "escape") {
+        setShimmerPanel(false)
+        consume()
+        return true
+      }
+      if (event.name === "up" || event.name === "down") {
+        const delta = event.name === "down" ? 1 : -1
+        setShimmerSelected((index) => (index + delta + SHIMMER_CONTROLS.length) % SHIMMER_CONTROLS.length)
+        consume()
+        return true
+      }
+      if (event.name === "left" || event.name === "right") {
+        const control = SHIMMER_CONTROLS[shimmerSelected()]
+        const step = control.step * (event.shift ? 5 : 1) * (event.name === "right" ? 1 : -1)
+        const next = { ...shimmerParams() }
+        next[control.key] = Math.min(control.max, Math.max(control.min, next[control.key] + step))
+        setShimmerParams(next)
+        shimmerOverlay?.setParams(next)
+        consume()
+        return true
+      }
+      return false
+    },
+    { priority: 102 },
+  )
+  onCleanup(() => {
+    offRippleKey()
   })
 
   // Wire up console copy-to-clipboard via opentui's onCopySelection callback
@@ -1270,6 +1322,14 @@ function App(props: { pair?: DialogPairCredentials }) {
     if (reconnectTimer) clearTimeout(reconnectTimer)
   })
 
+  // Annotation-mode overlay: a single custom renderable that paints per-cell translucent
+  // backgrounds directly into the frame buffer (see component/shimmer-overlay.tsx). Enabling
+  // it rolls a low-opacity sheet diagonally over the app; Ctrl+R opens a tuner panel whose
+  // arrows select and adjust parameters live.
+  let shimmerOverlay: ShimmerOverlayRenderable | undefined
+  const [shimmerPanel, setShimmerPanel] = createSignal(false)
+  const [shimmerSelected, setShimmerSelected] = createSignal(0)
+  const [shimmerParams, setShimmerParams] = createSignal<ShimmerParams>({ ...SHIMMER_DEFAULTS })
   return (
     <box
       width={dimensions().width}
@@ -1387,6 +1447,12 @@ function App(props: { pair?: DialogPairCredentials }) {
       </Show>
       <MigrationOverlay />
       <Toast />
+      <ShimmerOverlay
+        ref={(renderable) => (shimmerOverlay = renderable)}
+        width={dimensions().width}
+        height={dimensions().height}
+      />
+      <ShimmerTuner open={shimmerPanel()} selected={shimmerSelected()} params={shimmerParams()} />
     </box>
   )
 }

--- a/packages/tui/src/component/shimmer-overlay.tsx
+++ b/packages/tui/src/component/shimmer-overlay.tsx
@@ -1,0 +1,187 @@
+import { OptimizedBuffer, Renderable, RGBA, type RenderableOptions, type RenderContext } from "@opentui/core"
+import { extend } from "@opentui/solid"
+import { For, Show } from "solid-js"
+
+export type ShimmerParams = {
+  enabled: number
+  strength: number
+  band: number
+  fold: number
+  duration: number
+  red: number
+  green: number
+  blue: number
+}
+
+export const SHIMMER_DEFAULTS: ShimmerParams = {
+  enabled: 1,
+  strength: 0.08,
+  band: 8,
+  fold: 0.08,
+  duration: 600,
+  red: 150,
+  green: 190,
+  blue: 255,
+}
+
+export const SHIMMER_CONTROLS: {
+  key: keyof ShimmerParams
+  label: string
+  min: number
+  max: number
+  step: number
+  digits: number
+}[] = [
+  { key: "enabled", label: "Enabled", min: 0, max: 1, step: 1, digits: 0 },
+  { key: "strength", label: "Strength", min: 0, max: 0.5, step: 0.01, digits: 2 },
+  { key: "band", label: "Band", min: 2, max: 24, step: 1, digits: 0 },
+  { key: "fold", label: "Fold", min: 0, max: 0.3, step: 0.01, digits: 2 },
+  { key: "duration", label: "Duration", min: 200, max: 1500, step: 50, digits: 0 },
+  { key: "red", label: "Red", min: 0, max: 255, step: 5, digits: 0 },
+  { key: "green", label: "Green", min: 0, max: 255, step: 5, digits: 0 },
+  { key: "blue", label: "Blue", min: 0, max: 255, step: 5, digits: 0 },
+]
+
+// Annotation-mode overlay drawn directly into the frame buffer: one renderable, no per-cell
+// layout nodes or signals. Steady state is a constant very-low-opacity tint across the whole
+// app. Enabling it plays an entrance: the tint rolls diagonally onto the screen from the
+// top-left like a sheet settling over the UI, its leading edge a soft band that dissolves
+// into nothing, optionally with a faint brighter "fold" line riding the curl. Disabling is
+// instant. Once settled the renderable stops driving frames and just paints the flat tint
+// whenever the app renders anyway.
+export class ShimmerOverlayRenderable extends Renderable {
+  private elapsed = 0
+  private params: ShimmerParams = { ...SHIMMER_DEFAULTS }
+  private scratch = RGBA.fromInts(SHIMMER_DEFAULTS.red, SHIMMER_DEFAULTS.green, SHIMMER_DEFAULTS.blue, 0)
+
+  constructor(ctx: RenderContext, options: RenderableOptions<ShimmerOverlayRenderable>) {
+    super(ctx, { ...options, live: SHIMMER_DEFAULTS.enabled >= 0.5 })
+  }
+
+  setParams(value: ShimmerParams) {
+    const wasEnabled = this.params.enabled >= 0.5
+    const enabled = value.enabled >= 0.5
+    this.params = value
+    this.scratch = RGBA.fromInts(value.red, value.green, value.blue, 0)
+    // Re-enabling replays the entrance roll; disabling is instant.
+    if (enabled && !wasEnabled) {
+      this.elapsed = 0
+      this.live = true
+    }
+    if (!enabled) this.live = false
+    this.requestRender()
+  }
+
+  protected override onUpdate(deltaTime: number): void {
+    if (!this.live) return
+    this.elapsed += deltaTime
+    // Settled: stop driving frames; renderSelf keeps painting the flat tint on normal renders.
+    if (this.elapsed >= this.params.duration) this.live = false
+  }
+
+  protected override renderSelf(buffer: OptimizedBuffer): void {
+    const p = this.params
+    if (p.enabled < 0.5 || !this.visible || this.isDestroyed || this.width <= 0 || this.height <= 0) return
+    const settled = this.elapsed >= p.duration
+    // Settled fast path: one flat translucent sheet, no per-cell math.
+    if (settled) {
+      this.scratch.a = p.strength
+      buffer.fillRect(this.screenX, this.screenY, this.width, this.height, this.scratch)
+      return
+    }
+    // Diagonal roll: cells are ordered by i + 2j (rows span ~2 columns of visual space), and
+    // the front sweeps that span with an ease-out so the sheet arrives fast and lands gently.
+    const t = Math.min(1, this.elapsed / p.duration)
+    const eased = 1 - (1 - t) * (1 - t) * (1 - t)
+    const span = this.width - 1 + (this.height - 1) * 2 + p.band
+    const front = eased * span
+    for (let j = 0; j < this.height; j++) {
+      const base = j * 2
+      for (let i = 0; i < this.width; i++) {
+        const behind = front - (i + base)
+        if (behind <= 0) continue
+        if (behind >= p.band) {
+          this.scratch.a = p.strength
+          buffer.fillRect(this.screenX + i, this.screenY + j, 1, 1, this.scratch)
+          continue
+        }
+        // Inside the leading band: tint ramps smoothly into nothing toward the front, and an
+        // optional brighter fold line rides the curl just behind the edge.
+        const r = behind / p.band
+        const ramp = r * r * (3 - 2 * r)
+        const rise = Math.min(1, r / 0.25)
+        const fall = Math.max(0, 1 - (r - 0.25) / 0.75)
+        const bump = rise * rise * (3 - 2 * rise) * fall * fall
+        const alpha = ramp * p.strength + bump * p.fold
+        if (alpha < 0.004) continue
+        this.scratch.a = alpha > 1 ? 1 : alpha
+        buffer.fillRect(this.screenX + i, this.screenY + j, 1, 1, this.scratch)
+      }
+    }
+  }
+}
+
+declare module "@opentui/solid" {
+  interface OpenTUIComponents {
+    shimmer_overlay: typeof ShimmerOverlayRenderable
+  }
+}
+
+extend({ shimmer_overlay: ShimmerOverlayRenderable })
+
+export function ShimmerOverlay(props: {
+  width: number
+  height: number
+  ref?: (renderable: ShimmerOverlayRenderable) => void
+}) {
+  return (
+    <shimmer_overlay
+      ref={props.ref}
+      position="absolute"
+      left={0}
+      top={0}
+      width={props.width}
+      height={props.height}
+      zIndex={900}
+    />
+  )
+}
+
+const BAR_WIDTH = 12
+
+function formatRow(control: (typeof SHIMMER_CONTROLS)[number], value: number, selected: boolean) {
+  const filled = Math.round(((value - control.min) / (control.max - control.min)) * BAR_WIDTH)
+  const bar = "█".repeat(Math.max(0, Math.min(BAR_WIDTH, filled))).padEnd(BAR_WIDTH, "·")
+  const display = control.key === "enabled" ? (value >= 0.5 ? "on" : "off") : value.toFixed(control.digits)
+  return `${selected ? "▸ " : "  "}${control.label.padEnd(10)}${bar} ${display}`
+}
+
+export function ShimmerTuner(props: { open: boolean; selected: number; params: ShimmerParams }) {
+  return (
+    <Show when={props.open}>
+      <box
+        position="absolute"
+        top={1}
+        left={2}
+        zIndex={1100}
+        flexDirection="column"
+        backgroundColor={RGBA.fromInts(16, 20, 30, 235)}
+        border
+        borderColor={RGBA.fromInts(90, 130, 200)}
+        title="annotation overlay"
+        paddingLeft={1}
+        paddingRight={1}
+      >
+        <For each={SHIMMER_CONTROLS}>
+          {(control, index) => (
+            <text
+              fg={index() === props.selected ? RGBA.fromInts(255, 255, 255) : RGBA.fromInts(150, 160, 180)}
+              content={formatRow(control, props.params[control.key], index() === props.selected)}
+            />
+          )}
+        </For>
+        <text fg={RGBA.fromInts(110, 120, 145)} content="↑↓ select  ←→ adjust  shift ×5  esc close" />
+      </box>
+    </Show>
+  )
+}


### PR DESCRIPTION
## What

Adds a full-screen annotation-mode overlay to the TUI plus a live tuning panel.

- **`ShimmerOverlayRenderable`** (`packages/tui/src/component/shimmer-overlay.tsx`): a custom OpenTUI renderable (same pattern as `TabPulseRenderable`) that paints per-cell translucent backgrounds directly into the frame buffer — one render-tree node, no per-cell layout nodes or signals.
- **Steady state:** a constant very-low-opacity tint (default 0.08) marking annotation mode. Settled rendering is a single full-screen `fillRect` and the renderable stops driving frames, so the resting cost is ~zero.
- **Entrance:** enabling rolls the tint diagonally over the app from the top-left like a sheet settling — ease-out front, a soft leading band (default 8 cells) that dissolves into nothing, and an optional brighter "fold" line riding the curl. Disabling is instant.
- **Tuner panel:** `Ctrl+R` toggles a panel with live controls (Enabled, Strength, Band, Fold, Duration, R/G/B). `↑/↓` select, `←/→` adjust (`Shift` = ×5), `Esc` closes. Changes apply to the running overlay immediately.

## Why

Groundwork for annotation mode: a clear, whole-screen signal that the mode is active, with an entrance that communicates the mode sliding over the app rather than popping. The tuner exists to iterate on feel live in the terminal instead of rebuilding per tweak.

## Notes

- The overlay currently defaults to enabled and `Ctrl+R` is an interim binding so the effect can be exercised; wiring to real annotation-mode state (and moving the keybind into the keymap command system) is follow-up work before this ships to users.
- Perf history for reviewers: earlier iterations rendered the effect as thousands of 1×1 reactive `<box>` nodes, which was measurably CPU-heavy; the direct-buffer renderable replaced that approach.

## Test

- `bun typecheck` passes in `packages/tui`.
- Manual: `bun run dev:live`, observe the sheet roll on at startup; `Ctrl+R`, adjust each control, toggle Enabled off/on to replay the entrance; `Esc` and confirm arrow keys return to normal app behavior.