### PR TITLE
test(core): isolate project adoption fixture

### DIFF
--- a/packages/core/test/session-create.test.ts
+++ b/packages/core/test/session-create.test.ts
@@ -67,6 +67,17 @@ const liveIt = testEffect(
     ],
   ),
 )
+const projectIt = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Database.node, Bus.node, Project.node, SessionProjector.node, SessionStore.node, Session.node]),
+    [
+      [Bus.node, Bus.configured({ persist: true })],
+      // Project adoption needs plain-prompt admission, not live plugin/provider startup.
+      [LocationServiceMap.node, promptLocationLayer],
+      [SessionExecution.node, SessionExecution.noopLayer],
+    ],
+  ),
+)
 const location = Location.Ref.make({ directory: AbsolutePath.make("/project") })
 const id = Session.ID.create()
 
@@ -119,7 +130,7 @@ describe("Session.create", () => {
     ),
   )
 
-  liveIt.live("follows the directory's project identity established after creation", () =>
+  projectIt.live("follows the directory's project identity established after creation", () =>
     withTmp((directory) =>
       Effect.gen(function* () {
         const session = yield* Session.Service


### PR DESCRIPTION
## Why

The project-identity-after-creation integration test exceeded Bun's default five-second deadline in [Windows CI](https://github.com/anomalyco/opencode/actions/runs/33199939435/job/98950295122) while validating #45822. Its two plain prompt admissions use the full live Location map, booting plugin/provider/watcher services that are not part of the project-adoption assertions.

## What Changes

Give only that case an explicit `projectIt` fixture using the existing `promptLocationLayer` for admission services. Keep real Database, Bus, Project, SessionProjector, SessionStore, and Session implementations, with durable event persistence enabled.

| Boundary | Before | After |
| --- | --- | --- |
| Git and project identity/adoption | Real implementation | Same real implementation |
| Plain prompt admission's Location services | Full live Location bootstrap | Existing admission-only fixture |
| History, pending inbox, claim, and raw-row checks | 19 assertion sites | Same body and 19 assertion sites |
| Case registration and budget | `liveIt.live`, default five seconds | `projectIt.live`, same deadline |
| Shell and clone cases | Existing live fixtures | Unchanged |

## Scope

One test file, 12 additions and one deletion. No production, dependency, CI-command, deadline, skip, acquisition, or shared-fixture changes. This is a separate baseline-test cleanup, not another change to State-pull #45822. #45970 already owns the Session UI scan issue; #45745 owns disposable acquisitions in this file. Neither is duplicated here.

## Verification

```sh
# packages/core, with isolated HOME/XDG and credential filtering
RECORD=false bun run test test/session-create.test.ts --rerun-each 10 -t "follows the directory's project identity established after creation"
RECORD=false bun run test test/session-create.test.ts test/project.test.ts test/session-prompt.test.ts
bun typecheck

# repository root
bunx prettier --check packages/core/test/session-create.test.ts
bunx ast-grep scan -c script/ast-grep/effect-simplifications/sgconfig.yml --off=unused-suppression packages/core/test/session-create.test.ts
git diff --check
```

- Baseline and changed fixture each passed 10 repetitions with 190 assertions and the normal deadline. One paired Mac observation measured 7.31 seconds before and 4.99 seconds after for the entire ten-case run, including startup/Git/cleanup; this is not a Windows benchmark or proof of the CI cause.
- Session-create, Project, and Session-prompt suites: **111 passed, 1 existing skip, 0 failed**, 355 assertions across three files.
- Core typecheck, formatting, structural scan, and whitespace checks passed.
- Normal pre-push workspace typechecking passed all **33 tasks**, without bypassing hooks.
- GitHub [typecheck](https://github.com/anomalyco/opencode/actions/runs/33204517405) and the normal [Linux/Windows unit and e2e workflow](https://github.com/anomalyco/opencode/actions/runs/33204516911) passed for `6ce6d92199`. Windows freshly executed Core with a cache miss: **3,540 passed, 293 skipped, 0 failed**, 77,526 assertions across 222 files. The project case retains its body, assertions, and default deadline; no duplicate diagnostic workflow or test-budget override was added.
- Bounded source review confirmed required admission services remain available, real project/adoption paths remain exercised, and all assertions and scope lifetimes are preserved.
- The Windows timeout was not reproduced on the Mac. The narrowed fixture is now validated by a successful actual Windows unit run; this does not establish the broader cause of the earlier CI load/deadline failures. The PR remains draft for independent review and has not been merged.
