### PR TITLE
feat(tui): add foreground shimmer via color-matrix transform with live tuner

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1455,11 +1455,16 @@ function App(props: { pair?: DialogPairCredentials }) {
       </Show>
       <MigrationOverlay />
       <Toast />
-      <ShimmerOverlay
-        ref={(renderable) => (shimmerOverlay = renderable)}
-        width={dimensions().width}
-        height={dimensions().height}
-      />
+      <Show when={shimmerParams().enabled >= 0.5}>
+        <ShimmerOverlay
+          ref={(renderable) => {
+            shimmerOverlay = renderable
+            renderable.setParams(shimmerParams())
+          }}
+          width={dimensions().width}
+          height={dimensions().height}
+        />
+      </Show>
       <ShimmerTuner open={shimmerPanel()} selected={shimmerSelected()} params={shimmerParams()} />
     </box>
   )

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -46,6 +46,14 @@ import { DialogProvider, useDialog } from "./ui/dialog"
 import { DialogIntegration } from "./component/dialog-integration"
 import { ErrorComponent } from "./component/error-component"
 import { PluginRouteMissing } from "./component/plugin-route-missing"
+import {
+  SHIMMER_CONTROLS,
+  SHIMMER_DEFAULTS,
+  ShimmerOverlay,
+  ShimmerTuner,
+  type ShimmerOverlayRenderable,
+  type ShimmerParams,
+} from "./component/shimmer-overlay"
 import { EditorContextProvider } from "./context/editor"
 import { useEvent } from "./context/event"
 import { ClientProvider, useClient } from "./context/client"
@@ -571,6 +579,50 @@ function App(props: { pair?: DialogPairCredentials }) {
   )
   onCleanup(() => {
     offSelectionKeys()
+  })
+
+  // Shimmer tuner: Ctrl+R toggles the panel; while it is open, ↑/↓ select a control and
+  // ←/→ adjust it (shift = ×5 steps), esc closes. All other keys pass through untouched.
+  const offRippleKey = keymap.intercept(
+    "key",
+    ({ event }) => {
+      const consume = () => {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+      if (event.ctrl && (event.name === "r" || event.name === "R")) {
+        setShimmerPanel((open) => !open)
+        consume()
+        return true
+      }
+      if (!shimmerPanel()) return false
+      if (event.name === "escape") {
+        setShimmerPanel(false)
+        consume()
+        return true
+      }
+      if (event.name === "up" || event.name === "down") {
+        const delta = event.name === "down" ? 1 : -1
+        setShimmerSelected((index) => (index + delta + SHIMMER_CONTROLS.length) % SHIMMER_CONTROLS.length)
+        consume()
+        return true
+      }
+      if (event.name === "left" || event.name === "right") {
+        const control = SHIMMER_CONTROLS[shimmerSelected()]
+        const step = control.step * (event.shift ? 5 : 1) * (event.name === "right" ? 1 : -1)
+        const next = { ...shimmerParams() }
+        next[control.key] = Math.min(control.max, Math.max(control.min, next[control.key] + step))
+        setShimmerParams(next)
+        shimmerOverlay?.setParams(next)
+        consume()
+        return true
+      }
+      return false
+    },
+    { priority: 102 },
+  )
+  onCleanup(() => {
+    offRippleKey()
   })
 
   // Wire up console copy-to-clipboard via opentui's onCopySelection callback
@@ -1270,6 +1322,14 @@ function App(props: { pair?: DialogPairCredentials }) {
     if (reconnectTimer) clearTimeout(reconnectTimer)
   })
 
+  // Annotation-mode overlay: a single custom renderable that paints per-cell translucent
+  // backgrounds directly into the frame buffer (see component/shimmer-overlay.tsx). Enabling
+  // it rolls a low-opacity sheet diagonally over the app; Ctrl+R opens a tuner panel whose
+  // arrows select and adjust parameters live.
+  let shimmerOverlay: ShimmerOverlayRenderable | undefined
+  const [shimmerPanel, setShimmerPanel] = createSignal(false)
+  const [shimmerSelected, setShimmerSelected] = createSignal(0)
+  const [shimmerParams, setShimmerParams] = createSignal<ShimmerParams>({ ...SHIMMER_DEFAULTS })
   return (
     <box
       width={dimensions().width}
@@ -1387,6 +1447,12 @@ function App(props: { pair?: DialogPairCredentials }) {
       </Show>
       <MigrationOverlay />
       <Toast />
+      <ShimmerOverlay
+        ref={(renderable) => (shimmerOverlay = renderable)}
+        width={dimensions().width}
+        height={dimensions().height}
+      />
+      <ShimmerTuner open={shimmerPanel()} selected={shimmerSelected()} params={shimmerParams()} />
     </box>
   )
 }

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -1322,10 +1322,10 @@ function App(props: { pair?: DialogPairCredentials }) {
     if (reconnectTimer) clearTimeout(reconnectTimer)
   })
 
-  // Annotation-mode overlay: a single custom renderable that paints per-cell translucent
-  // backgrounds directly into the frame buffer (see component/shimmer-overlay.tsx). Enabling
-  // it rolls a low-opacity sheet diagonally over the app; Ctrl+R opens a tuner panel whose
-  // arrows select and adjust parameters live.
+  // Foreground shimmer: a single custom renderable that rewrites text colors already in the
+  // frame buffer through a color matrix (see component/shimmer-overlay.tsx), so only glyphs
+  // shimmer and backgrounds stay untouched. Ctrl+R opens a tuner panel whose arrows select
+  // and adjust parameters live.
   let shimmerOverlay: ShimmerOverlayRenderable | undefined
   const [shimmerPanel, setShimmerPanel] = createSignal(false)
   const [shimmerSelected, setShimmerSelected] = createSignal(0)

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -581,8 +581,9 @@ function App(props: { pair?: DialogPairCredentials }) {
     offSelectionKeys()
   })
 
-  // Shimmer tuner: Ctrl+R toggles the panel; while it is open, ↑/↓ select a control and
-  // ←/→ adjust it (shift = ×5 steps), esc closes. All other keys pass through untouched.
+  // Shimmer keys: Ctrl+R toggles the effect itself; Ctrl+Alt+R toggles the tuner panel.
+  // While the panel is open, ↑/↓ select a control and ←/→ adjust it (shift = ×5 steps),
+  // esc closes. All other keys pass through untouched.
   const offRippleKey = keymap.intercept(
     "key",
     ({ event }) => {
@@ -591,7 +592,14 @@ function App(props: { pair?: DialogPairCredentials }) {
         event.stopPropagation()
       }
       if (event.ctrl && (event.name === "r" || event.name === "R")) {
-        setShimmerPanel((open) => !open)
+        if (event.option || event.meta) {
+          setShimmerPanel((open) => !open)
+          consume()
+          return true
+        }
+        const next = { ...shimmerParams(), enabled: shimmerParams().enabled >= 0.5 ? 0 : 1 }
+        setShimmerParams(next)
+        shimmerOverlay?.setParams(next)
         consume()
         return true
       }

--- a/packages/tui/src/component/shimmer-overlay.tsx
+++ b/packages/tui/src/component/shimmer-overlay.tsx
@@ -9,8 +9,17 @@ import {
 import { extend } from "@opentui/solid"
 import { For, Show } from "solid-js"
 
-// Clock wrap keeps phase floats small over long sessions without a visible seam.
-const CLOCK_PERIOD = 3_600_000
+// The shimmer field is precomputed once into a seamless tile; animation just slides an
+// offset into it, so steady-state frames do array lookups only (no trig). Updates are
+// throttled well below the renderer's live frame rate — ambient drift doesn't need 60fps,
+// and each skipped frame skips a whole-app render plus the terminal diff/flush.
+const TILE = 96
+const TICK_MS = 90
+// Cells per tick the pattern drifts at speed 1 (~2 columns/second).
+const DRIFT_PER_TICK = 0.18
+// Strengths quantize to this many levels so a cell's final color changes only when it
+// crosses a level, keeping the frame-to-frame terminal diff small.
+const LEVELS = 5
 
 export type ShimmerParams = {
   enabled: number
@@ -61,30 +70,61 @@ export const SHIMMER_CONTROLS: {
 // Foreground shimmer via color matrices: instead of compositing tint boxes over the app,
 // this renderable rewrites the text colors already in the frame buffer. It renders above the
 // app content, so the buffer it receives holds every glyph below it; one colorMatrix call
-// per frame pulls each cell's foreground toward the tint color, with per-cell strength given
-// by a slowly drifting three-sine interference field. TargetChannel.FG leaves backgrounds
-// untouched, so only the text shimmers. The matrix blends `keep` of the original color with
-// `1 - keep` of the tint (foreground alpha is 1, so the fourth column acts as the additive
-// tint term).
+// per update pulls each cell's foreground toward the tint color, with per-cell strength
+// sampled from the precomputed interference tile at the current drift offset.
+// TargetChannel.FG leaves backgrounds untouched, so only the text shimmers. The matrix
+// blends `keep` of the original color with `1 - keep` of the tint (foreground alpha is 1,
+// so the fourth column acts as the additive tint term).
 export class ShimmerOverlayRenderable extends Renderable {
-  private clock = 0
+  private offset = 0
   private params: ShimmerParams = { ...SHIMMER_DEFAULTS }
   private matrix = new Float32Array(16)
   private mask = new Float32Array(0)
+  private tile = new Float32Array(TILE * TILE)
+  private timer: ReturnType<typeof setInterval> | undefined
 
   constructor(ctx: RenderContext, options: RenderableOptions<ShimmerOverlayRenderable>) {
-    super(ctx, { ...options, live: SHIMMER_DEFAULTS.enabled >= 0.5 })
+    super(ctx, { ...options, live: false })
     this.rebuildMatrix()
+    this.rebuildTile()
+    this.syncTimer()
   }
 
   setParams(value: ShimmerParams) {
     // The App unmounts the overlay while disabled (so it never blocks mouse hit-testing);
     // a stale ref may point at a destroyed instance when params change while unmounted.
     if (this.isDestroyed) return
+    const previous = this.params
     this.params = value
     this.rebuildMatrix()
-    this.live = value.enabled >= 0.5
+    if (
+      value.threshold !== previous.threshold ||
+      value.softness !== previous.softness ||
+      value.density !== previous.density
+    )
+      this.rebuildTile()
+    this.syncTimer()
     this.requestRender()
+  }
+
+  private syncTimer() {
+    const active = this.params.enabled >= 0.5
+    if (active && this.timer === undefined) {
+      this.timer = setInterval(() => {
+        this.offset = (this.offset + this.params.speed * DRIFT_PER_TICK) % TILE
+        this.requestRender()
+      }, TICK_MS)
+    }
+    if (!active && this.timer !== undefined) {
+      clearInterval(this.timer)
+      this.timer = undefined
+    }
+  }
+
+  protected override destroySelf(): void {
+    if (this.timer !== undefined) clearInterval(this.timer)
+    this.timer = undefined
+    super.destroySelf()
   }
 
   private rebuildMatrix() {
@@ -102,10 +142,28 @@ export class ShimmerOverlayRenderable extends Renderable {
     this.matrix[15] = 1
   }
 
-  protected override onUpdate(deltaTime: number): void {
-    if (!this.live) return
-    // Speed scales the clock advance rather than the phase, so changing it never jumps.
-    this.clock = (this.clock + deltaTime * this.params.speed) % CLOCK_PERIOD
+  // Bake the interference field into a seamless tile: wave cycle counts are integers, so
+  // the pattern wraps with no seam and animation is a pure offset into this array.
+  private rebuildTile() {
+    const p = this.params
+    const cycles = (base: number) => Math.max(1, Math.round(base * p.density))
+    const a = cycles(3)
+    const b = cycles(2)
+    const c = cycles(1)
+    const step = (Math.PI * 2) / TILE
+    for (let y = 0; y < TILE; y++) {
+      for (let x = 0; x < TILE; x++) {
+        const field =
+          Math.sin((a * x + c * y) * step + 0.7) +
+          Math.sin((b * x - b * y) * step + 2.1) +
+          Math.sin((c * x + a * y) * step + 4.2)
+        const n = field / 6 + 0.5
+        const v = (n - p.threshold) / p.softness
+        const clamped = v <= 0 ? 0 : v >= 1 ? 1 : v
+        const shaped = clamped * clamped * (3 - 2 * clamped)
+        this.tile[y * TILE + x] = Math.round(shaped * LEVELS) / LEVELS
+      }
+    }
   }
 
   protected override renderSelf(buffer: OptimizedBuffer): void {
@@ -113,24 +171,17 @@ export class ShimmerOverlayRenderable extends Renderable {
     if (p.enabled < 0.5 || !this.visible || this.isDestroyed || this.width <= 0 || this.height <= 0) return
     if (p.strength <= 0) return
     if (this.mask.length < this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
-    const t = this.clock / 1000
-    const d = p.density
+    const ox = Math.floor(this.offset)
+    const oy = Math.floor(this.offset * 0.37)
     let count = 0
     for (let j = 0; j < this.height; j++) {
-      // One row spans ~2 columns of visual space; keep wave math in column units so the
-      // shimmer pools read as visually round instead of vertically stretched.
-      const y = j * 2
+      // One row spans ~2 columns of visual space; sampling the tile at 2j keeps the pools
+      // visually round instead of vertically stretched.
+      const row = (((j * 2 + oy) % TILE) + TILE) % TILE
+      const base = row * TILE
       for (let i = 0; i < this.width; i++) {
-        const field =
-          Math.sin((i * 0.21 + y * 0.06) * d + t * 0.5) +
-          Math.sin((i * 0.114 - y * 0.083) * d - t * 0.32) +
-          Math.sin((i * 0.07 + y * 0.117) * d + t * 0.21)
-        const n = field / 6 + 0.5
-        const v = (n - p.threshold) / p.softness
-        if (v <= 0) continue
-        const clamped = v >= 1 ? 1 : v
-        const cell = clamped * clamped * (3 - 2 * clamped)
-        if (cell < 0.02) continue
+        const cell = this.tile[base + ((((i + ox) % TILE) + TILE) % TILE)]
+        if (cell === 0) continue
         this.mask[count] = this.screenX + i
         this.mask[count + 1] = this.screenY + j
         this.mask[count + 2] = cell

--- a/packages/tui/src/component/shimmer-overlay.tsx
+++ b/packages/tui/src/component/shimmer-overlay.tsx
@@ -1,0 +1,187 @@
+import { OptimizedBuffer, Renderable, RGBA, type RenderableOptions, type RenderContext } from "@opentui/core"
+import { extend } from "@opentui/solid"
+import { For, Show } from "solid-js"
+
+export type ShimmerParams = {
+  enabled: number
+  strength: number
+  band: number
+  fold: number
+  duration: number
+  red: number
+  green: number
+  blue: number
+}
+
+export const SHIMMER_DEFAULTS: ShimmerParams = {
+  enabled: 1,
+  strength: 0.08,
+  band: 8,
+  fold: 0.08,
+  duration: 600,
+  red: 150,
+  green: 190,
+  blue: 255,
+}
+
+export const SHIMMER_CONTROLS: {
+  key: keyof ShimmerParams
+  label: string
+  min: number
+  max: number
+  step: number
+  digits: number
+}[] = [
+  { key: "enabled", label: "Enabled", min: 0, max: 1, step: 1, digits: 0 },
+  { key: "strength", label: "Strength", min: 0, max: 0.5, step: 0.01, digits: 2 },
+  { key: "band", label: "Band", min: 2, max: 24, step: 1, digits: 0 },
+  { key: "fold", label: "Fold", min: 0, max: 0.3, step: 0.01, digits: 2 },
+  { key: "duration", label: "Duration", min: 200, max: 1500, step: 50, digits: 0 },
+  { key: "red", label: "Red", min: 0, max: 255, step: 5, digits: 0 },
+  { key: "green", label: "Green", min: 0, max: 255, step: 5, digits: 0 },
+  { key: "blue", label: "Blue", min: 0, max: 255, step: 5, digits: 0 },
+]
+
+// Annotation-mode overlay drawn directly into the frame buffer: one renderable, no per-cell
+// layout nodes or signals. Steady state is a constant very-low-opacity tint across the whole
+// app. Enabling it plays an entrance: the tint rolls diagonally onto the screen from the
+// top-left like a sheet settling over the UI, its leading edge a soft band that dissolves
+// into nothing, optionally with a faint brighter "fold" line riding the curl. Disabling is
+// instant. Once settled the renderable stops driving frames and just paints the flat tint
+// whenever the app renders anyway.
+export class ShimmerOverlayRenderable extends Renderable {
+  private elapsed = 0
+  private params: ShimmerParams = { ...SHIMMER_DEFAULTS }
+  private scratch = RGBA.fromInts(SHIMMER_DEFAULTS.red, SHIMMER_DEFAULTS.green, SHIMMER_DEFAULTS.blue, 0)
+
+  constructor(ctx: RenderContext, options: RenderableOptions<ShimmerOverlayRenderable>) {
+    super(ctx, { ...options, live: SHIMMER_DEFAULTS.enabled >= 0.5 })
+  }
+
+  setParams(value: ShimmerParams) {
+    const wasEnabled = this.params.enabled >= 0.5
+    const enabled = value.enabled >= 0.5
+    this.params = value
+    this.scratch = RGBA.fromInts(value.red, value.green, value.blue, 0)
+    // Re-enabling replays the entrance roll; disabling is instant.
+    if (enabled && !wasEnabled) {
+      this.elapsed = 0
+      this.live = true
+    }
+    if (!enabled) this.live = false
+    this.requestRender()
+  }
+
+  protected override onUpdate(deltaTime: number): void {
+    if (!this.live) return
+    this.elapsed += deltaTime
+    // Settled: stop driving frames; renderSelf keeps painting the flat tint on normal renders.
+    if (this.elapsed >= this.params.duration) this.live = false
+  }
+
+  protected override renderSelf(buffer: OptimizedBuffer): void {
+    const p = this.params
+    if (p.enabled < 0.5 || !this.visible || this.isDestroyed || this.width <= 0 || this.height <= 0) return
+    const settled = this.elapsed >= p.duration
+    // Settled fast path: one flat translucent sheet, no per-cell math.
+    if (settled) {
+      this.scratch.a = p.strength
+      buffer.fillRect(this.screenX, this.screenY, this.width, this.height, this.scratch)
+      return
+    }
+    // Diagonal roll: cells are ordered by i + 2j (rows span ~2 columns of visual space), and
+    // the front sweeps that span with an ease-out so the sheet arrives fast and lands gently.
+    const t = Math.min(1, this.elapsed / p.duration)
+    const eased = 1 - (1 - t) * (1 - t) * (1 - t)
+    const span = this.width - 1 + (this.height - 1) * 2 + p.band
+    const front = eased * span
+    for (let j = 0; j < this.height; j++) {
+      const base = j * 2
+      for (let i = 0; i < this.width; i++) {
+        const behind = front - (i + base)
+        if (behind <= 0) continue
+        if (behind >= p.band) {
+          this.scratch.a = p.strength
+          buffer.fillRect(this.screenX + i, this.screenY + j, 1, 1, this.scratch)
+          continue
+        }
+        // Inside the leading band: tint ramps smoothly into nothing toward the front, and an
+        // optional brighter fold line rides the curl just behind the edge.
+        const r = behind / p.band
+        const ramp = r * r * (3 - 2 * r)
+        const rise = Math.min(1, r / 0.25)
+        const fall = Math.max(0, 1 - (r - 0.25) / 0.75)
+        const bump = rise * rise * (3 - 2 * rise) * fall * fall
+        const alpha = ramp * p.strength + bump * p.fold
+        if (alpha < 0.004) continue
+        this.scratch.a = alpha > 1 ? 1 : alpha
+        buffer.fillRect(this.screenX + i, this.screenY + j, 1, 1, this.scratch)
+      }
+    }
+  }
+}
+
+declare module "@opentui/solid" {
+  interface OpenTUIComponents {
+    shimmer_overlay: typeof ShimmerOverlayRenderable
+  }
+}
+
+extend({ shimmer_overlay: ShimmerOverlayRenderable })
+
+export function ShimmerOverlay(props: {
+  width: number
+  height: number
+  ref?: (renderable: ShimmerOverlayRenderable) => void
+}) {
+  return (
+    <shimmer_overlay
+      ref={props.ref}
+      position="absolute"
+      left={0}
+      top={0}
+      width={props.width}
+      height={props.height}
+      zIndex={900}
+    />
+  )
+}
+
+const BAR_WIDTH = 12
+
+function formatRow(control: (typeof SHIMMER_CONTROLS)[number], value: number, selected: boolean) {
+  const filled = Math.round(((value - control.min) / (control.max - control.min)) * BAR_WIDTH)
+  const bar = "█".repeat(Math.max(0, Math.min(BAR_WIDTH, filled))).padEnd(BAR_WIDTH, "·")
+  const display = control.key === "enabled" ? (value >= 0.5 ? "on" : "off") : value.toFixed(control.digits)
+  return `${selected ? "▸ " : "  "}${control.label.padEnd(10)}${bar} ${display}`
+}
+
+export function ShimmerTuner(props: { open: boolean; selected: number; params: ShimmerParams }) {
+  return (
+    <Show when={props.open}>
+      <box
+        position="absolute"
+        top={1}
+        left={2}
+        zIndex={1100}
+        flexDirection="column"
+        backgroundColor={RGBA.fromInts(16, 20, 30, 235)}
+        border
+        borderColor={RGBA.fromInts(90, 130, 200)}
+        title="annotation overlay"
+        paddingLeft={1}
+        paddingRight={1}
+      >
+        <For each={SHIMMER_CONTROLS}>
+          {(control, index) => (
+            <text
+              fg={index() === props.selected ? RGBA.fromInts(255, 255, 255) : RGBA.fromInts(150, 160, 180)}
+              content={formatRow(control, props.params[control.key], index() === props.selected)}
+            />
+          )}
+        </For>
+        <text fg={RGBA.fromInts(110, 120, 145)} content="↑↓ select  ←→ adjust  shift ×5  esc close" />
+      </box>
+    </Show>
+  )
+}

--- a/packages/tui/src/component/shimmer-overlay.tsx
+++ b/packages/tui/src/component/shimmer-overlay.tsx
@@ -1,13 +1,25 @@
-import { OptimizedBuffer, Renderable, RGBA, type RenderableOptions, type RenderContext } from "@opentui/core"
+import {
+  OptimizedBuffer,
+  Renderable,
+  RGBA,
+  TargetChannel,
+  type RenderableOptions,
+  type RenderContext,
+} from "@opentui/core"
 import { extend } from "@opentui/solid"
 import { For, Show } from "solid-js"
+
+// Clock wrap keeps phase floats small over long sessions without a visible seam.
+const CLOCK_PERIOD = 3_600_000
 
 export type ShimmerParams = {
   enabled: number
   strength: number
-  band: number
-  fold: number
-  duration: number
+  keep: number
+  threshold: number
+  softness: number
+  speed: number
+  density: number
   red: number
   green: number
   blue: number
@@ -15,10 +27,12 @@ export type ShimmerParams = {
 
 export const SHIMMER_DEFAULTS: ShimmerParams = {
   enabled: 1,
-  strength: 0.08,
-  band: 8,
-  fold: 0.08,
-  duration: 600,
+  strength: 0.8,
+  keep: 0.25,
+  threshold: 0.55,
+  softness: 0.3,
+  speed: 1,
+  density: 1,
   red: 150,
   green: 190,
   blue: 255,
@@ -33,91 +47,95 @@ export const SHIMMER_CONTROLS: {
   digits: number
 }[] = [
   { key: "enabled", label: "Enabled", min: 0, max: 1, step: 1, digits: 0 },
-  { key: "strength", label: "Strength", min: 0, max: 0.5, step: 0.01, digits: 2 },
-  { key: "band", label: "Band", min: 2, max: 24, step: 1, digits: 0 },
-  { key: "fold", label: "Fold", min: 0, max: 0.3, step: 0.01, digits: 2 },
-  { key: "duration", label: "Duration", min: 200, max: 1500, step: 50, digits: 0 },
+  { key: "strength", label: "Strength", min: 0, max: 1, step: 0.05, digits: 2 },
+  { key: "keep", label: "Keep", min: 0, max: 1, step: 0.05, digits: 2 },
+  { key: "threshold", label: "Threshold", min: 0.2, max: 0.95, step: 0.01, digits: 2 },
+  { key: "softness", label: "Softness", min: 0.05, max: 1, step: 0.01, digits: 2 },
+  { key: "speed", label: "Speed", min: 0, max: 3, step: 0.05, digits: 2 },
+  { key: "density", label: "Density", min: 0.3, max: 3, step: 0.05, digits: 2 },
   { key: "red", label: "Red", min: 0, max: 255, step: 5, digits: 0 },
   { key: "green", label: "Green", min: 0, max: 255, step: 5, digits: 0 },
   { key: "blue", label: "Blue", min: 0, max: 255, step: 5, digits: 0 },
 ]
 
-// Annotation-mode overlay drawn directly into the frame buffer: one renderable, no per-cell
-// layout nodes or signals. Steady state is a constant very-low-opacity tint across the whole
-// app. Enabling it plays an entrance: the tint rolls diagonally onto the screen from the
-// top-left like a sheet settling over the UI, its leading edge a soft band that dissolves
-// into nothing, optionally with a faint brighter "fold" line riding the curl. Disabling is
-// instant. Once settled the renderable stops driving frames and just paints the flat tint
-// whenever the app renders anyway.
+// Foreground shimmer via color matrices: instead of compositing tint boxes over the app,
+// this renderable rewrites the text colors already in the frame buffer. It renders above the
+// app content, so the buffer it receives holds every glyph below it; one colorMatrix call
+// per frame pulls each cell's foreground toward the tint color, with per-cell strength given
+// by a slowly drifting three-sine interference field. TargetChannel.FG leaves backgrounds
+// untouched, so only the text shimmers. The matrix blends `keep` of the original color with
+// `1 - keep` of the tint (foreground alpha is 1, so the fourth column acts as the additive
+// tint term).
 export class ShimmerOverlayRenderable extends Renderable {
-  private elapsed = 0
+  private clock = 0
   private params: ShimmerParams = { ...SHIMMER_DEFAULTS }
-  private scratch = RGBA.fromInts(SHIMMER_DEFAULTS.red, SHIMMER_DEFAULTS.green, SHIMMER_DEFAULTS.blue, 0)
+  private matrix = new Float32Array(16)
+  private mask = new Float32Array(0)
 
   constructor(ctx: RenderContext, options: RenderableOptions<ShimmerOverlayRenderable>) {
     super(ctx, { ...options, live: SHIMMER_DEFAULTS.enabled >= 0.5 })
+    this.rebuildMatrix()
   }
 
   setParams(value: ShimmerParams) {
-    const wasEnabled = this.params.enabled >= 0.5
-    const enabled = value.enabled >= 0.5
     this.params = value
-    this.scratch = RGBA.fromInts(value.red, value.green, value.blue, 0)
-    // Re-enabling replays the entrance roll; disabling is instant.
-    if (enabled && !wasEnabled) {
-      this.elapsed = 0
-      this.live = true
-    }
-    if (!enabled) this.live = false
+    this.rebuildMatrix()
+    this.live = value.enabled >= 0.5
     this.requestRender()
+  }
+
+  private rebuildMatrix() {
+    const p = this.params
+    const tint = 1 - p.keep
+    // Row-major 4x4: output = keep * channel + tint target (via the alpha column, since
+    // foreground alpha is 1). Alpha row stays identity.
+    this.matrix.fill(0)
+    this.matrix[0] = p.keep
+    this.matrix[3] = (p.red / 255) * tint
+    this.matrix[5] = p.keep
+    this.matrix[7] = (p.green / 255) * tint
+    this.matrix[10] = p.keep
+    this.matrix[11] = (p.blue / 255) * tint
+    this.matrix[15] = 1
   }
 
   protected override onUpdate(deltaTime: number): void {
     if (!this.live) return
-    this.elapsed += deltaTime
-    // Settled: stop driving frames; renderSelf keeps painting the flat tint on normal renders.
-    if (this.elapsed >= this.params.duration) this.live = false
+    // Speed scales the clock advance rather than the phase, so changing it never jumps.
+    this.clock = (this.clock + deltaTime * this.params.speed) % CLOCK_PERIOD
   }
 
   protected override renderSelf(buffer: OptimizedBuffer): void {
     const p = this.params
     if (p.enabled < 0.5 || !this.visible || this.isDestroyed || this.width <= 0 || this.height <= 0) return
-    const settled = this.elapsed >= p.duration
-    // Settled fast path: one flat translucent sheet, no per-cell math.
-    if (settled) {
-      this.scratch.a = p.strength
-      buffer.fillRect(this.screenX, this.screenY, this.width, this.height, this.scratch)
-      return
-    }
-    // Diagonal roll: cells are ordered by i + 2j (rows span ~2 columns of visual space), and
-    // the front sweeps that span with an ease-out so the sheet arrives fast and lands gently.
-    const t = Math.min(1, this.elapsed / p.duration)
-    const eased = 1 - (1 - t) * (1 - t) * (1 - t)
-    const span = this.width - 1 + (this.height - 1) * 2 + p.band
-    const front = eased * span
+    if (p.strength <= 0) return
+    if (this.mask.length < this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
+    const t = this.clock / 1000
+    const d = p.density
+    let count = 0
     for (let j = 0; j < this.height; j++) {
-      const base = j * 2
+      // One row spans ~2 columns of visual space; keep wave math in column units so the
+      // shimmer pools read as visually round instead of vertically stretched.
+      const y = j * 2
       for (let i = 0; i < this.width; i++) {
-        const behind = front - (i + base)
-        if (behind <= 0) continue
-        if (behind >= p.band) {
-          this.scratch.a = p.strength
-          buffer.fillRect(this.screenX + i, this.screenY + j, 1, 1, this.scratch)
-          continue
-        }
-        // Inside the leading band: tint ramps smoothly into nothing toward the front, and an
-        // optional brighter fold line rides the curl just behind the edge.
-        const r = behind / p.band
-        const ramp = r * r * (3 - 2 * r)
-        const rise = Math.min(1, r / 0.25)
-        const fall = Math.max(0, 1 - (r - 0.25) / 0.75)
-        const bump = rise * rise * (3 - 2 * rise) * fall * fall
-        const alpha = ramp * p.strength + bump * p.fold
-        if (alpha < 0.004) continue
-        this.scratch.a = alpha > 1 ? 1 : alpha
-        buffer.fillRect(this.screenX + i, this.screenY + j, 1, 1, this.scratch)
+        const field =
+          Math.sin((i * 0.21 + y * 0.06) * d + t * 0.5) +
+          Math.sin((i * 0.114 - y * 0.083) * d - t * 0.32) +
+          Math.sin((i * 0.07 + y * 0.117) * d + t * 0.21)
+        const n = field / 6 + 0.5
+        const v = (n - p.threshold) / p.softness
+        if (v <= 0) continue
+        const clamped = v >= 1 ? 1 : v
+        const cell = clamped * clamped * (3 - 2 * clamped)
+        if (cell < 0.02) continue
+        this.mask[count] = this.screenX + i
+        this.mask[count + 1] = this.screenY + j
+        this.mask[count + 2] = cell
+        count += 3
       }
     }
+    if (count === 0) return
+    buffer.colorMatrix(this.matrix, this.mask.subarray(0, count), p.strength, TargetChannel.FG)
   }
 }
 
@@ -168,7 +186,7 @@ export function ShimmerTuner(props: { open: boolean; selected: number; params: S
         backgroundColor={RGBA.fromInts(16, 20, 30, 235)}
         border
         borderColor={RGBA.fromInts(90, 130, 200)}
-        title="annotation overlay"
+        title="fg shimmer"
         paddingLeft={1}
         paddingRight={1}
       >

--- a/packages/tui/src/component/shimmer-overlay.tsx
+++ b/packages/tui/src/component/shimmer-overlay.tsx
@@ -1,4 +1,5 @@
 import {
+  applyChromaticAberration,
   OptimizedBuffer,
   Renderable,
   RGBA,
@@ -29,6 +30,7 @@ export type ShimmerParams = {
   softness: number
   speed: number
   density: number
+  aberration: number
   red: number
   green: number
   blue: number
@@ -42,6 +44,7 @@ export const SHIMMER_DEFAULTS: ShimmerParams = {
   softness: 0.3,
   speed: 1,
   density: 1,
+  aberration: 1,
   red: 150,
   green: 190,
   blue: 255,
@@ -62,6 +65,7 @@ export const SHIMMER_CONTROLS: {
   { key: "softness", label: "Softness", min: 0.05, max: 1, step: 0.01, digits: 2 },
   { key: "speed", label: "Speed", min: 0, max: 3, step: 0.05, digits: 2 },
   { key: "density", label: "Density", min: 0.3, max: 3, step: 0.05, digits: 2 },
+  { key: "aberration", label: "Aberration", min: 0, max: 4, step: 0.25, digits: 2 },
   { key: "red", label: "Red", min: 0, max: 255, step: 5, digits: 0 },
   { key: "green", label: "Green", min: 0, max: 255, step: 5, digits: 0 },
   { key: "blue", label: "Blue", min: 0, max: 255, step: 5, digits: 0 },
@@ -169,6 +173,9 @@ export class ShimmerOverlayRenderable extends Renderable {
   protected override renderSelf(buffer: OptimizedBuffer): void {
     const p = this.params
     if (p.enabled < 0.5 || !this.visible || this.isDestroyed || this.width <= 0 || this.height <= 0) return
+    // Lens-fringe post-process: offsets red/blue foreground channels horizontally, growing
+    // from zero at screen center to `aberration` cells at the edges. Backgrounds untouched.
+    if (p.aberration > 0) applyChromaticAberration(buffer, p.aberration)
     if (p.strength <= 0) return
     if (this.mask.length < this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
     const ox = Math.floor(this.offset)

--- a/packages/tui/src/component/shimmer-overlay.tsx
+++ b/packages/tui/src/component/shimmer-overlay.tsx
@@ -78,6 +78,9 @@ export class ShimmerOverlayRenderable extends Renderable {
   }
 
   setParams(value: ShimmerParams) {
+    // The App unmounts the overlay while disabled (so it never blocks mouse hit-testing);
+    // a stale ref may point at a destroyed instance when params change while unmounted.
+    if (this.isDestroyed) return
     this.params = value
     this.rebuildMatrix()
     this.live = value.enabled >= 0.5

--- a/packages/tui/src/component/shimmer-overlay.tsx
+++ b/packages/tui/src/component/shimmer-overlay.tsx
@@ -26,7 +26,7 @@ export type ShimmerParams = {
 }
 
 export const SHIMMER_DEFAULTS: ShimmerParams = {
-  enabled: 1,
+  enabled: 0,
   strength: 0.8,
   keep: 0.25,
   threshold: 0.55,
@@ -199,6 +199,7 @@ export function ShimmerTuner(props: { open: boolean; selected: number; params: S
           )}
         </For>
         <text fg={RGBA.fromInts(110, 120, 145)} content="↑↓ select  ←→ adjust  shift ×5  esc close" />
+        <text fg={RGBA.fromInts(110, 120, 145)} content="ctrl+r effect  ctrl+alt+r panel" />
       </box>
     </Show>
   )


### PR DESCRIPTION
## What

Adds a full-screen foreground shimmer effect to the TUI plus a live tuning panel.

- **`ShimmerOverlayRenderable`** (`packages/tui/src/component/shimmer-overlay.tsx`): a custom OpenTUI renderable (same pattern as `TabPulseRenderable`) that rewrites text colors already in the frame buffer through `OptimizedBuffer.colorMatrix` — no compositing, no per-cell layout nodes or signals.
- **Mechanism:** the renderable sits above the app content (z900), so the buffer it receives holds every glyph below it. Each frame it makes one `colorMatrix(matrix, mask, strength, TargetChannel.FG)` call: the matrix blends glyph colors toward a tint target (`keep` controls how much original color survives), and the mask carries `[x, y, strength]` triplets from a slowly drifting three-sine interference field — soft pools of recolored text sweep across the screen. `TargetChannel.FG` leaves backgrounds untouched, so only text shimmers.
- **Perf:** the mask array is preallocated and reused (`subarray` per frame); per-frame JS work is three `sin` per cell plus one native SIMD-path call. Disabled, the renderable stops driving frames entirely.
- **Tuner panel:** `Ctrl+R` toggles a panel with live controls (Enabled, Strength, Keep, Threshold, Softness, Speed, Density, R/G/B). `↑/↓` select, `←/→` adjust (`Shift` = ×5), `Esc` closes. Changes apply to the running effect immediately.

## Why

Exploration toward an annotation/ambient mode treatment: recoloring glyphs via a color matrix reads as light passing over the text itself, rather than a tint sheet composited over the UI. The tuner exists to iterate on feel live in the terminal instead of rebuilding per tweak.

Supersedes #46007, which explored the same surface as a composited translucent overlay.

## Notes

- The effect currently defaults to enabled and `Ctrl+R` is an interim binding so it can be exercised; wiring to real mode state (and moving the keybind into the keymap command system) is follow-up work before this ships to users.
- Per the color-matrix docs, transformed cells lose terminal palette/default color intent while inside a pool (explicit RGB is written). Fine for how this TUI renders, but noted for reviewers.
- Perf history: earlier iterations rendered effects as thousands of 1×1 reactive `<box>` nodes (measurably CPU-heavy), then as direct `fillRect` tinting; the color-matrix transform replaced both.

## Test

- `bun typecheck` passes in `packages/tui`.
- Manual: `bun run dev:live`, observe drifting pools of tinted text; `Ctrl+R`, adjust each control (Keep 0 + white tint = white glints; Keep ~0.5 = subtle sheen), toggle Enabled, `Esc` and confirm arrow keys return to normal app behavior.