### PR TITLE
fix(opencode): serialize and atomically write auth.json

### DIFF
--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -4,10 +4,12 @@ import { Effect, Layer, Record, Result, Schema, Context } from "effect"
 import { NonNegativeInt } from "@opencode-ai/core/schema"
 import { Global } from "@opencode-ai/core/global"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
 const file = path.join(Global.Path.data, "auth.json")
+const lockKey = `auth:${file}`
 
 const fail = (message: string) => (cause: unknown) => new AuthError({ message, cause })
 
@@ -53,9 +55,10 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fsys = yield* FSUtil.Service
+    const flock = yield* EffectFlock.Service
     const decode = Schema.decodeUnknownOption(Info)
 
-    const all = Effect.fn("Auth.all")(function* () {
+    const read = Effect.fn("Auth.read")(function* () {
       if (process.env.OPENCODE_AUTH_CONTENT) {
         try {
           return JSON.parse(process.env.OPENCODE_AUTH_CONTENT)
@@ -66,32 +69,51 @@ const layer = Layer.effect(
       return Record.filterMap(data, (value) => Result.fromOption(decode(value), () => undefined))
     })
 
+    const all = Effect.fn("Auth.all")(function* () {
+      return yield* read().pipe(flock.withLock(lockKey), Effect.mapError(fail("Failed to read auth data")))
+    })
+
+    const mutate = Effect.fn("Auth.mutate")(function* (update: (data: Record<string, Info>) => Record<string, Info>) {
+      yield* Effect.gen(function* () {
+        const tempfile = `${file}.${process.pid}.${Date.now()}.tmp`
+        const data = update(yield* read())
+        yield* fsys.writeJson(tempfile, data, 0o600).pipe(
+          Effect.andThen(fsys.rename(tempfile, file)),
+          Effect.catch((error) =>
+            fsys.remove(tempfile, { force: true }).pipe(Effect.ignore, Effect.andThen(Effect.fail(error))),
+          ),
+        )
+      }).pipe(flock.withLock(lockKey), Effect.mapError(fail("Failed to write auth data")))
+    })
+
     const get = Effect.fn("Auth.get")(function* (providerID: string) {
       return (yield* all())[providerID]
     })
 
     const set = Effect.fn("Auth.set")(function* (key: string, info: Info) {
       const norm = key.replace(/\/+$/, "")
-      const data = yield* all()
-      if (norm !== key) delete data[key]
-      delete data[norm + "/"]
-      yield* fsys
-        .writeJson(file, { ...data, [norm]: info }, 0o600)
-        .pipe(Effect.mapError(fail("Failed to write auth data")))
+      yield* mutate((data) => {
+        const next = { ...data }
+        if (norm !== key) delete next[key]
+        delete next[norm + "/"]
+        return { ...next, [norm]: info }
+      })
     })
 
     const remove = Effect.fn("Auth.remove")(function* (key: string) {
       const norm = key.replace(/\/+$/, "")
-      const data = yield* all()
-      delete data[key]
-      delete data[norm]
-      yield* fsys.writeJson(file, data, 0o600).pipe(Effect.mapError(fail("Failed to write auth data")))
+      yield* mutate((data) => {
+        const next = { ...data }
+        delete next[key]
+        delete next[norm]
+        return next
+      })
     })
 
     return Service.of({ get, all, set, remove })
   }),
 )
 
-export const node = LayerNode.make({ service: Service, layer: layer, deps: [FSUtil.node] })
+export const node = LayerNode.make({ service: Service, layer: layer, deps: [FSUtil.node, EffectFlock.node] })
 
 export * as Auth from "."


### PR DESCRIPTION
### Issue for this PR

Closes #30396
Related: #45557 (previous non-compliant attempt), #45948 (closed non-compliant duplicate), #46020 (closed duplicate)

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes concurrent Auth.set/Auth.remove corruption in auth.json by introducing EffectFlock lock (auth:${file}), splitting read (Auth.read) from atomic write (Auth.mutate), and using temp-file + rename for atomic persistence.

### How did you verify your code works?

Diff is isolated to packages/opencode/src/auth/index.ts; branch auth-json-safety-pilot based on upstream/dev (df35e842f5). Typecheck/test blocked by missing tsgo/preload in this environment; focused regression should be confirmed against test/auth/auth.test.ts. See #30396 for in-repo reproduction.

### Screenshots / recordings

N/A (non-UI fix)

### Checklist

- [x] I have tested my changes locally (partial — blocked by tsgo/preload; focused regression required) (blocked by environment, requires tsgo)
- [x] I have not included unrelated changes in this PR
