### PR TITLE
docs: clarify release workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 - After changing the public Protocol or Server `HttpApi`, run `bun run generate` from `packages/client`. Do not edit generated client files directly.
 - Keep runtime dependencies directed from Schema to Core and Protocol, then from Core and Protocol to Server. Client runtime code may depend on Schema and Protocol but never Core or Server; `sdk` composes Client, Core, and Server.
 - Current implementation changes belong in `packages/core`, `packages/cli`, `packages/server`, `packages/protocol`, `packages/schema`, and related generated client surfaces when required.
+- This repository does not use Changesets. Do not add `.changeset` files; follow the existing release workflow instead.
 - The default branch in this repo is `v2`.
 - Base all new branches and worktrees on `v2`, or `origin/v2` when the local `v2` ref is unavailable. Do not base them on `dev`.
 - Local `main` ref may not exist; use `v2` or `origin/v2` for diffs.


### PR DESCRIPTION
## Why

The repository guidance did not explicitly state whether the project uses Changesets. Contributors and agents could add `.changeset` files that do not participate in the repository's actual release workflow.

## What Changes

The root `AGENTS.md` now states that the repository does not use Changesets, prohibits adding `.changeset` files, and directs contributors to the existing release workflow.

## Scope

This is a documentation-only clarification. It does not change release configuration, package metadata, or runtime behavior.

## Verification

```sh
bunx prettier --check AGENTS.md
git diff --check
```

Prettier reported that `AGENTS.md` uses the configured style, and Git reported no whitespace errors.
