### PR TITLE
fix(ai): reject unknown chat finishes

### DIFF
--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -815,7 +815,12 @@ const mapFinishReason = Effect.fn("OpenAIChat.mapFinishReason")(function* (event
     case "tool_calls":
       return "tool-calls" as const
     default:
-      return "unknown" as const
+      return yield* new AIError({
+        reason: new UnknownProviderError({
+          message: `Provider finish_reason: ${reason}`,
+          body: ProviderShared.encodeJson(event),
+        }),
+      })
   }
 })
 

--- a/packages/ai/test/provider/openai-chat.test.ts
+++ b/packages/ai/test/provider/openai-chat.test.ts
@@ -1572,6 +1572,50 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("rejects unknown finish reasons without finalizing streamed tool calls", () =>
+    Effect.gen(function* () {
+      const body = sseEvents(
+        deltaChunk({
+          tool_calls: [{ index: 0, id: "call_1", function: { name: "lookup", arguments: '{"query":"weather"' } }],
+        }),
+        deltaChunk({}, "future_reason"),
+      )
+      const events = yield* Ref.make<ReadonlyArray<LLMEvent>>([])
+      const error = yield* LLMClient.stream(
+        LLMRequest.update(request, {
+          tools: [ToolDefinition.make({ name: "lookup", description: "Lookup data", inputSchema: { type: "object" } })],
+        }),
+      ).pipe(
+        Stream.tap((event) => Ref.update(events, (current) => [...current, event])),
+        Stream.runDrain,
+        Effect.provide(fixedResponse(body)),
+        Effect.flip,
+      )
+
+      expect(error).toMatchObject({
+        reason: { _tag: "UnknownProvider" },
+        message: "Provider finish_reason: future_reason",
+      })
+      expect(yield* Ref.get(events)).toEqual([
+        { type: "step-start", index: 0 },
+        {
+          type: "tool-input-start",
+          id: "call_1",
+          name: "lookup",
+          providerExecuted: undefined,
+          providerMetadata: undefined,
+        },
+        {
+          type: "tool-input-delta",
+          id: "call_1",
+          name: "lookup",
+          text: '{"query":"weather"',
+          input: { query: "weather" },
+        },
+      ])
+    }),
+  )
+
   it.effect("ignores empty identity fields on later tool call deltas", () =>
     Effect.gen(function* () {
       const body = sseEvents(

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -554,6 +554,19 @@ describe("OpenAI-compatible Chat route", () => {
         reason: { _tag: "UnknownProvider" },
         message: "Provider reported an error (finish_reason: error)",
       })
+
+      const unknown = yield* LLMClient.generate(request).pipe(
+        Effect.provide(fixedResponse(sseEvents(deltaChunk({}, "future_reason")))),
+        Effect.flip,
+      )
+      expect(unknown).toMatchObject({
+        reason: { _tag: "UnknownProvider" },
+        message: "Provider finish_reason: future_reason",
+      })
+      expect(decodeJson(unknown.reason.body ?? "")).toMatchObject({
+        id: "chatcmpl_fixture",
+        choices: [{ finish_reason: "future_reason" }],
+      })
     }),
   )
 
@@ -581,17 +594,13 @@ describe("OpenAI-compatible Chat route", () => {
     }),
   )
 
-  it.effect("preserves provider finish outcomes in the common reason algebra", () =>
+  it.effect("preserves content-filter finishes in the common reason algebra", () =>
     Effect.gen(function* () {
       const filtered = yield* LLMClient.generate(request).pipe(
         Effect.provide(fixedResponse(sseEvents(deltaChunk({}, "content_filter")))),
       )
-      const future = yield* LLMClient.generate(request).pipe(
-        Effect.provide(fixedResponse(sseEvents(deltaChunk({}, "future_reason")))),
-      )
 
       expect(filtered.finishReason).toEqual({ normalized: "content-filter", raw: "content_filter" })
-      expect(future.finishReason).toEqual({ normalized: "unknown", raw: "future_reason" })
     }),
   )
 


### PR DESCRIPTION
## Summary
- reject literal unknown Chat `finish_reason` values as provider errors
- preserve the triggering provider frame in the typed error
- prevent pending tool input from being finalized when the terminal value is unknown
- leave missing required and optional finish-reason behavior unchanged

## Tests
- `bun test` (`packages/ai`)
- `bun typecheck` (`packages/ai`)