### PR TITLE
fix(ai): classify retryable server failures

### DIFF
--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -76,6 +76,7 @@ const INVALID_REQUEST_CODES = new Set(["invalid_prompt", "invalid_request_error"
 const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
 const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
 const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
+const CAPACITY_TEXT = /\b(?:currently|temporarily) at capacity\b/i
 
 export interface ProviderFailure {
   readonly message: string
@@ -139,6 +140,7 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
     input.status === 408 ||
     input.status === 409 ||
     (input.status !== undefined && input.status >= 500) ||
+    CAPACITY_TEXT.test(text) ||
     codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable"))
   )
     return new ProviderInternalError({

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -141,7 +141,9 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
     input.status === 408 ||
     input.status === 409 ||
     (input.status !== undefined && input.status >= 500) ||
-    SERVER_ERROR_TEXT.test(text) ||
+    ((input.status === undefined || input.status < 400) &&
+      !codes.some((code) => INVALID_REQUEST_CODES.has(code)) &&
+      SERVER_ERROR_TEXT.test(text)) ||
     codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable"))
   )
     return new ProviderInternalError({

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -76,7 +76,8 @@ const INVALID_REQUEST_CODES = new Set(["invalid_prompt", "invalid_request_error"
 const RATE_LIMIT_TEXT = /rate increased too quickly|rate[-_\s]?limit|too[_\s]?many[_\s]?requests/i
 const QUOTA_TEXT = /insufficient[-_\s]?quota|quota[-_\s]?exceeded/i
 const CONTENT_POLICY_TEXT = /content[-_\s]?policy|content_filter|safety/i
-const CAPACITY_TEXT = /\b(?:currently|temporarily) at capacity\b/i
+const SERVER_ERROR_TEXT =
+  /\b(?:try again|(?:please |you can )?retry (?:the |this |your )?request|try (?:the |this |your )?request again|(?:currently |temporarily )?at capacity|overloaded|temporarily unavailable|service[-_\s]?unavailable|(?:server|internal)[-_\s]?error|server (?:is )?busy|provider returned (?:an )?error|resource[-_\s]?exhausted|upstream (?:connect|connection|request)|request buffer limit while retrying upstream)\b/i
 
 export interface ProviderFailure {
   readonly message: string
@@ -140,7 +141,7 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
     input.status === 408 ||
     input.status === 409 ||
     (input.status !== undefined && input.status >= 500) ||
-    CAPACITY_TEXT.test(text) ||
+    SERVER_ERROR_TEXT.test(text) ||
     codes.some((code) => SERVER_CODES.has(code) || code.includes("exhausted") || code.includes("unavailable"))
   )
     return new ProviderInternalError({

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -115,8 +115,10 @@ describe("provider error classification", () => {
         classifyProviderFailure({ message: "Invalid credentials, try again", status: 401 }),
         classifyProviderFailure({ message: "Quota exceeded, try again", status: 429 }),
         classifyProviderFailure({ message: "Rate limit exceeded, try again" }),
+        classifyProviderFailure({ message: "Upstream request failed: validation failed", status: 400 }),
+        classifyProviderFailure({ message: "Try again", status: 200 }),
       ].map((failure) => failure._tag),
-    ).toEqual(["Authentication", "QuotaExceeded", "RateLimit"])
+    ).toEqual(["Authentication", "QuotaExceeded", "RateLimit", "InvalidRequest", "ProviderInternal"])
   })
 
   test("classifies transient client statuses as provider internal", () => {

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -81,20 +81,42 @@ describe("provider error classification", () => {
     ).toEqual(["ProviderInternal", "ProviderInternal", "ProviderInternal"])
   })
 
-  test("classifies provider capacity messages as provider internal", () => {
+  test("classifies retryable server messages as provider internal", () => {
     const message =
       "The model is currently at capacity due to high demand. Please try again in a few minutes, or use a higher service tier for priority processing."
 
     expect(
       [
-        classifyProviderFailure({ message }),
-        classifyProviderFailure({
-          message: "Provider request failed",
-          rawBody: "The service is temporarily at capacity.",
-        }),
+        message,
+        "Try again",
+        "Please retry your request shortly.",
+        "You can retry the request.",
+        "Try your request again.",
+        "The service is temporarily at capacity.",
+        "The model is overloaded.",
+        "Service unavailable",
+        "Internal server error",
+        "The server is busy.",
+        "Provider returned error",
+        "Provider returned an error",
+        "ResourceExhausted",
+        "Upstream connection failed",
+        "Exceeded request buffer limit while retrying upstream",
+      ].map((message) => classifyProviderFailure({ message })._tag),
+    ).toEqual(Array(15).fill("ProviderInternal"))
+    expect(
+      classifyProviderFailure({ message: "Provider request failed", rawBody: "Please try again later." })._tag,
+    ).toBe("ProviderInternal")
+  })
+
+  test("prioritizes specific failures over retryable server text", () => {
+    expect(
+      [
+        classifyProviderFailure({ message: "Invalid credentials, try again", status: 401 }),
+        classifyProviderFailure({ message: "Quota exceeded, try again", status: 429 }),
+        classifyProviderFailure({ message: "Rate limit exceeded, try again" }),
       ].map((failure) => failure._tag),
-    ).toEqual(["ProviderInternal", "ProviderInternal"])
-    expect(classifyProviderFailure({ message: "Please try again later." })._tag).toBe("UnknownProvider")
+    ).toEqual(["Authentication", "QuotaExceeded", "RateLimit"])
   })
 
   test("classifies transient client statuses as provider internal", () => {
@@ -127,7 +149,6 @@ describe("provider error classification", () => {
     expect(classifyProviderFailure({ message: '{"type":"error","error":{"code":123}}' })._tag).toBe("UnknownProvider")
     expect(classifyProviderFailure({ message: "not-json" })._tag).toBe("UnknownProvider")
     expect(classifyProviderFailure({ message: "network error" })._tag).toBe("UnknownProvider")
-    expect(classifyProviderFailure({ message: "Provider returned error" })._tag).toBe("UnknownProvider")
   })
 })
 

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -81,6 +81,22 @@ describe("provider error classification", () => {
     ).toEqual(["ProviderInternal", "ProviderInternal", "ProviderInternal"])
   })
 
+  test("classifies provider capacity messages as provider internal", () => {
+    const message =
+      "The model is currently at capacity due to high demand. Please try again in a few minutes, or use a higher service tier for priority processing."
+
+    expect(
+      [
+        classifyProviderFailure({ message }),
+        classifyProviderFailure({
+          message: "Provider request failed",
+          rawBody: "The service is temporarily at capacity.",
+        }),
+      ].map((failure) => failure._tag),
+    ).toEqual(["ProviderInternal", "ProviderInternal"])
+    expect(classifyProviderFailure({ message: "Please try again later." })._tag).toBe("UnknownProvider")
+  })
+
   test("classifies transient client statuses as provider internal", () => {
     expect([408, 409].map((status) => classifyProviderFailure({ message: `HTTP ${status}`, status })._tag)).toEqual([
       "ProviderInternal",


### PR DESCRIPTION
## Summary
- classify explicit retry guidance and common transient server wording as provider-internal failures
- cover capacity, overload, temporary unavailability, server errors, resource exhaustion, and upstream failures
- inspect both surfaced messages and captured raw response bodies, including midstream errors on successful HTTP responses
- preserve precedence for explicit client errors, authentication, quota, rate limits, content policy, and context overflow
- keep native network failures on their existing transport-error path

Supersedes #43788 against the current provider error model.

## Testing
- Full AI suite: 867 pass / 25 skip / 0 fail
- `bun typecheck`