### PR TITLE
feat(tui): expose scrollToMessage to TUI plugins

### DIFF
--- a/packages/opencode/specs/tui-plugins.md
+++ b/packages/opencode/specs/tui-plugins.md
@@ -389,6 +389,7 @@ Mode pushes are automatically tracked by the plugin runtime. If a plugin is disa
   - `part(messageID)`
   - `lsp()`
   - `mcp()`
+  - `scrollToMessage(messageID)` — scrolls the current session viewport to the given message id, returning `false` when no target session is attached
 - `api.client` always reflects the current runtime client.
 - `api.event.on(type, handler)` subscribes to the TUI event stream and returns an unsubscribe function.
 - `api.renderer` exposes the raw `CliRenderer`.

--- a/packages/opencode/specs/tui-plugins.md
+++ b/packages/opencode/specs/tui-plugins.md
@@ -390,6 +390,7 @@ Mode pushes are automatically tracked by the plugin runtime. If a plugin is disa
   - `lsp()`
   - `mcp()`
   - `scrollToMessage(messageID)` — scrolls the current session viewport to the given message id, returning `false` when no target session is attached
+  - `scrollToBottom()` — scrolls the current session viewport to the bottom, returning `false` when no target session is attached
 - `api.client` always reflects the current runtime client.
 - `api.event.on(type, handler)` subscribes to the TUI event stream and returns an unsubscribe function.
 - `api.renderer` exposes the raw `CliRenderer`.

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -105,6 +105,7 @@ type Opts = {
     lsp?: HostPluginApi["state"]["lsp"]
     mcp?: HostPluginApi["state"]["mcp"]
     scrollToMessage?: HostPluginApi["state"]["scrollToMessage"]
+    scrollToBottom?: HostPluginApi["state"]["scrollToBottom"]
   }
   theme?: {
     selected?: string
@@ -327,6 +328,7 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       lsp: opts.state?.lsp ?? (() => []),
       mcp: opts.state?.mcp ?? (() => []),
       scrollToMessage: opts.state?.scrollToMessage ?? (() => false),
+      scrollToBottom: opts.state?.scrollToBottom ?? (() => false),
     },
     theme: {
       get current() {

--- a/packages/opencode/test/fixture/tui-plugin.ts
+++ b/packages/opencode/test/fixture/tui-plugin.ts
@@ -104,6 +104,7 @@ type Opts = {
     part?: HostPluginApi["state"]["part"]
     lsp?: HostPluginApi["state"]["lsp"]
     mcp?: HostPluginApi["state"]["mcp"]
+    scrollToMessage?: HostPluginApi["state"]["scrollToMessage"]
   }
   theme?: {
     selected?: string
@@ -325,6 +326,7 @@ export function createTuiPluginApi(opts: Opts = {}): HostPluginApi {
       part: opts.state?.part ?? (() => []),
       lsp: opts.state?.lsp ?? (() => []),
       mcp: opts.state?.mcp ?? (() => []),
+      scrollToMessage: opts.state?.scrollToMessage ?? (() => false),
     },
     theme: {
       get current() {

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -396,6 +396,7 @@ export type TuiState = {
   part: (messageID: string) => ReadonlyArray<Part>
   lsp: () => ReadonlyArray<TuiSidebarLspItem>
   mcp: () => ReadonlyArray<TuiSidebarMcpItem>
+  scrollToMessage: (messageID: string) => boolean
 }
 
 type TuiBindingLookupView = {

--- a/packages/plugin/src/tui.ts
+++ b/packages/plugin/src/tui.ts
@@ -397,6 +397,7 @@ export type TuiState = {
   lsp: () => ReadonlyArray<TuiSidebarLspItem>
   mcp: () => ReadonlyArray<TuiSidebarMcpItem>
   scrollToMessage: (messageID: string) => boolean
+  scrollToBottom: () => boolean
 }
 
 type TuiBindingLookupView = {

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -16,6 +16,7 @@ import { Prompt } from "../component/prompt"
 import type { useToast } from "../ui/toast"
 import * as Keymap from "../keymap"
 import { createCommandShim } from "./command-shim"
+import { sessionScroll } from "../util/session-scroll"
 import type { PluginRoutes } from "./api"
 export type { RouteMap } from "./api"
 export { createPluginRoutes, createTuiApi } from "./api"
@@ -158,6 +159,9 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
           status: item.status,
           error: item.status === "failed" ? item.error : undefined,
         }))
+    },
+    scrollToMessage(messageID) {
+      return sessionScroll.scrollToMessage(messageID)
     },
   }
 }

--- a/packages/tui/src/plugin/adapters.tsx
+++ b/packages/tui/src/plugin/adapters.tsx
@@ -163,6 +163,9 @@ function stateApi(sync: ReturnType<typeof useSync>): TuiPluginApi["state"] {
     scrollToMessage(messageID) {
       return sessionScroll.scrollToMessage(messageID)
     },
+    scrollToBottom() {
+      return sessionScroll.scrollToBottom()
+    },
   }
 }
 

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -74,7 +74,8 @@ import { setPreLayoutSiblingMargin } from "../../util/layout"
 import { useTuiConfig } from "../../config"
 import { useClipboard } from "../../context/clipboard"
 import { nextThinkingMode, reasoningSummary, useThinkingMode, type ThinkingMode } from "../../context/thinking"
-import { getScrollAcceleration } from "../../util/scroll"
+import { getScrollAcceleration, scrollToMessageID } from "../../util/scroll"
+import { sessionScroll } from "../../util/session-scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
 import { usePluginRuntime } from "../../plugin/runtime"
 import { DialogRetryAction } from "../../component/dialog-retry-action"
@@ -343,6 +344,18 @@ export function Session() {
 
   let seeded = false
   let scroll: ScrollBoxRenderable
+  let scrollCleanup: (() => void) | undefined
+  const detachScroll = () => { scrollCleanup?.(); scrollCleanup = undefined }
+  onCleanup(detachScroll)
+  createEffect(
+    on(() => route.sessionID, (sessionID) => {
+      setTimeout(() => {
+        if (!scroll || scroll.isDestroyed) return
+        detachScroll()
+        scrollCleanup = sessionScroll.attach(sessionID, scroll)
+      }, 50)
+    }),
+  )
   let prompt: PromptRef | undefined
   const bind = (r: PromptRef | undefined) => {
     prompt = r
@@ -416,8 +429,7 @@ export function Session() {
       return
     }
 
-    const child = scroll.getChildren().find((c) => c.id === targetID)
-    if (child) scroll.scrollBy(child.y - scroll.y - 1)
+    scrollToMessageID(scroll, targetID)
     dialog.clear()
   }
 
@@ -526,10 +538,7 @@ export function Session() {
         dialog.replace(() => (
           <DialogTimeline
             onMove={(messageID) => {
-              const child = scroll.getChildren().find((child) => {
-                return child.id === messageID
-              })
-              if (child) scroll.scrollBy(child.y - scroll.y - 1)
+              scrollToMessageID(scroll, messageID)
             }}
             sessionID={route.sessionID}
             setPrompt={(promptInfo) => prompt?.set(promptInfo)}
@@ -549,10 +558,7 @@ export function Session() {
           <DialogForkFromTimeline
             onMove={(messageID) => {
               if (!messageID) return
-              const child = scroll.getChildren().find((child) => {
-                return child.id === messageID
-              })
-              if (child) scroll.scrollBy(child.y - scroll.y - 1)
+              scrollToMessageID(scroll, messageID)
             }}
             sessionID={route.sessionID}
           />
@@ -851,10 +857,7 @@ export function Session() {
           )
 
           if (hasValidTextPart) {
-            const child = scroll.getChildren().find((child) => {
-              return child.id === message.id
-            })
-            if (child) scroll.scrollBy(child.y - scroll.y - 1)
+            scrollToMessageID(scroll, message.id)
             break
           }
         }

--- a/packages/tui/src/util/scroll.ts
+++ b/packages/tui/src/util/scroll.ts
@@ -1,4 +1,4 @@
-import { MacOSScrollAccel, type ScrollAcceleration } from "@opentui/core"
+import { MacOSScrollAccel, type ScrollAcceleration, type ScrollBoxRenderable } from "@opentui/core"
 
 export type ScrollConfig = {
   scroll_acceleration?: { enabled?: boolean }
@@ -24,4 +24,11 @@ export function getScrollAcceleration(tuiConfig?: ScrollConfig): ScrollAccelerat
   }
 
   return new CustomSpeedScroll(3)
+}
+
+export function scrollToMessageID(scroll: ScrollBoxRenderable, messageID: string): boolean {
+  const child = scroll.getChildren().find((child) => child.id === messageID)
+  if (!child) return false
+  scroll.scrollBy(child.y - scroll.y - 1)
+  return true
 }

--- a/packages/tui/src/util/session-scroll.ts
+++ b/packages/tui/src/util/session-scroll.ts
@@ -17,4 +17,10 @@ export const sessionScroll = {
     if (!current) return false
     return scrollToMessageID(current.scroll, messageID)
   },
+  scrollToBottom(): boolean {
+    const current = target
+    if (!current || current.scroll.isDestroyed) return false
+    current.scroll.scrollTo(current.scroll.scrollHeight)
+    return true
+  },
 }

--- a/packages/tui/src/util/session-scroll.ts
+++ b/packages/tui/src/util/session-scroll.ts
@@ -1,0 +1,20 @@
+import type { ScrollBoxRenderable } from "@opentui/core"
+import { scrollToMessageID } from "./scroll"
+
+type Target = { sessionID: string; scroll: ScrollBoxRenderable }
+
+let target: Target | undefined
+
+export const sessionScroll = {
+  attach(sessionID: string, scroll: ScrollBoxRenderable) {
+    target = { sessionID, scroll }
+    return () => {
+      if (target?.sessionID === sessionID) target = undefined
+    }
+  },
+  scrollToMessage(messageID: string): boolean {
+    const current = target
+    if (!current) return false
+    return scrollToMessageID(current.scroll, messageID)
+  },
+}


### PR DESCRIPTION
### Issue for this PR

Related: #37699 (scrollbar message-boundary markers). No separate issue was filed for this; the motivation is the same "find an earlier message in a long session" problem.

### Type of change

- [x] New feature

### What does this PR do?

Adds `scrollToMessage(messageID)` to the TUI plugin `state` API, letting a plugin scroll the session chat viewport to a specific message.

There was previously no way for a plugin to do this: the session scrollbox is a module-local `ScrollBoxRenderable` inside the `Session` route, and the only built-in way to jump to a message is the `ctrl+x g` timeline dialog. This PR:

- adds a small `sessionScroll` controller (`packages/tui/src/util/session-scroll.ts`) that holds the currently displayed session's scrollbox,
- attaches/detaches it from the `Session` route, mirroring the existing `toBottom` `setTimeout`-deferred pattern so the ref is assigned before attach,
- exposes it on the plugin state API as `scrollToMessage(messageID): boolean` (returns `false` when no session is attached),
- factors the four existing "find child by id, then `scrollBy(child.y - scroll.y - 1)`" blocks into one shared `scrollToMessageID` helper in `util/scroll.ts`.

The plugin-facing types (`packages/plugin/src/tui.ts`) and the test fixture (`packages/opencode/test/fixture/tui-plugin.ts`) are updated, and the method is documented in `specs/tui-plugins.md`.

### How did you verify your code works?

- `bun run typecheck` passes (30/30 tasks).
- `oxlint` clean on the changed files.
- Ran `bun dev` and confirmed through a temporary `home_bottom` probe that `typeof api.state.scrollToMessage === "function"`.
- Built a small TUI plugin that registers a `sidebar_content` slot listing user messages and calls `scrollToMessage` on hover/click; confirmed the sidebar renders and the method is callable.

I did not verify the resulting scroll position pixel-perfectly beyond the above (headless terminal); the scroll math is unchanged from the existing timeline/fork call sites, which now share the same helper.

### Screenshots / recordings

None — terminal UI change, not meaningful as a static screenshot.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
