### PR TITLE
fix(core): flush short stream bursts on a bounded timer

### DIFF
--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -3,7 +3,7 @@ import type { Agent } from "@opencode-ai/schema/agent"
 import type { Model } from "@opencode-ai/schema/model"
 import type { RelativePath } from "@opencode-ai/schema/schema"
 import type { Snapshot } from "@opencode-ai/schema/snapshot"
-import { Clock, Effect, Iterable } from "effect"
+import { Effect, Fiber, Iterable, Scope, Semaphore } from "effect"
 import { isArrayNonEmpty, isReadonlyArrayNonEmpty } from "effect/Array"
 import { Bus } from "../../bus.js"
 import { SessionEvent } from "../event.js"
@@ -71,9 +71,10 @@ const hostedContent = (result: ToolResultValue): NonEmptyContent => {
  * uninterruptible through its writes so cancellation cannot strand a mark without
  * its durable event. (2) Never require a cross-source event
  * order: each publishing fiber is sequential, so per-source order holds by construction,
- * and consumers fold by id/ordinal rather than global position.
+ * and consumers fold by id/ordinal rather than global position. Fragment timers are
+ * the exception: they serialize with append/end to preserve their source's order.
  */
-export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, input: Input) => {
+export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, input: Input, scope: Scope.Scope) => {
   const deltaBatchInterval = 100
   type ToolState = {
     readonly name: string
@@ -130,10 +131,11 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
       readonly ordinal: number
       readonly values: string[]
       pending: string
-      publishedAt?: number
+      timer?: Fiber.Fiber<void>
       state?: Record<string, unknown>
     }
     const chunks = new Map<string, Fragment>()
+    const lock = Semaphore.makeUnsafe(1)
     let nextOrdinal = 0
     const start = (id: string, state?: Record<string, unknown>) =>
       Effect.suspend(() => {
@@ -143,45 +145,53 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         chunks.set(id, { ordinal, values: [], pending: "", state })
         return Effect.succeed(ordinal)
       })
-    const publishDelta = Effect.fnUntraced(function* (id: string, force = false) {
-      if (!delta) return undefined
-      const current = chunks.get(id)
-      if (!current) return yield* Effect.die(new Error(`${name} delta before start: ${id}`))
-      if (!current.pending) return undefined
-      const now = yield* Clock.currentTimeMillis
-      if (!force && current.publishedAt === undefined) {
-        current.publishedAt = now
-        return undefined
-      }
-      if (!force && current.publishedAt !== undefined && now - current.publishedAt < deltaBatchInterval)
-        return undefined
-      yield* delta(id, current.pending, current.ordinal)
+    const publishDelta = Effect.fnUntraced(function* (id: string, current: Fragment) {
+      if (!delta || !current.pending) return
+      const value = current.pending
       current.pending = ""
-      current.publishedAt = now
-      return undefined
-    })
+      yield* delta(id, value, current.ordinal)
+    }, Effect.uninterruptible)
     const append = Effect.fnUntraced(function* (id: string, value: string, state?: Record<string, unknown>) {
       const current = chunks.get(id)
       if (!current) return yield* Effect.die(new Error(`${name} delta before start: ${id}`))
       current.values.push(value)
       if (delta) current.pending += value
       if (state !== undefined) current.state = { ...current.state, ...state }
-      yield* publishDelta(id)
+      if (current.pending && !current.timer) {
+        // A fixed deadline, not a debounce: even the last burst of an open stream is visible.
+        current.timer = yield* Effect.sleep(deltaBatchInterval).pipe(
+          Effect.andThen(
+            lock.withPermit(
+              Effect.gen(function* () {
+                current.timer = undefined
+                yield* publishDelta(id, current)
+              }),
+            ),
+          ),
+          Effect.forkIn(scope),
+        )
+      }
       return current.ordinal
-    })
-    const end = Effect.fnUntraced(function* (id: string, state?: Record<string, unknown>, value?: string) {
-      const current = chunks.get(id)
-      if (!current) return yield* Effect.die(new Error(`${name} end before start: ${id}`))
-      yield* publishDelta(id, true)
-      yield* ended(
-        id,
-        value ?? current.values.join(""),
-        current.ordinal,
-        state === undefined ? current.state : { ...current.state, ...state },
-      )
-      chunks.delete(id)
-      return undefined
-    })
+    }, Semaphore.withPermit(lock))
+    const end = Effect.fnUntraced(
+      function* (id: string, state?: Record<string, unknown>, value?: string) {
+        const current = chunks.get(id)
+        if (!current) return yield* Effect.die(new Error(`${name} end before start: ${id}`))
+        // Take the lock before cancelling: an in-flight publication must complete before Ended.
+        if (current.timer) yield* Fiber.interrupt(current.timer)
+        yield* publishDelta(id, current)
+        yield* ended(
+          id,
+          value ?? current.values.join(""),
+          current.ordinal,
+          state === undefined ? current.state : { ...current.state, ...state },
+        )
+        chunks.delete(id)
+        return undefined
+      },
+      Effect.uninterruptible,
+      Semaphore.withPermit(lock),
+    )
     const flush = Effect.fnUntraced(function* () {
       for (const id of Array.from(chunks.keys())) yield* end(id)
     })

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -3,7 +3,7 @@ import type { Agent } from "@opencode-ai/schema/agent"
 import type { Model } from "@opencode-ai/schema/model"
 import type { RelativePath } from "@opencode-ai/schema/schema"
 import type { Snapshot } from "@opencode-ai/schema/snapshot"
-import { Cause, Deferred, Effect, Fiber, Iterable, Scope, Semaphore } from "effect"
+import { Cause, Deferred, Effect, Fiber, Iterable, Option, Scope, Semaphore } from "effect"
 import { isArrayNonEmpty, isReadonlyArrayNonEmpty } from "effect/Array"
 import { Bus } from "../../bus.js"
 import { SessionEvent } from "../event.js"
@@ -76,8 +76,8 @@ const hostedContent = (result: ToolResultValue): NonEmptyContent => {
  */
 export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, input: Input, scope: Scope.Scope) => {
   const deltaBatchInterval = 100
-  const publicationFailure = Deferred.makeUnsafe<Cause.Cause<never>>()
-  const awaitPublicationFailure = Deferred.await(publicationFailure).pipe(Effect.flatMap(Effect.failCause))
+  const publicationFailure = Deferred.makeUnsafe<never>()
+  const awaitPublicationFailure = Deferred.await(publicationFailure)
   type ToolState = {
     readonly name: string
     called: boolean
@@ -156,7 +156,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
       },
       // Report before releasing the fragment lock, so end cannot overtake a failed timer.
       Effect.tapCause((cause) =>
-        Cause.hasInterruptsOnly(cause) ? Effect.void : Deferred.succeed(publicationFailure, cause),
+        Cause.hasInterruptsOnly(cause) ? Effect.void : Deferred.failCause(publicationFailure, cause),
       ),
       Effect.uninterruptible,
     )
@@ -592,8 +592,8 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
 
   return {
     awaitPublicationFailure,
-    checkPublicationFailure: Effect.suspend(() =>
-      Deferred.isDoneUnsafe(publicationFailure) ? awaitPublicationFailure : Effect.void,
+    checkPublicationFailure: Deferred.poll(publicationFailure).pipe(
+      Effect.flatMap(Option.getOrElse(() => Effect.void)),
     ),
     publish: (event: LLMEvent) => {
       if (event.type === "text-delta" || event.type === "reasoning-delta" || event.type === "tool-input-delta")

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -3,7 +3,7 @@ import type { Agent } from "@opencode-ai/schema/agent"
 import type { Model } from "@opencode-ai/schema/model"
 import type { RelativePath } from "@opencode-ai/schema/schema"
 import type { Snapshot } from "@opencode-ai/schema/snapshot"
-import { Effect, Fiber, Iterable, Scope, Semaphore } from "effect"
+import { Cause, Deferred, Effect, Fiber, Iterable, Scope, Semaphore } from "effect"
 import { isArrayNonEmpty, isReadonlyArrayNonEmpty } from "effect/Array"
 import { Bus } from "../../bus.js"
 import { SessionEvent } from "../event.js"
@@ -76,6 +76,8 @@ const hostedContent = (result: ToolResultValue): NonEmptyContent => {
  */
 export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, input: Input, scope: Scope.Scope) => {
   const deltaBatchInterval = 100
+  const publicationFailure = Deferred.makeUnsafe<Cause.Cause<never>>()
+  const awaitPublicationFailure = Deferred.await(publicationFailure).pipe(Effect.flatMap(Effect.failCause))
   type ToolState = {
     readonly name: string
     called: boolean
@@ -145,12 +147,19 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         chunks.set(id, { ordinal, values: [], pending: "", state })
         return Effect.succeed(ordinal)
       })
-    const publishDelta = Effect.fnUntraced(function* (id: string, current: Fragment) {
-      if (!delta || !current.pending) return
-      const value = current.pending
-      current.pending = ""
-      yield* delta(id, value, current.ordinal)
-    }, Effect.uninterruptible)
+    const publishDelta = Effect.fnUntraced(
+      function* (id: string, current: Fragment) {
+        if (!delta || !current.pending) return
+        const value = current.pending
+        current.pending = ""
+        yield* delta(id, value, current.ordinal)
+      },
+      // Report before releasing the fragment lock, so end cannot overtake a failed timer.
+      Effect.tapCause((cause) =>
+        Cause.hasInterruptsOnly(cause) ? Effect.void : Deferred.succeed(publicationFailure, cause),
+      ),
+      Effect.uninterruptible,
+    )
     const append = Effect.fnUntraced(function* (id: string, value: string, state?: Record<string, unknown>) {
       const current = chunks.get(id)
       if (!current) return yield* Effect.die(new Error(`${name} delta before start: ${id}`))
@@ -582,6 +591,10 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
   })
 
   return {
+    awaitPublicationFailure,
+    checkPublicationFailure: Effect.suspend(() =>
+      Deferred.isDoneUnsafe(publicationFailure) ? awaitPublicationFailure : Effect.void,
+    ),
     publish: (event: LLMEvent) => {
       if (event.type === "text-delta" || event.type === "reasoning-delta" || event.type === "tool-input-delta")
         return publish(event)

--- a/packages/core/src/session/runner/step.ts
+++ b/packages/core/src/session/runner/step.ts
@@ -70,14 +70,18 @@ export const make = Effect.gen(function* () {
 
   const attempt = Effect.fn("SessionStep.attempt")(function* (input: Input) {
     const startSnapshot = yield* snapshots.capture()
-    const publisher = createLLMEventPublisher(bus, {
-      sessionID: input.sessionID,
-      assistantMessageID: input.assistantMessageID,
-      agent: input.agent,
-      model: input.model.ref,
-      providerMetadataKey: input.model.model.route.providerMetadataKey ?? input.model.model.provider,
-      snapshot: startSnapshot,
-    })
+    const publisher = createLLMEventPublisher(
+      bus,
+      {
+        sessionID: input.sessionID,
+        assistantMessageID: input.assistantMessageID,
+        agent: input.agent,
+        model: input.model.ref,
+        providerMetadataKey: input.model.model.route.providerMetadataKey ?? input.model.model.provider,
+        snapshot: startSnapshot,
+      },
+      yield* Effect.scope,
+    )
     const toolRuns: Array<{
       readonly call: ToolCall
       readonly fiber: Fiber.Fiber<void, Permission.DeclinedError | QuestionTool.CancelledError>

--- a/packages/core/src/session/runner/step.ts
+++ b/packages/core/src/session/runner/step.ts
@@ -131,7 +131,9 @@ export const make = Effect.gen(function* () {
           })
         }),
       ),
+      Effect.raceFirst(publisher.awaitPublicationFailure),
       Effect.ensuring(publisher.flush()),
+      Effect.andThen(publisher.checkPublicationFailure),
     )
 
     // Keep the final tool and Step events uninterruptible, even when the work itself is cancelled.
@@ -231,7 +233,7 @@ export const make = Effect.gen(function* () {
             ? { cost: SessionUsage.calculateCost(input.model.cost, record.finish.tokens), tokens: record.finish.tokens }
             : undefined
           if (record.failure) yield* publisher.publishStepFailure({ ...usage, snapshot, files })
-          if (record.finish && usage && !record.failure)
+          if (Exit.isSuccess(stream) && record.finish && usage && !record.failure)
             yield* bus.publish(SessionEvent.Step.Ended, {
               sessionID: input.sessionID,
               assistantMessageID: yield* publisher.startAssistant(),

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "bun:test"
-import { Cause, Deferred, Effect, Exit, Fiber, Schema } from "effect"
+import { afterEach, expect, test } from "bun:test"
+import { Cause, Deferred, Effect, Exit, Fiber, Latch, Schema, Scope } from "effect"
 import { eq } from "drizzle-orm"
 import { LLMEvent } from "@opencode-ai/ai"
 import { Money } from "@opencode-ai/schema/money"
@@ -27,8 +27,20 @@ import { TestClock } from "effect/testing"
 
 const sessionID = Session.ID.make("ses_tool_event_test")
 const base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+const scopes: Scope.Closeable[] = []
+afterEach(async () => {
+  await Effect.runPromise(Effect.forEach(scopes.splice(0), (scope) => Scope.close(scope, Exit.void)))
+})
 
-const capture = (providerMetadataKey = "anthropic", options?: { readonly interruptProgress?: boolean }) => {
+const capture = (
+  providerMetadataKey = "anthropic",
+  options?: {
+    readonly interruptProgress?: boolean
+    readonly beforeDelta?: Effect.Effect<void>
+  },
+) => {
+  const scope = Scope.makeUnsafe()
+  scopes.push(scope)
   const published: Array<{ readonly type: string; readonly data: unknown }> = []
   const bus: Pick<Bus.Interface, "publish"> = {
     publish: (definition, data) => {
@@ -40,6 +52,11 @@ const capture = (providerMetadataKey = "anthropic", options?: { readonly interru
         })
         return event
       })
+      if (
+        options?.beforeDelta &&
+        (definition.type === SessionEvent.Text.Delta.type || definition.type === SessionEvent.Reasoning.Delta.type)
+      )
+        return options.beforeDelta.pipe(Effect.andThen(publish))
       return definition.type === SessionEvent.Tool.Progress.type && options?.interruptProgress
         ? publish.pipe(Effect.andThen(Effect.interrupt))
         : publish
@@ -47,16 +64,21 @@ const capture = (providerMetadataKey = "anthropic", options?: { readonly interru
   }
   return {
     published,
-    publisher: createLLMEventPublisher(bus, {
-      sessionID,
-      agent: Agent.ID.make("build"),
-      model: {
-        id: Model.ID.make("model"),
-        providerID: Provider.ID.opencode,
+    scope,
+    publisher: createLLMEventPublisher(
+      bus,
+      {
+        sessionID,
+        agent: Agent.ID.make("build"),
+        model: {
+          id: Model.ID.make("model"),
+          providerID: Provider.ID.opencode,
+        },
+        providerMetadataKey,
+        assistantMessageID: SessionMessage.ID.create(),
       },
-      providerMetadataKey,
-      assistantMessageID: SessionMessage.ID.create(),
-    }),
+      scope,
+    ),
   }
 }
 
@@ -159,6 +181,7 @@ testEffect(
         model: { id: Model.ID.make("test-model"), providerID: Provider.ID.opencode },
         providerMetadataKey: "openai",
       },
+      yield* Effect.scope,
     )
     yield* publisher.publish(LLMEvent.toolCall({ ...call, providerExecuted: true }))
     yield* Effect.acquireRelease(
@@ -323,6 +346,158 @@ test("reasoning state from start, empty delta, and end is merged", async () => {
   })
 })
 
+for (const kind of ["text", "reasoning"] as const) {
+  it.effect(`publishes a complete short ${kind} burst while the stream remains open`, () =>
+    Effect.gen(function* () {
+      const { published, publisher } = capture()
+      yield* publisher.publish({ type: `${kind}-start`, id: "burst" })
+      yield* publisher.publish({ type: `${kind}-delta`, id: "burst", text: "interrupt-me-" })
+      yield* TestClock.adjust(20)
+      yield* publisher.publish({ type: `${kind}-delta`, id: "burst", text: "now" })
+      yield* TestClock.adjust(79)
+      expect(published.filter((event) => event.type === `session.${kind}.delta`)).toHaveLength(0)
+      yield* TestClock.adjust(1)
+      expect(
+        published.filter((event) => event.type === `session.${kind}.delta`).map((event) => event.data),
+      ).toMatchObject([{ delta: "interrupt-me-now", ordinal: 0 }])
+      expect(published.some((event) => event.type === `session.${kind}.ended.1`)).toBe(false)
+
+      yield* publisher.publish({ type: `${kind}-delta`, id: "burst", text: " trailing" })
+      yield* TestClock.adjust(100)
+      expect(
+        published.filter((event) => event.type === `session.${kind}.delta`).map((event) => event.data),
+      ).toMatchObject([{ delta: "interrupt-me-now" }, { delta: " trailing" }])
+      yield* publisher.publish({ type: `${kind}-end`, id: "burst" })
+      const count = published.length
+      yield* TestClock.adjust(1_000)
+      expect(published).toHaveLength(count)
+      expect(published.at(-1)?.data).toMatchObject({ text: "interrupt-me-now trailing" })
+    }),
+  )
+
+  it.effect(`serializes ${kind} append and end with an in-flight timer publication`, () =>
+    Effect.gen(function* () {
+      const publishing = yield* Latch.make()
+      const release = yield* Latch.make()
+      const { published, publisher } = capture("anthropic", {
+        beforeDelta: publishing.open.pipe(Effect.andThen(release.await)),
+      })
+      yield* publisher.publish({ type: `${kind}-start`, id: "burst" })
+      yield* publisher.publish({ type: `${kind}-delta`, id: "burst", text: "first" })
+      yield* TestClock.adjust(100)
+      yield* publishing.await
+      const provider = yield* publisher
+        .publish({ type: `${kind}-delta`, id: "burst", text: " suffix" })
+        .pipe(
+          Effect.andThen(publisher.publish({ type: `${kind}-end`, id: "burst" })),
+          Effect.forkScoped({ startImmediately: true }),
+        )
+      expect(published.some((event) => event.type === `session.${kind}.ended.1`)).toBe(false)
+      yield* release.open
+      yield* Fiber.join(provider)
+      expect(published.slice(-3).map((event) => event.type)).toEqual([
+        `session.${kind}.delta`,
+        `session.${kind}.delta`,
+        `session.${kind}.ended.1`,
+      ])
+      expect(published.slice(-3).map((event) => event.data)).toMatchObject([
+        { delta: "first" },
+        { delta: " suffix" },
+        { text: "first suffix" },
+      ])
+      const count = published.length
+      yield* TestClock.adjust(1_000)
+      expect(published).toHaveLength(count)
+    }),
+  )
+
+  it.effect(`commits a queued ${kind} append before interruption settlement`, () =>
+    Effect.gen(function* () {
+      const publishing = yield* Latch.make()
+      const release = yield* Latch.make()
+      const { published, publisher } = capture("anthropic", {
+        beforeDelta: publishing.open.pipe(Effect.andThen(release.await)),
+      })
+      yield* publisher.publish({ type: `${kind}-start`, id: "burst" })
+      yield* publisher.publish({ type: `${kind}-delta`, id: "burst", text: "first" })
+      yield* TestClock.adjust(100)
+      yield* publishing.await
+      const provider = yield* publisher
+        .publish({ type: `${kind}-delta`, id: "burst", text: " queued" })
+        .pipe(Effect.ensuring(publisher.flush()), Effect.forkScoped({ startImmediately: true }))
+      const interrupt = yield* Fiber.interrupt(provider).pipe(Effect.forkScoped({ startImmediately: true }))
+      expect(interrupt.pollUnsafe()).toBeUndefined()
+      expect(published.some((event) => event.type === `session.${kind}.ended.1`)).toBe(false)
+      yield* release.open
+      yield* Fiber.join(interrupt)
+      yield* publisher.failAssistant({ type: "aborted", message: "Step interrupted" })
+      yield* publisher.publishStepFailure()
+      expect(published.slice(-4).map((event) => event.type)).toEqual([
+        `session.${kind}.delta`,
+        `session.${kind}.delta`,
+        `session.${kind}.ended.1`,
+        "session.step.failed.1",
+      ])
+      expect(published.slice(-4).map((event) => event.data)).toMatchObject([
+        { delta: "first" },
+        { delta: " queued" },
+        { text: "first queued" },
+        { error: { type: "aborted" } },
+      ])
+      const count = published.length
+      yield* TestClock.adjust(1_000)
+      expect(published).toHaveLength(count)
+    }),
+  )
+
+  for (const termination of ["end", "failure", "interrupt"] as const) {
+    it.effect(`flushes ${kind} exactly once on ${termination} and cancels its deadline`, () =>
+      Effect.gen(function* () {
+        const { published, publisher } = capture()
+        const ready = yield* Latch.make()
+        const provider = yield* Effect.gen(function* () {
+          yield* publisher.publish({ type: `${kind}-start`, id: "burst" })
+          yield* publisher.publish({ type: `${kind}-delta`, id: "burst", text: "pending" })
+          yield* ready.open
+          yield* Effect.never
+        }).pipe(Effect.ensuring(publisher.flush()), Effect.forkScoped)
+        yield* ready.await
+        yield* TestClock.adjust(99)
+        if (termination === "end") yield* publisher.publish({ type: `${kind}-end`, id: "burst" })
+        if (termination === "failure") yield* publisher.publish(LLMEvent.providerError({ message: "fixture failure" }))
+        yield* Fiber.interrupt(provider)
+        if (termination === "interrupt")
+          yield* publisher.failAssistant({ type: "aborted", message: "Step interrupted" })
+        yield* publisher.publishStepFailure()
+        expect(
+          published.filter((event) => event.type === `session.${kind}.delta`).map((event) => event.data),
+        ).toMatchObject([{ delta: "pending", ordinal: 0 }])
+        expect(
+          published.filter((event) => event.type === `session.${kind}.ended.1`).map((event) => event.data),
+        ).toMatchObject([{ text: "pending", ordinal: 0 }])
+        const count = published.length
+        yield* TestClock.adjust(1_000)
+        expect(published).toHaveLength(count)
+        if (termination !== "end") expect(published.at(-1)?.type).toBe("session.step.failed.1")
+      }),
+    )
+  }
+
+  it.effect(`cancels the pending ${kind} timer when its owner scope closes`, () =>
+    Effect.gen(function* () {
+      const { published, publisher, scope } = capture()
+      yield* publisher.publish({ type: `${kind}-start`, id: "burst" })
+      yield* publisher.publish({ type: `${kind}-delta`, id: "burst", text: "pending" })
+      yield* TestClock.adjust(99)
+      yield* Scope.close(scope, Exit.void)
+      const count = published.length
+      yield* TestClock.adjust(1_000)
+      expect(published).toHaveLength(count)
+      expect(published.some((event) => event.type === `session.${kind}.delta`)).toBe(false)
+    }),
+  )
+}
+
 it.effect("batches text deltas and flushes pending text before the terminal event", () =>
   Effect.gen(function* () {
     const { published, publisher } = capture()
@@ -343,13 +518,13 @@ it.effect("batches text deltas and flushes pending text before the terminal even
     yield* TestClock.adjust("1 millis")
     yield* publisher.publish(LLMEvent.textDelta({ id: "text", text: " four" }))
     expect(published.filter((event) => event.type === "session.text.delta").map((event) => event.data)).toMatchObject([
-      { delta: "one two three four" },
+      { delta: "one two three" },
     ])
 
     yield* publisher.publish(LLMEvent.textDelta({ id: "text", text: " five" }))
     yield* publisher.publish(LLMEvent.textEnd({ id: "text" }))
     expect(published.slice(-2).map((event) => event.type)).toEqual(["session.text.delta", "session.text.ended.1"])
-    expect(published.at(-2)?.data).toMatchObject({ delta: " five" })
+    expect(published.at(-2)?.data).toMatchObject({ delta: " four five" })
   }),
 )
 

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -478,6 +478,7 @@ for (const kind of ["text", "reasoning"] as const) {
         const count = published.length
         yield* TestClock.adjust(1_000)
         expect(published).toHaveLength(count)
+        yield* publisher.checkPublicationFailure
         if (termination !== "end") expect(published.at(-1)?.type).toBe("session.step.failed.1")
       }),
     )
@@ -494,6 +495,7 @@ for (const kind of ["text", "reasoning"] as const) {
       yield* TestClock.adjust(1_000)
       expect(published).toHaveLength(count)
       expect(published.some((event) => event.type === `session.${kind}.delta`)).toBe(false)
+      yield* publisher.checkPublicationFailure
     }),
   )
 }

--- a/packages/core/test/session-step.test.ts
+++ b/packages/core/test/session-step.test.ts
@@ -21,7 +21,8 @@ import { ToolOutput } from "@opencode-ai/core/tool-output"
 import { Money } from "@opencode-ai/schema/money"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { asc, eq } from "drizzle-orm"
-import { Effect, Exit, Layer } from "effect"
+import { Cause, Effect, Exit, Fiber, Latch, Layer, Stream } from "effect"
+import { TestClock } from "effect/testing"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(
@@ -32,6 +33,136 @@ const it = testEffect(
     TestLLM.testLayer(),
   ),
 )
+
+for (const [kind, ending] of [
+  ["text", "open"],
+  ["reasoning", "open"],
+  ["text", "finish"],
+  ["reasoning", "finish"],
+  ["text", "eof"],
+  ["reasoning", "eof"],
+  ["text", "end"],
+  ["reasoning", "end"],
+  ["text", "interrupt"],
+  ["reasoning", "interrupt"],
+] as const) {
+  it.effect(`settles batched ${kind} publication with ${ending}`, () =>
+    Effect.gen(function* () {
+      const database = yield* Database.Service
+      const bus = yield* Bus.Service
+      const llm = yield* TestLLM.Test
+      const paused = yield* Latch.make()
+      const finish = yield* Latch.make()
+      const defected = yield* Latch.make()
+      const defect = new Error("delta listener defect")
+      const die = Effect.die(defect).pipe(Effect.ensuring(defected.open))
+      let failed = false
+      yield* bus.listen((event) =>
+        Effect.suspend(() => {
+          if (event.type !== `session.${kind}.delta` || failed || ending === "end" || ending === "interrupt")
+            return Effect.void
+          failed = true
+          // EOF wins the race before the defect, exercising the final post-flush check.
+          if (ending === "eof") return finish.open.pipe(Effect.andThen(Effect.yieldNow), Effect.andThen(die))
+          return ending === "finish" ? finish.open.pipe(Effect.andThen(die)) : die
+        }),
+      )
+      const sessionID = Session.ID.create()
+      const assistantMessageID = SessionMessage.ID.create()
+      yield* database.db
+        .insert(ProjectTable)
+        .values({
+          id: Project.ID.global,
+          worktree: AbsolutePath.make("/project"),
+          sandboxes: [],
+        })
+        .run()
+      yield* database.db
+        .insert(SessionTable)
+        .values({
+          id: sessionID,
+          project_id: Project.ID.global,
+          slug: "delta-failure",
+          directory: "/project",
+          version: "test",
+        })
+        .run()
+      const steps = yield* SessionStep.make.pipe(
+        Effect.provide(Layer.mock(Snapshot.Service)({ capture: () => Effect.succeed(undefined) })),
+      )
+      const model = SessionRunnerModel.resolved(
+        LanguageModel.make({ id: "test-model", provider: "test", route: OpenAIChat.route }),
+        {
+          capabilities: { tools: false, input: ["text"], output: ["text"] },
+          limit: { context: 100_000, output: 1_000 },
+          cost: [],
+        },
+      )
+      yield* llm.push(
+        Stream.make(
+          { type: `${kind}-start`, id: "burst" } satisfies LLMEvent,
+          { type: `${kind}-delta`, id: "burst", text: "complete short burst" } satisfies LLMEvent,
+        ).pipe(
+          Stream.concat(
+            Stream.fromEffect(paused.open.pipe(Effect.andThen(finish.await))).pipe(
+              Stream.flatMap(() =>
+                ending === "eof"
+                  ? Stream.empty
+                  : Stream.fromIterable(TestLLM.stop({ type: `${kind}-end`, id: "burst" })),
+              ),
+            ),
+          ),
+        ),
+      )
+      const attempt = yield* steps
+        .attempt({
+          sessionID,
+          assistantMessageID,
+          agent: Agent.defaultID,
+          model,
+          prepared: {
+            retry: () => Effect.void,
+            request: LLM.request({ model: model.model, prompt: "Stream a short burst" }),
+            options: {},
+            executeTool: () => Effect.die("unexpected tool"),
+          },
+          retry: () => Effect.die("unexpected provider retry"),
+          recoverContinuation: true,
+          recoverOverflow: Effect.succeed(false),
+        })
+        .pipe(Effect.forkScoped)
+      yield* paused.await
+      if (ending === "end") yield* finish.open
+      if (ending === "interrupt") yield* Fiber.interrupt(attempt)
+      yield* TestClock.adjust(100)
+      if (ending === "open" || ending === "finish" || ending === "eof") yield* defected.await
+      yield* TestClock.adjust(0)
+      const result = attempt.pollUnsafe()
+      expect(result).toBeDefined()
+      if (ending === "end") expect(result && Exit.isSuccess(result)).toBe(true)
+      if (ending === "interrupt")
+        expect(result && Exit.isFailure(result) && Cause.hasInterruptsOnly(result.cause)).toBe(true)
+      if (ending === "open" || ending === "finish" || ending === "eof")
+        expect(result && Exit.isFailure(result) && Cause.squash(result.cause)).toBe(defect)
+      yield* finish.open
+      yield* Fiber.await(attempt)
+      yield* TestClock.adjust(1_000)
+      const message = yield* database.db
+        .select()
+        .from(SessionMessageTable)
+        .where(eq(SessionMessageTable.id, assistantMessageID))
+        .get()
+      expect(message?.data).toMatchObject({ content: [{ type: kind, text: "complete short burst" }] })
+      const events = yield* database.db
+        .select({ type: EventTable.type })
+        .from(EventTable)
+        .where(eq(EventTable.aggregate_id, sessionID))
+        .all()
+      expect(events.some((event) => event.type === "session.step.ended.1")).toBe(ending === "end")
+      expect(events.filter((event) => event.type === `session.${kind}.ended.1`)).toHaveLength(1)
+    }),
+  )
+}
 
 for (const fixture of [
   { finish: "stop", toolChoice: undefined },


### PR DESCRIPTION
## Why

A model can emit a complete short burst and then pause, but the client sees nothing until another delta arrives or the stream ends. The existing batcher checks elapsed time only on append, with no timer to flush the final suffix. This makes a healthy stream look stalled and prevents the TUI from acknowledging received output during long provider pauses.

## What Changes

| Situation | Behavior |
| --- | --- |
| First text or reasoning burst, followed by silence | Start one 100ms publication deadline at the first pending append. |
| More chunks arrive before the deadline | Coalesce them without resetting that deadline. |
| A trailing burst follows an earlier publication | Publish the complete suffix without requiring another provider chunk or text-end. |
| Empty or metadata-only append | Do not create an idle ticker or unnecessary timer. |
| Normal end or interruption | Serialize with active publication, cancel a sleeping timer, drain remaining output, and then settle the fragment. |
| Physical Attempt scope closes | Interrupt pending timers; no delayed delta can appear after terminal settlement. |
| A Bus delta listener fails | Fail the Physical Attempt, including when provider EOF wins the initial race; do not report successful Step completion. |

## Publication Ownership

The existing Physical Attempt scope owns the timers. A fragment permit serializes append, timer publication, and end, so clearing a published batch cannot erase concurrent input and an Ended event cannot overtake a live delta.

Scope ownership alone does not propagate background failures. A publisher-owned failure-only Deferred records the full non-cancellation failure cause before releasing the permit. Provider consumption races that Deferred and polls it again after final flushing. Only a successful stream exit may publish `Step.Ended`. This preserves the Bus's existing fail-fast listener contract instead of swallowing asynchronous defects or introducing a new retry policy.

## Demo

Real production V2 TUI on clean immutable base `426e5c6389bc` and clean committed fix `6efafba1188b`, using the same generic simulated model, synthetic prompt, 100x30 viewport, unchanged Drive runtime `479d76c597`, and identical script. The provider emits two short text chunks, pauses without text-end, emits a trailing burst, and pauses again. Both runs are interrupted with two Escape presses.

The side-by-side comparison shows two equal 1.5-second checkpoint clips at normal speed: blank versus complete first output, then held versus complete trailing output. Both source labels and both checkpoint frames were inspected. No live user data or private models are involved. The 100ms bound is native publication timing, not end-to-end rendering latency; the video demonstrates complete output while the stream remains open.

This footage predates the rebase onto `a5f8869b3533`. Rebased revision `86a1071051` preserves the shown timer/failure-channel behavior and upstream publication-cancellation safety. The original lifecycle and ten-burst stress probes were rerun on that rebased head; the footage is not claimed as a recording of the new base. Later primitive-only follow-up `59f2b95ee3` changes the failure representation, not the rendered states.

https://github.com/user-attachments/assets/ec1a2c1a-80dd-41c5-8904-377f3d91091f

## Scope

This owns text/reasoning delta batching and the corresponding Physical Attempt failure boundary. Tool-input fragments retain their existing behavior. The deadline excludes Bus/listener backpressure and renderer scheduling; an indefinitely blocked uninterruptible Bus publication remains a limitation rather than being hidden behind a timeout. No public Protocol, Server HttpApi, generated-client, or durable-event surface changes.

## Verification

Run from `packages/core`:

```sh
bun run test test/session-runner-tool-events.test.ts test/session-step.test.ts --rerun-each 20
bun run test test/session-runner-tool-events.test.ts test/session-step.test.ts test/session-runner.test.ts test/session-runner-message.test.ts test/session-tool-progress.test.ts test/session-projector.test.ts test/session-view.test.ts test/session-model-transport.test.ts test/bus.test.ts
RECORD=false bun run test test/session-runner-recorded.test.ts test/session-execution.test.ts test/session-run-coordinator.test.ts test/session-tool-progress.test.ts
bun typecheck
```

- **940 repeated passes** across 47 publisher/attempt tests. Real TestClock, Bus, database, and projector fixtures cover complete short and trailing bursts, batching, backpressure with concurrent append/end, provider failure, owner interruption, normal end, and timer cleanup.
- **343 passes** across nine relevant suites, plus **63 passes** across four additional suites. The tool-progress suite overlaps; these are not claimed as unique combined coverage.
- One-shot Bus listener defects reproduced the asynchronous failure gap on parent `2e95edd8`: the attempt remained pending at the deadline. The fix passes both text/reasoning open-stream, concurrent-finish, and yielded-EOF cases while preserving full Ended content exactly once. Removing the final failure check made both EOF cases incorrectly succeed; restoring it makes them fail correctly.
- Typecheck, formatting, and diff checks pass. Targeted lint has zero errors and the same 21 inherited warnings as the base.
- The unchanged Drive interaction lifecycle fails on base waiting for `interrupt-me-now` before interruption, and passes on the final committed head without a sentinel or timing workaround.
- Ten alternating text/reasoning burst-interruption runs pass on final `6efafba1188b`: complete first/trailing suffixes are visible while the provider is still paused, exactly one prompt admission each, ten Ended events, ten interrupted Step failures, matching delta concatenation, and no late/duplicate deltas.
- Fresh matched capture runs both pass with identical runtime/script hashes. Before first/trailing visibility is `false/false`; after is `true/true`. Exact-marker stress uses source Markdown mode so concealment of underscores cannot be mistaken for missing output.

The final integrated sweep used clean Drive `77937563` and clean Core `6efafba1188b`: **42/42 ordinary real-TUI cases passed on the first run**, including the 25 expanded lifecycle/network cases, five compaction cases, and twelve picker cases. Two separate negative controls correctly reject a visible completion marker followed by failed execution. All 44 physical runs completed without unexpected failures, timeouts, or retries. This integrates the three Drive repairs with the stream fix; the separate question-answer branch is not part of that tree.

Runtime evidence was collected on macOS ARM64/Bun 1.3.14, not Windows Drive coverage. Native suites are scoped to the affected Core subsystems, not a claim that every Core test was run.

### Rebase Verification

Rebased the two commits onto pinned current `v2` revision `a5f8869b3533f0b7203d472c48baaa8ffb9f59b1`, producing `86a1071051a0409b1e3c7a2ddb606e463f4e2e19`. Conflicts were import unions in the publisher and its tests. Range-diff review preserved upstream canonical schema imports, nonempty guards, retry hooks, and uninterruptible provider publication. The queued-append interruption test now conserves that upstream-protected append instead of treating it as unsent; no timer/channel/race/final-check policy was changed.

On the rebased head: **960/960** repeated publisher/attempt cases (48 tests), **346/346** tests across nine relevant suites, **63/63** additional recorded/execution/coordinator checks, Core typecheck, and formatting passed. The normal force-with-lease push hook completed all 33 workspace typecheck tasks. The unchanged real-TUI interaction lifecycle and ten alternating burst/interruption scenarios also pass on `86a1071051`, with exactly one admission each, ten endings, ten interrupted Step failures, complete concatenated deltas, and no late-event violations. The prior 44-run combined sweep remains evidence for its original `6ef` pin and was not silently relabeled as rebased-head coverage.

### Effect Primitive Audit

Compared the installed `effect@4.0.0-rc.112` with freshly fetched upstream Effect `main` at `145d8e1013220425b8edf34f7011c73f73e1cdcf`. RC.112 remains the newest published v4 RC; no dependency upgrade is required. The relevant cancellation, Deferred, race, and semaphore implementations agree across these sources.

Follow-up `59f2b95ee3` uses native `Deferred.failCause` instead of encoding a Cause as a success value and converting it back, and `Deferred.poll` executes any stored failure for the post-flush check. The existing under-permit notification, cancellation-only exclusion, `raceFirst`, and EOF guard remain intact. On this follow-up, all **960 repeated cases**, **346 broader cases**, Core typecheck, formatting, diff checks, and all **33 normal pre-push typecheck tasks** passed. No new tests or infrastructure were added just for the equivalent encoding.

`Effect.sleep` plus `forkIn` remains the smallest demand-driven fixed-deadline timer. `Stream.groupedWithin` uses `aggregateWithin` with a recurring schedule, including idle schedule activity, and does not directly model individual fragment terminal boundaries. A one-permit `Semaphore` is the appropriate mutex. Keep the timer's default interruptibility: inheriting the publisher's uninterruptibility could deadlock cancellation while end holds the permit. `FiberSet` observes failure after fiber termination, too late to replace the required before-unlock notification. `raceFirst`, not success-biased `race`, is necessary to fail a still-open provider promptly.
