### PR TITLE
fix(server): await providers before catalog reads

### DIFF
--- a/packages/server/src/handlers/provider.ts
+++ b/packages/server/src/handlers/provider.ts
@@ -1,9 +1,18 @@
 import { Catalog } from "@opencode-ai/core/catalog"
+import { ProviderNotFoundError, ServiceUnavailableError } from "@opencode-ai/protocol/errors"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
-import { ProviderNotFoundError } from "@opencode-ai/protocol/errors"
 import { response } from "../location"
+import { pluginReadiness } from "./plugin-readiness"
+
+const flushPlugins = pluginReadiness(
+  () =>
+    new ServiceUnavailableError({
+      message: "Provider catalog initialization timed out",
+      service: "provider.catalog",
+    }),
+)
 
 export const ProviderHandler = HttpApiBuilder.group(Api, "server.provider", (handlers) =>
   Effect.gen(function* () {
@@ -11,6 +20,7 @@ export const ProviderHandler = HttpApiBuilder.group(Api, "server.provider", (han
       .handle(
         "provider.list",
         Effect.fn(function* () {
+          yield* flushPlugins
           const catalog = yield* Catalog.Service
           return yield* response(catalog.provider.available())
         }),
@@ -18,6 +28,7 @@ export const ProviderHandler = HttpApiBuilder.group(Api, "server.provider", (han
       .handle(
         "provider.get",
         Effect.fn(function* (ctx) {
+          yield* flushPlugins
           const catalog = yield* Catalog.Service
           const provider = yield* catalog.provider.get(ctx.params.providerID)
           if (!provider)

--- a/packages/server/test/provider.test.ts
+++ b/packages/server/test/provider.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { tmpdir } from "../../core/test/fixture/tmpdir"
+import { it } from "../../core/test/lib/effect"
+import { startServer } from "./fixture/server"
+
+it.live(
+  "waits for plugin initialization on the first provider list request",
+  () =>
+    Effect.gen(function* () {
+      const fixture = yield* configuredProvider("opencode-provider-list-endpoint-")
+      const url = new URL("/api/provider", fixture.server.base)
+      url.searchParams.set("location[directory]", fixture.path)
+      const response = yield* Effect.promise(() => fetch(url, { headers: fixture.server.headers }))
+
+      expect(response.status).toBe(200)
+      const body: unknown = yield* Effect.promise(() => response.json())
+      if (!isRecord(body) || !Array.isArray(body["data"])) throw new Error("Expected a provider list response")
+      expect(body["data"].some((provider) => isRecord(provider) && provider["id"] === "custom")).toBeTrue()
+    }),
+  15_000,
+)
+
+it.live(
+  "waits for plugin initialization on the first provider get request",
+  () =>
+    Effect.gen(function* () {
+      const fixture = yield* configuredProvider("opencode-provider-get-endpoint-")
+      const url = new URL("/api/provider/custom", fixture.server.base)
+      url.searchParams.set("location[directory]", fixture.path)
+      const response = yield* Effect.promise(() => fetch(url, { headers: fixture.server.headers }))
+
+      expect(response.status).toBe(200)
+      const body: unknown = yield* Effect.promise(() => response.json())
+      if (!isRecord(body) || !isRecord(body["data"])) throw new Error("Expected a provider response")
+      expect(body["data"]["id"]).toBe("custom")
+    }),
+  15_000,
+)
+
+const configuredProvider = Effect.fnUntraced(function* (prefix: string) {
+  const tmp = yield* Effect.acquireDisposable(Effect.promise(() => tmpdir(prefix)))
+  yield* Effect.promise(() =>
+    fs.writeFile(
+      path.join(tmp.path, "opencode.json"),
+      JSON.stringify({
+        providers: {
+          custom: {
+            package: "@opencode-ai/ai/providers/openai-compatible",
+            settings: { apiKey: "secret" },
+            models: { chat: {} },
+          },
+        },
+      }),
+    ),
+  )
+  return { server: yield* startServer(tmp.path), path: tmp.path }
+})
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}


### PR DESCRIPTION
## Why

An initial provider list or lookup could read the empty Catalog before configured plugins finished registering providers. The same request would then succeed after a model endpoint happened to flush plugin initialization.

## What Changes

`provider.list` and `provider.get` now use the existing lazy plugin-readiness policy before reading the Catalog:

| Startup state | Before | After |
| --- | --- | --- |
| Plugins settle in time | Empty list or transient 404 | Complete provider result |
| Readiness times out | Incomplete catalog result | Declared 503 error |

## Scope

Only the two provider catalog endpoints change. Their Protocol already declares the readiness error, so no client regeneration is required.

## Verification

```sh
cd packages/server
bun run test test/provider.test.ts test/handler-policy.test.ts
bun typecheck
git diff --check origin/v2...HEAD
```

- 5 focused tests passed.
- Server and workspace typechecks passed.
- Independent final review found no issues.
