### PR TITLE
fix(ai): validate cache tail counts

### DIFF
--- a/packages/ai/src/schema/options.ts
+++ b/packages/ai/src/schema/options.ts
@@ -267,7 +267,7 @@ export const CachePolicyObject = Schema.Struct({
     Schema.Union([
       Schema.Literal("latest-user-message"),
       Schema.Literal("latest-assistant"),
-      Schema.Struct({ tail: Schema.Number }),
+      Schema.Struct({ tail: Schema.Natural }),
     ]),
   ),
   ttlSeconds: Schema.optional(Schema.Number),

--- a/packages/ai/test/cache-policy.test.ts
+++ b/packages/ai/test/cache-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
-import { CacheHint, LLM, Message } from "../src/index.js"
+import { Effect, Schema } from "effect"
+import { CacheHint, CachePolicyObject, LLM, Message } from "../src/index.js"
 import { Auth } from "../src/route.js"
 import { compileRequest } from "../src/route/client.js"
 import { AmazonBedrock, GoogleVertexMessages } from "../src/providers.js"
@@ -28,6 +28,37 @@ const geminiModel = Gemini.route
     auth: Auth.header("x-goog-api-key", "test"),
   })
   .model({ id: "gemini-2.5-flash" })
+
+const decodeCachePolicyObject = Schema.decodeUnknownSync(CachePolicyObject)
+
+describe("cache policy schema", () => {
+  test.each([0, 2])("accepts messages.tail count %d when decoding and constructing", (tail) => {
+    expect(decodeCachePolicyObject({ messages: { tail } })).toEqual({ messages: { tail } })
+    expect(
+      LLM.request({
+        model: anthropicModel,
+        prompt: "hi",
+        cache: { messages: { tail } },
+      }).cache,
+    ).toEqual({ messages: { tail } })
+  })
+
+  test.each([
+    ["negative", -1],
+    ["fraction", 1.5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("rejects a %s messages.tail when decoding and constructing", (_name, tail) => {
+    expect(() => decodeCachePolicyObject({ messages: { tail } })).toThrow()
+    expect(() =>
+      LLM.request({
+        model: anthropicModel,
+        prompt: "hi",
+        cache: { messages: { tail } },
+      }),
+    ).toThrow()
+  })
+})
 
 describe("applyCachePolicy", () => {
   it.effect("undefined cache resolves to 'auto' (the recommended default)", () =>
@@ -315,6 +346,19 @@ describe("applyCachePolicy", () => {
       expect(body.messages[3]?.content[0]?.cache_control).toEqual({ type: "ephemeral" })
     }),
   )
+
+  test("messages: { tail: 0 } marks no message boundaries", () => {
+    const request = LLM.request({
+      model: anthropicModel,
+      messages: [Message.user("u1"), Message.assistant("a1")],
+      cache: { messages: { tail: 0 } },
+    })
+
+    expect(applyCachePolicy(request)).toBe(request)
+    expect(
+      request.messages.flatMap((message) => message.content.map((part) => ("cache" in part ? part.cache : undefined))),
+    ).toEqual([undefined, undefined])
+  })
 
   it.effect("'latest-assistant' marks the last assistant message", () =>
     Effect.gen(function* () {

--- a/packages/ai/test/cache-policy.test.ts
+++ b/packages/ai/test/cache-policy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import { Effect, Schema } from "effect"
-import { CacheHint, CachePolicyObject, LLM, Message } from "../src/index.js"
+import { Effect } from "effect"
+import { CacheHint, LLM, Message } from "../src/index.js"
 import { Auth } from "../src/route.js"
 import { compileRequest } from "../src/route/client.js"
 import { AmazonBedrock, GoogleVertexMessages } from "../src/providers.js"
@@ -28,37 +28,6 @@ const geminiModel = Gemini.route
     auth: Auth.header("x-goog-api-key", "test"),
   })
   .model({ id: "gemini-2.5-flash" })
-
-const decodeCachePolicyObject = Schema.decodeUnknownSync(CachePolicyObject)
-
-describe("cache policy schema", () => {
-  test.each([0, 2])("accepts messages.tail count %d when decoding and constructing", (tail) => {
-    expect(decodeCachePolicyObject({ messages: { tail } })).toEqual({ messages: { tail } })
-    expect(
-      LLM.request({
-        model: anthropicModel,
-        prompt: "hi",
-        cache: { messages: { tail } },
-      }).cache,
-    ).toEqual({ messages: { tail } })
-  })
-
-  test.each([
-    ["negative", -1],
-    ["fraction", 1.5],
-    ["NaN", Number.NaN],
-    ["Infinity", Number.POSITIVE_INFINITY],
-  ])("rejects a %s messages.tail when decoding and constructing", (_name, tail) => {
-    expect(() => decodeCachePolicyObject({ messages: { tail } })).toThrow()
-    expect(() =>
-      LLM.request({
-        model: anthropicModel,
-        prompt: "hi",
-        cache: { messages: { tail } },
-      }),
-    ).toThrow()
-  })
-})
 
 describe("applyCachePolicy", () => {
   it.effect("undefined cache resolves to 'auto' (the recommended default)", () =>
@@ -346,19 +315,6 @@ describe("applyCachePolicy", () => {
       expect(body.messages[3]?.content[0]?.cache_control).toEqual({ type: "ephemeral" })
     }),
   )
-
-  test("messages: { tail: 0 } marks no message boundaries", () => {
-    const request = LLM.request({
-      model: anthropicModel,
-      messages: [Message.user("u1"), Message.assistant("a1")],
-      cache: { messages: { tail: 0 } },
-    })
-
-    expect(applyCachePolicy(request)).toBe(request)
-    expect(
-      request.messages.flatMap((message) => message.content.map((part) => ("cache" in part ? part.cache : undefined))),
-    ).toEqual([undefined, undefined])
-  })
 
   it.effect("'latest-assistant' marks the last assistant message", () =>
     Effect.gen(function* () {


### PR DESCRIPTION
## Why

Cache policy `messages.tail` accepted negative, fractional, `NaN`, and infinite values even though it represents a message count. Fractional values could produce a fractional array index and defect during request compilation.

## What Changes

`messages.tail` now uses Effect Schema's canonical non-negative integer Schema:

```diff
-Schema.Struct({ tail: Schema.Number })
+Schema.Struct({ tail: Schema.Natural })
```

Zero and positive integer counts remain valid. Values that cannot represent an array-tail count are rejected by normal `LLMRequest` Schema validation.

## Scope

This is a one-line Schema correction. The cache-marking algorithm and persisted Session data are unchanged; the policy is transient request-compilation input.

## Verification

```sh
cd packages/ai
bun typecheck
bun run build
```

- AI typecheck and build passed.
- The pre-push workspace typecheck passed all 33 tasks.
