### PR TITLE
fix(server): detach PTYs when sockets close

### DIFF
--- a/packages/server/src/handlers/persistent-pty.ts
+++ b/packages/server/src/handlers/persistent-pty.ts
@@ -12,6 +12,7 @@ import { HttpApiBuilder, HttpApiSchema } from "effect/unstable/httpapi"
 import { Socket } from "effect/unstable/socket"
 import { Api } from "../api"
 import { CorsConfig, isAllowedRequestOrigin } from "../cors"
+import { runPtySocket } from "./pty-socket"
 
 export const PersistentPtyHandler = HttpApiBuilder.group(Api, "server.experimental", (handlers) =>
   Effect.gen(function* () {
@@ -191,7 +192,7 @@ export const PersistentPtyHandler = HttpApiBuilder.group(Api, "server.experiment
             }
           })
 
-          yield* Effect.race(
+          yield* runPtySocket(
             drain,
             socket.runRaw(
               (message) =>
@@ -221,9 +222,9 @@ export const PersistentPtyHandler = HttpApiBuilder.group(Api, "server.experiment
                 ),
               { onOpen },
             ),
+            () => attachment?.detach(),
           ).pipe(
             Effect.catchReason("SocketError", "SocketCloseError", () => Effect.void),
-            Effect.ensuring(Effect.sync(() => attachment?.detach())),
             Effect.orDie,
           )
           return HttpServerResponse.empty()

--- a/packages/server/src/handlers/pty-socket.ts
+++ b/packages/server/src/handlers/pty-socket.ts
@@ -1,0 +1,9 @@
+import { Effect } from "effect"
+
+export function runPtySocket<A, E, R, A2, E2, R2>(
+  drain: Effect.Effect<A, E, R>,
+  socket: Effect.Effect<A2, E2, R2>,
+  detach: () => void,
+) {
+  return Effect.raceFirst(drain, socket).pipe(Effect.ensuring(Effect.sync(detach)))
+}

--- a/packages/server/src/handlers/pty.ts
+++ b/packages/server/src/handlers/pty.ts
@@ -17,6 +17,7 @@ import {
 } from "@opencode-ai/protocol/groups/pty"
 import { response } from "../location"
 import { PtyEnvironment } from "../pty-environment"
+import { runPtySocket } from "./pty-socket"
 
 const ticketScope = Effect.gen(function* () {
   const location = yield* Location.Service
@@ -209,15 +210,15 @@ export const PtyHandler = HttpApiBuilder.group(Api, "server.pty", (handlers) =>
             }
           })
 
-          yield* Effect.race(
+          yield* runPtySocket(
             drain,
             socket.runRaw((message) => {
               const decoded = PtyProtocol.decodeInput(message)
               if (decoded !== undefined) attachment.write(decoded)
             }),
+            attachment.detach,
           ).pipe(
             Effect.catchReason("SocketError", "SocketCloseError", () => Effect.void),
-            Effect.ensuring(Effect.sync(() => attachment.detach())),
             Effect.orDie,
           )
           return HttpServerResponse.empty()

--- a/packages/server/test/pty-socket.test.ts
+++ b/packages/server/test/pty-socket.test.ts
@@ -1,0 +1,16 @@
+import { expect } from "bun:test"
+import { Effect, Option, Result } from "effect"
+import { it } from "../../core/test/lib/effect"
+import { runPtySocket } from "../src/handlers/pty-socket"
+
+it.live("detaches when the socket fails while the outbox drain is blocked", () =>
+  Effect.gen(function* () {
+    const state = { detached: false }
+    const result = yield* runPtySocket(Effect.never, Effect.fail("socket closed"), () => {
+      state.detached = true
+    }).pipe(Effect.result, Effect.timeoutOption("100 millis"))
+
+    expect(Option.isSome(result) && Result.isFailure(result.value)).toBeTrue()
+    expect(state.detached).toBeTrue()
+  }),
+)


### PR DESCRIPTION
## Why

PTY WebSocket handlers raced the outbound drain against the socket using first-success semantics. When a client socket closed or failed while the terminal remained alive, the failure could wait forever on the blocked drain, retaining the dead attachment and request fiber.

## What Changes

Both transient and persistent PTY handlers now share a first-exit socket lifecycle:

```mermaid
flowchart LR
  A[Socket or drain exits] --> B[Interrupt the other branch]
  B --> C[Normalize socket close]
  C --> D[Detach PTY attachment]
```

Drain completion still interrupts the socket, while socket success, close, or failure now promptly interrupts the drain and reaches the existing finalizer.

## Scope

This PR changes attachment cleanup only. PTY replay, controller selection, and socket error normalization are unchanged.

## Verification

```sh
cd packages/server
bun run test test/pty-socket.test.ts test/persistent-pty.test.ts
bun typecheck
git diff --check origin/v2...HEAD
```

- The deterministic cleanup regression passed 20 consecutive runs and fails under the previous `Effect.race` behavior.
- Server and workspace typechecks passed.
- Three daemon-backed persistent PTY tests were skipped because the local `opencode-pty` binary is unavailable.
- Independent final review found no issues.
