### PR TITLE
fix(ai): handle message-less Gemini errors

### DIFF
--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -618,7 +618,7 @@ const step = (state: ParserState, event: GeminiEvent) => {
       }),
     )
   }
-  if (event.error !== undefined && event.error !== null)
+  if ("error" in event)
     return Effect.fail(
       ProviderShared.eventError(state.route, `Invalid ${state.route} stream event`, ProviderShared.encodeJson(event)),
     )

--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -601,18 +601,27 @@ const finish = (state: ParserState): ReadonlyArray<LLMEvent> => {
 }
 
 const step = (state: ParserState, event: GeminiEvent) => {
-  if (ProviderShared.isRecord(event.error) && typeof event.error.message === "string") {
+  if (ProviderShared.isRecord(event.error)) {
     const body = ProviderShared.encodeJson(event)
     return Effect.fail(
       new AIError({
         reason: classifyProviderFailure({
-          message: event.error.message,
+          message:
+            typeof event.error.message === "string" && event.error.message.length > 0
+              ? event.error.message
+              : typeof event.error.status === "string" && event.error.status.length > 0
+                ? event.error.status
+                : "Gemini provider error",
           status: typeof event.error.code === "number" ? event.error.code : undefined,
           rawBody: body,
         }),
       }),
     )
   }
+  if (event.error !== undefined && event.error !== null)
+    return Effect.fail(
+      ProviderShared.eventError(state.route, `Invalid ${state.route} stream event`, ProviderShared.encodeJson(event)),
+    )
   const nextState = {
     ...state,
     promptFeedback: event.promptFeedback ?? state.promptFeedback,

--- a/packages/ai/test/provider/error-retention.test.ts
+++ b/packages/ai/test/provider/error-retention.test.ts
@@ -101,6 +101,23 @@ describe("provider error retention", () => {
     }),
   )
 
+  it.effect("rejects and retains an explicit null Gemini error", () =>
+    Effect.gen(function* () {
+      const body = JSON.stringify({ error: null, trace: { opaque: "outer" } })
+      const error = yield* LLMClient.generate(
+        LLM.request({ model: Google.configure(options).model("gemini"), prompt: "hello" }),
+      ).pipe(
+        Effect.provide(fixedResponse(sseEvents(body), { headers: { "x-provider-trace": "trace-null" } })),
+        Effect.flip,
+      )
+
+      expect(error.reason._tag).toBe("InvalidProviderOutput")
+      expect(error.reason.body).toBe(body)
+      expect(error.reason.http).toMatchObject({ status: 200, headers: { "x-provider-trace": "trace-null" } })
+      expect(error.reason.http?.url).toStartWith("https://provider.test/")
+    }),
+  )
+
   it.effect("retains malformed provider frames and the original decode cause", () =>
     Effect.gen(function* () {
       const body = '{"type":"error","error":{"message":42,"opaque":{"nested":true}},"trace":"outer"}'

--- a/packages/ai/test/provider/error-retention.test.ts
+++ b/packages/ai/test/provider/error-retention.test.ts
@@ -62,6 +62,45 @@ describe("provider error retention", () => {
     )
   }
 
+  it.effect("classifies a message-less Gemini 429 and retains its event and HTTP context", () =>
+    Effect.gen(function* () {
+      const body = JSON.stringify({
+        error: { code: 429, status: "RESOURCE_EXHAUSTED", details: { opaque: [1, 2] } },
+        trace: { opaque: "outer" },
+      })
+      const error = yield* LLMClient.generate(
+        LLM.request({ model: Google.configure(options).model("gemini"), prompt: "hello" }),
+      ).pipe(
+        Effect.provide(
+          fixedResponse(sseEvents(body), {
+            headers: { "content-type": "text/event-stream", "x-provider-trace": "trace-1" },
+          }),
+        ),
+        Effect.flip,
+      )
+
+      expect(error.message).toBe("RESOURCE_EXHAUSTED")
+      expect(error.reason._tag).toBe("RateLimit")
+      expect(error.reason.body).toBe(body)
+      expect(error.reason.http).toMatchObject({ status: 200, headers: { "x-provider-trace": "trace-1" } })
+      expect(error.reason.http?.url).toStartWith("https://provider.test/")
+    }),
+  )
+
+  it.effect("rejects a malformed non-record Gemini error", () =>
+    Effect.gen(function* () {
+      const body = JSON.stringify({ error: "RESOURCE_EXHAUSTED", trace: { opaque: "outer" } })
+      const error = yield* LLMClient.generate(
+        LLM.request({ model: Google.configure(options).model("gemini"), prompt: "hello" }),
+      ).pipe(Effect.provide(fixedResponse(sseEvents(body))), Effect.flip)
+
+      expect(error.reason._tag).toBe("InvalidProviderOutput")
+      expect(error.message).toContain("Invalid google/gemini stream event")
+      expect(error.reason.body).toBe(body)
+      expect(error.reason.http?.status).toBe(200)
+    }),
+  )
+
   it.effect("retains malformed provider frames and the original decode cause", () =>
     Effect.gen(function* () {
       const body = '{"type":"error","error":{"message":42,"opaque":{"nested":true}},"trace":"outer"}'


### PR DESCRIPTION
## Why

Gemini stream error objects without a string `message` were ignored and later surfaced as generic incomplete streams without their provider status or raw body. Present malformed values such as `error: null` could lose the original frame in the same way.

## What Changes

| `error` field | Result |
| --- | --- |
| Record with `message` | Existing provider failure behavior |
| Record without `message` | Provider failure using status or a stable fallback |
| Present non-record, including `null` | `InvalidProviderOutput` with raw frame context |
| Omitted | Normal event processing |

Numeric provider codes and the complete raw event remain available to failure classification and HTTP enrichment.

## Scope

This changes only Gemini stream error admission and retention. Message-bearing errors keep their existing behavior.

## Verification

```sh
cd packages/ai
bun run test test/provider/gemini.test.ts test/provider/error-retention.test.ts
bun typecheck
git diff --check origin/v2...HEAD
```

- 53 focused tests passed.
- AI package and workspace typechecks passed.
- Independent final review found no issues after the explicit-null regression was added.
