### PR TITLE
refactor(core): reuse catalog response digest

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -636,8 +636,8 @@ export const layer = (options?: Options) =>
       // population. The payload has outgrown some KV backends' per-value
       // limits (Durable Object SQLite caps values at 2 MB and api.json
       // passed it in Aug 2026); a boot without a cache hit just refetches.
-      const writeCache = Effect.fn("ModelsDev.writeCache")(function* (text: string) {
-        yield* kv.set(key, { updatedAt: Date.now(), digest: bodyDigest(text), body: text }).pipe(
+      const writeCache = Effect.fn("ModelsDev.writeCache")(function* (text: string, digest = bodyDigest(text)) {
+        yield* kv.set(key, { updatedAt: Date.now(), digest, body: text }).pipe(
           Effect.catchCauseIf(
             (cause) => !Cause.hasInterruptsOnly(cause),
             (cause) => Effect.logWarning("Failed to cache models.dev catalog", { cause }),
@@ -681,12 +681,13 @@ export const layer = (options?: Options) =>
               const stored = yield* loadFromCache()
               if (!force && stored && Date.now() - stored.updatedAt < Duration.toMillis(ttl)) return
               const text = yield* fetchApi()
+              const digest = bodyDigest(text)
               // models.dev rarely changes between polls; skip the cache write,
               // invalidation, and Refreshed event for a byte-identical body so
               // downstream catalog.updated listeners stay quiet.
-              if (!force && stored?.digest === bodyDigest(text)) return
+              if (!force && stored?.digest === digest) return
               yield* decodeCatalog(text)
-              yield* writeCache(text)
+              yield* writeCache(text, digest)
               yield* invalidate
               yield* bus.publish(ModelsDev.Event.Refreshed, {})
             }),

--- a/packages/core/test/models.test.ts
+++ b/packages/core/test/models.test.ts
@@ -297,7 +297,10 @@ describe("ModelsDev Service", () => {
       const context = yield* Layer.build(buildLayer(state, cache, { fetch: true, snapshot: false }))
       const result = yield* ModelsDev.Service.use((s) => s.get()).pipe(Effect.provide(context))
       expect(result).toEqual(fixture2Snapshot)
-      expect(cache.values.get(cacheKey)).toMatchObject({ body: JSON.stringify(fixture2) })
+      expect(cache.values.get(cacheKey)).toMatchObject({
+        body: JSON.stringify(fixture2),
+        digest: bodyDigest(JSON.stringify(fixture2)),
+      })
       const final = yield* Ref.get(state)
       expect(final.calls.length).toBe(1)
     }),
@@ -387,7 +390,10 @@ describe("ModelsDev Service", () => {
       )
       expect(result.before).toEqual(fixtureSnapshot)
       expect(result.after).toEqual(fixture2Snapshot)
-      expect(cache.values.get(cacheKey)).toMatchObject({ body: JSON.stringify(fixture2) })
+      expect(cache.values.get(cacheKey)).toMatchObject({
+        body: JSON.stringify(fixture2),
+        digest: bodyDigest(JSON.stringify(fixture2)),
+      })
       const final = yield* Ref.get(state)
       expect(final.calls.length).toBe(1)
       expect(final.calls[0].url).toContain("/api.json")
@@ -440,6 +446,10 @@ describe("ModelsDev Service", () => {
       const final = yield* Ref.get(state)
       expect(final.calls.length).toBe(1)
       expect(after).toEqual(fixture2Snapshot)
+      expect(cache.values.get(cacheKey)).toMatchObject({
+        body: JSON.stringify(fixture2),
+        digest: bodyDigest(JSON.stringify(fixture2)),
+      })
     }),
   )
 


### PR DESCRIPTION
## Why

A changed models.dev response is hashed once to compare it with the cached digest, then hashed again when writing the same body. The catalog is several megabytes, so the second SHA-256 pass is redundant.

## What Changes

Compute the response digest once in `refresh` and pass it to the existing private cache writer. Initial fetches still let the writer calculate their digest.

| Path | Before | After |
| --- | --- | --- |
| Changed, non-forced refresh | Hash for comparison, then hash for writing | Reuse the comparison digest for writing |
| Identical, non-forced refresh | Hash and skip the write/event | Unchanged |
| Forced refresh | Hash and write | Hash and write |
| Initial fetch | Writer calculates digest | Unchanged |

## Scope

One production file, with stronger existing cache assertions. Cache encoding, validation before writing, TTL, locking, refresh events, and best-effort write handling are unchanged. No public API or tool contract changes.

## Verification

```sh
cd packages/core
bun run test test/models.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/models-dev.ts packages/core/test/models.test.ts
git diff --check
```

16 tests passed with 46 assertions. Core typechecking, formatting, and whitespace checks passed. Tests verify persisted digests for initial recovery, forced refresh, and changed non-forced refresh, alongside unchanged-body suppression and legacy digest-less cache entries. No end-to-end or latency benchmark claim.
