### PR TITLE
refactor(core): merge defaults for selected MCP servers

### DIFF
--- a/packages/core/src/config/plugin/mcp.ts
+++ b/packages/core/src/config/plugin/mcp.ts
@@ -46,12 +46,12 @@ export const register = Effect.fn("ConfigMCPPlugin.register")(function* (
     const servers = new Map<string, ServerConfig>()
     for (const document of documents) {
       for (const [name, server] of Object.entries(document.info.mcp?.servers ?? {})) {
-        servers.set(name, { ...server, timeout: { ...timeout, ...server.timeout } })
+        servers.set(name, server)
       }
     }
     for (const [name, server] of servers) {
       if (draft.get(name)) continue
-      draft.set(name, server)
+      draft.set(name, { ...server, timeout: { ...timeout, ...server.timeout } })
     }
   })
 })

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -1207,6 +1207,68 @@ test("adds, disconnects, and reconnects MCP servers at runtime", async () => {
   )
 })
 
+testEffect(Layer.empty).live(
+  "merges MCP defaults into the winning configured server without changing runtime overrides",
+  () =>
+    Effect.gen(function* () {
+      const entries = [
+        new Document({
+          type: "document",
+          info: new Info({
+            mcp: new ConfigMCP.Info({
+              timeout: { startup: 10, catalog: 20, execution: 30 },
+              servers: {
+                resources: { type: "local", command: ["earlier"], disabled: true, timeout: { execution: 90 } },
+              },
+            }),
+          }),
+        }),
+        new Document({
+          type: "document",
+          info: new Info({
+            mcp: new ConfigMCP.Info({
+              timeout: { catalog: 40 },
+              servers: {
+                resources: { type: "local", command: ["later"], disabled: true, timeout: { startup: 50 } },
+              },
+            }),
+          }),
+        }),
+      ]
+      const original = JSON.stringify(entries)
+      yield* Effect.gen(function* () {
+        const service = yield* Mcp.Service
+        const check = yield* service.transform((draft) => {
+          expect(draft.get("resources")).toEqual({
+            type: "local",
+            command: ["later"],
+            disabled: true,
+            timeout: { startup: 50, catalog: 40, execution: 30 },
+          })
+        })
+        yield* check.dispose
+        const runtime = {
+          type: "local",
+          command: ["runtime"],
+          disabled: true,
+          timeout: { catalog: 60 },
+        } satisfies ConfigMCP.Local
+        yield* service.add("resources", runtime)
+        yield* service.reload()
+        yield* service.transform((draft) => {
+          expect(draft.get("resources")).toEqual(runtime)
+        })
+      }).pipe(
+        Effect.provide(
+          resourceMcpLayer("https://unused.example", undefined, undefined, {
+            entries: () => Effect.succeed(entries),
+          }),
+        ),
+      )
+      expect(JSON.stringify(entries)).toBe(original)
+    }),
+)
+
 testEffect(resourceMcpLayer(new ConfigMCP.Local({ type: "local", command: ["unused"], disabled: true }))).live(
   "manages live MCP servers entirely through scoped transforms",
   () =>


### PR DESCRIPTION
## Why

MCP config loading copies each server and merges timeout defaults before resolving duplicate names. Earlier definitions, and entries superseded by a runtime server, are discarded after that work.

## What Changes

Keep the original server definitions while selecting the last configured definition per name. Merge timeout defaults only when that winning definition is added to the draft.

```ts
// Before
merge defaults -> select last definition -> skip runtime overrides -> add

// After
select last definition -> skip runtime overrides -> merge defaults -> add
```

The resulting configuration is unchanged: global timeout fields merge in document order, the winning server overrides those defaults, and existing runtime servers remain authoritative. Config source objects are not mutated.

## Scope

Two production lines changed in the config plugin, plus one test using the real MCP registry and the existing fixture. This removes discarded allocations; it does not change subscriptions, reconnection policy, or any public contract.

## Verification

```sh
cd packages/core
bun run test test/mcp.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/config/plugin/mcp.ts packages/core/test/mcp.test.ts
git diff --check
```

57 tests passed with 218 assertions. Core typechecking, formatting, and whitespace checks passed. The new test covers duplicate server names, per-field global defaults, per-server overrides, runtime replacement across reload, and unmodified source entries. No allocation or latency benchmark claim.
