### PR TITLE
refactor(core): avoid encoding rejected image candidates

### DIFF
--- a/packages/core/src/image/photon.ts
+++ b/packages/core/src/image/photon.ts
@@ -78,9 +78,15 @@ export const make = Effect.gen(function* () {
             ...JPEG_QUALITIES.map((quality) => ["image/jpeg", () => resized.get_bytes_jpeg(quality)] as const),
           ]
           for (const [mime, encode] of encoders) {
-            const candidate = Buffer.from(encode()).toString("base64")
-            if (Buffer.byteLength(candidate, "utf-8") <= limits.maxBase64Bytes)
-              return { ...content, content: candidate, encoding: "base64" as const, mime }
+            const candidate = encode()
+            // Base64 uses four bytes per three input bytes, including padding.
+            if (Math.ceil(candidate.length / 3) * 4 <= limits.maxBase64Bytes)
+              return {
+                ...content,
+                content: Buffer.from(candidate).toString("base64"),
+                encoding: "base64" as const,
+                mime,
+              }
           }
         } finally {
           resized.free()

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -437,6 +437,44 @@ describe("ReadTool", () => {
     }),
   )
 
+  it.effect("accepts PNG candidates at the exact base64 limit and skips them one byte below", () =>
+    Effect.gen(function* () {
+      const photon = yield* Effect.promise(() => import("@silvia-odwyer/photon-node"))
+      const source = new photon.PhotonImage(
+        Uint8Array.from({ length: 16 * 4 }, () => 255),
+        16,
+        1,
+      )
+      const content = {
+        uri: "file:///wide.png",
+        content: Buffer.from(source.get_bytes()).toString("base64"),
+        encoding: "base64" as const,
+        mime: "image/png",
+      }
+      source.free()
+      const image = yield* Image.Service
+
+      for (const [maxWidth, padding] of [
+        [4, "=="],
+        [5, "="],
+        [6, ""],
+      ] as const) {
+        yield* image.transform((draft) => draft.configure({ maxWidth, maxBase64Bytes: 1_024 }))
+        const candidate = yield* image.normalize("wide.png", content)
+        expect(candidate.mime).toBe("image/png")
+        expect(candidate.content.match(/=*$/)?.[0]).toBe(padding)
+
+        yield* image.transform((draft) => draft.configure({ maxBase64Bytes: candidate.content.length }))
+        expect(yield* image.normalize("wide.png", content)).toEqual(candidate)
+
+        yield* image.transform((draft) => draft.configure({ maxBase64Bytes: candidate.content.length - 1 }))
+        const smaller = yield* image.normalize("wide.png", content)
+        expect(smaller.mime).toBe("image/png")
+        expect(smaller.content.length).toBeLessThan(candidate.content.length)
+      }
+    }),
+  )
+
   it.effect("drops images that cannot fit max base64 bytes after resize attempts", () =>
     Effect.gen(function* () {
       const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="


### PR DESCRIPTION
## Why

Image resizing tries PNG and several JPEG encodings at progressively smaller sizes. Each candidate currently gets copied into a Buffer and converted to base64 before checking whether it exceeds the output limit, even when that candidate is immediately discarded.

## What Changes

Keep the encoded bytes until a candidate fits. Canonical padded base64 has exactly `4 * ceil(bytes / 3)` ASCII bytes, so the size check does not require allocating the string.

```ts
// Before, for every candidate
encode -> Buffer copy -> base64 string -> size check

// After
encode -> size check -> Buffer copy and base64 only when accepted
```

The inclusive limit, candidate order, selected bytes/MIME, and cleanup remain unchanged. The original input's size check still measures its actual string rather than assuming canonical base64.

## Scope

One production loop and one boundary test using actual Photon encoding. This avoids work for rejected candidates; it does not change resizing policy or any public contract.

## Verification

```sh
cd packages/core
bun run test test/tool-read.test.ts test/config/image.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/test/tool-read.test.ts
bunx prettier --check --range-start 3702 --range-end 4113 packages/core/src/image/photon.ts
git diff --check HEAD^ HEAD
```

25 tests passed with 74 assertions, including exact-limit acceptance and rejection one byte below the limit for outputs with zero, one, and two padding characters. Existing dimension-constrained resize and impossible-limit cases also pass. Core typechecking and whitespace checks passed.

Formatting passed for the test file and changed production range. The Photon file's pre-existing unrelated WASM-path assignment formatting was left untouched. No allocation or latency benchmark claim.
