### PR TITLE
fix(core): backport invalidated location cleanup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1043,6 +1043,7 @@
     "@ai-sdk/mistral@3.0.51": "patches/@ai-sdk%2Fmistral@3.0.51.patch",
     "@npmcli/agent@4.0.2": "patches/@npmcli%2Fagent@4.0.2.patch",
     "@silvia-odwyer/photon-node@0.3.4": "patches/@silvia-odwyer%2Fphoton-node@0.3.4.patch",
+    "effect@4.0.0-rc.112": "patches/effect@4.0.0-rc.112.patch",
     "solid-js@1.9.15": "patches/solid-js@1.9.15.patch",
     "@ff-labs/fff-bun@0.10.5": "patches/@ff-labs%2Ffff-bun@0.10.5.patch",
     "@ai-sdk/google@3.0.73": "patches/@ai-sdk%2Fgoogle@3.0.73.patch",

--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "@pierre/trees@1.0.0-beta.4": "patches/@pierre%2Ftrees@1.0.0-beta.4.patch",
     "@modelcontextprotocol/sdk@1.29.0": "patches/@modelcontextprotocol%2Fsdk@1.29.0.patch",
     "@tanstack/virtual-core@3.17.8": "patches/@tanstack%2Fvirtual-core@3.17.8.patch",
-    "@ff-labs/fff-bun@0.10.5": "patches/@ff-labs%2Ffff-bun@0.10.5.patch"
+    "@ff-labs/fff-bun@0.10.5": "patches/@ff-labs%2Ffff-bun@0.10.5.patch",
+    "effect@4.0.0-rc.112": "patches/effect@4.0.0-rc.112.patch"
   }
 }

--- a/patches/effect@4.0.0-rc.112.patch
+++ b/patches/effect@4.0.0-rc.112.patch
@@ -1,0 +1,69 @@
+diff --git a/dist/RcMap.js b/dist/RcMap.js
+index 6e9a9ad04ec2c0fef0852cc0e6b3b1dba530a6f4..4e7feb00b0d0484b96f0543ce5e47b63a7ca8632 100644
+--- a/dist/RcMap.js
++++ b/dist/RcMap.js
+@@ -254,10 +254,14 @@ const release = (self, key, entry) => Effect.withFiber(fiber => {
+   entry.refCount--;
+   if (entry.refCount > 0) {
+     return Effect.void;
+-  } else if (self.state._tag === "Closed" || !MutableHashMap.has(self.state.map, key) || Duration.isZero(entry.idleTimeToLive)) {
+-    if (self.state._tag === "Open") {
+-      MutableHashMap.remove(self.state.map, key);
+-    }
++  } else if (self.state._tag === "Closed") {
++    return Scope.close(entry.scope, Exit.void);
++  }
++  const o = MutableHashMap.get(self.state.map, key);
++  if (o._tag === "None" || o.value !== entry) {
++    return Scope.close(entry.scope, Exit.void);
++  } else if (Duration.isZero(entry.idleTimeToLive)) {
++    MutableHashMap.remove(self.state.map, key);
+     return Scope.close(entry.scope, Exit.void);
+   } else if (!Duration.isFinite(entry.idleTimeToLive)) {
+     return Effect.void;
+@@ -270,6 +274,8 @@ const release = (self, key, entry) => Effect.withFiber(fiber => {
+     const remaining = entry.expiresAt - now;
+     if (remaining <= 0) {
+       if (self.state._tag === "Closed" || entry.refCount > 0) return Effect.void;
++      const o = MutableHashMap.get(self.state.map, key);
++      if (o._tag === "None" || o.value !== entry) return Effect.void;
+       MutableHashMap.remove(self.state.map, key);
+       return restore(Scope.close(entry.scope, Exit.void));
+     }
+diff --git a/src/RcMap.ts b/src/RcMap.ts
+index 67dcc147389a8fd0e8aae21b69ef58f44c295958..a98893a085e2f29d2c40125e2691a1e172c65f7d 100644
+--- a/src/RcMap.ts
++++ b/src/RcMap.ts
+@@ -738,14 +738,15 @@ const release = <K, A, E>(self: RcMap<K, A, E>, key: K, entry: State.Entry<A, E>
+     entry.refCount--
+     if (entry.refCount > 0) {
+       return Effect.void
+-    } else if (
+-      self.state._tag === "Closed"
+-      || !MutableHashMap.has(self.state.map, key)
+-      || Duration.isZero(entry.idleTimeToLive)
+-    ) {
+-      if (self.state._tag === "Open") {
+-        MutableHashMap.remove(self.state.map, key)
+-      }
++    } else if (self.state._tag === "Closed") {
++      return Scope.close(entry.scope, Exit.void)
++    }
++
++    const o = MutableHashMap.get(self.state.map, key)
++    if (o._tag === "None" || o.value !== entry) {
++      return Scope.close(entry.scope, Exit.void)
++    } else if (Duration.isZero(entry.idleTimeToLive)) {
++      MutableHashMap.remove(self.state.map, key)
+       return Scope.close(entry.scope, Exit.void)
+     } else if (!Duration.isFinite(entry.idleTimeToLive)) {
+       return Effect.void
+@@ -760,6 +761,8 @@ const release = <K, A, E>(self: RcMap<K, A, E>, key: K, entry: State.Entry<A, E>
+       const remaining = entry.expiresAt - now
+       if (remaining <= 0) {
+         if (self.state._tag === "Closed" || entry.refCount > 0) return Effect.void
++        const o = MutableHashMap.get(self.state.map, key)
++        if (o._tag === "None" || o.value !== entry) return Effect.void
+         MutableHashMap.remove(self.state.map, key)
+         return restore(Scope.close(entry.scope, Exit.void))
+       }

--- a/patches/effect@4.0.0-rc.112.patch
+++ b/patches/effect@4.0.0-rc.112.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/RcMap.js b/dist/RcMap.js
-index 6e9a9ad04ec2c0fef0852cc0e6b3b1dba530a6f4..4e7feb00b0d0484b96f0543ce5e47b63a7ca8632 100644
+index 6e9a9ad04ec2c0fef0852cc0e6b3b1dba530a6f4..ba5a15d9585438528ff3d6f549d22ac6e831a049 100644
 --- a/dist/RcMap.js
 +++ b/dist/RcMap.js
 @@ -254,10 +254,14 @@ const release = (self, key, entry) => Effect.withFiber(fiber => {


### PR DESCRIPTION
## Summary

Temporarily backport **Kit Langton's fix** from [Effect-TS/effect#7516](https://github.com/Effect-TS/effect/pull/7516), upstream commit [`0e4793c87c18c5e26ad7c4f21e38f84c3a6bb128`](https://github.com/Effect-TS/effect/commit/0e4793c87c18c5e26ad7c4f21e38f84c3a6bb128), onto the pinned Effect `4.0.0-rc.112`.

This is a backport of the existing upstream work, not a separate implementation. The patch includes the TypeScript source and matching executable JavaScript. Remove it when upgrading to an Effect release that contains the fix.

## Why

OpenCode's Location service map uses infinite idle TTL for existing directories. The server separately invalidates idle Locations after 60 minutes; explicit debug eviction can also invalidate them.

If Location A is invalidated while borrowed, the same key is reacquired as B, and A's last borrower then releases it, the unpatched RcMap checks only whether the key exists. With infinite TTL, it skips A's finalizers. With zero TTL, old cleanup can remove B's mapping. A surviving finite-TTL timer can also remove the replacement.

Kit's fix checks entry identity before removing a mapping, closes detached entries when their last borrower releases, and leaves replacement entries untouched. Ordinary TTL behavior and active borrowers are preserved.

Only the dependency patch and its `package.json` / `bun.lock` registration are included. No application API, Location eviction policy, test files, profiler, or changeset changes.

## Before / After

![Post-GC heap before and after 1000 replacement cycles, comparing unfixed and patched Effect](https://github.com/user-attachments/assets/550d8cd0-d798-406b-b59c-524009909036)

| Version | Before cycle 1 | After cycle 1,000 + GC | Resources finalized |
|---|---:|---:|---:|
| Unfixed rc.112 | 2.69 MiB | 1,004.70 MiB | 1,000 / 2,000 |
| Patched rc.112 | 2.69 MiB | 4.56 MiB | 2,000 / 2,000 |

The graph overlays two measured checkpoints per version, using the median of five fresh processes on Windows x64 / Bun 1.4.0. Each cycle acquires A, invalidates it while borrowed, acquires B, releases A, verifies B remains usable, then invalidates and releases B.

This is a **synthetic resource workload**, not 1,000 full production Location graphs. It uses the real `LayerMap`, `Layer.fresh`, and scope-owned timers. Each timer captures a distinct, filled 1-MiB Buffer; the resource finalizer cancels the timer. There are two resources per cycle. Plain unreachable data can be collected even when finalizers are missed, so the timers explicitly model resources whose callbacks require disposal.

Both versions use the same warm-up and eight full-GC rounds with 100-ms event-loop gaps. The map owner remains alive during measurement. Both maps have zero cached keys afterward, and all unrelated weak controls are collected. The patched run collects all payload sentinels; the unfixed run retains 1,000 and still misses those finalizers when the map owner closes.

Metric: `bun:jsc.heapStats().heapSize`, including external memory. These are not RSS figures or a prediction of production-server savings. The graph and probes are local validation artifacts, not committed files.

## Verification

- Local lifecycle matrix: 15 expected failures on unpatched rc.112; all 41 cases pass with the patch on Windows Bun 1.4.0 and repository-pinned Bun 1.3.14. Includes zero/finite/infinite TTL, multiple borrowers, stale timers, and ordinary cleanup controls. The 40 isolated RcMap/LayerMap cases also pass on Linux x64 / Bun 1.4.0 under WSL.
- The production `LocationServiceMap` probe constructs the actual Instance graph with isolated paths and ambient discovery disabled. Before: only B finalizes, even after shutdown. After: A finalizes when released, B remains usable, and shutdown finalizes B. No network requests occur; baseline-only emergency teardown is performed after recording results.
- Existing Location suites: 24 passed, 0 failed on Windows Bun 1.4.0, Windows Bun 1.3.14, and Linux Bun 1.4.0.
- The 1,000-cycle patched probe also completes all finalizers and releases all payload sentinels with Windows Bun 1.3.14 and Linux x64 Bun 1.4.0 under WSL.
- Core and Server `bun typecheck` passed; the pre-push workspace typecheck also passed all 33 tasks.
- Repository-pinned Bun 1.3.14 `install --frozen-lockfile` passed with the patch registered.
- `package.json` formatting and `git diff --check` passed.

The running OpenCode server was not patched or restarted for validation.
