### PR TITLE
refactor(core): bind standalone skill activation to Session

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,7 +1,7 @@
 export * as Session from "./session.js"
 export * from "./session/schema.js"
 
-import { Cause, Effect, Layer, Schema, Context, RcMap, Stream, Scope } from "effect"
+import { Cause, Effect, Layer, Schema, Context, RcMap, Stream } from "effect"
 import { ListAnchor } from "@opencode-ai/schema/session"
 import { and, asc, desc, eq, gt, isNull, like, lt, or, type SQL } from "drizzle-orm"
 import { Project } from "./project.js"
@@ -52,8 +52,6 @@ import { Session } from "./session/session.js"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { PluginSupervisor } from "./plugin/supervisor-service.js"
 import type { EventLog } from "@opencode-ai/schema/event-log"
-import { Event } from "@opencode-ai/schema/event"
-import { Skill } from "./skill.js"
 import { Job } from "./job.js"
 import { Command } from "./command.js"
 import { Global } from "@opencode-ai/util/global"
@@ -233,12 +231,9 @@ export interface Interface {
   readonly shell: (
     input: Parameters<Session.Handle["shell"]>[0] & { sessionID: SessionSchema.ID },
   ) => ReturnType<Session.Handle["shell"]>
-  readonly skill: (input: {
-    id?: SessionMessage.ID
-    sessionID: SessionSchema.ID
-    skill: Skill.ID
-    resume?: boolean
-  }) => Effect.Effect<void, NotFoundError | SkillNotFoundError>
+  readonly skill: (
+    input: Parameters<Session.Handle["skill"]>[0] & { sessionID: SessionSchema.ID },
+  ) => ReturnType<Session.Handle["skill"]>
   readonly compact: (
     input: CompactInput,
   ) => Effect.Effect<SessionInbox.Compaction, NotFoundError | CompactionConflictError>
@@ -278,7 +273,6 @@ const layer = Layer.effect(
     const fs = yield* FSUtil.Service
     const jobs = yield* Job.Service
     const environments = yield* SessionEnvironment.Service
-    const scope = yield* Scope.Scope
     const sessions = yield* Session.make((ref) => locations.get(ref))
     const admission = yield* SessionInbox.Service
     const closeTransport = Effect.fn("Session.closeTransport")(function* (session: SessionSchema.Info) {
@@ -537,26 +531,7 @@ const layer = Layer.effect(
         })
       }),
       shell: (input) => sessions.forSession(input.sessionID).shell(input),
-      skill: Effect.fn("Session.skill")(function* (input) {
-        const session = yield* result.get(input.sessionID)
-        const skills = yield* Skill.Service.pipe(Effect.provide(locations.get(session.location)))
-        const skill = yield* skills.get(input.skill)
-        if (!skill) return yield* new SkillNotFoundError({ skill: input.skill })
-        yield* bus.publish(
-          SessionEvent.Skill.Activated,
-          {
-            sessionID: input.sessionID,
-            id: skill.id,
-            name: skill.name,
-            text: skill.content,
-          },
-          { id: input.id ? Event.ID.make(input.id.replace(/^msg_/, "evt_")) : undefined },
-        )
-        if (input.resume !== false)
-          yield* execution
-            .resume(input.sessionID)
-            .pipe(Effect.ignore, Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)
-      }),
+      skill: (input) => sessions.forSession(input.sessionID).skill(input),
       switchAgent: (input) => sessions.forSession(input.sessionID).switchAgent(input),
       switchModel: (input) => sessions.forSession(input.sessionID).switchModel(input),
       rename: (input) => sessions.forSession(input.sessionID).rename(input),

--- a/packages/core/src/session/session.ts
+++ b/packages/core/src/session/session.ts
@@ -9,6 +9,7 @@ import { Location } from "../location.js"
 import { PluginSupervisor } from "../plugin/supervisor-service.js"
 import { Shell } from "../shell.js"
 import { ShellResult } from "../shell/result.js"
+import { Skill } from "../skill.js"
 import {
   BusyError,
   CompactionConflictError,
@@ -19,6 +20,7 @@ import {
   MessageToolIncompleteError,
   NotFoundError,
   PromptConflictError,
+  SkillNotFoundError,
   SyntheticConflictError,
 } from "./error.js"
 import { SessionEvent } from "./event.js"
@@ -30,7 +32,12 @@ import { SessionRevert } from "./revert.js"
 import { SessionSchema } from "./schema.js"
 import { SessionStore } from "./store.js"
 
-export type Services = PluginSupervisor.Service | SessionPrompt.Service | SessionRevert.Service | Shell.Service
+export type Services =
+  | PluginSupervisor.Service
+  | SessionPrompt.Service
+  | SessionRevert.Service
+  | Shell.Service
+  | Skill.Service
 
 type PromptRequest = SessionPrompt.Input & {
   id?: SessionMessage.ID
@@ -238,6 +245,29 @@ export const make = Effect.fn("Session.make")(function* (servicesFor: (ref: Loca
     }).pipe(Effect.forkIn(scope, { startImmediately: true }))
     yield* Fiber.join(running)
   })
+  const skill = Effect.fn("Session.skill")(function* (
+    sessionID: SessionSchema.ID,
+    input: { id?: SessionMessage.ID; skill: Skill.ID; resume?: boolean },
+  ) {
+    const session = yield* get(sessionID)
+    const skills = yield* Skill.Service.pipe(Effect.provide(servicesFor(session.location)))
+    const skill = yield* skills.get(input.skill)
+    if (!skill) return yield* new SkillNotFoundError({ skill: input.skill })
+    yield* bus.publish(
+      SessionEvent.Skill.Activated,
+      {
+        sessionID,
+        id: skill.id,
+        name: skill.name,
+        text: skill.content,
+      },
+      { id: input.id ? Event.ID.make(input.id.replace(/^msg_/, "evt_")) : undefined },
+    )
+    if (input.resume !== false)
+      yield* execution
+        .resume(sessionID)
+        .pipe(Effect.ignore, Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid)
+  })
   const compact = Effect.fn("Session.compact")(function* (
     sessionID: SessionSchema.ID,
     input: { id?: SessionMessage.ID; delivery?: SessionInbox.Delivery },
@@ -346,6 +376,7 @@ export const make = Effect.fn("Session.make")(function* (servicesFor: (ref: Loca
     prompt,
     synthetic,
     shell,
+    skill,
     compact,
     wait,
     resume,
@@ -368,6 +399,7 @@ export const make = Effect.fn("Session.make")(function* (servicesFor: (ref: Loca
     const prompt = operations.prompt.bind(undefined, sessionID)
     const synthetic = operations.synthetic.bind(undefined, sessionID)
     const shell = operations.shell.bind(undefined, sessionID)
+    const skill = operations.skill.bind(undefined, sessionID)
     const compact = operations.compact.bind(undefined, sessionID)
     const wait = operations.wait.bind(undefined, sessionID)
     const resume = operations.resume.bind(undefined, sessionID)
@@ -393,6 +425,7 @@ export const make = Effect.fn("Session.make")(function* (servicesFor: (ref: Loca
       prompt,
       synthetic,
       shell,
+      skill,
       compact,
       wait,
       resume,

--- a/packages/core/test/session-owned.test.ts
+++ b/packages/core/test/session-owned.test.ts
@@ -3,7 +3,6 @@ import { and, eq } from "drizzle-orm"
 import { Cause, Context, DateTime, Deferred, Effect, Exit, Fiber, Layer, Scope } from "effect"
 import { Agent } from "@opencode-ai/schema/agent"
 import { Event } from "@opencode-ai/schema/event"
-import { Location } from "@opencode-ai/schema/location"
 import { Model } from "@opencode-ai/schema/model"
 import { Money } from "@opencode-ai/schema/money"
 import { Project } from "@opencode-ai/schema/project"
@@ -16,6 +15,7 @@ import { Bus } from "../src/bus.js"
 import { Database } from "../src/database/database.js"
 import { EventTable } from "../src/event/sql.js"
 import { Image } from "../src/image.js"
+import { Location } from "../src/location.js"
 import { PluginHooks } from "../src/plugin/hooks.js"
 import { PluginSupervisor } from "../src/plugin/supervisor-service.js"
 import { ProjectTable } from "../src/project/sql.js"
@@ -37,6 +37,7 @@ import { Shell } from "../src/shell.js"
 import { Skill } from "../src/skill.js"
 import { Snapshot } from "../src/snapshot.js"
 import { tempGlobalLayer } from "./fixture/global"
+import { location } from "./fixture/location"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(
@@ -58,10 +59,18 @@ const it = testEffect(
 const sessionID = SessionSchema.ID.make("ses_owned")
 const otherID = SessionSchema.ID.make("ses_owned_other")
 const source = Location.Ref.make({ directory: AbsolutePath.make("/project") })
+const skillInfo = Skill.Info.make({
+  id: Skill.ID.make("guide"),
+  name: Skill.Name.make("Guide"),
+  description: "Session guidance",
+  location: AbsolutePath.make("/skills/guide/SKILL.md"),
+  content: "  Raw guidance\n",
+})
 
 const setup = Effect.fnUntraced(function* (options?: {
   execution?: SessionExecution.Interface
   shell?: Layer.Layer<Shell.Service>
+  skills?: (ref: Location.Ref) => Layer.Layer<Skill.Service>
   snapshot?: (ref: Location.Ref) => Layer.Layer<Snapshot.Service>
 }) {
   const database = yield* Database.Service
@@ -86,11 +95,15 @@ const setup = Effect.fnUntraced(function* (options?: {
   const hooks = yield* PluginHooks.Service.pipe(Effect.provide(LayerNode.compile(PluginHooks.node)))
   const locations: Location.Ref[] = []
   const flushes: Location.Ref[] = []
+  const resumes: SessionSchema.ID[] = []
   const wakes: Array<{ sessionID: SessionSchema.ID; pending: SessionMessage.ID[]; enqueued: number }> = []
   const execution = SessionExecution.Service.of({
     active: Effect.succeed(new Set<SessionSchema.ID>()),
     isActive: () => Effect.succeed(false),
-    resume: () => Effect.void,
+    resume: (id) =>
+      Effect.sync(() => {
+        resumes.push(id)
+      }),
     awaitIdle: () => Effect.void,
     interrupt: () => Effect.succeed(false),
     wake: (id) =>
@@ -113,7 +126,6 @@ const setup = Effect.fnUntraced(function* (options?: {
   const services = Layer.mergeAll(
     Layer.succeed(PluginHooks.Service, hooks),
     Layer.mock(Image.Service, {}),
-    Layer.mock(Skill.Service, {}),
     options?.shell ?? Layer.mock(Shell.Service, {}),
   )
   const servicesFor = (ref: Location.Ref): Layer.Layer<Session.Services> => {
@@ -122,6 +134,11 @@ const setup = Effect.fnUntraced(function* (options?: {
       Layer.provideMerge(
         Layer.mergeAll(
           services,
+          Layer.succeed(Location.Service, location(ref)),
+          options?.skills?.(ref) ??
+            Layer.mock(Skill.Service, {
+              get: (id) => Effect.succeed(id === skillInfo.id ? skillInfo : undefined),
+            }),
           options?.snapshot?.(ref) ?? Layer.mock(Snapshot.Service, {}),
           Layer.succeed(PluginSupervisor.Service, {
             flush: Effect.sync(() => {
@@ -146,7 +163,7 @@ const setup = Effect.fnUntraced(function* (options?: {
     >(),
     Effect.provideService(SessionExecution.Service, options?.execution ?? execution),
   )
-  return { sessions, hooks, locations, flushes, wakes, db: database.db, bus, store }
+  return { sessions, hooks, locations, flushes, resumes, wakes, db: database.db, bus, store }
 })
 
 describe("Session-owned handles", () => {
@@ -336,6 +353,145 @@ describe("Session-owned handles", () => {
       expect(fixture.locations).toEqual([source, destination])
       expect(fixture.flushes).toEqual([source, destination])
       expect((yield* fixture.sessions.forSession(otherID).get()).location).toEqual(source)
+    }),
+  )
+
+  it.live("activates skills through detached handles using fresh placement and ambient publication context", () =>
+    Effect.gen(function* () {
+      const fixture = yield* setup({
+        skills: (ref) =>
+          Layer.mock(Skill.Service, { get: () => Effect.succeed({ ...skillInfo, content: ref.directory }) }),
+      })
+      const handle = fixture.sessions.forSession(sessionID)
+      const { skill } = handle
+      const events: Event.Payload[] = []
+      yield* fixture.bus.listen((event) =>
+        Effect.sync(() => {
+          events.push(event)
+        }),
+      )
+      const initial = SessionMessage.ID.make("msg_owned_skill_initial")
+      yield* skill({ id: initial, skill: skillInfo.id, resume: false }).pipe(
+        Effect.satisfiesServicesType<never>(),
+        Effect.setContext(Context.empty()),
+      )
+      const moved = SessionMessage.ID.make("msg_owned_skill_moved")
+      const activation = skill({ id: moved, skill: skillInfo.id, resume: false })
+      const destination = Location.Ref.make({ directory: AbsolutePath.make("/project/moved") })
+      yield* fixture.bus.publish(SessionEvent.Moved, {
+        sessionID,
+        location: destination,
+        projectID: Project.ID.global,
+        subpath: RelativePath.make("moved"),
+      })
+
+      yield* activation.pipe(Effect.satisfiesServicesType<never>(), Effect.setContext(Context.empty()))
+      yield* skill({ skill: skillInfo.id, resume: false }).pipe(
+        Effect.provideService(Location.Service, location(source)),
+      )
+
+      expect(fixture.locations).toEqual([source, destination, destination])
+      expect(yield* handle.message(initial)).toMatchObject({ type: "skill", text: source.directory })
+      expect(yield* handle.message(moved)).toMatchObject({ type: "skill", text: destination.directory })
+      expect(
+        events.filter((event) => event.type === SessionEvent.Skill.Activated.type).map((event) => event.location),
+      ).toEqual([undefined, undefined, source])
+      expect(fixture.flushes).toEqual([])
+      expect(fixture.resumes).toEqual([])
+      expect(fixture.wakes).toEqual([])
+    }),
+  )
+
+  it.live("checks Session existence before skill lookup and leaves missing activations untouched", () =>
+    Effect.gen(function* () {
+      const fixture = yield* setup()
+      const events: Event.Payload[] = []
+      yield* fixture.bus.listen((event) =>
+        Effect.sync(() => {
+          events.push(event)
+        }),
+      )
+      const missingID = SessionSchema.ID.make("ses_missing_skill")
+      expect(
+        yield* fixture.sessions.forSession(missingID).skill({ skill: skillInfo.id }).pipe(Effect.flip),
+      ).toMatchObject({ _tag: "Session.NotFoundError", sessionID: missingID })
+      expect(fixture.locations).toEqual([])
+      const handle = fixture.sessions.forSession(sessionID)
+      const before = yield* handle.get()
+      const missing = Skill.ID.make("missing")
+
+      expect(yield* handle.skill({ skill: missing }).pipe(Effect.flip)).toMatchObject({
+        _tag: "Session.SkillNotFoundError",
+        skill: missing,
+      })
+
+      expect(fixture.locations).toEqual([source])
+      expect(events).toEqual([])
+      expect(yield* handle.get()).toEqual(before)
+      expect(yield* handle.inbox()).toEqual([])
+      expect(yield* fixture.store.context(sessionID)).toEqual([])
+      expect(fixture.flushes).toEqual([])
+      expect(fixture.resumes).toEqual([])
+      expect(fixture.wakes).toEqual([])
+    }),
+  )
+
+  it.live("publishes skills before detached resumes and owns those resumes in the host scope", () =>
+    Effect.gen(function* () {
+      const scope = yield* Scope.Scope
+      const host = yield* Scope.fork(scope, "sequential")
+      const release = yield* Deferred.make<void>()
+      const calls: string[] = []
+      const stopped: SessionSchema.ID[] = []
+      const execution = yield* SessionExecution.Service.pipe(Effect.provide(SessionExecution.noopLayer))
+      const fixture = yield* setup({
+        execution: {
+          ...execution,
+          resume: (id) =>
+            Effect.gen(function* () {
+              calls.push(`resume:${id}`)
+              yield* Deferred.await(release)
+            }).pipe(
+              Effect.onInterrupt(() =>
+                Effect.sync(() => {
+                  stopped.push(id)
+                }),
+              ),
+            ),
+          wake: () =>
+            Effect.sync(() => {
+              calls.push("wake")
+            }),
+        },
+      }).pipe(Scope.provide(host))
+      yield* fixture.bus.listen((event) =>
+        Effect.sync(() => {
+          if (event.type === SessionEvent.Skill.Activated.type) calls.push(`published:${event.id}`)
+        }),
+      )
+      const { skill } = fixture.sessions.forSession(sessionID)
+
+      yield* skill({ id: SessionMessage.ID.make("msg_skill_no_resume"), skill: skillInfo.id, resume: false })
+      expect(calls).toEqual(["published:evt_skill_no_resume"])
+      yield* Effect.forEach(
+        [
+          { id: SessionMessage.ID.make("msg_skill_default_resume"), skill: skillInfo.id },
+          { id: SessionMessage.ID.make("msg_skill_explicit_resume"), skill: skillInfo.id, resume: true },
+        ],
+        (input) => skill(input).pipe(Effect.scoped, Effect.forkScoped, Effect.flatMap(Fiber.join)),
+      )
+
+      expect(calls).toEqual([
+        "published:evt_skill_no_resume",
+        "published:evt_skill_default_resume",
+        `resume:${sessionID}`,
+        "published:evt_skill_explicit_resume",
+        `resume:${sessionID}`,
+      ])
+      expect(stopped).toEqual([])
+      yield* Scope.close(host, Exit.void)
+      expect(stopped).toEqual([sessionID, sessionID])
+      expect(yield* fixture.sessions.forSession(sessionID).inbox()).toEqual([])
     }),
   )
 

--- a/packages/core/test/session-owned.test.ts
+++ b/packages/core/test/session-owned.test.ts
@@ -440,7 +440,6 @@ describe("Session-owned handles", () => {
     Effect.gen(function* () {
       const scope = yield* Scope.Scope
       const host = yield* Scope.fork(scope, "sequential")
-      const release = yield* Deferred.make<void>()
       const calls: string[] = []
       const stopped: SessionSchema.ID[] = []
       const execution = yield* SessionExecution.Service.pipe(Effect.provide(SessionExecution.noopLayer))
@@ -450,7 +449,7 @@ describe("Session-owned handles", () => {
           resume: (id) =>
             Effect.gen(function* () {
               calls.push(`resume:${id}`)
-              yield* Deferred.await(release)
+              yield* Effect.never
             }).pipe(
               Effect.onInterrupt(() =>
                 Effect.sync(() => {

--- a/packages/core/test/session-skill.test.ts
+++ b/packages/core/test/session-skill.test.ts
@@ -17,12 +17,14 @@ import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
+import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionPrompt } from "@opencode-ai/core/session/prompt"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { SessionInbox } from "@opencode-ai/core/session/inbox"
 import { Skill } from "@opencode-ai/core/skill"
+import { Event } from "@opencode-ai/schema/event"
 import { testEffect } from "./lib/effect"
 import { globalProjectNode } from "./lib/project"
 
@@ -32,7 +34,7 @@ const info = Skill.Info.make({
   name: Skill.Name.make("Effect"),
   description: "Effect guidance",
   location: AbsolutePath.make(path.resolve("/skills/effect.md")),
-  content: "Use Effect",
+  content: "  Use Effect\n",
 })
 const locations = makeGlobalNode({
   service: LocationServiceMap.Service,
@@ -146,17 +148,32 @@ describe("Session.skill", () => {
     }),
   )
 
-  it.effect("projects the caller-supplied message ID", () =>
+  it.effect("publishes raw standalone content under the caller-supplied ID without inbox admission", () =>
     Effect.gen(function* () {
       const sessions = yield* Session.Service
+      const bus = yield* Bus.Service
       const session = yield* sessions.create({ location })
       const id = SessionMessage.ID.make("msg_caller_skill")
+      const events: Event.Payload[] = []
+      yield* bus.listen((event) =>
+        Effect.sync(() => {
+          events.push(event)
+        }),
+      )
 
       yield* sessions.skill({ id, sessionID: session.id, skill: Skill.ID.make("effect"), resume: false })
 
-      expect(yield* sessions.messages({ sessionID: session.id })).toContainEqual(
-        expect.objectContaining({ id, type: "skill", skill: "effect", name: "Effect", text: "Use Effect" }),
-      )
+      expect(events).toEqual([
+        expect.objectContaining({
+          id: "evt_caller_skill",
+          type: SessionEvent.Skill.Activated.type,
+          data: { sessionID: session.id, id: info.id, name: info.name, text: info.content },
+        }),
+      ])
+      expect(yield* sessions.messages({ sessionID: session.id })).toEqual([
+        expect.objectContaining({ id, type: "skill", skill: "effect", name: "Effect", text: info.content }),
+      ])
+      expect(yield* sessions.inbox(session.id)).toEqual([])
     }),
   )
 })


### PR DESCRIPTION
## Why

Standalone skill activation still lives in the public Session service after
prompts and controls moved into ID-bound handles. It therefore cannot
be used through a retained Session handle with the same captured host services
and current-placement lookup as prompts and controls.

## What Changes

Move the existing activation operation into the lower Session factory and make
the public service delegate to it. A retained handle resolves the Session's
current Location each time it runs, including after movement.

The standalone contract remains distinct from prompt-attached skills:

| Activation | Preserved behavior |
| --- | --- |
| Missing Session | Fail before acquiring Location services |
| Missing skill | `SkillNotFoundError`, without recording or scheduling |
| Successful activation | Record `SessionEvent.Skill.Activated` immediately with raw registered skill content |
| Supplied message ID | Preserve the existing message-to-event ID mapping |
| Default / `resume: true` | Start the existing detached resume in the host Scope after recording |
| `resume: false` | Record only |

Standalone activation still does not become prompt admission. The change does
not add prompt preparation, inbox delivery, or a different scheduling policy.

## Scope

This is the standalone skill ownership follow-up to #46019. It is independent of
the projected-read cleanup in #46075 and intentionally does not change skill readiness or
model-facing formatting.

## Verification

Initial validation at `135fe3bd97`:

```sh
# packages/core
bun typecheck
bun run test test/session-owned.test.ts test/session-skill.test.ts test/session-prompt.test.ts test/session-prompt-hooks.test.ts test/session-run-coordinator.test.ts test/bus-session-routing.test.ts
bun run test

# packages/sdk
bun typecheck
OPENCODE_DISABLE_MODELS_FETCH=true bun run ../core/script/test.ts

# packages/server
bun typecheck
bun run ../core/script/test.ts
```

Focused Core: **110 passed, 0 failed**, 455 assertions across six files, including
detached handles, movement, ambient event context, validation order, and host-owned
resume lifetime. SDK: **26 passed, 0 failed**. Server: **45 passed, 3 skipped,
0 failed**. All three package typechecks and all **33 pre-push typecheck tasks**
passed at `135fe3bd97`.

Full Core: **3,977 passed, 40 skipped, 0 failed**, 79,563 assertions across 225
files (191.25 seconds).

Three simplify passes reviewed the complete diff for reuse, quality, and
efficiency. No changes were warranted; the implementation retains the established
native binding and structural pass-through patterns. Formatting, both Effect AST
scans, and diff checks passed. Oxlint reported zero errors and four pre-existing
warnings, including one on the relocated implementation.

After integrating `v2` at `171947787c`, including the confirmed test-race fix in
#46083, the focused Core suite again passed **110/110** and all **33 pre-push
typecheck tasks** passed at `8c55494b11`. The refactor diff is byte-identical to
the reviewed version; only its base changed.

A final reuse, quality, and efficiency review led to a test-only simplification
in `009477ebcd`: an uncompleted `Deferred` became `Effect.never`, preserving
all ordering and host-shutdown assertions. No production changes were needed.
After that edit, the focused suite passed **110/110** again (455 assertions),
Core `bun typecheck` passed, and Prettier and `git diff --check` passed.
All **33 pre-push typecheck tasks** also passed for the final commit.
