### PR TITLE
refactor(util): reuse BOM-stripped text

### DIFF
--- a/packages/util/src/bom.test.ts
+++ b/packages/util/src/bom.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import { Bom } from "./bom.js"
+
+test.each([
+  { prefix: "", bom: false, expected: undefined },
+  { prefix: "", bom: true, expected: "\uFEFF" },
+  { prefix: "\uFEFF", bom: false, expected: "" },
+  { prefix: "\uFEFF", bom: true, expected: undefined },
+  { prefix: "\uFEFF\uFEFF", bom: false, expected: "" },
+  { prefix: "\uFEFF\uFEFF", bom: true, expected: "\uFEFF" },
+])("syncBytes(%j)", (row) => {
+  const encoder = new TextEncoder()
+  const text = "a\uFEFF\u00e9"
+  const input = encoder.encode(row.prefix + text)
+
+  expect(Bom.syncBytes(input, row.bom)).toEqual({
+    text,
+    bytes: row.expected === undefined ? undefined : encoder.encode(row.expected + text),
+  })
+  expect(input).toEqual(encoder.encode(row.prefix + text))
+})

--- a/packages/util/src/bom.ts
+++ b/packages/util/src/bom.ts
@@ -27,7 +27,7 @@ export function decodeBytes(content: Uint8Array) {
 export function syncBytes(content: Uint8Array, bom: boolean) {
   const decoded = decode(content)
   const current = split(decoded)
-  const canonical = join(current.text, bom)
+  const canonical = bom ? value + current.text : current.text
   return { text: current.text, bytes: decoded === canonical ? undefined : new TextEncoder().encode(canonical) }
 }
 


### PR DESCRIPTION
## Why

`syncBytes` strips leading byte-order marks, then calls `join`, which strips those same marks again. The second regex pass and temporary result object are redundant.

## What Changes

Build the canonical string directly from the already-stripped text and the requested BOM state. Public `join` behavior remains unchanged for callers that pass unnormalized text.

## Scope

One production expression and a small parameterized test. Returned text, encoded bytes, input immutability, and the `undefined` result for unchanged bytes are preserved.

## Verification

```sh
cd packages/util
bun run test
bun run test src/bom.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/util/src/bom.ts packages/util/src/bom.test.ts
git diff --check HEAD^ HEAD
```

All 27 Util tests passed, including six new cases covering absent, single, and repeated leading BOMs, both desired states, and interior Unicode/BOM content. Package typechecking, formatting, and whitespace checks passed.
