### PR TITLE
refactor(core): reuse Markdown chunk byte counts

### DIFF
--- a/packages/core/src/tool/html-markdown.ts
+++ b/packages/core/src/tool/html-markdown.ts
@@ -95,7 +95,7 @@ export function convertHTMLToMarkdown(html: string) {
     const remaining = limit - outputBytes
     const next = bytes.byteLength <= remaining ? value : sliceBytes(value, remaining)
     output.push(next)
-    outputBytes += encoder.encode(next).byteLength
+    outputBytes += bytes.byteLength <= remaining ? bytes.byteLength : encoder.encode(next).byteLength
     last = next.at(-1) ?? last
   }
   const appendRaw = (value: string) => {

--- a/packages/core/test/tool-webfetch.test.ts
+++ b/packages/core/test/tool-webfetch.test.ts
@@ -128,6 +128,15 @@ describe("WebFetchTool helpers", () => {
     expect(output).toHaveLength(WebFetchTool.MAX_RESPONSE_BYTES - 64 * 1024)
   })
 
+  test.each(["x", "\u00e9", "\u{1f600}"])("preserves UTF-8 boundaries at the content limit for %s", (character) => {
+    const budget = WebFetchTool.MAX_RESPONSE_BYTES - 64 * 1024
+    const fitting = "aa" + character.repeat(Math.floor((budget - 2) / Buffer.byteLength(character)))
+    expect(WebFetchTool.convertHTMLToMarkdown(fitting)).toBe(fitting)
+    const truncated = WebFetchTool.convertHTMLToMarkdown(fitting + character)
+    expect(truncated).toBe(fitting)
+    expect(Buffer.byteLength(truncated)).toBe(Buffer.byteLength(fitting))
+  })
+
   test("bounds deeply nested list output and fragmented code fences", () => {
     const lists = `${"<ul><li>item".repeat(2_000)}${"</li></ul>".repeat(2_000)}`
     const quotes = `${"<blockquote><p>item".repeat(2_000)}${"</p></blockquote>".repeat(2_000)}`


### PR DESCRIPTION
## Why

HTML-to-Markdown rendering encodes each appended chunk to measure its UTF-8 size, then encodes the same string again when it fits unchanged. The second encoding allocates a redundant byte array for the common path.

## What Changes

Reuse the first byte count when the chunk fits. If truncation changes the string, continue measuring the retained prefix as before. Output text, byte budgets, and room reserved for closing syntax are unchanged.

## Scope

One production expression and three boundary cases in the existing webfetch tests. No tool contracts or parser chunking changes; this does not address the existing surrogate-pair splitting behavior at parser chunk boundaries.

## Verification

```sh
cd packages/core
bun run test test/tool-webfetch.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/tool/html-markdown.ts packages/core/test/tool-webfetch.test.ts
git diff --check
```

57 tests passed with 102 assertions. Typechecking, formatting, and whitespace checks passed. Added cases cover fitting and truncated ASCII, two-byte, and four-byte UTF-8 content, with surrogate pairs aligned to parser chunks. No throughput benchmark claim.
