### PR TITLE
refactor(core): reuse formatter file extension

### DIFF
--- a/packages/core/src/formatter.ts
+++ b/packages/core/src/formatter.ts
@@ -54,9 +54,8 @@ const layer = Layer.effect(
     })
 
     const file = Effect.fn("Formatter.file")(function* (filepath: string) {
-      const matching = state
-        .get()
-        .formatters.filter((formatter) => formatter.extensions.includes(path.extname(filepath)))
+      const extension = path.extname(filepath)
+      const matching = state.get().formatters.filter((formatter) => formatter.extensions.includes(extension))
 
       for (const formatter of matching) {
         const enabled = yield* command(formatter)

--- a/packages/core/test/formatter.test.ts
+++ b/packages/core/test/formatter.test.ts
@@ -58,6 +58,34 @@ function withFormatter<A, E, R>(
 }
 
 describe("Formatter", () => {
+  ;[
+    { file: "test.match", extension: ".match", matches: true },
+    { file: "test.other", extension: ".match", matches: false },
+    { file: "test.MATCH", extension: ".match", matches: false },
+    { file: "test.MATCH", extension: ".MATCH", matches: true },
+    { file: ".match", extension: ".match", matches: false },
+    { file: ".match", extension: "", matches: true },
+    { file: "README", extension: ".match", matches: false },
+    { file: "README", extension: "", matches: true },
+    { file: "test.part.match", extension: ".match", matches: true },
+    { file: "test.part.match", extension: ".part.match", matches: false },
+  ].forEach((entry) =>
+    it.live(`matches ${entry.file} against ${JSON.stringify(entry.extension)}: ${entry.matches}`, () =>
+      withFormatter(
+        {
+          matching: {
+            command: [process.execPath, "-e", "process.exit(0)", "$FILE"],
+            extensions: [entry.extension],
+          },
+        },
+        (formatter, directory) =>
+          Effect.gen(function* () {
+            expect(yield* formatter.file(path.join(directory, entry.file))).toBe(entry.matches)
+          }),
+      ),
+    ),
+  )
+
   it.live("does not run formatters marked as disabled in config", () =>
     withFormatter(
       {


### PR DESCRIPTION
## Why

Each formatting request recalculates the same filename extension for every registered formatter. The extension depends only on the requested path.

## What Changes

Compute `path.extname(filepath)` once before selecting matching formatters. Matching remains case-sensitive and uses the same Node path semantics, registry order, and first-success/fallback behavior.

## Scope

The matching expression and focused matching tests only. Command resolution, process execution, timeout policy, and error handling are unchanged.

## Verification

```sh
cd packages/core
bun run test test/formatter.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/formatter.ts packages/core/test/formatter.test.ts
git diff --check HEAD^ HEAD
```

17 tests passed with 24 assertions. New real-harness cases cover matching/nonmatching extensions, case sensitivity, dotfiles, extensionless files, and multi-dot names. Core typechecking, formatting, and whitespace checks passed.
