### PR TITLE
refactor(codemode): avoid merging root definitions twice

### DIFF
--- a/packages/codemode/src/tool-schema.ts
+++ b/packages/codemode/src/tool-schema.ts
@@ -180,7 +180,7 @@ export const toTypeScript = (schema: Schema.Top, decoded = false, pretty = false
 
 export const jsonSchemaToTypeScript = (schema: JsonSchema, pretty = false): string => {
   try {
-    return renderSchema(schema, { definitions: { ...(schema.definitions ?? {}), ...(schema.$defs ?? {}) }, pretty })
+    return renderSchema(schema, { definitions: {}, pretty })
   } catch {
     return "unknown"
   }

--- a/packages/codemode/test/signature.test.ts
+++ b/packages/codemode/test/signature.test.ts
@@ -216,6 +216,35 @@ describe("pretty signature rendering", () => {
   })
 })
 
+describe("JSON Schema definition scope", () => {
+  test.each(["definitions", "$defs"])("resolves root %s and lets $defs take precedence", (key) => {
+    const schema = { $ref: `#/${key}/Value`, [key]: { Value: { type: "string" } } }
+    expect(jsonSchemaToTypeScript(schema)).toBe("string")
+    expect(jsonSchemaToTypeScript(schema, true)).toBe("string")
+
+    const overridden = { ...schema, $defs: { Value: { type: "number" } } }
+    expect(jsonSchemaToTypeScript(overridden)).toBe("number")
+    expect(jsonSchemaToTypeScript(overridden, true)).toBe("number")
+  })
+
+  test.each(["definitions", "$defs"])("nested %s shadow inherited definitions without affecting siblings", (key) => {
+    const schema = {
+      type: "object",
+      definitions: { Inherited: { type: "string" } },
+      $defs: { Value: { type: "number" } },
+      properties: {
+        nested: { $ref: `#/${key}/Value`, [key]: { Value: { type: "boolean" } } },
+        inherited: { $ref: "#/definitions/Inherited" },
+        sibling: { $ref: "#/$defs/Value" },
+      },
+    }
+    expect(jsonSchemaToTypeScript(schema)).toBe("{ nested?: boolean; inherited?: string; sibling?: number }")
+    expect(jsonSchemaToTypeScript(schema, true)).toBe(
+      ["{", "  nested?: boolean,", "  inherited?: string,", "  sibling?: number,", "}"].join("\n"),
+    )
+  })
+})
+
 describe("non-identifier property names render as quoted keys", () => {
   // MCP-style schemas routinely carry property names that are not bare TS identifiers
   // (`foo-bar`, `@type`, dotted names); the rendered signature must quote them so the


### PR DESCRIPTION
## Why

JSON Schema rendering constructs a dictionary from root `definitions` and `$defs`, then immediately passes it to `renderSchema`, which copies and merges those same definitions again.

## What Changes

Start the root renderer with an empty inherited-definition context. Its existing schema-local merge remains the single owner of root definitions, preserving `$defs` precedence, nested shadowing, sibling isolation, and compact/pretty output.

## Scope

One production line plus focused tests. Effect schema document definitions in `toTypeScript` are unchanged; no schema, tool API, or interpreter changes.

## Verification

```sh
cd packages/codemode
bun run test test/signature.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/codemode/src/tool-schema.ts packages/codemode/test/signature.test.ts
git diff --check HEAD^ HEAD
```

28 signature tests passed before and after the production change. Package typechecking, formatting, and whitespace checks passed. The new cases exercise legacy definitions, `$defs` precedence, and nested/sibling scope in both rendering modes.
