### PR TITLE
test(tui): wait for diff base search focus

### DIFF
--- a/packages/tui/test/cli/tui/diff-viewer.test.tsx
+++ b/packages/tui/test/cli/tui/diff-viewer.test.tsx
@@ -1,11 +1,14 @@
 /** @jsxImportSource @opentui/solid */
 import { afterAll, expect, test } from "bun:test"
+import { once } from "node:events"
 import { readdir } from "node:fs/promises"
 import path from "node:path"
 import {
   BoxRenderable,
+  CliRenderEvents,
   DiffRenderable,
   ImageRenderable,
+  InputRenderable,
   MouseButton,
   type Renderable,
   ScrollBoxRenderable,
@@ -315,6 +318,9 @@ test.each(["branch", "committed", "working"] as const)(
       expect(viewer.app.captureCharFrame()).toMatch(/●\s+v2/)
       expect(viewer.branchesRequests[0].searchParams.get("location[directory]")).toBe("/repo/session")
       expect(viewer.branchesRequests[0].searchParams.get("limit")).toBe("100")
+      // The picker can paint before its deferred input focus.
+      if (!viewer.app.renderer.currentFocusedEditor) await once(viewer.app.renderer, CliRenderEvents.FOCUSED_EDITOR)
+      expect(viewer.app.renderer.currentFocusedEditor).toBeInstanceOf(InputRenderable)
       await viewer.app.mockInput.typeText("origin/release")
       await Bun.sleep(160)
       await viewer.app.waitFor(() => viewer.branchesRequests.at(-1)?.searchParams.get("search") === "origin/release")


### PR DESCRIPTION
## Why

The diff-base selection test can type before the branch-search input receives
focus. DialogSelect schedules focus asynchronously; a rendered chooser is not
an input-readiness signal. When rendering wins that race, the input discards the
typed query and the later request assertion times out.

This failed in Windows CI on #46075 in the committed comparison, then in the
working comparison on an unchanged rerun. The same failure also blocked #46077.
The fixture was reproduced locally with fast rendering, independently of those
Session changes.

## What Changes

Wait for the search editor to receive focus before typing. An already-focused
editor proceeds immediately; otherwise the test observes the renderer's existing
focus event. The test still exercises the real component and retains its search,
comparison, review-count, and reopening assertions.

## Reproduction

Using a temporary `maxFps: Number.POSITIVE_INFINITY` fixture setting:

- Before: the committed-comparison case failed **10/10** runs with the same
  frame state and stack location as Windows CI.
- Targeted probes confirmed focus was absent before typing and the input text
  remained empty after the original debounce wait.
- After the focus barrier: all three source variants passed **90/90** runs
  under that identical fast-render setting.

The fast-render override and diagnostic logs are not part of the final change.

## Scope

Test synchronization only. No application focus changes, assertion weakening,
test retries, or timeout increases. Independent of both Session refactors.

## Verification

```sh
# packages/tui
bun typecheck
bun run test test/cli/tui/diff-viewer.test.tsx --test-name-pattern 'choosing a base remembers it and refreshes only the affected' --rerun-each 100
bun run test test/cli/tui/diff-viewer.test.tsx --rerun-each 3
bun run test
```

Normal-speed focused stress: **300 passed, 0 failed**, all three variants run
100 times, 4,400 assertions (195.02 seconds).
Normal-speed repeated diff-viewer suite: **273 passed, 0 failed**, 2,376
assertions. Full TUI: **989 passed, 4 skipped, 0 failed**, two snapshots and 4,371
assertions across 122 files. TUI typecheck and all **33 pre-push typecheck tasks**
passed at `d7bbe7a01d`.

Three simplify reviews of the complete six-line diff found no actionable
changes. Prettier and diff checks passed. The final patch contains no diagnostic
logging or fast-render override.
