### PR TITLE
fix(shell): bound post-exit pipe draining on all platforms

### DIFF
--- a/packages/core/src/mcp/stdio.ts
+++ b/packages/core/src/mcp/stdio.ts
@@ -53,13 +53,12 @@ export const make = Effect.fnUntraced(function* (options: Options) {
   let closing: Promise<void> | undefined
   let trailingBytes = 0
 
-  const stop = (handle: ChildProcessHandle) =>
-    Effect.gen(function* () {
-      const exit = yield* Effect.timeoutOption(handle.exitCode, CLOSE_GRACE)
-      if (exit._tag === "Some") return
-      const terminated = yield* Effect.timeoutOption(handle.kill({ killSignal: "SIGTERM" }), FORCE_KILL_AFTER)
-      if (terminated._tag === "None") yield* handle.kill({ killSignal: "SIGKILL" })
-    }).pipe(Effect.ignore)
+  const stop = Effect.fnUntraced(function* (handle: ChildProcessHandle) {
+    // Exit completion can precede descendant cleanup after the capture deadline.
+    yield* Effect.timeoutOption(handle.exitCode, CLOSE_GRACE).pipe(Effect.ignore)
+    const terminated = yield* Effect.timeoutOption(handle.kill({ killSignal: "SIGTERM" }), FORCE_KILL_AFTER)
+    if (terminated._tag === "None") yield* handle.kill({ killSignal: "SIGKILL" })
+  }, Effect.ignore())
 
   const close = () =>
     (closing ??= Effect.runPromise(

--- a/packages/core/src/shell.ts
+++ b/packages/core/src/shell.ts
@@ -384,7 +384,11 @@ const layer = () =>
                   command.timeoutFiber = runFork(
                     Effect.sleep(Duration.millis(duration)).pipe(
                       Effect.flatMap(() =>
-                        finish("timeout", undefined, handle.kill().pipe(Effect.catch(() => Effect.void))),
+                        finish(
+                          "timeout",
+                          undefined,
+                          handle.kill({ forceKillAfter: Duration.seconds(3) }).pipe(Effect.catch(() => Effect.void)),
+                        ),
                       ),
                     ),
                   )

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -2,7 +2,7 @@ import { describe, expect } from "bun:test"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
-import { Effect, Exit, PlatformError, Stream } from "effect"
+import { Deferred, Effect, Exit, PlatformError, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { CrossSpawnSpawner } from "@opencode-ai/util/cross-spawn-spawner"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
@@ -217,6 +217,52 @@ describe("cross-spawn spawner", () => {
   })
 
   describe("process control", () => {
+    for (const mode of ["exit", "SIGKILL"] as const) {
+      const test = mode === "SIGKILL" && process.platform === "win32" ? fx.live.skip : fx.live
+      test(
+        `finishes capture after ${mode} while a grandchild holds stdio`,
+        Effect.gen(function* () {
+          const tmp = yield* Effect.acquireRelease(
+            Effect.promise(() => tmpdir()),
+            (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+          )
+          const pidFile = path.join(tmp.path, "child.pid")
+          yield* Effect.addFinalizer(() =>
+            Effect.tryPromise(async () => process.kill(Number(await fs.readFile(pidFile, "utf8")), "SIGKILL")).pipe(
+              Effect.ignore,
+            ),
+          )
+          const ready = yield* Deferred.make<void>()
+          // The grandchild keeps both pipes open independently of the foreground process.
+          const handle = yield* ChildProcess.make(
+            "node",
+            [path.join(import.meta.dir, "../fixture/held-stdio.cjs"), mode, pidFile],
+            { stdin: "ignore", forceKillAfter: 100 },
+          )
+          const [exit, stdout, stderr] = yield* Effect.all(
+            [
+              Effect.exit(handle.exitCode),
+              decodeByteStream(handle.stdout),
+              decodeByteStream(handle.stderr.pipe(Stream.tap(() => Deferred.succeed(ready, undefined)))),
+              mode === "SIGKILL"
+                ? Deferred.await(ready).pipe(Effect.andThen(handle.kill({ killSignal: "SIGKILL" })))
+                : Effect.void,
+            ],
+            { concurrency: "unbounded" },
+          ).pipe(Effect.timeout("3 seconds"))
+
+          // Completion must retain foreground output without waiting for the inherited pipes to close.
+          expect(stdout).toBe("foreground-out")
+          expect(stderr).toBe("foreground-err")
+          expect(Exit.isSuccess(exit)).toBe(mode === "exit")
+          if (Exit.isSuccess(exit)) expect(exit.value).toBe(ChildProcessSpawner.ExitCode(0))
+          expect(yield* handle.isRunning).toBe(false)
+          expect(alive(Number(yield* Effect.promise(() => fs.readFile(pidFile, "utf8"))))).toBe(true)
+        }),
+        10_000,
+      )
+    }
+
     fx.effect(
       "kills a running process",
       Effect.gen(function* () {

--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -245,7 +245,7 @@ describe("cross-spawn spawner", () => {
       }),
     )
 
-    fx.effect(
+    fx.live(
       "forceKillAfter escalates for stubborn processes",
       Effect.gen(function* () {
         if (process.platform === "win32") return

--- a/packages/core/test/fixture/held-stdio.cjs
+++ b/packages/core/test/fixture/held-stdio.cjs
@@ -1,0 +1,36 @@
+const { spawn } = require("node:child_process")
+const fs = require("node:fs")
+
+const mode = process.argv[2]
+const child = spawn(
+  process.execPath,
+  [
+    "-e",
+    `
+  process.on("SIGTERM", () => {})
+  process.stdout.on("error", () => {})
+  process.stderr.on("error", () => {})
+  process.send("ready")
+  setTimeout(() => process.exit(0), 15000)
+`,
+  ],
+  {
+    detached: mode !== "mcp",
+    stdio: ["ignore", "inherit", "inherit", "ipc"],
+  },
+)
+fs.writeFileSync(process.argv[3], String(child.pid))
+
+child.once("message", () => {
+  child.disconnect()
+  child.unref()
+  if (mode === "mcp") {
+    fs.writeSync(1, JSON.stringify({ jsonrpc: "2.0", method: "ready" }) + "\n")
+    process.stdin.resume().once("end", () => process.exit(0))
+    return
+  }
+  fs.writeSync(1, "foreground-out\n")
+  fs.writeSync(2, "foreground-err\n")
+  if (mode === "exit") process.exit(0)
+  setTimeout(() => process.exit(0), 15000)
+})

--- a/packages/core/test/mcp.test.ts
+++ b/packages/core/test/mcp.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path"
+import fs from "node:fs/promises"
 import { describe, expect, test } from "bun:test"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
@@ -43,6 +44,7 @@ import { Image } from "@opencode-ai/core/image"
 import { testEffect } from "./lib/effect"
 import { imagePassthrough } from "./lib/image"
 import { location } from "./fixture/location"
+import { tmpdirScoped } from "./fixture/tmpdir"
 import { hostEnvironmentLayer, recordingEnvironmentLayer } from "./fixture/environment"
 import { executeTool, toolDefinitions, toolIdentity, waitForTool } from "./lib/tool"
 
@@ -651,6 +653,47 @@ test("joins concurrent stdio transport closes", async () => {
     ),
   )
 })
+
+const testMcpDescendants =
+  process.platform === "win32" ? testEffect(hostEnvironmentLayer).live.skip : testEffect(hostEnvironmentLayer).live
+testMcpDescendants(
+  "terminates MCP descendants after the wrapper exits successfully",
+  Effect.gen(function* () {
+    const tmp = yield* tmpdirScoped()
+    const pidFile = path.join(tmp.path, "child.pid")
+    yield* Effect.addFinalizer(() =>
+      Effect.tryPromise(async () => process.kill(Number(await fs.readFile(pidFile, "utf8")), "SIGKILL")).pipe(
+        Effect.ignore,
+      ),
+    )
+    const ready = yield* Deferred.make<void>()
+    // Stdin EOF exits the wrapper, but its ready descendant ignores SIGTERM and retains both pipes.
+    const transport = yield* McpStdio.make({
+      server: "held-stdio",
+      command: "node",
+      args: [path.join(import.meta.dir, "fixture/held-stdio.cjs"), "mcp", pidFile],
+      cwd: tmp.path,
+      environment: {},
+    })
+    transport.onmessage = () => {
+      Deferred.doneUnsafe(ready, Exit.void)
+    }
+    yield* Effect.promise(() => transport.start())
+    yield* Deferred.await(ready).pipe(Effect.timeout("3 seconds"))
+    const pid = Number(yield* Effect.promise(() => fs.readFile(pidFile, "utf8")))
+
+    yield* Effect.promise(() => transport.close()).pipe(Effect.timeout("6 seconds"))
+
+    // close() must kill the descendant, not merely observe the wrapper's bounded exitCode.
+    const stopped = yield* Effect.try(() => process.kill(pid, 0)).pipe(
+      Effect.exit,
+      Effect.repeat({ while: Exit.isSuccess, schedule: Schedule.spaced("25 millis") }),
+      Effect.timeout("2 seconds"),
+    )
+    expect(Exit.isFailure(stopped)).toBe(true)
+  }),
+  15_000,
+)
 
 test("closes a stdio process that finishes spawning after close", async () => {
   const spawning = Deferred.makeUnsafe<void>()

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -1,5 +1,5 @@
 import fs from "fs/promises"
-import { realpathSync } from "node:fs"
+import { realpathSync, watch } from "node:fs"
 import os from "os"
 import path from "path"
 import { describe, expect } from "bun:test"
@@ -39,7 +39,7 @@ import { Shell as ShellSchema } from "@opencode-ai/schema/shell"
 import { ShellTool } from "@opencode-ai/core/tool/plugin/shell"
 import { ToolOutput } from "@opencode-ai/core/tool-output"
 import { Tool } from "@opencode-ai/core/tool"
-import { tmpdir } from "./fixture/tmpdir"
+import { tmpdir, tmpdirScoped } from "./fixture/tmpdir"
 import { tempGlobalLayer } from "./fixture/global"
 import { testEffect } from "./lib/effect"
 import { permissionLayer } from "./lib/permission"
@@ -1508,6 +1508,55 @@ describe("ShellTool", () => {
         (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]().then(() => undefined)),
       ),
     { timeout: 15_000 },
+  )
+
+  const signalTest = isWindows ? it.live.skip : it.live
+  signalTest(
+    "escalates a shell timeout when the ready process ignores SIGTERM",
+    () =>
+      Effect.gen(function* () {
+        const tmp = yield* tmpdirScoped()
+        const ready = yield* Deferred.make<void>()
+        yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            watch(tmp.path, (_event, filename) => {
+              if (filename === "ready") Deferred.doneUnsafe(ready, Exit.void)
+            }),
+          ),
+          (watcher) => Effect.sync(() => watcher.close()),
+        )
+        yield* withSession(tmp.path, () =>
+          Effect.gen(function* () {
+            const shell = yield* Shell.Service
+            yield* Effect.acquireUseRelease(
+              // Arm the timeout only after the child announces that SIGTERM is ignored.
+              shell.create({
+                shell: "/bin/sh",
+                command: "trap '' TERM; : > ready; while :; do sleep 60; done",
+                timeout: 0,
+              }),
+              (info) =>
+                Effect.gen(function* () {
+                  yield* Deferred.await(ready).pipe(Effect.timeout("5 seconds"))
+                  yield* shell.timeout(info.id, 1)
+                  // Completion must reap the process, not only mark the command as timed out.
+                  expect((yield* shell.wait(info.id).pipe(Effect.timeout("10 seconds"))).status).toBe("timeout")
+                  const pid = info.pid
+                  if (pid === undefined) throw new Error("Expected shell PID")
+                  expect(() => process.kill(pid, 0)).toThrow()
+                }),
+              (info) =>
+                Effect.try(() => {
+                  if (info.pid !== undefined) process.kill(-info.pid, "SIGKILL")
+                }).pipe(
+                  Effect.catch(() => Effect.void),
+                  Effect.andThen(shell.remove(info.id)),
+                ),
+            )
+          }),
+        )
+      }),
+    { timeout: 30_000 },
   )
 
   it.live("does not retain removed running shells in exit order", () =>

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -250,10 +250,8 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
         })
       : Stream.empty
 
-    if (process.platform === "win32") {
-      stdout = Stream.interruptWhen(stdout, Deferred.await(stopOutput))
-      stderr = Stream.interruptWhen(stderr, Deferred.await(stopOutput))
-    }
+    stdout = Stream.interruptWhen(stdout, Deferred.await(stopOutput))
+    stderr = Stream.interruptWhen(stderr, Deferred.await(stopOutput))
     if (Sink.isSink(out.stream)) stdout = Stream.transduce(stdout, out.stream)
     if (Sink.isSink(err.stream)) stderr = Stream.transduce(stderr, err.stream)
 
@@ -275,7 +273,6 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
-        if (process.platform !== "win32") return // POSIX stop() needs stream closure for kill escalation.
         // Particularly on Windows, some shell calls will cause detached descendants. Inherited stdio can hang the call.
         // Almost every ecosystem has tried to fix this; there's no single "good" answer here.
         // Calls that trigger this are e.g. dotnet build with warmed MSBuild processes, agent-browser, etc.
@@ -348,36 +345,47 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
     exit: ExitSignal,
     opts: ChildProcess.KillOptions | undefined,
   ) => {
+    let group = false
     const send = (signal: NodeJS.Signals) =>
-      Effect.catch(killGroup(command, proc, signal), () => killOne(command, proc, signal))
-    const attempt = send(opts?.killSignal ?? "SIGTERM").pipe(Effect.andThen(Deferred.await(exit)), Effect.asVoid)
-    if (!opts?.forceKillAfter) return attempt
+      killGroup(command, proc, signal).pipe(
+        Effect.as(true),
+        Effect.catch(() => Effect.as(killOne(command, proc, signal), false)),
+      )
+    const attempt = Effect.gen(function* () {
+      group = yield* send(opts?.killSignal ?? "SIGTERM")
+      // Closing captured pipes does not mean a POSIX process group has stopped.
+      if (process.platform !== "win32" && group && opts?.forceKillAfter !== undefined) {
+        while (
+          yield* Effect.try({ try: () => process.kill(-proc.pid!, 0), catch: toError }).pipe(
+            Effect.catch((error) =>
+              Predicate.hasProperty(error, "code") && error.code === "ESRCH"
+                ? Effect.succeed(false)
+                : Effect.fail(toPlatformError("kill", error, command)),
+            ),
+          )
+        ) {
+          yield* Effect.sleep(50)
+        }
+      }
+      yield* Deferred.await(exit)
+    })
+    if (opts?.forceKillAfter === undefined) return attempt
     return Effect.timeoutOrElse(attempt, {
       duration: opts.forceKillAfter,
-      orElse: () => send("SIGKILL").pipe(Effect.andThen(Deferred.await(exit)), Effect.asVoid),
+      // Do not poll after SIGKILL: unreaped zombies can still appear in the group.
+      orElse: () =>
+        (group && process.platform !== "win32"
+          ? killGroup(command, proc, "SIGKILL").pipe(
+              Effect.catch((error) =>
+                Predicate.hasProperty(error.reason.cause, "code") && error.reason.cause.code === "ESRCH"
+                  ? Effect.void
+                  : Effect.fail(error),
+              ),
+            )
+          : send("SIGKILL")
+        ).pipe(Effect.andThen(Deferred.await(exit)), Effect.asVoid),
     })
   }
-
-  const timeout =
-    (
-      proc: NodeChildProcess.ChildProcess,
-      command: ChildProcess.StandardCommand,
-      opts: ChildProcess.KillOptions | undefined,
-    ) =>
-    <A, E, R>(
-      f: (
-        command: ChildProcess.StandardCommand,
-        proc: NodeChildProcess.ChildProcess,
-        signal: NodeJS.Signals,
-      ) => Effect.Effect<A, E, R>,
-    ) => {
-      const signal = opts?.killSignal ?? "SIGTERM"
-      if (Predicate.isUndefined(opts?.forceKillAfter)) return f(command, proc, signal)
-      return Effect.timeoutOrElse(f(command, proc, signal), {
-        duration: opts.forceKillAfter,
-        orElse: () => f(command, proc, "SIGKILL"),
-      })
-    }
 
   const source = (handle: ChildProcessHandle, from: ChildProcess.PipeFromOption | undefined) => {
     const opt = from ?? "stdout"
@@ -418,12 +426,10 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
             }),
             Effect.fnUntraced(function* ([proc, signal]) {
               const done = yield* Deferred.isDone(signal)
-              const kill = timeout(proc, command, command.options)
               if (done) {
                 const [code] = yield* Deferred.await(signal)
                 if (process.platform === "win32") return yield* Effect.void
-                if (code !== 0 && Predicate.isNotNull(code)) return yield* Effect.ignore(kill(killGroup))
-                return yield* Effect.void
+                if (code === 0 || Predicate.isNull(code)) return yield* Effect.void
               }
               return yield* Effect.ignore(stop(command, proc, signal, command.options))
             }),

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -86,6 +86,7 @@ const toPlatformError = (
 }
 
 type ExitSignal = Deferred.Deferred<readonly [code: number | null, signal: NodeJS.Signals | null]>
+type Spawned = readonly [process: NodeChildProcess.ChildProcess, closed: ExitSignal, exited: ExitSignal]
 
 const makeCrossSpawnSpawner = Effect.gen(function* () {
   const fs = yield* FileSystem.FileSystem
@@ -237,21 +238,26 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
     err: ChildProcess.StderrConfig,
     stopOutput: Deferred.Deferred<void>,
   ) => {
-    let stdout = proc.stdout
-      ? NodeStream.fromReadable({
-          evaluate: () => proc.stdout!,
-          onError: (cause) => toPlatformError("fromReadable(stdout)", toError(cause), command),
-        })
-      : Stream.empty
-    let stderr = proc.stderr
-      ? NodeStream.fromReadable({
-          evaluate: () => proc.stderr!,
-          onError: (cause) => toPlatformError("fromReadable(stderr)", toError(cause), command),
-        })
-      : Stream.empty
+    const capture = (readable: NodeChildProcess.ChildProcess["stdout"], name: string) => {
+      if (!readable) return Stream.empty
+      return NodeStream.fromReadable({
+        evaluate: () => readable,
+        onError: (cause) => toPlatformError(`fromReadable(${name})`, toError(cause), command),
+        closeOnDone: false,
+      }).pipe(
+        Stream.interruptWhen(Deferred.await(stopOutput)),
+        Stream.ensuring(
+          Effect.gen(function* () {
+            // Only the capture deadline transfers the reader back to the process scope.
+            if (yield* Deferred.isDone(stopOutput)) return
+            readable.destroy()
+          }),
+        ),
+      )
+    }
 
-    stdout = Stream.interruptWhen(stdout, Deferred.await(stopOutput))
-    stderr = Stream.interruptWhen(stderr, Deferred.await(stopOutput))
+    let stdout = capture(proc.stdout, "stdout")
+    let stderr = capture(proc.stderr, "stderr")
     if (Sink.isSink(out.stream)) stdout = Stream.transduce(stdout, out.stream)
     if (Sink.isSink(err.stream)) stderr = Stream.transduce(stderr, err.stream)
 
@@ -259,12 +265,9 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
   }
 
   const launchProcess = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
-    Effect.callback<
-      readonly [NodeChildProcess.ChildProcess, ExitSignal, Deferred.Deferred<void>],
-      PlatformError.PlatformError
-    >((resume) => {
-      const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
-      const stopOutput = Deferred.makeUnsafe<void>()
+    Effect.callback<Spawned, PlatformError.PlatformError>((resume) => {
+      const closed = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
+      const exited = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
       const proc = launch(command.command, command.args, opts)
       let end = false
       let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
@@ -273,26 +276,16 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
-        // Particularly on Windows, some shell calls will cause detached descendants. Inherited stdio can hang the call.
-        // Almost every ecosystem has tried to fix this; there's no single "good" answer here.
-        // Calls that trigger this are e.g. dotnet build with warmed MSBuild processes, agent-browser, etc.
-        // One shared deadline covers stdout and stderr, then the output pump finishes its file.
-        const drain = setTimeout(() => {
-          // A plain close does not wake Effect's pending readable pull.
-          Deferred.doneUnsafe(stopOutput, Exit.void)
-          proc.stdout?.destroy()
-          proc.stderr?.destroy()
-        }, 1000)
-        drain.unref()
-        proc.once("close", () => clearTimeout(drain))
+        Deferred.doneUnsafe(exited, Exit.succeed(args))
       })
       proc.on("close", (...args) => {
         if (end) return
         end = true
-        Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
+        Deferred.doneUnsafe(exited, Exit.succeed(exit ?? args))
+        Deferred.doneUnsafe(closed, Exit.succeed(exit ?? args))
       })
       proc.on("spawn", () => {
-        resume(Effect.succeed([proc, signal, stopOutput]))
+        resume(Effect.succeed([proc, closed, exited]))
       })
       return Effect.sync(() => {
         proc.kill("SIGTERM")
@@ -304,8 +297,36 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
     opts: NodeChildProcess.SpawnOptions,
   ) {
     yield* Effect.logInfo("spawning process", { command: command.command, args: command.args, cwd: opts.cwd })
-    return yield* launchProcess(command, opts)
+    const [proc, closed, exited] = yield* launchProcess(command, opts)
+    const stopOutput = yield* Deferred.make<void>()
+    // Register before process release so the deadline remains active during termination.
+    yield* Effect.forkScoped(
+      Effect.gen(function* () {
+        yield* Deferred.await(exited)
+        // Particularly on Windows, some shell calls will cause detached descendants. Inherited stdio can hang the call.
+        // Almost every ecosystem has tried to fix this; there's no single "good" answer here.
+        // Calls that trigger this are e.g. dotnet build with warmed MSBuild processes, agent-browser, etc.
+        // One shared deadline covers stdout and stderr, then the output pump finishes its file.
+        if ((yield* Effect.timeoutOption(Deferred.await(closed), 1000))._tag === "Some") return
+        yield* Deferred.succeed(stopOutput, undefined)
+        discard(proc.stdout)
+        discard(proc.stderr)
+      }),
+    )
+    return [proc, closed, exited, stopOutput] as const
   })
+
+  const discard = (readable: NodeChildProcess.ChildProcess["stdout"]) => {
+    if (!readable) return
+    // read() also drains while a backpressured Effect adapter still has a readable listener.
+    const drain = () => {
+      while (readable.read() !== null) {}
+    }
+    readable.on("readable", drain)
+    readable.once("error", () => {})
+    readable.once("close", () => readable.off("readable", drain))
+    drain()
+  }
 
   const killGroup = (
     command: ChildProcess.StandardCommand,
@@ -342,48 +363,24 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
   const stop = (
     command: ChildProcess.StandardCommand,
     proc: NodeChildProcess.ChildProcess,
-    exit: ExitSignal,
+    closed: ExitSignal,
+    stopOutput: Deferred.Deferred<void>,
     opts: ChildProcess.KillOptions | undefined,
   ) => {
-    let group = false
-    const send = (signal: NodeJS.Signals) =>
-      killGroup(command, proc, signal).pipe(
-        Effect.as(true),
-        Effect.catch(() => Effect.as(killOne(command, proc, signal), false)),
+    const terminate = (signal: NodeJS.Signals) =>
+      Effect.catch(killGroup(command, proc, signal), () => killOne(command, proc, signal)).pipe(
+        Effect.andThen(
+          signal === "SIGKILL"
+            ? Effect.raceFirst(Deferred.await(closed), Deferred.await(stopOutput))
+            : Deferred.await(closed),
+        ),
+        Effect.asVoid,
       )
-    const attempt = Effect.gen(function* () {
-      group = yield* send(opts?.killSignal ?? "SIGTERM")
-      // Closing captured pipes does not mean a POSIX process group has stopped.
-      if (process.platform !== "win32" && group && opts?.forceKillAfter !== undefined) {
-        while (
-          yield* Effect.try({ try: () => process.kill(-proc.pid!, 0), catch: toError }).pipe(
-            Effect.catch((error) =>
-              Predicate.hasProperty(error, "code") && error.code === "ESRCH"
-                ? Effect.succeed(false)
-                : Effect.fail(toPlatformError("kill", error, command)),
-            ),
-          )
-        ) {
-          yield* Effect.sleep(50)
-        }
-      }
-      yield* Deferred.await(exit)
-    })
+    const attempt = terminate(opts?.killSignal ?? "SIGTERM")
     if (opts?.forceKillAfter === undefined) return attempt
     return Effect.timeoutOrElse(attempt, {
       duration: opts.forceKillAfter,
-      // Do not poll after SIGKILL: unreaped zombies can still appear in the group.
-      orElse: () =>
-        (group && process.platform !== "win32"
-          ? killGroup(command, proc, "SIGKILL").pipe(
-              Effect.catch((error) =>
-                Predicate.hasProperty(error.reason.cause, "code") && error.reason.cause.code === "ESRCH"
-                  ? Effect.void
-                  : Effect.fail(error),
-              ),
-            )
-          : send("SIGKILL")
-        ).pipe(Effect.andThen(Deferred.await(exit)), Effect.asVoid),
+      orElse: () => terminate("SIGKILL"),
     })
   }
 
@@ -415,7 +412,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
           const extra = fds(command.options)
           const dir = yield* cwd(command.options)
 
-          const [proc, signal, stopOutput] = yield* Effect.acquireRelease(
+          const [proc, closed, exited, stopOutput] = yield* Effect.acquireRelease(
             spawn(command, {
               cwd: dir,
               env: env(command.options),
@@ -424,17 +421,36 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
               shell: command.options.shell,
               windowsHide: process.platform === "win32",
             }),
-            Effect.fnUntraced(function* ([proc, signal]) {
-              const done = yield* Deferred.isDone(signal)
-              if (done) {
-                const [code] = yield* Deferred.await(signal)
-                if (process.platform === "win32") return yield* Effect.void
-                if (code === 0 || Predicate.isNull(code)) return yield* Effect.void
-              }
-              return yield* Effect.ignore(stop(command, proc, signal, command.options))
-            }),
+            Effect.fnUntraced(
+              function* ([proc, closed, exited, stopOutput]) {
+                const done = (yield* Deferred.isDone(closed)) || (yield* Deferred.isDone(stopOutput))
+                if (done) {
+                  const [code] = yield* Deferred.await(exited)
+                  if (process.platform === "win32") return
+                  if (code === 0 || Predicate.isNull(code)) return
+                  if (command.options.forceKillAfter === undefined) {
+                    return yield* Effect.ignore(killGroup(command, proc, command.options.killSignal ?? "SIGTERM"))
+                  }
+                }
+                yield* Effect.ignore(stop(command, proc, closed, stopOutput, command.options))
+              },
+              (effect, [proc, , , stopOutput]) =>
+                effect.pipe(
+                  Effect.ensuring(
+                    Effect.gen(function* () {
+                      yield* Deferred.succeed(stopOutput, undefined)
+                      proc.stdout?.destroy()
+                      proc.stderr?.destroy()
+                    }),
+                  ),
+                ),
+            ),
           )
 
+          const completion = Effect.raceFirst(
+            Deferred.await(closed),
+            Deferred.await(stopOutput).pipe(Effect.andThen(Deferred.await(exited))),
+          )
           const fd = yield* setupFds(command, proc, extra)
           const out = setupOutput(command, proc, sout, serr, stopOutput)
           let ref = true
@@ -446,8 +462,10 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
             all: out.all,
             getInputFd: fd.getInputFd,
             getOutputFd: fd.getOutputFd,
-            isRunning: Effect.map(Deferred.isDone(signal), (done) => !done),
-            exitCode: Effect.flatMap(Deferred.await(signal), ([code, signal]) => {
+            isRunning: Effect.gen(function* () {
+              return !(yield* Deferred.isDone(closed)) && !(yield* Deferred.isDone(stopOutput))
+            }),
+            exitCode: Effect.flatMap(completion, ([code, signal]) => {
               if (Predicate.isNotNull(code)) return Effect.succeed(ExitCode(code))
               return Effect.fail(
                 toPlatformError(
@@ -457,7 +475,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
                 ),
               )
             }),
-            kill: (opts?: ChildProcess.KillOptions) => stop(command, proc, signal, opts),
+            kill: (opts?: ChildProcess.KillOptions) => stop(command, proc, closed, stopOutput, opts),
             unref: Effect.sync(() => {
               if (ref) {
                 proc.unref()

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -267,12 +267,14 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
       proc.on("exit", (...args) => {
         exit = args
         if (process.platform !== "win32") return
-        // Descendants can keep Windows stdio open after exit. Bound the EOF wait;
-        // the output pump still drains buffered chunks and flushes its file.
+        // Particularly on Windows, some shell calls will cause detached descendants. Inherited stdio can hang the call.
+        // Almost every ecosystem has tried to fix this; there's no single "good" answer here.
+        // Calls that trigger this are e.g. dotnet build with warmed MSBuild processes, agent-browser, etc.
+        // One shared deadline covers stdout and stderr, then the output pump finishes its file.
         const drain = setTimeout(() => {
           proc.stdout?.push(null)
           proc.stderr?.push(null)
-        }, 200)
+        }, 1000)
         drain.unref()
         proc.once("close", () => clearTimeout(drain))
       })

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -307,7 +307,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
         // Almost every ecosystem has tried to fix this; there's no single "good" answer here.
         // Calls that trigger this are e.g. dotnet build with warmed MSBuild processes, agent-browser, etc.
         // One shared deadline covers stdout and stderr, then the output pump finishes its file.
-        if ((yield* Effect.timeoutOption(Deferred.await(closed), 1000))._tag === "Some") return
+        if ((yield* Effect.timeoutOption(Deferred.await(closed), "1 second"))._tag === "Some") return
         yield* Deferred.succeed(stopOutput, undefined)
         discard(proc.stdout)
         discard(proc.stderr)
@@ -317,7 +317,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
   })
 
   const discard = (readable: NodeChildProcess.ChildProcess["stdout"]) => {
-    if (!readable) return
+    if (!readable || readable.destroyed) return
     // read() also drains while a backpressured Effect adapter still has a readable listener.
     const drain = () => {
       while (readable.read() !== null) {}

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -272,7 +272,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
         const drain = setTimeout(() => {
           proc.stdout?.push(null)
           proc.stderr?.push(null)
-        }, 1000)
+        }, 200)
         drain.unref()
         proc.once("close", () => clearTimeout(drain))
       })

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -235,6 +235,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
     proc: NodeChildProcess.ChildProcess,
     out: ChildProcess.StdoutConfig,
     err: ChildProcess.StderrConfig,
+    stopOutput: Deferred.Deferred<void>,
   ) => {
     let stdout = proc.stdout
       ? NodeStream.fromReadable({
@@ -249,6 +250,10 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
         })
       : Stream.empty
 
+    if (process.platform === "win32") {
+      stdout = Stream.interruptWhen(stdout, Deferred.await(stopOutput))
+      stderr = Stream.interruptWhen(stderr, Deferred.await(stopOutput))
+    }
     if (Sink.isSink(out.stream)) stdout = Stream.transduce(stdout, out.stream)
     if (Sink.isSink(err.stream)) stderr = Stream.transduce(stderr, err.stream)
 
@@ -256,8 +261,12 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
   }
 
   const launchProcess = (command: ChildProcess.StandardCommand, opts: NodeChildProcess.SpawnOptions) =>
-    Effect.callback<readonly [NodeChildProcess.ChildProcess, ExitSignal], PlatformError.PlatformError>((resume) => {
+    Effect.callback<
+      readonly [NodeChildProcess.ChildProcess, ExitSignal, Deferred.Deferred<void>],
+      PlatformError.PlatformError
+    >((resume) => {
       const signal = Deferred.makeUnsafe<readonly [code: number | null, signal: NodeJS.Signals | null]>()
+      const stopOutput = Deferred.makeUnsafe<void>()
       const proc = launch(command.command, command.args, opts)
       let end = false
       let exit: readonly [code: number | null, signal: NodeJS.Signals | null] | undefined
@@ -266,14 +275,16 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
-        if (process.platform !== "win32") return
+        if (process.platform !== "win32") return // POSIX stop() needs stream closure for kill escalation.
         // Particularly on Windows, some shell calls will cause detached descendants. Inherited stdio can hang the call.
         // Almost every ecosystem has tried to fix this; there's no single "good" answer here.
         // Calls that trigger this are e.g. dotnet build with warmed MSBuild processes, agent-browser, etc.
         // One shared deadline covers stdout and stderr, then the output pump finishes its file.
         const drain = setTimeout(() => {
-          proc.stdout?.push(null)
-          proc.stderr?.push(null)
+          // A plain close does not wake Effect's pending readable pull.
+          Deferred.doneUnsafe(stopOutput, Exit.void)
+          proc.stdout?.destroy()
+          proc.stderr?.destroy()
         }, 1000)
         drain.unref()
         proc.once("close", () => clearTimeout(drain))
@@ -284,7 +295,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
         Deferred.doneUnsafe(signal, Exit.succeed(exit ?? args))
       })
       proc.on("spawn", () => {
-        resume(Effect.succeed([proc, signal]))
+        resume(Effect.succeed([proc, signal, stopOutput]))
       })
       return Effect.sync(() => {
         proc.kill("SIGTERM")
@@ -396,7 +407,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
           const extra = fds(command.options)
           const dir = yield* cwd(command.options)
 
-          const [proc, signal] = yield* Effect.acquireRelease(
+          const [proc, signal, stopOutput] = yield* Effect.acquireRelease(
             spawn(command, {
               cwd: dir,
               env: env(command.options),
@@ -419,7 +430,7 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
           )
 
           const fd = yield* setupFds(command, proc, extra)
-          const out = setupOutput(command, proc, sout, serr)
+          const out = setupOutput(command, proc, sout, serr, stopOutput)
           let ref = true
           return makeHandle({
             pid: ProcessId(proc.pid!),

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -266,6 +266,15 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
       })
       proc.on("exit", (...args) => {
         exit = args
+        if (process.platform !== "win32") return
+        // Descendants can keep Windows stdio open after exit. Bound the EOF wait;
+        // the output pump still drains buffered chunks and flushes its file.
+        const drain = setTimeout(() => {
+          proc.stdout?.push(null)
+          proc.stderr?.push(null)
+        }, 1000)
+        drain.unref()
+        proc.once("close", () => clearTimeout(drain))
       })
       proc.on("close", (...args) => {
         if (end) return


### PR DESCRIPTION
### Issue for this PR

A command can exit while a background child still has its output pipes open. We keep waiting for EOF, so the shell tool never finishes.

<details>
<summary>Related issue reports</summary>

This fixes the V2 implementation of the post-exit hangs reported below.

- Fixes #20902
- Fixes #25038
- Fixes #28697
- Fixes #32504
- Fixes #36342
- Fixes #36384
- Fixes #36799
- Fixes #37838
- Fixes #38276
- Fixes #38291
- Fixes #42044
- Fixes #42524
- Fixes #43315
- Fixes #43910

Earlier reports, already closed: #19252, #22012, #22154, #24731, #24784, #24926, #25938, #29294, #29822, #33363.

Previous fix attempts: #20901, #28336, #29831, #42756, #43511, #44601.

</details>

### Type of change

- [x] Bug fix

### What does this PR do?

Give stdout and stderr one shared second to drain after the parent exits. Then finish capture and let the shell return instead of waiting on the background child.

The important part is keeping that separate from process cleanup. Shell timeouts still escalate to SIGKILL, and closing an MCP server still cleans up its descendants. No public API changes.

The tradeoff is that we can lose trailing output. Later bytes are discarded, and writers can get `EPIPE`/`SIGPIPE` once their readers close.

### How did you verify your code works?

Added four real-process regression cases: held pipes after exit, SIGKILL completion, MCP descendant cleanup, and shell timeout escalation. Each test also fails when its corresponding fix is disabled.

<details>
<summary>Validation and remaining limits</summary>

- Typechecks pass. Linux MCP, spawner, and available shell-tool tests pass.
- Windows checks pass apart from the existing `echo` quoting failure; Unix-only cases are skipped.
- Native macOS and the reported browser/.NET workloads have not been tested directly.
- Parallel scope cleanup can still fall back to the old EOF wait. No affected production caller was established.
- Normal Windows MCP shutdown now makes an extra `taskkill` attempt, taking roughly 0.35-0.73 seconds in our checks.

</details>

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
