### PR TITLE
fix(core): bound consumed job history

### DIFF
--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -36,6 +36,8 @@ export type Status = Background["status"]
 
 const decodeBackground = Schema.decodeUnknownResult(Background)
 const backgroundPrefix = "job.background/"
+const HISTORY_LIMIT = 100
+const HISTORY_BYTES = 16 * 1024 * 1024
 
 export type Info = {
   id: string
@@ -58,6 +60,8 @@ type Active = {
   token: object
   blockingSessions: Map<SessionSchema.ID, number>
   isBackgrounded: boolean
+  observed: boolean
+  notificationPending: boolean
   recovery?: Recovery
 }
 
@@ -148,6 +152,28 @@ function errorText(error: unknown) {
   return String(error)
 }
 
+function prune(jobs: Map<string, Active>) {
+  const history = [...jobs.values()].filter(
+    (job) => job.info.status !== "running" && job.observed && !job.notificationPending,
+  )
+  let count = history.length
+  let bytes = history.reduce((sum, job) => sum + historyBytes(job), 0)
+  if (count <= HISTORY_LIMIT && bytes <= HISTORY_BYTES) return jobs
+  const next = new Map(jobs)
+  for (const job of history) {
+    if (count <= HISTORY_LIMIT && bytes <= HISTORY_BYTES) break
+    next.delete(job.info.id)
+    count--
+    bytes -= historyBytes(job)
+  }
+  return next
+}
+
+// The byte budget covers result/error text, not arbitrary caller-owned metadata or total heap size.
+function historyBytes(job: Active) {
+  return Buffer.byteLength(job.info.output ?? "", "utf8") + Buffer.byteLength(job.info.error ?? "", "utf8")
+}
+
 function incrementSession(input: Map<SessionSchema.ID, number>, sessionID: SessionSchema.ID) {
   return new Map(input).set(sessionID, (input.get(sessionID) ?? 0) + 1)
 }
@@ -164,6 +190,8 @@ function decrementSession(input: Map<SessionSchema.ID, number>, sessionID: Sessi
 /**
  * Makes one scoped, process-local registry. Explicitly recoverable background
  * work also owns a durable notification marker until its notification is admitted.
+ * Only claimed terminal results enter bounded history; unclaimed handoffs and
+ * pending notifications remain protected. Evicted IDs use the normal missing result.
  */
 export const make = Effect.gen(function* () {
   const kv = yield* KV.Service
@@ -173,7 +201,7 @@ export const make = Effect.gen(function* () {
   }
 
   const persistBackground = Effect.fnUntraced(function* (job: Active) {
-    if (!job.recovery || !job.info.notificationID) return
+    if (!job.notificationPending || !job.recovery || !job.info.notificationID) return
     yield* kv.set(`${backgroundPrefix}${job.info.notificationID}`, {
       id: job.info.id,
       notificationID: job.info.notificationID,
@@ -183,6 +211,17 @@ export const make = Effect.gen(function* () {
       ...(job.info.error !== undefined ? { error: job.info.error } : {}),
     })
   })
+
+  // Recoverable work may be observed with wait() before it is backgrounded. Only block() or
+  // notification acknowledgment completes that handoff; get() and running polls never consume it.
+  const observe = (job: Active) =>
+    job.recovery
+      ? Effect.void
+      : SynchronizedRef.update(state.jobs, (jobs) => {
+          const current = jobs.get(job.info.id)
+          if (!current || current.token !== job.token) return jobs
+          return prune(new Map(jobs).set(job.info.id, { ...current, observed: true }))
+        })
 
   const settle = Effect.fnUntraced(function* (id: string, token: object, exit: Exit.Exit<string, unknown>) {
     const completed_at = yield* Clock.currentTimeMillis
@@ -210,7 +249,11 @@ export const make = Effect.gen(function* () {
           },
         }
         if (status !== "cancelled") yield* persistBackground(next)
-        return [{ info: snapshot(next), done: job.done, scope: job.scope }, new Map(jobs).set(id, next)]
+        // Terminal entries are ordered by completion, including reused IDs.
+        const updated = new Map(jobs)
+        updated.delete(id)
+        updated.set(id, next)
+        return [{ info: snapshot(next), done: job.done, scope: job.scope }, prune(updated)]
       }),
     )
     if (result.info && result.done) yield* Deferred.succeed(result.done, result.info)
@@ -258,6 +301,8 @@ export const make = Effect.gen(function* () {
               token,
               blockingSessions: new Map<SessionSchema.ID, number>(),
               isBackgrounded: false,
+              observed: false,
+              notificationPending: input.recovery !== undefined && input.notificationID !== undefined,
               recovery: input.recovery,
             }
             return [{ info: snapshot(job), scope, token }, new Map(jobs).set(id, job)]
@@ -278,11 +323,21 @@ export const make = Effect.gen(function* () {
   const wait: Interface["wait"] = Effect.fn("Job.wait")(function* (input) {
     const job = (yield* SynchronizedRef.get(state.jobs)).get(input.id)
     if (!job) return { timedOut: false }
-    if (job.info.status !== "running") return { info: snapshot(job), timedOut: false }
-    if (input.timeout === undefined) return { info: yield* Deferred.await(job.done), timedOut: false }
+    if (job.info.status !== "running") {
+      yield* observe(job)
+      return { info: snapshot(job), timedOut: false }
+    }
+    if (input.timeout === undefined) {
+      const info = yield* Deferred.await(job.done)
+      yield* observe(job)
+      return { info, timedOut: false }
+    }
     if (input.timeout <= 0) return { info: snapshot(job), timedOut: true }
     const info = yield* Deferred.await(job.done).pipe(Effect.timeoutOption(input.timeout))
-    if (info._tag === "Some") return { info: info.value, timedOut: false }
+    if (info._tag === "Some") {
+      yield* observe(job)
+      return { info: info.value, timedOut: false }
+    }
     return { info: snapshot(job), timedOut: true }
   })
 
@@ -301,12 +356,17 @@ export const make = Effect.gen(function* () {
     const result = yield* SynchronizedRef.modify(state.jobs, (jobs): readonly [BlockStart, Map<string, Active>] => {
       const job = jobs.get(input.id)
       if (!job) return [{ type: "missing" }, jobs]
-      if (job.info.status !== "running") return [{ type: "finished", info: snapshot(job) }, jobs]
+      if (job.info.status !== "running")
+        return [
+          { type: "finished", info: snapshot(job) },
+          prune(new Map(jobs).set(input.id, { ...job, observed: true })),
+        ]
       if (job.isBackgrounded) return [{ type: "backgrounded", info: snapshot(job) }, jobs]
       return [
         { type: "wait", wait: { done: job.done, backgrounded: job.backgrounded } },
         new Map(jobs).set(input.id, {
           ...job,
+          observed: true,
           blockingSessions: incrementSession(job.blockingSessions, input.sessionID),
         }),
       ]
@@ -324,6 +384,8 @@ export const make = Effect.gen(function* () {
     const next = {
       ...job,
       isBackgrounded: true,
+      observed: false,
+      notificationPending: job.recovery !== undefined,
       blockingSessions: new Map<SessionSchema.ID, number>(),
       info: {
         ...job.info,
@@ -392,7 +454,10 @@ export const make = Effect.gen(function* () {
           },
         }
         yield* persistBackground(next)
-        return [{ info: snapshot(next), done: job.done, scope: job.scope }, new Map(jobs).set(id, next)]
+        const updated = new Map(jobs)
+        updated.delete(id)
+        updated.set(id, next)
+        return [{ info: snapshot(next), done: job.done, scope: job.scope }, prune(updated)]
       }),
     )
     if (result.info && result.done) yield* Deferred.succeed(result.done, result.info)
@@ -412,7 +477,15 @@ export const make = Effect.gen(function* () {
   }).pipe(Effect.withSpan("Job.pendingBackground"))
 
   const completeBackground: Interface["completeBackground"] = Effect.fn("Job.completeBackground")((notificationID) =>
-    kv.remove(`${backgroundPrefix}${notificationID}`),
+    SynchronizedRef.updateEffect(
+      state.jobs,
+      Effect.fnUntraced(function* (jobs) {
+        yield* kv.remove(`${backgroundPrefix}${notificationID}`)
+        const job = [...jobs.values()].find((job) => job.info.notificationID === notificationID)
+        if (!job) return jobs
+        return prune(new Map(jobs).set(job.info.id, { ...job, notificationPending: false, observed: true }))
+      }),
+    ),
   )
 
   return Service.of({


### PR DESCRIPTION
## Summary

Bound the process-global Job registry's **consumed terminal history** to the newest **100 jobs** and **16 MiB of UTF-8 output/error text**, evicting whole entries in completion order. Only `packages/core/src/job.ts` changes.

Completed foreground shell and subagent jobs currently remain in the registry for the server's lifetime. Closing a job's scope does not remove its Info and Deferred-held result snapshots. Notification acknowledgment currently removes only the durable KV marker.

## Retention Policy

- Running jobs, unclaimed results, and unacknowledged completion notifications remain protected.
- `block()` claims a foreground result; registered waiters already hold their generation's Deferred and still receive the full result after eviction.
- A successful terminal `wait()` claims non-recoverable output. Recoverable `wait()` alone does not: the existing `wait -> background` handoff remains supported, including immediately failed work.
- Background registration resets the foreground claim and protects notification ownership. Acknowledgment releases that protection by notification ID, not just job ID.
- Evicted `get` / `wait` / `block` calls use their existing missing-result shapes. Oversized results still reach the first caller in full; they are not truncated to fit history.
- No TTL or grace timer, new configuration surface, durable schema, or public API change. Existing ID reuse and shutdown/recovery semantics remain intact.

The byte budget covers **output and error strings**, not arbitrary metadata or total heap size. Metadata is bounded only by the history entry count. Running work, unclaimed handoffs, pending notifications, and caller-held results can exceed these limits; this is not a hard cap on total Job or server memory.

## Before / After

![Two checkpoints comparing Job heap before and after 1000 claimed results, unfixed versus fixed](https://github.com/user-attachments/assets/b7286af7-2bda-43c5-b722-8997dfc8eda1)

| Version | Before job 1 | After job 1,000 + GC | Results still retained/readable |
|---|---:|---:|---:|
| Unfixed | 12.54 MiB | 1,016.32 MiB | 1,000 |
| Fixed | 12.56 MiB | 30.36 MiB | 16 |

One graph, two measured checkpoints per version, with the median of five fresh processes on Windows x64 / Bun 1.4.0. The fixture uses the production Job service and real in-memory SQLite KV. Each job produces a distinct, materialized **synthetic 1-MiB result string** and has its foreground result claimed through `block()`. This is not 1 MiB of normal shell stdout; default shell previews are smaller.

The Job service remains alive during measurement. Both versions use the same warm-up and eight explicit full-GC rounds with 100-ms event-loop gaps. All unrelated weak controls are collected, retained metadata sentinels match readable history counts, and retained results remain complete. A separate 1,000-job run with 50-KiB results retains exactly 100 entries, exercising the count limit rather than the text-byte limit.

Metric: `bun:jsc.heapStats().heapSize`, including external memory, **not RSS or a production-server savings forecast**. A preliminary batch run alongside integration tests failed a reachability control; the final plotted batch ran separately and passed all controls. The graph and validation probes are local artifacts, not committed files.

## Verification

- Local lifecycle probe: 20 retention checks fail on the original implementation while 10 controls pass; all 30 cases pass with the fix on Windows Bun 1.4.0, Windows Bun 1.3.14, and Linux x64 Bun 1.4.0 under WSL.
- Coverage includes count/UTF-8 byte pressure, completion order, full oversized-result delivery, pending notifications, late background registration, generation reuse, cancellation, missing-result shapes, and unchanged scope/recovery behavior.
- Existing Job, shell, subagent, and restart suites: Windows 101 passed / 44 platform skips; Linux 110 passed / 36 platform skips.
- Repository-pinned Bun 1.3.14: existing Job, subagent, and restart suites passed (57 tests).
- Core `bun typecheck`, targeted Oxlint, Effect AST rules, Prettier, and `git diff --check` passed. The pre-push workspace typecheck passed all 33 tasks.

No test files or changesets are included. The running server was not patched or restarted for validation.
