### PR TITLE
fix(app): preserve Windows panel top outlines

### DIFF
--- a/packages/app/src/shell/shell.tsx
+++ b/packages/app/src/shell/shell.tsx
@@ -43,12 +43,12 @@ export default function Layout(props: ParentProps) {
         style={{
           "padding-top": "env(safe-area-inset-top, 0px)",
           "padding-bottom": "env(safe-area-inset-bottom, 0px)",
-          // The native Windows titlebar already includes the gap above the content panels.
+          // Native Windows chrome supplies the gap; retain paint clearance for the panels' outer outlines.
           "--shell-top-inset":
             platform.platform === "desktop" &&
             platform.os === "windows" &&
             !(mobile() && preferences.general.mobileTitlebarPosition() === "bottom")
-              ? "0px"
+              ? "1px"
               : "8px",
         }}
       >


### PR DESCRIPTION
## Summary

Keep 1 CSS px of paint clearance above Windows content panels so their outer top outlines are not clipped. This changes only the Windows branch of `--shell-top-inset` and its comment.

The raised panels use an outward half-pixel shadow stroke. With a zero inset, the stroke falls above the route/main clipping boundary. The existing Windows titlebar space is outside that boundary and cannot provide paint clearance inside it.

- Preserve the compact Windows layout instead of restoring the full 8px gap.
- Leave native caption-button geometry and renderer titlebar dimensions unchanged. The content panels and vertical tab list move down by 1px; the titlebar icons do not move.
- Keep clipping, elevation tokens, typography, and session/timeline code unchanged.
- Preserve the 8px inset for other platforms and the mobile bottom-titlebar layout.

This predates the session-switch performance work. The zero Windows inset came from #45397 (`954cdc7bc81`).

## Verification

- `bun typecheck` in `packages/app`; all 33 pre-push typecheck tasks passed (32 cached).
- `bun run test` with Bun 1.3.14: 604 unit tests and 69 browser-condition tests passed. An initial parallel run hit the existing 5-second Playwright-config subprocess timeout; the complete serial rerun passed without code changes.
- Seven existing production web E2E cases passed: new-session dark corners and titlebar navigation/orientation/resizing, including mobile and LTR/RTL coverage.
- Production-built app components in an isolated Electron window, using the production native `windowAppearance` implementation and synthetic API data. No live app or service was restarted or modified.
- **32 Electron cases passed:** Windows display scaling 100%; application zoom 80%, 100%, 125%, and 150%; light/dark themes; horizontal/vertical tabs; English in LTR and forced RTL. Verified session/review/Home/draft paint clearance and the unchanged 8px mobile bottom-titlebar inset.
- Renderer titlebar height matched `windowControlsOverlay` in every case. Maximum titlebar icon-center error: **0.03 CSS px**. Native minimize/maximize/close glyphs in the paired captures remain centered within half a physical pixel; their pixels are unchanged before/after.

At 100% zoom the titlebar remains 44px tall, the icon center remains at 22px, and the panels start at 45px instead of the clipping boundary at 44px. Pixel samples confirm the previously missing top stroke is now painted in both themes.

No new committed test harness: the normal app E2E entry always uses the web platform, so it cannot exercise this Windows branch. The desktop diagnostic and screenshots remain outside Git.

## Before And After

These are matching crops from native Windows window captures, including the real minimize, maximize, and close buttons. The fixture renders the production shell, session, and review components. Only synthetic example content is shown.

### Light, 150% App Zoom

Before:

![Before: the top outlines are clipped; native titlebar controls are centered](https://github.com/user-attachments/assets/28d550e8-690f-4c2d-ba22-281083436f7f)

After:

![After: the top outlines have paint clearance; native titlebar controls stay centered](https://github.com/user-attachments/assets/8b100719-df92-4c20-9315-e1cb9442f3d1)

### Dark, 100% App Zoom

Before:

![Before: dark panel top outlines are clipped](https://github.com/user-attachments/assets/1a5d7db3-efe6-496f-aa97-fb8888ff12be)

After:

![After: dark panel top outlines are visible with unchanged titlebar alignment](https://github.com/user-attachments/assets/c6332e74-22cd-450a-934c-c413e245edaa)
