### PR TITLE
fix(session): mint message ids and timestamps from one clock read

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/agent.handler.ts
+++ b/packages/opencode/src/cli/cmd/debug/agent.handler.ts
@@ -8,6 +8,7 @@ import { Provider } from "@/provider/provider"
 import { Session } from "@/session/session"
 import type { MessageV2 } from "../../../session/message-v2"
 import { MessageID, PartID } from "../../../session/schema"
+import { Identifier } from "@/id/id"
 import { ToolRegistry } from "@/tool/registry"
 import { Permission } from "../../../permission"
 import { iife } from "../../../util/iife"
@@ -129,7 +130,6 @@ const createToolContext = Effect.fn("Cli.debug.agent.createToolContext")(functio
 ) {
   const sessionSvc = yield* Session.Service
   const session = yield* sessionSvc.create({ title: `Debug tool run (${agent.name})` })
-  const messageID = MessageID.ascending()
   const model = agent.model
     ? agent.model
     : yield* Effect.gen(function* () {
@@ -149,12 +149,13 @@ const createToolContext = Effect.fn("Cli.debug.agent.createToolContext")(functio
           }),
         )
       })
-  const now = Date.now()
+  const created = Date.now()
+  const messageID = MessageID.ascending(Identifier.create("msg", "ascending", created))
   const message: SessionV1.Assistant = {
     id: messageID,
     sessionID: session.id,
     role: "assistant",
-    time: { created: now },
+    time: { created },
     parentID: messageID,
     modelID: model.modelID,
     providerID: model.providerID,

--- a/packages/opencode/src/cli/cmd/github.handler.ts
+++ b/packages/opencode/src/cli/cmd/github.handler.ts
@@ -22,7 +22,7 @@ import { InstanceRef } from "@/effect/instance-ref"
 import { SessionShare } from "@/share/session"
 import { Session } from "@/session/session"
 import type { SessionID } from "../../session/schema"
-import { MessageID, PartID } from "../../session/schema"
+import { PartID } from "../../session/schema"
 import { Provider } from "@/provider/provider"
 import { MessageV2 } from "../../session/message-v2"
 import { EventV2Bridge } from "@/event-v2-bridge"
@@ -902,7 +902,6 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
           const prompt = sessionPrompt
           const result = yield* prompt.prompt({
             sessionID: session.id,
-            messageID: MessageID.ascending(),
             variant,
             model: {
               providerID,
@@ -950,7 +949,6 @@ export const githubRun = Effect.fn("Cli.github.run")(function* (args: { event?: 
           console.log("Requesting summary from agent...")
           const summary = yield* prompt.prompt({
             sessionID: session.id,
-            messageID: MessageID.ascending(),
             variant,
             model: {
               providerID,

--- a/packages/opencode/src/cli/cmd/run/runtime.queue.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.queue.ts
@@ -168,6 +168,7 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
               : {
                   ...prompt,
                   messageID: prompt.messageID ?? queued?.messageID ?? MessageID.ascending(),
+                  localMessageID: prompt.messageID ? undefined : true,
                 }
           state.active = sent
 

--- a/packages/opencode/src/cli/cmd/run/stream.transport.ts
+++ b/packages/opencode/src/cli/cmd/run/stream.transport.ts
@@ -1219,7 +1219,7 @@ function createLayer(input: StreamInput) {
 
           const req = {
             sessionID: input.sessionID,
-            messageID: next.prompt.messageID,
+            messageID: next.prompt.localMessageID ? undefined : next.prompt.messageID,
             agent: next.agent,
             model: next.model,
             variant: next.variant,
@@ -1281,7 +1281,7 @@ function createLayer(input: StreamInput) {
                         input.sdk.session.command(
                           {
                             sessionID: input.sessionID,
-                            messageID: next.prompt.messageID,
+                            messageID: next.prompt.localMessageID ? undefined : next.prompt.messageID,
                             agent: next.agent,
                             model: next.model ? `${next.model.providerID}/${next.model.modelID}` : undefined,
                             variant: next.variant,

--- a/packages/opencode/src/cli/cmd/run/types.ts
+++ b/packages/opencode/src/cli/cmd/run/types.ts
@@ -32,6 +32,7 @@ export type RunProvider = NonNullable<Awaited<ReturnType<OpencodeClient["provide
 
 export type RunPrompt = {
   messageID?: string
+  localMessageID?: boolean
   partID?: string
   text: string
   parts: RunPromptPart[]

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -3,6 +3,7 @@ import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import { Session } from "./session"
 import { SessionID, MessageID, PartID } from "./schema"
+import { Identifier } from "@/id/id"
 import { Provider } from "@/provider/provider"
 import { MessageV2 } from "./message-v2"
 import { Token } from "@/util/token"
@@ -390,8 +391,9 @@ const layer = Layer.effect(
           .filter(Boolean)
           .join("\n\n")
       const ctx = yield* InstanceState.context
+      const created = Date.now()
       const msg: SessionV1.Assistant = {
-        id: MessageID.ascending(),
+        id: MessageID.ascending(Identifier.create("msg", "ascending", created)),
         role: "assistant",
         parentID: input.parentID,
         sessionID: input.sessionID,
@@ -412,9 +414,7 @@ const layer = Layer.effect(
         },
         modelID: model.id,
         providerID: model.providerID,
-        time: {
-          created: Date.now(),
-        },
+        time: { created },
       }
       yield* session.updateMessage(msg)
       const processor = yield* processors.create({
@@ -468,11 +468,12 @@ const layer = Layer.effect(
       if (result === "continue" && input.auto) {
         if (replay) {
           const original = replay.info
+          const created = Date.now()
           const replayMsg = yield* session.updateMessage({
-            id: MessageID.ascending(),
+            id: MessageID.ascending(Identifier.create("msg", "ascending", created)),
             role: "user",
             sessionID: input.sessionID,
-            time: { created: Date.now() },
+            time: { created },
             agent: original.agent,
             model: original.model,
             format: original.format,
@@ -516,11 +517,12 @@ const layer = Layer.effect(
               { enabled: true },
             )).enabled
           ) {
+            const created = Date.now()
             const continueMsg = yield* session.updateMessage({
-              id: MessageID.ascending(),
+              id: MessageID.ascending(Identifier.create("msg", "ascending", created)),
               role: "user",
               sessionID: input.sessionID,
-              time: { created: Date.now() },
+              time: { created },
               agent: userMessage.agent,
               model: userMessage.model,
             })
@@ -563,13 +565,14 @@ const layer = Layer.effect(
       auto: boolean
       overflow?: boolean
     }) {
+      const created = Date.now()
       const msg = yield* session.updateMessage({
-        id: MessageID.ascending(),
+        id: MessageID.ascending(Identifier.create("msg", "ascending", created)),
         role: "user",
         model: input.model,
         sessionID: input.sessionID,
         agent: input.agent,
-        time: { created: Date.now() },
+        time: { created },
       })
       yield* session.updatePart({
         id: PartID.ascending(),

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import os from "os"
 import { SessionID, MessageID, PartID } from "./schema"
+import { Identifier } from "@/id/id"
 import { MessageV2 } from "./message-v2"
 import { SessionRevert } from "./revert"
 import { Session } from "./session"
@@ -265,8 +266,9 @@ const layer = Layer.effect(
       const promptOps = yield* ops()
       const { task: taskTool } = yield* registry.named()
       const taskModel = task.model ? yield* getModel(task.model.providerID, task.model.modelID, sessionID) : model
+      const created = Date.now()
       const assistantMessage: SessionV1.Assistant = yield* sessions.updateMessage({
-        id: MessageID.ascending(),
+        id: MessageID.ascending(Identifier.create("msg", "ascending", created)),
         role: "assistant",
         parentID: lastUser.id,
         sessionID,
@@ -278,7 +280,7 @@ const layer = Layer.effect(
         tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
         modelID: taskModel.id,
         providerID: taskModel.providerID,
-        time: { created: Date.now() },
+        time: { created },
       })
       let part: SessionV1.ToolPart = yield* sessions.updatePart({
         id: PartID.ascending(),
@@ -429,11 +431,12 @@ const layer = Layer.effect(
 
       if (!task.command) return
 
+      const summaryCreated = Date.now()
       const summaryUserMsg: SessionV1.User = {
-        id: MessageID.ascending(),
+        id: MessageID.ascending(Identifier.create("msg", "ascending", summaryCreated)),
         sessionID,
         role: "user",
-        time: { created: Date.now() },
+        time: { created: summaryCreated },
         agent: lastUser.agent,
         model: lastUser.model,
       }
@@ -467,10 +470,11 @@ const layer = Layer.effect(
               throw error
             }
             const model = input.model ?? agent.model ?? (yield* currentModel(input.sessionID))
+            const userCreated = Date.now()
             const userMsg: SessionV1.User = {
-              id: input.messageID ?? MessageID.ascending(),
+              id: input.messageID ?? MessageID.ascending(Identifier.create("msg", "ascending", userCreated)),
               sessionID: input.sessionID,
-              time: { created: Date.now() },
+              time: { created: userCreated },
               role: "user",
               agent: input.agent,
               model: { providerID: model.providerID, modelID: model.modelID },
@@ -486,15 +490,16 @@ const layer = Layer.effect(
             }
             yield* sessions.updatePart(userPart)
 
+            const assistantCreated = Date.now()
             const msg: SessionV1.Assistant = {
-              id: MessageID.ascending(),
+              id: MessageID.ascending(Identifier.create("msg", "ascending", assistantCreated)),
               sessionID: input.sessionID,
               parentID: userMsg.id,
               mode: input.agent,
               agent: input.agent,
               cost: 0,
               path: { cwd: ctx.directory, root: ctx.worktree },
-              time: { created: Date.now() },
+              time: { created: assistantCreated },
               role: "assistant",
               tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
               modelID: model.modelID,
@@ -653,11 +658,12 @@ const layer = Layer.effect(
           : undefined
       const variant = input.variant ?? (ag.variant && full?.variants?.[ag.variant] ? ag.variant : undefined)
 
+      const created = Date.now()
       const info: SessionV1.User = {
-        id: input.messageID ?? MessageID.ascending(),
+        id: input.messageID ?? MessageID.ascending(Identifier.create("msg", "ascending", created)),
         role: "user",
         sessionID: input.sessionID,
-        time: { created: Date.now() },
+        time: { created },
         tools: input.tools,
         agent: ag.name,
         model: {
@@ -1183,8 +1189,9 @@ const layer = Layer.effect(
             Effect.provideService(Session.Service, sessions),
           )
 
+          const created = Date.now()
           const msg: SessionV1.Assistant = {
-            id: MessageID.ascending(),
+            id: MessageID.ascending(Identifier.create("msg", "ascending", created)),
             parentID: lastUser.id,
             role: "assistant",
             mode: agent.name,
@@ -1195,7 +1202,7 @@ const layer = Layer.effect(
             tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
             modelID: model.id,
             providerID: model.providerID,
-            time: { created: Date.now() },
+            time: { created },
             sessionID,
           }
           yield* sessions.updateMessage(msg)

--- a/packages/opencode/src/tool/plan.ts
+++ b/packages/opencode/src/tool/plan.ts
@@ -7,6 +7,7 @@ import { Session } from "@/session/session"
 import { MessageV2 } from "../session/message-v2"
 import { Provider } from "@/provider/provider"
 import { InstanceState } from "@/effect/instance-state"
+import { Identifier } from "@/id/id"
 import { MessageID, PartID } from "../session/schema"
 import EXIT_DESCRIPTION from "./plan-exit.txt"
 
@@ -50,11 +51,12 @@ export const PlanExitTool = Tool.define(
           const model =
             lastUser?.info.role === "user" && lastUser.info.model ? lastUser.info.model : yield* provider.defaultModel()
 
+          const created = Date.now()
           const msg: SessionV1.User = {
-            id: MessageID.ascending(),
+            id: MessageID.ascending(Identifier.create("msg", "ascending", created)),
             sessionID: ctx.sessionID,
             role: "user",
-            time: { created: Date.now() },
+            time: { created },
             agent: "build",
             model,
           }

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -4,7 +4,7 @@ import { ToolJsonSchema } from "./json-schema"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { BackgroundJob } from "@/background/job"
 import { Session } from "@/session/session"
-import { SessionID, MessageID } from "../session/schema"
+import { SessionID } from "../session/schema"
 import { MessageV2 } from "../session/message-v2"
 import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
@@ -200,7 +200,6 @@ export const TaskTool = Tool.define(
       const runTask = Effect.fn("TaskTool.runTask")(function* () {
         const parts = yield* ops.resolvePromptParts(params.prompt)
         const result = yield* ops.prompt({
-          messageID: MessageID.ascending(),
           sessionID: nextSession.id,
           model: {
             modelID: model.modelID,

--- a/packages/opencode/test/cli/run/runtime.queue.test.ts
+++ b/packages/opencode/test/cli/run/runtime.queue.test.ts
@@ -76,6 +76,11 @@ function footer() {
     removeQueued(messageID: string) {
       for (const fn of [...queuedRemoves]) fn(messageID)
     },
+    submitPrompt(prompt: RunPrompt) {
+      for (const fn of [...prompts]) {
+        fn(prompt)
+      }
+    },
   }
 }
 
@@ -263,6 +268,47 @@ describe("run runtime queue", () => {
     })
 
     expect(seen).toEqual(["  hello  "])
+  })
+
+  test("marks queue-minted message IDs as local and preserves caller IDs", async () => {
+    const ui = footer()
+    const seen: RunPrompt[] = []
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+
+    const task = runPromptQueue({
+      footer: ui.api,
+      initialInput: "generated",
+      run: async (input) => {
+        seen.push(input)
+        if (seen.length === 1) {
+          await gate
+          return
+        }
+
+        ui.api.close()
+      },
+    })
+
+    await Promise.resolve()
+    ui.submitPrompt({ messageID: "msg-explicit", text: "explicit", parts: [] })
+    release()
+    await task
+
+    expect(seen[0]).toEqual(
+      expect.objectContaining({
+        messageID: expect.any(String),
+        localMessageID: true,
+      }),
+    )
+    expect(seen[1]).toEqual(
+      expect.objectContaining({
+        messageID: "msg-explicit",
+        localMessageID: undefined,
+      }),
+    )
   })
 
   test("appends the user row before the turn starts", async () => {

--- a/packages/opencode/test/cli/run/stream.transport.test.ts
+++ b/packages/opencode/test/cli/run/stream.transport.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test"
-import { OpencodeClient, type GlobalEvent } from "@opencode-ai/sdk/v2"
+import { OpencodeClient, type AssistantMessage, type GlobalEvent } from "@opencode-ai/sdk/v2"
 import { createSessionTransport } from "@/cli/cmd/run/stream.transport"
 import type { FooterApi, FooterEvent, LocalReplayRow, RunFilePart, StreamCommit } from "@/cli/cmd/run/types"
 
@@ -219,6 +219,13 @@ function assistantMessage(input: { sessionID: string; id: string; parts: Session
   }
 }
 
+function commandResponse() {
+  return {
+    info: assistantMessage({ sessionID: "session-1", id: "msg-command", parts: [] }).info as AssistantMessage,
+    parts: [],
+  }
+}
+
 function runningTool(input: {
   sessionID: string
   messageID: string
@@ -420,6 +427,7 @@ function sdk(
     subscribe?: OpencodeClient["event"]["subscribe"]
     globalEvent?: OpencodeClient["global"]["event"]
     promptAsync?: OpencodeClient["session"]["promptAsync"]
+    command?: OpencodeClient["session"]["command"]
     status?: OpencodeClient["session"]["status"]
     messages?: OpencodeClient["session"]["messages"]
     children?: OpencodeClient["session"]["children"]
@@ -442,6 +450,9 @@ function sdk(
   spyOn(client.event, "subscribe").mockImplementation(subscribe)
   spyOn(client.global, "event").mockImplementation(globalEvent)
   spyOn(client.session, "promptAsync").mockImplementation(promptAsync)
+  if (input.command) {
+    spyOn(client.session, "command").mockImplementation(input.command)
+  }
   spyOn(client.session, "status").mockImplementation(status)
   spyOn(client.session, "messages").mockImplementation(messages)
   spyOn(client.session, "children").mockImplementation(children)
@@ -2061,6 +2072,173 @@ describe("run stream transport", () => {
           parts: [{ type: "text", text: "again" }],
         }),
       ])
+    } finally {
+      src.close()
+      await transport.close()
+    }
+  })
+
+  test("omits queue-local message IDs from prompt requests", async () => {
+    const src = eventFeed()
+    const ui = footer()
+    let seen: unknown
+    const transport = await createSessionTransport({
+      sdk: sdk({
+        stream: src.stream,
+        promptAsync: async (input) => {
+          seen = input
+          queueMicrotask(() => {
+            src.push(busy())
+            src.push(idle())
+          })
+          return ok(undefined)
+        },
+      }),
+      sessionID: "session-1",
+      thinking: true,
+      limits: () => ({}),
+      footer: ui.api,
+    })
+
+    try {
+      await transport.runPromptTurn({
+        agent: undefined,
+        model: undefined,
+        variant: undefined,
+        prompt: { messageID: "msg-local", localMessageID: true, text: "hello", parts: [] },
+        files: [],
+        includeFiles: false,
+      })
+
+      expect(seen).toEqual(expect.objectContaining({ messageID: undefined }))
+    } finally {
+      src.close()
+      await transport.close()
+    }
+  })
+
+  test("preserves caller message IDs in prompt requests", async () => {
+    const src = eventFeed()
+    const ui = footer()
+    let seen: unknown
+    const transport = await createSessionTransport({
+      sdk: sdk({
+        stream: src.stream,
+        promptAsync: async (input) => {
+          seen = input
+          queueMicrotask(() => {
+            src.push(busy())
+            src.push(idle())
+          })
+          return ok(undefined)
+        },
+      }),
+      sessionID: "session-1",
+      thinking: true,
+      limits: () => ({}),
+      footer: ui.api,
+    })
+
+    try {
+      await transport.runPromptTurn({
+        agent: undefined,
+        model: undefined,
+        variant: undefined,
+        prompt: { messageID: "msg-explicit", text: "hello", parts: [] },
+        files: [],
+        includeFiles: false,
+      })
+
+      expect(seen).toEqual(expect.objectContaining({ messageID: "msg-explicit" }))
+    } finally {
+      src.close()
+      await transport.close()
+    }
+  })
+
+  test("omits queue-local message IDs from command requests", async () => {
+    const src = eventFeed()
+    const ui = footer()
+    let seen: unknown
+    const transport = await createSessionTransport({
+      sdk: sdk({
+        stream: src.stream,
+        command: async (input) => {
+          seen = input
+          queueMicrotask(() => {
+            src.push(busy())
+            src.push(idle())
+          })
+          return ok(commandResponse())
+        },
+      }),
+      sessionID: "session-1",
+      thinking: true,
+      limits: () => ({}),
+      footer: ui.api,
+    })
+
+    try {
+      await transport.runPromptTurn({
+        agent: undefined,
+        model: undefined,
+        variant: undefined,
+        prompt: {
+          messageID: "msg-local",
+          localMessageID: true,
+          text: "/skill",
+          parts: [],
+          command: { name: "skill", arguments: "" },
+        },
+        files: [],
+        includeFiles: false,
+      })
+
+      expect(seen).toEqual(expect.objectContaining({ messageID: undefined }))
+    } finally {
+      src.close()
+      await transport.close()
+    }
+  })
+
+  test("preserves caller message IDs in command requests", async () => {
+    const src = eventFeed()
+    const ui = footer()
+    let seen: unknown
+    const transport = await createSessionTransport({
+      sdk: sdk({
+        stream: src.stream,
+        command: async (input) => {
+          seen = input
+          queueMicrotask(() => {
+            src.push(busy())
+            src.push(idle())
+          })
+          return ok(commandResponse())
+        },
+      }),
+      sessionID: "session-1",
+      thinking: true,
+      limits: () => ({}),
+      footer: ui.api,
+    })
+
+    try {
+      await transport.runPromptTurn({
+        agent: undefined,
+        model: undefined,
+        variant: undefined,
+        prompt: {
+          messageID: "msg-explicit",
+          text: "/skill",
+          parts: [],
+          command: { name: "skill", arguments: "" },
+        },
+        files: [],
+        includeFiles: false,
+      })
+
+      expect(seen).toEqual(expect.objectContaining({ messageID: "msg-explicit" }))
     } finally {
       src.close()
       await transport.close()

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -5,6 +5,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { eq } from "drizzle-orm"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { Identifier } from "@/id/id"
 import { expect } from "bun:test"
 import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
@@ -441,6 +442,34 @@ const boot = Effect.fn("test.boot")(function* (input?: { title?: string }) {
   const chat = yield* sessions.create(input ?? { title: "Pinned" })
   return { prompt, run, sessions, chat }
 })
+
+it.instance("prompt persists the timestamp embedded in its freshly minted message ID", () =>
+  Effect.acquireUseRelease(
+    Effect.sync(() => {
+      const original = Date.now
+      let reads = 0
+      Date.now = () => 1_000 + reads++
+      return original
+    }),
+    () =>
+      Effect.gen(function* () {
+        const { prompt, chat } = yield* boot()
+        const message = yield* prompt.prompt({
+          sessionID: chat.id,
+          agent: "build",
+          model: ref,
+          noReply: true,
+          parts: [{ type: "text", text: "timestamp invariant" }],
+        })
+
+        expect(Identifier.timestamp(message.info.id)).toBe(message.info.time.created)
+      }),
+    (original) =>
+      Effect.sync(() => {
+        Date.now = original
+      }),
+  ),
+)
 
 // Loop semantics
 


### PR DESCRIPTION
### Issue for this PR

Closes #46102

### Type of change

- [x] Bug fix

### What does this PR do?

A message's `id` and its `time.created` come from two different clocks. `Identifier.ascending()` reads `Date.now()` inside `Identifier.create`; each producer then reads `Date.now()` again for `time.created`. If the assembly path yields between the two reads, a message minted later can capture an earlier `time.created` than one minted before it.

Messages sort `(time_created DESC, id DESC)` (`message-v2.ts:439`). When `time.created` disagrees with mint order, history sorts wrong — and since `time.created` is the primary sort key, it sorts by the corrupted value.

Read the clock once, mint the id from that same timestamp:

```ts
const created = Date.now()
const id = MessageID.ascending(Identifier.create("msg", created))
info: { id, time: { created } }
```

`Identifier.create` already accepts an explicit timestamp, and its per-millisecond counter still applies on that path, so same-millisecond ids stay unique and strictly ascending. Applied at the message producers in `prompt.ts`, `compaction.ts`, `plan.ts`, and the debug/github CLI callers. The session-fork path is left alone — it clones an existing message's `time` on purpose — as are the ephemeral, never-persisted messages that never reach the ordering query.

Two neighbouring issues this is *not*:

- #38791 was fixed by ordering on `time.created` instead of the id string. That makes ordering robust to id/time disagreement, but here `time.created` itself is wrong, so preferring it doesn't help.
- #39624 / #43303 (the 36-bit timestamp field wrapping every ~2.18 years) is a full id rollover — a different mechanism, untouched here.

Deriving `time.created` *from* the id (via `Identifier.timestamp`) is the obvious alternative and it's wrong: the id's embedded timestamp can predate a legacy row's separately-read `Date.now()`, sorting a new message ahead of existing data.

### How did you verify your code works?

Red-first, through the real producer — the test asserts a minted message's embedded id timestamp equals its stored `time.created`, observed through `SessionPrompt.prompt`, not a hand-built fixture. Reverse-applying only the `src/` hunks (test kept present) shows it fail against unmodified `dev`:

```
production reverted, test present:
  (fail) persists message IDs with their creation timestamp — Expected 1016, Received 1015
  58 pass, 1 fail
restored: 59 pass, 1 skip, 0 fail
```

500 ids minted at one explicit timestamp were all unique and strictly ascending. Full suite `packages/opencode`: 3396 pass / 0 fail. `bun typecheck` clean in `opencode` and `core`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR