### PR TITLE
feat(tui): show tokens per second in the response footer

### DIFF
--- a/packages/core/src/session/tokens.ts
+++ b/packages/core/src/session/tokens.ts
@@ -1,0 +1,92 @@
+export const DEFAULT_MIN_TPS_ELAPSED_MS = 250
+export const DEFAULT_INCLUDE_REASONING = true
+
+export interface TokenMetrics {
+  output: number
+  reasoning: number
+}
+
+export interface TimestampMetrics {
+  created: number
+  firstToken?: number
+  completed?: number
+}
+
+export interface TPSResult {
+  rate: number
+  totalTokens: number
+  elapsedMs: number
+  isValid: boolean
+}
+
+export function stampFirstToken(time: TimestampMetrics, now: number): number {
+  if (time.firstToken === undefined) time.firstToken = now
+  return time.firstToken
+}
+
+export function totalGeneratedTokens(tokens: TokenMetrics, includeReasoning = DEFAULT_INCLUDE_REASONING): number {
+  return tokens.output + (includeReasoning ? tokens.reasoning : 0)
+}
+
+type TPSMessage = {
+  summary?: boolean
+  finish?: string | null
+  tokens: TokenMetrics
+  time: TimestampMetrics
+}
+
+function tpsInputs(msg: TPSMessage): { totalTokens: number; elapsedMs: number } | undefined {
+  if (msg.summary) return undefined
+  if (!msg.finish) return undefined
+  if (["tool-calls", "unknown", "error"].includes(msg.finish)) return undefined
+
+  const totalTokens = totalGeneratedTokens(msg.tokens)
+  if (totalTokens <= 0) return undefined
+  const { firstToken, completed } = msg.time
+  if (firstToken === undefined || completed === undefined) return undefined
+
+  return { totalTokens, elapsedMs: completed - firstToken }
+}
+
+export function isValidForTPS(msg: TPSMessage & {
+  minElapsedMs?: number
+}): boolean {
+  const inputs = tpsInputs(msg)
+  if (!inputs) return false
+  const minElapsedMs = msg.minElapsedMs ?? DEFAULT_MIN_TPS_ELAPSED_MS
+  return inputs.elapsedMs >= minElapsedMs
+}
+
+export function calculateTPS(
+  totalTokens: number,
+  elapsedMs: number,
+  minElapsedMs = DEFAULT_MIN_TPS_ELAPSED_MS,
+): TPSResult | undefined {
+  if (totalTokens <= 0) return undefined
+  if (elapsedMs < minElapsedMs) return undefined
+
+  const rate = totalTokens / (elapsedMs / 1000)
+  if (!Number.isFinite(rate) || rate < 0) return undefined
+
+  return {
+    rate: Math.round(rate),
+    totalTokens,
+    elapsedMs,
+    isValid: true,
+  }
+}
+
+export function formatTPS(result: TPSResult): string {
+  return `${result.rate.toLocaleString()} tok/s`
+}
+
+export function getMessageTPS(msg: {
+  summary?: boolean
+  finish?: string | null
+  tokens: TokenMetrics
+  time: TimestampMetrics
+}): TPSResult | undefined {
+  const inputs = tpsInputs(msg)
+  if (!inputs) return undefined
+  return calculateTPS(inputs.totalTokens, inputs.elapsedMs)
+}

--- a/packages/core/src/session/tokens.ts
+++ b/packages/core/src/session/tokens.ts
@@ -38,7 +38,7 @@ type TPSMessage = {
 function tpsInputs(msg: TPSMessage): { totalTokens: number; elapsedMs: number } | undefined {
   if (msg.summary) return undefined
   if (!msg.finish) return undefined
-  if (["tool-calls", "unknown", "error"].includes(msg.finish)) return undefined
+  if (msg.finish === "error") return undefined
 
   const totalTokens = totalGeneratedTokens(msg.tokens)
   if (totalTokens <= 0) return undefined

--- a/packages/core/src/session/tokens.ts
+++ b/packages/core/src/session/tokens.ts
@@ -48,15 +48,6 @@ function tpsInputs(msg: TPSMessage): { totalTokens: number; elapsedMs: number } 
   return { totalTokens, elapsedMs: completed - firstToken }
 }
 
-export function isValidForTPS(msg: TPSMessage & {
-  minElapsedMs?: number
-}): boolean {
-  const inputs = tpsInputs(msg)
-  if (!inputs) return false
-  const minElapsedMs = msg.minElapsedMs ?? DEFAULT_MIN_TPS_ELAPSED_MS
-  return inputs.elapsedMs >= minElapsedMs
-}
-
 export function calculateTPS(
   totalTokens: number,
   elapsedMs: number,

--- a/packages/core/test/session-tps.test.ts
+++ b/packages/core/test/session-tps.test.ts
@@ -30,12 +30,12 @@ describe("getMessageTPS", () => {
     expect(getMessageTPS({ ...validMessage, finish: null })).toBeUndefined()
   })
 
-  test("returns no value for tool-call finishes", () => {
-    expect(getMessageTPS({ ...validMessage, finish: "tool-calls" })).toBeUndefined()
+  test("calculates tokens per second for tool-call finishes", () => {
+    expect(getMessageTPS({ ...validMessage, finish: "tool-calls" })?.rate).toBe(150)
   })
 
-  test("returns no value for unknown finishes", () => {
-    expect(getMessageTPS({ ...validMessage, finish: "unknown" })).toBeUndefined()
+  test("calculates tokens per second for unknown finishes", () => {
+    expect(getMessageTPS({ ...validMessage, finish: "unknown" })?.rate).toBe(150)
   })
 
   test("returns no value for error finishes", () => {

--- a/packages/core/test/session-tps.test.ts
+++ b/packages/core/test/session-tps.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test"
+import {
+  calculateTPS,
+  DEFAULT_MIN_TPS_ELAPSED_MS,
+  getMessageTPS,
+  isValidForTPS,
+  stampFirstToken,
+  type TimestampMetrics,
+} from "../src/session/tokens"
+
+const validMessage = {
+  finish: "stop",
+  tokens: { output: 100, reasoning: 50 },
+  time: { created: 1000, firstToken: 1100, completed: 2100 },
+}
+
+describe("getMessageTPS", () => {
+  test("calculates rounded output and reasoning tokens per second", () => {
+    expect(getMessageTPS(validMessage)?.rate).toBe(150)
+  })
+
+  test("returns no value for summary messages", () => {
+    expect(getMessageTPS({ ...validMessage, summary: true })).toBeUndefined()
+  })
+
+  test("returns no value when finish is missing", () => {
+    expect(getMessageTPS({ ...validMessage, finish: undefined })).toBeUndefined()
+  })
+
+  test("returns no value for tool-call finishes", () => {
+    expect(getMessageTPS({ ...validMessage, finish: "tool-calls" })).toBeUndefined()
+  })
+
+  test("returns no value for unknown finishes", () => {
+    expect(getMessageTPS({ ...validMessage, finish: "unknown" })).toBeUndefined()
+  })
+
+  test("returns no value for error finishes", () => {
+    expect(getMessageTPS({ ...validMessage, finish: "error" })).toBeUndefined()
+  })
+
+  test("returns no value when token total is zero", () => {
+    expect(getMessageTPS({ ...validMessage, tokens: { output: 0, reasoning: 0 } })).toBeUndefined()
+  })
+
+  test("returns no value when first token timestamp is missing", () => {
+    expect(getMessageTPS({ ...validMessage, time: { created: 1000, completed: 2100 } })).toBeUndefined()
+  })
+
+  test("returns no value when completion timestamp is missing", () => {
+    expect(getMessageTPS({ ...validMessage, time: { created: 1000, firstToken: 1100 } })).toBeUndefined()
+  })
+
+  test("returns no value when elapsed time is below 250 milliseconds", () => {
+    expect(
+      getMessageTPS({
+        ...validMessage,
+        time: {
+          ...validMessage.time,
+          completed: validMessage.time.firstToken! + DEFAULT_MIN_TPS_ELAPSED_MS - 1,
+        },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("accepts elapsed time at the 250 millisecond threshold", () => {
+    expect(
+      getMessageTPS({
+        ...validMessage,
+        time: {
+          ...validMessage.time,
+          completed: validMessage.time.firstToken! + DEFAULT_MIN_TPS_ELAPSED_MS,
+        },
+      })?.rate,
+    ).toBe(600)
+  })
+})
+
+describe("isValidForTPS", () => {
+  test("rejects negative token totals", () => {
+    expect(isValidForTPS({ ...validMessage, tokens: { output: -1, reasoning: 0 } })).toBe(false)
+  })
+
+  test("rejects zero token totals", () => {
+    expect(isValidForTPS({ ...validMessage, tokens: { output: 0, reasoning: 0 } })).toBe(false)
+  })
+
+  test("rejects missing finish values", () => {
+    expect(isValidForTPS({ ...validMessage, finish: null })).toBe(false)
+  })
+
+  test("rejects invalid finish values", () => {
+    for (const finish of ["tool-calls", "unknown", "error"]) {
+      expect(isValidForTPS({ ...validMessage, finish })).toBe(false)
+    }
+  })
+
+  test("rejects a missing first token timestamp", () => {
+    expect(isValidForTPS({ ...validMessage, time: { created: 1000, completed: 2100 } })).toBe(false)
+  })
+
+  test("rejects a missing completion timestamp", () => {
+    expect(isValidForTPS({ ...validMessage, time: { created: 1000, firstToken: 1100 } })).toBe(false)
+  })
+
+  test("rejects elapsed time below the configured threshold", () => {
+    expect(
+      isValidForTPS({
+        ...validMessage,
+        time: { ...validMessage.time, completed: validMessage.time.firstToken! + 249 },
+      }),
+    ).toBe(false)
+  })
+})
+
+describe("calculateTPS", () => {
+  test("rounds fractional rates to the nearest integer", () => {
+    expect(calculateTPS(100, 327)?.rate).toBe(306)
+  })
+
+  test("rejects zero and negative token totals", () => {
+    expect(calculateTPS(0, 1000)).toBeUndefined()
+    expect(calculateTPS(-1, 1000)).toBeUndefined()
+  })
+
+  test("rejects elapsed time below the configured threshold", () => {
+    expect(calculateTPS(100, 249)).toBeUndefined()
+  })
+})
+
+describe("stampFirstToken", () => {
+  test("stamps the first event and preserves it for later deltas", () => {
+    const time: TimestampMetrics = { created: 1000 }
+
+    expect(stampFirstToken(time, 1100)).toBe(1100)
+    expect(stampFirstToken(time, 1200)).toBe(1100)
+    expect(time.firstToken).toBe(1100)
+  })
+})

--- a/packages/core/test/session-tps.test.ts
+++ b/packages/core/test/session-tps.test.ts
@@ -3,7 +3,6 @@ import {
   calculateTPS,
   DEFAULT_MIN_TPS_ELAPSED_MS,
   getMessageTPS,
-  isValidForTPS,
   stampFirstToken,
   type TimestampMetrics,
 } from "../src/session/tokens"
@@ -27,6 +26,10 @@ describe("getMessageTPS", () => {
     expect(getMessageTPS({ ...validMessage, finish: undefined })).toBeUndefined()
   })
 
+  test("returns no value when finish is null", () => {
+    expect(getMessageTPS({ ...validMessage, finish: null })).toBeUndefined()
+  })
+
   test("returns no value for tool-call finishes", () => {
     expect(getMessageTPS({ ...validMessage, finish: "tool-calls" })).toBeUndefined()
   })
@@ -41,6 +44,10 @@ describe("getMessageTPS", () => {
 
   test("returns no value when token total is zero", () => {
     expect(getMessageTPS({ ...validMessage, tokens: { output: 0, reasoning: 0 } })).toBeUndefined()
+  })
+
+  test("returns no value when token total is negative", () => {
+    expect(getMessageTPS({ ...validMessage, tokens: { output: -1, reasoning: 0 } })).toBeUndefined()
   })
 
   test("returns no value when first token timestamp is missing", () => {
@@ -73,43 +80,6 @@ describe("getMessageTPS", () => {
         },
       })?.rate,
     ).toBe(600)
-  })
-})
-
-describe("isValidForTPS", () => {
-  test("rejects negative token totals", () => {
-    expect(isValidForTPS({ ...validMessage, tokens: { output: -1, reasoning: 0 } })).toBe(false)
-  })
-
-  test("rejects zero token totals", () => {
-    expect(isValidForTPS({ ...validMessage, tokens: { output: 0, reasoning: 0 } })).toBe(false)
-  })
-
-  test("rejects missing finish values", () => {
-    expect(isValidForTPS({ ...validMessage, finish: null })).toBe(false)
-  })
-
-  test("rejects invalid finish values", () => {
-    for (const finish of ["tool-calls", "unknown", "error"]) {
-      expect(isValidForTPS({ ...validMessage, finish })).toBe(false)
-    }
-  })
-
-  test("rejects a missing first token timestamp", () => {
-    expect(isValidForTPS({ ...validMessage, time: { created: 1000, completed: 2100 } })).toBe(false)
-  })
-
-  test("rejects a missing completion timestamp", () => {
-    expect(isValidForTPS({ ...validMessage, time: { created: 1000, firstToken: 1100 } })).toBe(false)
-  })
-
-  test("rejects elapsed time below the configured threshold", () => {
-    expect(
-      isValidForTPS({
-        ...validMessage,
-        time: { ...validMessage.time, completed: validMessage.time.firstToken! + 249 },
-      }),
-    ).toBe(false)
   })
 })
 

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { stampFirstToken } from "@opencode-ai/core/session/tokens"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { Image } from "@/image/image"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
@@ -119,6 +120,10 @@ const layer = Layer.effect(
           providerID: input.model.providerID,
           aborted,
         })
+
+      const markFirstToken = () => {
+        stampFirstToken(ctx.assistantMessage.time, Date.now())
+      }
 
       const settleToolCall = Effect.fn("SessionProcessor.settleToolCall")(function* (toolCallID: string) {
         const done = ctx.toolcalls[toolCallID]?.done
@@ -279,6 +284,7 @@ const layer = Layer.effect(
         switch (value.type) {
           case "reasoning-start":
             if (value.id in ctx.reasoningMap) return
+            markFirstToken()
             ctx.reasoningMap[value.id] = {
               id: PartID.ascending(),
               messageID: ctx.assistantMessage.id,
@@ -294,6 +300,7 @@ const layer = Layer.effect(
           case "reasoning-delta":
             // Match dev: silently drop orphan deltas (no preceding reasoning-start).
             if (!(value.id in ctx.reasoningMap)) return
+            markFirstToken()
             ctx.reasoningMap[value.id].text += value.text
             if (value.providerMetadata) ctx.reasoningMap[value.id].metadata = value.providerMetadata
             yield* session.updatePartDelta({
@@ -316,15 +323,18 @@ const layer = Layer.effect(
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.name}`)
             }
+            markFirstToken()
             yield* ensureToolCall(value)
             return
 
           case "tool-input-delta":
             yield* ensureToolCall(value)
+            markFirstToken()
             return
 
           case "tool-input-end": {
             yield* ensureToolCall(value)
+            markFirstToken()
             return
           }
 
@@ -332,6 +342,7 @@ const layer = Layer.effect(
             if (ctx.assistantMessage.summary) {
               throw new Error(`Tool call not allowed while generating summary: ${value.name}`)
             }
+            markFirstToken()
             yield* ensureToolCall(value)
             const input = isRecord(value.input) ? value.input : { value: value.input }
             yield* updateToolCall(value.id, (match) => ({
@@ -433,6 +444,7 @@ const layer = Layer.effect(
             return
 
           case "step-finish": {
+            markFirstToken()
             const completedSnapshot = yield* snapshot.track()
             yield* Effect.forEach(Object.keys(ctx.reasoningMap), finishReasoning)
             // Anthropic reports thinking blocks it removed before the model saw the
@@ -498,6 +510,7 @@ const layer = Layer.effect(
           }
 
           case "text-start":
+            markFirstToken()
             ctx.currentText = {
               id: PartID.ascending(),
               messageID: ctx.assistantMessage.id,
@@ -512,6 +525,7 @@ const layer = Layer.effect(
 
           case "text-delta":
             if (!ctx.currentText) return
+            markFirstToken()
             ctx.currentText.text += value.text
             if (value.providerMetadata) ctx.currentText.metadata = value.providerMetadata
             yield* session.updatePartDelta({
@@ -546,6 +560,7 @@ const layer = Layer.effect(
             return
 
           case "finish":
+            markFirstToken()
             return
         }
       })

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -209,6 +209,27 @@ const providerErrorLLM = Layer.succeed(
 const providerErrorEnv = LayerNode.compile(root, [...replacements, [LLM.node, providerErrorLLM]])
 const itProviderError = testEffect(providerErrorEnv)
 
+const toolOnlyLLM = Layer.succeed(
+  LLM.Service,
+  LLM.Service.of({
+    stream: () =>
+      Stream.make(
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.toolCall({ id: "call-only", name: "lookup", input: {}, providerExecuted: true }),
+        LLMEvent.toolResult({
+          id: "call-only",
+          name: "lookup",
+          result: { type: "json", value: { output: "tool result" } },
+          providerExecuted: true,
+        }),
+        LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+        LLMEvent.finish({ reason: "stop" }),
+      ),
+  }),
+)
+const toolOnlyEnv = LayerNode.compile(root, [...replacements, [LLM.node, toolOnlyLLM]])
+const itToolOnly = testEffect(toolOnlyEnv)
+
 const fragmentFailureLLM = Layer.succeed(
   LLM.Service,
   LLM.Service.of({
@@ -1112,6 +1133,40 @@ itProviderError.live("session.processor effect tests fail provider-executed erro
         expect(seen).toContain(MessageV2.Event.PartUpdated.type)
         expect(seen).toContain(MessageV2.Event.Updated.type)
         expect(seen.filter((type) => type.startsWith("session.next."))).toEqual([])
+      }),
+    { config: cfg },
+  ),
+)
+
+itToolOnly.live("session.processor effect tests stamp first token for tool-only turns", () =>
+  provideTmpdirInstance(
+    (dir) =>
+      Effect.gen(function* () {
+        const { processors, session, provider } = yield* boot()
+        const chat = yield* session.create({})
+        const parent = yield* user(chat.id, "tool-only")
+        const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+        const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+        const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model: mdl })
+
+        yield* handle.process({
+          user: {
+            id: parent.id,
+            sessionID: chat.id,
+            role: "user",
+            time: parent.time,
+            agent: parent.agent,
+            model: { providerID: ref.providerID, modelID: ref.modelID },
+          } satisfies SessionV1.User,
+          sessionID: chat.id,
+          model: mdl,
+          agent: agent(),
+          system: [],
+          messages: [{ role: "user", content: "tool-only" }],
+          tools: {},
+        })
+
+        expect(handle.message.time.firstToken).toBeDefined()
       }),
     { config: cfg },
   ),

--- a/packages/schema/src/v1/session.ts
+++ b/packages/schema/src/v1/session.ts
@@ -456,6 +456,7 @@ export const Assistant = Schema.Struct({
   time: Schema.Struct({
     created: NonNegativeInt,
     completed: Schema.optional(NonNegativeInt),
+    firstToken: Schema.optional(NonNegativeInt),
   }),
   error: Schema.optional(AssistantErrorSchema),
   parentID: MessageID,

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -337,6 +337,7 @@ export type AssistantMessage = {
   time: {
     created: number
     completed?: number
+    firstToken?: number
   }
   error?:
     | ProviderAuthError

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -16256,6 +16256,10 @@
               "completed": {
                 "type": "integer",
                 "minimum": 0
+              },
+              "firstToken": {
+                "type": "integer",
+                "minimum": 0
               }
             },
             "required": ["created"],

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -75,6 +75,7 @@ import { useClipboard } from "../../context/clipboard"
 import { nextThinkingMode, reasoningSummary, useThinkingMode, type ThinkingMode } from "../../context/thinking"
 import { getScrollAcceleration } from "../../util/scroll"
 import { collapseToolOutput } from "../../util/collapse-tool-output"
+import { formatTPS, getMessageTPS } from "@opencode-ai/core/session/tokens"
 import { usePluginRuntime } from "../../plugin/runtime"
 import { DialogRetryAction } from "../../component/dialog-retry-action"
 import { getRevertDiffFiles } from "../../util/revert-diff"
@@ -1486,6 +1487,8 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
     return props.message.time.completed - user.time.created
   })
 
+  const tps = createMemo(() => getMessageTPS(props.message))
+
   const childShortcut = useCommandShortcut("session.child.first")
   const backgroundShortcut = useCommandShortcut("session.background")
 
@@ -1563,6 +1566,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               <span style={{ fg: theme.textMuted }}> · {model()}</span>
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
+              </Show>
+              <Show when={tps()}>
+                <span style={{ fg: theme.textMuted }}> · {formatTPS(tps()!)}</span>
               </Show>
               <Show when={props.message.error?.name === "MessageAbortedError"}>
                 <span style={{ fg: theme.textMuted }}> · interrupted</span>


### PR DESCRIPTION
### Issue for this PR

Closes #6096

### Type of change

- [x] New feature

### Credit

This is @JohnC0de's #12721 rebased onto current `dev` — same design (TPS calc in `core/` so non-TUI consumers can use it, `firstToken` recorded in `processor.ts`), which is itself a clean take on @edlsh's #5497. #12721 only went stale — it's `dirty` against `dev` now. If @JohnC0de rebases it, theirs should land and I'll close this. Take anything from here that helps.

### What does this PR do?

Adds a `tok/s` readout to the assistant footer, after the duration: `18.3s · 131 tok/s`.

`processor.ts` stamps `time.firstToken` on the first streamed event (tool-only turns included). TPS is `generatedTokens / ((completed − firstToken) / 1000)`, output plus reasoning. The calc lives in `packages/core/src/session/tokens.ts` so the SDK can reuse it; `firstToken` is optional on the message schema and persisted, so a session-level average can come later without a migration.

One departure from #12721: tool-call turns are **not** filtered out. A turn that ends in a tool call is one provider step with its own usage and timestamps, and in practice it's most turns — on my box over three days, 83% of assistant turns in top-level sessions and 98% in subagent sessions end in `tool-calls`, so filtering them made the readout look intermittent. Sampled tool-call turns give ordinary rates (47–183 tok/s). Errored turns, summaries, and unfinished turns are still skipped, and the 250 ms floor stays — it's what suppresses non-streamed responses that arrive in one chunk (a 228-token turn landing in 43 ms would otherwise read as 5,000 tok/s).

### How did you verify your code works?

The timestamp guard is compiler-enforced, not test-enforced: delete the narrowing and it's a type error (`'completed' is possibly 'undefined'`). The zero-token, sub-threshold, rounding, and finish-reason guards each go red when reverted.

- `packages/core` TPS tests: 17 pass / 0 fail
- `packages/opencode` full suite: 3396 pass / 0 fail
- `bun typecheck` clean in `opencode`, `core`, `tui`

### Screenshots / recordings

Footer gains a `· NN tok/s` segment; no new surface.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR