### PR TITLE
feat(tui): list active session subagents in the sidebar

### DIFF
--- a/packages/tui/src/feature-plugins/builtins.ts
+++ b/packages/tui/src/feature-plugins/builtins.ts
@@ -6,6 +6,7 @@ import SidebarFiles from "./sidebar/files"
 import SidebarFooter from "./sidebar/footer"
 import SidebarLsp from "./sidebar/lsp"
 import SidebarMcp from "./sidebar/mcp"
+import SidebarSubagents from "./sidebar/subagents"
 import SidebarTodo from "./sidebar/todo"
 import DiffViewer from "./system/diff-viewer"
 import Notifications from "./system/notifications"
@@ -27,6 +28,7 @@ export function createBuiltinPlugins(options: { experimentalEventSystem: boolean
     SidebarLsp,
     SidebarTodo,
     SidebarFiles,
+    SidebarSubagents,
     SidebarFooter,
     Notifications,
     PluginManager,

--- a/packages/tui/src/feature-plugins/sidebar/subagents.tsx
+++ b/packages/tui/src/feature-plugins/sidebar/subagents.tsx
@@ -1,0 +1,139 @@
+import type { Part, SessionStatus } from "@opencode-ai/sdk/v2"
+import type { TuiPlugin, TuiPluginApi } from "@opencode-ai/plugin/tui"
+import type { BuiltinTuiPlugin } from "../builtins"
+import { createMemo, For, Show } from "solid-js"
+
+const id = "internal:sidebar-subagents"
+
+export type SidebarSubagent = {
+  description: string
+  status: "pending" | "active" | "done" | "failed"
+  session_id: string | undefined
+}
+
+export function deriveSubagents(
+  messages: ReadonlyArray<{ id: string }>,
+  getParts: (messageID: string) => ReadonlyArray<Part>,
+): SidebarSubagent[] {
+  const entries = messages.flatMap((message) =>
+    getParts(message.id).flatMap((part) => {
+      if (part.type !== "tool" || part.tool !== "task") return []
+
+      const inputDescription = part.state.input.description
+      const title = "title" in part.state ? part.state.title : undefined
+      const description =
+        typeof inputDescription === "string"
+          ? inputDescription
+          : typeof title === "string"
+            ? title
+            : "Subagent"
+      const metadata = "metadata" in part.state ? part.state.metadata : undefined
+      const sessionID =
+        typeof metadata === "object" && metadata !== null && "sessionId" in metadata && typeof metadata.sessionId === "string"
+          ? metadata.sessionId
+          : undefined
+
+      const status: SidebarSubagent["status"] =
+        part.state.status === "running"
+          ? "active"
+          : part.state.status === "completed"
+            ? "done"
+            : part.state.status === "error"
+              ? "failed"
+              : "pending"
+
+      return [{ description, status, session_id: sessionID }]
+    }),
+  )
+  const latestBySession = new Map<string, SidebarSubagent>()
+  const pending: SidebarSubagent[] = []
+  for (const entry of entries) {
+    if (entry.session_id) latestBySession.set(entry.session_id, entry)
+    else pending.push(entry)
+  }
+  return [...latestBySession.values(), ...pending]
+}
+
+export function activeSubagents(
+  messages: ReadonlyArray<{ id: string }>,
+  getParts: (messageID: string) => ReadonlyArray<Part>,
+  getStatus: (sessionID: string) => SessionStatus | undefined,
+) {
+  return deriveSubagents(messages, getParts).flatMap((entry) => {
+    if (!entry.session_id) return entry.status === "active" || entry.status === "pending" ? [entry] : []
+
+    const status = getStatus(entry.session_id)
+    if (status?.type !== "busy" && status?.type !== "retry") return []
+    return [{ ...entry, status: "active" as const }]
+  })
+}
+
+function View(props: { api: TuiPluginApi; session_id: string }) {
+  const theme = () => props.api.theme.current
+  const list = createMemo(() =>
+    activeSubagents(
+      props.api.state.session.messages(props.session_id),
+      (messageID) => props.api.state.part(messageID),
+      props.api.state.session.status,
+    ),
+  )
+
+  const statusColor = (status: SidebarSubagent["status"]) => {
+    if (status === "active") return theme().success
+    if (status === "failed") return theme().error
+    if (status === "pending") return theme().warning
+    return theme().textMuted
+  }
+
+  const statusLabel = (status: SidebarSubagent["status"]) => {
+    if (status === "active") return "Active"
+    if (status === "done") return "Done"
+    if (status === "failed") return "Failed"
+    return "Pending"
+  }
+
+  return (
+    <Show when={list().length > 0}>
+      <box>
+        <text fg={theme().text}>
+          <b>Subagents</b>
+        </text>
+        <For each={list()}>
+          {(item) => {
+            const navigate = item.session_id
+              ? () => props.api.route.navigate("session", { sessionID: item.session_id })
+              : undefined
+            return (
+              <box flexDirection="row" gap={1} onMouseUp={navigate}>
+                <text flexShrink={0} style={{ fg: statusColor(item.status) }}>
+                  •
+                </text>
+                <text fg={theme().text} wrapMode="word">
+                  {item.description} <span style={{ fg: theme().textMuted }}>{statusLabel(item.status)}</span>
+                </text>
+              </box>
+            )
+          }}
+        </For>
+      </box>
+    </Show>
+  )
+}
+
+const tui: TuiPlugin = async (api) => {
+  api.slots.register({
+    order: 600,
+    slots: {
+      sidebar_content(_ctx, props) {
+        return <View api={api} session_id={props.session_id} />
+      },
+    },
+  })
+}
+
+const plugin: BuiltinTuiPlugin = {
+  id,
+  tui,
+}
+
+export default plugin

--- a/packages/tui/test/feature-plugins/sidebar-subagents.test.ts
+++ b/packages/tui/test/feature-plugins/sidebar-subagents.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test"
+import type { Part } from "@opencode-ai/sdk/v2"
+import { activeSubagents, deriveSubagents } from "../../src/feature-plugins/sidebar/subagents"
+
+const messages = [{ id: "message-1" }]
+const noStatus = () => undefined
+const busyStatus = () => ({ type: "busy" as const })
+
+describe("sidebar subagents", () => {
+  test("returns no entries when the session has no task parts", () => {
+    expect(activeSubagents(messages, () => [], noStatus)).toEqual([])
+  })
+
+  test("derives running and completed subagents", () => {
+    expect(
+      activeSubagents(messages, () => [
+        {
+          type: "tool",
+          tool: "task",
+          state: {
+            status: "running",
+            input: { description: "Research APIs" },
+            metadata: { sessionId: "child-running" },
+          },
+        },
+        {
+          type: "tool",
+          tool: "task",
+          state: {
+            status: "completed",
+            input: { description: "Review changes" },
+            title: "Review changes",
+            metadata: { sessionId: "child-completed" },
+          },
+        },
+      ] as unknown as Part[], (sessionID) => (sessionID === "child-running" ? busyStatus() : undefined)),
+    ).toEqual([{ description: "Research APIs", status: "active", session_id: "child-running" }])
+  })
+
+  test("marks errored subagents as failed", () => {
+    expect(
+      activeSubagents(messages, () => [
+        {
+          type: "tool",
+          tool: "task",
+          state: {
+            status: "error",
+            input: { description: "Run checks" },
+            error: "failed",
+            metadata: { sessionId: "child-error" },
+          },
+        },
+      ] as unknown as Part[], noStatus),
+    ).toEqual([])
+  })
+
+  test("keeps pending subagents without a session id non-navigable", () => {
+    expect(
+      activeSubagents(messages, () => [
+        {
+          type: "tool",
+          tool: "task",
+          state: {
+            status: "pending",
+            input: { description: "Start worker" },
+            raw: "{}",
+          },
+        },
+      ] as unknown as Part[], noStatus),
+    ).toEqual([{ description: "Start worker", status: "pending", session_id: undefined }])
+  })
+
+  test("deduplicates one child session across messages", () => {
+    expect(
+      activeSubagents(
+        [{ id: "message-1" }, { id: "message-2" }],
+        () =>
+          [
+            {
+              type: "tool",
+              tool: "task",
+              state: {
+                status: "running",
+                input: { description: "Research APIs" },
+                metadata: { sessionId: "child-1" },
+              },
+            },
+          ] as unknown as Part[],
+          busyStatus,
+      ),
+    ).toEqual([{ description: "Research APIs", status: "active", session_id: "child-1" }])
+  })
+
+  test("keeps the latest status when a child session is resumed", () => {
+    const parts = [
+      {
+        type: "tool",
+        tool: "task",
+        state: {
+          status: "running",
+          input: { description: "Research APIs" },
+          metadata: { sessionId: "child-1" },
+        },
+      },
+      {
+        type: "tool",
+        tool: "task",
+        state: {
+          status: "completed",
+          input: { description: "Research APIs" },
+          title: "Research APIs",
+          metadata: { sessionId: "child-1" },
+        },
+      },
+    ] as unknown as Part[]
+
+    expect(
+      deriveSubagents(
+        [{ id: "message-1" }, { id: "message-2" }],
+        (messageID) => [parts[messageID === "message-1" ? 0 : 1]!],
+      ),
+    ).toEqual([{ description: "Research APIs", status: "done", session_id: "child-1" }])
+    expect(
+      activeSubagents(
+        [{ id: "message-1" }, { id: "message-2" }],
+        (messageID) => [parts[messageID === "message-1" ? 0 : 1]!],
+        noStatus,
+      ),
+    ).toEqual([])
+  })
+
+  test("keeps multiple pending entries without session ids", () => {
+    expect(
+      activeSubagents(messages, () => [
+        {
+          type: "tool",
+          tool: "task",
+          state: { status: "pending", input: { description: "Start worker one" }, raw: "{}" },
+        },
+        {
+          type: "tool",
+          tool: "task",
+          state: { status: "pending", input: { description: "Start worker two" }, raw: "{}" },
+        },
+      ] as unknown as Part[], noStatus),
+    ).toEqual([
+      { description: "Start worker one", status: "pending", session_id: undefined },
+      { description: "Start worker two", status: "pending", session_id: undefined },
+    ])
+  })
+
+  test("renders only in-flight entries from a mixed session", () => {
+    expect(
+      activeSubagents(messages, () => [
+        {
+          type: "tool",
+          tool: "task",
+          state: {
+            status: "completed",
+            input: { description: "Finished one" },
+            title: "Finished one",
+            metadata: { sessionId: "child-done-1" },
+          },
+        },
+        {
+          type: "tool",
+          tool: "task",
+          state: {
+            status: "completed",
+            input: { description: "Finished two" },
+            title: "Finished two",
+            metadata: { sessionId: "child-done-2" },
+          },
+        },
+        {
+          type: "tool",
+          tool: "task",
+          state: { status: "running", input: { description: "Working" }, metadata: { sessionId: "child-running" } },
+        },
+        {
+          type: "tool",
+          tool: "task",
+          state: { status: "pending", input: { description: "Waiting" }, raw: "{}" },
+        },
+      ] as unknown as Part[], (sessionID) => (sessionID === "child-running" ? { type: "busy" as const } : undefined)),
+    ).toEqual([
+      { description: "Working", status: "active", session_id: "child-running" },
+      { description: "Waiting", status: "pending", session_id: undefined },
+    ])
+  })
+
+  test("includes a completed background task while its child session is busy", () => {
+    expect(
+      activeSubagents(messages, () => [
+        {
+          type: "tool",
+          tool: "task",
+          state: {
+            status: "completed",
+            input: { description: "Background research" },
+            title: "Background research",
+            metadata: { sessionId: "child-busy" },
+          },
+        },
+      ] as unknown as Part[], busyStatus),
+    ).toEqual([{ description: "Background research", status: "active", session_id: "child-busy" }])
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #41249. Supersedes #4865 by @franlol (open).

### Type of change

- [x] New feature

### Credit

The feature and the original implementation are @franlol's in #4865 — subagents in the sidebar, click to navigate. This is that, rebased onto `dev`, with one change that came out of using it: we ran an orchestration session with hundreds of subagents, and listing every one made the sidebar useless. So this lists only **active** subagents and dedupes by child session id, so a resumed `task_id` doesn't render twice. If @franlol revisits #4865, that filter is the part worth lifting. If theirs lands, I'll close this. @giovannic96 requested the same feature in #41249 after shipping it as an external plugin.

Parent navigation and the return-to-parent keybind #4865 also added are already on `dev`, so this is just the list.

### What does this PR do?

Adds a collapsible "Subagents" section to the sidebar showing the session's active subagents; select one to open that child session. The derive helper sits in `packages/core` since `packages/tui` can't import opencode's private symbols.

Liveness comes from the **child session's** status, not the parent's `task` tool-part status. That distinction is load-bearing: a background dispatch completes the parent's tool part the instant the child spawns, so the parent part reads `completed` while the child runs for minutes. On my machine, of the last 300 `task` parts, 270 were `completed` and **zero** were `running` — including a subagent that was executing at the time. Filtering on the parent part yields an empty list forever and the section silently never renders. `api.state.session.status(childID)` is the correct signal, since idle sessions are absent from that map by design.

### How did you verify your code works?

- `packages/tui`: 257 pass / 0 fail — covers derive, dedup, the active filter, and the background-completed-parent-with-busy-child case that the parent-status approach got wrong
- `bun typecheck` clean in `packages/tui`
- Confirmed rendering in a live session with a running background subagent

### Screenshots / recordings

A "Subagents" list in the sidebar, active only, collapsible like the other lists.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR