### PR TITLE
fix(tui): use path.sep for plugin name extraction in /status dialog

### DIFF
--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -1,5 +1,6 @@
 import { TextAttributes } from "@opentui/core"
 import { fileURLToPath } from "bun"
+import path from "path"
 import { useTheme } from "../context/theme"
 import { useDialog } from "../ui/dialog"
 import { useSync } from "../context/sync"
@@ -19,9 +20,9 @@ export function DialogStatus() {
     const result = list.map((item) => {
       const value = typeof item === "string" ? item : item[0]
       if (value.startsWith("file://")) {
-        const path = fileURLToPath(value)
-        const parts = path.split("/")
-        const filename = parts.pop() || path
+        const filePath = fileURLToPath(value)
+        const parts = filePath.split(path.sep)
+        const filename = parts.pop() || filePath
         if (!filename.includes(".")) return { name: filename }
         const basename = filename.split(".")[0]
         if (basename === "index") {


### PR DESCRIPTION
### Issue for this PR

Closes #46101

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Windows, `fileURLToPath()` returns backslash-separated paths, but the status dialog was splitting on `/` only. The entire path became a single token, and the first `.` in `.config` made the displayed name `C:\Users\Administrator\` instead of `rtk`.

Changed `split("/")` to `split(path.sep)` and renamed the local variable to avoid shadowing the `path` module import.

### How did you verify your code works?

Ran a Node script comparing old vs new logic on a Windows path:
- Old (split "/"): name = `C:\Users\Administrator\`
- New (split path.sep): name = `rtk`

### Screenshots / recordings

See screenshot in linked issue #46101.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes

---

**History:** This bug was reported in #34141 and two prior PRs attempted to fix it (#33375, #34183). Both were closed without merging. The bug still exists on dev, re-reported as #46101.