### PR TITLE
feat(tui): make the sidebar width configurable

### DIFF
--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -19,6 +19,7 @@ export const PluginOptions = Schema.Record(Schema.String, Schema.Unknown)
 export const PluginSpec = Schema.Union([Schema.String, Schema.mutable(Schema.Tuple([Schema.String, PluginOptions]))])
 
 export const LeaderTimeoutDefault = 2000
+export const SidebarWidthDefault = 42
 export const LeaderTimeout = Schema.Int.check(Schema.isGreaterThan(0)).annotate({
   description: "Leader key timeout in milliseconds",
 })
@@ -51,6 +52,7 @@ export const Attention = Schema.Struct({
 }).annotate({ description: "Attention notification and sound settings" })
 
 const PromptSize = Schema.Int.check(Schema.isGreaterThan(0))
+const SidebarWidth = Schema.Int.check(Schema.isGreaterThan(0))
 export const Prompt = Schema.Struct({
   max_height: Schema.optional(PromptSize).annotate({ description: "Prompt textarea max height" }),
   max_width: Schema.optional(Schema.Union([PromptSize, Schema.Literal("auto")])).annotate({
@@ -72,10 +74,11 @@ export const Info = Schema.Struct({
   diff_style: Schema.optional(DiffStyle),
   cursor: Schema.optional(Cursor),
   mouse: Schema.optional(Schema.Boolean).annotate({ description: "Enable or disable mouse capture (default: true)" }),
+  sidebar_width: Schema.optional(SidebarWidth).annotate({ description: "Sidebar width in columns (default: 42)" }),
 })
 export type Info = Schema.Schema.Type<typeof Info>
 
-export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse" | "cursor"> & {
+export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | "mouse" | "cursor" | "sidebar_width"> & {
   attention: {
     enabled: boolean
     notifications: boolean
@@ -87,6 +90,7 @@ export type Resolved = Omit<Info, "attention" | "keybinds" | "leader_timeout" | 
   keybinds: TuiKeybind.BindingLookupView
   leader_timeout: number
   mouse: boolean
+  sidebar_width: number
   cursor?: {
     style: "block" | "underline" | "line" | "default"
     blinking: boolean
@@ -126,6 +130,7 @@ export function resolve(input: Info, options: ResolveOptions): Resolved {
     }),
     leader_timeout: input.leader_timeout ?? LeaderTimeoutDefault,
     mouse: input.mouse ?? true,
+    sidebar_width: input.sidebar_width ?? SidebarWidthDefault,
     cursor: input.cursor
       ? {
           style: input.cursor.style ?? "block",

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -53,6 +53,7 @@ import { DialogTimeline } from "./dialog-timeline"
 import { DialogForkFromTimeline } from "./dialog-fork-from-timeline"
 import { DialogSessionRename } from "../../component/dialog-session-rename"
 import { Sidebar } from "./sidebar"
+import { clampSidebarWidth } from "../../util/sidebar-width"
 import { SubagentFooter } from "./subagent-footer.tsx"
 import { filetype } from "../../util/filetype"
 import parsers from "../../parsers-config"
@@ -274,8 +275,9 @@ export function Session() {
     if (sidebar() === "auto" && wide()) return true
     return false
   })
+  const sidebarWidth = createMemo(() => clampSidebarWidth(tuiConfig.sidebar_width, dimensions().width))
   const showTimestamps = createMemo(() => timestamps() === "show")
-  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? 42 : 0) - 4)
+  const contentWidth = createMemo(() => dimensions().width - (sidebarVisible() ? sidebarWidth() : 0) - 4)
   const providers = createMemo(() => Model.index(sync.data.provider))
 
   const scrollAcceleration = createMemo(() => getScrollAcceleration(tuiConfig))
@@ -1338,7 +1340,7 @@ export function Session() {
           <Show when={sidebarVisible()}>
             <Switch>
               <Match when={wide()}>
-                <Sidebar sessionID={route.sessionID} />
+                <Sidebar sessionID={route.sessionID} width={sidebarWidth()} />
               </Match>
               <Match when={!wide()}>
                 <box
@@ -1350,7 +1352,7 @@ export function Session() {
                   alignItems="flex-end"
                   backgroundColor={RGBA.fromInts(0, 0, 0, 70)}
                 >
-                  <Sidebar sessionID={route.sessionID} />
+                  <Sidebar sessionID={route.sessionID} width={sidebarWidth()} />
                 </box>
               </Match>
             </Switch>

--- a/packages/tui/src/routes/session/sidebar.tsx
+++ b/packages/tui/src/routes/session/sidebar.tsx
@@ -9,7 +9,7 @@ import { usePluginRuntime } from "../../plugin/runtime"
 import { getScrollAcceleration } from "../../util/scroll"
 import { WorkspaceLabel } from "../../component/workspace-label"
 
-export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
+export function Sidebar(props: { sessionID: string; overlay?: boolean; width: number }) {
   const pluginRuntime = usePluginRuntime()
   const project = useProject()
   const sync = useSync()
@@ -27,7 +27,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
     <Show when={session()}>
       <box
         backgroundColor={theme.backgroundPanel}
-        width={42}
+        width={props.width}
         height="100%"
         paddingTop={1}
         paddingBottom={1}

--- a/packages/tui/src/util/sidebar-width.ts
+++ b/packages/tui/src/util/sidebar-width.ts
@@ -1,0 +1,5 @@
+import { SidebarWidthDefault } from "../config"
+
+export function clampSidebarWidth(configured: number | undefined, terminalWidth: number) {
+  return Math.max(20, Math.min(configured ?? SidebarWidthDefault, terminalWidth - 40, 100))
+}

--- a/packages/tui/test/config.test.tsx
+++ b/packages/tui/test/config.test.tsx
@@ -7,6 +7,7 @@ import {
   Info,
   LeaderTimeoutDefault,
   PluginSpec,
+  SidebarWidthDefault,
   resolve,
   TuiConfigProvider,
   type Info as TuiConfigInfo,
@@ -45,6 +46,7 @@ test("validates config constraints", () => {
   expect(() => decodeInfo({ prompt: { max_width: 0 } })).toThrow()
   expect(() => decodeInfo({ scroll_speed: 0 })).toThrow()
   expect(() => decodeInfo({ cursor: { style: "beam" } })).toThrow()
+  expect(() => decodeInfo({ sidebar_width: 42.7 })).toThrow()
   expect(decodeInfo({ attention: { sounds: { unknown: "sound.wav" } } })).toEqual({ attention: { sounds: {} } })
 })
 
@@ -61,6 +63,7 @@ test("resolves host-neutral defaults", () => {
   })
   expect(config.leader_timeout).toBe(LeaderTimeoutDefault)
   expect(config.mouse).toBe(true)
+  expect(config.sidebar_width).toBe(SidebarWidthDefault)
   expect(config.keybinds.has("terminal.suspend")).toBe(true)
   expect(config.keybinds.has("session.list")).toBe(true)
   expect(config.cursor).toBeUndefined()
@@ -70,6 +73,7 @@ test("resolves overrides without mutating input", () => {
   const input: TuiConfigInfo = {
     theme: "custom",
     mouse: false,
+    sidebar_width: 56,
     leader_timeout: 750,
     attention: {
       enabled: true,
@@ -87,6 +91,7 @@ test("resolves overrides without mutating input", () => {
   expect(config).toMatchObject({
     theme: "custom",
     mouse: false,
+    sidebar_width: 56,
     leader_timeout: 750,
     attention: input.attention,
     cursor: { style: "block", blinking: false },

--- a/packages/tui/test/util/sidebar-width.test.ts
+++ b/packages/tui/test/util/sidebar-width.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test"
+import { clampSidebarWidth } from "../../src/util/sidebar-width"
+
+describe("util.sidebar-width", () => {
+  test("passes through a configured width within bounds", () => {
+    expect(clampSidebarWidth(48, 120)).toBe(48)
+  })
+
+  test("clamps widths below the minimum to 20", () => {
+    expect(clampSidebarWidth(12, 120)).toBe(20)
+  })
+
+  test("clamps widths above the terminal content limit", () => {
+    expect(clampSidebarWidth(90, 120)).toBe(80)
+  })
+
+  test("clamps widths above the hard cap to 100", () => {
+    expect(clampSidebarWidth(120, 200)).toBe(100)
+  })
+
+  test("keeps the minimum when terminal bounds are inverted", () => {
+    expect(clampSidebarWidth(30, 55)).toBe(20)
+  })
+
+  test("defaults absent configuration to 42", () => {
+    expect(clampSidebarWidth(undefined, 120)).toBe(42)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #35513

### Type of change

- [x] New feature

### What does this PR do?

Adds a `sidebar_width` key to the TUI config. `42` stays the default, so nothing changes unless you set it.

The width was hardcoded in two places that had to agree: `<box width={42}>` in the sidebar component, and the session route's content math (`dimensions().width - (sidebarVisible() ? 42 : 0) - 4`). Both now read one `sidebarWidth()` memo. Collapsing that duplication is half the value here — two literals that must stay in sync is where the next layout bug was going to come from.

The resolved width is clamped to `max(20, min(configured, terminalWidth - 40, 100))`:

- **20 floor** — below this the sidebar content stops being legible
- **`terminalWidth - 40`** — the main pane keeps at least 40 columns
- **100 cap**

The clamp runs on read rather than only at config load, so shrinking the terminal degrades the sidebar instead of squeezing the main pane. The outer `max(20, …)` matters on small terminals where the bounds invert (at 55 columns, `terminalWidth - 40` is 15, under the floor) — the minimum wins there and the function stays total. That case is unreachable today since terminals at or below 120 columns render the sidebar as an overlay, but the function shouldn't depend on that.

`sidebar_width` is `Schema.Int.check(Schema.isGreaterThan(0))`, matching `leader_timeout` and the prompt size fields, so a fractional or negative value is a config error rather than a fractional column count.

This is deliberately just the config key. A follow-up adds a drag rail, a collapse state, and runtime persistence — kept separate so this part is reviewable on its own.

### How did you verify your code works?

- `packages/tui`: 199 pass / 0 fail; 6 focused tests on the clamp covering the floor, the terminal-content cap, the hard cap, the inverted-bounds case, and the default
- `bun typecheck` clean in `packages/tui` and `packages/opencode`
- Mutation check: making `clampSidebarWidth` return the raw configured value fails 4 of the 6 focused tests

### Screenshots / recordings

No visual change at the default width.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR