### PR TITLE
fix(app): reduce session cache memory

### DIFF
--- a/packages/app/src/context/global-sync/session-cache.ts
+++ b/packages/app/src/context/global-sync/session-cache.ts
@@ -2,7 +2,7 @@ import type { Message, Part, PermissionRequest, QuestionRequest, SessionStatus, 
 import type { FileDiffInfo } from "@opencode-ai/client/promise"
 import type { SessionMessageInfo } from "@opencode-ai/client/promise"
 
-export const SESSION_CACHE_LIMIT = 40
+export const SESSION_CACHE_LIMIT = 10
 
 type SessionCache = {
   session_status: Record<string, SessionStatus | undefined>


### PR DESCRIPTION
### Issue for this PR

Closes #46119

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reduces the app session cache from 40 transcripts to 10, matching the nearby-session prefetch working set. In a 50-session CDP run, retained JS heap after GC fell from 134.4 MB to 72.5 MB.

### How did you verify your code works?

- App cache unit test: 3 passed
- App typecheck passed
- Repository pre-push typecheck: 30 packages passed
- Repeated the 50-session CDP memory run against the changed app

### Screenshots / recordings

Not applicable. This change has no visual effect.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._