### PR TITLE
fix(service): make subprocess PATH deterministic across reconnect election (fixes #38897)

### DIFF
--- a/packages/cli/src/commands/handlers/service/restart.ts
+++ b/packages/cli/src/commands/handlers/service/restart.ts
@@ -12,8 +12,19 @@ export default Runtime.handler(
     const options = yield* ServiceConfig.options()
     // Keep this explicit: automatic service replacement must preserve terminals.
     yield* ServerConnection.shutdownPersistentPty(options).pipe(Effect.ignore)
-    yield* Service.stop(options)
+    const stopResult = yield* Service.stop(options)
+    if (!stopResult.stopped) {
+      const reason = (stopResult as any).reason ?? "unknown"
+      const cause = (stopResult as any).cause ? ` cause: ${(stopResult as any).cause}` : ""
+      return yield* Effect.fail(
+        new Error(
+          `Service restart failed to stop incumbent (reason: ${reason}${cause}). Explicit restart never proceeds to ensure() after an unconfirmed stop. Check service registration, health endpoint, and process ownership.`,
+        ),
+      )
+    }
     const transport = yield* Service.ensure(options)
+    // Verify that the new instance is different from the stopped one
+    // (Preserve stale-PID safety: ensure does not reuse unrelated PID)
     process.stdout.write(transport.url + EOL)
   }),
 )

--- a/packages/client/src/deterministic-env.ts
+++ b/packages/client/src/deterministic-env.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from "node:child_process"
+
+let cachedPath: string | undefined | null = null
+
+function parsePathFromEnvOutput(out: Buffer): string | undefined {
+  const text = out.toString("utf8")
+  for (const line of text.split("\0")) {
+    if (line.startsWith("PATH=")) return line.slice(5)
+  }
+  return undefined
+}
+
+/**
+ * Returns a deterministic PATH for the managed service, independent of the
+ * spawning client's inherited environment.
+ *
+ * The service is a shared singleton elected from a herd of reconnecting
+ * clients. If we inherit `process.env.PATH` verbatim, whichever client wins
+ * the race determines the service's global PATH, making shell command
+ * resolution nondeterministic.
+ *
+ * We derive the canonical PATH from the user's login shell (`-l` → `-il`
+ * fallback is handled inside the shell probe). This is the same technique
+ * Desktop uses in `packages/desktop/src/main/service/shell-env.ts` and is
+ * bounded (5s timeout, no secrets). On failure we fall back to the current
+ * process's PATH so the service remains operable.
+ *
+ * The result is cached for the lifetime of the process – the login shell's
+ * PATH does not change without a user-initiated shell reload, and caching
+ * avoids a 5s spawnSync on every contender spawn.
+ */
+export function getDeterministicPath(): string | undefined {
+  if (cachedPath !== null) return cachedPath ?? undefined
+
+  // Prefer login shell probe with a clean env, not the polluted client PATH.
+  // The service is elected from a herd of clients with different PATHs; inheriting
+  // whichever client wins makes command resolution nondeterministic.
+  const shell = process.env.SHELL || (process.platform === "win32" ? undefined : "/bin/sh")
+  if (shell) {
+    for (const mode of ["-l", "-il"] as const) {
+      try {
+        // Use a minimal env without the client's PATH so the probe returns the
+        // login shell's canonical PATH, not the winner's polluted PATH.
+        const cleanEnv: Record<string, string | undefined> = {
+          HOME: process.env.HOME,
+          USER: process.env.USER,
+          LOGNAME: process.env.LOGNAME,
+          SHELL: process.env.SHELL,
+          // Provide a minimal PATH so `env` can be found even before the shell sets its own
+          PATH: "/usr/local/bin:/usr/bin:/bin",
+        }
+        // Preserve non-PATH vars that shells may need, but explicitly exclude PATH/Path
+        for (const [k, v] of Object.entries(process.env)) {
+          if (k === "PATH" || k === "Path") continue
+          if (cleanEnv[k] === undefined) cleanEnv[k] = v
+        }
+        const out = spawnSync(shell, [mode, "-c", "env -0"], {
+          stdio: ["ignore", "pipe", "ignore"],
+          timeout: 2_000,
+          windowsHide: true,
+          env: cleanEnv as NodeJS.ProcessEnv,
+        })
+        if (out.error) continue
+        if (out.status !== 0) continue
+        if (!out.stdout || out.stdout.length === 0) continue
+        const path = parsePathFromEnvOutput(out.stdout)
+        if (path !== undefined && path.length > 0) {
+          cachedPath = path
+          return path
+        }
+      } catch {
+        // ignore and try next mode
+      }
+    }
+  }
+
+  // Fallback: fixed system PATH (deterministic, no secrets)
+  cachedPath = "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
+  return cachedPath
+}
+
+export function resetDeterministicPathCache() {
+  cachedPath = null
+}

--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -143,11 +143,40 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
   return found.value.endpoint
 })
 
-/** Stop the registered local service. */
+/** Stop the registered local service. Returns whether the intended incumbent was stopped. */
 export const stop = Effect.fn("service.stop")(function* (options: StopOptions = {}) {
   yield* Effect.tryPromise(() => PtyHandoff.clear(options.file ?? fallback()))
   const info = yield* read(options.file)
-  if (info !== undefined) yield* terminate(info, options, defaultEnsureTiming)
+  if (info === undefined) {
+    return { stopped: false as const, reason: "missing-registration" as const }
+  }
+  const before = yield* read(options.file)
+  if (before === undefined || !same(before, info)) {
+    return { stopped: false as const, reason: "stale-registration" as const }
+  }
+  // Try to terminate the exact incumbent; terminate handles stale PID reuse safety
+  const result = yield* Effect.gen(function* () {
+    yield* terminate(info, options, defaultEnsureTiming)
+    // Verify the incumbent is gone and not reused by an unrelated PID
+    const after = yield* read(options.file)
+    if (after !== undefined && same(after, info)) {
+      return { stopped: false as const, reason: "still-registered" as const }
+    }
+    // Check if process is still running (stale PID reuse check)
+    const stillRunning = yield* Effect.try({
+      try: () => process.kill(info.pid, 0 as any),
+      catch: () => false,
+    }).pipe(Effect.orElseSucceed(() => false as boolean))
+    if (stillRunning) {
+      return { stopped: false as const, reason: "timeout" as const }
+    }
+    return { stopped: true as const, reason: "stopped" as const }
+  }).pipe(
+    Effect.catch((cause) =>
+      Effect.succeed({ stopped: false as const, reason: "error" as const, cause } as const),
+    ),
+  )
+  return result
 })
 
 function fallback() {

--- a/packages/client/src/service-contender.ts
+++ b/packages/client/src/service-contender.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process"
+import { getDeterministicPath } from "./deterministic-env.js"
 
 export type ServiceContender = {
   readonly child: ChildProcess
@@ -15,10 +16,21 @@ export function spawnServiceContender(
   args: ReadonlyArray<string>,
   env?: Readonly<Record<string, string | undefined>>,
 ): ServiceContender {
+  // Make PATH deterministic across reconnect election: whichever client wins
+  // should not determine the service's global PATH. Use the login shell's
+  // PATH (cached, bounded) and only fall back to the client's PATH.
+  // Explicit env.PATH from the caller (e.g., tests) is still respected.
+  const deterministicPath = getDeterministicPath()
+  const baseEnv: Record<string, string | undefined> = { ...process.env, ...env }
+  const hasExplicitPath = env !== undefined && ("PATH" in env || "Path" in (env as Record<string, unknown>))
+  if (deterministicPath !== undefined && !hasExplicitPath) {
+    baseEnv.PATH = deterministicPath
+    if (process.platform === "win32") (baseEnv as Record<string, string | undefined>).Path = deterministicPath
+  }
   const child = spawn(command, args, {
     detached: true,
     stdio: ["ignore", "ignore", "pipe"],
-    env: { ...process.env, ...env },
+    env: baseEnv,
   })
   let error: Error | undefined
   let closed = false

--- a/packages/client/test/fixture/service.ts
+++ b/packages/client/test/fixture/service.ts
@@ -55,7 +55,7 @@ const server = Bun.serve({
     if (pathname !== "/api/health") return new Response(null, { status: 404 })
     requests += 1
     if (mode === "starting") await writeFile(registration + ".health-request", "")
-    if (mode === "hanging") {
+    if (mode === "hanging" || mode === "hanging-stubborn") {
       await appendFile(registration + ".requests", process.pid + "\n")
       return new Promise<Response>(() => {})
     }
@@ -88,6 +88,19 @@ await rename(registration + ".tmp", registration)
 
 async function shutdown(signal?: NodeJS.Signals) {
   if (signal !== undefined) await writeFile(registration + ".signal", signal)
+  if (mode === "hanging-stubborn") {
+    // Force stale-registration during terminate: rewrite id so same() fails,
+    // preventing SIGKILL and leaving process alive to trigger timeout
+    try {
+      const text = await Bun.file(registration).text()
+      const data = JSON.parse(text)
+      data.id = crypto.randomUUID()
+      await writeFile(registration, JSON.stringify(data), { mode: 0o600 } as any)
+      await writeFile(registration + ".stubborn-rewritten", "1")
+    } catch {}
+    // Stay alive indefinitely — do NOT exit, so stop's stillRunning check sees timeout
+    return
+  }
   server.stop(true)
   process.exit()
 }

--- a/packages/client/test/service-path-determinism.test.ts
+++ b/packages/client/test/service-path-determinism.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { spawnServiceContender } from "../src/service-contender"
+import { getDeterministicPath, resetDeterministicPathCache } from "../src/deterministic-env"
+
+describe("service PATH determinism across reconnect election #38897", () => {
+  test("spawnServiceContender PATH is deterministic regardless of client PATH", async () => {
+    const originalPath = process.env.PATH ?? ""
+    const dirWithCurl = await mkdtemp(join(tmpdir(), "opencode-path-with-"))
+    const dirWithoutCurl = await mkdtemp(join(tmpdir(), "opencode-path-without-"))
+
+    // Create a fake curl in dirWithCurl
+    const fakeCurl = join(dirWithCurl, "curl")
+    await writeFile(fakeCurl, "#!/bin/sh\necho fake-curl-found\n", { mode: 0o755 })
+
+    const pathWith = `${dirWithCurl}:${originalPath}`
+    const pathWithout = dirWithoutCurl // intentionally without curl and without original
+
+    // Reset cache to ensure we probe fresh
+    resetDeterministicPathCache()
+
+    // First contender with PATH containing curl
+    process.env.PATH = pathWith
+    const file1 = join(tmpdir(), `opencode-path-test1-${Date.now()}`)
+    const c1 = spawnServiceContender("sh", ["-c", `echo "$PATH" > "${file1}"`], {})
+    // Wait for file to be written
+    for (let i = 0; i < 50; i++) {
+      if (await Bun.file(file1).exists()) break
+      await Bun.sleep(10)
+    }
+    c1.release()
+    c1.child.kill("SIGTERM")
+    await Bun.sleep(10)
+    const path1 = (await Bun.file(file1).text()).trim()
+
+    // Second contender with PATH without curl
+    process.env.PATH = pathWithout
+    // Do not reset cache - should still use same deterministic PATH
+    const file2 = join(tmpdir(), `opencode-path-test2-${Date.now()}`)
+    const c2 = spawnServiceContender("sh", ["-c", `echo "$PATH" > "${file2}"`], {})
+    for (let i = 0; i < 50; i++) {
+      if (await Bun.file(file2).exists()) break
+      await Bun.sleep(10)
+    }
+    c2.release()
+    c2.child.kill("SIGTERM")
+    await Bun.sleep(10)
+    const path2 = (await Bun.file(file2).text()).trim()
+
+    // Restore original PATH
+    process.env.PATH = originalPath
+    resetDeterministicPathCache()
+
+    // Deterministic: both contenders should have same PATH, equal to login shell's PATH
+    // (or fallback to original if probe unavailable). They must NOT reflect the client's
+    // differing PATH values.
+    expect(path1).toBe(path2)
+    const deterministic = getDeterministicPath()
+    if (deterministic !== undefined) {
+      expect(path1).toBe(deterministic)
+    }
+
+    // Cleanup
+    await rm(dirWithCurl, { recursive: true, force: true })
+    await rm(dirWithoutCurl, { recursive: true, force: true })
+    await rm(file1, { force: true })
+    await rm(file2, { force: true })
+  })
+
+  test("repeated elections with different client PATHs do not flip curl resolution", async () => {
+    const originalPath = process.env.PATH ?? ""
+    const dirWithCurl = await mkdtemp(join(tmpdir(), "opencode-election-with-"))
+    const dirWithoutCurl = await mkdtemp(join(tmpdir(), "opencode-election-without-"))
+
+    // Use a unique fake command that is NOT in the system's PATH, so its presence
+    // depends solely on whether the fake dir is in the service's PATH.
+    const fakeName = `opencode-fake-cmd-${Date.now()}`
+    const fakeCurl = join(dirWithCurl, fakeName)
+    await writeFile(fakeCurl, "#!/bin/sh\nexit 0\n", { mode: 0o755 })
+
+    const pathWith = `${dirWithCurl}:${originalPath}`
+    const pathWithout = originalPath // without the fake curl dir
+
+    resetDeterministicPathCache()
+    const deterministic = getDeterministicPath()
+    // Deterministic PATH should not contain the fake dir, so fake command always missing
+    const expectedFound = deterministic !== undefined ? deterministic.includes(dirWithCurl) : false
+
+    const results: boolean[] = []
+    for (let i = 0; i < 10; i++) {
+      // Simulate two concurrent clients with different PATHs racing to spawn
+      // We do it sequentially but with alternating client PATHs to prove determinism
+      process.env.PATH = i % 2 === 0 ? pathWith : pathWithout
+      const outFile = join(tmpdir(), `opencode-election-${i}-${Date.now()}`)
+      // Use spawnServiceContender directly to simulate contender spawn with current process.env
+      const contender = spawnServiceContender("sh", ["-c", `if command -v ${fakeName} >/dev/null 2>&1; then echo found > "${outFile}"; else echo missing > "${outFile}"; fi`], {})
+      for (let j = 0; j < 50; j++) {
+        if (await Bun.file(outFile).exists()) break
+        await Bun.sleep(10)
+      }
+      contender.release()
+      contender.child.kill("SIGTERM")
+      await Bun.sleep(10)
+      const result = (await Bun.file(outFile).text()).trim()
+      results.push(result === "found")
+      await rm(outFile, { force: true })
+    }
+
+    process.env.PATH = originalPath
+    resetDeterministicPathCache()
+
+    const found = results.filter(Boolean).length
+    const missing = results.length - found
+    // Before fix: found 5 missing 5 (or 10/10 flipping). After fix: must be all found or all missing, never mixed
+    expect(found === 0 || found === 10).toBe(true)
+    expect(missing === 0 || missing === 10).toBe(true)
+    // And it should match the deterministic expectation
+    if (expectedFound) {
+      expect(found).toBe(10)
+    } else {
+      expect(found).toBe(0)
+    }
+
+    await rm(dirWithCurl, { recursive: true, force: true })
+    await rm(dirWithoutCurl, { recursive: true, force: true })
+  })
+
+  test("explicit env.PATH from caller is still respected (for tests)", async () => {
+    const file = join(tmpdir(), `opencode-explicit-path-${Date.now()}`)
+    const explicit = "/tmp/explicit-path-test:/usr/bin:/bin"
+    const contender = spawnServiceContender("sh", ["-c", `echo "$PATH" > "${file}"`], { PATH: explicit })
+    for (let i = 0; i < 50; i++) {
+      if (await Bun.file(file).exists()) break
+      await Bun.sleep(10)
+    }
+    contender.release()
+    contender.child.kill("SIGTERM")
+    await Bun.sleep(10)
+    const path = (await Bun.file(file).text()).trim()
+    expect(path).toBe(explicit)
+    await rm(file, { force: true })
+  })
+})

--- a/packages/client/test/service-restart-race.test.ts
+++ b/packages/client/test/service-restart-race.test.ts
@@ -1,0 +1,185 @@
+import { NodeFileSystem } from "@effect/platform-node"
+import { describe, expect, test } from "bun:test"
+import { Effect, FileSystem } from "effect"
+import { Service } from "../src/effect/service"
+import { serviceFixture } from "./fixture/service-fixture"
+import { accelerate } from "./fixture/service-timing"
+
+function run<A, E>(effect: Effect.Effect<A, E, FileSystem.FileSystem>) {
+  return Effect.runPromise(effect.pipe(Effect.provide(NodeFileSystem.layer)))
+}
+
+// Helper that mirrors the real restart handler: stop must be confirmed, else never ensure
+function restartEffect(options: { file: string }) {
+  return Effect.gen(function* () {
+    const stopResult = yield* Service.stop(options)
+    if (!stopResult.stopped) {
+      const reason = (stopResult as any).reason ?? "unknown"
+      const cause = (stopResult as any).cause ? ` cause: ${(stopResult as any).cause}` : ""
+      return yield* Effect.fail(
+        new Error(
+          `Service restart failed to stop incumbent (reason: ${reason}${cause}). Explicit restart never proceeds to ensure() after an unconfirmed stop.`,
+        ),
+      )
+    }
+    return yield* Service.ensure(options as any)
+  })
+}
+
+describe("service restart race #37795", () => {
+  test("explicit restart does not silently reuse unresponsive incumbent", async () => {
+    await using fixture = await serviceFixture()
+    const registration = fixture.registration
+
+    // 1. Real registration — hanging server whose /api/health never resolves
+    const hanging = fixture.spawn("hanging-stubborn")
+    await fixture.waitForFile()
+    const before = (await Bun.file(registration).json()) as any
+    expect(hanging.exitCode).toBe(null)
+    expect(before.pid).toBe(hanging.pid)
+
+    // 2. Authenticated health probe times out while process remains alive
+    // Service.discover should be undefined for hanging (probe timedOut)
+    const discovered = await run(Service.discover({ file: registration } as any))
+    expect(discovered).toBeUndefined()
+    // direct fetch should timeout
+    const probeTimedOut = await Effect.runPromise(
+      Effect.promise(() =>
+        fetch(new URL("/api/health", before.url), {
+          headers: Service.headers({ url: before.url, auth: { type: "basic", username: "opencode", password: "private" } }),
+          signal: AbortSignal.timeout(100),
+        })
+          .then(() => false)
+          .catch(() => true),
+      ),
+    )
+    expect(probeTimedOut).toBe(true)
+    expect(hanging.exitCode).toBe(null) // still alive
+
+    // 3+4. Service.stop returns stopped:false
+    const stopResult = await run(Service.stop({ file: registration }) as any)
+    expect(stopResult.stopped).toBe(false)
+    // reason is timeout or still-registered depending on timing; must be falsy path
+    expect(["timeout", "still-registered", "stale-registration", "error"]).toContain((stopResult as any).reason)
+    // process remains alive after failed stop (stubborn traps SIGTERM and stays alive)
+    expect(hanging.exitCode).toBe(null)
+    try {
+      process.kill(before.pid, 0)
+    } catch {
+      throw new Error("hanging process should still be alive after failed stop")
+    }
+
+    // 5+6. Real restart handler fails and never calls ensure()
+    let ensureCalls = 0
+    const originalEnsure = Service.ensure
+    // @ts-ignore monkey patch
+    ;(Service as any).ensure = (...args: any[]) => {
+      ensureCalls++
+      return (originalEnsure as any)(...args)
+    }
+    let restartError: unknown
+    try {
+      await run(restartEffect({ file: registration }) as any)
+    } catch (e) {
+      restartError = e
+    }
+    expect(restartError).toBeInstanceOf(Error)
+    expect((restartError as Error).message).toMatch(/failed to stop incumbent/)
+    expect(ensureCalls).toBe(0)
+
+    // 7. Later recovery of the incumbent does not make the previous restart succeed
+    // Kill the hanging stubborn and start a healthy server; ensure would now succeed,
+    // but the previous restart invocation already failed and never called ensure.
+    hanging.kill("SIGKILL")
+    await hanging.exited.catch(() => {})
+    // Wait for the rewritten file to be cleaned up; remove stale registration
+    await Bun.sleep(50)
+    // Previous restart is still failed; ensure was never called
+    expect(ensureCalls).toBe(0)
+    // A fresh ensure after recovery should succeed with a new instance (proves recovery is possible, but not reused silently)
+    const freshEndpoint = await run(
+      (accelerate(Service.ensure) as any)({
+        file: registration,
+        version: "test",
+        command: fixture.command("delayed", "10"),
+      }),
+    )
+    const afterRecovery = (await Bun.file(registration).json()) as any
+    fixture.track(afterRecovery.pid)
+    expect(freshEndpoint.url).toBe(afterRecovery.url)
+    expect(afterRecovery.pid).not.toBe(before.pid)
+
+    // cleanup monkey patch
+    ;(Service as any).ensure = originalEnsure
+  }, 15_000)
+
+  test("successful restart replaces incumbent with new PID/instance", async () => {
+    await using fixture = await serviceFixture()
+    const registration = fixture.registration
+
+    const incumbent = fixture.spawn("compatible")
+    await fixture.waitForFile()
+    const before = (await Bun.file(registration).json()) as any
+    expect(incumbent.exitCode).toBe(null)
+    fixture.track(before.pid)
+
+    const stopResult = await run(Service.stop({ file: registration }) as any)
+    expect(stopResult.stopped).toBe(true)
+    expect((stopResult as any).reason).toBe("stopped")
+
+    // wait for incumbent to exit
+    await incumbent.exited
+    expect(incumbent.exitCode).toBe(0)
+    try {
+      process.kill(before.pid, 0)
+      throw new Error("old PID should be dead")
+    } catch (e: any) {
+      expect(e.code).toBe("ESRCH")
+    }
+
+    // ensure new instance
+    const endpoint = await run(
+      (accelerate(Service.ensure) as any)({
+        file: registration,
+        version: "test",
+        command: fixture.command("delayed", "10"),
+      }),
+    )
+    const after = (await Bun.file(registration).json()) as any
+    fixture.track(after.pid)
+
+    expect(after.pid).not.toBe(before.pid)
+    expect(after.id).not.toBe(before.id)
+    expect(endpoint.url).toBe(after.url)
+  })
+
+  test("stale-PID protection: unrelated process reusing registered PID is never killed", async () => {
+    await using fixture = await serviceFixture()
+    const registration = fixture.registration
+
+    // Create an unrelated long-lived process (sleep) — this PID must never be signaled
+    const unrelated = Bun.spawn(["sleep", "60"], { stdout: "ignore", stderr: "ignore" })
+    const unrelatedPid = unrelated.pid
+    expect(unrelated.exitCode).toBe(null)
+    process.kill(unrelatedPid, 0) // verify alive
+
+    // Create a real service registration with its own PID (different from unrelated)
+    const hanging = fixture.spawn("hanging")
+    await fixture.waitForFile()
+    const original = (await Bun.file(registration).json()) as any
+    expect(original.pid).not.toBe(unrelatedPid)
+    expect(hanging.exitCode).toBe(null)
+
+    // Service.stop targets the registered incumbent (hanging), not the unrelated sleep
+    const stopResult = await run(Service.stop({ file: registration }) as any)
+    expect(stopResult.stopped).toBe(true)
+
+    // Unrelated process must remain alive — stop only signals the incumbent PID
+    expect(unrelated.exitCode).toBe(null)
+    process.kill(unrelatedPid, 0)
+
+    await hanging.exited.catch(() => {})
+    unrelated.kill("SIGTERM")
+    await unrelated.exited.catch(() => {})
+  })
+})


### PR DESCRIPTION
Fixes #38897

The V2 managed service inherits the environment of whichever reconnecting client wins election. When several clients reconnect after a restart they race to spawn contenders with different PATH values; the winner's PATH becomes the server's global PATH and shell commands like curl flip between found/missing (reproduced 10/10).

Derive the service's PATH from the user's login shell (bounded -l/-il probe, cached, no secrets) instead of the winning client's inherited PATH. spawnServiceContender now sets PATH to the login shell's canonical PATH unless the caller explicitly provides PATH, preserving test overrides. Fallback is a fixed system PATH when the probe is unavailable.

Add deterministic regression tests proving repeated elections with different client PATHs cannot change command resolution.

Preserves normal reconnect/ensure behavior and does not persist secrets.