### PR TITLE
fix(opencode): write auth.json atomically under a lock

### DIFF
--- a/packages/core/src/fs-util.ts
+++ b/packages/core/src/fs-util.ts
@@ -2,6 +2,7 @@ import { NodeFileSystem } from "@effect/platform-node"
 import { dirname, isAbsolute, join, relative, resolve as pathResolve, sep } from "path"
 import { realpathSync } from "fs"
 import * as NFS from "fs/promises"
+import { randomUUID } from "crypto"
 import { lookup } from "mime-types"
 import { Context, Effect, FileSystem, Layer, Schema } from "effect"
 import type { PlatformError } from "effect/PlatformError"
@@ -35,6 +36,7 @@ export namespace FSUtil {
     readonly readFileStringSafe: (path: string) => Effect.Effect<string | undefined, Error>
     readonly readJson: (path: string) => Effect.Effect<unknown, Error>
     readonly writeJson: (path: string, data: unknown, mode?: number) => Effect.Effect<void, Error>
+    readonly writeJsonAtomic: (path: string, data: unknown, mode?: number) => Effect.Effect<void, Error>
     readonly ensureDir: (path: string) => Effect.Effect<void, Error>
     readonly writeWithDirs: (path: string, content: string | Uint8Array, mode?: number) => Effect.Effect<void, Error>
     readonly readDirectoryEntries: (path: string) => Effect.Effect<DirEntry[], Error>
@@ -111,6 +113,18 @@ export namespace FSUtil {
         const content = JSON.stringify(data, null, 2)
         yield* fs.writeFileString(path, content)
         if (mode) yield* fs.chmod(path, mode)
+      })
+
+      const writeJsonAtomic = Effect.fn("FileSystem.writeJsonAtomic")(function* (path: string, data: unknown, mode?: number) {
+        const temporary = `${path}.${process.pid}.${randomUUID()}.tmp`
+        yield* ensureDir(dirname(path))
+        yield* Effect.gen(function* () {
+          // The mode is applied at create so the temp is never briefly world-readable, and rename
+          // carries it to the target. A chmod after the rename would follow a symlink planted in
+          // the window between the two.
+          yield* fs.writeFileString(temporary, JSON.stringify(data, null, 2), mode ? { flag: "wx", mode } : { flag: "wx" })
+          yield* fs.rename(temporary, path)
+        }).pipe(Effect.ensuring(fs.remove(temporary, { force: true }).pipe(Effect.ignore)))
       })
 
       const ensureDir = Effect.fn("FileSystem.ensureDir")(function* (path: string) {
@@ -207,6 +221,7 @@ export namespace FSUtil {
         resolve,
         readJson,
         writeJson,
+        writeJsonAtomic,
         ensureDir,
         writeWithDirs,
         findUp,

--- a/packages/core/test/filesystem/filesystem.test.ts
+++ b/packages/core/test/filesystem/filesystem.test.ts
@@ -4,6 +4,7 @@ import { LayerNodePlatform } from "@opencode-ai/core/effect/app-node-platform"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { testEffect } from "../lib/effect"
+import nodeFs from "fs/promises"
 import path from "path"
 
 const live = LayerNode.compile(LayerNode.group([FSUtil.node, LayerNodePlatform.filesystem]))
@@ -95,6 +96,23 @@ describe("FSUtil", () => {
   })
 
   describe("readJson / writeJson", () => {
+    it(
+      "writes JSON atomically with the requested mode and cleans up its temporary file",
+      Effect.gen(function* () {
+        const fs = yield* FSUtil.Service
+        const filesys = yield* FileSystem.FileSystem
+        const tmp = yield* filesys.makeTempDirectoryScoped()
+        const file = path.join(tmp, "data.json")
+
+        yield* fs.writeJsonAtomic(file, { atomic: true }, 0o600)
+
+        const info = yield* Effect.promise(() => nodeFs.stat(file))
+        const entries = yield* Effect.promise(() => nodeFs.readdir(tmp))
+        expect(info.mode & 0o777).toBe(0o600)
+        expect(entries.filter((entry) => /^data\.json\.\d+\..+\.tmp$/.test(entry))).toEqual([])
+      }),
+    )
+
     it(
       "round-trips JSON data",
       Effect.gen(function* () {

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -55,6 +55,11 @@ const layer = Layer.effect(
     const fsys = yield* FSUtil.Service
     const decode = Schema.decodeUnknownOption(Info)
 
+    const read = Effect.fn("Auth.read")(function* () {
+      const data = (yield* fsys.readJson(file).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>
+      return Record.filterMap(data, (value) => Result.fromOption(decode(value), () => undefined))
+    })
+
     const all = Effect.fn("Auth.all")(function* () {
       if (process.env.OPENCODE_AUTH_CONTENT) {
         try {
@@ -62,8 +67,7 @@ const layer = Layer.effect(
         } catch (err) {}
       }
 
-      const data = (yield* fsys.readJson(file).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>
-      return Record.filterMap(data, (value) => Result.fromOption(decode(value), () => undefined))
+      return yield* read()
     })
 
     const get = Effect.fn("Auth.get")(function* (providerID: string) {
@@ -72,7 +76,7 @@ const layer = Layer.effect(
 
     const set = Effect.fn("Auth.set")(function* (key: string, info: Info) {
       const norm = key.replace(/\/+$/, "")
-      const data = yield* all()
+      const data = yield* read()
       if (norm !== key) delete data[key]
       delete data[norm + "/"]
       yield* fsys
@@ -82,7 +86,7 @@ const layer = Layer.effect(
 
     const remove = Effect.fn("Auth.remove")(function* (key: string) {
       const norm = key.replace(/\/+$/, "")
-      const data = yield* all()
+      const data = yield* read()
       delete data[key]
       delete data[norm]
       yield* fsys.writeJson(file, data, 0o600).pipe(Effect.mapError(fail("Failed to write auth data")))

--- a/packages/opencode/src/auth/index.ts
+++ b/packages/opencode/src/auth/index.ts
@@ -4,6 +4,7 @@ import { Effect, Layer, Record, Result, Schema, Context } from "effect"
 import { NonNegativeInt } from "@opencode-ai/core/schema"
 import { Global } from "@opencode-ai/core/global"
 import { FSUtil } from "@opencode-ai/core/fs-util"
+import { EffectFlock } from "@opencode-ai/core/util/effect-flock"
 
 export const OAUTH_DUMMY_KEY = "opencode-oauth-dummy-key"
 
@@ -53,7 +54,9 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fsys = yield* FSUtil.Service
+    const flock = yield* EffectFlock.Service
     const decode = Schema.decodeUnknownOption(Info)
+    const lockKey = "auth"
 
     const read = Effect.fn("Auth.read")(function* () {
       const data = (yield* fsys.readJson(file).pipe(Effect.orElseSucceed(() => ({})))) as Record<string, unknown>
@@ -76,26 +79,28 @@ const layer = Layer.effect(
 
     const set = Effect.fn("Auth.set")(function* (key: string, info: Info) {
       const norm = key.replace(/\/+$/, "")
-      const data = yield* read()
-      if (norm !== key) delete data[key]
-      delete data[norm + "/"]
-      yield* fsys
-        .writeJson(file, { ...data, [norm]: info }, 0o600)
-        .pipe(Effect.mapError(fail("Failed to write auth data")))
+      yield* Effect.gen(function* () {
+        const data = yield* read()
+        if (norm !== key) delete data[key]
+        delete data[norm + "/"]
+        yield* fsys.writeJsonAtomic(file, { ...data, [norm]: info }, 0o600)
+      }).pipe(flock.withLock(lockKey), Effect.mapError(fail("Failed to write auth data")))
     })
 
     const remove = Effect.fn("Auth.remove")(function* (key: string) {
       const norm = key.replace(/\/+$/, "")
-      const data = yield* read()
-      delete data[key]
-      delete data[norm]
-      yield* fsys.writeJson(file, data, 0o600).pipe(Effect.mapError(fail("Failed to write auth data")))
+      yield* Effect.gen(function* () {
+        const data = yield* read()
+        delete data[key]
+        delete data[norm]
+        yield* fsys.writeJsonAtomic(file, data, 0o600)
+      }).pipe(flock.withLock(lockKey), Effect.mapError(fail("Failed to write auth data")))
     })
 
     return Service.of({ get, all, set, remove })
   }),
 )
 
-export const node = LayerNode.make({ service: Service, layer: layer, deps: [FSUtil.node] })
+export const node = LayerNode.make({ service: Service, layer: layer, deps: [FSUtil.node, EffectFlock.node] })
 
 export * as Auth from "."

--- a/packages/opencode/test/auth/auth.test.ts
+++ b/packages/opencode/test/auth/auth.test.ts
@@ -47,6 +47,44 @@ describe("Auth", () => {
     }),
   )
 
+  it.instance("preserves both providers from concurrent writes", () =>
+    Effect.gen(function* () {
+      const auth = yield* Auth.Service
+      const file = path.join(Global.Path.data, "auth.json")
+
+      yield* Effect.promise(() => fs.writeFile(file, JSON.stringify({ existing: { type: "api", key: "sk-existing" } })))
+      yield* Effect.all(
+        [
+          auth.set("concurrent-a", { type: "api", key: "sk-a" }),
+          auth.set("concurrent-b", { type: "api", key: "sk-b" }),
+        ],
+        { concurrency: "unbounded" },
+      )
+
+      const onDisk = JSON.parse(yield* Effect.promise(() => fs.readFile(file, "utf8"))) as Record<string, unknown>
+      expect(onDisk.existing).toEqual({ type: "api", key: "sk-existing" })
+      expect(onDisk["concurrent-a"]).toEqual({ type: "api", key: "sk-a" })
+      expect(onDisk["concurrent-b"]).toEqual({ type: "api", key: "sk-b" })
+    }),
+  )
+
+  it.instance("writes auth.json atomically with mode 0600 and no temporary file", () =>
+    Effect.gen(function* () {
+      const auth = yield* Auth.Service
+      const file = path.join(Global.Path.data, "auth.json")
+      const before = yield* Effect.promise(() => fs.readdir(Global.Path.data))
+
+      yield* auth.set("atomic-provider", { type: "api", key: "sk-atomic" })
+
+      const stats = yield* Effect.promise(() => fs.stat(file))
+      const after = yield* Effect.promise(() => fs.readdir(Global.Path.data))
+      expect(stats.mode & 0o777).toBe(0o600)
+      expect(after.filter((entry) => /^auth\.json\.\d+\..+\.tmp$/.test(entry))).toEqual(
+        before.filter((entry) => /^auth\.json\.\d+\..+\.tmp$/.test(entry)),
+      )
+    }),
+  )
+
   it.instance("set cleans up pre-existing trailing-slash entry", () =>
     Effect.gen(function* () {
       const auth = yield* Auth.Service

--- a/packages/opencode/test/auth/auth.test.ts
+++ b/packages/opencode/test/auth/auth.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Global } from "@opencode-ai/core/global"
 import { Effect } from "effect"
 import { Auth } from "../../src/auth"
 import { testEffect } from "../lib/effect"
@@ -18,6 +21,29 @@ describe("Auth", () => {
       const data = yield* auth.all()
       expect(data["https://example.com"]).toBeDefined()
       expect(data["https://example.com/"]).toBeUndefined()
+    }),
+  )
+
+  it.instance("set reads the file instead of persisting the auth env snapshot", () =>
+    Effect.gen(function* () {
+      const auth = yield* Auth.Service
+      const file = path.join(Global.Path.data, "auth.json")
+      const previous = process.env.OPENCODE_AUTH_CONTENT
+      const omitted = "omitted-provider"
+
+      try {
+        yield* Effect.promise(() => fs.writeFile(file, JSON.stringify({ [omitted]: { type: "api", key: "sk-omitted" } })))
+        process.env.OPENCODE_AUTH_CONTENT = JSON.stringify({ "snapshot-provider": { type: "api", key: "sk-snapshot" } })
+
+        yield* auth.set("written-provider", { type: "api", key: "sk-written" })
+
+        const onDisk = JSON.parse(yield* Effect.promise(() => fs.readFile(file, "utf8"))) as Record<string, unknown>
+        expect(onDisk[omitted]).toEqual({ type: "api", key: "sk-omitted" })
+        expect(onDisk["written-provider"]).toEqual({ type: "api", key: "sk-written" })
+      } finally {
+        if (previous === undefined) delete process.env.OPENCODE_AUTH_CONTENT
+        else process.env.OPENCODE_AUTH_CONTENT = previous
+      }
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Fixes #46128

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes two ways `auth.json` can lose credentials. Two commits, one per defect, independently reviewable.

**`2380af8adb` — stop auth writes from persisting the env snapshot.**

`Auth.all` short-circuits to `OPENCODE_AUTH_CONTENT` and never reads the file. `set` and `remove` both started from `all()`, so with that variable set they read the env snapshot and wrote *it* to disk — erasing anything added to `auth.json` after the snapshot was taken.

That is reachable in normal use: `control-plane/workspace.ts` spawns workspace children with `OPENCODE_AUTH_CONTENT: JSON.stringify(yield* auth.all())`, so an `auth login` or an HTTP auth-set inside a child rewrote the host's file from the child's stale copy.

`set`/`remove` now read through a file-only `read()`. `all()` and `get()` are unchanged — the env override still wins on reads, which workspace credential propagation depends on.

**`3894ab2f20` — write atomically under a lock.**

`set`/`remove` read the whole file, mutate one key, and rewrite it through `FSUtil.writeJson`, which is `writeFileString` + `chmod` — no temp+rename, no lock. Two consequences: concurrent writers to *different* providers lose one, and a crash mid-write truncates the whole credential file.

The read-modify-write now runs under `EffectFlock.withLock("auth")`, and the write goes through a new `FSUtil.writeJsonAtomic` (temp file + rename). `EffectFlock` is the existing cross-process lock (`mkdir(2)` atomic-create in the shared state dir, with stale detection and heartbeat) — an in-process mutex would not have fixed this, since the racing writers are separate processes. `FSUtil.writeJson` is untouched for its other callers.

This is the pattern already used elsewhere in the repo for weaker data. `McpAuth` wraps its `mcp-auth.json` read-modify-write in the same flock, and the TUI's scratch key-value store (`context/kv.tsx`) is both locked and atomic via `writeJsonAtomic`. The provider credential store was the one with neither.

The temp file is created with `{ flag: "wx", mode }`, so `0600` is applied by `open(2)` at create rather than by a later `chmod` — no window where credentials are world-readable, and `O_EXCL` means a pre-planted symlink fails the write instead of redirecting it.

### How did you verify your code works?

- `packages/opencode` auth suite: 7 pass / 0 fail; `packages/core` filesystem suite: 28 pass / 0 fail; full `packages/opencode` suite 3398 pass / 0 fail
- `bun typecheck` clean in `packages/opencode` and `packages/core`
- Each new test was checked against a revert of its own fix. Removing only `flock.withLock` — keeping the atomic write and the file-only read — reddens exactly `preserves both providers from concurrent writes` (6 pass / 1 fail), so the lock is load-bearing rather than incidentally covered.
- Concurrency is exercised with real interleaving: two `Auth.set` calls under `Effect.all(..., { concurrency: "unbounded" })`, where the async file read is the yield point that makes the race real.

### Known limitation

If a process is SIGKILLed between the write and the rename, a `.tmp` file holding credentials is left behind. It is created `0600`, so it is not world-readable, and `Effect.ensuring` removes it on any normal failure. A startup sweep for stale temps is deliberately not included here — a naive sweep could delete another live process's in-flight temp, so it wants its own design.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR