### PR TITLE
fix(session): resume loop when user message arrives during question prompt

### DIFF
--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -2,7 +2,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { Image } from "@/image/image"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
-import { Cause, Deferred, Effect, Exit, Layer, Context, Scope, Schema } from "effect"
+import { Cause, Deferred, Effect, Exit, Layer, Context, Option, Scope, Schema } from "effect"
 import * as Stream from "effect/Stream"
 import { Agent } from "@/agent/agent"
 import { Config } from "@/config/config"
@@ -197,8 +197,16 @@ const layer = Layer.effect(
             time: { start: match.part.state.time.start, end: Date.now() },
           },
         })
-        if (error instanceof PermissionV1.RejectedError || error instanceof Question.RejectedError) {
+        if (error instanceof PermissionV1.RejectedError) {
           ctx.blocked = ctx.shouldBreak
+        }
+        if (error instanceof Question.RejectedError) {
+          const latestUser = yield* session
+            .findMessage(ctx.sessionID, (message) => message.info.role === "user")
+            .pipe(Effect.orDie)
+          ctx.blocked =
+            ctx.shouldBreak &&
+            (Option.isNone(latestUser) || latestUser.value.info.id === ctx.assistantMessage.parentID)
         }
         yield* settleToolCall(toolCallID)
         return true

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -56,6 +56,7 @@ import { SessionTable } from "@opencode-ai/core/session/sql"
 import { SessionReminders } from "./reminders"
 import { SessionTools } from "./tools"
 import { LLMEvent } from "@opencode-ai/llm"
+import { Question } from "@/question"
 
 // @ts-ignore
 globalThis.AI_SDK_LOG_WARNINGS = false
@@ -140,6 +141,7 @@ const layer = Layer.effect(
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
     const database = yield* Database.Service
+    const question = yield* Question.Service
     const { db } = database
     const ops = Effect.fn("SessionPrompt.ops")(function* () {
       return {
@@ -1057,6 +1059,12 @@ const layer = Layer.effect(
       const message = yield* createUserMessage(input)
       yield* sessions.touch(input.sessionID)
 
+      yield* Effect.forEach(
+        (yield* question.list()).filter((item) => item.sessionID === input.sessionID),
+        (item) => question.reject(item.id).pipe(Effect.ignore),
+        { concurrency: "unbounded", discard: true },
+      )
+
       const permissions: PermissionV1.Rule[] = []
       for (const [t, enabled] of Object.entries(input.tools ?? {})) {
         permissions.push({ permission: t, action: enabled ? "allow" : "deny", pattern: "*" })
@@ -1625,6 +1633,7 @@ export const node = LayerNode.make({
     EventV2Bridge.node,
     RuntimeFlags.node,
     Database.node,
+    Question.node,
   ],
 })
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -1496,6 +1496,73 @@ it.instance("prompt submitted during an active run is included in the next LLM i
   }),
 )
 
+it.instance("prompt submitted while question tool is pending resumes the loop", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const question = yield* Question.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    const secondID = MessageID.ascending()
+
+    yield* llm.tool("question", {
+      questions: [
+        {
+          question: "Should I continue?",
+          header: "Continue",
+          options: [
+            { label: "Yes", description: "Continue working" },
+            { label: "No", description: "Stop working" },
+          ],
+        },
+      ],
+    })
+    yield* llm.text("continued")
+
+    const first = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "start" }],
+      })
+      .pipe(Effect.forkChild)
+
+    yield* pollWithTimeout(
+      question.list().pipe(Effect.map((items) => (items.some((item) => item.sessionID === chat.id) ? true : undefined))),
+      "timed out waiting for question",
+    )
+
+    const second = yield* prompt
+      .prompt({
+        sessionID: chat.id,
+        messageID: secondID,
+        agent: "build",
+        model: ref,
+        parts: [{ type: "text", text: "So?" }],
+      })
+      .pipe(Effect.forkChild)
+
+    yield* awaitWithTimeout(llm.wait(2), "timed out waiting for loop to resume", "2 seconds")
+    const [firstExit, secondExit] = yield* Effect.all([Fiber.await(first), Fiber.await(second)])
+    expect(Exit.isSuccess(firstExit)).toBe(true)
+    expect(Exit.isSuccess(secondExit)).toBe(true)
+
+    const msgs = yield* sessions.messages({ sessionID: chat.id })
+    const last = msgs.findLast((msg) => msg.info.role === "assistant")
+    expect(last?.info.role).toBe("assistant")
+    if (!last || last.info.role !== "assistant") throw new Error("expected resumed assistant")
+    expect(last.info.parentID).toBe(secondID)
+    expect(last.parts.some((part) => part.type === "text" && part.text === "continued")).toBe(true)
+    const questionTool = msgs
+      .flatMap((msg) => msg.parts)
+      .find((part): part is SessionV1.ToolPart => part.type === "tool" && part.tool === "question")
+    expect(questionTool?.state.status).toBe("error")
+    expect(JSON.stringify((yield* llm.inputs).at(-1)?.messages)).toContain("So?")
+    expect(yield* question.list()).toEqual([])
+  }),
+)
+
 it.instance("assertNotBusy fails with BusyError when loop running", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Closes #46135

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Repro: run the agent until it blocks on an interactive `question` tool prompt, then submit a new message instead of answering inline. The message gets persisted, but the session never resumes — the engine just hangs with no error.

Root cause: the `question` tool parks the session run inside `Question.ask()` on a pending deferred. A new prompt is persisted before the loop is invoked, but because the session is already running the fresh `runLoop` work is ignored — so the existing run stays stuck in the question wait forever, and nothing ever consumes the new message. No `step-finish`, no abort, no error event.

Fix: when a fresh prompt is persisted, reject any pending questions for that session. The processor's `Question.RejectedError` handler then checks whether a newer user message exists; if one does, the loop is allowed to continue — the tool settles, history reloads, and the queued message is processed as the next turn. Dismissing the prompt without a newer message still stops the run, same as before.

### How did you verify your code works?

Added a regression test: submit a prompt while a `question` tool is pending, then submit a second prompt. It asserts both prompt fibers complete, the second user message reaches the next LLM input, the question tool settles to an error state, and the pending-question list drains. Before the fix it hung with "timed out waiting for loop to resume"; after the fix it passes (~3s).

Typecheck (`tsgo --noEmit`) is clean. I also ran the full package suite: 3353 pass, 43 fail — the failures are pre-existing environment issues on this machine (subprocess tests can't find bare `bun` on PATH; a host-umask assertion expects 0644 vs 0664), unrelated to this change.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
