### PR TITLE
fix(snapshot): add --ignore-errors to git add in stage to prevent transient missing file failures

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -146,7 +146,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
         const stage = Effect.fnUntraced(function* (files: string[]) {
           if (!files.length) return
           const result = yield* git(
-            [...cfg, ...args(["add", "--all", "--sparse", "--pathspec-from-file=-", "--pathspec-file-nul"])],
+            [...cfg, ...args(["add", "--all", "--sparse", "--ignore-errors", "--pathspec-from-file=-", "--pathspec-file-nul"])],
             {
               cwd: state.worktree,
               stdin: encodeTopLevelLiteralPathspecs(files),


### PR DESCRIPTION
### Issue for this PR

Closes #46138

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When external processes (such as Docker containers, database servers, or build tools) create and delete temporary files in the repository workspace while OpenCode's snapshot engine is running, a transient file can disappear between the candidate list discovery (`ls-files` / `diff-files`) and the staging step (`git add`).

Without `--ignore-errors`, `git add` fails with exit code 128 (`fatal: pathspec did not match any files`), which causes snapshot staging to fail completely.

Adding `--ignore-errors` to the `git add` invocation in `Snapshot.stage()` allows git to skip transient missing files during snapshot staging rather than failing the entire snapshot operation.

### How did you verify your code works?

- Verified git flag compatibility (`git add --ignore-errors`).
- Verified snapshot staging completes without error when transient files are deleted between candidate discovery and staging.
- Ran snapshot test suite.

### Screenshots / recordings

_N/A (backend snapshot service change, no UI changes)_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
