### PR TITLE
fix(core): report missing glob and grep search paths

### DIFF
--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -75,9 +75,13 @@ const layer = Layer.effectDiscard(
                 source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },
               })
               const cwd = path.resolve(location.directory, input.path ?? ".")
-              const info = yield* fs.stat(cwd).pipe(Effect.catch(() => Effect.succeed(undefined)))
-              if (info === undefined)
-                return yield* new ToolFailure({ message: `Search path does not exist: ${input.path ?? "."}` })
+              yield* fs
+                .stat(cwd)
+                .pipe(
+                  Effect.catchReason("PlatformError", "NotFound", () =>
+                    Effect.fail(new ToolFailure({ message: `Search path does not exist: ${input.path ?? "."}` })),
+                  ),
+                )
               return yield* ripgrep
                 .glob({
                   cwd,

--- a/packages/core/src/tool/glob.ts
+++ b/packages/core/src/tool/glob.ts
@@ -5,6 +5,7 @@ import { Effect, Layer, Schema } from "effect"
 import path from "path"
 import { makeLocationNode } from "../effect/app-node"
 import { FileSystem } from "../filesystem"
+import { FSUtil } from "../fs-util"
 import { Location } from "../location"
 import { Ripgrep } from "../ripgrep"
 import { RelativePath } from "../schema"
@@ -38,6 +39,7 @@ export const toModelOutput = (output: ModelOutput) => {
 const layer = Layer.effectDiscard(
   Effect.gen(function* () {
     const tools = yield* Tools.Service
+    const fs = yield* FSUtil.Service
     const ripgrep = yield* Ripgrep.Service
     const location = yield* Location.Service
     const permission = yield* PermissionV2.Service
@@ -73,6 +75,9 @@ const layer = Layer.effectDiscard(
                 source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },
               })
               const cwd = path.resolve(location.directory, input.path ?? ".")
+              const info = yield* fs.stat(cwd).pipe(Effect.catch(() => Effect.succeed(undefined)))
+              if (info === undefined)
+                return yield* new ToolFailure({ message: `Search path does not exist: ${input.path ?? "."}` })
               return yield* ripgrep
                 .glob({
                   cwd,
@@ -90,7 +95,11 @@ const layer = Layer.effectDiscard(
                   ),
                 )
             }).pipe(
-              Effect.mapError(() => new ToolFailure({ message: `Unable to find files matching ${input.pattern}` })),
+              Effect.mapError((cause) =>
+                cause instanceof ToolFailure
+                  ? cause
+                  : new ToolFailure({ message: `Unable to find files matching ${input.pattern}` }),
+              ),
             ),
         }),
       })
@@ -101,5 +110,5 @@ const layer = Layer.effectDiscard(
 export const node = makeLocationNode({
   name: "tool/glob",
   layer,
-  deps: [ToolRegistry.node, Ripgrep.node, Location.node, PermissionV2.node],
+  deps: [ToolRegistry.node, FSUtil.node, Ripgrep.node, Location.node, PermissionV2.node],
 })

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -93,9 +93,13 @@ const layer = Layer.effectDiscard(
                 source: { type: "tool", messageID: context.assistantMessageID, callID: context.toolCallID },
               })
               const target = path.resolve(location.directory, input.path ?? ".")
-              const info = yield* fs.stat(target).pipe(Effect.catch(() => Effect.succeed(undefined)))
-              if (info === undefined)
-                return yield* new ToolFailure({ message: `Search path does not exist: ${input.path ?? "."}` })
+              const info = yield* fs
+                .stat(target)
+                .pipe(
+                  Effect.catchReason("PlatformError", "NotFound", () =>
+                    Effect.fail(new ToolFailure({ message: `Search path does not exist: ${input.path ?? "."}` })),
+                  ),
+                )
               return yield* ripgrep
                 .grep({
                   cwd: info?.type === "Directory" ? target : path.dirname(target),

--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -94,6 +94,8 @@ const layer = Layer.effectDiscard(
               })
               const target = path.resolve(location.directory, input.path ?? ".")
               const info = yield* fs.stat(target).pipe(Effect.catch(() => Effect.succeed(undefined)))
+              if (info === undefined)
+                return yield* new ToolFailure({ message: `Search path does not exist: ${input.path ?? "."}` })
               return yield* ripgrep
                 .grep({
                   cwd: info?.type === "Directory" ? target : path.dirname(target),
@@ -123,7 +125,13 @@ const layer = Layer.effectDiscard(
                     ),
                   ),
                 )
-            }).pipe(Effect.mapError(() => new ToolFailure({ message: `Unable to grep for ${input.pattern}` }))),
+            }).pipe(
+              Effect.mapError((cause) =>
+                cause instanceof ToolFailure
+                  ? cause
+                  : new ToolFailure({ message: `Unable to grep for ${input.pattern}` }),
+              ),
+            ),
         }),
       })
       .pipe(Effect.orDie)

--- a/packages/core/test/tool-search.test.ts
+++ b/packages/core/test/tool-search.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Effect, Layer } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Location } from "@opencode-ai/core/location"
+import { PermissionV2 } from "@opencode-ai/core/permission"
+import { SessionV2 } from "@opencode-ai/core/session"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { GrepTool } from "@opencode-ai/core/tool/grep"
+import { GlobTool } from "@opencode-ai/core/tool/glob"
+import { ToolRegistry } from "@opencode-ai/core/tool/registry"
+import { ToolOutputStore } from "@opencode-ai/core/tool-output-store"
+import { location } from "./fixture/location"
+import { tmpdir } from "./fixture/tmpdir"
+import { testEffect } from "./lib/effect"
+import { toolIdentity, executeTool, settleTool } from "./lib/tool"
+
+const sessionID = SessionV2.ID.make("ses_search_tool_test")
+const assertions: PermissionV2.AssertInput[] = []
+let allow = true
+const permission = Layer.succeed(
+  PermissionV2.Service,
+  PermissionV2.Service.of({
+    assert: (input) =>
+      Effect.sync(() => {
+        assertions.push(input)
+      }).pipe(Effect.andThen(allow ? Effect.void : Effect.fail(new PermissionV2.BlockedError({ rules: [] })))),
+    ask: () => Effect.die("unused"),
+    reply: () => Effect.die("unused"),
+    get: () => Effect.die("unused"),
+    forSession: () => Effect.die("unused"),
+    list: () => Effect.die("unused"),
+  }),
+)
+let locationDirectory: string | undefined
+const locationLayer = Layer.unwrap(
+  Effect.acquireRelease(
+    Effect.promise(() => tmpdir()),
+    (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+  ).pipe(
+    Effect.map((tmp) => {
+      locationDirectory = tmp.path
+      const ref = Location.Ref.make({ directory: AbsolutePath.make(tmp.path) })
+      return Layer.succeed(Location.Service, Location.Service.of(location(ref)))
+    }),
+  ),
+)
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([ToolRegistry.node, ToolRegistry.toolsNode, GlobTool.node, GrepTool.node]), [
+    [PermissionV2.node, permission],
+    [Location.node, locationLayer],
+    [ToolOutputStore.node, ToolOutputStore.nodeWithoutConfig],
+  ]),
+)
+
+const fixture = Effect.promise(async () => {
+  if (locationDirectory === undefined) throw new Error("location layer was not built before the test body")
+  await fs.mkdir(path.join(locationDirectory, "src"), { recursive: true })
+  await fs.writeFile(path.join(locationDirectory, "src", "haystack.ts"), "needle")
+})
+
+describe("GlobTool", () => {
+  beforeEach(() => {
+    assertions.length = 0
+    allow = true
+  })
+
+  it.effect("fails with a path-specific error when the search path does not exist", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+
+      expect(
+        yield* settleTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: {
+            type: "tool-call",
+            id: "call-glob-missing",
+            name: "glob",
+            input: { pattern: "**/*", path: "missing-dir" },
+          },
+        }),
+      ).toEqual({
+        result: { type: "error", value: "Search path does not exist: missing-dir" },
+      })
+    }),
+  )
+
+  it.live("finds files under an existing search path", () =>
+    Effect.gen(function* () {
+      yield* fixture
+      const registry = yield* ToolRegistry.Service
+
+      const result = yield* executeTool(registry, {
+        sessionID,
+        ...toolIdentity,
+        call: {
+          type: "tool-call",
+          id: "call-glob-src",
+          name: "glob",
+          input: { pattern: "**/*.ts", path: "src" },
+        },
+      })
+
+      expect(result).toEqual({
+        type: "text",
+        value: `${locationDirectory}/src/haystack.ts`,
+      })
+      expect(assertions).toMatchObject([{ action: "glob", resources: ["**/*.ts"], save: ["*"] }])
+    }),
+  )
+})
+
+describe("GrepTool", () => {
+  beforeEach(() => {
+    assertions.length = 0
+    allow = true
+  })
+
+  it.effect("fails with a path-specific error when the search path does not exist", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+
+      expect(
+        yield* settleTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: {
+            type: "tool-call",
+            id: "call-grep-missing",
+            name: "grep",
+            input: { pattern: "needle", path: "missing-dir" },
+          },
+        }),
+      ).toEqual({
+        result: { type: "error", value: "Search path does not exist: missing-dir" },
+      })
+    }),
+  )
+
+  it.effect("fails with a path-specific error when the path points at a missing file", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+
+      expect(
+        yield* settleTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: {
+            type: "tool-call",
+            id: "call-grep-missing-file",
+            name: "grep",
+            input: { pattern: "needle", path: "src/missing.ts" },
+          },
+        }),
+      ).toEqual({
+        result: { type: "error", value: "Search path does not exist: src/missing.ts" },
+      })
+    }),
+  )
+
+  it.live("searches file contents under an existing search path", () =>
+    Effect.gen(function* () {
+      yield* fixture
+      const registry = yield* ToolRegistry.Service
+
+      const result = yield* executeTool(registry, {
+        sessionID,
+        ...toolIdentity,
+        call: {
+          type: "tool-call",
+          id: "call-grep-src",
+          name: "grep",
+          input: { pattern: "needle", path: "src" },
+        },
+      })
+
+      expect(result).toEqual({
+        type: "text",
+        value: `Found 1 matches\n${locationDirectory}/src/haystack.ts:\n  Line 1: needle`,
+      })
+      expect(assertions).toMatchObject([{ action: "grep", resources: ["needle"], save: ["*"] }])
+    }),
+  )
+})


### PR DESCRIPTION
### Issue for this PR

Closes #45293

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When the `path` argument doesn't exist, the search tools fail silently or misleadingly:

- `grep` swallows the failed `stat` and searches the parent directory instead, so a stale or mistyped path (removed worktree, pruned cache dir) returns an empty result with no hint the path was wrong — this is #45293.
- `glob` passes the missing directory as ripgrep's `cwd`, the spawn dies with `ENOENT`, and the failure surfaces as a generic `Unable to find files matching ...` (a bare `ripgrep execution failed` in release builds) that looks like a ripgrep defect rather than a bad argument.

Both tools now stat the resolved path and fail with `Search path does not exist: <path>` when stat reports `NotFound`, restoring the behavior of #35337. The generic `mapError` wrappers pass `ToolFailure` through unchanged so the path-specific message actually reaches the model. Detection is narrowed to `NotFound` via `Effect.catchReason` (matching #35337 and the existing convention in `file-mutation.ts` / `fs-util.ts`), so a permission error is not misreported as a missing path. Symlink behavior is unchanged: stat still follows symlinks, and a broken symlink now reports the missing path instead of silently searching its parent.

History of the regression: reported in #35261, fixed in #35337 (merged 2026-07-04), the pre-check was dropped when the search tools were rewritten on the V2 node architecture, and the silent variant was re-reported as #45293.

Relationship to #45300: same problem, grep-only, still open. This PR also covers `glob`, keeps the `NotFound`-only narrowing from #35337, and adds happy-path controls. Happy to defer to whichever approach maintainers prefer.

### How did you verify your code works?

- `bun test tool-search` (packages/core) → 5/5 pass: missing dir for glob/grep, missing file for grep, plus two happy-path controls against a temp location
- `bun test tool-read ripgrep tool-question tool-edit` → 43 pass, 0 fail
- Full packages/core suite: failing set identical to a clean-checkout baseline except the three new tests now passing (remaining failures reproduce without this change)
- `tsgo --noEmit` → no new errors; `oxlint` on changed files → 0 warnings, 0 errors

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
