### PR TITLE
fix(core): fail directory listing on out-of-range offset

### DIFF
--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -61,6 +61,7 @@ export class PathKindError extends Schema.TaggedErrorClass<PathKindError>()("Rea
 }
 
 export type InspectError = FSUtil.Error | PathKindError
+export type ListError = FSUtil.Error | OffsetOutOfRangeError
 export type ReadError =
   | FSUtil.Error
   | BinaryFileError
@@ -97,7 +98,7 @@ export interface Interface {
     resource: string,
     page?: PageInput,
   ) => Effect.Effect<FileSystem.Content | TextPage, ReadError>
-  readonly list: (path: AbsolutePath, page?: PageInput) => Effect.Effect<ListPage, FSUtil.Error>
+  readonly list: (path: AbsolutePath, page?: PageInput) => Effect.Effect<ListPage, ListError>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ReadToolFileSystem") {}
@@ -347,6 +348,7 @@ export const list = Effect.fn("ReadTool.list")(function* (fs: FSUtil.Interface, 
     .filter((item): item is FileSystem.Entry => item !== undefined)
     .sort((a, b) => (a.type === b.type ? a.path.localeCompare(b.path) : a.type === "directory" ? -1 : 1))
   const selected = visible.slice(offset - 1, offset - 1 + limit)
+  if (selected.length === 0 && offset !== 1) return yield* Effect.fail(new OffsetOutOfRangeError({ offset }))
   const truncated = offset - 1 + selected.length < visible.length
   return new ListPage({ entries: selected, truncated, ...(truncated ? { next: offset + selected.length } : {}) })
 })

--- a/packages/core/src/tool/read.ts
+++ b/packages/core/src/tool/read.ts
@@ -96,6 +96,7 @@ const layer = Layer.effectDiscard(
                 const message =
                   error instanceof ReadToolFileSystem.BinaryFileError ||
                   error instanceof ReadToolFileSystem.MediaIngestLimitError ||
+                  error instanceof ReadToolFileSystem.OffsetOutOfRangeError ||
                   error instanceof Image.DecodeError ||
                   error instanceof Image.SizeError
                     ? error.message

--- a/packages/core/test/tool-read-filesystem.test.ts
+++ b/packages/core/test/tool-read-filesystem.test.ts
@@ -82,6 +82,29 @@ describe("ReadToolFileSystem", () => {
     }),
   )
 
+  it.effect("reports out-of-range directory pagination as a typed error", () =>
+    Effect.gen(function* () {
+      const { fs, files, directory } = yield* fixture
+      yield* files.writeFileString(path.join(directory, "a.txt"), "a")
+      yield* files.writeFileString(path.join(directory, "b.txt"), "b")
+
+      const error = yield* ReadToolFileSystem.list(fs, directory, { offset: 100 }).pipe(Effect.flip)
+
+      expect(error).toBeInstanceOf(ReadToolFileSystem.OffsetOutOfRangeError)
+      expect(error.message).toBe("Offset 100 is out of range")
+    }),
+  )
+
+  it.effect("returns an empty directory page at offset 1", () =>
+    Effect.gen(function* () {
+      const { fs, directory } = yield* fixture
+
+      const result = yield* ReadToolFileSystem.list(fs, directory, { offset: 1 })
+
+      expect(result).toMatchObject({ entries: [], truncated: false })
+    }),
+  )
+
   it.effect("stops reading after the requested page is complete", () =>
     Effect.gen(function* () {
       const { fs, files, directory } = yield* fixture

--- a/packages/core/test/tool-read.test.ts
+++ b/packages/core/test/tool-read.test.ts
@@ -511,6 +511,26 @@ describe("ReadTool", () => {
     }),
   )
 
+  it.effect("returns out-of-range offsets to the model", () =>
+    Effect.gen(function* () {
+      readFailure = new ReadToolFileSystem.OffsetOutOfRangeError({ offset: 100 })
+      const registry = yield* ToolRegistry.Service
+
+      expect(
+        yield* executeTool(registry, {
+          sessionID,
+          ...toolIdentity,
+          call: {
+            type: "tool-call",
+            id: "call-offset",
+            name: "read",
+            input: { path: "short.txt", offset: 100 },
+          },
+        }),
+      ).toEqual({ type: "error", value: "Offset 100 is out of range" })
+    }),
+  )
+
   it.effect("preserves unexpected filesystem defects", () =>
     Effect.gen(function* () {
       resolveFailure = new Error("unexpected")


### PR DESCRIPTION
### Issue for this PR

Closes #45928

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Directory `read` with an offset past the last entry returned `{ entries: [], truncated: false }`. That looks like a short/empty listing, so the model cannot tell the offset was wrong.

`list()` now fails with `OffsetOutOfRangeError` when the page is empty and offset is not 1, same as text-file pagination. Empty directories at offset 1 still succeed. The tool also forwards that error message to the model instead of a generic "Unable to read".

### How did you verify your code works?

Ran in `packages/core`:

- `bun test test/tool-read-filesystem.test.ts test/tool-read.test.ts`
- `bun typecheck`

Also covered: offset 100 on a small directory fails; offset 1 on an empty directory still returns an empty page.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR