### PR TITLE
fix(opencode): time out internal plugin init and config hooks; don't pin plugin version for 0.0.0-dev builds

### DIFF
--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -454,7 +454,10 @@ const layer = Layer.effect(
               add: [
                 {
                   name: "@opencode-ai/plugin",
-                  version: InstallationLocal ? undefined : InstallationVersion,
+                  version:
+                    InstallationLocal || InstallationVersion.startsWith("0.0.0-dev")
+                      ? undefined
+                      : InstallationVersion,
                 },
               ],
             })

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -167,15 +167,20 @@ const layer = Layer.effect(
           $: typeof Bun === "undefined" ? undefined : Bun.$,
         }
 
-        for (const plugin of flags.disableDefaultPlugins ? [] : internalPlugins(flags)) {
+        for (const [index, plugin] of (flags.disableDefaultPlugins ? [] : internalPlugins(flags)).entries()) {
+          const name = plugin.name || `internal-${index + 1}`
+          yield* Effect.logInfo("internal plugin init started", { plugin: name })
           const init = yield* Effect.tryPromise({
             try: () => plugin(input),
             catch: errorMessage,
           }).pipe(
-            Effect.tapError((error) => Effect.logError("failed to load internal plugin", { name: plugin.name, error })),
+            Effect.timeout("5 seconds"),
+            Effect.tapError((error) => Effect.logError("failed to load internal plugin", { plugin: name, error })),
             Effect.option,
           )
-          if (init._tag === "Some") hooks.push(init.value)
+          if (init._tag === "None") continue
+          hooks.push(init.value)
+          yield* Effect.logInfo("internal plugin init completed", { plugin: name })
         }
 
         const plugins = flags.pure ? [] : (cfg.plugin_origins ?? [])
@@ -242,12 +247,13 @@ const layer = Layer.effect(
         }
 
         // Notify plugins of current config
-        for (const hook of hooks) {
+        for (const [index, hook] of hooks.entries()) {
           yield* Effect.tryPromise({
             try: () => Promise.resolve((hook as any).config?.(cfg)),
             catch: errorMessage,
           }).pipe(
-            Effect.tapError((error) => Effect.logError("plugin config hook failed", { error })),
+            Effect.timeout("5 seconds"),
+            Effect.tapError((error) => Effect.logError("plugin config hook failed", { plugin: index + 1, error })),
             Effect.ignore,
           )
         }


### PR DESCRIPTION
### Issue for this PR

Closes #42002
Closes #46161

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two related plugin-init safety fixes in the opencode package, split into one commit each so they are reviewable on their own:

**Commit 1 — `fix(opencode): don't pin plugin version for 0.0.0-dev builds`** (`packages/opencode/src/config/config.ts`)

When the running opencode binary is a `0.0.0-dev` build, the install of `@opencode-ai/plugin` into each project config directory was pinned to that exact `0.0.0-dev.<commit>` version, which is unpublished and not resolvable from the npm registry. The previous code only skipped the pin when `InstallationLocal` was true, so a `bun run` against the dev build would fail to install the plugin at startup. The fix extends the existing guard to also skip the pin when `InstallationVersion.startsWith("0.0.0-dev")`. Issue #42002.

**Commit 2 — `fix(opencode): time out internal plugin init and config hooks`** (`packages/opencode/src/plugin/index.ts`)

`internalPlugins(flags)` and the per-hook `config?.(cfg)` notification were unbounded async calls. A misbehaving or hung plugin would block the entire plugin layer init forever (or, in the config hook case, silently hang the start-up sequence). This PR adds a 5-second `Effect.timeout` to both call sites, plus a stable per-plugin name (the plugin's own `name` if set, otherwise `internal-<index+1>`) and matching `logInfo` start/finish lines so the existing `logError` on timeout is actionable. The two changes are deliberately in one commit because they share the same debuggability story (a name to log against) and the same timeout scope (per-plugin init or per-hook call, not the layer).

Both changes are non-breaking: existing successful plugin inits are unchanged, and timeouts only fire on genuinely stuck plugins, which were already breaking the layer anyway.

### How did you verify your code works?

- Two commits, one file each:
  - `packages/opencode/src/config/config.ts` +4/-1
  - `packages/opencode/src/plugin/index.ts` +11/-5
- `bun typecheck` in `packages/opencode` passes (`tsgo --noEmit` exit 0) after `bun install` in the worktree, against `upstream/dev` head `dc4449df0d` plus both commits.
- Manually traced both call sites:
  - `config.ts`: `npmSvc.install(dir, { add: [...] })` is the only place that pins `@opencode-ai/plugin`; the new guard sits next to the existing `InstallationLocal` check.
  - `plugin/index.ts`: `plugin(input)` and `(hook as any).config?.(cfg)` are the only async plugin calls inside the layer; both previously had no timeout and only logged on rejection, not on hang.

### Screenshots / recordings

N/A — server-side fix, no UI change.

### Checklist

- [x] I have tested my changes locally
  - `bun typecheck` in `packages/opencode` passes (`tsgo --noEmit` exit 0) after `bun install` in the worktree, against `upstream/dev` head `dc4449df0d` plus both commits.
- [x] I have not included unrelated changes in this PR
