### PR TITLE
feat(provider): add none variant that disables thinking for DeepSeek V4

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1655,10 +1655,15 @@ export function reasoningVariants(model: ModelsDev.Model, target: Provider.Model
   if (options === undefined) return
   if (options.length === 0) return {}
 
-  const effort = options.find((option) => option.type === "effort")
-  if (effort) return effortVariants(target, effort.values)
-
   const toggle = options.some((option) => option.type === "toggle")
+  const effort = options.find((option) => option.type === "effort")
+  if (effort) {
+    // A model can declare both a toggle and effort values. Effort values cannot
+    // express "off", so keep the toggle's none variant rather than dropping it.
+    const off = toggle ? reasoningToggle(target).none : undefined
+    return { ...(off ? { none: off } : {}), ...effortVariants(target, effort.values) }
+  }
+
   const budget = options.find((option) => option.type === "budget_tokens")
   if (!budget) return toggle ? nonEmptyVariants(reasoningToggle(target)) : undefined
 
@@ -1712,6 +1717,15 @@ function reasoningToggle(model: Provider.Model): NonNullable<Provider.Model["var
       none: { thinking: { type: "disabled" } },
       high: { thinking: { type: "enabled" } },
     }
+  // Turning DeepSeek V4 thinking off is provider specific, so it is scoped the same
+  // way topP() scopes these models rather than matched on the model id alone.
+  if (model.api.npm === "@ai-sdk/openai-compatible" && model.api.id.toLowerCase().includes("deepseek-v4")) {
+    // api.deepseek.com uses thinking.type and rejects a "none" effort.
+    // https://api-docs.deepseek.com/guides/thinking_mode
+    if (model.providerID === "deepseek") return { none: { thinking: { type: "disabled" } } }
+    // zen accepts reasoning_effort "none" and ignores thinking entirely.
+    if (model.providerID.startsWith("opencode")) return { none: { reasoningEffort: "none" } }
+  }
   return {}
 }
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3448,10 +3448,10 @@ describe("ProviderTransform sampling defaults - DeepSeek", () => {
 
 describe("ProviderTransform.reasoningVariants", () => {
   const model = (reasoning_options: ModelsDev.Model["reasoning_options"]) => ({ reasoning_options }) as ModelsDev.Model
-  const target = (npm: string, id = "test-model") =>
+  const target = (npm: string, id = "test-model", providerID = "test") =>
     ({
       id,
-      providerID: "test",
+      providerID,
       api: { id, npm, url: "" },
       capabilities: { reasoning: true },
       limit: { output: 64_000 },
@@ -3772,6 +3772,56 @@ describe("ProviderTransform.reasoningVariants", () => {
       )
     },
   )
+
+  test("keeps the thinking toggle as a none variant when effort values are also declared", () => {
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "toggle" }, { type: "effort", values: ["low", "high", "max"] }]),
+        target("@ai-sdk/openai-compatible", "deepseek-v4-flash", "deepseek"),
+      ),
+    ).toEqual({
+      none: { thinking: { type: "disabled" } },
+      low: { reasoningEffort: "low" },
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+  })
+
+  test("disables deepseek thinking through reasoning effort on zen", () => {
+    // zen accepts reasoning_effort "none" and ignores thinking; api.deepseek.com
+    // is the other way round, so the payload follows the provider.
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "toggle" }, { type: "effort", values: ["low", "high", "max"] }]),
+        target("@ai-sdk/openai-compatible", "deepseek-v4-flash", "opencode"),
+      ),
+    ).toEqual({
+      none: { reasoningEffort: "none" },
+      low: { reasoningEffort: "low" },
+      high: { reasoningEffort: "high" },
+      max: { reasoningEffort: "max" },
+    })
+  })
+
+  test("only offers the deepseek toggle on providers known to support it", () => {
+    // 30 other providers resell deepseek over openai-compatible and may not
+    // accept either switch, so matching on the model id alone is too broad.
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "toggle" }, { type: "effort", values: ["high"] }]),
+        target("@ai-sdk/openai-compatible", "deepseek/deepseek-v4-flash", "novita-ai"),
+      ),
+    ).toEqual({ high: { reasoningEffort: "high" } })
+  })
+
+  test("does not add a none variant for openai-compatible models that are not deepseek", () => {
+    expect(
+      ProviderTransform.reasoningVariants(
+        model([{ type: "toggle" }, { type: "effort", values: ["high"] }]),
+        target("@ai-sdk/openai-compatible", "some-other-model"),
+      ),
+    ).toEqual({ high: { reasoningEffort: "high" } })
+  })
 })
 
 describe("ProviderTransform.variants", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #46178

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`reasoningVariants` returns as soon as it finds an effort entry, so for any model that declares both a toggle and effort values the toggle is silently dropped. models.dev declares both for `deepseek-v4-*`, so `--variant none` was accepted but did nothing — the model still returned reasoning. That early return is also non-undefined, so the `reasoningVariants(model, base) ?? variants(base)` fallback at `provider.ts:1310` never runs for these models either.

This keeps the toggle's `none` variant alongside the effort variants, and sends the switch each provider actually honours. Zen ignores `thinking` (even `thinking: "nonsense"` returns 200) but accepts `reasoning_effort: "none"`; api.deepseek.com is the reverse — its docs disable thinking with `{"thinking": {"type": "disabled"}}` and list `reasoning_effort` as `low|high|max` only.

The effort branch deliberately returns a plain object rather than going through `nonEmptyVariants`, because the existing "does not replace unsupported effort options with heuristic variants" test relies on `{}` being returned to block the fallback. Scoping follows `topP()` at `transform.ts:555` rather than matching on model id, since around 30 other providers resell these models over openai-compatible and may accept neither switch.

### How did you verify your code works?

Ran `opencode run --model opencode/deepseek-v4-flash --variant none --format json --thinking -- "What is 17*23? Answer with just the number."` against this branch and against unpatched `dev`.

Before: a `{"type":"reasoning","part":{"text":"The user is asking for the product of 17 and 23. Let me calculate: 17 * 23 = 391."}}` part is still emitted. After: no reasoning part is emitted. Control on the patched build with the default variant still emits one, so the variant is what changes the behaviour.

I could not exercise api.deepseek.com directly — that account has no balance — so the official-provider payload comes from https://api-docs.deepseek.com/guides/thinking_mode rather than a live response.

Tests: `bun test test/provider/transform.test.ts` 429 pass (3 new), `bun test test/provider/provider.test.ts` 102 pass, `bun typecheck` clean, all from `packages/opencode`.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
