### PR TITLE
fix(core): keep healthy well-known origins when one is unreachable

### DIFF
--- a/packages/core/src/wellknown.ts
+++ b/packages/core/src/wellknown.ts
@@ -111,15 +111,25 @@ const layer = Layer.effect(
       return { origin, integrationID: Integration.ID.make(origin), manifest }
     })
 
-    const load = Effect.fn("WellKnown.load")(function* () {
-      const value = yield* kv.get(sourcesKey)
-      const origins = Schema.is(Sources)(value) ? value : []
-      const current = yield* Ref.get(cache)
+    const loadEntries = Effect.fn("WellKnown.loadEntries")(function* (origins: readonly string[], reuse: boolean) {
+      const current = Ref.getUnsafe(cache)
       const entries = yield* Effect.forEach(origins, (origin) => {
         const cached = current.get(origin)
-        if (cached) return Effect.succeed(cached)
-        return loadEntry(origin)
+        if (cached && reuse) return Effect.succeed(cached)
+        // An unreachable origin keeps its last known manifest, or is skipped when nothing is
+        // cached. One torn-down deployment must not hide every other origin's integrations.
+        return loadEntry(origin).pipe(
+          Effect.catch((error) =>
+            Effect.logWarning("failed to load wellknown manifest", { origin, error }).pipe(Effect.as(cached)),
+          ),
+        )
       })
+      return entries.filter((entry): entry is Entry => entry !== undefined)
+    })
+
+    const load = Effect.fn("WellKnown.load")(function* () {
+      const value = yield* kv.get(sourcesKey)
+      const entries = yield* loadEntries(Schema.is(Sources)(value) ? value : [], true)
       yield* Ref.set(cache, new Map(entries.map((entry) => [entry.origin, entry])))
       return entries
     })
@@ -129,7 +139,7 @@ const layer = Layer.effect(
         const value = yield* kv.get(sourcesKey)
         const origins = Schema.is(Sources)(value) ? value : []
         if (!origins.length) return false
-        const entries = yield* Effect.forEach(origins, loadEntry)
+        const entries = yield* loadEntries(origins, false)
         const next = new Map(entries.map((entry) => [entry.origin, entry]))
         const changed = !isDeepStrictEqual(Ref.getUnsafe(cache), next)
         if (!changed) return false

--- a/packages/core/src/wellknown/plugin.ts
+++ b/packages/core/src/wellknown/plugin.ts
@@ -10,7 +10,11 @@ export const Plugin = define({
   effect: Effect.fn(function* (ctx) {
     const bus = yield* Bus.Service
     const wellknown = yield* WellKnown.Service
-    yield* wellknown.entries().pipe(Effect.orDie)
+    // Priming the cache is best effort. Failing here would abort the plugin before it registers
+    // its transform, permanently hiding every well-known integration until the next restart.
+    yield* wellknown
+      .entries()
+      .pipe(Effect.catch((error) => Effect.logWarning("failed to load wellknown entries", { error })))
     yield* ctx.integration.transform((draft) => {
       wellknown.snapshot().forEach((entry) => {
         if (!entry.manifest.auth) return

--- a/packages/core/test/wellknown.test.ts
+++ b/packages/core/test/wellknown.test.ts
@@ -117,3 +117,40 @@ serviceIt.live("refreshes changed manifests", () =>
     ({ server }) => Effect.promise(() => server.stop(true)),
   ),
 )
+
+serviceIt.live("keeps healthy origins when another is unreachable", () =>
+  Effect.acquireUseRelease(
+    Effect.sync(() =>
+      Bun.serve({
+        port: 0,
+        fetch: () => Response.json({ auth: { command: ["login"], env: "TOKEN" } }),
+      }),
+    ),
+    (server) =>
+      Effect.gen(function* () {
+        const wellknown = yield* WellKnown.Service
+        const kv = yield* KV.Service
+        // Port 1 is closed, standing in for a torn-down deployment still listed in sources.
+        yield* kv.set("wellknown:sources", ["http://127.0.0.1:1", server.url.origin])
+
+        expect((yield* wellknown.entries()).map((entry) => entry.origin)).toEqual([server.url.origin])
+        expect(wellknown.snapshot().map((entry) => entry.origin)).toEqual([server.url.origin])
+      }),
+    (server) => Effect.promise(() => server.stop(true)),
+  ),
+)
+
+serviceIt.live("keeps the last manifest when an origin becomes unreachable", () =>
+  Effect.gen(function* () {
+    const server = Bun.serve({ port: 0, fetch: () => Response.json({ auth: { command: ["login"], env: "TOKEN" } }) })
+    const wellknown = yield* WellKnown.Service
+    const kv = yield* KV.Service
+    yield* kv.set("wellknown:sources", [server.url.origin])
+    yield* wellknown.entries()
+    yield* Effect.promise(() => server.stop(true))
+
+    // A temporary outage must not drop the integration and its remote config mid-session.
+    expect(yield* wellknown.refresh()).toBe(false)
+    expect(wellknown.snapshot().map((entry) => entry.origin)).toEqual([server.url.origin])
+  }),
+)


### PR DESCRIPTION
### Issue for this PR

Closes #46187

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`WellKnown.load()` resolved origins with a fail-fast `Effect.forEach`, so one unreachable origin failed the whole batch. The wellknown plugin called it through `Effect.orDie`, so that failure killed the plugin before it registered its transform — and every well-known integration disappeared, not just the dead one. `Config.loadWellknown` catches the same failure and returns `[]`, so the remote config for the healthy origins went with it.

Each origin is now resolved independently. If one fails we keep its last known manifest, or skip it when nothing is cached. `refresh()` goes through the same path, so a temporary outage falls back to the cache and correctly reports "no change" instead of failing.

I also swapped the plugin's `orDie` for a logged catch. Worth noting it has to *catch and continue* — simply deleting `orDie` isn't enough, because `yield*` would still short-circuit before `ctx.integration.transform(...)` and the symptom would be unchanged.

The confusing part of the original bug is that `auth login <url>` prints "Authentication provider discovered" and then "Integration not found" for the same URL. Those come from different paths: `wellknown.add` only fetches the one origin you passed, so it genuinely succeeds, and the lookup afterwards reads a registry the dead plugin never populated.

It also only appears after a restart, since `load()` reuses the in-memory cache — which makes it look like whichever version you just installed broke it.

### How did you verify your code works?

Two tests in `packages/core/test/wellknown.test.ts`, both of which fail on `v2` and pass with this change (I checked by stashing the `src/` changes and re-running):

- a closed port listed alongside a live fixture server — `entries()` returns only the live origin
- an origin that goes away after being loaded — `refresh()` returns `false` and keeps the manifest

From `packages/core`: `bun run test test/wellknown.test.ts` (5 pass) and `bun run test test/config/config.test.ts` (35 pass), plus `bun typecheck`.

I also reproduced the original failure end-to-end with the installed `0.0.0-beta-18684` client against `packages/core/script/wellknown-server.ts`: adding an unresolvable origin to `wellknown:sources` makes `auth login` fail for a healthy origin, and removing it fixes it.

Not in this PR, but related: `WellKnown.remove()` exists and nothing reaches it — no route and no CLI — so `wellknown:sources` only ever grows and the only way out of this state today is editing SQLite by hand. Happy to follow up if you want that exposed.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
