### PR TITLE
fix(app): inset iOS PWA navigation below native chrome

### DIFF
--- a/packages/app/e2e/regression/pwa-navigation.spec.ts
+++ b/packages/app/e2e/regression/pwa-navigation.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+const directory = "C:/OpenCode/PwaNavigation"
+const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+
+// Browser smoke coverage only: native status-bar hit testing requires an installed iOS PWA.
+for (const viewport of [
+  { width: 390, height: 844 },
+  { width: 844, height: 390 },
+  { width: 1280, height: 800 },
+]) {
+  test.describe(`${viewport.width}x${viewport.height}`, () => {
+    test.use({ viewport, hasTouch: true })
+
+    test("keeps home and new-session navigation usable", async ({ page }) => {
+      await mockOpenCodeServer(page, {
+        directory,
+        project: {
+          id: "proj_pwa_navigation",
+          worktree: directory,
+          vcs: "git",
+          name: "pwa-navigation",
+          time: { created: 1700000000000, updated: 1700000000000 },
+          sandboxes: [],
+        },
+        provider: { all: [], connected: [], default: {} },
+        sessions: [],
+        pageMessages: () => ({ items: [] }),
+      })
+      await page.addInitScript(
+        ({ directory, server }) => {
+          localStorage.setItem(
+            "opencode.global.dat:server",
+            JSON.stringify({
+              projects: { [server]: [{ worktree: directory, expanded: true }] },
+              lastProject: { [server]: directory },
+            }),
+          )
+        },
+        { directory, server },
+      )
+
+      await page.goto("/")
+      await expect(page.locator('meta[name="apple-mobile-web-app-status-bar-style"]')).toHaveAttribute(
+        "content",
+        "default",
+      )
+      const titlebar = page.locator('[data-slot="titlebar-v2"]')
+      const home = titlebar.getByRole("button", { name: "Home", exact: true })
+      const create = titlebar.getByRole("button", { name: "New session", exact: true })
+      await expect(home).toHaveAttribute("aria-pressed", "true")
+      await expect(page.getByText("pwa-navigation", { exact: true })).toBeVisible()
+      await expect(create).toBeInViewport({ ratio: 1 })
+      await create.tap()
+      await expect(page).toHaveURL(/\/new-session\?draftId=.+/)
+      await expect(page.locator('[data-component="composer-editor"]')).toBeEditable()
+      await expect(home).toHaveAttribute("aria-pressed", "false")
+      await home.tap()
+      await expect(page).toHaveURL(/\/$/)
+      await expect(home).toHaveAttribute("aria-pressed", "true")
+    })
+  })
+}

--- a/packages/app/e2e/regression/pwa-navigation.spec.ts
+++ b/packages/app/e2e/regression/pwa-navigation.spec.ts
@@ -4,16 +4,44 @@ import { mockOpenCodeServer } from "../utils/mock-server"
 const directory = "C:/OpenCode/PwaNavigation"
 const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
 
-// Browser smoke coverage only: native status-bar hit testing requires an installed iOS PWA.
-for (const viewport of [
-  { width: 390, height: 844 },
-  { width: 844, height: 390 },
-  { width: 1280, height: 800 },
-]) {
-  test.describe(`${viewport.width}x${viewport.height}`, () => {
-    test.use({ viewport, hasTouch: true })
+const portrait = { width: 390, height: 844 }
+const empty = { top: 0, right: 0, bottom: 0, left: 0 }
 
-    test("keeps home and new-session navigation usable", async ({ page }) => {
+// Insets and iOS standalone are emulated; native status-bar rendering still needs a device check.
+for (const input of [
+  { name: "browser", viewport: portrait, insets: empty, ios: false, standalone: false },
+  { name: "desktop", viewport: { width: 1280, height: 800 }, insets: empty, ios: false, standalone: false },
+  { name: "Android PWA", viewport: portrait, insets: { ...empty, top: 24, bottom: 24 }, ios: false },
+  { name: "iOS PWA", viewport: portrait, insets: { ...empty, top: 47, bottom: 34 }, ios: true },
+  { name: "iOS zero inset", viewport: portrait, insets: empty, ios: true },
+  { name: "iOS Dynamic Island", viewport: portrait, insets: { ...empty, top: 59, bottom: 34 }, ios: true },
+  {
+    name: "iOS bottom navigation",
+    viewport: portrait,
+    insets: { ...empty, top: 47, bottom: 34 },
+    ios: true,
+    bottom: true,
+  },
+  {
+    name: "iOS landscape RTL",
+    viewport: { width: 844, height: 390 },
+    insets: { top: 0, right: 47, bottom: 21, left: 47 },
+    ios: true,
+    rtl: true,
+  },
+].map((input) => ({ standalone: true, bottom: false, rtl: false, ...input }))) {
+  test.describe(input.name, () => {
+    test.use({ viewport: input.viewport, hasTouch: true })
+
+    test("keeps navigation outside the reserved edges and accepts taps", async ({ page, browserName }) => {
+      const insets = browserName === "chromium" ? input.insets : empty
+      if (browserName === "chromium") {
+        const cdp = await page.context().newCDPSession(page)
+        await cdp.send("Emulation.setSafeAreaInsetsOverride", { insets })
+        await cdp.send("Emulation.setEmulatedMedia", {
+          features: [{ name: "display-mode", value: input.standalone ? "standalone" : "browser" }],
+        })
+      }
       await mockOpenCodeServer(page, {
         directory,
         project: {
@@ -29,7 +57,12 @@ for (const viewport of [
         pageMessages: () => ({ items: [] }),
       })
       await page.addInitScript(
-        ({ directory, server }) => {
+        ({ directory, server, ios, bottom }) => {
+          Object.defineProperty(navigator, "standalone", { value: ios })
+          localStorage.setItem(
+            "settings.v3",
+            JSON.stringify({ general: { mobileTitlebarPosition: bottom ? "bottom" : "top" } }),
+          )
           localStorage.setItem(
             "opencode.global.dat:server",
             JSON.stringify({
@@ -38,20 +71,33 @@ for (const viewport of [
             }),
           )
         },
-        { directory, server },
+        { directory, server, ios: input.ios, bottom: input.bottom },
       )
 
       await page.goto("/")
       await expect(page.locator('meta[name="apple-mobile-web-app-status-bar-style"]')).toHaveAttribute(
         "content",
-        "default",
+        "black-translucent",
       )
+      if (input.rtl) await page.locator("html").evaluate((element) => element.setAttribute("dir", "rtl"))
+      const shell = page.locator('[data-slot="app-shell"]')
+      await expect(shell).toHaveCSS("padding-top", `${insets.top + (input.ios ? 32 : 0)}px`)
+      await expect(shell).toHaveCSS("padding-right", `${insets.right}px`)
+      await expect(shell).toHaveCSS("padding-bottom", `${insets.bottom}px`)
+      await expect(shell).toHaveCSS("padding-left", `${insets.left}px`)
       const titlebar = page.locator('[data-slot="titlebar-v2"]')
       const home = titlebar.getByRole("button", { name: "Home", exact: true })
       const create = titlebar.getByRole("button", { name: "New session", exact: true })
       await expect(home).toHaveAttribute("aria-pressed", "true")
       await expect(page.getByText("pwa-navigation", { exact: true })).toBeVisible()
       await expect(create).toBeInViewport({ ratio: 1 })
+      const bounds = await titlebar.boundingBox()
+      expect(bounds).not.toBeNull()
+      expect(bounds!.y).toBeGreaterThanOrEqual(insets.top + (input.ios ? 32 : 0))
+      expect(bounds!.y + bounds!.height).toBeLessThanOrEqual(input.viewport.height - insets.bottom)
+      expect(bounds!.x).toBeGreaterThanOrEqual(insets.left)
+      expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(input.viewport.width - insets.right)
+      if (input.bottom) expect(bounds!.y + bounds!.height).toBe(input.viewport.height - insets.bottom - 1)
       await create.tap()
       await expect(page).toHaveURL(/\/new-session\?draftId=.+/)
       await expect(page.locator('[data-component="composer-editor"]')).toBeEditable()
@@ -59,6 +105,7 @@ for (const viewport of [
       await home.tap()
       await expect(page).toHaveURL(/\/$/)
       await expect(home).toHaveAttribute("aria-pressed", "true")
+      expect(await titlebar.boundingBox()).toEqual(bounds)
     })
   })
 }

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -13,7 +13,8 @@
     <meta name="theme-color" content="#fafafa" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <!-- Let iOS reserve space for the status bar instead of overlaying app navigation. -->
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta property="og:image" content="/social-share.png" />
     <meta property="twitter:image" content="/social-share.png" />
     <script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>

--- a/packages/app/index.html
+++ b/packages/app/index.html
@@ -13,8 +13,7 @@
     <meta name="theme-color" content="#fafafa" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
-    <!-- Let iOS reserve space for the status bar instead of overlaying app navigation. -->
-    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta property="og:image" content="/social-share.png" />
     <meta property="twitter:image" content="/social-share.png" />
     <script id="oc-theme-preload-script" src="/oc-theme-preload.js"></script>

--- a/packages/app/src/shell/shell.tsx
+++ b/packages/app/src/shell/shell.tsx
@@ -39,10 +39,17 @@ export default function Layout(props: ParentProps) {
   return (
     <TitlebarRightProvider>
       <div
+        data-slot="app-shell"
         class="relative bg-v2-background-bg-deep flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text"
         style={{
-          "padding-top": "env(safe-area-inset-top, 0px)",
+          // Leave clearance for the native iOS PWA status-bar fade beyond the device inset.
+          "padding-top":
+            platform.platform === "web" && "standalone" in navigator && navigator.standalone === true
+              ? "calc(env(safe-area-inset-top, 0px) + 32px)"
+              : "env(safe-area-inset-top, 0px)",
+          "padding-right": "env(safe-area-inset-right, 0px)",
           "padding-bottom": "env(safe-area-inset-bottom, 0px)",
+          "padding-left": "env(safe-area-inset-left, 0px)",
           // Native Windows chrome supplies the gap; retain paint clearance for the panels' outer outlines.
           "--shell-top-inset":
             platform.platform === "desktop" &&


### PR DESCRIPTION
### Issue for this PR

Closes #36142. Related: #35480.

### Type of change

- [x] Bug fix

### What does this PR do?

Keep `viewport-fit=cover` and `black-translucent`, with device safe-area padding around the shell. Add left/right insets for landscape and 32 CSS pixels of extra top clearance only when the web app runs in iOS standalone mode (`navigator.standalone`). This moves navigation away from the reported native status-bar blur without changing normal browser or Android PWA spacing.

This replaces the earlier status-bar-meta-only workaround. The device insets follow [WebKit's safe-area guidance](https://webkit.org/blog/7929/designing-websites-for-iphone-x/); the extra 32px is an app-level clearance allowance, not an Apple-defined inset. The existing standalone height workaround remains unchanged.

### How did you verify your code works?

- App `bun typecheck` and `bun run build` passed.
- Eight Chromium geometry/tap cases passed against both development and production builds: browser, desktop, Android PWA, iOS portrait, Dynamic Island insets, zero insets, bottom navigation, and RTL landscape. Tests use emulated safe-area values and verify all four paddings, navigation bounds, New session, the editable composer, and return to Home.
- The revised WebKit run was interrupted by a host server restart; it is not counted as a completed pass.
- E2E typecheck is blocked by an existing `HTMLElement | SVGElement` `.dir` error in `new-session-workspace-pending.spec.ts:38`.

**Draft pending an affected iPhone check.** Automation cannot validate the native fade's extent or OS-level touch interception. Verify cold launch, top-navigation taps, rotation, keyboard dismissal, and bottom navigation on the affected device with the updated build active.

### Screenshots / recordings

Same 390x844 viewport with emulated 47px top / 34px bottom insets. These show the layout change; native iOS chrome is not rendered.

Before: ![](https://github.com/user-attachments/assets/a196a154-b711-48cc-8129-8827d27635d7)

After: ![](https://github.com/user-attachments/assets/52e7ab25-c664-4031-b402-ded961661d6f)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
