### PR TITLE
fix(tui): scope reasoning-effort variants to the agent, seed from agent config

### DIFF
--- a/packages/tui/src/context/local.tsx
+++ b/packages/tui/src/context/local.tsx
@@ -363,8 +363,18 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           selected() {
             const m = currentModel()
             if (!m) return undefined
-            const key = `${m.providerID}/${m.modelID}`
-            return modelStore.variant[key]
+            const a = agent.current()
+            const modelKey = `${m.providerID}/${m.modelID}`
+            // Manual overrides are keyed per agent+model so agents that pin
+            // different reasoning efforts on the same model stay distinct
+            // (e.g. quick=low, build=high, debug=max). Falls back to the
+            // agent's configured variant, then to no variant at all — the
+            // server then applies the agent's own variant server-side.
+            const key = a ? `${a.name}:${modelKey}` : modelKey
+            const manual = modelStore.variant[key]
+            if (manual !== undefined) return manual
+            if (a?.variant && this.list().includes(a.variant)) return a.variant
+            return undefined
           },
           current() {
             const v = this.selected()
@@ -383,7 +393,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
           set(value: string | undefined) {
             const m = currentModel()
             if (!m) return
-            const key = `${m.providerID}/${m.modelID}`
+            const a = agent.current()
+            const modelKey = `${m.providerID}/${m.modelID}`
+            const key = a ? `${a.name}:${modelKey}` : modelKey
             setModelStore("variant", key, value ?? "default")
             save()
           },


### PR DESCRIPTION
Agents can pin a reasoning effort in their frontmatter (`variant: low` / `max`), which is how I run the same model at different efforts across profiles — quick is low, build is high, debug is max.

That broke because the TUI stores the selected variant per model, not per agent. Once you've cycled the variant on a model (ctrl+t), that one stored value is what every agent using that model displays and sends. The agent's own variant only applies when the client sends nothing (`input.variant ?? agent variant` in the session handler), and the TUI always sends something — so the last manually picked effort silently overrides every agent's config, permanently.

Which means quick/build/debug all thought at the same effort, and you couldn't tell from the footer either, because it shows the stored value, not the agent's pin.

Fix: key manual overrides by `<agent>:<provider>/<model>` and fall back to the agent's configured variant when there's no manual pick. Switching agents now shows and sends each agent's own effort, ctrl+t stays a per-agent override. Old per-model entries in model.json go inert, which is the point.

Typecheck clean, full tui suite passes (193).
