### PR TITLE
feat(build): add --no-minify flag to opt out of minification

### DIFF
--- a/packages/opencode/script/build.ts
+++ b/packages/opencode/script/build.ts
@@ -20,6 +20,7 @@ const singleFlag = process.argv.includes("--single")
 const baselineFlag = process.argv.includes("--baseline")
 const skipInstall = process.argv.includes("--skip-install")
 const sourcemapsFlag = process.argv.includes("--sourcemaps")
+const noMinifyFlag = process.argv.includes("--no-minify")
 const plugin = createSolidTransformPlugin()
 const skipEmbedWebUi = process.argv.includes("--skip-embed-web-ui")
 
@@ -166,7 +167,7 @@ for (const item of targets) {
     plugins: [plugin],
     external: ["node-gyp"],
     format: "esm",
-    minify: true,
+    minify: !noMinifyFlag,
     sourcemap: sourcemapsFlag ? "linked" : "none",
     splitting: true,
     compile: {


### PR DESCRIPTION
### Issue for this PR

Closes #46194

### Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a `--no-minify` flag to `packages/opencode/script/build.ts` as a sibling to the existing flags (`--sourcemaps`, `--single`, `--baseline`, ...). When set, `minify` becomes `false`; default behaviour is unchanged (`minify: true`). This gives contributors a one-shot way to build the unminified bundle for readable stack traces and exact symbol names without editing the source.

### How did you verify your code works?

- Flag is parsed alongside the other CLI flags.
- `minify: !noMinifyFlag` keeps the default at `true` when the flag is absent.
- File parses cleanly (esbuild transform, same parser family as Bun).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR