### PR TITLE
fix(app): encode server credentials as UTF-8

### DIFF
--- a/packages/app/src/utils/server.test.ts
+++ b/packages/app/src/utils/server.test.ts
@@ -20,4 +20,15 @@ describe("authTokenFromCredentials", () => {
   test("encodes credentials with the default username", () => {
     expect(authTokenFromCredentials({ password: "secret" })).toBe(btoa("opencode:secret"))
   })
+
+  test("encodes unicode credentials as UTF-8", () => {
+    expect(authTokenFromCredentials({ password: "päss" })).toBe(
+      Buffer.from("opencode:päss", "utf8").toString("base64"),
+    )
+  })
+
+  test("round trips multibyte credentials", () => {
+    const token = authTokenFromCredentials({ username: "用户", password: "秘密🔐" })
+    expect(authFromToken(token)).toEqual({ username: "用户", password: "秘密🔐" })
+  })
 })

--- a/packages/app/src/utils/server.ts
+++ b/packages/app/src/utils/server.ts
@@ -4,7 +4,12 @@ import type { ServerConnection } from "@/context/server"
 import { decode64 } from "@/utils/base64"
 
 export function authTokenFromCredentials(input: { username?: string; password: string }) {
-  return btoa(`${input.username ?? "opencode"}:${input.password}`)
+  return btoa(
+    Array.from(
+      new TextEncoder().encode(`${input.username ?? "opencode"}:${input.password}`),
+      (byte) => String.fromCharCode(byte),
+    ).join(""),
+  )
 }
 
 export function authFromToken(token: string | null) {


### PR DESCRIPTION
### Issue for this PR

Closes #46224

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The app passed `username:password` directly to `btoa()`, which either encoded non-ASCII credentials with the wrong bytes or threw `InvalidCharacterError`. This change converts the credential string to UTF-8 bytes before standard Base64 encoding, matching the server decoder. Regression tests cover both Latin-1-range and multibyte credentials while preserving the existing ASCII result.

### How did you verify your code works?

From `packages/app` at reduced process priority:

- `bun test src/utils/server.test.ts src/utils/server-health.test.ts src/utils/server-protocol.test.ts src/utils/server-compat.test.ts src/utils/terminal-websocket-url.test.ts` — 30 tests passed
- `bun typecheck` — passed

### Screenshots / recordings

Not applicable. This changes authentication encoding logic without changing the rendered UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR