### PR TITLE
fix(app): reflect global permission:allow in Settings auto-accept toggle

### DIFF
--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -95,7 +95,16 @@ export const SettingsGeneral: Component = () => {
 
   const linux = createMemo(() => platform.platform === "desktop" && platform.os === "linux")
   const dir = createMemo(() => decode64(params.dir))
+  const serverSync = useServerSync()
+  const serverSdk = useServerSDK()
+  const globalAutoAccept = createMemo(() => {
+    const perm = (serverSync().data.config as any)?.permission
+    if (perm === "allow") return true
+    if (perm && typeof perm === "object" && perm["*"] === "allow") return true
+    return false
+  })
   const accepting = createMemo(() => {
+    if (globalAutoAccept()) return true
     const value = dir()
     if (!value) return false
     if (!params.id) return permission.isAutoAcceptingDirectory(value)
@@ -122,9 +131,6 @@ export const SettingsGeneral: Component = () => {
   const desktop = createMemo(() => platform.platform === "desktop")
 
   const themeOptions = createMemo<ThemeOption[]>(() => theme.ids().map((id) => ({ id, name: theme.name(id) })))
-
-  const serverSync = useServerSync()
-  const serverSdk = useServerSDK()
 
   const [shells] = createResource(
     async () => {
@@ -321,7 +327,7 @@ export const SettingsGeneral: Component = () => {
           description={language.t("toast.permissions.autoaccept.on.description")}
         >
           <div data-action="settings-auto-accept-permissions">
-            <Switch checked={accepting()} disabled={!dir()} onChange={toggleAccept} />
+            <Switch checked={accepting()} disabled={!dir() || globalAutoAccept()} onChange={toggleAccept} />
           </div>
         </SettingsRow>
 

--- a/packages/app/src/components/settings-v2/general-controllers.ts
+++ b/packages/app/src/components/settings-v2/general-controllers.ts
@@ -25,6 +25,12 @@ export type { ShellOption, ShellSelectOption } from "./general-controller-behavi
 export function createPermissionScopeController(sessionID: Accessor<string | undefined>) {
   const permission = usePermission()
   const serverSync = useServerSync()
+  const globalAutoAccept = createMemo(() => {
+    const perm = (serverSync().data.config as any)?.permission
+    if (perm === "allow") return true
+    if (perm && typeof perm === "object" && perm["*"] === "allow") return true
+    return false
+  })
   const directory = createMemo(() => {
     const id = sessionID()
     if (!id) return undefined
@@ -33,12 +39,13 @@ export function createPermissionScopeController(sessionID: Accessor<string | und
 
   return {
     accepting: createMemo(() => {
+      if (globalAutoAccept()) return true
       const id = sessionID()
       const dir = directory()
       if (!id || !dir) return false
       return permission.isAutoAccepting(id, dir)
     }),
-    enabled: createMemo(() => !!directory()),
+    enabled: createMemo(() => !globalAutoAccept() && !!directory()),
     set: (checked: boolean) => {
       const id = sessionID()
       const dir = directory()


### PR DESCRIPTION
### Issue for this PR

Closes #38154

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `permission` is set to `"allow"` globally (in `opencode.json` / `opencode.jsonc`), the Settings -> Auto-accept permissions toggle previously showed off even though permissions were already auto-approved via config. The toggle is per-directory/session (`permission.isAutoAccepting`), so a global `"allow"` was invisible in the UI - new sessions appeared as toggle off after restart. Reported as bug family across #38154, #41069, #16258, #37617.

This makes `accepting()` return `true` when global permission is `"allow"` or `{"*":"allow"}` (via `serverSync().data.config.permission`), and disables the toggle when global auto-accept is active (global config overrides per-directory). `deny` rules still enforced - only `allow` is reflected.

### How did you verify your code works?

- `opencode debug config` shows `permission: {"*":"allow"}` loaded from `~/.config/opencode/opencode.jsonc:3`
- `bun run typecheck` in `packages/app` - passed (no new deps)
- Manual: with global `permission: "allow"` Settings toggle now shows on and disabled; without it, per-directory behaviour unchanged (checked `settings-general.tsx` and `settings-v2/general-controllers.ts`)

### Screenshots / recordings

No visual change except toggle state. With global `permission: "allow"` toggle shows `on` + disabled; without, existing enabled/disabled/checked states unchanged (same as #43193 coverage).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
