### PR TITLE
docs: add opencode-telegram to ecosystem list

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -54,6 +54,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-firecrawl](https://github.com/firecrawl/opencode-firecrawl)                              | Web scraping, crawling, and search via the Firecrawl CLI                                           |
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
+| [opencode-telegram](https://github.com/gutchapa/opencode-telegram)                                 | Control OpenCode from your phone via Telegram: 70+ slash commands, run shell commands, approve permissions, and manage sessions |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
 
 ---


### PR DESCRIPTION
## Add opencode-telegram to the ecosystem

Adds **[opencode-telegram](https://github.com/gutchapa/opencode-telegram)** — a Telegram bot that gives you full remote control of OpenCode from your phone:

- 70+ slash commands (send prompts, manage sessions, run shell commands, approve permissions)
- Works with the opencode SDK client (TUI, `opencode serve`, or `opencode run`)
- Local-first: pairs with local llama.cpp / Ollama endpoints
- npm: `gutchapa-opencode-telegram`

One-line addition to the plugins table.
