### PR TITLE
fix(grep): fail when requested path does not exist

### DIFF
--- a/packages/core/src/tool/grep.ts
+++ b/packages/core/src/tool/grep.ts
@@ -94,11 +94,14 @@ const layer = Layer.effectDiscard(
               })
               const target = path.resolve(location.directory, input.path ?? ".")
               const info = yield* fs.stat(target).pipe(Effect.catch(() => Effect.succeed(undefined)))
+              if (!info) {
+                return yield* Effect.fail(new ToolFailure({ message: `Path does not exist: ${target}` }))
+              }
               return yield* ripgrep
                 .grep({
-                  cwd: info?.type === "Directory" ? target : path.dirname(target),
+                  cwd: info.type === "Directory" ? target : path.dirname(target),
                   pattern: input.pattern,
-                  file: info?.type === "File" ? path.basename(target) : undefined,
+                  file: info.type === "File" ? path.basename(target) : undefined,
                   include: input.include,
                   limit: input.limit ?? Number.MAX_SAFE_INTEGER,
                 })
@@ -113,7 +116,7 @@ const layer = Layer.effectDiscard(
                             path.relative(
                               location.directory,
                               path.resolve(
-                                info?.type === "Directory" ? target : path.dirname(target),
+                                info.type === "Directory" ? target : path.dirname(target),
                                 match.entry.path,
                               ),
                             ),
@@ -123,7 +126,9 @@ const layer = Layer.effectDiscard(
                     ),
                   ),
                 )
-            }).pipe(Effect.mapError(() => new ToolFailure({ message: `Unable to grep for ${input.pattern}` }))),
+            }).pipe(Effect.mapError((error) =>
+              error instanceof ToolFailure ? error : new ToolFailure({ message: `Unable to grep for ${input.pattern}`, error }),
+            )),
         }),
       })
       .pipe(Effect.orDie)


### PR DESCRIPTION
### Issue for this PR

Closes #45293

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When `grep` is called with a search path that does not exist, it currently silently falls back to searching the parent directory.

This change makes `grep` return a `ToolFailure` when the requested path does not exist, consistent with the behavior expected by the issue.

Existing behavior for valid paths is unchanged.

### How did you verify your code works?

The change is isolated to `packages/core/src/tool/grep.ts` and the resulting diff was reviewed against the reported behavior in #45293.

### Screenshots / recordings

Not applicable.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR