### PR TITLE
fix(plugin): reject invalid tool arguments

### DIFF
--- a/packages/plugin/src/tool.ts
+++ b/packages/plugin/src/tool.ts
@@ -47,6 +47,10 @@ export function tool<Args extends z.ZodRawShape>(input: {
   args: Args
   execute(args: z.infer<z.ZodObject<Args>>, context: ToolContext): Promise<ToolResult>
 }) {
+  const invalid = Object.entries(input.args).find(
+    (entry) => typeof entry[1] !== "object" || entry[1] === null || !("_zod" in entry[1]),
+  )
+  if (invalid) throw new TypeError(`Invalid tool argument "${invalid[0]}": args must contain Zod schemas`)
   return input
 }
 tool.schema = z

--- a/packages/plugin/test/tool.test.ts
+++ b/packages/plugin/test/tool.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test"
+import { tool } from "../src/tool"
+
+describe("tool", () => {
+  test("rejects plain-object argument definitions with a clear error", () => {
+    expect(() =>
+      tool({
+        description: "invalid tool",
+        args: { foo: "string" } as never,
+        execute: async () => "ok",
+      }),
+    ).toThrow('Invalid tool argument "foo": args must contain Zod schemas')
+  })
+
+  test("accepts Zod argument definitions", () => {
+    expect(
+      tool({
+        description: "valid tool",
+        args: { foo: tool.schema.string() },
+        execute: async ({ foo }) => foo,
+      }),
+    ).toBeDefined()
+  })
+})

--- a/packages/plugin/test/tool.test.ts
+++ b/packages/plugin/test/tool.test.ts
@@ -6,7 +6,10 @@ describe("tool", () => {
     expect(() =>
       tool({
         description: "invalid tool",
-        args: { foo: "string" } as never,
+        args: {
+          // @ts-expect-error Verify the runtime diagnostic for JavaScript callers.
+          foo: "string",
+        },
         execute: async () => "ok",
       }),
     ).toThrow('Invalid tool argument "foo": args must contain Zod schemas')


### PR DESCRIPTION
### Issue for this PR

Closes #45532

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Rejects custom tool argument definitions that are not Zod schemas. The error identifies the invalid argument instead of allowing it to be silently reduced to an empty schema.

### How did you verify your code works?

- Added tests for invalid plain-object arguments and valid Zod arguments
- Ran `bun test test/tool.test.ts` from `packages/plugin`
- Ran changed-scope `oxlint`
- Ran the repository typecheck across 30 packages

### Screenshots / recordings

Not applicable; this change has no UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR