### PR TITLE
docs: add opencode-usage-tui to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-usage-tui](https://github.com/Eros483/opencode-usage-tui)                                | OpenCode Go usage in the TUI — sidebar section and `/usage` slash command                          |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes # (no issue — adding a plugin to the ecosystem list)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-usage-tui](https://github.com/Eros483/opencode-usage-tui) to the Plugins table in the ecosystem docs. It's a TUI plugin that shows OpenCode Go usage (5-hour/weekly/monthly) as a sidebar section plus a `/usage` slash command, published on npm as `opencode-usage-tui`.

### How did you verify your code works?

Docs-only change — one row appended to the existing Plugins table, matching the current format.

### Screenshots / recordings

<img width="422" height="307" alt="image" src="https://github.com/user-attachments/assets/ad2153e9-52e4-4dbd-ab35-1e769a75d121" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
