### PR TITLE
fix: resolve vcs diff paths against the worktree root

### DIFF
--- a/packages/opencode/src/project/vcs.ts
+++ b/packages/opencode/src/project/vcs.ts
@@ -121,18 +121,18 @@ const batchPatches = Effect.fnUntraced(function* (
 
 const nativePatch = Effect.fnUntraced(function* (
   git: Git.Interface,
-  cwd: string,
+  worktree: string,
   ref: string | undefined,
   item: Git.Item,
   options?: DiffOptions,
 ) {
   const result =
     item.code === "??" || !ref
-      ? yield* git.patchUntracked(cwd, item.file, {
+      ? yield* git.patchUntracked(worktree, item.file, {
           context: options?.context ?? PATCH_CONTEXT_LINES,
           maxOutputBytes: MAX_PATCH_BYTES,
         })
-      : yield* git.patch(cwd, ref, item.file, {
+      : yield* git.patch(worktree, ref, item.file, {
           context: options?.context ?? PATCH_CONTEXT_LINES,
           maxOutputBytes: MAX_PATCH_BYTES,
         })
@@ -148,7 +148,7 @@ const totalPatch = (file: string, patch: string, total: number) => {
 
 const patchForItem = Effect.fnUntraced(function* (
   git: Git.Interface,
-  cwd: string,
+  worktree: string,
   ref: string | undefined,
   item: Git.Item,
   batch: { patches: Map<string, string>; capped: boolean },
@@ -160,12 +160,12 @@ const patchForItem = Effect.fnUntraced(function* (
   const batched = batch.patches.get(item.file)
   if (batched !== undefined) return batched
   if (item.code !== "??" && batch.capped) return emptyPatch(item.file)
-  return yield* nativePatch(git, cwd, ref, item, options)
+  return yield* nativePatch(git, worktree, ref, item, options)
 })
 
 const files = Effect.fnUntraced(function* (
   git: Git.Interface,
-  cwd: string,
+  worktree: string,
   ref: string | undefined,
   list: Git.Item[],
   map: Map<string, { additions: number; deletions: number }>,
@@ -177,8 +177,9 @@ const files = Effect.fnUntraced(function* (
   let capped = false
 
   for (const item of list.toSorted((a, b) => a.file.localeCompare(b.file))) {
-    const stat = map.get(item.file) ?? (item.status === "added" ? yield* git.statUntracked(cwd, item.file) : undefined)
-    const patch = yield* patchForItem(git, cwd, ref, item, batch, capped, options)
+    const stat =
+      map.get(item.file) ?? (item.status === "added" ? yield* git.statUntracked(worktree, item.file) : undefined)
+    const patch = yield* patchForItem(git, worktree, ref, item, batch, capped, options)
     const result: { patch: string; capped: boolean } = capped
       ? { patch, capped: true }
       : totalPatch(item.file, patch, total)
@@ -202,6 +203,7 @@ const files = Effect.fnUntraced(function* (
 const diffAgainstRef = Effect.fnUntraced(function* (
   git: Git.Interface,
   cwd: string,
+  worktree: string,
   ref: string,
   options?: DiffOptions,
 ) {
@@ -210,7 +212,7 @@ const diffAgainstRef = Effect.fnUntraced(function* (
   })
   return yield* files(
     git,
-    cwd,
+    worktree,
     ref,
     merge(
       list,
@@ -225,11 +227,12 @@ const diffAgainstRef = Effect.fnUntraced(function* (
 const track = Effect.fnUntraced(function* (
   git: Git.Interface,
   cwd: string,
+  worktree: string,
   ref: string | undefined,
   options?: DiffOptions,
 ) {
-  if (!ref) return yield* files(git, cwd, ref, yield* git.status(cwd), new Map(), emptyBatch(), options)
-  return yield* diffAgainstRef(git, cwd, ref, options)
+  if (!ref) return yield* files(git, worktree, ref, yield* git.status(cwd), new Map(), emptyBatch(), options)
+  return yield* diffAgainstRef(git, cwd, worktree, ref, options)
 })
 
 export const Mode = Schema.Literals(["git", "branch"])
@@ -375,14 +378,20 @@ const layer: Layer.Layer<Service, never, Git.Service | EventV2Bridge.Service> = 
         const ctx = yield* InstanceState.context
         if (ctx.project.vcs !== "git") return []
         if (mode === "git") {
-          return yield* track(git, ctx.directory, (yield* git.hasHead(ctx.directory)) ? "HEAD" : undefined, options)
+          return yield* track(
+            git,
+            ctx.directory,
+            ctx.worktree,
+            (yield* git.hasHead(ctx.directory)) ? "HEAD" : undefined,
+            options,
+          )
         }
 
         if (!value.root) return []
         if (value.current && value.current === value.root.name) return []
         const ref = yield* git.mergeBase(ctx.directory, value.root.ref)
         if (!ref) return []
-        return yield* diffAgainstRef(git, ctx.directory, ref, options)
+        return yield* diffAgainstRef(git, ctx.directory, ctx.worktree, ref, options)
       }),
       diffRaw: Effect.fn("Vcs.diffRaw")(function* () {
         const ctx = yield* InstanceState.context
@@ -393,7 +402,7 @@ const layer: Layer.Layer<Service, never, Git.Service | EventV2Bridge.Service> = 
         const tracked = hasHead ? (yield* git.patchAll(ctx.directory, "HEAD")).text : ""
         const untracked = yield* Effect.forEach(
           status.filter((item) => item.code === "??"),
-          (item) => git.patchUntracked(ctx.directory, item.file).pipe(Effect.map((patch) => patch.text)),
+          (item) => git.patchUntracked(ctx.worktree, item.file).pipe(Effect.map((patch) => patch.text)),
         )
         return [tracked, ...untracked].filter(Boolean).join("\n")
       }),

--- a/packages/opencode/test/project/vcs.test.ts
+++ b/packages/opencode/test/project/vcs.test.ts
@@ -285,6 +285,31 @@ describe("Vcs diff", () => {
     { git: true },
   )
 
+  worktreeIt.live("diff('git') resolves untracked files when the session directory is a subdirectory", () =>
+    Effect.gen(function* () {
+      const root = yield* tmpdirScoped({ git: true })
+      const sub = path.join(root, "nested", "dir")
+      yield* write(path.join(sub, "new.md"), "# hello\n\nworld\n")
+
+      const diff = yield* Effect.gen(function* () {
+        const vcs = yield* init()
+        return yield* vcs.diff("git")
+      }).pipe(provideInstance(sub))
+
+      expect(diff).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            file: "nested/dir/new.md",
+            status: "added",
+          }),
+        ]),
+      )
+      const item = diff.find((d) => d.file === "nested/dir/new.md")
+      expect(item?.additions).toBeGreaterThan(0)
+      expect(item?.patch).toContain("+world")
+    }),
+  )
+
   it.instance(
     "diff('git') keeps carriage returns inside patch hunks",
     () =>


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes new/untracked files showing as "Binary file" in the changes view when the session directory is a subdirectory of the git worktree (e.g. running opencode inside a subfolder of a repo).

`git status --porcelain=v1` and `git diff --name-status`/`--numstat` always report paths relative to the repository root. The VCS layer, however, fed those paths back to `git diff --patch <ref> -- <path>` and `git diff --no-index -- /dev/null <path>` relative to the *session directory*. When `directory != worktree`, the path resolved to a nonexistent location, so untracked files got `0` additions/deletions and an empty patch. The review UI treats a 0/0 diff as unrenderable and falls back to the "Binary file" label.

The fix threads the worktree root through the diff pipeline and resolves file paths against it, matching what `Vcs.status` already does for untracked stats. Tracked-file patches and untracked-file stats/patches now both resolve correctly from any session directory.

### How did you verify your code works?

- Added a regression test in `packages/opencode/test/project/vcs.test.ts` that runs `vcs.diff("git")` with the session directory set to a subdirectory and asserts an untracked file has `additions > 0` and a non-empty patch. It fails without the change (`additions` is `0`) and passes with it.
- `bun run typecheck` (tsgo) is clean.
- Full vcs test suite: 13 pass, 0 fail.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

## Before/After
<img width="1032" height="330" alt="Screenshot_20260830_145403" src="https://github.com/user-attachments/assets/45c46647-01ff-4896-bedb-69748fd13833" />
<img width="1304" height="257" alt="Screenshot_20260830_145416" src="https://github.com/user-attachments/assets/5735e135-7830-41f7-874c-4208894f3102" />

