### PR TITLE
fix(tui): open markdown hyperlinks on click while mouse capture stays on

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -85,6 +85,7 @@ import { createTuiAttention } from "./attention"
 import * as TuiAudio from "./audio"
 import { win32DisableProcessedInput, win32FlushInputBuffer } from "./terminal-win32"
 import { destroyRenderer } from "./util/renderer"
+import { openableUrlAt } from "./util/hyperlink"
 import { cliErrorMessage, errorFormat } from "./util/error"
 
 registerOpencodeSpinner()
@@ -1084,6 +1085,9 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
     return render({ params: route.data.data })
   })
 
+  let mouseDownX = Number.NaN
+  let mouseDownY = Number.NaN
+
   return (
     <box
       width={dimensions().width}
@@ -1091,6 +1095,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
       flexDirection="column"
       backgroundColor={theme.background}
       onMouseDown={(evt) => {
+        mouseDownX = evt.x
+        mouseDownY = evt.y
         if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
         if (evt.button !== MouseButton.RIGHT) return
 
@@ -1098,11 +1104,21 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         evt.preventDefault()
         evt.stopPropagation()
       }}
-      onMouseUp={
-        !Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT
-          ? () => Selection.copy(renderer, toast, clipboard)
-          : undefined
-      }
+      onMouseUp={(evt) => {
+        const clicked = evt.x === mouseDownX && evt.y === mouseDownY
+        if (clicked && evt.button === MouseButton.LEFT) {
+          // Mouse capture swallows native OSC 8 activation, including in Terminal.app.
+          const url = openableUrlAt(renderer.currentRenderBuffer, evt.x, evt.y)
+          if (url) {
+            renderer.clearSelection()
+            open(url).catch(() => {})
+            return
+          }
+        }
+        if (!Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) {
+          Selection.copy(renderer, toast, clipboard)
+        }
+      }}
     >
       <Show when={Flag.OPENCODE_SHOW_TTFD}>
         <TimeToFirstDraw />

--- a/packages/tui/src/util/hyperlink.ts
+++ b/packages/tui/src/util/hyperlink.ts
@@ -1,0 +1,40 @@
+const URL_MAX_LEN = 4096
+const OPENABLE = new Set(["http:", "https:", "mailto:"])
+
+export type HyperlinkBuffer = {
+  width: number
+  height: number
+  buffers: { attributes: ArrayLike<number> }
+  lib: {
+    attributesGetLinkId: (attributes: number) => number
+    linkGetUrl: (linkId: number, maxLen?: number) => string
+  }
+}
+
+export function urlAt(buffer: HyperlinkBuffer, x: number, y: number): string | null {
+  if (!Number.isInteger(x) || !Number.isInteger(y)) return null
+  if (x < 0 || y < 0 || x >= buffer.width || y >= buffer.height) return null
+
+  const attributes = buffer.buffers.attributes[y * buffer.width + x]
+  if (attributes === undefined) return null
+
+  const linkId = buffer.lib.attributesGetLinkId(attributes)
+  if (!linkId) return null
+
+  const url = buffer.lib.linkGetUrl(linkId, URL_MAX_LEN).trim()
+  return url || null
+}
+
+export function isOpenableHyperlink(url: string): boolean {
+  try {
+    return OPENABLE.has(new URL(url).protocol)
+  } catch {
+    return false
+  }
+}
+
+export function openableUrlAt(buffer: HyperlinkBuffer, x: number, y: number): string | null {
+  const url = urlAt(buffer, x, y)
+  if (!url || !isOpenableHyperlink(url)) return null
+  return url
+}

--- a/packages/tui/test/util/hyperlink.test.ts
+++ b/packages/tui/test/util/hyperlink.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+import { isOpenableHyperlink, openableUrlAt, urlAt, type HyperlinkBuffer } from "../../src/util/hyperlink"
+
+function buffer(options: {
+  width: number
+  height: number
+  attributes: number[]
+  links: Record<number, string>
+}): HyperlinkBuffer {
+  const ids = new Map<number, number>()
+  for (const [index, attributes] of options.attributes.entries()) {
+    if (attributes) ids.set(attributes, attributes)
+  }
+  return {
+    width: options.width,
+    height: options.height,
+    buffers: { attributes: options.attributes },
+    lib: {
+      attributesGetLinkId: (attributes) => ids.get(attributes) ?? 0,
+      linkGetUrl: (linkId) => options.links[linkId] ?? "",
+    },
+  }
+}
+
+describe("util.hyperlink", () => {
+  test("returns the URL stored on the clicked cell", () => {
+    const screen = buffer({
+      width: 4,
+      height: 1,
+      attributes: [0, 7, 7, 0],
+      links: { 7: "https://example.com/docs" },
+    })
+    expect(urlAt(screen, 1, 0)).toBe("https://example.com/docs")
+    expect(urlAt(screen, 2, 0)).toBe("https://example.com/docs")
+    expect(urlAt(screen, 0, 0)).toBeNull()
+  })
+
+  test("rejects out-of-bounds and empty link cells", () => {
+    const screen = buffer({
+      width: 2,
+      height: 1,
+      attributes: [3, 0],
+      links: { 3: "https://example.com" },
+    })
+    expect(urlAt(screen, -1, 0)).toBeNull()
+    expect(urlAt(screen, 2, 0)).toBeNull()
+    expect(urlAt(screen, 0, 1)).toBeNull()
+    expect(urlAt(screen, 1.5, 0)).toBeNull()
+  })
+
+  test("allows http, https, and mailto and rejects other schemes", () => {
+    expect(isOpenableHyperlink("https://example.com")).toBe(true)
+    expect(isOpenableHyperlink("http://example.com")).toBe(true)
+    expect(isOpenableHyperlink("mailto:a@example.com")).toBe(true)
+    expect(isOpenableHyperlink("file:///etc/passwd")).toBe(false)
+    expect(isOpenableHyperlink("javascript:alert(1)")).toBe(false)
+    expect(isOpenableHyperlink("not a url")).toBe(false)
+  })
+
+  test("openableUrlAt ignores cells whose URL is not a safe scheme", () => {
+    const screen = buffer({
+      width: 1,
+      height: 1,
+      attributes: [4],
+      links: { 4: "file:///tmp/x" },
+    })
+    expect(urlAt(screen, 0, 0)).toBe("file:///tmp/x")
+    expect(openableUrlAt(screen, 0, 0)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Problem

OpenCode underlines markdown links, but in macOS Terminal.app click / Cmd-click / Cmd-double-click never opens them.

Two things stack:

1. Mouse capture is on by default, so Terminal.app never sees the click.
2. Terminal.app does not implement OSC 8, so even a native Cmd-click would not work for named markdown links.

Disabling mouse (`tui.json` `"mouse": false`) restores native URL detection for visible `https://…` text, but it also kills in-app scrolling. That is not an acceptable workaround.

Related: anomalyco/opentui#1380, anomalyco/opentui#1439, anomalyco/opencode#5799.

## Fix

Keep mouse capture on. On a left-click that did not drag, look up the OSC 8 link id already stored in the cell attributes and `open()` http(s)/mailto URLs.

Dedicated `<Link>` widgets already did this via `onMouseUp`. Assistant markdown goes through `<markdown>` / OSC 8 and did not.

`file:` and `javascript:` are ignored (see anomalyco/opentui#864).

## Test plan

- [x] Unit tests for cell lookup and scheme allowlist
- [ ] Manual: Apple Terminal.app, mouse enabled, click an underlined markdown link in an assistant message — default browser opens, wheel scrolling still works
- [ ] Manual: drag-select still copies on mouse up
- [ ] Manual: click a non-link does not open anything