### PR TITLE
fix(cli): show a proper error message when port is already in use for web and serve

### DIFF
--- a/packages/opencode/src/cli/cmd/serve.ts
+++ b/packages/opencode/src/cli/cmd/serve.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
-import { effectCmd } from "../effect-cmd"
-import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { effectCmd, fail } from "../effect-cmd"
+import { isPortInUseError, withNetworkOptions, resolveNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 
 export const ServeCommand = effectCmd({
@@ -16,7 +16,11 @@ export const ServeCommand = effectCmd({
       console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = yield* resolveNetworkOptions(args)
-    const server = yield* Effect.promise(() => Server.listen(opts))
+    const server = yield* Effect.promise(() => Server.listen(opts)).pipe(
+      Effect.catchDefect((error) =>
+        isPortInUseError(error) ? fail(`Port ${opts.port} is already in use`) : Effect.die(error),
+      ),
+    )
     console.log(`opencode server listening on http://${server.hostname}:${server.port}`)
 
     yield* Effect.never

--- a/packages/opencode/src/cli/cmd/web.ts
+++ b/packages/opencode/src/cli/cmd/web.ts
@@ -1,7 +1,7 @@
 import { Effect } from "effect"
 import { UI } from "../ui"
-import { effectCmd } from "../effect-cmd"
-import { withNetworkOptions, resolveNetworkOptions } from "../network"
+import { effectCmd, fail } from "../effect-cmd"
+import { isPortInUseError, resolveNetworkOptions, withNetworkOptions } from "../network"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import open from "open"
 import { networkInterfaces } from "os"
@@ -41,7 +41,11 @@ export const WebCommand = effectCmd({
       UI.println(UI.Style.TEXT_WARNING_BOLD + "!  OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
     }
     const opts = yield* resolveNetworkOptions(args)
-    const server = yield* Effect.promise(() => Server.listen(opts))
+    const server = yield* Effect.promise(() => Server.listen(opts)).pipe(
+      Effect.catchDefect((error) =>
+        isPortInUseError(error) ? fail(`Port ${opts.port} is already in use`) : Effect.die(error),
+      ),
+    )
     UI.empty()
     UI.println(UI.logo("  "))
     UI.empty()

--- a/packages/opencode/src/cli/network.ts
+++ b/packages/opencode/src/cli/network.ts
@@ -1,6 +1,7 @@
 import type { Argv, InferredOptionTypes } from "yargs"
 import { ConfigV1 } from "@opencode-ai/core/v1/config/config"
 import type { Config } from "@/config/config"
+import { isRecord } from "@/util/record"
 import { Effect } from "effect"
 
 const options = {
@@ -77,4 +78,8 @@ export function resolveNetworkOptionsNoConfig(args: NetworkOptions, config?: Con
   const cors = [...configCors, ...argsCors]
 
   return { hostname, port, mdns, mdnsDomain, cors }
+}
+
+export function isPortInUseError(error: unknown) {
+  return isRecord(error) && isRecord(error.cause) && error.cause.code === "EADDRINUSE"
 }


### PR DESCRIPTION
### Issue for this PR

Closes #46263

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
Handle the case where the port is already used when using `opencode web` and `opencode serve` 
instead of the generic:
```
Error: Unexpected error.
ServeError
```
Now it shows:
```
Error: Port 4096 is already in use
```

### How did you verify your code works?

- `bun typecheck`

### Screenshots / recordings
Before: 
<img width="807" height="157" alt="image" src="https://github.com/user-attachments/assets/428d4588-ff64-4285-b066-2529c3b6722d" />

After: 
<img width="1119" height="86" alt="image" src="https://github.com/user-attachments/assets/7068b3a1-78fa-48ef-a520-d56f66eef998" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
