### PR TITLE
docs(ecosystem): add opencode-dashscope-imagegen plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-dashscope-imagegen](https://github.com/WhiteBite/opencode-dashscope-imagegen)                        | Text-to-image generation via Alibaba DashScope (Qwen-Image / Wan models) exposed as an image_generate tool      |
 
 ---
 


### PR DESCRIPTION
Adds opencode-dashscope-imagegen to the Plugins table of the ecosystem page.

- npm: https://www.npmjs.com/package/opencode-dashscope-imagegen (published, v0.1.1)
- OpenCode plugin adding an \image_generate\ tool: text-to-image via Alibaba DashScope (qwen-image-2.0/3.0, wan2.7-image), saves PNG locally, key resolved from env or any \dashscope*\ provider in opencode.json.
- MIT, CI (typecheck) + npm publish via GitHub Actions on release.