### PR TITLE
fix(cli): make serve honor OPENCODE_SERVER_PASSWORD as documented opt-in

### DIFF
--- a/packages/cli/src/commands/handlers/serve.ts
+++ b/packages/cli/src/commands/handlers/serve.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect"
 import { HttpRouter, HttpServer } from "effect/unstable/http"
 import { createServer } from "node:http"
 import { createRoutes } from "@opencode-ai/server/routes"
+import { Flag } from "@opencode-ai/core/flag/flag"
 import { Commands } from "../commands"
 import { Runtime } from "../../framework/runtime"
 import { Daemon } from "../../services/daemon"
@@ -18,7 +19,18 @@ export default Runtime.handler(
     return yield* Effect.scoped(
       Effect.gen(function* () {
         const daemon = yield* Daemon.Service
-        const address = yield* listen(input.hostname, input.port, yield* daemon.password())
+        // Honor the documented opt-in: enforce basic auth only when
+        // OPENCODE_SERVER_PASSWORD is set. Standalone serves without a
+        // password stay unsecured with a warning, matching the
+        // `packages/opencode` serve behavior; daemon-registered servers
+        // keep their persisted private credential for managed clients.
+        const password = input.register
+          ? (yield* daemon.password())
+          : (Flag.OPENCODE_SERVER_PASSWORD ?? undefined)
+        const address = yield* listen(input.hostname, input.port, password)
+        if (!password) {
+          console.log("Warning: OPENCODE_SERVER_PASSWORD is not set; server is unsecured.")
+        }
         if (input.register) yield* daemon.register(address)
         console.log(`server listening on ${HttpServer.formatAddress(address)}`)
         return yield* Effect.never
@@ -27,7 +39,7 @@ export default Runtime.handler(
   }),
 )
 
-function listen(hostname: string, port: Option.Option<number>, password: string) {
+function listen(hostname: string, port: Option.Option<number>, password?: string) {
   if (Option.isSome(port)) return bind(hostname, port.value, password)
   const next = (port: number): ReturnType<typeof bind> =>
     bind(hostname, port, password).pipe(
@@ -36,7 +48,7 @@ function listen(hostname: string, port: Option.Option<number>, password: string)
   return next(4096)
 }
 
-function bind(hostname: string, port: number, password: string) {
+function bind(hostname: string, port: number, password?: string) {
   return Layer.build(
     HttpRouter.serve(createRoutes(password), { disableListenLog: true, disableLogger: true }).pipe(
       Layer.provideMerge(NodeHttpServer.layer(() => createServer(), { port, host: hostname })),


### PR DESCRIPTION
## Problem

`opencode2 serve` unconditionally resolved the daemon-managed password and served with mandatory HTTP basic auth — generating and printing a fresh password per start when `OPENCODE_SERVER_PASSWORD` was unset. This contradicts the documented behavior (both V1 and V2 docs describe `OPENCODE_SERVER_PASSWORD` as opt-in: "Set OPENCODE_SERVER_PASSWORD to protect the server with HTTP basic auth"), and it breaks headless deployments that are already gated at the edge (e.g. Cloudflare Access in front of a tunnel), which get a rotating credential they never asked for.

## Repro (beta 18684)

```
OPENCODE_DB=/tmp/x.db opencode2 serve --port 5199   # prints "server password ..."
curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:5199/api/health   # 401 without basic auth
```

## Change

`packages/cli` serve handler: pass the password to `createRoutes` only when `OPENCODE_SERVER_PASSWORD` is set; otherwise serve unsecured with the same warning that `packages/opencode` serve prints. Daemon (`--register`) flows keep the daemon-managed credential, so managed clients (TUI/desktop) are unaffected.

`ServerAuth.required()` and the authorization middleware already treat a missing password as "no auth", and `createRoutes(password?: string)` already accepted an optional password — so this only removes the forced resolution in the CLI handler.

## Test

- Built `packages/cli` (linux-x64) and verified: no env → warning + unauthenticated `200 /api/health`; `OPENCODE_SERVER_PASSWORD=secret123` → `401` unauthenticated, `200` with `Basic opencode:secret123`.
- Existing suite covers the server side (`httpapi-authorization.test.ts`: "allows requests when server password is not configured`).