### PR TITLE
fix: stop repeated identical tool call loops

### DIFF
--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1078,38 +1078,38 @@ const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
-  const LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 10
+    const LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 10
 
-  function canonicalize(value: unknown): string {
-    if (value === undefined) return "undefined"
-    if (value === null || typeof value !== "object") return JSON.stringify(value)
-    if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`
-    const entries = Object.entries(value as Record<string, unknown>)
-      .filter(([, v]) => v !== undefined)
-      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",")}}`
-  }
+    function canonicalize(value: unknown): string {
+      if (value === undefined) return "undefined"
+      if (value === null || typeof value !== "object") return JSON.stringify(value)
+      if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`
+      const entries = Object.entries(value as Record<string, unknown>)
+        .filter(([, v]) => v !== undefined)
+        .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",")}}`
+    }
 
-  function identicalToolCallLoop(
-    msgs: SessionV1.WithParts[],
-    userID: string,
-  ): { tool: string; count: number } | undefined {
-    const calls: { tool: string; signature: string }[] = []
-    for (const msg of msgs) {
-      if (msg.info.role !== "assistant" || msg.info.parentID !== userID) continue
-      for (const part of msg.parts) {
-        if (part.type !== "tool" || part.metadata?.providerExecuted || isOrphanedInterruptedTool(part)) continue
-        const input = "input" in part.state ? part.state.input : undefined
-        calls.push({ tool: part.tool, signature: `${part.tool}:${canonicalize(input)}` })
+    function identicalToolCallLoop(
+      msgs: SessionV1.WithParts[],
+      userID: string,
+    ): { tool: string; count: number } | undefined {
+      const calls: { tool: string; signature: string }[] = []
+      for (const msg of msgs) {
+        if (msg.info.role !== "assistant" || msg.info.parentID !== userID) continue
+        for (const part of msg.parts) {
+          if (part.type !== "tool" || part.metadata?.providerExecuted || isOrphanedInterruptedTool(part)) continue
+          const input = "input" in part.state ? part.state.input : undefined
+          calls.push({ tool: part.tool, signature: `${part.tool}:${canonicalize(input)}` })
+        }
       }
+      if (calls.length < LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS) return undefined
+      const tail = calls.slice(-LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS)
+      if (tail.every((call) => call.signature === tail[0].signature)) {
+        return { tool: tail[0].tool, count: tail.length }
+      }
+      return undefined
     }
-    if (calls.length < LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS) return undefined
-    const tail = calls.slice(-LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS)
-    if (tail.every((call) => call.signature === tail[0].signature)) {
-      return { tool: tail[0].tool, count: tail.length }
-    }
-    return undefined
-  }
 
     const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1078,6 +1078,39 @@ const layer = Layer.effect(
       throw new Error("Impossible")
     })
 
+  const LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS = 10
+
+  function canonicalize(value: unknown): string {
+    if (value === undefined) return "undefined"
+    if (value === null || typeof value !== "object") return JSON.stringify(value)
+    if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalize(v)}`).join(",")}}`
+  }
+
+  function identicalToolCallLoop(
+    msgs: SessionV1.WithParts[],
+    userID: string,
+  ): { tool: string; count: number } | undefined {
+    const calls: { tool: string; signature: string }[] = []
+    for (const msg of msgs) {
+      if (msg.info.role !== "assistant" || msg.info.parentID !== userID) continue
+      for (const part of msg.parts) {
+        if (part.type !== "tool" || part.metadata?.providerExecuted || isOrphanedInterruptedTool(part)) continue
+        const input = "input" in part.state ? part.state.input : undefined
+        calls.push({ tool: part.tool, signature: `${part.tool}:${canonicalize(input)}` })
+      }
+    }
+    if (calls.length < LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS) return undefined
+    const tail = calls.slice(-LOOP_GUARD_CONSECUTIVE_IDENTICAL_TOOL_CALLS)
+    if (tail.every((call) => call.signature === tail[0].signature)) {
+      return { tool: tail[0].tool, count: tail.length }
+    }
+    return undefined
+  }
+
     const runLoop: (sessionID: SessionID) => Effect.Effect<SessionV1.WithParts> = Effect.fn("SessionPrompt.run")(
       function* (sessionID: SessionID) {
         const ctx = yield* InstanceState.context
@@ -1126,6 +1159,21 @@ const layer = Layer.effect(
               })
             }
             yield* Effect.logInfo("exiting loop", { "session.id": sessionID })
+            break
+          }
+
+          const loopTrip = identicalToolCallLoop(msgs, lastUser.id)
+          if (loopTrip) {
+            const error = new NamedError.Unknown({
+              message: `Stopped: tool "${loopTrip.tool}" was called ${loopTrip.count} consecutive times with identical arguments. This looks like an agent loop; aborting to prevent unbounded token burn.`,
+              ref: "repeated-identical-tool-call",
+            }).toObject()
+            yield* Effect.logWarning("loop exit: repeated identical tool calls", {
+              "session.id": sessionID,
+              tool: loopTrip.tool,
+              count: loopTrip.count,
+            })
+            yield* events.publish(Session.Event.Error, { sessionID, error })
             break
           }
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -628,6 +628,89 @@ it.instance("legacy prompt emits message events without session.next events", ()
   }),
 )
 
+it.instance("loop aborts on 10 consecutive identical tool calls", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const events = yield* EventV2Bridge.Service
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    const errors: NonNullable<SessionV1.Assistant["error"]>[] = []
+    const off = yield* events.listen((event) => {
+      if (event.type !== Session.Event.Error.type) return Effect.void
+      const data = event.data as typeof Session.Event.Error.data.Type
+      if (data.sessionID === chat.id && data.error) errors.push(data.error)
+      return Effect.void
+    })
+
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    for (let i = 0; i < 12; i++) yield* llm.tool("glob", { pattern: "**/*.txt" })
+    yield* llm.text("should never be consumed")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    yield* off
+
+    expect(yield* llm.calls).toBe(10)
+    expect(result.info.role).toBe("assistant")
+    expect(errors).toContainEqual(
+      expect.objectContaining({
+        name: "UnknownError",
+        data: expect.objectContaining({
+          ref: "repeated-identical-tool-call",
+          message: expect.stringContaining('tool "glob" was called 10 consecutive times'),
+        }),
+      }),
+    )
+  }),
+)
+
+it.instance("loop does not abort below the identical-call threshold", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    for (let i = 0; i < 9; i++) yield* llm.tool("glob", { pattern: "**/*.txt" })
+    yield* llm.text("done")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    expect(yield* llm.calls).toBe(10)
+    expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
+  }),
+)
+
+it.instance("loop does not abort on alternating tool call arguments", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    for (let i = 0; i < 12; i++) yield* llm.tool("glob", { pattern: i % 2 === 0 ? "**/*.txt" : "**/*.ts" })
+    yield* llm.text("done")
+
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    expect(yield* llm.calls).toBe(13)
+    expect(result.parts.some((part) => part.type === "text" && part.text === "done")).toBe(true)
+  }),
+)
+
 it.instance("loop surfaces content-filter finishes as session errors", () =>
   Effect.gen(function* () {
     const { llm } = yield* useServerConfig(providerCfg)


### PR DESCRIPTION
### Issue for this PR

Closes #45442

Related: #43603

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Stops a session after 10 consecutive calls with the same tool name and canonical arguments. Before returning to idle, it emits a visible session error so repeated read loops do not continue indefinitely. Tests cover the threshold, below-threshold calls, and alternating arguments.

### How did you verify your code works?

- `bun test packages/opencode/test/session/prompt.test.ts` — 61 passed, 1 skipped, 0 failed
- `bun turbo typecheck` — 30/30 packages passed

### Screenshots / recordings

Not applicable; this is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
