### PR TITLE
fix(tools): filter undefined values from permission metadata

### DIFF
--- a/packages/opencode/src/tool/glob.ts
+++ b/packages/opencode/src/tool/glob.ts
@@ -29,10 +29,11 @@ export const GlobTool = Tool.define(
             permission: "glob",
             patterns: [params.pattern],
             always: ["*"],
-            metadata: {
-              pattern: params.pattern,
-              path: params.path,
-            },
+            metadata: Object.fromEntries(
+              Object.entries({ pattern: params.pattern, path: params.path }).filter(
+                (entry): entry is [string, string] => entry[1] !== undefined,
+              ),
+            ),
           })
 
           let search = params.path ?? ins.directory

--- a/packages/opencode/src/tool/grep.ts
+++ b/packages/opencode/src/tool/grep.ts
@@ -40,11 +40,11 @@ export const GrepTool = Tool.define(
             permission: "grep",
             patterns: [params.pattern],
             always: ["*"],
-            metadata: {
-              pattern: params.pattern,
-              path: params.path,
-              include: params.include,
-            },
+            metadata: Object.fromEntries(
+              Object.entries({ pattern: params.pattern, path: params.path, include: params.include }).filter(
+                (entry): entry is [string, string] => entry[1] !== undefined,
+              ),
+            ),
           })
 
           const ins = yield* InstanceState.context


### PR DESCRIPTION
## Summary

The  and  tools store optional fields (, ) in permission metadata even when they are . This causes schema encoding failures in  because the ACP SDK cannot serialize  values.

## Reproduction

1. Configure permissions to ask by default
2. Emit a  tool call without the optional  field
3. While the permission is pending, request 

The endpoint fails with:


## Fix

Filter out  entries from metadata before sending permission requests using  + .

## Testing

- Verified that metadata only contains defined values
- Existing glob/grep tests pass

Fixes #37650