### PR TITLE
fix(ai): close Gemini text before tools

### DIFF
--- a/packages/ai/src/protocols/gemini.ts
+++ b/packages/ai/src/protocols/gemini.ts
@@ -743,6 +743,16 @@ const step = (state: ParserState, event: GeminiEvent) => {
         reasoningId = undefined
         reasoningSignature = undefined
       }
+      if (textId !== undefined) {
+        lifecycle = Lifecycle.textEnd(
+          lifecycle,
+          events,
+          textId,
+          textSignature ? providerMetadata(state.providerMetadataKey, { thoughtSignature: textSignature }) : undefined,
+        )
+        textId = undefined
+        textSignature = undefined
+      }
       lifecycle = Lifecycle.stepStart(lifecycle, events)
       events.push(
         LLMEvent.toolCall({

--- a/packages/ai/test/provider/gemini.test.ts
+++ b/packages/ai/test/provider/gemini.test.ts
@@ -1368,6 +1368,56 @@ describe("Gemini route", () => {
     }),
   )
 
+  it.effect("separates text blocks around streamed tool calls", () =>
+    Effect.gen(function* () {
+      const body = sseEvents({
+        candidates: [
+          {
+            content: {
+              role: "model",
+              parts: [
+                { text: "before" },
+                { functionCall: { id: "call_1", name: "lookup", args: { query: "weather" } } },
+                { text: "after" },
+              ],
+            },
+            finishReason: "STOP",
+          },
+        ],
+      })
+      const response = yield* LLMClient.generate(
+        LLMRequest.update(request, {
+          tools: [ToolDefinition.make({ name: "lookup", description: "Lookup data", inputSchema: { type: "object" } })],
+        }),
+      ).pipe(Effect.provide(fixedResponse(body)))
+
+      expect(response.events.slice(1, 8)).toEqual([
+        { type: "text-start", id: "text-0" },
+        { type: "text-delta", id: "text-0", text: "before" },
+        { type: "text-end", id: "text-0" },
+        {
+          type: "tool-call",
+          id: "call_1",
+          name: "lookup",
+          input: { query: "weather" },
+          providerExecuted: undefined,
+          providerMetadata: undefined,
+        },
+        { type: "text-start", id: "text-1" },
+        { type: "text-delta", id: "text-1", text: "after" },
+        { type: "text-end", id: "text-1" },
+      ])
+      const textStarts = response.events.filter((event) => event.type === "text-start")
+      expect(textStarts[0]?.id).not.toBe(textStarts[1]?.id)
+      expect(response.message.content).toEqual([
+        { type: "text", text: "before" },
+        { type: "tool-call", id: "call_1", name: "lookup", input: { query: "weather" } },
+        { type: "text", text: "after" },
+      ])
+      expect(response.finishReason).toEqual({ normalized: "tool-calls", raw: "STOP" })
+    }),
+  )
+
   it.effect("defaults omitted function call args to an empty object", () =>
     Effect.gen(function* () {
       const response = yield* LLMClient.generate(


### PR DESCRIPTION
## Summary
- end an active Gemini text block before emitting a function call
- allow text after the call to start a fresh block with a distinct ID
- preserve Gemini Content.parts ordering in common events and assembled assistant content

Gemini Content.parts are ordered, but active text previously remained open across a function-call part. The adapter now ends active text before emitting the call, preserving pending text signature metadata and allowing subsequent text to start a fresh block.

## Verification
- bun test test/provider/gemini.test.ts
- bun typecheck