### PR TITLE
fix: coalesce shell progress updates

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Duration, Effect, Schedule, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -25,6 +25,7 @@ import { BashArity } from "@/permission/arity"
 export { Parameters } from "./shell/prompt"
 
 const MAX_METADATA_LENGTH = 30_000
+const METADATA_UPDATE_INTERVAL = 100
 const CWD = new Set(["cd", "chdir", "popd", "pushd", "push-location", "set-location"])
 const FILES = new Set([
   ...CWD,
@@ -446,6 +447,17 @@ export const ShellTool = Tool.define(
       let cut = false
       let expired = false
       let aborted = false
+      let metadataOutput = ""
+
+      const updateMetadata = Effect.suspend(() => {
+        if (last === metadataOutput) return Effect.void
+        const output = last
+        return ctx.metadata({
+          metadata: {
+            output,
+          },
+        }).pipe(Effect.andThen(Effect.sync(() => (metadataOutput = output))))
+      })
 
       const closeSink = Effect.fnUntraced(function* () {
         const stream = sink
@@ -483,6 +495,11 @@ export const ShellTool = Tool.define(
           yield* Effect.addFinalizer(closeSink)
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
+          yield* updateMetadata.pipe(
+            Effect.repeat(Schedule.spaced(Duration.millis(METADATA_UPDATE_INTERVAL))),
+            Effect.forkScoped,
+          )
+
           yield* Effect.forkScoped(
             Stream.runForEach(Stream.decodeText(handle.all), (chunk) => {
               const size = Buffer.byteLength(chunk, "utf-8")
@@ -511,22 +528,11 @@ export const ShellTool = Tool.define(
                         full = ""
                       }),
                     ),
-                    Effect.andThen(
-                      ctx.metadata({
-                        metadata: {
-                          output: last,
-                        },
-                      }),
-                    ),
                   )
                 }
               }
 
-              return ctx.metadata({
-                metadata: {
-                  output: last,
-                },
-              })
+              return Effect.void
             }),
           )
 
@@ -557,6 +563,8 @@ export const ShellTool = Tool.define(
           return exit.kind === "exit" ? exit.code : null
         }),
       ).pipe(Effect.orDie)
+
+      yield* updateMetadata
 
       const meta: string[] = []
       if (expired) {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1112,7 +1112,7 @@ describe("tool.shell abort", () => {
         const updates: string[] = []
         const result = yield* run(
           {
-            command: `echo first && sleep 0.1 && echo second`,
+            command: `echo first && sleep 0.2 && echo second`,
           },
           {
             ...ctx,
@@ -1128,6 +1128,72 @@ describe("tool.shell abort", () => {
         expect(updates.length).toBeGreaterThan(1)
       }),
     ),
+  )
+
+  it.live("publishes coalesced output before process exit", () =>
+    runIn(
+      projectRoot,
+      Effect.gen(function* () {
+        const controller = new AbortController()
+        const updates: string[] = []
+        const code =
+          "let i=0;const timer=setInterval(()=>{process.stdout.write(String(++i)+String.fromCharCode(10));if(i===30){clearInterval(timer);setTimeout(()=>{},30000)}},10)"
+        const result = yield* run(
+          {
+            command: `${PS.has(sh()) ? "& " : ""}${bin} -e ${evalarg(code)}`,
+          },
+          {
+            ...ctx,
+            abort: controller.signal,
+            metadata: (input) =>
+              Effect.sync(() => {
+                const output = (input.metadata as { output?: string })?.output
+                if (!output) return
+                updates.push(output)
+                if (output.includes("30")) controller.abort()
+              }),
+          },
+        )
+        expect(result.output).toContain("30")
+        expect(result.output).toContain("User aborted the command")
+        expect(updates.at(-1)).toContain("30")
+      }),
+    ),
+  )
+
+  it.live("flushes the latest output after the process scope closes", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      const marker = path.join(tmp, "release")
+      const updates: string[] = []
+      let released = false
+      const code =
+        "console.log(1);while(!(await Bun.file(Bun.argv[1]).exists()))await Bun.sleep(1);console.log(2)"
+
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const result = yield* run(
+            {
+              command: `${PS.has(sh()) ? "& " : ""}${bin} -e ${evalarg(code)} ${quote(marker)}`,
+            },
+            {
+              ...ctx,
+              metadata: (input) => {
+                const output = (input.metadata as { output?: string })?.output
+                if (!output) return Effect.void
+                updates.push(output)
+                if (released || !output.includes("1")) return Effect.void
+                released = true
+                return Effect.promise(() => Bun.write(marker, "")).pipe(Effect.asVoid)
+              },
+            },
+          )
+          expect(result.output).toContain("2")
+          expect(updates.at(-1)).toContain("2")
+        }),
+      )
+    }),
   )
 })
 


### PR DESCRIPTION
## Summary

- keep draining and truncating every shell output chunk immediately
- publish changed shell metadata previews at most once per 100 ms
- force the latest changed preview after process settlement

## Why

Each metadata callback persists and broadcasts another complete `message.part.updated.1` snapshot. Fast or chatty commands can therefore generate many full-preview updates without improving the UI at chunk-level cadence.

A synthetic burst wrote 30 numbered chunks 10 ms apart, then kept the process alive until metadata exposed the final line. Across 10 fresh test processes per implementation:

| Implementation | Median metadata updates | Range |
| --- | ---: | ---: |
| Exact baseline | 30 | 30-30 |
| This change | 4 | 4-5 |

That is an 86.7% median callback-count reduction in this workload. It does not claim an RSS reduction or equivalent production database-byte savings.

The implementation does not group the output stream: pipe draining, output capture, truncation, abort, and timeout behavior still process every chunk. The periodic publisher is scope-bound, deduplicates unchanged previews, and the final forced update prevents a burst ending between intervals from becoming stale.

Related: #33356

## Validation

- `bun test ./test/tool/shell.test.ts`: 25 pass, 0 fail on clean rerun
- `bun test ./test/session/prompt.test.ts -t 'cancel finalizes interrupted bash tool output through normal truncation'`: 1 pass, 0 fail
- `bun typecheck`: pass
- targeted `oxlint` on both changed files: 0 errors
- independent defect-first review: no implementation blocker

The package-wide run reached 3,394 pass, 22 skip, 1 todo, with 2 unrelated PTY/session-route failures; both passed immediate targeted reruns.
