### PR TITLE
fix: skip unused compaction clone

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -375,8 +375,9 @@ const layer = Layer.effect(
         { sessionID: input.sessionID },
         { context: [], prompt: undefined },
       )
-      const msgs = structuredClone(selected.head)
-      yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+      const hasTransform = (yield* plugin.list()).some((hook) => hook["experimental.chat.messages.transform"])
+      const msgs = hasTransform ? structuredClone(selected.head) : selected.head
+      if (hasTransform) yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
       const conversation = msgs.map(serialize).filter(Boolean).join("\n\n")
       const nextPrompt =
         compacting.prompt ??

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -29,6 +29,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { TestConfig } from "../fixture/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { LLMEvent, Usage } from "@opencode-ai/llm"
+import type { Hooks } from "@opencode-ai/plugin"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -375,6 +376,25 @@ function compactionContext(context: string) {
       })
     },
     list: () => Effect.succeed([]),
+    init: () => Effect.void,
+  })
+}
+
+function compactionMessageTransform(text: string) {
+  const hook: Hooks = {
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const part = output.messages[0]?.parts.find((item) => item.type === "text")
+      if (part?.type === "text") part.text = text
+    },
+  }
+  return Layer.mock(Plugin.Service)({
+    trigger: <Name extends string, Input, Output>(name: Name, input: Input, output: Output) => {
+      if (name !== "experimental.chat.messages.transform") return Effect.succeed(output)
+      return Effect.promise(() =>
+        hook["experimental.chat.messages.transform"]!(input as never, output as never),
+      ).pipe(Effect.as(output))
+    },
+    list: () => Effect.succeed([hook]),
     init: () => Effect.void,
   })
 }
@@ -1503,6 +1523,49 @@ describe("session.compaction.process", () => {
         withCompaction({
           llm: stub.llmLayer,
           plugin: compactionContext("Prioritize unresolved migration details"),
+        }),
+      )
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "isolates compaction message-transform mutations from source history",
+    () => {
+      const stub = llm()
+      let captured = ""
+      stub.push(
+        reply("summary", (input) => {
+          captured = JSON.stringify(input.messages)
+        }),
+      )
+
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        yield* createUserMessage(session.id, "older context")
+        yield* createUserMessage(session.id, "keep this turn")
+        yield* createUserMessage(session.id, "and this one too")
+        yield* createCompactionMarker(session.id)
+
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+        yield* SessionCompaction.use.process({
+          parentID: parent!,
+          messages: msgs,
+          sessionID: session.id,
+          auto: false,
+        })
+
+        expect(captured).toContain("transformed context")
+        expect(JSON.stringify(msgs)).toContain("older context")
+        expect(JSON.stringify(msgs)).not.toContain("transformed context")
+      }).pipe(
+        withCompaction({
+          llm: stub.llmLayer,
+          config: cfg({ tail_turns: 2, preserve_recent_tokens: 10_000 }),
+          plugin: compactionMessageTransform("transformed context"),
         }),
       )
     },


### PR DESCRIPTION
## Summary

- skip cloning compaction history when no message-transform hook is registered
- preserve the existing clone and transform behavior when a hook exists
- test that transform mutations reach the compaction prompt without mutating source history

## Why

Compaction currently `structuredClone`s the selected history before serializing it, even when no `experimental.chat.messages.transform` hook exists. Serialization later caps completed tool output at 2,000 characters, so a large discarded tool result can be copied in full immediately before being reduced.

An isolated Bun 1.3.14 benchmark used one synthetic 64 MiB completed tool output in that same clone-before-bounded-serialization shape. Five counterbalanced fresh processes per path measured:

| Path | Median max RSS | Range |
| --- | ---: | ---: |
| Direct serialization | 159.2 MB | 159.2-159.3 MB |
| `structuredClone` first | 293.6 MB | 293.6-293.7 MB |

The group-median difference was 134.4 MB. This isolates the clone cost; it is not an end-to-end OpenCode or active-session RSS claim.

`Plugin.list()` and `Plugin.trigger()` read the same fully initialized, location-scoped hook array. When there is no matching hook, `trigger()` is otherwise a no-op. When there is one, this change preserves the old clone-plus-trigger path and its mutation isolation.

Related: #20695

## Validation

- `bun test ./test/session/compaction.test.ts`: 56 pass, 1 skip, 0 fail
- `bun typecheck`: pass
- full `packages/opencode` suite: 3,396 pass, 22 skip, 1 todo, 0 fail
- targeted `oxlint` on both changed files: 0 errors
- independent defect-first review: no issues found
