### PR TITLE
fix(ai): omit empty Bedrock system blocks

### DIFF
--- a/packages/ai/src/protocols/bedrock-converse.ts
+++ b/packages/ai/src/protocols/bedrock-converse.ts
@@ -410,7 +410,12 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
 const lowerSystem = (
   breakpoints: BedrockCache.Breakpoints,
   system: ReadonlyArray<LLMRequest["system"][number]>,
-): BedrockSystemBlock[] => system.flatMap((part) => textWithCache(breakpoints, part.text, part.cache))
+) => {
+  const content = system
+    .filter((part) => part.text.length > 0)
+    .flatMap((part) => textWithCache(breakpoints, part.text, part.cache))
+  return content.length === 0 ? undefined : content
+}
 
 const fromRequest = Effect.fn("BedrockConverse.fromRequest")(function* (request: LLMRequest) {
   const toolChoice = request.toolChoice ? yield* lowerToolChoice(request.toolChoice) : undefined
@@ -427,7 +432,7 @@ const fromRequest = Effect.fn("BedrockConverse.fromRequest")(function* (request:
       toolChoice,
     }
   })()
-  const system = request.system.length === 0 ? undefined : lowerSystem(breakpoints, request.system)
+  const system = lowerSystem(breakpoints, request.system)
   const messages = yield* lowerMessages(request, breakpoints)
   if (breakpoints.dropped > 0) {
     yield* Effect.logWarning(

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -125,6 +125,50 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
+  it.effect("omits empty initial system blocks", () =>
+    Effect.gen(function* () {
+      const empty = yield* compileRequest(LLM.request({ model, system: "", prompt: "hello" }))
+      const cachedEmpty = yield* compileRequest(
+        LLM.request({
+          model,
+          system: [{ type: "text", text: "", cache: new CacheHint({ type: "ephemeral" }) }],
+          prompt: "hello",
+          cache: "none",
+        }),
+      )
+
+      expect(empty.body.system).toBeUndefined()
+      expect(cachedEmpty.body.system).toBeUndefined()
+    }),
+  )
+
+  it.effect("omits empty system blocks while preserving order and cache hints", () =>
+    Effect.gen(function* () {
+      const cache = new CacheHint({ type: "ephemeral" })
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          system: [
+            { type: "text", text: "", cache },
+            { type: "text", text: "First." },
+            { type: "text", text: " " },
+            { type: "text", text: "" },
+            { type: "text", text: "Second.", cache },
+          ],
+          prompt: "hello",
+          cache: "none",
+        }),
+      )
+
+      expect(prepared.body.system).toEqual([
+        { text: "First." },
+        { text: " " },
+        { text: "Second." },
+        { cachePoint: { type: "default" } },
+      ])
+    }),
+  )
+
   it.effect("passes topK through additionalModelRequestFields as top_k", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(


### PR DESCRIPTION
## Summary

- Direct `@opencode-ai/ai` requests with an exactly empty initial system prompt compiled to `system: [{ text: "" }]`. AWS Bedrock Converse requires `SystemContentBlock.text` to have a minimum length of 1, so the wire request fails with a validation error.
- Filter exactly empty initial system text during Bedrock-specific lowering and omit the top-level `system` property when no blocks remain.
- Preserve whitespace-only blocks, nonempty block order, and cache points for retained blocks without emitting cache-only system content. Chronological system messages are unchanged.

## Tests

- `bun test test/provider/bedrock-converse.test.ts --timeout 30000` (66 pass, 0 fail)
- `bun typecheck` (pass)