### PR TITLE
fix(ai): sanitize empty Bedrock tool input keys

### DIFF
--- a/packages/ai/src/protocols/bedrock-converse.ts
+++ b/packages/ai/src/protocols/bedrock-converse.ts
@@ -271,11 +271,19 @@ const reasoningRedactedData = (part: ReasoningPart, providerMetadataKey: string)
   if (ProviderShared.isRecord(metadata) && typeof metadata.redactedData === "string") return metadata.redactedData
 }
 
+const removeEmptyToolInputKeys = (input: unknown): unknown => {
+  if (Array.isArray(input)) return input.map(removeEmptyToolInputKeys)
+  if (!ProviderShared.isRecord(input)) return input
+  return Object.fromEntries(
+    Object.entries(input).flatMap(([key, value]) => (key === "" ? [] : [[key, removeEmptyToolInputKeys(value)]])),
+  )
+}
+
 const lowerToolCall = (part: ToolCallPart): BedrockToolUseBlock => ({
   toolUse: {
     toolUseId: part.id,
     name: part.name,
-    input: part.input,
+    input: removeEmptyToolInputKeys(part.input),
   },
 })
 

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -311,6 +311,79 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
+  it.effect("removes empty keys recursively from outbound tool inputs without mutating history", () =>
+    Effect.gen(function* () {
+      const input = {
+        path: "file.ts",
+        edits: [
+          { oldText: "a", newText: "b", "": "" },
+          null,
+          true,
+          7,
+          "text",
+          ["kept", { "": false, nested: { "": null, value: "ok" } }],
+        ],
+        nested: { "": "drop", empty: {}, onlyEmpty: { "": 1 } },
+        " ": "preserve whitespace key",
+        "": "drop",
+      }
+      const original = structuredClone(input)
+      const call = ToolCallPart.make({ id: "tool_1", name: "edit", input })
+      const prepared = yield* compileRequest(
+        LLM.request({ model, messages: [Message.assistant([call])], cache: "none" }),
+      )
+
+      expect(prepared.body.messages).toEqual([
+        {
+          role: "assistant",
+          content: [
+            {
+              toolUse: {
+                toolUseId: "tool_1",
+                name: "edit",
+                input: {
+                  path: "file.ts",
+                  edits: [{ oldText: "a", newText: "b" }, null, true, 7, "text", ["kept", { nested: { value: "ok" } }]],
+                  nested: { empty: {}, onlyEmpty: {} },
+                  " ": "preserve whitespace key",
+                },
+              },
+            },
+          ],
+        },
+      ])
+      expect(input).toEqual(original)
+      expect(call.input).toBe(input)
+    }),
+  )
+
+  it.effect("keeps empty tool inputs and empties inputs containing only empty keys", () =>
+    Effect.gen(function* () {
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [
+            Message.assistant([
+              ToolCallPart.make({ id: "tool_empty_key", name: "first", input: { "": { value: true } } }),
+              ToolCallPart.make({ id: "tool_empty_object", name: "second", input: {} }),
+            ]),
+          ],
+          cache: "none",
+        }),
+      )
+
+      expect(prepared.body.messages).toEqual([
+        {
+          role: "assistant",
+          content: [
+            { toolUse: { toolUseId: "tool_empty_key", name: "first", input: {} } },
+            { toolUse: { toolUseId: "tool_empty_object", name: "second", input: {} } },
+          ],
+        },
+      ])
+    }),
+  )
+
   it.effect("merges parallel tool results into one user message", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(


### PR DESCRIPTION
## Summary

- Handle model-emitted tool input containing empty object property names before it is replayed into a Bedrock Converse request. Previously, the persisted canonical input was lowered unchanged, producing an invalid `toolUse.input` document that Bedrock rejects.
- Recursively omit only keys that are exactly empty at the outbound Bedrock adapter boundary, including nested records inside arrays, while preserving array positions, scalar values, nulls, whitespace-only keys, and existing empty objects.
- Build a cleaned outbound value without mutating `ToolCallPart.input` or persisted message history. Tool definitions, results, IDs, names, and other message content remain unchanged.

## Verification

- `bun test test/provider/bedrock-converse.test.ts --timeout 30000`: 68 pass, 0 fail, 115 expectations
- `bun typecheck`: passed (`tsgo --noEmit` and `tsgo --noEmit -p tsconfig.types.json`)
