### PR TITLE
fix(ai): omit empty Responses user messages

### DIFF
--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -577,10 +577,8 @@ const lowerMessages = Effect.fn("OpenResponses.lowerMessages")(function* (reques
     }
 
     if (message.role === "user") {
-      input.push({
-        role: "user",
-        content: yield* Effect.forEach(message.content, (part) => lowerUserContent(part, request, extension)),
-      })
+      const content = yield* Effect.forEach(message.content, (part) => lowerUserContent(part, request, extension))
+      if (content.length > 0) input.push({ role: "user", content })
       continue
     }
 

--- a/packages/ai/test/provider/openai-compatible-responses.test.ts
+++ b/packages/ai/test/provider/openai-compatible-responses.test.ts
@@ -96,6 +96,27 @@ describe("Open Responses-compatible route", () => {
     }),
   )
 
+  it.effect("omits user messages with no content", () =>
+    Effect.gen(function* () {
+      const model = configure({
+        apiKey: "test-key",
+        baseURL: "https://responses.example.test/v1",
+        provider: "example",
+      }).model("example-model")
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model,
+          messages: [Message.user("Before."), Message.user([]), Message.user("After.")],
+        }),
+      )
+
+      expect(prepared.body.input).toEqual([
+        { role: "user", content: [{ type: "input_text", text: "Before." }] },
+        { role: "user", content: [{ type: "input_text", text: "After." }] },
+      ])
+    }),
+  )
+
   it.effect("uses data URLs for embedded PDF messages and tool results", () =>
     Effect.gen(function* () {
       const model = configure({


### PR DESCRIPTION
## Summary

- omit user input items when Open Responses lowering produces no content
- preserve surrounding message order and all non-empty lowered user content

## Tests

- `bun test test/provider/openai-compatible-responses.test.ts --timeout 30000`
- `bun typecheck`