### PR TITLE
fix(opencode): don't crash skill discovery on unscoped scan errors

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -156,12 +156,11 @@ const scan = Effect.fnUntraced(function* (
       }),
     catch: (error) => error,
   }).pipe(
-    Effect.catch((error) => {
-      if (!opts?.scope) return Effect.die(error)
-      return Effect.logError(`failed to scan ${opts.scope} skills`, { dir: root, error: error }).pipe(
+    Effect.catch((error) =>
+      Effect.logError(`failed to scan ${opts?.scope ?? "project"} skills`, { dir: root, error: error }).pipe(
         Effect.as([] as string[]),
-      )
-    }),
+      ),
+    ),
   )
 
   for (const match of matches) {


### PR DESCRIPTION
### Issue for this PR

Closes #45961

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`scan()` in `packages/opencode/src/skill/index.ts` only logged and continued
when a `scope` (`global`/`project`, used for external `.claude`/`.agents`
skill directories) was passed to it. Scans without a scope — the
project-local `.opencode/skill` / `.opencode/skills` directories — called
`Effect.die(error)` on any glob failure, crashing skill discovery entirely.

The reported trigger is a self-referential symlink cycle producing
`ENAMETOOLONG`, but the same hard crash happens for any glob error (e.g.
`EACCES` on a permission-restricted directory) as long as the failing scan
has no `scope`. This change makes all scan failures log a warning and
continue with no matches, matching the existing behavior for external skill
directories, instead of taking down the whole discovery pass.

I wasn't able to reproduce the exact `ENAMETOOLONG` locally (the `glob`
package bundled in this repo already has its own symlink-cycle guard), but
the `Effect.die` vs. graceful-skip asymmetry between scoped and unscoped
calls is verifiable directly from the code and is a real crash surface
regardless of which specific error trips it.

### Testing

- `bun test test/skill/` — 24 pass, 0 fail (unchanged behavior for the
  happy path)
- `oxlint packages/opencode/src/skill/index.ts` — clean
- `tsc --noEmit` — no new errors