### PR TITLE
docs(ecosystem): add opencode-todo plugin

### DIFF
--- a/packages/web/src/content/docs/ar/ecosystem.mdx
+++ b/packages/web/src/content/docs/ar/ecosystem.mdx
@@ -49,6 +49,7 @@ description: مشاريع وتكاملات مبنية باستخدام OpenCode.
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | حزمة تنسيق متعددة الوكلاء – 16 مكونًا، تثبيت واحد                                                              |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | أشجار عمل git (worktrees) خالية من الاحتكاك لـ OpenCode                                                        |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | تتبع وتصحيح أخطاء وكلاء الذكاء الاصطناعي باستخدام Sentry AI Monitoring                                         |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | قائمة مهام شخصية لك أنت، لا للوكيل.                                                                            |
 
 ---
 

--- a/packages/web/src/content/docs/bs/ecosystem.mdx
+++ b/packages/web/src/content/docs/bs/ecosystem.mdx
@@ -49,6 +49,7 @@ Također možete pogledati [awesome-opencode](https://github.com/awesome-opencod
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Uvezeni višeagentni orkestracijski pojas – 16 komponenti, jedna instalacija                                   |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Git radna stabla bez trenja za OpenCode                                                                       |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Pratite i otklanjajte greške svojih AI agenata uz Sentry AI Monitoring                                        |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Lični backlog zadataka za vas, ne za agenta.                                                                  |
 
 ---
 

--- a/packages/web/src/content/docs/da/ecosystem.mdx
+++ b/packages/web/src/content/docs/da/ecosystem.mdx
@@ -49,6 +49,7 @@ Du kan også tjekke [awesome-opencode](https://github.com/awesome-opencode/aweso
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orkestreringssele – 16 komponenter, én installation                                           |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Nulfriktions git-arbejdstræer for OpenCode                                                                        |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Spor og fejlfind dine AI-agenter med Sentry AI Monitoring                                                         |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | En personlig opgavebacklog til dig, ikke til agenten.                                                             |
 
 ---
 

--- a/packages/web/src/content/docs/de/ecosystem.mdx
+++ b/packages/web/src/content/docs/de/ecosystem.mdx
@@ -49,6 +49,7 @@ Sie können sich auch [awesome-opencode](https://github.com/awesome-opencode/awe
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Gebündelter Multi-Agent-Orchestrierungs-Harness – 16 Komponenten, eine Installation                                           |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Reibungslose Git-Arbeitsbäume für OpenCode                                                                                    |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Tracen und debuggen Sie Ihre AI-Agenten mit Sentry AI Monitoring                                                              |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Ein persönliches Aufgaben-Backlog für Sie, nicht für den Agenten.                                                             |
 
 ---
 

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | A personal task backlog for you, not the agent.                                                    |
 
 ---
 

--- a/packages/web/src/content/docs/es/ecosystem.mdx
+++ b/packages/web/src/content/docs/es/ecosystem.mdx
@@ -49,6 +49,7 @@ También puedes consultar [awesome-opencode](https://github.com/awesome-opencode
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Arnés de orquestación multiagente incluido: 16 componentes, una instalación                                                 |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Árboles de trabajo de Git de fricción cero para OpenCode                                                                    |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Rastree y depure sus agentes de IA con Sentry AI Monitoring                                                                 |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Una lista de tareas pendientes personal para ti, no para el agente.                                                         |
 
 ---
 

--- a/packages/web/src/content/docs/fr/ecosystem.mdx
+++ b/packages/web/src/content/docs/fr/ecosystem.mdx
@@ -49,6 +49,7 @@ Vous pouvez également consulter [awesome-opencode](https://github.com/awesome-o
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Harnais d'orchestration multi-agents groupé – 16 composants, une installation                                                          |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Worktrees git sans friction pour OpenCode                                                                                              |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Tracez et déboguez vos agents IA avec Sentry AI Monitoring                                                                             |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Un backlog de tâches personnel pour vous, et non pour l'agent.                                                                         |
 
 ---
 

--- a/packages/web/src/content/docs/it/ecosystem.mdx
+++ b/packages/web/src/content/docs/it/ecosystem.mdx
@@ -49,6 +49,7 @@ Puoi anche dare un'occhiata a [awesome-opencode](https://github.com/awesome-open
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Harness di orchestrazione multi-agente bundle: 16 componenti, una installazione                   |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Git worktree senza attriti per OpenCode                                                           |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Traccia e debugga i tuoi agenti AI con Sentry AI Monitoring                                       |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Un backlog di attività personale per te, non per l'agente.                                        |
 
 ---
 

--- a/packages/web/src/content/docs/ja/ecosystem.mdx
+++ b/packages/web/src/content/docs/ja/ecosystem.mdx
@@ -49,6 +49,7 @@ OpenCode 関連プロジェクトをこのリストに追加したいですか? 
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | バンドルされたマルチエージェントオーケストレーションハーネス – 16 コンポーネント、1 回のインストール                 |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | OpenCode 用のゼロフリクション Git ワークツリー                                                                       |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Sentry AI Monitoring を使用して AI エージェントをトレースおよびデバッグする                                          |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | エージェントではなく、あなた自身のための個人タスクバックログ。                                                                                      |
 
 ---
 

--- a/packages/web/src/content/docs/ko/ecosystem.mdx
+++ b/packages/web/src/content/docs/ko/ecosystem.mdx
@@ -49,6 +49,7 @@ OpenCode를 기반으로 만들어진 커뮤니티 프로젝트 모음입니다.
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | 16개 구성요소를 한 번에 설치하는 bundled multi-agent orchestration harness를 제공합니다.        |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | OpenCode용 git worktree를 손쉽게 사용할 수 있도록 돕습니다.                                     |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Sentry AI 모니터링으로 AI 에이전트를 추적하고 디버그합니다.                                     |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | 에이전트가 아닌 사용자를 위한 개인 작업 백로그입니다.                                                                  |
 
 ---
 

--- a/packages/web/src/content/docs/nb/ecosystem.mdx
+++ b/packages/web/src/content/docs/nb/ecosystem.mdx
@@ -49,6 +49,7 @@ Du kan også sjekke ut [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Medfølgende multi-agent orkestreringsrammeverk – 16 komponenter, én installasjon                              |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Nullfriksjon git-arbeidstre for OpenCode                                                                      |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Spor og feilsøk AI-agentene dine med Sentry AI Monitoring                                                     |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | En personlig oppgavebacklog for deg, ikke for agenten.                                                        |
 
 ---
 

--- a/packages/web/src/content/docs/pl/ecosystem.mdx
+++ b/packages/web/src/content/docs/pl/ecosystem.mdx
@@ -49,6 +49,7 @@ Możesz również sprawdzić [awesome-opencode](https://github.com/awesome-openc
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Zestaw orkiestracji wieloagentowej – 16 komponentów, jedna instalacja                                                 |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Bezproblemowe drzewa robocze git dla OpenCode                                                                         |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Śledź i debuguj swoich agentów AI za pomocą Sentry AI Monitoring                                                      |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Osobisty backlog zadań dla Ciebie, nie dla agenta.                                                                    |
 
 ---
 

--- a/packages/web/src/content/docs/pt-br/ecosystem.mdx
+++ b/packages/web/src/content/docs/pt-br/ecosystem.mdx
@@ -49,6 +49,7 @@ Você também pode conferir [awesome-opencode](https://github.com/awesome-openco
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Conjunto de orquestração multi-agente – 16 componentes, uma instalação                                                         |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Worktrees git sem atrito para OpenCode                                                                                         |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Rastreie e depure seus agentes de IA com o Sentry AI Monitoring                                                                |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Um backlog de tarefas pessoal para você, não para o agente.                                                                    |
 
 ---
 

--- a/packages/web/src/content/docs/ru/ecosystem.mdx
+++ b/packages/web/src/content/docs/ru/ecosystem.mdx
@@ -49,6 +49,7 @@ description: Проекты и интеграции, созданные с по�
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Комплексный пакет многоагентной оркестровки — 16 компонентов, одна установка                                                                     |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Рабочие деревья git с нулевым трением для OpenCode                                                                                               |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Отслеживайте и отлаживайте ваших ИИ-агентов с помощью Sentry AI Monitoring                                                                       |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Личный бэклог задач для вас, а не для агента.                                                                                                    |
 
 ---
 

--- a/packages/web/src/content/docs/th/ecosystem.mdx
+++ b/packages/web/src/content/docs/th/ecosystem.mdx
@@ -49,6 +49,7 @@ description: โปรเจ็กต์และการผสานรวม�
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | ชุดสายรัดประสานหลายเอเจนต์ที่ให้มา – ส่วนประกอบ 16 ชิ้น ติดตั้งเพียงครั้งเดียว                                        |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | เวิร์กทรีคอมไพล์ไร้แรงเสียดทานสำหรับ OpenCode                                                                         |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | ติดตามและแก้ไขข้อบกพร่องเอเจนต์ AI ของคุณด้วย Sentry AI Monitoring                                                    |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | รายการงานส่วนตัวสำหรับคุณ ไม่ใช่สำหรับเอเจนต์                                                                         |
 
 ---
 

--- a/packages/web/src/content/docs/tr/ecosystem.mdx
+++ b/packages/web/src/content/docs/tr/ecosystem.mdx
@@ -49,6 +49,7 @@ Ayrıca ekosistemi ve topluluğu bir araya getiren [awesome-opencode](https://gi
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Paketlenmiş çoklu aracı orkestrasyon donanımı – 16 bileşen, tek kurulum                                                       |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | OpenCode için sıfır sürtünmeli git çalışma ağaçları (worktrees)                                                               |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | Sentry AI Monitoring ile yapay zeka aracılarınızı izleyin ve hatalarını ayıklayın                                             |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | Sizin için kişisel bir görev listesi, ajan için değil.                                                                        |
 
 ---
 

--- a/packages/web/src/content/docs/zh-cn/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-cn/ecosystem.mdx
@@ -49,6 +49,7 @@ description: 基于 OpenCode 构建的项目与集成。
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | 捆绑式多代理编排套件——16 个组件，一次安装                              |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | OpenCode 的零摩擦 git worktree 管理                                    |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | 使用 Sentry AI Monitoring 追踪和调试您的 AI 代理                       |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | 属于你而非代理的个人任务待办清单。                                                      |
 
 ---
 

--- a/packages/web/src/content/docs/zh-tw/ecosystem.mdx
+++ b/packages/web/src/content/docs/zh-tw/ecosystem.mdx
@@ -49,6 +49,7 @@ description: 基於 OpenCode 建置的專案與整合。
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | 捆綁式多代理編排套件——16 個元件，一次安裝                                  |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | OpenCode 的零摩擦 git worktree 管理                                        |
 | [opencode-sentry-monitor](https://github.com/stolinski/opencode-sentry-monitor)                    | 使用 Sentry AI Monitoring 追蹤與除錯您的 AI 代理                           |
+| [opencode-todo](https://github.com/ainformatico/opencode-todo)                                     | 屬於你而非代理的個人任務待辦清單。                                                          |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — adding a community plugin to the ecosystem list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds my plugin [opencode-todo](https://github.com/ainformatico/opencode-todo) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

It's a personal task backlog: `/todo-add`, `/todo-run` and `/todo-remove` commands plus a "My Backlog" panel in the sidebar, backed by a single JSON file. The list belongs to you rather than the agent, so follow-up ideas you get mid-run don't derail the session.

I also added the row to the localized ecosystem pages with the description translated into each language.

### How did you verify your code works?

Docs-only row. Checked that the entry matches each table's column alignment and that the link points at the repo.

### Screenshots / recordings

N/A — docs-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR