### PR TITLE
fix(ai): deduplicate request tools

### DIFF
--- a/packages/ai/src/route/client.ts
+++ b/packages/ai/src/route/client.ts
@@ -446,7 +446,9 @@ export function make<Body, Prepared, Frame, Event, State>(
 
 const compile = Effect.fn("LLM.compile")(function* (request: LLMRequest, options?: StreamOptions) {
   const original = applyCachePolicy(resolveRequestOptions(request))
-  const resolved = LLMRequest.update(original, sanitizeSurrogates({ ...LLMRequest.input(original), model: undefined }))
+  const sanitized = LLMRequest.update(original, sanitizeSurrogates({ ...LLMRequest.input(original), model: undefined }))
+  const tools = [...new Map(sanitized.tools.map((tool) => [tool.name, tool])).values()]
+  const resolved = tools.length === sanitized.tools.length ? sanitized : LLMRequest.update(sanitized, { tools })
   const route = resolved.model.route
 
   const body = yield* route.body

--- a/packages/ai/test/compile.test.ts
+++ b/packages/ai/test/compile.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { Effect, Ref, Schema } from "effect"
 import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
-import { LLM, Message, ToolCallPart, mergeProviderOptions } from "../src/index.js"
+import { LLM, LLMRequest, Message, ToolCallPart, ToolDefinition, mergeProviderOptions } from "../src/index.js"
 import { AnthropicMessages, OpenAIChat } from "../src/protocols.js"
 import { Auth, LLMClient } from "../src/route.js"
 import { compileRequest } from "../src/route/client.js"
@@ -74,6 +74,35 @@ describe("request option precedence", () => {
         reasoning_effort: "medium",
       })
       expect(prepared.body.stop).toEqual(["request"])
+    }),
+  )
+
+  it.effect("keeps the last tool definition for duplicate names", () =>
+    Effect.gen(function* () {
+      const request = LLM.request({
+        model: OpenAIChat.route.model({ id: "gpt-4o-mini" }),
+        prompt: "Use a tool.",
+      })
+      const prepared = yield* compileRequest(
+        LLMRequest.update(request, {
+          tools: [
+            ToolDefinition.make({ name: "lookup", description: "old", inputSchema: { type: "object" } }),
+            ToolDefinition.make({ name: "search", description: "search", inputSchema: { type: "object" } }),
+            ToolDefinition.make({ name: "lookup", description: "new", inputSchema: { type: "object" } }),
+          ],
+        }),
+      )
+
+      expect(prepared.body.tools).toEqual([
+        {
+          type: "function",
+          function: { name: "lookup", description: "new", parameters: { type: "object" }, strict: false },
+        },
+        {
+          type: "function",
+          function: { name: "search", description: "search", parameters: { type: "object" }, strict: false },
+        },
+      ])
     }),
   )
 


### PR DESCRIPTION
## Summary

- deduplicate tool definitions by name in the shared request compiler
- keep the final definition while preserving the name's original list position
- apply the behavior consistently before every protocol lowers the request

## Testing

- `bun test` from `packages/ai` (910 passed, 25 skipped)
- `bun typecheck` from `packages/ai`
- `bunx prettier --check packages/ai/src/route/client.ts packages/ai/test/compile.test.ts`
- `git diff --check`
