### PR TITLE
feat(openai): add OAuth cost estimates

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -1996,6 +1996,7 @@ export type ConfigEntry =
             name?: string
             env?: Array<string>
             package?: string
+            oauth_cost_estimates?: boolean
             settings?: { [x: string]: JsonValue }
             headers?: { [x: string]: string }
             body?: { [x: string]: JsonValue }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -30,6 +30,19 @@ export function latest<K extends keyof Info>(entries: readonly Entry[], key: K):
     ?.info[key]
 }
 
+type ProviderInfo = NonNullable<Info["providers"]>[string]
+
+export function latestProviderField<K extends keyof ProviderInfo>(
+  entries: readonly Entry[],
+  providerID: string,
+  key: K,
+): ProviderInfo[K] | undefined {
+  const entry = entries.findLast(
+    (entry): entry is Document => entry.type === "document" && entry.info.providers?.[providerID]?.[key] !== undefined,
+  )
+  return entry?.info.providers?.[providerID]?.[key]
+}
+
 export interface Interface {
   /** Returns location config documents and discovery sources from lowest to highest priority. */
   readonly entries: () => Effect.Effect<Entry[]>

--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -5,6 +5,8 @@ import type { Server } from "node:http"
 import { App } from "../../app.js"
 import { Credential } from "../../credential.js"
 import { Bus } from "../../bus.js"
+import { Config } from "../../config.js"
+import { ConfigEntryObserver } from "../../config/plugin/entry-observer.js"
 import { Integration } from "../../integration.js"
 import { OauthCallbackPage } from "../../oauth/page.js"
 import { Provider } from "../../provider.js"
@@ -230,6 +232,7 @@ export const OpenAIPlugin = define({
   id: "opencode.provider.openai",
   effect: Effect.fn(function* (ctx) {
     const bus = yield* Bus.Service
+    const config = yield* Config.Service
     const loading = Semaphore.makeUnsafe(1)
     let chatgpt: Credential.OAuth | undefined
 
@@ -250,6 +253,8 @@ export const OpenAIPlugin = define({
       draft.method.update(headless(ctx.app))
     })
     yield* load()
+    // Observe config entries so changing the opt-in rebuilds the catalog.
+    const loaded = yield* ConfigEntryObserver.observe(config, ctx.event, ctx.catalog.reload())
     yield* ctx.catalog.transform((evt) => {
       const item = evt.provider.get(Provider.ID.openai)
       if (!item) return
@@ -259,6 +264,9 @@ export const OpenAIPlugin = define({
         })
       }
       if (!chatgpt) return
+      // Enabled pricing is an optional local API-equivalent estimate, not a subscription charge.
+      const oauthCostEstimates =
+        Config.latestProviderField(loaded.entries, Provider.ID.openai, "oauth_cost_estimates") === true
       item.provider.settings = Provider.mergeOverlay(item.provider.settings, { baseURL: codexBaseURL })
       const account = chatgpt.metadata?.accountID
       item.provider.headers = Provider.mergeHeaders(item.provider.headers, {
@@ -266,8 +274,7 @@ export const OpenAIPlugin = define({
         ...(typeof account === "string" ? { "chatgpt-account-id": account } : {}),
       })
       for (const model of item.models.values()) {
-        // ChatGPT-plan tokens only authorize codex-eligible models, and the
-        // subscription covers usage, so hide the rest and zero the cost.
+        // ChatGPT-plan tokens only authorize Codex-eligible models, so hide the rest and apply Codex-compatible limits.
         evt.model.update(item.provider.id, model.id, (draft) => {
           if (Schema.is(Schema.Struct({ mode: Schema.Literal("pro") }))(draft.body?.reasoning)) {
             draft.enabled = false
@@ -282,7 +289,7 @@ export const OpenAIPlugin = define({
             draft.enabled = false
             return
           }
-          draft.cost = []
+          if (!oauthCostEstimates) draft.cost = []
           // Match Codex CLI so context consumption and subscription usage stay consistent between clients.
           draft.limit = { ...draft.limit, context: 400_000, input: 272_000 }
         })

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -367,6 +367,26 @@ describe("Config", () => {
     expect(Config.latest(entries, "default_agent")).toBeUndefined()
   })
 
+  test("returns the latest explicitly defined provider field", () => {
+    const enabled = new Document({
+      type: "document",
+      info: new Info({ providers: { openai: { oauth_cost_estimates: true } } }),
+    })
+    const disabled = new Document({
+      type: "document",
+      info: new Info({ providers: { openai: { oauth_cost_estimates: false } } }),
+    })
+    const omitted = new Document({
+      type: "document",
+      info: new Info({ providers: { openai: {} } }),
+    })
+
+    expect(Config.latestProviderField([enabled, disabled], "openai", "oauth_cost_estimates")).toBe(false)
+    expect(Config.latestProviderField([enabled, disabled, omitted], "openai", "oauth_cost_estimates")).toBe(false)
+    expect(Config.latestProviderField([enabled, omitted], "openai", "oauth_cost_estimates")).toBe(true)
+    expect(Config.latestProviderField([omitted], "openai", "oauth_cost_estimates")).toBeUndefined()
+  })
+
   it.live("tolerates unavailable authenticated wellknown config and reloads it later", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/core/test/config/provider.test.ts
+++ b/packages/core/test/config/provider.test.ts
@@ -86,6 +86,30 @@ describe("ConfigProviderPlugin.Plugin", () => {
     }),
   )
 
+  it.effect("does not forward OAuth cost estimate configuration to provider settings", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      yield* addPlugin([
+        new Document({
+          type: "document",
+          info: decode({
+            providers: {
+              custom: {
+                package: "aisdk:@ai-sdk/openai-compatible",
+                oauth_cost_estimates: true,
+                settings: { baseURL: "https://example.test/v1" },
+              },
+            },
+          }),
+        }),
+      ])
+
+      const provider = required(yield* catalog.provider.get(Provider.ID.make("custom")))
+      expect(provider.settings).toEqual({ baseURL: "https://example.test/v1" })
+      expect(provider.settings).not.toHaveProperty("oauth_cost_estimates")
+    }),
+  )
+
   it.effect("preserves catalog capabilities unless config overrides them", () =>
     Effect.gen(function* () {
       const catalog = yield* Catalog.Service

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -1,10 +1,14 @@
 import { Money } from "@opencode-ai/schema/money"
 import { Agent } from "@opencode-ai/schema/agent"
+import { Document, Event, Info } from "@opencode-ai/schema/config"
 import { Session } from "@opencode-ai/schema/session"
 import { OpenAIResponses } from "@opencode-ai/ai/protocols/openai-responses"
 import { describe, expect } from "bun:test"
-import { ConfigProvider, DateTime, Effect } from "effect"
+import { ConfigProvider, DateTime, Effect, Fiber, Layer, Stream } from "effect"
+import { TestClock } from "effect/testing"
+import { Bus } from "@opencode-ai/core/bus"
 import { Catalog } from "@opencode-ai/core/catalog"
+import { Config } from "@opencode-ai/core/config"
 import { Credential } from "@opencode-ai/core/credential"
 import { Integration } from "@opencode-ai/core/integration"
 import { Location } from "@opencode-ai/core/location"
@@ -23,7 +27,7 @@ import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { testEffect } from "../lib/effect"
 import { PluginTestLayer } from "./fixture"
 
-const it = testEffect(PluginTestLayer)
+const it = testEffect(Layer.merge(PluginTestLayer, Config.testLayer()))
 
 const addPlugin = Effect.fn(function* () {
   const plugin = yield* Plugin.Service
@@ -160,6 +164,103 @@ describe("OpenAIPlugin", () => {
       expect(gpt56.enabled).toBe(true)
       expect(gpt56.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-4.1"))).enabled).toBe(false)
+    }),
+  )
+
+  it.effect("uses OAuth cost estimates only when enabled and reloads the option", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const config = yield* Config.Test
+      const bus = yield* Bus.Service
+      const credentials = yield* Credential.Service
+      yield* catalog.transform((catalog) => {
+        catalog.provider.update(Provider.ID.openai, (draft) => {
+          draft.package = Provider.aisdk("@ai-sdk/openai")
+        })
+        catalog.model.update(Provider.ID.openai, Model.ID.make("gpt-5.5"), (model) => {
+          model.cost = [
+            {
+              tier: { type: "context", size: 100_000 },
+              input: Money.USDPerMillionTokens.make(1),
+              output: Money.USDPerMillionTokens.make(2),
+              cache: {
+                read: Money.USDPerMillionTokens.make(0.1),
+                write: Money.USDPerMillionTokens.make(0.2),
+              },
+            },
+          ]
+        })
+      })
+      yield* credentials.create({
+        integrationID: Integration.ID.make("openai"),
+        value: Credential.OAuth.make({
+          type: "oauth",
+          methodID: Integration.MethodID.make("chatgpt-browser"),
+          access: "chatgpt-token",
+          refresh: "refresh",
+          expires: Date.now() + 60_000,
+          metadata: { accountID: "acct_123" },
+        }),
+      })
+      yield* addPlugin()
+      yield* Effect.yieldNow
+
+      expect((yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5")))?.cost).toEqual([])
+
+      yield* config.setEntries([
+        new Document({
+          type: "document",
+          info: new Info({ providers: { openai: { oauth_cost_estimates: true } } }),
+        }),
+      ])
+      yield* Effect.yieldNow
+      const enabled = yield* bus
+        .subscribe(Catalog.Event.Updated)
+        .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+      yield* bus.publish(Event.Updated, {}, { global: true })
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(enabled)
+      expect((yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5")))?.cost).toEqual([
+        {
+          tier: { type: "context", size: 100_000 },
+          input: Money.USDPerMillionTokens.make(1),
+          output: Money.USDPerMillionTokens.make(2),
+          cache: {
+            read: Money.USDPerMillionTokens.make(0.1),
+            write: Money.USDPerMillionTokens.make(0.2),
+          },
+        },
+      ])
+
+      yield* config.setEntries([
+        new Document({
+          type: "document",
+          info: new Info({ providers: { openai: { oauth_cost_estimates: false } } }),
+        }),
+      ])
+      yield* Effect.yieldNow
+      const disabled = yield* bus
+        .subscribe(Catalog.Event.Updated)
+        .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+      yield* bus.publish(Event.Updated, {}, { global: true })
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(disabled)
+      expect((yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5")))?.cost).toEqual([])
+
+      yield* config.setEntries([
+        new Document({
+          type: "document",
+          info: new Info({ providers: { openai: {} } }),
+        }),
+      ])
+      yield* Effect.yieldNow
+      const omitted = yield* bus
+        .subscribe(Catalog.Event.Updated)
+        .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+      yield* bus.publish(Event.Updated, {}, { global: true })
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(omitted)
+      expect((yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.5")))?.cost).toEqual([])
     }),
   )
 

--- a/packages/schema/src/config/provider.ts
+++ b/packages/schema/src/config/provider.ts
@@ -60,6 +60,9 @@ export class Info extends Schema.Class<Info>("Config.Provider")({
   name: Schema.String.pipe(optional),
   env: Schema.String.pipe(Schema.Array, optional),
   package: Schema.String.pipe(optional),
+  oauth_cost_estimates: Schema.Boolean.pipe(optional).annotate({
+    description: "Enable local API-equivalent cost estimates for ChatGPT and Codex OAuth usage",
+  }),
   ...Overlays,
   models: Schema.Record(Schema.String, Model).pipe(optional),
 }) {}

--- a/packages/schema/test/config.test.ts
+++ b/packages/schema/test/config.test.ts
@@ -9,6 +9,14 @@ import { AbsolutePath } from "../src/schema.js"
 import { WebSearch } from "../src/websearch.js"
 
 describe("Config.Entry", () => {
+  test("decodes and omits the OAuth cost estimate option", () => {
+    const decode = Schema.decodeUnknownSync(ConfigProvider.Info)
+
+    expect(decode({ oauth_cost_estimates: true }).oauth_cost_estimates).toBe(true)
+    expect(decode({ oauth_cost_estimates: false }).oauth_cost_estimates).toBe(false)
+    expect(Schema.encodeSync(ConfigProvider.Info)(new ConfigProvider.Info({}))).not.toHaveProperty("oauth_cost_estimates")
+  })
+
   test("accepts disabled, fixed, and random web search selection", () => {
     const decode = Schema.decodeUnknownSync(Config.Info)
 


### PR DESCRIPTION
### Issue for this PR

Closes #46320

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `providers.openai.oauth_cost_estimates` so ChatGPT and Codex OAuth users can opt in to catalog-price-based local API-equivalent estimates.

The default and explicit `false` retain the current zero-cost behavior, and configuration reloads update the catalog without forwarding this OpenCode-only setting to the provider SDK.

### How did you verify your code works?

- `bun test test/plugin/provider-openai.test.ts test/config/config.test.ts test/config/provider.test.ts && bun typecheck` from `packages/core`
- `bun test test/config.test.ts && bun typecheck` from `packages/schema`
- `bun run check:generated && bun typecheck` from `packages/client`
- `bun lint`, Effect simplification rules, and generated OpenAPI checks

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
