### PR TITLE
fix(core): flush trailing stream chunks while providers pause

### DIFF
--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -3,7 +3,7 @@ import type { Agent } from "@opencode-ai/schema/agent"
 import type { Model } from "@opencode-ai/schema/model"
 import type { RelativePath } from "@opencode-ai/schema/schema"
 import type { Snapshot } from "@opencode-ai/schema/snapshot"
-import { Clock, Effect, Iterable } from "effect"
+import { Effect, Fiber, Iterable } from "effect"
 import { isArrayNonEmpty, isReadonlyArrayNonEmpty } from "effect/Array"
 import { Bus } from "../../bus.js"
 import { SessionEvent } from "../event.js"
@@ -130,7 +130,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
       readonly ordinal: number
       readonly values: string[]
       pending: string
-      publishedAt?: number
+      timer?: Fiber.Fiber<void>
       state?: Record<string, unknown>
     }
     const chunks = new Map<string, Fragment>()
@@ -143,36 +143,46 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         chunks.set(id, { ordinal, values: [], pending: "", state })
         return Effect.succeed(ordinal)
       })
-    const publishDelta = Effect.fnUntraced(function* (id: string, force = false) {
+    const publishDelta = Effect.fnUntraced(function* (id: string) {
       if (!delta) return undefined
       const current = chunks.get(id)
       if (!current) return yield* Effect.die(new Error(`${name} delta before start: ${id}`))
       if (!current.pending) return undefined
-      const now = yield* Clock.currentTimeMillis
-      if (!force && current.publishedAt === undefined) {
-        current.publishedAt = now
-        return undefined
-      }
-      if (!force && current.publishedAt !== undefined && now - current.publishedAt < deltaBatchInterval)
-        return undefined
-      yield* delta(id, current.pending, current.ordinal)
+      const value = current.pending
+      // New chunks can arrive while the timer is publishing this batch.
       current.pending = ""
-      current.publishedAt = now
+      yield* delta(id, value, current.ordinal)
       return undefined
-    })
+    }, Effect.uninterruptible)
     const append = Effect.fnUntraced(function* (id: string, value: string, state?: Record<string, unknown>) {
       const current = chunks.get(id)
       if (!current) return yield* Effect.die(new Error(`${name} delta before start: ${id}`))
       current.values.push(value)
       if (delta) current.pending += value
       if (state !== undefined) current.state = { ...current.state, ...state }
-      yield* publishDelta(id)
+      if (current.pending && !current.timer) {
+        // Own the trailing flush in the provider fiber, even if no more chunks arrive.
+        current.timer = yield* Effect.gen(function* () {
+          while (current.pending) {
+            yield* Effect.sleep(deltaBatchInterval)
+            yield* publishDelta(id)
+          }
+        }).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              current.timer = undefined
+            }),
+          ),
+          Effect.forkChild({ startImmediately: true }),
+        )
+      }
       return current.ordinal
     })
     const end = Effect.fnUntraced(function* (id: string, state?: Record<string, unknown>, value?: string) {
       const current = chunks.get(id)
       if (!current) return yield* Effect.die(new Error(`${name} end before start: ${id}`))
-      yield* publishDelta(id, true)
+      if (current.timer) yield* Fiber.interrupt(current.timer)
+      yield* publishDelta(id)
       yield* ended(
         id,
         value ?? current.values.join(""),

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -28,7 +28,10 @@ import { TestClock } from "effect/testing"
 const sessionID = Session.ID.make("ses_tool_event_test")
 const base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
 
-const capture = (providerMetadataKey = "anthropic", options?: { readonly interruptProgress?: boolean }) => {
+const capture = (
+  providerMetadataKey = "anthropic",
+  options?: { readonly interruptProgress?: boolean; readonly beforeTextDelta?: Effect.Effect<void> },
+) => {
   const published: Array<{ readonly type: string; readonly data: unknown }> = []
   const bus: Pick<Bus.Interface, "publish"> = {
     publish: (definition, data) => {
@@ -40,6 +43,8 @@ const capture = (providerMetadataKey = "anthropic", options?: { readonly interru
         })
         return event
       })
+      if (definition.type === SessionEvent.Text.Delta.type && options?.beforeTextDelta)
+        return options.beforeTextDelta.pipe(Effect.andThen(publish))
       return definition.type === SessionEvent.Tool.Progress.type && options?.interruptProgress
         ? publish.pipe(Effect.andThen(Effect.interrupt))
         : publish
@@ -323,6 +328,30 @@ test("reasoning state from start, empty delta, and end is merged", async () => {
   })
 })
 
+for (const kind of ["text", "reasoning"] as const) {
+  it.effect(`publishes the trailing ${kind} chunk while the provider is paused`, () =>
+    Effect.gen(function* () {
+      const { published, publisher } = capture()
+      yield* publisher.publish(LLMEvent[kind === "text" ? "textStart" : "reasoningStart"]({ id: kind }))
+      yield* publisher.publish(
+        LLMEvent[kind === "text" ? "textDelta" : "reasoningDelta"]({ id: kind, text: "Running the comm" }),
+      )
+      yield* TestClock.adjust("100 millis")
+      expect(
+        published.filter((event) => event.type === `session.${kind}.delta`).map((event) => event.data),
+      ).toMatchObject([{ delta: "Running the comm" }])
+
+      yield* publisher.publish(LLMEvent[kind === "text" ? "textDelta" : "reasoningDelta"]({ id: kind, text: "and." }))
+      yield* TestClock.adjust("100 millis")
+      expect(
+        published.filter((event) => event.type === `session.${kind}.delta`).map((event) => event.data),
+      ).toMatchObject([{ delta: "Running the comm" }, { delta: "and." }])
+      expect(published.some((event) => event.type === `session.${kind}.ended.1`)).toBe(false)
+      yield* publisher.flush()
+    }),
+  )
+}
+
 it.effect("batches text deltas and flushes pending text before the terminal event", () =>
   Effect.gen(function* () {
     const { published, publisher } = capture()
@@ -341,15 +370,44 @@ it.effect("batches text deltas and flushes pending text before the terminal even
     yield* TestClock.adjust("99 millis")
     expect(published.filter((event) => event.type === "session.text.delta")).toHaveLength(0)
     yield* TestClock.adjust("1 millis")
-    yield* publisher.publish(LLMEvent.textDelta({ id: "text", text: " four" }))
     expect(published.filter((event) => event.type === "session.text.delta").map((event) => event.data)).toMatchObject([
-      { delta: "one two three four" },
+      { delta: "one two three" },
     ])
 
+    yield* publisher.publish(LLMEvent.textDelta({ id: "text", text: " four" }))
     yield* publisher.publish(LLMEvent.textDelta({ id: "text", text: " five" }))
     yield* publisher.publish(LLMEvent.textEnd({ id: "text" }))
     expect(published.slice(-2).map((event) => event.type)).toEqual(["session.text.delta", "session.text.ended.1"])
-    expect(published.at(-2)?.data).toMatchObject({ delta: " five" })
+    expect(published.at(-2)?.data).toMatchObject({ delta: " four five" })
+    const count = published.length
+    yield* TestClock.adjust("1 second")
+    expect(published).toHaveLength(count)
+  }),
+)
+
+it.effect("retains new chunks and orders text-end behind an in-flight timer publication", () =>
+  Effect.gen(function* () {
+    const entered = yield* Deferred.make<void>()
+    const release = yield* Deferred.make<void>()
+    const { published, publisher } = capture("anthropic", {
+      beforeTextDelta: Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(release))),
+    })
+    yield* publisher.publish(LLMEvent.textStart({ id: "text" }))
+    yield* publisher.publish(LLMEvent.textDelta({ id: "text", text: "comm" }))
+    yield* TestClock.adjust("100 millis")
+    yield* Deferred.await(entered)
+    yield* publisher.publish(LLMEvent.textDelta({ id: "text", text: "and." }))
+    const ending = yield* publisher
+      .publish(LLMEvent.textEnd({ id: "text" }))
+      .pipe(Effect.forkChild({ startImmediately: true }))
+    expect(published.some((event) => event.type === "session.text.ended.1")).toBe(false)
+    yield* Deferred.succeed(release, undefined)
+    yield* Fiber.join(ending)
+    expect(published.slice(-3)).toMatchObject([
+      { type: "session.text.delta", data: { delta: "comm" } },
+      { type: "session.text.delta", data: { delta: "and." } },
+      { type: "session.text.ended.1", data: { text: "command." } },
+    ])
   }),
 )
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -5541,6 +5541,29 @@ describe("SessionRunnerLLM", () => {
     ])
   })
 
+  scenario("broadcasts pending text while the provider stream is paused", function* (s) {
+    const paused = yield* Deferred.make<void>()
+    yield* s.admit("Check before running a command")
+    yield* s.llm.push(
+      Stream.concat(
+        Stream.fromIterable([
+          LLMEvent.textStart({ id: "text" }),
+          LLMEvent.textDelta({ id: "text", text: "Checking the project." }),
+        ]),
+        Stream.fromEffect(Deferred.succeed(paused, undefined)).pipe(Stream.flatMap(() => Stream.never)),
+      ),
+    )
+    const deltas = yield* s.bus
+      .subscribe(SessionEvent.Text.Delta)
+      .pipe(Stream.take(1), Stream.runCollect, Effect.forkScoped({ startImmediately: true }))
+    const running = yield* s.resume.pipe(Effect.forkScoped)
+    yield* Deferred.await(paused)
+    yield* TestClock.adjust("100 millis")
+    expect(deltas.pollUnsafe()).toBeDefined()
+    expect(Array.from(yield* Fiber.join(deltas)).map((event) => event.data.delta)).toEqual(["Checking the project."])
+    yield* Fiber.interrupt(running)
+  })
+
   for (const kind of fragmentKinds) {
     scenario(
       kind === "tool input"

--- a/packages/session-ui/component-tests/markdown.spec.ts
+++ b/packages/session-ui/component-tests/markdown.spec.ts
@@ -215,6 +215,22 @@ story("renders cached Mermaid blocks and falls back to code for invalid diagrams
   await expect(markdown.getByRole("button", { name: "Copy", exact: true })).toBeVisible()
 })
 
+story("renders the trailing chunk while the stream is paused", async ({ page }) => {
+  await page.evaluate(async (fixture) => {
+    const { mountMarkdown } = await import(fixture)
+    await mountMarkdown({ text: "Checking **the project** before running the comm", streaming: true, cached: true })
+  }, fixture)
+  const harness = page.getByTestId("markdown-fixture")
+  const markdown = harness.locator('[data-component="markdown"]')
+  await expect(markdown).toHaveAttribute("data-markdown-ready", "")
+  await expect(markdown.locator("p")).toHaveText("Checking the project before running the comm")
+  await harness.getByLabel("Markdown text").fill("Checking **the project** before running the command.")
+  await expect(markdown.locator("p")).toHaveText("Checking the project before running the command.")
+  await expect(markdown).toHaveAttribute("data-markdown-ready", "")
+  await expect(markdown.locator("strong")).toHaveText("the project")
+  await expect(harness.getByLabel("Streaming")).toBeChecked()
+})
+
 story("keeps live elements and selection when a stream completes and later changes", async ({ page }) => {
   await page.evaluate(async (fixture) => {
     const { mountMarkdown } = await import(fixture)


### PR DESCRIPTION
## Before

The 100 ms batching check ran only when a chunk arrived. If the provider paused, pending text waited for another chunk or a text-end event.

```mermaid
flowchart TD
    A[Chunk arrives] --> B[Add to pending buffer]
    B --> C{100 ms elapsed?}
    C -->|Yes| D[Publish pending text]
    C -->|No| E[Wait for another chunk]
    E --> A
    F[Text ends] --> G[Flush pending text]
    G --> H[Publish text-end]
```

## After

A timer flushes pending text after 100 ms, even if no more chunks arrive. Text-end still flushes any remaining text before completing.

```mermaid
flowchart TD
    A[Chunk arrives] --> B[Add to pending buffer]
    B --> C{Flush timer active?}
    C -->|No| D[Start 100 ms timer]
    C -->|Yes| E[Keep batching]
    D --> F[Timer fires]
    F --> G[Publish pending text]
    G --> H{More text pending?}
    H -->|Yes| D
    H -->|No| I[Stop timer]
    J[Text ends] --> K[Cancel and wait for timer]
    K --> L[Flush remaining text]
    L --> M[Publish text-end]
```

Applies to text and reasoning. Markdown parsing and parsed-only rendering are unchanged.