### PR TITLE
docs(ecosystem): add opencode-fix-empty-assistant-messages plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-fix-empty-assistant-messages](https://github.com/impptg/opencode-fix-empty-assistant-messages) | Prevent "assistant message must not be empty" 400s by stripping empty text and reasoning-only steps from replayed history |
 
 ---
 


### PR DESCRIPTION
Adds [opencode-fix-empty-assistant-messages](https://github.com/impptg/opencode-fix-empty-assistant-messages) to the Plugins table.

**What it does:** prevents sessions from being bricked by `400: the message at position N with role 'assistant' must not be empty` on strict providers (Moonshot/Kimi, DeepSeek, litellm gateways). It hooks `experimental.chat.messages.transform` and drops empty `text` parts and reasoning-only step segments from replayed history before conversion.

**Context:** this is a send-time workaround for the same root cause addressed in core PR #45839 (authored by the same user). The plugin README tells users to uninstall it once #45839 ships, since conversion-time filtering in core also heals already-bricked sessions.