### PR TITLE
fix: skip unused compaction clone

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -375,8 +375,9 @@ const layer = Layer.effect(
         { sessionID: input.sessionID },
         { context: [], prompt: undefined },
       )
-      const msgs = structuredClone(selected.head)
-      yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+      const hasTransform = (yield* plugin.list()).some((hook) => hook["experimental.chat.messages.transform"])
+      const msgs = hasTransform ? structuredClone(selected.head) : selected.head
+      if (hasTransform) yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
       const conversation = msgs.map(serialize).filter(Boolean).join("\n\n")
       const nextPrompt =
         compacting.prompt ??

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -29,6 +29,7 @@ import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { TestConfig } from "../fixture/config"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { LLMEvent, Usage } from "@opencode-ai/llm"
+import type { Hooks } from "@opencode-ai/plugin"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -375,6 +376,25 @@ function compactionContext(context: string) {
       })
     },
     list: () => Effect.succeed([]),
+    init: () => Effect.void,
+  })
+}
+
+function compactionMessageTransform(text: string) {
+  const hook: Hooks = {
+    "experimental.chat.messages.transform": async (_input, output) => {
+      const part = output.messages[0]?.parts.find((item) => item.type === "text")
+      if (part?.type === "text") part.text = text
+    },
+  }
+  return Layer.mock(Plugin.Service)({
+    trigger: <Name extends string, Input, Output>(name: Name, input: Input, output: Output) => {
+      if (name !== "experimental.chat.messages.transform") return Effect.succeed(output)
+      return Effect.promise(() =>
+        hook["experimental.chat.messages.transform"]!(input as never, output as never),
+      ).pipe(Effect.as(output))
+    },
+    list: () => Effect.succeed([hook]),
     init: () => Effect.void,
   })
 }
@@ -1503,6 +1523,49 @@ describe("session.compaction.process", () => {
         withCompaction({
           llm: stub.llmLayer,
           plugin: compactionContext("Prioritize unresolved migration details"),
+        }),
+      )
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "isolates compaction message-transform mutations from source history",
+    () => {
+      const stub = llm()
+      let captured = ""
+      stub.push(
+        reply("summary", (input) => {
+          captured = JSON.stringify(input.messages)
+        }),
+      )
+
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        yield* createUserMessage(session.id, "older context")
+        yield* createUserMessage(session.id, "keep this turn")
+        yield* createUserMessage(session.id, "and this one too")
+        yield* createCompactionMarker(session.id)
+
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+        yield* SessionCompaction.use.process({
+          parentID: parent!,
+          messages: msgs,
+          sessionID: session.id,
+          auto: false,
+        })
+
+        expect(captured).toContain("transformed context")
+        expect(JSON.stringify(msgs)).toContain("older context")
+        expect(JSON.stringify(msgs)).not.toContain("transformed context")
+      }).pipe(
+        withCompaction({
+          llm: stub.llmLayer,
+          config: cfg({ tail_turns: 2, preserve_recent_tokens: 10_000 }),
+          plugin: compactionMessageTransform("transformed context"),
         }),
       )
     },


### PR DESCRIPTION
### Issue for this PR

Fixes #46331

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Compaction currently clones selected history before serialization even when no message-transform hook exists. This checks the existing plugin hook list first, skips the clone on the no-hook path, and preserves clone-plus-trigger behavior when a transform hook is registered.

This replaces #46290, which was auto-closed for missing the required issue-first link and PR template.

### How did you verify your code works?

- `bun test ./test/session/compaction.test.ts`: 56 pass, 1 skip
- `bun typecheck`
- Added a regression test proving transform mutations reach the prompt without mutating source history.

### Screenshots / recordings

N/A; this is a non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
