### PR TITLE
fix(desktop): preserve Windows editing shortcuts

### DIFF
--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -298,7 +298,7 @@ export function Titlebar(props: {
                 id: "home.toggle",
                 title: language.t("home.title"),
                 category: language.t("command.category.view"),
-                keybind: "mod+b",
+                keybind: windows() ? "alt+home" : "mod+b",
                 hidden: true,
                 onSelect: toggleHome,
               },

--- a/packages/app/src/shell/titlebar/windows-menu.test.ts
+++ b/packages/app/src/shell/titlebar/windows-menu.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { DESKTOP_MENU } from "@/shell/commands/desktop-menu"
 import { windowsMenuAccelerator } from "./windows-menu"
 
 describe("Windows app menu", () => {
@@ -10,5 +11,17 @@ describe("Windows app menu", () => {
 
   test("ignores the accelerator without its modifiers", () => {
     expect(windowsMenuAccelerator(new KeyboardEvent("keydown", { key: "N" }))).toBeUndefined()
+  })
+
+  test.each(["v", "c", "x", "a", "z", "y"])("leaves Ctrl+%s to the focused editor", (key) => {
+    expect(windowsMenuAccelerator(new KeyboardEvent("keydown", { key, ctrlKey: true }))).toBeUndefined()
+  })
+
+  test("preserves the paste menu action and shortcut label", () => {
+    expect(
+      DESKTOP_MENU.flatMap((menu) => menu.items ?? []).find(
+        (entry) => entry.type === "item" && entry.action === "edit.paste",
+      ),
+    ).toMatchObject({ action: "edit.paste", accelerator: { windows: "Ctrl+V" } })
   })
 })

--- a/packages/app/src/shell/titlebar/windows-menu.tsx
+++ b/packages/app/src/shell/titlebar/windows-menu.tsx
@@ -16,6 +16,8 @@ import { useLanguage } from "@/runtime/i18n/language"
 
 const accelerators = DESKTOP_MENU.flatMap((menu) => menu.items ?? []).flatMap((entry) => {
   if (entry.type === "separator" || !entry.action || !entry.accelerator?.windows) return []
+  // Let the focused editor handle editing shortcuts without restoring stale menu focus.
+  if (entry.action.startsWith("edit.")) return []
   return [{ action: entry.action, keybind: parseKeybind(entry.accelerator.windows) }]
 })
 


### PR DESCRIPTION
## Summary
- Change the Windows desktop Home shortcut from Ctrl+B to Alt+Home, leaving Ctrl+B available for backgrounding session work.
- Stop intercepting standard Windows editing shortcuts in the app menu. Ctrl+V now reaches the focused composer instead of restoring stale menu focus before pasting.
- Preserve menu-click editing actions and shortcut labels. Other platforms are unchanged.

## Validation
- App unit tests: 611 passed.
- App type checking passed.
- Pre-push repository type checks: 33 tasks passed.
- Added regression coverage for paste, copy, cut, select-all, undo, and redo shortcuts.
- Live desktop behavior was not tested. The app and server were not restarted. No screenshots are included because this change affects keyboard routing rather than layout.