### PR TITLE
fix(app): keep composer select all scoped to the editor

### DIFF
--- a/packages/app/component-tests/composer.spec.ts
+++ b/packages/app/component-tests/composer.spec.ts
@@ -1,5 +1,34 @@
 import { expect, story } from "../../storybook/playwright/story"
 
+for (const draft of ["empty-draft", "multiline-draft", "mixed-attachments"]) {
+  story(`select all stays inside the composer with ${draft}`, async ({ mount, page }) => {
+    const component = await mount(`opencode-composer-flow--${draft}`)
+    const input = component.getByRole("textbox", { name: "Prompt", exact: true })
+    const text = await input.textContent()
+
+    for (let count = 0; count < 2; count++) {
+      await input.press("ControlOrMeta+a")
+      expect(
+        await input.evaluate((editor) => {
+          const selection = window.getSelection()
+          return {
+            text: selection?.toString(),
+            inside: editor.contains(selection?.anchorNode ?? null) && editor.contains(selection?.focusNode ?? null),
+          }
+        }),
+      ).toEqual({ text, inside: true })
+    }
+
+    await page.keyboard.type("Replacement draft")
+    await expect(input).toHaveText("Replacement draft")
+    await expect(component.getByRole("status")).toHaveText("Ready")
+    if (draft === "mixed-attachments") {
+      await expect(component.getByAltText("layout.png")).toBeVisible()
+      await expect(component.getByText("Keep the normal flow flat", { exact: true })).toBeVisible()
+    }
+  })
+}
+
 story("renders a draft once and supports editing, caret restoration, and failure recovery", async ({ mount, page }) => {
   await page.addInitScript(() => {
     const replace = Element.prototype.replaceChildren

--- a/packages/app/src/shell/titlebar/windows-menu.test.ts
+++ b/packages/app/src/shell/titlebar/windows-menu.test.ts
@@ -8,6 +8,11 @@ describe("Windows app menu", () => {
     )
   })
 
+  test("leaves select all to the focused browser editor", () => {
+    expect(windowsMenuAccelerator(new KeyboardEvent("keydown", { key: "a", ctrlKey: true }))).toBeUndefined()
+    expect(windowsMenuAccelerator(new KeyboardEvent("keydown", { key: "A", ctrlKey: true }))).toBeUndefined()
+  })
+
   test("ignores the accelerator without its modifiers", () => {
     expect(windowsMenuAccelerator(new KeyboardEvent("keydown", { key: "N" }))).toBeUndefined()
   })

--- a/packages/app/src/shell/titlebar/windows-menu.tsx
+++ b/packages/app/src/shell/titlebar/windows-menu.tsx
@@ -16,6 +16,8 @@ import { useLanguage } from "@/runtime/i18n/language"
 
 const accelerators = DESKTOP_MENU.flatMap((menu) => menu.items ?? []).flatMap((entry) => {
   if (entry.type === "separator" || !entry.action || !entry.accelerator?.windows) return []
+  // Let Chromium select within the focused editor without restoring the menu's saved focus.
+  if (entry.action === "edit.selectAll") return []
   return [{ action: entry.action, keybind: parseKeybind(entry.accelerator.windows) }]
 })
 


### PR DESCRIPTION
## Summary
- Let Chromium handle Ctrl+A instead of intercepting it in the Windows desktop menu.
- Avoid the menu action path restoring an old focus target before Select All, which can select the whole page instead of the composer.
- Keep the Select All menu item and its shortcut label unchanged.

## Tests
- App unit suite: 605 passed. The new accelerator regression fails before the fix.
- Composer component browser suite: 5 passed, including empty, multiline, and mixed-attachment drafts. Repeated Select All stays inside the editor; replacement typing preserves attachments and comments.
- App type check, pre-push workspace type checks, and formatting checks passed.

## Screenshots
Isolated production composer fixture, not the running desktop app. Before reproduces the saved-focus/native Select All sequence in Electron. After shows Chromium's editor-scoped Ctrl+A behavior. Full desktop end-to-end automation was not run.

Before: ![](https://github.com/user-attachments/assets/632d3963-83af-406c-8376-35a3b6f76fbe)

After: ![](https://github.com/user-attachments/assets/404b4b4b-542c-4010-8229-86b6972697a9)