### PR TITLE
fix(app): reveal pasted composer content with custom scrollbar

### DIFF
--- a/packages/app/e2e/regression/composer-large-paste.spec.ts
+++ b/packages/app/e2e/regression/composer-large-paste.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test"
+import { expect, test, type Locator } from "@playwright/test"
 import { mockOpenCodeServer } from "../utils/mock-server"
 import { expectAppVisible } from "../utils/waits"
 
@@ -65,9 +65,62 @@ for (const lines of [6000, 25000]) {
     await expect.poll(async () => (await input.innerText()) === text).toBe(true)
     expect(await events.evaluate((events) => events.count)).toBe(1)
     await expect(input).toBeFocused()
+    await expectCaretVisible(input)
+    const scroll = page.locator('[data-component="composer-scroll"]')
+    await expect(scroll.locator(".scroll-view__viewport")).toHaveCSS("scrollbar-width", "none")
+    await expect(scroll.locator(".scroll-view__thumb")).toBeVisible()
     await page.keyboard.type("!")
     await expect.poll(async () => (await input.innerText()) === text + "!").toBe(true)
+    await expectCaretVisible(input)
+    const thumb = await scroll.locator(".scroll-view__thumb").boundingBox()
+    const bounds = await scroll.boundingBox()
+    if (!thumb || !bounds) throw new Error("Missing composer scrollbar bounds")
+    await page.mouse.move(thumb.x + thumb.width / 2, thumb.y + thumb.height / 2)
+    await page.mouse.down()
+    await page.mouse.move(thumb.x + thumb.width / 2, bounds.y + 8 + thumb.height / 2)
+    await page.mouse.up()
+    await expect(scroll.locator(".scroll-view__viewport")).toHaveJSProperty("scrollTop", 0)
+    await expect(input).toBeFocused()
+    await page.keyboard.press("ControlOrMeta+Home")
+    await page.keyboard.press("ControlOrMeta+End")
+    await expectCaretVisible(input)
   })
+}
+
+async function expectCaretVisible(input: Locator) {
+  await expect
+    .poll(() =>
+      input.evaluate((element) => {
+        const selection = window.getSelection()
+        if (!selection?.isCollapsed || !selection.rangeCount || !element.contains(selection.anchorNode)) return false
+        const caret = selection.getRangeAt(0).getBoundingClientRect()
+        const viewport = (element.closest("[data-scrollable]") ?? element).getBoundingClientRect()
+        return caret.height > 0 && caret.top >= viewport.top - 1 && caret.bottom <= viewport.bottom + 1
+      }),
+    )
+    .toBe(true)
+}
+
+for (const width of [390, 1280]) {
+  for (const direction of ["ltr", "rtl"]) {
+    test(`reveals a multiline paste in the middle at ${width}px in ${direction}`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 800 })
+      await page.evaluate((direction) => (document.documentElement.dir = direction), direction)
+      const input = page.getByRole("textbox", { name: "Prompt", exact: true })
+      const suffix = "\nExisting trailing content".repeat(100)
+      await input.fill("Before " + suffix)
+      await input.press("ControlOrMeta+Home")
+      await input.press("ArrowRight")
+      const text = "Pasted line /tmp/example.ts 123 \u0645\u0631\u062d\u0628\u0627\n".repeat(100) + "End of paste"
+      await page.evaluate((text) => navigator.clipboard.writeText(text), text)
+      await page.keyboard.press("ControlOrMeta+V")
+      await expect.poll(() => input.innerText()).toBe("B" + text + "efore " + suffix)
+      await expectCaretVisible(input)
+      await page.keyboard.type("!")
+      await expect.poll(() => input.innerText()).toBe("B" + text + "!efore " + suffix)
+      await expectCaretVisible(input)
+    })
+  }
 }
 
 for (const text of [

--- a/packages/app/src/composer/editor/editor.tsx
+++ b/packages/app/src/composer/editor/editor.tsx
@@ -9,6 +9,7 @@ import { Button } from "@opencode-ai/ui/button"
 import { Keybind } from "@opencode-ai/ui/keybind"
 import { Menu } from "@opencode-ai/ui/menu"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
+import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import { AttachmentCard } from "@opencode-ai/session-ui/attachment-card"
 import { CommentCard } from "@opencode-ai/session-ui/comment-card"
 import { typeLabel } from "@opencode-ai/session-ui/message-file"
@@ -53,6 +54,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
   const state = props.controller.state
   const view = props.controller.view
   let editor: HTMLDivElement | undefined
+  let viewport: HTMLDivElement | undefined
   let localInput = false
   const updateCursor = () => {
     if (!editor || !window.getSelection()?.isCollapsed) return
@@ -145,7 +147,14 @@ export function ComposerEditor(props: ComposerEditorProps) {
           />
         </Show>
 
-        <div class="relative min-h-[60px]">
+        <ScrollView
+          data-component="composer-scroll"
+          class="min-h-[60px] max-h-[180px]"
+          viewportRef={(element) => {
+            viewport = element
+            element.tabIndex = -1
+          }}
+        >
           <div
             ref={(element) => {
               editor = element
@@ -162,7 +171,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
             spellcheck={state.mode === "normal"}
             // @ts-expect-error
             autocomplete="off"
-            class="relative z-10 block min-h-[60px] max-h-[180px] w-full overflow-y-auto whitespace-pre-wrap bg-transparent px-4 pt-4 pb-2 text-[13px] font-[440] leading-5 text-v2-text-text-base focus:outline-none [&_[data-mention=file]]:text-syntax-property [&_[data-mention=agent]]:text-syntax-type [&_[data-mention=reference]]:text-syntax-keyword"
+            class="relative z-10 block min-h-[60px] w-full whitespace-pre-wrap bg-transparent px-4 pt-4 pb-2 text-[13px] font-[440] leading-5 text-v2-text-text-base focus:outline-none [&_[data-mention=file]]:text-syntax-property [&_[data-mention=agent]]:text-syntax-type [&_[data-mention=reference]]:text-syntax-keyword"
             classList={{ "font-mono!": state.mode === "shell", "opacity-50": props.disabled }}
             style={{
               "unicode-bidi": state.mode === "normal" ? "plaintext" : undefined,
@@ -190,7 +199,20 @@ export function ComposerEditor(props: ComposerEditorProps) {
             }}
             onKeyUp={updateCursor}
             onPointerUp={updateCursor}
-            onPaste={props.controller.onPaste}
+            onPaste={(event) => {
+              props.controller.onPaste(event)
+              // Programmatic multiline insertion does not reliably reveal the caret.
+              requestAnimationFrame(() => {
+                const selection = window.getSelection()
+                if (!editor || !viewport || !selection?.isCollapsed || !selection.rangeCount) return
+                if (!editor.contains(selection.anchorNode)) return
+                const caret = selection.getRangeAt(0).getBoundingClientRect()
+                if (!caret.height) return
+                const bounds = viewport.getBoundingClientRect()
+                if (caret.bottom > bounds.bottom - 8) viewport.scrollTop += caret.bottom - bounds.bottom + 8
+                if (caret.top < bounds.top + 8) viewport.scrollTop += caret.top - bounds.top - 8
+              })
+            }}
             onFocus={() => props.controller.dispatch({ type: "focus.editor" })}
           />
           <Show when={!props.controller.value()}>
@@ -206,7 +228,7 @@ export function ComposerEditor(props: ComposerEditorProps) {
                   : i18n.t("ui.promptInput.placeholder.normal", { slash: "/", at: "@" }))}
             </div>
           </Show>
-        </div>
+        </ScrollView>
 
         <div class="flex h-11 items-center px-2">
           <div


### PR DESCRIPTION
## Summary
- Use the shared ScrollView for the composer instead of native editor scrolling, preserving its 60-180px height and keyboard focus order.
- Reveal the caret after paste with a small visible margin. Scroll only the composer and follow the insertion point rather than always jumping to the bottom of the draft.
- Cover 6,000/25,000-line pastes, custom thumb dragging, focus, keyboard navigation, and middle-of-draft pastes at 390px/1280px in LTR and RTL with mixed-script content.

## Verification
- Reproduced the off-screen caret with the new regression assertion before the fix.
- Paste E2E suite: 24 passed (12 tests, repeated twice).
- App unit suite: 604 passed.
- App typecheck, pre-push workspace typechecks, and formatting checks passed.
- E2E typecheck has an existing error in `e2e/regression/new-session-workspace-pending.spec.ts:38`: `dir` does not exist on `HTMLElement | SVGElement`.

## Scope
The insertion and native undo implementation is unchanged. A separate existing Chromium insertion issue remains: text ending in a newline can leave the caret before that final newline. This change reveals the actual caret rather than changing insertion semantics.

## Screenshots
Before: the start of the report remains visible after paste.
![Before](https://github.com/user-attachments/assets/018585f5-d4a3-4eaf-8ef2-7481473f1eed)

After: the insertion point is visible, with the shared scrollbar thumb.
![After](https://github.com/user-attachments/assets/7f056b9a-198b-4a58-9e20-1413fea365b6)