### PR TITLE
fix(opencode): don't crash skill discovery on unscoped scan errors

### DIFF
--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -156,12 +156,11 @@ const scan = Effect.fnUntraced(function* (
       }),
     catch: (error) => error,
   }).pipe(
-    Effect.catch((error) => {
-      if (!opts?.scope) return Effect.die(error)
-      return Effect.logError(`failed to scan ${opts.scope} skills`, { dir: root, error: error }).pipe(
+    Effect.catch((error) =>
+      Effect.logError(`failed to scan ${opts?.scope ?? "project"} skills`, { dir: root, error: error }).pipe(
         Effect.as([] as string[]),
-      )
-    }),
+      ),
+    ),
   )
 
   for (const match of matches) {


### PR DESCRIPTION
### Issue for this PR

Closes #45961

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`scan()` in `packages/opencode/src/skill/index.ts` only logs a warning and continues with no matches when a `scope` (`global`/`project`, used for the external `.claude`/`.agents` skill directories) is passed to it. Scans without a scope — the project-local `.opencode/skill` and `.opencode/skills` directories — call `Effect.die(error)` on any glob failure, which crashes skill discovery entirely instead of just skipping that path.

The issue's reported trigger is a self-referential symlink cycle producing `ENAMETOOLONG`, but the same hard crash happens for any glob error on an unscoped scan (e.g. `EACCES` on a permission-restricted directory), since the `scope` check is what decides whether the failure is caught gracefully or left to die. The fix removes that branch so every scan failure is logged and skipped the same way, regardless of whether it has a scope.

### How did you verify your code works?

I could not reproduce the exact `ENAMETOOLONG` locally — the `glob` package version bundled in this repo already guards against the specific symlink-cycle in the issue's repro steps. But the `Effect.die` vs. graceful-skip asymmetry between scoped and unscoped scan calls is directly verifiable by reading the code, and is a real crash surface for any unscoped glob error, not just this specific errno.

- `bun test test/skill/` — 24 pass, 0 fail (unchanged behavior on the happy path)
- `oxlint packages/opencode/src/skill/index.ts` — clean
- `tsc --noEmit` — no new errors

### Screenshots / recordings

_Not applicable — this is not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR