### PR TITLE
fix(ai): drop protocol branding from missing finish_reason errors

### DIFF
--- a/packages/ai/src/protocols/mistral-chat.ts
+++ b/packages/ai/src/protocols/mistral-chat.ts
@@ -726,7 +726,7 @@ const finishEvents = Effect.fn("MistralChat.finishEvents")(function* (state: Par
   if (!state.finishReason)
     return yield* new AIError({
       reason: new InvalidProviderOutputError({
-        message: "Mistral Chat stream ended without finish_reason",
+        message: "Stream ended without finish_reason",
         classification: "incomplete-stream",
         route: ADAPTER,
       }),

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -1106,7 +1106,7 @@ const finishEvents = Effect.fn("OpenAIChat.finishEvents")(function* (state: Pars
   if (state.finishReason === undefined && state.requireFinishReason)
     return yield* new AIError({
       reason: new InvalidProviderOutputError({
-        message: "OpenAI Chat stream ended without finish_reason",
+        message: "Stream ended without finish_reason",
         classification: "incomplete-stream",
         route: ADAPTER,
       }),

--- a/packages/ai/test/provider/openai-compatible-chat.test.ts
+++ b/packages/ai/test/provider/openai-compatible-chat.test.ts
@@ -502,7 +502,7 @@ describe("OpenAI-compatible Chat route", () => {
 
       expect(error).toMatchObject({
         reason: { _tag: "InvalidProviderOutput", classification: "incomplete-stream" },
-        message: "OpenAI Chat stream ended without finish_reason",
+        message: "Stream ended without finish_reason",
       })
     }),
   )


### PR DESCRIPTION
Picking a non-OpenAI model on an OpenAI-compatible endpoint surfaces vendor-branded protocol jargon in the retry banner. Concrete repro: GLM-5.3-Flash on OpenCode Go — the stream drops mid-answer, the host auto-retries, and the TUI shows:

```
⚠ Retry attempt 2 scheduled: OpenAI Chat stream ended without finish_reason
```

Neither OpenAI nor "OpenAI Chat" has anything to do with that session — it is the internal name of the openai-chat protocol client, leaking through `InvalidProviderOutputError.message` → `SessionEvent.RetryScheduled` → `RetryPart` → the `AssistantRetry` banner (and the same text resurfaces via the terminal `Error:` line if retries exhaust).

Both throw sites hardcode the protocol display name in the message:

- `packages/ai/src/protocols/openai-chat.ts` — `"OpenAI Chat stream ended without finish_reason"`
- `packages/ai/src/protocols/mistral-chat.ts` — `"Mistral Chat stream ended without finish_reason"`

The error struct already carries the protocol identity in `route` and `classification: "incomplete-stream"`, so the message does not need to brand it. This changes both messages to `"Stream ended without finish_reason"`:

```
⚠ Retry attempt 2 scheduled: Stream ended without finish_reason
```

and updates the single exact-match test expectation. The mistral test checks `toContain("without finish_reason")` and still passes unchanged.

Verification: `bun test` in `packages/ai` — 910 pass / 0 fail across 58 files (incl. the updated openai-compatible expectation), and `tsgo --noEmit` clean for the package.