### PR TITLE
fix(www): render branded 404 page instead of Astro default

### DIFF
--- a/packages/www/src/pages/404.astro
+++ b/packages/www/src/pages/404.astro
@@ -1,0 +1,124 @@
+---
+import "../docs/styles/global.css"
+
+export const prerender = false
+
+const base = import.meta.env.BASE_URL
+
+Astro.response.status = 404
+Astro.response.headers.set("Cache-Control", "no-store")
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="icon" type="image/svg+xml" href={`${base}favicon.svg`} />
+    <title>404 - Page Not Found | OpenCode</title>
+  </head>
+  <body>
+    <main class="not-found">
+      <div class="not-found-box">
+        <section class="not-found-top">
+          <a href={base} aria-label="OpenCode home">
+            <img src={`${base}assets/logo-dark.svg`} alt="OpenCode" />
+          </a>
+          <h1>404 - Page Not Found</h1>
+        </section>
+        <nav class="not-found-actions" aria-label="Helpful links">
+          <a href="/">Home</a>
+          <a href={`${base}docs/`}>Docs</a>
+          <a href="https://github.com/anomalyco/opencode">GitHub</a>
+          <a href="/discord">Discord</a>
+        </nav>
+      </div>
+    </main>
+  </body>
+</html>
+
+<style>
+  .not-found {
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+
+  .not-found-box {
+    width: 100%;
+    max-width: 40rem;
+    border: 1px solid var(--border);
+  }
+
+  .not-found-top {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 3rem;
+    text-align: center;
+  }
+
+  .not-found-top img {
+    height: auto;
+    width: clamp(160px, 60vw, 320px);
+  }
+
+  .not-found-top h1 {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .not-found-actions {
+    display: flex;
+    border-top: 1px solid var(--border);
+  }
+
+  .not-found-actions a {
+    flex: 1;
+    padding: 1rem;
+    text-align: center;
+    text-transform: uppercase;
+    color: var(--foreground);
+    text-decoration: underline;
+    text-underline-offset: 0.25em;
+    text-decoration-thickness: 1px;
+  }
+
+  .not-found-actions a + a {
+    border-left: 1px solid var(--border);
+  }
+
+  .not-found-actions a:hover {
+    background: var(--surface-hover);
+  }
+
+  @media (max-width: 30rem) {
+    .not-found-top {
+      padding: 1.5rem;
+    }
+
+    .not-found-actions {
+      flex-wrap: wrap;
+    }
+
+    .not-found-actions a {
+      flex-basis: 50%;
+    }
+
+    .not-found-actions a:nth-child(3) {
+      border-left: none;
+    }
+
+    .not-found-actions a:nth-child(n + 3) {
+      border-top: 1px solid var(--border);
+    }
+  }
+</style>

--- a/packages/www/src/pages/docs/[...slug].astro
+++ b/packages/www/src/pages/docs/[...slug].astro
@@ -6,7 +6,7 @@ export const prerender = false
 
 const slug = Astro.params.slug || "index"
 const entry = (await getEntry("docs", slug)) ?? (await getEntry("docs", `${slug}/index`))
-if (!entry) return new Response("Not found", { status: 404, headers: { "Cache-Control": "no-store" } })
+if (!entry) return Astro.rewrite("/404")
 
 const headers = {
   "Cache-Control": "public, max-age=300, stale-while-revalidate=3600",


### PR DESCRIPTION
### Issue for this PR

Closes #46348

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Any URL under /v2 that matches no route shows Astro's stock 404 page, and a wrong docs slug returns plain text "Not found". This adds `src/pages/404.astro` styled like the opencode.ai 404, and sends unknown docs slugs to it with `Astro.rewrite("/404")`. In server output Astro renders `404.astro` for every unmatched route, so both cases land on the same branded page. Status stays 404 and the page sends `Cache-Control: no-store`, same as the old plain-text response.

### How did you verify your code works?

On the dev server: `/v2/docs.md`, `/v2/docs/bogus-page`, and `/v2/nope/deep/path` return 404 with the branded page; `/v2/docs/` still returns 200. `bun typecheck`, `bun run build`, and `bun run check:generated` all pass.

### Screenshots / recordings

#### Before:
<img width="1466" height="987" alt="image" src="https://github.com/user-attachments/assets/73a87749-a4de-48d9-a329-c75ca1e62eed" />

#### After:
<img width="1440" alt="Branded 404 page at /v2/docs.md" src="https://github.com/user-attachments/assets/303c0bdb-c1a7-4268-8d24-1f1f1d6079ad" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
