### PR TITLE
feat(app): add shell navigation rails

### DIFF
--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -32,7 +32,7 @@ import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
 import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { reviewTooltipKeybind } from "../command-tooltip-keybind"
-import { useTitlebarRightMount } from "../titlebar"
+import { useShellRailRightMount, useTitlebarRightMount } from "../titlebar"
 
 const OPEN_APPS = [
   "vscode",
@@ -235,13 +235,21 @@ export function SessionHeader() {
     messageAgentColor(params.id ? sync().data.message[params.id] : undefined, sync().data.agent),
   )
   const v2ActionsState = createMemo<SessionHeaderV2ActionsState>(() => ({
+    rail: isDesktop(),
     statusVisible: status(),
     statusLabel: language.t("status.popover.trigger"),
     reviewLabel: language.t("command.review.toggle"),
     reviewKeybind: reviewTooltipKeybind(command),
-    reviewVisible: isDesktop(),
     reviewOpened: view().reviewPanel.opened(),
     onReviewToggle: () => view().reviewPanel.toggle(),
+    fileTreeLabel: language.t("command.fileTree.toggle"),
+    fileTreeKeybind: command.keybindParts("fileTree.toggle"),
+    fileTreeOpened: layout.fileTree.opened(),
+    onFileTreeToggle: () => layout.fileTree.toggle(),
+    terminalLabel: language.t("command.terminal.toggle"),
+    terminalKeybind: command.keybindParts("terminal.toggle"),
+    terminalOpened: view().terminal.opened(),
+    onTerminalToggle: toggleTerminal,
   }))
 
   const selectApp = (app: OpenApp) => {
@@ -282,7 +290,9 @@ export function SessionHeader() {
   }
 
   const [centerMount, setCenterMount] = createSignal<HTMLElement | null>(null)
-  const rightMount = useTitlebarRightMount()
+  const titlebarRightMount = useTitlebarRightMount()
+  const shellRailRightMount = useShellRailRightMount()
+  const rightMount = createMemo(() => (isV2() && isDesktop() ? shellRailRightMount() : titlebarRightMount()))
   onMount(() => {
     setCenterMount(document.getElementById("opencode-titlebar-center"))
   })
@@ -517,29 +527,39 @@ export function SessionHeader() {
 }
 
 type SessionHeaderV2ActionsState = {
+  rail: boolean
   statusVisible: boolean
   statusLabel: string
   reviewLabel: string
   reviewKeybind: string[]
-  reviewVisible: boolean
   reviewOpened: boolean
   onReviewToggle: () => void
+  fileTreeLabel: string
+  fileTreeKeybind: string[]
+  fileTreeOpened: boolean
+  onFileTreeToggle: () => void
+  terminalLabel: string
+  terminalKeybind: string[]
+  terminalOpened: boolean
+  onTerminalToggle: () => void
 }
 
 function SessionHeaderV2Actions(props: { state: SessionHeaderV2ActionsState }) {
-  const language = useLanguage()
-
   return (
-    <div class="flex items-center gap-2">
-      <Show when={props.state.statusVisible}>
-        <Tooltip placement="bottom" value={props.state.statusLabel}>
-          <StatusPopoverV2 />
-        </Tooltip>
-      </Show>
-      <Show when={props.state.reviewVisible}>
+    <Show
+      when={props.state.rail}
+      fallback={
+        <Show when={props.state.statusVisible}>
+          <Tooltip placement="bottom" value={props.state.statusLabel}>
+            <StatusPopoverV2 />
+          </Tooltip>
+        </Show>
+      }
+    >
+      <div class="flex size-full flex-col items-center gap-1 py-2">
         <TooltipV2
           class="shrink-0"
-          placement="bottom"
+          placement="left"
           value={
             <>
               {props.state.reviewLabel}
@@ -553,16 +573,73 @@ function SessionHeaderV2Actions(props: { state: SessionHeaderV2ActionsState }) {
             type="button"
             variant="ghost-muted"
             size="large"
-            class="!w-9 shrink-0"
+            class="!size-8 shrink-0"
             state={props.state.reviewOpened ? "pressed" : undefined}
             onClick={props.state.onReviewToggle}
             aria-label={props.state.reviewLabel}
             aria-expanded={props.state.reviewOpened}
             aria-controls="review-panel"
-            icon={<IconV2 name="sidebar-right" />}
+            icon={<IconV2 name="review" />}
           />
         </TooltipV2>
-      </Show>
-    </div>
+        <TooltipV2
+          class="shrink-0"
+          placement="left"
+          value={
+            <>
+              {props.state.fileTreeLabel}
+              <Show when={props.state.fileTreeKeybind.length > 0}>
+                <KeybindV2 keys={props.state.fileTreeKeybind} variant="neutral" />
+              </Show>
+            </>
+          }
+        >
+          <IconButtonV2
+            type="button"
+            variant="ghost-muted"
+            size="large"
+            class="!size-8 shrink-0"
+            state={props.state.fileTreeOpened ? "pressed" : undefined}
+            onClick={props.state.onFileTreeToggle}
+            aria-label={props.state.fileTreeLabel}
+            aria-expanded={props.state.fileTreeOpened}
+            aria-controls="file-tree-panel"
+            icon={<IconV2 name="filetree" />}
+          />
+        </TooltipV2>
+        <TooltipV2
+          class="shrink-0"
+          placement="left"
+          value={
+            <>
+              {props.state.terminalLabel}
+              <Show when={props.state.terminalKeybind.length > 0}>
+                <KeybindV2 keys={props.state.terminalKeybind} variant="neutral" />
+              </Show>
+            </>
+          }
+        >
+          <IconButtonV2
+            type="button"
+            variant="ghost-muted"
+            size="large"
+            class="!size-8 shrink-0"
+            state={props.state.terminalOpened ? "pressed" : undefined}
+            onClick={props.state.onTerminalToggle}
+            aria-label={props.state.terminalLabel}
+            aria-expanded={props.state.terminalOpened}
+            aria-controls="terminal-panel"
+            icon={<IconV2 name="monitor" />}
+          />
+        </TooltipV2>
+        <Show when={props.state.statusVisible}>
+          <div class="mt-auto">
+            <TooltipV2 placement="left" value={props.state.statusLabel}>
+              <StatusPopoverV2 />
+            </TooltipV2>
+          </div>
+        </Show>
+      </div>
+    </Show>
   )
 }

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -61,7 +61,17 @@ export function useTitlebarRightMount() {
   return mount
 }
 
-export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visible: boolean; toggle: () => void } }) {
+export function useShellRailRightMount() {
+  const [mount, setMount] = createSignal<HTMLElement | null>(null)
+  onMount(() => setMount(document.getElementById("opencode-shell-rail-right")))
+  return mount
+}
+
+export function Titlebar(props: {
+  update?: TitlebarUpdate
+  debugTools?: { visible: boolean; toggle: () => void }
+  showHomeButton?: boolean
+}) {
   const layout = useLayout()
   const platform = usePlatform()
   const command = useCommand()
@@ -173,7 +183,7 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
       data-slot={useV2Titlebar() ? "titlebar-v2" : undefined}
       classList={{
         "shrink-0 relative flex flex-row": true,
-        "h-9 bg-v2-background-bg-deep overflow-visible": useV2Titlebar(),
+        "h-9 bg-black overflow-visible": useV2Titlebar(),
         "h-10 bg-background-base overflow-hidden": !useV2Titlebar(),
         "order-last": bottom(),
       }}
@@ -372,28 +382,30 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} variant="v2" />
                 </Show>
-                <TooltipV2
-                  placement="bottom"
-                  value={
-                    <>
-                      {language.t("home.title")}
-                      <KeybindV2 keys={command.keybindParts("home.toggle")} variant="neutral" />
-                    </>
-                  }
-                  class="shrink-0"
-                >
-                  <IconButtonV2
-                    type="button"
-                    variant="ghost-muted"
-                    size="large"
-                    class="!w-9 shrink-0"
-                    icon={<IconV2 name="grid-plus" />}
-                    state={layout.route().type === "home" ? "pressed" : undefined}
-                    onClick={toggleHome}
-                    aria-label={language.t("home.title")}
-                    aria-pressed={layout.route().type === "home"}
-                  />
-                </TooltipV2>
+                <Show when={props.showHomeButton !== false || mobile()}>
+                  <TooltipV2
+                    placement="bottom"
+                    value={
+                      <>
+                        {language.t("home.title")}
+                        <KeybindV2 keys={command.keybindParts("home.toggle")} variant="neutral" />
+                      </>
+                    }
+                    class="shrink-0"
+                  >
+                    <IconButtonV2
+                      type="button"
+                      variant="ghost-muted"
+                      size="large"
+                      class="!w-9 shrink-0"
+                      icon={<IconV2 name="grid-plus" />}
+                      state={layout.route().type === "home" ? "pressed" : undefined}
+                      onClick={toggleHome}
+                      aria-label={language.t("home.title")}
+                      aria-pressed={layout.route().type === "home"}
+                    />
+                  </TooltipV2>
+                </Show>
 
                 <TitlebarTabStrip
                   tabs={tabsStore}

--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -1,13 +1,59 @@
-import { createEffect, Suspense, type ParentProps } from "solid-js"
+import { createEffect, Show, Suspense, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
+import { Mark } from "@opencode-ai/ui/logo"
+import { Icon } from "@opencode-ai/ui/v2/icon"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { DebugBar } from "@/components/debug-bar"
 import { TabsInfoPopup } from "@/components/help-button"
 import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
+import { useCommand } from "@/context/command"
+import { useLanguage } from "@/context/language"
+import { useLayout } from "@/context/layout"
 import { usePlatform } from "@/context/platform"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
 
+function RailButton(
+  props: ParentProps<{
+    label: string
+    keybind?: string[]
+    active?: boolean
+    onClick: () => void
+  }>,
+) {
+  return (
+    <TooltipV2
+      placement="right"
+      value={
+        <>
+          {props.label}
+          <Show when={props.keybind?.length}>
+            <KeybindV2 keys={props.keybind ?? []} variant="neutral" />
+          </Show>
+        </>
+      }
+    >
+      <IconButtonV2
+        type="button"
+        variant="ghost-muted"
+        size="large"
+        class="!size-8"
+        state={props.active ? "pressed" : undefined}
+        onClick={props.onClick}
+        aria-label={props.label}
+        aria-pressed={props.active}
+        icon={props.children}
+      />
+    </TooltipV2>
+  )
+}
+
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
+  const command = useCommand()
+  const language = useLanguage()
+  const layout = useLayout()
   const [state, setState] = createStore({ debugTools: true })
 
   createEffect(() => setV2Toast(true))
@@ -24,13 +70,14 @@ export default function NewLayout(props: ParentProps) {
 
   return (
     <div
-      class="relative bg-v2-background-bg-deep flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text"
+      class="relative bg-black flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text"
       style={{
         "padding-top": "env(safe-area-inset-top, 0px)",
         "padding-bottom": "env(safe-area-inset-bottom, 0px)",
       }}
     >
       <Titlebar
+        showHomeButton={false}
         update={update}
         debugTools={
           import.meta.env.DEV
@@ -38,9 +85,75 @@ export default function NewLayout(props: ParentProps) {
             : undefined
         }
       />
-      <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
-        <Suspense>{props.children}</Suspense>
-      </main>
+      <div class="flex-1 min-h-0 min-w-0 flex">
+        <aside
+          aria-label={language.t("sidebar.nav.projectsAndSessions")}
+          class="hidden md:flex w-12 shrink-0 flex-col items-center border-e border-v2-border-border-base bg-black px-2 py-2"
+          style={{
+            "--icon-strong-base": "#fff",
+            "--icon-weak-base": "#666",
+            "--v2-icon-icon-base": "#fff",
+            "--v2-icon-icon-muted": "#858585",
+          }}
+        >
+          <Mark class="mb-3 h-5 w-4 shrink-0" />
+          <div class="flex flex-col items-center gap-1">
+            <RailButton
+              label={language.t("home.title")}
+              keybind={command.keybindParts("home.toggle")}
+              active={layout.route().type === "home"}
+              onClick={() => command.trigger("home.toggle")}
+            >
+              <Icon name="grid-plus" />
+            </RailButton>
+            <RailButton
+              label={language.t("command.session.new")}
+              keybind={command.keybindParts("tab.new")}
+              active={layout.route().type === "draft"}
+              onClick={() => command.trigger("tab.new")}
+            >
+              <Icon name="plus" />
+            </RailButton>
+            <RailButton
+              label={language.t("command.palette")}
+              keybind={command.keybindParts("command.palette")}
+              onClick={command.show}
+            >
+              <Icon name="magnifying-glass" />
+            </RailButton>
+          </div>
+          <div class="mt-auto flex flex-col items-center gap-1">
+            <RailButton
+              label={language.t("sidebar.settings")}
+              keybind={command.keybindParts("settings.open")}
+              onClick={() => command.trigger("settings.open")}
+            >
+              <Icon name="settings-gear" />
+            </RailButton>
+            <RailButton
+              label={language.t("sidebar.help")}
+              onClick={() => platform.openExternal("https://opencode.ai/desktop-feedback")}
+            >
+              <Icon name="help" />
+            </RailButton>
+          </div>
+        </aside>
+        <div class="flex-1 min-h-0 min-w-0 flex bg-v2-background-bg-deep">
+          <main class="flex-1 min-h-0 min-w-0 overflow-hidden flex flex-col items-start contain-strict">
+            <Suspense>{props.children}</Suspense>
+          </main>
+        </div>
+        <aside
+          aria-label={language.t("command.category.view")}
+          class="hidden md:flex w-12 shrink-0 border-s border-v2-border-border-base bg-black"
+          style={{
+            "--v2-icon-icon-base": "#fff",
+            "--v2-icon-icon-muted": "#858585",
+          }}
+        >
+          <div id="opencode-shell-rail-right" class="size-full" />
+        </aside>
+      </div>
       {import.meta.env.DEV && state.debugTools && <DebugBar inline />}
       <TabsInfoPopup />
       <ToastRegion v2 />


### PR DESCRIPTION
The new layout now uses a continuous T3Code-style frame instead of keeping navigation and session controls in the content header.

## What changed

- Adds true-black top, left, and right shell bars on desktop.
- Reuses the existing Home, new session, command palette, settings, help, review, file tree, terminal, and status actions.
- Keeps the side rails hidden below the `md` breakpoint and retains Home in the mobile titlebar.

## Verification

- `bun typecheck`
- `bun run build`
- Checked the desktop home shell in the T3 preview.
- Checked review, file tree, and terminal controls in a session. Their `aria-expanded` state updates on click.
- Reviewed the mobile breakpoint behavior in source. The T3 preview resize tool timed out without changing its 1280px viewport.

## Evidence

Local interaction recording: `/Users/iouthna/.t3/userdata/browser-artifacts/browser-recording-mtgul5c5.mp4`

No hosted media attached.
