### PR TITLE
feat(ecosystem): add Capybara AI Coding Assistant

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -74,6 +74,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
 
+| [Capybara AI Coding Assistant](https://github.com/Assassin-Q/capybaraAICodingAssistant) | IntelliJ IDEA plugin and JCEF client for OpenCode with native IDE context, file attachments, approvals, session tabs, native diffs, browser, Maven and Gradle integration. |
 ---
 
 ## Agents


### PR DESCRIPTION
Add Capybara AI Coding Assistant to the OpenCode ecosystem Projects list. It is an IntelliJ IDEA plugin and JCEF client that uses OpenCode for coding workflows, while adding native IDE context and actions.

### Issue for this PR
Closes #

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?
Adds one entry to the `Projects` table in `packages/web/src/content/docs/ecosystem.mdx` with the project name, repository link, and a short description of the OpenCode/IntelliJ integration. No runtime OpenCode code was changed.

### How did you verify your code works?
This is a documentation-only change, so no runtime test is required. I checked the completed Markdown diff and GitHub preview, verified that the change contains one added row in `ecosystem.mdx`, confirmed the project link, and confirmed that no other files are included.

### Screenshots / recordings
Not applicable; this PR changes documentation only.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes

