### PR TITLE
fix(session): reconcile compaction summary with preserved tail

### DIFF
--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -28,6 +28,13 @@ export const Event = SessionCompactionEvent
 export const PRUNE_MINIMUM = 20_000
 export const PRUNE_PROTECT = 40_000
 const TOOL_OUTPUT_MAX_CHARS = 2_000
+const RECENT_TAIL_AUDIT_MAX_CHARS = 4_000
+const RECENT_TAIL_AUDIT_PART_MAX_CHARS = 1_000
+const RECENT_TAIL_AUDIT_PREFIX = [
+  "<recent-preserved-tail-audit>",
+  "Use this text-only view only to reconcile Work State and Next Move. Do not copy it wholesale into the summary.",
+].join("\n")
+const RECENT_TAIL_AUDIT_SUFFIX = "</recent-preserved-tail-audit>"
 const PRUNE_PROTECTED_TOOLS = ["skill"]
 const MIN_PRESERVE_RECENT_TOKENS = 2_000
 const MAX_PRESERVE_RECENT_TOKENS = 15_000
@@ -110,6 +117,49 @@ function completedCompactions(messages: SessionV1.WithParts[]) {
     if (userIndex === undefined) return []
     return [{ userIndex, assistantIndex, summary: summaryText(msg) }]
   })
+}
+
+function recentTailAudit(messages: SessionV1.WithParts[]) {
+  const selected: Array<{ role: "user" | "assistant"; parts: string[] }> = []
+  let remaining = RECENT_TAIL_AUDIT_MAX_CHARS - RECENT_TAIL_AUDIT_PREFIX.length - RECENT_TAIL_AUDIT_SUFFIX.length - 2
+
+  for (const message of messages.toReversed()) {
+    if (message.info.role !== "user" && message.info.role !== "assistant") continue
+    const role = message.info.role
+    const parts: string[] = []
+    for (const text of recentTailMessageText(message).toReversed()) {
+      const part = text.trim()
+      if (!part) continue
+
+      const prefix = parts.length ? "\n".length : `### ${role}\n`.length + (selected.length ? "\n\n".length : 0)
+      if (remaining <= prefix) break
+
+      const value = truncateTail(part, Math.min(RECENT_TAIL_AUDIT_PART_MAX_CHARS, remaining - prefix))
+      parts.unshift(value)
+      remaining -= prefix + value.length
+    }
+    if (parts.length) selected.unshift({ role, parts })
+    if (remaining === 0) break
+  }
+
+  if (!selected.length) return undefined
+  return [
+    RECENT_TAIL_AUDIT_PREFIX,
+    selected.map((message) => `### ${message.role}\n${message.parts.join("\n")}`).join("\n\n"),
+    RECENT_TAIL_AUDIT_SUFFIX,
+  ].join("\n")
+}
+
+function recentTailMessageText(message: SessionV1.WithParts) {
+  if (message.info.role !== "user" && message.info.role !== "assistant") return []
+  return message.parts.flatMap((part) => (part.type === "text" && !part.ignored && !part.synthetic ? [part.text] : []))
+}
+
+function truncateTail(text: string, max: number) {
+  if (text.length <= max) return text
+  const marker = "\n[truncated]"
+  if (max <= marker.length) return text.slice(-max)
+  return `${marker}${text.slice(-(max - marker.length))}`
 }
 
 function preserveRecentBudget(input: { cfg: ConfigV1.Info; model: Provider.Model }) {
@@ -226,10 +276,10 @@ const layer = Layer.effect(
       model: Provider.Model
     }) {
       const limit = input.cfg.compaction?.tail_turns
-      if (limit !== undefined && limit <= 0) return { head: input.messages, tail_start_id: undefined }
+      if (limit !== undefined && limit <= 0) return { head: input.messages, tail: [], tail_start_id: undefined }
       const budget = preserveRecentBudget({ cfg: input.cfg, model: input.model })
       const all = turns(input.messages)
-      if (!all.length) return { head: input.messages, tail_start_id: undefined }
+      if (!all.length) return { head: input.messages, tail: [], tail_start_id: undefined }
       const recent = limit === undefined ? all : all.slice(-limit)
 
       let total = 0
@@ -261,9 +311,10 @@ const layer = Layer.effect(
         break
       }
 
-      if (!keep || keep.start === 0) return { head: input.messages, tail_start_id: undefined }
+      if (!keep || keep.start === 0) return { head: input.messages, tail: [], tail_start_id: undefined }
       return {
         head: input.messages.slice(0, keep.start),
+        tail: input.messages.slice(keep.start),
         tail_start_id: keep.id,
       }
     })
@@ -375,15 +426,19 @@ const layer = Layer.effect(
         { sessionID: input.sessionID },
         { context: [], prompt: undefined },
       )
-      const msgs = structuredClone(selected.head)
-      yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
-      const conversation = msgs.map(serialize).filter(Boolean).join("\n\n")
+      const tailIDs = new Set(selected.tail.map((message) => message.info.id))
+      const msgs = structuredClone([...selected.head, ...selected.tail])
+      const transformed = yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
+      const tail = transformed.messages.filter((message) => tailIDs.has(message.info.id))
+      const head = transformed.messages.filter((message) => !tailIDs.has(message.info.id))
+      const conversation = head.map(serialize).filter(Boolean).join("\n\n")
+      const context = [conversation, recentTailAudit(tail)].filter((item): item is string => Boolean(item))
       const nextPrompt =
         compacting.prompt ??
         [
           buildPrompt({
             previousSummary,
-            context: [conversation],
+            context,
           }),
           ...compacting.context,
         ]
@@ -436,7 +491,7 @@ const layer = Layer.effect(
                 type: "text",
                 text: [
                   nextPrompt,
-                  ...(compacting.prompt ? ["The following is the conversation history:", conversation] : []),
+                  ...(compacting.prompt ? ["The following is the conversation history:", ...context] : []),
                 ]
                   .filter(Boolean)
                   .join("\n\n"),

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -337,6 +337,13 @@ function reply(
   }
 }
 
+function userPrompt(input: LLM.StreamInput) {
+  const message = input.messages.at(-1)
+  if (message?.role !== "user") return ""
+  if (typeof message.content === "string") return message.content
+  return message.content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n")
+}
+
 function plugin(ready: Deferred.Deferred<void>) {
   return Layer.mock(Plugin.Service)({
     trigger: <Name extends string, Input, Output>(name: Name, _input: Input, output: Output) => {
@@ -1055,8 +1062,8 @@ describe("session.compaction.process", () => {
     "retains a split turn suffix when a later message fits the preserve token budget",
     () => {
       const stub = llm()
-      let captured = ""
-      stub.push(reply("summary", (input) => (captured = JSON.stringify(input.messages))))
+      let prompt = ""
+      stub.push(reply("summary", (input) => (prompt = userPrompt(input))))
       return Effect.gen(function* () {
         const test = yield* TestInstance
         const ssn = yield* SessionNs.Service
@@ -1089,8 +1096,10 @@ describe("session.compaction.process", () => {
         const part = yield* readCompactionPart(session.id)
         expect(part?.type).toBe("compaction")
         expect(part?.tail_start_id).toBe(keep.id)
-        expect(captured).toContain("zzzz")
-        expect(captured).not.toContain("keep tail")
+        const auditStart = prompt.indexOf("<recent-preserved-tail-audit>")
+        expect(auditStart).toBeGreaterThan(0)
+        expect(prompt.slice(0, auditStart)).toContain("zzzz")
+        expect(prompt.slice(auditStart)).toContain("keep tail")
 
         const filtered = MessageV2.filterCompacted(yield* MessageV2.stream(session.id))
         expect(filtered.map((msg) => msg.info.id).slice(0, 3)).toEqual([parent!, expect.any(String), keep.id])
@@ -1373,13 +1382,15 @@ describe("session.compaction.process", () => {
   )
 
   itCompaction.instance(
-    "summarizes only the head while keeping recent tail out of summary input",
+    "serializes the head separately from the preserved tail audit",
     () => {
       const stub = llm()
       let messages: LLM.StreamInput["messages"] = []
+      let prompt = ""
       stub.push(
         reply("summary", (input) => {
           messages = input.messages
+          prompt = userPrompt(input)
         }),
       )
       return Effect.gen(function* () {
@@ -1408,9 +1419,14 @@ describe("session.compaction.process", () => {
         expect(captured.indexOf("[User]: older context")).toBeLessThan(
           captured.indexOf("Create a new anchored summary"),
         )
-        expect(captured).toContain("[User]: older context")
-        expect(captured).not.toContain("keep this turn")
-        expect(captured).not.toContain("and this one too")
+        const conversation = prompt.match(/<conversation>\n([\s\S]*?)\n<\/conversation>/)?.[1] ?? ""
+        const audit = prompt.match(/<recent-preserved-tail-audit>[\s\S]*?<\/recent-preserved-tail-audit>/)?.[0] ?? ""
+        const history = conversation.slice(0, conversation.indexOf("<recent-preserved-tail-audit>"))
+        expect(history).toContain("[User]: older context")
+        expect(history).not.toContain("keep this turn")
+        expect(history).not.toContain("and this one too")
+        expect(audit).toContain("keep this turn")
+        expect(audit).toContain("and this one too")
         expect(captured).not.toContain("What did we do so far?")
       }).pipe(
         withCompaction({
@@ -1418,6 +1434,106 @@ describe("session.compaction.process", () => {
           config: cfg({ tail_turns: 2, preserve_recent_tokens: 10_000 }),
         }),
       )
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "audits only transformed visible tail text",
+    () => {
+      const stub = llm()
+      let prompt = ""
+      let transforms = 0
+      const redactingPlugin = Layer.succeed(
+        Plugin.Service,
+        Plugin.Service.of({
+          trigger: (<Name extends string, Input, Output>(name: Name, _input: Input, output: Output) => {
+            if (name === "experimental.chat.messages.transform") {
+              transforms++
+              const transformed = output as { messages: Array<{ parts: SessionV1.Part[] }> }
+              transformed.messages = transformed.messages.map((message) => ({
+                ...message,
+                parts: message.parts.map((part) =>
+                  part.type === "text" ? { ...part, text: part.text.replaceAll("raw secret", "[redacted]") } : part,
+                ),
+              }))
+            }
+            return Effect.succeed(output)
+          }) as Plugin.Interface["trigger"],
+          list: () => Effect.succeed([]),
+          init: () => Effect.void,
+        }),
+      )
+      stub.push(reply("summary", (input) => (prompt = userPrompt(input))))
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        yield* createUserMessage(session.id, "older context")
+        const recent = yield* createUserMessage(session.id, "raw secret")
+        yield* ssn.updatePart({
+          id: PartID.ascending(),
+          messageID: recent.id,
+          sessionID: session.id,
+          type: "text",
+          text: "ignored tail text",
+          ignored: true,
+        })
+        yield* ssn.updatePart({
+          id: PartID.ascending(),
+          messageID: recent.id,
+          sessionID: session.id,
+          type: "text",
+          text: "synthetic tail text",
+          synthetic: true,
+        })
+        yield* createCompactionMarker(session.id)
+
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+        yield* SessionCompaction.use.process({ parentID: parent!, messages: msgs, sessionID: session.id, auto: false })
+
+        expect(transforms).toBe(1)
+        expect(prompt).toContain("[redacted]")
+        expect(prompt).not.toContain("raw secret")
+        expect(prompt).not.toContain("ignored tail text")
+        expect(prompt).not.toContain("synthetic tail text")
+      }).pipe(
+        withCompaction({
+          llm: stub.llmLayer,
+          plugin: redactingPlugin,
+          config: cfg({ tail_turns: 1, preserve_recent_tokens: 10_000 }),
+        }),
+      )
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "retains the newest completion evidence when the tail audit is truncated",
+    () => {
+      const stub = llm()
+      let prompt = ""
+      const completion = "COMPLETION_MARKER"
+      stub.push(reply("summary", (input) => (prompt = userPrompt(input))))
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        yield* createUserMessage(session.id, "older context")
+        for (let index = 0; index < 5; index++) {
+          yield* createUserMessage(session.id, `${"x".repeat(1_200)}${index === 4 ? completion : `old-${index}`}`)
+        }
+        yield* createCompactionMarker(session.id)
+
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const parent = msgs.at(-1)?.info.id
+        expect(parent).toBeTruthy()
+        yield* SessionCompaction.use.process({ parentID: parent!, messages: msgs, sessionID: session.id, auto: false })
+
+        const audit = prompt.match(/<recent-preserved-tail-audit>[\s\S]*?<\/recent-preserved-tail-audit>/)?.[0] ?? ""
+        expect(audit).toContain(completion)
+        expect(audit.length).toBeLessThanOrEqual(4_000)
+      }).pipe(withCompaction({ llm: stub.llmLayer, config: cfg({ tail_turns: 5, preserve_recent_tokens: 10_000 }) }))
     },
     { git: true },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #38530

Replaces #28067, which was auto-closed for template compliance without maintainer review.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Repeated compaction can retain stale work under `Next Move` when the previous summary lists an action and the preserved recent turns show it was completed. The summarizer currently cannot reconcile that evidence because the preserved tail is excluded from its input.

This supplies a bounded, transformed audit of visible user and assistant text from the preserved tail while keeping the normal tail replay unchanged.

### How did you verify your code works?

- `cd packages/opencode && bun test test/session/compaction.test.ts` (57 pass, 1 skip)
- `cd packages/opencode && bun run typecheck`
- Changed-file Prettier and `git diff --check`
- Pre-push workspace typecheck (30 packages passed)

### Screenshots / recordings

N/A. This is not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR