### PR TITLE
fix(mcp): drain local stdio server stderr

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -355,6 +355,9 @@ const layer = Layer.effect(
           ...mcp.environment,
         },
       })
+      // Piped stderr uses an SDK PassThrough that blocks verbose MCP servers
+      // once its buffer fills unless the caller consumes it.
+      transport.stderr?.on("data", () => {})
 
       const connectTimeout = mcp.timeout ?? DEFAULT_TIMEOUT
       return yield* connectTransport(transport, connectTimeout).pipe(

--- a/packages/opencode/test/fixture/mcp-lifecycle-stdio.ts
+++ b/packages/opencode/test/fixture/mcp-lifecycle-stdio.ts
@@ -1,6 +1,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js"
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
-import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js"
+import { once } from "node:events"
 
 if (process.argv.includes("--hang")) {
   const pidFile = process.env.MCP_LIFECYCLE_PID_FILE
@@ -19,8 +20,22 @@ server.setRequestHandler(ListToolsRequestSchema, () =>
         description: process.cwd(),
         inputSchema: { type: "object", properties: {} },
       },
+      ...(process.argv.includes("--stderr-flood")
+        ? [
+            {
+              name: "stderr_flood",
+              inputSchema: { type: "object" },
+            },
+          ]
+        : []),
     ],
   }),
 )
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name !== "stderr_flood") throw new Error(`Unknown tool: ${request.params.name}`)
+  if (!process.stderr.write("x".repeat(1024 * 1024))) await once(process.stderr, "drain")
+  return { content: [{ type: "text", text: "ok" }] }
+})
 
 await server.connect(new StdioServerTransport())

--- a/packages/opencode/test/mcp/lifecycle.test.ts
+++ b/packages/opencode/test/mcp/lifecycle.test.ts
@@ -528,6 +528,28 @@ it.instance("local stdio timeout terminates the real server process", () =>
   }),
 )
 
+it.instance("local stdio drains server stderr", () =>
+  Effect.gen(function* () {
+    const mcp = yield* MCP.Service
+    const result = yield* mcp.add("stderr-flood", {
+      type: "local",
+      command: [process.execPath, stdioFixture, "--stderr-flood"],
+      timeout: 2_000,
+    })
+
+    expect(statusName(result.status, "stderr-flood")).toBe("connected")
+    expect((yield* mcp.tools())["stderr-flood_current_directory"]).toBeDefined()
+    const client = (yield* mcp.clients())["stderr-flood"]
+    expect(client).toBeDefined()
+    for (let i = 0; i < 3; i++) {
+      const response = yield* Effect.promise(() =>
+        client.callTool({ name: "stderr_flood", arguments: {} }, undefined, { timeout: 2_000 }),
+      )
+      expect(response.content).toEqual([{ type: "text", text: "ok" }])
+    }
+  }),
+)
+
 it.instance("remote timeout aborts both real HTTP transport attempts", () =>
   Effect.gen(function* () {
     const server = yield* hangingLifecycleServer()


### PR DESCRIPTION
### Issue for this PR

Fixes #46367

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Drain stderr from local MCP stdio transports so a verbose server cannot block on pipe backpressure. Adds a deterministic 1 MiB-stderr fixture and covers three repeated tool calls over the same MCP connection.

Prior attempt #37634 was closed by automated cleanup without being merged; it addressed related stderr draining together with concurrency and retry changes. This PR focuses on the minimal drain fix and regression coverage. Related issue #35719 covers preserving stderr diagnostics rather than request deadlock.

### How did you verify your code works?

- `bun test test/mcp/lifecycle.test.ts` - 22 passed, 0 failed
- `bun typecheck`
- Targeted Oxlint - 0 errors, 6 pre-existing warnings
- Deterministic fixture writes 1 MiB to stderr, waits for `drain`, and completes three repeated tool calls successfully

### Screenshots / recordings

_N/A - no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR