### PR TITLE
feat(opencode): add cache-preserving compaction

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -173,6 +173,13 @@ export const buildPrompt = (input: { readonly previousSummary?: string; readonly
   ].join("\n\n")
 }
 
+export const buildReplayPrompt = () =>
+  [
+    "Create a new anchored summary from the conversation messages above so another coding agent can continue the work.",
+    "Do not continue the task or call tools. Output only the summary.",
+    SUMMARY_TEMPLATE,
+  ].join("\n\n")
+
 export const make = (dependencies: Dependencies) => {
   const config = settings(dependencies.config)
   const compactAfterOverflow = Effect.fn("SessionCompaction.compactAfterOverflow")(function* (input: Input) {

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -164,6 +164,10 @@ export const Info = Schema.Struct({
       reserved: Schema.optional(NonNegativeInt).annotate({
         description: "Token buffer for compaction. Leaves enough window to avoid overflow during compaction.",
       }),
+      preserve_prefix_cache: Schema.optional(Schema.Boolean).annotate({
+        description:
+          "Reuse the current request prefix during compaction for supported OpenAI-compatible providers. Falls back to serialized compaction when replay is unsafe (experimental, default: false)",
+      }),
     }),
   ),
   experimental: Schema.optional(

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -30,6 +30,13 @@ test("compaction prompt gives update instructions for a prior summary", () => {
   expect(prompt).toContain('Update "Objective" and "Next Move" to reflect the current work state.')
 })
 
+test("replay prompt summarizes preceding messages", () => {
+  const prompt = SessionCompaction.buildReplayPrompt()
+  expect(prompt).toContain("conversation messages above")
+  expect(prompt).toContain("Do not continue the task or call tools")
+  expect(prompt).not.toContain("<conversation>")
+})
+
 test("compaction describes tool media without embedding base64", () => {
   const base64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
   const serialized = SessionCompaction.serializeToolContent([

--- a/packages/opencode/src/session/compaction.ts
+++ b/packages/opencode/src/session/compaction.ts
@@ -20,7 +20,7 @@ import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
-import { buildPrompt } from "@opencode-ai/core/session/compaction"
+import { buildPrompt, buildReplayPrompt } from "@opencode-ai/core/session/compaction"
 import { SessionCompactionEvent } from "@opencode-ai/schema/session-compaction-event"
 
 export const Event = SessionCompactionEvent
@@ -162,6 +162,26 @@ function splitTurn(input: {
   })
 }
 
+function containsMedia(messages: SessionV1.WithParts[]) {
+  return messages.some((message) =>
+    message.parts.some((part) => {
+      if (part.type === "file") return MessageV2.isMedia(part.mime)
+      if (part.type !== "tool" || part.state.status !== "completed") return false
+      return part.state.attachments?.some((attachment) => MessageV2.isMedia(attachment.mime)) ?? false
+    }),
+  )
+}
+
+export type Run = (input: {
+  user: SessionV1.User
+  agent: Agent.Info
+  model: Provider.Model
+  processor: SessionProcessor.Handle
+  messages: SessionV1.WithParts[]
+  prompt: string
+  bypassAgentCheck: boolean
+}) => Effect.Effect<SessionProcessor.Result>
+
 export interface Interface {
   readonly isOverflow: (input: {
     tokens: SessionV1.Assistant["tokens"]
@@ -174,6 +194,7 @@ export interface Interface {
     sessionID: SessionID
     auto: boolean
     overflow?: boolean
+    run?: Run
   }) => Effect.Effect<"continue" | "stop">
   readonly create: (input: {
     sessionID: SessionID
@@ -322,6 +343,7 @@ const layer = Layer.effect(
       sessionID: SessionID
       auto: boolean
       overflow?: boolean
+      run?: Run
     }) {
       const parent = input.messages.findLast((m) => m.info.id === input.parentID)
       if (!parent || parent.info.role !== "user") {
@@ -355,40 +377,77 @@ const layer = Layer.effect(
         }
       }
 
-      const agent = yield* agents.get("compaction")
-      const model = agent.model
-        ? yield* provider.getModel(agent.model.providerID, agent.model.modelID).pipe(Effect.orDie)
+      const compactionAgent = yield* agents.get("compaction")
+      const compactionModel = compactionAgent.model
+        ? yield* provider.getModel(compactionAgent.model.providerID, compactionAgent.model.modelID).pipe(Effect.orDie)
         : yield* provider.getModel(userMessage.model.providerID, userMessage.model.modelID).pipe(Effect.orDie)
       const cfg = yield* config.get()
       const history = compactionPart && messages.at(-1)?.info.id === input.parentID ? messages.slice(0, -1) : messages
       const prior = completedCompactions(history)
       const hidden = new Set(prior.flatMap((item) => [item.userIndex, item.assistantIndex]))
       const previousSummary = prior.at(-1)?.summary
+      const filtered = history.filter((_, index) => !hidden.has(index))
+      // Replay cannot merge an earlier summary without changing the cached prefix.
+      const replayRequest =
+        cfg.compaction?.preserve_prefix_cache === true &&
+        input.run !== undefined &&
+        input.overflow !== true &&
+        cfg.agent?.compaction === undefined &&
+        prior.length === 0
+          ? { run: input.run }
+          : undefined
+      const active = replayRequest
+        ? history.findLast(
+            (message): message is SessionV1.WithParts & { info: SessionV1.User } =>
+              message.info.role === "user" && !message.parts.some((part) => part.type === "compaction"),
+          )
+        : undefined
+      const activeAgent = active ? yield* agents.get(active.info.agent) : undefined
+      const activeModel = active
+        ? yield* provider.getModel(active.info.model.providerID, active.info.model.modelID).pipe(Effect.orDie)
+        : undefined
+      const replayModel =
+        active !== undefined &&
+        active.info.format?.type !== "json_schema" &&
+        activeAgent !== undefined &&
+        activeModel !== undefined &&
+        activeModel.api.npm === "@ai-sdk/openai-compatible" &&
+        !activeModel.providerID.startsWith("opencode") &&
+        activeModel.id === compactionModel.id &&
+        activeModel.providerID === compactionModel.providerID
+          ? { user: active, agent: activeAgent, model: activeModel }
+          : undefined
       const selected = yield* select({
-        messages: history.filter((_, index) => !hidden.has(index)),
+        messages: filtered,
         cfg,
-        model,
+        model: replayModel?.model ?? compactionModel,
       })
+      const tail = selected.tail_start_id
+        ? filtered.find((message) => message.info.id === selected.tail_start_id)
+        : undefined
+      // Structured replay is deliberately narrow; every other request keeps the
+      // provider-safe serialized path.
+      const replayCandidate =
+        replayRequest && replayModel !== undefined && tail?.info.role === "user" && !containsMedia(selected.head)
+          ? { ...replayModel, run: replayRequest.run }
+          : undefined
       // Allow plugins to inject context or replace compaction prompt.
       const compacting = yield* plugin.trigger(
         "experimental.session.compacting",
         { sessionID: input.sessionID },
         { context: [], prompt: undefined },
       )
+      const replayContext =
+        compacting.prompt === undefined && compacting.context.length === 0 ? replayCandidate : undefined
+      const agent = replayContext?.agent ?? compactionAgent
+      const model = replayContext?.model ?? compactionModel
       const msgs = structuredClone(selected.head)
       yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
       const conversation = msgs.map(serialize).filter(Boolean).join("\n\n")
-      const nextPrompt =
+      const fallbackPrompt =
         compacting.prompt ??
-        [
-          buildPrompt({
-            previousSummary,
-            context: [conversation],
-          }),
-          ...compacting.context,
-        ]
-          .filter(Boolean)
-          .join("\n\n")
+        [buildPrompt({ previousSummary, context: [conversation] }), ...compacting.context].filter(Boolean).join("\n\n")
+      const nextPrompt = replayContext ? buildReplayPrompt() : fallbackPrompt
       const ctx = yield* InstanceState.context
       const msg: SessionV1.Assistant = {
         id: MessageID.ascending(),
@@ -397,7 +456,7 @@ const layer = Layer.effect(
         sessionID: input.sessionID,
         mode: "compaction",
         agent: "compaction",
-        variant: userMessage.model.variant,
+        variant: replayContext?.user.info.model.variant ?? userMessage.model.variant,
         summary: true,
         path: {
           cwd: ctx.directory,
@@ -422,30 +481,44 @@ const layer = Layer.effect(
         sessionID: input.sessionID,
         model,
       })
-      const result = yield* processor.process({
-        user: userMessage,
-        agent,
-        sessionID: input.sessionID,
-        tools: {},
-        system: [],
-        messages: [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: [
-                  nextPrompt,
-                  ...(compacting.prompt ? ["The following is the conversation history:", conversation] : []),
-                ]
-                  .filter(Boolean)
-                  .join("\n\n"),
-              },
-            ],
-          },
-        ],
-        model,
-      })
+      const runSerialized = () =>
+        processor.process({
+          user: userMessage,
+          agent: compactionAgent,
+          sessionID: input.sessionID,
+          tools: {},
+          system: [],
+          messages: [
+            {
+              role: "user",
+              content: [
+                {
+                  type: "text",
+                  text: [
+                    fallbackPrompt,
+                    ...(compacting.prompt ? ["The following is the conversation history:", conversation] : []),
+                  ]
+                    .filter(Boolean)
+                    .join("\n\n"),
+                },
+              ],
+            },
+          ],
+          model: compactionModel,
+        })
+      const result = replayContext
+        ? yield* replayContext
+            .run({
+              user: replayContext.user.info,
+              agent,
+              model,
+              processor,
+              messages: msgs,
+              prompt: nextPrompt,
+              bypassAgentCheck: replayContext.user.parts.some((part) => part.type === "agent"),
+            })
+            .pipe(Effect.flatMap((result) => (result === "compact" ? runSerialized() : Effect.succeed(result))))
+        : yield* runSerialized()
 
       if (result === "compact") {
         processor.message.error = new SessionV1.ContextOverflowError({

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -149,6 +149,46 @@ const layer = Layer.effect(
       } satisfies TaskPromptOps
     })
 
+    const resolveTools = Effect.fn("SessionPrompt.resolveTools")(function* (input: {
+      agent: Agent.Info
+      session: Session.Info
+      model: Provider.Model
+      processor: SessionProcessor.Handle
+      messages: SessionV1.WithParts[]
+      bypassAgentCheck: boolean
+    }) {
+      return yield* SessionTools.resolve({
+        ...input,
+        promptOps: yield* ops(),
+      }).pipe(
+        Effect.provideService(Plugin.Service, plugin),
+        Effect.provideService(Permission.Service, permission),
+        Effect.provideService(ToolRegistry.Service, registry),
+        Effect.provideService(MCP.Service, mcp),
+        Effect.provideService(Truncate.Service, truncate),
+        Effect.provideService(RuntimeFlags.Service, flags),
+      )
+    })
+
+    const prepareMessages = Effect.fn("SessionPrompt.prepareMessages")(function* (input: {
+      agent: Agent.Info
+      session: Session.Info
+      model: Provider.Model
+      messages: SessionV1.WithParts[]
+    }) {
+      const [skills, env, instructions, mcpInstructions, modelMessages] = yield* Effect.all([
+        sys.skills(input.agent),
+        sys.environment(input.model),
+        instruction.system().pipe(Effect.orDie),
+        sys.mcp(input.agent, input.session.permission),
+        MessageV2.toModelMessagesEffect(input.messages, input.model),
+      ])
+      return {
+        modelMessages,
+        system: [...env, ...instructions, ...(mcpInstructions ? [mcpInstructions] : []), ...(skills ? [skills] : [])],
+      }
+    })
+
     const cancel = Effect.fn("SessionPrompt.cancel")(function* (sessionID: SessionID) {
       yield* Effect.logInfo("cancel", { "session.id": sessionID })
       yield* state.cancel(sessionID)
@@ -1153,6 +1193,36 @@ const layer = Layer.effect(
               sessionID,
               auto: task.auto,
               overflow: task.overflow,
+              run: ({ user, agent, model, processor, messages, prompt, bypassAgentCheck }) =>
+                Effect.gen(function* () {
+                  // Keep tool definitions in the cached prefix, but never let a provider
+                  // execute them if it ignores toolChoice: "none".
+                  const tools = Object.fromEntries(
+                    Object.entries(
+                      yield* resolveTools({
+                        agent,
+                        session,
+                        model,
+                        processor,
+                        messages,
+                        bypassAgentCheck,
+                      }),
+                    ).map(([name, item]) => [name, { ...item, execute: undefined }]),
+                  )
+                  const prepared = yield* prepareMessages({ agent, session, model, messages })
+                  return yield* processor.process({
+                    user,
+                    agent,
+                    permission: session.permission,
+                    sessionID,
+                    parentSessionID: session.parentID,
+                    system: prepared.system,
+                    messages: [...prepared.modelMessages, { role: "user", content: prompt }],
+                    tools,
+                    model,
+                    toolChoice: "none",
+                  })
+                }),
             })
             if (result === "stop") break
             continue
@@ -1221,24 +1291,14 @@ const layer = Layer.effect(
           const outcome: "break" | "continue" = yield* Effect.gen(function* () {
             const lastUserMsg = msgs.findLast((m) => m.info.role === "user")
             const bypassAgentCheck = lastUserMsg?.parts.some((p) => p.type === "agent") ?? false
-            const promptOps = yield* ops()
-
-            const tools = yield* SessionTools.resolve({
+            const tools = yield* resolveTools({
               agent,
               session,
               model,
               processor: handle,
               bypassAgentCheck,
               messages: msgs,
-              promptOps,
-            }).pipe(
-              Effect.provideService(Plugin.Service, plugin),
-              Effect.provideService(Permission.Service, permission),
-              Effect.provideService(ToolRegistry.Service, registry),
-              Effect.provideService(MCP.Service, mcp),
-              Effect.provideService(Truncate.Service, truncate),
-              Effect.provideService(RuntimeFlags.Service, flags),
-            )
+            })
 
             if (lastUser.format?.type === "json_schema") {
               tools["StructuredOutput"] = createStructuredOutputTool({
@@ -1254,30 +1314,18 @@ const layer = Layer.effect(
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
-            const [skills, env, instructions, mcpInstructions, modelMsgs] = yield* Effect.all([
-              sys.skills(agent),
-              sys.environment(model),
-              instruction.system().pipe(Effect.orDie),
-              sys.mcp(agent, session.permission),
-              MessageV2.toModelMessagesEffect(msgs, model),
-            ])
-            const system = [
-              ...env,
-              ...instructions,
-              ...(mcpInstructions ? [mcpInstructions] : []),
-              ...(skills ? [skills] : []),
-            ]
+            const prepared = yield* prepareMessages({ agent, session, model, messages: msgs })
             const format = lastUser.format ?? { type: "text" as const }
-            if (format.type === "json_schema") system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
+            if (format.type === "json_schema") prepared.system.push(STRUCTURED_OUTPUT_SYSTEM_PROMPT)
             const result = yield* handle.process({
               user: lastUser,
               agent,
               permission: session.permission,
               sessionID,
               parentSessionID: session.parentID,
-              system,
+              system: prepared.system,
               messages: [
-                ...modelMsgs,
+                ...prepared.modelMessages,
                 ...(isLastStep ? [{ role: "assistant" as const, content: MAX_STEPS_PROMPT }] : []),
               ],
               tools,

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -812,6 +812,152 @@ describe("session.compaction.prune", () => {
 })
 
 describe("session.compaction.process", () => {
+  itCompaction.instance(
+    "uses opt-in replay for an eligible OpenAI-compatible request",
+    () => {
+      const provider = ProviderTest.fake({
+        model: createModel({ context: 100_000, output: 32_000, npm: "@ai-sdk/openai-compatible" }),
+      })
+      let replayed = false
+      return Effect.gen(function* () {
+        const test = yield* TestInstance
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        const first = yield* createUserMessage(session.id, "earlier")
+        yield* createAssistantMessage(session.id, first.id, test.directory)
+        const msg = yield* createUserMessage(session.id, "latest")
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+
+        const result = yield* SessionCompaction.use.process({
+          parentID: msg.id,
+          messages: msgs,
+          sessionID: session.id,
+          auto: false,
+          run: (input) =>
+            Effect.sync(() => {
+              replayed = true
+              expect(input.user.id).toBe(msg.id)
+              expect(input.prompt).toContain("Create a new anchored summary")
+              return "continue" as const
+            }),
+        })
+
+        expect(result).toBe("continue")
+        expect(replayed).toBe(true)
+      }).pipe(
+        withCompaction({
+          provider,
+          config: cfg({ preserve_prefix_cache: true, tail_turns: 1 }),
+        }),
+      )
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "keeps serialized fallback for unsupported providers",
+    () => {
+      const provider = ProviderTest.fake({
+        model: createModel({ context: 100_000, output: 32_000, npm: "@ai-sdk/anthropic" }),
+      })
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        const msg = yield* createUserMessage(session.id, "hello")
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+        const fail = () => Effect.die("unexpected replay")
+
+        expect(
+          yield* SessionCompaction.use.process({
+            parentID: msg.id,
+            messages: msgs,
+            sessionID: session.id,
+            auto: false,
+            run: fail,
+          }),
+        ).toBe("continue")
+      }).pipe(
+        withCompaction({
+          provider,
+          config: cfg({ preserve_prefix_cache: true }),
+        }),
+      )
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "keeps serialized fallback during overflow recovery",
+    () => {
+      const provider = ProviderTest.fake({
+        model: createModel({ context: 100_000, output: 32_000, npm: "@ai-sdk/openai-compatible" }),
+      })
+      return Effect.gen(function* () {
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        const msg = yield* createUserMessage(session.id, "hello")
+        const msgs = yield* ssn.messages({ sessionID: session.id })
+
+        expect(
+          yield* SessionCompaction.use.process({
+            parentID: msg.id,
+            messages: msgs,
+            sessionID: session.id,
+            auto: false,
+            overflow: true,
+            run: () => Effect.die("unexpected replay"),
+          }),
+        ).toBe("continue")
+      }).pipe(
+        withCompaction({
+          provider,
+          config: cfg({ preserve_prefix_cache: true }),
+        }),
+      )
+    },
+    { git: true },
+  )
+
+  itCompaction.instance(
+    "keeps serialized fallback after a prior compaction",
+    () => {
+      const provider = ProviderTest.fake({
+        model: createModel({ context: 100_000, output: 32_000, npm: "@ai-sdk/openai-compatible" }),
+      })
+      return Effect.gen(function* () {
+        const test = yield* TestInstance
+        const ssn = yield* SessionNs.Service
+        const session = yield* ssn.create({})
+        const first = yield* createUserMessage(session.id, "first")
+        yield* createAssistantMessage(session.id, first.id, test.directory)
+        yield* SessionCompaction.use.create({ sessionID: session.id, agent: "build", model: ref, auto: false })
+        const prior = (yield* ssn.messages({ sessionID: session.id })).at(-1)!
+        yield* createSummaryAssistantMessage(session.id, prior.info.id, test.directory, "prior summary")
+        const latest = yield* createUserMessage(session.id, "latest")
+        yield* createAssistantMessage(session.id, latest.id, test.directory)
+        yield* SessionCompaction.use.create({ sessionID: session.id, agent: "build", model: ref, auto: false })
+        const messages = yield* ssn.messages({ sessionID: session.id })
+        const marker = messages.at(-1)!
+
+        expect(
+          yield* SessionCompaction.use.process({
+            parentID: marker.info.id,
+            messages,
+            sessionID: session.id,
+            auto: false,
+            run: () => Effect.die("unexpected replay"),
+          }),
+        ).toBe("continue")
+      }).pipe(
+        withCompaction({
+          provider,
+          config: cfg({ preserve_prefix_cache: true }),
+        }),
+      )
+    },
+    { git: true },
+  )
+
   it.instance(
     "throws when parent is not a user message",
     Effect.gen(function* () {

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -444,6 +444,134 @@ const boot = Effect.fn("test.boot")(function* (input?: { title?: string }) {
 
 // Loop semantics
 
+it.instance("reuses the ordinary wire prefix for opt-in compaction", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      compaction: { preserve_prefix_cache: true, tail_turns: 1 },
+    }))
+    const { prompt, sessions, chat } = yield* boot()
+
+    yield* user(chat.id, "earlier request")
+    yield* llm.text("earlier response")
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const latest = yield* sessions.updateMessage({
+      id: MessageID.ascending(),
+      role: "user",
+      sessionID: chat.id,
+      agent: "build",
+      model: ref,
+      system: "trigger system",
+      tools: { bash: false },
+      time: { created: Date.now() },
+    })
+    yield* sessions.updatePart({
+      id: PartID.ascending(),
+      messageID: latest.id,
+      sessionID: chat.id,
+      type: "text",
+      text: "latest request",
+    })
+    yield* llm.text("latest response")
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const compact = yield* SessionCompaction.Service
+    yield* compact.create({ sessionID: chat.id, agent: "build", model: ref, auto: false })
+    yield* llm.text("compacted summary")
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const inputs = yield* llm.inputs
+    expect(inputs).toHaveLength(3)
+    const normal = inputs[1]
+    const compaction = inputs[2]
+    expect(compaction.tools).toEqual(normal.tools)
+    expect(compaction.tool_choice).toBe("none")
+    const normalMessages = Array.isArray(normal.messages) ? normal.messages : []
+    const compactionMessages = Array.isArray(compaction.messages) ? compaction.messages : []
+    expect(compactionMessages.slice(0, -1)).toEqual(normalMessages.slice(0, compactionMessages.length - 1))
+    expect(JSON.stringify(compactionMessages)).toContain("Create a new anchored summary")
+    expect(JSON.stringify(compactionMessages)).not.toContain("[User]: earlier request")
+  }),
+)
+
+it.instance("does not execute tools if the provider ignores tool choice during compaction", () =>
+  Effect.gen(function* () {
+    const { dir, llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      compaction: { preserve_prefix_cache: true, tail_turns: 1 },
+    }))
+    const { prompt, chat } = yield* boot()
+
+    yield* user(chat.id, "earlier request")
+    yield* llm.text("earlier response")
+    yield* prompt.loop({ sessionID: chat.id })
+    yield* user(chat.id, "latest request")
+    yield* llm.text("latest response")
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const compact = yield* SessionCompaction.Service
+    yield* compact.create({ sessionID: chat.id, agent: "build", model: ref, auto: false })
+    const marker = path.join(dir, "compaction-tool-ran")
+    yield* llm.tool("bash", { command: `touch ${JSON.stringify(marker)}` })
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const fs = yield* FSUtil.Service
+    expect(yield* fs.existsSafe(marker)).toBe(false)
+  }),
+)
+
+it.instance("uses serialized compaction if prefix replay overflows", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig((url) => ({
+      ...providerCfg(url),
+      compaction: { preserve_prefix_cache: true, tail_turns: 1 },
+    }))
+    const { prompt, chat } = yield* boot()
+
+    yield* user(chat.id, "earlier request")
+    yield* llm.text("earlier response")
+    yield* prompt.loop({ sessionID: chat.id })
+    yield* user(chat.id, "latest request")
+    yield* llm.text("latest response")
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const compact = yield* SessionCompaction.Service
+    yield* compact.create({ sessionID: chat.id, agent: "build", model: ref, auto: false })
+    yield* llm.error(400, { type: "error", error: { code: "context_length_exceeded" } })
+    yield* llm.text("compacted summary")
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const inputs = yield* llm.inputs
+    expect(inputs).toHaveLength(4)
+    expect(inputs[2]?.tool_choice).toBe("none")
+    expect(inputs[3]?.tools).toBeUndefined()
+    expect(JSON.stringify(inputs[3]?.messages)).toContain("[User]: earlier request")
+  }),
+)
+
+it.instance("keeps serialized compaction as the default", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const { prompt, chat } = yield* boot()
+    yield* user(chat.id, "default request")
+    yield* llm.text("default response")
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const compact = yield* SessionCompaction.Service
+    yield* compact.create({ sessionID: chat.id, agent: "build", model: ref, auto: false })
+    yield* llm.text("compacted summary")
+    yield* prompt.loop({ sessionID: chat.id })
+
+    const inputs = yield* llm.inputs
+    expect(inputs).toHaveLength(2)
+    const compaction = inputs[1]
+    expect(compaction.tools).toBeUndefined()
+    expect(compaction.tool_choice).toBeUndefined()
+    expect(JSON.stringify(compaction.messages)).toContain("[User]: default request")
+  }),
+)
+
 noLLMServer.instance(
   "loop exits immediately when last assistant has stop finish",
   () =>

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2017,6 +2017,7 @@ export type Config = {
     tail_turns?: number
     preserve_recent_tokens?: number
     reserved?: number
+    preserve_prefix_cache?: boolean
   }
   experimental?: {
     disable_paste_summary?: boolean

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -21515,6 +21515,9 @@
               "reserved": {
                 "type": "integer",
                 "minimum": 0
+              },
+              "preserve_prefix_cache": {
+                "type": "boolean"
               }
             },
             "additionalProperties": false


### PR DESCRIPTION
### Issue for this PR

Closes #43249

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

@rekram1-node, could you review this one?

This adds an opt-in way to keep the stable prompt prefix during compaction. It avoids reprocessing the whole prompt and reduces compaction delay on supported local and OpenAI-compatible providers.

The default path does not change. Replay is limited to the same model and a safe turn boundary. It is disabled for media, a custom compaction agent, plugin changes, and overflow recovery. Tool definitions stay in the cached prefix, but cannot run. If replay exceeds the context limit, OpenCode uses normal serialized compaction.

### How did you verify your code works?

- 121 focused OpenCode tests passed; 2 existing tests skipped
- 4 core compaction tests passed
- all 30 repository typecheck tasks passed

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR