### PR TITLE
fix(app): keep streamed session state across refresh races

### DIFF
--- a/packages/app/src/context/server-session.test.ts
+++ b/packages/app/src/context/server-session.test.ts
@@ -1639,4 +1639,57 @@ describe("server session", () => {
     expect(ctx.store.data.message.active?.map((message) => message.id)).toEqual(["message"])
     expect(ctx.store.data.session_status["session-0"]).toBeUndefined()
   })
+
+  test("preserves streamed parts when a refresh page returns none", async () => {
+    const message = userMessage("message")
+    const streamed = textPart(message.id, { text: "streamed" })
+    const store = createServerSession(
+      messageClient(
+        response([{ info: message, parts: [streamed] }]),
+        response([{ info: message, parts: [] }]),
+      ),
+    )
+    await store.sync("child")
+    store.apply({ type: "message.part.updated", properties: { sessionID: "child", part: streamed, time: 1 } })
+    await store.sync("child", { force: true })
+
+    expect(store.data.part[message.id]).toEqual([streamed])
+  })
+
+  test("refreshes with a full page after the session outgrows its first page", async () => {
+    const first = userMessage("first", { time: { created: 1 } })
+    const second = userMessage("second", { time: { created: 2 } })
+    let loads = 0
+    const client = {
+      session: {
+        get: async () => ({ data: session("child", "root") }),
+        messages: async (input: unknown) => {
+          const limit = (input as { limit?: number }).limit ?? 20
+          loads += 1
+          const available = loads === 1 ? [first] : [first, second]
+          return response(available.slice(0, limit).map((info) => ({ info, parts: [] })))
+        },
+      },
+    } as unknown as OpencodeClient
+    const store = createServerSession(client)
+    await store.sync("child")
+    await store.sync("child", { force: true })
+
+    expect(store.data.message.child).toEqual([first, second])
+    expect(store.data.session_message.child.map((message) => message.id)).toEqual(["first", "second"])
+  })
+
+  test("does not shrink the fetched page limit on refresh", async () => {
+    const a = userMessage("a", { time: { created: 1 } })
+    const b = userMessage("b", { time: { created: 2 } })
+    const client = messageClient(
+      response([{ info: a, parts: [] }, { info: b, parts: [] }]),
+      response([{ info: a, parts: [] }, { info: b, parts: [] }]),
+    )
+    const store = createServerSession(client)
+    await store.sync("child")
+    await store.sync("child", { force: true })
+
+    expect((client.requests[1] as { limit?: number }).limit).toBe(20)
+  })
 })

--- a/packages/app/src/context/server-session.ts
+++ b/packages/app/src/context/server-session.ts
@@ -648,6 +648,19 @@ export function createServerSession(
       }
       const parts = reconcileFetched(fetched, data.part[item.id] ?? [], { touched })
       if (!parts.length) {
+        // A refresh page without parts races parts confirmed by events between
+        // pages (the session may not be fully persisted yet). Accept the
+        // omission when this load marked the message's parts explicitly: on the
+        // first page, through a removal signal, or via in-flight event tracking.
+        const racy =
+          meta.limit[sessionID] !== undefined &&
+          !load?.clearedMessageParts.has(item.id) &&
+          !(load?.touchedParts.get(item.id)?.size ?? 0) &&
+          !(load?.carriedDeltaParts.get(item.id)?.size ?? 0)
+        if (racy) {
+          orphanParts.get(sessionID)?.delete(item.id)
+          continue
+        }
         orphanParts.get(sessionID)?.delete(item.id)
         setData(produce((draft) => deleteMessageParts(draft, item.id)))
         continue
@@ -723,7 +736,7 @@ export function createServerSession(
         }
         orphanParts.delete(sessionID)
       }
-      setMeta("limit", sessionID, messages.length)
+      setMeta("limit", sessionID, Math.max(meta.limit[sessionID] ?? initialMessagePageSize, messages.length))
       setMeta("cursor", sessionID, merged.cursor)
       setMeta("complete", sessionID, merged.complete)
       setMeta("at", sessionID, Date.now())


### PR DESCRIPTION
### Issue for this PR

Closes #34804

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes chat history going blank right after an assistant response finishes. While streaming, the client tracks messages from events; a refresh fetch can arrive before the session is fully persisted, and the fetched page then overwrote fresher client state in two ways:

- `replaceParts` cleared parts that events had already confirmed when the fetched page omitted them, leaving empty message rows (0 height + `overflow: clip` = blank timeline) until the tab reloaded.
- `meta.limit` was written as the fetched message count. A small early page permanently shrank later fetches, so a session that outgrew its first page could refresh into a one-message timeline.

The fix keeps event-confirmed parts unless the load itself marked them (first page, explicit removal, or in-flight event tracking), and keeps `meta.limit` from shrinking below the initial page size.

### How did you verify your code works?

- Added three tests to `server-session.test.ts`; each fails on the previous behavior and passes with the fix.
- `bun test` over `src/context` passes (316 tests).
- `oxlint` on the changed files reports no errors.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR