### PR TITLE
fix(opencode): scope workspaceSymbol to the requesting file's LSP client

### DIFF
--- a/packages/opencode/src/cli/cmd/debug/lsp.ts
+++ b/packages/opencode/src/cli/cmd/debug/lsp.ts
@@ -3,6 +3,7 @@ import { Effect } from "effect"
 import { effectCmd } from "../../effect-cmd"
 import { cmd } from "../cmd"
 import { EOL } from "os"
+import path from "path"
 
 export const LSPCommand = cmd({
   command: "lsp",
@@ -28,12 +29,15 @@ const DiagnosticsCommand = effectCmd({
 })
 
 export const SymbolsCommand = effectCmd({
-  command: "symbols <query>",
+  command: "symbols <query> <file>",
   describe: "search workspace symbols",
-  builder: (yargs) => yargs.positional("query", { type: "string", demandOption: true }),
+  builder: (yargs) =>
+    yargs
+      .positional("query", { type: "string", demandOption: true })
+      .positional("file", { type: "string", demandOption: true, describe: "file used to select the LSP client" }),
   handler: Effect.fn("Cli.debug.lsp.symbols")(function* (args) {
     yield* Effect.logInfo("symbols")
-    const results = yield* LSP.Service.use((lsp) => lsp.workspaceSymbol(args.query))
+    const results = yield* LSP.Service.use((lsp) => lsp.workspaceSymbol(args.query, path.resolve(args.file)))
     process.stdout.write(JSON.stringify(results, null, 2) + EOL)
   }),
 })

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -127,7 +127,7 @@ export interface Interface {
   readonly references: (input: LocInput) => Effect.Effect<any[]>
   readonly implementation: (input: LocInput) => Effect.Effect<any[]>
   readonly documentSymbol: (uri: string) => Effect.Effect<(DocumentSymbol | Symbol)[]>
-  readonly workspaceSymbol: (query: string) => Effect.Effect<Symbol[]>
+  readonly workspaceSymbol: (query: string, file: string) => Effect.Effect<Symbol[]>
   readonly prepareCallHierarchy: (input: LocInput) => Effect.Effect<any[]>
   readonly incomingCalls: (input: LocInput) => Effect.Effect<any[]>
   readonly outgoingCalls: (input: LocInput) => Effect.Effect<any[]>
@@ -430,8 +430,8 @@ const layer = Layer.effect(
       return (results.flat() as (DocumentSymbol | Symbol)[]).filter(Boolean)
     })
 
-    const workspaceSymbol = Effect.fn("LSP.workspaceSymbol")(function* (query: string) {
-      const results = yield* runAll((client) =>
+    const workspaceSymbol = Effect.fn("LSP.workspaceSymbol")(function* (query: string, file: string) {
+      const results = yield* run(file, (client) =>
         client.connection
           .sendRequest<Symbol[]>("workspace/symbol", { query })
           .then((result) => result.filter((x) => kinds.includes(x.kind)).slice(0, 10))

--- a/packages/opencode/src/tool/lsp.ts
+++ b/packages/opencode/src/tool/lsp.ts
@@ -90,7 +90,7 @@ export const LspTool = Tool.define(
               case "documentSymbol":
                 return lsp.documentSymbol(uri)
               case "workspaceSymbol":
-                return lsp.workspaceSymbol(args.query ?? "")
+                return lsp.workspaceSymbol(args.query ?? "", file)
               case "goToImplementation":
                 return lsp.implementation(position)
               case "prepareCallHierarchy":

--- a/packages/opencode/test/lsp/lifecycle.test.ts
+++ b/packages/opencode/test/lsp/lifecycle.test.ts
@@ -87,7 +87,20 @@ describe("LSP service lifecycle", () => {
   it.instance("workspaceSymbol() returns empty array with no clients", () =>
     LSP.Service.use((lsp) =>
       Effect.gen(function* () {
-        const result = yield* lsp.workspaceSymbol("test")
+        const result = yield* lsp.workspaceSymbol("test", path.join((yield* TestInstance).directory, "test.ts"))
+        expect(Array.isArray(result)).toBe(true)
+        expect(result.length).toBe(0)
+      }),
+    ),
+  )
+
+  it.instance("workspaceSymbol() returns empty array for file outside instance", () =>
+    LSP.Service.use((lsp) =>
+      Effect.gen(function* () {
+        const result = yield* lsp.workspaceSymbol(
+          "test",
+          path.join((yield* TestInstance).directory, "..", "outside.ts"),
+        )
         expect(Array.isArray(result)).toBe(true)
         expect(result.length).toBe(0)
       }),

--- a/packages/opencode/test/tool/lsp.test.ts
+++ b/packages/opencode/test/tool/lsp.test.ts
@@ -31,6 +31,7 @@ const ctx = {
 }
 
 const workspaceSymbolQueries: string[] = []
+const workspaceSymbolFiles: string[] = []
 
 const lsp = Layer.succeed(
   LSP.Service,
@@ -45,9 +46,10 @@ const lsp = Layer.succeed(
     references: () => Effect.succeed([]),
     implementation: () => Effect.succeed([]),
     documentSymbol: () => Effect.succeed([]),
-    workspaceSymbol: (query) =>
+    workspaceSymbol: (query, file) =>
       Effect.sync(() => {
         workspaceSymbolQueries.push(query)
+        workspaceSymbolFiles.push(file)
         return []
       }),
     prepareCallHierarchy: () => Effect.succeed([]),
@@ -165,11 +167,12 @@ describe("tool.lsp", () => {
     )
 
     it.instance(
-      "passes workspaceSymbol query to LSP",
+      "passes workspaceSymbol query and filePath to LSP",
       () =>
         Effect.gen(function* () {
           const dir = (yield* TestInstance).directory
           workspaceSymbolQueries.length = 0
+          workspaceSymbolFiles.length = 0
           const file = path.join(dir, "test.ts")
           yield* put(file)
 
@@ -177,6 +180,7 @@ describe("tool.lsp", () => {
           yield* run({ operation: "workspaceSymbol", filePath: file, line: 3, character: 7 })
 
           expect(workspaceSymbolQueries).toEqual(["TestSymbol", ""])
+          expect(workspaceSymbolFiles).toEqual([file, file])
         }),
       { git: true },
     )


### PR DESCRIPTION
## Summary

`LSP.workspaceSymbol()` used `runAll()`, which queries whatever LSP clients happen to already be active in `state.clients`, instead of `run(file, fn)` (used by every other operation in `lsp.ts`), which calls `getClients(file)` to init/select the correct client for that file.

Effects:
- In a fresh process, `workspaceSymbol` returns an empty array until some other LSP operation happens to initialize a client first.
- In multi-root repos, it queries all currently-active clients and can return unrelated/duplicate results from other projects instead of scoping to the requesting file's workspace.

## Fix

Threads `filePath` through `LSP.workspaceSymbol(query, file)` so it uses `run(file, fn)` -> `getClients(file)`, matching the pattern already used by `hover`/`definition`/`documentSymbol`/etc. Wires `filePath` from the `lsp` tool call site (`tool/lsp.ts`) and the `debug lsp symbols` CLI command into the new signature.

Fixes #46356

## Verification

- `bun run typecheck` — clean (tsgo --noEmit, 0 errors)
- `bun test test/tool/lsp.test.ts test/lsp/lifecycle.test.ts` — all pass, including new assertions that `filePath` is threaded to the LSP service and used for client scoping
- `bun run lint` — no new errors introduced (repo-wide lint has pre-existing unrelated warnings/errors in other files, confirmed unaffected by this diff)
- Full monorepo `typecheck` via pre-push hook passed (30/30)

## AI disclosure

This fix was written and verified by an AI coding agent (Claude) under human supervision (repro against current source, fix, tests, typecheck all run and reviewed before opening this PR).
