### PR TITLE
feat(app): refine mobile shell home and settings

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
       "name": "@opencode-ai/app",
       "version": "1.18.15",
       "dependencies": {
+        "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
         "@dnd-kit/dom": "0.5.0",
         "@dnd-kit/helpers": "0.5.0",
@@ -1642,6 +1643,10 @@
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20251008.0", "", {}, "sha512-dZLkO4PbCL0qcCSKzuW7KE4GYe49lI12LCfQ5y9XeSwgYBoAUbwH4gmJ6A0qUIURiTJTkGkRkhVPqpq2XNgYRA=="],
 
+    "@corvu/dialog": ["@corvu/dialog@0.2.4", "", { "dependencies": { "@corvu/utils": "~0.4.2", "solid-dismissible": "~0.1.1", "solid-focus-trap": "~0.1.8", "solid-presence": "~0.2.0", "solid-prevent-scroll": "~0.1.10" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-n54vJq+fOy8GVrnYBdJpD6JXNuyx7LOeMrRxwzAvZnYGpW8+AA12tnb/P/2emJj/HjOO5otheGKb0breshdFlA=="],
+
+    "@corvu/drawer": ["@corvu/drawer@0.2.4", "", { "dependencies": { "@corvu/dialog": "~0.2.4", "@corvu/utils": "~0.4.2", "@solid-primitives/memo": "^1.4.1", "solid-transition-size": "~0.1.4" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-7jQoGZ8ROB9CmXam2nMY2wEskU3IoFwZQywkF/7vrBc/edGsPv7mOVQ1GN6G+4nd7nrMZ3UtqHAhmRh9V0azlw=="],
+
     "@corvu/utils": ["@corvu/utils@0.4.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.11" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
@@ -2875,6 +2880,8 @@
     "@solid-primitives/map": ["@solid-primitives/map@0.4.13", "", { "dependencies": { "@solid-primitives/trigger": "^1.1.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-B1zyFbsiTQvqPr+cuPCXO72sRuczG9Swncqk5P74NCGw1VE8qa/Ry9GlfI1e/VdeQYHjan+XkbE3rO2GW/qKew=="],
 
     "@solid-primitives/media": ["@solid-primitives/media@2.3.6", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.6", "@solid-primitives/rootless": "^1.5.4", "@solid-primitives/static-store": "^0.1.4", "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-pk49gPOq/UMRUJ+pTSrOfBiR8xJjRYHXIf1iR/jSnyQ/KroU+ZXhkZzavC7hvfp2vJeOTW5k2/HN0r3Q1VJ7Pw=="],
+
+    "@solid-primitives/memo": ["@solid-primitives/memo@1.5.1", "", { "dependencies": { "@solid-primitives/scheduled": "^1.5.3", "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-VDPrkl9epp0tbby9MvsqphGFCYCtDRC5J8FKzTqHbQiG5hhR8n6xv4MfjhTW231IaBxxPHLxS43EE8c5Q23mSQ=="],
 
     "@solid-primitives/props": ["@solid-primitives/props@3.2.4", "", { "dependencies": { "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-MXXdvi2TSB6d+0N6ueA/HP1j/Kh9SEc4WdF1ZDMLwPagxW6pIHHSS9xbRO0RjqSVpNP4j0nxCWT1hx3CkJNhNA=="],
 
@@ -5302,6 +5309,10 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
+    "solid-dismissible": ["solid-dismissible@0.1.1", "", { "dependencies": { "@corvu/utils": "~0.4.1" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-9kcKBJIMdS+586cA1g63HYWxKh3h89leeNHbPZ1csYjuni+NvPBtNr11l0iEX2AKKEt6FHk6qNhc/gjoYAW1pA=="],
+
+    "solid-focus-trap": ["solid-focus-trap@0.1.9", "", { "dependencies": { "@corvu/utils": "~0.4.2" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-LTyNki6GUJPRLXV5uMWPkYClB07SUMubbr2EkAddiR0CJCF/I283txilMU9RURSr/P8EewMfXWu2o3aWrK7A5A=="],
+
     "solid-js": ["solid-js@1.9.15", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" } }, "sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg=="],
 
     "solid-list": ["solid-list@0.3.0", "", { "dependencies": { "@corvu/utils": "~0.4.0" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-t4hx/F/l8Vmq+ib9HtZYl7Z9F1eKxq3eKJTXlvcm7P7yI4Z8O7QSOOEVHb/K6DD7M0RxzVRobK/BS5aSfLRwKg=="],
@@ -5315,6 +5326,8 @@
     "solid-sonner": ["solid-sonner@0.3.1", "", { "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-F/+zi9yKJTHh5hX1UGJfkDvyC+F34Vi3jgy44NJwOKCgic1QtAon0b1iT9OsDO77RTgR+PCil+3Y5B8T2Owy1Q=="],
 
     "solid-stripe": ["solid-stripe@0.8.1", "", { "peerDependencies": { "@stripe/stripe-js": ">=1.44.1 <8.0.0", "solid-js": "^1.6.0" } }, "sha512-l2SkWoe51rsvk9u1ILBRWyCHODZebChSGMR6zHYJTivTRC0XWrRnNNKs5x1PYXsaIU71KYI6ov5CZB5cOtGLWw=="],
+
+    "solid-transition-size": ["solid-transition-size@0.1.4", "", { "dependencies": { "@corvu/utils": "~0.3.2" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-ocHVnbfy23CgfaH4cEUR/AFg0Y3CEL8Oh3n9Qv8OHFJgPh+zkmERKZQfi/xH5XvxDCizg8VjPrVUhiHB1Gza8g=="],
 
     "solid-use": ["solid-use@0.9.1", "", { "peerDependencies": { "solid-js": "^1.7" } }, "sha512-UwvXDVPlrrbj/9ewG9ys5uL2IO4jSiwys2KPzK4zsnAcmEl7iDafZWW1Mo4BSEWOmQCGK6IvpmGHo1aou8iOFw=="],
 
@@ -6629,6 +6642,8 @@
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "solid-transition-size/@corvu/utils": ["@corvu/utils@0.3.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.7" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-ZWlyWEE8qV9+CB9OAyo2bTrZGXQN9ZeM+JfYv89zoR+lRACKTDuoOZEdiyL8Uc7U5dUSH1uTqKhTTnaHWb+wZA=="],
 
     "sort-keys/is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
 

--- a/packages/app/e2e/regression/mobile-shell.spec.ts
+++ b/packages/app/e2e/regression/mobile-shell.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test"
+import { fixture } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true })
+
+test.beforeEach(async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory: fixture.directory,
+    project: fixture.project,
+    provider: fixture.provider,
+    sessions: fixture.sessions,
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.addInitScript(
+    ({ directory, server, sessions }) => {
+      localStorage.setItem(
+        "opencode.global.dat:server",
+        JSON.stringify({ projects: { local: [{ worktree: directory, expanded: true }] } }),
+      )
+      localStorage.setItem(
+        "opencode.window.browser.dat:tabs",
+        JSON.stringify(sessions.map((session) => ({ type: "session", server, sessionId: session.id }))),
+      )
+    },
+    { directory: fixture.directory, server: fixture.serverKey, sessions: fixture.sessions },
+  )
+  await page.goto("/")
+  await expect(page.locator('[data-component="home-session-row"]')).toHaveCount(fixture.sessions.length)
+})
+
+test("mobile project selection and drawer navigation preserve session identity", async ({ page }) => {
+  const projects = page.getByRole("button", { name: "Projects", exact: true })
+  await projects.click()
+  const picker = page.getByRole("dialog", { name: "Projects", exact: true })
+  await expect(picker.getByRole("button", { name: "All projects", exact: true })).toBeVisible()
+  await picker.getByRole("button", { name: new RegExp(` ${fixture.project.name}$`) }).click()
+  await expect(picker).toBeHidden()
+  await expect(projects).toContainText(fixture.project.name)
+
+  const trigger = page.locator('[data-slot="mobile-tabs-trigger"]')
+  const drawer = page.locator('[data-slot="mobile-tabs-drawer"]')
+  await trigger.click()
+  await expect(trigger).toHaveAttribute("aria-expanded", "true")
+  await expect(drawer.locator('[data-slot="tab-project"]')).toHaveText([fixture.project.name, fixture.project.name])
+  const settings = drawer.getByRole("button", { name: "Settings", exact: true })
+  const help = drawer.getByRole("button", { name: "Help", exact: true })
+  await expect(settings).toBeVisible()
+  await expect(help).toBeVisible()
+  expect((await settings.boundingBox())?.width).toBeGreaterThan((await help.boundingBox())?.width ?? 0)
+
+  await drawer.locator('[data-slot="tab-link"]').filter({ hasText: fixture.expected.sourceTitle }).click()
+  await expect(page).toHaveURL(new RegExp(`/session/${fixture.sourceID}$`))
+  await expect(drawer).toBeHidden()
+  await expect(trigger).toContainText(fixture.expected.sourceTitle)
+  await trigger.click()
+  await drawer.getByRole("button", { name: "Home", exact: true }).click()
+  await expect(page).toHaveURL("/")
+  await expect(drawer).toBeHidden()
+  await expect(page.locator('[data-component="home-session-row"]')).toHaveCount(fixture.sessions.length)
+})
+
+test("mobile settings section menu stays above a full-width panel", async ({ page }) => {
+  await page.locator('[data-slot="mobile-tabs-trigger"]').click()
+  await page.locator('[data-slot="mobile-tabs-drawer"]').getByRole("button", { name: "Settings", exact: true }).click()
+  const settings = page.getByTestId("settings-screen")
+  const menu = settings.getByRole("button", { name: "Preferences", exact: true })
+  const panel = settings.getByRole("tabpanel")
+  await expect(settings.getByRole("heading", { name: "General", exact: true })).toBeVisible()
+  await expect(menu).toBeVisible()
+  await menu.click()
+  await expect(page.getByRole("menuitemradio", { name: "Preferences", exact: true })).toBeChecked()
+  await page.keyboard.press("Escape")
+  await expect(page.getByRole("menuitemradio", { name: "Preferences", exact: true })).toBeHidden()
+  await expect(settings).toBeVisible()
+  await menu.click()
+  await page.getByRole("menuitemradio", { name: "Models", exact: true }).click()
+  await expect(settings.getByRole("heading", { name: "Models", exact: true })).toBeVisible()
+  await expect(settings.getByRole("button", { name: "Models", exact: true })).toBeVisible()
+  await expect(settings.getByRole("switch", { name: "Claude Opus 4.6", exact: true })).toBeAttached()
+  await expect
+    .poll(async () => {
+      const navigation = await settings.getByRole("button", { name: "Models", exact: true }).boundingBox()
+      const content = await panel.boundingBox()
+      return !!navigation && !!content && navigation.y + navigation.height <= content.y
+    })
+    .toBe(true)
+  await expect.poll(async () => (await panel.boundingBox())?.width ?? 0).toBeGreaterThan(350)
+  await settings.getByRole("button", { name: "Back to app", exact: true }).click()
+  await expect(settings).toBeHidden()
+  await expect(page.locator('[data-component="home-session-row"]')).toHaveCount(fixture.sessions.length)
+})

--- a/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
+++ b/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
@@ -69,7 +69,7 @@ test("keyboard navigation follows the visible tab order", async ({ page }) => {
   await expect(page).toHaveURL(new RegExp(`${hrefC.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`))
 })
 
-test("cramped tabs only show the close button for the active tab", async ({ page }) => {
+test("mobile drawer exposes close controls and navigates between tabs", async ({ page }) => {
   await page.setViewportSize({ width: 360, height: 720 })
   await mockServer(page)
   await page.addInitScript(
@@ -89,26 +89,31 @@ test("cramped tabs only show the close button for the active tab", async ({ page
   const hrefA = `/server/${base64Encode(server)}/session/${sessionA.id}`
   const hrefB = `/server/${base64Encode(server)}/session/${sessionB.id}`
   await page.goto(hrefA)
+  await page.getByRole("button", { name: "Tabs", exact: true }).click()
 
   const tabA = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefA}"])`)
   const tabB = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefB}"])`)
   await expect(tabA).toHaveAttribute("data-active", "true")
   await expect(tabB).toBeVisible()
   await expect(tabA.locator('[data-slot="tab-close"]')).toBeVisible()
-  await expect(tabB.locator('[data-slot="tab-close"]')).toBeHidden()
+  await expect(tabB.locator('[data-slot="tab-close"]')).toBeVisible()
 
   await tabB.locator(`a[href="${hrefB}"]`).click()
 
   await expect(page).toHaveURL(new RegExp(`${hrefB.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`))
-  await expect(tabA.locator('[data-slot="tab-close"]')).toBeHidden()
+  await expect(page.getByRole("dialog", { name: "Tabs", exact: true })).toBeHidden()
+  await page.getByRole("button", { name: "Tabs", exact: true }).click()
+  await expect(tabA.locator('[data-slot="tab-close"]')).toBeVisible()
   await expect(tabB.locator('[data-slot="tab-close"]')).toBeVisible()
 
   for (const direction of ["ltr", "rtl"]) {
     await page.evaluate((direction) => document.documentElement.setAttribute("dir", direction), direction)
     await page.setViewportSize({ width: 450, height: 720 })
-    await expect(tabA.locator("[data-titlebar-tab]")).toHaveAttribute("data-title-overflow", "true")
+    await expect(tabA).toBeVisible()
     await page.setViewportSize({ width: 1280, height: 720 })
     await expect(tabA.locator("[data-titlebar-tab]")).toHaveAttribute("data-title-overflow", "false")
+    await page.setViewportSize({ width: 450, height: 720 })
+    await page.getByRole("button", { name: "Tabs", exact: true }).click()
   }
 })
 
@@ -202,28 +207,28 @@ test("appearance experimental setting switches tab orientation", async ({ page }
 
   await page.setViewportSize({ width: 920, height: 720 })
   await expect(page.locator('[data-slot="vertical-tabs-sidebar"]')).toHaveCSS("width", "260px")
-  await expect(settings.getByRole("tablist")).toHaveCSS("width", "160px")
+  await expect(settings.getByRole("tablist")).toBeHidden()
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeVisible()
 
   await page.setViewportSize({ width: 800, height: 720 })
-  await expect(settings.getByRole("tablist")).toHaveCSS("width", "160px")
-  await expect(version).toBeInViewport()
+  await expect(settings.getByRole("tablist")).toBeHidden()
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeVisible()
 
   await page.setViewportSize({ width: 390, height: 720 })
-  await expect(version).toBeInViewport()
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeVisible()
   await settings.evaluate((element) => element.setAttribute("dir", "rtl"))
-  await expect(version).toBeInViewport()
-  await expect(version).toHaveCSS("direction", "ltr")
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeInViewport()
 
   await page.setViewportSize({ width: 390, height: 360 })
-  await version.scrollIntoViewIfNeeded()
-  await expect(version).toBeInViewport()
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeInViewport()
 
   // Reload the UI-selected preference without seeding settings storage.
   await page.reload()
   const href = `/server/${base64Encode(server)}/session/${sessionA.id}`
+  await page.getByRole("button", { name: "Tabs", exact: true }).click()
   await expect(
     page
-      .locator('[data-slot="titlebar-tabs"]')
+      .locator('[data-slot="mobile-tabs-drawer"]')
       .locator(`[data-titlebar-tab-link][href="${href}"]`)
       .getByText(sessionA.title, { exact: true }),
   ).toBeVisible()
@@ -242,7 +247,7 @@ test("appearance experimental setting switches tab orientation", async ({ page }
   await expect(layout).toContainText("Vertical")
 })
 
-test("vertical tab preference falls back to horizontal on mobile", async ({ page }) => {
+test("vertical tab preference uses the drawer on mobile", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 720 })
   await mockServer(page)
   await page.addInitScript(
@@ -259,7 +264,8 @@ test("vertical tab preference falls back to horizontal on mobile", async ({ page
   const href = `/server/${base64Encode(server)}/session/${sessionA.id}`
   await page.goto(href)
 
-  const tabs = page.locator('[data-slot="titlebar-tabs"]')
+  await page.getByRole("button", { name: "Tabs", exact: true }).click()
+  const tabs = page.locator('[data-slot="mobile-tabs-drawer"]')
   await expect(tabs.locator(`[data-titlebar-tab-link][href="${href}"]`)).toContainText(sessionA.title)
   await expect(page.locator('[data-slot="vertical-tabs-sidebar"]')).toHaveCount(0)
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -56,6 +56,7 @@
     "vite-plugin-solid": "2.11.14"
   },
   "dependencies": {
+    "@corvu/drawer": "catalog:",
     "@dnd-kit/abstract": "0.5.0",
     "@dnd-kit/dom": "0.5.0",
     "@dnd-kit/helpers": "0.5.0",

--- a/packages/app/src/home/projects/region.tsx
+++ b/packages/app/src/home/projects/region.tsx
@@ -2,9 +2,14 @@ import type { HomeProjectsController } from "./controller"
 import { HomeProjectsView } from "./view"
 import type { HomeScrollController } from "../scroll"
 
-export function HomeProjects(props: { projects: HomeProjectsController; scroll: HomeScrollController }) {
+export function HomeProjects(props: {
+  projects: HomeProjectsController
+  scroll: HomeScrollController
+  dropdown?: boolean
+}) {
   return (
     <HomeProjectsView
+      dropdown={props.dropdown}
       language={props.projects.copy.language}
       servers={props.projects.server.list()}
       projects={props.projects.project.list()}

--- a/packages/app/src/home/projects/view.tsx
+++ b/packages/app/src/home/projects/view.tsx
@@ -1,5 +1,6 @@
 import { createMemo, For, type JSX, onCleanup, Show, splitProps } from "solid-js"
 import { createStore } from "solid-js/store"
+import { Popover } from "@kobalte/core/popover"
 import { DragDropProvider, PointerSensor } from "@dnd-kit/solid"
 import { isSortable, useSortable } from "@dnd-kit/solid/sortable"
 import { AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
@@ -28,6 +29,7 @@ const projectContextMenuID = (server: ServerConnection.Any, directory: string) =
   `project:${ServerConnection.key(server)}:${directory}`
 
 export type HomeProjectsViewProps = {
+  dropdown?: boolean
   language: ReturnType<typeof useLanguage>
   servers: ServerConnection.Any[]
   projects: LocalProject[]
@@ -64,6 +66,81 @@ export type HomeProjectsViewProps = {
 }
 
 export function HomeProjectsView(props: HomeProjectsViewProps) {
+  const [state, setState] = createStore({ open: false })
+  const selected = createMemo(() => props.projects.find((project) => project.worktree === props.selection.directory))
+  const server = createMemo(() =>
+    props.servers.find((server) => ServerConnection.key(server) === props.selection.server),
+  )
+  return (
+    <Show when={props.dropdown} fallback={<HomeProjectsPanel {...props} />}>
+      <Popover
+        open={state.open}
+        onOpenChange={(open) => setState("open", open)}
+        placement="bottom-start"
+        sameWidth
+        gutter={6}
+      >
+        <Popover.Trigger
+          data-component="home-projects-dropdown"
+          aria-label={props.language.t("home.projects")}
+          class="flex h-10 w-full min-w-0 items-center gap-2 rounded-[6px] bg-v2-background-bg-base px-1.5 text-start text-v2-text-text-base outline-none hover:bg-v2-background-bg-layer-01"
+        >
+          <Show when={selected()} fallback={<Icon name="folder" size="small" />}>
+            {(project) => <HomeProjectAvatar project={project()} />}
+          </Show>
+          <span class="flex min-w-0 flex-1 flex-col leading-[var(--line-height-compact)]">
+            <bdi class="truncate">
+              <Show when={selected()} fallback={props.language.t("home.projects.all")}>
+                {(project) => displayName(project())}
+              </Show>
+            </bdi>
+            <Show when={props.servers.length > 1 && server()}>
+              {(server) => (
+                <bdi class="truncate text-v2-text-text-muted opacity-70">
+                  {server().displayName ?? new URL(server().http.url).host}
+                </bdi>
+              )}
+            </Show>
+          </span>
+          <Icon name="chevron-down" size="small" class="shrink-0 text-v2-icon-icon-muted" />
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            aria-label={props.language.t("home.projects")}
+            dir={props.language.direction()}
+            class="z-50 max-h-[min(70dvh,var(--kb-popper-content-available-height))] overflow-hidden rounded-[10px] bg-v2-background-bg-base p-1.5 shadow-[var(--v2-elevation-floating)] outline-none data-[expanded]:animate-in data-[expanded]:fade-in data-[expanded]:slide-in-from-top-2 duration-150 ease-out motion-reduce:animate-none"
+          >
+            <HomeProjectsPanel
+              {...props}
+              onSelectProject={(server, directory) => {
+                props.onSelectProject(server, directory)
+                setState("open", false)
+              }}
+              onFocusServer={(server) => {
+                props.onFocusServer(server)
+                setState("open", false)
+              }}
+              onChooseProject={(server) => {
+                setState("open", false)
+                props.onChooseProject(server)
+              }}
+              onAddProjects={(server, directories) => {
+                setState("open", false)
+                props.onAddProjects(server, directories)
+              }}
+              onOpenProjectNewSession={(server, directory) => {
+                setState("open", false)
+                props.onOpenProjectNewSession(server, directory)
+              }}
+            />
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover>
+    </Show>
+  )
+}
+
+function HomeProjectsPanel(props: HomeProjectsViewProps) {
   const [contextMenu, setContextMenu] = createStore({ open: undefined as string | undefined })
   const contextMenuProps = {
     contextMenuOpen: (id: string) => contextMenu.open === id,
@@ -71,48 +148,77 @@ export function HomeProjectsView(props: HomeProjectsViewProps) {
   }
   return (
     <aside
-      class={`
+      class={
+        props.dropdown
+          ? "flex max-h-[min(60dvh,calc(var(--kb-popper-content-available-height)-12px))] min-h-0 min-w-0 flex-col overflow-hidden"
+          : `
         mt-6 flex min-h-0 min-w-0 flex-col gap-4 overflow-hidden
         lg:sticky lg:top-14 lg:mt-14 lg:h-[calc(100cqh-56px)] lg:self-start lg:pt-[52px]
-      `}
+      `
+      }
       aria-label={props.language.t("home.projects")}
       onWheel={(event) => {
         if (event.target === event.currentTarget) return
         props.onWheel(event)
       }}
     >
-      <div class="flex h-7 min-w-0 shrink-0 items-center justify-between pl-1.5 pr-3">
-        <div class="text-v2-text-text-muted [font-weight:530]">{props.language.t("home.projects")}</div>
-        <Show when={props.servers.length === 1 && !(props.projects.length === 0 && props.recentlyClosed.length > 0)}>
-          <Tooltip placement="bottom" value={props.language.t("home.project.add")}>
-            <IconButton
-              data-action="home-add-project"
-              variant="ghost-muted"
-              size="large"
-              class="titlebar-icon [&_[data-slot=icon-svg]]:text-v2-icon-icon-muted"
-              icon={<Icon name="folder-add-left" />}
-              disabled={props.serverHealth(props.servers[0])?.healthy === false}
-              onClick={() => props.onChooseProject(props.servers[0])}
-              aria-label={props.language.t("home.project.add")}
-            />
-          </Tooltip>
-        </Show>
-      </div>
+      <Show when={!props.dropdown}>
+        <div class="flex h-7 min-w-0 shrink-0 items-center justify-between pl-1.5 pr-3">
+          <div class="text-v2-text-text-muted [font-weight:530]">{props.language.t("home.projects")}</div>
+          <Show when={props.servers.length === 1 && !(props.projects.length === 0 && props.recentlyClosed.length > 0)}>
+            <Tooltip placement="bottom" value={props.language.t("home.project.add")}>
+              <IconButton
+                data-action="home-add-project"
+                variant="ghost-muted"
+                size="large"
+                class="titlebar-icon [&_[data-slot=icon-svg]]:text-v2-icon-icon-muted"
+                icon={<Icon name="folder-add-left" />}
+                disabled={props.serverHealth(props.servers[0])?.healthy === false}
+                onClick={() => props.onChooseProject(props.servers[0])}
+                aria-label={props.language.t("home.project.add")}
+              />
+            </Tooltip>
+          </Show>
+        </div>
+      </Show>
       <ScrollView data-slot="home-projects-scroll" class="min-h-0 min-w-0 shrink">
+        <Show when={props.dropdown && props.servers.length === 1}>
+          <HomeProjectNavButton
+            type="button"
+            class="mb-1"
+            data-selected={!props.selection.directory ? "" : undefined}
+            onClick={() => props.onFocusServer(props.servers[0])}
+          >
+            <Icon name="folder" size="small" />
+            <span class={HOME_PROJECT_NAV_LABEL}>{props.language.t("home.projects.all")}</span>
+          </HomeProjectNavButton>
+        </Show>
         <Show
           when={props.servers.length > 1}
           fallback={
-            <div class="pr-3">
+            <div class={props.dropdown ? "" : "pr-3"}>
               <Show
                 when={props.projects.length > 0}
                 fallback={<HomeProjectEmpty {...props} server={props.servers[0]} items={props.recentlyClosed} />}
               >
                 <HomeProjectList {...props} {...contextMenuProps} server={props.servers[0]} items={props.projects} />
+                <Show when={props.dropdown}>
+                  <HomeProjectNavButton
+                    type="button"
+                    data-action="home-add-project-row"
+                    class="mt-1 disabled:opacity-60"
+                    disabled={props.serverHealth(props.servers[0])?.healthy === false}
+                    onClick={() => props.onChooseProject(props.servers[0])}
+                  >
+                    <Icon name="folder-add-left" size="small" />
+                    <span class={HOME_PROJECT_NAV_LABEL}>{props.language.t("home.project.add")}</span>
+                  </HomeProjectNavButton>
+                </Show>
               </Show>
             </div>
           }
         >
-          <div class="flex min-w-0 flex-col gap-4 pr-3">
+          <div class={`flex min-w-0 flex-col ${props.dropdown ? "gap-1" : "gap-4 pr-3"}`}>
             <For each={props.servers}>
               {(item) => {
                 const projects = () => props.projectsForServer(item)
@@ -157,7 +263,9 @@ export function HomeUtilityNav(props: {
   language: ReturnType<typeof useLanguage>
 }) {
   return (
-    <div class={`${props.class ?? ""} min-w-0 flex-col gap-1 pr-3`}>
+    <div
+      class={`${props.class ?? ""} min-w-0 flex-row justify-between gap-1 lg:flex-col lg:justify-start lg:pr-3 [&>button]:w-auto lg:[&>button]:w-full`}
+    >
       <HomeProjectNavButton
         type="button"
         class="text-v2-text-text-faint [&>[data-slot=icon-svg]]:text-v2-icon-icon-muted"
@@ -511,6 +619,7 @@ function HomeProjectRow(
           // does not focus that server and load its session index. Touch is
           // excluded so flick-scrolling the list cannot select rows.
           pointerDownSelected = undefined
+          if (props.dropdown) return
           if (event.button !== 0 || event.pointerType === "touch") return
           if (!props.serverSelected) return
           pointerDownSelected = props.selected

--- a/packages/app/src/home/route.tsx
+++ b/packages/app/src/home/route.tsx
@@ -1,4 +1,6 @@
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
+import { createMediaQuery } from "@solid-primitives/media"
+import { Show } from "solid-js"
 import { createHomeController } from "./model"
 import { createHomeProjectsController } from "./projects/controller"
 import { HomeUtilityNav } from "./projects/view"
@@ -9,6 +11,7 @@ import { createHomeSessionsController } from "./sessions/controller"
 import { HomeSessions } from "./sessions/region"
 
 export function Home() {
+  const mobile = createMediaQuery("(max-width: 767px)")
   const home = createHomeController()
   const projects = createHomeProjectsController(home)
   const sessions = createHomeSessionsController(home)
@@ -17,12 +20,17 @@ export function Home() {
   return (
     <div
       class={`
-        mx-2 mb-2 mt-[var(--shell-top-inset,8px)] min-h-0 flex-1 self-stretch overflow-hidden rounded-[10px]
+        mx-2 mb-[var(--shell-bottom-inset,8px)] mt-[var(--shell-top-inset,8px)] flex min-h-0 flex-1 flex-col self-stretch overflow-hidden rounded-[10px]
         bg-v2-background-bg-base shadow-[var(--v2-elevation-raised)]
       `}
     >
+      <Show when={mobile()}>
+        <div class="relative z-40 -mb-3 shrink-0 px-3 pt-3">
+          <HomeProjects projects={projects} scroll={scroll} dropdown />
+        </div>
+      </Show>
       <ScrollView
-        class="h-full [container-type:size]"
+        class="min-h-0 flex-1 [container-type:size]"
         thumbContainer={scroll.viewport.thumbTrack()}
         thumbHoverTarget={scroll.viewport.hoverTarget()}
         viewportRef={scroll.viewport.setViewport}
@@ -31,20 +39,24 @@ export function Home() {
       >
         <div
           class={`
-            mx-auto grid min-h-full w-full max-w-[1080px] grid-rows-[auto_minmax(0,1fr)_auto] gap-4 px-3
-            lg:grid-cols-[280px_minmax(0,720px)] lg:grid-rows-1 lg:gap-8 lg:px-6
+            mx-auto grid min-h-full w-full max-w-[1080px] grid-rows-[auto_minmax(0,1fr)] gap-4 px-3
+            max-md:grid-rows-[minmax(0,1fr)] lg:grid-cols-[280px_minmax(0,720px)] lg:grid-rows-1 lg:gap-8 lg:px-6
           `}
         >
-          <HomeProjects projects={projects} scroll={scroll} />
+          <Show when={!mobile()}>
+            <HomeProjects projects={projects} scroll={scroll} />
+          </Show>
           <HomeSessions sessions={sessions} search={search} scroll={scroll} />
-          <HomeUtilityNav
-            class="flex lg:hidden"
-            onOpenSettings={projects.utility.settings}
-            onOpenHelp={projects.utility.help}
-            language={projects.copy.language}
-          />
         </div>
       </ScrollView>
+      <div class="hidden shrink-0 px-3 py-2 md:block lg:hidden">
+        <HomeUtilityNav
+          class="flex"
+          onOpenSettings={projects.utility.settings}
+          onOpenHelp={projects.utility.help}
+          language={projects.copy.language}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/app/src/home/sessions/view.css
+++ b/packages/app/src/home/sessions/view.css
@@ -1,0 +1,26 @@
+@media (max-width: 767px) {
+  [data-component="home-session-row-container"][data-project-name="true"],
+  [data-component="home-session-row-container"][data-project-name="true"] [data-component="home-session-row"],
+  [data-component="home-session-row-container"][data-project-name="true"] [data-slot="home-session-editor"],
+  [data-component="home-session-search-row"][data-project-name="true"] {
+    height: 48px;
+    padding-block: 0;
+  }
+
+  [data-project-name="true"] [data-slot="home-session-labels"] {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    text-align: start;
+  }
+
+  [data-project-name="true"] [data-slot="home-session-labels"] > * {
+    max-width: 100%;
+    flex: none;
+    font-size: 13px;
+    line-height: var(--line-height-compact);
+  }
+}

--- a/packages/app/src/home/sessions/view.tsx
+++ b/packages/app/src/home/sessions/view.tsx
@@ -15,6 +15,7 @@ import { ServerConnection } from "@/runtime/server/registry"
 import { SessionTabAvatarView } from "@/shell/layout/session-tab-avatar"
 import { sessionLabel } from "@/session/title"
 import { shouldOpenSessionInBackground } from "./open"
+import "./view.css"
 import {
   HomeSessionStatusController,
   homeSessionSearchKey,
@@ -96,10 +97,13 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
       class="min-h-0 min-w-0 flex-1 flex flex-col"
       aria-label={props.language.t("sidebar.project.recentSessions")}
     >
-      <div class="sticky top-0 z-30 shrink-0 bg-v2-background-bg-base pb-3 pt-6 lg:pt-12" onWheel={props.onWheel}>
+      <div
+        class="sticky top-0 z-30 shrink-0 bg-v2-background-bg-base pb-1 pt-6 md:pb-3 lg:pt-12"
+        onWheel={props.onWheel}
+      >
         <HomeSessionSearch {...props} />
         <Show when={props.groups.length > 0 && props.canCreateSession}>
-          <div class="pointer-events-none absolute right-0 top-[84px] z-20 flex lg:top-[108px]">
+          <div class="pointer-events-none absolute right-0 top-[68px] z-20 flex md:top-[84px] lg:top-[108px]">
             <Button
               data-action="home-new-session"
               variant="ghost-muted"
@@ -113,18 +117,18 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
           </div>
         </Show>
       </div>
-      <div class="pointer-events-none sticky top-[84px] z-40 h-0 -mr-3 lg:top-[108px]">
+      <div class="pointer-events-none sticky top-[68px] z-40 h-0 -mr-3 md:top-[84px] lg:top-[108px]">
         <div
           ref={props.onSetThumbTrack}
           data-component="home-session-scroll-track"
-          class="relative ml-auto h-[calc(100cqh-84px)] w-3 lg:h-[calc(100cqh-108px)]"
+          class="relative ml-auto h-[calc(100cqh-68px)] w-3 md:h-[calc(100cqh-84px)] lg:h-[calc(100cqh-108px)]"
         />
       </div>
-      <div class="-mr-3 min-h-[calc(100cqh-72px)] lg:min-h-[calc(100cqh-96px)]">
+      <div class="-mr-3 min-h-[calc(100cqh-64px)] md:min-h-[calc(100cqh-72px)] lg:min-h-[calc(100cqh-96px)]">
         <Show
           when={!props.loading}
           fallback={
-            <div class="pt-3">
+            <div class="pt-1 md:pt-3">
               <HomeSessionSkeleton label={props.language.t("common.loading")} />
             </div>
           }
@@ -138,7 +142,7 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
               />
             }
           >
-            <div ref={props.onSetContent} class="flex flex-col pt-3 pr-3 pb-16">
+            <div ref={props.onSetContent} class="flex flex-col pt-1 pr-3 pb-16 md:pt-3">
               {/* Index keeps group subtrees mounted when the group arrays are
                   rebuilt, so store updates cannot recreate rows mid-gesture. */}
               <Index each={props.groups}>
@@ -150,7 +154,9 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
                       onSetRef={(element) => props.onSetHeader(group().id, element)}
                       elevated={index === 0}
                     />
-                    <div class={`flex min-w-0 flex-col gap-px pt-4 ${index === props.groups.length - 1 ? "" : "mb-6"}`}>
+                    <div
+                      class={`flex min-w-0 flex-col gap-px pt-2 md:pt-4 ${index === props.groups.length - 1 ? "" : "mb-6"}`}
+                    >
                       {/* Rows key by session ID: session.sync replaces the
                           stored session object wholesale, so reference-keyed
                           rows would be disposed mid-interaction whenever a
@@ -235,7 +241,11 @@ function HomeSessionSearch(props: HomeSessionsViewProps) {
               absolute flex flex-col overflow-hidden rounded-[12px]
               bg-v2-background-bg-base shadow-[var(--v2-elevation-floating)]
             `}
-            style={{ top: "-6px", left: "-6px", width: "calc(100% + 12px)" }}
+            style={{
+              top: "-6px",
+              "inset-inline-start": "-6px",
+              width: "calc(100% + 12px)",
+            }}
           >
             <div class="flex flex-col pt-9">
               <div id={HOME_SESSION_SEARCH_RESULTS_ID} role="listbox" class="flex flex-col gap-4 pt-4">
@@ -269,7 +279,7 @@ function HomeSessionSearch(props: HomeSessionsViewProps) {
                       >
                         {props.language.t("home.sessions.search.sessions")}
                       </p>
-                      <ScrollView class="max-h-80" viewportRef={props.onSetSearchList}>
+                      <ScrollView class="max-h-[min(20rem,40dvh)]" viewportRef={props.onSetSearchList}>
                         <div class="flex flex-col gap-px pb-2">
                           <For each={props.searchResults}>
                             {(record) => (
@@ -291,7 +301,7 @@ function HomeSessionSearch(props: HomeSessionsViewProps) {
         </Show>
         <label
           class={`
-            relative z-20 flex h-9 w-full items-center gap-2 rounded-[6px] py-1 pl-3 pr-2
+            relative z-20 flex h-9 w-full items-center gap-2 rounded-[6px] py-1 ps-3 pe-2
             bg-v2-background-bg-layer-02/60 text-v2-icon-icon-muted transition-[background-color,box-shadow]
             duration-[120ms] ease-in-out hover:bg-v2-background-bg-layer-02 focus-within:bg-v2-background-bg-layer-02
           `}
@@ -375,6 +385,7 @@ function HomeSessionSearchResultRow(
       id={`home-session-search-option-${key()}`}
       data-key={key()}
       data-component="home-session-search-row"
+      data-project-name={!!showProjectName()}
       role="option"
       aria-selected={props.selected}
       class={`
@@ -403,7 +414,7 @@ function HomeSessionSearchResultRow(
         record={props.record}
         revealProjectOnHover={!!showProjectName()}
       />
-      <div class="flex min-w-0 flex-1 items-center gap-1.5">
+      <div data-slot="home-session-labels" class="flex min-w-0 flex-1 items-center gap-1.5">
         <HomeSessionTitle title={title()} showProjectName={!!showProjectName()} search />
         <Show when={showProjectName()}>
           <HomeSessionProjectName name={props.record.projectName} search />
@@ -423,8 +434,8 @@ function HomeSessionGroupHeader(props: {
     <div
       ref={props.onSetRef}
       class={`
-        pointer-events-none sticky top-[84px] flex h-7 min-w-0 items-center justify-between
-        bg-v2-background-bg-base pl-3 lg:top-[108px]
+        pointer-events-none sticky top-[68px] flex h-7 min-w-0 items-center justify-between
+        bg-v2-background-bg-base ps-1.5 md:ps-3 md:top-[84px] lg:top-[108px]
       `}
       classList={{ "home-session-group-header z-[5]": !!props.elevated, "z-10": !props.elevated }}
     >
@@ -510,6 +521,7 @@ function HomeSessionRow(
   return (
     <div
       data-component="home-session-row-container"
+      data-project-name={!!showProjectName()}
       data-session-id={props.record.session.id}
       class="group/session relative flex h-10 min-w-0 items-center rounded-[6px] outline-none focus:outline-none focus-visible:outline-none"
       classList={{ group: !!showProjectName() }}
@@ -523,51 +535,56 @@ function HomeSessionRow(
       <Show
         when={!editor()}
         fallback={
-          <div class="flex h-10 min-w-0 w-full flex-1 items-center gap-2 py-3 pl-3 pr-10">
+          <div
+            data-slot="home-session-editor"
+            class="flex h-10 min-w-0 w-full flex-1 items-center gap-2 py-3 ps-1.5 pe-3 md:ps-3 md:pe-10"
+          >
             <HomeSessionLeadingController
               server={props.server}
               isOpenTab={props.isOpenTab}
               record={props.record}
               revealProjectOnHover={false}
             />
-            <InlineInput
-              data-component="home-session-rename"
-              aria-label={props.language.t("common.rename")}
-              dir="auto"
-              value={editor()?.draft ?? ""}
-              disabled={editor()?.renaming ?? false}
-              class={`
+            <div data-slot="home-session-labels" class="contents">
+              <InlineInput
+                data-component="home-session-rename"
+                aria-label={props.language.t("common.rename")}
+                dir="auto"
+                value={editor()?.draft ?? ""}
+                disabled={editor()?.renaming ?? false}
+                class={`
                 block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-base
                 [font-weight:530] field-sizing-content outline-none focus:outline-none focus-visible:outline-none
                 ${showProjectName() ? "max-w-[min(70%,480px)] flex-[0_1_auto]" : "flex-[1_1_auto]"}
               `}
-              style={{ "--inline-input-shadow": "none", "text-align": "start" }}
-              onInput={(event) => {
-                const draft = event.currentTarget.value
-                props.setRowUI("editor", (value) => (value?.id === sessionID() ? { ...value, draft } : value))
-              }}
-              onKeyDown={(event) => {
-                event.stopPropagation()
-                // Enter and Escape during IME composition commit or cancel
-                // the composition, not the rename. Safari can report the
-                // composition-confirming keydown with isComposing false but
-                // keyCode 229.
-                if (event.isComposing || event.keyCode === 229) return
-                if (event.key === "Enter") {
+                style={{ "--inline-input-shadow": "none", "text-align": "start" }}
+                onInput={(event) => {
+                  const draft = event.currentTarget.value
+                  props.setRowUI("editor", (value) => (value?.id === sessionID() ? { ...value, draft } : value))
+                }}
+                onKeyDown={(event) => {
+                  event.stopPropagation()
+                  // Enter and Escape during IME composition commit or cancel
+                  // the composition, not the rename. Safari can report the
+                  // composition-confirming keydown with isComposing false but
+                  // keyCode 229.
+                  if (event.isComposing || event.keyCode === 229) return
+                  if (event.key === "Enter") {
+                    event.preventDefault()
+                    void saveEditor()
+                    return
+                  }
+                  if (event.key !== "Escape") return
                   event.preventDefault()
-                  void saveEditor()
-                  return
-                }
-                if (event.key !== "Escape") return
-                event.preventDefault()
-                closeEditor()
-                requestAnimationFrame(() => rowButton()?.focus())
-              }}
-              onBlur={closeEditor}
-            />
-            <Show when={showProjectName()}>
-              <HomeSessionProjectName name={props.record.projectName} />
-            </Show>
+                  closeEditor()
+                  requestAnimationFrame(() => rowButton()?.focus())
+                }}
+                onBlur={closeEditor}
+              />
+              <Show when={showProjectName()}>
+                <HomeSessionProjectName name={props.record.projectName} />
+              </Show>
+            </div>
           </div>
         }
       >
@@ -578,7 +595,7 @@ function HomeSessionRow(
           aria-expanded={!!menu()}
           class={`
             flex h-10 min-w-0 w-full flex-1 shrink-0 cursor-default items-center gap-2 rounded-[6px] border-0
-            bg-transparent py-3 pl-3 pr-10 text-left text-v2-text-text-muted [font-weight:530]
+            bg-transparent py-3 ps-1.5 pe-3 md:ps-3 md:pe-10 text-start text-v2-text-text-muted [font-weight:530]
             transition-[background-color,color,box-shadow] duration-[120ms] ease-in-out
             hover:bg-v2-overlay-simple-overlay-hover focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:outline-none
           `}
@@ -641,10 +658,12 @@ function HomeSessionRow(
             record={props.record}
             revealProjectOnHover={!!showProjectName()}
           />
-          <HomeSessionTitle title={title()} showProjectName={!!showProjectName()} />
-          <Show when={showProjectName()}>
-            <HomeSessionProjectName name={props.record.projectName} />
-          </Show>
+          <div data-slot="home-session-labels" class="contents">
+            <HomeSessionTitle title={title()} showProjectName={!!showProjectName()} />
+            <Show when={showProjectName()}>
+              <HomeSessionProjectName name={props.record.projectName} />
+            </Show>
+          </div>
         </button>
       </Show>
       <Menu
@@ -723,6 +742,7 @@ function HomeSessionTitle(props: { title: string; showProjectName: boolean; sear
   return (
     <span
       data-component="home-session-title"
+      dir="auto"
       class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-base [font-weight:530]"
       classList={{
         "text-[13px] leading-4 tracking-[-0.04px]": !!props.search,
@@ -738,6 +758,8 @@ function HomeSessionTitle(props: { title: string; showProjectName: boolean; sear
 function HomeSessionProjectName(props: { name: string; search?: boolean }) {
   return (
     <span
+      data-component="home-session-project-name"
+      dir="auto"
       class="min-w-0 flex-[1_1_auto] overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-muted [font-weight:440]"
       classList={{ "text-[13px] leading-4 tracking-[-0.04px]": !!props.search }}
     >
@@ -779,7 +801,7 @@ function HomeSessionsEmpty(props: { onNewSession?: () => void; language: ReturnT
 function HomeSessionSkeleton(props: { label: string }) {
   return (
     <div class="flex min-w-0 flex-col gap-4">
-      <div class="flex h-7 min-w-0 items-center justify-between px-4">
+      <div class="flex h-7 min-w-0 items-center justify-between ps-1.5 pe-4 md:ps-4">
         <div class={HOME_SECTION_LABEL}>{props.label}</div>
       </div>
       <div class="flex min-w-0 flex-col gap-px" aria-hidden="true">

--- a/packages/app/src/new-session/screen.tsx
+++ b/packages/app/src/new-session/screen.tsx
@@ -73,7 +73,7 @@ export default function NewSessionPage(props: { draftId: string }) {
     <div class="relative size-full overflow-hidden flex flex-col">
       {suspendUntilPromptReady()}
       <NewSessionStatus visible={settings.visibility.status()} />
-      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
+      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
         <NewSessionView composer={model} project={project} workspace={workspace} />
       </div>
     </div>

--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -643,6 +643,7 @@ export const dict = {
   "home.empty.description": "Get started by opening a local project",
   "home.title": "Home",
   "home.projects": "Projects",
+  "home.projects.all": "All projects",
   "home.project.add": "Add project",
   "home.recentlyClosed": "Recently closed",
   "home.server.collapse": "Collapse server projects",
@@ -799,6 +800,7 @@ export const dict = {
   "terminal.connectTicket.statusError": "PTY connect ticket failed with {{status}}",
 
   "titlebar.update": "Update",
+  "titlebar.tabs": "Tabs",
   "titlebar.updateVersion": "Update {{version}}",
 
   "common.closeTab": "Close tab",

--- a/packages/app/src/session/route.tsx
+++ b/packages/app/src/session/route.tsx
@@ -154,7 +154,7 @@ function PendingSessionState(props: { sessionID: string }) {
 
 function SessionStatePanel(props: ParentProps) {
   return (
-    <div class="flex min-h-0 flex-1 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
+    <div class="flex min-h-0 flex-1 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
       <SessionPanelFrame raised>{props.children}</SessionPanelFrame>
     </div>
   )

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -157,7 +157,7 @@ export function SessionScreen(props: { session: SessionModel }) {
   return (
     <>
       <SessionHeader />
-      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
+      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
         <div ref={screen.panel.ref} class="relative flex-1 min-h-0 flex flex-col md:flex-row gap-2">
           <div
             classList={{

--- a/packages/app/src/session/session-frame.tsx
+++ b/packages/app/src/session/session-frame.tsx
@@ -3,8 +3,8 @@ import type { ParentProps } from "solid-js"
 export function SessionRouteFrame(props: ParentProps<{ padded?: boolean }>) {
   return (
     <div
-      class="relative flex size-full flex-col overflow-hidden"
-      classList={{ "px-2 pb-2 pt-[var(--shell-top-inset,8px)]": props.padded }}
+      class="relative flex size-full flex-col"
+      classList={{ "px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]": props.padded }}
     >
       {props.children}
     </div>

--- a/packages/app/src/settings/settings.css
+++ b/packages/app/src/settings/settings.css
@@ -335,7 +335,7 @@
 }
 
 @container settings-screen (max-width: 799px) {
-  .settings-screen > .settings {
+  .settings-screen > .settings[data-component="tabs-v2"] {
     flex-direction: column;
   }
 

--- a/packages/app/src/settings/settings.css
+++ b/packages/app/src/settings/settings.css
@@ -24,6 +24,13 @@
   min-width: 0;
 }
 
+@media (max-width: 767px) {
+  .settings-screen {
+    --settings-mobile-inner-inset: 8px;
+    padding-block: var(--settings-top-inset, var(--shell-top-inset, 8px)) var(--shell-bottom-inset, 8px);
+  }
+}
+
 .settings-screen
   > .settings[data-component="tabs-v2"][data-variant="settings"][data-orientation="vertical"]
   > [data-slot="tabs-v2-list"] {
@@ -49,6 +56,7 @@
 
 .settings-screen .settings-tab-body {
   padding-inline: 0;
+  padding-bottom: var(--settings-bottom-inset, 0px);
 }
 
 .settings-nav {
@@ -57,6 +65,26 @@
   flex-shrink: 0;
   flex-direction: column;
   gap: 16px;
+}
+
+.settings-mobile-nav {
+  display: none;
+}
+
+.settings-mobile-menu-trigger {
+  min-width: 0;
+}
+
+.settings-mobile-menu-trigger > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-mobile-menu[data-component="menu-v2-content"] {
+  max-width: calc(100vw - 32px);
+  max-height: var(--kb-popper-content-available-height);
+  overflow-y: auto;
 }
 
 .settings-nav-footer {
@@ -291,36 +319,6 @@
   background-color: var(--v2-background-bg-layer-01);
 }
 
-@media (max-width: 639px) {
-  .settings-screen .settings-nav {
-    width: 100%;
-  }
-
-  .settings-screen > .settings > .settings-panel {
-    padding-inline-end: 16px;
-  }
-
-  .settings-screen .settings-tab-header {
-    padding-top: 24px;
-  }
-
-  .settings[data-component="tabs-v2"][data-variant="settings"][data-orientation="vertical"]
-    > [data-slot="tabs-v2-list"] {
-    width: 144px;
-    min-width: 144px;
-    padding-inline: 8px;
-  }
-
-  .settings-screen
-    > .settings[data-component="tabs-v2"][data-variant="settings"][data-orientation="vertical"]
-    > [data-slot="tabs-v2-list"] {
-    width: 160px;
-    min-width: 160px;
-    padding-block: 24px;
-    padding-inline: 12px;
-  }
-}
-
 @container settings-screen (min-width: 800px) and (max-width: 1047px) {
   .settings-screen > .settings {
     padding-inline: 24px;
@@ -337,25 +335,60 @@
 }
 
 @container settings-screen (max-width: 799px) {
-  .settings-screen .settings-nav {
-    width: 100%;
+  .settings-screen > .settings {
+    flex-direction: column;
+  }
+
+  .settings-mobile-nav {
+    position: relative;
+    z-index: 11;
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 8px var(--settings-mobile-inner-inset, 16px);
+    border-bottom: 0.5px solid var(--v2-border-border-muted);
+    background: var(--v2-background-bg-deep);
+  }
+
+  .settings-mobile-nav::after {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    inset-block-start: 100%;
+    height: 1px;
+    background: var(--v2-background-bg-deep);
+    pointer-events: none;
+  }
+
+  .settings-mobile-nav .settings-back {
+    flex-shrink: 0;
   }
 
   .settings-screen > .settings > .settings-panel {
-    padding-inline-end: 16px;
+    min-height: 0;
+    max-width: none;
+  }
+
+  .settings-screen .settings-tab-header,
+  .settings-screen .settings-tab-body {
+    padding-inline: var(--settings-mobile-inner-inset, 16px);
   }
 
   .settings-screen .settings-tab-header {
-    padding-top: 24px;
+    padding-top: 12px;
+  }
+
+  .settings-screen .settings-tab-title,
+  .settings-screen .settings-section-title {
+    line-height: var(--line-height-base);
   }
 
   .settings-screen
     > .settings[data-component="tabs-v2"][data-variant="settings"][data-orientation="vertical"]
     > [data-slot="tabs-v2-list"] {
-    width: 160px;
-    min-width: 160px;
-    padding-block: 24px;
-    padding-inline: 12px;
+    display: none;
   }
 }
 
@@ -634,6 +667,15 @@
 
 .settings-models [data-slot="settings-row-copy"] {
   gap: 0;
+}
+
+.settings-models [data-component="settings-row"] {
+  flex-wrap: nowrap;
+}
+
+.settings-models [data-slot="settings-row-control"] {
+  width: auto;
+  flex-shrink: 0;
 }
 
 .settings-models [data-slot="settings-row-title"] {

--- a/packages/app/src/settings/shell.tsx
+++ b/packages/app/src/settings/shell.tsx
@@ -1,6 +1,18 @@
-import { Component, createEffect, createMemo, createSignal, onCleanup, onMount, startTransition } from "solid-js"
+import {
+  Component,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  Show,
+  onCleanup,
+  onMount,
+  startTransition,
+} from "solid-js"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { Icon } from "@opencode-ai/ui/icon"
+import { Menu } from "@opencode-ai/ui/menu"
+import { Button } from "@opencode-ai/ui/button"
 import { useLanguage } from "@/runtime/i18n/language"
 import { usePlatform } from "@/runtime/platform/platform"
 import { SettingsGeneral } from "./general/general"
@@ -22,6 +34,25 @@ import { ServerConnection, useServers } from "@/runtime/server/registry"
 import { useCommand } from "@/shell/commands/command"
 import { useSettingsSurface } from "./surface"
 import "@/settings/settings.css"
+
+const sections = [
+  [
+    { value: "general", icon: "sliders", label: "settings.tab.preferences" },
+    { value: "appearance", icon: "appearance", label: "settings.general.section.appearance" },
+    { value: "notifications", icon: "notifications", label: "settings.tab.notifications" },
+    { value: "shortcuts", icon: "keyboard", label: "settings.tab.shortcuts" },
+  ],
+  [
+    { value: "servers", icon: "server", label: "status.popover.tab.servers" },
+    { value: "projects", icon: "folder", label: "settings.tab.projects" },
+    { value: "workspaces", icon: "workspace-isolated", label: "settings.tab.workspaces" },
+  ],
+  [
+    { value: "providers", icon: "providers", label: "settings.providers.title" },
+    { value: "models", icon: "models", label: "settings.models.title" },
+    { value: "extensions", icon: "extensions", label: "settings.tab.extensions" },
+  ],
+] as const
 
 export const SettingsScreen: Component<{
   defaultValue?: string
@@ -103,6 +134,45 @@ export const SettingsScreen: Component<{
         onChange={(value) => void startTransition(() => setTab(value))}
         class="settings"
       >
+        <div class="settings-mobile-nav">
+          <button type="button" class="settings-back" onClick={surface.close}>
+            <Icon name="arrow-left" size="small" class="settings-back-icon" />
+            <span>{language.t("settings.backToApp")}</span>
+          </button>
+          <Menu placement="bottom-end" gutter={8}>
+            <Menu.Trigger as={Button} size="normal" variant="outline" class="settings-mobile-menu-trigger">
+              <span>
+                {language.t(
+                  sections.flat().find((section) => section.value === tab())?.label ?? "settings.tab.preferences",
+                )}
+              </span>
+              <Icon name="chevron-down" size="small" />
+            </Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Content class="settings-mobile-menu" onEscapeKeyDown={(event) => event.stopPropagation()}>
+                <Menu.RadioGroup value={tab()} onChange={(value) => void startTransition(() => setTab(value))}>
+                  <For each={sections}>
+                    {(group, index) => (
+                      <>
+                        <Show when={index() > 0}>
+                          <Menu.Separator />
+                        </Show>
+                        <For each={group}>
+                          {(section) => (
+                            <Menu.RadioItem value={section.value} closeOnSelect>
+                              <Icon name={section.icon} />
+                              {language.t(section.label)}
+                            </Menu.RadioItem>
+                          )}
+                        </For>
+                      </>
+                    )}
+                  </For>
+                </Menu.RadioGroup>
+              </Menu.Content>
+            </Menu.Portal>
+          </Menu>
+        </div>
         <Tabs.List>
           <div class="settings-nav">
             <button type="button" class="settings-back" onClick={surface.close}>
@@ -110,57 +180,20 @@ export const SettingsScreen: Component<{
               <span>{language.t("settings.backToApp")}</span>
             </button>
             <div class="flex flex-col gap-4 w-full">
-              {/* Group 1: Preferences */}
-              <div class="flex flex-col gap-1 w-full">
-                <Tabs.Trigger value="general">
-                  <Icon name="sliders" />
-                  {language.t("settings.tab.preferences")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="appearance">
-                  <Icon name="appearance" />
-                  {language.t("settings.general.section.appearance")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="notifications">
-                  <Icon name="notifications" />
-                  {language.t("settings.tab.notifications")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="shortcuts">
-                  <Icon name="keyboard" />
-                  {language.t("settings.tab.shortcuts")}
-                </Tabs.Trigger>
-              </div>
-
-              {/* Group 2: Environment & Workspaces */}
-              <div class="flex flex-col gap-1 w-full">
-                <Tabs.Trigger value="servers">
-                  <Icon name="server" />
-                  {language.t("status.popover.tab.servers")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="projects">
-                  <Icon name="folder" />
-                  {language.t("settings.tab.projects")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="workspaces">
-                  <Icon name="workspace-isolated" />
-                  {language.t("settings.tab.workspaces")}
-                </Tabs.Trigger>
-              </div>
-
-              {/* Group 3: Capabilities & Extensions */}
-              <div class="flex flex-col gap-1 w-full">
-                <Tabs.Trigger value="providers">
-                  <Icon name="providers" />
-                  {language.t("settings.providers.title")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="models">
-                  <Icon name="models" />
-                  {language.t("settings.models.title")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="extensions">
-                  <Icon name="extensions" />
-                  {language.t("settings.tab.extensions")}
-                </Tabs.Trigger>
-              </div>
+              <For each={sections}>
+                {(group) => (
+                  <div class="flex flex-col gap-1 w-full">
+                    <For each={group}>
+                      {(section) => (
+                        <Tabs.Trigger value={section.value}>
+                          <Icon name={section.icon} />
+                          {language.t(section.label)}
+                        </Tabs.Trigger>
+                      )}
+                    </For>
+                  </div>
+                )}
+              </For>
             </div>
           </div>
           <div class="settings-nav-footer">

--- a/packages/app/src/shell/routes/routes.tsx
+++ b/packages/app/src/shell/routes/routes.tsx
@@ -35,7 +35,7 @@ export function AppRoutes() {
           <SessionRouteFrame>
             <Suspense
               fallback={
-                <div class="flex min-h-0 flex-1 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
+                <div class="flex min-h-0 flex-1 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
                   <SessionPanelFrame raised />
                 </div>
               }

--- a/packages/app/src/shell/shell.tsx
+++ b/packages/app/src/shell/shell.tsx
@@ -23,6 +23,7 @@ export default function Layout(props: ParentProps) {
     tabsMount: undefined as HTMLElement | undefined,
   })
   const verticalTabs = () => preferences.appearance.tabLayout() === "vertical" && !mobile()
+  const bottomTitlebar = () => mobile() && preferences.general.mobileTitlebarPosition() === "bottom"
 
   const update: TitlebarUpdate = {
     get version() {
@@ -41,15 +42,13 @@ export default function Layout(props: ParentProps) {
       <div
         class="relative bg-v2-background-bg-deep flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text"
         style={{
-          "padding-top": "env(safe-area-inset-top, 0px)",
-          "padding-bottom": "env(safe-area-inset-bottom, 0px)",
           // Native Windows chrome supplies the gap; retain paint clearance for the panels' outer outlines.
-          "--shell-top-inset":
-            platform.platform === "desktop" &&
-            platform.os === "windows" &&
-            !(mobile() && preferences.general.mobileTitlebarPosition() === "bottom")
+          "--shell-top-inset": bottomTitlebar()
+            ? "max(0px, calc(8px - env(safe-area-inset-top, 0px)))"
+            : platform.platform === "desktop" && platform.os === "windows"
               ? "1px"
               : "8px",
+          "--shell-bottom-inset": bottomTitlebar() ? "8px" : "max(0px, calc(8px - env(safe-area-inset-bottom, 0px)))",
         }}
       >
         <Titlebar
@@ -66,8 +65,11 @@ export default function Layout(props: ParentProps) {
             <aside
               ref={(element) => setState("tabsMount", element)}
               data-slot="vertical-tabs-sidebar"
-              class="relative flex min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 pb-2 pt-[var(--shell-top-inset,8px)]"
-              style={{ width: `${state.tabsWidth}px` }}
+              class="relative flex min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]"
+              style={{
+                width: `${state.tabsWidth}px`,
+                "padding-bottom": "max(8px, env(safe-area-inset-bottom, 0px))",
+              }}
             >
               <ResizeHandle
                 class="-end-2"
@@ -80,7 +82,15 @@ export default function Layout(props: ParentProps) {
             </aside>
           </Show>
           {/* Size containment collapses percentage-height descendants in WebKit. */}
-          <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-content">
+          <main
+            class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-content"
+            style={{
+              "padding-top": bottomTitlebar() ? "env(safe-area-inset-top, 0px)" : "0px",
+              "padding-bottom": bottomTitlebar() || settings.store.open ? "0px" : "env(safe-area-inset-bottom, 0px)",
+              "--settings-bottom-inset": bottomTitlebar() ? "40px" : "env(safe-area-inset-bottom, 0px)",
+              "--settings-top-inset": mobile() && !bottomTitlebar() ? "0px" : "var(--shell-top-inset, 8px)",
+            }}
+          >
             <div
               class="flex size-full min-h-0 min-w-0 flex-col"
               hidden={settings.store.open}

--- a/packages/app/src/shell/titlebar/tab-nav.css
+++ b/packages/app/src/shell/titlebar/tab-nav.css
@@ -57,9 +57,10 @@
   margin-block: auto;
 }
 
-[data-titlebar-tab]:is(:hover, :has(> [data-slot="tab-link"]:focus-visible)):not([data-state="pressed"]):not(
-    [data-dragging="true"]
-  ):not([data-editing="true"]) {
+[data-titlebar-tab]:not(:where([data-slot="mobile-tabs-drawer"] *)):is(
+    :hover,
+    :has(> [data-slot="tab-link"]:focus-visible)
+  ):not([data-state="pressed"]):not([data-dragging="true"]):not([data-editing="true"]) {
   --tab-base: var(--v2-background-bg-layer-02);
   --tab-overlay: var(--v2-overlay-simple-overlay-hover);
 }
@@ -183,11 +184,52 @@
   display: none;
 }
 
+@media (hover: none) {
+  [data-titlebar-tab] [data-slot="tab-close"] {
+    background: linear-gradient(var(--tab-overlay), var(--tab-overlay)), var(--tab-base);
+  }
+
+  [data-titlebar-tab]:not([data-editing="true"]) [data-slot="tab-link"],
+  [data-titlebar-tab][data-title-overflow="true"]:not([data-editing="true"]) [data-slot="tab-link"] {
+    --tab-title-fade-offset: 24px;
+    --tab-title-fade-direction: to right;
+    -webkit-mask-image: linear-gradient(
+      var(--tab-title-fade-direction),
+      black 0,
+      black calc(100% - var(--tab-title-fade-offset) - 16px),
+      transparent calc(100% - var(--tab-title-fade-offset)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      var(--tab-title-fade-direction),
+      black 0,
+      black calc(100% - var(--tab-title-fade-offset) - 16px),
+      transparent calc(100% - var(--tab-title-fade-offset)),
+      transparent 100%
+    );
+  }
+
+  [data-titlebar-tab]:dir(rtl) [data-slot="tab-link"] {
+    --tab-title-fade-direction: to left;
+  }
+}
+
 @container (max-width: 64px) {
   [data-titlebar-tab]:not([data-orientation="vertical"]) [data-titlebar-tab-link] {
     justify-content: center;
     gap: 0;
     padding-inline: 0;
+  }
+
+  @media (hover: none) {
+    [data-titlebar-tab]:not([data-orientation="vertical"]):not([data-editing="true"]) [data-slot="tab-link"],
+    [data-titlebar-tab][data-title-overflow="true"]:not([data-orientation="vertical"]):not([data-editing="true"]):dir(
+        rtl
+      )
+      [data-slot="tab-link"] {
+      -webkit-mask-image: none;
+      mask-image: none;
+    }
   }
 
   [data-titlebar-tab]:not([data-orientation="vertical"]) [data-titlebar-tab-title] {

--- a/packages/app/src/shell/titlebar/tab-popover.tsx
+++ b/packages/app/src/shell/titlebar/tab-popover.tsx
@@ -1,6 +1,7 @@
 import { HoverCard } from "@kobalte/core/hover-card"
 import { createSignal, Show, type JSXElement } from "solid-js"
 import { useLanguage } from "@/runtime/i18n/language"
+import { createMediaQuery } from "@solid-primitives/media"
 import "./tab-popover.css"
 
 // Initial hover delay before the preview appears, per design.
@@ -28,6 +29,7 @@ export function TabPreviewPopover(props: {
   orientation?: "horizontal" | "vertical"
 }) {
   const language = useLanguage()
+  const mobile = createMediaQuery("(max-width: 767px)")
   let triggerEl: HTMLDivElement | undefined
   // When opened during a rapid tab-hopping streak, this preview appears and
   // disappears instantly (no repeated enter/exit animation) — only the first,
@@ -46,7 +48,7 @@ export function TabPreviewPopover(props: {
 
   return (
     <HoverCard
-      open={props.open}
+      open={props.open && !mobile()}
       onOpenChange={handleOpenChange}
       openDelay={resolveOpenDelay()}
       closeDelay={CLOSE_DELAY}

--- a/packages/app/src/shell/titlebar/titlebar.css
+++ b/packages/app/src/shell/titlebar/titlebar.css
@@ -2,6 +2,155 @@
   user-select: none;
 }
 
+[data-slot="mobile-tabs-trigger"][aria-expanded="true"] {
+  background:
+    linear-gradient(var(--v2-overlay-simple-overlay-hover), var(--v2-overlay-simple-overlay-hover)),
+    var(--v2-background-bg-layer-02);
+}
+
+[data-action="mobile-tabs-home"][data-state="pressed"] {
+  background:
+    linear-gradient(var(--v2-overlay-simple-overlay-pressed), var(--v2-overlay-simple-overlay-pressed)),
+    var(--v2-background-bg-layer-02);
+}
+
+[data-slot="mobile-tabs-overlay"] {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: var(--v2-overlay-simple-overlay-scrim);
+  animation: mobile-tabs-backdrop-in 240ms ease-out;
+}
+
+[data-slot="mobile-tabs-overlay"]:is([data-closing], [data-closed]) {
+  animation: mobile-tabs-backdrop-out 200ms ease-in forwards;
+}
+
+/* Keep the strip mounted for tab shortcuts and session metadata while collapsed. */
+[data-slot="mobile-tabs-drawer"] {
+  box-sizing: border-box;
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 51;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: min(75dvh, calc(100dvh - env(safe-area-inset-top, 0px) - 16px));
+  padding: 0 12px max(12px, env(safe-area-inset-bottom, 0px));
+  border-radius: 16px 16px 0 0;
+  background: var(--v2-background-bg-deep);
+  box-shadow: var(--v2-elevation-overlay);
+  outline: none;
+}
+
+[data-slot="mobile-tabs-drawer"][data-transitioning] {
+  transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+[data-slot="mobile-tabs-drawer"][data-closing] {
+  transition-duration: 200ms;
+}
+
+[data-slot="mobile-tabs-drawer"][data-closed] {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+[data-slot="mobile-tabs-drag-handle"] {
+  display: flex;
+  height: 28px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+}
+
+[data-slot="mobile-tabs-drag-handle"] span {
+  width: 32px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--v2-border-border-strong);
+}
+
+[data-slot="mobile-tabs-drawer-list"] {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+}
+
+@keyframes mobile-tabs-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes mobile-tabs-backdrop-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot="mobile-tabs-drawer"][data-transitioning],
+  [data-slot="mobile-tabs-drawer"][data-closing] {
+    transition: none;
+  }
+
+  [data-slot="mobile-tabs-overlay"],
+  [data-slot="mobile-tabs-overlay"]:is([data-closing], [data-closed]) {
+    animation: none;
+  }
+}
+
+[data-slot="mobile-tabs-drawer"] [data-slot="vertical-tabs"] {
+  display: flex;
+  flex-direction: column;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-slot="vertical-tabs-scroll"] {
+  min-height: 0;
+  overscroll-behavior: contain;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] {
+  min-height: 44px;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] [data-slot="tab-close"] {
+  inset-inline-end: 0;
+  width: 44px;
+  height: 44px;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-slot="tab-close"] button {
+  width: 44px;
+  height: 44px;
+  opacity: 1;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] [data-slot="tab-link"] {
+  padding-inline-end: 38px;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] [data-slot="tab-title"] {
+  color: var(--v2-text-text-base);
+  font-weight: 530;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] [data-slot="tab-project"] {
+  color: var(--v2-text-text-faint);
+  font-weight: 440;
+}
+
 [data-slot="titlebar-tab-item"] a {
   outline: none;
 }

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -25,6 +25,11 @@ import type { ComposerState } from "@/composer/persistence"
 import "./titlebar.css"
 import { newTabTooltipKeybind } from "@/shell/commands/tooltip-keybind"
 import { TitlebarRightMount } from "@/shell/titlebar/right-slot"
+import Drawer from "@corvu/drawer"
+import { sessionLabel } from "@/session/title"
+import { SessionTabAvatar } from "@/shell/layout/session-tab-avatar"
+import { projectForSession } from "@/shell/layout/helpers"
+import { useSettingsDialog } from "@/settings/command"
 
 const titlebarHeight = 36
 const windowsTitlebarHeight = 44 // Includes the content inset; matches the native Windows overlay.
@@ -47,6 +52,7 @@ export function Titlebar(props: {
   const command = useCommand()
   const language = useLanguage()
   const settings = useSettings()
+  const openSettings = useSettingsDialog()
   const navigate = useNavigate()
   const location = useLocation()
   const mobile = createMediaQuery("(max-width: 767px)")
@@ -138,6 +144,14 @@ export function Titlebar(props: {
         "order-last": bottom(),
       }}
       style={{
+        height:
+          platform.platform === "web"
+            ? bottom()
+              ? "calc(28px + max(8px, env(safe-area-inset-bottom, 0px)))"
+              : "calc(28px + max(8px, env(safe-area-inset-top, 0px)))"
+            : undefined,
+        "padding-top": bottom() ? "0px" : "env(safe-area-inset-top, 0px)",
+        "padding-bottom": bottom() ? "env(safe-area-inset-bottom, 0px)" : "0px",
         "min-height": minHeight(),
         // Keep native macOS traffic lights clear even when the desktop window is narrow.
         "padding-left": macTrafficLights() ? `${macTrafficLightsBaseWidth / zoom()}px` : 0,
@@ -336,116 +350,283 @@ export function Titlebar(props: {
               ].filter((v) => v !== undefined)
             })
 
+            const [mobileTabs, setMobileTabs] = createStore({ open: false, settings: false })
+            const currentProject = createMemo(() => {
+              const tab = currentTab()
+              const value = session()
+              if (!tab || !value) return
+              const conn = global.servers.list().find((item) => ServerConnection.key(item) === tab.server)
+              return projectForSession(value, conn ? global.ensureServerCtx(conn).projects.list() : [])
+            })
+            const currentTitle = () => {
+              const tab = currentTab()
+              if (!tab) return language.t("home.title")
+              if (tab.type === "draft") return language.t("command.session.new")
+              const value = session()
+              return value ? sessionLabel(value) : (tabs.info[tabKey(tab)]?.title ?? language.t("command.session.new"))
+            }
+            createEffect(() => {
+              path()
+              mobile()
+              setMobileTabs("open", false)
+            })
+
             return (
               <div
                 class="h-full flex-1 overflow-hidden flex flex-row items-center gap-1.5 px-2 md:pr-3"
                 classList={{
-                  "pt-2": !bottom() && !windows(),
-                  "pb-2": bottom(),
+                  "pt-[max(0px,calc(8px-env(safe-area-inset-top,0px)))]": !bottom() && !windows(),
+                  "pb-[max(0px,calc(8px-env(safe-area-inset-bottom,0px)))]": bottom(),
                   "md:pl-2": macTrafficLights(),
                   "md:pl-4": !macTrafficLights(),
                 }}
               >
-                <ChannelIndicator debugTools={props.debugTools} />
+                <Show when={!mobile()}>
+                  <ChannelIndicator debugTools={props.debugTools} />
+                </Show>
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} />
                 </Show>
-                <Tooltip
-                  placement="bottom"
-                  value={
-                    <>
-                      {language.t("home.title")}
-                      <Keybind keys={command.keybindParts("home.toggle")} variant="neutral" />
-                    </>
-                  }
-                  class="shrink-0"
-                >
-                  <IconButton
-                    type="button"
-                    variant="ghost-muted"
-                    size="large"
-                    class="!w-9 shrink-0"
-                    icon={<Icon name="grid-plus" />}
-                    state={layout.route().type === "home" ? "pressed" : undefined}
-                    onClick={toggleHome}
-                    aria-label={language.t("home.title")}
-                    aria-pressed={layout.route().type === "home"}
-                  />
-                </Tooltip>
+                <Show when={!mobile()}>
+                  <Tooltip
+                    placement="bottom"
+                    value={
+                      <>
+                        {language.t("home.title")}
+                        <Keybind keys={command.keybindParts("home.toggle")} variant="neutral" />
+                      </>
+                    }
+                    class="shrink-0"
+                  >
+                    <IconButton
+                      type="button"
+                      variant="ghost-muted"
+                      size="large"
+                      class="!w-9 shrink-0"
+                      icon={<Icon name="grid-plus" />}
+                      state={layout.route().type === "home" ? "pressed" : undefined}
+                      onClick={toggleHome}
+                      aria-label={language.t("home.title")}
+                      aria-pressed={layout.route().type === "home"}
+                    />
+                  </Tooltip>
+                </Show>
 
                 <Show
-                  when={props.verticalTabs}
+                  when={!mobile()}
                   fallback={
-                    <>
-                      <TitlebarTabStrip
-                        tabs={tabsStore}
-                        currentTab={currentTab()}
-                        onNavigate={(tab, el) => {
-                          tabs.select(tab)
-                          el?.scrollIntoView({ behavior: "instant" })
-                        }}
-                        onClose={(tab) => {
-                          const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
-                          if (index !== -1) tabsStoreActions.closeTab(index)
-                        }}
-                        onReorder={(keys) => tabsStoreActions.reorder(keys)}
-                      />
-                      <Tooltip
-                        placement="bottom"
-                        value={
-                          <>
-                            {language.t("command.session.new")}
-                            <Keybind keys={newTabTooltipKeybind(command)} variant="neutral" />
-                          </>
-                        }
+                    <Drawer
+                      open={mobileTabs.open}
+                      onOpenChange={(open) => setMobileTabs("open", open)}
+                      onContentPresentChange={(present) => {
+                        if (present || !mobileTabs.settings) return
+                        setMobileTabs("settings", false)
+                        openSettings()
+                      }}
+                      side="bottom"
+                    >
+                      <Drawer.Trigger
+                        data-slot="mobile-tabs-trigger"
+                        aria-expanded={mobileTabs.open}
+                        class="flex h-7 min-w-0 flex-1 items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-base focus-visible:outline-none [app-region:no-drag]"
+                        aria-label={language.t("titlebar.tabs")}
                       >
-                        <IconButton
-                          type="button"
-                          variant="ghost-muted"
-                          size="large"
-                          class="shrink-0"
-                          icon={<Icon name="plus" />}
-                          onClick={openNewTab}
-                          aria-label={language.t("command.session.new")}
-                        />
-                      </Tooltip>
-                    </>
-                  }
-                >
-                  {(vertical) => (
-                    <Show when={vertical().mount} keyed>
-                      {(mount) => (
-                        <Portal mount={mount}>
-                          <TitlebarTabStrip
-                            orientation="vertical"
-                            tabs={tabsStore}
-                            currentTab={currentTab()}
-                            onNavigate={(tab, el) => {
-                              tabs.select(tab)
-                              el?.scrollIntoView({ behavior: "instant", block: "nearest" })
-                            }}
-                            onClose={(tab) => {
-                              const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
-                              if (index !== -1) tabsStoreActions.closeTab(index)
-                            }}
-                            onReorder={(keys) => tabsStoreActions.reorder(keys)}
-                          />
+                        <Show when={currentTab()} fallback={<Icon name="grid-plus" class="shrink-0" />}>
+                          {(tab) => (
+                            <span
+                              data-slot="project-avatar-slot"
+                              class="flex size-4 shrink-0 items-center justify-center"
+                            >
+                              <Show
+                                when={session()}
+                                fallback={
+                                  tab().type === "draft" ? (
+                                    <Icon name="edit" />
+                                  ) : (
+                                    <span
+                                      class="block size-4 rounded-[3px] border border-v2-border-border-muted"
+                                      aria-hidden="true"
+                                    />
+                                  )
+                                }
+                              >
+                                {(value) => (
+                                  <SessionTabAvatar
+                                    project={currentProject()}
+                                    directory={value().location.directory}
+                                    sessionId={value().id}
+                                    server={tab().server}
+                                    revealProjectOnHover={false}
+                                  />
+                                )}
+                              </Show>
+                            </span>
+                          )}
+                        </Show>
+                        <span dir="auto" class="min-w-0 flex-1 truncate text-start">
+                          {currentTitle()}
+                        </span>
+                        <span class="shrink-0 text-v2-text-text-muted">{tabsStore.length}</span>
+                      </Drawer.Trigger>
+                      <Drawer.Portal forceMount>
+                        <Drawer.Overlay data-slot="mobile-tabs-overlay" />
+                        <Drawer.Content forceMount data-slot="mobile-tabs-drawer" dir={language.direction()}>
+                          <Drawer.Label class="sr-only">{language.t("titlebar.tabs")}</Drawer.Label>
+                          <div data-slot="mobile-tabs-drag-handle" aria-hidden="true">
+                            <span />
+                          </div>
+                          <div data-slot="mobile-tabs-drawer-list" data-corvu-no-drag>
+                            <TitlebarTabStrip
+                              orientation="vertical"
+                              tabs={tabsStore}
+                              currentTab={currentTab()}
+                              onNavigate={(tab) => {
+                                tabs.select(tab)
+                                setMobileTabs("open", false)
+                              }}
+                              onClose={(tab) => {
+                                const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                                if (index !== -1) tabsStoreActions.closeTab(index)
+                              }}
+                              onReorder={(keys) => tabsStoreActions.reorder(keys)}
+                            />
+                          </div>
                           <button
                             type="button"
-                            data-action="vertical-tabs-new-session"
-                            class="mt-1 flex h-7 w-full shrink-0 items-center gap-1.5 rounded-[6px] px-1.5 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 hover:text-v2-text-text-base"
-                            onClick={openNewTab}
-                            aria-label={language.t("command.session.new")}
+                            data-corvu-no-drag
+                            data-action="mobile-tabs-new-session"
+                            class="flex h-7 w-full shrink-0 items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-base hover:bg-v2-background-bg-layer-02 focus-visible:outline-none focus-visible:bg-v2-background-bg-layer-02"
+                            onClick={() => {
+                              openNewTab()
+                              setMobileTabs("open", false)
+                            }}
                           >
                             <Icon name="plus" />
                             {language.t("command.session.new")}
                           </button>
-                        </Portal>
-                      )}
-                    </Show>
-                  )}
+                          <div
+                            class="flex shrink-0 flex-col gap-1 border-t border-v2-border-border-muted pt-2"
+                            data-corvu-no-drag
+                          >
+                            <button
+                              type="button"
+                              data-action="mobile-tabs-home"
+                              data-state={layout.route().type === "home" ? "pressed" : undefined}
+                              aria-current={layout.route().type === "home" ? "page" : undefined}
+                              class="flex h-7 w-full items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-faint data-[state=pressed]:text-v2-text-text-base focus-visible:outline-none"
+                              onClick={() => {
+                                if (layout.route().type !== "home") toggleHome()
+                                setMobileTabs("open", false)
+                              }}
+                            >
+                              <Icon name="grid-plus" />
+                              {language.t("home.title")}
+                            </button>
+                            <div class="flex items-center gap-1">
+                              <button
+                                type="button"
+                                data-action="mobile-tabs-settings"
+                                class="flex h-7 min-w-0 flex-1 items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 focus-visible:outline-none focus-visible:bg-v2-background-bg-layer-02"
+                                onClick={() => setMobileTabs({ open: false, settings: true })}
+                              >
+                                <Icon name="settings-gear" size="small" />
+                                {language.t("sidebar.settings")}
+                              </button>
+                              <button
+                                type="button"
+                                data-action="mobile-tabs-help"
+                                class="flex h-7 shrink-0 items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 focus-visible:outline-none focus-visible:bg-v2-background-bg-layer-02"
+                                onClick={() => {
+                                  setMobileTabs("open", false)
+                                  platform.openExternal("https://opencode.ai/desktop-feedback")
+                                }}
+                              >
+                                <Icon name="help" size="small" />
+                                {language.t("sidebar.help")}
+                              </button>
+                            </div>
+                          </div>
+                        </Drawer.Content>
+                      </Drawer.Portal>
+                    </Drawer>
+                  }
+                >
+                  <Show
+                    when={props.verticalTabs}
+                    fallback={
+                      <>
+                        <TitlebarTabStrip
+                          tabs={tabsStore}
+                          currentTab={currentTab()}
+                          onNavigate={(tab, el) => {
+                            tabs.select(tab)
+                            el?.scrollIntoView({ behavior: "instant" })
+                          }}
+                          onClose={(tab) => {
+                            const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                            if (index !== -1) tabsStoreActions.closeTab(index)
+                          }}
+                          onReorder={(keys) => tabsStoreActions.reorder(keys)}
+                        />
+                        <Tooltip
+                          placement="bottom"
+                          value={
+                            <>
+                              {language.t("command.session.new")}
+                              <Keybind keys={newTabTooltipKeybind(command)} variant="neutral" />
+                            </>
+                          }
+                        >
+                          <IconButton
+                            type="button"
+                            variant="ghost-muted"
+                            size="large"
+                            class="shrink-0"
+                            icon={<Icon name="plus" />}
+                            onClick={openNewTab}
+                            aria-label={language.t("command.session.new")}
+                          />
+                        </Tooltip>
+                      </>
+                    }
+                  >
+                    {(vertical) => (
+                      <Show when={vertical().mount} keyed>
+                        {(mount) => (
+                          <Portal mount={mount}>
+                            <TitlebarTabStrip
+                              orientation="vertical"
+                              tabs={tabsStore}
+                              currentTab={currentTab()}
+                              onNavigate={(tab, el) => {
+                                tabs.select(tab)
+                                el?.scrollIntoView({ behavior: "instant", block: "nearest" })
+                              }}
+                              onClose={(tab) => {
+                                const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                                if (index !== -1) tabsStoreActions.closeTab(index)
+                              }}
+                              onReorder={(keys) => tabsStoreActions.reorder(keys)}
+                            />
+                            <button
+                              type="button"
+                              data-action="vertical-tabs-new-session"
+                              class="mt-1 flex h-7 w-full shrink-0 items-center gap-1.5 rounded-[6px] px-1.5 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 hover:text-v2-text-text-base"
+                              onClick={openNewTab}
+                              aria-label={language.t("command.session.new")}
+                            >
+                              <Icon name="plus" />
+                              {language.t("command.session.new")}
+                            </button>
+                          </Portal>
+                        )}
+                      </Show>
+                    )}
+                  </Show>
                 </Show>
-                <div class="flex-1" />
+                <Show when={!mobile()}>
+                  <div class="flex-1" />
+                </Show>
                 <TitlebarRight state={rightState()} />
               </div>
             )


### PR DESCRIPTION
## Summary
- Replace mobile tab strips with a bottom drawer retaining session title/project identity, tab closing/reordering, Home, and horizontal Settings/Help actions.
- Keep Projects and search above Home sessions in both navigation layouts, with a project dropdown, multi-server sublabel, compact spacing, and stacked project/session labels.
- Replace the mobile settings sidebar with the existing compact section menu; improve safe-area scrolling, header seams, shadow clearance, and inline model checkboxes.
- Avoid double-counting safe-area padding around titlebars and content panels, preserve session panel shadows, and fade touch tab titles behind close controls.
- Hide release-channel indicators on mobile while retaining desktop behavior.

## Stack
1. #46388: mobile shell, Home, and settings (base v2).
2. #46389: mobile session views, Files, Status, and details (base #46388).
3. #46390: mobile Changes summaries, Open file, and wrapping preferences (base #46389).

Merge in that order; each PR's diff and before/after evidence compare against its immediate base. Independent #46391 (touch controls/PWA) can land separately.

## Sessions
- `ses_fa9929a54ffeG0AAK1g2BwuFHj`: safe areas, panel shadows, touch tab fade, persistent Home utility footer.
- `ses_fa96329bbffdPCp54xCdIn18M0`: mobile settings menu, safe-area scrolling, channel indicator visibility.
- `ses_fa94e625fffdatsz7sy2hC4tMI`: mobile tabs drawer and Home/Settings/Help placement.
- `ses_fa93a9c41ffdv86XF9fhdYPok9`: horizontal Home utility alignment.
- `ses_fa9375bf2ffd1qwP3qNWRyj1dW`: Projects dropdown, spacing, drawer typography/actions, settings layout refinements.
- `ses_fa92bcf95ffefmn2bqtEY6z23J`: stacked mobile session/project labels. The later-reverted bottom-mounted Home search is intentionally excluded.

## Before / After

PR #46388 mobile-shell-polish: original V2 e56ceed32b versus fixed committed head 4e0db6a875

| Surface | Before | After |
| --- | --- | --- |
| home projects closed: Mobile Home: closed project dropdown, Studio server sublabel and two-line sessions | ![Before: home projects closed: Mobile Home: closed project dropdown, Studio server sublabel and two-line sessions](https://github.com/user-attachments/assets/80c75973-0cd4-4f6d-a66e-d7b07254d507) | ![After: home projects closed: Mobile Home: closed project dropdown, Studio server sublabel and two-line sessions](https://github.com/user-attachments/assets/c0115d2c-23bf-4909-883f-4895e68af0e7) |
| home projects open: Mobile Home: project dropdown open with two servers | ![Before: home projects open: Mobile Home: project dropdown open with two servers](https://github.com/user-attachments/assets/440c78da-f257-4598-bb8b-6dc5ddcbd46b) | ![After: home projects open: Mobile Home: project dropdown open with two servers](https://github.com/user-attachments/assets/395ea931-8fc7-4c12-b432-36e5efd66448) |
| settings general: Mobile General: closed section menu and compact panel | ![Before: settings general: Mobile General: closed section menu and compact panel](https://github.com/user-attachments/assets/db06bd8f-3f8d-4308-a49d-3cababe95217) | ![After: settings general: Mobile General: closed section menu and compact panel](https://github.com/user-attachments/assets/f989c5db-7a0a-48a6-ba3c-7a9a9b7938cf) |
| settings sections open: Mobile settings: section menu open | ![Before: settings sections open: Mobile settings: section menu open](https://github.com/user-attachments/assets/bccd9776-033b-4c60-a33b-50ffc3032ba3) | ![After: settings sections open: Mobile settings: section menu open](https://github.com/user-attachments/assets/06afcadc-e552-4ae7-be0b-228ffb1e0101) |
| settings models: Mobile Models: inline visibility controls, search and provider header | ![Before: settings models: Mobile Models: inline visibility controls, search and provider header](https://github.com/user-attachments/assets/fa886a93-4770-48e2-b356-6dc823357df8) | ![After: settings models: Mobile Models: inline visibility controls, search and provider header](https://github.com/user-attachments/assets/87c61d6c-ed6f-4f95-81dc-0f198db55f1a) |
| settings models scrolled: Mobile Models: scrollTop 340, sticky header and list borders | ![Before: settings models scrolled: Mobile Models: scrollTop 340, sticky header and list borders](https://github.com/user-attachments/assets/b2bf9b03-1bfe-4cc4-96ea-0b2b6b5911b1) | ![After: settings models scrolled: Mobile Models: scrollTop 340, sticky header and list borders](https://github.com/user-attachments/assets/04bb919b-da28-46e2-836b-fa11d8143081) |
| titlebar top safe area: Mobile top titlebar: CDP safe-area simulation (top 44px, bottom 34px) | ![Before: titlebar top safe area: Mobile top titlebar: CDP safe-area simulation (top 44px, bottom 34px)](https://github.com/user-attachments/assets/b14b22b1-450a-4ee5-b4d9-cb45b43d8493) | ![After: titlebar top safe area: Mobile top titlebar: CDP safe-area simulation (top 44px, bottom 34px)](https://github.com/user-attachments/assets/08e34f2b-37d9-441f-b1ad-f9f47396a811) |
| tabs top open safe area: Mobile top: open drawer with title/project emphasis and Settings beside Help, simulated safe area | ![Before: tabs top open safe area: Mobile top: open drawer with title/project emphasis and Settings beside Help, simulated safe area](https://github.com/user-attachments/assets/7b1bb797-68d0-4aaf-8936-d177b6e51604) | ![After: tabs top open safe area: Mobile top: open drawer with title/project emphasis and Settings beside Help, simulated safe area](https://github.com/user-attachments/assets/e280dcbf-264d-4749-97f7-90f0582f5748) |
| titlebar bottom safe area: Mobile bottom titlebar: CDP safe-area simulation (top 44px, bottom 34px) | ![Before: titlebar bottom safe area: Mobile bottom titlebar: CDP safe-area simulation (top 44px, bottom 34px)](https://github.com/user-attachments/assets/5e979503-1ee5-4b15-b701-e348347a9eac) | ![After: titlebar bottom safe area: Mobile bottom titlebar: CDP safe-area simulation (top 44px, bottom 34px)](https://github.com/user-attachments/assets/5342936a-9435-4938-b728-2b9a98a5ae6f) |
| tabs bottom open safe area: Mobile bottom: open drawer with title/project emphasis and Settings beside Help, simulated safe area | ![Before: tabs bottom open safe area: Mobile bottom: open drawer with title/project emphasis and Settings beside Help, simulated safe area](https://github.com/user-attachments/assets/08bca62a-d3e5-421c-b19b-22a1de9be627) | ![After: tabs bottom open safe area: Mobile bottom: open drawer with title/project emphasis and Settings beside Help, simulated safe area](https://github.com/user-attachments/assets/60ed651e-a603-431f-bc2a-cf43a5cd9f2d) |
| desktop home: desktop: unchanged wide Home layout and horizontal tabs | ![Before: desktop home: desktop: unchanged wide Home layout and horizontal tabs](https://github.com/user-attachments/assets/4645c968-626f-4bd3-8020-ab9d504c9d3b) | ![After: desktop home: desktop: unchanged wide Home layout and horizontal tabs](https://github.com/user-attachments/assets/2c45c879-af44-4d5f-b869-6ec583a6fec1) |
| desktop settings: desktop: General settings wide sidebar sample | ![Before: desktop settings: desktop: General settings wide sidebar sample](https://github.com/user-attachments/assets/d4d0a4c0-4ead-4e23-aa99-e8290a4ea8cb) | ![After: desktop settings: desktop: General settings wide sidebar sample](https://github.com/user-attachments/assets/99aea4c4-3416-4cfd-a04e-21c86078cda9) |
| tablet touch home: tablet-touch: unchanged wide Home layout and horizontal tabs | ![Before: tablet touch home: tablet-touch: unchanged wide Home layout and horizontal tabs](https://github.com/user-attachments/assets/86f26397-16b4-4e8a-bdf1-dd7660312789) | ![After: tablet touch home: tablet-touch: unchanged wide Home layout and horizontal tabs](https://github.com/user-attachments/assets/28096d2b-b51a-4a02-8b23-746e78686340) |
| tablet touch tab fade: 820px touch tablet: active horizontal tab, close-button title fade | ![Before: tablet touch tab fade: 820px touch tablet: active horizontal tab, close-button title fade](https://github.com/user-attachments/assets/83e7dab7-db21-4c85-9a75-b37632855832) | ![After: tablet touch tab fade: 820px touch tablet: active horizontal tab, close-button title fade](https://github.com/user-attachments/assets/b4973d0e-27b5-4bf4-8268-02851d08f4fa) |
| tablet touch settings: tablet-touch: General settings wide sidebar sample | ![Before: tablet touch settings: tablet-touch: General settings wide sidebar sample](https://github.com/user-attachments/assets/0ef0384a-bb54-4368-a7d4-54710a9b6e85) | ![After: tablet touch settings: tablet-touch: General settings wide sidebar sample](https://github.com/user-attachments/assets/5960eb9e-f106-4ea8-8f57-886fdb4311d0) |

- 15 raw screenshot pairs; all before PNGs retained unchanged
- Dark theme and identical deterministic synthetic fixture data on every pair
- Mobile 390x844, touch tablet 820x1000, desktop 1440x1000; device scale 1
- Base interfaces are genuine: no fabricated project dropdown, tab drawer or Settings section menu
- Safe-area pairs are CDP simulations using Emulation.setSafeAreaInsetsOverride: 44px top and 34px bottom, not physical iOS validation
- General and Models full-width geometry and inline model control alignment asserted before capture
- Initial Settings CSS load-order regression fixed in committed source; these after images contain the fix
- DEV badge hidden for capture only; no product DOM/CSS modifications
- Routes, dimensions and commit inventory are recorded separately in manifest.json

## Recording

Mobile tab drawer navigation and reopening, Settings section selection, and inline Models controls on the corrected full-width settings layout. Chromium, dark theme, 390x844, 3.16 seconds; synthetic fixture data.

https://github.com/user-attachments/assets/b7243e78-e01e-4250-bf8c-d996b4878989

## Validation
- Follow-up screenshot verification found and fixed a production settings CSS-cascade issue; all 16 focused stack regressions now pass, including full-width settings geometry and updated drawer/sidebar expectations.
- All four PR groups merge cleanly in an isolated integration worktree; the combined production build passes all eight mobile browser regressions and app typechecking.
- App package typecheck and 48 focused Home/settings/titlebar tests pass.
- Production build and home-to-session navigation benchmark pass on clean v2 and this head: stable content observation 134.8ms and 156.1ms. Single machine-local samples, not statistical performance conclusions.
- Preserved upstream Windows 1px outline clearance, internal tab-strip overflow handling, and existing tab rename/context-menu behavior.
- Declare @corvu/drawer as an app dependency, using the existing catalog version.
- Original user worktree/staging and existing app/server processes remain untouched. Already-merged CORS/favicon/PWA icons and generated declaration artifacts are excluded.
