### PR TITLE
feat(app): add mobile session panels and detail drawers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -54,6 +54,7 @@
       "name": "@opencode-ai/app",
       "version": "1.18.15",
       "dependencies": {
+        "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
         "@dnd-kit/dom": "0.5.0",
         "@dnd-kit/helpers": "0.5.0",
@@ -1642,6 +1643,10 @@
 
     "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20251008.0", "", {}, "sha512-dZLkO4PbCL0qcCSKzuW7KE4GYe49lI12LCfQ5y9XeSwgYBoAUbwH4gmJ6A0qUIURiTJTkGkRkhVPqpq2XNgYRA=="],
 
+    "@corvu/dialog": ["@corvu/dialog@0.2.4", "", { "dependencies": { "@corvu/utils": "~0.4.2", "solid-dismissible": "~0.1.1", "solid-focus-trap": "~0.1.8", "solid-presence": "~0.2.0", "solid-prevent-scroll": "~0.1.10" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-n54vJq+fOy8GVrnYBdJpD6JXNuyx7LOeMrRxwzAvZnYGpW8+AA12tnb/P/2emJj/HjOO5otheGKb0breshdFlA=="],
+
+    "@corvu/drawer": ["@corvu/drawer@0.2.4", "", { "dependencies": { "@corvu/dialog": "~0.2.4", "@corvu/utils": "~0.4.2", "@solid-primitives/memo": "^1.4.1", "solid-transition-size": "~0.1.4" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-7jQoGZ8ROB9CmXam2nMY2wEskU3IoFwZQywkF/7vrBc/edGsPv7mOVQ1GN6G+4nd7nrMZ3UtqHAhmRh9V0azlw=="],
+
     "@corvu/utils": ["@corvu/utils@0.4.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.11" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
@@ -2875,6 +2880,8 @@
     "@solid-primitives/map": ["@solid-primitives/map@0.4.13", "", { "dependencies": { "@solid-primitives/trigger": "^1.1.0" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-B1zyFbsiTQvqPr+cuPCXO72sRuczG9Swncqk5P74NCGw1VE8qa/Ry9GlfI1e/VdeQYHjan+XkbE3rO2GW/qKew=="],
 
     "@solid-primitives/media": ["@solid-primitives/media@2.3.6", "", { "dependencies": { "@solid-primitives/event-listener": "^2.4.6", "@solid-primitives/rootless": "^1.5.4", "@solid-primitives/static-store": "^0.1.4", "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-pk49gPOq/UMRUJ+pTSrOfBiR8xJjRYHXIf1iR/jSnyQ/KroU+ZXhkZzavC7hvfp2vJeOTW5k2/HN0r3Q1VJ7Pw=="],
+
+    "@solid-primitives/memo": ["@solid-primitives/memo@1.5.1", "", { "dependencies": { "@solid-primitives/scheduled": "^1.5.3", "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-VDPrkl9epp0tbby9MvsqphGFCYCtDRC5J8FKzTqHbQiG5hhR8n6xv4MfjhTW231IaBxxPHLxS43EE8c5Q23mSQ=="],
 
     "@solid-primitives/props": ["@solid-primitives/props@3.2.4", "", { "dependencies": { "@solid-primitives/utils": "^6.4.1" }, "peerDependencies": { "solid-js": "^1.6.12" } }, "sha512-MXXdvi2TSB6d+0N6ueA/HP1j/Kh9SEc4WdF1ZDMLwPagxW6pIHHSS9xbRO0RjqSVpNP4j0nxCWT1hx3CkJNhNA=="],
 
@@ -5302,6 +5309,10 @@
 
     "socks-proxy-agent": ["socks-proxy-agent@8.0.5", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "^4.3.4", "socks": "^2.8.3" } }, "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw=="],
 
+    "solid-dismissible": ["solid-dismissible@0.1.1", "", { "dependencies": { "@corvu/utils": "~0.4.1" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-9kcKBJIMdS+586cA1g63HYWxKh3h89leeNHbPZ1csYjuni+NvPBtNr11l0iEX2AKKEt6FHk6qNhc/gjoYAW1pA=="],
+
+    "solid-focus-trap": ["solid-focus-trap@0.1.9", "", { "dependencies": { "@corvu/utils": "~0.4.2" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-LTyNki6GUJPRLXV5uMWPkYClB07SUMubbr2EkAddiR0CJCF/I283txilMU9RURSr/P8EewMfXWu2o3aWrK7A5A=="],
+
     "solid-js": ["solid-js@1.9.15", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.4", "seroval-plugins": "~1.5.4" } }, "sha512-EeiY2xfpZJqPLjXspVEKjAII4yv8NyG//NxZ3IpOFHdUNnnTyL0uJOeS9LWGvA7cFCz5y94cjFwYlmw5Luncsg=="],
 
     "solid-list": ["solid-list@0.3.0", "", { "dependencies": { "@corvu/utils": "~0.4.0" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-t4hx/F/l8Vmq+ib9HtZYl7Z9F1eKxq3eKJTXlvcm7P7yI4Z8O7QSOOEVHb/K6DD7M0RxzVRobK/BS5aSfLRwKg=="],
@@ -5315,6 +5326,8 @@
     "solid-sonner": ["solid-sonner@0.3.1", "", { "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-F/+zi9yKJTHh5hX1UGJfkDvyC+F34Vi3jgy44NJwOKCgic1QtAon0b1iT9OsDO77RTgR+PCil+3Y5B8T2Owy1Q=="],
 
     "solid-stripe": ["solid-stripe@0.8.1", "", { "peerDependencies": { "@stripe/stripe-js": ">=1.44.1 <8.0.0", "solid-js": "^1.6.0" } }, "sha512-l2SkWoe51rsvk9u1ILBRWyCHODZebChSGMR6zHYJTivTRC0XWrRnNNKs5x1PYXsaIU71KYI6ov5CZB5cOtGLWw=="],
+
+    "solid-transition-size": ["solid-transition-size@0.1.4", "", { "dependencies": { "@corvu/utils": "~0.3.2" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-ocHVnbfy23CgfaH4cEUR/AFg0Y3CEL8Oh3n9Qv8OHFJgPh+zkmERKZQfi/xH5XvxDCizg8VjPrVUhiHB1Gza8g=="],
 
     "solid-use": ["solid-use@0.9.1", "", { "peerDependencies": { "solid-js": "^1.7" } }, "sha512-UwvXDVPlrrbj/9ewG9ys5uL2IO4jSiwys2KPzK4zsnAcmEl7iDafZWW1Mo4BSEWOmQCGK6IvpmGHo1aou8iOFw=="],
 
@@ -6629,6 +6642,8 @@
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "solid-transition-size/@corvu/utils": ["@corvu/utils@0.3.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.7" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-ZWlyWEE8qV9+CB9OAyo2bTrZGXQN9ZeM+JfYv89zoR+lRACKTDuoOZEdiyL8Uc7U5dUSH1uTqKhTTnaHWb+wZA=="],
 
     "sort-keys/is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
 

--- a/packages/app/component-tests/timeline-virtualizer.spec.ts
+++ b/packages/app/component-tests/timeline-virtualizer.spec.ts
@@ -8,6 +8,30 @@ story.beforeEach(async ({ mount }) => {
   await expect(component.getByRole("textbox", { name: "Prompt", exact: true })).toBeVisible()
 })
 
+story("spaces the first mobile message without changing desktop spacing", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await page.evaluate(async (fixture) => {
+    const { mountTimelineVirtualizer } = await import(fixture)
+    mountTimelineVirtualizer({ count: 1, rowHeight: 60, immediate: true })
+  }, fixture)
+  const root = page.getByTestId("timeline-virtualizer-fixture")
+  await root.getByRole("button", { name: "Complete Markdown", exact: true }).click()
+  const content = root.locator("[data-timeline-virtual-content]")
+  await expect(content).toHaveCSS("visibility", "visible")
+  const gap = () =>
+    root.locator('[data-timeline-key="user-message:message-0"]').evaluate((element) => {
+      const viewport = element.closest("[data-scrollable]")!
+      return element.getBoundingClientRect().top - viewport.getBoundingClientRect().top
+    })
+  await expect.poll(gap).toBe(16)
+  await root.evaluate((element) => element.setAttribute("dir", "rtl"))
+  await expect.poll(gap).toBe(16)
+  await page.setViewportSize({ width: 1280, height: 900 })
+  await expect.poll(gap).toBe(0)
+  await page.setViewportSize({ width: 390, height: 844 })
+  await expect.poll(gap).toBe(16)
+})
+
 story("bounds the cheap suffix and reveals only ready measured rows", async ({ page }) => {
   await page.evaluate(async (fixture) => {
     const { mountTimelineVirtualizer } = await import(fixture)

--- a/packages/app/e2e/regression/mobile-files.spec.ts
+++ b/packages/app/e2e/regression/mobile-files.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test } from "@playwright/test"
+import { fixture, pageMessages } from "../performance/timeline/session-timeline-stress.fixture"
+import { stressSessionHref } from "../performance/timeline/timeline-test-helpers"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+for (const direction of ["ltr", "rtl"] as const) {
+  test(`mobile files browse, search, switch, and close shared file tabs in ${direction}`, async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await mockOpenCodeServer(page, {
+      directory: fixture.directory,
+      project: fixture.project,
+      sessions: fixture.sessions,
+      provider: fixture.provider,
+      pageMessages,
+      fileList: (path) =>
+        path
+          ? []
+          : ["first.ts", "second.ts"].map((name) => ({
+              name,
+              path: name,
+              absolute: `${fixture.directory}/${name}`,
+              type: "file",
+              ignored: false,
+            })),
+      fileContent: (path) => `contents:${path}`,
+      findFiles: ({ query }) => ["first.ts", "second.ts"].filter((path) => path.includes(query)),
+    })
+    await page.goto(stressSessionHref(fixture.targetID))
+    const navigation = page.getByRole("tablist", { name: "Session view", exact: true })
+    await navigation.getByRole("tab", { name: "Files", exact: true }).click()
+    const files = page.locator('[data-slot="session-mobile-files"]')
+    await expect(files.getByRole("button", { name: "first.ts", exact: true })).toBeVisible()
+    await page.evaluate((direction) => (document.documentElement.dir = direction), direction)
+    await expect(files.locator('[data-slot="session-mobile-files-header"]')).toHaveCSS("border-bottom-width", "0px")
+    await expect
+      .poll(() =>
+        files.getByRole("tablist", { name: "Open files", exact: true }).evaluate((element) => {
+          const header = element.closest('[data-slot="session-mobile-files-header"]')!
+          const separator = getComputedStyle(element, "::before")
+          return {
+            height: separator.height,
+            fullWidth: parseFloat(separator.width) === header.clientWidth,
+            start: separator.insetInlineStart,
+            bottom: separator.bottom,
+          }
+        }),
+      )
+      .toEqual({ height: "1px", fullWidth: true, start: "0px", bottom: "0px" })
+    await files.getByRole("button", { name: "first.ts", exact: true }).click()
+    await expect(files.getByText("contents:first.ts", { exact: true })).toBeVisible()
+    await files.locator('[data-column-number="1"]').click()
+    const editor = files.locator('[data-component="line-comment-v2"][data-variant="editor"]')
+    await expect(editor.getByRole("textbox")).toBeVisible()
+    for (const width of [390, 700]) {
+      await page.setViewportSize({ width, height: 844 })
+      await expect
+        .poll(async () => {
+          const panel = await files.boundingBox()
+          const comment = await editor.boundingBox()
+          if (!panel || !comment) return false
+          return Math.abs(comment.x - panel.x - 12) < 2 && Math.abs(comment.width - panel.width + 24) < 2
+        })
+        .toBe(true)
+    }
+    await editor.getByRole("textbox").fill("Full-width file comment")
+    await editor.getByRole("button", { name: "Comment", exact: true }).click()
+    const comment = files.locator('[data-component="line-comment-v2"][data-variant="display"]')
+    await expect(comment).toContainText("Full-width file comment")
+    await expect
+      .poll(async () => {
+        const panel = await files.boundingBox()
+        const card = await comment.boundingBox()
+        if (!panel || !card) return false
+        return Math.abs(card.x - panel.x - 12) < 2 && Math.abs(card.width - panel.width + 24) < 2
+      })
+      .toBe(true)
+    await page.setViewportSize({ width: 390, height: 844 })
+    await expect(files.getByRole("combobox", { name: "Filter files", exact: true })).toBeHidden()
+    await files.getByRole("button", { name: "All files", exact: true }).click()
+    await files.getByRole("combobox", { name: "Filter files", exact: true }).fill("second")
+    await files.getByRole("option", { name: "second.ts", exact: true }).click()
+    await expect(files.getByText("contents:second.ts", { exact: true })).toBeVisible()
+    const openTabs = files.getByRole("tablist", { name: "Open files", exact: true })
+    await expect(openTabs.getByRole("tab")).toHaveText(["first.ts", "second.ts"])
+    await expect
+      .poll(() =>
+        openTabs.getByRole("tab", { name: "second.ts", exact: true }).evaluate((element) => {
+          const tab = element.closest('[data-slot="tabs-v2-trigger-wrapper"]')!
+          const header = element.closest('[data-slot="session-mobile-files-header"]')!
+          return Math.abs(tab.getBoundingClientRect().bottom - header.getBoundingClientRect().bottom) < 1
+        }),
+      )
+      .toBe(true)
+    await openTabs.getByRole("tab", { name: "first.ts", exact: true }).click()
+    await expect(files.getByText("contents:first.ts", { exact: true })).toBeVisible()
+    await navigation.getByRole("tab", { name: "Session", exact: true }).click()
+    await navigation.getByRole("tab", { name: "Files", exact: true }).click()
+    await expect(files.getByText("contents:first.ts", { exact: true })).toBeVisible()
+    await files
+      .locator('[data-slot="tabs-v2-trigger-wrapper"]')
+      .filter({ has: page.getByRole("tab", { name: "first.ts", exact: true }) })
+      .getByRole("button", { name: "Close tab", exact: true })
+      .click()
+    await expect(openTabs.getByRole("tab")).toHaveText(["second.ts"])
+    await expect(files.getByText("contents:second.ts", { exact: true })).toBeVisible()
+    await files.getByRole("button", { name: "Close tab", exact: true }).click()
+    await expect(files.getByRole("combobox", { name: "Filter files", exact: true })).toBeVisible()
+    await expect(openTabs.getByRole("tab")).toHaveCount(0)
+  })
+}

--- a/packages/app/e2e/regression/mobile-session-views.spec.ts
+++ b/packages/app/e2e/regression/mobile-session-views.spec.ts
@@ -73,9 +73,8 @@ for (const position of ["top", "bottom"] as const) {
       .poll(async () => {
         const bar = await tabs.boundingBox()
         const input = await composer.boundingBox()
-        return (
-          !!bar && !!input && (position === "bottom" ? bar.y >= input.y + input.height : bar.y + bar.height <= input.y)
-        )
+        const panel = await page.locator('[data-slot="session-chat-panel"]').boundingBox()
+        return !!bar && !!input && !!panel && Math.abs(bar.y - panel.y) <= 1 && bar.y + bar.height <= input.y
       })
       .toBe(true)
     await expect(page.locator("[data-session-title]")).toHaveCount(0)
@@ -98,6 +97,10 @@ for (const position of ["top", "bottom"] as const) {
     await page.getByRole("menuitem", { name: "Usage", exact: true }).click()
     await expect(picker).toHaveCount(0)
     await expect(page.getByText("Total Cost", { exact: true })).toBeVisible()
+    const usage = page.locator('[data-slot="session-usage-content"]')
+    await expect(usage).toHaveCSS("padding-top", "16px")
+    await expect(usage).toHaveCSS("padding-inline-start", "16px")
+    await expect(usage).toHaveCSS("padding-inline-end", "16px")
     await expect(composer).toBeHidden()
 
     await more.click()

--- a/packages/app/e2e/regression/mobile-session-views.spec.ts
+++ b/packages/app/e2e/regression/mobile-session-views.spec.ts
@@ -1,0 +1,183 @@
+import { expect, test } from "@playwright/test"
+import { fixture, pageMessages } from "../performance/timeline/session-timeline-stress.fixture"
+import { installStressSessionTabs, stressSessionHref } from "../performance/timeline/timeline-test-helpers"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+for (const position of ["top", "bottom"] as const) {
+  test(`mobile session tabs switch views and keep the terminal cached with ${position} navigation`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 })
+    await mockOpenCodeServer(page, {
+      directory: fixture.directory,
+      project: fixture.project,
+      sessions: fixture.sessions,
+      provider: fixture.provider,
+      pageMessages,
+      fileList: () => [],
+    })
+    await installStressSessionTabs(page)
+    await page.addInitScript(
+      (position) =>
+        localStorage.setItem("settings.v3", JSON.stringify({ general: { mobileTitlebarPosition: position } })),
+      position,
+    )
+    await page.route("**/api/pty*", (route) =>
+      route.fulfill({
+        json: {
+          location: { directory: fixture.directory, project: { id: fixture.project.id, directory: fixture.directory } },
+          data: {
+            id: "pty_mobile_views",
+            title: "Terminal 1",
+            command: "sh",
+            args: [],
+            cwd: fixture.directory,
+            status: "running",
+            pid: 1,
+          },
+        },
+      }),
+    )
+    await page.routeWebSocket("**/api/pty/pty_mobile_views/connect", () => undefined)
+    await page.route("**/api/pty/pty_mobile_views/connect-token*", (route) =>
+      route.fulfill({
+        json: {
+          location: { directory: fixture.directory, project: { id: fixture.project.id, directory: fixture.directory } },
+          data: { ticket: "e2e-ticket", expires_in: 60 },
+        },
+      }),
+    )
+    await page.goto(stressSessionHref(fixture.targetID))
+
+    const tabs = page.getByRole("tablist", { name: "Session view", exact: true })
+    const navigation = page.locator('[data-slot="session-mobile-view-navigation"]')
+    const more = navigation.getByRole("button", { name: "More options", exact: true })
+    const picker = tabs.getByRole("tab", { selected: true })
+    const message = page.locator(
+      `[data-timeline-row="UserMessage"][data-message-id="${fixture.expected.targetMessageIDs.at(-1)}"]`,
+    )
+    const composer = page.getByRole("textbox", { name: "Prompt", exact: true })
+    await expect(picker).toHaveText("Session")
+    await expect(message).toBeVisible()
+    await expect(composer).toBeVisible()
+    await expect(tabs.getByRole("tab")).toHaveText(["Session", "Changes", "Files", "Terminal"])
+    await expect(tabs).toHaveCSS("padding-left", "0px")
+    await expect(tabs).toHaveCSS("padding-right", "0px")
+    await expect
+      .poll(async () => {
+        const bounds = await navigation.boundingBox()
+        return !!bounds && bounds.x >= 8 && bounds.x <= 9 && bounds.width >= 372 && bounds.width <= 374
+      })
+      .toBe(true)
+    await expect
+      .poll(async () => {
+        const bar = await tabs.boundingBox()
+        const input = await composer.boundingBox()
+        return (
+          !!bar && !!input && (position === "bottom" ? bar.y >= input.y + input.height : bar.y + bar.height <= input.y)
+        )
+      })
+      .toBe(true)
+    await expect(page.locator("[data-session-title]")).toHaveCount(0)
+    await expect(page.locator('[data-slot="mobile-tabs-trigger"]')).toContainText(fixture.expected.targetTitle)
+    await page.getByRole("button", { name: "Tabs", exact: true }).click()
+    const drawer = page.getByRole("dialog", { name: "Tabs", exact: true })
+    await expect(drawer).toHaveAttribute("data-open", "")
+    await expect(drawer).not.toHaveAttribute("data-transitioning")
+    await expect(drawer.getByRole("button", { name: "Settings", exact: true })).toBeInViewport()
+    await drawer.getByRole("button", { name: "Settings", exact: true }).click()
+    await expect(page.getByTestId("settings-screen")).toBeVisible()
+    await page.getByRole("button", { name: "Back to app", exact: true }).click()
+    await page.getByRole("button", { name: "Tabs", exact: true }).click()
+    await expect(drawer).not.toHaveAttribute("data-transitioning")
+    await expect(drawer.getByRole("button", { name: "Settings", exact: true })).toBeInViewport()
+    await page.keyboard.press("Escape")
+    await expect(drawer).toBeHidden()
+
+    await more.click()
+    await page.getByRole("menuitem", { name: "Usage", exact: true }).click()
+    await expect(picker).toHaveCount(0)
+    await expect(page.getByText("Total Cost", { exact: true })).toBeVisible()
+    await expect(composer).toBeHidden()
+
+    await more.click()
+    await page.getByRole("menuitem", { name: "Status", exact: true }).click()
+    const status = page.getByRole("dialog", { name: "Status", exact: true })
+    await expect(status.getByRole("tab", { name: "MCP", exact: true })).toBeVisible()
+    await status.getByRole("tab", { name: "Plugins", exact: true }).click()
+    await expect(status.getByText("opencode.json", { exact: true })).toBeVisible()
+    await status.getByRole("button", { name: "Close", exact: true }).click()
+    await expect(status).toBeHidden()
+    await expect(more).toBeFocused()
+
+    await more.click()
+    await page.getByRole("menuitem", { name: "Session details", exact: true }).click()
+    const details = page.getByRole("dialog", { name: "Session details", exact: true })
+    await expect(details.getByText(fixture.project.name, { exact: true })).toBeVisible()
+    await expect(details.getByRole("button", { name: "No changes", exact: true })).toBeVisible()
+    await details.getByRole("button", { name: "Close", exact: true }).click()
+    await expect(details).toBeHidden()
+    await expect(more).toBeFocused()
+    await more.click()
+    await page.getByRole("menuitem", { name: "Session details", exact: true }).click()
+    await expect(details.getByRole("button", { name: "No changes", exact: true })).toBeVisible()
+    await expect(details).not.toHaveAttribute("data-transitioning")
+    await page.keyboard.press("Escape")
+    await expect(details).toBeHidden()
+    await expect(more).toBeFocused()
+    await more.click()
+    await page.getByRole("menuitem", { name: "Session details", exact: true }).click()
+    await details.getByRole("button", { name: "No changes", exact: true }).click()
+    await expect(details).toBeHidden()
+    await expect(picker).toHaveText("Changes")
+    await expect(page.getByText("No uncommitted changes yet", { exact: true })).toBeVisible()
+    await expect(page.locator('[data-slot="session-review-header"]')).toHaveCSS("height", "40px")
+    await expect(page.locator('[data-slot="session-review-header"]')).toHaveCSS("padding-left", "8px")
+    await expect(composer).toBeHidden()
+
+    await tabs.getByRole("tab", { name: "Files", exact: true }).click()
+    await expect(picker).toHaveText("Files")
+    await expect(page.getByRole("combobox", { name: "Filter files", exact: true })).toBeVisible()
+    await expect(composer).toBeHidden()
+
+    await tabs.getByRole("tab", { name: "Terminal", exact: true }).click()
+    const panel = page.locator("#terminal-panel")
+    await expect(panel).toHaveAttribute("data-opened", "true")
+    await expect(panel.getByRole("tab", { name: /Terminal 1/ })).toBeVisible()
+    await expect(panel.locator('[data-component="terminal"]')).toBeVisible()
+    await expect(panel.locator("textarea")).toBeEditable()
+    await expect(panel).toHaveCount(1)
+    await panel.evaluate((element) => element.setAttribute("data-cache-probe", "original"))
+    await expect(composer).toBeHidden()
+
+    await tabs.getByRole("tab", { name: "Session", exact: true }).click()
+    await expect(message).toBeVisible()
+    await expect(panel).toBeHidden()
+    await expect(panel).toHaveAttribute("inert", "")
+    await expect(panel).toHaveAttribute("data-cache-probe", "original")
+
+    await page.keyboard.press("Control+Backquote")
+    await expect(picker).toHaveText("Terminal")
+    await expect(panel).toBeVisible()
+    await expect(panel).toHaveAttribute("data-cache-probe", "original")
+    await page.keyboard.press("Control+Backquote")
+    await expect(picker).toHaveText("Session")
+
+    await page.keyboard.press("Control+Backquote")
+    await expect(picker).toHaveText("Terminal")
+    await panel.getByRole("button", { name: "Close terminal", exact: true }).click()
+    await expect(picker).toHaveText("Session")
+    await expect(panel).toBeHidden()
+
+    await more.click()
+    await page.getByRole("menuitem", { name: "Usage", exact: true }).click()
+    await expect(page.getByText("Total Cost", { exact: true })).toBeVisible()
+    await page.goto(stressSessionHref(fixture.sourceID))
+    await expect(picker).toHaveText("Session")
+    await expect(page.locator('[data-slot="mobile-tabs-trigger"]')).toContainText(fixture.expected.sourceTitle)
+
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await expect(picker).toBeHidden()
+    await expect(page.locator("[data-session-title]")).toBeVisible()
+  })
+}

--- a/packages/app/e2e/regression/mobile-shell.spec.ts
+++ b/packages/app/e2e/regression/mobile-shell.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from "@playwright/test"
+import { fixture } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+test.use({ viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true })
+
+test.beforeEach(async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory: fixture.directory,
+    project: fixture.project,
+    provider: fixture.provider,
+    sessions: fixture.sessions,
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.addInitScript(
+    ({ directory, server, sessions }) => {
+      localStorage.setItem(
+        "opencode.global.dat:server",
+        JSON.stringify({ projects: { local: [{ worktree: directory, expanded: true }] } }),
+      )
+      localStorage.setItem(
+        "opencode.window.browser.dat:tabs",
+        JSON.stringify(sessions.map((session) => ({ type: "session", server, sessionId: session.id }))),
+      )
+    },
+    { directory: fixture.directory, server: fixture.serverKey, sessions: fixture.sessions },
+  )
+  await page.goto("/")
+  await expect(page.locator('[data-component="home-session-row"]')).toHaveCount(fixture.sessions.length)
+})
+
+test("mobile project selection and drawer navigation preserve session identity", async ({ page }) => {
+  const projects = page.getByRole("button", { name: "Projects", exact: true })
+  await projects.click()
+  const picker = page.getByRole("dialog", { name: "Projects", exact: true })
+  await expect(picker.getByRole("button", { name: "All projects", exact: true })).toBeVisible()
+  await picker.getByRole("button", { name: new RegExp(` ${fixture.project.name}$`) }).click()
+  await expect(picker).toBeHidden()
+  await expect(projects).toContainText(fixture.project.name)
+
+  const trigger = page.locator('[data-slot="mobile-tabs-trigger"]')
+  const drawer = page.locator('[data-slot="mobile-tabs-drawer"]')
+  await trigger.click()
+  await expect(trigger).toHaveAttribute("aria-expanded", "true")
+  await expect(drawer.locator('[data-slot="tab-project"]')).toHaveText([fixture.project.name, fixture.project.name])
+  const settings = drawer.getByRole("button", { name: "Settings", exact: true })
+  const help = drawer.getByRole("button", { name: "Help", exact: true })
+  await expect(settings).toBeVisible()
+  await expect(help).toBeVisible()
+  expect((await settings.boundingBox())?.width).toBeGreaterThan((await help.boundingBox())?.width ?? 0)
+
+  await drawer.locator('[data-slot="tab-link"]').filter({ hasText: fixture.expected.sourceTitle }).click()
+  await expect(page).toHaveURL(new RegExp(`/session/${fixture.sourceID}$`))
+  await expect(drawer).toBeHidden()
+  await expect(trigger).toContainText(fixture.expected.sourceTitle)
+  await trigger.click()
+  await drawer.getByRole("button", { name: "Home", exact: true }).click()
+  await expect(page).toHaveURL("/")
+  await expect(drawer).toBeHidden()
+  await expect(page.locator('[data-component="home-session-row"]')).toHaveCount(fixture.sessions.length)
+})
+
+test("mobile settings section menu stays above a full-width panel", async ({ page }) => {
+  await page.locator('[data-slot="mobile-tabs-trigger"]').click()
+  await page.locator('[data-slot="mobile-tabs-drawer"]').getByRole("button", { name: "Settings", exact: true }).click()
+  const settings = page.getByTestId("settings-screen")
+  const menu = settings.getByRole("button", { name: "Preferences", exact: true })
+  const panel = settings.getByRole("tabpanel")
+  await expect(settings.getByRole("heading", { name: "General", exact: true })).toBeVisible()
+  await expect(menu).toBeVisible()
+  await menu.click()
+  await expect(page.getByRole("menuitemradio", { name: "Preferences", exact: true })).toBeChecked()
+  await page.keyboard.press("Escape")
+  await expect(page.getByRole("menuitemradio", { name: "Preferences", exact: true })).toBeHidden()
+  await expect(settings).toBeVisible()
+  await menu.click()
+  await page.getByRole("menuitemradio", { name: "Models", exact: true }).click()
+  await expect(settings.getByRole("heading", { name: "Models", exact: true })).toBeVisible()
+  await expect(settings.getByRole("button", { name: "Models", exact: true })).toBeVisible()
+  await expect(settings.getByRole("switch", { name: "Claude Opus 4.6", exact: true })).toBeAttached()
+  await expect
+    .poll(async () => {
+      const navigation = await settings.getByRole("button", { name: "Models", exact: true }).boundingBox()
+      const content = await panel.boundingBox()
+      return !!navigation && !!content && navigation.y + navigation.height <= content.y
+    })
+    .toBe(true)
+  await expect.poll(async () => (await panel.boundingBox())?.width ?? 0).toBeGreaterThan(350)
+  await settings.getByRole("button", { name: "Back to app", exact: true }).click()
+  await expect(settings).toBeHidden()
+  await expect(page.locator('[data-component="home-session-row"]')).toHaveCount(fixture.sessions.length)
+})

--- a/packages/app/e2e/regression/mobile-status-drawer.spec.ts
+++ b/packages/app/e2e/regression/mobile-status-drawer.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test"
+import { fixture } from "../performance/timeline/session-timeline-stress.fixture"
+import { mockStressTimeline, stressSessionHref } from "../performance/timeline/timeline-test-helpers"
+
+test("status drawer dismisses and reopens after button, backdrop, Escape, and drag", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 })
+  await mockStressTimeline(page)
+  await page.goto(stressSessionHref(fixture.targetID))
+  const more = page
+    .locator('[data-slot="session-mobile-view-navigation"]')
+    .getByRole("button", { name: "More options", exact: true })
+  const drawer = page.getByRole("dialog", { name: "Status", exact: true })
+  const overlay = page.locator('[data-slot="mobile-status-overlay"]')
+
+  for (const dismissal of ["button", "backdrop", "escape", "drag", "button"] as const) {
+    await more.click()
+    await page.getByRole("menuitem", { name: "Status", exact: true }).click()
+    await expect(drawer.getByRole("tab", { name: "MCP", exact: true })).toBeVisible()
+    await expect(drawer).not.toHaveAttribute("data-transitioning")
+    if (dismissal === "button") await drawer.getByRole("button", { name: "Close", exact: true }).click()
+    if (dismissal === "backdrop") await overlay.click({ position: { x: 10, y: 10 } })
+    if (dismissal === "escape") await page.keyboard.press("Escape")
+    if (dismissal === "drag") {
+      const handle = drawer.locator('[data-slot="mobile-status-drag-handle"]')
+      const bounds = await handle.boundingBox()
+      expect(bounds).not.toBeNull()
+      await page.mouse.move(bounds!.x + bounds!.width / 2, bounds!.y + bounds!.height / 2)
+      await page.mouse.down()
+      await page.mouse.move(bounds!.x + bounds!.width / 2, bounds!.y + bounds!.height / 2 + 1)
+      await page.mouse.move(bounds!.x + bounds!.width / 2, 843)
+      await page.mouse.up()
+    }
+    await expect(drawer, `dismissal: ${dismissal}`).toBeHidden()
+    await expect(overlay).toHaveCount(0)
+    await expect(more).toBeFocused()
+  }
+})

--- a/packages/app/e2e/regression/review-line-comment.spec.ts
+++ b/packages/app/e2e/regression/review-line-comment.spec.ts
@@ -89,7 +89,7 @@ async function openReview(page: Page) {
   )
   await changes.click()
   expect((await (await diffResponse).json()).data).toHaveLength(1)
-  await expect(page.getByRole("tab", { selected: true })).toHaveAccessibleName(/Files Changed/)
+  await expect(changes).toHaveAttribute("aria-selected", "true")
 
   const review = page.locator('[data-component="session-review"]')
   await expectAppVisible(review)

--- a/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
+++ b/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
@@ -69,7 +69,7 @@ test("keyboard navigation follows the visible tab order", async ({ page }) => {
   await expect(page).toHaveURL(new RegExp(`${hrefC.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`))
 })
 
-test("cramped tabs only show the close button for the active tab", async ({ page }) => {
+test("mobile drawer exposes close controls and navigates between tabs", async ({ page }) => {
   await page.setViewportSize({ width: 360, height: 720 })
   await mockServer(page)
   await page.addInitScript(
@@ -89,26 +89,31 @@ test("cramped tabs only show the close button for the active tab", async ({ page
   const hrefA = `/server/${base64Encode(server)}/session/${sessionA.id}`
   const hrefB = `/server/${base64Encode(server)}/session/${sessionB.id}`
   await page.goto(hrefA)
+  await page.getByRole("button", { name: "Tabs", exact: true }).click()
 
   const tabA = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefA}"])`)
   const tabB = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefB}"])`)
   await expect(tabA).toHaveAttribute("data-active", "true")
   await expect(tabB).toBeVisible()
   await expect(tabA.locator('[data-slot="tab-close"]')).toBeVisible()
-  await expect(tabB.locator('[data-slot="tab-close"]')).toBeHidden()
+  await expect(tabB.locator('[data-slot="tab-close"]')).toBeVisible()
 
   await tabB.locator(`a[href="${hrefB}"]`).click()
 
   await expect(page).toHaveURL(new RegExp(`${hrefB.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`))
-  await expect(tabA.locator('[data-slot="tab-close"]')).toBeHidden()
+  await expect(page.getByRole("dialog", { name: "Tabs", exact: true })).toBeHidden()
+  await page.getByRole("button", { name: "Tabs", exact: true }).click()
+  await expect(tabA.locator('[data-slot="tab-close"]')).toBeVisible()
   await expect(tabB.locator('[data-slot="tab-close"]')).toBeVisible()
 
   for (const direction of ["ltr", "rtl"]) {
     await page.evaluate((direction) => document.documentElement.setAttribute("dir", direction), direction)
     await page.setViewportSize({ width: 450, height: 720 })
-    await expect(tabA.locator("[data-titlebar-tab]")).toHaveAttribute("data-title-overflow", "true")
+    await expect(tabA).toBeVisible()
     await page.setViewportSize({ width: 1280, height: 720 })
     await expect(tabA.locator("[data-titlebar-tab]")).toHaveAttribute("data-title-overflow", "false")
+    await page.setViewportSize({ width: 450, height: 720 })
+    await page.getByRole("button", { name: "Tabs", exact: true }).click()
   }
 })
 
@@ -202,28 +207,28 @@ test("appearance experimental setting switches tab orientation", async ({ page }
 
   await page.setViewportSize({ width: 920, height: 720 })
   await expect(page.locator('[data-slot="vertical-tabs-sidebar"]')).toHaveCSS("width", "260px")
-  await expect(settings.getByRole("tablist")).toHaveCSS("width", "160px")
+  await expect(settings.getByRole("tablist")).toBeHidden()
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeVisible()
 
   await page.setViewportSize({ width: 800, height: 720 })
-  await expect(settings.getByRole("tablist")).toHaveCSS("width", "160px")
-  await expect(version).toBeInViewport()
+  await expect(settings.getByRole("tablist")).toBeHidden()
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeVisible()
 
   await page.setViewportSize({ width: 390, height: 720 })
-  await expect(version).toBeInViewport()
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeVisible()
   await settings.evaluate((element) => element.setAttribute("dir", "rtl"))
-  await expect(version).toBeInViewport()
-  await expect(version).toHaveCSS("direction", "ltr")
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeInViewport()
 
   await page.setViewportSize({ width: 390, height: 360 })
-  await version.scrollIntoViewIfNeeded()
-  await expect(version).toBeInViewport()
+  await expect(settings.getByRole("button", { name: "Appearance", exact: true })).toBeInViewport()
 
   // Reload the UI-selected preference without seeding settings storage.
   await page.reload()
   const href = `/server/${base64Encode(server)}/session/${sessionA.id}`
+  await page.getByRole("button", { name: "Tabs", exact: true }).click()
   await expect(
     page
-      .locator('[data-slot="titlebar-tabs"]')
+      .locator('[data-slot="mobile-tabs-drawer"]')
       .locator(`[data-titlebar-tab-link][href="${href}"]`)
       .getByText(sessionA.title, { exact: true }),
   ).toBeVisible()
@@ -242,7 +247,7 @@ test("appearance experimental setting switches tab orientation", async ({ page }
   await expect(layout).toContainText("Vertical")
 })
 
-test("vertical tab preference falls back to horizontal on mobile", async ({ page }) => {
+test("vertical tab preference uses the drawer on mobile", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 720 })
   await mockServer(page)
   await page.addInitScript(
@@ -259,7 +264,8 @@ test("vertical tab preference falls back to horizontal on mobile", async ({ page
   const href = `/server/${base64Encode(server)}/session/${sessionA.id}`
   await page.goto(href)
 
-  const tabs = page.locator('[data-slot="titlebar-tabs"]')
+  await page.getByRole("button", { name: "Tabs", exact: true }).click()
+  const tabs = page.locator('[data-slot="mobile-tabs-drawer"]')
   await expect(tabs.locator(`[data-titlebar-tab-link][href="${href}"]`)).toContainText(sessionA.title)
   await expect(page.locator('[data-slot="vertical-tabs-sidebar"]')).toHaveCount(0)
 

--- a/packages/app/e2e/utils/waits.ts
+++ b/packages/app/e2e/utils/waits.ts
@@ -8,6 +8,12 @@ export async function expectAppVisible(locator: Locator) {
 }
 
 export async function expectSessionTitle(page: Page, title: string) {
+  if ((page.viewportSize()?.width ?? 1280) < 768) {
+    const trigger = page.locator('[data-slot="mobile-tabs-trigger"]')
+    await expectAppVisible(trigger)
+    await expect(trigger.locator('span[dir="auto"]')).toHaveText(title, { timeout: APP_READY_TIMEOUT })
+    return
+  }
   await expectAppVisible(page.getByRole("heading", { name: title }))
 }
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -56,6 +56,7 @@
     "vite-plugin-solid": "2.11.14"
   },
   "dependencies": {
+    "@corvu/drawer": "catalog:",
     "@dnd-kit/abstract": "0.5.0",
     "@dnd-kit/dom": "0.5.0",
     "@dnd-kit/helpers": "0.5.0",

--- a/packages/app/src/home/projects/region.tsx
+++ b/packages/app/src/home/projects/region.tsx
@@ -2,9 +2,14 @@ import type { HomeProjectsController } from "./controller"
 import { HomeProjectsView } from "./view"
 import type { HomeScrollController } from "../scroll"
 
-export function HomeProjects(props: { projects: HomeProjectsController; scroll: HomeScrollController }) {
+export function HomeProjects(props: {
+  projects: HomeProjectsController
+  scroll: HomeScrollController
+  dropdown?: boolean
+}) {
   return (
     <HomeProjectsView
+      dropdown={props.dropdown}
       language={props.projects.copy.language}
       servers={props.projects.server.list()}
       projects={props.projects.project.list()}

--- a/packages/app/src/home/projects/view.tsx
+++ b/packages/app/src/home/projects/view.tsx
@@ -1,5 +1,6 @@
 import { createMemo, For, type JSX, onCleanup, Show, splitProps } from "solid-js"
 import { createStore } from "solid-js/store"
+import { Popover } from "@kobalte/core/popover"
 import { DragDropProvider, PointerSensor } from "@dnd-kit/solid"
 import { isSortable, useSortable } from "@dnd-kit/solid/sortable"
 import { AutoScroller, Feedback, PointerActivationConstraints } from "@dnd-kit/dom"
@@ -28,6 +29,7 @@ const projectContextMenuID = (server: ServerConnection.Any, directory: string) =
   `project:${ServerConnection.key(server)}:${directory}`
 
 export type HomeProjectsViewProps = {
+  dropdown?: boolean
   language: ReturnType<typeof useLanguage>
   servers: ServerConnection.Any[]
   projects: LocalProject[]
@@ -64,6 +66,81 @@ export type HomeProjectsViewProps = {
 }
 
 export function HomeProjectsView(props: HomeProjectsViewProps) {
+  const [state, setState] = createStore({ open: false })
+  const selected = createMemo(() => props.projects.find((project) => project.worktree === props.selection.directory))
+  const server = createMemo(() =>
+    props.servers.find((server) => ServerConnection.key(server) === props.selection.server),
+  )
+  return (
+    <Show when={props.dropdown} fallback={<HomeProjectsPanel {...props} />}>
+      <Popover
+        open={state.open}
+        onOpenChange={(open) => setState("open", open)}
+        placement="bottom-start"
+        sameWidth
+        gutter={6}
+      >
+        <Popover.Trigger
+          data-component="home-projects-dropdown"
+          aria-label={props.language.t("home.projects")}
+          class="flex h-10 w-full min-w-0 items-center gap-2 rounded-[6px] bg-v2-background-bg-base px-1.5 text-start text-v2-text-text-base outline-none hover:bg-v2-background-bg-layer-01"
+        >
+          <Show when={selected()} fallback={<Icon name="folder" size="small" />}>
+            {(project) => <HomeProjectAvatar project={project()} />}
+          </Show>
+          <span class="flex min-w-0 flex-1 flex-col leading-[var(--line-height-compact)]">
+            <bdi class="truncate">
+              <Show when={selected()} fallback={props.language.t("home.projects.all")}>
+                {(project) => displayName(project())}
+              </Show>
+            </bdi>
+            <Show when={props.servers.length > 1 && server()}>
+              {(server) => (
+                <bdi class="truncate text-v2-text-text-muted opacity-70">
+                  {server().displayName ?? new URL(server().http.url).host}
+                </bdi>
+              )}
+            </Show>
+          </span>
+          <Icon name="chevron-down" size="small" class="shrink-0 text-v2-icon-icon-muted" />
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Content
+            aria-label={props.language.t("home.projects")}
+            dir={props.language.direction()}
+            class="z-50 max-h-[min(70dvh,var(--kb-popper-content-available-height))] overflow-hidden rounded-[10px] bg-v2-background-bg-base p-1.5 shadow-[var(--v2-elevation-floating)] outline-none data-[expanded]:animate-in data-[expanded]:fade-in data-[expanded]:slide-in-from-top-2 duration-150 ease-out motion-reduce:animate-none"
+          >
+            <HomeProjectsPanel
+              {...props}
+              onSelectProject={(server, directory) => {
+                props.onSelectProject(server, directory)
+                setState("open", false)
+              }}
+              onFocusServer={(server) => {
+                props.onFocusServer(server)
+                setState("open", false)
+              }}
+              onChooseProject={(server) => {
+                setState("open", false)
+                props.onChooseProject(server)
+              }}
+              onAddProjects={(server, directories) => {
+                setState("open", false)
+                props.onAddProjects(server, directories)
+              }}
+              onOpenProjectNewSession={(server, directory) => {
+                setState("open", false)
+                props.onOpenProjectNewSession(server, directory)
+              }}
+            />
+          </Popover.Content>
+        </Popover.Portal>
+      </Popover>
+    </Show>
+  )
+}
+
+function HomeProjectsPanel(props: HomeProjectsViewProps) {
   const [contextMenu, setContextMenu] = createStore({ open: undefined as string | undefined })
   const contextMenuProps = {
     contextMenuOpen: (id: string) => contextMenu.open === id,
@@ -71,48 +148,77 @@ export function HomeProjectsView(props: HomeProjectsViewProps) {
   }
   return (
     <aside
-      class={`
+      class={
+        props.dropdown
+          ? "flex max-h-[min(60dvh,calc(var(--kb-popper-content-available-height)-12px))] min-h-0 min-w-0 flex-col overflow-hidden"
+          : `
         mt-6 flex min-h-0 min-w-0 flex-col gap-4 overflow-hidden
         lg:sticky lg:top-14 lg:mt-14 lg:h-[calc(100cqh-56px)] lg:self-start lg:pt-[52px]
-      `}
+      `
+      }
       aria-label={props.language.t("home.projects")}
       onWheel={(event) => {
         if (event.target === event.currentTarget) return
         props.onWheel(event)
       }}
     >
-      <div class="flex h-7 min-w-0 shrink-0 items-center justify-between pl-1.5 pr-3">
-        <div class="text-v2-text-text-muted [font-weight:530]">{props.language.t("home.projects")}</div>
-        <Show when={props.servers.length === 1 && !(props.projects.length === 0 && props.recentlyClosed.length > 0)}>
-          <Tooltip placement="bottom" value={props.language.t("home.project.add")}>
-            <IconButton
-              data-action="home-add-project"
-              variant="ghost-muted"
-              size="large"
-              class="titlebar-icon [&_[data-slot=icon-svg]]:text-v2-icon-icon-muted"
-              icon={<Icon name="folder-add-left" />}
-              disabled={props.serverHealth(props.servers[0])?.healthy === false}
-              onClick={() => props.onChooseProject(props.servers[0])}
-              aria-label={props.language.t("home.project.add")}
-            />
-          </Tooltip>
-        </Show>
-      </div>
+      <Show when={!props.dropdown}>
+        <div class="flex h-7 min-w-0 shrink-0 items-center justify-between pl-1.5 pr-3">
+          <div class="text-v2-text-text-muted [font-weight:530]">{props.language.t("home.projects")}</div>
+          <Show when={props.servers.length === 1 && !(props.projects.length === 0 && props.recentlyClosed.length > 0)}>
+            <Tooltip placement="bottom" value={props.language.t("home.project.add")}>
+              <IconButton
+                data-action="home-add-project"
+                variant="ghost-muted"
+                size="large"
+                class="titlebar-icon [&_[data-slot=icon-svg]]:text-v2-icon-icon-muted"
+                icon={<Icon name="folder-add-left" />}
+                disabled={props.serverHealth(props.servers[0])?.healthy === false}
+                onClick={() => props.onChooseProject(props.servers[0])}
+                aria-label={props.language.t("home.project.add")}
+              />
+            </Tooltip>
+          </Show>
+        </div>
+      </Show>
       <ScrollView data-slot="home-projects-scroll" class="min-h-0 min-w-0 shrink">
+        <Show when={props.dropdown && props.servers.length === 1}>
+          <HomeProjectNavButton
+            type="button"
+            class="mb-1"
+            data-selected={!props.selection.directory ? "" : undefined}
+            onClick={() => props.onFocusServer(props.servers[0])}
+          >
+            <Icon name="folder" size="small" />
+            <span class={HOME_PROJECT_NAV_LABEL}>{props.language.t("home.projects.all")}</span>
+          </HomeProjectNavButton>
+        </Show>
         <Show
           when={props.servers.length > 1}
           fallback={
-            <div class="pr-3">
+            <div class={props.dropdown ? "" : "pr-3"}>
               <Show
                 when={props.projects.length > 0}
                 fallback={<HomeProjectEmpty {...props} server={props.servers[0]} items={props.recentlyClosed} />}
               >
                 <HomeProjectList {...props} {...contextMenuProps} server={props.servers[0]} items={props.projects} />
+                <Show when={props.dropdown}>
+                  <HomeProjectNavButton
+                    type="button"
+                    data-action="home-add-project-row"
+                    class="mt-1 disabled:opacity-60"
+                    disabled={props.serverHealth(props.servers[0])?.healthy === false}
+                    onClick={() => props.onChooseProject(props.servers[0])}
+                  >
+                    <Icon name="folder-add-left" size="small" />
+                    <span class={HOME_PROJECT_NAV_LABEL}>{props.language.t("home.project.add")}</span>
+                  </HomeProjectNavButton>
+                </Show>
               </Show>
             </div>
           }
         >
-          <div class="flex min-w-0 flex-col gap-4 pr-3">
+          <div class={`flex min-w-0 flex-col ${props.dropdown ? "gap-1" : "gap-4 pr-3"}`}>
             <For each={props.servers}>
               {(item) => {
                 const projects = () => props.projectsForServer(item)
@@ -157,7 +263,9 @@ export function HomeUtilityNav(props: {
   language: ReturnType<typeof useLanguage>
 }) {
   return (
-    <div class={`${props.class ?? ""} min-w-0 flex-col gap-1 pr-3`}>
+    <div
+      class={`${props.class ?? ""} min-w-0 flex-row justify-between gap-1 lg:flex-col lg:justify-start lg:pr-3 [&>button]:w-auto lg:[&>button]:w-full`}
+    >
       <HomeProjectNavButton
         type="button"
         class="text-v2-text-text-faint [&>[data-slot=icon-svg]]:text-v2-icon-icon-muted"
@@ -511,6 +619,7 @@ function HomeProjectRow(
           // does not focus that server and load its session index. Touch is
           // excluded so flick-scrolling the list cannot select rows.
           pointerDownSelected = undefined
+          if (props.dropdown) return
           if (event.button !== 0 || event.pointerType === "touch") return
           if (!props.serverSelected) return
           pointerDownSelected = props.selected

--- a/packages/app/src/home/route.tsx
+++ b/packages/app/src/home/route.tsx
@@ -1,4 +1,6 @@
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
+import { createMediaQuery } from "@solid-primitives/media"
+import { Show } from "solid-js"
 import { createHomeController } from "./model"
 import { createHomeProjectsController } from "./projects/controller"
 import { HomeUtilityNav } from "./projects/view"
@@ -9,6 +11,7 @@ import { createHomeSessionsController } from "./sessions/controller"
 import { HomeSessions } from "./sessions/region"
 
 export function Home() {
+  const mobile = createMediaQuery("(max-width: 767px)")
   const home = createHomeController()
   const projects = createHomeProjectsController(home)
   const sessions = createHomeSessionsController(home)
@@ -17,12 +20,17 @@ export function Home() {
   return (
     <div
       class={`
-        mx-2 mb-2 mt-[var(--shell-top-inset,8px)] min-h-0 flex-1 self-stretch overflow-hidden rounded-[10px]
+        mx-2 mb-[var(--shell-bottom-inset,8px)] mt-[var(--shell-top-inset,8px)] flex min-h-0 flex-1 flex-col self-stretch overflow-hidden rounded-[10px]
         bg-v2-background-bg-base shadow-[var(--v2-elevation-raised)]
       `}
     >
+      <Show when={mobile()}>
+        <div class="relative z-40 -mb-3 shrink-0 px-3 pt-3">
+          <HomeProjects projects={projects} scroll={scroll} dropdown />
+        </div>
+      </Show>
       <ScrollView
-        class="h-full [container-type:size]"
+        class="min-h-0 flex-1 [container-type:size]"
         thumbContainer={scroll.viewport.thumbTrack()}
         thumbHoverTarget={scroll.viewport.hoverTarget()}
         viewportRef={scroll.viewport.setViewport}
@@ -31,20 +39,24 @@ export function Home() {
       >
         <div
           class={`
-            mx-auto grid min-h-full w-full max-w-[1080px] grid-rows-[auto_minmax(0,1fr)_auto] gap-4 px-3
-            lg:grid-cols-[280px_minmax(0,720px)] lg:grid-rows-1 lg:gap-8 lg:px-6
+            mx-auto grid min-h-full w-full max-w-[1080px] grid-rows-[auto_minmax(0,1fr)] gap-4 px-3
+            max-md:grid-rows-[minmax(0,1fr)] lg:grid-cols-[280px_minmax(0,720px)] lg:grid-rows-1 lg:gap-8 lg:px-6
           `}
         >
-          <HomeProjects projects={projects} scroll={scroll} />
+          <Show when={!mobile()}>
+            <HomeProjects projects={projects} scroll={scroll} />
+          </Show>
           <HomeSessions sessions={sessions} search={search} scroll={scroll} />
-          <HomeUtilityNav
-            class="flex lg:hidden"
-            onOpenSettings={projects.utility.settings}
-            onOpenHelp={projects.utility.help}
-            language={projects.copy.language}
-          />
         </div>
       </ScrollView>
+      <div class="hidden shrink-0 px-3 py-2 md:block lg:hidden">
+        <HomeUtilityNav
+          class="flex"
+          onOpenSettings={projects.utility.settings}
+          onOpenHelp={projects.utility.help}
+          language={projects.copy.language}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/app/src/home/sessions/view.css
+++ b/packages/app/src/home/sessions/view.css
@@ -1,0 +1,26 @@
+@media (max-width: 767px) {
+  [data-component="home-session-row-container"][data-project-name="true"],
+  [data-component="home-session-row-container"][data-project-name="true"] [data-component="home-session-row"],
+  [data-component="home-session-row-container"][data-project-name="true"] [data-slot="home-session-editor"],
+  [data-component="home-session-search-row"][data-project-name="true"] {
+    height: 48px;
+    padding-block: 0;
+  }
+
+  [data-project-name="true"] [data-slot="home-session-labels"] {
+    display: flex;
+    min-width: 0;
+    flex: 1;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0;
+    text-align: start;
+  }
+
+  [data-project-name="true"] [data-slot="home-session-labels"] > * {
+    max-width: 100%;
+    flex: none;
+    font-size: 13px;
+    line-height: var(--line-height-compact);
+  }
+}

--- a/packages/app/src/home/sessions/view.tsx
+++ b/packages/app/src/home/sessions/view.tsx
@@ -15,6 +15,7 @@ import { ServerConnection } from "@/runtime/server/registry"
 import { SessionTabAvatarView } from "@/shell/layout/session-tab-avatar"
 import { sessionLabel } from "@/session/title"
 import { shouldOpenSessionInBackground } from "./open"
+import "./view.css"
 import {
   HomeSessionStatusController,
   homeSessionSearchKey,
@@ -96,10 +97,13 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
       class="min-h-0 min-w-0 flex-1 flex flex-col"
       aria-label={props.language.t("sidebar.project.recentSessions")}
     >
-      <div class="sticky top-0 z-30 shrink-0 bg-v2-background-bg-base pb-3 pt-6 lg:pt-12" onWheel={props.onWheel}>
+      <div
+        class="sticky top-0 z-30 shrink-0 bg-v2-background-bg-base pb-1 pt-6 md:pb-3 lg:pt-12"
+        onWheel={props.onWheel}
+      >
         <HomeSessionSearch {...props} />
         <Show when={props.groups.length > 0 && props.canCreateSession}>
-          <div class="pointer-events-none absolute right-0 top-[84px] z-20 flex lg:top-[108px]">
+          <div class="pointer-events-none absolute right-0 top-[68px] z-20 flex md:top-[84px] lg:top-[108px]">
             <Button
               data-action="home-new-session"
               variant="ghost-muted"
@@ -113,18 +117,18 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
           </div>
         </Show>
       </div>
-      <div class="pointer-events-none sticky top-[84px] z-40 h-0 -mr-3 lg:top-[108px]">
+      <div class="pointer-events-none sticky top-[68px] z-40 h-0 -mr-3 md:top-[84px] lg:top-[108px]">
         <div
           ref={props.onSetThumbTrack}
           data-component="home-session-scroll-track"
-          class="relative ml-auto h-[calc(100cqh-84px)] w-3 lg:h-[calc(100cqh-108px)]"
+          class="relative ml-auto h-[calc(100cqh-68px)] w-3 md:h-[calc(100cqh-84px)] lg:h-[calc(100cqh-108px)]"
         />
       </div>
-      <div class="-mr-3 min-h-[calc(100cqh-72px)] lg:min-h-[calc(100cqh-96px)]">
+      <div class="-mr-3 min-h-[calc(100cqh-64px)] md:min-h-[calc(100cqh-72px)] lg:min-h-[calc(100cqh-96px)]">
         <Show
           when={!props.loading}
           fallback={
-            <div class="pt-3">
+            <div class="pt-1 md:pt-3">
               <HomeSessionSkeleton label={props.language.t("common.loading")} />
             </div>
           }
@@ -138,7 +142,7 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
               />
             }
           >
-            <div ref={props.onSetContent} class="flex flex-col pt-3 pr-3 pb-16">
+            <div ref={props.onSetContent} class="flex flex-col pt-1 pr-3 pb-16 md:pt-3">
               {/* Index keeps group subtrees mounted when the group arrays are
                   rebuilt, so store updates cannot recreate rows mid-gesture. */}
               <Index each={props.groups}>
@@ -150,7 +154,9 @@ export function HomeSessionsView(props: HomeSessionsViewProps) {
                       onSetRef={(element) => props.onSetHeader(group().id, element)}
                       elevated={index === 0}
                     />
-                    <div class={`flex min-w-0 flex-col gap-px pt-4 ${index === props.groups.length - 1 ? "" : "mb-6"}`}>
+                    <div
+                      class={`flex min-w-0 flex-col gap-px pt-2 md:pt-4 ${index === props.groups.length - 1 ? "" : "mb-6"}`}
+                    >
                       {/* Rows key by session ID: session.sync replaces the
                           stored session object wholesale, so reference-keyed
                           rows would be disposed mid-interaction whenever a
@@ -235,7 +241,11 @@ function HomeSessionSearch(props: HomeSessionsViewProps) {
               absolute flex flex-col overflow-hidden rounded-[12px]
               bg-v2-background-bg-base shadow-[var(--v2-elevation-floating)]
             `}
-            style={{ top: "-6px", left: "-6px", width: "calc(100% + 12px)" }}
+            style={{
+              top: "-6px",
+              "inset-inline-start": "-6px",
+              width: "calc(100% + 12px)",
+            }}
           >
             <div class="flex flex-col pt-9">
               <div id={HOME_SESSION_SEARCH_RESULTS_ID} role="listbox" class="flex flex-col gap-4 pt-4">
@@ -269,7 +279,7 @@ function HomeSessionSearch(props: HomeSessionsViewProps) {
                       >
                         {props.language.t("home.sessions.search.sessions")}
                       </p>
-                      <ScrollView class="max-h-80" viewportRef={props.onSetSearchList}>
+                      <ScrollView class="max-h-[min(20rem,40dvh)]" viewportRef={props.onSetSearchList}>
                         <div class="flex flex-col gap-px pb-2">
                           <For each={props.searchResults}>
                             {(record) => (
@@ -291,7 +301,7 @@ function HomeSessionSearch(props: HomeSessionsViewProps) {
         </Show>
         <label
           class={`
-            relative z-20 flex h-9 w-full items-center gap-2 rounded-[6px] py-1 pl-3 pr-2
+            relative z-20 flex h-9 w-full items-center gap-2 rounded-[6px] py-1 ps-3 pe-2
             bg-v2-background-bg-layer-02/60 text-v2-icon-icon-muted transition-[background-color,box-shadow]
             duration-[120ms] ease-in-out hover:bg-v2-background-bg-layer-02 focus-within:bg-v2-background-bg-layer-02
           `}
@@ -375,6 +385,7 @@ function HomeSessionSearchResultRow(
       id={`home-session-search-option-${key()}`}
       data-key={key()}
       data-component="home-session-search-row"
+      data-project-name={!!showProjectName()}
       role="option"
       aria-selected={props.selected}
       class={`
@@ -403,7 +414,7 @@ function HomeSessionSearchResultRow(
         record={props.record}
         revealProjectOnHover={!!showProjectName()}
       />
-      <div class="flex min-w-0 flex-1 items-center gap-1.5">
+      <div data-slot="home-session-labels" class="flex min-w-0 flex-1 items-center gap-1.5">
         <HomeSessionTitle title={title()} showProjectName={!!showProjectName()} search />
         <Show when={showProjectName()}>
           <HomeSessionProjectName name={props.record.projectName} search />
@@ -423,8 +434,8 @@ function HomeSessionGroupHeader(props: {
     <div
       ref={props.onSetRef}
       class={`
-        pointer-events-none sticky top-[84px] flex h-7 min-w-0 items-center justify-between
-        bg-v2-background-bg-base pl-3 lg:top-[108px]
+        pointer-events-none sticky top-[68px] flex h-7 min-w-0 items-center justify-between
+        bg-v2-background-bg-base ps-1.5 md:ps-3 md:top-[84px] lg:top-[108px]
       `}
       classList={{ "home-session-group-header z-[5]": !!props.elevated, "z-10": !props.elevated }}
     >
@@ -510,6 +521,7 @@ function HomeSessionRow(
   return (
     <div
       data-component="home-session-row-container"
+      data-project-name={!!showProjectName()}
       data-session-id={props.record.session.id}
       class="group/session relative flex h-10 min-w-0 items-center rounded-[6px] outline-none focus:outline-none focus-visible:outline-none"
       classList={{ group: !!showProjectName() }}
@@ -523,51 +535,56 @@ function HomeSessionRow(
       <Show
         when={!editor()}
         fallback={
-          <div class="flex h-10 min-w-0 w-full flex-1 items-center gap-2 py-3 pl-3 pr-10">
+          <div
+            data-slot="home-session-editor"
+            class="flex h-10 min-w-0 w-full flex-1 items-center gap-2 py-3 ps-1.5 pe-3 md:ps-3 md:pe-10"
+          >
             <HomeSessionLeadingController
               server={props.server}
               isOpenTab={props.isOpenTab}
               record={props.record}
               revealProjectOnHover={false}
             />
-            <InlineInput
-              data-component="home-session-rename"
-              aria-label={props.language.t("common.rename")}
-              dir="auto"
-              value={editor()?.draft ?? ""}
-              disabled={editor()?.renaming ?? false}
-              class={`
+            <div data-slot="home-session-labels" class="contents">
+              <InlineInput
+                data-component="home-session-rename"
+                aria-label={props.language.t("common.rename")}
+                dir="auto"
+                value={editor()?.draft ?? ""}
+                disabled={editor()?.renaming ?? false}
+                class={`
                 block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-base
                 [font-weight:530] field-sizing-content outline-none focus:outline-none focus-visible:outline-none
                 ${showProjectName() ? "max-w-[min(70%,480px)] flex-[0_1_auto]" : "flex-[1_1_auto]"}
               `}
-              style={{ "--inline-input-shadow": "none", "text-align": "start" }}
-              onInput={(event) => {
-                const draft = event.currentTarget.value
-                props.setRowUI("editor", (value) => (value?.id === sessionID() ? { ...value, draft } : value))
-              }}
-              onKeyDown={(event) => {
-                event.stopPropagation()
-                // Enter and Escape during IME composition commit or cancel
-                // the composition, not the rename. Safari can report the
-                // composition-confirming keydown with isComposing false but
-                // keyCode 229.
-                if (event.isComposing || event.keyCode === 229) return
-                if (event.key === "Enter") {
+                style={{ "--inline-input-shadow": "none", "text-align": "start" }}
+                onInput={(event) => {
+                  const draft = event.currentTarget.value
+                  props.setRowUI("editor", (value) => (value?.id === sessionID() ? { ...value, draft } : value))
+                }}
+                onKeyDown={(event) => {
+                  event.stopPropagation()
+                  // Enter and Escape during IME composition commit or cancel
+                  // the composition, not the rename. Safari can report the
+                  // composition-confirming keydown with isComposing false but
+                  // keyCode 229.
+                  if (event.isComposing || event.keyCode === 229) return
+                  if (event.key === "Enter") {
+                    event.preventDefault()
+                    void saveEditor()
+                    return
+                  }
+                  if (event.key !== "Escape") return
                   event.preventDefault()
-                  void saveEditor()
-                  return
-                }
-                if (event.key !== "Escape") return
-                event.preventDefault()
-                closeEditor()
-                requestAnimationFrame(() => rowButton()?.focus())
-              }}
-              onBlur={closeEditor}
-            />
-            <Show when={showProjectName()}>
-              <HomeSessionProjectName name={props.record.projectName} />
-            </Show>
+                  closeEditor()
+                  requestAnimationFrame(() => rowButton()?.focus())
+                }}
+                onBlur={closeEditor}
+              />
+              <Show when={showProjectName()}>
+                <HomeSessionProjectName name={props.record.projectName} />
+              </Show>
+            </div>
           </div>
         }
       >
@@ -578,7 +595,7 @@ function HomeSessionRow(
           aria-expanded={!!menu()}
           class={`
             flex h-10 min-w-0 w-full flex-1 shrink-0 cursor-default items-center gap-2 rounded-[6px] border-0
-            bg-transparent py-3 pl-3 pr-10 text-left text-v2-text-text-muted [font-weight:530]
+            bg-transparent py-3 ps-1.5 pe-3 md:ps-3 md:pe-10 text-start text-v2-text-text-muted [font-weight:530]
             transition-[background-color,color,box-shadow] duration-[120ms] ease-in-out
             hover:bg-v2-overlay-simple-overlay-hover focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:outline-none
           `}
@@ -641,10 +658,12 @@ function HomeSessionRow(
             record={props.record}
             revealProjectOnHover={!!showProjectName()}
           />
-          <HomeSessionTitle title={title()} showProjectName={!!showProjectName()} />
-          <Show when={showProjectName()}>
-            <HomeSessionProjectName name={props.record.projectName} />
-          </Show>
+          <div data-slot="home-session-labels" class="contents">
+            <HomeSessionTitle title={title()} showProjectName={!!showProjectName()} />
+            <Show when={showProjectName()}>
+              <HomeSessionProjectName name={props.record.projectName} />
+            </Show>
+          </div>
         </button>
       </Show>
       <Menu
@@ -723,6 +742,7 @@ function HomeSessionTitle(props: { title: string; showProjectName: boolean; sear
   return (
     <span
       data-component="home-session-title"
+      dir="auto"
       class="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-base [font-weight:530]"
       classList={{
         "text-[13px] leading-4 tracking-[-0.04px]": !!props.search,
@@ -738,6 +758,8 @@ function HomeSessionTitle(props: { title: string; showProjectName: boolean; sear
 function HomeSessionProjectName(props: { name: string; search?: boolean }) {
   return (
     <span
+      data-component="home-session-project-name"
+      dir="auto"
       class="min-w-0 flex-[1_1_auto] overflow-hidden text-ellipsis whitespace-nowrap text-v2-text-text-muted [font-weight:440]"
       classList={{ "text-[13px] leading-4 tracking-[-0.04px]": !!props.search }}
     >
@@ -779,7 +801,7 @@ function HomeSessionsEmpty(props: { onNewSession?: () => void; language: ReturnT
 function HomeSessionSkeleton(props: { label: string }) {
   return (
     <div class="flex min-w-0 flex-col gap-4">
-      <div class="flex h-7 min-w-0 items-center justify-between px-4">
+      <div class="flex h-7 min-w-0 items-center justify-between ps-1.5 pe-4 md:ps-4">
         <div class={HOME_SECTION_LABEL}>{props.label}</div>
       </div>
       <div class="flex min-w-0 flex-col gap-px" aria-hidden="true">

--- a/packages/app/src/new-session/screen.tsx
+++ b/packages/app/src/new-session/screen.tsx
@@ -73,7 +73,7 @@ export default function NewSessionPage(props: { draftId: string }) {
     <div class="relative size-full overflow-hidden flex flex-col">
       {suspendUntilPromptReady()}
       <NewSessionStatus visible={settings.visibility.status()} />
-      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
+      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
         <NewSessionView composer={model} project={project} workspace={workspace} />
       </div>
     </div>

--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -643,6 +643,7 @@ export const dict = {
   "home.empty.description": "Get started by opening a local project",
   "home.title": "Home",
   "home.projects": "Projects",
+  "home.projects.all": "All projects",
   "home.project.add": "Add project",
   "home.recentlyClosed": "Recently closed",
   "home.server.collapse": "Collapse server projects",
@@ -799,6 +800,7 @@ export const dict = {
   "terminal.connectTicket.statusError": "PTY connect ticket failed with {{status}}",
 
   "titlebar.update": "Update",
+  "titlebar.tabs": "Tabs",
   "titlebar.updateVersion": "Update {{version}}",
 
   "common.closeTab": "Close tab",

--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -660,6 +660,10 @@ export const dict = {
   "home.providerTip": "Connect to 75+ providers to use other models, including Claude, GPT, Gemini, etc",
 
   "session.tab.session": "Session",
+  "session.tab.files": "Files",
+  "session.files.openTabs": "Open files",
+  "session.tab.usage": "Usage",
+  "session.view.select": "Session view",
   "session.tab.review": "Review",
   "session.tab.context": "Context",
   "session.tab.unknown": "Unknown Session",

--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -982,7 +982,7 @@ export const dict = {
   "settings.general.row.showProjectIcon.description": "Show the project icon in the session header",
   "settings.general.row.mobileTitlebarBottom.title": "Bottom navigation",
   "settings.general.row.mobileTitlebarBottom.description":
-    "Place the title bar and session tabs at the bottom of the screen on mobile",
+    "Place the title bar at the bottom of the screen on mobile",
   "settings.general.row.showCustomAgents.title": "Show agent",
   "settings.general.row.showCustomAgents.description":
     "Switch between agents in the composer. When hidden, defaults to Build agent.",

--- a/packages/app/src/session/files/session-context-tab.tsx
+++ b/packages/app/src/session/files/session-context-tab.tsx
@@ -271,7 +271,7 @@ export function SessionContextTab() {
       }}
       onScroll={handleScroll}
     >
-      <div class="px-2 pt-2 pb-6 flex flex-col gap-6 md:px-6 md:pt-4 md:pb-10 md:gap-10">
+      <div data-slot="session-usage-content" class="px-4 pt-4 pb-6 flex flex-col gap-6 md:px-6 md:pb-10 md:gap-10">
         <div class="grid grid-cols-1 @[32rem]:grid-cols-2 gap-4">
           <For each={stats}>
             {(stat) => <Stat label={language.t(stat.label as Parameters<typeof language.t>[0])} value={stat.value()} />}

--- a/packages/app/src/session/files/session-context-tab.tsx
+++ b/packages/app/src/session/files/session-context-tab.tsx
@@ -271,7 +271,7 @@ export function SessionContextTab() {
       }}
       onScroll={handleScroll}
     >
-      <div class="px-6 pt-4 pb-10 flex flex-col gap-10">
+      <div class="px-2 pt-2 pb-6 flex flex-col gap-6 md:px-6 md:pt-4 md:pb-10 md:gap-10">
         <div class="grid grid-cols-1 @[32rem]:grid-cols-2 gap-4">
           <For each={stats}>
             {(stat) => <Stat label={language.t(stat.label as Parameters<typeof language.t>[0])} value={stat.value()} />}

--- a/packages/app/src/session/files/session-file-browser-tab.tsx
+++ b/packages/app/src/session/files/session-file-browser-tab.tsx
@@ -1,4 +1,5 @@
-import { createMemo, createSignal, createUniqueId, Show } from "solid-js"
+import { createMemo, createUniqueId, Show } from "solid-js"
+import { createStore } from "solid-js/store"
 import { createQuery } from "@tanstack/solid-query"
 import { Icon } from "@opencode-ai/ui/icon"
 import { SessionFilePanelV2, SessionFilePanelV2Empty } from "@opencode-ai/session-ui/v2/session-file-panel-v2"
@@ -34,6 +35,7 @@ export function SessionFileBrowserTab(props: {
   onSelect: (path: string) => void
   onSelectPermanent: (path: string) => void
   filterRef?: (element: HTMLInputElement) => void
+  mobile?: boolean
 }) {
   const file = useFile()
   const language = useLanguage()
@@ -42,8 +44,10 @@ export function SessionFileBrowserTab(props: {
   const serverSDK = useServerSDK()
   const { workspaceKey } = useSessionLayout()
   const resultsID = `session-file-browser-results-${createUniqueId()}`
-  const [filter, setFilter] = createSignal("")
-  const [explicitHighlight, setExplicitHighlight] = createSignal<string>()
+  const [store, setStore] = createStore({ filter: "", explicitHighlight: undefined as string | undefined })
+  const filter = () => store.filter
+  const setFilter = (value: string) => setStore("filter", value)
+  const setExplicitHighlight = (value: string) => setStore("explicitHighlight", value)
   const sidebarOpened = () => props.placeholder || props.state.sidebarOpened()
   const query = createMemo(() => filter().trim())
   const search = createQuery(() => {
@@ -61,7 +65,7 @@ export function SessionFileBrowserTab(props: {
   const highlighted = createMemo(() => {
     const values = files()
     if (values.length === 0) return undefined
-    const explicit = explicitHighlight()
+    const explicit = store.explicitHighlight
     if (explicit && values.includes(explicit)) return explicit
     return values[0]
   })
@@ -105,13 +109,13 @@ export function SessionFileBrowserTab(props: {
           filter={filter()}
           onFilterChange={setFilter}
           onFilterKeyDown={onFilterKeyDown}
-          filterAutofocus={props.placeholder}
-          filterRef={props.filterRef}
+          filterAutofocus={props.placeholder && !props.mobile}
+          filterRef={(element) => props.filterRef?.(element)}
           filterControls={resultsID}
           filterActiveDescendant={highlighted() ? optionID(highlighted()!) : undefined}
           filterExpanded={query().length > 0 && files().length > 0}
           width={props.state.sidebarWidth()}
-          onWidthChange={props.state.resizeSidebar}
+          onWidthChange={props.mobile ? undefined : props.state.resizeSidebar}
         >
           <Show
             when={query()}
@@ -119,6 +123,7 @@ export function SessionFileBrowserTab(props: {
               <FileTreeV2
                 active={props.active}
                 kinds={props.kinds}
+                draggable={!props.mobile}
                 onFileClick={(node) => props.onSelect(node.path)}
                 onFileDoubleClick={(node) => props.onSelectPermanent(node.path)}
               />

--- a/packages/app/src/session/files/session-mobile-files.css
+++ b/packages/app/src/session/files/session-mobile-files.css
@@ -1,0 +1,35 @@
+[data-slot="session-mobile-files"]
+  [data-slot="session-mobile-files-header"]
+  [data-component="tabs-v2"][data-variant="normal"][data-orientation="horizontal"]
+  [data-slot="tabs-v2-list"] {
+  position: static;
+
+  &::before {
+    inset-inline-start: 0;
+    width: 100%;
+  }
+}
+
+[data-slot="session-mobile-files"] [data-component="line-comment-v2"] {
+  max-width: none;
+}
+
+[data-slot="session-mobile-files"][data-browsing="true"] {
+  [data-component="session-review-v2-sidebar-root"] {
+    width: 100%;
+  }
+
+  [data-slot="session-review-v2-sidebar"] {
+    width: 100% !important;
+    border-inline-end: 0;
+  }
+
+  [data-slot="session-review-v2-preview"] {
+    display: none;
+  }
+}
+
+[data-slot="session-mobile-files"] [data-slot="tabs-v2-trigger-close-button"] [data-slot="tabs-close-button"] {
+  width: 32px;
+  height: 36px;
+}

--- a/packages/app/src/session/files/session-mobile-files.tsx
+++ b/packages/app/src/session/files/session-mobile-files.tsx
@@ -1,0 +1,100 @@
+import { Button } from "@opencode-ai/ui/button"
+import { Tabs } from "@opencode-ai/ui/tabs"
+import { getFilename } from "@opencode-ai/util/path"
+import { createMemo, For } from "solid-js"
+import { createStore } from "solid-js/store"
+import { useLanguage } from "@/runtime/i18n/language"
+import { useSessionLayout } from "@/session/session-layout"
+import { createSessionTabs, SESSION_OPEN_FILE_TAB } from "@/session/helpers"
+import { useFile } from "@/workspaces/files/model"
+import { SessionFileBrowserTab } from "./session-file-browser-tab"
+import type { Kind } from "./file-tree-v2"
+import "./session-mobile-files.css"
+
+export function SessionMobileFiles() {
+  const file = useFile()
+  const language = useLanguage()
+  const layout = useSessionLayout()
+  const tabs = createSessionTabs({
+    tabs: layout.tabs,
+    pathFromTab: file.pathFromTab,
+    normalizeTab: file.tab,
+  })
+  const [store, setStore] = createStore({ browsing: !tabs.activeFileTab() })
+  const browsing = () => store.browsing || !tabs.activeFileTab()
+  const active = createMemo(() => file.pathFromTab(tabs.activeFileTab() ?? ""))
+  const kinds = new Map<string, Kind>()
+  const open = (path: string) => {
+    layout.tabs().open(file.tab(path))
+    void file.load(path)
+    setStore("browsing", false)
+  }
+
+  return (
+    <div data-slot="session-mobile-files" data-browsing={browsing()} class="flex h-full min-h-0 flex-col">
+      <div data-slot="session-mobile-files-header" class="relative flex h-10 shrink-0 items-center">
+        <Button
+          size="small"
+          variant="ghost"
+          class="shrink-0 mx-2"
+          onClick={() => setStore("browsing", true)}
+          aria-pressed={browsing()}
+        >
+          {language.t("session.files.all")}
+        </Button>
+        <Tabs
+          value={browsing() ? SESSION_OPEN_FILE_TAB : tabs.activeFileTab()}
+          onChange={(tab) => {
+            // Kobalte falls back to a file tab when the browse view has no trigger.
+            if (browsing()) return
+            const path = file.pathFromTab(tab)
+            if (path) open(path)
+          }}
+          variant="line"
+          class="min-w-0 flex-1 !h-auto"
+        >
+          <Tabs.List aria-label={language.t("session.files.openTabs")} class="!h-10 !px-0 overflow-x-auto">
+            <For each={tabs.openedTabs()}>
+              {(tab) => (
+                <Tabs.Trigger
+                  value={tab}
+                  onClick={() => open(file.pathFromTab(tab)!)}
+                  class="shrink-0 max-w-48"
+                  classes={{ button: "min-w-0" }}
+                  closeButton={
+                    <Tabs.CloseButton
+                      aria-label={language.t("common.closeTab")}
+                      onClick={() => layout.tabs().close(tab)}
+                    />
+                  }
+                >
+                  <span dir="ltr" class="truncate">
+                    {getFilename(file.pathFromTab(tab) ?? tab)}
+                  </span>
+                </Tabs.Trigger>
+              )}
+            </For>
+          </Tabs.List>
+        </Tabs>
+      </div>
+      <div class="min-h-0 flex-1">
+        <SessionFileBrowserTab
+          mobile
+          tab={tabs.activeFileTab() ?? SESSION_OPEN_FILE_TAB}
+          placeholder={browsing()}
+          active={active()}
+          kinds={kinds}
+          state={{
+            sidebarOpened: browsing,
+            sidebarWidth: () => 240,
+            sidebarTransition: () => false,
+            resizeSidebar: () => undefined,
+            toggleSidebar: () => setStore("browsing", !browsing()),
+          }}
+          onSelect={open}
+          onSelectPermanent={open}
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/app/src/session/header/session-header.tsx
+++ b/packages/app/src/session/header/session-header.tsx
@@ -19,7 +19,10 @@ export function SessionHeader() {
   const isDesktop = createMediaQuery("(min-width: 768px)")
 
   const actions = createMemo<SessionHeaderActionsState>(() => ({
-    status: status() ? { label: language.t("status.popover.trigger"), content: () => <StatusPopover /> } : undefined,
+    status:
+      isDesktop() && status()
+        ? { label: language.t("status.popover.trigger"), content: () => <StatusPopover /> }
+        : undefined,
     reviewLabel: language.t("command.review.toggle"),
     reviewKeybind: reviewTooltipKeybind(command),
     reviewVisible: isDesktop(),

--- a/packages/app/src/session/review/model.ts
+++ b/packages/app/src/session/review/model.ts
@@ -38,7 +38,7 @@ export function createSessionReview(input: {
   const location = useWorkspaceLocation()
   const server = useServerSDK()
   const [state, setState] = createStore({
-    mobileTab: "session" as "session" | "changes",
+    mobileTab: "session" as "session" | "changes" | "files" | "usage",
     detailsOpen: false,
     scroll: undefined as HTMLDivElement | undefined,
     pendingFile: undefined as string | undefined,
@@ -66,7 +66,9 @@ export function createSessionReview(input: {
     }
     return list
   })
-  const mobileChanges = createMemo(() => !input.session.isDesktop() && state.mobileTab === "changes")
+  const mobileChanges = createMemo(
+    () => !input.session.isDesktop() && !input.screen.terminal.open() && state.mobileTab === "changes",
+  )
   const vcsMode = createMemo<VcsMode | undefined>(() => {
     const value = mode()
     return value === "git" || value === "branch" ? value : undefined
@@ -407,7 +409,7 @@ export function createSessionReview(input: {
     loadDiff,
     mobile: {
       changes: mobileChanges,
-      setTab: (tab: "session" | "changes") => setState("mobileTab", tab),
+      setTab: (tab: "session" | "changes" | "files" | "usage") => setState("mobileTab", tab),
       tab: () => state.mobileTab,
     },
     mode,

--- a/packages/app/src/session/review/view.tsx
+++ b/packages/app/src/session/review/view.tsx
@@ -26,7 +26,6 @@ const MobilePanelDrawer = lazy(async () => {
 export function SessionMobileViewTabs(props: {
   current: "session" | "changes" | "files" | "usage" | "terminal"
   onSelect: (view: "session" | "changes" | "files" | "usage" | "terminal") => void
-  bottom?: boolean
   details?: (close: () => void) => JSX.Element
   onDetailsOpenChange?: (open: boolean) => void
 }) {
@@ -44,8 +43,7 @@ export function SessionMobileViewTabs(props: {
   let trigger: HTMLButtonElement | undefined
   return (
     <div
-      class="relative flex shrink-0 items-center before:pointer-events-none before:absolute before:inset-x-0 before:h-px before:bg-v2-border-border-base before:content-['']"
-      classList={{ "before:top-0": props.bottom, "before:bottom-0": !props.bottom }}
+      class="relative flex shrink-0 items-center before:pointer-events-none before:absolute before:inset-x-0 before:bottom-0 before:h-px before:bg-v2-border-border-base before:content-['']"
       data-slot="session-mobile-view-navigation"
     >
       <Tabs value={props.current} variant="line" class="!h-auto min-w-0 flex-1" data-slot="session-mobile-view-tabs">
@@ -57,10 +55,6 @@ export function SessionMobileViewTabs(props: {
                 class="min-w-0 flex-1"
                 classes={{ button: "w-full justify-center" }}
                 onClick={() => props.onSelect(view)}
-                classList={{
-                  "!border-b-0 border-t border-transparent [&:has([data-selected])]:border-t-v2-text-text-faint":
-                    props.bottom,
-                }}
               >
                 {view === "session"
                   ? language.t("session.tab.session")
@@ -77,7 +71,7 @@ export function SessionMobileViewTabs(props: {
       <Menu
         appearance="standard"
         modal={false}
-        placement={props.bottom ? "top-end" : "bottom-end"}
+        placement="bottom-end"
         gutter={4}
         open={store.menu}
         onOpenChange={(open) => setStore("menu", open)}

--- a/packages/app/src/session/review/view.tsx
+++ b/packages/app/src/session/review/view.tsx
@@ -2,51 +2,142 @@ import { SessionReviewEmptyChangesV2 } from "@opencode-ai/session-ui/v2/session-
 import { SessionReviewV2SidebarToggle } from "@opencode-ai/session-ui/v2/session-review-v2"
 import { Select } from "@opencode-ai/ui/select"
 import { Tabs } from "@opencode-ai/ui/tabs"
-import { Match, Show, Suspense, Switch } from "solid-js"
+import { Icon } from "@opencode-ai/ui/icon"
+import { IconButton } from "@opencode-ai/ui/icon-button"
+import { Menu } from "@opencode-ai/ui/menu"
+import { For, Match, Show, Suspense, Switch, lazy, createEffect, onCleanup, type JSX } from "solid-js"
+import { createStore } from "solid-js/store"
 import { useLanguage } from "@/runtime/i18n/language"
 import { SessionSidePanel } from "../files/session-side-panel"
 import { ReviewPanel } from "./panel"
 import { SessionReviewTab } from "./review-tab"
 import type { ChangeMode, SessionReviewModel } from "./model"
 
-export function SessionMobileTabs(props: { review: SessionReviewModel; compact?: boolean; bottom?: boolean }) {
+const StatusDrawer = lazy(async () => {
+  const { StatusDrawer } = await import("@/shell/status/status-drawer")
+  return { default: StatusDrawer }
+})
+
+const MobilePanelDrawer = lazy(async () => {
+  const { MobilePanelDrawer } = await import("@/shell/mobile-panel-drawer")
+  return { default: MobilePanelDrawer }
+})
+
+export function SessionMobileViewTabs(props: {
+  current: "session" | "changes" | "files" | "usage" | "terminal"
+  onSelect: (view: "session" | "changes" | "files" | "usage" | "terminal") => void
+  bottom?: boolean
+  details?: (close: () => void) => JSX.Element
+  onDetailsOpenChange?: (open: boolean) => void
+}) {
   const language = useLanguage()
+  const [store, setStore] = createStore({
+    menu: false,
+    status: false,
+    statusLoaded: false,
+    details: false,
+    detailsLoaded: false,
+    pending: undefined as "status" | "details" | undefined,
+  })
+  createEffect(() => props.onDetailsOpenChange?.(store.details))
+  onCleanup(() => props.onDetailsOpenChange?.(false))
+  let trigger: HTMLButtonElement | undefined
   return (
-    <Tabs value={props.review.mobile.tab()} class="h-auto">
-      <Tabs.List
-        classList={{
-          "!h-9": props.compact,
-          "[&::after]:!border-b-0 [&::after]:!border-t [&::after]:!border-border-weak-base": props.bottom,
-        }}
+    <div
+      class="relative flex shrink-0 items-center before:pointer-events-none before:absolute before:inset-x-0 before:h-px before:bg-v2-border-border-base before:content-['']"
+      classList={{ "before:top-0": props.bottom, "before:bottom-0": !props.bottom }}
+      data-slot="session-mobile-view-navigation"
+    >
+      <Tabs value={props.current} variant="line" class="!h-auto min-w-0 flex-1" data-slot="session-mobile-view-tabs">
+        <Tabs.List aria-label={language.t("session.view.select")} class="!h-9 !gap-0 !px-0 before:!hidden">
+          <For each={["session", "changes", "files", "terminal"] as const}>
+            {(view) => (
+              <Tabs.Trigger
+                value={view}
+                class="min-w-0 flex-1"
+                classes={{ button: "w-full justify-center" }}
+                onClick={() => props.onSelect(view)}
+                classList={{
+                  "!border-b-0 border-t border-transparent [&:has([data-selected])]:border-t-v2-text-text-faint":
+                    props.bottom,
+                }}
+              >
+                {view === "session"
+                  ? language.t("session.tab.session")
+                  : view === "changes"
+                    ? language.plural("session.review.change", 0)
+                    : view === "files"
+                      ? language.t("session.tab.files")
+                      : language.t("terminal.title")}
+              </Tabs.Trigger>
+            )}
+          </For>
+        </Tabs.List>
+      </Tabs>
+      <Menu
+        appearance="standard"
+        modal={false}
+        placement={props.bottom ? "top-end" : "bottom-end"}
+        gutter={4}
+        open={store.menu}
+        onOpenChange={(open) => setStore("menu", open)}
       >
-        <Tabs.Trigger
-          value="session"
-          classes={{ button: props.compact ? "w-full !py-2" : "w-full" }}
-          classList={{
-            "!w-1/2 !max-w-none": true,
-            "!border-b-0 !border-t !border-border-weak-base [&:has([data-selected])]:!border-t-transparent":
-              props.bottom,
+        <Menu.Trigger
+          as={IconButton}
+          ref={(element: HTMLButtonElement) => {
+            trigger = element
           }}
-          onClick={() => props.review.mobile.setTab("session")}
-        >
-          {language.t("session.tab.session")}
-        </Tabs.Trigger>
-        <Tabs.Trigger
-          value="changes"
-          classes={{ button: props.compact ? "w-full !py-2" : "w-full" }}
-          classList={{
-            "!w-1/2 !max-w-none !border-r-0": true,
-            "!border-b-0 !border-t !border-border-weak-base [&:has([data-selected])]:!border-t-transparent":
-              props.bottom,
-          }}
-          onClick={() => props.review.mobile.setTab("changes")}
-        >
-          {props.review.hasChanges()
-            ? language.t("session.review.filesChanged", { count: props.review.count() })
-            : language.plural("session.review.change", 0)}
-        </Tabs.Trigger>
-      </Tabs.List>
-    </Tabs>
+          icon={<Icon name="menu" />}
+          variant="ghost-muted"
+          size="normal"
+          class="mx-1.5 shrink-0"
+          state={props.current === "usage" || store.menu ? "pressed" : undefined}
+          aria-label={language.t("common.moreOptions")}
+        />
+        <Menu.Portal>
+          <Menu.Content
+            onCloseAutoFocus={(event) => {
+              if (!store.pending) return
+              event.preventDefault()
+              if (store.pending === "status") setStore({ status: true, statusLoaded: true })
+              if (store.pending === "details") setStore({ details: true, detailsLoaded: true })
+              setStore("pending", undefined)
+            }}
+          >
+            <Menu.Item onSelect={() => props.onSelect("usage")}>{language.t("session.tab.usage")}</Menu.Item>
+            <Show when={props.details}>
+              <Menu.Item onSelect={() => setStore({ pending: "details", menu: false })}>
+                {language.t("session.summary.title")}
+              </Menu.Item>
+            </Show>
+            <Menu.Item onSelect={() => setStore({ pending: "status", menu: false })}>
+              {language.t("status.popover.trigger")}
+            </Menu.Item>
+          </Menu.Content>
+        </Menu.Portal>
+      </Menu>
+      <Show when={store.statusLoaded}>
+        <Suspense>
+          <StatusDrawer
+            open={store.status}
+            onOpenChange={(open) => setStore("status", open)}
+            returnFocus={() => trigger}
+          />
+        </Suspense>
+      </Show>
+      <Show when={store.detailsLoaded}>
+        <Suspense>
+          <MobilePanelDrawer
+            title={language.t("session.summary.title")}
+            open={store.details}
+            onOpenChange={(open) => setStore("details", open)}
+            returnFocus={() => trigger}
+          >
+            {props.details?.(() => setStore("details", false))}
+          </MobilePanelDrawer>
+        </Suspense>
+      </Show>
+    </div>
   )
 }
 
@@ -92,7 +183,7 @@ function ReviewContent(props: { review: SessionReviewModel }) {
     <Show when={!props.review.deferRender()}>
       <SessionReviewTab
         title={<ReviewTitle review={props.review} />}
-        empty={<ReviewEmpty review={props.review} loadingClass="px-4 py-4 text-text-weak" />}
+        empty={<ReviewEmpty review={props.review} loadingClass="px-2 py-2 text-text-weak" />}
         diffs={props.review.diffs()}
         view={props.review.view()}
         diffStyle="unified"
@@ -109,7 +200,7 @@ function ReviewContent(props: { review: SessionReviewModel }) {
         onViewFile={props.review.openFile}
         classes={{
           root: "pb-8 [&_[data-slot=session-review-list]]:pb-0",
-          header: "px-4 !h-16 !pb-4",
+          header: "!px-2 !h-10 !pb-0",
           container: "px-4",
         }}
       />

--- a/packages/app/src/session/route.tsx
+++ b/packages/app/src/session/route.tsx
@@ -154,7 +154,7 @@ function PendingSessionState(props: { sessionID: string }) {
 
 function SessionStatePanel(props: ParentProps) {
   return (
-    <div class="flex min-h-0 flex-1 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
+    <div class="flex min-h-0 flex-1 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
       <SessionPanelFrame raised>{props.children}</SessionPanelFrame>
     </div>
   )

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -157,7 +157,7 @@ export function SessionScreen(props: { session: SessionModel }) {
   return (
     <>
       <SessionHeader />
-      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
+      <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
         <div ref={screen.panel.ref} class="relative flex-1 min-h-0 flex flex-col md:flex-row gap-2">
           <div
             classList={{

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -15,7 +15,6 @@ import createPresence from "solid-presence"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
 import { SessionHeader } from "@/session/header/session-header"
 import { useLayout } from "@/shell/state/layout"
-import { useSettings } from "@/settings/model"
 import { MessageTimeline, SessionSummaryPanel } from "@/session/timeline/message-timeline"
 import { useServer } from "@/runtime/server/current"
 import { projectForSession } from "@/shell/layout/helpers"
@@ -41,14 +40,12 @@ const SessionMobileFiles = lazy(async () => {
 export function SessionScreen(props: { session: SessionModel }) {
   const session = props.session
   const layout = useLayout()
-  const settings = useSettings()
   const server = useServer()
   const detailsProject = createMemo(() => {
     const info = session.data.info()
     return info ? projectForSession(info, server.ctx.sync.data.project) : undefined
   })
   const isDesktop = session.isDesktop
-  const mobileTabsBottom = () => !isDesktop() && settings.general.mobileTitlebarPosition() === "bottom"
   const screen = createSessionScreenLayout(session)
   const timeline = createSessionTimelineInteraction(session)
   const messagesReady = timeline.ready
@@ -127,7 +124,6 @@ export function SessionScreen(props: { session: SessionModel }) {
       {(_key) => (
         <SessionMobileViewTabs
           current={mobileView()}
-          bottom={mobileTabsBottom()}
           onDetailsOpenChange={review.details.setOpen}
           details={
             !session.data.isChild() && detailsProject()
@@ -178,7 +174,7 @@ export function SessionScreen(props: { session: SessionModel }) {
 
   const sessionPanelContent = () => (
     <>
-      <Show when={!isDesktop() && !!session.identity.params.id && !mobileTabsBottom()}>{mobileTabs()}</Show>
+      <Show when={!isDesktop() && !!session.identity.params.id}>{mobileTabs()}</Show>
       {/* Surface query errors without suspending session metadata while messages load. */}
       <Show when={timeline.resource.error}>
         {(error) => {
@@ -248,7 +244,6 @@ export function SessionScreen(props: { session: SessionModel }) {
           <ActiveSessionComposerRegion model={composer} session={session} onResponseSubmit={timeline.actions.resume} />
         )}
       </Show>
-      <Show when={!!session.identity.params.id && mobileTabsBottom()}>{mobileTabs()}</Show>
     </>
   )
 

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -1,11 +1,24 @@
-import { ErrorBoundary, Show, Match, Switch, createMemo, createEffect, createComputed, on } from "solid-js"
+import {
+  ErrorBoundary,
+  Show,
+  Match,
+  Switch,
+  Suspense,
+  lazy,
+  createMemo,
+  createEffect,
+  createComputed,
+  on,
+} from "solid-js"
 import { createStore } from "solid-js/store"
 import createPresence from "solid-presence"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
 import { SessionHeader } from "@/session/header/session-header"
 import { useLayout } from "@/shell/state/layout"
 import { useSettings } from "@/settings/model"
-import { MessageTimeline } from "@/session/timeline/message-timeline"
+import { MessageTimeline, SessionSummaryPanel } from "@/session/timeline/message-timeline"
+import { useServer } from "@/runtime/server/current"
+import { projectForSession } from "@/shell/layout/helpers"
 import type { SessionModel } from "@/session/model"
 import { SESSION_PANEL_WIDTH_MIN } from "@/session/session-panel-width"
 import { SessionPanelFrame } from "@/session/session-frame"
@@ -14,16 +27,28 @@ import { useUsageExceededDialogs } from "./usage-exceeded-dialogs"
 import { SessionErrorFallback } from "./route-error"
 import { createSessionScreenLayout } from "./screen-layout"
 import { createSessionReview } from "./review/model"
-import { SessionDesktopReview, SessionMobileReview, SessionMobileTabs } from "./review/view"
+import { SessionDesktopReview, SessionMobileReview, SessionMobileViewTabs } from "./review/view"
+import { SessionContextTab } from "./files/session-context-tab"
 import { createSessionTimelineInteraction } from "./timeline/interaction"
 import { ActiveSessionComposerRegion, createActiveSessionRegion } from "./composer/region"
 import { SessionIdentityHeader } from "./session-identity-header"
+
+const SessionMobileFiles = lazy(async () => {
+  const { SessionMobileFiles } = await import("./files/session-mobile-files")
+  return { default: SessionMobileFiles }
+})
 
 export function SessionScreen(props: { session: SessionModel }) {
   const session = props.session
   const layout = useLayout()
   const settings = useSettings()
+  const server = useServer()
+  const detailsProject = createMemo(() => {
+    const info = session.data.info()
+    return info ? projectForSession(info, server.ctx.sync.data.project) : undefined
+  })
   const isDesktop = session.isDesktop
+  const mobileTabsBottom = () => !isDesktop() && settings.general.mobileTitlebarPosition() === "bottom"
   const screen = createSessionScreenLayout(session)
   const timeline = createSessionTimelineInteraction(session)
   const messagesReady = timeline.ready
@@ -34,6 +59,8 @@ export function SessionScreen(props: { session: SessionModel }) {
     sideRegionPresent: false,
     sideReviewPresent: false,
     sideTerminalPresent: false,
+    mobileTerminalCached: false,
+    mobileMoveDismissed: false,
   })
   const [elements, setElements] = createStore<{
     side?: HTMLDivElement
@@ -41,7 +68,7 @@ export function SessionScreen(props: { session: SessionModel }) {
   }>({})
   const sideVisible = createMemo(() => isDesktop() && screen.side.layout().visible)
   const sideTerminalVisible = createMemo(() => isDesktop() && screen.terminal.side() && screen.terminal.open())
-  const bottomTerminalVisible = createMemo(() => screen.terminal.open() && (!isDesktop() || screen.terminal.bottom()))
+  const bottomTerminalVisible = createMemo(() => isDesktop() && screen.terminal.open() && screen.terminal.bottom())
   const sidePresence = createPresence({
     show: sideVisible,
     element: () => elements.side ?? null,
@@ -67,6 +94,7 @@ export function SessionScreen(props: { session: SessionModel }) {
   createComputed((prev) => {
     const key = session.identity.sessionKey()
     if (key !== prev) {
+      setStore("mobileMoveDismissed", false)
       setStore("deferRender", true)
       const owner = session.ownership.capture()
       requestAnimationFrame(() => {
@@ -76,6 +104,11 @@ export function SessionScreen(props: { session: SessionModel }) {
     return key
   })
   const review = createSessionReview({ session, screen, deferRender: () => store.deferRender })
+  const mobileView = createMemo(() => (screen.terminal.open() ? "terminal" : review.mobile.tab()))
+  const conversationVisible = createMemo(() => isDesktop() || mobileView() === "session")
+  createEffect(() => {
+    if (!isDesktop() && screen.terminal.open()) setStore("mobileTerminalCached", true)
+  })
   const composer = createActiveSessionRegion({
     session,
     screen,
@@ -84,36 +117,103 @@ export function SessionScreen(props: { session: SessionModel }) {
 
   useUsageExceededDialogs()
 
-  const mobileTabsBottom = createMemo(() => !isDesktop() && settings.general.mobileTitlebarPosition() === "bottom")
-
   const sessionErrorFallback = (error: unknown, reset: () => void) => {
     createEffect(on(session.identity.sessionKey, reset, { defer: true }))
     return <SessionErrorFallback error={error} sessionID={session.identity.params.id} />
   }
 
+  const mobileTabs = () => (
+    <Show when={session.identity.sessionKey()} keyed>
+      {(_key) => (
+        <SessionMobileViewTabs
+          current={mobileView()}
+          bottom={mobileTabsBottom()}
+          onDetailsOpenChange={review.details.setOpen}
+          details={
+            !session.data.isChild() && detailsProject()
+              ? (close) => (
+                  <Show when={detailsProject()}>
+                    {(project) => (
+                      <SessionSummaryPanel
+                        mobile
+                        project={project()}
+                        directory={session.workspace.directory()}
+                        local={!session.workspace.current()}
+                        branch={
+                          session.shared.data.location.vcs.info({ directory: session.workspace.directory() })?.branch
+                            .current
+                        }
+                        baseBranch={
+                          session.shared.data.location.vcs.info({ directory: project().worktree })?.branch.current
+                        }
+                        diffs={project().vcs === "git" ? review.details.diffs() : []}
+                        sessionID={session.identity.params.id ?? ""}
+                        moveEligible={composer.workspaceMoveEligible()}
+                        moveDismissed={store.mobileMoveDismissed}
+                        onMoveDismiss={() => setStore("mobileMoveDismissed", true)}
+                        onReview={() => {
+                          close()
+                          review.mobile.setTab("changes")
+                          session.layout.view().terminal.close()
+                        }}
+                        backgroundTasks={composer.region.state.background.tasks()}
+                      />
+                    )}
+                  </Show>
+                )
+              : undefined
+          }
+          onSelect={(view) => {
+            if (view === "terminal") {
+              session.layout.view().terminal.open()
+              return
+            }
+            review.mobile.setTab(view)
+            session.layout.view().terminal.close()
+          }}
+        />
+      )}
+    </Show>
+  )
+
   const sessionPanelContent = () => (
     <>
-      <Show when={!isDesktop() && !!session.identity.params.id && !mobileTabsBottom()}>
-        <SessionMobileTabs review={review} compact />
-      </Show>
+      <Show when={!isDesktop() && !!session.identity.params.id && !mobileTabsBottom()}>{mobileTabs()}</Show>
       {/* Surface query errors without suspending session metadata while messages load. */}
       <Show when={timeline.resource.error}>
         {(error) => {
           throw error()
         }}
       </Show>
-      <div class="flex-1 min-h-0 overflow-hidden">
+      <div class="relative flex-1 min-h-0 overflow-hidden">
+        <Show when={!isDesktop() && store.mobileTerminalCached}>
+          <div class="absolute inset-0" classList={{ invisible: mobileView() !== "terminal" }}>
+            <TerminalPanel fill embedded present contentHeight="100%" />
+          </div>
+        </Show>
         <Switch>
+          <Match when={!isDesktop() && mobileView() === "terminal"}>
+            <></>
+          </Match>
+          <Match when={!isDesktop() && mobileView() === "usage"}>
+            <SessionContextTab />
+          </Match>
+          <Match when={!isDesktop() && mobileView() === "files"}>
+            <Suspense>
+              <SessionMobileFiles />
+            </Suspense>
+          </Match>
           <Match when={session.identity.params.id && review.mobile.changes()}>
             <SessionMobileReview review={review} />
           </Match>
           <Match when={session.identity.params.id}>
-            <Show when={!messagesReady()}>
+            <Show when={isDesktop() && !messagesReady()}>
               <SessionIdentityHeader sessionID={session.identity.params.id ?? ""} session={session.data.info()} />
             </Show>
             <Show when={messagesReady() ? session.identity.params.id : undefined} keyed>
               {(_id) => (
                 <MessageTimeline
+                  hideHeader={!isDesktop()}
                   session={session}
                   background={composer.region.state.background}
                   actions={composer.actions.timeline}
@@ -143,14 +243,12 @@ export function SessionScreen(props: { session: SessionModel }) {
         </Switch>
       </div>
 
-      <Show when={!review.mobile.changes() ? session.identity.params.id : undefined} keyed>
+      <Show when={conversationVisible() ? session.identity.params.id : undefined} keyed>
         {(_id) => (
           <ActiveSessionComposerRegion model={composer} session={session} onResponseSubmit={timeline.actions.resume} />
         )}
       </Show>
-      <Show when={!!session.identity.params.id && mobileTabsBottom()}>
-        <SessionMobileTabs review={review} compact bottom />
-      </Show>
+      <Show when={!!session.identity.params.id && mobileTabsBottom()}>{mobileTabs()}</Show>
     </>
   )
 
@@ -300,7 +398,7 @@ export function SessionScreen(props: { session: SessionModel }) {
           </Show>
         </div>
 
-        <Show when={bottomTerminalPresence.present() || store.bottomTerminalCached}>
+        <Show when={isDesktop() && (bottomTerminalPresence.present() || store.bottomTerminalCached)}>
           <div
             ref={(element) => setElements("bottomTerminal", element)}
             data-slot="terminal-panel-presence"

--- a/packages/app/src/session/session-frame.tsx
+++ b/packages/app/src/session/session-frame.tsx
@@ -3,8 +3,8 @@ import type { ParentProps } from "solid-js"
 export function SessionRouteFrame(props: ParentProps<{ padded?: boolean }>) {
   return (
     <div
-      class="relative flex size-full flex-col overflow-hidden"
-      classList={{ "px-2 pb-2 pt-[var(--shell-top-inset,8px)]": props.padded }}
+      class="relative flex size-full flex-col"
+      classList={{ "px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]": props.padded }}
     >
       {props.children}
     </div>

--- a/packages/app/src/session/terminal/panel.tsx
+++ b/packages/app/src/session/terminal/panel.tsx
@@ -38,7 +38,14 @@ type CachedTerminalSurface = {
 }
 
 export function TerminalPanel(
-  props: { stacked?: boolean; fill?: boolean; framed?: boolean; present?: boolean; contentHeight?: string } = {},
+  props: {
+    stacked?: boolean
+    fill?: boolean
+    framed?: boolean
+    present?: boolean
+    contentHeight?: string
+    embedded?: boolean
+  } = {},
 ) {
   const layout = useLayout()
   const terminal = useTerminal()
@@ -223,6 +230,7 @@ export function TerminalPanel(
       opened={opened()}
       present={present()}
       framed={props.framed}
+      embedded={props.embedded}
       desktop={isDesktop()}
       stacked={stacked()}
       height={panelHeight()}

--- a/packages/app/src/session/terminal/surface.tsx
+++ b/packages/app/src/session/terminal/surface.tsx
@@ -7,6 +7,7 @@ export function TerminalSurface(
     opened: boolean
     present?: boolean
     framed?: boolean
+    embedded?: boolean
     desktop: boolean
     stacked: boolean
     height: string
@@ -26,7 +27,7 @@ export function TerminalSurface(
       id="terminal-panel"
       data-component="terminal-panel"
       data-opened={props.opened}
-      data-size-animated={!props.resizing && (!props.desktop || props.stacked)}
+      data-size-animated={!props.embedded && !props.resizing && (!props.desktop || props.stacked)}
       role="region"
       aria-label={props.label}
       aria-hidden={!props.opened}
@@ -37,11 +38,14 @@ export function TerminalSurface(
         "min-w-0 h-full flex-1": props.desktop && (props.present ?? props.opened) && !props.stacked,
         "w-0 h-full pointer-events-none": props.desktop && !(props.present ?? props.opened),
         "rounded-[10px] shadow-[var(--v2-elevation-raised)]": props.desktop && (props.framed ?? true),
-        "will-change-[height]": !props.resizing && (!props.desktop || props.stacked),
+        "will-change-[height]": !props.embedded && !props.resizing && (!props.desktop || props.stacked),
       }}
       style={{ height: props.height, "--terminal-panel-height": props.contentHeight }}
     >
-      <div classList={{ "md:hidden": !props.stacked, hidden: props.stacked }} onPointerDown={props.onResizeStart}>
+      <div
+        classList={{ "md:hidden": !props.stacked, hidden: props.stacked || props.embedded }}
+        onPointerDown={props.onResizeStart}
+      >
         <ResizeHandle
           class="-top-1"
           direction="vertical"
@@ -57,7 +61,7 @@ export function TerminalSurface(
         data-slot="terminal-panel-content"
         class="absolute inset-x-0 top-0 flex flex-col overflow-hidden"
         classList={{
-          "border-t border-border-weak-base": props.opened && !props.desktop,
+          "border-t border-border-weak-base": props.opened && !props.desktop && !props.embedded,
           "pointer-events-none": !props.opened,
         }}
         style={{ height: props.contentHeight }}

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -411,7 +411,7 @@ function MessageTimelineView(
     }),
   )
   const turnPadding = () => "px-4 md:px-5"
-  const showHeader = createMemo(() => props.data.showHeader() || workspaceSession())
+  const showHeader = createMemo(() => !props.hideHeader && (props.data.showHeader() || workspaceSession()))
   const pinned = createMemo(() => props.pinned)
   const messageByID = projection.messageByID
   const virtualized = createTimelineVirtualizer({

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -69,7 +69,7 @@ export function BackgroundMoveHint(props: { keybind?: string[] }) {
   )
 }
 
-export function BackgroundWorkSummary(props: { tasks: BackgroundTask[] }) {
+export function BackgroundWorkSummary(props: { tasks: BackgroundTask[]; mobile?: boolean }) {
   const language = useLanguage()
   const [open, setOpen] = createSignal(false)
   const taskType = (task: BackgroundTask) => {
@@ -81,7 +81,7 @@ export function BackgroundWorkSummary(props: { tasks: BackgroundTask[] }) {
   return (
     <Popover
       open={open()}
-      placement={language.direction() === "rtl" ? "right-end" : "left-end"}
+      placement={props.mobile ? "top-end" : language.direction() === "rtl" ? "right-end" : "left-end"}
       gutter={4}
       onOpenChange={setOpen}
     >
@@ -126,6 +126,7 @@ export function BackgroundWorkSummary(props: { tasks: BackgroundTask[] }) {
 
 function WorkspaceMoveAction(props: {
   variant: "inline" | "panel"
+  mobile?: boolean
   eligible: boolean
   sessionID: string
   project: Project
@@ -150,9 +151,17 @@ function WorkspaceMoveAction(props: {
         sessionID={props.sessionID}
         project={props.project}
         directory={props.directory}
-        placement={inline() ? "bottom-end" : language.direction() === "rtl" ? "right-start" : "left-start"}
-        gutter={inline() ? 4 : -22}
-        contentClass={inline() ? undefined : "relative top-3.5"}
+        placement={
+          props.mobile
+            ? "top-end"
+            : inline()
+              ? "bottom-end"
+              : language.direction() === "rtl"
+                ? "right-start"
+                : "left-start"
+        }
+        gutter={props.mobile || inline() ? 4 : -22}
+        contentClass={props.mobile || inline() ? undefined : "relative top-3.5"}
         class={
           inline()
             ? "flex h-5 w-full items-center gap-1.5 rounded-[4px] pe-6 text-[13px] font-[440] leading-5 tracking-[-0.04px] text-v2-text-text-faint hover:bg-v2-overlay-simple-overlay-hover focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:outline-none data-[expanded]:bg-v2-overlay-simple-overlay-pressed"
@@ -181,7 +190,8 @@ function WorkspaceMoveAction(props: {
   )
 }
 
-function SessionSummaryPanel(props: {
+export function SessionSummaryPanel(props: {
+  mobile?: boolean
   project: Project
   avatar?: JSX.Element
   directory: string
@@ -207,7 +217,7 @@ function SessionSummaryPanel(props: {
     "flex h-7 w-full items-center gap-2 rounded-[4px] px-3 text-[13px] font-[440] leading-5 tracking-[-0.04px] text-v2-text-text-base"
 
   return (
-    <div data-component="session-summary-panel" class="w-[280px]">
+    <div data-component="session-summary-panel" class={props.mobile ? "w-full" : "w-[280px]"}>
       <div class="relative z-10 flex flex-col gap-1 overflow-hidden rounded-[6px] bg-v2-background-bg-base px-0.5 py-1.5 shadow-[var(--v2-elevation-raised)]">
         <div class={row}>
           {props.avatar ?? (
@@ -217,19 +227,23 @@ function SessionSummaryPanel(props: {
               variant={getProjectAvatarVariant(props.project.icon?.color)}
             />
           )}
-          <span class="min-w-0 flex-1 truncate text-v2-text-text-muted">{displayName(props.project)}</span>
+          <span dir="auto" class="min-w-0 flex-1 truncate text-v2-text-text-muted">
+            {displayName(props.project)}
+          </span>
         </div>
         <SessionWorkspaceMenu
           eligible={props.moveEligible}
           sessionID={props.sessionID}
           project={props.project}
           directory={props.directory}
-          placement={language.direction() === "rtl" ? "right-start" : "left-start"}
-          gutter={-22}
+          placement={props.mobile ? "top-end" : language.direction() === "rtl" ? "right-start" : "left-start"}
+          gutter={props.mobile ? 4 : -22}
           class={`${row} hover:bg-v2-overlay-simple-overlay-hover focus-visible:bg-v2-overlay-simple-overlay-hover focus-visible:outline-none data-[expanded]:bg-v2-overlay-simple-overlay-pressed`}
         >
           <Icon name={props.local ? "monitor" : "workspace-isolated"} class="shrink-0 text-v2-icon-icon-muted" />
-          <span class="min-w-0 flex-1 truncate text-start">{location()}</span>
+          <span dir="auto" class="min-w-0 flex-1 truncate text-start">
+            {location()}
+          </span>
           <Icon name="chevron-down" size="small" class="shrink-0 text-v2-icon-icon-muted" />
         </SessionWorkspaceMenu>
         <div class={row}>
@@ -252,7 +266,9 @@ function SessionSummaryPanel(props: {
               </span>
             }
           >
-            <span class="min-w-0 truncate">{branch()}</span>
+            <span dir="auto" class="min-w-0 truncate">
+              {branch()}
+            </span>
           </Show>
         </div>
         <button
@@ -272,12 +288,13 @@ function SessionSummaryPanel(props: {
           </Show>
         </button>
         <Show when={props.backgroundTasks.length > 0}>
-          <BackgroundWorkSummary tasks={props.backgroundTasks} />
+          <BackgroundWorkSummary tasks={props.backgroundTasks} mobile={props.mobile} />
         </Show>
       </div>
       <Show when={props.local && props.diffs && props.diffs.length > 0 && props.moveEligible}>
         <WorkspaceMoveAction
           variant="panel"
+          mobile={props.mobile}
           eligible={props.moveEligible}
           sessionID={props.sessionID}
           project={props.project}
@@ -291,6 +308,7 @@ function SessionSummaryPanel(props: {
 }
 
 type MessageTimelineProps = {
+  hideHeader?: boolean
   session: TimelineSessionSource
   background: SessionBackground
   actions?: SessionUserActions
@@ -556,198 +574,200 @@ function MessageTimelineView(
       }}
       renderRow={(row, onSizeChange) => <rowRenderer.Row row={row} onSizeChange={onSizeChange} />}
       header={
-        <SessionTitleHeader>
-          <div class="h-12 w-full flex items-center justify-between gap-2">
-            <div class="flex items-center gap-1 min-w-0 flex-1">
-              <div class="flex items-center min-w-0 flex-1 w-full">
-                <Show
-                  when={workspaceSession()}
-                  fallback={
-                    <span class="flex size-6 shrink-0 items-center justify-center text-v2-icon-icon-muted">
-                      <Show when={showProjectIcon()} fallback={<Icon name="monitor" />}>
-                        {projectAvatar()}
-                      </Show>
-                    </span>
-                  }
-                >
-                  <Tooltip
-                    placement="bottom-start"
-                    value={sessionDirectory()}
-                    contentClass="max-w-[calc(100vw-32px)] break-all"
-                  >
-                    <span
-                      tabIndex={0}
-                      aria-label={sessionDirectory()}
-                      classList={{
-                        "flex size-6 shrink-0 items-center justify-center": true,
-                        "text-v2-icon-icon-accent": !showProjectIcon(),
-                      }}
-                    >
-                      <Show when={showProjectIcon()} fallback={<Icon name="workspace-isolated" />}>
-                        {projectAvatar()}
-                      </Show>
-                    </span>
-                  </Tooltip>
-                </Show>
-                <Show when={parentID()}>
-                  <button
-                    type="button"
-                    data-slot="session-title-parent"
-                    class="min-w-0 max-w-[40%] truncate pl-2 text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-faint transition-colors hover:text-v2-text-text-muted"
-                    onClick={props.action.navigateParent}
-                  >
-                    {parentTitle()}
-                  </button>
-                  <span
-                    data-slot="session-title-separator"
-                    class="-translate-y-[0.5px] pl-2 pr-1 text-[11px] font-medium text-v2-text-text-faint"
-                    aria-hidden="true"
-                  >
-                    /
-                  </span>
-                </Show>
-                <Show when={childTitle() || title.editing}>
+        <Show when={!props.hideHeader}>
+          <SessionTitleHeader>
+            <div class="h-12 w-full flex items-center justify-between gap-2">
+              <div class="flex items-center gap-1 min-w-0 flex-1">
+                <div class="flex items-center min-w-0 flex-1 w-full">
                   <Show
-                    when={title.editing}
+                    when={workspaceSession()}
                     fallback={
-                      <h1
-                        data-slot="session-title-child"
-                        class="truncate text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-base w-fit rounded-[6px] px-2 py-1 hover:bg-v2-overlay-simple-overlay-hover"
-                        onClick={openTitleEditor}
-                      >
-                        {childTitle()}
-                      </h1>
+                      <span class="flex size-6 shrink-0 items-center justify-center text-v2-icon-icon-muted">
+                        <Show when={showProjectIcon()} fallback={<Icon name="monitor" />}>
+                          {projectAvatar()}
+                        </Show>
+                      </span>
                     }
                   >
-                    <InlineInput
-                      ref={(el) => {
-                        titleRef = el
-                      }}
-                      data-slot="session-title-child"
-                      dir="auto"
-                      value={title.draft}
-                      disabled={props.pending.rename()}
-                      class="block text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-base field-sizing-content self-start rounded-[6px] px-2 py-1"
-                      style={{
-                        "--inline-input-shadow": "none",
-                        "text-align": "start",
-                      }}
-                      onInput={(event) => setTitle("draft", event.currentTarget.value)}
-                      onKeyDown={(event) => {
-                        event.stopPropagation()
-                        if (event.isComposing || event.keyCode === 229) return
-                        if (event.key === "Enter") {
-                          event.preventDefault()
-                          void saveTitleEditor()
-                          return
-                        }
-                        if (event.key === "Escape") {
-                          event.preventDefault()
-                          closeTitleEditor()
-                        }
-                      }}
-                      onBlur={() => void saveTitleEditor()}
-                    />
-                  </Show>
-                </Show>
-              </div>
-            </div>
-            <Show when={sessionID()} keyed>
-              {(id) => (
-                <div class="shrink-0 flex items-center gap-2">
-                  <SessionContextUsage placement="bottom" />
-                  <Show when={!parentID() && project()}>
-                    {(project) => (
-                      <Popover open={summaryOpen()} placement="bottom-end" gutter={6} onOpenChange={setSummary}>
-                        <Popover.Trigger
-                          as={IconButton}
-                          icon={<Icon name="window-analytics" />}
-                          variant="ghost-muted"
-                          size="large"
-                          state={summaryOpen() ? "pressed" : undefined}
-                          aria-label={language.t("session.summary.title")}
-                          aria-expanded={summaryOpen()}
-                        />
-                        <Popover.Portal>
-                          <Popover.Content class="z-50 border-0 bg-transparent p-0 outline-none">
-                            <SessionSummaryPanel
-                              project={project()}
-                              avatar={showProjectIcon() ? projectAvatar() : undefined}
-                              directory={sessionDirectory()}
-                              local={!workspaceSession()}
-                              branch={data.location.vcs.info({ directory: sdk().directory })?.branch.current}
-                              baseBranch={data.location.vcs.info({ directory: project().worktree })?.branch.current}
-                              diffs={sessionDiffs()}
-                              sessionID={id}
-                              moveEligible={props.workspaceMoveEligible}
-                              moveDismissed={workspaceSuggestionDismissed()}
-                              onMoveDismiss={() => setWorkspaceSuggestionDismissed(true)}
-                              onReview={() => {
-                                setSummary(false)
-                                props.onReview()
-                              }}
-                              backgroundTasks={props.background.tasks()}
-                            />
-                          </Popover.Content>
-                        </Popover.Portal>
-                      </Popover>
-                    )}
-                  </Show>
-                  <Show when={!parentID()}>
-                    <Menu
-                      gutter={6}
-                      placement="bottom-end"
-                      open={title.menuOpen}
-                      onOpenChange={(open) => {
-                        setTitle("menuOpen", open)
-                        if (open) return
-                      }}
+                    <Tooltip
+                      placement="bottom-start"
+                      value={sessionDirectory()}
+                      contentClass="max-w-[calc(100vw-32px)] break-all"
                     >
-                      <Menu.Trigger
-                        as={IconButton}
-                        icon={<Icon name="outline-dots" />}
-                        variant="ghost-muted"
-                        size="large"
-                        aria-label={language.t("common.moreOptions")}
-                        aria-expanded={title.menuOpen}
-                      />
-                      <Menu.Portal>
-                        <Menu.Content
-                          style={{ width: "120px", "min-width": "120px" }}
-                          onCloseAutoFocus={(event) => {
-                            if (title.pendingRename) {
-                              event.preventDefault()
-                              setTitle("pendingRename", false)
-                              openTitleEditor()
-                              return
-                            }
-                          }}
+                      <span
+                        tabIndex={0}
+                        aria-label={sessionDirectory()}
+                        classList={{
+                          "flex size-6 shrink-0 items-center justify-center": true,
+                          "text-v2-icon-icon-accent": !showProjectIcon(),
+                        }}
+                      >
+                        <Show when={showProjectIcon()} fallback={<Icon name="workspace-isolated" />}>
+                          {projectAvatar()}
+                        </Show>
+                      </span>
+                    </Tooltip>
+                  </Show>
+                  <Show when={parentID()}>
+                    <button
+                      type="button"
+                      data-slot="session-title-parent"
+                      class="min-w-0 max-w-[40%] truncate pl-2 text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-faint transition-colors hover:text-v2-text-text-muted"
+                      onClick={props.action.navigateParent}
+                    >
+                      {parentTitle()}
+                    </button>
+                    <span
+                      data-slot="session-title-separator"
+                      class="-translate-y-[0.5px] pl-2 pr-1 text-[11px] font-medium text-v2-text-text-faint"
+                      aria-hidden="true"
+                    >
+                      /
+                    </span>
+                  </Show>
+                  <Show when={childTitle() || title.editing}>
+                    <Show
+                      when={title.editing}
+                      fallback={
+                        <h1
+                          data-slot="session-title-child"
+                          class="truncate text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-base w-fit rounded-[6px] px-2 py-1 hover:bg-v2-overlay-simple-overlay-hover"
+                          onClick={openTitleEditor}
                         >
-                          <Menu.Item
-                            onSelect={() => {
-                              setTitle("pendingRename", true)
-                              setTitle("menuOpen", false)
-                            }}
-                          >
-                            {language.t("common.rename")}
-                          </Menu.Item>
-                          <Menu.Item onSelect={() => void props.action.export(id)}>
-                            {language.t("common.export")}...
-                          </Menu.Item>
-                          {/* TODO: Need a session archive API. */}
-                          <Menu.Separator />
-                          <Menu.Item onSelect={() => props.action.showDelete(id)}>
-                            {language.t("common.delete")}...
-                          </Menu.Item>
-                        </Menu.Content>
-                      </Menu.Portal>
-                    </Menu>
+                          {childTitle()}
+                        </h1>
+                      }
+                    >
+                      <InlineInput
+                        ref={(el) => {
+                          titleRef = el
+                        }}
+                        data-slot="session-title-child"
+                        dir="auto"
+                        value={title.draft}
+                        disabled={props.pending.rename()}
+                        class="block text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-base field-sizing-content self-start rounded-[6px] px-2 py-1"
+                        style={{
+                          "--inline-input-shadow": "none",
+                          "text-align": "start",
+                        }}
+                        onInput={(event) => setTitle("draft", event.currentTarget.value)}
+                        onKeyDown={(event) => {
+                          event.stopPropagation()
+                          if (event.isComposing || event.keyCode === 229) return
+                          if (event.key === "Enter") {
+                            event.preventDefault()
+                            void saveTitleEditor()
+                            return
+                          }
+                          if (event.key === "Escape") {
+                            event.preventDefault()
+                            closeTitleEditor()
+                          }
+                        }}
+                        onBlur={() => void saveTitleEditor()}
+                      />
+                    </Show>
                   </Show>
                 </div>
-              )}
-            </Show>
-          </div>
-        </SessionTitleHeader>
+              </div>
+              <Show when={sessionID()} keyed>
+                {(id) => (
+                  <div class="shrink-0 flex items-center gap-2">
+                    <SessionContextUsage placement="bottom" />
+                    <Show when={!parentID() && project()}>
+                      {(project) => (
+                        <Popover open={summaryOpen()} placement="bottom-end" gutter={6} onOpenChange={setSummary}>
+                          <Popover.Trigger
+                            as={IconButton}
+                            icon={<Icon name="window-analytics" />}
+                            variant="ghost-muted"
+                            size="large"
+                            state={summaryOpen() ? "pressed" : undefined}
+                            aria-label={language.t("session.summary.title")}
+                            aria-expanded={summaryOpen()}
+                          />
+                          <Popover.Portal>
+                            <Popover.Content class="z-50 border-0 bg-transparent p-0 outline-none">
+                              <SessionSummaryPanel
+                                project={project()}
+                                avatar={showProjectIcon() ? projectAvatar() : undefined}
+                                directory={sessionDirectory()}
+                                local={!workspaceSession()}
+                                branch={data.location.vcs.info({ directory: sdk().directory })?.branch.current}
+                                baseBranch={data.location.vcs.info({ directory: project().worktree })?.branch.current}
+                                diffs={sessionDiffs()}
+                                sessionID={id}
+                                moveEligible={props.workspaceMoveEligible}
+                                moveDismissed={workspaceSuggestionDismissed()}
+                                onMoveDismiss={() => setWorkspaceSuggestionDismissed(true)}
+                                onReview={() => {
+                                  setSummary(false)
+                                  props.onReview()
+                                }}
+                                backgroundTasks={props.background.tasks()}
+                              />
+                            </Popover.Content>
+                          </Popover.Portal>
+                        </Popover>
+                      )}
+                    </Show>
+                    <Show when={!parentID()}>
+                      <Menu
+                        gutter={6}
+                        placement="bottom-end"
+                        open={title.menuOpen}
+                        onOpenChange={(open) => {
+                          setTitle("menuOpen", open)
+                          if (open) return
+                        }}
+                      >
+                        <Menu.Trigger
+                          as={IconButton}
+                          icon={<Icon name="outline-dots" />}
+                          variant="ghost-muted"
+                          size="large"
+                          aria-label={language.t("common.moreOptions")}
+                          aria-expanded={title.menuOpen}
+                        />
+                        <Menu.Portal>
+                          <Menu.Content
+                            style={{ width: "120px", "min-width": "120px" }}
+                            onCloseAutoFocus={(event) => {
+                              if (title.pendingRename) {
+                                event.preventDefault()
+                                setTitle("pendingRename", false)
+                                openTitleEditor()
+                                return
+                              }
+                            }}
+                          >
+                            <Menu.Item
+                              onSelect={() => {
+                                setTitle("pendingRename", true)
+                                setTitle("menuOpen", false)
+                              }}
+                            >
+                              {language.t("common.rename")}
+                            </Menu.Item>
+                            <Menu.Item onSelect={() => void props.action.export(id)}>
+                              {language.t("common.export")}...
+                            </Menu.Item>
+                            {/* TODO: Need a session archive API. */}
+                            <Menu.Separator />
+                            <Menu.Item onSelect={() => props.action.showDelete(id)}>
+                              {language.t("common.delete")}...
+                            </Menu.Item>
+                          </Menu.Content>
+                        </Menu.Portal>
+                      </Menu>
+                    </Show>
+                  </div>
+                )}
+              </Show>
+            </div>
+          </SessionTitleHeader>
+        </Show>
       }
     />
   )

--- a/packages/app/src/session/timeline/virtualizer.tsx
+++ b/packages/app/src/session/timeline/virtualizer.tsx
@@ -22,6 +22,7 @@ import {
   type JSX,
 } from "solid-js"
 import { createStore } from "solid-js/store"
+import { createMediaQuery } from "@solid-primitives/media"
 import type { createTimelineProjection } from "./projection"
 import { observeElementOffsetReconnectAware } from "./observe-element-offset"
 import { filterVirtualIndexes } from "./virtual-items"
@@ -73,6 +74,8 @@ type ViewProps = {
 
 export function createTimelineVirtualizer(input: Input) {
   const language = useLanguage()
+  const isDesktop = createMediaQuery("(min-width: 768px)")
+  const topOffset = () => (input.showHeader() ? 64 : isDesktop() ? 0 : 16)
   const ownerSessionKey = input.sessionKey()
   const cached = cache.get(ownerSessionKey)
   const initialMeasurements = cached?.measurements
@@ -186,7 +189,7 @@ export function createTimelineVirtualizer(input: Input) {
     },
     scrollEndThreshold: 80,
     get scrollMargin() {
-      return input.showHeader() ? 64 : 0
+      return topOffset()
     },
     paddingEnd: 64,
     get rangeExtractor() {
@@ -446,7 +449,7 @@ export function createTimelineVirtualizer(input: Input) {
           data-timeline-key={rowProps.rowKey}
           style={{
             position: "absolute",
-            top: `${item().start - (input.showHeader() ? 64 : 0)}px`,
+            top: `${item().start - topOffset()}px`,
             left: "0",
             width: "100%",
             height: `${item().size}px`,
@@ -516,7 +519,9 @@ export function createTimelineVirtualizer(input: Input) {
           class="relative min-w-0 w-full h-full"
           style={{ "--sticky-accordion-top": input.showHeader() ? "48px" : "0px" }}
         >
-          <Show when={input.showHeader()}>{props.header}</Show>
+          <Show when={input.showHeader()} fallback={<div aria-hidden="true" class="h-4 md:hidden" />}>
+            {props.header}
+          </Show>
           <div
             data-timeline-virtual-content
             ref={(element) => {

--- a/packages/app/src/settings/settings.css
+++ b/packages/app/src/settings/settings.css
@@ -335,7 +335,7 @@
 }
 
 @container settings-screen (max-width: 799px) {
-  .settings-screen > .settings {
+  .settings-screen > .settings[data-component="tabs-v2"] {
     flex-direction: column;
   }
 

--- a/packages/app/src/settings/settings.css
+++ b/packages/app/src/settings/settings.css
@@ -24,6 +24,13 @@
   min-width: 0;
 }
 
+@media (max-width: 767px) {
+  .settings-screen {
+    --settings-mobile-inner-inset: 8px;
+    padding-block: var(--settings-top-inset, var(--shell-top-inset, 8px)) var(--shell-bottom-inset, 8px);
+  }
+}
+
 .settings-screen
   > .settings[data-component="tabs-v2"][data-variant="settings"][data-orientation="vertical"]
   > [data-slot="tabs-v2-list"] {
@@ -49,6 +56,7 @@
 
 .settings-screen .settings-tab-body {
   padding-inline: 0;
+  padding-bottom: var(--settings-bottom-inset, 0px);
 }
 
 .settings-nav {
@@ -57,6 +65,26 @@
   flex-shrink: 0;
   flex-direction: column;
   gap: 16px;
+}
+
+.settings-mobile-nav {
+  display: none;
+}
+
+.settings-mobile-menu-trigger {
+  min-width: 0;
+}
+
+.settings-mobile-menu-trigger > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-mobile-menu[data-component="menu-v2-content"] {
+  max-width: calc(100vw - 32px);
+  max-height: var(--kb-popper-content-available-height);
+  overflow-y: auto;
 }
 
 .settings-nav-footer {
@@ -291,36 +319,6 @@
   background-color: var(--v2-background-bg-layer-01);
 }
 
-@media (max-width: 639px) {
-  .settings-screen .settings-nav {
-    width: 100%;
-  }
-
-  .settings-screen > .settings > .settings-panel {
-    padding-inline-end: 16px;
-  }
-
-  .settings-screen .settings-tab-header {
-    padding-top: 24px;
-  }
-
-  .settings[data-component="tabs-v2"][data-variant="settings"][data-orientation="vertical"]
-    > [data-slot="tabs-v2-list"] {
-    width: 144px;
-    min-width: 144px;
-    padding-inline: 8px;
-  }
-
-  .settings-screen
-    > .settings[data-component="tabs-v2"][data-variant="settings"][data-orientation="vertical"]
-    > [data-slot="tabs-v2-list"] {
-    width: 160px;
-    min-width: 160px;
-    padding-block: 24px;
-    padding-inline: 12px;
-  }
-}
-
 @container settings-screen (min-width: 800px) and (max-width: 1047px) {
   .settings-screen > .settings {
     padding-inline: 24px;
@@ -337,25 +335,60 @@
 }
 
 @container settings-screen (max-width: 799px) {
-  .settings-screen .settings-nav {
-    width: 100%;
+  .settings-screen > .settings {
+    flex-direction: column;
+  }
+
+  .settings-mobile-nav {
+    position: relative;
+    z-index: 11;
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 8px var(--settings-mobile-inner-inset, 16px);
+    border-bottom: 0.5px solid var(--v2-border-border-muted);
+    background: var(--v2-background-bg-deep);
+  }
+
+  .settings-mobile-nav::after {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    inset-block-start: 100%;
+    height: 1px;
+    background: var(--v2-background-bg-deep);
+    pointer-events: none;
+  }
+
+  .settings-mobile-nav .settings-back {
+    flex-shrink: 0;
   }
 
   .settings-screen > .settings > .settings-panel {
-    padding-inline-end: 16px;
+    min-height: 0;
+    max-width: none;
+  }
+
+  .settings-screen .settings-tab-header,
+  .settings-screen .settings-tab-body {
+    padding-inline: var(--settings-mobile-inner-inset, 16px);
   }
 
   .settings-screen .settings-tab-header {
-    padding-top: 24px;
+    padding-top: 12px;
+  }
+
+  .settings-screen .settings-tab-title,
+  .settings-screen .settings-section-title {
+    line-height: var(--line-height-base);
   }
 
   .settings-screen
     > .settings[data-component="tabs-v2"][data-variant="settings"][data-orientation="vertical"]
     > [data-slot="tabs-v2-list"] {
-    width: 160px;
-    min-width: 160px;
-    padding-block: 24px;
-    padding-inline: 12px;
+    display: none;
   }
 }
 
@@ -634,6 +667,15 @@
 
 .settings-models [data-slot="settings-row-copy"] {
   gap: 0;
+}
+
+.settings-models [data-component="settings-row"] {
+  flex-wrap: nowrap;
+}
+
+.settings-models [data-slot="settings-row-control"] {
+  width: auto;
+  flex-shrink: 0;
 }
 
 .settings-models [data-slot="settings-row-title"] {

--- a/packages/app/src/settings/shell.tsx
+++ b/packages/app/src/settings/shell.tsx
@@ -1,6 +1,18 @@
-import { Component, createEffect, createMemo, createSignal, onCleanup, onMount, startTransition } from "solid-js"
+import {
+  Component,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  Show,
+  onCleanup,
+  onMount,
+  startTransition,
+} from "solid-js"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { Icon } from "@opencode-ai/ui/icon"
+import { Menu } from "@opencode-ai/ui/menu"
+import { Button } from "@opencode-ai/ui/button"
 import { useLanguage } from "@/runtime/i18n/language"
 import { usePlatform } from "@/runtime/platform/platform"
 import { SettingsGeneral } from "./general/general"
@@ -22,6 +34,25 @@ import { ServerConnection, useServers } from "@/runtime/server/registry"
 import { useCommand } from "@/shell/commands/command"
 import { useSettingsSurface } from "./surface"
 import "@/settings/settings.css"
+
+const sections = [
+  [
+    { value: "general", icon: "sliders", label: "settings.tab.preferences" },
+    { value: "appearance", icon: "appearance", label: "settings.general.section.appearance" },
+    { value: "notifications", icon: "notifications", label: "settings.tab.notifications" },
+    { value: "shortcuts", icon: "keyboard", label: "settings.tab.shortcuts" },
+  ],
+  [
+    { value: "servers", icon: "server", label: "status.popover.tab.servers" },
+    { value: "projects", icon: "folder", label: "settings.tab.projects" },
+    { value: "workspaces", icon: "workspace-isolated", label: "settings.tab.workspaces" },
+  ],
+  [
+    { value: "providers", icon: "providers", label: "settings.providers.title" },
+    { value: "models", icon: "models", label: "settings.models.title" },
+    { value: "extensions", icon: "extensions", label: "settings.tab.extensions" },
+  ],
+] as const
 
 export const SettingsScreen: Component<{
   defaultValue?: string
@@ -103,6 +134,45 @@ export const SettingsScreen: Component<{
         onChange={(value) => void startTransition(() => setTab(value))}
         class="settings"
       >
+        <div class="settings-mobile-nav">
+          <button type="button" class="settings-back" onClick={surface.close}>
+            <Icon name="arrow-left" size="small" class="settings-back-icon" />
+            <span>{language.t("settings.backToApp")}</span>
+          </button>
+          <Menu placement="bottom-end" gutter={8}>
+            <Menu.Trigger as={Button} size="normal" variant="outline" class="settings-mobile-menu-trigger">
+              <span>
+                {language.t(
+                  sections.flat().find((section) => section.value === tab())?.label ?? "settings.tab.preferences",
+                )}
+              </span>
+              <Icon name="chevron-down" size="small" />
+            </Menu.Trigger>
+            <Menu.Portal>
+              <Menu.Content class="settings-mobile-menu" onEscapeKeyDown={(event) => event.stopPropagation()}>
+                <Menu.RadioGroup value={tab()} onChange={(value) => void startTransition(() => setTab(value))}>
+                  <For each={sections}>
+                    {(group, index) => (
+                      <>
+                        <Show when={index() > 0}>
+                          <Menu.Separator />
+                        </Show>
+                        <For each={group}>
+                          {(section) => (
+                            <Menu.RadioItem value={section.value} closeOnSelect>
+                              <Icon name={section.icon} />
+                              {language.t(section.label)}
+                            </Menu.RadioItem>
+                          )}
+                        </For>
+                      </>
+                    )}
+                  </For>
+                </Menu.RadioGroup>
+              </Menu.Content>
+            </Menu.Portal>
+          </Menu>
+        </div>
         <Tabs.List>
           <div class="settings-nav">
             <button type="button" class="settings-back" onClick={surface.close}>
@@ -110,57 +180,20 @@ export const SettingsScreen: Component<{
               <span>{language.t("settings.backToApp")}</span>
             </button>
             <div class="flex flex-col gap-4 w-full">
-              {/* Group 1: Preferences */}
-              <div class="flex flex-col gap-1 w-full">
-                <Tabs.Trigger value="general">
-                  <Icon name="sliders" />
-                  {language.t("settings.tab.preferences")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="appearance">
-                  <Icon name="appearance" />
-                  {language.t("settings.general.section.appearance")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="notifications">
-                  <Icon name="notifications" />
-                  {language.t("settings.tab.notifications")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="shortcuts">
-                  <Icon name="keyboard" />
-                  {language.t("settings.tab.shortcuts")}
-                </Tabs.Trigger>
-              </div>
-
-              {/* Group 2: Environment & Workspaces */}
-              <div class="flex flex-col gap-1 w-full">
-                <Tabs.Trigger value="servers">
-                  <Icon name="server" />
-                  {language.t("status.popover.tab.servers")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="projects">
-                  <Icon name="folder" />
-                  {language.t("settings.tab.projects")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="workspaces">
-                  <Icon name="workspace-isolated" />
-                  {language.t("settings.tab.workspaces")}
-                </Tabs.Trigger>
-              </div>
-
-              {/* Group 3: Capabilities & Extensions */}
-              <div class="flex flex-col gap-1 w-full">
-                <Tabs.Trigger value="providers">
-                  <Icon name="providers" />
-                  {language.t("settings.providers.title")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="models">
-                  <Icon name="models" />
-                  {language.t("settings.models.title")}
-                </Tabs.Trigger>
-                <Tabs.Trigger value="extensions">
-                  <Icon name="extensions" />
-                  {language.t("settings.tab.extensions")}
-                </Tabs.Trigger>
-              </div>
+              <For each={sections}>
+                {(group) => (
+                  <div class="flex flex-col gap-1 w-full">
+                    <For each={group}>
+                      {(section) => (
+                        <Tabs.Trigger value={section.value}>
+                          <Icon name={section.icon} />
+                          {language.t(section.label)}
+                        </Tabs.Trigger>
+                      )}
+                    </For>
+                  </div>
+                )}
+              </For>
             </div>
           </div>
           <div class="settings-nav-footer">

--- a/packages/app/src/shell/mobile-panel-drawer.tsx
+++ b/packages/app/src/shell/mobile-panel-drawer.tsx
@@ -1,0 +1,44 @@
+import Drawer from "@corvu/drawer"
+import type { ParentProps } from "solid-js"
+import { useLanguage } from "@/runtime/i18n/language"
+import "./status/status-drawer.css"
+
+export function MobilePanelDrawer(
+  props: ParentProps<{
+    title: string
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    returnFocus?: () => HTMLElement | undefined
+  }>,
+) {
+  const language = useLanguage()
+  return (
+    <Drawer
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      side="bottom"
+      finalFocusEl={props.returnFocus?.()}
+      // Menu focus handoff must not dismiss the drawer during its opening transition.
+      closeOnOutsideFocus={false}
+    >
+      {/* Preserve Corvu's content and dismissal lifecycle across reopenings. */}
+      <Drawer.Portal forceMount>
+        <Drawer.Overlay data-slot="mobile-status-overlay" />
+        <Drawer.Content forceMount data-slot="mobile-status-drawer" dir={language.direction()}>
+          <div data-slot="mobile-status-drag-handle" aria-hidden="true">
+            <span />
+          </div>
+          <div data-slot="mobile-status-header" data-corvu-no-drag>
+            <Drawer.Label>{props.title}</Drawer.Label>
+            <Drawer.Close data-slot="mobile-status-close" aria-label={language.t("common.close")}>
+              {language.t("common.close")}
+            </Drawer.Close>
+          </div>
+          <div data-slot="mobile-status-content" data-corvu-no-drag>
+            {props.children}
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer>
+  )
+}

--- a/packages/app/src/shell/routes/routes.tsx
+++ b/packages/app/src/shell/routes/routes.tsx
@@ -35,7 +35,7 @@ export function AppRoutes() {
           <SessionRouteFrame>
             <Suspense
               fallback={
-                <div class="flex min-h-0 flex-1 px-2 pb-2 pt-[var(--shell-top-inset,8px)]">
+                <div class="flex min-h-0 flex-1 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
                   <SessionPanelFrame raised />
                 </div>
               }

--- a/packages/app/src/shell/shell.tsx
+++ b/packages/app/src/shell/shell.tsx
@@ -23,6 +23,7 @@ export default function Layout(props: ParentProps) {
     tabsMount: undefined as HTMLElement | undefined,
   })
   const verticalTabs = () => preferences.appearance.tabLayout() === "vertical" && !mobile()
+  const bottomTitlebar = () => mobile() && preferences.general.mobileTitlebarPosition() === "bottom"
 
   const update: TitlebarUpdate = {
     get version() {
@@ -41,15 +42,13 @@ export default function Layout(props: ParentProps) {
       <div
         class="relative bg-v2-background-bg-deep flex-1 min-h-0 min-w-0 flex flex-col select-none [&_input]:select-text [&_textarea]:select-text [&_[contenteditable]]:select-text"
         style={{
-          "padding-top": "env(safe-area-inset-top, 0px)",
-          "padding-bottom": "env(safe-area-inset-bottom, 0px)",
           // Native Windows chrome supplies the gap; retain paint clearance for the panels' outer outlines.
-          "--shell-top-inset":
-            platform.platform === "desktop" &&
-            platform.os === "windows" &&
-            !(mobile() && preferences.general.mobileTitlebarPosition() === "bottom")
+          "--shell-top-inset": bottomTitlebar()
+            ? "max(0px, calc(8px - env(safe-area-inset-top, 0px)))"
+            : platform.platform === "desktop" && platform.os === "windows"
               ? "1px"
               : "8px",
+          "--shell-bottom-inset": bottomTitlebar() ? "8px" : "max(0px, calc(8px - env(safe-area-inset-bottom, 0px)))",
         }}
       >
         <Titlebar
@@ -66,8 +65,11 @@ export default function Layout(props: ParentProps) {
             <aside
               ref={(element) => setState("tabsMount", element)}
               data-slot="vertical-tabs-sidebar"
-              class="relative flex min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 pb-2 pt-[var(--shell-top-inset,8px)]"
-              style={{ width: `${state.tabsWidth}px` }}
+              class="relative flex min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]"
+              style={{
+                width: `${state.tabsWidth}px`,
+                "padding-bottom": "max(8px, env(safe-area-inset-bottom, 0px))",
+              }}
             >
               <ResizeHandle
                 class="-end-2"
@@ -80,7 +82,15 @@ export default function Layout(props: ParentProps) {
             </aside>
           </Show>
           {/* Size containment collapses percentage-height descendants in WebKit. */}
-          <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-content">
+          <main
+            class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-content"
+            style={{
+              "padding-top": bottomTitlebar() ? "env(safe-area-inset-top, 0px)" : "0px",
+              "padding-bottom": bottomTitlebar() || settings.store.open ? "0px" : "env(safe-area-inset-bottom, 0px)",
+              "--settings-bottom-inset": bottomTitlebar() ? "40px" : "env(safe-area-inset-bottom, 0px)",
+              "--settings-top-inset": mobile() && !bottomTitlebar() ? "0px" : "var(--shell-top-inset, 8px)",
+            }}
+          >
             <div
               class="flex size-full min-h-0 min-w-0 flex-col"
               hidden={settings.store.open}

--- a/packages/app/src/shell/status/body.tsx
+++ b/packages/app/src/shell/status/body.tsx
@@ -20,7 +20,7 @@ const pluginEmptyMessage = (value: string, file: string): JSXElement => {
   )
 }
 
-export function StatusPopoverBody(props: { shown: boolean }) {
+export function StatusPopoverBody(props: { shown: boolean; embedded?: boolean }) {
   const data = useData()
   const sdk = useWorkspaceLocation()
   const serverSDK = useServerSDK()
@@ -42,7 +42,13 @@ export function StatusPopoverBody(props: { shown: boolean }) {
   const pluginEmpty = createMemo(() => pluginEmptyMessage(language.t("dialog.plugins.empty"), "opencode.json"))
 
   return (
-    <div class="flex items-center gap-1 w-[360px] rounded-xl shadow-[var(--shadow-lg-border-base)]">
+    <div
+      class="flex items-center gap-1 rounded-xl"
+      classList={{
+        "w-[360px] shadow-[var(--shadow-lg-border-base)]": !props.embedded,
+        "w-full min-w-0": props.embedded,
+      }}
+    >
       <Tabs
         aria-label={language.t("status.popover.ariaLabel")}
         class="tabs bg-background-strong rounded-xl overflow-hidden"

--- a/packages/app/src/shell/status/status-drawer.css
+++ b/packages/app/src/shell/status/status-drawer.css
@@ -1,0 +1,145 @@
+[data-slot="mobile-status-overlay"] {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: var(--v2-overlay-simple-overlay-scrim);
+  animation: mobile-status-backdrop-in 240ms ease-out;
+}
+
+[data-slot="mobile-status-overlay"]:is([data-closing], [data-closed]) {
+  animation: mobile-status-backdrop-out 200ms ease-in forwards;
+}
+
+[data-slot="mobile-status-drawer"] {
+  box-sizing: border-box;
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 51;
+  display: flex;
+  flex-direction: column;
+  max-height: min(75dvh, calc(100dvh - env(safe-area-inset-top, 0px) - 16px));
+  padding: 0 12px max(12px, env(safe-area-inset-bottom, 0px));
+  padding-left: max(12px, env(safe-area-inset-left, 0px));
+  padding-right: max(12px, env(safe-area-inset-right, 0px));
+  border-radius: 16px 16px 0 0;
+  background: var(--v2-background-bg-deep);
+  color: var(--v2-text-text-base);
+  box-shadow: var(--v2-elevation-overlay);
+  outline: none;
+  app-region: no-drag;
+}
+
+[data-slot="mobile-status-drawer"][data-transitioning] {
+  transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+[data-slot="mobile-status-drawer"][data-closing] {
+  transition-duration: 200ms;
+}
+
+[data-slot="mobile-status-drawer"][data-closed] {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+[data-slot="mobile-status-drag-handle"] {
+  display: flex;
+  height: 28px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+}
+
+[data-slot="mobile-status-drag-handle"] span {
+  width: 32px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--v2-border-border-strong);
+}
+
+[data-slot="mobile-status-header"] {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-inline-start: 8px;
+  padding-block-end: 8px;
+}
+
+[data-slot="mobile-status-header"] h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 530;
+  line-height: var(--line-height-base);
+}
+
+[data-slot="mobile-status-close"] {
+  min-height: 44px;
+  flex-shrink: 0;
+  padding-inline: 12px;
+  border-radius: 6px;
+  color: var(--v2-text-text-base);
+  font-size: 13px;
+  line-height: var(--line-height-compact);
+}
+
+@media (hover: hover) {
+  [data-slot="mobile-status-close"]:hover {
+    background: var(--v2-overlay-simple-overlay-hover);
+  }
+}
+
+[data-slot="mobile-status-close"]:focus-visible {
+  outline: 2px solid var(--v2-border-border-focus);
+  outline-offset: -2px;
+}
+
+[data-slot="mobile-status-content"] {
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+}
+
+[data-slot="mobile-status-loading"] {
+  display: flex;
+  min-height: 56px;
+  align-items: center;
+  justify-content: center;
+  color: var(--v2-text-text-muted);
+  font-size: 13px;
+  line-height: var(--line-height-base);
+}
+
+@keyframes mobile-status-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes mobile-status-backdrop-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot="mobile-status-drawer"][data-transitioning],
+  [data-slot="mobile-status-drawer"][data-closing] {
+    transition: none;
+  }
+
+  [data-slot="mobile-status-overlay"],
+  [data-slot="mobile-status-overlay"]:is([data-closing], [data-closed]) {
+    animation: none;
+  }
+}

--- a/packages/app/src/shell/status/status-drawer.tsx
+++ b/packages/app/src/shell/status/status-drawer.tsx
@@ -1,0 +1,35 @@
+import { lazy, Suspense } from "solid-js"
+import { useLanguage } from "@/runtime/i18n/language"
+import { MobilePanelDrawer } from "../mobile-panel-drawer"
+
+const Body = lazy(async () => {
+  const { StatusPopoverBody } = await import("./body")
+  return { default: StatusPopoverBody }
+})
+
+export function StatusDrawer(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  returnFocus?: () => HTMLElement | undefined
+}) {
+  const language = useLanguage()
+
+  return (
+    <MobilePanelDrawer
+      title={language.t("status.popover.trigger")}
+      open={props.open}
+      onOpenChange={props.onOpenChange}
+      returnFocus={props.returnFocus}
+    >
+      <Suspense
+        fallback={
+          <div data-slot="mobile-status-loading" role="status">
+            {language.t("common.loading")}
+          </div>
+        }
+      >
+        <Body shown={props.open} embedded />
+      </Suspense>
+    </MobilePanelDrawer>
+  )
+}

--- a/packages/app/src/shell/titlebar/tab-nav.css
+++ b/packages/app/src/shell/titlebar/tab-nav.css
@@ -57,9 +57,10 @@
   margin-block: auto;
 }
 
-[data-titlebar-tab]:is(:hover, :has(> [data-slot="tab-link"]:focus-visible)):not([data-state="pressed"]):not(
-    [data-dragging="true"]
-  ):not([data-editing="true"]) {
+[data-titlebar-tab]:not(:where([data-slot="mobile-tabs-drawer"] *)):is(
+    :hover,
+    :has(> [data-slot="tab-link"]:focus-visible)
+  ):not([data-state="pressed"]):not([data-dragging="true"]):not([data-editing="true"]) {
   --tab-base: var(--v2-background-bg-layer-02);
   --tab-overlay: var(--v2-overlay-simple-overlay-hover);
 }
@@ -183,11 +184,52 @@
   display: none;
 }
 
+@media (hover: none) {
+  [data-titlebar-tab] [data-slot="tab-close"] {
+    background: linear-gradient(var(--tab-overlay), var(--tab-overlay)), var(--tab-base);
+  }
+
+  [data-titlebar-tab]:not([data-editing="true"]) [data-slot="tab-link"],
+  [data-titlebar-tab][data-title-overflow="true"]:not([data-editing="true"]) [data-slot="tab-link"] {
+    --tab-title-fade-offset: 24px;
+    --tab-title-fade-direction: to right;
+    -webkit-mask-image: linear-gradient(
+      var(--tab-title-fade-direction),
+      black 0,
+      black calc(100% - var(--tab-title-fade-offset) - 16px),
+      transparent calc(100% - var(--tab-title-fade-offset)),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      var(--tab-title-fade-direction),
+      black 0,
+      black calc(100% - var(--tab-title-fade-offset) - 16px),
+      transparent calc(100% - var(--tab-title-fade-offset)),
+      transparent 100%
+    );
+  }
+
+  [data-titlebar-tab]:dir(rtl) [data-slot="tab-link"] {
+    --tab-title-fade-direction: to left;
+  }
+}
+
 @container (max-width: 64px) {
   [data-titlebar-tab]:not([data-orientation="vertical"]) [data-titlebar-tab-link] {
     justify-content: center;
     gap: 0;
     padding-inline: 0;
+  }
+
+  @media (hover: none) {
+    [data-titlebar-tab]:not([data-orientation="vertical"]):not([data-editing="true"]) [data-slot="tab-link"],
+    [data-titlebar-tab][data-title-overflow="true"]:not([data-orientation="vertical"]):not([data-editing="true"]):dir(
+        rtl
+      )
+      [data-slot="tab-link"] {
+      -webkit-mask-image: none;
+      mask-image: none;
+    }
   }
 
   [data-titlebar-tab]:not([data-orientation="vertical"]) [data-titlebar-tab-title] {

--- a/packages/app/src/shell/titlebar/tab-popover.tsx
+++ b/packages/app/src/shell/titlebar/tab-popover.tsx
@@ -1,6 +1,7 @@
 import { HoverCard } from "@kobalte/core/hover-card"
 import { createSignal, Show, type JSXElement } from "solid-js"
 import { useLanguage } from "@/runtime/i18n/language"
+import { createMediaQuery } from "@solid-primitives/media"
 import "./tab-popover.css"
 
 // Initial hover delay before the preview appears, per design.
@@ -28,6 +29,7 @@ export function TabPreviewPopover(props: {
   orientation?: "horizontal" | "vertical"
 }) {
   const language = useLanguage()
+  const mobile = createMediaQuery("(max-width: 767px)")
   let triggerEl: HTMLDivElement | undefined
   // When opened during a rapid tab-hopping streak, this preview appears and
   // disappears instantly (no repeated enter/exit animation) — only the first,
@@ -46,7 +48,7 @@ export function TabPreviewPopover(props: {
 
   return (
     <HoverCard
-      open={props.open}
+      open={props.open && !mobile()}
       onOpenChange={handleOpenChange}
       openDelay={resolveOpenDelay()}
       closeDelay={CLOSE_DELAY}

--- a/packages/app/src/shell/titlebar/titlebar.css
+++ b/packages/app/src/shell/titlebar/titlebar.css
@@ -2,6 +2,155 @@
   user-select: none;
 }
 
+[data-slot="mobile-tabs-trigger"][aria-expanded="true"] {
+  background:
+    linear-gradient(var(--v2-overlay-simple-overlay-hover), var(--v2-overlay-simple-overlay-hover)),
+    var(--v2-background-bg-layer-02);
+}
+
+[data-action="mobile-tabs-home"][data-state="pressed"] {
+  background:
+    linear-gradient(var(--v2-overlay-simple-overlay-pressed), var(--v2-overlay-simple-overlay-pressed)),
+    var(--v2-background-bg-layer-02);
+}
+
+[data-slot="mobile-tabs-overlay"] {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: var(--v2-overlay-simple-overlay-scrim);
+  animation: mobile-tabs-backdrop-in 240ms ease-out;
+}
+
+[data-slot="mobile-tabs-overlay"]:is([data-closing], [data-closed]) {
+  animation: mobile-tabs-backdrop-out 200ms ease-in forwards;
+}
+
+/* Keep the strip mounted for tab shortcuts and session metadata while collapsed. */
+[data-slot="mobile-tabs-drawer"] {
+  box-sizing: border-box;
+  position: fixed;
+  inset-inline: 0;
+  bottom: 0;
+  z-index: 51;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: min(75dvh, calc(100dvh - env(safe-area-inset-top, 0px) - 16px));
+  padding: 0 12px max(12px, env(safe-area-inset-bottom, 0px));
+  border-radius: 16px 16px 0 0;
+  background: var(--v2-background-bg-deep);
+  box-shadow: var(--v2-elevation-overlay);
+  outline: none;
+}
+
+[data-slot="mobile-tabs-drawer"][data-transitioning] {
+  transition: transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+[data-slot="mobile-tabs-drawer"][data-closing] {
+  transition-duration: 200ms;
+}
+
+[data-slot="mobile-tabs-drawer"][data-closed] {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+[data-slot="mobile-tabs-drag-handle"] {
+  display: flex;
+  height: 28px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  touch-action: none;
+}
+
+[data-slot="mobile-tabs-drag-handle"] span {
+  width: 32px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--v2-border-border-strong);
+}
+
+[data-slot="mobile-tabs-drawer-list"] {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+}
+
+@keyframes mobile-tabs-backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes mobile-tabs-backdrop-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-slot="mobile-tabs-drawer"][data-transitioning],
+  [data-slot="mobile-tabs-drawer"][data-closing] {
+    transition: none;
+  }
+
+  [data-slot="mobile-tabs-overlay"],
+  [data-slot="mobile-tabs-overlay"]:is([data-closing], [data-closed]) {
+    animation: none;
+  }
+}
+
+[data-slot="mobile-tabs-drawer"] [data-slot="vertical-tabs"] {
+  display: flex;
+  flex-direction: column;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-slot="vertical-tabs-scroll"] {
+  min-height: 0;
+  overscroll-behavior: contain;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] {
+  min-height: 44px;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] [data-slot="tab-close"] {
+  inset-inline-end: 0;
+  width: 44px;
+  height: 44px;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-slot="tab-close"] button {
+  width: 44px;
+  height: 44px;
+  opacity: 1;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] [data-slot="tab-link"] {
+  padding-inline-end: 38px;
+  -webkit-mask-image: none;
+  mask-image: none;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] [data-slot="tab-title"] {
+  color: var(--v2-text-text-base);
+  font-weight: 530;
+}
+
+[data-slot="mobile-tabs-drawer"] [data-titlebar-tab] [data-slot="tab-project"] {
+  color: var(--v2-text-text-faint);
+  font-weight: 440;
+}
+
 [data-slot="titlebar-tab-item"] a {
   outline: none;
 }

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -25,6 +25,11 @@ import type { ComposerState } from "@/composer/persistence"
 import "./titlebar.css"
 import { newTabTooltipKeybind } from "@/shell/commands/tooltip-keybind"
 import { TitlebarRightMount } from "@/shell/titlebar/right-slot"
+import Drawer from "@corvu/drawer"
+import { sessionLabel } from "@/session/title"
+import { SessionTabAvatar } from "@/shell/layout/session-tab-avatar"
+import { projectForSession } from "@/shell/layout/helpers"
+import { useSettingsDialog } from "@/settings/command"
 
 const titlebarHeight = 36
 const windowsTitlebarHeight = 44 // Includes the content inset; matches the native Windows overlay.
@@ -47,6 +52,7 @@ export function Titlebar(props: {
   const command = useCommand()
   const language = useLanguage()
   const settings = useSettings()
+  const openSettings = useSettingsDialog()
   const navigate = useNavigate()
   const location = useLocation()
   const mobile = createMediaQuery("(max-width: 767px)")
@@ -138,6 +144,14 @@ export function Titlebar(props: {
         "order-last": bottom(),
       }}
       style={{
+        height:
+          platform.platform === "web"
+            ? bottom()
+              ? "calc(28px + max(8px, env(safe-area-inset-bottom, 0px)))"
+              : "calc(28px + max(8px, env(safe-area-inset-top, 0px)))"
+            : undefined,
+        "padding-top": bottom() ? "0px" : "env(safe-area-inset-top, 0px)",
+        "padding-bottom": bottom() ? "env(safe-area-inset-bottom, 0px)" : "0px",
         "min-height": minHeight(),
         // Keep native macOS traffic lights clear even when the desktop window is narrow.
         "padding-left": macTrafficLights() ? `${macTrafficLightsBaseWidth / zoom()}px` : 0,
@@ -336,116 +350,283 @@ export function Titlebar(props: {
               ].filter((v) => v !== undefined)
             })
 
+            const [mobileTabs, setMobileTabs] = createStore({ open: false, settings: false })
+            const currentProject = createMemo(() => {
+              const tab = currentTab()
+              const value = session()
+              if (!tab || !value) return
+              const conn = global.servers.list().find((item) => ServerConnection.key(item) === tab.server)
+              return projectForSession(value, conn ? global.ensureServerCtx(conn).projects.list() : [])
+            })
+            const currentTitle = () => {
+              const tab = currentTab()
+              if (!tab) return language.t("home.title")
+              if (tab.type === "draft") return language.t("command.session.new")
+              const value = session()
+              return value ? sessionLabel(value) : (tabs.info[tabKey(tab)]?.title ?? language.t("command.session.new"))
+            }
+            createEffect(() => {
+              path()
+              mobile()
+              setMobileTabs("open", false)
+            })
+
             return (
               <div
                 class="h-full flex-1 overflow-hidden flex flex-row items-center gap-1.5 px-2 md:pr-3"
                 classList={{
-                  "pt-2": !bottom() && !windows(),
-                  "pb-2": bottom(),
+                  "pt-[max(0px,calc(8px-env(safe-area-inset-top,0px)))]": !bottom() && !windows(),
+                  "pb-[max(0px,calc(8px-env(safe-area-inset-bottom,0px)))]": bottom(),
                   "md:pl-2": macTrafficLights(),
                   "md:pl-4": !macTrafficLights(),
                 }}
               >
-                <ChannelIndicator debugTools={props.debugTools} />
+                <Show when={!mobile()}>
+                  <ChannelIndicator debugTools={props.debugTools} />
+                </Show>
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} />
                 </Show>
-                <Tooltip
-                  placement="bottom"
-                  value={
-                    <>
-                      {language.t("home.title")}
-                      <Keybind keys={command.keybindParts("home.toggle")} variant="neutral" />
-                    </>
-                  }
-                  class="shrink-0"
-                >
-                  <IconButton
-                    type="button"
-                    variant="ghost-muted"
-                    size="large"
-                    class="!w-9 shrink-0"
-                    icon={<Icon name="grid-plus" />}
-                    state={layout.route().type === "home" ? "pressed" : undefined}
-                    onClick={toggleHome}
-                    aria-label={language.t("home.title")}
-                    aria-pressed={layout.route().type === "home"}
-                  />
-                </Tooltip>
+                <Show when={!mobile()}>
+                  <Tooltip
+                    placement="bottom"
+                    value={
+                      <>
+                        {language.t("home.title")}
+                        <Keybind keys={command.keybindParts("home.toggle")} variant="neutral" />
+                      </>
+                    }
+                    class="shrink-0"
+                  >
+                    <IconButton
+                      type="button"
+                      variant="ghost-muted"
+                      size="large"
+                      class="!w-9 shrink-0"
+                      icon={<Icon name="grid-plus" />}
+                      state={layout.route().type === "home" ? "pressed" : undefined}
+                      onClick={toggleHome}
+                      aria-label={language.t("home.title")}
+                      aria-pressed={layout.route().type === "home"}
+                    />
+                  </Tooltip>
+                </Show>
 
                 <Show
-                  when={props.verticalTabs}
+                  when={!mobile()}
                   fallback={
-                    <>
-                      <TitlebarTabStrip
-                        tabs={tabsStore}
-                        currentTab={currentTab()}
-                        onNavigate={(tab, el) => {
-                          tabs.select(tab)
-                          el?.scrollIntoView({ behavior: "instant" })
-                        }}
-                        onClose={(tab) => {
-                          const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
-                          if (index !== -1) tabsStoreActions.closeTab(index)
-                        }}
-                        onReorder={(keys) => tabsStoreActions.reorder(keys)}
-                      />
-                      <Tooltip
-                        placement="bottom"
-                        value={
-                          <>
-                            {language.t("command.session.new")}
-                            <Keybind keys={newTabTooltipKeybind(command)} variant="neutral" />
-                          </>
-                        }
+                    <Drawer
+                      open={mobileTabs.open}
+                      onOpenChange={(open) => setMobileTabs("open", open)}
+                      onContentPresentChange={(present) => {
+                        if (present || !mobileTabs.settings) return
+                        setMobileTabs("settings", false)
+                        openSettings()
+                      }}
+                      side="bottom"
+                    >
+                      <Drawer.Trigger
+                        data-slot="mobile-tabs-trigger"
+                        aria-expanded={mobileTabs.open}
+                        class="flex h-7 min-w-0 flex-1 items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-base focus-visible:outline-none [app-region:no-drag]"
+                        aria-label={language.t("titlebar.tabs")}
                       >
-                        <IconButton
-                          type="button"
-                          variant="ghost-muted"
-                          size="large"
-                          class="shrink-0"
-                          icon={<Icon name="plus" />}
-                          onClick={openNewTab}
-                          aria-label={language.t("command.session.new")}
-                        />
-                      </Tooltip>
-                    </>
-                  }
-                >
-                  {(vertical) => (
-                    <Show when={vertical().mount} keyed>
-                      {(mount) => (
-                        <Portal mount={mount}>
-                          <TitlebarTabStrip
-                            orientation="vertical"
-                            tabs={tabsStore}
-                            currentTab={currentTab()}
-                            onNavigate={(tab, el) => {
-                              tabs.select(tab)
-                              el?.scrollIntoView({ behavior: "instant", block: "nearest" })
-                            }}
-                            onClose={(tab) => {
-                              const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
-                              if (index !== -1) tabsStoreActions.closeTab(index)
-                            }}
-                            onReorder={(keys) => tabsStoreActions.reorder(keys)}
-                          />
+                        <Show when={currentTab()} fallback={<Icon name="grid-plus" class="shrink-0" />}>
+                          {(tab) => (
+                            <span
+                              data-slot="project-avatar-slot"
+                              class="flex size-4 shrink-0 items-center justify-center"
+                            >
+                              <Show
+                                when={session()}
+                                fallback={
+                                  tab().type === "draft" ? (
+                                    <Icon name="edit" />
+                                  ) : (
+                                    <span
+                                      class="block size-4 rounded-[3px] border border-v2-border-border-muted"
+                                      aria-hidden="true"
+                                    />
+                                  )
+                                }
+                              >
+                                {(value) => (
+                                  <SessionTabAvatar
+                                    project={currentProject()}
+                                    directory={value().location.directory}
+                                    sessionId={value().id}
+                                    server={tab().server}
+                                    revealProjectOnHover={false}
+                                  />
+                                )}
+                              </Show>
+                            </span>
+                          )}
+                        </Show>
+                        <span dir="auto" class="min-w-0 flex-1 truncate text-start">
+                          {currentTitle()}
+                        </span>
+                        <span class="shrink-0 text-v2-text-text-muted">{tabsStore.length}</span>
+                      </Drawer.Trigger>
+                      <Drawer.Portal forceMount>
+                        <Drawer.Overlay data-slot="mobile-tabs-overlay" />
+                        <Drawer.Content forceMount data-slot="mobile-tabs-drawer" dir={language.direction()}>
+                          <Drawer.Label class="sr-only">{language.t("titlebar.tabs")}</Drawer.Label>
+                          <div data-slot="mobile-tabs-drag-handle" aria-hidden="true">
+                            <span />
+                          </div>
+                          <div data-slot="mobile-tabs-drawer-list" data-corvu-no-drag>
+                            <TitlebarTabStrip
+                              orientation="vertical"
+                              tabs={tabsStore}
+                              currentTab={currentTab()}
+                              onNavigate={(tab) => {
+                                tabs.select(tab)
+                                setMobileTabs("open", false)
+                              }}
+                              onClose={(tab) => {
+                                const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                                if (index !== -1) tabsStoreActions.closeTab(index)
+                              }}
+                              onReorder={(keys) => tabsStoreActions.reorder(keys)}
+                            />
+                          </div>
                           <button
                             type="button"
-                            data-action="vertical-tabs-new-session"
-                            class="mt-1 flex h-7 w-full shrink-0 items-center gap-1.5 rounded-[6px] px-1.5 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 hover:text-v2-text-text-base"
-                            onClick={openNewTab}
-                            aria-label={language.t("command.session.new")}
+                            data-corvu-no-drag
+                            data-action="mobile-tabs-new-session"
+                            class="flex h-7 w-full shrink-0 items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-base hover:bg-v2-background-bg-layer-02 focus-visible:outline-none focus-visible:bg-v2-background-bg-layer-02"
+                            onClick={() => {
+                              openNewTab()
+                              setMobileTabs("open", false)
+                            }}
                           >
                             <Icon name="plus" />
                             {language.t("command.session.new")}
                           </button>
-                        </Portal>
-                      )}
-                    </Show>
-                  )}
+                          <div
+                            class="flex shrink-0 flex-col gap-1 border-t border-v2-border-border-muted pt-2"
+                            data-corvu-no-drag
+                          >
+                            <button
+                              type="button"
+                              data-action="mobile-tabs-home"
+                              data-state={layout.route().type === "home" ? "pressed" : undefined}
+                              aria-current={layout.route().type === "home" ? "page" : undefined}
+                              class="flex h-7 w-full items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-faint data-[state=pressed]:text-v2-text-text-base focus-visible:outline-none"
+                              onClick={() => {
+                                if (layout.route().type !== "home") toggleHome()
+                                setMobileTabs("open", false)
+                              }}
+                            >
+                              <Icon name="grid-plus" />
+                              {language.t("home.title")}
+                            </button>
+                            <div class="flex items-center gap-1">
+                              <button
+                                type="button"
+                                data-action="mobile-tabs-settings"
+                                class="flex h-7 min-w-0 flex-1 items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 focus-visible:outline-none focus-visible:bg-v2-background-bg-layer-02"
+                                onClick={() => setMobileTabs({ open: false, settings: true })}
+                              >
+                                <Icon name="settings-gear" size="small" />
+                                {language.t("sidebar.settings")}
+                              </button>
+                              <button
+                                type="button"
+                                data-action="mobile-tabs-help"
+                                class="flex h-7 shrink-0 items-center gap-2 rounded-[6px] px-2 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 focus-visible:outline-none focus-visible:bg-v2-background-bg-layer-02"
+                                onClick={() => {
+                                  setMobileTabs("open", false)
+                                  platform.openExternal("https://opencode.ai/desktop-feedback")
+                                }}
+                              >
+                                <Icon name="help" size="small" />
+                                {language.t("sidebar.help")}
+                              </button>
+                            </div>
+                          </div>
+                        </Drawer.Content>
+                      </Drawer.Portal>
+                    </Drawer>
+                  }
+                >
+                  <Show
+                    when={props.verticalTabs}
+                    fallback={
+                      <>
+                        <TitlebarTabStrip
+                          tabs={tabsStore}
+                          currentTab={currentTab()}
+                          onNavigate={(tab, el) => {
+                            tabs.select(tab)
+                            el?.scrollIntoView({ behavior: "instant" })
+                          }}
+                          onClose={(tab) => {
+                            const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                            if (index !== -1) tabsStoreActions.closeTab(index)
+                          }}
+                          onReorder={(keys) => tabsStoreActions.reorder(keys)}
+                        />
+                        <Tooltip
+                          placement="bottom"
+                          value={
+                            <>
+                              {language.t("command.session.new")}
+                              <Keybind keys={newTabTooltipKeybind(command)} variant="neutral" />
+                            </>
+                          }
+                        >
+                          <IconButton
+                            type="button"
+                            variant="ghost-muted"
+                            size="large"
+                            class="shrink-0"
+                            icon={<Icon name="plus" />}
+                            onClick={openNewTab}
+                            aria-label={language.t("command.session.new")}
+                          />
+                        </Tooltip>
+                      </>
+                    }
+                  >
+                    {(vertical) => (
+                      <Show when={vertical().mount} keyed>
+                        {(mount) => (
+                          <Portal mount={mount}>
+                            <TitlebarTabStrip
+                              orientation="vertical"
+                              tabs={tabsStore}
+                              currentTab={currentTab()}
+                              onNavigate={(tab, el) => {
+                                tabs.select(tab)
+                                el?.scrollIntoView({ behavior: "instant", block: "nearest" })
+                              }}
+                              onClose={(tab) => {
+                                const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                                if (index !== -1) tabsStoreActions.closeTab(index)
+                              }}
+                              onReorder={(keys) => tabsStoreActions.reorder(keys)}
+                            />
+                            <button
+                              type="button"
+                              data-action="vertical-tabs-new-session"
+                              class="mt-1 flex h-7 w-full shrink-0 items-center gap-1.5 rounded-[6px] px-1.5 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 hover:text-v2-text-text-base"
+                              onClick={openNewTab}
+                              aria-label={language.t("command.session.new")}
+                            >
+                              <Icon name="plus" />
+                              {language.t("command.session.new")}
+                            </button>
+                          </Portal>
+                        )}
+                      </Show>
+                    )}
+                  </Show>
                 </Show>
-                <div class="flex-1" />
+                <Show when={!mobile()}>
+                  <div class="flex-1" />
+                </Show>
                 <TitlebarRight state={rightState()} />
               </div>
             )

--- a/packages/session-ui/src/pierre/index.ts
+++ b/packages/session-ui/src/pierre/index.ts
@@ -137,6 +137,19 @@ const unsafeCSS = `
   color: var(--diffs-selection-number-fg);
 }
 
+@media (max-width: 767px) {
+  /* File annotations share the code column; reclaim the measured number gutter. */
+  [data-file] [data-line-annotation] {
+    margin-inline-start: calc(-1 * var(--diffs-column-number-width, 0px));
+    z-index: 4;
+  }
+
+  [data-file] [data-annotation-content] {
+    width: var(--diffs-column-width, auto);
+    inset-inline-start: 0;
+  }
+}
+
 @media (pointer: fine) {
   [data-gutter-utility-slot] {
     opacity: 0;


### PR DESCRIPTION
## Summary
- Give mobile sessions full-width Session, Changes, Files, and Terminal tabs, placed above content or below the composer according to bottom-navigation preference.
- Add a mobile Files browser with shared open tabs, searching, closing, and full-width line comments; remove doubled dividers.
- Move Usage to a compact More menu and render real Status and Session details panels in bottom drawers, preserving dismissal, focus return, and reopen behavior.
- Hide desktop-only session identity controls on mobile while retaining the current title in the shell drawer trigger.
- Keep the embedded Terminal mounted across view switches and preserve shortcut behavior and session-scoped lifecycle.

## Stack
1. #46388: mobile shell, Home, and settings (base v2).
2. #46389: mobile session views, Files, Status, and details (base #46388).
3. #46390: mobile Changes summaries, Open file, and wrapping preferences (base #46389).

Merge in that order; each PR's diff and before/after evidence compare against its immediate base. Independent #46391 (touch controls/PWA) can land separately.

## Sessions
- `ses_fa9375bf2ffd1qwP3qNWRyj1dW`: mobile view navigation and embedded Terminal.
- `ses_fa8e8d9a1ffedn46jvXHQkVsgx`: Files/More/Status integration and drawer lifecycle fixes.
- `ses_fa8d40a0bffelgYWDAaU1XvYj8`: child of the preceding session; embedded Status body and initial drawer.
- `ses_fa8b885a0ffdKRQ0V2AMcGEu9a`: shared drawer shell extraction, Session details, compact burger/divider.
- `ses_fa8c9b9c6ffeULe3oLIORr07X2`: Files borders and full-width annotations/comments.
- `ses_fa8b34988ffdpVySqqaO61cULj`: mobile Usage spacing.

## Before / After

Before/after against the immediate shell base. Real production components with synthetic Atlas fixture data, dark theme; mobile 390x844 and desktop 1440x1000. New mobile Files/Usage/Terminal/menu surfaces did not exist on the base, so those BEFORE images show the original mobile Session rather than a fabricated view.

| Surface | Before | After |
| --- | --- | --- |
| Mobile session, top view navigation; identity header hidden, titlebar retained | ![Before: Mobile session, top view navigation; identity header hidden, titlebar retained](https://github.com/user-attachments/assets/fe6248de-4ac3-4ff2-92ca-21cd79c27d4e) | ![After: Mobile session, top view navigation; identity header hidden, titlebar retained](https://github.com/user-attachments/assets/adba3ec3-bd64-4154-85fd-cbaa8340be57) |
| Mobile Changes: compact 40px review header and 8px gutters | ![Before: Mobile Changes: compact 40px review header and 8px gutters](https://github.com/user-attachments/assets/73202e67-5986-4507-a77f-05e8b554154d) | ![After: Mobile Changes: compact 40px review header and 8px gutters](https://github.com/user-attachments/assets/b1042528-6972-4371-a0c4-1b0a9feb7abc) |
| Mobile Usage: compact padding with realistic token and cost summary | ![Before: Mobile Usage: compact padding with realistic token and cost summary](https://github.com/user-attachments/assets/190616d6-d0d0-4fab-80a7-e72326396921) | ![After: Mobile Usage: compact padding with realistic token and cost summary](https://github.com/user-attachments/assets/ca9060b5-131c-4a5e-ba3f-aac8c6daec5f) |
| Mobile Usage scrolled: total cost and token breakdown | ![Before: Mobile Usage scrolled: total cost and token breakdown](https://github.com/user-attachments/assets/7d30fdd6-be5a-451d-9634-21ed92f99983) | ![After: Mobile Usage scrolled: total cost and token breakdown](https://github.com/user-attachments/assets/e4df61b0-9ffa-4580-9871-4f8a4dbb8563) |
| Mobile Terminal: dedicated view with fixture-only terminal output | ![Before: Mobile Terminal: dedicated view with fixture-only terminal output](https://github.com/user-attachments/assets/fbfb4c04-b27f-462e-bd6d-7b7596898795) | ![After: Mobile Terminal: dedicated view with fixture-only terminal output](https://github.com/user-attachments/assets/b8dd158c-b53b-483f-b3c3-df054fe2b0e8) |
| Mobile More menu: Usage, Status and Session details | ![Before: Mobile More menu: Usage, Status and Session details](https://github.com/user-attachments/assets/ca7f855e-e2e9-417b-b0f4-1f038c8f3658) | ![After: Mobile More menu: Usage, Status and Session details](https://github.com/user-attachments/assets/758d1c84-0f9f-470f-b8ea-9fc7b2a3fa19) |
| Mobile Status drawer: MCP tab | ![Before: Mobile Status drawer: MCP tab](https://github.com/user-attachments/assets/016ab22a-2534-425a-8d07-2ef5523f6243) | ![After: Mobile Status drawer: MCP tab](https://github.com/user-attachments/assets/af7b102a-98c9-4e95-b7c0-3e39119e8e62) |
| Mobile Status drawer: Plugins tab | ![Before: Mobile Status drawer: Plugins tab](https://github.com/user-attachments/assets/48739c73-6b52-427e-a75d-1e40268b0e7f) | ![After: Mobile Status drawer: Plugins tab](https://github.com/user-attachments/assets/274d9688-265f-427f-8e93-01d2723922fa) |
| Mobile Status drawer successfully reopened after close, backdrop, Escape and drag | ![Before: Mobile Status drawer successfully reopened after close, backdrop, Escape and drag](https://github.com/user-attachments/assets/a5c0f058-fb39-48c1-860e-26e612dc8f56) | ![After: Mobile Status drawer successfully reopened after close, backdrop, Escape and drag](https://github.com/user-attachments/assets/3bf9e66f-e863-4fe3-9337-203a4985e809) |
| Mobile Session details drawer: real production project, workspace, branch and changes summary | ![Before: Mobile Session details drawer: real production project, workspace, branch and changes summary](https://github.com/user-attachments/assets/b1a25925-0e85-455c-9a62-0d5e0500606f) | ![After: Mobile Session details drawer: real production project, workspace, branch and changes summary](https://github.com/user-attachments/assets/049028ee-2e24-43ee-aeea-f94703ca8182) |
| Mobile session, bottom view navigation; identity header hidden, titlebar retained | ![Before: Mobile session, bottom view navigation; identity header hidden, titlebar retained](https://github.com/user-attachments/assets/49046491-7398-462f-93be-39fd50f1dbda) | ![After: Mobile session, bottom view navigation; identity header hidden, titlebar retained](https://github.com/user-attachments/assets/432dad4f-6dad-495d-aba0-53d21f700b96) |
| Mobile Files browse (LTR): full-width header separator | ![Before: Mobile Files browse (LTR): full-width header separator](https://github.com/user-attachments/assets/94dd2b51-f0bf-41ee-909b-42f87dc6d811) | ![After: Mobile Files browse (LTR): full-width header separator](https://github.com/user-attachments/assets/624b2ee2-7aaf-4de6-b0e8-130678562b88) |
| Mobile Files opened tabs (LTR): aligned tab and full-width border | ![Before: Mobile Files opened tabs (LTR): aligned tab and full-width border](https://github.com/user-attachments/assets/2b88f5d1-c579-4447-a151-55f214f3fe51) | ![After: Mobile Files opened tabs (LTR): aligned tab and full-width border](https://github.com/user-attachments/assets/a59d7d1c-ed3e-49f3-aa46-6e11f332957f) |
| Mobile Files full-width comment editor (LTR): 12px inline gutters | ![Before: Mobile Files full-width comment editor (LTR): 12px inline gutters](https://github.com/user-attachments/assets/88a881bf-efde-4d90-9d5b-60cac899ec9c) | ![After: Mobile Files full-width comment editor (LTR): 12px inline gutters](https://github.com/user-attachments/assets/6bbb1a7c-51c1-4546-9b05-5b9fa5508bee) |
| Mobile Files saved full-width comment (LTR) | ![Before: Mobile Files saved full-width comment (LTR)](https://github.com/user-attachments/assets/105ba945-680a-42ff-a494-7bee97934a7b) | ![After: Mobile Files saved full-width comment (LTR)](https://github.com/user-attachments/assets/b9ebd46c-8664-44b0-acfa-3e5cb7892817) |
| Mobile Files browse (RTL): full-width header separator | ![Before: Mobile Files browse (RTL): full-width header separator](https://github.com/user-attachments/assets/d53891bf-5f0a-4485-9baa-5c5c6cf5ae24) | ![After: Mobile Files browse (RTL): full-width header separator](https://github.com/user-attachments/assets/32be181e-2de2-4705-884d-c51f3e1ba240) |
| Mobile Files opened tabs (RTL): aligned tab and full-width border | ![Before: Mobile Files opened tabs (RTL): aligned tab and full-width border](https://github.com/user-attachments/assets/0787aaaf-f831-4bd3-88c9-c8c01d85b395) | ![After: Mobile Files opened tabs (RTL): aligned tab and full-width border](https://github.com/user-attachments/assets/2b496048-a3a1-4b7d-92a5-dc57fd3c9708) |
| Mobile Files full-width comment editor (RTL): 12px inline gutters | ![Before: Mobile Files full-width comment editor (RTL): 12px inline gutters](https://github.com/user-attachments/assets/720391d4-076a-4647-bc1a-6c149f590506) | ![After: Mobile Files full-width comment editor (RTL): 12px inline gutters](https://github.com/user-attachments/assets/d4b8cbdd-40b3-41c7-b3fc-388b6ab323cb) |
| Mobile Files saved full-width comment (RTL) | ![Before: Mobile Files saved full-width comment (RTL)](https://github.com/user-attachments/assets/07f347a4-9dbd-467c-908a-7c5756db51cb) | ![After: Mobile Files saved full-width comment (RTL)](https://github.com/user-attachments/assets/cb35178e-bfdc-4b95-9363-02347dcab646) |
| Desktop 1440px session: unchanged identity and summary panel layout check | ![Before: Desktop 1440px session: unchanged identity and summary panel layout check](https://github.com/user-attachments/assets/c4ead8cc-5dd9-46f1-9eac-e6fd80e592e9) | ![After: Desktop 1440px session: unchanged identity and summary panel layout check](https://github.com/user-attachments/assets/786e8397-f186-4d74-9d32-9ef68a29225d) |
| Desktop Session details summary: unchanged real production panel | ![Before: Desktop Session details summary: unchanged real production panel](https://github.com/user-attachments/assets/7668a5fc-14d8-47e9-8372-4d0b2b83987a) | ![After: Desktop Session details summary: unchanged real production panel](https://github.com/user-attachments/assets/a8c51617-716f-4326-884f-84f43265b2d2) |
| Desktop original Status popover: MCP tab, unchanged reference | ![Before: Desktop original Status popover: MCP tab, unchanged reference](https://github.com/user-attachments/assets/8150f580-5a8f-4ebc-b1cd-00b9e13ec3ea) | ![After: Desktop original Status popover: MCP tab, unchanged reference](https://github.com/user-attachments/assets/fdee89d6-b2e4-4d1f-8d85-9dba9836a3cd) |
| Desktop original Status popover: Plugins tab, unchanged reference | ![Before: Desktop original Status popover: Plugins tab, unchanged reference](https://github.com/user-attachments/assets/15978896-ae21-425b-a1d8-3f422dfe0263) | ![After: Desktop original Status popover: Plugins tab, unchanged reference](https://github.com/user-attachments/assets/519c9384-5de0-4feb-8a0f-9917e3a195d9) |

- Status and Session details compare their real old popovers with the new bottom drawers.
- Files and comment screenshots include English LTR and forced RTL; terminal output is synthetic.
- All raw screenshots and the recorded interaction were inspected. The later shell settings cascade fix does not affect these session-only captures.

## Recording

Fixture-backed mobile view switching, Files and full-width comments, terminal caching, then Status and Session details dismissal/reopen. Chromium, dark theme, 390x844, 14.88 seconds; assertions also passed without recording pacing.

https://github.com/user-attachments/assets/09b77c2b-f094-4111-8a5e-5e6ad757a18c

## Validation
- Updated shared mobile session readiness checks to verify titlebar identity rather than the intentionally removed heading. Eighteen affected notice/history/projection regressions and the mobile line-comment regression pass after updating the selected Changes expectation.
- A full combined local E2E run was not green. After fixing mobile readiness/selection expectations, all ten remaining failures reproduced identically on clean v2: macOS keyboard assumptions in large-paste caret movement, MCP dialog shortcuts, and Shift+F10 context-menu tests. Baseline run: 10 failed, 14 passed; alternative native key probes passed. These unrelated harness fixes are excluded. Do not treat focused passes as a full-suite pass.
- Follow-up screenshot verification found and fixed a production settings CSS-cascade issue; all 16 focused stack regressions now pass, including full-width settings geometry and updated drawer/sidebar expectations.
- All four PR groups merge cleanly in an isolated integration worktree; the combined production build passes all eight mobile browser regressions and app typechecking.
- App and session-ui package typechecks pass.
- Pre-push full workspace typecheck passes all 33 tasks, with hooks enabled.
- Five production-build browser regressions pass: Files in LTR/RTL, view/Terminal switching in top/bottom layouts, and Status dismissal/reopen using button, backdrop, Escape, and drag.
- Production navigation benchmark passes on base and head: stable content observation 156.1ms and 143.1ms respectively. Single machine-local samples, not statistical performance conclusions.
- Preserved v2's title-save-on-blur and IME handling during timeline extraction.
- E2E typecheck has a pre-existing `dir` type error in `new-session-workspace-pending.spec.ts:38`, reproduced on clean v2.
- Original user worktree/staging and existing app/server processes remain untouched.
