### PR TITLE
fix(app): improve touch controls and standalone PWA relaunch

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -6,6 +6,7 @@ import { AppBaseProviders, AppInterface } from "@/app"
 import { loadInitialLocale } from "@/runtime/i18n/language"
 import { PlatformProvider } from "@/runtime/platform/platform"
 import { createWebPlatform } from "@/runtime/platform/web"
+import { isStandalone, PwaRoutePersistence, restorePwaRoute } from "@/runtime/platform/pwa"
 import en from "@/runtime/i18n/en"
 import zh from "@/runtime/i18n/zh"
 import { authFromToken } from "@/runtime/server/api"
@@ -71,6 +72,8 @@ if (root instanceof HTMLElement && root.dataset.opencodeMounted === undefined) {
   void loadInitialLocale().then((locale) => {
     const auth = authFromToken(new URLSearchParams(location.search).get("auth_token"))
     clearAuthToken()
+    const standalone = isStandalone()
+    if (standalone) restorePwaRoute()
     const server: ServerConnection.Http = {
       type: "http",
       authToken: !!auth,
@@ -87,7 +90,9 @@ if (root instanceof HTMLElement && root.dataset.opencodeMounted === undefined) {
               defaultServer={ServerConnection.Key.make(web.defaultServerUrl)}
               canonicalLocalServer={ServerConnection.key(server)}
               servers={[server]}
-            />
+            >
+              {standalone && <PwaRoutePersistence />}
+            </AppInterface>
           </AppBaseProviders>
         </PlatformProvider>
       ),

--- a/packages/app/src/runtime/platform/pwa.ts
+++ b/packages/app/src/runtime/platform/pwa.ts
@@ -1,0 +1,43 @@
+import { useLocation } from "@solidjs/router"
+import { createEffect } from "solid-js"
+
+const LAST_ROUTE_KEY = "opencode.pwa.last-route"
+
+export function isStandalone() {
+  return (
+    window.matchMedia("(display-mode: standalone)").matches ||
+    ("standalone" in navigator && navigator.standalone === true)
+  )
+}
+
+export function restorePwaRoute() {
+  if (location.pathname !== "/" || location.search || location.hash) return
+  try {
+    const value = localStorage.getItem(LAST_ROUTE_KEY)
+    if (!value) return
+    const url = new URL(value, location.origin)
+    if (url.origin !== location.origin || url.searchParams.has("auth_token")) return
+    if (
+      url.pathname !== "/" &&
+      url.pathname !== "/new-session" &&
+      !/^\/server\/[^/]+\/session\/[^/]+$/.test(url.pathname)
+    )
+      return
+    history.replaceState(history.state, "", url.pathname + url.search + url.hash)
+  } catch {
+    // Storage may be unavailable; keep the launch URL in that case.
+  }
+}
+
+export function PwaRoutePersistence() {
+  const location = useLocation()
+  createEffect(() => {
+    const value = location.pathname + location.search + location.hash
+    try {
+      localStorage.setItem(LAST_ROUTE_KEY, value)
+    } catch {
+      // Navigation must still work when storage is unavailable or full.
+    }
+  })
+  return null
+}

--- a/packages/app/test-browser/pwa-route.test.ts
+++ b/packages/app/test-browser/pwa-route.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import { MemoryRouter, createMemoryHistory } from "@solidjs/router"
+import { createComponent, render } from "solid-js/web"
+import { isStandalone, PwaRoutePersistence, restorePwaRoute } from "../src/runtime/platform/pwa"
+
+const key = "opencode.pwa.last-route"
+const originalUrl = window.location.href
+
+beforeEach(() => {
+  window.location.href = "http://localhost/"
+})
+
+afterEach(() => {
+  localStorage.removeItem(key)
+  window.location.href = originalUrl
+})
+
+test("normal browser windows are not standalone", () => {
+  expect(isStandalone()).toBe(false)
+})
+
+test("restores the last PWA route including query and hash without adding history", () => {
+  window.history.replaceState({ retained: true }, "", "http://localhost/")
+  const length = window.history.length
+  localStorage.setItem(key, "/server/local/session/session-1?view=files#file")
+
+  restorePwaRoute()
+
+  expect(window.location.pathname + window.location.search + window.location.hash).toBe(
+    "/server/local/session/session-1?view=files#file",
+  )
+  expect(window.history.length).toBe(length)
+  expect(window.history.state).toEqual({ retained: true })
+})
+
+test("preserves explicit launch routes, queries, and hashes", () => {
+  localStorage.setItem(key, "/server/local/session/saved")
+  for (const route of ["/server/local/session/linked", "/new-session?draftId=123", "/?launch=1", "/#launch"]) {
+    window.history.replaceState(null, "", `http://localhost${route}`)
+    restorePwaRoute()
+    expect(window.location.pathname + window.location.search + window.location.hash).toBe(route)
+  }
+})
+
+test("ignores missing, invalid, external, and auth-bearing saved routes", () => {
+  window.history.replaceState(null, "", "http://localhost/")
+  restorePwaRoute()
+  expect(window.location.pathname).toBe("/")
+
+  for (const value of [
+    "/removed-route",
+    "https://example.com/new-session",
+    "//example.com/new-session",
+    "http://[",
+    "/new-session?auth_token=secret",
+  ]) {
+    localStorage.setItem(key, value)
+    restorePwaRoute()
+    expect(window.location.href).toBe("http://localhost/")
+  }
+})
+
+test("persists router navigation including returning home", async () => {
+  const host = document.createElement("div")
+  const history = createMemoryHistory()
+  history.set({ value: "/new-session?draftId=123", replace: true, scroll: false })
+  const dispose = render(() => createComponent(MemoryRouter, { history, root: PwaRoutePersistence }), host)
+  try {
+    expect(localStorage.getItem(key)).toBe("/new-session?draftId=123")
+    history.set({ value: "/server/local/session/next#file", scroll: false })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(localStorage.getItem(key)).toBe("/server/local/session/next#file")
+    history.set({ value: "/", scroll: false })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(localStorage.getItem(key)).toBe("/")
+  } finally {
+    dispose()
+  }
+})

--- a/packages/session-ui/component-tests/session-timeline-mobile.spec.ts
+++ b/packages/session-ui/component-tests/session-timeline-mobile.spec.ts
@@ -32,10 +32,11 @@ story.describe("touch timeline", () => {
     await expect(copy).toHaveCSS("pointer-events", "auto")
   })
 
-  story("keeps error copy visible without hover", async ({ mount }) => {
+  story("keeps error copy visible without hover", async ({ mount, page }) => {
     const errors = await mount("components-tool-error-card--all")
     const patch = errors.locator('[data-kind="tool-error-card"]').filter({ hasText: "Patch" })
     await patch.getByRole("button", { name: /Patch.*Verification failed/ }).tap()
+    await page.touchscreen.tap(385, 800)
     const copy = patch.locator('[data-slot="tool-error-card-copy"]')
     await expect(copy).toHaveCSS("opacity", "1")
     await expect(copy).toHaveCSS("pointer-events", "auto")

--- a/packages/session-ui/component-tests/session-timeline-mobile.spec.ts
+++ b/packages/session-ui/component-tests/session-timeline-mobile.spec.ts
@@ -1,0 +1,74 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+story.describe("touch timeline", () => {
+  story.use({ hasTouch: true, isMobile: true, viewport: { width: 390, height: 844 } })
+
+  story("keeps message actions and metadata visible without hover", async ({ mount, page }) => {
+    const timeline = await mount("current-session-timeline-rows--conversation", { args: { scenario: "interruption" } })
+    expect(await page.evaluate(() => matchMedia("(hover: none)").matches)).toBe(true)
+
+    for (const action of [
+      { slot: "user-message-copy-wrapper", name: "Copy message" },
+      { slot: "text-part-copy-wrapper", name: "Copy response" },
+    ]) {
+      const actions = timeline.locator(`[data-slot="${action.slot}"]`)
+      await expect(actions).toHaveCount(1)
+      await expect(actions).toHaveCSS("opacity", "1")
+      await expect(actions).toHaveCSS("pointer-events", "auto")
+      await expect(actions.getByRole("button", { name: action.name, exact: true })).toBeVisible()
+    }
+
+    await expect(timeline.locator('[data-slot="user-message-meta"]')).toContainText("Build")
+    await expect(timeline.locator('[data-slot="user-message-meta-tail"]')).not.toBeEmpty()
+    await expect(timeline.locator('[data-slot="text-part-meta"]')).toContainText("Build")
+    await expect(timeline.locator('[data-slot="text-part-meta"]')).toContainText("Sonnet")
+  })
+
+  story("keeps shell copy visible without hover", async ({ mount }) => {
+    const timeline = await mount("current-session-terminal-work--expanded-shell")
+    const copy = timeline.locator('[data-slot="bash-copy"]')
+    await expect(copy).toHaveCount(1)
+    await expect(copy).toHaveCSS("opacity", "1")
+    await expect(copy).toHaveCSS("pointer-events", "auto")
+  })
+
+  story("keeps error copy visible without hover", async ({ mount }) => {
+    const errors = await mount("components-tool-error-card--all")
+    const patch = errors.locator('[data-kind="tool-error-card"]').filter({ hasText: "Patch" })
+    await patch.getByRole("button", { name: /Patch.*Verification failed/ }).tap()
+    const copy = patch.locator('[data-slot="tool-error-card-copy"]')
+    await expect(copy).toHaveCSS("opacity", "1")
+    await expect(copy).toHaveCSS("pointer-events", "auto")
+  })
+
+  story("keeps fenced code copy visible without hover", async ({ mount }) => {
+    const markdown = await mount("components-markdown--complete-response")
+    const code = markdown.locator('[data-component="markdown-code"]').filter({ hasText: "export const value = 42" })
+    await expect(code).toHaveCount(1)
+    await expect(code.locator('[data-slot="markdown-copy-button"]')).toHaveCSS("opacity", "1")
+  })
+})
+
+story("desktop message actions still appear on hover and keyboard focus", async ({ mount, page }) => {
+  const timeline = await mount("current-session-timeline-rows--conversation", { args: { scenario: "interruption" } })
+  expect(await page.evaluate(() => matchMedia("(hover: hover)").matches)).toBe(true)
+
+  for (const action of [
+    { slot: "user-message-copy-wrapper", name: "Copy message" },
+    { slot: "text-part-copy-wrapper", name: "Copy response" },
+  ]) {
+    const actions = timeline.locator(`[data-slot="${action.slot}"]`)
+    await expect(actions).toHaveCount(1)
+    await expect(actions).toHaveCSS("opacity", "0")
+    await expect(actions).toHaveCSS("pointer-events", "none")
+    await actions.locator("..").hover()
+    await expect(actions).toHaveCSS("opacity", "1")
+    await expect(actions).toHaveCSS("pointer-events", "auto")
+    await page.mouse.move(0, 0)
+    await expect(actions).toHaveCSS("opacity", "0")
+    await actions.getByRole("button", { name: action.name, exact: true }).focus()
+    await expect(actions).toHaveCSS("opacity", "1")
+    await expect(actions).toHaveCSS("pointer-events", "auto")
+    await page.getByRole("button", { name: "Reset", exact: true }).focus()
+  }
+})

--- a/packages/session-ui/src/components/basic-tool.css
+++ b/packages/session-ui/src/components/basic-tool.css
@@ -249,10 +249,13 @@
     flex-shrink: 0;
     color: var(--v2-text-text-faint);
     margin-left: auto;
-    opacity: 0;
     transition:
       opacity 0.15s ease,
       color 0.15s ease;
+
+    @media (hover: hover) {
+      opacity: 0;
+    }
   }
 
   [data-component="task-tool-title"] {
@@ -391,11 +394,15 @@
   }
 
   .webfetch-link-icon {
-    display: none;
+    display: inline-flex;
     width: 16px;
     height: 16px;
     flex-shrink: 0;
     color: var(--v2-icon-icon-accent, var(--v2-text-text-accent));
+
+    @media (hover: hover) {
+      display: none;
+    }
   }
 
   &:hover {

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -240,9 +240,12 @@
     position: absolute;
     top: 4px;
     inset-inline-end: 4px;
-    opacity: 0;
     transition: opacity 0.15s ease;
     z-index: 1;
+
+    @media (hover: hover) {
+      opacity: 0;
+    }
   }
 
   [data-component="markdown-code"]:hover [data-slot="markdown-copy-button"],

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -167,10 +167,13 @@
     justify-content: flex-end;
     gap: 10px;
     width: 100%;
-    opacity: 0;
-    pointer-events: none;
     transition: opacity 0.15s ease;
     will-change: opacity;
+
+    @media (hover: hover) {
+      opacity: 0;
+      pointer-events: none;
+    }
 
     [data-component="tooltip-v2-trigger"] {
       display: inline-flex;
@@ -235,10 +238,13 @@
     align-items: center;
     justify-content: flex-start;
     gap: 10px;
-    opacity: 0;
-    pointer-events: none;
     transition: opacity 0.15s ease;
     will-change: opacity;
+
+    @media (hover: hover) {
+      opacity: 0;
+      pointer-events: none;
+    }
 
     [data-component="tooltip-v2-trigger"] {
       display: inline-flex;
@@ -371,9 +377,12 @@
     position: absolute;
     top: 4px;
     right: 4px;
-    opacity: 0;
-    pointer-events: none;
     transition: opacity 0.15s ease;
+
+    @media (hover: hover) {
+      opacity: 0;
+      pointer-events: none;
+    }
   }
 
   &:hover [data-slot="bash-copy"],

--- a/packages/session-ui/src/components/session-review.css
+++ b/packages/session-ui/src/components/session-review.css
@@ -130,19 +130,25 @@
     color: var(--text-base);
     cursor: pointer;
     border-radius: 4px;
-    opacity: 0;
+    opacity: 1;
     will-change: opacity;
     transform: translateZ(0);
     transition: opacity 0.15s ease;
 
-    &:hover {
-      color: var(--text-strong);
-      background: var(--surface-base);
+    @media (hover: hover) {
+      opacity: 0;
+
+      &:hover {
+        color: var(--text-strong);
+        background: var(--surface-base);
+      }
     }
   }
 
-  [data-slot="accordion-trigger"]:hover [data-slot="session-review-view-button"] {
-    opacity: 1;
+  @media (hover: hover) {
+    [data-slot="accordion-trigger"]:hover [data-slot="session-review-view-button"] {
+      opacity: 1;
+    }
   }
 
   [data-slot="session-review-trigger-actions"] {

--- a/packages/session-ui/src/components/session-turn.css
+++ b/packages/session-ui/src/components/session-turn.css
@@ -126,9 +126,12 @@
     font-weight: var(--font-weight-regular);
     line-height: var(--line-height-large);
     cursor: pointer;
-    opacity: 0;
     transition: opacity 0.15s ease;
     margin-left: 4px;
+
+    @media (hover: hover) {
+      opacity: 0;
+    }
   }
 
   [data-component="session-turn-diffs-group"]:hover [data-slot="session-turn-diffs-toggle"] {

--- a/packages/session-ui/src/components/tool-error-card.css
+++ b/packages/session-ui/src/components/tool-error-card.css
@@ -123,10 +123,13 @@
     position: absolute;
     top: 0;
     right: 0;
-    opacity: 0;
-    pointer-events: none;
     transition: opacity 0.15s ease;
     will-change: opacity;
+
+    @media (hover: hover) {
+      opacity: 0;
+      pointer-events: none;
+    }
   }
 
   &:hover [data-slot="tool-error-card-copy"],

--- a/packages/ui/src/styles/base.css
+++ b/packages/ui/src/styles/base.css
@@ -401,4 +401,9 @@ input:where([type="button"], [type="reset"], [type="submit"]),
   [contenteditable="true"] {
     font-size: 16px !important;
   }
+
+  input::placeholder,
+  textarea::placeholder {
+    font-size: 13px;
+  }
 }


### PR DESCRIPTION
## Summary
- Keep transcript copy controls, agent/model/time metadata, and shell/code/tool actions visible on non-hover devices while preserving desktop hover and keyboard-focus behavior.
- Keep touch input placeholders compact at 13px while actual entered text remains 16px to avoid iOS focus zoom.
- Detect standalone PWA mode and restore the last allowed route at root startup, then persist router location; retain the existing URL router rather than introducing a separate memory router.

## Related PRs
Independent against v2. The mobile UI stack is #46388 (shell/Home/settings), #46389 (session panels), and #46390 (diff review). This PR can merge separately; its shared review CSS changes are limited to non-hover Open file visibility, separate from #46390's summaries and header layout.

## Sessions
- `ses_fa8ce9ae1ffeJaH6I8O4Ut1d67`: touch transcript controls and metadata.
- `ses_fa8f428cfffe2PwaFX2PhjaYy0`: compact iOS placeholders.
- `ses_fa8c9b9c6ffeULe3oLIORr07X2`: standalone PWA route restoration.
- Commits retain these associations as Session-Id trailers.

## Before / After

Touch controls, compact mobile placeholders, and standalone PWA route restoration. Before/after captures use real production components with deterministic fixture data at 390x844, light mode, English, UTC, and touch input.

| Surface | Before | After |
| --- | --- | --- |
| Message copy actions and agent/model/timestamp metadata without hover | ![Before: Message copy actions and agent/model/timestamp metadata without hover](https://github.com/user-attachments/assets/b775f1f8-bbdc-471b-8bfd-26c7e10d0a7c) | ![After: Message copy actions and agent/model/timestamp metadata without hover](https://github.com/user-attachments/assets/0df52492-8315-48b4-9a87-2a5fcd124e36) |
| Completed shell command copy without hover | ![Before: Completed shell command copy without hover](https://github.com/user-attachments/assets/d80f7a9c-594f-49b8-b855-5c587ed2ec58) | ![After: Completed shell command copy without hover](https://github.com/user-attachments/assets/1e7dc7a1-e3f1-4d52-b13b-1b8f7ad2ef91) |
| Code Mode execution copy without hover | ![Before: Code Mode execution copy without hover](https://github.com/user-attachments/assets/8b430268-bada-421e-821f-879cb662ea7a) | ![After: Code Mode execution copy without hover](https://github.com/user-attachments/assets/f1d2ae04-e75f-48b9-883d-01197cd3ba05) |
| Fenced Markdown code copy without hover | ![Before: Fenced Markdown code copy without hover](https://github.com/user-attachments/assets/fef188bf-004b-41aa-b94e-06bc1ba5f72a) | ![After: Fenced Markdown code copy without hover](https://github.com/user-attachments/assets/25f9da2d-63e1-4edb-a1f1-ab2accfde482) |
| Webfetch external-link affordance without hover | ![Before: Webfetch external-link affordance without hover](https://github.com/user-attachments/assets/d9a80b6d-cb40-4229-b603-b15a6dd3cd5d) | ![After: Webfetch external-link affordance without hover](https://github.com/user-attachments/assets/d32c3be2-07b8-4b34-97f5-a90b0d57267f) |
| Expanded patch failure copy without hover | ![Before: Expanded patch failure copy without hover](https://github.com/user-attachments/assets/d05fa2a6-1313-46fc-8b54-e02b45c383da) | ![After: Expanded patch failure copy without hover](https://github.com/user-attachments/assets/40b1cf75-cc1d-4a3c-bf87-e3578e3ad671) |
| Compact mobile input placeholders while input font stays 16px | ![Before: Compact mobile input placeholders while input font stays 16px](https://github.com/user-attachments/assets/2ea87865-c22d-4910-8e5b-e0d8998e0e83) | ![After: Compact mobile input placeholders while input font stays 16px](https://github.com/user-attachments/assets/af98cdd2-86b8-4660-8a60-ef7386117e6d) |
| Standalone relaunch: Home before, restored Session after | ![Before: Standalone relaunch: Home before, restored Session after](https://github.com/user-attachments/assets/0f52633a-29b8-4443-9fbe-e7cdf5e3c59e) | ![After: Standalone relaunch: Home before, restored Session after](https://github.com/user-attachments/assets/1560c546-b5bc-4bb0-ad06-cb7a7c9ab04b) |
| Delegated task Session navigation affordance without hover | ![Before: Delegated task Session navigation affordance without hover](https://github.com/user-attachments/assets/16a7f47b-761e-4202-8c4f-ec0dd332a36c) | ![After: Delegated task Session navigation affordance without hover](https://github.com/user-attachments/assets/f4237798-ea2f-47ca-91f5-d39c9cfbefb1) |
| Shared review Open File control without hover | ![Before: Shared review Open File control without hover](https://github.com/user-attachments/assets/bd2f4534-f7c6-4198-a620-42edd1091df5) | ![After: Shared review Open File control without hover](https://github.com/user-attachments/assets/1362f7b2-74d0-476d-8b88-b1c9ada5ab46) |

- All ten pairs were visually inspected. No live personal data or credentials are included.
- Task navigation and shared review screenshots use a temporary fixture rendering the real ToolDisplay and SessionReview with existing providers and local no-op callbacks. The temporary story was removed from the worktree after capture; no production component changes or extra commits were made.
- The legacy session-turn diff toggle has no active TSX consumer, so there is no user-visible surface to capture.
- PWA standalone mode is emulated using navigator.standalone; service workers are blocked. This comparison verifies route restoration, not an actual installed-device lifecycle.

## Validation
- CI Linux/Windows E2E and typecheck passed. Linux unit CI failed in untouched CLI ACP permission-behavior timeout (2 seconds); Linux rerun failed with the same untouched CLI timeout; Windows rerun is pending. UI tests passed locally.
- All four PR groups merge cleanly in an isolated integration worktree; the combined production build passes all eight mobile browser regressions and app typechecking.
- App and session-ui package typechecks, production app build, formatting, and diff checks pass.
- Five PWA unit tests; all 74 app browser tests; all 166 session-ui unit tests pass.
- Five component regressions pass, covering mobile non-hover metadata/actions, shell/error controls, and desktop hover/keyboard focus.
- Production navigation benchmark passes before and after: stable content 134.8ms on clean v2 and 139.8ms on this head; stable tab 47.4ms and 46.2ms. Single machine-local samples, not statistical performance conclusions.
- PWA capture uses emulated standalone detection, not an actual installed-device lifecycle; service workers are blocked to isolate route restoration.
- Actual iOS Safari focus zoom still needs device validation. No production behavior was added solely for screenshots.
- Original dirty user worktree/staging and existing app/server processes remain untouched. This does not duplicate the already-merged channel favicon/PWA icon PR.
