### PR TITLE
feat(snapshot): restore file changes on undo in non-Git projects

### DIFF
--- a/packages/opencode/src/snapshot/index.ts
+++ b/packages/opencode/src/snapshot/index.ts
@@ -25,6 +25,31 @@ const limit = 2 * 1024 * 1024
 const core = ["-c", "core.longpaths=true", "-c", "core.symlinks=true"]
 const cfg = ["-c", "core.autocrlf=false", ...core]
 const quote = [...cfg, "-c", "core.quotepath=false"]
+// Applied only to worktrees without Git (where no .gitignore hierarchy exists).
+// Keeps the snapshot out of dependency and cache directories so tracking stays
+// fast and the shadow repo stays small. Everything else is snapshotted so undo
+// can restore it.
+const defaultExcludes = [
+  "node_modules/",
+  ".git/",
+  "__pycache__/",
+  ".venv/",
+  "venv/",
+  ".tox/",
+  ".mypy_cache/",
+  ".pytest_cache/",
+  ".ruff_cache/",
+  ".gradle/",
+  ".cache/",
+  ".parcel-cache/",
+  ".next/",
+  ".nuxt/",
+  ".output/",
+  ".turbo/",
+  ".yarn/",
+  "target/",
+  "coverage/",
+]
 interface GitResult {
   readonly code: ChildProcessSpawner.ExitCode
   readonly text: string
@@ -65,10 +90,14 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
 
     const state = yield* InstanceState.make<State>(
       Effect.fn("Snapshot.state")(function* (ctx) {
+        // Non-Git projects resolve to a synthetic global project whose worktree is
+        // the filesystem root. Snapshot those instances at the opened directory
+        // instead so tracking stays scoped to the actual project.
+        const worktree = ctx.project.vcs === "git" ? ctx.worktree : ctx.directory
         const state = {
           directory: ctx.directory,
-          worktree: ctx.worktree,
-          gitdir: path.join(Global.Path.data, "snapshot", ctx.project.id, Hash.fast(ctx.worktree)),
+          worktree,
+          gitdir: path.join(Global.Path.data, "snapshot", ctx.project.id, Hash.fast(worktree)),
           vcs: ctx.project.vcs,
         }
 
@@ -103,11 +132,14 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
           if (!files.length) return new Set<string>()
           // check-ignore treats a leading colon as pathspec magic but accepts and echoes a protective ./ prefix.
           const checkIgnorePaths = files.map((item) => (item.startsWith(":") ? `./${item}` : item))
+          // Worktrees without Git have no .git dir to resolve excludes against, so
+          // point check-ignore at the shadow gitdir where sync() mirrors the rules.
+          const gitdir = state.vcs === "git" ? path.join(state.worktree, ".git") : state.gitdir
           const check = yield* git(
             [
               ...quote,
               "--git-dir",
-              path.join(state.worktree, ".git"),
+              gitdir,
               "--work-tree",
               state.worktree,
               "check-ignore",
@@ -165,7 +197,6 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
         const locked = <A, E, R>(fx: Effect.Effect<A, E, R>) => lock(state.gitdir).withPermits(1)(fx)
 
         const enabled = Effect.fnUntraced(function* () {
-          if (state.vcs !== "git") return false
           return (yield* config.get()).snapshot !== false
         })
 
@@ -184,6 +215,7 @@ const layer: Layer.Layer<Service, never, FSUtil.Service | AppProcess.Service | C
           const target = path.join(state.gitdir, "info", "exclude")
           const text = [
             file ? (yield* read(file)).trimEnd() : "",
+            ...(state.vcs === "git" ? [] : defaultExcludes),
             ...list.map((item) => `/${item.replaceAll("\\", "/")}`),
           ]
             .filter(Boolean)

--- a/packages/opencode/test/session/revert-compact.test.ts
+++ b/packages/opencode/test/session/revert-compact.test.ts
@@ -680,4 +680,90 @@ describe("revert + compact workflow", () => {
       { git: true },
     ),
   )
+
+  it.live(
+    "reverts file changes without git",
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const revert = yield* SessionRevert.Service
+          const snapshot = yield* Snapshot.Service
+
+          yield* write(path.join(dir, "a.txt"), "a0")
+          yield* write(path.join(dir, "b.txt"), "b0")
+
+          const info = yield* session.create({})
+          const sid = info.id
+
+          const turn = Effect.fn("test.turn")(function* (file: string, next: string) {
+            const u = yield* user(sid)
+            yield* text(sid, u.id, `${file}:${next}`)
+            const a = yield* assistant(sid, u.id, dir)
+            const before = yield* snapshot.track()
+            if (!before) throw new Error("expected snapshot")
+            yield* write(path.join(dir, file), next)
+            const patch = yield* snapshot.patch(before)
+            if (!patch.files.length) throw new Error("expected patch files")
+            yield* session.updatePart({
+              id: PartID.ascending(),
+              messageID: a.id,
+              sessionID: sid,
+              type: "step-start",
+              snapshot: before,
+            })
+            yield* session.updatePart({
+              id: PartID.ascending(),
+              messageID: a.id,
+              sessionID: sid,
+              type: "step-finish",
+              reason: "stop",
+              snapshot: before,
+              cost: 0,
+              tokens,
+            })
+            yield* session.updatePart({
+              id: PartID.ascending(),
+              messageID: a.id,
+              sessionID: sid,
+              type: "patch",
+              hash: patch.hash,
+              files: patch.files,
+            })
+            return u.id
+          })
+
+          const first = yield* turn("a.txt", "a1")
+          const second = yield* turn("b.txt", "b1")
+
+          yield* revert.revert({
+            sessionID: sid,
+            messageID: first,
+          })
+          expect((yield* session.get(sid)).revert?.messageID).toBe(first)
+          expect(yield* read(path.join(dir, "a.txt"))).toBe("a0")
+          expect(yield* read(path.join(dir, "b.txt"))).toBe("b0")
+
+          yield* revert.unrevert({
+            sessionID: sid,
+          })
+          expect((yield* session.get(sid)).revert).toBeUndefined()
+          expect(yield* read(path.join(dir, "a.txt"))).toBe("a1")
+          expect(yield* read(path.join(dir, "b.txt"))).toBe("b1")
+
+          yield* revert.revert({
+            sessionID: sid,
+            messageID: second,
+          })
+          expect((yield* session.get(sid)).revert?.messageID).toBe(second)
+          expect(yield* read(path.join(dir, "b.txt"))).toBe("b0")
+
+          const state = yield* session.get(sid)
+          yield* revert.cleanup(state)
+          const messages = yield* session.messages({ sessionID: sid })
+          expect(messages.length).toBe(2)
+        }),
+      { git: false },
+    ),
+  )
 })

--- a/packages/opencode/test/session/snapshot-tool-race.test.ts
+++ b/packages/opencode/test/session/snapshot-tool-race.test.ts
@@ -19,6 +19,7 @@ import path from "path"
 import { Session } from "@/session/session"
 import { SessionPrompt } from "../../src/session/prompt"
 import { SessionSummary } from "../../src/session/summary"
+import { SessionRevert } from "../../src/session/revert"
 import { MessageV2 } from "../../src/session/message-v2"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Database } from "@opencode-ai/core/database/database"
@@ -82,6 +83,7 @@ const root = LayerNode.group([
   Session.node,
   SessionProjector.node,
   SessionSummary.node,
+  SessionRevert.node,
   Database.node,
   CrossSpawnSpawner.node,
   LayerNode.make({ service: TestLLMServer, layer: TestLLMServer.layer, deps: [] }),
@@ -185,5 +187,56 @@ it.live("tool execution produces non-empty session diff (snapshot race)", () =>
       expect(diff.length).toBeGreaterThan(0)
     }),
     { git: true, config: providerCfg },
+  ),
+)
+
+it.live("undo restores agent file changes in non-git projects", () =>
+  provideTmpdirServer(
+    Effect.fnUntraced(function* ({ dir, llm }) {
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const revert = yield* SessionRevert.Service
+
+      const session = yield* sessions.create({
+        title: "non-git undo test",
+        permission: [{ permission: "*", pattern: "*", action: "allow" }],
+      })
+
+      const filePath = path.join(dir, "undo-test.txt")
+      const command = `echo 'agent was here' > ${filePath}`
+      yield* llm.toolMatch((hit) => JSON.stringify(hit.body).includes("create the file"), "bash", {
+        command,
+      })
+      yield* llm.textMatch((hit) => JSON.stringify(hit.body).includes("bash"), "done")
+
+      yield* prompt.prompt({
+        sessionID: session.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "create the file" }],
+      })
+      yield* prompt.loop({ sessionID: session.id })
+
+      expect(yield* Effect.promise(() => fs.readFile(filePath, "utf8"))).toContain("agent was here")
+
+      const messages = yield* sessions.messages({ sessionID: session.id })
+      const user = messages.findLast((msg) => msg.info.role === "user")
+      if (!user) throw new Error("Expected user message")
+
+      yield* revert.revert({ sessionID: session.id, messageID: user.info.id })
+      yield* revert.cleanup(yield* sessions.get(session.id))
+
+      const restored = yield* Effect.promise(() =>
+        fs
+          .access(filePath)
+          .then(() => true)
+          .catch(() => false),
+      )
+      expect(restored).toBe(false)
+
+      const remaining = yield* sessions.messages({ sessionID: session.id })
+      expect(remaining.length).toBe(0)
+    }),
+    { config: providerCfg },
   ),
 )

--- a/packages/opencode/test/snapshot/snapshot.test.ts
+++ b/packages/opencode/test/snapshot/snapshot.test.ts
@@ -84,6 +84,9 @@ const bootstrapScoped = Effect.fn("SnapshotTest.bootstrapScoped")(function* () {
 const scopedGitTmpdir = () =>
   tmpdirScoped({ git: true }).pipe(Effect.provide(LayerNode.compile(CrossSpawnSpawner.node)))
 
+const scopedPlainTmpdir = () =>
+  tmpdirScoped().pipe(Effect.provide(LayerNode.compile(CrossSpawnSpawner.node)))
+
 const cleanupWorktree = (repo: string, worktree: string, files: string[] = []) =>
   Effect.promise(async () => {
     await $`git worktree remove --force ${worktree}`.cwd(repo).quiet().nothrow()
@@ -1215,4 +1218,104 @@ it.instance(
     for (const file of fresh) expect(yield* exists(file)).toBe(false)
   }),
   { git: true },
+)
+
+it.live(
+  "tracks and reverts changes without git",
+  Effect.gen(function* () {
+    const dir = yield* scopedPlainTmpdir()
+    yield* write(`${dir}/a.txt`, "a0")
+    yield* write(`${dir}/b.txt`, "b0")
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(`${dir}/a.txt`, "a1")
+      yield* write(`${dir}/new.txt`, "new")
+      yield* rm(`${dir}/b.txt`)
+      const patch = yield* snapshot.patch(before!)
+      expect(patch.files).toContain(fwd(dir, "a.txt"))
+      expect(patch.files).toContain(fwd(dir, "new.txt"))
+      expect(patch.files).toContain(fwd(dir, "b.txt"))
+      yield* snapshot.revert([patch])
+      expect(yield* readText(`${dir}/a.txt`)).toBe("a0")
+      expect(yield* readText(`${dir}/b.txt`)).toBe("b0")
+      expect(yield* exists(`${dir}/new.txt`)).toBe(false)
+    }).pipe(provideInstance(dir))
+  }),
+)
+
+it.live(
+  "restores a snapshot without git",
+  Effect.gen(function* () {
+    const dir = yield* scopedPlainTmpdir()
+    yield* write(`${dir}/a.txt`, "a0")
+    yield* write(`${dir}/b.txt`, "b0")
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(`${dir}/a.txt`, "a1")
+      yield* rm(`${dir}/b.txt`)
+      yield* write(`${dir}/new.txt`, "new")
+      yield* snapshot.restore(before!)
+      expect(yield* readText(`${dir}/a.txt`)).toBe("a0")
+      expect(yield* readText(`${dir}/b.txt`)).toBe("b0")
+      expect(yield* exists(`${dir}/new.txt`)).toBe(true)
+    }).pipe(provideInstance(dir))
+  }),
+)
+
+it.live(
+  "respects gitignore and default excludes without git",
+  Effect.gen(function* () {
+    const dir = yield* scopedPlainTmpdir()
+    yield* write(`${dir}/.gitignore`, "*.log\nignored-dir/\n")
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before = yield* snapshot.track()
+      expect(before).toBeTruthy()
+      yield* write(`${dir}/normal.txt`, "normal")
+      yield* write(`${dir}/x.log`, "log")
+      yield* mkdirp(`${dir}/ignored-dir`)
+      yield* write(`${dir}/ignored-dir/file.txt`, "ignored")
+      yield* mkdirp(`${dir}/node_modules/pkg`)
+      yield* write(`${dir}/node_modules/pkg/index.js`, "dep")
+      yield* write(`${dir}/node_modules/new-dep.js`, "dep2")
+      const patch = yield* snapshot.patch(before!)
+      expect(patch.files).toContain(fwd(dir, "normal.txt"))
+      expect(patch.files).not.toContain(fwd(dir, "x.log"))
+      expect(patch.files).not.toContain(fwd(dir, "ignored-dir", "file.txt"))
+      expect(patch.files).not.toContain(fwd(dir, "node_modules", "pkg", "index.js"))
+      expect(patch.files).not.toContain(fwd(dir, "node_modules", "new-dep.js"))
+    }).pipe(provideInstance(dir))
+  }),
+)
+
+it.live(
+  "snapshot state is isolated between non-git projects",
+  Effect.gen(function* () {
+    const dir1 = yield* scopedPlainTmpdir()
+    const dir2 = yield* scopedPlainTmpdir()
+    yield* write(`${dir1}/project1.txt`, "project1")
+    yield* write(`${dir2}/project2.txt`, "project2")
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before1 = yield* snapshot.track()
+      expect(before1).toBeTruthy()
+      yield* write(`${dir1}/project1.txt`, "changed1")
+      const patch1 = yield* snapshot.patch(before1!)
+      expect(patch1.files).toContain(fwd(dir1, "project1.txt"))
+      expect(patch1.files).not.toContain(fwd(dir2, "project2.txt"))
+    }).pipe(provideInstance(dir1))
+    yield* Effect.gen(function* () {
+      const snapshot = yield* Snapshot.Service
+      const before2 = yield* snapshot.track()
+      expect(before2).toBeTruthy()
+      yield* write(`${dir2}/project2.txt`, "changed2")
+      const patch2 = yield* snapshot.patch(before2!)
+      expect(patch2.files).toContain(fwd(dir2, "project2.txt"))
+      expect(patch2.files).not.toContain(fwd(dir1, "project1.txt"))
+    }).pipe(provideInstance(dir2))
+  }),
 )

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -627,9 +627,9 @@ Customize TUI keyboard shortcuts in `tui.json` with `keybinds`.
 
 ### Snapshot
 
-OpenCode uses snapshots to track file changes during agent operations, enabling you to undo and revert changes within a session. Snapshots are enabled by default.
+OpenCode uses snapshots to track file changes during agent operations, enabling you to undo and revert changes within a session. Snapshots are enabled by default, in Git and non-Git projects alike.
 
-For large repositories or projects with many submodules, the snapshot system can cause slow indexing and significant disk usage as it tracks all changes using an internal git repository. You can disable snapshots using the `snapshot` option.
+In Git projects, snapshots reuse the project's ignore rules. In non-Git projects, an internal git repository tracks your files, skipping common dependency and cache directories like `node_modules` or `.venv`. You can disable snapshots using the `snapshot` option.
 
 ```json title="opencode.json"
 {

--- a/packages/web/src/content/docs/tui.mdx
+++ b/packages/web/src/content/docs/tui.mdx
@@ -195,8 +195,8 @@ Redo a previously undone message. Only available after using `/undo`.
 Any file changes will also be restored.
 :::
 
-Internally, this uses Git to manage the file changes. So your project **needs to
-be a Git repository**.
+File changes are tracked with snapshots in an internal git repository, so they
+are restored whether or not your project itself is a Git repository.
 
 ```bash frame="none"
 /redo
@@ -262,8 +262,8 @@ Undo last message in the conversation. Removes the most recent user message, all
 Any file changes made will also be reverted.
 :::
 
-Internally, this uses Git to manage the file changes. So your project **needs to
-be a Git repository**.
+File changes are tracked with snapshots in an internal git repository, so they
+are reverted whether or not your project itself is a Git repository.
 
 ```bash frame="none"
 /undo


### PR DESCRIPTION
### Issue for this PR

Closes #38672

Related: #37106, #9978 — requests for undo that also restores code, including outside Git repos.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Claude Code-style rewind capability to `/undo`: it now restores both the conversation **and** the agent's file changes in **any** project — including non-Git directories, where undo previously only rolled back messages and left the agent's edits on disk (see #38672). Users without Git are exactly the ones who most need this, since they cannot fall back to `git restore`.

The snapshot system is already a self-contained shadow repo (a git dir under `~/.local/share/opencode/snapshot`); it doesn't need the project itself to be Git. This PR turns that capability on for non-Git worktrees:

- Snapshot non-Git instances at the opened directory instead of the synthetic global project's worktree (which is the filesystem root `/`), and key the shadow gitdir by directory hash.
- When the worktree has no `.git`, resolve ignore rules against the shadow gitdir (`check-ignore --no-index` still reads the project's `.gitignore` hierarchy and the shadow repo's `info/exclude`), keeping tracking and patch filtering consistent — so ignored files can't be deleted by a revert.
- Apply a default exclude list in non-Git worktrees (node_modules, .venv, __pycache__, target, ...) via the shadow repo's `info/exclude`. Project `.gitignore` files are still honored; `snapshot: false` still disables everything.

Git projects take exactly the same code paths as before.

### How did you verify your code works?

- New tests: non-Git snapshot track/patch/revert/restore in `test/snapshot/snapshot.test.ts`; session-level revert/unrevert/cleanup without Git in `test/session/revert-compact.test.ts`; full agent loop (mock LLM + real bash tool creating a file) where undo removes the created file and clears the conversation in `test/session/snapshot-tool-race.test.ts`.
- Manually verified with `bun dev serve` in a non-Git directory against a real model: agent created `hello.txt` and edited `src/app.js`; the recorded patch listed exactly those two files (node_modules excluded); the revert endpoint deleted the new file and restored the old content of `src/app.js`; unrevert brought both back.
- `typecheck` clean; `test/snapshot/` 59 pass, `test/session/` 412 pass; full `bun test` failure set identical to dev baseline (pre-existing timeouts only).

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
