### PR TITLE
feat(opencode): add session import endpoint

### DIFF
--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -1,20 +1,12 @@
 import type { Session as SDKSession, Message, Part } from "@opencode-ai/sdk/v2"
-import { SessionV1 } from "@opencode-ai/core/v1/session"
-import { Session } from "@/session/session"
-import { MessageV2 } from "../../session/message-v2"
+import { SessionImport } from "@/session/import"
 import { CliError, effectCmd } from "../effect-cmd"
-import { Database } from "@opencode-ai/core/database/database"
-import { SessionTable, MessageTable, PartTable } from "@opencode-ai/core/session/sql"
 import { InstanceRef } from "@/effect/instance-ref"
 import { ShareNext } from "@/share/share-next"
 import { EOL } from "os"
-import path from "path"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Effect, Schema } from "effect"
 import type { InstanceContext } from "@/project/instance-context"
-
-const decodeMessageInfo = Schema.decodeUnknownSync(SessionV1.Info)
-const decodePart = Schema.decodeUnknownSync(SessionV1.Part)
 
 /** Discriminated union returned by the ShareNext API (GET /api/shares/:id/data) */
 export type ShareData =
@@ -89,8 +81,6 @@ export function transformShareData(shareData: ShareData[]): {
   }
 }
 
-type ExportData = { info: SDKSession; messages: Array<{ info: Message; parts: Part[] }> }
-
 export const ImportCommand = effectCmd({
   command: "import <file>",
   describe: "import session data from JSON file or URL",
@@ -110,9 +100,7 @@ export const ImportCommand = effectCmd({
 const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: InstanceContext) {
   const share = yield* ShareNext.Service
   const fs = yield* FSUtil.Service
-  const { db } = yield* Database.Service
-
-  let exportData: ExportData | undefined
+  let exportData: unknown
 
   const isUrl = file.startsWith("http://") || file.startsWith("https://")
 
@@ -165,9 +153,9 @@ const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: Ins
 
     exportData = transformed
   } else {
-    exportData = (yield* fs
+    exportData = yield* fs
       .readJson(file)
-      .pipe(Effect.mapError((error) => new CliError({ message: formatImportFileError(file, error) })))) as ExportData
+      .pipe(Effect.mapError((error) => new CliError({ message: formatImportFileError(file, error) })))
   }
 
   if (!exportData) {
@@ -176,55 +164,13 @@ const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: Ins
     return
   }
 
-  const info = Schema.decodeUnknownSync(Session.Info)({
-    ...exportData.info,
-    projectID: ctx.project.id,
-    directory: ctx.directory,
-    path: path.relative(path.resolve(ctx.worktree), ctx.directory).replaceAll("\\", "/"),
-  }) as Session.Info
-  const row = Session.toRow(info)
-  yield* db
-    .insert(SessionTable)
-    .values(row)
-    .onConflictDoUpdate({
-      target: SessionTable.id,
-      set: { project_id: row.project_id, directory: row.directory, path: row.path },
-    })
-    .run()
-    .pipe(Effect.orDie)
+  const data = yield* Schema.decodeUnknownEffect(SessionImport.Data)(exportData).pipe(
+    Effect.mapError(() => new CliError({ message: "Session data is invalid" })),
+  )
+  const info = yield* SessionImport.run({ data, context: ctx }).pipe(
+    Effect.mapError((error) => new CliError({ message: error.message })),
+  )
 
-  for (const msg of exportData.messages) {
-    const msgInfo = decodeMessageInfo(msg.info) as SessionV1.Info
-    const { id, sessionID: _, ...msgData } = msgInfo
-    yield* db
-      .insert(MessageTable)
-      .values({
-        id,
-        session_id: row.id,
-        time_created: msgInfo.time?.created ?? Date.now(),
-        data: msgData as never,
-      })
-      .onConflictDoNothing()
-      .run()
-      .pipe(Effect.orDie)
-
-    for (const part of msg.parts) {
-      const partInfo = decodePart(part) as SessionV1.Part
-      const { id: partId, sessionID: _s, messageID, ...partData } = partInfo
-      yield* db
-        .insert(PartTable)
-        .values({
-          id: partId,
-          message_id: messageID,
-          session_id: row.id,
-          data: partData,
-        })
-        .onConflictDoNothing()
-        .run()
-        .pipe(Effect.orDie)
-    }
-  }
-
-  process.stdout.write(`Imported session: ${exportData.info.id}`)
+  process.stdout.write(`Imported session: ${info.id}`)
   process.stdout.write(EOL)
 })

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -3,6 +3,7 @@ import { Permission } from "@/permission"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 
 import { Session } from "@/session/session"
+import { SessionImport } from "@/session/import"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
 import { SessionRevert } from "@/session/revert"
@@ -78,6 +79,7 @@ export const PermissionResponsePayload = Schema.Struct({
 export const SessionPaths = {
   list: root,
   status: `${root}/status`,
+  import: `${root}/import`,
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
@@ -108,6 +110,18 @@ export const SessionApi = HttpApi.make("session")
   .add(
     HttpApiGroup.make("session")
       .add(
+        HttpApiEndpoint.post("importSession", SessionPaths.import, {
+          query: WorkspaceRoutingQuery,
+          payload: SessionImport.Data,
+          success: described(Session.Info, "Imported session"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.import",
+            summary: "Import session",
+            description: "Import a session transcript from an OpenCode session export.",
+          }),
+        ),
         HttpApiEndpoint.get("list", SessionPaths.list, {
           query: ListQuery,
           success: described(Schema.Array(Session.Info), "List of sessions"),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -6,6 +6,7 @@ import { Command } from "@/command"
 import { Permission } from "@/permission"
 import { SessionShare } from "@/share/session"
 import { Session } from "@/session/session"
+import { SessionImport } from "@/session/import"
 import { SessionCompaction } from "@/session/compaction"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
@@ -19,6 +20,7 @@ import { NamedError } from "@opencode-ai/core/util/error"
 import { Cause, Effect, Option, Schema, Scope } from "effect"
 import * as Stream from "effect/Stream"
 import { InstanceState } from "@/effect/instance-state"
+import { InstanceRef } from "@/effect/instance-ref"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
@@ -72,6 +74,17 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
         search: ctx.query.search,
         limit: ctx.query.limit,
       })
+    })
+
+    const importSession = Effect.fn("SessionHttpApi.import")(function* (ctx: {
+      payload: typeof SessionImport.Data.Type
+    }) {
+      const instance = yield* InstanceRef
+      if (!instance) return yield* new HttpApiError.BadRequest({})
+      const info = yield* SessionImport.run({ data: ctx.payload, context: instance }).pipe(
+        Effect.mapError(() => new HttpApiError.BadRequest({})),
+      )
+      return yield* session.get(info.id).pipe(Effect.orDie)
     })
 
     const status = Effect.fn("SessionHttpApi.status")(function* () {
@@ -411,6 +424,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     })
 
     return handlers
+      .handle("importSession", importSession)
       .handle("list", list)
       .handle("status", status)
       .handle("get", get)

--- a/packages/opencode/src/server/shared/workspace-routing.ts
+++ b/packages/opencode/src/server/shared/workspace-routing.ts
@@ -18,7 +18,7 @@ export function isLocalWorkspaceRoute(method: string, path: string) {
 }
 
 export function getWorkspaceRouteSessionID(url: URL) {
-  if (url.pathname === "/session/status") return null
+  if (url.pathname === "/session/status" || url.pathname === "/session/import") return null
 
   const id =
     url.pathname.match(/^\/session\/([^/]+)(?:\/|$)/)?.[1] ??

--- a/packages/opencode/src/session/import.ts
+++ b/packages/opencode/src/session/import.ts
@@ -1,0 +1,86 @@
+export * as SessionImport from "./import"
+
+import { Database } from "@opencode-ai/core/database/database"
+import { MessageTable, PartTable, SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import type { InstanceContext } from "@/project/instance-context"
+import path from "path"
+import { Effect, Schema } from "effect"
+import { Session } from "./session"
+
+export const Data = Schema.Struct({
+  info: Session.Info,
+  messages: Schema.Array(SessionV1.WithParts),
+})
+export type Data = typeof Data.Type
+
+export class InvalidError extends Schema.TaggedErrorClass<InvalidError>()("SessionImportInvalidError", {
+  message: Schema.String,
+}) {}
+
+export const run = Effect.fn("SessionImport.run")(function* (input: { data: Data; context: InstanceContext }) {
+  const invalid = input.data.messages.find(
+    (message) =>
+      message.info.sessionID !== input.data.info.id ||
+      message.parts.some((part) => part.sessionID !== input.data.info.id || part.messageID !== message.info.id),
+  )
+  if (invalid) return yield* new InvalidError({ message: "Session transcript contains mismatched IDs" })
+
+  const { db } = yield* Database.Service
+  const events = yield* EventV2Bridge.Service
+  const info = {
+    ...input.data.info,
+    projectID: input.context.project.id,
+    directory: input.context.directory,
+    path: path.relative(path.resolve(input.context.worktree), input.context.directory).replaceAll("\\", "/"),
+  }
+  const row = Session.toRow(info)
+
+  yield* db
+    .transaction((tx) =>
+      Effect.gen(function* () {
+        yield* tx
+          .insert(SessionTable)
+          .values(row)
+          .onConflictDoUpdate({
+            target: SessionTable.id,
+            set: { project_id: row.project_id, directory: row.directory, path: row.path },
+          })
+          .run()
+
+        for (const message of input.data.messages) {
+          const messageInfo = message.info
+          const { id, sessionID: _, ...data } = messageInfo
+          yield* tx
+            .insert(MessageTable)
+            .values({
+              id,
+              session_id: row.id,
+              time_created: messageInfo.time?.created ?? Date.now(),
+              data: data as never,
+            })
+            .onConflictDoNothing()
+            .run()
+
+          for (const part of message.parts) {
+            const { id: partID, sessionID: _sessionID, messageID, ...partData } = part
+            yield* tx
+              .insert(PartTable)
+              .values({
+                id: partID,
+                message_id: messageID,
+                session_id: row.id,
+                data: partData,
+              })
+              .onConflictDoNothing()
+              .run()
+          }
+        }
+      }),
+    )
+    .pipe(Effect.orDie)
+
+  yield* events.publish(SessionV1.Event.Updated, { sessionID: info.id, info })
+  return info
+})

--- a/packages/opencode/src/session/import.ts
+++ b/packages/opencode/src/session/import.ts
@@ -34,6 +34,7 @@ export const run = Effect.fn("SessionImport.run")(function* (input: { data: Data
     projectID: input.context.project.id,
     directory: input.context.directory,
     path: path.relative(path.resolve(input.context.worktree), input.context.directory).replaceAll("\\", "/"),
+    time: { ...input.data.info.time, updated: Date.now() },
   }
   const row = Session.toRow(info)
 
@@ -45,7 +46,12 @@ export const run = Effect.fn("SessionImport.run")(function* (input: { data: Data
           .values(row)
           .onConflictDoUpdate({
             target: SessionTable.id,
-            set: { project_id: row.project_id, directory: row.directory, path: row.path },
+            set: {
+              project_id: row.project_id,
+              directory: row.directory,
+              path: row.path,
+              time_updated: row.time_updated,
+            },
           })
           .run()
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -117,7 +117,7 @@ export function fromRow(row: SessionRow): Info {
   }
 }
 
-export function toRow(info: Info) {
+export function toRow(info: typeof Info.Type) {
   return {
     id: info.id,
     project_id: info.projectID,
@@ -134,7 +134,7 @@ export function toRow(info: Info) {
     summary_additions: info.summary?.additions,
     summary_deletions: info.summary?.deletions,
     summary_files: info.summary?.files,
-    summary_diffs: info.summary?.diffs,
+    summary_diffs: info.summary?.diffs?.map((diff) => ({ ...diff })),
     metadata: info.metadata,
     cost: info.cost ?? 0,
     tokens_input: (info.tokens ?? EmptyTokens).input,
@@ -150,7 +150,7 @@ export function toRow(info: Info) {
           diff: info.revert.diff,
         }
       : null,
-    permission: info.permission,
+    permission: info.permission ? [...info.permission] : undefined,
     time_created: info.time.created,
     time_updated: info.time.updated,
     time_compacting: info.time.compacting,

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1165,6 +1165,31 @@ const scenarios: Scenario[] = [
     .seeded((ctx) => ctx.session({ title: "Status session" }))
     .json(200, object),
   http.protected
+    .post("/session/import", "session.import")
+    .mutating()
+    .seeded((ctx) => ctx.session({ title: "Imported session" }))
+    .at((ctx) => ({
+      path: "/session/import",
+      headers: ctx.headers(),
+      body: {
+        info: {
+          id: ctx.state.id,
+          slug: ctx.state.slug,
+          projectID: ctx.state.projectID,
+          directory: ctx.state.directory,
+          title: ctx.state.title,
+          version: ctx.state.version,
+          time: ctx.state.time,
+        },
+        messages: [],
+      },
+    }))
+    .json(200, (body, ctx) => {
+      object(body)
+      check(body.id === ctx.state.id, "imported session should preserve its ID")
+      check(body.directory === ctx.directory, "imported session should use scenario directory")
+    }),
+  http.protected
     .post("/session", "session.create")
     .mutating()
     .at((ctx) => ({ path: "/session", headers: ctx.headers(), body: { title: "Created session" } }))

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -6,6 +6,7 @@ import type { Project } from "../../../src/project/project"
 import type { Worktree } from "../../../src/worktree"
 import type { MessageV2 } from "../../../src/session/message-v2"
 import type { SessionID } from "../../../src/session/schema"
+import type { Session } from "../../../src/session/session"
 
 export const OpenApiMethods = ["get", "post", "put", "delete", "patch"] as const
 export const Methods = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const
@@ -118,7 +119,7 @@ export type Result =
   | { status: "fail"; scenario: ActiveScenario; message: string }
   | { status: "skip"; scenario: TodoScenario }
 
-export type SessionInfo = { id: SessionID; title: string; parentID?: SessionID }
+export type SessionInfo = Session.Info
 export type TodoInfo = {
   content: string
   status: "pending" | "in_progress" | "completed" | "cancelled"

--- a/packages/opencode/test/server/workspace-routing.test.ts
+++ b/packages/opencode/test/server/workspace-routing.test.ts
@@ -51,6 +51,11 @@ describe("getWorkspaceRouteSessionID", () => {
     expect(getWorkspaceRouteSessionID(url)).toBeNull()
   })
 
+  test("returns null for /session/import", () => {
+    const url = new URL("http://localhost/session/import")
+    expect(getWorkspaceRouteSessionID(url)).toBeNull()
+  })
+
   test("returns null for non-session paths", () => {
     const url = new URL("http://localhost/config")
     expect(getWorkspaceRouteSessionID(url)).toBeNull()

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -5,7 +5,7 @@ import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { Deferred, Effect, Exit, Layer } from "effect"
 import { Session as SessionNs } from "@/session/session"
 import { MessageV2 } from "../../src/session/message-v2"
-import { MessageID, PartID, type SessionID } from "../../src/session/schema"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { provideInstance, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -16,11 +16,17 @@ import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { InstanceStore } from "@/project/instance-store"
 import { InstanceBootstrap } from "@/project/bootstrap"
+import { InstanceRef } from "@/effect/instance-ref"
+import { SessionImport } from "@/session/import"
+import { Database } from "@opencode-ai/core/database/database"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 
 const it = testEffect(
   AppNodeBuilder.build(
     LayerNode.group([
       SessionNs.node,
+      Database.node,
       EventV2Bridge.node,
       SessionProjector.node,
       CrossSpawnSpawner.node,
@@ -127,6 +133,84 @@ describe("session.created event", () => {
         data: { sessionID: info.id },
       })
 
+      yield* session.remove(info.id)
+    }),
+  )
+})
+
+describe("session import", () => {
+  it.instance("imports a transcript into the active project", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const context = yield* InstanceRef
+      if (!context) return yield* Effect.die("InstanceRef not provided")
+
+      const info = yield* session.create({ title: "Imported session" })
+      const messageID = MessageID.ascending()
+      yield* session.updateMessage({
+        id: messageID,
+        sessionID: info.id,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "build",
+        model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+      })
+      yield* session.updatePart({
+        id: PartID.ascending(),
+        messageID,
+        sessionID: info.id,
+        type: "text",
+        text: "hello",
+      })
+      const data = { info, messages: yield* session.messages({ sessionID: info.id }) }
+      yield* session.remove(info.id)
+
+      const imported = yield* SessionImport.run({ data, context }).pipe(Effect.orDie)
+      const messages = yield* session.messages({ sessionID: imported.id })
+
+      expect(imported.projectID).toBe(context.project.id)
+      expect(imported.directory).toBe(context.directory)
+      expect(messages).toHaveLength(1)
+      expect(messages[0].parts).toHaveLength(1)
+      expect(messages[0].parts[0]).toMatchObject({ type: "text", text: "hello" })
+
+      yield* session.remove(imported.id)
+    }),
+  )
+
+  it.instance("rejects mismatched transcript IDs", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const context = yield* InstanceRef
+      if (!context) return yield* Effect.die("InstanceRef not provided")
+      const info = yield* session.create({})
+
+      const result = yield* SessionImport.run({
+        context,
+        data: {
+          info,
+          messages: [
+            {
+              info: {
+                id: MessageID.ascending(),
+                sessionID: SessionID.descending(),
+                role: "user",
+                time: { created: Date.now() },
+                agent: "build",
+                model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+              },
+              parts: [],
+            },
+          ],
+        },
+      }).pipe(
+        Effect.match({
+          onFailure: (error) => error._tag,
+          onSuccess: () => "success",
+        }),
+      )
+
+      expect(result).toBe("SessionImportInvalidError")
       yield* session.remove(info.id)
     }),
   )

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -146,6 +146,7 @@ describe("session import", () => {
       if (!context) return yield* Effect.die("InstanceRef not provided")
 
       const info = yield* session.create({ title: "Imported session" })
+      const exportedAt = Date.now() - 60_000
       const messageID = MessageID.ascending()
       yield* session.updateMessage({
         id: messageID,
@@ -162,14 +163,20 @@ describe("session import", () => {
         type: "text",
         text: "hello",
       })
-      const data = { info, messages: yield* session.messages({ sessionID: info.id }) }
+      const data = {
+        info: { ...info, time: { ...info.time, updated: exportedAt } },
+        messages: yield* session.messages({ sessionID: info.id }),
+      }
       yield* session.remove(info.id)
 
       const imported = yield* SessionImport.run({ data, context }).pipe(Effect.orDie)
+      const saved = yield* session.get(imported.id)
       const messages = yield* session.messages({ sessionID: imported.id })
 
       expect(imported.projectID).toBe(context.project.id)
       expect(imported.directory).toBe(context.directory)
+      expect(imported.time.updated).toBeGreaterThan(exportedAt)
+      expect(saved.time.updated).toBe(imported.time.updated)
       expect(messages).toHaveLength(1)
       expect(messages[0].parts).toHaveLength(1)
       expect(messages[0].parts[0]).toMatchObject({ type: "text", text: "hello" })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -111,6 +111,7 @@ import type {
   McpRemoteConfig,
   McpStatusErrors,
   McpStatusResponses,
+  Message,
   ModelRef,
   MoveSessionDestination,
   OutputFormat,
@@ -175,6 +176,7 @@ import type {
   QuestionReplyErrors,
   QuestionReplyResponses,
   QuestionV2Reply,
+  Session as Session4,
   SessionAbortErrors,
   SessionAbortResponses,
   SessionChildrenErrors,
@@ -193,6 +195,8 @@ import type {
   SessionForkResponses,
   SessionGetErrors,
   SessionGetResponses,
+  SessionImportErrors,
+  SessionImportResponses,
   SessionInitErrors,
   SessionInitResponses,
   SessionListErrors,
@@ -3360,6 +3364,48 @@ export class Provider extends HeyApiClient {
 }
 
 export class Session2 extends HeyApiClient {
+  /**
+   * Import session
+   *
+   * Import a session transcript from an OpenCode session export.
+   */
+  public import<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      info?: Session4
+      messages?: Array<{
+        info: Message
+        parts: Array<Part2>
+      }>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "info" },
+            { in: "body", key: "messages" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionImportResponses, SessionImportErrors, ThrowOnError>({
+      url: "/session/import",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
   /**
    * List sessions
    *

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -9436,6 +9436,40 @@ export type ProviderOauthCallbackResponses = {
 
 export type ProviderOauthCallbackResponse = ProviderOauthCallbackResponses[keyof ProviderOauthCallbackResponses]
 
+export type SessionImportData = {
+  body?: {
+    info: Session
+    messages: Array<{
+      info: Message
+      parts: Array<Part>
+    }>
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/import"
+}
+
+export type SessionImportErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+}
+
+export type SessionImportError = SessionImportErrors[keyof SessionImportErrors]
+
+export type SessionImportResponses = {
+  /**
+   * Imported session
+   */
+  200: Session
+}
+
+export type SessionImportResponse = SessionImportResponses[keyof SessionImportResponses]
+
 export type SessionListData = {
   body?: never
   path?: never


### PR DESCRIPTION
### Issue for this PR

Part of #32696

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a typed `POST /session/import` endpoint and reuses the same validated, transactional importer from the existing CLI command. Imported sessions are retargeted to the requested project directory, malformed transcript relationships are rejected, and the SDK is regenerated for clients.

This is the base of a two-PR stack. The desktop project-menu UI will follow in a PR based on this branch.

### How did you verify your code works?

- `bun typecheck` in `packages/opencode`
- `bun typecheck` in `packages/sdk/js`
- `bun test test/server/workspace-routing.test.ts test/session/session.test.ts test/cli/import.test.ts` in `packages/opencode`
- `bun run test:httpapi` in `packages/opencode`
- repository pre-push typecheck hook

### Screenshots / recordings

Not applicable; this PR only adds the server and SDK support.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR