### PR TITLE
feat(app): add desktop session import

### DIFF
--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -688,6 +688,7 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
     updateConfig: updateConfigMutation.mutateAsync,
     project: projectApi,
     session,
+    indexSession,
     homeSessions,
     mcp: {
       toggle: async (directory: string, name: string) => {

--- a/packages/app/src/i18n/am.ts
+++ b/packages/app/src/i18n/am.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "ሳይክል ቋንቋ",
   "command.language.set": "ቋንቋን ተጠቀም፡ {{language}}",
   "command.session.new": "አዲስ ክፍለ ጊዜ",
+  "command.session.import": "ክፍለ ጊዜን አስመጣ",
   "command.file.open": "ክፍት ፋይል",
   "command.tab.close": "ትርፉን ዝጋ",
   "command.tab.reopenClosed": "የተዘጋውን ትር እንደገና ክፈት",

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -139,6 +139,7 @@ export const dict = {
   "command.language.cycle": "تغيير اللغة",
   "command.language.set": "استخدام اللغة: {{language}}",
   "command.session.new": "جلسة جديدة",
+  "command.session.import": "استيراد الجلسة",
   "command.file.open": "فتح ملف",
   "command.tab.close": "إغلاق علامة التبويب",
   "command.tab.reopenClosed": "إعادة فتح علامة التبويب المغلقة",

--- a/packages/app/src/i18n/az.ts
+++ b/packages/app/src/i18n/az.ts
@@ -135,6 +135,7 @@ export const dict = {
   "command.language.cycle": "Dili dəyiş",
   "command.language.set": "Dildən istifadə et: {{language}}",
   "command.session.new": "Yeni sessiya",
+  "command.session.import": "Sessiyanı idxal et",
   "command.file.open": "Faylı aç",
   "command.tab.close": "Tabı bağla",
   "command.tab.reopenClosed": "Bağlanmış tabı yenidən aç",

--- a/packages/app/src/i18n/bg.ts
+++ b/packages/app/src/i18n/bg.ts
@@ -135,6 +135,7 @@ export const dict = {
   "command.language.cycle": "Цикличен език",
   "command.language.set": "Използвайте език: {{language}}",
   "command.session.new": "Нова сесия",
+  "command.session.import": "Импортиране на сесия",
   "command.file.open": "Отворете файла",
   "command.tab.close": "Затваряне на раздела",
   "command.tab.reopenClosed": "Повторно отваряне на затворен раздел",

--- a/packages/app/src/i18n/bn.ts
+++ b/packages/app/src/i18n/bn.ts
@@ -134,6 +134,7 @@ export const dict: Record<string, string> = {
   "command.language.cycle": "সাইকেল ভাষা",
   "command.language.set": "ভাষা ব্যবহার করুন: {{language}}",
   "command.session.new": "নতুন সেশন",
+  "command.session.import": "সেশন আমদানি করুন",
   "command.file.open": "ফাইল খুলুন",
   "command.tab.close": "ট্যাব বন্ধ করুন",
   "command.tab.reopenClosed": "বন্ধ ট্যাব আবার খুলুন",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -141,6 +141,7 @@ export const dict = {
   "command.language.cycle": "Alternar idioma",
   "command.language.set": "Usar idioma: {{language}}",
   "command.session.new": "Nova sessão",
+  "command.session.import": "Importar sessão",
   "command.file.open": "Abrir arquivo",
   "command.tab.close": "Fechar aba",
   "command.tab.reopenClosed": "Reabrir aba fechada",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -147,6 +147,7 @@ export const dict = {
   "command.language.set": "Koristi jezik: {{language}}",
 
   "command.session.new": "Nova sesija",
+  "command.session.import": "Uvezi sesiju",
   "command.file.open": "Otvori datoteku",
   "command.tab.close": "Zatvori karticu",
   "command.tab.reopenClosed": "Ponovo otvori zatvorenu karticu",

--- a/packages/app/src/i18n/ca.ts
+++ b/packages/app/src/i18n/ca.ts
@@ -135,6 +135,7 @@ export const dict = {
   "command.language.cycle": "Llenguatge de cicle",
   "command.language.set": "Utilitza l'idioma: {{language}}",
   "command.session.new": "Nova sessió",
+  "command.session.import": "Importa la sessió",
   "command.file.open": "Obre el fitxer",
   "command.tab.close": "Tanca la pestanya",
   "command.tab.reopenClosed": "Torneu a obrir la pestanya tancada",

--- a/packages/app/src/i18n/cs.ts
+++ b/packages/app/src/i18n/cs.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Jazyk cyklu",
   "command.language.set": "Použít jazyk: {{language}}",
   "command.session.new": "Nová relace",
+  "command.session.import": "Importovat relaci",
   "command.file.open": "Otevřít soubor",
   "command.tab.close": "Zavřít kartu",
   "command.tab.reopenClosed": "Znovu otevřete zavřenou kartu",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -46,6 +46,7 @@ export const dict = {
   "command.language.set": "Brug sprog: {{language}}",
 
   "command.session.new": "Ny session",
+  "command.session.import": "Importér session",
   "command.file.open": "Åbn fil",
   "command.tab.close": "Luk fane",
   "command.tab.reopenClosed": "Åbn lukket fane igen",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -44,6 +44,7 @@ export const dict = {
   "command.language.cycle": "Sprache wechseln",
   "command.language.set": "Sprache verwenden: {{language}}",
   "command.session.new": "Neue Sitzung",
+  "command.session.import": "Sitzung importieren",
   "command.file.open": "Datei öffnen",
   "command.tab.close": "Tab schließen",
   "command.tab.reopenClosed": "Geschlossenen Tab wieder öffnen",

--- a/packages/app/src/i18n/dv.ts
+++ b/packages/app/src/i18n/dv.ts
@@ -136,6 +136,7 @@ export const dict = {
   "command.language.cycle": "ސައިކަލް ބަސް",
   "command.language.set": "ބަސް ބޭނުންކުރުން: {{language}}",
   "command.session.new": "އާ ޖަލްސާއެއް",
+  "command.session.import": "އިމްޕޯޓް ސެޝަން",
   "command.file.open": "ފައިލް ހުޅުވާލާށެވެ",
   "command.tab.close": "ޓެބް ބަންދުކުރުން",
   "command.tab.reopenClosed": "ބަންދުކޮށްފައިވާ ޓެބް އަލުން ހުޅުވާލާށެވެ",

--- a/packages/app/src/i18n/dz.ts
+++ b/packages/app/src/i18n/dz.ts
@@ -136,6 +136,7 @@ export const dict: Record<string, string> = {
   "command.language.cycle": "འཁོར་བའི་སྐད་ཡིག།",
   "command.language.set": "སྐད་ཡིག་ལག་ལེན་འཐབ།: {{language}}",
   "command.session.new": "ལཱ་ཡུན་གསརཔ།",
+  "command.session.import": "ལཱ་ཡུན་ནང་འདྲེན་འབད་ནི།",
   "command.file.open": "ཡིག་སྣོད་ཁ་ཕྱེ།",
   "command.tab.close": "མཆོང་ལྡེ་ཁ་བསྡམས།",
   "command.tab.reopenClosed": "ཁ་བསྡམས་ཡོད་པའི་མཆོང་ལྡེ་ལོག་ཁ་ཕྱེ།",

--- a/packages/app/src/i18n/el.ts
+++ b/packages/app/src/i18n/el.ts
@@ -134,6 +134,7 @@ export const dict = {
   "command.language.cycle": "Γλώσσα κύκλου",
   "command.language.set": "Γλώσσα χρήσης: {{language}}",
   "command.session.new": "Νέα συνεδρία",
+  "command.session.import": "Εισαγωγή συνεδρίας",
   "command.file.open": "Άνοιγμα αρχείου",
   "command.tab.close": "Κλείσιμο καρτέλας",
   "command.tab.reopenClosed": "Άνοιγμα ξανά κλειστής καρτέλας",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -50,6 +50,7 @@ export const dict = {
   "command.language.set": "Use language: {{language}}",
 
   "command.session.new": "New session",
+  "command.session.import": "Import session",
   "command.file.open": "Open file",
   "command.tab.close": "Close tab",
   "command.tab.reopenClosed": "Reopen closed tab",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -147,6 +147,7 @@ export const dict = {
   "command.language.set": "Usar idioma: {{language}}",
 
   "command.session.new": "Nueva sesión",
+  "command.session.import": "Importar sesión",
   "command.file.open": "Abrir archivo",
   "command.tab.close": "Cerrar pestaña",
   "command.tab.reopenClosed": "Reabrir pestaña cerrada",

--- a/packages/app/src/i18n/et.ts
+++ b/packages/app/src/i18n/et.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Tsükli keel",
   "command.language.set": "Kasuta keelt: {{language}}",
   "command.session.new": "Uus seanss",
+  "command.session.import": "Impordi seanss",
   "command.file.open": "Ava fail",
   "command.tab.close": "Sule vahekaart",
   "command.tab.reopenClosed": "Ava suletud vaheleht uuesti",

--- a/packages/app/src/i18n/fa.ts
+++ b/packages/app/src/i18n/fa.ts
@@ -134,6 +134,7 @@ export const dict = {
   "command.language.cycle": "زبان چرخه",
   "command.language.set": "استفاده از زبان: {{language}}",
   "command.session.new": "جلسه جدید",
+  "command.session.import": "درون‌ریزی جلسه",
   "command.file.open": "باز کردن فایل",
   "command.tab.close": "بستن برگه",
   "command.tab.reopenClosed": "برگه بسته را دوباره باز کنید",

--- a/packages/app/src/i18n/fi.ts
+++ b/packages/app/src/i18n/fi.ts
@@ -40,6 +40,7 @@ export const dict = {
   "command.language.cycle": "Vaihda kieltä",
   "command.language.set": "Käytä kieltä: {{language}}",
   "command.session.new": "Uusi istunto",
+  "command.session.import": "Tuo istunto",
   "command.file.open": "Avaa tiedosto",
   "command.tab.close": "Sulje välilehti",
   "command.tab.reopenClosed": "Avaa suljettu välilehti uudelleen",

--- a/packages/app/src/i18n/fo.ts
+++ b/packages/app/src/i18n/fo.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Súkklumál",
   "command.language.set": "Brúka mál: {{language}}",
   "command.session.new": "Nýggj setan",
+  "command.session.import": "Flytja inn setu",
   "command.file.open": "Opna fíluna",
   "command.tab.close": "Lat flipan aftur",
   "command.tab.reopenClosed": "Opna aftur stongdan flipan",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -141,6 +141,7 @@ export const dict = {
   "command.language.cycle": "Changer de langue",
   "command.language.set": "Utiliser la langue : {{language}}",
   "command.session.new": "Nouvelle session",
+  "command.session.import": "Importer la session",
   "command.file.open": "Ouvrir un fichier",
   "command.tab.close": "Fermer l'onglet",
   "command.tab.reopenClosed": "Rouvrir l'onglet fermé",

--- a/packages/app/src/i18n/hi.ts
+++ b/packages/app/src/i18n/hi.ts
@@ -140,6 +140,7 @@ export const dict = {
   "command.language.cycle": "भाषा बदलें",
   "command.language.set": "भाषा का प्रयोग करें: {{language}}",
   "command.session.new": "नया सेशन",
+  "command.session.import": "सेशन आयात करें",
   "command.file.open": "फ़ाइल खोलें",
   "command.tab.close": "टैब बंद करें",
   "command.tab.reopenClosed": "बंद टैब पुनः खोलें",

--- a/packages/app/src/i18n/hr.ts
+++ b/packages/app/src/i18n/hr.ts
@@ -137,6 +137,7 @@ export const dict = {
   "command.language.cycle": "Promijeni jezik",
   "command.language.set": "Koristite jezik: {{language}}",
   "command.session.new": "Nova sesija",
+  "command.session.import": "Uvezi sesiju",
   "command.file.open": "Otvori datoteku",
   "command.tab.close": "Zatvori karticu",
   "command.tab.reopenClosed": "Ponovno otvori zatvorenu karticu",

--- a/packages/app/src/i18n/hu.ts
+++ b/packages/app/src/i18n/hu.ts
@@ -137,6 +137,7 @@ export const dict = {
   "command.language.cycle": "Nyelv váltása",
   "command.language.set": "Nyelv használata: {{language}}",
   "command.session.new": "Új munkamenet",
+  "command.session.import": "Munkamenet importálása",
   "command.file.open": "Nyissa meg a fájlt",
   "command.tab.close": "Lap bezárása",
   "command.tab.reopenClosed": "Nyissa meg újra a bezárt lapot",

--- a/packages/app/src/i18n/hy.ts
+++ b/packages/app/src/i18n/hy.ts
@@ -135,6 +135,7 @@ export const dict = {
   "command.language.cycle": "Ցիկլի լեզու",
   "command.language.set": "Օգտագործել լեզուն՝ {{language}}",
   "command.session.new": "Նոր նիստ",
+  "command.session.import": "Ներմուծել նիստը",
   "command.file.open": "Բացել ֆայլ",
   "command.tab.close": "Փակել ներդիրը",
   "command.tab.reopenClosed": "Վերաբացել փակ ներդիրը",

--- a/packages/app/src/i18n/id.ts
+++ b/packages/app/src/i18n/id.ts
@@ -147,6 +147,7 @@ export const dict = {
   "command.language.set": "Gunakan bahasa: {{language}}",
 
   "command.session.new": "Sesi baru",
+  "command.session.import": "Impor sesi",
   "command.file.open": "Buka berkas",
   "command.tab.close": "Tutup tab",
   "command.tab.reopenClosed": "Buka kembali tab yang ditutup",

--- a/packages/app/src/i18n/is.ts
+++ b/packages/app/src/i18n/is.ts
@@ -137,6 +137,7 @@ export const dict = {
   "command.language.cycle": "Skipta um tungumál",
   "command.language.set": "Notaðu tungumál: {{language}}",
   "command.session.new": "Ný seta",
+  "command.session.import": "Flytja inn setu",
   "command.file.open": "Opna skrá",
   "command.tab.close": "Loka flipa",
   "command.tab.reopenClosed": "Opnaðu aftur lokaðan flipa",

--- a/packages/app/src/i18n/it.ts
+++ b/packages/app/src/i18n/it.ts
@@ -41,6 +41,7 @@ export const dict = {
   "command.language.cycle": "Cambia lingua",
   "command.language.set": "Usa la lingua: {{language}}",
   "command.session.new": "Nuova sessione",
+  "command.session.import": "Importa sessione",
   "command.file.open": "Apri file",
   "command.tab.close": "Chiudi scheda",
   "command.tab.reopenClosed": "Riapri la scheda chiusa",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -139,6 +139,7 @@ export const dict = {
   "command.language.cycle": "言語の切り替え",
   "command.language.set": "言語を使用: {{language}}",
   "command.session.new": "新しいセッション",
+  "command.session.import": "セッションをインポート",
   "command.file.open": "ファイルを開く",
   "command.tab.close": "タブを閉じる",
   "command.tab.reopenClosed": "閉じたタブを再度開く",

--- a/packages/app/src/i18n/ka.ts
+++ b/packages/app/src/i18n/ka.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "ციკლის ენა",
   "command.language.set": "გამოიყენე ენა: {{language}}",
   "command.session.new": "ახალი სესია",
+  "command.session.import": "სესიის იმპორტი",
   "command.file.open": "გახსენით ფაილი",
   "command.tab.close": "ჩანართის დახურვა",
   "command.tab.reopenClosed": "დახურული ჩანართის ხელახლა გახსნა",

--- a/packages/app/src/i18n/km.ts
+++ b/packages/app/src/i18n/km.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "ភាសាវដ្ត",
   "command.language.set": "ប្រើភាសា៖ {{language}}",
   "command.session.new": "សម័យថ្មី។",
+  "command.session.import": "នាំចូលសម័យ",
   "command.file.open": "បើកឯកសារ",
   "command.tab.close": "បិទផ្ទាំង",
   "command.tab.reopenClosed": "បើកផ្ទាំងបិទឡើងវិញ",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -37,6 +37,7 @@ export const dict = {
   "command.language.cycle": "언어 순환",
   "command.language.set": "언어 사용: {{language}}",
   "command.session.new": "새 세션",
+  "command.session.import": "세션 가져오기",
   "command.file.open": "파일 열기",
   "command.tab.close": "탭 닫기",
   "command.context.addSelection": "선택 영역을 컨텍스트에 추가",

--- a/packages/app/src/i18n/lo.ts
+++ b/packages/app/src/i18n/lo.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "ພາສາຮອບວຽນ",
   "command.language.set": "ໃຊ້ພາສາ: {{language}}",
   "command.session.new": "ເຊດຊັນໃໝ່",
+  "command.session.import": "ນຳເຂົ້າເຊດຊັນ",
   "command.file.open": "ເປີດໄຟລ໌",
   "command.tab.close": "ປິດແຖບ",
   "command.tab.reopenClosed": "ເປີດແຖບປິດຄືນໃໝ່",

--- a/packages/app/src/i18n/lt.ts
+++ b/packages/app/src/i18n/lt.ts
@@ -137,6 +137,7 @@ export const dict = {
   "command.language.cycle": "Perjungti kalbą",
   "command.language.set": "Naudokite kalbą: {{language}}",
   "command.session.new": "Naujas seansas",
+  "command.session.import": "Importuoti seansą",
   "command.file.open": "Atidaryti failą",
   "command.tab.close": "Uždaryti skirtuką",
   "command.tab.reopenClosed": "Iš naujo atidaryti uždarytą skirtuką",

--- a/packages/app/src/i18n/lv.ts
+++ b/packages/app/src/i18n/lv.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Mainīt valodu",
   "command.language.set": "Izmantot valodu: {{language}}",
   "command.session.new": "Jauna sesija",
+  "command.session.import": "Importēt sesiju",
   "command.file.open": "Atvērt failu",
   "command.tab.close": "Aizvērt cilni",
   "command.tab.reopenClosed": "Atvērt aizvērtu cilni",

--- a/packages/app/src/i18n/mk.ts
+++ b/packages/app/src/i18n/mk.ts
@@ -134,6 +134,7 @@ export const dict = {
   "command.language.cycle": "Јазик на циклус",
   "command.language.set": "Користете јазик: {{language}}",
   "command.session.new": "Нова сесија",
+  "command.session.import": "Увези сесија",
   "command.file.open": "Отворете ја датотеката",
   "command.tab.close": "Затвори ја картичката",
   "command.tab.reopenClosed": "Повторно отворете го затворениот таб",

--- a/packages/app/src/i18n/mn.ts
+++ b/packages/app/src/i18n/mn.ts
@@ -135,6 +135,7 @@ export const dict = {
   "command.language.cycle": "Циклийн хэл",
   "command.language.set": "Хэл ашиглах: {{language}}",
   "command.session.new": "Шинэ сесс",
+  "command.session.import": "Сесс импортлох",
   "command.file.open": "Файлыг нээх",
   "command.tab.close": "Табыг хаах",
   "command.tab.reopenClosed": "Хаагдсан табыг дахин нээнэ үү",

--- a/packages/app/src/i18n/ms.ts
+++ b/packages/app/src/i18n/ms.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Tukar bahasa",
   "command.language.set": "Guna bahasa: {{language}}",
   "command.session.new": "Sesi baharu",
+  "command.session.import": "Import sesi",
   "command.file.open": "Buka fail",
   "command.tab.close": "Tutup tab",
   "command.tab.reopenClosed": "Buka semula tab tertutup",

--- a/packages/app/src/i18n/my.ts
+++ b/packages/app/src/i18n/my.ts
@@ -135,6 +135,7 @@ export const dict = {
   "command.language.cycle": "စက်ဝိုင်းဘာသာစကား",
   "command.language.set": "ဘာသာစကားကို အသုံးပြုပါ- {{language}}",
   "command.session.new": "စက်ရှင်အသစ်",
+  "command.session.import": "စက်ရှင်ကို တင်သွင်းရန်",
   "command.file.open": "ဖိုင်ကိုဖွင့်ပါ။",
   "command.tab.close": "တဘ်ကို ပိတ်ပါ။",
   "command.tab.reopenClosed": "ပိတ်ထားသော တက်ဘ်ကို ပြန်ဖွင့်ပါ။",

--- a/packages/app/src/i18n/ne.ts
+++ b/packages/app/src/i18n/ne.ts
@@ -134,6 +134,7 @@ export const dict: Record<string, string> = {
   "command.language.cycle": "साइकल भाषा",
   "command.language.set": "भाषा प्रयोग गर्नुहोस्: {{language}}",
   "command.session.new": "नयाँ सत्र",
+  "command.session.import": "सत्र आयात गर्नुहोस्",
   "command.file.open": "फाइल खोल्नुहोस्",
   "command.tab.close": "ट्याब बन्द गर्नुहोस्",
   "command.tab.reopenClosed": "बन्द ट्याब पुन: खोल्नुहोस्",

--- a/packages/app/src/i18n/nl.ts
+++ b/packages/app/src/i18n/nl.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Volgende taal",
   "command.language.set": "Gebruik taal: {{language}}",
   "command.session.new": "Nieuwe sessie",
+  "command.session.import": "Sessie importeren",
   "command.file.open": "Bestand openen",
   "command.tab.close": "Tabblad sluiten",
   "command.tab.reopenClosed": "Gesloten tabblad opnieuw openen",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -146,6 +146,7 @@ export const dict = {
   "command.language.set": "Bruk språk: {{language}}",
 
   "command.session.new": "Ny sesjon",
+  "command.session.import": "Importer sesjon",
   "command.file.open": "Åpne fil",
   "command.tab.close": "Lukk fane",
   "command.context.addSelection": "Legg til markering i kontekst",

--- a/packages/app/src/i18n/pa.ts
+++ b/packages/app/src/i18n/pa.ts
@@ -139,6 +139,7 @@ export const dict = {
   "command.language.cycle": "اگلی بولی ورتو",
   "command.language.set": "بولی ورتو: {{language}}",
   "command.session.new": "نواں سیشن",
+  "command.session.import": "سیشن درآمد کرو",
   "command.file.open": "فائل کھولو",
   "command.tab.close": "ٹیب بند کرو",
   "command.tab.reopenClosed": "بند ٹیب دوبارہ کھولو",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -140,6 +140,7 @@ export const dict = {
   "command.language.cycle": "Przełącz język",
   "command.language.set": "Użyj języka: {{language}}",
   "command.session.new": "Nowa sesja",
+  "command.session.import": "Importuj sesję",
   "command.file.open": "Otwórz plik",
   "command.tab.close": "Zamknij kartę",
   "command.tab.reopenClosed": "Otwórz ponownie zamkniętą kartę",

--- a/packages/app/src/i18n/ro.ts
+++ b/packages/app/src/i18n/ro.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Schimbă limba",
   "command.language.set": "Folosește limba: {{language}}",
   "command.session.new": "Sesiune nouă",
+  "command.session.import": "Importă sesiunea",
   "command.file.open": "Deschide fișier",
   "command.tab.close": "Închide fila",
   "command.tab.reopenClosed": "Redeschide fila închisă",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -146,6 +146,7 @@ export const dict = {
   "command.language.set": "Использовать язык: {{language}}",
 
   "command.session.new": "Новая сессия",
+  "command.session.import": "Импортировать сессию",
   "command.file.open": "Открыть файл",
   "command.tab.close": "Закрыть вкладку",
   "command.tab.reopenClosed": "Повторно открыть закрытую вкладку",

--- a/packages/app/src/i18n/si.ts
+++ b/packages/app/src/i18n/si.ts
@@ -133,6 +133,7 @@ export const dict: Record<string, string> = {
   "command.language.cycle": "චක්‍ර භාෂාව",
   "command.language.set": "භාෂාව භාවිතා කරන්න: {{language}}",
   "command.session.new": "නව සැසිය",
+  "command.session.import": "සැසිය ආයාත කරන්න",
   "command.file.open": "ගොනුව විවෘත කරන්න",
   "command.tab.close": "ටැබ් එක වසන්න",
   "command.tab.reopenClosed": "වසා දැමූ ටැබය නැවත විවෘත කරන්න",

--- a/packages/app/src/i18n/sk.ts
+++ b/packages/app/src/i18n/sk.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Prepnúť jazyk",
   "command.language.set": "Použiť jazyk: {{language}}",
   "command.session.new": "Nová relácia",
+  "command.session.import": "Importovať reláciu",
   "command.file.open": "Otvoriť súbor",
   "command.tab.close": "Zavrieť kartu",
   "command.tab.reopenClosed": "Obnoviť zatvorenú kartu",

--- a/packages/app/src/i18n/sl.ts
+++ b/packages/app/src/i18n/sl.ts
@@ -133,6 +133,7 @@ export const dict = {
   "command.language.cycle": "Jezik cikla",
   "command.language.set": "Uporabi jezik: {{language}}",
   "command.session.new": "Nova seja",
+  "command.session.import": "Uvozi sejo",
   "command.file.open": "Odpri datoteko",
   "command.tab.close": "Zapri zavihek",
   "command.tab.reopenClosed": "Ponovno odpri zaprt zavihek",

--- a/packages/app/src/i18n/sq.ts
+++ b/packages/app/src/i18n/sq.ts
@@ -134,6 +134,7 @@ export const dict = {
   "command.language.cycle": "Gjuha e ciklit",
   "command.language.set": "Përdorni gjuhën: {{language}}",
   "command.session.new": "Sesion i ri",
+  "command.session.import": "Importo sesionin",
   "command.file.open": "Hap skedarin",
   "command.tab.close": "Mbyll skedën",
   "command.tab.reopenClosed": "Rihap skedën e mbyllur",

--- a/packages/app/src/i18n/sr.ts
+++ b/packages/app/src/i18n/sr.ts
@@ -134,6 +134,7 @@ export const dict = {
   "command.language.cycle": "језик циклуса",
   "command.language.set": "Користи језик: {{language}}",
   "command.session.new": "Нова сесија",
+  "command.session.import": "Увези сесију",
   "command.file.open": "Отворите датотеку",
   "command.tab.close": "Затвори картицу",
   "command.tab.reopenClosed": "Поново отворите затворену картицу",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -134,6 +134,7 @@ export const dict = {
   "command.language.cycle": "Växla språk",
   "command.language.set": "Använd språk: {{language}}",
   "command.session.new": "Ny session",
+  "command.session.import": "Importera session",
   "command.file.open": "Öppna filen",
   "command.tab.close": "Stäng fliken",
   "command.tab.reopenClosed": "Öppna stängd flik igen",

--- a/packages/app/src/i18n/tg.ts
+++ b/packages/app/src/i18n/tg.ts
@@ -134,6 +134,7 @@ export const dict = {
   "command.language.cycle": "Забони даврӣ",
   "command.language.set": "Истифодаи забон: {{language}}",
   "command.session.new": "Сеанси нав",
+  "command.session.import": "Ворид кардани сеанс",
   "command.file.open": "Файлро кушоед",
   "command.tab.close": "Варақаро пӯшед",
   "command.tab.reopenClosed": "Варақаи пӯшидаро аз нав кушоед",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -145,6 +145,7 @@ export const dict = {
   "command.language.set": "ใช้ภาษา: {{language}}",
 
   "command.session.new": "เซสชันใหม่",
+  "command.session.import": "นำเข้าเซสชัน",
   "command.file.open": "เปิดไฟล์",
   "command.tab.close": "ปิดแท็บ",
   "command.tab.reopenClosed": "เปิดแท็บที่ปิดไปอีกครั้ง",

--- a/packages/app/src/i18n/tk.ts
+++ b/packages/app/src/i18n/tk.ts
@@ -134,6 +134,7 @@ export const dict = {
   "command.language.cycle": "Sikl dili",
   "command.language.set": "Dil ulanyň: {{language}}",
   "command.session.new": "Täze sessiýa",
+  "command.session.import": "Sessiýany import et",
   "command.file.open": "Faýl açyň",
   "command.tab.close": "Salgy ýapyň",
   "command.tab.reopenClosed": "Closedapyk goýmany açyň",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -151,6 +151,7 @@ export const dict = {
   "command.language.set": "Dil kullan: {{language}}",
 
   "command.session.new": "Yeni oturum",
+  "command.session.import": "Oturumu içe aktar",
   "command.file.open": "Dosya aç",
   "command.tab.close": "Sekmeyi kapat",
   "command.tab.reopenClosed": "Kapatılan sekmeyi yeniden aç",

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -147,6 +147,7 @@ export const dict = {
   "command.language.set": "Використати мову: {{language}}",
 
   "command.session.new": "Нова сесія",
+  "command.session.import": "Імпортувати сесію",
   "command.file.open": "Відкрити файл",
   "command.tab.close": "Закрити вкладку",
   "command.tab.reopenClosed": "Повторно відкрити закриту вкладку",

--- a/packages/app/src/i18n/ur.ts
+++ b/packages/app/src/i18n/ur.ts
@@ -141,6 +141,7 @@ export const dict = {
   "command.language.cycle": "اگلی زبان منتخب کریں",
   "command.language.set": "زبان استعمال کریں: {{language}}",
   "command.session.new": "نیا سیشن",
+  "command.session.import": "سیشن درآمد کریں",
   "command.file.open": "فائل کھولیں۔",
   "command.tab.close": "ٹیب بند کریں۔",
   "command.tab.reopenClosed": "بند ٹیب کو دوبارہ کھولیں۔",

--- a/packages/app/src/i18n/uz.ts
+++ b/packages/app/src/i18n/uz.ts
@@ -135,6 +135,7 @@ export const dict = {
   "command.language.cycle": "Keyingi til",
   "command.language.set": "Tildan foydalaning: {{language}}",
   "command.session.new": "Yangi sessiya",
+  "command.session.import": "Sessiyani import qilish",
   "command.file.open": "Faylni ochish",
   "command.tab.close": "Tabni yoping",
   "command.tab.reopenClosed": "Yopiq tabni qayta oching",

--- a/packages/app/src/i18n/vi.ts
+++ b/packages/app/src/i18n/vi.ts
@@ -140,6 +140,7 @@ export const dict = {
   "command.language.cycle": "Chuyển ngôn ngữ",
   "command.language.set": "Sử dụng ngôn ngữ: {{language}}",
   "command.session.new": "Phiên mới",
+  "command.session.import": "Nhập phiên",
   "command.file.open": "Mở tệp",
   "command.tab.close": "Đóng tab",
   "command.tab.reopenClosed": "Mở lại tab đã đóng",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -154,6 +154,7 @@ export const dict = {
   "command.language.set": "使用语言：{{language}}",
 
   "command.session.new": "新建会话",
+  "command.session.import": "导入会话",
 
   "command.file.open": "打开文件",
 

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -149,6 +149,7 @@ export const dict = {
   "command.language.set": "使用語言: {{language}}",
 
   "command.session.new": "新增工作階段",
+  "command.session.import": "匯入工作階段",
   "command.file.open": "開啟檔案",
   "command.tab.close": "關閉分頁",
   "command.tab.reopenClosed": "重新開啟已關閉的分頁",

--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -53,6 +53,14 @@ export function createHomeController() {
     void tabs.newDraft({ server: ServerConnection.key(conn), directory })
   }
 
+  function openProjectSession(conn: ServerConnection.Any, directory: string, sessionID: string) {
+    const ctx = global.ensureServerCtx(conn)
+    ctx.projects.open(directory)
+    ctx.projects.touch(directory)
+    const tab = tabs.addSessionTab({ server: ServerConnection.key(conn), sessionId: sessionID })
+    tabs.select(tab)
+  }
+
   return {
     selection: {
       value: selection,
@@ -114,6 +122,7 @@ export function createHomeController() {
         openProjectNewSession(conn, project.worktree)
       },
       openProjectNewSession,
+      openProjectSession,
     },
   }
 }

--- a/packages/app/src/pages/home/home-projects-controller.tsx
+++ b/packages/app/src/pages/home/home-projects-controller.tsx
@@ -94,6 +94,8 @@ export function createHomeProjectsController(home: HomeController) {
                 type: "session.updated",
                 properties: { sessionID: result.data.id, info: result.data },
               })
+              ctx.sync.session.remember(result.data)
+              ctx.sync.indexSession(result.data)
               home.project.openProjectSession(conn, project.worktree, result.data.id)
             },
           )

--- a/packages/app/src/pages/home/home-projects-controller.tsx
+++ b/packages/app/src/pages/home/home-projects-controller.tsx
@@ -84,11 +84,17 @@ export function createHomeProjectsController(home: HomeController) {
             },
             async (file) => {
               const data = JSON.parse(await file.text()) as SessionExportData
-              const result = await home.server.context(conn).sdk.client.session.import({
+              const ctx = home.server.context(conn)
+              const result = await ctx.sdk.client.session.import({
                 directory: project.worktree,
                 ...data,
               })
               if (!result.data) throw new Error(language.t("common.requestFailed"))
+              ctx.sync.homeSessions.apply({
+                type: "session.updated",
+                properties: { sessionID: result.data.id, info: result.data },
+              })
+              home.project.openProjectSession(conn, project.worktree, result.data.id)
             },
           )
           .catch((cause: unknown) =>

--- a/packages/app/src/pages/home/home-projects-controller.tsx
+++ b/packages/app/src/pages/home/home-projects-controller.tsx
@@ -9,6 +9,7 @@ import { usePlatform } from "@/context/platform"
 import { ServerConnection } from "@/context/server"
 import { closeHomeProject, errorMessage, homeProjectDirectories } from "@/pages/layout/helpers"
 import { Persist, persisted } from "@/utils/persist"
+import type { SessionExportData } from "@/utils/session-export"
 import { showToast } from "@/utils/toast"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { createResource } from "solid-js"
@@ -71,6 +72,32 @@ export function createHomeProjectsController(home: HomeController) {
       select: home.project.select,
       add: home.project.add,
       openNewSession: home.project.openProjectNewSession,
+      canImportSession: !!platform.openAttachmentPickerDialog,
+      importSession: (conn: ServerConnection.Any, project: LocalProject) => {
+        if (!platform.openAttachmentPickerDialog) return
+        void platform
+          .openAttachmentPickerDialog(
+            {
+              title: language.t("command.session.import"),
+              accept: ["application/json"],
+              extensions: ["json"],
+            },
+            async (file) => {
+              const data = JSON.parse(await file.text()) as SessionExportData
+              const result = await home.server.context(conn).sdk.client.session.import({
+                directory: project.worktree,
+                ...data,
+              })
+              if (!result.data) throw new Error(language.t("common.requestFailed"))
+            },
+          )
+          .catch((cause: unknown) =>
+            showToast({
+              title: language.t("common.requestFailed"),
+              description: errorMessage(cause, language.t("common.requestFailed")),
+            }),
+          )
+      },
       edit: (conn: ServerConnection.Any, project: LocalProject) => {
         void import("@/components/dialog-edit-project-v2").then(({ DialogEditProjectV2 }) => {
           void dialog.show(() => <DialogEditProjectV2 server={conn} project={project} />)

--- a/packages/app/src/pages/home/home-projects-view.tsx
+++ b/packages/app/src/pages/home/home-projects-view.tsx
@@ -40,6 +40,7 @@ export type HomeProjectsViewProps = {
   canDefaultServer: Accessor<boolean>
   defaultServerKey: Accessor<ServerConnection.Key | null | undefined>
   canRevealProject: (server: ServerConnection.Any) => boolean
+  canImportSession: boolean
   unseenCount: (server: ServerConnection.Any, project: LocalProject) => number
   onWheel: (event: WheelEvent) => void
   onChooseProject: (server: ServerConnection.Any) => void
@@ -53,6 +54,7 @@ export type HomeProjectsViewProps = {
   onAddProjects: (server: ServerConnection.Any, directories: string[]) => void
   onOpenProjectNewSession: (server: ServerConnection.Any, directory: string) => void
   onEditProject: (server: ServerConnection.Any, project: LocalProject) => void
+  onImportSession: (server: ServerConnection.Any, project: LocalProject) => void
   onRevealProject: (server: ServerConnection.Any, project: LocalProject) => void
   onClearNotifications: (server: ServerConnection.Any, project: LocalProject) => void
   onCloseProject: (server: ServerConnection.Any, directory: string) => void
@@ -551,6 +553,11 @@ function HomeProjectRow(
               <MenuV2.Item onSelect={() => props.onEditProject(props.server, props.project)}>
                 {props.language.t("dialog.project.edit.title")}
               </MenuV2.Item>
+              <Show when={props.canImportSession}>
+                <MenuV2.Item onSelect={() => props.onImportSession(props.server, props.project)}>
+                  {props.language.t("command.session.import")}
+                </MenuV2.Item>
+              </Show>
               <Show when={props.canRevealProject(props.server)}>
                 <MenuV2.Item onSelect={() => props.onRevealProject(props.server, props.project)}>
                   {props.language.t(

--- a/packages/app/src/pages/home/home-projects.tsx
+++ b/packages/app/src/pages/home/home-projects.tsx
@@ -17,6 +17,7 @@ export function HomeProjects(props: { projects: HomeProjectsController; scroll: 
       canDefaultServer={props.projects.server.canDefault}
       defaultServerKey={props.projects.server.defaultKey}
       canRevealProject={props.projects.project.canReveal}
+      canImportSession={props.projects.project.canImportSession}
       unseenCount={props.projects.project.unseenCount}
       onWheel={props.scroll.viewport.containWheel}
       onChooseProject={props.projects.project.choose}
@@ -30,6 +31,7 @@ export function HomeProjects(props: { projects: HomeProjectsController; scroll: 
       onAddProjects={props.projects.project.add}
       onOpenProjectNewSession={props.projects.project.openNewSession}
       onEditProject={props.projects.project.edit}
+      onImportSession={props.projects.project.importSession}
       onRevealProject={props.projects.project.reveal}
       onClearNotifications={props.projects.project.clearNotifications}
       onCloseProject={props.projects.project.close}

--- a/packages/opencode/src/cli/cmd/import.ts
+++ b/packages/opencode/src/cli/cmd/import.ts
@@ -1,20 +1,12 @@
 import type { Session as SDKSession, Message, Part } from "@opencode-ai/sdk/v2"
-import { SessionV1 } from "@opencode-ai/core/v1/session"
-import { Session } from "@/session/session"
-import { MessageV2 } from "../../session/message-v2"
+import { SessionImport } from "@/session/import"
 import { CliError, effectCmd } from "../effect-cmd"
-import { Database } from "@opencode-ai/core/database/database"
-import { SessionTable, MessageTable, PartTable } from "@opencode-ai/core/session/sql"
 import { InstanceRef } from "@/effect/instance-ref"
 import { ShareNext } from "@/share/share-next"
 import { EOL } from "os"
-import path from "path"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Effect, Schema } from "effect"
 import type { InstanceContext } from "@/project/instance-context"
-
-const decodeMessageInfo = Schema.decodeUnknownSync(SessionV1.Info)
-const decodePart = Schema.decodeUnknownSync(SessionV1.Part)
 
 /** Discriminated union returned by the ShareNext API (GET /api/shares/:id/data) */
 export type ShareData =
@@ -89,8 +81,6 @@ export function transformShareData(shareData: ShareData[]): {
   }
 }
 
-type ExportData = { info: SDKSession; messages: Array<{ info: Message; parts: Part[] }> }
-
 export const ImportCommand = effectCmd({
   command: "import <file>",
   describe: "import session data from JSON file or URL",
@@ -110,9 +100,7 @@ export const ImportCommand = effectCmd({
 const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: InstanceContext) {
   const share = yield* ShareNext.Service
   const fs = yield* FSUtil.Service
-  const { db } = yield* Database.Service
-
-  let exportData: ExportData | undefined
+  let exportData: unknown
 
   const isUrl = file.startsWith("http://") || file.startsWith("https://")
 
@@ -165,9 +153,9 @@ const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: Ins
 
     exportData = transformed
   } else {
-    exportData = (yield* fs
+    exportData = yield* fs
       .readJson(file)
-      .pipe(Effect.mapError((error) => new CliError({ message: formatImportFileError(file, error) })))) as ExportData
+      .pipe(Effect.mapError((error) => new CliError({ message: formatImportFileError(file, error) })))
   }
 
   if (!exportData) {
@@ -176,55 +164,13 @@ const runImport = Effect.fn("Cli.import.body")(function* (file: string, ctx: Ins
     return
   }
 
-  const info = Schema.decodeUnknownSync(Session.Info)({
-    ...exportData.info,
-    projectID: ctx.project.id,
-    directory: ctx.directory,
-    path: path.relative(path.resolve(ctx.worktree), ctx.directory).replaceAll("\\", "/"),
-  }) as Session.Info
-  const row = Session.toRow(info)
-  yield* db
-    .insert(SessionTable)
-    .values(row)
-    .onConflictDoUpdate({
-      target: SessionTable.id,
-      set: { project_id: row.project_id, directory: row.directory, path: row.path },
-    })
-    .run()
-    .pipe(Effect.orDie)
+  const data = yield* Schema.decodeUnknownEffect(SessionImport.Data)(exportData).pipe(
+    Effect.mapError(() => new CliError({ message: "Session data is invalid" })),
+  )
+  const info = yield* SessionImport.run({ data, context: ctx }).pipe(
+    Effect.mapError((error) => new CliError({ message: error.message })),
+  )
 
-  for (const msg of exportData.messages) {
-    const msgInfo = decodeMessageInfo(msg.info) as SessionV1.Info
-    const { id, sessionID: _, ...msgData } = msgInfo
-    yield* db
-      .insert(MessageTable)
-      .values({
-        id,
-        session_id: row.id,
-        time_created: msgInfo.time?.created ?? Date.now(),
-        data: msgData as never,
-      })
-      .onConflictDoNothing()
-      .run()
-      .pipe(Effect.orDie)
-
-    for (const part of msg.parts) {
-      const partInfo = decodePart(part) as SessionV1.Part
-      const { id: partId, sessionID: _s, messageID, ...partData } = partInfo
-      yield* db
-        .insert(PartTable)
-        .values({
-          id: partId,
-          message_id: messageID,
-          session_id: row.id,
-          data: partData,
-        })
-        .onConflictDoNothing()
-        .run()
-        .pipe(Effect.orDie)
-    }
-  }
-
-  process.stdout.write(`Imported session: ${exportData.info.id}`)
+  process.stdout.write(`Imported session: ${info.id}`)
   process.stdout.write(EOL)
 })

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/session.ts
@@ -3,6 +3,7 @@ import { Permission } from "@/permission"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 
 import { Session } from "@/session/session"
+import { SessionImport } from "@/session/import"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
 import { SessionRevert } from "@/session/revert"
@@ -78,6 +79,7 @@ export const PermissionResponsePayload = Schema.Struct({
 export const SessionPaths = {
   list: root,
   status: `${root}/status`,
+  import: `${root}/import`,
   get: `${root}/:sessionID`,
   children: `${root}/:sessionID/children`,
   todo: `${root}/:sessionID/todo`,
@@ -108,6 +110,18 @@ export const SessionApi = HttpApi.make("session")
   .add(
     HttpApiGroup.make("session")
       .add(
+        HttpApiEndpoint.post("importSession", SessionPaths.import, {
+          query: WorkspaceRoutingQuery,
+          payload: SessionImport.Data,
+          success: described(Session.Info, "Imported session"),
+          error: HttpApiError.BadRequest,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "session.import",
+            summary: "Import session",
+            description: "Import a session transcript from an OpenCode session export.",
+          }),
+        ),
         HttpApiEndpoint.get("list", SessionPaths.list, {
           query: ListQuery,
           success: described(Schema.Array(Session.Info), "List of sessions"),

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -6,6 +6,7 @@ import { Command } from "@/command"
 import { Permission } from "@/permission"
 import { SessionShare } from "@/share/session"
 import { Session } from "@/session/session"
+import { SessionImport } from "@/session/import"
 import { SessionCompaction } from "@/session/compaction"
 import { MessageV2 } from "@/session/message-v2"
 import { SessionPrompt } from "@/session/prompt"
@@ -19,6 +20,7 @@ import { NamedError } from "@opencode-ai/core/util/error"
 import { Cause, Effect, Option, Schema, Scope } from "effect"
 import * as Stream from "effect/Stream"
 import { InstanceState } from "@/effect/instance-state"
+import { InstanceRef } from "@/effect/instance-ref"
 import { HttpServerRequest, HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder, HttpApiError, HttpApiSchema } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
@@ -72,6 +74,17 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
         search: ctx.query.search,
         limit: ctx.query.limit,
       })
+    })
+
+    const importSession = Effect.fn("SessionHttpApi.import")(function* (ctx: {
+      payload: typeof SessionImport.Data.Type
+    }) {
+      const instance = yield* InstanceRef
+      if (!instance) return yield* new HttpApiError.BadRequest({})
+      const info = yield* SessionImport.run({ data: ctx.payload, context: instance }).pipe(
+        Effect.mapError(() => new HttpApiError.BadRequest({})),
+      )
+      return yield* session.get(info.id).pipe(Effect.orDie)
     })
 
     const status = Effect.fn("SessionHttpApi.status")(function* () {
@@ -411,6 +424,7 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
     })
 
     return handlers
+      .handle("importSession", importSession)
       .handle("list", list)
       .handle("status", status)
       .handle("get", get)

--- a/packages/opencode/src/server/shared/workspace-routing.ts
+++ b/packages/opencode/src/server/shared/workspace-routing.ts
@@ -18,7 +18,7 @@ export function isLocalWorkspaceRoute(method: string, path: string) {
 }
 
 export function getWorkspaceRouteSessionID(url: URL) {
-  if (url.pathname === "/session/status") return null
+  if (url.pathname === "/session/status" || url.pathname === "/session/import") return null
 
   const id =
     url.pathname.match(/^\/session\/([^/]+)(?:\/|$)/)?.[1] ??

--- a/packages/opencode/src/session/import.ts
+++ b/packages/opencode/src/session/import.ts
@@ -1,0 +1,86 @@
+export * as SessionImport from "./import"
+
+import { Database } from "@opencode-ai/core/database/database"
+import { MessageTable, PartTable, SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import type { InstanceContext } from "@/project/instance-context"
+import path from "path"
+import { Effect, Schema } from "effect"
+import { Session } from "./session"
+
+export const Data = Schema.Struct({
+  info: Session.Info,
+  messages: Schema.Array(SessionV1.WithParts),
+})
+export type Data = typeof Data.Type
+
+export class InvalidError extends Schema.TaggedErrorClass<InvalidError>()("SessionImportInvalidError", {
+  message: Schema.String,
+}) {}
+
+export const run = Effect.fn("SessionImport.run")(function* (input: { data: Data; context: InstanceContext }) {
+  const invalid = input.data.messages.find(
+    (message) =>
+      message.info.sessionID !== input.data.info.id ||
+      message.parts.some((part) => part.sessionID !== input.data.info.id || part.messageID !== message.info.id),
+  )
+  if (invalid) return yield* new InvalidError({ message: "Session transcript contains mismatched IDs" })
+
+  const { db } = yield* Database.Service
+  const events = yield* EventV2Bridge.Service
+  const info = {
+    ...input.data.info,
+    projectID: input.context.project.id,
+    directory: input.context.directory,
+    path: path.relative(path.resolve(input.context.worktree), input.context.directory).replaceAll("\\", "/"),
+  }
+  const row = Session.toRow(info)
+
+  yield* db
+    .transaction((tx) =>
+      Effect.gen(function* () {
+        yield* tx
+          .insert(SessionTable)
+          .values(row)
+          .onConflictDoUpdate({
+            target: SessionTable.id,
+            set: { project_id: row.project_id, directory: row.directory, path: row.path },
+          })
+          .run()
+
+        for (const message of input.data.messages) {
+          const messageInfo = message.info
+          const { id, sessionID: _, ...data } = messageInfo
+          yield* tx
+            .insert(MessageTable)
+            .values({
+              id,
+              session_id: row.id,
+              time_created: messageInfo.time?.created ?? Date.now(),
+              data: data as never,
+            })
+            .onConflictDoNothing()
+            .run()
+
+          for (const part of message.parts) {
+            const { id: partID, sessionID: _sessionID, messageID, ...partData } = part
+            yield* tx
+              .insert(PartTable)
+              .values({
+                id: partID,
+                message_id: messageID,
+                session_id: row.id,
+                data: partData,
+              })
+              .onConflictDoNothing()
+              .run()
+          }
+        }
+      }),
+    )
+    .pipe(Effect.orDie)
+
+  yield* events.publish(SessionV1.Event.Updated, { sessionID: info.id, info })
+  return info
+})

--- a/packages/opencode/src/session/import.ts
+++ b/packages/opencode/src/session/import.ts
@@ -34,6 +34,7 @@ export const run = Effect.fn("SessionImport.run")(function* (input: { data: Data
     projectID: input.context.project.id,
     directory: input.context.directory,
     path: path.relative(path.resolve(input.context.worktree), input.context.directory).replaceAll("\\", "/"),
+    time: { ...input.data.info.time, updated: Date.now() },
   }
   const row = Session.toRow(info)
 
@@ -45,7 +46,12 @@ export const run = Effect.fn("SessionImport.run")(function* (input: { data: Data
           .values(row)
           .onConflictDoUpdate({
             target: SessionTable.id,
-            set: { project_id: row.project_id, directory: row.directory, path: row.path },
+            set: {
+              project_id: row.project_id,
+              directory: row.directory,
+              path: row.path,
+              time_updated: row.time_updated,
+            },
           })
           .run()
 

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -117,7 +117,7 @@ export function fromRow(row: SessionRow): Info {
   }
 }
 
-export function toRow(info: Info) {
+export function toRow(info: typeof Info.Type) {
   return {
     id: info.id,
     project_id: info.projectID,
@@ -134,7 +134,7 @@ export function toRow(info: Info) {
     summary_additions: info.summary?.additions,
     summary_deletions: info.summary?.deletions,
     summary_files: info.summary?.files,
-    summary_diffs: info.summary?.diffs,
+    summary_diffs: info.summary?.diffs?.map((diff) => ({ ...diff })),
     metadata: info.metadata,
     cost: info.cost ?? 0,
     tokens_input: (info.tokens ?? EmptyTokens).input,
@@ -150,7 +150,7 @@ export function toRow(info: Info) {
           diff: info.revert.diff,
         }
       : null,
-    permission: info.permission,
+    permission: info.permission ? [...info.permission] : undefined,
     time_created: info.time.created,
     time_updated: info.time.updated,
     time_compacting: info.time.compacting,

--- a/packages/opencode/test/server/httpapi-exercise/index.ts
+++ b/packages/opencode/test/server/httpapi-exercise/index.ts
@@ -1165,6 +1165,31 @@ const scenarios: Scenario[] = [
     .seeded((ctx) => ctx.session({ title: "Status session" }))
     .json(200, object),
   http.protected
+    .post("/session/import", "session.import")
+    .mutating()
+    .seeded((ctx) => ctx.session({ title: "Imported session" }))
+    .at((ctx) => ({
+      path: "/session/import",
+      headers: ctx.headers(),
+      body: {
+        info: {
+          id: ctx.state.id,
+          slug: ctx.state.slug,
+          projectID: ctx.state.projectID,
+          directory: ctx.state.directory,
+          title: ctx.state.title,
+          version: ctx.state.version,
+          time: ctx.state.time,
+        },
+        messages: [],
+      },
+    }))
+    .json(200, (body, ctx) => {
+      object(body)
+      check(body.id === ctx.state.id, "imported session should preserve its ID")
+      check(body.directory === ctx.directory, "imported session should use scenario directory")
+    }),
+  http.protected
     .post("/session", "session.create")
     .mutating()
     .at((ctx) => ({ path: "/session", headers: ctx.headers(), body: { title: "Created session" } }))

--- a/packages/opencode/test/server/httpapi-exercise/types.ts
+++ b/packages/opencode/test/server/httpapi-exercise/types.ts
@@ -6,6 +6,7 @@ import type { Project } from "../../../src/project/project"
 import type { Worktree } from "../../../src/worktree"
 import type { MessageV2 } from "../../../src/session/message-v2"
 import type { SessionID } from "../../../src/session/schema"
+import type { Session } from "../../../src/session/session"
 
 export const OpenApiMethods = ["get", "post", "put", "delete", "patch"] as const
 export const Methods = ["GET", "POST", "PUT", "DELETE", "PATCH"] as const
@@ -118,7 +119,7 @@ export type Result =
   | { status: "fail"; scenario: ActiveScenario; message: string }
   | { status: "skip"; scenario: TodoScenario }
 
-export type SessionInfo = { id: SessionID; title: string; parentID?: SessionID }
+export type SessionInfo = Session.Info
 export type TodoInfo = {
   content: string
   status: "pending" | "in_progress" | "completed" | "cancelled"

--- a/packages/opencode/test/server/workspace-routing.test.ts
+++ b/packages/opencode/test/server/workspace-routing.test.ts
@@ -51,6 +51,11 @@ describe("getWorkspaceRouteSessionID", () => {
     expect(getWorkspaceRouteSessionID(url)).toBeNull()
   })
 
+  test("returns null for /session/import", () => {
+    const url = new URL("http://localhost/session/import")
+    expect(getWorkspaceRouteSessionID(url)).toBeNull()
+  })
+
   test("returns null for non-session paths", () => {
     const url = new URL("http://localhost/config")
     expect(getWorkspaceRouteSessionID(url)).toBeNull()

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -5,7 +5,7 @@ import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { Deferred, Effect, Exit, Layer } from "effect"
 import { Session as SessionNs } from "@/session/session"
 import { MessageV2 } from "../../src/session/message-v2"
-import { MessageID, PartID, type SessionID } from "../../src/session/schema"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { provideInstance, tmpdirScoped } from "../fixture/fixture"
 import { testEffect } from "../lib/effect"
@@ -16,11 +16,17 @@ import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { InstanceStore } from "@/project/instance-store"
 import { InstanceBootstrap } from "@/project/bootstrap"
+import { InstanceRef } from "@/effect/instance-ref"
+import { SessionImport } from "@/session/import"
+import { Database } from "@opencode-ai/core/database/database"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 
 const it = testEffect(
   AppNodeBuilder.build(
     LayerNode.group([
       SessionNs.node,
+      Database.node,
       EventV2Bridge.node,
       SessionProjector.node,
       CrossSpawnSpawner.node,
@@ -127,6 +133,84 @@ describe("session.created event", () => {
         data: { sessionID: info.id },
       })
 
+      yield* session.remove(info.id)
+    }),
+  )
+})
+
+describe("session import", () => {
+  it.instance("imports a transcript into the active project", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const context = yield* InstanceRef
+      if (!context) return yield* Effect.die("InstanceRef not provided")
+
+      const info = yield* session.create({ title: "Imported session" })
+      const messageID = MessageID.ascending()
+      yield* session.updateMessage({
+        id: messageID,
+        sessionID: info.id,
+        role: "user",
+        time: { created: Date.now() },
+        agent: "build",
+        model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+      })
+      yield* session.updatePart({
+        id: PartID.ascending(),
+        messageID,
+        sessionID: info.id,
+        type: "text",
+        text: "hello",
+      })
+      const data = { info, messages: yield* session.messages({ sessionID: info.id }) }
+      yield* session.remove(info.id)
+
+      const imported = yield* SessionImport.run({ data, context }).pipe(Effect.orDie)
+      const messages = yield* session.messages({ sessionID: imported.id })
+
+      expect(imported.projectID).toBe(context.project.id)
+      expect(imported.directory).toBe(context.directory)
+      expect(messages).toHaveLength(1)
+      expect(messages[0].parts).toHaveLength(1)
+      expect(messages[0].parts[0]).toMatchObject({ type: "text", text: "hello" })
+
+      yield* session.remove(imported.id)
+    }),
+  )
+
+  it.instance("rejects mismatched transcript IDs", () =>
+    Effect.gen(function* () {
+      const session = yield* SessionNs.Service
+      const context = yield* InstanceRef
+      if (!context) return yield* Effect.die("InstanceRef not provided")
+      const info = yield* session.create({})
+
+      const result = yield* SessionImport.run({
+        context,
+        data: {
+          info,
+          messages: [
+            {
+              info: {
+                id: MessageID.ascending(),
+                sessionID: SessionID.descending(),
+                role: "user",
+                time: { created: Date.now() },
+                agent: "build",
+                model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("test") },
+              },
+              parts: [],
+            },
+          ],
+        },
+      }).pipe(
+        Effect.match({
+          onFailure: (error) => error._tag,
+          onSuccess: () => "success",
+        }),
+      )
+
+      expect(result).toBe("SessionImportInvalidError")
       yield* session.remove(info.id)
     }),
   )

--- a/packages/opencode/test/session/session.test.ts
+++ b/packages/opencode/test/session/session.test.ts
@@ -146,6 +146,7 @@ describe("session import", () => {
       if (!context) return yield* Effect.die("InstanceRef not provided")
 
       const info = yield* session.create({ title: "Imported session" })
+      const exportedAt = Date.now() - 60_000
       const messageID = MessageID.ascending()
       yield* session.updateMessage({
         id: messageID,
@@ -162,14 +163,20 @@ describe("session import", () => {
         type: "text",
         text: "hello",
       })
-      const data = { info, messages: yield* session.messages({ sessionID: info.id }) }
+      const data = {
+        info: { ...info, time: { ...info.time, updated: exportedAt } },
+        messages: yield* session.messages({ sessionID: info.id }),
+      }
       yield* session.remove(info.id)
 
       const imported = yield* SessionImport.run({ data, context }).pipe(Effect.orDie)
+      const saved = yield* session.get(imported.id)
       const messages = yield* session.messages({ sessionID: imported.id })
 
       expect(imported.projectID).toBe(context.project.id)
       expect(imported.directory).toBe(context.directory)
+      expect(imported.time.updated).toBeGreaterThan(exportedAt)
+      expect(saved.time.updated).toBe(imported.time.updated)
       expect(messages).toHaveLength(1)
       expect(messages[0].parts).toHaveLength(1)
       expect(messages[0].parts[0]).toMatchObject({ type: "text", text: "hello" })

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -111,6 +111,7 @@ import type {
   McpRemoteConfig,
   McpStatusErrors,
   McpStatusResponses,
+  Message,
   ModelRef,
   MoveSessionDestination,
   OutputFormat,
@@ -175,6 +176,7 @@ import type {
   QuestionReplyErrors,
   QuestionReplyResponses,
   QuestionV2Reply,
+  Session as Session4,
   SessionAbortErrors,
   SessionAbortResponses,
   SessionChildrenErrors,
@@ -193,6 +195,8 @@ import type {
   SessionForkResponses,
   SessionGetErrors,
   SessionGetResponses,
+  SessionImportErrors,
+  SessionImportResponses,
   SessionInitErrors,
   SessionInitResponses,
   SessionListErrors,
@@ -3360,6 +3364,48 @@ export class Provider extends HeyApiClient {
 }
 
 export class Session2 extends HeyApiClient {
+  /**
+   * Import session
+   *
+   * Import a session transcript from an OpenCode session export.
+   */
+  public import<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      info?: Session4
+      messages?: Array<{
+        info: Message
+        parts: Array<Part2>
+      }>
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "info" },
+            { in: "body", key: "messages" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<SessionImportResponses, SessionImportErrors, ThrowOnError>({
+      url: "/session/import",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
   /**
    * List sessions
    *

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -9436,6 +9436,40 @@ export type ProviderOauthCallbackResponses = {
 
 export type ProviderOauthCallbackResponse = ProviderOauthCallbackResponses[keyof ProviderOauthCallbackResponses]
 
+export type SessionImportData = {
+  body?: {
+    info: Session
+    messages: Array<{
+      info: Message
+      parts: Array<Part>
+    }>
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/session/import"
+}
+
+export type SessionImportErrors = {
+  /**
+   * BadRequest | InvalidRequestError
+   */
+  400: EffectHttpApiErrorBadRequest | InvalidRequestError
+}
+
+export type SessionImportError = SessionImportErrors[keyof SessionImportErrors]
+
+export type SessionImportResponses = {
+  /**
+   * Imported session
+   */
+  200: Session
+}
+
+export type SessionImportResponse = SessionImportResponses[keyof SessionImportResponses]
+
 export type SessionListData = {
   body?: never
   path?: never


### PR DESCRIPTION
### Issue for this PR

Closes #32696

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an Import session action to each desktop project ellipsis menu. The action opens the native JSON file picker, imports the selected session into the project that owns the menu, and shows errors using the existing toast behavior.

This is stacked on #46400. The branch includes the server commit from that PR followed by the desktop/app commit, so the server changes appear in the cumulative GitHub diff. Review the server portion in #46400 first, then review the desktop/app changes here.

The menu label is localized across all app locales. The import action is currently shown only where the native desktop picker is available. Remote/no-picker handling can be addressed separately.

### How did you verify your code works?

- `bun typecheck` in `packages/app`
- `bun typecheck` in `packages/desktop`
- `bun test --conditions=solid --preload ./happydom.ts src/i18n/parity.test.ts` in `packages/app`
- repository pre-push typecheck hook

The full app unit suite has one unrelated pre-existing failure in desktop locale detection for `pa-PK`.

### Screenshots / recordings

Not included; this change adds an item to the existing project menu.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR