### PR TITLE
fix(app): robust client-side image attachments

### DIFF
--- a/packages/app/src/components/prompt-input/attachments.ts
+++ b/packages/app/src/components/prompt-input/attachments.ts
@@ -6,12 +6,69 @@ import { useLanguage } from "@/context/language"
 import { usePlatform } from "@/context/platform"
 import { uuid } from "@/utils/uuid"
 import { getCursorPosition } from "./editor-dom"
-import { createBlobReference, type DraftStore } from "@/utils/draft-store"
+import { createBlobReference, type BlobReference, type DraftStore } from "@/utils/draft-store"
 import { attachmentMime } from "./files"
 import { normalizePaste, pasteMode } from "./paste"
 
 type PromptTarget = Pick<ReturnType<ReturnType<typeof usePrompt>["capture"]>, "current" | "cursor" | "set">
 type AttachmentTarget = { prompt: PromptTarget; cursor: number | undefined }
+
+const MAX_IMAGE_DIM = 1920
+const IMAGE_QUALITY = 0.82
+
+// Downscale and re-encode an image client-side. Converts HEIC/WebP/JPEG to JPEG so the
+// payload stays small across slow/remote links and the vision model receives a supported
+// format. PNG is kept as PNG to preserve transparency. Returns null when the image can't
+// be decoded or the size wasn't reduced, so callers fall back to the original file.
+async function optimizeImage(file: File, mime: string): Promise<{ blob: Blob; mime: string } | null> {
+  if (!mime.startsWith("image/") || mime === "image/svg+xml" || mime === "image/gif") return null
+  try {
+    const bitmap = await createImageBitmap(file)
+    const scale = Math.min(MAX_IMAGE_DIM / bitmap.width, MAX_IMAGE_DIM / bitmap.height, 1)
+    const width = Math.max(1, Math.round(bitmap.width * scale))
+    const height = Math.max(1, Math.round(bitmap.height * scale))
+    const canvas = document.createElement("canvas")
+    canvas.width = width
+    canvas.height = height
+    const ctx = canvas.getContext("2d")
+    if (!ctx) {
+      bitmap.close()
+      return null
+    }
+    ctx.drawImage(bitmap, 0, 0, width, height)
+    bitmap.close()
+    const keepPng = mime === "image/png"
+    const outMime = keepPng ? "image/png" : "image/jpeg"
+    const blob = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, outMime, keepPng ? undefined : IMAGE_QUALITY),
+    )
+    if (!blob || blob.size >= file.size) return null
+    return { blob, mime: outMime }
+  } catch (error) {
+    console.warn("[attachments] image optimize failed, using original:", error)
+    return null
+  }
+}
+
+const OPTIMIZE_TIMEOUT = 2000
+
+// Resolve to the value, or null if `p` doesn't settle within `ms`. Lets a slow or
+// hanging image-decode/canvas fall back to the original file without blocking the UI.
+function withTimeout<T>(p: Promise<T | null>, ms: number): Promise<T | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(null), ms)
+    p.then(
+      (value) => {
+        clearTimeout(timer)
+        resolve(value)
+      },
+      () => {
+        clearTimeout(timer)
+        resolve(null)
+      },
+    )
+  })
+}
 
 type PromptAttachmentsCoreInput = {
   capture: () => PromptTarget
@@ -51,13 +108,37 @@ export function createPromptAttachmentsCore(input: PromptAttachmentsCoreInput) {
       return false
     }
 
+    let finalMime = mime
+    let payload: Blob = file
+    if (mime.startsWith("image/")) {
+      const optimized = await withTimeout(optimizeImage(file, mime), OPTIMIZE_TIMEOUT)
+      if (optimized) {
+        finalMime = optimized.mime
+        payload = optimized.blob
+      } else {
+        console.warn("[attachments] image not optimized (timeout/fail/same-size), using original:", {
+          name: file.name,
+          mime,
+          size: file.size,
+        })
+      }
+    }
+
+    let blob: BlobReference | null = null
+    try {
+      blob = input.draftStore ? await input.draftStore.putBlob(payload) : await createBlobReference(payload)
+    } catch (error) {
+      console.warn("[attachments] putBlob failed, falling back to createBlobReference:", error)
+      blob = await createBlobReference(payload)
+    }
+
     const attachment: ImageAttachmentPart = {
       type: "image",
       id: uuid(),
       filename: file.name,
       sourcePath: input.getPathForFile?.(file) || undefined,
-      mime,
-      blob: input.draftStore ? await input.draftStore.putBlob(file) : await createBlobReference(file),
+      mime: finalMime,
+      blob,
     }
     target.prompt.set([...target.prompt.current(), attachment], target.cursor)
     return true

--- a/packages/app/src/components/prompt-input/files.ts
+++ b/packages/app/src/components/prompt-input/files.ts
@@ -41,6 +41,8 @@ const IMAGE_EXTS = new Map([
   ["jpg", "image/jpeg"],
   ["png", "image/png"],
   ["webp", "image/webp"],
+  ["heic", "image/heic"],
+  ["heif", "image/heif"],
 ])
 const TEXT_MIMES = new Set([
   "application/json",

--- a/packages/app/src/constants/file-picker.ts
+++ b/packages/app/src/constants/file-picker.ts
@@ -1,4 +1,4 @@
-export const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp"]
+export const ACCEPTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/gif", "image/webp", "image/heic", "image/heif"]
 
 export const ACCEPTED_FILE_TYPES = [
   ...ACCEPTED_IMAGE_TYPES,

--- a/packages/app/src/utils/draft-store.ts
+++ b/packages/app/src/utils/draft-store.ts
@@ -21,11 +21,27 @@ function blobUrl(id: string, blob: Blob) {
   return url
 }
 
-async function blobID(blob: Blob) {
-  const id = Array.from(new Uint8Array(await crypto.subtle.digest("SHA-256", await blob.arrayBuffer())))
+const hex = (bytes: Uint8Array) =>
+  Array.from(bytes)
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("")
-  return id
+
+function randomID() {
+  const bytes = new Uint8Array(32)
+  crypto.getRandomValues(bytes)
+  return hex(bytes)
+}
+
+async function blobID(blob: Blob) {
+  // crypto.subtle is undefined on insecure (http) origins; getRandomValues works everywhere.
+  if (crypto.subtle?.digest) {
+    try {
+      return hex(new Uint8Array(await crypto.subtle.digest("SHA-256", await blob.arrayBuffer())))
+    } catch {
+      // fall through to the random fallback below
+    }
+  }
+  return randomID()
 }
 
 export async function createBlobReference(blob: Blob): Promise<BlobReference> {


### PR DESCRIPTION
### Issue for this PR

Closes #46419

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes image attachments failing on insecure origins and sizes the payload down before upload.

Root cause for the silent-fail: `draft-store.ts` computed blob IDs with `crypto.subtle.digest`, but `crypto.subtle` is undefined on `http:` (insecure) origins, so `putBlob` throws and the image is never added to the prompt.

Changes:
- `attachments.ts`: on attach, downscale + re-encode images client-side (HEIC/WebP/JPEG -> JPEG, PNG kept) capped at 1920px / quality 0.82, wrapped in a 2s timeout that falls back to the original file if decode/encode stalls. This keeps payloads small on slow links and gives the vision model a supported format.
- `draft-store.ts`: keep the deterministic SHA-256 id when `crypto.subtle` is available, otherwise fall back to `crypto.getRandomValues`.
- `files.ts` + `file-picker.ts`: accept `image/heic` / `image/heif` in the picker and extension map.

No server or infra behavior is changed; the optimization runs fully in the browser.

### How did you verify your code works?

- Attached a >1MP JPEG and a PNG image in the web app; both appear in the prompt and upload cleanly over an HTTPS link.
- Verified the served bundle contains `createImageBitmap` and the `getRandomValues` fallback.
- Attached a HEIC photo; it converts to JPEG and attaches.
- Confirmed the previous failure (`TypeError: Cannot read properties of undefined (reading 'digest')`) no longer reproduces on an insecure origin.

### Screenshots / recordings

N/A - no visual change; behavior verified manually in the web app.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
