### PR TITLE
fix(app): preserve restored reference paths

### DIFF
--- a/packages/app/src/utils/prompt.test.ts
+++ b/packages/app/src/utils/prompt.test.ts
@@ -3,6 +3,75 @@ import type { Part } from "@opencode-ai/sdk/v2"
 import { extractPromptFromParts } from "./prompt"
 
 describe("extractPromptFromParts", () => {
+  test("restores the resolved path for a reference alias", () => {
+    const parts = [
+      {
+        id: "text_1",
+        type: "text",
+        text: "check @docs",
+        sessionID: "ses_1",
+        messageID: "msg_1",
+      },
+      {
+        id: "file_1",
+        type: "file",
+        mime: "text/plain",
+        url: "file:///shared/company-docs",
+        filename: "docs",
+        sessionID: "ses_1",
+        messageID: "msg_1",
+        source: {
+          type: "file",
+          path: "/shared/company-docs",
+          text: {
+            value: "@docs",
+            start: 6,
+            end: 11,
+          },
+        },
+      },
+    ] satisfies Part[]
+
+    expect(extractPromptFromParts(parts, { directory: "/repo" })).toMatchObject([
+      { type: "text", content: "check " },
+      { type: "file", path: "/shared/company-docs", content: "@docs" },
+    ])
+  })
+
+  test("normalizes a restored Windows reference path inside the session directory", () => {
+    const parts = [
+      {
+        id: "text_1",
+        type: "text",
+        text: "@docs",
+        sessionID: "ses_1",
+        messageID: "msg_1",
+      },
+      {
+        id: "file_1",
+        type: "file",
+        mime: "text/plain",
+        url: "file:///C:/repo/shared/docs",
+        filename: "docs",
+        sessionID: "ses_1",
+        messageID: "msg_1",
+        source: {
+          type: "file",
+          path: "C:\\repo\\shared\\docs",
+          text: {
+            value: "@docs",
+            start: 0,
+            end: 5,
+          },
+        },
+      },
+    ] satisfies Part[]
+
+    expect(extractPromptFromParts(parts, { directory: "C:\\repo" })).toMatchObject([
+      { type: "file", path: "shared/docs", content: "@docs" },
+    ])
+  })
+
   test("restores multiple uploaded attachments", () => {
     const parts = [
       {

--- a/packages/app/src/utils/prompt.ts
+++ b/packages/app/src/utils/prompt.ts
@@ -60,19 +60,19 @@ export function extractPromptFromParts(parts: Part[], opts?: { directory?: strin
   const directory = opts?.directory
   const attachmentName = opts?.attachmentName ?? "attachment"
 
-  const toRelative = (path: string) => {
-    if (!directory) return path
+  const toRelative = (filepath: string) => {
+    if (!directory) return filepath
 
-    const prefix = directory.endsWith("/") ? directory : directory + "/"
-    if (path.startsWith(prefix)) return path.slice(prefix.length)
+    const path = filepath.replaceAll("\\", "/")
+    const base = directory.replaceAll("\\", "/").replace(/\/+$/, "") || "/"
+    const windows = /^[A-Za-z]:(?:\/|$)/.test(base) || base.startsWith("//")
+    const target = windows ? path.toLowerCase() : path
+    const root = windows ? base.toLowerCase() : base
+    if (target === root) return ""
 
-    if (path.startsWith(directory)) {
-      const next = path.slice(directory.length)
-      if (next.startsWith("/")) return next.slice(1)
-      return next
-    }
-
-    return path
+    const prefix = root.endsWith("/") ? root : root + "/"
+    if (!target.startsWith(prefix)) return filepath
+    return path.slice(prefix.length)
   }
 
   const inline: Inline[] = []
@@ -86,11 +86,12 @@ export function extractPromptFromParts(parts: Part[], opts?: { directory?: strin
         const value = sourceText.value
         const start = sourceText.start
         const end = sourceText.end
-        let path = value
-        if (value.startsWith("@")) path = value.slice(1)
-        if (!value.startsWith("@") && filePart.source && "path" in filePart.source) {
-          path = filePart.source.path
-        }
+        const path =
+          filePart.source && "path" in filePart.source
+            ? filePart.source.path
+            : value.startsWith("@")
+              ? value.slice(1)
+              : value
         inline.push({
           type: "file",
           start,


### PR DESCRIPTION
### Issue for this PR

Fixes #46422

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Restores configured reference aliases from the persisted source path instead of treating their visible `@alias` text as a project-relative file path.

Path conversion now normalizes separators for comparison, respects directory boundaries, handles Windows paths case-insensitively, and keeps external paths absolute. Focused coverage exercises an external POSIX reference and an in-project Windows reference.

### How did you verify your code works?

From `packages/app`:

- `bun test --conditions=solid --preload ./happydom.ts ./src/utils/prompt.test.ts`: 3 pass, 0 fail
- `bun run test:unit`: 726 pass, 0 fail
- `bun typecheck`: pass in a clean temporary worktree with the repository symlink materialized for Windows
- `bun run build`: pass
- Production microbenchmark, 200,000 restorations: 552 ns/call before and 644 ns/call after

Also ran `git diff --check` successfully.

### Screenshots / recordings

N/A — no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR