### PR TITLE
fix: intermittent first-request stall on Bun serve under CPU load

### DIFF
--- a/patches/effect@4.0.0-beta.83.patch
+++ b/patches/effect@4.0.0-beta.83.patch
@@ -1,3 +1,68 @@
+diff --git a/dist/Scheduler.js b/dist/Scheduler.js
+index cab3d90..293a913 100644
+--- a/dist/Scheduler.js
++++ b/dist/Scheduler.js
+@@ -29,15 +29,51 @@ import * as Context from "./Context.js";
+ export const Scheduler = /*#__PURE__*/Context.Reference("effect/Scheduler", {
+   defaultValue: () => new MixedScheduler()
+ });
+-const setImmediate = "setImmediate" in globalThis ? f => {
+-  // @ts-ignore
+-  const timer = globalThis.setImmediate(f);
+-  // @ts-ignore
+-  return () => globalThis.clearImmediate(timer);
+-} : f => {
+-  const timer = setTimeout(f, 0);
+-  return () => clearTimeout(timer);
+-};
++const setImmediate = (() => {
++  // On Bun, flushing queued fiber dispatch through `globalThis.setImmediate`
++  // can be starved during the event loop's check phase under CPU load, which
++  // also strands node:http first-request dispatch (the connection is accepted
++  // and read natively, but the `request` event is never emitted, hanging the
++  // first request for tens of seconds). Delivering the flush through a
++  // `MessageChannel` — an fd-backed message serviced in the poll phase — keeps
++  // the loop cycling and avoids the stall. Same technique React's scheduler
++  // uses for its macrotask. Falls back to setImmediate/setTimeout when
++  // `MessageChannel` is unavailable.
++  try {
++    const channel = new MessageChannel();
++    const queue = new Map();
++    let nextId = 0;
++    channel.port1.onmessage = event => {
++      const run = queue.get(event.data);
++      if (run !== undefined) {
++        queue.delete(event.data);
++        run();
++      }
++    };
++    if (channel.port1.start) channel.port1.start();
++    // Do not let the channel keep the process alive (e.g. short-lived CLI runs).
++    if (channel.port1.unref) channel.port1.unref();
++    if (channel.port2.unref) channel.port2.unref();
++    return f => {
++      const id = ++nextId;
++      queue.set(id, f);
++      channel.port2.postMessage(id);
++      return () => {
++        queue.delete(id);
++      };
++    };
++  } catch {
++    return "setImmediate" in globalThis ? f => {
++      // @ts-ignore
++      const timer = globalThis.setImmediate(f);
++      // @ts-ignore
++      return () => globalThis.clearImmediate(timer);
++    } : f => {
++      const timer = setTimeout(f, 0);
++      return () => clearTimeout(timer);
++    };
++  }
++})();
+ class PriorityBuckets {
+   buckets = [];
+   scheduleTask(task, priority) {
 diff --git a/dist/unstable/httpapi/HttpApiSchema.js b/dist/unstable/httpapi/HttpApiSchema.js
 index ecb6603d1ee4e89e92174b3a1100e8c9c720b3f3..08b832b6b3e9e4d10df156eca36b16f571f67f6e 100644
 --- a/dist/unstable/httpapi/HttpApiSchema.js


### PR DESCRIPTION
### Issue for this PR

Closes #46437

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On Bun, `opencode serve` intermittently hangs its **first** request for tens of seconds under CPU load, then recovers (startup-only). I traced it end to end: the request-handler fiber is never forked — the TCP connection is accepted and the request bytes are read into userspace (`rx_queue=0`), but Bun's `node:http` never emits the JS `request` event while the loop is parked in `epoll_pwait2`, so Effect never sees the request. It's a Bun regression: 1.3.11 doesn't stall, 1.3.12/1.3.13/1.3.14 do — `setImmediate`-style work gets starved under load.

Effect's default `MixedScheduler` flushes fiber dispatch through `globalThis.setImmediate`, which hits the same starvation. This routes that flush through a `MessageChannel` macrotask instead (with a `setImmediate`/`setTimeout` fallback) — a different event-loop scheduling path than re-entering `setImmediate`, which keeps the loop turning over so Bun's pending `node:http` dispatch runs. Ports are `unref`'d so short-lived CLI runs still exit (the default scheduler is process-wide, not just `serve`). Delivered through the existing `patches/effect@4.0.0-beta.83.patch`.

### How did you verify your code works?

Cold-cycled `opencode serve` on a 2-vCPU container under CPU contention and timed the first request (`>8s` counted as a stall):

- unpatched (Bun 1.3.14): ~100% stall (6/6, 40s timeouts)
- Bun 1.3.11 downgrade only: 2/40 (~5%)
- **this patch:** 1/340 (~0.3%), non-stalling requests < 1s

### Screenshots / recordings

N/A (not a UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
