### PR TITLE
fix(core): preserve active session continuation when moving

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -468,7 +468,8 @@ const layer = Layer.effect(
           Effect.gen(function* () {
             const latest = yield* result.get(input.sessionID)
             const source = yield* fs.stat(latest.location.directory).pipe(Effect.orElseSucceed(() => undefined))
-            if (!source || source.type !== "Directory") {
+            // Active runners must hand off at a step boundary to retain their continuation.
+            if ((!source || source.type !== "Directory") && !(yield* execution.isActive(input.sessionID))) {
               const cancellations = (yield* SessionInbox.moveIDs(db, input.sessionID)).map(
                 (item) => [SessionEvent.InboxCancelled, { sessionID: input.sessionID, inboxID: item.id }] as const,
               )

--- a/packages/core/test/session-move.test.ts
+++ b/packages/core/test/session-move.test.ts
@@ -15,6 +15,7 @@ import { Session } from "@opencode-ai/core/session"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { SessionRunner } from "@opencode-ai/core/session/runner/index"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { tmpdirScoped } from "./fixture/tmpdir"
@@ -27,6 +28,34 @@ const it = testEffect(
     [
       [Project.node, globalProjectNode],
       [SessionExecution.node, SessionExecution.noopLayer],
+    ],
+  ),
+)
+const itWithActiveExecution = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([
+      Database.node,
+      Bus.node,
+      SessionProjector.node,
+      SessionStore.node,
+      SessionExecution.node,
+      Session.node,
+    ]),
+    [
+      [Project.node, globalProjectNode],
+      [
+        LocationServiceMap.node,
+        Layer.effect(
+          LocationServiceMap.Service,
+          LayerMap.make(
+            (ref: Location.Ref) =>
+              Layer.merge(
+                LayerNode.compile(Location.boundNode(ref), [[Project.node, globalProjectNode]]),
+                Layer.succeed(SessionRunner.Service, { drain: () => Effect.never }),
+              ) as unknown as Layer.Layer<LocationServices>,
+          ),
+        ),
+      ],
     ],
   ),
 )
@@ -99,6 +128,41 @@ describe("Session.move", () => {
           })
           yield* session.move({ sessionID: steered.id, directory: destination, delivery: "queue" })
           expect(yield* session.inbox(steered.id)).toMatchObject([{ type: "move", delivery: "queue" }])
+        }),
+      ),
+    ),
+  )
+
+  itWithActiveExecution.live("defers an active move when the source directory no longer exists", () =>
+    tmpdirScoped().pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const session = yield* Session.Service
+          const execution = yield* SessionExecution.Service
+          const source = AbsolutePath.make(path.join(tmp.path, "source"))
+          const destination = AbsolutePath.make(tmp.path)
+          yield* Effect.promise(() => mkdir(source))
+          const created = yield* session.create({ location: Location.Ref.make({ directory: source }) })
+
+          // Hold real execution open so the move cannot be consumed before admission is checked.
+          yield* execution.wake(created.id)
+          expect(yield* execution.isActive(created.id)).toBe(true)
+          yield* Effect.promise(() => rm(source, { recursive: true }))
+
+          yield* session.move({ sessionID: created.id, directory: destination })
+
+          expect((yield* session.get(created.id)).location.directory).toBe(source)
+          expect(yield* session.inbox(created.id)).toMatchObject([
+            {
+              type: "move",
+              delivery: "steer",
+              payload: { location: { directory: destination } },
+            },
+          ])
+          expect(yield* execution.isActive(created.id)).toBe(true)
+
+          yield* execution.interrupt(created.id)
+          yield* execution.awaitIdle(created.id)
         }),
       ),
     ),


### PR DESCRIPTION
## Why

An agent can stop unexpectedly after renaming its working directory and moving its active Session to the new path. Missing-source recovery updates the Session's location immediately, so the old-location runner interrupts on the location mismatch and loses its pending continuation instead of continuing automatically.

## What Changes

Restrict immediate missing-source recovery to idle Sessions. Active Sessions use the existing inbox and step-boundary handoff, preserving their continuation and step count.

| Source directory | Execution | Move behavior |
| --- | --- | --- |
| Exists | Active or idle | Existing inbox delivery, unchanged |
| Missing | Idle | Immediate recovery, unchanged |
| Missing | Active | Inbox delivery and normal runner handoff, rather than changing location mid-step |

Use the existing per-Session `execution.isActive` query without allocating an active-session snapshot.

## Scope

This changes missing-source move admission and adds a regression test using real Session execution ownership with a held runner. Existing runner tests cover tool continuation across a steered move; the new test locks down the missing-source admission boundary.

## Verification

```sh
# From packages/core
bun run test test/session-move.test.ts -t 'defers an active move'
bun run test test/session-move.test.ts test/session-runner.test.ts test/session-execution.test.ts
bun typecheck
bun run test
bun run test test/tool-shell.test.ts -t 'ordinary shell syntax'

# From the repository root
bunx prettier --check packages/core/src/session.ts packages/core/test/session-move.test.ts
git diff --check
```

- The new regression failed without the fix because the active Session's location changed immediately instead of leaving the move pending. It passes with the fix.
- All 219 targeted tests pass, including existing idle missing-source recovery and steered-move continuation coverage.
- Core typechecking, formatting, and whitespace checks pass.
- The broader core suite timed out after 120 seconds and reported shell-syntax test failures. An isolated run with the production fix removed reproduced two shell-syntax failures (30 passed); the full suite is not claimed green.
- No live-server deployment or end-to-end UI verification was performed.
