### PR TITLE
fix(stats): merge deepseek flash variants

### DIFF
--- a/packages/stats/core/src/domain/inference.test.ts
+++ b/packages/stats/core/src/domain/inference.test.ts
@@ -50,6 +50,10 @@ describe("inference stat normalization", () => {
   })
 
   test("merges renamed models under their current name", () => {
+    expect(statModel("deepseek-v4-flash-0731", "")).toBe("deepseek-v4-flash")
+    expect(statModel("deepseek-v4-flash-0731-free", "")).toBe("deepseek-v4-flash")
+    expect(statModel("deepseek-v4-flash-dsv4-flash-final-rnaovd", "")).toBe("deepseek-v4-flash")
+    expect(statModel("deepseek-v4-flash-vision-exp", "")).toBe("deepseek-v4-flash-vision-exp")
     expect(statModel("x-preview-f", "")).toBe("glm-5.3-flash")
     expect(statModel("ox-alpha", "")).toBe("glm-5.3-flash")
     expect(statModel("ox-alpha-free", "")).toBe("glm-5.3-flash")
@@ -130,6 +134,11 @@ describe("inference stat normalization", () => {
     expect(queries[0]).toContain("COALESCE(NULLIF(lower(model_tier), ''), '') AS raw_tier")
     expect(queries[0]).toContain("WHEN lower(COALESCE(raw_tier, '')) = 'free'")
     expect(queries[0]).toContain("regexp_replace(NULLIF(route_model, ''), '^.*/', '')")
+    expect(queries[0]).toContain("= 'deepseek-v4-flash-0731' THEN 'deepseek-v4-flash'")
+    expect(queries[0]).toContain(
+      "= 'deepseek-v4-flash-dsv4-flash-final-rnaovd' THEN 'deepseek-v4-flash'",
+    )
+    expect(queries[0]).not.toContain("= 'deepseek-v4-flash-vision-exp' THEN 'deepseek-v4-flash'")
     expect(queries[0]).toContain("= 'ox-alpha' THEN 'glm-5.3-flash'")
     expect(queries[0]).toContain("= 'x-preview-f' THEN 'glm-5.3-flash'")
     expect(queries[0]).toContain("OR lower(raw_model) IN ('gpt-5-nano', 'grok-code', 'big-pickle')")

--- a/packages/stats/core/src/domain/model-normalization.ts
+++ b/packages/stats/core/src/domain/model-normalization.ts
@@ -16,6 +16,8 @@ export const MODEL_AUTHOR_RULES = [
 export const EXCLUDED_MODELS = new Set(["alpha-gpt-next"])
 export const FREE_MODELS = new Set(["gpt-5-nano", "grok-code", "big-pickle"])
 export const MODEL_NAME_ALIASES: Record<string, string> = {
+  "deepseek-v4-flash-0731": "deepseek-v4-flash",
+  "deepseek-v4-flash-dsv4-flash-final-rnaovd": "deepseek-v4-flash",
   "ox-alpha": "glm-5.3-flash",
   "x-preview-f": "glm-5.3-flash",
   "xiaomi/mimo-v2.5": "mimo-v2.5",


### PR DESCRIPTION
## Summary
- map the two internal DeepSeek V4 Flash IDs to `deepseek-v4-flash` during stats sync
- preserve `deepseek-v4-flash-vision-exp` as a distinct model
- cover runtime and generated R2 SQL normalization

## Testing
- `bun test src/domain/inference.test.ts`
- `bun typecheck` in `packages/stats/core`
- repository pre-push `bun turbo typecheck`