### PR TITLE
fix(core): preserve snapshots across session moves

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -14,6 +14,8 @@ export class Repository extends Schema.Class<Repository>("Git.Repository")({
   worktree: AbsolutePath,
   gitDirectory: AbsolutePath,
   commonDirectory: AbsolutePath,
+  /** Additional read-only object databases; index and worktree remain local. */
+  objectDirectories: Schema.optional(Schema.Array(AbsolutePath)),
 }) {}
 
 // Included from $GIT_DIR/config via include.path (git >= 1.7.10); OpenCode owns
@@ -50,6 +52,7 @@ export class OperationError extends Schema.TaggedError<OperationError>()("Git.Op
     "list_files",
     "diff",
     "restore",
+    "retain",
   ]),
   message: Schema.String,
   directory: Schema.optional(AbsolutePath),
@@ -132,6 +135,12 @@ export interface Interface {
     }) => Effect.Effect<ReadonlySet<RelativePath>, OperationError>
   }
   readonly tree: {
+    readonly exists: (repository: Repository, tree: TreeID) => Effect.Effect<boolean, OperationError>
+    /** Retain a tree's borrowed objects in this repository, independent of its alternates. */
+    readonly retain: (input: {
+      repository: Repository
+      trees: readonly TreeID[]
+    }) => Effect.Effect<void, OperationError>
     readonly capture: (input: {
       repository: Repository
       scopes: readonly RelativePath[]
@@ -314,7 +323,16 @@ const layer = Layer.effect(
         .run(
           ChildProcess.make("git", repositoryArgs(repository, args), {
             cwd: repository.worktree,
-            env: options?.env,
+            env: {
+              ...(repository.objectDirectories?.length
+                ? {
+                    GIT_ALTERNATE_OBJECT_DIRECTORIES: repository.objectDirectories
+                      .map((directory) => JSON.stringify(directory))
+                      .join(path.delimiter),
+                  }
+                : {}),
+              ...options?.env,
+            },
             extendEnv: true,
           }),
           { stdin: options?.stdin },
@@ -477,6 +495,46 @@ const layer = Layer.effect(
       return TreeID.make((yield* repositoryOperation("write_tree", repository, ["write-tree"])).text.trim())
     })
 
+    const treeExists = Effect.fn("Git.tree.exists")(function* (repository: Repository, tree: TreeID) {
+      return yield* repositoryOperation("list_files", repository, ["cat-file", "-e", `${tree}^{tree}`]).pipe(
+        Effect.as(true),
+        Effect.catch(() => Effect.succeed(false)),
+      )
+    })
+
+    const retain = Effect.fn("Git.tree.retain")((input: { repository: Repository; trees: readonly TreeID[] }) =>
+      locked(
+        input.repository,
+        Effect.gen(function* () {
+          const retained = (yield* repositoryOperation("retain", input.repository, [
+            "for-each-ref",
+            "--format=%(objectname)",
+            "refs/opencode/snapshots/",
+          ])).text
+            .trim()
+            .split("\n")
+            .filter(Boolean)
+          const missing = Array.from(new Set(input.trees)).filter((tree) => !retained.includes(tree))
+          if (!missing.length) return
+          // Only these refs certify locally retained objects. Ordinary refs or alternates do not.
+          yield* repositoryOperation(
+            "retain",
+            input.repository,
+            [
+              "pack-objects",
+              "--revs",
+              "--non-empty",
+              path.join(input.repository.gitDirectory, "objects", "pack", "pack"),
+            ],
+            { stdin: [...missing, ...retained.map((tree) => `^${tree}`)].join("\n") + "\n" },
+          )
+          yield* repositoryOperation("retain", input.repository, ["update-ref", "--stdin"], {
+            stdin: missing.map((tree) => `update refs/opencode/snapshots/${tree} ${tree}\n`).join(""),
+          })
+        }),
+      ),
+    )
+
     const captureTree = Effect.fn("Git.tree.capture")(
       (input: {
         repository: Repository
@@ -586,28 +644,57 @@ const layer = Layer.effect(
       (input: { repository: Repository; files: ReadonlyMap<RelativePath, TreeID> }) =>
         locked(
           input.repository,
-          Effect.forEach(
-            input.files,
-            ([file, tree]) =>
-              Effect.gen(function* () {
-                if (yield* hasEntry(input.repository, tree, file)) {
-                  yield* repositoryOperation("restore", input.repository, ["checkout", tree, "--", file])
-                  return
-                }
-                yield* fs.remove(path.join(input.repository.worktree, file), { recursive: true, force: true }).pipe(
-                  Effect.mapError(
-                    (cause) =>
-                      new OperationError({
-                        operation: "restore",
-                        directory: input.repository.worktree,
-                        message: `Failed to remove ${file}`,
-                        cause,
-                      }),
-                  ),
-                )
-              }),
-            { discard: true },
-          ),
+          Effect.gen(function* () {
+            const entries = yield* Effect.forEach(input.files, ([file, tree]) =>
+              hasEntry(input.repository, tree, file).pipe(
+                Effect.map((present) => ({ file, tree, present, depth: file.split("/").length })),
+              ),
+            )
+            // Remove descendants before any restoration can replace their ancestor with a symlink or file.
+            yield* Effect.forEach(
+              entries.toSorted(
+                (a, b) => Number(a.present) - Number(b.present) || (a.present ? a.depth - b.depth : b.depth - a.depth),
+              ),
+              ({ file, tree, present }) =>
+                Effect.gen(function* () {
+                  if (present) {
+                    // Re-index the restored content without foreign alternates so future local captures can read it.
+                    yield* repositoryOperation("restore", input.repository, [
+                      "--literal-pathspecs",
+                      "restore",
+                      `--source=${tree}`,
+                      "--worktree",
+                      "--",
+                      file,
+                    ])
+                    yield* repositoryOperation(
+                      "restore",
+                      new Repository({ ...input.repository, objectDirectories: undefined }),
+                      ["--literal-pathspecs", "add", "--force", "--sparse", "--", file],
+                    )
+                    return
+                  }
+                  yield* fs.remove(path.join(input.repository.worktree, file), { recursive: true, force: true }).pipe(
+                    Effect.mapError(
+                      (cause) =>
+                        new OperationError({
+                          operation: "restore",
+                          directory: input.repository.worktree,
+                          message: `Failed to remove ${file}`,
+                          cause,
+                        }),
+                    ),
+                  )
+                  yield* repositoryOperation("restore", input.repository, [
+                    "update-index",
+                    "--force-remove",
+                    "--",
+                    file,
+                  ])
+                }),
+              { discard: true },
+            )
+          }),
         ),
     )
 
@@ -690,6 +777,8 @@ const layer = Layer.effect(
       worktree: { create: worktreeCreate, remove: worktreeRemove, list: worktreeList },
       index: { refresh, ignored },
       tree: {
+        exists: treeExists,
+        retain,
         capture: captureTree,
         write: writeTree,
         files: treeFiles,

--- a/packages/core/src/snapshot.ts
+++ b/packages/core/src/snapshot.ts
@@ -42,9 +42,9 @@ export type Draft = {
 
 export interface Interface extends State.Transformable<Draft> {
   /**
-   * Capture the current Location-scoped filesystem state as a content-addressed
-   * tree. Returns `undefined` when snapshots are disabled, unsupported, or the
-   * best-effort capture fails.
+   * Capture the current Location-scoped filesystem state as an opaque reference
+   * to a content-addressed tree and its storage. Returns `undefined` when
+   * snapshots are disabled, unsupported, or the best-effort capture fails.
    */
   readonly capture: () => Effect.Effect<ID | undefined>
 
@@ -114,18 +114,93 @@ const layer = Layer.effect(
 
     const enabled = () => location.vcs?.type === "git" && state.get().enabled
 
+    const resolved = new Map<ID, { directory: AbsolutePath; tree: Git.TreeID }>()
+    const resolve = Effect.fnUntraced(function* (id: ID) {
+      const cached = resolved.get(id)
+      if (cached) return cached
+      const qualified = /^snapshot:([a-zA-Z0-9_-]+)\/([a-f0-9]{40})\/([a-f0-9]{40}|[a-f0-9]{64})$/.exec(id)
+      if (qualified)
+        return {
+          directory: AbsolutePath.make(path.join(global.data, "snapshot", qualified[1], qualified[2])),
+          tree: Git.TreeID.make(qualified[3]),
+        }
+      if (!/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/.test(id))
+        return yield* new Error({ operation: "restore", message: "Invalid snapshot reference" })
+      const repo = yield* repository
+      const tree = Git.TreeID.make(id)
+      if (yield* git.tree.exists(repo.snapshotRepository, tree))
+        return { directory: repo.snapshotRepository.gitDirectory, tree }
+      // Persisted hash-only IDs predate storage-qualified references. Search only on a local miss.
+      const root = path.join(global.data, "snapshot")
+      const projects = yield* fs.readDirectoryEntries(root).pipe(Effect.mapError((cause) => failure("restore", cause)))
+      for (const project of projects.filter(
+        (entry) => entry.type === "directory" && /^[a-zA-Z0-9_-]+$/.test(entry.name),
+      )) {
+        const stores = yield* fs
+          .readDirectoryEntries(path.join(root, project.name))
+          .pipe(Effect.mapError((cause) => failure("restore", cause)))
+        for (const store of stores.filter((entry) => entry.type === "directory" && /^[a-f0-9]{40}$/.test(entry.name))) {
+          const directory = AbsolutePath.make(path.join(root, project.name, store.name))
+          const candidate = new Git.Repository({
+            worktree: repo.worktree,
+            gitDirectory: directory,
+            commonDirectory: directory,
+            objectDirectories: [AbsolutePath.make(path.join(repo.source.commonDirectory, "objects"))],
+          })
+          if (!(yield* git.tree.exists(candidate, tree))) continue
+          // Identical legacy trees can exist in several stores; skip incomplete copies.
+          if (
+            !(yield* git.tree.retain({ repository: candidate, trees: [tree] }).pipe(
+              Effect.as(true),
+              Effect.orElseSucceed(() => false),
+            ))
+          )
+            continue
+          const result = { directory, tree }
+          resolved.set(id, result)
+          return result
+        }
+      }
+      return yield* new Error({ operation: "restore", message: `Snapshot tree not found: ${id}` })
+    })
+
+    const read = Effect.fnUntraced(function* (ids: readonly ID[]) {
+      const repo = yield* repository
+      const stores = new Map<AbsolutePath, Git.TreeID[]>()
+      for (const id of new Set(ids)) {
+        const ref = yield* resolve(id)
+        if (ref.directory === repo.snapshotRepository.gitDirectory) continue
+        stores.set(ref.directory, [...(stores.get(ref.directory) ?? []), ref.tree])
+      }
+      for (const [directory, trees] of stores) {
+        // A renamed checkout can supply the old store's borrowed objects at its new path.
+        yield* git.tree.retain({
+          repository: new Git.Repository({
+            worktree: repo.worktree,
+            gitDirectory: directory,
+            commonDirectory: directory,
+            objectDirectories: [AbsolutePath.make(path.join(repo.source.commonDirectory, "objects"))],
+          }),
+          trees,
+        })
+      }
+      return new Git.Repository({
+        ...repo.snapshotRepository,
+        objectDirectories: Array.from(stores.keys(), (directory) => AbsolutePath.make(path.join(directory, "objects"))),
+      })
+    })
+
     const capture = Effect.fn("Snapshot.capture")(function* () {
       if (!enabled()) return undefined
       return yield* Effect.gen(function* () {
         const repo = yield* repository
-        return ID.make(
-          yield* git.tree.capture({
-            repository: repo.snapshotRepository,
-            scopes: [yield* scope(repo.worktree)],
-            ignores: repo.source,
-            maximumUntrackedFileBytes: 2 * 1024 * 1024,
-          }),
-        )
+        const tree = yield* git.tree.capture({
+          repository: repo.snapshotRepository,
+          scopes: [yield* scope(repo.worktree)],
+          ignores: repo.source,
+          maximumUntrackedFileBytes: 2 * 1024 * 1024,
+        })
+        return ID.make(`snapshot:${location.project.id}/${Hash.fast(repo.worktree)}/${tree}`)
       }).pipe(
         Effect.catch((cause) => Effect.logWarning("failed to capture snapshot", { cause }).pipe(Effect.as(undefined))),
       )
@@ -133,10 +208,11 @@ const layer = Layer.effect(
 
     const compare = Effect.fnUntraced(function* (operation: "files" | "diff", input: CompareInput) {
       const repo = yield* repository.pipe(Effect.mapError((cause) => failure(operation, cause)))
+      const snapshots = yield* read([input.from, input.to]).pipe(Effect.mapError((cause) => failure(operation, cause)))
       const comparison = {
-        repository: repo.snapshotRepository,
-        from: Git.TreeID.make(input.from),
-        to: Git.TreeID.make(input.to),
+        repository: snapshots,
+        from: treeID(input.from),
+        to: treeID(input.to),
       }
       const files = yield* git.tree.files(comparison).pipe(Effect.mapError((cause) => failure(operation, cause)))
       const ignored = yield* git.index
@@ -171,7 +247,23 @@ const layer = Layer.effect(
         const absolute = path.resolve(worktree, file)
         if (!FSUtil.contains(worktree, absolute))
           return yield* new Error({ operation: "restore", message: `Path escapes the project: ${file}` })
-        files.set(file, Git.TreeID.make(snapshot))
+        // Check ancestors, not the leaf: removing a symlink itself must not follow its target.
+        for (let parent = path.dirname(absolute); parent !== worktree; parent = path.dirname(parent)) {
+          const canonical = yield* fs.realPath(parent).pipe(
+            Effect.catchReason("PlatformError", "NotFound", () => Effect.undefined),
+            Effect.catchReason("PlatformError", "BadResource", (reason, error) =>
+              Schema.is(Schema.Struct({ code: Schema.Literal("ENOTDIR") }))(reason.cause)
+                ? Effect.undefined
+                : Effect.fail(error),
+            ),
+            Effect.mapError((cause) => failure("restore", cause)),
+          )
+          if (canonical === undefined) continue
+          if (!FSUtil.contains(worktree, canonical))
+            return yield* new Error({ operation: "restore", message: `Path escapes the project: ${file}` })
+          break
+        }
+        files.set(file, treeID(snapshot))
       }
       return files
     })
@@ -179,8 +271,11 @@ const layer = Layer.effect(
     const restore = Effect.fn("Snapshot.restore")(function* (input: RestoreInput) {
       if (!enabled()) return yield* new Error({ operation: "restore", message: "Snapshots are disabled" })
       const repo = yield* repository.pipe(Effect.mapError((cause) => failure("restore", cause)))
+      const snapshots = yield* read(Array.from(input.files.values())).pipe(
+        Effect.mapError((cause) => failure("restore", cause)),
+      )
       yield* git.tree
-        .restore({ repository: repo.snapshotRepository, files: yield* plan(repo.worktree, input) })
+        .restore({ repository: snapshots, files: yield* plan(repo.worktree, input) })
         .pipe(Effect.mapError((cause) => failure("restore", cause)))
     })
 
@@ -205,6 +300,10 @@ export const noopLayer = Layer.succeed(
     restore: () => Effect.void,
   }),
 )
+
+function treeID(id: ID) {
+  return Git.TreeID.make(id.slice(id.lastIndexOf("/") + 1))
+}
 
 function failure(operation: Error["operation"], cause: unknown) {
   if (cause instanceof Error && cause.operation === operation) return cause

--- a/packages/core/test/git.test.ts
+++ b/packages/core/test/git.test.ts
@@ -105,6 +105,46 @@ describe("Git worktrees", () => {
 })
 
 describe("Git trees", () => {
+  it.live("retains borrowed tree objects once for restoration without the source repository", () =>
+    Effect.gen(function* () {
+      const root = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (dir) => Effect.promise(() => dir[Symbol.asyncDispose]()),
+      )
+      const source = AbsolutePath.make(path.join(root.path, "source"))
+      const destination = AbsolutePath.make(path.join(root.path, "destination"))
+      yield* Effect.promise(async () => {
+        await fs.mkdir(source)
+        await fs.mkdir(destination)
+        await initRepo(source)
+        await Bun.write(path.join(source, "file.txt"), "Borrowed committed content.\n")
+        await $`git add .`.cwd(source).quiet()
+        await $`git commit -qm initial`.cwd(source).quiet()
+      })
+      const git = yield* Git.Service
+      const seed = yield* git.repo.discover(source)
+      if (!seed) throw new Error("Repository not found")
+      const repository = yield* git.repo.create({
+        worktree: source,
+        gitDirectory: AbsolutePath.make(path.join(root.path, "snapshot storage")),
+        seed,
+      })
+      const before = yield* git.tree.capture({ repository, scopes: [RelativePath.make(".")] })
+      yield* git.tree.retain({ repository, trees: [before, before] })
+      yield* Effect.promise(() => Bun.write(path.join(source, "file.txt"), "Snapshot-only content.\n"))
+      const after = yield* git.tree.capture({ repository, scopes: [RelativePath.make(".")] })
+      yield* git.tree.retain({ repository, trees: [before, after] })
+      const packs = yield* Effect.promise(() => fs.readdir(path.join(repository.gitDirectory, "objects/pack")))
+      yield* git.tree.retain({ repository, trees: [before, after] })
+      expect(yield* Effect.promise(() => fs.readdir(path.join(repository.gitDirectory, "objects/pack")))).toEqual(packs)
+      yield* Effect.promise(() => fs.rm(source, { recursive: true }))
+      const moved = new Git.Repository({ ...repository, worktree: destination })
+      yield* git.tree.restore({ repository: moved, files: new Map([[RelativePath.make("file.txt"), before]]) })
+      expect(yield* read(path.join(destination, "file.txt"))).toBe("Borrowed committed content.\n")
+      yield* git.tree.restore({ repository: moved, files: new Map([[RelativePath.make("file.txt"), after]]) })
+      expect(yield* read(path.join(destination, "file.txt"))).toBe("Snapshot-only content.\n")
+    }),
+  )
   ;[0, 1, 128].forEach((exitCode) => {
     it.live(`refresh handles check-ignore exit ${exitCode}`, () =>
       Effect.gen(function* () {

--- a/packages/core/test/session-revert.test.ts
+++ b/packages/core/test/session-revert.test.ts
@@ -29,16 +29,205 @@ import { testEffect } from "./lib/effect"
 
 const it = testEffect(
   AppNodeBuilder.build(
-    LayerNode.group([Database.node, Bus.node, SessionProjector.node, Session.node, LocationServiceMap.node]),
+    LayerNode.group([
+      Database.node,
+      Bus.node,
+      SessionProjector.node,
+      Session.node,
+      SessionExecution.node,
+      LocationServiceMap.node,
+    ]),
     [
       [Bus.node, Bus.configured({ persist: true })],
       [Global.node, tempGlobalLayer],
-      [SessionExecution.node, SessionExecution.noopLayer],
     ],
   ),
 )
 
 describe("Session.revert files", () => {
+  for (const encoding of ["qualified", "legacy"] as const) {
+    for (const move of [
+      "repository rename",
+      "another worktree",
+      "another project",
+      "symlink ancestor",
+      "same worktree subdirectory",
+    ] as const) {
+      it.live(
+        move === "symlink ancestor"
+          ? `rejects ${encoding} redo through a destination symlink ancestor`
+          : `restores ${encoding} staged file changes after moving to ${move}`,
+        () =>
+          Effect.gen(function* () {
+            const tmp = yield* tmpdirScoped()
+            const directory = path.join(tmp.path, "project")
+            const file = move === "symlink ancestor" ? "assets/logo.svg" : "file.txt"
+            const destination = AbsolutePath.make(
+              move === "same worktree subdirectory"
+                ? path.join(directory, "nested")
+                : path.join(tmp.path, "destination"),
+            )
+            yield* Effect.promise(async () => {
+              await fs.mkdir(path.dirname(path.join(directory, file)), { recursive: true })
+              await Bun.write(path.join(directory, file), "Before assistant edit.\n")
+              await Bun.write(path.join(directory, "unrelated.txt"), "Unrelated source content.\n")
+              await $`git init -q`.cwd(directory).quiet()
+              await $`git -c core.fsmonitor=false add .`.cwd(directory).quiet()
+              await $`git -c user.name=Test -c user.email=test@example.com -c commit.gpgsign=false commit -qm initial`
+                .cwd(directory)
+                .quiet()
+              if (move === "another worktree")
+                await $`git worktree add --detach ${destination} HEAD`.cwd(directory).quiet()
+              if (move === "another project" || move === "symlink ancestor") {
+                await fs.mkdir(destination)
+                if (move === "another project") await Bun.write(path.join(destination, file), "Destination content.\n")
+                if (move === "symlink ancestor")
+                  await fs.symlink(path.join(directory, "assets"), path.join(destination, "assets"), "dir")
+                await $`git init -q`.cwd(destination).quiet()
+                await $`git -c core.fsmonitor=false add .`.cwd(destination).quiet()
+              }
+              if (move === "same worktree subdirectory") await fs.mkdir(destination)
+            })
+
+            const session = yield* Session.Service
+            const database = yield* Database.Service
+            const bus = yield* Bus.Service
+            const execution = yield* SessionExecution.Service
+            const created = yield* session.create({ location: { directory: AbsolutePath.make(directory) } })
+            const prompt = yield* session.prompt({ sessionID: created.id, text: "Edit the file", resume: false })
+            yield* SessionInbox.promote(database.db, bus, created.id, "steer")
+            const stored = (id: Snapshot.ID) =>
+              encoding === "legacy" ? Snapshot.ID.make(id.slice(id.lastIndexOf("/") + 1)) : id
+            yield* Effect.gen(function* () {
+              const plugins = yield* PluginSupervisor.Service
+              yield* plugins.flush
+              const snapshot = yield* Snapshot.Service
+              const before = yield* snapshot.capture()
+              if (!before) throw new Error("Initial snapshot missing")
+              const assistantMessageID = SessionMessage.ID.create()
+              yield* bus.publish(SessionEvent.Step.Started, {
+                sessionID: created.id,
+                assistantMessageID,
+                agent: Agent.defaultID,
+                model: { id: Model.ID.make("test-model"), providerID: Provider.ID.make("test-provider") },
+                snapshot: stored(before),
+              })
+              yield* Effect.promise(async () => {
+                if (move === "symlink ancestor") return fs.rm(path.join(directory, file))
+                await Bun.write(path.join(directory, file), "After assistant edit.\n")
+              })
+              const after = yield* snapshot.capture()
+              if (!after) throw new Error("Edited snapshot missing")
+              yield* bus.publish(SessionEvent.Step.Ended, {
+                sessionID: created.id,
+                assistantMessageID,
+                finish: "stop",
+                cost: Money.USD.zero,
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                snapshot: stored(after),
+                files: yield* snapshot.files({ from: before, to: after }),
+              })
+            }).pipe(Effect.provide(LocationServiceMap.Service.get(created.location)))
+
+            const staged = yield* session.revert.stage({ sessionID: created.id, messageID: prompt.id, files: true })
+            const reverted = { ...staged, snapshot: staged.snapshot && stored(staged.snapshot) }
+            if (encoding === "legacy")
+              yield* bus.publish(SessionEvent.RevertEvent.Staged, { sessionID: created.id, revert: reverted })
+            expect(reverted.snapshot).toBeDefined()
+            expect(reverted.files?.map((file) => file.file)).toEqual([file])
+            expect(yield* Effect.promise(() => Bun.file(path.join(directory, file)).text())).toBe(
+              "Before assistant edit.\n",
+            )
+
+            if (move === "repository rename") yield* Effect.promise(() => fs.rename(directory, destination))
+            const root = move === "same worktree subdirectory" ? directory : destination
+            yield* Effect.promise(() => Bun.write(path.join(root, "unrelated.txt"), "Keep this destination edit.\n"))
+            const indexPath = yield* Effect.promise(async () =>
+              path.resolve(root, (await $`git rev-parse --git-path index`.cwd(root).quiet().text()).trim()),
+            )
+            const index = yield* Effect.promise(() => Bun.file(indexPath).arrayBuffer())
+            yield* session.move({ sessionID: created.id, directory: destination })
+            yield* execution.awaitIdle(created.id)
+            const moved = yield* session.get(created.id)
+            expect(moved.location.directory).toBe(destination)
+            if (move === "another project" || move === "symlink ancestor")
+              expect(moved.projectID).not.toBe(created.projectID)
+            if (move !== "another project" && move !== "symlink ancestor")
+              expect(moved.projectID).toBe(created.projectID)
+            expect(moved.revert).toEqual(reverted)
+
+            if (move === "symlink ancestor") {
+              const error = yield* session.revert
+                .clear(created.id)
+                .pipe(Effect.match({ onSuccess: () => undefined, onFailure: (error) => error }))
+              expect(yield* Effect.promise(() => Bun.file(path.join(directory, file)).exists())).toBe(true)
+              expect(yield* Effect.promise(() => Bun.file(path.join(directory, file)).text())).toBe(
+                "Before assistant edit.\n",
+              )
+              expect(error).toBeInstanceOf(Snapshot.Error)
+              expect(error).toMatchObject({
+                operation: "restore",
+                message: expect.stringContaining("Path escapes the project"),
+              })
+              expect((yield* session.get(created.id)).revert).toEqual(reverted)
+              return
+            }
+
+            if (move === "another project") {
+              const unavailable = {
+                ...reverted,
+                snapshot: Snapshot.ID.make(
+                  encoding === "legacy" ? "0".repeat(40) : `snapshot:missing/${"0".repeat(40)}/${"0".repeat(40)}`,
+                ),
+              }
+              yield* bus.publish(SessionEvent.RevertEvent.Staged, { sessionID: created.id, revert: unavailable })
+              expect(yield* session.revert.clear(created.id).pipe(Effect.flip)).toBeInstanceOf(Snapshot.Error)
+              expect((yield* session.get(created.id)).revert).toEqual(unavailable)
+              expect(yield* Effect.promise(() => Bun.file(path.join(root, "file.txt")).text())).toBe(
+                "Destination content.\n",
+              )
+              yield* bus.publish(SessionEvent.RevertEvent.Staged, { sessionID: created.id, revert: reverted })
+              yield* Effect.promise(() =>
+                fs.rename(path.join(directory, ".git"), path.join(tmp.path, "unavailable-seed")),
+              )
+              expect(yield* session.revert.clear(created.id).pipe(Effect.flip)).toBeInstanceOf(Snapshot.Error)
+              expect((yield* session.get(created.id)).revert).toEqual(reverted)
+              expect(yield* Effect.promise(() => Bun.file(path.join(root, "file.txt")).text())).toBe(
+                "Destination content.\n",
+              )
+              yield* Effect.promise(() =>
+                fs.rename(path.join(tmp.path, "unavailable-seed"), path.join(directory, ".git")),
+              )
+            }
+
+            yield* session.revert.clear(created.id)
+            expect(yield* Effect.promise(() => Bun.file(path.join(root, "file.txt")).text())).toBe(
+              "After assistant edit.\n",
+            )
+            expect((yield* session.get(created.id)).revert).toBeUndefined()
+            expect(yield* Effect.promise(() => Bun.file(path.join(root, "unrelated.txt")).text())).toBe(
+              "Keep this destination edit.\n",
+            )
+            if (move === "another worktree" || move === "another project")
+              expect(yield* Effect.promise(() => Bun.file(path.join(directory, "file.txt")).text())).toBe(
+                "Before assistant edit.\n",
+              )
+            yield* execution.awaitIdle(created.id)
+            yield* session.revert.stage({ sessionID: created.id, messageID: prompt.id, files: true })
+            expect(yield* Effect.promise(() => Bun.file(path.join(root, "file.txt")).text())).toBe(
+              "Before assistant edit.\n",
+            )
+            yield* session.revert.clear(created.id)
+            expect(yield* Effect.promise(() => Bun.file(path.join(root, "file.txt")).text())).toBe(
+              "After assistant edit.\n",
+            )
+            expect(yield* Effect.promise(() => Bun.file(indexPath).arrayBuffer())).toEqual(index)
+          }),
+        { timeout: 15_000 },
+      )
+    }
+  }
+
   it.live(
     "undoes and restores a file rename without losing either path",
     () =>

--- a/packages/core/test/snapshot.test.ts
+++ b/packages/core/test/snapshot.test.ts
@@ -14,6 +14,76 @@ import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
 describe("Snapshot", () => {
+  for (const transition of ["symlink", "file"] as const) {
+    testEffect(Layer.empty).live(`restores directory/${transition} transitions without touching external files`, () =>
+      Effect.acquireUseRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) =>
+          Effect.gen(function* () {
+            const project = path.join(tmp.path, "project")
+            const assets = path.join(project, "assets")
+            const external = path.join(tmp.path, "external")
+            const leaf = transition === "symlink" ? "assets/logo.svg" : "assets/nested/logo.svg"
+            yield* Effect.promise(async () => {
+              await fs.mkdir(project)
+              await fs.mkdir(external)
+              await Bun.write(path.join(external, "logo.svg"), "External content must survive.\n")
+              if (transition === "symlink") await fs.symlink(external, assets, "dir")
+              if (transition === "file") {
+                await fs.mkdir(path.dirname(path.join(project, leaf)), { recursive: true })
+                await Bun.write(path.join(project, leaf), "Directory content.\n")
+              }
+              await initGit(project)
+            })
+            yield* Effect.gen(function* () {
+              const snapshot = yield* Snapshot.Service
+              const before = yield* snapshot.capture()
+              if (!before) throw new Error("Initial snapshot missing")
+              yield* Effect.promise(async () => {
+                await fs.rm(assets, { recursive: true })
+                if (transition === "file") await Bun.write(assets, "File content.\n")
+                if (transition === "symlink") {
+                  await fs.mkdir(assets)
+                  await Bun.write(path.join(project, leaf), "Directory content.\n")
+                }
+              })
+              const after = yield* snapshot.capture()
+              if (!after) throw new Error("Changed snapshot missing")
+              const files = yield* snapshot.files({ from: before, to: after })
+              expect(files).toEqual([RelativePath.make("assets"), RelativePath.make(leaf)])
+              const restored = yield* snapshot
+                .restore({ files: new Map(files.map((file) => [file, before])) })
+                .pipe(Effect.exit)
+              expect(yield* Effect.promise(() => Bun.file(path.join(external, "logo.svg")).exists())).toBe(true)
+              expect(yield* read(path.join(external, "logo.svg"))).toBe("External content must survive.\n")
+              yield* restored
+              if (transition === "symlink") {
+                expect(yield* Effect.promise(() => fs.readlink(assets))).toBe(external)
+                yield* Effect.promise(async () => {
+                  await fs.rm(assets)
+                  await fs.mkdir(assets)
+                })
+                yield* snapshot.restore({
+                  files: new Map([
+                    [RelativePath.make("assets"), before],
+                    [RelativePath.make(leaf), after],
+                  ]),
+                })
+                expect(yield* read(path.join(external, "logo.svg"))).toBe("External content must survive.\n")
+                expect(yield* Effect.promise(async () => (await fs.lstat(assets)).isDirectory())).toBe(true)
+                expect(yield* read(path.join(project, leaf))).toBe("Directory content.\n")
+                return
+              }
+              expect(yield* read(path.join(project, leaf))).toBe("Directory content.\n")
+              yield* snapshot.restore({ files: new Map(files.toReversed().map((file) => [file, after])) })
+              expect(yield* read(assets)).toBe("File content.\n")
+            }).pipe(Effect.provide(snapshotLayer(tmp.path, project)))
+          }),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      ),
+    )
+  }
+
   testEffect(Layer.empty).live("keeps lazy repository discovery after the first caller is interrupted", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),
@@ -119,8 +189,46 @@ describe("Snapshot", () => {
             const plan = new Map([[RelativePath.make("scope/tracked.txt"), before]])
             yield* snapshot.restore({ files: plan })
             expect(yield* read(path.join(location, "tracked.txt"))).toBe("one\n")
+            yield* Effect.promise(() => fs.symlink("loop", path.join(location, "loop")))
+            expect(
+              yield* snapshot
+                .restore({ files: new Map([[RelativePath.make("scope/loop/file.txt"), before]]) })
+                .pipe(Effect.flip),
+            ).toMatchObject({
+              operation: "restore",
+              cause: { reason: { cause: { code: "ELOOP" } } },
+            })
             expect(yield* read(path.join(location, "added.txt"))).toBe("added\n")
             expect(yield* read(path.join(project, "outside.txt"))).toBe("changed outside\n")
+            const error = yield* snapshot
+              .restore({
+                files: new Map([[RelativePath.make("../escape.txt"), before]]),
+              })
+              .pipe(Effect.flip)
+            expect(error.message).toContain("Path escapes the project")
+            expect(yield* Effect.promise(() => Bun.file(path.join(tmp.path, "escape.txt")).exists())).toBe(false)
+            expect(
+              yield* snapshot
+                .restore({
+                  files: new Map([
+                    [
+                      RelativePath.make("scope/tracked.txt"),
+                      Snapshot.ID.make(`snapshot:../${"0".repeat(40)}/${"0".repeat(40)}`),
+                    ],
+                  ]),
+                })
+                .pipe(Effect.flip),
+            ).toMatchObject({ operation: "restore", message: "Invalid snapshot reference" })
+            yield* Effect.promise(async () => {
+              await Bun.write(path.join(tmp.path, "target.txt"), "Keep the external target.\n")
+              await fs.symlink(path.join(tmp.path, "target.txt"), path.join(location, "link.txt"))
+            })
+            yield* snapshot.restore({ files: new Map([[RelativePath.make("scope/link.txt"), before]]) })
+            expect(yield* Effect.promise(() => Bun.file(path.join(location, "link.txt")).exists())).toBe(false)
+            expect(yield* read(path.join(tmp.path, "target.txt"))).toBe("Keep the external target.\n")
+            yield* Effect.promise(() => fs.rm(location, { recursive: true }))
+            yield* snapshot.restore({ files: plan })
+            expect(yield* read(path.join(location, "tracked.txt"))).toBe("one\n")
           }).pipe(Effect.provide(layer))
         }),
       (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
@@ -214,8 +322,20 @@ describe("Snapshot", () => {
                 const snapshot = yield* Snapshot.Service
                 return yield* snapshot.capture()
               }).pipe(Effect.provide(snapshotLayer(tmp.path, directory)))
-            expect(yield* capture(project)).toBeDefined()
+            yield* Effect.promise(() => Bun.write(path.join(project, "tracked.txt"), "Uncommitted source content.\n"))
+            const captured = yield* capture(project)
+            if (!captured) throw new Error("Snapshot missing")
             expect(yield* capture(linked)).toBeDefined()
+            yield* Effect.gen(function* () {
+              const snapshot = yield* Snapshot.Service
+              expect(
+                yield* snapshot.diff({
+                  from: captured,
+                  to: Snapshot.ID.make(captured.slice(captured.lastIndexOf("/") + 1)),
+                }),
+              ).toEqual([])
+              expect(yield* read(path.join(linked, "tracked.txt"))).toBe("main\n")
+            }).pipe(Effect.provide(snapshotLayer(tmp.path, linked)))
 
             const projectID = yield* Effect.gen(function* () {
               return (yield* Location.Service).project.id


### PR DESCRIPTION
## Why

Undo can leave a session with a staged redo snapshot. Renaming its repository or moving the session to another worktree preserves that staged boundary, but redo then searches the destination's snapshot store for a tree that lives in the old store and fails with `not a tree object`.

## What Changes

Undo/Redo follows the session's destination worktree while retaining access to its historical snapshot data.

| Move | File behavior |
| --- | --- |
| Repository renamed | Redo restores the staged changes at the renamed location. |
| Another worktree or project | Restore the selected files in the destination; leave the source unchanged. |
| Same-worktree subdirectory | Preserve existing worktree-relative restoration. |

New opaque snapshot IDs include their storage identity. Existing V2 hash-only IDs remain readable: after a local miss, Snapshot searches validated snapshot-store directories and caches the resolved origin.

## Snapshot Storage

Storage and restoration targets remain separate. Cross-store reads use read-only Git object alternates; they do not move shared snapshot repositories or reuse a foreign index. The first cross-store read retains the referenced tree's object closure in its source snapshot store so subsequent reads no longer depend on the original checkout. A renamed destination can supply objects formerly borrowed from the original Git repository.

Restoration updates selected destination paths and its private snapshot index. The destination's ordinary Git index is untouched. Validate every destination path's ancestors before applying the file plan, then process descendant deletions before restoring ancestors. This prevents both existing symlinks and symlinks created by the same plan from redirecting deletion outside the worktree. Removing a symlink itself and restoring file/directory transitions remain supported. Missing snapshot data remains a typed failure, leaving the staged revert pointer intact.

## Scope

Git snapshot storage and restoration only. The HTTP contract and opaque string shape of `Snapshot.ID` are unchanged; no event migration or Session-history lookup is introduced. Legacy cold misses may search snapshot directories. First cross-store retention may pack a full tree, but normal capture and same-store reads do not pay that cost.

## Verification

```sh
cd packages/core
bun run test test/git.test.ts test/snapshot.test.ts test/session-revert.test.ts
bun run test test/git.test.ts test/snapshot.test.ts test/config/snapshot.test.ts test/session-revert.test.ts test/session-owned.test.ts test/session-step.test.ts test/session-projector.test.ts test/session-move.test.ts test/session-prompt.test.ts test/session-runner-tool-events.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/core/src/git.ts packages/core/src/snapshot.ts packages/core/test/git.test.ts packages/core/test/snapshot.test.ts packages/core/test/session-revert.test.ts
git diff origin/v2...HEAD --check
```

The original real-filesystem regressions fail before the fix after both a repository rename and an ordinary linked-worktree move. Expanded coverage exercises qualified, legacy, and mixed references; cross-project movement; repeated Undo/Redo; missing snapshots and borrowed data; unrelated files; unchanged sources; and byte-for-byte preservation of the destination's Git index.

Review regressions also reproduced deletion through existing and plan-created symlinks, file-to-directory rejection, and duplicate retention updates before fixing them. These are real Git/Snapshot/Session integration tests, not live-provider verification. Large-repository cold retention has not been benchmarked.

141 tests pass across the ten-file suite. Independent safety review also reran all 29 focused Git/Snapshot/revert tests without failures. Core typecheck, the repository's pre-push typechecks, formatting, and whitespace checks pass.
