### PR TITLE
fix(tui): speed up clipboard image paste

### DIFF
--- a/packages/tui/src/clipboard.ts
+++ b/packages/tui/src/clipboard.ts
@@ -1,10 +1,5 @@
-import { execFile, spawn } from "node:child_process"
-import { readFile, rm } from "node:fs/promises"
-import { platform, release, tmpdir } from "node:os"
-import path from "node:path"
-import { promisify } from "node:util"
-
-const exec = promisify(execFile)
+import { spawn } from "node:child_process"
+import { platform, release } from "node:os"
 
 function command(command: string, args: string[] = [], input?: string) {
   return new Promise<Buffer>((resolve, reject) => {
@@ -27,28 +22,30 @@ function writeOsc52(text: string) {
   process.stdout.write(process.env.TMUX ? sequence + passthrough : process.env.STY ? passthrough : sequence)
 }
 
+// AppleScript's `the clipboard as "PNGf"` coercion costs time in proportion to the image size.
+const readImage = `ObjC.import('AppKit')
+function toPng(data) {
+  return $.NSBitmapImageRep.imageRepWithData(data).representationUsingTypeProperties($.NSBitmapImageFileTypePNG, $())
+}
+function png() {
+  const pb = $.NSPasteboard.generalPasteboard
+  const direct = pb.dataForType('public.png')
+  if (!direct.isNil()) return direct
+  const tiff = pb.dataForType('public.tiff')
+  if (!tiff.isNil()) return toPng(tiff)
+  const jpeg = pb.dataForType('public.jpeg')
+  if (jpeg.isNil()) return jpeg
+  return toPng(jpeg)
+}
+const data = png()
+data.isNil() ? '' : data.base64EncodedStringWithOptions(0)`
+
 export async function read() {
   if (platform() === "darwin") {
-    const file = path.join(tmpdir(), "opencode-clipboard.png")
-    try {
-      await exec("osascript", [
-        "-e",
-        'set imageData to the clipboard as "PNGf"',
-        "-e",
-        `set fileRef to open for access POSIX file "${file}" with write permission`,
-        "-e",
-        "set eof fileRef to 0",
-        "-e",
-        "write imageData to fileRef",
-        "-e",
-        "close access fileRef",
-      ])
-      return { data: (await readFile(file)).toString("base64"), mime: "image/png" }
-    } catch {
-      // Fall through to text clipboard.
-    } finally {
-      await rm(file, { force: true }).catch(() => {})
-    }
+    const image = await command("osascript", ["-l", "JavaScript", "-e", readImage])
+      .then((output) => output.toString().trim())
+      .catch(() => "")
+    if (image) return { data: image, mime: "image/png" }
   }
 
   if (platform() === "win32" || release().includes("WSL")) {


### PR DESCRIPTION
### Issue for this PR

Closes #38879

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Make clipboard images paste quickly.

Same root cause as #38880, which fixed it with a native addon. This PR does not add a dependency.

On macOS the TUI reads clipboard images with `osascript -e 'the clipboard as "PNGf"'`. AppleScript passes the whole image through an Apple event descriptor. That costs about 200ms per megabyte, so a 12MB screenshot takes 2.5s. Starting `osascript` costs only 40ms of that, so the process spawn is not the cause.

`osascript -l JavaScript` runs the same binary. Its Objective-C bridge reads `NSPasteboard` directly and returns the bytes that already sit on the pasteboard. The time no longer depends on the size of the image.

The change touches the macOS branch of `read()` only. Windows, Linux and WSL keep their current paths. `write()` and `copyCommand()` do not change, so the four existing tests still pass.

One thing improves as a side effect:

- The macOS branch no longer writes to `$TMPDIR/opencode-clipboard.png`. Two instances of opencode could overwrite each other on that shared path.

### How did you verify your code works?

I measured timing on the TUI w/ a script (pty sends ctrl+v, and times the gap until the `[Image N]` marker reaches the output stream). Each number below is the median of 5 pastes on macOS 26, arm64, after a warmup run.

| Screenshot | Before | After |
| --- | --- | --- |
| 3.0 MB | 744 ms | 103 ms |
| 6.0 MB | 1286 ms | 121 ms |
| 12.1 MB | 2541 ms | 167 ms |

The old path grows at about 200ms per megabyte. The new path adds about 7ms per megabyte on an 85ms floor. I can share the timing script if it is useful.

https://github.com/user-attachments/assets/735377c6-3dbc-4526-8724-037f5bccd195

- compiled binary of change (right) tested in screen recording above against current opencode version (left)
- verified parity with the old path on 8 clipboard states: PNG 2.1 MB, PNG 5.6 MB, TIFF only, JPEG only, Finder file copy, a 3-page PDF, text only, and an empty clipboard

Commands run:

- `bun typecheck` at the repo root — 30 packages, all clean
- `bun test test/clipboard.test.ts` in `packages/tui` — 4 pass, 0 fail
- `./packages/opencode/script/build.ts --single` — builds, smoke test passes

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

