### PR TITLE
test: migrate fixture layer replacements

### DIFF
--- a/packages/core/test/session-execution.test.ts
+++ b/packages/core/test/session-execution.test.ts
@@ -1374,7 +1374,9 @@ function buildExecution(
         Layer.provide(Layer.succeed(Job.Service, jobs)),
         // Do not reuse the outer harness's selector with its already-captured Location map.
         Layer.provide(
-          LayerNode.compile(Instance.byLocationNode, [[LocationServiceMap.node, locations]]).pipe(Layer.fresh),
+          LayerNode.compile(Instance.byLocationNode, {
+            replacements: [LocationServiceMap.node.replace(locations)],
+          }).pipe(Layer.fresh),
         ),
       ),
       scope,

--- a/packages/server/test/session-instances.test.ts
+++ b/packages/server/test/session-instances.test.ts
@@ -52,18 +52,19 @@ it.live(
       const cell = PluginRuntime.makeCell()
       // Host and private instances must reuse the same global layer identities.
       const replacements: LayerNode.Replacements = [
-        [Global.node, tempGlobalLayer],
-        [Database.node, Database.node],
-        [Bus.node, Bus.node],
-        [App.node, App.node],
-        [ModelsDev.node, ModelsDev.configured({ fetch: false })],
-        [Watcher.node, Watcher.configured({ enabled: false })],
-        [PluginRuntime.node, PluginRuntime.layerWithCell(cell)],
-        [PluginRuntime.providerNode, PluginRuntime.providerNodeWithCell(cell)],
-        [llmClient, Layer.succeed(LLMClient.Service, llm)],
-        [SessionRunnerModel.node, Layer.succeed(SessionRunnerModel.Service, { resolve: () => Effect.succeed(model) })],
-        [
-          Instance.byLocationNode,
+        Global.node.replace(tempGlobalLayer),
+        Database.node.replace(Database.node),
+        Bus.node.replace(Bus.node),
+        App.node.replace(App.node),
+        ModelsDev.node.replace(ModelsDev.configured({ fetch: false })),
+        Watcher.node.replace(Watcher.configured({ enabled: false })),
+        PluginRuntime.node.replace(PluginRuntime.layerWithCell(cell)),
+        PluginRuntime.providerNode.replace(PluginRuntime.providerNodeWithCell(cell)),
+        llmClient.replace(Layer.succeed(LLMClient.Service, llm)),
+        SessionRunnerModel.node.replace(
+          Layer.succeed(SessionRunnerModel.Service, { resolve: () => Effect.succeed(model) }),
+        ),
+        Instance.byLocationNode.replace(
           Layer.effect(
             Instance.Service,
             Effect.gen(function* () {
@@ -151,7 +152,7 @@ it.live(
               })
             }),
           ),
-        ],
+        ),
       ]
       const context = yield* Layer.build(
         createEmbeddedRoutes({}, replacements).pipe(Layer.provide(HttpServer.layerServices)),


### PR DESCRIPTION
## Why
Core typechecking fails with TS2559 because the session-execution fixture still passes an array where `LayerNode.compile` now expects `CompileOptions`. The session-instances fixture also has 11 TS2322 errors because replacement tuples no longer satisfy `LayerNode.Replacements`.

## What Changes
- Core: pass `{ replacements: [LocationServiceMap.node.replace(locations)] }` to the existing compile call.
- Server: convert the 11 `[node, replacement]` tuples to `node.replace(replacement)` values.

Both fixtures now use the checked replacement API while retaining the same replacement targets, test expectations, and layer lifetimes.

## Scope
Mechanical migration repair in two test fixtures only. Production code and the separate patch-buffer cleanup are not part of this PR.

## Verification
```sh
# Workspace root
bun install --frozen-lockfile
bunx prettier --check packages/core/test/session-execution.test.ts packages/server/test/session-instances.test.ts
git diff --check origin/v2...HEAD

# packages/core
bun run test test/session-execution.test.ts
bun typecheck

# packages/server
bun run test test/session-instances.test.ts
bun typecheck

# Workspace root, normal Husky pre-push hook enabled
git push -u origin compile-options
```
Full frozen workspace install passed. Core: 35 tests passed, 161 assertions. Server: 1 test passed, 53 assertions. Both package typechecks, formatting, and diff checks passed. The normal pre-push workspace typecheck passed all 33 tasks (32 cached). The initial push exposed the Server fixture errors; the successful retry includes their mechanical repair.