### PR TITLE
refactor(util): reuse private patch buffers

### DIFF
--- a/packages/core/test/patch.test.ts
+++ b/packages/core/test/patch.test.ts
@@ -248,6 +248,16 @@ describe("Patch", () => {
     ).toBe("line 1\nline 2\nadded 1\nadded 2\n")
   })
 
+  test.each(["", "original\n"])("preserves equal-offset insertion order and frozen chunks for %j", (original) => {
+    const chunks = Object.freeze([
+      Object.freeze({ oldLines: Object.freeze([]), newLines: Object.freeze(["first"]) }),
+      Object.freeze({ oldLines: Object.freeze([]), newLines: Object.freeze(["second", "third"]) }),
+    ])
+    const expected = { content: original + "first\nsecond\nthird\n", bom: false }
+    expect(Patch.derive("update.txt", chunks, original)).toEqual(expected)
+    expect(Patch.derive("update.txt", chunks, original)).toEqual(expected)
+  })
+
   test("applies a pure-addition chunk after an earlier replacement", () => {
     expect(
       Patch.derive(

--- a/packages/util/src/patch.ts
+++ b/packages/util/src/patch.ts
@@ -130,10 +130,9 @@ export function derive(path: string, chunks: ReadonlyArray<UpdateFileChunk>, ori
   const lines = source.text.split("\n")
   if (lines.at(-1) === "") lines.pop()
   const replacements = computeReplacements(lines, path, chunks)
-  const updated = [...lines]
-  for (const [start, remove, insert] of replacements.toReversed()) updated.splice(start, remove, ...insert)
-  if (updated.at(-1) !== "") updated.push("")
-  const next = Bom.split(updated.join("\n"))
+  for (const [start, remove, insert] of replacements.reverse()) lines.splice(start, remove, ...insert)
+  if (lines.at(-1) !== "") lines.push("")
+  const next = Bom.split(lines.join("\n"))
   return { content: next.text, bom: source.bom || next.bom }
 }
 
@@ -339,7 +338,7 @@ function computeReplacements(lines: ReadonlyArray<string>, path: string, chunks:
     replacements.push([found, oldLines.length, newLines])
     lineIndex = found + oldLines.length
   }
-  return replacements.toSorted((left, right) => left[0] - right[0])
+  return replacements.sort((left, right) => left[0] - right[0])
 }
 
 function seek(lines: ReadonlyArray<string>, pattern: ReadonlyArray<string>, start: number, eof = false) {


### PR DESCRIPTION
## Why

Patch derivation creates private arrays for file lines and replacements, then copies them before applying changes. Those copies protect no caller-owned data and include an extra array proportional to the entire file.

## What Changes

Apply replacements to the existing private line array. Sort and reverse the private replacement array in place instead of allocating copies.

All matching still finishes before mutation. Ascending stable sort followed by reversal is preserved, including the existing order of multiple insertions at the same offset. Caller-owned chunks, BOM handling, trailing newlines, matching precedence, and failures remain unchanged.

## Scope

One production file (+4/-5 lines) and two regression cases in the existing patch suite. No public API, parser, filesystem, or execution-policy changes.

## Verification

```sh
cd packages/core
bun run test test/patch.test.ts test/tool-patch.test.ts
bun typecheck
cd ../util
bun run test
bun typecheck
cd ../..
bunx prettier --check packages/util/src/patch.ts packages/core/test/patch.test.ts
git diff --check origin/v2...HEAD
```

85 patch/tool-patch tests passed with 195 assertions; all 27 Util tests passed with 91 assertions. Core and Util typechecking, formatting, and whitespace checks passed. The new cases also passed before the production change and cover equal-offset insertion order, frozen input chunks, and repeated derivation for empty/nonempty files. Independent review found no issues and reran the 46-test patch suite. No performance benchmark claim.
