### PR TITLE
fix(shell): preserve output from fast-exiting commands

### DIFF
--- a/packages/core/test/effect/cross-spawn-spawner.test.ts
+++ b/packages/core/test/effect/cross-spawn-spawner.test.ts
@@ -147,6 +147,20 @@ describe("cross-spawn spawner", () => {
   })
 
   describe("stderr", () => {
+    fx.live(
+      "captures both streams across backpressure",
+      Effect.gen(function* () {
+        const handle = yield* js(
+          'process.stdout.write("o".repeat(256 * 1024)); process.stderr.write("e".repeat(256 * 1024))',
+        )
+        const output = yield* Effect.all([decodeByteStream(handle.stdout), decodeByteStream(handle.stderr)], {
+          concurrency: "unbounded",
+        })
+        expect(output).toEqual(["o".repeat(256 * 1024), "e".repeat(256 * 1024)])
+        expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(0))
+      }),
+    )
+
     fx.effect(
       "captures stderr output",
       Effect.gen(function* () {
@@ -197,6 +211,30 @@ describe("cross-spawn spawner", () => {
         expect(all).toBe("hello from stderr")
       }),
     )
+  })
+
+  describe("delayed output consumption", () => {
+    for (const combined of [false, true]) {
+      fx.live(
+        `retains ${combined ? "combined" : "separate"} output after process completion`,
+        Effect.gen(function* () {
+          const handle = yield* js(
+            'require("node:fs").writeSync(1, "stdout\\n"); require("node:fs").writeSync(2, "stderr\\n")',
+          )
+          expect(yield* handle.exitCode).toBe(ChildProcessSpawner.ExitCode(0))
+          if (combined) {
+            const output = yield* decodeByteStream(handle.all)
+            expect(output).toContain("stdout")
+            expect(output).toContain("stderr")
+            return
+          }
+          const output = yield* Effect.all([decodeByteStream(handle.stdout), decodeByteStream(handle.stderr)], {
+            concurrency: "unbounded",
+          })
+          expect(output).toEqual(["stdout", "stderr"])
+        }),
+      )
+    }
   })
 
   describe("stdin", () => {

--- a/packages/util/src/cross-spawn-spawner.ts
+++ b/packages/util/src/cross-spawn-spawner.ts
@@ -240,10 +240,13 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
   ) => {
     const capture = (readable: NodeChildProcess.ChildProcess["stdout"], name: string) => {
       if (!readable) return Stream.empty
+      // Bun resumes stdio on exit; retain bytes before the lazy Effect reader attaches.
+      const buffer = new PassThrough()
+      readable.on("error", (cause) => buffer.destroy(toError(cause)))
+      readable.pipe(buffer)
       return NodeStream.fromReadable({
-        evaluate: () => readable,
+        evaluate: () => buffer,
         onError: (cause) => toPlatformError(`fromReadable(${name})`, toError(cause), command),
-        closeOnDone: false,
       }).pipe(
         Stream.interruptWhen(Deferred.await(stopOutput)),
         Stream.ensuring(
@@ -318,7 +321,8 @@ const makeCrossSpawnSpawner = Effect.gen(function* () {
 
   const discard = (readable: NodeChildProcess.ChildProcess["stdout"]) => {
     if (!readable || readable.destroyed) return
-    // read() also drains while a backpressured Effect adapter still has a readable listener.
+    readable.unpipe()
+    // Discard descendant output without refilling a capture buffer that is no longer consumed.
     const drain = () => {
       while (readable.read() !== null) {}
     }


### PR DESCRIPTION
## Why

Short-lived shell commands can finish successfully but return `(no output)` instead of the bytes they printed. Bun resumes child stdout and stderr on exit; our Effect readers attach lazily, so output can be discarded before consumption starts.

The failure also reproduces using the spawner implementation from before #46085. This is an older capture bug, not a reason to remove the post-exit drain deadline.

## What Changes

- Pipe stdout and stderr into backpressured `PassThrough` buffers when setting up the handle, before the lazy Effect readers attach. This follows the capture pattern in Effect's Node spawner.
- Let the stream adapter clean up the capture buffer while preserving the existing raw-stream cleanup policy.
- Unpipe before deadline-driven discard, so late descendant output cannot refill an abandoned capture buffer.

```mermaid
flowchart LR
  Child[Child stdout / stderr] --> Buffer[Eager PassThrough buffer]
  Buffer --> Reader[Lazy Effect reader]
```

The regression tests keep the process scope open, wait for a real child to exit, then read its output. Before the fix, separate and combined capture both return empty output in under 60 ms. Afterward, both retain stdout and stderr. A third case checks simultaneous 256 KiB outputs across backpressure.

## Scope

Only child-output capture and its tests change. The shared one-second post-exit deadline, process-group termination, SIGKILL escalation, and MCP shutdown behavior remain intact. No public API or SDK cancellation-contract changes.

## Verification

Run from package directories on macOS with Bun 1.3.14:

```sh
cd packages/core
bun typecheck
bun run test test/effect/cross-spawn-spawner.test.ts test/tool-shell.test.ts test/session-shell.test.ts test/shell-cleanup.test.ts test/mcp.test.ts
bun run test test/effect/cross-spawn-spawner.test.ts --test-name-pattern 'delayed output consumption|captures stdout via' --rerun-each 100
bun run test test/tool-shell.test.ts --test-name-pattern 'ordinary shell syntax' --rerun-each 10
bun run test

cd ../util
bun typecheck
bun run test
bun run build
```

- Targeted spawner, shell, Session-shell, cleanup, and MCP suites: **168 pass, 19 skip, 0 fail**.
- Repeated capture checks: **300 pass, 0 fail**. Repeated shell-syntax checks: **320 pass, 190 skip, 0 fail**.
- A separate real-process probe ran **500 commands at concurrency 16** and retained both stdout and stderr in every case.
- The built Util package also retained output in **100 delayed-consumption checks under Node 26.5.0** at concurrency 8.
- Util tests: **27 pass, 0 fail**. Util builds, Core and Util typechecks, and all **33 repository pre-push typecheck tasks** pass.
- Prettier and `git diff --check` pass. Targeted lint has no errors and three pre-existing warnings.
- Full Core suite: **4,047 pass, 40 skip, 0 fail** across 229 files, including the formerly intermittent shell-output failures.
