### PR TITLE
refactor(codemode): simplify input conflict detection

### DIFF
--- a/packages/codemode/src/openapi/spec.ts
+++ b/packages/codemode/src/openapi/spec.ts
@@ -461,9 +461,7 @@ export const operationInput = (
   const fields = [...parameters.value, ...requestBody.value.fields]
 
   const conflicts = new Set(
-    [...Map.groupBy(fields, (field) => field.name)]
-      .filter(([, matches]) => new Set(matches.map((field) => field.location)).size > 1)
-      .map(([name]) => name),
+    [...Map.groupBy(fields, (field) => field.name)].filter(([, matches]) => matches.length > 1).map(([name]) => name),
   )
   const used = new Set<string>()
   return {

--- a/packages/codemode/test/openapi.test.ts
+++ b/packages/codemode/test/openapi.test.ts
@@ -315,7 +315,10 @@ describe("OpenAPI.fromSpec", () => {
               parameters: [{ name: "limit", in: "query", schema: { type: "string" } }],
               get: {
                 operationId: "test",
-                parameters: [{ name: "limit", in: "query", required: true, schema: { type: "number" } }],
+                parameters: [
+                  { name: "limit", in: "query", schema: { type: "boolean" } },
+                  { name: "limit", in: "query", required: true, schema: { type: "number" } },
+                ],
                 responses: { 200: { description: "Success" } },
               },
             },


### PR DESCRIPTION
## Why

OpenAPI input naming groups fields by name, then builds an array and Set of locations for every group to detect conflicts. That repeats a guarantee already established by input parsing: each location/name pair is unique.

## What Changes

Use `matches.length > 1` to identify names shared across locations. Parameter declarations are already deduplicated by location/name, and body fields come from unique object properties or a single body value.

Repeated query declarations still resolve to one unprefixed input. A name shared by path, query, header, or body fields still receives the same location prefixes and collision suffixes.

## Scope

Only the conflict predicate and the existing parameter-override test. No public contracts, transport rules, validation, or execution changes. Formatting reduces production code by two lines.

## Verification

```sh
cd packages/codemode
bun run test test/openapi.test.ts
bun typecheck
cd ../..
bunx prettier --check packages/codemode/src/openapi/spec.ts packages/codemode/test/openapi.test.ts
git diff --check
```

41 OpenAPI tests passed with 179 assertions before and after the production change. The extended test checks that multiple operation-level declarations override the path-level declaration while preserving exactly `{ limit: number }`. Existing tests cover cross-location conflicts and generated-prefix collisions. Package typechecking, formatting, and whitespace checks passed.
