### PR TITLE
refactor(util): slice the final filename segment

### DIFF
--- a/packages/util/src/path.test.ts
+++ b/packages/util/src/path.test.ts
@@ -18,6 +18,21 @@ describe("client paths", () => {
     expect(getDirectory("")).toBe("")
   })
 
+  test.each([
+    ["/repo/src/index.ts///", "index.ts"],
+    ["C:\\repo\\src\\index.ts", "index.ts"],
+    ["C:\\repo/src\\file", "file"],
+    ["C:/repo\\src/file/\\", "file"],
+    ["/", ""],
+    ["\\", ""],
+    ["/\\/\\", ""],
+    ["C:\\", "C:"],
+    ["file", "file"],
+    ["", ""],
+  ])("reads the filename from %j", (path, filename) => {
+    expect(getFilename(path)).toBe(filename)
+  })
+
   test("keeps filename truncation stable", () => {
     expect(getFilenameTruncated("/repo/long-component-name.tsx", 16)).toBe("long-compon….tsx")
     expect(truncateMiddle("abcdefghijklmnop", 9)).toBe("abcd…mnop")

--- a/packages/util/src/path.ts
+++ b/packages/util/src/path.ts
@@ -1,8 +1,8 @@
 export function getFilename(path: string | undefined) {
   if (!path) return ""
   const trimmed = path.replace(/[/\\]+$/, "")
-  const parts = trimmed.split(/[/\\]/)
-  return parts[parts.length - 1] ?? ""
+  const index = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"))
+  return trimmed.slice(index + 1)
 }
 
 export function getDirectory(path: string | undefined) {


### PR DESCRIPTION
## Why

`getFilename` splits the entire path into segments even though it only returns the last one. This cleanup selects that segment directly without changing the cross-platform path rules.

## What Changes

Keep the existing empty/undefined guard and trailing-separator regex trim. Find the last slash or backslash with `Math.max` and slice after it instead of splitting.

Representative unchanged results (inputs and outputs shown as string literals):

| Input | Filename |
| --- | --- |
| `"/repo/src/index.ts///"` | `"index.ts"` |
| `"C:\\repo/src\\file"` | `"file"` |
| `"C:/repo\\src/file/\\"` | `"file"` |
| `"C:\\"` | `"C:"` |
| `"/"`, `"\\"`, `""`, or `undefined` | `""` |

Add ten table cases for previously uncovered filename inputs, retaining existing POSIX, Windows, UNC, and undefined coverage.

## Scope

Only `getFilename` and its existing path test file: production +2/-2 lines, tests +15/-0 lines. No platform `basename`, API change, or changes to directory extraction or truncation.

## Verification

```sh
# Repository root
bun install --frozen-lockfile

# packages/util: run with enhanced tests before AND after the production edit
bun run test src/path.test.ts

# packages/util: after the production edit
bun run test
bun typecheck

# Repository root
bunx prettier --check packages/util/src/path.ts packages/util/src/path.test.ts
git diff --check
```

- Full frozen-lockfile install passed with Bun 1.3.14.
- Enhanced focused tests passed on both the unchanged baseline and the refactor: 13 tests, 22 assertions, zero failures each.
- Full Util suite passed: 37 tests across 8 files, 101 assertions, zero failures.
- Typecheck, Prettier, and whitespace checks passed.
