### PR TITLE
refactor(core): slice model references at the first slash

### DIFF
--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -38,10 +38,10 @@ export function compatibility(input: unknown): Compatibility | undefined {
 }
 
 export function parse(input: string): { providerID: Provider.ID; modelID: ID } {
-  const [providerID, ...modelID] = input.split("/")
+  const index = input.indexOf("/")
   return {
-    providerID: Provider.ID.make(providerID),
-    modelID: ID.make(modelID.join("/")),
+    providerID: Provider.ID.make(index === -1 ? input : input.slice(0, index)),
+    modelID: ID.make(index === -1 ? "" : input.slice(index + 1)),
   }
 }
 

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -5,6 +5,23 @@ import { Provider } from "@opencode-ai/core/provider"
 
 const decode = Schema.decodeUnknownSync(Model.Ref)
 
+describe("Model.parse", () => {
+  test.each([
+    ["vendor/model", "vendor", "model"],
+    ["vendor/team/model", "vendor", "team/model"],
+    ["vendor", "vendor", ""],
+    ["", "", ""],
+    ["/model", "", "model"],
+    ["vendor/", "vendor", ""],
+    ["vendor//model/", "vendor", "/model/"],
+  ])("parses %j at the first slash", (input, providerID, modelID) => {
+    expect(Model.parse(input)).toEqual({
+      providerID: Provider.ID.make(providerID),
+      modelID: Model.ID.make(modelID),
+    })
+  })
+})
+
 describe("Model.Ref", () => {
   test("accepts a model selection without a variant", () => {
     expect(decode({ id: "claude-sonnet", providerID: "anthropic" })).toEqual({


### PR DESCRIPTION
## Why

`Model.parse` splits every slash and rejoins the model portion even though only the first slash separates the provider from the model. This cleanup expresses that boundary directly while preserving permissive parsing.

## What Changes

Use `indexOf` and slices, retaining `Provider.ID.make` and `Model.ID.make`. A table-based regression test locks in the existing results:

| Input | Provider ID | Model ID |
| --- | --- | --- |
| `vendor/model` | `vendor` | `model` |
| `vendor/team/model` | `vendor` | `team/model` |
| `vendor` | `vendor` | `""` |
| `""` | `""` | `""` |
| `/model` | `""` | `model` |
| `vendor/` | `vendor` | `""` |
| `vendor//model/` | `vendor` | `/model/` |

## Scope

Only Core's `Model.parse` implementation and its existing test file change. No new validation, helper, or public API; the separate `Model.Ref.parse` contract is unchanged.

## Verification

```bash
# Repository root
bun install --frozen-lockfile

# packages/core: original tests, before any edits
bun run test test/model.test.ts
# packages/core: enhanced tests, before the production edit
bun run test test/model.test.ts
# packages/core: enhanced tests, after the production edit
bun run test test/model.test.ts
bun typecheck

# Repository root
bunx prettier --check packages/core/src/model.ts packages/core/test/model.test.ts
git diff --check
```

- Frozen installation passed without changing the lockfile.
- Original tests: 2 passed, 0 failed. Enhanced tests: 9 passed, 0 failed both before and after the production edit.
- Core typecheck, Prettier, and diff whitespace checks passed.
- Inspected the ID schemas and current Effect source: both IDs are branded strings, and branding adds no runtime checks. The regression cases verify that empty IDs remain accepted.
