### PR TITLE
refactor(codemode): reject unresolved intersections before rendering

### DIFF
--- a/packages/codemode/src/tool-schema.ts
+++ b/packages/codemode/src/tool-schema.ts
@@ -127,8 +127,8 @@ const renderSchema = (
     ])
   }
   if (schema.allOf) {
-    const members = schema.allOf.map((item) => renderSchema(item, nested, depth + 1, seen))
     if (schema.allOf.some((item) => hasUnresolvedRef(item, nested.definitions))) return "unknown"
+    const members = schema.allOf.map((item) => renderSchema(item, nested, depth + 1, seen))
     return intersection([renderSchema({ ...schema, allOf: undefined }, nested, depth + 1, seen), ...members])
   }
   if (Array.isArray(schema.type)) {

--- a/packages/codemode/test/signature.test.ts
+++ b/packages/codemode/test/signature.test.ts
@@ -344,28 +344,34 @@ describe("union schemas render every alternative", () => {
     expect(outputTypeScript(tool)).toBe("number | boolean")
   })
 
-  test("allOf renders intersections with parenthesized union members", () => {
+  test("allOf keeps siblings and parenthesized union members in order", () => {
     const schema = {
+      properties: { common: { type: "boolean" } },
       allOf: [{ type: "object", properties: { id: { type: "string" } } }, { type: ["string", "null"] }],
     } as const
-    expect(jsonSchemaToTypeScript(schema)).toBe("{ id?: string } & (string | null)")
+    expect(jsonSchemaToTypeScript(schema)).toBe("{ common?: boolean } & { id?: string } & (string | null)")
+    expect(jsonSchemaToTypeScript(schema, true)).toBe(
+      ["{", "    common?: boolean,", "  } & {", "    id?: string,", "  } & (string | null)"].join("\n"),
+    )
   })
 
-  test("allOf does not discard an unresolved constraint", () => {
-    expect(jsonSchemaToTypeScript({ allOf: [{ type: "string" }, { $ref: "https://example.com/external.json" }] })).toBe(
-      "unknown",
-    )
+  test.each([false, true])("allOf does not discard an unresolved constraint (pretty=%s)", (pretty) => {
+    for (const $ref of ["#/$defs/Missing", "#/definitions/Missing", "https://example.com/external.json"]) {
+      expect(jsonSchemaToTypeScript({ allOf: [{ type: "string" }, { $ref }] }, pretty)).toBe("unknown")
+      expect(jsonSchemaToTypeScript({ allOf: [{ type: "string" }, { allOf: [{ $ref }] }] }, pretty)).toBe("unknown")
+      expect(
+        jsonSchemaToTypeScript({ allOf: [{ properties: { nested: { $ref } } }, { type: "string" }] }, pretty),
+      ).toBe("unknown")
+    }
     expect(
-      jsonSchemaToTypeScript({
-        allOf: [{ type: "string" }, { allOf: [{ $ref: "https://example.com/external.json" }] }],
-      }),
-    ).toBe("unknown")
-    expect(
-      jsonSchemaToTypeScript({
-        type: "string",
-        allOf: [{ $ref: "#/$defs/Constraint" }],
-        $defs: { Constraint: { description: "TypeScript-neutral constraint" } },
-      }),
+      jsonSchemaToTypeScript(
+        {
+          type: "string",
+          allOf: [{ $ref: "#/$defs/Constraint" }],
+          $defs: { Constraint: { description: "TypeScript-neutral constraint" } },
+        },
+        pretty,
+      ),
     ).toBe("string")
   })
 })


### PR DESCRIPTION
**Why**
An `allOf` containing an unresolved reference renders every member before discarding the result as `unknown`. The existing rejection check can run first without changing the rendered output.

**What Changes**
Move the unchanged `hasUnresolvedRef` guard before the member-rendering map. Both traversals keep their state local; neither mutates the schema, definitions, or shared traversal state. Successful intersections retain their rendering order.

| Input | Output in both compact and pretty mode |
| --- | --- |
| Missing local or external reference, directly or nested inside an intersection member | `unknown` |
| Valid intersection with sibling properties and a union member | Siblings first, then members in their original order, with the union parenthesized |
| Resolved TypeScript-neutral constraint intersected with a string | `string` |

**Scope**
One production line moved in `tool-schema.ts` (+1/-1), with existing signature tests expanded (+22/-16). No new helper, API, or error policy.

**Verification**
```sh
# Worktree root, before testing
bun install --frozen-lockfile

# packages/codemode, expanded tests before the production edit
bun run test test/signature.test.ts test/openapi.test.ts

# packages/codemode, after the production edit
bun run test test/signature.test.ts test/openapi.test.ts
bun typecheck

# Worktree root
bunx prettier --check packages/codemode/src/tool-schema.ts packages/codemode/test/signature.test.ts
git diff --check
```

- Frozen-lockfile install succeeded: 4,843 packages installed with Bun 1.3.14.
- Expanded tests against the unchanged V2 implementation at `566ca864a01d04ca215c9464b6b07b37412176d4`: 70 passed, 0 failed, 266 assertions across 2 files.
- The same tests after the guard move: 70 passed, 0 failed, 266 assertions across 2 files.
- Package typecheck, formatting, and whitespace checks all passed.
