### PR TITLE
fix(desktop): separate unpackaged app identity

### DIFF
--- a/packages/desktop/src/main/app-identity.test.ts
+++ b/packages/desktop/src/main/app-identity.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { resolveAppUserModelId, UNPACKAGED_APP_ID } from "./app-identity"
+
+describe("desktop app identity", () => {
+  test("keeps the packaged application identity", () => {
+    expect(resolveAppUserModelId("ai.opencode.desktop.dev", true)).toBe("ai.opencode.desktop.dev")
+    expect(resolveAppUserModelId("ai.opencode.desktop.beta", true)).toBe("ai.opencode.desktop.beta")
+    expect(resolveAppUserModelId("ai.opencode.desktop", true)).toBe("ai.opencode.desktop")
+  })
+
+  test("keeps the unpackaged application separate from installed builds", () => {
+    expect(resolveAppUserModelId("ai.opencode.desktop.dev", false)).toBe(UNPACKAGED_APP_ID)
+    expect(UNPACKAGED_APP_ID).not.toBe("ai.opencode.desktop.dev")
+  })
+})

--- a/packages/desktop/src/main/app-identity.ts
+++ b/packages/desktop/src/main/app-identity.ts
@@ -1,0 +1,6 @@
+export const UNPACKAGED_APP_ID = "ai.opencode.desktop.dev.unpacked"
+
+export function resolveAppUserModelId(appId: string, packaged: boolean) {
+  if (packaged) return appId
+  return UNPACKAGED_APP_ID
+}

--- a/packages/desktop/src/main/index.ts
+++ b/packages/desktop/src/main/index.ts
@@ -13,6 +13,7 @@ import contextMenu from "electron-context-menu"
 
 import type { ServerReadyData } from "../preload/types"
 import { checkAppExists, resolveAppPath } from "./apps"
+import { resolveAppUserModelId } from "./app-identity"
 import { CHANNEL } from "./constants"
 import { registerIpcHandlers, sendDeepLinks, sendMenuCommand } from "./ipc"
 import { forwardInitializationFailure } from "./initialization"
@@ -139,7 +140,7 @@ const main = Effect.gen(function* () {
     return root
   })()
   app.setName(app.isPackaged ? APP_NAMES[CHANNEL] : "OpenCode Dev")
-  app.setAppUserModelId(appId)
+  app.setAppUserModelId(resolveAppUserModelId(appId, app.isPackaged))
   app.setPath(
     "userData",
     onboardingTestRoot ? join(onboardingTestRoot, "desktop") : join(app.getPath("appData"), appId),


### PR DESCRIPTION
### Issue for this PR

Closes #46473

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Gives the unpackaged Electron desktop process its own Windows AppUserModelID instead of reusing the installed Dev application's identity.

The existing Dev user-data directory and every packaged channel ID remain unchanged. This prevents stale Electron shortcuts or pins from taking over the installed Dev taskbar group while preserving the taskbar identity setup introduced in #23368.

### How did you verify your code works?

- `bun test src/main/app-identity.test.ts` in `packages/desktop` (2 passed)
- `bun typecheck` in `packages/desktop`
- `bun run build` in `packages/desktop`
- Reproduced the identity collision on Windows 11 with installed and unpackaged downstream builds that preserve the same upstream ID relationship

### Screenshots / recordings

N/A — this changes the native Windows process identity used for taskbar association; the regression test covers the packaged and unpackaged identity contract.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
