### PR TITLE
fix(core): allow patch file-to-directory replacements

### DIFF
--- a/packages/core/test/tool-patch.test.ts
+++ b/packages/core/test/tool-patch.test.ts
@@ -241,6 +241,22 @@ describe("PatchTool", () => {
     ),
   )
 
+  it.live("replaces a file with a directory containing an added file", () =>
+    withTempTool((directory, registry) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "parent"), "before\n"))
+        const settled = yield* executeTool(
+          registry,
+          call("*** Begin Patch\n*** Delete File: parent\n*** Add File: parent/child.txt\n+after\n*** End Patch"),
+        )
+        expect(settled.status).toBe("completed")
+        expect(yield* Effect.promise(() => fs.readFile(path.join(directory, "parent/child.txt"), "utf8"))).toBe(
+          "after\n",
+        )
+      }),
+    ),
+  )
+
   it.live("counts deleted lines with and without a trailing newline", () =>
     withTempTool((directory, registry) =>
       Effect.gen(function* () {

--- a/packages/util/src/fs-util.ts
+++ b/packages/util/src/fs-util.ts
@@ -250,7 +250,7 @@ export namespace FSUtil {
     try {
       return normalizePath(realpathSync(resolved))
     } catch (e: any) {
-      if (e?.code === "ENOENT") return normalizePath(resolved)
+      if (e?.code === "ENOENT" || e?.code === "ENOTDIR") return normalizePath(resolved)
       throw e
     }
   }


### PR DESCRIPTION
### Issue for this PR

Found while auditing patch failures; no existing issue.

### Type of change

- [x] Bug fix

### What does this PR do?

`Delete parent; Add parent/child.txt` currently fails while resolving transaction lock paths: parent is still a file, so realpath throws ENOTDIR before deletion runs. Treat ENOTDIR like ENOENT and retain the normalized prospective path. Existing paths still resolve normally, and other errors still propagate.

The production change is one line, with a tool-level regression test.

### How did you verify your code works?

- The new regression failed with ENOTDIR before the fix.
- From packages/core: `bun test test/tool-patch.test.ts test/file-mutation.test.ts test/tool-edit.test.ts test/tool-write.test.ts` (73 passed).
- `bun typecheck` from packages/core and packages/util.
- Prettier check and `git diff --check` passed.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR