### PR TITLE
fix(tui): rendering of colors in Markdown diff blocks

### DIFF
--- a/packages/tui/src/parsers-config.ts
+++ b/packages/tui/src/parsers-config.ts
@@ -302,7 +302,7 @@ export default {
       wasm: "https://github.com/tree-sitter-grammars/tree-sitter-diff/releases/download/v0.1.0/tree-sitter-diff.wasm",
       queries: {
         highlights: [
-          "https://raw.githubusercontent.com/tree-sitter-grammars/tree-sitter-diff/master/queries/highlights.scm",
+          "https://raw.githubusercontent.com/tree-sitter-grammars/tree-sitter-diff/v0.1.0/queries/highlights.scm",
         ],
       },
     },


### PR DESCRIPTION
### Issue for this PR



### Type of change

- [x] Bug fix

### What does this PR do?

Fixes missing colors in Markdown diff blocks.

Diff blocks appear without colors because OpenCode downloads highlighting rules that are too new for its diff parser. This change uses the rules from the same v0.1.0 release as the parser, which then fixes colors for added and removed lines as seen below.

This fix downloads the highlighting rules from the same v0.1.0 release as the parser.

### How did you verify your code works?

I reproduced the failure with the existing parser and query, then tested the v0.1.0 query with OpenTUI's Markdown renderer.

### Screenshots

| Before | After |
| --- | --- |
| <img width="400" alt="Diff blocks without colors" src="https://github.com/user-attachments/assets/abbc5828-35c5-41bb-94d9-260139d710e4" /> | <img width="400" alt="Diff blocks with colors" src="https://github.com/user-attachments/assets/f982ab2d-8012-418d-aba9-45e6df964ff1" /> |


### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
