### PR TITLE
fix(provider): support Cloudflare Workers AI sessions

### DIFF
--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -98,18 +98,16 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
   }
   if (isOpenaiOauth) options.instructions = system.join("\n")
 
-  const messages =
-    isOpenaiOauth || input.isWorkflow
-      ? input.messages
-      : [
-          ...system.map(
-            (x): ModelMessage => ({
-              role: "system",
-              content: x,
-            }),
-          ),
-          ...input.messages,
-        ]
+  const isWorkersAi =
+    input.model.providerID === "cloudflare-workers-ai" ||
+    (input.model.providerID === "cloudflare-ai-gateway" &&
+      (input.model.api.id.startsWith("workers-ai/") || input.model.api.id.startsWith("@cf/")))
+
+  const systemMessages: ModelMessage[] =
+    isWorkersAi && system.length
+      ? [{ role: "system", content: system.join("\n\n") }]
+      : system.map((x): ModelMessage => ({ role: "system", content: x }))
+  const messages = isOpenaiOauth || input.isWorkflow ? input.messages : [...systemMessages, ...input.messages]
 
   const params = yield* input.plugin.trigger(
     "chat.params",

--- a/packages/opencode/src/session/overflow.ts
+++ b/packages/opencode/src/session/overflow.ts
@@ -16,7 +16,11 @@ export function usable(input: { cfg: ConfigV1.Info; model: Provider.Model; outpu
     Math.min(COMPACTION_BUFFER, ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
   return input.model.limit.input
     ? Math.max(0, input.model.limit.input - reserved)
-    : Math.max(0, context - ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax))
+    : Math.max(
+        0,
+        context -
+          Math.min(ProviderTransform.maxOutputTokens(input.model, input.outputTokenMax), Math.floor(context / 2)),
+      )
 }
 
 export function isOverflow(input: {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -5809,3 +5809,103 @@ describe("ProviderTransform.options - kimi family adaptive thinking", () => {
     expect(result.thinking).toBeUndefined()
   })
 })
+
+describe("LLMRequestPrep.prepare - system messages", () => {
+  const sessionID = "test-session-123"
+
+  function prepareWith(providerID: string, modelID: string) {
+    return Effect.runPromise(
+      LLMRequestPrep.prepare({
+        user: {
+          id: "msg_user-test",
+          sessionID,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "test",
+          model: { providerID, modelID },
+        } as any,
+        sessionID,
+        model: {
+          id: `${providerID}/${modelID}`,
+          providerID,
+          api: { id: modelID, url: "https://example.com", npm: "@ai-sdk/openai-compatible" },
+          name: modelID,
+          capabilities: {
+            temperature: true,
+            reasoning: false,
+            attachment: false,
+            toolcall: true,
+            input: { text: true, audio: false, image: false, video: false, pdf: false },
+            output: { text: true, audio: false, image: false, video: false, pdf: false },
+            interleaved: false,
+          },
+          cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+          limit: { context: 262_144, output: 262_144 },
+          status: "active",
+          options: {},
+          headers: {},
+        } as any,
+        agent: {
+          name: "test",
+          mode: "primary",
+          prompt: "base prompt",
+          options: {},
+          permission: [],
+        } as any,
+        system: [],
+        messages: [{ role: "user", content: "Hello" }],
+        tools: {},
+        provider: { id: providerID, options: {} } as any,
+        auth: undefined,
+        plugin: {
+          trigger: (name: string, _input: unknown, output: unknown) => {
+            if (name !== "experimental.chat.system.transform") return Effect.succeed(output)
+            return Effect.sync(() => {
+              ;(output as { system: string[] }).system.push("dynamic suffix")
+              return output
+            })
+          },
+          list: () => Effect.succeed([]),
+          init: () => Effect.void,
+        } as any,
+        flags: { outputTokenMax: 32_000, client: "test" } as any,
+        isWorkflow: false,
+      }),
+    )
+  }
+
+  test("Workers AI merges system prompts into a single leading message", async () => {
+    const result = await prepareWith("cloudflare-workers-ai", "@cf/qwen/qwen3.8-27b")
+    const systemMessages = result.messages.filter((m) => m.role === "system")
+    expect(systemMessages).toHaveLength(1)
+    expect(result.messages[0]).toEqual({ role: "system", content: "base prompt\n\ndynamic suffix" })
+    expect(result.messages.at(-1)).toEqual({ role: "user", content: "Hello" })
+  })
+
+  test("Workers AI through the Cloudflare gateway merges system prompts", async () => {
+    const result = await prepareWith("cloudflare-ai-gateway", "workers-ai/@cf/qwen/qwen3.8-27b")
+    expect(result.messages.filter((m) => m.role === "system")).toEqual([
+      { role: "system", content: "base prompt\n\ndynamic suffix" },
+    ])
+  })
+
+  test("bare Workers AI IDs through the Cloudflare gateway merge system prompts", async () => {
+    const result = await prepareWith("cloudflare-ai-gateway", "@cf/qwen/qwen3.8-27b")
+    expect(result.messages.filter((m) => m.role === "system")).toEqual([
+      { role: "system", content: "base prompt\n\ndynamic suffix" },
+    ])
+  })
+
+  test("other Cloudflare gateway models keep one system message per entry", async () => {
+    const result = await prepareWith("cloudflare-ai-gateway", "anthropic/claude-sonnet-4-5")
+    const systemMessages = result.messages.filter((m) => m.role === "system")
+    expect(systemMessages.map((m) => m.content)).toEqual(["base prompt", "dynamic suffix"])
+  })
+
+  test("other providers keep one system message per entry", async () => {
+    const result = await prepareWith("anthropic", "claude-sonnet-4-5")
+    const systemMessages = result.messages.filter((m) => m.role === "system")
+    expect(systemMessages).toHaveLength(2)
+    expect(systemMessages.map((m) => m.content)).toEqual(["base prompt", "dynamic suffix"])
+  })
+})

--- a/packages/opencode/test/session/compaction.test.ts
+++ b/packages/opencode/test/session/compaction.test.ts
@@ -405,6 +405,34 @@ describe("session.compaction.isOverflow", () => {
   )
 
   it.live(
+    "returns false for small sessions on output==context models without input limit",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const compact = yield* SessionCompaction.Service
+        const tokens = { input: 5_000, output: 500, reasoning: 0, cache: { read: 0, write: 0 } }
+        for (const model of [
+          createModel({ context: 32_768, output: 32_768 }),
+          createModel({ context: 24_000, output: 24_000 }),
+        ]) {
+          expect(yield* compact.isOverflow({ tokens, model })).toBe(false)
+        }
+      }),
+    ),
+  )
+
+  it.live(
+    "preserves the output reserve for ordinary models without an input limit",
+    provideTmpdirInstance(() =>
+      Effect.gen(function* () {
+        const compact = yield* SessionCompaction.Service
+        const model = createModel({ context: 200_000, output: 32_000 })
+        const tokens = { input: 169_000, output: 1_000, reasoning: 0, cache: { read: 0, write: 0 } }
+        expect(yield* compact.isOverflow({ tokens, model })).toBe(true)
+      }),
+    ),
+  )
+
+  it.live(
     "includes cache.read in token count",
     provideTmpdirInstance(() =>
       Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Closes #46481

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes two issues preventing Cloudflare Workers AI models from working:

- Caps the output reserve for models that report `output == context`, preventing immediate context overflow.
- Merges system prompts into one leading message for Workers AI, including Workers AI models routed through Cloudflare AI Gateway.

Other gateway providers keep their existing system-message behavior.

### How did you verify your code works?

- `bun test test/session/compaction.test.ts -t "output==context|output reserve"` (2 passed)
- `bun test test/provider/transform.test.ts` (430 passed)
- Pre-push `bun turbo typecheck` (30 tasks passed)

### Screenshots / recordings

_N/A, no UI changes._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR