### PR TITLE
feat(sdk): configure session-selected instances

### DIFF
--- a/packages/core/src/location-service-map.ts
+++ b/packages/core/src/location-service-map.ts
@@ -1,6 +1,8 @@
 import { Context, Effect, Layer, LayerMap } from "effect"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Node } from "@opencode-ai/util/effect/app-node"
+import { AbsolutePath } from "@opencode-ai/schema/schema"
+import path from "path"
 import { Location } from "./location.js"
 import type { Instance } from "./instance.js"
 
@@ -14,5 +16,13 @@ export class Service extends Context.Service<
 }
 
 export const node = LayerNode.unbound(Service, Node.tags.values.global)
+
+/** Normalize equivalent placements before they become resource-cache keys. */
+export function canonical(ref: Location.Ref) {
+  return Location.Ref.make({
+    directory: AbsolutePath.make(process.platform === "win32" ? path.normalize(ref.directory) : ref.directory),
+    workspaceID: ref.workspaceID,
+  })
+}
 
 export * as LocationServiceMap from "./location-service-map.js"

--- a/packages/core/src/location-services.ts
+++ b/packages/core/src/location-services.ts
@@ -1,11 +1,9 @@
 import { Duration, Effect, Layer, LayerMap } from "effect"
 import { existsSync } from "fs"
-import path from "path"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Instance } from "./instance.js"
 import { Location } from "./location.js"
 import { LocationServiceMap } from "./location-service-map.js"
-import { AbsolutePath } from "./schema.js"
 
 export { LocationServiceMap } from "./location-service-map.js"
 
@@ -15,13 +13,6 @@ export type LocationError = Instance.Error
 export function buildLocationServiceMap(
   replacements: LayerNode.Replacements = [],
 ): Layer.Layer<LocationServiceMap.Service> {
-  // Structural Equal distinguishes optional-key shape and Windows separator style.
-  // The RcMap caches the raw key before the build callback, so normalize both here.
-  const canonical = (ref: Location.Ref) =>
-    Location.Ref.make({
-      directory: AbsolutePath.make(process.platform === "win32" ? path.normalize(ref.directory) : ref.directory),
-      workspaceID: ref.workspaceID,
-    })
   return Layer.effect(
     LocationServiceMap.Service,
     Effect.gen(function* () {
@@ -35,10 +26,10 @@ export function buildLocationServiceMap(
       })
       const map = {
         ...inner,
-        get: (ref: Location.Ref) => inner.get(canonical(ref)),
-        contextEffect: (ref: Location.Ref) => inner.contextEffect(canonical(ref)),
-        contextEffectOption: (ref: Location.Ref) => inner.contextEffectOption(canonical(ref)),
-        invalidate: (ref: Location.Ref) => inner.invalidate(canonical(ref)),
+        get: (ref: Location.Ref) => inner.get(LocationServiceMap.canonical(ref)),
+        contextEffect: (ref: Location.Ref) => inner.contextEffect(LocationServiceMap.canonical(ref)),
+        contextEffectOption: (ref: Location.Ref) => inner.contextEffectOption(LocationServiceMap.canonical(ref)),
+        invalidate: (ref: Location.Ref) => inner.invalidate(LocationServiceMap.canonical(ref)),
       }
       // Cached instances borrow their owner instead of retaining its Layer scope.
       const bindings: LayerNode.Replacements = [

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -28,6 +28,53 @@ await using opencode = await OpenCode.create({
 
 `close()` and `Symbol.asyncDispose` release router resources, Location services, fibers, and scoped plugin registrations.
 
+## Session-Selected Plugins
+
+Use `instances` when Sessions in the same directory need different application plugins. The application selects a stable key from Session metadata; the SDK constructs and caches an instance for that key and the Session's current Location.
+
+```ts
+import { OpenCode } from "@opencode-ai/sdk"
+import { threads } from "./threads"
+import { slackPlugin } from "./slack-plugin"
+
+await using opencode = await OpenCode.create({
+  database: { path: "./sessions.db" },
+  instances: {
+    key(session) {
+      const threadID = session.metadata?.threadID
+      if (typeof threadID !== "string") throw new Error("Session has no thread ID")
+      return threadID
+    },
+    configure: async (threadID) => ({
+      plugins: [slackPlugin(await threads.get(threadID))],
+    }),
+  },
+})
+
+const session = await opencode.sessions.create({
+  location: { directory: "/workspace" },
+  metadata: { threadID: "thread-42" },
+})
+await opencode.sessions.prompt({ sessionID: session.id, text: "Review the changes" })
+```
+
+`threads` and `slackPlugin` are application-owned modules. `key` is synchronous and should only select identity, not initialize plugins. `configure` returns plugin definitions; their setup receives the selected instance's `ctx.location`.
+
+- The same key and Location share one live instance. Different directories or workspace IDs always select separate instances, even with the same application key.
+- `configure` runs on a cache miss, not on each prompt. Loaded instances live until the host closes; change the application key or restart the host to reconstruct their birth configuration. Plugin transforms and reloads remain available within that lifetime.
+- Session metadata, message, inbox, and context reads do not initialize plugins; permission and form lists read instance services and therefore acquire the Session's instance. Configuration failure, an instance plugin ID that collides with a host `plugins` entry, or initial setup failure of a supplied plugin prevents capability acquisition, without falling back to another instance. A subsequent request can retry a failed construction.
+- Existing HTTP prompt middleware also acquires capabilities for an idempotent retry. After restart, that retry can reconstruct plugins before returning the original admission; prompt preparation and hooks do not rerun. Configuration failure can therefore block the retry even when its input was already saved.
+- Instance selection is not an authorization or storage-isolation boundary. Plugin Session APIs and the existing plugin-ID-based durable storage retain their normal scope.
+- Omitting `instances` preserves default Location sharing. Host-wide plugins remain separate from Session-selected configuration; retain host-wide catalog policy when locationless generation needs it.
+
+### Restart and Lifetime
+
+The selector is installed before automatic recovery starts. Its callbacks must be able to load application data without depending on the returned `opencode` handle or a later registration call. Functions are reconstructed, not serialized.
+
+Use a persistent `database.path` to recover Sessions after restart; the default database is in memory. Workerd uses its injected Durable Object storage. After restart, the next capability-dependent operation or recovery drain rebuilds the selected instance from saved Session metadata and application data.
+
+Promise plugin resources should be acquired in `setup` and released by its cleanup function. Effect configuration can acquire resources in its supplied instance Scope; capture application services before creating the SDK host.
+
 ## Workerd
 
 Use the Workerd entrypoint inside a Cloudflare Durable Object. Hold one host for the lifetime of the object instance rather than creating one per request.
@@ -70,3 +117,25 @@ const session = yield * opencode.sessions.get({ sessionID })
 ```
 
 The Effect Workerd entrypoint is `@opencode-ai/sdk/workerd/effect`.
+
+Effect configuration uses the same keys and lifetime rules, with canonical `Session.Info` values and an Effect-returning factory:
+
+```ts
+import { OpenCode } from "@opencode-ai/sdk/effect"
+import { Effect, Schema } from "effect"
+import { threads } from "./threads-effect"
+import { slackPlugin } from "./slack-plugin-effect"
+
+const threadMetadata = Schema.decodeUnknownSync(Schema.Struct({ threadID: Schema.String }))
+const opencode =
+  yield *
+  OpenCode.create({
+    database: { path: "./sessions.db" },
+    instances: {
+      key: (session) => threadMetadata(session.metadata).threadID,
+      configure: (threadID) => threads.get(threadID).pipe(Effect.map((thread) => ({ plugins: [slackPlugin(thread)] }))),
+    },
+  })
+```
+
+Both Workerd entrypoints also accept `instances`. The public `OpenCode.InstanceOptions` and `OpenCode.InstanceConfiguration` types describe the corresponding Promise or Effect callbacks.

--- a/packages/sdk/script/verify-package.ts
+++ b/packages/sdk/script/verify-package.ts
@@ -105,9 +105,30 @@ import { OpenCodeWorkerd } from "@opencode-ai/sdk/workerd"
 
 export class OpenCodeDO {
   constructor(state) {
+    this.configurations = 0
     this.opencode = state.blockConcurrencyWhile(() => OpenCodeWorkerd.create({
       storage: state.storage,
       app: { version: "packed-workerd" },
+      models: { fetch: false },
+      instances: {
+        key: session => String(session.metadata.thread),
+        configure: key => {
+          this.configurations++
+          return {
+            plugins: [{
+              id: "packed-instance",
+              async setup(ctx) {
+                if (ctx.app.version !== "packed-workerd" || ctx.location.directory !== "/workspace") {
+                  throw new Error("Selected instance did not inherit the host configuration")
+                }
+                await ctx.session.hook("prompt", event => {
+                  event.prompt.text += ":" + key
+                })
+              },
+            }],
+          }
+        },
+      },
     }))
   }
 
@@ -116,6 +137,18 @@ export class OpenCodeDO {
       throw new Error("Packed workerd SHA-256 mismatch")
     }
     const opencode = await this.opencode
+    const sessions = await Promise.all([1, 2].map(() => opencode.sessions.create({
+      location: { directory: "/workspace" },
+      metadata: { thread: "packed-thread" },
+    })))
+    const admitted = await Promise.all(sessions.map(session => opencode.sessions.prompt({
+      sessionID: session.id,
+      text: "Packed prompt",
+      resume: false,
+    })))
+    if (this.configurations !== 1 || admitted.some(item => item.payload.text !== "Packed prompt:packed-thread")) {
+      throw new Error("Packed instance configuration did not share or prepare prompts correctly")
+    }
     return Response.json(await opencode.health.get())
   }
 }

--- a/packages/sdk/src/effect/opencode.ts
+++ b/packages/sdk/src/effect/opencode.ts
@@ -6,11 +6,14 @@ import { Context, Effect, Layer } from "effect"
 import type { Config, Scope } from "effect"
 import { FetchHttpClient } from "effect/unstable/http"
 import { EmbeddedHost } from "../internal/host"
+import type { SdkInstances } from "../internal/instances"
 
 export type { LogEntry, LogLevel, LogOptions, LogWriter } from "../logging"
 
 export type CreateOptions = EmbeddedHost.CreateOptions
 export type EmbedOptions = EmbeddedHost.EmbedOptions
+export type InstanceOptions = SdkInstances.Options
+export type InstanceConfiguration = SdkInstances.Configuration
 
 export type Interface = Omit<OpenCodeClient, "plugin" | "workspace"> & {
   readonly sessions: OpenCodeClient["session"]

--- a/packages/sdk/src/effect/workerd.ts
+++ b/packages/sdk/src/effect/workerd.ts
@@ -10,11 +10,15 @@ export type Configuration = WorkerdProfile.Configuration
 export interface CreateOptions extends WorkerdProfile.Options {
   readonly log?: OpenCode.CreateOptions["log"]
   readonly workspaceProviders?: OpenCode.CreateOptions["workspaceProviders"]
+  readonly instances?: OpenCode.CreateOptions["instances"]
 }
 
-export const create = ({ log, workspaceProviders, ...options }: CreateOptions) => {
+export const create = ({ log, workspaceProviders, instances, ...options }: CreateOptions) => {
   const profile = WorkerdProfile.make(options)
-  return OpenCode.create({ ...profile.options, log, workspaceProviders }, { overrides: profile.replacements })
+  return OpenCode.create(
+    { ...profile.options, log, workspaceProviders, instances },
+    { overrides: profile.replacements },
+  )
 }
 
 export const layer = (options: CreateOptions): Layer.Layer<OpenCode.Service, Config.ConfigError | Error> =>

--- a/packages/sdk/src/internal/host.ts
+++ b/packages/sdk/src/internal/host.ts
@@ -11,10 +11,12 @@ import { Context, Effect, Layer, ManagedRuntime, Scope } from "effect"
 import { HttpEffect, HttpRouter, HttpServer, HttpServerRequest } from "effect/unstable/http"
 import { context, layer, type LogOptions } from "../logging"
 import { OwnedFetch } from "./fetch"
+import { SdkInstances } from "./instances"
 
 export interface CreateOptions extends Omit<ServerOptions, "hostname" | "port" | "password"> {
   readonly log?: LogOptions
   readonly workspaceProviders?: Readonly<Record<string, WorkspaceDriver.Interface>>
+  readonly instances?: SdkInstances.Options
 }
 
 /** Host hooks for embedding opencode on a non-default runtime profile. */
@@ -26,7 +28,7 @@ export const create = Effect.fn("EmbeddedHost.create")(function* (
   options: CreateOptions = {},
   embed: EmbedOptions = {},
 ) {
-  const { log, workspaceProviders, ...server } = options
+  const { log, workspaceProviders, instances, ...server } = options
   const runtime = ManagedRuntime.make(
     createEmbeddedRoutes(
       {
@@ -37,6 +39,7 @@ export const create = Effect.fn("EmbeddedHost.create")(function* (
       workspaceProviders
         ? [...(embed.overrides ?? []), WorkspaceDriver.node.replace(WorkspaceDriver.registryNode(workspaceProviders))]
         : embed.overrides,
+      instances ? (replacements) => SdkInstances.node(instances, replacements) : undefined,
     ).pipe(Layer.provide(HttpServer.layerServices), Layer.provideMerge(layer(log))),
   )
 

--- a/packages/sdk/src/internal/instances.ts
+++ b/packages/sdk/src/internal/instances.ts
@@ -1,0 +1,100 @@
+export * as SdkInstances from "./instances"
+
+import { Instance } from "@opencode-ai/core/instance"
+import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
+import { Plugin } from "@opencode-ai/core/plugin"
+import type { InstancePlugins } from "@opencode-ai/core/plugin/instance"
+import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
+import { Location } from "@opencode-ai/schema/location"
+import type { Session } from "@opencode-ai/schema/session"
+import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
+import type { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Duration, Effect, Layer, LayerMap, Scope } from "effect"
+
+export interface Configuration {
+  readonly plugins: InstancePlugins.List
+}
+
+export interface Options {
+  /** Select a sharing key within the Session's current Location. Must not initialize plugins. */
+  readonly key: (session: Session.Info) => string
+  /** Reconstruct configuration on a cache miss. Resources belong to the instance Scope. */
+  readonly configure: (key: string) => Effect.Effect<Configuration, unknown, Scope.Scope>
+}
+
+/** Replaces the host's `Instance.node`; `replacements` resolves lazily so instances inherit the final host graph. */
+export function node(options: Options, replacements: () => LayerNode.Replacements) {
+  return makeGlobalNode({
+    service: Instance.Service,
+    layer: layer(options, replacements),
+    deps: [LocationServiceMap.node, SdkPlugins.node],
+  })
+}
+
+export function layer(options: Options, replacements: () => LayerNode.Replacements) {
+  return Layer.effect(
+    Instance.Service,
+    Effect.gen(function* () {
+      const scope = yield* Effect.scope
+      const locations = yield* LocationServiceMap.Service
+      const sdk = yield* SdkPlugins.Service
+      const key = (session: Session.Info) => ({
+        key: options.key(session),
+        ...LocationServiceMap.canonical(session.location),
+      })
+      const provide = (session: Session.Info) => Effect.provide(instances.get(key(session)))
+      const instances: LayerMap.LayerMap<ReturnType<typeof key>, Instance.Services> = yield* LayerMap.make(
+        (input: ReturnType<typeof key>) =>
+          Layer.unwrap(
+            Effect.gen(function* () {
+              const configuration = yield* options.configure(input.key).pipe(Effect.orDie)
+              // A host/instance ID collision fails the whole plugin generation, which leaves no inventory
+              // trace to check after activation. Reject it before constructing anything.
+              const collisions = configuration.plugins.filter((plugin) =>
+                sdk.all().some((host) => host.id === plugin.id),
+              )
+              if (collisions.length > 0)
+                yield* Effect.die(
+                  new Error(
+                    `Instance plugin IDs collide with host plugins: ${collisions.map((plugin) => plugin.id).join(", ")}`,
+                  ),
+                )
+              return Instance.layer(Location.Ref.make({ directory: input.directory, workspaceID: input.workspaceID }), {
+                plugins: configuration.plugins,
+                replacements: [
+                  ...replacements(),
+                  // Instances borrow this selector and the host's Location map instead of retaining
+                  // their Layer scopes; retaining the selector would block its shutdown on its own entries.
+                  Instance.node.replace(Layer.succeed(Instance.Service, { provide })),
+                  LocationServiceMap.node.replace(Layer.succeed(LocationServiceMap.Service, locations)),
+                ],
+              }).pipe(
+                Layer.tap((context) =>
+                  Effect.gen(function* () {
+                    const plugins = yield* Plugin.Service
+                    yield* plugins.awaitActivation
+                    const failed = (yield* plugins.list()).filter(
+                      (plugin) =>
+                        plugin.state.status === "failed" &&
+                        configuration.plugins.some((configured) => configured.id === plugin.id),
+                    )
+                    if (failed.length > 0)
+                      yield* Effect.die(
+                        new Error(`Instance plugin setup failed: ${failed.map((plugin) => plugin.id).join(", ")}`),
+                      )
+                  }).pipe(Effect.provide(context)),
+                ),
+              )
+            }),
+          ).pipe(
+            // Eviction can close the lookup's scope; do not make that fiber wait on itself.
+            Layer.tapCause(() =>
+              instances.invalidate(input).pipe(Effect.forkIn(scope, { startImmediately: true }), Effect.asVoid),
+            ),
+          ),
+        { idleTimeToLive: Duration.infinity },
+      )
+      return Instance.Service.of({ provide })
+    }),
+  )
+}

--- a/packages/sdk/src/opencode.ts
+++ b/packages/sdk/src/opencode.ts
@@ -3,6 +3,8 @@ import { PromiseSdk } from "./promise"
 export type { LogEntry, LogLevel, LogOptions, LogWriter } from "./logging"
 
 export type CreateOptions = PromiseSdk.CreateOptions
+export type InstanceOptions = PromiseSdk.InstanceOptions
+export type InstanceConfiguration = PromiseSdk.InstanceConfiguration
 export type Interface = PromiseSdk.Interface
 
 export const create = (options: CreateOptions = {}) => PromiseSdk.create(options)

--- a/packages/sdk/src/promise.ts
+++ b/packages/sdk/src/promise.ts
@@ -2,11 +2,24 @@ export * as PromiseSdk from "./promise"
 
 import { OpenCode, type OpenCodeClient } from "@opencode-ai/client"
 import type { Plugin } from "@opencode-ai/plugin"
-import { Effect } from "effect"
+import { Session } from "@opencode-ai/schema/session"
+import { Effect, Schema } from "effect"
 import { EmbeddedHost } from "./internal/host"
 
-export interface CreateOptions extends Omit<EmbeddedHost.CreateOptions, "workspaceProviders"> {
+export interface InstanceConfiguration {
+  readonly plugins: ReadonlyArray<Plugin.Plugin>
+}
+
+export interface InstanceOptions {
+  /** Select a sharing key within the Session's current Location. Must not initialize plugins. */
+  readonly key: (session: typeof Session.Info.Encoded) => string
+  /** Reconstruct configuration on a cache miss, including after a host restart. */
+  readonly configure: (key: string) => InstanceConfiguration | Promise<InstanceConfiguration>
+}
+
+export interface CreateOptions extends Omit<EmbeddedHost.CreateOptions, "workspaceProviders" | "instances"> {
   readonly plugins?: ReadonlyArray<Plugin.Plugin>
+  readonly instances?: InstanceOptions
 }
 
 export type Interface = Omit<OpenCodeClient, "plugin"> & {
@@ -18,8 +31,26 @@ export type Interface = Omit<OpenCodeClient, "plugin"> & {
 }
 
 export async function create(options: CreateOptions = {}, embed: EmbeddedHost.EmbedOptions = {}): Promise<Interface> {
-  const { plugins, ...hostOptions } = options
-  const host = await Effect.runPromise(EmbeddedHost.create(hostOptions, embed))
+  const { plugins, instances, ...hostOptions } = options
+  const host = await Effect.runPromise(
+    EmbeddedHost.create(
+      {
+        ...hostOptions,
+        instances: instances
+          ? {
+              key: (session) => instances.key(Schema.encodeSync(Session.Info)(session)),
+              configure: (key) =>
+                Effect.gen(function* () {
+                  const { PluginPromise } = yield* Effect.promise(() => import("@opencode-ai/core/plugin/promise"))
+                  const configuration = yield* Effect.tryPromise(async () => instances.configure(key))
+                  return { plugins: configuration.plugins.map(PluginPromise.fromPromise) }
+                }),
+            }
+          : undefined,
+      },
+      embed,
+    ),
+  )
   const client = OpenCode.make({ baseUrl: "http://opencode.local", fetch: host.fetch })
   const register = async (plugin: Plugin.Plugin) => {
     const { PluginPromise } = await import("@opencode-ai/core/plugin/promise")

--- a/packages/sdk/src/workerd.ts
+++ b/packages/sdk/src/workerd.ts
@@ -9,6 +9,7 @@ export type Configuration = WorkerdProfile.Configuration
 export interface CreateOptions extends WorkerdProfile.Options {
   readonly log?: LogOptions
   readonly plugins?: PromiseSdk.CreateOptions["plugins"]
+  readonly instances?: PromiseSdk.CreateOptions["instances"]
 }
 
 /**
@@ -25,9 +26,9 @@ export interface CreateOptions extends WorkerdProfile.Options {
  * session operations plus the live `events.subscribe()` stream — served over
  * an in-process fetch transport, so no request leaves the isolate.
  */
-export const create = ({ log, plugins, ...options }: CreateOptions) => {
+export const create = ({ log, plugins, instances, ...options }: CreateOptions) => {
   const profile = WorkerdProfile.make(options)
-  return PromiseSdk.create({ ...profile.options, log, plugins }, { overrides: profile.replacements })
+  return PromiseSdk.create({ ...profile.options, log, plugins, instances }, { overrides: profile.replacements })
 }
 
 export type Interface = PromiseSdk.Interface

--- a/packages/sdk/test/instances-effect.test.ts
+++ b/packages/sdk/test/instances-effect.test.ts
@@ -1,0 +1,236 @@
+import { expect } from "bun:test"
+import path from "path"
+import { LanguageModel, LLMClient } from "@opencode-ai/ai"
+import { OpenAIChat } from "@opencode-ai/ai/protocols"
+import { TestLLM } from "@opencode-ai/ai/testing"
+import { llmClient } from "@opencode-ai/core/effect/app-node-platform"
+import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
+import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
+import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
+import { Plugin } from "@opencode-ai/plugin/effect"
+import { Deferred, Effect, Exit, Layer, Schema, Scope } from "effect"
+import { tmpdirScoped } from "../../core/test/fixture/tmpdir"
+import { testEffect } from "../../core/test/lib/effect"
+import { AbsolutePath, Agent, Location, OpenCode } from "../src/effect"
+
+const it = testEffect(Layer.empty)
+const metadata = Schema.decodeUnknownSync(Schema.Struct({ threadID: Schema.String }))
+const model = SessionRunnerModel.resolved(
+  LanguageModel.make({ id: "instance-model", provider: "test", route: OpenAIChat.route }),
+  {
+    capabilities: { tools: true, input: ["text"], output: ["text"] },
+    cost: [],
+    limit: { context: 200_000, output: 8_192 },
+  },
+)
+
+it.live(
+  "reconstructs configured instances before automatic recovery executes tools",
+  () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const scope = yield* Effect.scope
+      const firstScope = yield* Scope.fork(scope)
+      const secondScope = yield* Scope.fork(scope)
+      const started = yield* Deferred.make<void>()
+      const release = yield* Deferred.make<void>()
+      const llm = yield* TestLLM.Test.pipe(Effect.provide(TestLLM.testLayer()))
+      const configured: string[] = []
+      const closed: number[] = []
+      const executed: number[] = []
+      const options: OpenCode.CreateOptions = {
+        database: { path: path.join(directory.path, "sessions.db") },
+        app: { name: "instance-test", version: "1.2.3" },
+        events: { persist: true },
+        config: { directory: directory.path, project: false, content: "{}" },
+        models: { fetch: false },
+        fs: { filewatcher: false },
+        instances: {
+          key: (session) => metadata(session.metadata).threadID,
+          configure: (key) =>
+            Effect.gen(function* () {
+              const generation = configured.push(key)
+              yield* Effect.addFinalizer(() => Effect.sync(() => closed.push(generation)))
+              if (generation === 2) {
+                yield* Deferred.succeed(started, undefined)
+                yield* Deferred.await(release)
+              }
+              return {
+                plugins: [
+                  Plugin.define({
+                    id: "thread-tools",
+                    effect: (ctx) =>
+                      Effect.gen(function* () {
+                        expect(ctx.app).toMatchObject({ name: "instance-test", version: "1.2.3" })
+                        yield* ctx.agent.transform((draft) =>
+                          draft.update(Agent.ID.make("build"), (agent) => {
+                            agent.permissions = [{ action: "*", resource: "*", effect: "allow" }]
+                          }),
+                        )
+                        yield* ctx.session.hook("context", (event) =>
+                          Effect.sync(() => {
+                            event.generation.temperature = 0.25
+                          }),
+                        )
+                        yield* ctx.tool.transform((draft) =>
+                          draft.add({
+                            name: "thread_echo",
+                            description: "Report the configured thread",
+                            input: Schema.Struct({}),
+                            output: Schema.String,
+                            options: { codemode: false },
+                            execute: (_, tool) =>
+                              Effect.gen(function* () {
+                                executed.push(generation)
+                                yield* ctx.session
+                                  .rename({ sessionID: tool.sessionID, title: `${key}:${generation}` })
+                                  .pipe(Effect.orDie)
+                                return { output: key, content: key }
+                              }),
+                          }),
+                        )
+                      }),
+                  }),
+                ],
+              }
+            }),
+        },
+      }
+      const embed = {
+        overrides: [
+          llmClient.replace(Layer.succeed(LLMClient.Service, llm)),
+          SessionRunnerModel.node.replace(
+            Layer.succeed(SessionRunnerModel.Service, { resolve: () => Effect.succeed(model) }),
+          ),
+        ],
+      }
+      yield* llm.push(TestLLM.hangAfter())
+      const first = yield* OpenCode.create(options, embed).pipe(Scope.provide(firstScope))
+      const session = yield* first.sessions.create({
+        title: "Recovery fixture",
+        location: Location.Ref.make({ directory: AbsolutePath.make(directory.path) }),
+        model: model.ref,
+        metadata: { threadID: "thread-recovery" },
+      })
+      expect(configured).toEqual([])
+      yield* first.sessions.prompt({ sessionID: session.id, text: "Use the thread tool" })
+      yield* llm.wait(1).pipe(Effect.timeout("5 seconds"))
+      expect(configured).toEqual(["thread-recovery"])
+
+      // Closing the host interrupts active execution while preserving its durable recovery claim.
+      yield* Scope.close(firstScope, Exit.void)
+      expect(closed).toEqual([1])
+      yield* llm.push(TestLLM.tool("recovered-tool", "thread_echo", {}), TestLLM.text("Recovered", "answer"))
+      const second = yield* OpenCode.create(options, embed).pipe(Scope.provide(secondScope))
+      yield* Deferred.await(started).pipe(Effect.timeout("5 seconds"))
+      expect((yield* llm.requests()).length).toBe(1)
+      yield* Deferred.succeed(release, undefined)
+      yield* llm.wait(3).pipe(Effect.timeout("5 seconds"))
+      yield* second.sessions.wait({ sessionID: session.id })
+
+      expect(configured).toEqual(["thread-recovery", "thread-recovery"])
+      expect(executed).toEqual([2])
+      expect((yield* second.sessions.get({ sessionID: session.id })).title).toBe("thread-recovery:2")
+      expect(
+        (yield* llm.requests()).map((request) => ({
+          temperature: request.generation?.temperature,
+          tools: request.tools?.filter((tool) => tool.name.startsWith("thread_")).map((tool) => tool.name),
+        })),
+      ).toEqual(Array.from({ length: 3 }, () => ({ temperature: 0.25, tools: ["thread_echo"] })))
+      yield* Scope.close(secondScope, Exit.void)
+      expect(closed).toEqual([1, 2])
+    }),
+  15_000,
+)
+
+it.live(
+  "qualifies application keys by workspace and reselects a moved Session",
+  () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const llm = yield* TestLLM.Test.pipe(
+        Effect.provide(TestLLM.testLayer({ fallback: TestLLM.text("Ready", "answer") })),
+      )
+      const configured: string[] = []
+      const placements: Location.Ref[] = []
+      const driver = WorkspaceDriver.make({
+        create: ({ workspaceID }) => Effect.succeed({ binding: { workspaceID } }),
+        connect: () => Effect.succeed(makeMemoryDriver()),
+        suspendForIdle: () => Effect.void,
+        destroy: () => Effect.void,
+      })
+      const opencode = yield* OpenCode.create(
+        {
+          config: { directory: directory.path, project: false, content: "{}" },
+          models: { fetch: false },
+          fs: { filewatcher: false },
+          workspaceProviders: { memory: driver },
+          instances: {
+            key: (session) => metadata(session.metadata).threadID,
+            configure: (key) =>
+              Effect.sync(() => {
+                configured.push(key)
+                return {
+                  plugins: [
+                    Plugin.define({
+                      id: "placement-hook",
+                      effect: (ctx) =>
+                        Effect.gen(function* () {
+                          placements.push(Location.Ref.make(ctx.location))
+                          yield* ctx.session.hook("prompt", (event) =>
+                            Effect.sync(() => {
+                              event.prompt.text += `:${ctx.location.workspaceID}`
+                            }),
+                          )
+                        }),
+                    }),
+                  ],
+                }
+              }),
+          },
+        },
+        {
+          overrides: [
+            llmClient.replace(Layer.succeed(LLMClient.Service, llm)),
+            SessionRunnerModel.node.replace(
+              Layer.succeed(SessionRunnerModel.Service, { resolve: () => Effect.succeed(model) }),
+            ),
+          ],
+        },
+      )
+      const firstWorkspace = yield* opencode.workspace.create({ provider: "memory" })
+      const secondWorkspace = yield* opencode.workspace.create({ provider: "memory" })
+      const first = yield* opencode.sessions.create({
+        title: "First placement",
+        location: Location.Ref.make({ directory: AbsolutePath.make(directory.path), workspaceID: firstWorkspace }),
+        model: model.ref,
+        metadata: { threadID: "same-thread" },
+      })
+      const second = yield* opencode.sessions.create({
+        title: "Second placement",
+        location: Location.Ref.make({ directory: AbsolutePath.make(directory.path), workspaceID: secondWorkspace }),
+        model: model.ref,
+        metadata: { threadID: "same-thread" },
+      })
+      for (const session of [first, second]) {
+        const admitted = yield* opencode.sessions.prompt({ sessionID: session.id, text: "Hello" })
+        expect(admitted.payload.text).toBe(`Hello:${session.location.workspaceID}`)
+        yield* opencode.sessions.wait({ sessionID: session.id })
+      }
+      expect(configured).toEqual(["same-thread", "same-thread"])
+      expect(placements.map((location) => location.workspaceID)).toEqual([firstWorkspace, secondWorkspace])
+
+      yield* opencode.sessions.move({
+        sessionID: first.id,
+        directory: AbsolutePath.make(directory.path),
+        workspaceID: secondWorkspace,
+      })
+      yield* opencode.sessions.wait({ sessionID: first.id })
+      const moved = yield* opencode.sessions.get({ sessionID: first.id })
+      expect(moved.location.workspaceID).toBe(secondWorkspace)
+      const admitted = yield* opencode.sessions.prompt({ sessionID: first.id, text: "Moved", resume: false })
+      expect(admitted.payload.text).toBe(`Moved:${secondWorkspace}`)
+      expect(configured).toEqual(["same-thread", "same-thread"])
+    }),
+  15_000,
+)

--- a/packages/sdk/test/instances-lifecycle.test.ts
+++ b/packages/sdk/test/instances-lifecycle.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "bun:test"
+import { Instance } from "@opencode-ai/core/instance/service"
+import { Session } from "@opencode-ai/core/session"
+import { Location } from "@opencode-ai/schema/location"
+import { AbsolutePath } from "@opencode-ai/schema/schema"
+import { Context, Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import { tmpdirScoped } from "../../core/test/fixture/tmpdir"
+import { testEffect } from "../../core/test/lib/effect"
+import { EmbeddedHost } from "../src/internal/host"
+
+const it = testEffect(Layer.empty)
+
+it.live("a cancelled borrower cannot strand a later failed instance construction", () =>
+  Effect.gen(function* () {
+    const directory = yield* tmpdirScoped()
+    const started = yield* Deferred.make<Fiber.Fiber<unknown, unknown>>()
+    const release = yield* Deferred.make<void>()
+    const acquired: number[] = []
+    const released: number[] = []
+    const host = yield* Effect.acquireRelease(
+      EmbeddedHost.create({
+        config: { directory: directory.path, project: false, content: "{}" },
+        models: { fetch: false },
+        fs: { filewatcher: false },
+        instances: {
+          key: () => "shared",
+          configure: () =>
+            Effect.gen(function* () {
+              const attempt = acquired.length + 1
+              yield* Effect.acquireRelease(
+                Effect.sync(() => acquired.push(attempt)),
+                () => Effect.sync(() => released.push(attempt)),
+              )
+              if (attempt !== 1) return { plugins: [] }
+              yield* Effect.withFiber((fiber) => Deferred.succeed(started, fiber))
+              yield* Deferred.await(release)
+              return yield* Effect.fail(new Error("Configuration unavailable"))
+            }),
+        },
+      }),
+      (host) => Effect.promise(host.close),
+    )
+    const services = yield* host.runtime.contextEffect
+    const instances = Context.get(services, Instance.Service)
+    const sessions = Context.get(services, Session.Service)
+    const session = yield* sessions.create({
+      location: Location.Ref.make({ directory: AbsolutePath.make(directory.path) }),
+    })
+    expect(acquired).toEqual([])
+
+    const borrower = yield* Effect.void.pipe(instances.provide(session), Effect.forkScoped)
+    const lookup = yield* Deferred.await(started)
+    yield* Fiber.interrupt(borrower)
+    expect(released).toEqual([])
+    yield* Deferred.succeed(release, undefined)
+    expect(Exit.isFailure(yield* Fiber.await(lookup).pipe(Effect.timeout("1 second")))).toBe(true)
+    expect(released).toEqual([1])
+
+    yield* Effect.void.pipe(instances.provide(session))
+    expect(acquired).toEqual([1, 2])
+    expect(released).toEqual([1])
+
+    yield* Effect.promise(host.close)
+    expect(released).toEqual([1, 2])
+  }),
+)

--- a/packages/sdk/test/instances.test.ts
+++ b/packages/sdk/test/instances.test.ts
@@ -1,0 +1,353 @@
+import { expect, test } from "bun:test"
+import { mkdir } from "node:fs/promises"
+import { join } from "node:path"
+import { Schema } from "effect"
+import { tmpdir } from "../../core/test/fixture/tmpdir"
+import { OpenCode, Session, SessionMessage } from "../src"
+
+const metadata = Schema.decodeUnknownSync(Schema.Struct({ account: Schema.String }))
+const hostOptions = (directory: string) => ({
+  database: { path: join(directory, "opencode.sqlite") },
+  config: { directory, project: false, content: "{}" },
+  models: { fetch: false },
+  fs: { filewatcher: false },
+})
+
+test("Promise instances are lazy, share by key and Location, and stay isolated between hosts", async () => {
+  await using directory = await tmpdir("opencode-promise-instances-")
+  const otherDirectory = join(directory.path, "other")
+  await mkdir(otherDirectory)
+  const configured: string[] = []
+  const setups: string[] = []
+  const cleanups: string[] = []
+  const createHost = (name: string) => {
+    const instances: OpenCode.InstanceOptions = {
+      key(session) {
+        expect(typeof session.time.created).toBe("number")
+        return metadata(session.metadata).account
+      },
+      configure(key): OpenCode.InstanceConfiguration {
+        configured.push(`${name}:${key}`)
+        return {
+          plugins: [
+            {
+              id: "account-prompts",
+              async setup(ctx) {
+                const activation = `${name}:${key}@${ctx.location.directory}`
+                setups.push(activation)
+                await ctx.session.hook("prompt", (event) => {
+                  event.prompt.text = `${activation}: ${event.prompt.text}`
+                })
+                return () => {
+                  cleanups.push(activation)
+                }
+              },
+            },
+          ],
+        }
+      },
+    }
+    return OpenCode.create({
+      ...hostOptions(directory.path),
+      database: { path: join(directory.path, `${name}.sqlite`) },
+      instances,
+    })
+  }
+
+  await using first = await createHost("first")
+  await using second = await createHost("second")
+  const sessionID = Session.ID.create()
+  const original = await first.sessions.create({
+    id: sessionID,
+    location: { directory: directory.path },
+    metadata: { account: "alpha", labels: ["review", 2] },
+  })
+  const sameKey = await first.sessions.create({
+    location: { directory: directory.path },
+    metadata: original.metadata,
+  })
+  const separateKey = await first.sessions.create({
+    location: { directory: directory.path },
+    metadata: { account: "beta" },
+  })
+  const separateLocation = await first.sessions.create({
+    location: { directory: otherDirectory },
+    metadata: { account: "alpha" },
+  })
+  const separateHost = await second.sessions.create({
+    id: sessionID,
+    location: { directory: directory.path },
+    metadata: original.metadata,
+  })
+
+  expect(await first.sessions.get({ sessionID })).toEqual(original)
+  expect((await first.sessions.list()).data).toHaveLength(4)
+  expect((await first.message.list({ sessionID })).data).toEqual([])
+  expect(await first.sessions.context({ sessionID })).toEqual([])
+  expect(await first.sessions.inbox.list({ sessionID })).toEqual([])
+  expect(await second.sessions.get({ sessionID })).toEqual(separateHost)
+  expect(configured).toEqual([])
+  expect(setups).toEqual([])
+  // Permission and form lists read instance services, so they acquire the Session's instance.
+  expect(await first.permission.list({ sessionID })).toEqual([])
+  expect(await first.form.list({ sessionID })).toEqual([])
+  expect(configured).toEqual(["first:alpha"])
+
+  await Promise.all(
+    [
+      { host: first, session: original, prefix: `first:alpha@${directory.path}` },
+      { host: first, session: sameKey, prefix: `first:alpha@${directory.path}` },
+      { host: first, session: separateKey, prefix: `first:beta@${directory.path}` },
+      { host: first, session: separateLocation, prefix: `first:alpha@${otherDirectory}` },
+      { host: second, session: separateHost, prefix: `second:alpha@${directory.path}` },
+    ].map(async (input) => {
+      const admitted = await input.host.sessions.prompt({
+        sessionID: input.session.id,
+        text: "Review this change",
+        resume: false,
+      })
+      expect(admitted.payload.text).toBe(`${input.prefix}: Review this change`)
+      expect(await input.host.sessions.inbox.list({ sessionID: input.session.id })).toEqual([admitted])
+    }),
+  )
+
+  await first.sessions.switchAgent({ sessionID, agent: "plan" })
+  const fork = await first.sessions.fork({ sessionID, boundary: { type: "through" } })
+  expect(fork.metadata).toEqual(original.metadata)
+  expect(fork.location).toEqual(original.location)
+  expect(fork.fork?.sessionID).toBe(sessionID)
+  const inherited = await first.sessions.prompt({ sessionID: fork.id, text: "Review the fork", resume: false })
+  expect(inherited.payload.text).toBe(`first:alpha@${directory.path}: Review the fork`)
+  expect(await first.sessions.inbox.list({ sessionID: fork.id })).toEqual([inherited])
+
+  expect(configured.toSorted()).toEqual(["first:alpha", "first:alpha", "first:beta", "second:alpha"])
+  expect(setups.toSorted()).toEqual(
+    [
+      `first:alpha@${directory.path}`,
+      `first:alpha@${otherDirectory}`,
+      `first:beta@${directory.path}`,
+      `second:alpha@${directory.path}`,
+    ].toSorted(),
+  )
+  expect(cleanups).toEqual([])
+  expect(await first.sessions.active()).toEqual({})
+  await first.close()
+  expect(cleanups.toSorted()).toEqual(setups.filter((activation) => activation.startsWith("first:")).toSorted())
+
+  const continued = await second.sessions.prompt({ sessionID, text: "Keep working", resume: false })
+  expect(continued.payload.text).toBe(`second:alpha@${directory.path}: Keep working`)
+  expect(await second.sessions.inbox.list({ sessionID })).toHaveLength(2)
+  expect(configured).toHaveLength(4)
+  await second.close()
+  expect(cleanups.toSorted()).toEqual(setups.toSorted())
+}, 20_000)
+
+test.each(["configuration", "plugin setup"])(
+  "Promise instance %s failure admits nothing, preserves healthy instances, and can be retried",
+  async (failure) => {
+    await using directory = await tmpdir("opencode-promise-instance-failure-")
+    const configured: string[] = []
+    const setups: string[] = []
+    const cleanups: string[] = []
+    await using opencode = await OpenCode.create({
+      ...hostOptions(directory.path),
+      instances: {
+        key: (session) => metadata(session.metadata).account,
+        async configure(key) {
+          configured.push(key)
+          if (key === "retry" && failure === "configuration" && configured.filter((item) => item === key).length === 1)
+            throw new Error("Account configuration unavailable")
+          return {
+            plugins: [
+              {
+                id: "account-prompts",
+                async setup(ctx) {
+                  setups.push(key)
+                  await ctx.session.hook("prompt", (event) => {
+                    event.prompt.text = `${key}: ${event.prompt.text}`
+                  })
+                  if (
+                    key === "retry" &&
+                    failure === "plugin setup" &&
+                    setups.filter((item) => item === key).length === 1
+                  )
+                    throw new Error("Account plugin unavailable")
+                  return () => {
+                    cleanups.push(key)
+                  }
+                },
+              },
+            ],
+          }
+        },
+      },
+    })
+    const healthy = await opencode.sessions.create({
+      location: { directory: directory.path },
+      metadata: { account: "healthy" },
+    })
+    const retry = await opencode.sessions.create({
+      location: { directory: directory.path },
+      metadata: { account: "retry" },
+    })
+    const before = await opencode.sessions.prompt({ sessionID: healthy.id, text: "Before failure", resume: false })
+    expect(before.payload.text).toBe("healthy: Before failure")
+    const input = { sessionID: retry.id, id: SessionMessage.ID.create(), text: "Retry this input", resume: false }
+
+    expect(await opencode.sessions.prompt(input).catch((error: unknown) => error)).toMatchObject({
+      name: "ClientError",
+      reason: "UnexpectedStatus",
+    })
+    expect(await opencode.sessions.inbox.list({ sessionID: retry.id })).toEqual([])
+    expect((await opencode.message.list({ sessionID: retry.id })).data).toEqual([])
+    expect(await opencode.sessions.get({ sessionID: retry.id })).toEqual(retry)
+    expect(configured).toEqual(["healthy", "retry"])
+    expect(cleanups).toEqual([])
+
+    const after = await opencode.sessions.prompt({ sessionID: healthy.id, text: "After failure", resume: false })
+    expect(after.payload.text).toBe("healthy: After failure")
+    expect(await opencode.sessions.inbox.list({ sessionID: healthy.id })).toEqual([before, after])
+    const admitted = await opencode.sessions.prompt(input)
+    expect(admitted.id).toBe(input.id)
+    expect(admitted.payload.text).toBe("retry: Retry this input")
+    expect(await opencode.sessions.inbox.list({ sessionID: retry.id })).toEqual([admitted])
+    expect(configured).toEqual(["healthy", "retry", "retry"])
+    expect(setups).toEqual(failure === "configuration" ? ["healthy", "retry"] : ["healthy", "retry", "retry"])
+    expect(cleanups).toEqual([])
+    await opencode.close()
+    expect(cleanups.toSorted()).toEqual(["healthy", "retry"])
+  },
+  20_000,
+)
+
+test("Promise instances reconstruct callbacks for persisted Sessions only on a cold prompt", async () => {
+  await using directory = await tmpdir("opencode-promise-instance-restart-")
+  const sessionID = Session.ID.create()
+  const configured: string[] = []
+  const setups: number[] = []
+  const cleanups: number[] = []
+  const options: OpenCode.CreateOptions = {
+    ...hostOptions(directory.path),
+    instances: {
+      key: (session) => metadata(session.metadata).account,
+      configure(key) {
+        configured.push(key)
+        const generation = configured.length
+        return {
+          plugins: [
+            {
+              id: "account-prompts",
+              async setup(ctx) {
+                setups.push(generation)
+                await ctx.session.hook("prompt", (event) => {
+                  event.prompt.text = `${key}/${generation}: ${event.prompt.text}`
+                })
+                return () => {
+                  cleanups.push(generation)
+                }
+              },
+            },
+          ],
+        }
+      },
+    },
+  }
+  await using first = await OpenCode.create(options)
+  const created = await first.sessions.create({
+    id: sessionID,
+    location: { directory: directory.path },
+    metadata: { account: "alpha", labels: ["review"] },
+  })
+  const before = await first.sessions.prompt({ sessionID, text: "Before restart", resume: false })
+  expect(before.payload.text).toBe("alpha/1: Before restart")
+  await first.close()
+  expect(cleanups).toEqual([1])
+
+  await using second = await OpenCode.create(options)
+  expect(await second.sessions.get({ sessionID })).toMatchObject({
+    id: sessionID,
+    location: created.location,
+    metadata: created.metadata,
+    time: { created: created.time.created },
+  })
+  expect((await second.sessions.list()).data.map((session) => session.id)).toEqual([sessionID])
+  expect(await second.sessions.inbox.list({ sessionID })).toEqual([before])
+  expect((await second.message.list({ sessionID })).data).toEqual([])
+  expect(configured).toEqual(["alpha"])
+  expect(setups).toEqual([1])
+
+  // The HTTP prompt boundary still acquires capabilities, even when Core reconciles an existing admission.
+  expect(await second.sessions.prompt({ sessionID, id: before.id, text: "Already admitted", resume: false })).toEqual(
+    before,
+  )
+  expect(configured).toEqual(["alpha", "alpha"])
+  expect(setups).toEqual([1, 2])
+  expect(await second.sessions.active()).toEqual({})
+
+  const after = await second.sessions.prompt({ sessionID, text: "After restart", resume: false })
+  expect(after.payload.text).toBe("alpha/2: After restart")
+  expect(await second.sessions.inbox.list({ sessionID })).toEqual([before, after])
+  expect(configured).toEqual(["alpha", "alpha"])
+  expect(setups).toEqual([1, 2])
+  expect(cleanups).toEqual([1])
+  await second.close()
+  expect(cleanups).toEqual([1, 2])
+}, 20_000)
+
+test("Promise instance plugin ID collisions reject admission and reconstruct on retry", async () => {
+  await using directory = await tmpdir("opencode-promise-instance-collision-")
+  const configured: string[] = []
+  const setups: string[] = []
+  await using opencode = await OpenCode.create({
+    ...hostOptions(directory.path),
+    plugins: [
+      {
+        id: "account-prompts",
+        setup() {
+          setups.push("host")
+        },
+      },
+    ],
+    instances: {
+      key: (session) => metadata(session.metadata).account,
+      configure(key) {
+        configured.push(key)
+        return {
+          plugins: [
+            {
+              id: configured.length === 1 ? "account-prompts" : "instance-prompts",
+              async setup(ctx) {
+                setups.push(key)
+                await ctx.session.hook("prompt", (event) => {
+                  event.prompt.text = `${key}: ${event.prompt.text}`
+                })
+              },
+            },
+          ],
+        }
+      },
+    },
+  })
+  const session = await opencode.sessions.create({
+    location: { directory: directory.path },
+    metadata: { account: "alpha" },
+  })
+  const input = { sessionID: session.id, id: SessionMessage.ID.create(), text: "Retry this input", resume: false }
+  expect(configured).toEqual([])
+
+  expect(await opencode.sessions.prompt(input).catch((error: unknown) => error)).toMatchObject({
+    name: "ClientError",
+    reason: "UnexpectedStatus",
+  })
+  expect(await opencode.sessions.inbox.list({ sessionID: session.id })).toEqual([])
+  expect((await opencode.message.list({ sessionID: session.id })).data).toEqual([])
+  expect(configured).toEqual(["alpha"])
+  expect(setups).toEqual([])
+
+  const admitted = await opencode.sessions.prompt(input)
+  expect(admitted.id).toBe(input.id)
+  expect(admitted.payload.text).toBe("alpha: Retry this input")
+  expect(await opencode.sessions.inbox.list({ sessionID: session.id })).toEqual([admitted])
+  expect(configured).toEqual(["alpha", "alpha"])
+  expect(setups).toEqual(["host", "alpha"])
+}, 20_000)

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -2,6 +2,7 @@ import { Database } from "@opencode-ai/core/database/database"
 import { V1Migration } from "@opencode-ai/core/database/v1-migration"
 import { App } from "@opencode-ai/core/app"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Node } from "@opencode-ai/util/effect/app-node"
 import { httpClient } from "@opencode-ai/util/effect/app-node-platform"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Bus } from "@opencode-ai/core/bus"
@@ -89,8 +90,16 @@ export function createRoutes(
   )
 }
 
-export function createEmbeddedRoutes(options: ServerOptions = {}, overrides: LayerNode.Replacements = []) {
-  return makeRoutes(ServerAuth.Config.configLayer({ password: Option.none() }), options, () => [], overrides)
+type InstanceNode = (
+  replacements: () => LayerNode.Replacements,
+) => LayerNode.Provider<Instance.Service, never, typeof Node.tags.values.global>
+
+export function createEmbeddedRoutes(
+  options: ServerOptions = {},
+  overrides: LayerNode.Replacements = [],
+  instances?: InstanceNode,
+) {
+  return makeRoutes(ServerAuth.Config.configLayer({ password: Option.none() }), options, () => [], overrides, instances)
 }
 
 function makeRoutes<AuthError, AuthServices>(
@@ -99,6 +108,7 @@ function makeRoutes<AuthError, AuthServices>(
   serviceURLs: () => ReadonlyArray<string>,
   // Runtime-profile replacements (e.g. workerd) applied after the standard set, so later entries win.
   overrides: LayerNode.Replacements,
+  instances?: InstanceNode,
 ) {
   const standard: LayerNode.Replacements = [
     Database.node.replace(Database.configured(options.database)),
@@ -127,16 +137,24 @@ function makeRoutes<AuthError, AuthServices>(
       }),
     ),
   ]
-  const replacements: LayerNode.Replacements = [...standard, ...overrides]
+  const build = (overrides: LayerNode.Replacements) => {
+    const replacements: LayerNode.Replacements = [
+      ...standard,
+      // Private instances resolve this list lazily so they inherit the complete host graph, including the selector.
+      ...(instances ? [Instance.node.replace(instances(() => replacements))] : []),
+      ...overrides,
+    ]
+    return AppNodeBuilder.build(applicationServices, replacements)
+  }
   const serviceLayer = options.simulation
     ? Layer.unwrap(
         Effect.gen(function* () {
           const { simulationReplacements } = yield* Effect.promise(() => import("@opencode-ai/simulation/backend"))
           const simulation = yield* simulationReplacements({ version: App.make(options.app).version })
-          return AppNodeBuilder.build(applicationServices, [...replacements, ...simulation])
+          return build([...overrides, ...simulation])
         }),
       )
-    : AppNodeBuilder.build(applicationServices, replacements)
+    : build(overrides)
   return serviceLayer.pipe(
     Layer.flatMap((context) => {
       const services = Layer.succeedContext(context)


### PR DESCRIPTION
## Why

An embedded application can already replace Core's Session-aware instance selector, but doing so requires Effect graph wiring. Host-wide plugin registration cannot give two application threads in the same directory different plugin stacks, and post-construction registration is too late to configure automatic restart recovery.

## What Changes

Add `instances: { key, configure }` to the Promise, Effect, and Workerd SDK constructors:

```ts
const opencode = await OpenCode.create({
  database: { path: "./sessions.db" },
  instances: {
    key(session) {
      const threadID = session.metadata?.threadID
      if (typeof threadID !== "string") throw new Error("Session has no thread ID")
      return threadID
    },
    configure: async (threadID) => ({
      plugins: [slackPlugin(await threads.get(threadID))],
    }),
  },
})
```

`threads` and `slackPlugin` are application code. Effect callers return an Effect from `configure` instead.

| Situation | Behavior |
| --- | --- |
| Same application key and canonical Location | Reuse one live instance, including concurrent acquisition. |
| Different key, directory, or workspace identity | Build separate Location-bound instances. |
| Session metadata, message, inbox, and context reads | Do not run configuration or plugin setup. Permission and form lists read instance services and acquire the instance, following Core's current handlers. |
| Persistent host restart | Reconstruct callbacks before recovered execution uses them. |
| Configuration fails, an instance plugin ID collides with a host `plugins` entry, or a supplied plugin's setup fails | Fail acquisition without admitting a new prompt or falling back; a later request can reconstruct. |
| No `instances` option | Preserve default Location sharing. |

## Instance Lifetimes

The selector is a global `Instance.node` replacement over a scoped `LayerMap`. Successful instances remain cached until the host closes; `configure` runs on cache misses, not on every prompt. Server supplies its final replacement set so selected graphs share the correct host Database, Bus, and runtime-profile overrides rather than creating another host. Both instance caches use the existing canonical Location normalization.

Inside each selected instance, `Instance.node` and `LocationServiceMap.node` are bound to cheap borrowers of the selector and the host Location map, mirroring `buildLocationServiceMap`. Retaining the selector's own Layer from its entries would make host shutdown wait on those entries to release it first, and plugin cleanups would never run.

After construction, the selector waits on `Plugin.awaitActivation` and rejects supplied plugins reported `failed`. A host/instance plugin ID collision fails the whole generation before anything reaches the inventory, so it is rejected before construction instead. Failed lookup eviction runs in the selector's host Scope so cancelling the last borrower cannot leave the lookup waiting for itself.

## Scope

This PR targets `v2` directly and contains only the keyed SDK adapter, its Server wiring, the `LocationServiceMap.canonical` extraction, documentation, and SDK regressions. The former Core prerequisite #46615 was closed: #46639 removed `PluginSupervisor.Service`, and the collision it guarded is now handled here without new Core surface.

Independent ACP startup repair is #46613. The former SDK fixture maintenance #46614 was closed as superseded by #46639.

This does not share plugin activations across Locations. Selection is not an authorization or plugin-storage isolation boundary. No Protocol or HTTP resource contracts change.

Existing HTTP prompt middleware remains eager: a cold idempotent retry can reconstruct its instance before Core returns the original admission. Preparation and prompt hooks do not repeat. This PR preserves that eager capability acquisition on idempotent retries.

## Verification

Using Bun 1.4.0:

```sh
# packages/sdk
bun typecheck
bun run ../core/script/test.ts test/instances.test.ts test/instances-effect.test.ts test/instances-lifecycle.test.ts --rerun-each 5
bun run ../core/script/test.ts
bun run verify:package

# packages/server
bun run ../core/script/test.ts
```

Rebased onto `v2` at `c8f81c8b83`, after #46639 removed `PluginSupervisor.Service`, `Instance.provideIfLoaded`, and `Instance.byLocationNode`. SDK, Server, and Core typechecking passed. All eight instance-selection cases passed **40/40** repeated runs, including host/instance collision rejection and cleanup on host close. The full Server suite passed **48 tests with 3 skipped**.

Full SDK run: **26 passed, 2 failed**. Both failures reproduce **3/3** on a pristine `v2` checkout at the same commit without this branch: `embedded client exposes plugin-backed web search` (`Web search provider not found`) and the cancellation assertion at `test/promise.test.ts:73`. Neither file is changed here.

Packed-consumer validation: all four entrypoints load, the Workerd bundle passes the no-Bun checks, and a real Miniflare consumer exercises selected-instance reuse and prompt hooks against injected Durable Object SQLite. Wrangler ran in dry-run mode; nothing was deployed.
