### PR TITLE
feat(app): edit files in the review pane

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1079,7 +1079,7 @@
     "@opentui/core": "0.5.9",
     "@opentui/keymap": "0.5.9",
     "@opentui/solid": "0.5.9",
-    "@pierre/diffs": "1.2.10",
+    "@pierre/diffs": "1.3.6",
     "@playwright/test": "1.59.1",
     "@sentry/solid": "10.71.0",
     "@sentry/vite-plugin": "5.4.0",
@@ -2493,11 +2493,11 @@
 
     "@peculiar/webcrypto": ["@peculiar/webcrypto@1.7.1", "", { "dependencies": { "@peculiar/asn1-schema": "^2.7.0", "@peculiar/json-schema": "^1.1.12", "@peculiar/utils": "^2.0.2", "tslib": "^2.8.1", "webcrypto-core": "^1.9.2" } }, "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ=="],
 
-    "@pierre/diffs": ["@pierre/diffs@1.2.10", "", { "dependencies": { "@pierre/theme": "1.0.3", "@pierre/theming": "0.0.1", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "8.0.3", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-rPeAmDWarxFVTQpaf4y6wTxjZxU44xKJKoJti2zU21P06DVd9nRHZX+xSIObLB307Qjpaesyb1x/j0z94t7vLw=="],
+    "@pierre/diffs": ["@pierre/diffs@1.3.6", "", { "dependencies": { "@pierre/theme": "2.0.0", "@pierre/theming": "1.0.1", "@shikijs/transformers": "^3.0.0 || ^4.0.0", "diff": "9.0.0", "hast-util-to-html": "9.0.5", "lru_map": "0.4.1", "shiki": "^3.0.0 || ^4.0.0" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-a3woaW2QHy78JDxPJK0OJzwZUN4xoQLLIS/pceO8X6+L8gA5D682mP7/w3YxxEVRPXOaoe/p/RJ5Oj/3nrEzew=="],
 
-    "@pierre/theme": ["@pierre/theme@1.0.3", "", {}, "sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA=="],
+    "@pierre/theme": ["@pierre/theme@2.0.0", "", {}, "sha512-yNDd9GYLQl1mEUJR8AneJ5e4ohLIHQd/wZLWr4fagt78vS2RwwZNW530vVgHqXFAyFVcFlRmGUD5ramXH46OXw=="],
 
-    "@pierre/theming": ["@pierre/theming@0.0.1", "", { "peerDependencies": { "@pierre/theme": "^1.0.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-1thlEtJbqdyLzc1ZS2KQa1q7FzDGHT4dTEdKHoyQjOMeWWOmbVG5/ndEfOKfAb5Fzkz8cNJrOjFLiZoDH/A03A=="],
+    "@pierre/theming": ["@pierre/theming@1.0.1", "", { "peerDependencies": { "@pierre/theme": "^1.1.0 || ^2.0.0", "@shikijs/themes": "^3.0.0 || ^4.0.0", "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0", "shiki": "^3.0.0 || ^4.0.0" }, "optionalPeers": ["@pierre/theme", "@shikijs/themes", "react", "react-dom", "shiki"] }, "sha512-WCI5Qd7iprDpISL9fBYOLe8RV53+b7mFNA3bPzl60/2CKCSrsKN8zEcep6Y3BAzvARlmca50zGjDodqPGiTUKA=="],
 
     "@pierre/trees": ["@pierre/trees@1.0.0-beta.4", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag=="],
 
@@ -3210,8 +3210,6 @@
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
     "@upstash/redis": ["@upstash/redis@1.38.0", "", { "dependencies": { "uncrypto": "^0.1.3" } }, "sha512-wu+dZBptlLy0+MCUEoHmzrY/TnmgDey3+c7EbIGwrLqAvkP8yi5MWZHYGIFtAygmL4Bkz2TdFu+eU0vFPncIcg=="],
-
-    "@valibot/to-json-schema": ["@valibot/to-json-schema@1.6.0", "", { "peerDependencies": { "valibot": "^1.3.0" } }, "sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
@@ -5451,8 +5449,6 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "sury": ["sury@11.0.0-alpha.4", "", { "peerDependencies": { "rescript": "12.x" }, "optionalPeers": ["rescript"] }, "sha512-oeG/GJWZvQCKtGPpLbu0yCZudfr5LxycDo5kh7SJmKHDPCsEPJssIZL2Eb4Tl7g9aPEvIDuRrkS+L0pybsMEMA=="],
-
     "svgo": ["svgo@4.0.2", "", { "dependencies": { "commander": "^11.1.0", "css-select": "^5.1.0", "css-tree": "^3.0.1", "css-what": "^6.1.0", "csso": "^5.0.5", "picocolors": "^1.1.1", "sax": "^1.5.0" }, "bin": "./bin/svgo.js" }, "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
@@ -5667,8 +5663,6 @@
 
     "uuid": ["uuid@14.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ=="],
 
-    "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
-
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
@@ -5817,9 +5811,7 @@
 
     "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
-    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
-
-    "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+    "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "xmlhttprequest-ssl": ["xmlhttprequest-ssl@2.1.2", "", {}, "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ=="],
 
@@ -5850,8 +5842,6 @@
     "zip-stream": ["zip-stream@6.0.1", "", { "dependencies": { "archiver-utils": "^5.0.0", "compress-commons": "^6.0.2", "readable-stream": "^4.0.0" } }, "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA=="],
 
     "zod": ["zod@4.1.8", "", {}, "sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ=="],
-
-    "zod-openapi": ["zod-openapi@5.4.6", "", { "peerDependencies": { "zod": "^3.25.74 || ^4.0.0" } }, "sha512-P2jsOOBAq/6hCwUsMCjUATZ8szkMsV5VAwZENfyxp2Hc/XPJQpVwAgevWZc65xZauCwWB9LAn7zYeiCJFAEL+A=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
@@ -6305,7 +6295,7 @@
 
     "@parcel/watcher/detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
 
-    "@pierre/diffs/diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
+    "@pierre/diffs/diff": ["diff@9.0.0", "", {}, "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw=="],
 
     "@pierre/diffs/react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
@@ -6344,10 +6334,6 @@
     "@solidjs/start/shiki": ["shiki@1.29.2", "", { "dependencies": { "@shikijs/core": "1.29.2", "@shikijs/engine-javascript": "1.29.2", "@shikijs/engine-oniguruma": "1.29.2", "@shikijs/langs": "1.29.2", "@shikijs/themes": "1.29.2", "@shikijs/types": "1.29.2", "@shikijs/vscode-textmate": "^10.0.1", "@types/hast": "^3.0.4" } }, "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg=="],
 
     "@solidjs/start/vite": ["vite@7.1.10", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA=="],
-
-    "@standard-community/standard-json/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
-
-    "@standard-community/standard-openapi/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -6606,8 +6592,6 @@
     "pkijs/@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
-    "plist/xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
 
     "postcss-css-variables/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -6928,8 +6912,6 @@
     "@brendonovich/vite-plugin-opencode/@opencode-ai/client/@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-beta-18050", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-beta-18050", "effect": "4.0.0-rc.111" } }, "sha512-HDQMnvGp8IU0MdBRbEuydX1WQm09BZ4HJm9iSMQwzweJuQ2HNscgzHJPIH6P02BsbbtfJ8J7sZGPItrz1tWSgw=="],
 
     "@brendonovich/vite-plugin-opencode/@opencode-ai/client/@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-beta-18050", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-rc.111" } }, "sha512-/D6VXaWlytTXR3IOiMLIKuPcfp7FQNUzRPm9z3K7UBFd1Bw4q/WZksaf5RVcBGz+0YRxYMc1V4D7MFlceSgtyg=="],
-
-    "@brendonovich/vite-plugin-opencode/@opencode-ai/client/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
 
     "@bruits/satteri-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
       "@tsconfig/bun": "1.0.9",
       "@cloudflare/workers-types": "4.20251008.0",
       "@openauthjs/openauth": "0.0.0-20250322224806",
-      "@pierre/diffs": "1.2.10",
+      "@pierre/diffs": "1.3.6",
       "opentui-spinner": "0.0.7",
       "@solid-primitives/event-listener": "2.4.6",
       "@solid-primitives/media": "2.3.6",

--- a/packages/app/component-tests/review-editing.spec.ts
+++ b/packages/app/component-tests/review-editing.spec.ts
@@ -1,0 +1,28 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+story("keeps same-path drafts separate when switching workspaces", async ({ mount, page }) => {
+  const root = await mount("app-review-editing--workspaces")
+  const editor = root.getByRole("textbox", { name: "src/shared.ts", exact: true })
+  await root.getByRole("button", { name: "Edit file", exact: true }).click()
+  await expect(editor).toHaveText("// Workspace A\n", { useInnerText: true })
+  await editor.focus()
+  await editor.press("ControlOrMeta+a")
+  await page.keyboard.insertText("// Draft A\n")
+  await expect(editor).toHaveText("// Draft A\n", { useInnerText: true })
+
+  await root.getByRole("button", { name: "Workspace B", exact: true }).click()
+  await root.getByRole("button", { name: "Edit file", exact: true }).click()
+  await expect(editor).toHaveText("// Workspace B\n", { useInnerText: true })
+  await editor.focus()
+  await editor.press("ControlOrMeta+a")
+  await page.keyboard.insertText("// Draft B\n")
+  await expect(editor).toHaveText("// Draft B\n", { useInnerText: true })
+
+  await root.getByRole("button", { name: "Workspace A", exact: true }).click()
+  await expect(editor).toHaveText("// Draft A\n", { useInnerText: true })
+  await editor.press("ControlOrMeta+End")
+  await page.keyboard.insertText("// Still A")
+  await expect(editor).toContainText("// Still A")
+  await root.getByRole("button", { name: "Workspace B", exact: true }).click()
+  await expect(editor).toHaveText("// Draft B\n", { useInnerText: true })
+})

--- a/packages/app/e2e/regression/review-editing.spec.ts
+++ b/packages/app/e2e/regression/review-editing.spec.ts
@@ -1,0 +1,307 @@
+import { base64Encode } from "@opencode-ai/util/encode"
+import { expect, test, type Page, type Request } from "@playwright/test"
+import { createTwoFilesPatch } from "diff"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectSessionTitle } from "../utils/waits"
+
+const directory = "C:/OpenCode/ReviewEditing-linked"
+const canonical = "C:/OpenCode/ReviewEditing"
+const sessionDirectory = `${directory}/src`
+const projectID = "proj_review_editing"
+const sessionID = "ses_review_editing"
+const title = "Review full-file edits"
+const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+const alpha = "src/alpha.ts"
+const beta = "src/beta.ts"
+const header = "// Header outside the patch"
+const original = `${header}\n\nexport function greeting() {\n  return "after"\n}\n\n// Footer outside the patch\n`
+const editedHeader = "// Edited outside the patch: caf\u00e9"
+const edited = original.replace(header, editedHeader)
+
+test.use({ viewport: { width: 1440, height: 900 } })
+
+test("edits the full file and retains drafts across file and pane navigation", async ({ page }) => {
+  const loading = Promise.withResolvers<void>()
+  const fixture = await setup(page, { read: loading.promise })
+  await openReview(page)
+  const diff = page.locator('[data-slot="session-review-v2-diff-scroll"]')
+  await expect(diff.getByText('return "after"', { exact: true })).toBeVisible()
+  await expect(diff.getByText(header, { exact: true })).toHaveCount(0)
+  if (process.env.E2E_CAPTURE_REVIEW_EDITING === "1") {
+    await page.screenshot({ path: "C:/tmp/opencode/review-editing-before.png" })
+  }
+
+  const read = page.waitForRequest((request) => new URL(request.url()).pathname === `/api/fs/read/${alpha}`)
+  await page.getByRole("button", { name: "Edit file", exact: true }).click()
+  expect(new URL((await read).url()).searchParams.get("location[directory]")).toBe(directory)
+  await expect(page.locator('[data-slot="review-file-editor"]').getByRole("status")).toHaveText("Loading")
+  await expect(page.getByRole("button", { name: "Save", exact: true })).toBeDisabled()
+  loading.resolve()
+  await expect(editor(page)).toHaveText(original, { useInnerText: true })
+  await expect(editor(page)).toBeEditable()
+  await replaceHeader(page)
+  await expect(page.getByRole("status").filter({ hasText: "Unsaved" })).toHaveText("Unsaved")
+  if (process.env.E2E_CAPTURE_REVIEW_EDITING === "1") {
+    await page.screenshot({ path: "C:/tmp/opencode/review-editing-after.png" })
+  }
+
+  for (const key of ["ArrowRight", "ArrowLeft", "ArrowDown", "ArrowUp"]) {
+    await editor(page).press(key)
+    await expect(editor(page)).toBeFocused()
+    await expect(page.locator('[data-slot="session-review-v2-file-name"]')).toHaveText("alpha.ts")
+  }
+  await editor(page).press("ControlOrMeta+Home")
+  await editor(page).press("ControlOrMeta+]")
+  await expect(editor(page).locator('[data-line="1"]')).toHaveText(/^[\t ]+\/\/ Edited outside the patch: caf\u00e9$/)
+  await expect(editor(page)).toBeFocused()
+  await expect(page.locator('[data-slot="session-review-v2-file-name"]')).toHaveText("alpha.ts")
+  await editor(page).press("ControlOrMeta+[")
+  await expect(editor(page)).toHaveText(edited, { useInnerText: true })
+  await selectFile(page, "beta.ts")
+  await expect(page.getByRole("button", { name: "Edit file", exact: true })).toBeEnabled()
+  await expect(page.locator('[data-slot="review-file-editor"]')).toHaveCount(0)
+  await selectFile(page, "alpha.ts")
+  await expect(editor(page)).toHaveText(edited, { useInnerText: true })
+
+  await page.getByRole("button", { name: "Toggle review", exact: true }).click()
+  await expect(page.locator('[data-slot="session-review-v2-file-name"]')).toBeHidden()
+  await page.getByRole("button", { name: "Toggle review", exact: true }).click()
+  await expect(page.locator('[data-slot="session-review-v2-file-name"]')).toHaveText("alpha.ts")
+  await expect(editor(page)).toHaveText(edited, { useInnerText: true })
+  await expect(page.getByRole("button", { name: "Save", exact: true })).toBeEnabled()
+  expect(fixture.writes).toHaveLength(0)
+})
+
+for (const save of ["button", "shortcut"] as const) {
+  test(`saves full-file bytes in the linked worktree root with the ${save} and refreshes the diff`, async ({
+    page,
+  }) => {
+    const saving = Promise.withResolvers<void>()
+    const fixture = await setup(page, { write: saving.promise })
+    await openReview(page)
+    await page.getByRole("button", { name: "Edit file", exact: true }).click()
+    await expect(editor(page)).toHaveText(original, { useInnerText: true })
+    await replaceHeader(page)
+    expect(fixture.writes).toHaveLength(0)
+
+    const write = page.waitForRequest((request) => new URL(request.url()).pathname === "/api/fs/write")
+    const response = page.waitForResponse((response) => new URL(response.url()).pathname === "/api/fs/write")
+    const refreshed = page.waitForResponse(
+      (response) => new URL(response.url()).pathname === "/api/vcs/diff" && fixture.files.get(alpha) === edited,
+    )
+    await (save === "button"
+      ? page.getByRole("button", { name: "Save", exact: true }).click()
+      : editor(page).press("ControlOrMeta+s"))
+    const request = await write
+    expect(request.method()).toBe("POST")
+    expect(new URL(request.url()).searchParams.get("location[directory]")).toBe(directory)
+    expect(request.postDataJSON()).toEqual({
+      path: alpha,
+      content: Buffer.from(edited).toString("base64"),
+      expected: Buffer.from(original).toString("base64"),
+    })
+    await expect(page.getByRole("button", { name: "Saving...", exact: true })).toBeDisabled()
+    await expect(page.getByRole("button", { name: "Discard", exact: true })).toBeDisabled()
+    saving.resolve()
+    expect((await response).status()).toBe(200)
+    await refreshed
+    await expect(page.getByRole("button", { name: "Edit file", exact: true })).toBeEnabled()
+    await expect(page.locator('[data-slot="review-file-editor"]')).toHaveCount(0)
+    await expect(
+      page.locator('[data-slot="session-review-v2-diff-scroll"]').getByText(editedHeader, { exact: true }),
+    ).toBeVisible()
+    expect(fixture.writes).toHaveLength(1)
+
+    await page.getByRole("button", { name: "Edit file", exact: true }).click()
+    await expect(editor(page)).toHaveText(edited, { useInnerText: true })
+    await expect(page.getByRole("button", { name: "Save", exact: true })).toBeDisabled()
+  })
+}
+
+for (const failure of ["save", "conflict"] as const) {
+  test(`keeps the draft after a ${failure === "save" ? "failed" : "conflicting"} save`, async ({ page }) => {
+    const fixture = await setup(page, { failure })
+    await openReview(page)
+    await page.getByRole("button", { name: "Edit file", exact: true }).click()
+    await expect(editor(page)).toHaveText(original, { useInnerText: true })
+    await replaceHeader(page)
+    const response = page.waitForResponse((response) => new URL(response.url()).pathname === "/api/fs/write")
+    await page.getByRole("button", { name: "Save", exact: true }).click()
+    expect((await response).status()).toBe(failure === "conflict" ? 409 : 500)
+    await expect(page.locator('[data-slot="review-file-editor"]').getByRole("alert")).toContainText(
+      failure === "conflict" ? "This file changed on disk." : "Could not save this file.",
+    )
+    await expect(editor(page)).toHaveText(edited, { useInnerText: true })
+    await expect(page.getByRole("status").filter({ hasText: "Unsaved" })).toHaveText("Unsaved")
+    await expect(page.getByRole("button", { name: "Save", exact: true })).toBeEnabled()
+    await selectFile(page, "beta.ts")
+    await selectFile(page, "alpha.ts")
+    await expect(editor(page)).toHaveText(edited, { useInnerText: true })
+    expect(fixture.files.get(alpha)).toBe(original)
+    expect(fixture.writes).toHaveLength(1)
+  })
+}
+
+test("discard returns to the diff without writing and reopens the original file", async ({ page }) => {
+  const fixture = await setup(page)
+  await openReview(page)
+  await page.getByRole("button", { name: "Edit file", exact: true }).click()
+  await expect(editor(page)).toHaveText(original, { useInnerText: true })
+  await replaceHeader(page)
+  await page.getByRole("button", { name: "Discard", exact: true }).click()
+  await expect(page.getByRole("button", { name: "Edit file", exact: true })).toBeEnabled()
+  await expect(page.locator('[data-slot="review-file-editor"]')).toHaveCount(0)
+  await expect(
+    page.locator('[data-slot="session-review-v2-diff-scroll"]').getByText('return "after"', { exact: true }),
+  ).toBeVisible()
+  await page.getByRole("button", { name: "Edit file", exact: true }).click()
+  await expect(editor(page)).toHaveText(original, { useInnerText: true })
+  await expect(page.getByRole("button", { name: "Save", exact: true })).toBeDisabled()
+  expect(fixture.files.get(alpha)).toBe(original)
+  expect(fixture.writes).toHaveLength(0)
+})
+
+function editor(page: Page) {
+  return page.locator('[data-slot="review-file-editor"]').getByRole("textbox", { name: alpha, exact: true })
+}
+
+async function replaceHeader(page: Page) {
+  await expect(editor(page)).toBeEditable()
+  await editor(page).focus()
+  await editor(page).press("ControlOrMeta+Home")
+  await editor(page).press("Shift+End")
+  await page.keyboard.insertText(editedHeader)
+  await expect(editor(page)).toHaveText(edited, { useInnerText: true })
+  await expect(page.getByRole("button", { name: "Save", exact: true })).toBeEnabled()
+}
+
+async function selectFile(page: Page, file: string) {
+  await page.getByRole("button", { name: file, exact: true }).click()
+  await expect(page.locator('[data-slot="session-review-v2-file-name"]')).toHaveText(file)
+}
+
+async function openReview(page: Page) {
+  await page.goto(`/server/${base64Encode(server)}/session/${sessionID}`)
+  await expectSessionTitle(page, title)
+  await page.getByRole("button", { name: "Toggle review", exact: true }).click()
+  await selectFile(page, "alpha.ts")
+  await expect(page.getByRole("button", { name: "Edit file", exact: true })).toBeEnabled()
+}
+
+async function setup(
+  page: Page,
+  options: { read?: Promise<void>; write?: Promise<void>; failure?: "save" | "conflict" } = {},
+) {
+  const files = new Map([
+    [alpha, original],
+    [beta, original.replace("greeting", "farewell")],
+  ])
+  const writes: Request[] = []
+  const location = { directory: sessionDirectory, project: { id: projectID, directory, canonical } }
+  await mockOpenCodeServer(page, {
+    directory: sessionDirectory,
+    project: {
+      id: projectID,
+      worktree: canonical,
+      vcs: "git",
+      name: "review-editing",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [directory],
+    },
+    provider: {
+      all: [
+        {
+          id: "opencode",
+          name: "OpenCode",
+          models: { test: { id: "test", name: "Test", limit: { context: 200_000 } } },
+        },
+      ],
+      connected: ["opencode"],
+      default: { providerID: "opencode", modelID: "test" },
+    },
+    sessions: [
+      {
+        id: sessionID,
+        projectID,
+        directory: sessionDirectory,
+        title,
+        time: { created: 1700000000000, updated: 1700000000000 },
+      },
+    ],
+    pageMessages: () => ({ items: [] }),
+    fileList: () => [],
+  })
+  await page.route(/\/api\/location(?:\?.*)?$/, (route) => route.fulfill({ status: 200, json: location }))
+  await page.route("**/api/fs/read/**", async (route) => {
+    await options.read
+    const url = new URL(route.request().url())
+    const scope = url.searchParams.get("location[directory]")
+    expect([directory, sessionDirectory]).toContain(scope)
+    const relative = decodeURIComponent(url.pathname.slice("/api/fs/read/".length))
+    const path = scope === directory ? relative : `src/${relative}`
+    expect(files.has(path)).toBe(true)
+    await route.fulfill({ status: 200, contentType: "application/octet-stream", body: Buffer.from(files.get(path)!) })
+  })
+  await page.route("**/api/fs/write**", async (route) => {
+    writes.push(route.request())
+    await options.write
+    const body = route.request().postDataJSON() as { path: string; content: string; expected: string }
+    if (options.failure) {
+      await route.fulfill({
+        status: options.failure === "conflict" ? 409 : 500,
+        json:
+          options.failure === "conflict"
+            ? { _tag: "FileSystemWriteConflictError", path: body.path, message: "File changed on disk" }
+            : { message: "Fixture write failed" },
+      })
+      return
+    }
+    expect(files.has(body.path)).toBe(true)
+    expect(body.expected).toBe(Buffer.from(files.get(body.path)!).toString("base64"))
+    files.set(body.path, Buffer.from(body.content, "base64").toString("utf8"))
+    await route.fulfill({ status: 200, json: { location: { ...location, directory }, data: true } })
+  })
+  await page.route("**/api/vcs/diff**", (route) =>
+    route.fulfill({
+      status: 200,
+      json: {
+        location,
+        data: [...files].map(([file, content]) => {
+          const initial = file === alpha ? original : original.replace("greeting", "farewell")
+          return {
+            file,
+            additions: content === initial ? 1 : 2,
+            deletions: content === initial ? 1 : 2,
+            status: "modified",
+            patch: createTwoFilesPatch(
+              `a/${file}`,
+              `b/${file}`,
+              initial.replace('"after"', '"before"'),
+              content,
+              undefined,
+              undefined,
+              { context: 0 },
+            ),
+          }
+        }),
+      },
+    }),
+  )
+  await page.addInitScript(
+    ({ directory, server, sessionID }) => {
+      localStorage.setItem(
+        "opencode.global.dat:server",
+        JSON.stringify({
+          projects: { local: [{ worktree: directory, expanded: true }] },
+          lastProject: { local: directory },
+        }),
+      )
+      localStorage.setItem(
+        "opencode.window.browser.dat:tabs",
+        JSON.stringify([{ type: "session", server, sessionId: sessionID }]),
+      )
+    },
+    { directory, server, sessionID },
+  )
+  return { files, writes }
+}

--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -2,6 +2,18 @@ import { DESKTOP_NATIVE_ENGLISH } from "./desktop-native"
 
 export const dict = {
   ...DESKTOP_NATIVE_ENGLISH,
+  "session.review.editFile": "Edit file",
+  "session.review.unsaved": "Unsaved",
+  "session.review.discard": "Discard",
+  "session.review.saving": "Saving...",
+  "session.review.leaveUnsaved": "You have unsaved file edits. Leave this page?",
+  "session.review.editError.load": "Could not read this file. Discard to return to the review and try again.",
+  "session.review.editError.save": "Could not save this file. Your edits are still available. Try saving again.",
+  "session.review.editError.conflict":
+    "This file changed on disk. Your edits were not saved. Copy any edits you want to keep, then discard and reopen the file.",
+  "session.review.editError.unsupported": "Only UTF-8 text files can be edited here.",
+  "session.review.editError.editor":
+    "Could not load the editor. Your edits are still available. Switch files and return to try again.",
   "session.location.unavailable": "Session location unavailable",
   "session.location.description": "Choose another directory to continue this session.",
   "session.location.choose": "Choose directory",
@@ -982,8 +994,7 @@ export const dict = {
   "settings.general.row.showProjectIcon.title": "Project icon",
   "settings.general.row.showProjectIcon.description": "Show the project icon in the session header",
   "settings.general.row.mobileTitlebarBottom.title": "Bottom navigation",
-  "settings.general.row.mobileTitlebarBottom.description":
-    "Place the title bar at the bottom of the screen on mobile",
+  "settings.general.row.mobileTitlebarBottom.description": "Place the title bar at the bottom of the screen on mobile",
   "settings.general.row.mobileDiffWrap.description":
     "Wrap long lines in mobile diffs instead of scrolling horizontally",
   "settings.general.row.showCustomAgents.title": "Show agent",

--- a/packages/app/src/session/review/editor.test.ts
+++ b/packages/app/src/session/review/editor.test.ts
@@ -1,0 +1,369 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import type { FileDiffInfo } from "@opencode-ai/client/promise"
+import { createMemo, createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import { isServer } from "solid-js/web"
+import { createReviewEditor } from "./editor"
+
+const disposers: Array<() => void> = []
+afterEach(() => disposers.splice(0).forEach((dispose) => dispose()))
+
+const diff = {
+  file: "src/file.ts",
+  patch: "@@ -2 +2 @@\n-old\n+new",
+  additions: 1,
+  deletions: 1,
+  status: "modified",
+} satisfies FileDiffInfo
+
+const utf8 = (text: string) => new TextEncoder().encode(text)
+
+function setup(input: Partial<Pick<Parameters<typeof createReviewEditor>[0], "read" | "write">> = {}) {
+  return createRoot((dispose) => {
+    disposers.push(dispose)
+    const [state, setState] = createStore({ directory: "/repo" })
+    const files = new Map<string, Uint8Array>()
+    const reads: Array<{ directory: string; path: string }> = []
+    const writes: Array<{ directory: string; path: string; content: Uint8Array; expected: Uint8Array }> = []
+    const saved: Array<{ directory: string; path: string }> = []
+    files.set(JSON.stringify(["/repo", diff.file]), utf8("before\nnew\nafter\n"))
+    const editor = createReviewEditor({
+      directory: () => state.directory,
+      read: async (directory, path) => {
+        reads.push({ directory, path })
+        if (input.read) return input.read(directory, path)
+        const bytes = files.get(JSON.stringify([directory, path]))
+        if (!bytes) throw new Error("Missing file")
+        return bytes.slice()
+      },
+      write: async (directory, path, content, expected) => {
+        writes.push({ directory, path, content, expected })
+        if (input.write) await input.write(directory, path, content, expected)
+        const key = JSON.stringify([directory, path])
+        const current = files.get(key)
+        if (
+          !current ||
+          current.length !== expected.length ||
+          !current.every((byte, index) => byte === expected[index])
+        ) {
+          throw { _tag: "FileSystemWriteConflictError", path, message: "File changed" }
+        }
+        files.set(key, content.slice())
+      },
+      onSaved: (directory, path) => saved.push({ directory, path }),
+    })
+    return {
+      editor,
+      // Browser runs also verify reactivity; the default unit command uses Solid's server build.
+      pending: isServer ? () => editor.pending() : createMemo(() => editor.pending()),
+      diffs: isServer ? () => editor.diffs() : createMemo(() => editor.diffs()),
+      reads,
+      writes,
+      saved,
+      setDirectory: (directory: string) => setState("directory", directory),
+      put: (contents: Uint8Array, directory = "/repo", path = diff.file) =>
+        files.set(JSON.stringify([directory, path]), contents),
+      bytes: (directory = "/repo", path = diff.file) => files.get(JSON.stringify([directory, path])),
+    }
+  })
+}
+
+describe("review editor", () => {
+  test("loads full file bytes, not the diff patch, and keeps a diff snapshot", async () => {
+    const ctx = setup()
+    const snapshot = { ...diff }
+    const opening = ctx.editor.open(snapshot)
+    expect(ctx.editor.get(diff.file)).toMatchObject({ loading: true, loaded: false, contents: "" })
+    expect(ctx.pending()).toBe(false)
+    await opening
+
+    snapshot.patch = "changed outside the editor"
+    expect(ctx.editor.get(diff.file)).toMatchObject({
+      diff,
+      original: "before\nnew\nafter\n",
+      contents: "before\nnew\nafter\n",
+      loading: false,
+      loaded: true,
+      saving: false,
+    })
+    expect(ctx.reads).toEqual([{ directory: "/repo", path: diff.file }])
+    expect(ctx.diffs()).toEqual([diff])
+    ctx.editor.change(diff.file, "edited\n")
+    expect(ctx.pending()).toBe(true)
+    expect(ctx.diffs()).toEqual([diff])
+    ctx.editor.discard(diff.file)
+    expect(ctx.pending()).toBe(false)
+    expect(ctx.diffs()).toEqual([])
+  })
+
+  test.each([
+    { name: "UTF-8 LF", original: "caf\u00e9\nold\n", edited: "caf\u00e9\nnew\n", saved: "caf\u00e9\nnew\n" },
+    {
+      name: "UTF-8 BOM CRLF",
+      original: "\ufeffold\r\nline\r\n",
+      edited: "new\nline\n",
+      saved: "\ufeffnew\r\nline\r\n",
+    },
+    { name: "CRLF", original: "old\r\nline", edited: "new\nline", saved: "new\r\nline" },
+    { name: "BOM only", original: "\ufeff", edited: "new", saved: "\ufeffnew" },
+    { name: "empty file", original: "", edited: "new\n", saved: "new\n" },
+    { name: "CR", original: "old\rline\r", edited: "new\nline\n", saved: "new\rline\r" },
+  ])("preserves $name when saving normalized text", async (value) => {
+    const ctx = setup()
+    ctx.put(utf8(value.original))
+    await ctx.editor.open(diff)
+    expect(ctx.editor.get(diff.file)?.contents).toBe(value.original.replace(/^\ufeff/, "").replace(/\r\n?/g, "\n"))
+    ctx.editor.change(diff.file, value.edited)
+    await ctx.editor.save(diff.file)
+
+    expect(ctx.writes[0]?.expected).toEqual(utf8(value.original))
+    expect(ctx.bytes()).toEqual(utf8(value.saved))
+    expect(ctx.saved).toEqual([{ directory: "/repo", path: diff.file }])
+    expect(ctx.editor.get(diff.file)).toBeUndefined()
+    expect(ctx.pending()).toBe(false)
+  })
+
+  test.each([
+    { name: "NUL", bytes: utf8("before\0after") },
+    { name: "invalid UTF-8", bytes: new Uint8Array([0xc3, 0x28]) },
+    { name: "incomplete UTF-8", bytes: new Uint8Array([0xe2, 0x82]) },
+  ])("rejects $name without allowing a write", async (value) => {
+    const ctx = setup()
+    ctx.put(value.bytes)
+    await ctx.editor.open(diff)
+    expect(ctx.editor.get(diff.file)).toMatchObject({ loading: false, loaded: false, error: "unsupported" })
+    ctx.editor.change(diff.file, "replacement")
+    await ctx.editor.save(diff.file)
+    expect(ctx.writes).toEqual([])
+    expect(ctx.pending()).toBe(false)
+    expect(ctx.bytes()).toEqual(value.bytes)
+  })
+
+  test("retains load errors and can reopen after discard", async () => {
+    const ctx = setup()
+    const missing = { ...diff, file: "missing.ts" }
+    await ctx.editor.open(missing)
+    expect(ctx.editor.get(missing.file)).toMatchObject({ loaded: false, loading: false, error: "load" })
+    await ctx.editor.save(missing.file)
+    expect(ctx.writes).toEqual([])
+    ctx.editor.discard(missing.file)
+    ctx.put(utf8("available"), "/repo", missing.file)
+    await ctx.editor.open(missing)
+    expect(ctx.editor.get(missing.file)).toMatchObject({ loaded: true, contents: "available" })
+    expect(ctx.editor.get(missing.file)?.error).toBeUndefined()
+  })
+
+  test("retains failed saves and retries against the original bytes", async () => {
+    const failure = { active: true }
+    const ctx = setup({
+      write: async () => {
+        if (failure.active) throw new Error("Write failed")
+      },
+    })
+    await ctx.editor.open(diff)
+    ctx.editor.change(diff.file, "edited\n")
+    await ctx.editor.save(diff.file)
+    ctx.editor.ready(diff.file)
+    expect(ctx.editor.get(diff.file)).toMatchObject({
+      original: "before\nnew\nafter\n",
+      contents: "edited\n",
+      saving: false,
+      error: "save",
+    })
+    expect(ctx.pending()).toBe(true)
+    expect(ctx.saved).toEqual([])
+    failure.active = false
+    await ctx.editor.save(diff.file)
+    expect(ctx.bytes()).toEqual(utf8("edited\n"))
+    expect(ctx.writes[1]?.expected).toEqual(ctx.writes[0]?.expected)
+    expect(ctx.editor.get(diff.file)).toBeUndefined()
+  })
+
+  test("retains a conflicted draft without replacing external changes", async () => {
+    const ctx = setup()
+    await ctx.editor.open(diff)
+    ctx.editor.change(diff.file, "my edits")
+    ctx.put(utf8("external edits"))
+    await ctx.editor.save(diff.file)
+    ctx.editor.ready(diff.file)
+    expect(ctx.editor.get(diff.file)).toMatchObject({ error: "conflict", contents: "my edits", saving: false })
+    expect(ctx.bytes()).toEqual(utf8("external edits"))
+    expect(ctx.saved).toEqual([])
+    expect(ctx.pending()).toBe(true)
+    await ctx.editor.save(diff.file)
+    expect(ctx.editor.get(diff.file)?.error).toBe("conflict")
+    ctx.editor.discard(diff.file)
+    await ctx.editor.open(diff)
+    expect(ctx.editor.get(diff.file)?.original).toBe("external edits")
+  })
+
+  test("keeps A-B-A navigation scoped while tracking all unsaved drafts", async () => {
+    const ctx = setup()
+    await ctx.editor.open(diff)
+    ctx.editor.change(diff.file, "A edits")
+    ctx.setDirectory("/other")
+    expect(ctx.editor.get(diff.file)).toBeUndefined()
+    expect(ctx.diffs()).toEqual([])
+    expect(ctx.pending()).toBe(true)
+    ctx.put(utf8("B original"), "/other")
+    await ctx.editor.open(diff)
+    ctx.editor.change(diff.file, "B edits")
+    ctx.setDirectory("/repo")
+    expect(ctx.editor.get(diff.file)?.contents).toBe("A edits")
+    await ctx.editor.save(diff.file)
+    expect(ctx.bytes()).toEqual(utf8("A edits"))
+    expect(ctx.bytes("/other")).toEqual(utf8("B original"))
+    expect(ctx.pending()).toBe(true)
+    ctx.setDirectory("/other")
+    expect(ctx.editor.get(diff.file)?.contents).toBe("B edits")
+    ctx.editor.discard(diff.file)
+    expect(ctx.pending()).toBe(false)
+  })
+
+  test("keeps in-flight reads and writes attached to their starting directory", async () => {
+    const reading = Promise.withResolvers<Uint8Array>()
+    const writing = Promise.withResolvers<void>()
+    const ctx = setup({ read: () => reading.promise, write: () => writing.promise })
+    const opening = ctx.editor.open(diff)
+    ctx.setDirectory("/other")
+    reading.resolve(utf8("before\nnew\nafter\n"))
+    await opening
+    expect(ctx.editor.get(diff.file)).toBeUndefined()
+    ctx.setDirectory("/repo")
+    ctx.editor.change(diff.file, "A edits")
+    const saving = ctx.editor.save(diff.file)
+    ctx.setDirectory("/other")
+    expect(ctx.pending()).toBe(true)
+    writing.resolve()
+    await saving
+    expect(ctx.saved).toEqual([{ directory: "/repo", path: diff.file }])
+    expect(ctx.writes[0]?.directory).toBe("/repo")
+    expect(ctx.bytes()).toEqual(utf8("A edits"))
+    expect(ctx.diffs()).toEqual([])
+    ctx.setDirectory("/repo")
+    expect(ctx.editor.get(diff.file)).toBeUndefined()
+  })
+
+  test("ignores duplicate opens and saves and cannot discard a saving draft", async () => {
+    const reading = Promise.withResolvers<Uint8Array>()
+    const writing = Promise.withResolvers<void>()
+    const ctx = setup({ read: () => reading.promise, write: () => writing.promise })
+    const opening = ctx.editor.open(diff)
+    await ctx.editor.open({ ...diff, patch: "duplicate" })
+    ctx.editor.change(diff.file, "ignored before loading")
+    await ctx.editor.save(diff.file)
+    expect(ctx.reads).toHaveLength(1)
+    expect(ctx.writes).toHaveLength(0)
+    reading.resolve(utf8("before\nnew\nafter\n"))
+    await opening
+    ctx.editor.change(diff.file, "edited")
+    await ctx.editor.open(diff)
+    expect(ctx.editor.get(diff.file)?.contents).toBe("edited")
+    expect(ctx.reads).toHaveLength(1)
+    const saving = ctx.editor.save(diff.file)
+    await ctx.editor.save(diff.file)
+    ctx.editor.discard(diff.file)
+    expect(ctx.editor.get(diff.file)).toMatchObject({ saving: true, contents: "edited" })
+    expect(ctx.writes).toHaveLength(1)
+    writing.resolve()
+    await saving
+    expect(ctx.saved).toHaveLength(1)
+    expect(ctx.editor.get(diff.file)).toBeUndefined()
+  })
+
+  test.each([false, true])("ignores a discarded stale load, including rejection=%s", async (reject) => {
+    const first = Promise.withResolvers<Uint8Array>()
+    const second = Promise.withResolvers<Uint8Array>()
+    const requests = [first.promise, second.promise]
+    const ctx = setup({ read: () => requests.shift()! })
+    const stale = ctx.editor.open(diff)
+    ctx.editor.discard(diff.file)
+    expect(ctx.editor.get(diff.file)).toBeUndefined()
+    const current = ctx.editor.open(diff)
+    second.resolve(utf8("current"))
+    await current
+    ctx.editor.change(diff.file, "current edits")
+    reject ? first.reject(new Error("Stale failure")) : first.resolve(utf8("stale"))
+    await stale
+    expect(ctx.editor.get(diff.file)).toMatchObject({ original: "current", contents: "current edits", loaded: true })
+    expect(ctx.editor.get(diff.file)?.error).toBeUndefined()
+  })
+
+  test("retains typing during save and uses the saved bytes as the next baseline", async () => {
+    const writing = Promise.withResolvers<void>()
+    const ctx = setup({ write: () => writing.promise })
+    ctx.put(utf8("\ufefforiginal\r\n"))
+    await ctx.editor.open(diff)
+    ctx.editor.change(diff.file, "first\n")
+    const saving = ctx.editor.save(diff.file)
+    ctx.editor.change(diff.file, "second\n")
+    writing.resolve()
+    await saving
+    expect(ctx.bytes()).toEqual(utf8("\ufefffirst\r\n"))
+    expect(ctx.editor.get(diff.file)).toMatchObject({ original: "first\n", contents: "second\n", saving: false })
+    expect(ctx.pending()).toBe(true)
+    await ctx.editor.save(diff.file)
+    expect(ctx.writes[1]?.expected).toEqual(utf8("\ufefffirst\r\n"))
+    expect(ctx.bytes()).toEqual(utf8("\ufeffsecond\r\n"))
+    expect(ctx.saved).toHaveLength(2)
+    expect(ctx.pending()).toBe(false)
+  })
+
+  test("stays pending when text is reverted during a save", async () => {
+    const writing = Promise.withResolvers<void>()
+    const ctx = setup({ write: () => writing.promise })
+    await ctx.editor.open(diff)
+    ctx.editor.change(diff.file, "edited")
+    const saving = ctx.editor.save(diff.file)
+    ctx.editor.change(diff.file, "before\nnew\nafter\n")
+    expect(ctx.pending()).toBe(true)
+    writing.resolve()
+    await saving
+    expect(ctx.pending()).toBe(true)
+    expect(ctx.editor.get(diff.file)).toMatchObject({ original: "edited", contents: "before\nnew\nafter\n" })
+    await ctx.editor.save(diff.file)
+    expect(ctx.bytes()).toEqual(utf8("before\nnew\nafter\n"))
+  })
+
+  test("retains editor failures and does not write clean or missing drafts", async () => {
+    const ctx = setup()
+    ctx.editor.change(diff.file, "missing")
+    ctx.editor.fail(diff.file)
+    await ctx.editor.save(diff.file)
+    expect(ctx.editor.get(diff.file)).toBeUndefined()
+    await ctx.editor.open(diff)
+    await ctx.editor.save(diff.file)
+    expect(ctx.writes).toHaveLength(0)
+    ctx.editor.change(diff.file, "unsaved")
+    ctx.editor.fail(diff.file)
+    expect(ctx.editor.get(diff.file)).toMatchObject({ error: "editor", contents: "unsaved" })
+    await ctx.editor.save(diff.file)
+    expect(ctx.writes).toHaveLength(0)
+    expect(ctx.pending()).toBe(true)
+    ctx.editor.ready(diff.file)
+    expect(ctx.editor.get(diff.file)?.error).toBeUndefined()
+    expect(ctx.editor.get(diff.file)?.contents).toBe("unsaved")
+    ctx.editor.discard(diff.file)
+    expect(ctx.pending()).toBe(false)
+  })
+
+  test("handles prototype names and directory-path tuple collisions", async () => {
+    const ctx = setup()
+    ctx.put(utf8("prototype"), "/repo", "__proto__")
+    await ctx.editor.open({ ...diff, file: "__proto__" })
+    ctx.editor.change("__proto__", "safe")
+    await ctx.editor.save("__proto__")
+    expect(ctx.bytes("/repo", "__proto__")).toEqual(utf8("safe"))
+
+    ctx.setDirectory("/repo")
+    ctx.put(utf8("first"), "/repo", "nested/file")
+    await ctx.editor.open({ ...diff, file: "nested/file" })
+    ctx.editor.change("nested/file", "first edits")
+    ctx.setDirectory("/repo/nested")
+    ctx.put(utf8("second"), "/repo/nested", "file")
+    await ctx.editor.open({ ...diff, file: "file" })
+    expect(ctx.editor.get("file")?.contents).toBe("second")
+    ctx.setDirectory("/repo")
+    expect(ctx.editor.get("nested/file")?.contents).toBe("first edits")
+  })
+})

--- a/packages/app/src/session/review/editor.ts
+++ b/packages/app/src/session/review/editor.ts
@@ -1,0 +1,136 @@
+import { isFileSystemWriteConflictError, type FileDiffInfo } from "@opencode-ai/client/promise"
+import type { Accessor } from "solid-js"
+import { createStore } from "solid-js/store"
+
+export type ReviewEditorError = "load" | "save" | "conflict" | "unsupported" | "editor"
+
+export type Draft = {
+  diff: FileDiffInfo
+  original: string
+  contents: string
+  loading: boolean
+  saving: boolean
+  error?: ReviewEditorError
+  loaded: boolean
+}
+
+export function createReviewEditor(input: {
+  directory: Accessor<string>
+  read: (directory: string, path: string) => Promise<Uint8Array>
+  write: (directory: string, path: string, content: Uint8Array, expected: Uint8Array) => Promise<unknown>
+  onSaved: (directory: string, path: string) => void
+}) {
+  const [drafts, setDrafts] = createStore<
+    Record<string, (Draft & { directory: string; source?: ReturnType<typeof decode> }) | undefined>
+  >({})
+
+  return {
+    get(path: string): Draft | undefined {
+      return drafts[JSON.stringify([input.directory(), path])]
+    },
+    async open(diff: FileDiffInfo): Promise<void> {
+      const directory = input.directory()
+      const key = JSON.stringify([directory, diff.file])
+      if (drafts[key]) return
+      setDrafts(key, {
+        directory,
+        diff: { ...diff },
+        original: "",
+        contents: "",
+        loading: true,
+        saving: false,
+        loaded: false,
+      })
+      const draft = drafts[key]
+      try {
+        const bytes = await input.read(directory, diff.file)
+        if (drafts[key] !== draft) return
+        const source = decode(bytes)
+        if (!source) {
+          setDrafts(key, { loading: false, error: "unsupported" })
+          return
+        }
+        setDrafts(key, {
+          source,
+          original: source.contents,
+          contents: source.contents,
+          loading: false,
+          loaded: true,
+        })
+      } catch {
+        if (drafts[key] !== draft) return
+        setDrafts(key, { loading: false, error: "load" })
+      }
+    },
+    change(path: string, contents: string): void {
+      const key = JSON.stringify([input.directory(), path])
+      const draft = drafts[key]
+      if (!draft?.loaded) return
+      setDrafts(key, { contents, error: undefined })
+    },
+    async save(path: string): Promise<void> {
+      const directory = input.directory()
+      const key = JSON.stringify([directory, path])
+      const draft = drafts[key]
+      if (!draft?.loaded || draft.saving || !draft.source || draft.error === "editor") return
+      if (draft.contents === draft.original) return
+      const contents = draft.contents
+      const bytes = encode(contents, draft.source)
+      setDrafts(key, { saving: true, error: undefined })
+      try {
+        await input.write(directory, path, bytes, draft.source.bytes)
+      } catch (error) {
+        setDrafts(key, { saving: false, error: isFileSystemWriteConflictError(error) ? "conflict" : "save" })
+        return
+      }
+      // Edits made during the write now compare against the bytes that reached disk.
+      setDrafts(
+        key,
+        draft.contents === contents
+          ? undefined
+          : { original: contents, saving: false, source: { ...draft.source, bytes, contents } },
+      )
+      input.onSaved(directory, path)
+    },
+    discard(path: string): void {
+      const key = JSON.stringify([input.directory(), path])
+      if (drafts[key]?.saving) return
+      setDrafts(key, undefined)
+    },
+    fail(path: string): void {
+      const key = JSON.stringify([input.directory(), path])
+      if (!drafts[key]) return
+      setDrafts(key, "error", "editor")
+    },
+    ready(path: string): void {
+      const key = JSON.stringify([input.directory(), path])
+      if (drafts[key]?.error === "editor") setDrafts(key, "error", undefined)
+    },
+    pending(): boolean {
+      return Object.values(drafts).some((draft) => draft && (draft.saving || draft.contents !== draft.original))
+    },
+    diffs(): FileDiffInfo[] {
+      const directory = input.directory()
+      return Object.values(drafts).flatMap((draft) => (draft?.directory === directory ? [draft.diff] : []))
+    },
+  }
+}
+
+function decode(bytes: Uint8Array) {
+  try {
+    const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes)
+    if (text.includes("\0")) return undefined
+    return {
+      bytes,
+      contents: text.replace(/\r\n?/g, "\n"),
+      bom: bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf,
+      eol: text.match(/\r\n|\r|\n/)?.[0] ?? "\n",
+    }
+  } catch {
+    return undefined
+  }
+}
+
+function encode(contents: string, source: { bom: boolean; eol: string }) {
+  return new TextEncoder().encode((source.bom ? "\ufeff" : "") + contents.replace(/\n/g, source.eol))
+}

--- a/packages/app/src/session/review/file-preview.stories.tsx
+++ b/packages/app/src/session/review/file-preview.stories.tsx
@@ -1,0 +1,55 @@
+import { File } from "@opencode-ai/session-ui/file"
+import { FileComponentProvider } from "@opencode-ai/ui/context/file"
+import { Button } from "@opencode-ai/ui/button"
+import { createStore } from "solid-js/store"
+import { createReviewEditor } from "./editor"
+import { ReviewFilePreview } from "./file-preview"
+
+function WorkspacesStory() {
+  const [state, setState] = createStore({ directory: "/workspace-a" })
+  const files = new Map<string, Uint8Array>([
+    ["/workspace-a", new TextEncoder().encode("// Workspace A\n")],
+    ["/workspace-b", new TextEncoder().encode("// Workspace B\n")],
+  ])
+  const editor = createReviewEditor({
+    directory: () => state.directory,
+    read: async (directory) => files.get(directory)!,
+    write: async (directory, _path, contents) => {
+      files.set(directory, contents)
+    },
+    onSaved() {},
+  })
+  return (
+    <FileComponentProvider component={File}>
+      <div class="flex h-[560px] max-w-[800px] flex-col gap-3">
+        <div class="flex gap-2">
+          <Button onClick={() => setState("directory", "/workspace-a")}>Workspace A</Button>
+          <Button onClick={() => setState("directory", "/workspace-b")}>Workspace B</Button>
+          <span>{state.directory}</span>
+        </div>
+        <div data-component="session-review-v2" class="border border-border-base">
+          <ReviewFilePreview
+            file="src/shared.ts"
+            diff={{
+              file: "src/shared.ts",
+              status: "modified",
+              additions: 1,
+              deletions: 1,
+              patch: "@@ -1 +1 @@\n-before\n+after\n",
+            }}
+            diffStyle="unified"
+            editor={editor}
+          />
+        </div>
+      </div>
+    </FileComponentProvider>
+  )
+}
+
+export default {
+  title: "OpenCode/Review/Editing",
+  id: "app-review-editing",
+  component: WorkspacesStory,
+}
+
+export const Workspaces = { render: () => <WorkspacesStory /> }

--- a/packages/app/src/session/review/file-preview.tsx
+++ b/packages/app/src/session/review/file-preview.tsx
@@ -1,0 +1,114 @@
+import type { FileDiffInfo } from "@opencode-ai/client/promise"
+import { FileEditor } from "@opencode-ai/session-ui/file-editor"
+import { mediaKindFromPath } from "@opencode-ai/session-ui/pierre/media"
+import {
+  SessionReviewFilePreviewV2,
+  type SessionReviewFilePreviewV2Props,
+} from "@opencode-ai/session-ui/v2/session-review-file-preview-v2"
+import { Button } from "@opencode-ai/ui/button"
+import { makeEventListener } from "@solid-primitives/event-listener"
+import { Show, untrack } from "solid-js"
+import { useLanguage } from "@/runtime/i18n/language"
+import type { createReviewEditor } from "./editor"
+
+export function ReviewFilePreview(
+  props: SessionReviewFilePreviewV2Props & {
+    diff: FileDiffInfo
+    editor?: ReturnType<typeof createReviewEditor>
+  },
+) {
+  const language = useLanguage()
+  const draft = () => props.editor?.get(props.file)
+  const dirty = () => draft()?.loaded && draft()?.contents !== draft()?.original
+  const canEdit = () => props.editor && props.diff.status !== "deleted" && !mediaKindFromPath(props.file)
+
+  return (
+    <SessionReviewFilePreviewV2
+      {...props}
+      headerActions={
+        <Show when={canEdit() || draft()}>
+          <div class="flex shrink-0 items-center gap-1" data-slot="review-edit-actions">
+            <Show
+              when={draft()}
+              fallback={
+                <Button size="small" variant="ghost" onClick={() => void props.editor?.open(props.diff)}>
+                  {language.t("session.review.editFile")}
+                </Button>
+              }
+            >
+              <Show when={dirty()}>
+                <span class="text-12-regular text-text-weak" role="status">
+                  {language.t("session.review.unsaved")}
+                </span>
+              </Show>
+              <Button
+                size="small"
+                variant="ghost"
+                disabled={draft()?.saving}
+                onClick={() => props.editor?.discard(props.file)}
+              >
+                {language.t("session.review.discard")}
+              </Button>
+              <Button
+                size="small"
+                aria-keyshortcuts="Control+S Meta+S"
+                disabled={!dirty() || draft()?.saving || draft()?.error === "editor"}
+                onClick={() => void props.editor?.save(props.file)}
+              >
+                {language.t(draft()?.saving ? "session.review.saving" : "common.save")}
+              </Button>
+            </Show>
+          </div>
+        </Show>
+      }
+      content={
+        <Show when={draft()}>
+          <div
+            class="flex min-h-full flex-col"
+            data-slot="review-file-editor"
+            ref={(element) =>
+              makeEventListener(
+                element,
+                "keydown",
+                (event) => {
+                  if (!(event.ctrlKey || event.metaKey) || event.key.toLowerCase() !== "s") return
+                  event.preventDefault()
+                  event.stopPropagation()
+                  if (dirty()) void props.editor?.save(props.file)
+                },
+                { capture: true },
+              )
+            }
+          >
+            <Show when={draft()?.loading}>
+              <div class="p-3 text-13-regular text-text-weak" role="status">
+                {language.t("common.loading")}
+              </div>
+            </Show>
+            <Show when={draft()?.error}>
+              {(error) => (
+                <div class="p-3 text-13-regular text-text-strong" role="alert">
+                  {language.t(`session.review.editError.${error()}`)}
+                </div>
+              )}
+            </Show>
+            <Show when={draft()?.loaded && draft()} keyed>
+              {(value) => {
+                // The editor owns its live buffer; parent updates must not reset its undo history.
+                const file = untrack(() => ({ name: props.file, contents: value.contents }))
+                return (
+                  <FileEditor
+                    file={file}
+                    onChange={(contents) => props.editor?.change(props.file, contents)}
+                    onError={() => props.editor?.fail(props.file)}
+                    onReady={() => props.editor?.ready(props.file)}
+                  />
+                )
+              }}
+            </Show>
+          </div>
+        </Show>
+      }
+    />
+  )
+}

--- a/packages/app/src/session/review/model.ts
+++ b/packages/app/src/session/review/model.ts
@@ -6,12 +6,16 @@ import { createQuery, skipToken, useQueryClient } from "@tanstack/solid-query"
 import { debounce } from "@solid-primitives/scheduled"
 import { createEffect, createMemo, on, onCleanup, type Accessor } from "solid-js"
 import { createStore } from "solid-js/store"
+import { Encoding } from "effect"
+import { useBeforeLeave } from "@solidjs/router"
+import { makeEventListener } from "@solid-primitives/event-listener"
 import { useComments } from "@/composer/comments"
 import { selectionFromLines, useFile, type FileSelection, type SelectedLineRange } from "@/workspaces/files/model"
 import { useLanguage } from "@/runtime/i18n/language"
 import { useLayout } from "@/shell/state/layout"
 import { useComposerState } from "@/composer/persistence"
 import { useWorkspaceLocation } from "@/workspaces/location"
+import { containsDirectory } from "@/workspaces/paths"
 import { useServerSDK } from "@/runtime/server/client"
 import { createOpenReviewFile } from "../helpers"
 import type { SessionModel } from "../model"
@@ -19,6 +23,7 @@ import type { SessionScreenLayout } from "../screen-layout"
 import { createReviewPanelState } from "./panel-state"
 import { reviewDiffDirectory, reviewDiffNeedsLoad, reviewRootDirectory } from "./review-diff-kinds"
 import type { DiffStyle } from "./review-tab"
+import { createReviewEditor } from "./editor"
 
 export type ChangeMode = "git" | "branch" | "turn"
 type VcsMode = "git" | "branch"
@@ -126,6 +131,36 @@ export function createSessionReview(input: {
       queryKey: [server.scope, "session-details", input.session.workspace.directory()],
     })
   }, 100)
+  const reviewDirectory = () => reviewRootDirectory(location().current?.project.directory ?? location().directory)
+  const editor = createReviewEditor({
+    directory: reviewDirectory,
+    read: (directory, path) => server.api.file.read({ location: { directory }, path }),
+    write: (directory, path, content, expected) =>
+      server.api.file.write({
+        location: { directory },
+        path,
+        content: Encoding.encodeBase64(content),
+        expected: Encoding.encodeBase64(expected),
+      }),
+    onSaved: (directory, path) => {
+      const target = `${directory}/${path}`
+      if (containsDirectory(location().directory, target)) void file.load(target, { force: true })
+      // A save can finish after navigation; invalidate the originating server's caches,
+      // not only whichever session happens to be active now.
+      void queryClient.invalidateQueries({ queryKey: [server.scope, "session-vcs"] })
+      void queryClient.invalidateQueries({ queryKey: [server.scope, "session-details"] })
+    },
+  })
+  makeEventListener(window, "beforeunload", (event) => {
+    if (!editor.pending()) return
+    event.preventDefault()
+    event.returnValue = ""
+  })
+  useBeforeLeave((event) => {
+    if (event.defaultPrevented) return
+    if (!editor.pending() || window.confirm(language.t("session.review.leaveUnsaved"))) return
+    event.preventDefault()
+  })
   createEffect(() => {
     const stop = location().event.listen((event) => {
       if (event.type === "filesystem.changed") refresh()
@@ -143,8 +178,9 @@ export function createSessionReview(input: {
     ),
   )
   const diffs = () => {
-    if (mode() === "git" || mode() === "branch") return vcsQuery.isFetched ? (vcsQuery.data ?? []) : []
-    return []
+    const current = (mode() === "git" || mode() === "branch") && vcsQuery.isFetched ? (vcsQuery.data ?? []) : []
+    // Keep open drafts reachable even when an external edit removes a file from the diff.
+    return [...current, ...editor.diffs().filter((draft) => !current.some((diff) => diff.file === draft.file))]
   }
   const activeFile = () => {
     const list = diffs()
@@ -161,7 +197,7 @@ export function createSessionReview(input: {
   const loadDiff = async (path: string, version?: number): Promise<FileDiffInfo | undefined> => {
     const value = vcsMode()
     if (!value) return undefined
-    const root = reviewRootDirectory(input.session.project()?.worktree ?? location().directory)
+    const root = reviewDirectory()
     const directory = reviewDiffDirectory(root, path)
     const source = diffs().find((diff) => diff.file === path)
     const valid = (diff: FileDiffInfo | undefined): FileDiffInfo | undefined => {
@@ -404,6 +440,7 @@ export function createSessionReview(input: {
       set: (style: DiffStyle) => layout.review.setDiffStyle(style),
     },
     diffs,
+    editor: () => (location().current && !location().ref.workspaceID ? editor : undefined),
     focusFile,
     hasChanges,
     loadDiff,

--- a/packages/app/src/session/review/panel.tsx
+++ b/packages/app/src/session/review/panel.tsx
@@ -6,7 +6,8 @@ import {
   SessionReviewV2,
   SessionReviewV2Sidebar,
 } from "@opencode-ai/session-ui/v2/session-review-v2"
-import { SessionReviewFilePreviewV2 } from "@opencode-ai/session-ui/v2/session-review-file-preview-v2"
+import { ReviewFilePreview } from "./file-preview"
+import type { createReviewEditor } from "./editor"
 import { DiffChanges } from "@opencode-ai/ui/diff-changes"
 import type {
   SessionReviewComment,
@@ -53,6 +54,7 @@ export type ReviewPanelProps = {
   focusedComment?: SessionReviewFocus | null
   onFocusedCommentChange?: (focus: SessionReviewFocus | null) => void
   fileList?: "tree" | "flat"
+  editor?: ReturnType<typeof createReviewEditor>
 }
 
 export function ReviewPanel(props: ReviewPanelProps) {
@@ -155,7 +157,8 @@ export function ReviewPanelView(
           {(file) => (
             <Show when={activeItem()}>
               {(diff) => (
-                <SessionReviewFilePreviewV2
+                <ReviewFilePreview
+                  editor={props.editor}
                   file={file}
                   diff={diff()}
                   diffStyle={props.diffStyle}

--- a/packages/app/src/session/review/view.tsx
+++ b/packages/app/src/session/review/view.tsx
@@ -222,6 +222,7 @@ function ReviewPanelContent(props: { review: SessionReviewModel }) {
           diffsReady={props.review.ready()}
           diffVersion={props.review.diffVersion()}
           loadDiff={props.review.loadDiff}
+          editor={props.review.editor()}
           activeFile={props.review.activeFile()}
           onSelectFile={props.review.focusFile}
           diffStyle={props.review.diffStyle.current()}

--- a/packages/app/src/shell/commands/command.tsx
+++ b/packages/app/src/shell/commands/command.tsx
@@ -394,6 +394,13 @@ export const { use: useCommand, provider: CommandProvider } = createSimpleContex
 
       const sig = signatureFromEvent(event)
       const isPalette = palette().has(sig)
+      // Shadow DOM retargets event.target to the host; editor shortcuts own their
+      // composed path even before the editor's bubbling handlers run.
+      if (
+        !isPalette &&
+        event.composedPath().some((node) => node instanceof HTMLElement && node.dataset.component === "file-editor")
+      )
+        return
       const option = resolveKeybindOption(keymap().get(sig), event)
       const modified = event.ctrlKey || event.metaKey || event.altKey
       const isTab = event.key === "Tab"

--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -1532,6 +1532,15 @@ export interface PermissionApi<E = never> {
   readonly reply: PermissionReplyOperation<E>
 }
 
+export type FileWriteInput = {
+  readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  readonly path: RelativePath
+  readonly content: string
+  readonly expected: string
+}
+export type FileWriteOutput = { readonly location: Location.Info; readonly data: boolean }
+export type FileWriteOperation<E = never> = (input: FileWriteInput) => Effect.Effect<FileWriteOutput, E>
+
 export type FileListInput = {
   readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
   readonly path?: RelativePath | undefined
@@ -1549,6 +1558,7 @@ export type FileFindOutput = { readonly location: Location.Info; readonly data: 
 export type FileFindOperation<E = never> = (input: FileFindInput) => Effect.Effect<FileFindOutput, E>
 
 export interface FileApi<E = never> {
+  readonly write: FileWriteOperation<E>
   readonly list: FileListOperation<E>
   readonly find: FileFindOperation<E>
 }

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -177,6 +177,8 @@ import type {
   PermissionGetOutput,
   PermissionReplyInput,
   PermissionReplyOutput,
+  FileWriteInput,
+  FileWriteOutput,
   FileListInput,
   FileListOutput,
   FileFindInput,
@@ -1138,6 +1140,14 @@ const adaptGroupPermission = (raw: RawClient["server.permission"]) => ({
   reply: EndpointPermissionReply(raw),
 })
 
+const EndpointFileWrite = (raw: RawClient["server.fs"]) => (input: FileWriteInput) =>
+  preserveEffect<FileWriteOutput>()(
+    raw["fs.write"]({
+      query: { location: input["location"] },
+      payload: { path: input["path"], content: input["content"], expected: input["expected"] },
+    }).pipe(Effect.mapError(mapClientError)),
+  )
+
 const EndpointFileList = (raw: RawClient["server.fs"]) => (input?: FileListInput) =>
   preserveEffect<FileListOutput>()(
     raw["fs.list"]({ query: { location: input?.["location"], path: input?.["path"] } }).pipe(
@@ -1152,7 +1162,11 @@ const EndpointFileFind = (raw: RawClient["server.fs"]) => (input: FileFindInput)
     }).pipe(Effect.mapError(mapClientError)),
   )
 
-const adaptGroupFile = (raw: RawClient["server.fs"]) => ({ list: EndpointFileList(raw), find: EndpointFileFind(raw) })
+const adaptGroupFile = (raw: RawClient["server.fs"]) => ({
+  write: EndpointFileWrite(raw),
+  list: EndpointFileList(raw),
+  find: EndpointFileFind(raw),
+})
 
 const EndpointCommandList = (raw: RawClient["server.command"]) => (input?: CommandListInput) =>
   preserveEffect<CommandListOutput>()(

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -173,6 +173,8 @@ import type {
   PermissionReplyOutput,
   FileReadInput,
   FileReadOutput,
+  FileWriteInput,
+  FileWriteOutput,
   FileListInput,
   FileListOutput,
   FileFindInput,
@@ -1540,6 +1542,19 @@ export function make(options: ClientOptions) {
             declaredStatuses: [401, 400],
             empty: false,
             binary: true,
+          },
+          requestOptions,
+        ),
+      write: (input: FileWriteInput, requestOptions?: RequestOptions) =>
+        request<FileWriteOutput>(
+          {
+            method: "POST",
+            path: `/api/fs/write`,
+            query: { location: input["location"] },
+            body: { path: input["path"], content: input["content"], expected: input["expected"] },
+            successStatus: 200,
+            declaredStatuses: [409, 400, 401],
+            empty: false,
           },
           requestOptions,
         ),

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -2495,6 +2495,14 @@ export type PermissionNotFoundError = {
 export const isPermissionNotFoundError = (value: unknown): value is PermissionNotFoundError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "PermissionNotFoundError"
 
+export type FileSystemWriteConflictError = {
+  readonly _tag: "FileSystemWriteConflictError"
+  readonly path: string
+  readonly message: string
+}
+export const isFileSystemWriteConflictError = (value: unknown): value is FileSystemWriteConflictError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "FileSystemWriteConflictError"
+
 export type RpcError = {
   readonly _tag: "RpcError"
   readonly type: string
@@ -5630,6 +5638,20 @@ export type FileReadInput = {
 }
 
 export type FileReadOutput = globalThis.Uint8Array
+
+export type FileWriteInput = {
+  readonly location?: {
+    readonly location?: { readonly directory?: string | undefined; readonly workspace?: string | undefined } | undefined
+  }["location"]
+  readonly path: { readonly path: string; readonly content: string; readonly expected: string }["path"]
+  readonly content: { readonly path: string; readonly content: string; readonly expected: string }["content"]
+  readonly expected: { readonly path: string; readonly content: string; readonly expected: string }["expected"]
+}
+
+export type FileWriteOutput = {
+  location: { directory: string; workspaceID?: string; project: { id: string; directory: string; canonical: string } }
+  data: boolean
+}
 
 export type FileListInput = {
   readonly location?: {

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -47,7 +47,7 @@ test("exposes every standard HTTP API group", () => {
   expect(Object.keys(client.integration.oauth)).toEqual(["connect", "status", "complete", "cancel"])
   expect(Object.keys(client.integration.command)).toEqual(["connect", "status", "cancel"])
   expect(Object.keys(client.websearch)).toEqual(["providers", "query"])
-  expect(Object.keys(client.file)).toEqual(["read", "list", "find"])
+  expect(Object.keys(client.file)).toEqual(["read", "write", "list", "find"])
   expect(Object.keys(client.vcs)).toEqual(["get", "base", "status", "branches", "diff"])
   expect(Object.keys(client.pty)).toEqual(["list", "create", "get", "update", "remove", "connect"])
   expect(Object.keys(client.pty.connect)).toEqual(["token"])

--- a/packages/core/src/file-mutation.ts
+++ b/packages/core/src/file-mutation.ts
@@ -61,6 +61,11 @@ export const syncTextBom = Effect.fn("FileMutation.syncTextBom")(function* (
 /** Share transaction locks across Location graphs that address the same file. */
 const transactionLocks = KeyedMutex.makeUnsafe<string>()
 
+export const withLock: Interface["withLock"] = (targets) => (effect) =>
+  [...new Set(targets.map(FSUtil.resolve))]
+    .sort()
+    .reduceRight((result, target) => transactionLocks.withLock(target)(result), effect)
+
 /**
  * Mutation locking is process-local and serializes cooperating OpenCode
  * changes; external writes can still race.
@@ -70,10 +75,6 @@ const layer = Layer.effect(
   Effect.gen(function* () {
     const environment = yield* Environment.Service
     const locks = KeyedMutex.makeUnsafe<string>()
-    const withLock: Interface["withLock"] = (targets) => (effect) =>
-      [...new Set(targets.map(FSUtil.resolve))]
-        .sort()
-        .reduceRight((result, target) => transactionLocks.withLock(target)(result), effect)
     const withTargetLock =
       (target: Target) =>
       <A, E, R>(effect: Effect.Effect<A, E, R>) =>

--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -7,8 +7,9 @@ import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Location } from "./location.js"
 import { PositiveInt, RelativePath } from "./schema.js"
 import { FileSystemSearch } from "./filesystem/search.js"
-import { Entry, FileSystem, FindInput } from "@opencode-ai/schema/filesystem"
-export { Entry, Match, Submatch } from "@opencode-ai/schema/filesystem"
+import { FileMutation } from "./file-mutation.js"
+import { Entry, FileSystem, FindInput, WriteConflictError, WriteInput } from "@opencode-ai/schema/filesystem"
+export { Entry, Match, Submatch, WriteConflictError, WriteInput } from "@opencode-ai/schema/filesystem"
 
 export const ReadInput = Schema.Struct({
   path: RelativePath,
@@ -51,6 +52,7 @@ export const Event = FileSystem.Event
 
 export interface Interface {
   readonly read: (input: ReadInput) => Effect.Effect<{ readonly content: Uint8Array; readonly mime: string }>
+  readonly write: (input: WriteInput) => Effect.Effect<boolean, WriteConflictError>
   readonly list: (input?: ListInput) => Effect.Effect<Entry[]>
   readonly find: (input: FindInput) => Effect.Effect<Entry[]>
 }
@@ -88,6 +90,23 @@ const baseLayer = Layer.effect(
           content: yield* fs.readFile(target.real).pipe(Effect.orDie),
           mime: FSUtil.mimeType(target.real),
         }
+      }),
+      write: Effect.fn("FileSystem.write")(function* (input) {
+        // Host filesystem operations do not yet address workspace placement (#44568).
+        if (location.workspaceID) return yield* Effect.die(new Error("Writing workspace files is not supported"))
+        const target = yield* resolve(input.path)
+        return yield* Effect.gen(function* () {
+          const info = yield* fs.stat(target.real).pipe(Effect.orDie)
+          if (info.type !== "File") return yield* Effect.die(new Error("Path is not a file"))
+          const current = yield* fs.readFile(target.real).pipe(Effect.orDie)
+          if (
+            current.length !== input.expected.length ||
+            !current.every((byte, index) => byte === input.expected[index])
+          )
+            return yield* new WriteConflictError({ path: input.path, message: "File changed since it was read" })
+          yield* fs.writeFile(target.real, input.content).pipe(Effect.orDie)
+          return true
+        }).pipe(Effect.uninterruptible, FileMutation.withLock([target.absolute, target.real]))
       }),
       list: Effect.fn("FileSystem.list")(function* (input = {}) {
         const target = yield* resolve(input.path)

--- a/packages/core/test/location-filesystem.test.ts
+++ b/packages/core/test/location-filesystem.test.ts
@@ -62,6 +62,134 @@ describe("FileSystem", () => {
     ),
   )
 
+  it.live("writes exact bytes including UTF-8, CRLF, BOM, binary, and empty content", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const filesystem = yield* FileSystem.Service
+        yield* Effect.forEach(
+          [
+            ...["caf\u00e9\n", "first\r\nsecond\r\n", "\ufeffBOM\r\n", ""].map((text) =>
+              new TextEncoder().encode(text),
+            ),
+            new Uint8Array([0, 128, 255]),
+          ],
+          (content) =>
+            Effect.gen(function* () {
+              const expected = new TextEncoder().encode("original content is longer\r\n")
+              yield* Effect.promise(() => fs.writeFile(path.join(directory, "file.txt"), expected))
+              expect(yield* filesystem.write({ path: RelativePath.make("file.txt"), content, expected })).toBe(true)
+              expect((yield* filesystem.read({ path: RelativePath.make("file.txt") })).content).toEqual(content)
+            }),
+        )
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("rejects changed bytes without modifying the file", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const filesystem = yield* FileSystem.Service
+        const current = new TextEncoder().encode("new\r\n")
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "file.txt"), current))
+        yield* Effect.forEach(["old\r\n", "new\n", "\ufeffnew\r\n", ""], (text) =>
+          Effect.gen(function* () {
+            const result = yield* filesystem
+              .write({
+                path: RelativePath.make("file.txt"),
+                content: new TextEncoder().encode("replacement"),
+                expected: new TextEncoder().encode(text),
+              })
+              .pipe(Effect.flip)
+            expect(result).toBeInstanceOf(FileSystem.WriteConflictError)
+            expect(result.path).toBe(RelativePath.make("file.txt"))
+            expect(result.message).toBe("File changed since it was read")
+            expect((yield* filesystem.read({ path: RelativePath.make("file.txt") })).content).toEqual(current)
+          }),
+        )
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("allows only one concurrent save against the same baseline", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const filesystem = yield* FileSystem.Service
+        const expected = new TextEncoder().encode("before")
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "file.txt"), expected))
+        const results = yield* Effect.forEach(
+          Array.from({ length: 8 }, (_, index) => index),
+          (index) =>
+            filesystem
+              .write({
+                path: RelativePath.make("file.txt"),
+                expected,
+                content: new TextEncoder().encode(`writer ${index}`),
+              })
+              .pipe(Effect.exit),
+          { concurrency: "unbounded" },
+        )
+        expect(results.filter(Exit.isSuccess)).toHaveLength(1)
+        expect(results.filter(Exit.isFailure)).toHaveLength(7)
+        expect(yield* Effect.promise(() => Bun.file(path.join(directory, "file.txt")).text())).toBe(
+          `writer ${results.findIndex(Exit.isSuccess)}`,
+        )
+      }).pipe(provide(directory)),
+    ),
+  )
+
+  it.live("writes only existing regular files within lexical and real path boundaries", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        const root = path.join(directory, "root")
+        const outside = path.join(directory, "outside")
+        yield* Effect.promise(async () => {
+          await fs.mkdir(root)
+          await fs.mkdir(outside)
+          await fs.mkdir(path.join(root, "inside"))
+          await fs.writeFile(path.join(outside, "file.txt"), "before")
+          await fs.writeFile(path.join(root, "inside", "file.txt"), "before")
+          await fs.symlink(outside, path.join(root, "escape"), "junction")
+          await fs.symlink(path.join(root, "inside"), path.join(root, "link"), "junction")
+        })
+        yield* Effect.gen(function* () {
+          const filesystem = yield* FileSystem.Service
+          const expected = new TextEncoder().encode("before")
+          const content = new TextEncoder().encode("after")
+          yield* Effect.forEach(["missing.txt", "inside", "../outside/file.txt", "escape/file.txt"], (file) =>
+            Effect.gen(function* () {
+              const result = yield* filesystem
+                .write({ path: RelativePath.make(file), content, expected })
+                .pipe(Effect.exit)
+              expect(Exit.isFailure(result)).toBe(true)
+            }),
+          )
+          expect(yield* Effect.promise(() => Bun.file(path.join(root, "missing.txt")).exists())).toBe(false)
+          expect(yield* Effect.promise(() => Bun.file(path.join(outside, "file.txt")).text())).toBe("before")
+          expect(yield* filesystem.write({ path: RelativePath.make("link/file.txt"), content, expected })).toBe(true)
+          expect((yield* filesystem.read({ path: RelativePath.make("inside/file.txt") })).content).toEqual(content)
+        }).pipe(provide(root))
+      }),
+    ),
+  )
+
+  it.live("does not write a host file for a workspace location", () =>
+    withTmp((directory) =>
+      Effect.gen(function* () {
+        yield* Effect.promise(() => fs.writeFile(path.join(directory, "file.txt"), "before"))
+        const filesystem = yield* FileSystem.Service
+        const result = yield* filesystem
+          .write({
+            path: RelativePath.make("file.txt"),
+            expected: new TextEncoder().encode("before"),
+            content: new TextEncoder().encode("after"),
+          })
+          .pipe(Effect.exit)
+        expect(Exit.isFailure(result)).toBe(true)
+        expect(yield* Effect.promise(() => Bun.file(path.join(directory, "file.txt")).text())).toBe("before")
+      }).pipe(provide(directory, Workspace.ID.make("wrk_filesystem"))),
+    ),
+  )
+
   it.live("skips host canonicalization for workspace locations at boot", () =>
     withTmp((directory) =>
       Effect.gen(function* () {

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -8519,6 +8519,126 @@
         "summary": "Read file"
       }
     },
+    "/api/fs/write": {
+      "post": {
+        "tags": ["filesystem"],
+        "operationId": "v2.fs.write",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "query",
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "directory": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "workspace": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "required": false,
+            "style": "deepObject",
+            "explode": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "location": {
+                      "$ref": "#/components/schemas/Location.InfoEncoded"
+                    },
+                    "data": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": ["location", "data"],
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "InvalidRequestError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InvalidRequestErrorEncoded"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedErrorEncoded"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "FileSystemWriteConflictError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileSystemWriteConflictErrorEncoded"
+                }
+              }
+            }
+          }
+        },
+        "description": "Replace an existing regular file relative to the requested location only when its bytes match expected.",
+        "summary": "Write file",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileSystem.WriteInput"
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
     "/api/fs/list": {
       "get": {
         "tags": ["filesystem"],
@@ -14267,6 +14387,43 @@
           }
         },
         "required": ["path", "type"],
+        "additionalProperties": false
+      },
+      "FileSystem.WriteInput": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string",
+            "format": "byte",
+            "contentEncoding": "base64"
+          },
+          "expected": {
+            "type": "string",
+            "format": "byte",
+            "contentEncoding": "base64"
+          }
+        },
+        "required": ["path", "content", "expected"],
+        "additionalProperties": false
+      },
+      "FileSystemWriteConflictErrorEncoded": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["FileSystemWriteConflictError"]
+          },
+          "path": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "path", "message"],
         "additionalProperties": false
       },
       "ForbiddenErrorEncoded": {

--- a/packages/protocol/src/groups/fs.ts
+++ b/packages/protocol/src/groups/fs.ts
@@ -3,6 +3,7 @@ import { Location } from "@opencode-ai/schema/location"
 import { PositiveInt, RelativePath } from "@opencode-ai/schema/schema"
 import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, HttpApiSchema, OpenApi } from "effect/unstable/httpapi"
+import { InvalidRequestError } from "../errors.js"
 import { LocationQuery, locationQueryOpenApi } from "./location.js"
 
 const ListQuery = Schema.Struct({
@@ -29,6 +30,24 @@ export const FileSystemGroup = HttpApiGroup.make("server.fs")
           identifier: "v2.fs.read",
           summary: "Read file",
           description: "Serve one file relative to the requested location.",
+        }),
+      ),
+  )
+  .add(
+    HttpApiEndpoint.post("fs.write", "/api/fs/write", {
+      query: LocationQuery,
+      // Keep the JSON wire type explicit for clients; the handler decodes bytes.
+      payload: Schema.toEncoded(FileSystem.WriteInput),
+      success: Location.response(Schema.Boolean),
+      error: [FileSystem.WriteConflictError, InvalidRequestError],
+    })
+      .annotateMerge(locationQueryOpenApi)
+      .annotateMerge(
+        OpenApi.annotations({
+          identifier: "v2.fs.write",
+          summary: "Write file",
+          description:
+            "Replace an existing regular file relative to the requested location only when its bytes match expected.",
         }),
       ),
   )

--- a/packages/schema/src/filesystem.ts
+++ b/packages/schema/src/filesystem.ts
@@ -41,3 +41,19 @@ export class FindInput extends Schema.Class<FindInput>("FileSystem.FindInput")({
   type: Schema.Literals(["file", "directory"]).pipe(optional),
   limit: PositiveInt.pipe(optional),
 }) {}
+
+export interface WriteInput extends Schema.Schema.Type<typeof WriteInput> {}
+export const WriteInput = Schema.Struct({
+  path: RelativePath,
+  content: Schema.Uint8ArrayFromBase64,
+  expected: Schema.Uint8ArrayFromBase64,
+}).annotate({ identifier: "FileSystem.WriteInput" })
+
+export class WriteConflictError extends Schema.TaggedError<WriteConflictError>()(
+  "FileSystemWriteConflictError",
+  {
+    path: RelativePath,
+    message: Schema.String,
+  },
+  { httpApiStatus: 409 },
+) {}

--- a/packages/schema/test/contract-hygiene.test.ts
+++ b/packages/schema/test/contract-hygiene.test.ts
@@ -165,10 +165,21 @@ describe("contract hygiene", () => {
     expect(Schema.encodeSync(Vcs.Info)({ branch: { current: undefined, default: undefined } })).toEqual({ branch: {} })
   })
 
+  test("filesystem writes decode base64 once and preserve exact bytes on the wire", () => {
+    const wire = { path: "file.bin", content: "77u/AID/DQo=", expected: "" }
+    const decoded = Schema.decodeUnknownSync(FileSystem.WriteInput)(wire)
+    expect(decoded.content).toEqual(new Uint8Array([0xef, 0xbb, 0xbf, 0, 128, 255, 13, 10]))
+    expect(decoded.expected).toEqual(new Uint8Array())
+    expect(Schema.encodeSync(FileSystem.WriteInput)(decoded)).toEqual(wire)
+    expect(() => Schema.decodeUnknownSync(FileSystem.WriteInput)({ ...wire, content: "!invalid!" })).toThrow()
+    expect(() => Schema.decodeUnknownSync(FileSystem.WriteInput)({ ...wire, expected: "!invalid!" })).toThrow()
+  })
+
   test("reusable public identifiers are stable and unique", () => {
     const identifiers = [
       Agent.Color,
       FileSystem.Submatch,
+      FileSystem.WriteInput,
       Form.Field,
       Form.Fields,
       Form.Info,

--- a/packages/server/src/handlers/fs.ts
+++ b/packages/server/src/handlers/fs.ts
@@ -1,6 +1,7 @@
 import { FileSystem } from "@opencode-ai/core/filesystem"
 import { RelativePath } from "@opencode-ai/core/schema"
-import { Effect } from "effect"
+import { InvalidRequestError } from "@opencode-ai/protocol/errors"
+import { Effect, Schema } from "effect"
 import { HttpServerResponse } from "effect/unstable/http"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
@@ -19,6 +20,17 @@ export const FileSystemHandler = HttpApiBuilder.group(Api, "server.fs", (handler
           })
           return HttpServerResponse.uint8Array(file.content, { contentType: file.mime })
         }),
+      )
+      .handle("fs.write", (ctx) =>
+        response(
+          Effect.gen(function* () {
+            const fs = yield* FileSystem.Service
+            const input = yield* Schema.decodeEffect(FileSystem.WriteInput)(ctx.payload).pipe(
+              Effect.mapError(() => new InvalidRequestError({ message: "Content and expected must be valid base64" })),
+            )
+            return yield* fs.write(input)
+          }),
+        ),
       )
       .handle("fs.list", (ctx) =>
         response(

--- a/packages/server/src/workerd.ts
+++ b/packages/server/src/workerd.ts
@@ -111,6 +111,7 @@ const fileSystemLayer = Layer.succeed(
   FileSystem.Service,
   FileSystem.Service.of({
     read: () => unavailable("FileSystem.read"),
+    write: () => unavailable("FileSystem.write"),
     list: () => unavailable("FileSystem.list"),
     find: () => unavailable("FileSystem.find"),
   }),

--- a/packages/server/test/filesystem.test.ts
+++ b/packages/server/test/filesystem.test.ts
@@ -1,0 +1,155 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { OpenCode } from "../../client/src/promise/index"
+import { tmpdir } from "../../core/test/fixture/tmpdir"
+import { it } from "../../core/test/lib/effect"
+import { ServerFetch } from "../src/fetch"
+
+const setup = Effect.fnUntraced(function* () {
+  const tmp = yield* Effect.acquireDisposable(Effect.promise(() => tmpdir("opencode-fs-endpoint-")))
+  const directory = path.join(tmp.path, "root")
+  yield* Effect.promise(() => fs.mkdir(directory))
+  const handler = yield* ServerFetch.make({
+    database: { path: ":memory:" },
+    config: { directory: path.join(tmp.path, "config"), project: false },
+    models: { fetch: false },
+    fs: { filewatcher: false },
+  })
+  const url = new URL("http://opencode.local/api/fs/write")
+  url.searchParams.set("location[directory]", directory)
+  return {
+    directory,
+    outside: tmp.path,
+    client: OpenCode.make({
+      baseUrl: url.origin,
+      fetch: Object.assign((input: RequestInfo | URL, init?: RequestInit) => handler(new Request(input, init)), {
+        preconnect: fetch.preconnect,
+      }),
+    }),
+    write: (payload: { path: string; content: string; expected: string }) =>
+      Effect.promise(() =>
+        handler(
+          new Request(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(payload),
+          }),
+        ),
+      ),
+  }
+})
+
+it.live("the generated Promise client sends base64 strings and exposes typed write conflicts", () =>
+  Effect.gen(function* () {
+    const server = yield* setup()
+    const expected = Buffer.from("before\r\n")
+    const content = Buffer.from([0xef, 0xbb, 0xbf, 0x00, 0x80, 0xff, 0x0d, 0x0a])
+    yield* Effect.promise(() => fs.writeFile(path.join(server.directory, "file.bin"), expected))
+    const input = {
+      location: { directory: server.directory },
+      path: "file.bin",
+      content: content.toString("base64"),
+      expected: expected.toString("base64"),
+    }
+    const response = yield* Effect.promise(() => server.client.file.write(input))
+    expect(response.data).toBe(true)
+    expect(yield* Effect.promise(() => fs.readFile(path.join(server.directory, "file.bin")))).toEqual(content)
+    yield* Effect.promise(async () => {
+      await expect(server.client.file.write(input)).rejects.toEqual({
+        _tag: "FileSystemWriteConflictError",
+        path: "file.bin",
+        message: "File changed since it was read",
+      })
+    })
+    expect(yield* Effect.promise(() => fs.readFile(path.join(server.directory, "file.bin")))).toEqual(content)
+  }),
+)
+
+it.live("writes base64 payloads as exact bytes in the requested location", () =>
+  Effect.gen(function* () {
+    const server = yield* setup()
+    yield* Effect.forEach(["caf\u00e9\n", "first\r\nsecond\r\n", "\ufeffBOM\r\n", "\x00\xff", ""], (text) =>
+      Effect.gen(function* () {
+        const expected = Buffer.from("original content is longer\r\n")
+        const content = Buffer.from(text)
+        yield* Effect.promise(() => fs.writeFile(path.join(server.directory, "file.txt"), expected))
+        const response = yield* server.write({
+          path: "file.txt",
+          content: content.toString("base64"),
+          expected: expected.toString("base64"),
+        })
+        expect(response.status).toBe(200)
+        expect(yield* Effect.promise(() => response.json())).toMatchObject({
+          location: { directory: server.directory },
+          data: true,
+        })
+        expect(yield* Effect.promise(() => fs.readFile(path.join(server.directory, "file.txt")))).toEqual(content)
+      }),
+    )
+  }),
+)
+
+it.live("returns a typed HTTP 409 conflict and leaves changed bytes untouched", () =>
+  Effect.gen(function* () {
+    const server = yield* setup()
+    const current = Buffer.from("new\r\n")
+    yield* Effect.promise(() => fs.writeFile(path.join(server.directory, "file.txt"), current))
+    yield* Effect.forEach(["old\r\n", "new\n", "\ufeffnew\r\n", ""], (text) =>
+      Effect.gen(function* () {
+        const response = yield* server.write({
+          path: "file.txt",
+          content: Buffer.from("replacement").toString("base64"),
+          expected: Buffer.from(text).toString("base64"),
+        })
+        expect(response.status).toBe(409)
+        expect(yield* Effect.promise(() => response.json())).toEqual({
+          _tag: "FileSystemWriteConflictError",
+          path: "file.txt",
+          message: "File changed since it was read",
+        })
+        expect(yield* Effect.promise(() => fs.readFile(path.join(server.directory, "file.txt")))).toEqual(current)
+      }),
+    )
+  }),
+)
+
+it.live("rejects missing files, directories, escapes, and invalid base64 without writing", () =>
+  Effect.gen(function* () {
+    const server = yield* setup()
+    yield* Effect.promise(async () => {
+      await fs.mkdir(path.join(server.directory, "inside"))
+      await fs.writeFile(path.join(server.outside, "file.txt"), "before")
+      await fs.writeFile(path.join(server.directory, "inside", "file.txt"), "before")
+      await fs.symlink(server.outside, path.join(server.directory, "escape"), "junction")
+      await fs.symlink(path.join(server.directory, "inside"), path.join(server.directory, "link"), "junction")
+    })
+    const payload = {
+      content: Buffer.from("after").toString("base64"),
+      expected: Buffer.from("before").toString("base64"),
+    }
+    yield* Effect.forEach(["missing.txt", "inside", "../file.txt", "escape/file.txt"], (file) =>
+      Effect.gen(function* () {
+        const response = yield* server.write({ path: file, ...payload })
+        expect(response.status).toBe(500)
+      }),
+    )
+    yield* Effect.forEach(["content", "expected"] as const, (field) =>
+      Effect.gen(function* () {
+        const response = yield* server.write({ path: "inside/file.txt", ...payload, [field]: "!not-base64!" })
+        expect(response.status).toBe(400)
+      }),
+    )
+    expect(yield* Effect.promise(() => Bun.file(path.join(server.directory, "missing.txt")).exists())).toBe(false)
+    expect(yield* Effect.promise(() => Bun.file(path.join(server.outside, "file.txt")).text())).toBe("before")
+    expect(yield* Effect.promise(() => Bun.file(path.join(server.directory, "inside", "file.txt")).text())).toBe(
+      "before",
+    )
+    const response = yield* server.write({ path: "link/file.txt", ...payload })
+    expect(response.status).toBe(200)
+    expect(yield* Effect.promise(() => Bun.file(path.join(server.directory, "inside", "file.txt")).text())).toBe(
+      "after",
+    )
+  }),
+)

--- a/packages/session-ui/component-tests/file-editor.spec.ts
+++ b/packages/session-ui/component-tests/file-editor.spec.ts
@@ -1,0 +1,168 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+for (const theme of ["light", "dark"]) {
+  story(`edits full contents with native undo and redo in ${theme}`, async ({ mount, page }) => {
+    const root = await mount("components-file-editor--default", { globals: { theme } })
+    const editor = root.getByRole("textbox", { name: "src/greeting.ts" })
+    await expect(editor).toBeVisible()
+    await expect(root.locator("diffs-container")).toHaveAttribute("data-color-scheme", theme)
+    await expect(root.locator('[data-line] [style*="--syntax-"]')).not.toHaveCount(0)
+    const colors = await editor
+      .locator('[data-line="1"] [data-char]')
+      .evaluateAll((tokens) => tokens.map((token) => getComputedStyle(token).color))
+    await expect(root.getByTestId("editor-changes")).toHaveText("Changes: 0")
+    await editor.focus()
+    await page.keyboard.press("ControlOrMeta+Home")
+    await page.keyboard.type("// note\n")
+    await expect(root.getByTestId("editor-contents")).toHaveJSProperty(
+      "textContent",
+      '// note\nexport const greeting = "Hello"\nexport const message = "Hello again"\n',
+    )
+    await page.setViewportSize({ width: 1000, height: 720 })
+    await expect
+      .poll(() =>
+        editor
+          .locator('[data-line="2"] [data-char]')
+          .evaluateAll((tokens) => tokens.map((token) => getComputedStyle(token).color)),
+      )
+      .toEqual(colors)
+    await page.keyboard.press("ControlOrMeta+z")
+    await expect(root.getByTestId("editor-contents")).toHaveJSProperty(
+      "textContent",
+      '// noteexport const greeting = "Hello"\nexport const message = "Hello again"\n',
+    )
+    await page.keyboard.press("ControlOrMeta+Shift+z")
+    await expect(root.getByTestId("editor-contents")).toHaveJSProperty(
+      "textContent",
+      '// note\nexport const greeting = "Hello"\nexport const message = "Hello again"\n',
+    )
+    await expect(root.getByTestId("editor-error")).toBeEmpty()
+  })
+}
+
+story("native find and replace do not trigger review navigation", async ({ mount, page }) => {
+  const root = await mount("components-file-editor--default")
+  const editor = root.getByRole("textbox", { name: "src/greeting.ts" })
+  await editor.focus()
+  await page.keyboard.press("ControlOrMeta+Home")
+  await page.keyboard.press("ArrowRight")
+  await page.keyboard.press("ArrowLeft")
+  await page.keyboard.press("ControlOrMeta+f")
+  await root.locator("input[data-search]").fill("Hello")
+  await expect(root.locator("[data-matches]")).toContainText("2")
+  await page.keyboard.press("ArrowLeft")
+  await page.keyboard.press("Escape")
+  await expect(root.locator("input[data-search]")).toHaveCount(0)
+  await editor.focus()
+  await page.keyboard.press("ControlOrMeta+Alt+f")
+  await root.locator("input[data-search]").fill("Hello")
+  await root.locator("input[data-replace]").fill("Welcome")
+  await root.getByRole("button", { name: "Replace All", exact: true }).click()
+  await expect(root.getByTestId("editor-contents")).toHaveJSProperty(
+    "textContent",
+    'export const greeting = "Welcome"\nexport const message = "Welcome again"\n',
+  )
+  await expect(root.getByTestId("editor-navigation")).toHaveText("Navigation: 0")
+  await expect(root.getByTestId("editor-error")).toBeEmpty()
+})
+
+story("preserves the editor and its history across theme changes in a narrow RTL shell", async ({ mount, page }) => {
+  await page.setViewportSize({ width: 380, height: 700 })
+  const root = await mount("components-file-editor--default", {
+    args: { narrow: true },
+    globals: { theme: "light", direction: "rtl", locale: "ar" },
+  })
+  const editor = root.getByRole("textbox", { name: "src/greeting.ts" })
+  await expect(editor).toHaveCSS("direction", "ltr")
+  await expect(page.locator("html")).toHaveAttribute("dir", "rtl")
+  await editor.focus()
+  await page.keyboard.press("ControlOrMeta+Home")
+  await page.keyboard.type("x")
+  const host = await root.locator("diffs-container").elementHandle()
+  await root.getByRole("button", { name: "Toggle theme" }).click()
+  await expect(root.locator("diffs-container")).toHaveAttribute("data-color-scheme", "dark")
+  expect(await host?.evaluate((node) => node === document.querySelector("diffs-container"))).toBe(true)
+  await expect(root.getByTestId("editor-contents")).toContainText("xexport")
+  await editor.focus()
+  await page.keyboard.press("ControlOrMeta+z")
+  await expect(root.getByTestId("editor-contents")).toContainText("export const greeting")
+  await expect(root.getByTestId("editor-contents")).not.toContainText("xexport")
+  await root.locator('[data-component="file-editor"]').evaluate((node) => {
+    if (node instanceof HTMLElement) node.style.setProperty("--syntax-keyword", "rgb(120, 80, 200)")
+  })
+  await expect(editor.getByText("export", { exact: true }).first()).toHaveCSS("color", "rgb(120, 80, 200)")
+  await expect(root.getByTestId("editor-error")).toBeEmpty()
+})
+
+story("unmounts cleanly and starts a fresh editing session on remount", async ({ mount, page }) => {
+  const errors: Error[] = []
+  page.on("pageerror", (error) => errors.push(error))
+  const root = await mount("components-file-editor--default", { args: { empty: true } })
+  const editor = root.getByRole("textbox", { name: "src/greeting.ts" })
+  await editor.click()
+  await expect(root.locator("[data-caret]")).toBeAttached()
+  await page.keyboard.type("draft")
+  await expect(root.getByTestId("editor-contents")).toHaveText("draft")
+  await root.getByRole("button", { name: "Unmount editor" }).click()
+  await expect(root.locator("diffs-container")).toHaveCount(0)
+  await root.getByRole("button", { name: "Mount editor" }).click()
+  await expect(editor).toHaveText("")
+  await editor.click()
+  await expect(root.locator("[data-caret]")).toBeAttached()
+  await page.keyboard.type("fresh")
+  await expect(root.getByTestId("editor-contents")).toHaveText("fresh")
+  await expect(root.getByTestId("editor-error")).toBeEmpty()
+  expect(errors).toEqual([])
+})
+
+story("ignores a lazy editor import that resolves after unmount", async ({ mount, page }) => {
+  const requested = Promise.withResolvers<void>()
+  const release = Promise.withResolvers<void>()
+  const loaded = Promise.withResolvers<void>()
+  await page.route(/(?:@pierre_diffs_edit|\/diffs\/dist\/edit\/index)\.js(?:\?|$)/, async (route) => {
+    requested.resolve()
+    await release.promise
+    await route.continue()
+    loaded.resolve()
+  })
+  const root = await mount("components-file-editor--default")
+  await requested.promise
+  const detached = await root.locator('[data-component="file-editor"]').elementHandle()
+  await root.getByRole("button", { name: "Unmount editor" }).click()
+  release.resolve()
+  await loaded.promise
+  await expect(root.locator("diffs-container")).toHaveCount(0)
+  await root.getByRole("button", { name: "Mount editor" }).click()
+  await expect(root.getByRole("textbox", { name: "src/greeting.ts" })).toBeVisible()
+  await expect(root.locator("diffs-container")).toHaveCount(1)
+  expect(await detached?.evaluate((node) => node.childElementCount)).toBe(0)
+  await expect(root.getByTestId("editor-changes")).toHaveText("Changes: 0")
+  await expect(root.getByTestId("editor-error")).toBeEmpty()
+})
+
+story("virtualizes large files and edits the final line with Ctrl+End", async ({ mount, page }) => {
+  const root = await mount("components-file-editor--large")
+  const editor = root.getByRole("textbox", { name: "src/large.ts" })
+  await expect(editor).toBeVisible()
+  expect(Number(await root.getByTestId("editor-size").textContent())).toBeGreaterThan(500_000)
+  await expect.poll(() => editor.locator("[data-line]").count()).toBeLessThan(300)
+  await editor.focus()
+  await page.keyboard.press("ControlOrMeta+End")
+  await expect(editor.locator('[data-line="8001"]')).toBeVisible()
+  await page.keyboard.type(" // edited")
+  await expect(root.getByTestId("editor-contents")).toContainText('export const finalLine = "end" // edited')
+  await page.keyboard.press("ControlOrMeta+Home")
+  await expect(editor.locator('[data-line="1"]')).toBeVisible()
+  await page.keyboard.press("ControlOrMeta+End")
+  await expect(editor.locator('[data-line="8001"] [data-char]').filter({ hasText: "export" })).not.toHaveCSS(
+    "color",
+    /rgba\(0, 0, 0, 0\./,
+  )
+  await expect.poll(() => editor.locator("[data-line]").count()).toBeLessThan(300)
+  await expect(root.getByTestId("editor-error")).toBeEmpty()
+  await root.getByRole("button", { name: "Unmount editor" }).click()
+  await expect(root.locator("diffs-container")).toHaveCount(0)
+  await root.getByRole("button", { name: "Mount editor" }).click()
+  await expect(editor).toBeVisible()
+  await expect.poll(() => editor.locator("[data-line]").count()).toBeLessThan(300)
+})

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -14,6 +14,7 @@
     "./basic-tool": "./src/components/basic-tool.tsx",
     "./dock-prompt": "./src/components/dock-prompt.tsx",
     "./file": "./src/components/file.tsx",
+    "./file-editor": "./src/components/file-editor.tsx",
     "./file-media": "./src/components/file-media.tsx",
     "./file-search": "./src/components/file-search.tsx",
     "./file-ssr": "./src/components/file-ssr.tsx",

--- a/packages/session-ui/src/components/file-editor.stories.tsx
+++ b/packages/session-ui/src/components/file-editor.stories.tsx
@@ -1,0 +1,98 @@
+import type { FileContents } from "@pierre/diffs"
+import { useTheme } from "@opencode-ai/ui/theme"
+import { createSignal, onCleanup, onMount, Show } from "solid-js"
+import { FileEditor } from "./file-editor"
+
+const fixture: FileContents = {
+  name: "src/greeting.ts",
+  contents: 'export const greeting = "Hello"\nexport const message = "Hello again"\n',
+}
+
+function EditorStory(props: { narrow?: boolean; empty?: boolean; large?: boolean }) {
+  const theme = useTheme()
+  const initial = props.large
+    ? {
+        name: "src/large.ts",
+        contents: `// ${"unchanged ".repeat(7)}\n`.repeat(8_000) + 'export const finalLine = "end"',
+      }
+    : props.empty
+      ? { ...fixture, contents: "" }
+      : fixture
+  const [mounted, setMounted] = createSignal(true)
+  const [contents, setContents] = createSignal(initial.contents)
+  const [changes, setChanges] = createSignal(0)
+  const [navigation, setNavigation] = createSignal(0)
+  const [error, setError] = createSignal("")
+
+  onMount(() => {
+    const navigate = (event: KeyboardEvent) => {
+      if (event.key === "ArrowLeft" || event.key === "ArrowRight") setNavigation((value) => value + 1)
+    }
+    document.addEventListener("keydown", navigate)
+    onCleanup(() => document.removeEventListener("keydown", navigate))
+  })
+
+  return (
+    <div class="mx-auto flex min-h-screen w-full max-w-[960px] flex-col gap-4 bg-background-base p-4">
+      <div class="flex flex-wrap items-center gap-4">
+        <button type="button" onClick={() => setMounted((value) => !value)}>
+          {mounted() ? "Unmount editor" : "Mount editor"}
+        </button>
+        <button type="button" onClick={() => theme.setColorScheme(theme.mode() === "dark" ? "light" : "dark")}>
+          Toggle theme
+        </button>
+        <span data-testid="editor-changes">Changes: {changes()}</span>
+        <span data-testid="editor-navigation">Navigation: {navigation()}</span>
+        <span>
+          Characters: <span data-testid="editor-size">{contents().length}</span>
+        </span>
+      </div>
+      <p>Local fixture only. Type, undo, redo, or use Ctrl/Cmd+F and Ctrl/Cmd+Alt+F to find and replace.</p>
+      <div
+        class="max-h-[60vh] min-h-40 w-full overflow-auto border border-border-base"
+        style={{ "max-width": props.narrow ? "320px" : undefined }}
+      >
+        <Show when={mounted()}>
+          <FileEditor
+            file={initial}
+            onChange={(value) => {
+              setContents(value)
+              setChanges((count) => count + 1)
+            }}
+            onError={(value) => setError(String(value))}
+          />
+        </Show>
+      </div>
+      <pre data-testid="editor-contents" dir="ltr" class="whitespace-pre-wrap break-all text-12-regular">
+        {props.large ? contents().slice(-200) : contents()}
+      </pre>
+      <output data-testid="editor-error">{error()}</output>
+    </div>
+  )
+}
+
+export default {
+  title: "OpenCode/Review/File editor",
+  id: "components-file-editor",
+  component: FileEditor,
+  parameters: { layout: "fullscreen" },
+}
+
+export const Default = {
+  args: { narrow: false, empty: false },
+  render: (args: { narrow: boolean; empty: boolean }) => <EditorStory {...args} />,
+}
+
+export const Dark = {
+  globals: { theme: "dark" },
+  render: () => <EditorStory />,
+}
+
+export const NarrowRtl = {
+  globals: { direction: "rtl" },
+  render: () => <EditorStory narrow />,
+}
+
+export const Large = {
+  render: () => <EditorStory large />,
+}

--- a/packages/session-ui/src/components/file-editor.tsx
+++ b/packages/session-ui/src/components/file-editor.tsx
@@ -1,0 +1,114 @@
+import {
+  DEFAULT_VIRTUAL_FILE_METRICS,
+  File,
+  type FileContents,
+  getSharedHighlighter,
+  VirtualizedFile,
+} from "@pierre/diffs"
+import type { Editor } from "@pierre/diffs/edit"
+import { checksum } from "@opencode-ai/util/encode"
+import { onCleanup, onMount } from "solid-js"
+import { createDefaultOptions, styleVariables } from "../pierre"
+import { applyViewerScheme, getViewerHost, observeViewerScheme } from "../pierre/file-runtime"
+import { acquireVirtualizer } from "../pierre/virtualizer"
+import { getWorkerPool } from "../pierre/worker"
+
+export type FileEditorProps = {
+  /** Initial contents only. Remount to edit a different file or reset the document. */
+  file: FileContents
+  onChange: (contents: string) => void
+  onError?: (error: unknown) => void
+  onReady?: () => void
+}
+
+export function FileEditor(props: FileEditorProps) {
+  let container!: HTMLDivElement
+
+  onMount(() => {
+    // Pierre writes edited contents back to this object during cleanup.
+    const initial = { ...props.file, cacheKey: `${props.file.name}:${checksum(props.file.contents)}` }
+    let disposed = false
+    let file: File | undefined
+    let editor: Editor<undefined> | undefined
+    let virtual: ReturnType<typeof acquireVirtualizer>
+
+    const cleanup = () => {
+      editor?.cleanUp()
+      editor = undefined
+      file?.cleanUp()
+      file = undefined
+      virtual?.release()
+      virtual = undefined
+    }
+
+    onCleanup(() => {
+      disposed = true
+      cleanup()
+    })
+    onCleanup(observeViewerScheme(() => getViewerHost(container)))
+
+    void (async () => {
+      const { Editor } = await import("@pierre/diffs/edit")
+      if (disposed) return
+
+      const highlighter = await getSharedHighlighter({
+        themes: ["OpenCode"],
+        langs: [],
+        preferredHighlighter: "shiki-wasm",
+      })
+      if (disposed) return
+
+      const defaults = createDefaultOptions<undefined>("unified")
+      const color = document.createElement("span").style
+      const options = {
+        ...defaults,
+        disableErrorHandling: true,
+        // Pierre 1.3.6's native tokenizer skips Shiki's CSS-variable replacements.
+        // Cover both native DOM styles and cached HTML without rewriting tokens on each edit.
+        unsafeCSS:
+          defaults.unsafeCSS +
+          Object.entries(highlighter.getTheme("OpenCode").colorReplacements ?? {})
+            .map(([placeholder, replacement]) => {
+              color.color = placeholder
+              return `[data-line] [data-char]:is([style*="color:${placeholder};" i], [style*="color: ${color.color};"]) { color: ${replacement} !important; }`
+            })
+            .join("\n"),
+      }
+      virtual = initial.contents.length > 500_000 ? acquireVirtualizer(container) : undefined
+      file = virtual
+        ? new VirtualizedFile(
+            options,
+            virtual.virtualizer,
+            { ...DEFAULT_VIRTUAL_FILE_METRICS, lineHeight: 24, spacing: 0 },
+            getWorkerPool(),
+          )
+        : new File(options, getWorkerPool())
+      file.render({ file: initial, containerWrapper: container })
+      applyViewerScheme(getViewerHost(container))
+      editor = new Editor<undefined>({
+        onChange: (value) => props.onChange(value.contents),
+        onAttach: () => {
+          if (!disposed) props.onReady?.()
+        },
+      })
+      editor.edit(file)
+    })().catch((error: unknown) => {
+      if (disposed) return
+      cleanup()
+      props.onError?.(error)
+    })
+  })
+
+  return (
+    <div
+      ref={container}
+      data-component="file-editor"
+      dir="ltr"
+      style={styleVariables}
+      class="relative min-w-0 select-text outline-none"
+      // Native listeners stop shadow-retargeted shortcuts before document-level review navigation.
+      on:keydown={(event) => event.stopPropagation()}
+      on:keyup={(event) => event.stopPropagation()}
+    />
+  )
+}

--- a/packages/session-ui/src/components/file-ssr.tsx
+++ b/packages/session-ui/src/components/file-ssr.tsx
@@ -119,21 +119,17 @@ function DiffSSRViewer<T>(props: SSRDiffFileProps<T>) {
     // @ts-expect-error private field required for hydration
     fileDiffInstance.fileContainer = fileDiffRef
     fileDiffInstance.hydrate(
-      local.fileDiff
+      props.fileDiff !== undefined
         ? {
-            fileDiff: local.fileDiff,
+            fileDiff: props.fileDiff,
             lineAnnotations: annotations,
             fileContainer: fileDiffRef,
             containerWrapper: container,
             prerenderedHTML: local.preloadedDiff.prerenderedHTML,
           }
         : {
-            oldFile: local.before
-              ? { ...local.before, contents: typeof local.before.contents === "string" ? local.before.contents : "" }
-              : local.before,
-            newFile: local.after
-              ? { ...local.after, contents: typeof local.after.contents === "string" ? local.after.contents : "" }
-              : local.after,
+            oldFile: props.before,
+            newFile: props.after,
             lineAnnotations: annotations,
             fileContainer: fileDiffRef,
             containerWrapper: container,

--- a/packages/session-ui/src/components/session-diff.test.ts
+++ b/packages/session-ui/src/components/session-diff.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, test } from "bun:test"
 import { normalize, resolveFileDiff, text } from "./session-diff"
 
 describe("session diff", () => {
+  test.each([1, 4])("uses content-specific worker cache keys for patches starting at line %s", (line) => {
+    const patch = `diff --git a/file.ts b/file.ts\n--- a/file.ts\n+++ b/file.ts\n@@ -${line} +${line} @@\n-old\n+new\n`
+    const first = resolveFileDiff({ file: "file.ts", patch })
+    const updated = resolveFileDiff({ file: "file.ts", patch: patch.replace("+new", "+edited") })
+    expect(first.cacheKey).toBeDefined()
+    expect(updated.cacheKey).not.toBe(first.cacheKey)
+    expect(resolveFileDiff({ file: "file.ts", patch })).toBe(first)
+  })
+
+  test("uses content-specific worker cache keys for full file pairs", () => {
+    const first = resolveFileDiff({ file: "file.ts", before: "before", after: "after" })
+    const updated = resolveFileDiff({ file: "file.ts", before: "before", after: "edited" })
+    expect(first.cacheKey).toBeDefined()
+    expect(updated.cacheKey).not.toBe(first.cacheKey)
+  })
+
   test.each([
     ["carriage return", "\r"],
     ["line separator", "\u2028"],

--- a/packages/session-ui/src/components/session-diff.ts
+++ b/packages/session-ui/src/components/session-diff.ts
@@ -1,5 +1,6 @@
 import { parseDiffFromFile, parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs"
 import { parsePatch } from "diff"
+import { checksum } from "@opencode-ai/util/encode"
 import type { FileDiffInfo } from "@opencode-ai/client/promise"
 import type { PresentationFileDiff } from "../file-presentation"
 
@@ -65,6 +66,8 @@ function fileDiffFromPatch(file: string, patch: string) {
   const value = contents
     ? fileDiffFromContent(file, contents.before, contents.after)
     : ((input ? parsePatchFiles(input)[0]?.files[0] : undefined) ?? emptyFileDiff(file))
+  // Pierre's default key is filename-based; refreshed patches need a new worker cache entry.
+  value.cacheKey = `${file}:${checksum(patch)}`
   patchFileDiffCache.set(key, value)
   while (patchFileDiffCache.size > diffCacheLimit) patchFileDiffCache.delete(patchFileDiffCache.keys().next().value!)
   return value
@@ -136,7 +139,10 @@ function patchInput(file: string, patch: string) {
 
 function fileDiffFromContent(file: string, before: string, after: string) {
   if (!before && !after) return emptyFileDiff(file)
-  return parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
+  return parseDiffFromFile(
+    { name: file, contents: before, cacheKey: `${file}:${checksum(before)}` },
+    { name: file, contents: after, cacheKey: `${file}:${checksum(after)}` },
+  )
 }
 
 function emptyFileDiff(file: string) {

--- a/packages/session-ui/src/v2/components/session-review-file-preview-v2.tsx
+++ b/packages/session-ui/src/v2/components/session-review-file-preview-v2.tsx
@@ -8,7 +8,7 @@ import { mediaKindFromPath } from "../../pierre/media"
 import { cloneSelectedLineRange, previewSelectedLines } from "../../pierre/selection-bridge"
 import type { FileDiffInfo } from "@opencode-ai/client/promise"
 import type { PresentationFileContent, PresentationFileDiff } from "../../file-presentation"
-import { createEffect, createMemo, onCleanup, Show, untrack } from "solid-js"
+import { children, createEffect, createMemo, onCleanup, Show, untrack, type JSX } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Dynamic } from "solid-js/web"
 import { normalize, text, type ViewDiff } from "../../components/session-diff"
@@ -43,6 +43,8 @@ export type SessionReviewFilePreviewV2Props = {
   comments?: SessionReviewComment[]
   focusedComment?: SessionReviewFocus | null
   onFocusedCommentChange?: (focus: SessionReviewFocus | null) => void
+  headerActions?: JSX.Element
+  content?: JSX.Element
 }
 
 function statusLabel(status: ViewDiff["status"]) {
@@ -212,6 +214,8 @@ export function SessionReviewFilePreviewV2(props: SessionReviewFilePreviewV2Prop
   })
 
   const expandUnchanged = () => props.expandMode === "expand"
+  const content = children(() => props.content)
+  const headerActions = children(() => props.headerActions)
 
   const diffViewer = () => (
     <Dynamic
@@ -267,6 +271,9 @@ export function SessionReviewFilePreviewV2(props: SessionReviewFilePreviewV2Prop
         <div data-slot="session-review-v2-file-diff">
           <DiffChanges changes={view()} />
         </div>
+        <Show when={headerActions()}>
+          <div data-slot="session-review-v2-file-actions">{headerActions()}</div>
+        </Show>
       </div>
       <div
         ref={(el) => {
@@ -275,14 +282,21 @@ export function SessionReviewFilePreviewV2(props: SessionReviewFilePreviewV2Prop
         data-slot="session-review-v2-diff-scroll"
       >
         <Show
-          when={diffCanRender() || mediaKind()}
+          when={content()}
           fallback={
-            <div data-slot="session-review-v2-empty">
-              <span class="text-12-regular text-text-weak">{i18n.t("ui.fileMedia.binary.title")}</span>
-            </div>
+            <Show
+              when={diffCanRender() || mediaKind()}
+              fallback={
+                <div data-slot="session-review-v2-empty">
+                  <span class="text-12-regular text-text-weak">{i18n.t("ui.fileMedia.binary.title")}</span>
+                </div>
+              }
+            >
+              {diffViewer()}
+            </Show>
           }
         >
-          {diffViewer()}
+          {content()}
         </Show>
       </div>
     </>

--- a/packages/session-ui/src/v2/components/session-review-v2.css
+++ b/packages/session-ui/src/v2/components/session-review-v2.css
@@ -329,6 +329,23 @@
   unicode-bidi: isolate;
 }
 
+[data-component="session-review-v2"]
+  [data-slot="session-review-v2-file-header"]:has([data-slot="session-review-v2-file-actions"]) {
+  flex-wrap: wrap;
+
+  [data-slot="session-review-v2-file-title"] {
+    flex-basis: 120px;
+    overflow: hidden;
+  }
+}
+
+[data-component="session-review-v2"] [data-slot="session-review-v2-file-actions"] {
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  margin-inline-start: auto;
+}
+
 [data-component="session-review-v2"] [data-slot="session-review-v2-file-diff"] {
   position: relative;
   flex-shrink: 0;


### PR DESCRIPTION
## Summary
- Upgrade `@pierre/diffs` from 1.2.10 to 1.3.6 and lazy-load its native editor in the desktop review pane.
- Edit complete file contents, not patch fragments, with Save, Discard, Ctrl/Cmd+S, undo/redo, find/replace, and large-file virtualization.
- Retain unsaved drafts across file/pane navigation and isolate same-path drafts between workspaces.
- Add a generated-client filesystem write API with expected-byte conflict detection and shared process-local mutation locks. Preserve UTF-8 BOM and line endings; use the actual linked-worktree root rather than the canonical checkout.
- Adapt native token colors to OpenCode's theme variables and version diff worker cache keys by content so saved changes render immediately.

## Validation
- Repository pre-push typecheck: all 33 tasks passed.
- App production build passed.
- 169 Session UI unit tests, 22 draft-controller tests, 18 filesystem/mutation tests, 4 write-endpoint tests, and 34 Promise-client tests passed.
- 19 Session UI browser checks and the same-path workspace draft component test passed.
- All 6 new full-app regression scenarios and both existing review navigation tests passed.
- Benchmarks skipped as requested.
- The separate full E2E typecheck still reports an unrelated existing `HTMLElement | SVGElement` `.dir` error in `new-session-workspace-pending.spec.ts:38`.

## Scope
Editing is an explicit whole-file mode for existing local UTF-8 text files. Pierre marks the editing API experimental. External programs can still race filesystem operations; the shared lock coordinates cooperating OpenCode mutations. Binary/deleted files and explicit remote workspace placement are not editable.

## Screenshots
Before entering edit mode:
![Review mode](https://github.com/user-attachments/assets/53e76817-9137-4108-bd38-7838377ff51d)

After editing the full file:
![Edit mode](https://github.com/user-attachments/assets/da9ed6d5-8e6c-454d-9280-2760915791fc)