### PR TITLE
test(tui): capture flushed Mini scrollback output

### DIFF
--- a/packages/tui/test/mini/scrollback.surface.test.ts
+++ b/packages/tui/test/mini/scrollback.surface.test.ts
@@ -93,6 +93,8 @@ async function setup(
 
   return {
     renderer: out.renderer,
+    renderOnce: out.renderOnce,
+    externalOutput: out.externalOutput,
     scrollback: new RunScrollbackStream(out.renderer, input.theme ?? RUN_THEME_FALLBACK, {
       treeSitterClient,
       wrote: input.wrote ?? false,
@@ -220,28 +222,22 @@ test.each([false, true])("monochrome switches preserve printed blocks and open f
     await out.scrollback.setMono(mono)
     out.scrollback.setTheme(mono ? RUN_THEME_MONO : RUN_THEME_FALLBACK)
     await out.scrollback.append(assistant('Printed block\n\n```ts\nconst arrow = "'))
-    const printed = claim(out.renderer)
-    try {
-      expect(render(printed)).toContain("Printed block")
-      expect(render(printed)).not.toContain("const arrow")
-      await out.scrollback.setMono(!mono)
-      out.scrollback.setTheme(mono ? RUN_THEME_FALLBACK : RUN_THEME_MONO)
-      expect(render(claim(out.renderer))).toBe("")
-      await out.scrollback.append(assistant('\u2192"\n```\n\nNext block'))
-      await out.scrollback.complete()
-      const next = claim(out.renderer)
-      try {
-        expect(render(next)).toContain(mono ? 'const arrow = "\u2192"' : 'const arrow = "->"')
-        expect(render(next)).toContain("Next block")
-        expect(render(next)).not.toContain("Printed block")
-        expect(render(next)).not.toContain("```")
-        expect(render(printed)).toContain("Printed block")
-      } finally {
-        destroy(next)
-      }
-    } finally {
-      destroy(printed)
-    }
+    await out.renderOnce()
+    const printed = out.externalOutput.takeText()
+    expect(printed).toContain("Printed block")
+    expect(printed).not.toContain("const arrow")
+    await out.scrollback.setMono(!mono)
+    out.scrollback.setTheme(mono ? RUN_THEME_FALLBACK : RUN_THEME_MONO)
+    expect(out.externalOutput.takeText()).toBe("")
+    await out.scrollback.append(assistant('\u2192"\n```\n\nNext block'))
+    // A frame can flush the code block while completion is awaiting highlighting.
+    await out.renderOnce()
+    await out.scrollback.complete()
+    const next = out.externalOutput.takeText()
+    expect(next).toContain(mono ? 'const arrow = "\u2192"' : 'const arrow = "->"')
+    expect(next).toContain("Next block")
+    expect(next).not.toContain("Printed block")
+    expect(next).not.toContain("```")
   } finally {
     out.scrollback.destroy()
     destroy(claim(out.renderer))


### PR DESCRIPTION
## Why

The Mini monochrome scrollback test intermittently reports that its code block disappeared, receiving only `Next block`. This predates preview tabs on [v2](https://github.com/anomalyco/opencode/actions/runs/33441157898/job/99649432358) and has blocked unrelated PRs including #46496 and #46497.

The test reads the renderer's private pending-output queue after asynchronous highlighting. A renderer frame can correctly flush the code block while completion is awaiting highlighting, leaving only the final paragraph in that queue. The output was emitted; the test inspected an incomplete observation of it.

## What Changes

- Read each output phase through the test renderer's existing `externalOutput.takeText()` recorder, which preserves emitted output independently of queue consumption.
- Explicitly render between streaming steps to exercise the formerly failing schedule without sleeps.
- Keep both monochrome directions and assertions for open-fence continuation, arrow conversion, no premature code output, and no repeated blocks or fence markers.

## Scope

One test file only. No production rendering changes, retries, timeout increases, or skipped tests. Other tests retain their existing queue assertions.

## Verification

```sh
cd packages/tui
bun run test test/mini/scrollback.surface.test.ts --rerun-each 20
bun run test
bun typecheck
```

- Deterministic red/green: inserting a renderer frame before completion reproduced the exact CI failure in both existing variants; the same schedule passes with the output recorder.
- Independent timing probe: a temporary 250 ms highlighter delay made the old test fail 10/10 runs. The fixed test passed 20/20 delayed runs. Instrumentation confirmed the code line was enqueued and flushed before the failing assertion. The probe is not part of this PR.
- Focused file: 420 passed across 20 runs.
- Full TUI suite: 1,183 passed, 4 skipped, 0 failures.
- TUI typecheck, formatting, and `git diff --check` passed.
