### PR TITLE
fix(tui): honor disable-copy-on-select flag in mouse selection

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -436,6 +436,7 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   // Wire up console copy-to-clipboard via opentui's onCopySelection callback
   renderer.console.onCopySelection = async (text: string) => {
     if (!text || text.length === 0) return
+    if (Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
 
     await clipboard
       .write?.(text)


### PR DESCRIPTION
## Problem

When `OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT` is set, selecting text with the mouse in the TUI still writes to the clipboard and shows the "Copied to clipboard" toast. The other copy paths (the key interceptor in `app.tsx`, right-click handling) all check `Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT`, but the `renderer.console.onCopySelection` callback does not. This makes the flag half-broken for the mouse-selection case (see anomalyco/opencode#21542).

## Change

Add the same `Flag` guard at the top of `onCopySelection` so that when the flag is enabled, mouse selection neither copies nor toasts:

```ts
renderer.console.onCopySelection = async (text: string) => {
  if (!text || text.length === 0) return
  if (Flag.OPENCODE_EXPERIMENTAL_DISABLE_COPY_ON_SELECT) return
  ...
}
```

Because the callback previously always called `renderer.clearSelection()`, this also means the selection highlight is now preserved when the flag is on, matching what users wanted (keep the highlight, no copy/toast).

## Verification

- `bun typecheck` in `packages/tui` passes.
- `oxlint` reports 0 errors on the changed file (warnings are pre-existing on unrelated lines).

## Related

- #4751 (original feature request)
- #21542 (bug: toast cannot be disabled via the flag)