### PR TITLE
feat(core): add firecrawl developer search provider

### DIFF
--- a/packages/core/src/plugin/websearch/firecrawl.ts
+++ b/packages/core/src/plugin/websearch/firecrawl.ts
@@ -1,6 +1,7 @@
 export * as WebSearchFirecrawl from "./firecrawl.js"
 
 import { define } from "@opencode-ai/plugin/effect/plugin"
+import type { WebSearch } from "@opencode-ai/schema/websearch"
 import { Effect, Option, Schema, Scope } from "effect"
 import { HttpClient } from "effect/unstable/http"
 import { App } from "../../app.js"
@@ -11,6 +12,7 @@ export const endpoint = "https://mcp.firecrawl.dev/v2/mcp"
 const McpInput = Schema.Struct({
   query: Schema.String,
   limit: Schema.Number.pipe(Schema.optional),
+  categories: Schema.Array(Schema.String).pipe(Schema.optional),
 })
 
 const McpOutput = Schema.Struct({
@@ -48,36 +50,47 @@ export const Plugin = define<HttpClient.HttpClient | Scope.Scope>({
         method: { type: "env", names: ["FIRECRAWL_API_KEY"] },
       })
     })
+    const search =
+      (categories?: readonly string[]) =>
+      (input: WebSearch.ProviderInput): Effect.Effect<readonly WebSearch.Result[], unknown> =>
+        Effect.gen(function* () {
+          const connection = yield* ctx.integration.connection.active("firecrawl")
+          const credential = connection ? yield* ctx.integration.connection.resolve(connection) : undefined
+          const result = yield* WebSearchMcp.call(
+            http,
+            endpoint,
+            "firecrawl_search",
+            { input: McpInput, output: McpOutput },
+            { query: input.query, limit: 8, ...(categories ? { categories } : {}) },
+            {
+              "User-Agent": App.useragent(ctx.app),
+              ...(credential?.type === "key" ? { Authorization: `Bearer ${credential.key}` } : {}),
+            },
+          )
+          const content = result?.content.find((item) => item.text)
+          const response = content ? Option.getOrUndefined(decodeSearchResponse(content.text)) : undefined
+          return (
+            response?.data.web.map((item) => ({
+              url: item.url,
+              ...(item.title ? { title: item.title } : {}),
+              ...(item.description ? { content: item.description } : {}),
+              time: {},
+            })) ?? []
+          )
+        })
+
     yield* ctx.websearch.transform((draft) => {
       draft.add({
         id: "firecrawl",
         name: "Firecrawl",
-        execute: (input) =>
-          Effect.gen(function* () {
-            const connection = yield* ctx.integration.connection.active("firecrawl")
-            const credential = connection ? yield* ctx.integration.connection.resolve(connection) : undefined
-            const result = yield* WebSearchMcp.call(
-              http,
-              endpoint,
-              "firecrawl_search",
-              { input: McpInput, output: McpOutput },
-              { query: input.query, limit: 8 },
-              {
-                "User-Agent": App.useragent(ctx.app),
-                ...(credential?.type === "key" ? { Authorization: `Bearer ${credential.key}` } : {}),
-              },
-            )
-            const content = result?.content.find((item) => item.text)
-            const response = content ? Option.getOrUndefined(decodeSearchResponse(content.text)) : undefined
-            return (
-              response?.data.web.map((item) => ({
-                url: item.url,
-                ...(item.title ? { title: item.title } : {}),
-                ...(item.description ? { content: item.description } : {}),
-                time: {},
-              })) ?? []
-            )
-          }),
+        execute: search(),
+      })
+      // The developer category resolves against an index of GitHub issues, merged
+      // pull requests, READMEs, and curated documentation rather than the open web.
+      draft.add({
+        id: "firecrawl-developer",
+        name: "Firecrawl Developer",
+        execute: search(["developer"]),
       })
     })
   }),

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -260,9 +260,11 @@ function webSearchProviderLabel(provider: unknown, i18n: ReturnType<typeof useI1
         ? "Exa"
         : provider === "firecrawl"
           ? "Firecrawl"
-          : provider === "tavily"
-            ? "Tavily"
-            : undefined
+          : provider === "firecrawl-developer"
+            ? "Firecrawl Developer"
+            : provider === "tavily"
+              ? "Tavily"
+              : undefined
   if (name) return i18n.t("ui.tool.websearch.provider", { provider: name })
   return i18n.t("ui.tool.websearch")
 }

--- a/packages/tui/src/util/tool-display.ts
+++ b/packages/tui/src/util/tool-display.ts
@@ -19,9 +19,16 @@ export function primitiveInputSummary(input: Record<string, unknown>, omit: read
   return `[${entries.map(([key, value]) => `${key}=${String(value)}`).join(", ")}]`
 }
 
+// Capitalizing the id is enough for single-word providers; anything hyphenated
+// needs a spelling here or it renders as "Firecrawl-developer".
+const WEB_SEARCH_PROVIDER_LABELS: Record<string, string> = {
+  "firecrawl-developer": "Firecrawl Developer",
+}
+
 export function webSearchProviderLabel(provider: unknown) {
   if (typeof provider !== "string" || !provider) return "Web Search"
-  return `Web Search via ${provider[0].toUpperCase()}${provider.slice(1)}`
+  const label = WEB_SEARCH_PROVIDER_LABELS[provider] ?? `${provider[0].toUpperCase()}${provider.slice(1)}`
+  return `Web Search via ${label}`
 }
 
 export function toolDisplayMetadata(state: unknown): Record<string, unknown> {

--- a/packages/tui/test/util/tool-display.test.ts
+++ b/packages/tui/test/util/tool-display.test.ts
@@ -24,6 +24,7 @@ describe("webSearchProviderLabel", () => {
     expect(webSearchProviderLabel("parallel")).toBe("Web Search via Parallel")
     expect(webSearchProviderLabel("exa")).toBe("Web Search via Exa")
     expect(webSearchProviderLabel("firecrawl")).toBe("Web Search via Firecrawl")
+    expect(webSearchProviderLabel("firecrawl-developer")).toBe("Web Search via Firecrawl Developer")
     expect(webSearchProviderLabel("tavily")).toBe("Web Search via Tavily")
   })
 


### PR DESCRIPTION
Follow-up to #41042. Adds a second Firecrawl websearch provider, `firecrawl-developer`, that passes `categories: ["developer"]` to the same `firecrawl_search` MCP tool.

That category resolves queries against Firecrawl's developer index (GitHub issues, merged pull requests, READMEs, and curated documentation) rather than the open web, which is the difference between asking "what happened this week" and "how does this library actually behave". For a retry-policy question about TanStack Query, for instance, it returns `docs/framework/*/guides/query-retries.md` from the TanStack repo itself.

Both providers share one `execute` path, so the only behavioural difference is the category argument.

### Notes

- Keyless, same as the existing provider. `FIRECRAWL_API_KEY` only raises the rate limit, and the existing integration wiring covers it unchanged.
- The two provider label sites have been refactored since #41042 landed, so this adds `firecrawl-developer` to the session-ui chain and introduces a small override map in the TUI. Without it the generic capitalizer renders "Web Search via Firecrawl-developer".

### Verification

- `bun typecheck` in `packages/core`, `packages/tui`, `packages/session-ui`
- `bun test test/websearch.test.ts test/tool-websearch.test.ts` in `packages/core` (19 pass)
- `bun test test/util/tool-display.test.ts` in `packages/tui` (11 pass, includes a new case for the label)
- Live call against the endpoint with the exact arguments the provider sends, confirming the response still decodes through the existing `SearchResponse` schema

Made with [Cursor](https://cursor.com)