### PR TITLE
fix(app): show global-project sessions in web Home

### DIFF
--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -254,7 +254,14 @@ function buildHomeSessionRecords(input: {
   projectByID: () => Map<string, LocalProject>
 }) {
   const directories = new Set(input.projectDirectories().map(pathKey))
-  const sessions = input.sessions().filter((session) => directories.has(pathKey(session.directory)))
+  const sessions = input.sessions().filter((session) => {
+    // Sessions outside any git repo belong to the global project, whose
+    // worktree is forced to "/" and which never accumulates sandboxes — so
+    // their real directory (e.g. C:/Users/Raphael) never matches the filter
+    // and they silently vanish from Home (#46444). Keep them visible.
+    if (session.projectID === "global") return true
+    return directories.has(pathKey(session.directory))
+  })
   return [...new Map(sessions.map((session) => [session.id, session] as const)).values()]
     .sort(compareSessionTime)
     .flatMap((session) => {


### PR DESCRIPTION
### Issue for this PR

Closes #46444

### Type of change

- [x] Bug fix

### What does this PR do?

The web Home page silently hides sessions created outside any git repo (e.g. `C:\Users\Raphael`, `C:/`, `I:/Projetos`) when launched from a non-git directory. `buildHomeSessionRecords` filters sessions by matching `session.directory` against the selected project's `projectDirectories()` (= worktree + sandboxes). Sessions outside a git repo belong to the `global` project, whose worktree is forced to `/` in `project.ts` `fromDirectory` and which never accumulates sandboxes — so the session's real directory never matches and it's dropped from the Home list. The CLI doesn't hit this because it lists by `project_id`.

Fix: keep `global`-project sessions visible in the Home filter (their `projectID` is `"global"`). The directory-based filter still applies to all git-backed projects; the follow-up `projectForSession` lookup still resolves the correct project for display.

Changes:
- `packages/app/src/pages/home/home-sessions-controller.tsx`: skip the directory filter for sessions whose `projectID === "global"`.

### How did you verify your code works?

- Ran the Home session index unit suite (`bun test --conditions=solid ./src/context/global-sync/home-session-index.test.ts`): 7 pass, 0 fail.
- The change is a one-line filter guard; git-backed session filtering is unchanged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR