### PR TITLE
chore(ci): align Bun with the release runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.3.14",
+  "packageManager": "bun@1.4.0",
   "scripts": {
     "dev": "bun run --cwd packages/cli --conditions=browser src/index.ts",
     "dev:live": "sh -c 'OPENCODE_TUI_CHANNEL=dev OPENCODE_PASSWORD=\"$(opencode2 service get password)\" exec bun run dev \"$@\" --server \"$(opencode2 service status)\"' --",


### PR DESCRIPTION
## Summary
Bump the root `packageManager` from `bun@1.3.14` to `bun@1.4.0`, matching the existing CLI publish setup and `BUN_COMPILE_RELEASE` pins.

The shared CI setup reads this value whenever no explicit version override is supplied. Unit tests and typechecking were therefore still running on 1.3.14 even though published CLI builds use 1.4.0. The Windows failure in #46521 explicitly downloaded 1.3.14 from the root manifest; this was not a stale runtime cache.

This is a one-line configuration change, with no dependency or lockfile changes. It does not include the compact-comment work.

## Validation
Using an isolated Bun 1.4.0 binary on macOS:
- Frozen-lockfile install for the root, core, codemode, and TUI packages passed without lockfile changes.
- Codemode suite: 1,125 passed.
- Core codemode tests: 22 passed.
- TUI footer view tests: 77 passed, 4 skipped.
- Formatting and `git diff --check` passed.

Windows CI must still verify whether the runtime upgrade resolves the native TUI crash; local macOS results do not establish that.