### PR TITLE
fix(tui): simplify narrow interrupt footer

### DIFF
--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -159,7 +159,7 @@ export interface Page {
 type PromptFooterInput = {
   readonly sessionID?: string
   readonly mode: "normal" | "shell"
-  readonly details: boolean
+  readonly showDetails: boolean
 }
 
 /**

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -156,7 +156,11 @@ export interface Page {
   readonly render: (input: { readonly data?: Record<string, any> }) => JSX.Element
 }
 
-type PromptFooterInput = { readonly sessionID?: string; readonly mode: "normal" | "shell" }
+type PromptFooterInput = {
+  readonly sessionID?: string
+  readonly mode: "normal" | "shell"
+  readonly interruptArmed: boolean
+}
 
 /**
  * The host UI's slot tree. Every path is one slot: a named boundary a plugin

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -159,7 +159,7 @@ export interface Page {
 type PromptFooterInput = {
   readonly sessionID?: string
   readonly mode: "normal" | "shell"
-  readonly confirmingInterrupt: boolean
+  readonly showDetails: boolean
 }
 
 /**

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -159,7 +159,7 @@ export interface Page {
 type PromptFooterInput = {
   readonly sessionID?: string
   readonly mode: "normal" | "shell"
-  readonly showDetails: boolean
+  readonly details: boolean
 }
 
 /**

--- a/packages/plugin/src/tui/context.ts
+++ b/packages/plugin/src/tui/context.ts
@@ -159,7 +159,7 @@ export interface Page {
 type PromptFooterInput = {
   readonly sessionID?: string
   readonly mode: "normal" | "shell"
-  readonly interruptArmed: boolean
+  readonly confirmingInterrupt: boolean
 }
 
 /**

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1595,7 +1595,7 @@ export function Prompt(props: PromptProps) {
     if (agentLabel()) revealedPromptMetadata.add(local)
   })
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
-  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode, confirmingInterrupt: store.interrupt > 0 })
+  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode, showDetails: store.interrupt === 0 })
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1595,7 +1595,7 @@ export function Prompt(props: PromptProps) {
     if (agentLabel()) revealedPromptMetadata.add(local)
   })
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
-  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode })
+  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode, interruptArmed: store.interrupt > 0 })
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1595,7 +1595,7 @@ export function Prompt(props: PromptProps) {
     if (agentLabel()) revealedPromptMetadata.add(local)
   })
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
-  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode, showDetails: store.interrupt === 0 })
+  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode, details: store.interrupt === 0 })
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1595,7 +1595,7 @@ export function Prompt(props: PromptProps) {
     if (agentLabel()) revealedPromptMetadata.add(local)
   })
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
-  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode, interruptArmed: store.interrupt > 0 })
+  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode, confirmingInterrupt: store.interrupt > 0 })
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1598,7 +1598,7 @@ export function Prompt(props: PromptProps) {
   const footerInput = () => ({
     sessionID: props.sessionID,
     mode: store.mode,
-    details: store.interrupt === 0 || dimensions().width >= 80,
+    showDetails: store.interrupt === 0 || dimensions().width >= 80,
   })
 
   const placeholderText = createMemo(() => {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -1595,7 +1595,11 @@ export function Prompt(props: PromptProps) {
     if (agentLabel()) revealedPromptMetadata.add(local)
   })
   const borderHighlight = createMemo(() => tint(theme.border.default, highlight(), agentMetaAlpha()))
-  const footerInput = () => ({ sessionID: props.sessionID, mode: store.mode, details: store.interrupt === 0 })
+  const footerInput = () => ({
+    sessionID: props.sessionID,
+    mode: store.mode,
+    details: store.interrupt === 0 || dimensions().width >= 80,
+  })
 
   const placeholderText = createMemo(() => {
     if (props.showPlaceholder === false) return undefined

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -12,7 +12,7 @@ export function PromptFooter(props: {
   context: Plugin.Context
   sessionID?: string
   mode: "normal" | "shell"
-  showDetails: boolean
+  details: boolean
 }) {
   const dimensions = useTerminalDimensions()
   const [liveHovered, setLiveHovered] = createSignal(false)
@@ -74,7 +74,7 @@ export function PromptFooter(props: {
                   </text>
                 </box>
               </Show>
-              <Show when={props.showDetails && status().length > 0}>
+              <Show when={props.details && status().length > 0}>
                 <text fg={props.context.theme.text.subdued} wrapMode="none" truncate flexShrink={1}>
                   <Show when={live()}> · </Show>
                   {status().join(" · ")}
@@ -88,7 +88,7 @@ export function PromptFooter(props: {
             </text>
           </Match>
         </Switch>
-        <Show when={props.showDetails}>
+        <Show when={props.details}>
           <text fg={props.context.theme.text.default} wrapMode="none" flexShrink={0}>
             {shortcut("command.palette.show")} <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
           </text>
@@ -116,7 +116,7 @@ export default Plugin.define({
           context={context}
           sessionID={props.sessionID}
           mode={props.mode}
-          showDetails={props.showDetails}
+          details={props.details}
         />
       ),
     })

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -82,7 +82,7 @@ export function PromptFooter(props: {
               </Show>
             </box>
           </Match>
-          <Match when={dimensions().width >= 44}>
+          <Match when={props.details && dimensions().width >= 44}>
             <text fg={props.context.theme.text.default} flexShrink={0}>
               {shortcut("agent.cycle")} <span style={{ fg: props.context.theme.text.subdued }}>agents</span>
             </text>

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -12,10 +12,9 @@ export function PromptFooter(props: {
   context: Plugin.Context
   sessionID?: string
   mode: "normal" | "shell"
-  interruptArmed: boolean
+  confirmingInterrupt: boolean
 }) {
   const dimensions = useTerminalDimensions()
-  const showDetails = () => !props.interruptArmed || dimensions().width >= 80
   const [liveHovered, setLiveHovered] = createSignal(false)
   const subagents = createMemo(() => {
     if (!props.sessionID) return 0
@@ -75,7 +74,7 @@ export function PromptFooter(props: {
                   </text>
                 </box>
               </Show>
-              <Show when={showDetails() && status().length > 0}>
+              <Show when={!props.confirmingInterrupt && status().length > 0}>
                 <text fg={props.context.theme.text.subdued} wrapMode="none" truncate flexShrink={1}>
                   <Show when={live()}> · </Show>
                   {status().join(" · ")}
@@ -89,7 +88,7 @@ export function PromptFooter(props: {
             </text>
           </Match>
         </Switch>
-        <Show when={showDetails()}>
+        <Show when={!props.confirmingInterrupt}>
           <text fg={props.context.theme.text.default} wrapMode="none" flexShrink={0}>
             {shortcut("command.palette.show")} <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
           </text>
@@ -117,7 +116,7 @@ export default Plugin.define({
           context={context}
           sessionID={props.sessionID}
           mode={props.mode}
-          interruptArmed={props.interruptArmed}
+          confirmingInterrupt={props.confirmingInterrupt}
         />
       ),
     })

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -8,8 +8,14 @@ const money = new Intl.NumberFormat("en-US", {
   currency: "USD",
 })
 
-export function PromptFooter(props: { context: Plugin.Context; sessionID?: string; mode: "normal" | "shell" }) {
+export function PromptFooter(props: {
+  context: Plugin.Context
+  sessionID?: string
+  mode: "normal" | "shell"
+  interruptArmed: boolean
+}) {
   const dimensions = useTerminalDimensions()
+  const showDetails = () => !props.interruptArmed || dimensions().width >= 80
   const [liveHovered, setLiveHovered] = createSignal(false)
   const subagents = createMemo(() => {
     if (!props.sessionID) return 0
@@ -69,7 +75,7 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
                   </text>
                 </box>
               </Show>
-              <Show when={status().length > 0}>
+              <Show when={showDetails() && status().length > 0}>
                 <text fg={props.context.theme.text.subdued} wrapMode="none" truncate flexShrink={1}>
                   <Show when={live()}> · </Show>
                   {status().join(" · ")}
@@ -83,8 +89,8 @@ export function PromptFooter(props: { context: Plugin.Context; sessionID?: strin
             </text>
           </Match>
         </Switch>
-        <Show when={dimensions().width >= 44}>
-          <text fg={props.context.theme.text.default} flexShrink={0}>
+        <Show when={showDetails()}>
+          <text fg={props.context.theme.text.default} wrapMode="none" flexShrink={0}>
             {shortcut("command.palette.show")} <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
           </text>
         </Show>
@@ -106,7 +112,14 @@ export default Plugin.define({
   setup(context) {
     context.ui.slot({
       append: "prompt.footer",
-      render: (props) => <PromptFooter context={context} sessionID={props.sessionID} mode={props.mode} />,
+      render: (props) => (
+        <PromptFooter
+          context={context}
+          sessionID={props.sessionID}
+          mode={props.mode}
+          interruptArmed={props.interruptArmed}
+        />
+      ),
     })
   },
 })

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -12,7 +12,7 @@ export function PromptFooter(props: {
   context: Plugin.Context
   sessionID?: string
   mode: "normal" | "shell"
-  details: boolean
+  showDetails: boolean
 }) {
   const dimensions = useTerminalDimensions()
   const [liveHovered, setLiveHovered] = createSignal(false)
@@ -74,7 +74,7 @@ export function PromptFooter(props: {
                   </text>
                 </box>
               </Show>
-              <Show when={props.details && status().length > 0}>
+              <Show when={props.showDetails && status().length > 0}>
                 <text fg={props.context.theme.text.subdued} wrapMode="none" truncate flexShrink={1}>
                   <Show when={live()}> · </Show>
                   {status().join(" · ")}
@@ -82,13 +82,13 @@ export function PromptFooter(props: {
               </Show>
             </box>
           </Match>
-          <Match when={props.details && dimensions().width >= 44}>
+          <Match when={props.showDetails && dimensions().width >= 44}>
             <text fg={props.context.theme.text.default} flexShrink={0}>
               {shortcut("agent.cycle")} <span style={{ fg: props.context.theme.text.subdued }}>agents</span>
             </text>
           </Match>
         </Switch>
-        <Show when={props.details}>
+        <Show when={props.showDetails}>
           <text fg={props.context.theme.text.default} wrapMode="none" flexShrink={0}>
             {shortcut("command.palette.show")} <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
           </text>
@@ -116,7 +116,7 @@ export default Plugin.define({
           context={context}
           sessionID={props.sessionID}
           mode={props.mode}
-          details={props.details}
+          showDetails={props.showDetails}
         />
       ),
     })

--- a/packages/tui/src/feature-plugins/prompt/footer.tsx
+++ b/packages/tui/src/feature-plugins/prompt/footer.tsx
@@ -12,7 +12,7 @@ export function PromptFooter(props: {
   context: Plugin.Context
   sessionID?: string
   mode: "normal" | "shell"
-  confirmingInterrupt: boolean
+  showDetails: boolean
 }) {
   const dimensions = useTerminalDimensions()
   const [liveHovered, setLiveHovered] = createSignal(false)
@@ -74,7 +74,7 @@ export function PromptFooter(props: {
                   </text>
                 </box>
               </Show>
-              <Show when={!props.confirmingInterrupt && status().length > 0}>
+              <Show when={props.showDetails && status().length > 0}>
                 <text fg={props.context.theme.text.subdued} wrapMode="none" truncate flexShrink={1}>
                   <Show when={live()}> · </Show>
                   {status().join(" · ")}
@@ -88,7 +88,7 @@ export function PromptFooter(props: {
             </text>
           </Match>
         </Switch>
-        <Show when={!props.confirmingInterrupt}>
+        <Show when={props.showDetails}>
           <text fg={props.context.theme.text.default} wrapMode="none" flexShrink={0}>
             {shortcut("command.palette.show")} <span style={{ fg: props.context.theme.text.subdued }}>commands</span>
           </text>
@@ -116,7 +116,7 @@ export default Plugin.define({
           context={context}
           sessionID={props.sessionID}
           mode={props.mode}
-          confirmingInterrupt={props.confirmingInterrupt}
+          showDetails={props.showDetails}
         />
       ),
     })

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -3,6 +3,7 @@ import { expect, test } from "bun:test"
 import { RGBA, TextRenderable } from "@opentui/core"
 import { testRender } from "@opentui/solid"
 import type { Context } from "@opencode-ai/plugin/tui/context"
+import { createSignal } from "solid-js"
 import { PromptFooter } from "../../src/feature-plugins/prompt/footer"
 
 test("prompt footer separates simultaneous subagent, shell, and usage status", async () => {
@@ -38,10 +39,13 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
       },
     },
   } as unknown as Context
-  const app = await testRender(() => <PromptFooter context={context} sessionID="session" mode="normal" />, {
-    width: 80,
-    height: 2,
-  })
+  const app = await testRender(
+    () => <PromptFooter context={context} sessionID="session" mode="normal" interruptArmed={false} />,
+    {
+      width: 80,
+      height: 2,
+    },
+  )
 
   try {
     await app.renderOnce()
@@ -55,6 +59,71 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
 
     await app.mockMouse.click(2, 0)
     expect(dispatched).toEqual(["session.child.first"])
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("prompt footer hides details when narrow only during interrupt confirmation", async () => {
+  const color = RGBA.fromInts(200, 200, 200)
+  const context = {
+    location: { directory: "/workspace" },
+    theme: {
+      text: {
+        default: color,
+        subdued: color,
+      },
+    },
+    keymap: {
+      shortcuts: (id: string) => (id === "command.palette.show" ? ["ctrl+p"] : []),
+    },
+    data: {
+      session: {
+        family: () => ["session"],
+        status: () => "running",
+        get: () => ({ id: "session", location: { directory: "/workspace" } }),
+        cost: () => 1,
+        message: {
+          list: () => [
+            {
+              id: "message",
+              type: "assistant",
+              model: { providerID: "provider", id: "model" },
+              tokens: { input: 1_000, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            },
+          ],
+        },
+      },
+      shell: { list: () => [] },
+      location: {
+        model: { list: () => [{ providerID: "provider", id: "model", limit: { context: 10_000 } }] },
+      },
+    },
+  } as unknown as Context
+  const [interruptArmed, setInterruptArmed] = createSignal(false)
+  const app = await testRender(
+    () => (
+      <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
+        <PromptFooter context={context} sessionID="session" mode="normal" interruptArmed={interruptArmed()} />
+      </box>
+    ),
+    {
+      width: 79,
+      height: 1,
+    },
+  )
+
+  try {
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("1.0K (10%) · $1.00")
+    expect(app.captureCharFrame()).toContain("ctrl+p commands")
+
+    setInterruptArmed(true)
+    await app.renderOnce()
+    const frame = app.captureCharFrame()
+    expect(frame).not.toContain("1.0K (10%)")
+    expect(frame).not.toContain("$1.00")
+    expect(frame).not.toContain("ctrl+p commands")
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -75,7 +75,11 @@ test("prompt footer can hide details", async () => {
       },
     },
     keymap: {
-      shortcuts: (id: string) => (id === "command.palette.show" ? ["ctrl+p"] : []),
+      shortcuts: (id: string) => {
+        if (id === "command.palette.show") return ["ctrl+p"]
+        if (id === "agent.cycle") return ["shift+tab"]
+        return []
+      },
     },
     data: {
       session: {
@@ -101,12 +105,13 @@ test("prompt footer can hide details", async () => {
     },
   } as unknown as Context
   const [details, setDetails] = createSignal(true)
+  const [sessionID, setSessionID] = createSignal<string | undefined>("session")
   const app = await testRender(
     () => (
       <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
         <PromptFooter
           context={context}
-          sessionID="session"
+          sessionID={sessionID()}
           mode="normal"
           details={details()}
         />
@@ -129,6 +134,10 @@ test("prompt footer can hide details", async () => {
     expect(frame).not.toContain("1.0K (10%)")
     expect(frame).not.toContain("$1.00")
     expect(frame).not.toContain("ctrl+p commands")
+
+    setSessionID(undefined)
+    await app.renderOnce()
+    expect(app.captureCharFrame()).not.toContain("shift+tab agents")
   } finally {
     app.renderer.destroy()
   }

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -40,7 +40,7 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
     },
   } as unknown as Context
   const app = await testRender(
-    () => <PromptFooter context={context} sessionID="session" mode="normal" showDetails={true} />,
+    () => <PromptFooter context={context} sessionID="session" mode="normal" details={true} />,
     {
       width: 80,
       height: 2,
@@ -100,7 +100,7 @@ test("prompt footer can hide details", async () => {
       },
     },
   } as unknown as Context
-  const [showDetails, setShowDetails] = createSignal(true)
+  const [details, setDetails] = createSignal(true)
   const app = await testRender(
     () => (
       <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
@@ -108,7 +108,7 @@ test("prompt footer can hide details", async () => {
           context={context}
           sessionID="session"
           mode="normal"
-          showDetails={showDetails()}
+          details={details()}
         />
       </box>
     ),
@@ -123,7 +123,7 @@ test("prompt footer can hide details", async () => {
     expect(app.captureCharFrame()).toContain("1.0K (10%) · $1.00")
     expect(app.captureCharFrame()).toContain("ctrl+p commands")
 
-    setShowDetails(false)
+    setDetails(false)
     await app.renderOnce()
     const frame = app.captureCharFrame()
     expect(frame).not.toContain("1.0K (10%)")

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -40,7 +40,7 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
     },
   } as unknown as Context
   const app = await testRender(
-    () => <PromptFooter context={context} sessionID="session" mode="normal" details={true} />,
+    () => <PromptFooter context={context} sessionID="session" mode="normal" showDetails={true} />,
     {
       width: 80,
       height: 2,
@@ -104,7 +104,7 @@ test("prompt footer can hide details", async () => {
       },
     },
   } as unknown as Context
-  const [details, setDetails] = createSignal(true)
+  const [showDetails, setShowDetails] = createSignal(true)
   const [sessionID, setSessionID] = createSignal<string | undefined>("session")
   const app = await testRender(
     () => (
@@ -113,7 +113,7 @@ test("prompt footer can hide details", async () => {
           context={context}
           sessionID={sessionID()}
           mode="normal"
-          details={details()}
+          showDetails={showDetails()}
         />
       </box>
     ),
@@ -128,7 +128,7 @@ test("prompt footer can hide details", async () => {
     expect(app.captureCharFrame()).toContain("1.0K (10%) · $1.00")
     expect(app.captureCharFrame()).toContain("ctrl+p commands")
 
-    setDetails(false)
+    setShowDetails(false)
     await app.renderOnce()
     const frame = app.captureCharFrame()
     expect(frame).not.toContain("1.0K (10%)")

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -40,7 +40,7 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
     },
   } as unknown as Context
   const app = await testRender(
-    () => <PromptFooter context={context} sessionID="session" mode="normal" interruptArmed={false} />,
+    () => <PromptFooter context={context} sessionID="session" mode="normal" confirmingInterrupt={false} />,
     {
       width: 80,
       height: 2,
@@ -64,7 +64,7 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
   }
 })
 
-test("prompt footer hides details when narrow only during interrupt confirmation", async () => {
+test("prompt footer hides details during interrupt confirmation", async () => {
   const color = RGBA.fromInts(200, 200, 200)
   const context = {
     location: { directory: "/workspace" },
@@ -100,15 +100,20 @@ test("prompt footer hides details when narrow only during interrupt confirmation
       },
     },
   } as unknown as Context
-  const [interruptArmed, setInterruptArmed] = createSignal(false)
+  const [confirmingInterrupt, setConfirmingInterrupt] = createSignal(false)
   const app = await testRender(
     () => (
       <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
-        <PromptFooter context={context} sessionID="session" mode="normal" interruptArmed={interruptArmed()} />
+        <PromptFooter
+          context={context}
+          sessionID="session"
+          mode="normal"
+          confirmingInterrupt={confirmingInterrupt()}
+        />
       </box>
     ),
     {
-      width: 79,
+      width: 80,
       height: 1,
     },
   )
@@ -118,7 +123,7 @@ test("prompt footer hides details when narrow only during interrupt confirmation
     expect(app.captureCharFrame()).toContain("1.0K (10%) · $1.00")
     expect(app.captureCharFrame()).toContain("ctrl+p commands")
 
-    setInterruptArmed(true)
+    setConfirmingInterrupt(true)
     await app.renderOnce()
     const frame = app.captureCharFrame()
     expect(frame).not.toContain("1.0K (10%)")

--- a/packages/tui/test/feature-plugins/prompt-footer.test.tsx
+++ b/packages/tui/test/feature-plugins/prompt-footer.test.tsx
@@ -40,7 +40,7 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
     },
   } as unknown as Context
   const app = await testRender(
-    () => <PromptFooter context={context} sessionID="session" mode="normal" confirmingInterrupt={false} />,
+    () => <PromptFooter context={context} sessionID="session" mode="normal" showDetails={true} />,
     {
       width: 80,
       height: 2,
@@ -64,7 +64,7 @@ test("prompt footer separates simultaneous subagent, shell, and usage status", a
   }
 })
 
-test("prompt footer hides details during interrupt confirmation", async () => {
+test("prompt footer can hide details", async () => {
   const color = RGBA.fromInts(200, 200, 200)
   const context = {
     location: { directory: "/workspace" },
@@ -100,7 +100,7 @@ test("prompt footer hides details during interrupt confirmation", async () => {
       },
     },
   } as unknown as Context
-  const [confirmingInterrupt, setConfirmingInterrupt] = createSignal(false)
+  const [showDetails, setShowDetails] = createSignal(true)
   const app = await testRender(
     () => (
       <box width="100%" flexDirection="row" justifyContent="space-between" gap={2}>
@@ -108,7 +108,7 @@ test("prompt footer hides details during interrupt confirmation", async () => {
           context={context}
           sessionID="session"
           mode="normal"
-          confirmingInterrupt={confirmingInterrupt()}
+          showDetails={showDetails()}
         />
       </box>
     ),
@@ -123,7 +123,7 @@ test("prompt footer hides details during interrupt confirmation", async () => {
     expect(app.captureCharFrame()).toContain("1.0K (10%) · $1.00")
     expect(app.captureCharFrame()).toContain("ctrl+p commands")
 
-    setConfirmingInterrupt(true)
+    setShowDetails(false)
     await app.renderOnce()
     const frame = app.captureCharFrame()
     expect(frame).not.toContain("1.0K (10%)")


### PR DESCRIPTION
## Summary

- expose a presentation-only `showDetails` flag to prompt footer slots
- have the prompt hide context usage, cost, and the command-palette shortcut on narrow terminals while interrupt confirmation is active
- keep the footer component independent of Escape and interrupt behavior
- keep subagent and shell status visible
- prevent the command shortcut label from wrapping

## Behavior

The running-state prompt continues to show `esc interrupt` with context usage, cost, and `ctrl+p commands`. After the first Escape enters interrupt confirmation, the prompt disables secondary footer details below 80 columns so `esc again to interrupt` remains the focus.

## Screenshot

![Narrow TUI interrupt confirmation with secondary footer details hidden](https://github.com/user-attachments/assets/79f71dd0-9ccc-4b90-9e03-07443fc881f2)

72-column interrupt confirmation: the confirmation remains on one line and secondary footer details are hidden.

## Testing

- `bun test test/feature-plugins/prompt-footer.test.tsx test/cli/tui/prompt-interrupt-status.test.tsx` from `packages/tui`
- `bun typecheck` from `packages/tui`
- `bun typecheck` from `packages/plugin`
- manually verified in the V2 standalone TUI at 72 columns