### PR TITLE
fix(tui): show real duration for subagents over 60 minutes

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -29,6 +29,7 @@ import { BoxRenderable, ScrollBoxRenderable, addDefaultParsers, TextAttributes, 
 import { Prompt, type PromptRef } from "../../component/prompt"
 import type {
   AssistantMessage,
+  Message,
   Part,
   Provider,
   ToolPart,
@@ -2258,12 +2259,7 @@ function Task(props: ToolProps) {
     return value
   })
 
-  const duration = createMemo(() => {
-    const first = messages().find((x) => x.role === "user")?.time.created
-    const assistant = messages().findLast((x) => x.role === "assistant")?.time.completed
-    if (!first || !assistant) return 0
-    return assistant - first
-  })
+  const duration = createMemo(() => subagentDuration(props.part.state, messages()))
 
   const content = createMemo(() => {
     const description = stringValue(props.input.description)
@@ -2331,6 +2327,20 @@ export function formatSubagentRetry(attempt: number, message: string) {
 export function formatCompletedSubagentDetail(toolcalls: number, duration: string) {
   if (toolcalls === 0) return duration
   return `${formatSubagentToolcalls(toolcalls)} · ${duration}`
+}
+
+export function subagentDuration(state: ToolPart["state"], messages: Message[]): number {
+  // The tool part's own time range covers the full subagent run. The message
+  // scan below can only see the latest synced page of the child session, so it
+  // misses the first user message once the session grows beyond the sync
+  // window and would report 0ms for long-running subagents.
+  if (state.status === "completed" && Number.isFinite(state.time?.start) && Number.isFinite(state.time?.end)) {
+    return Math.max(0, state.time.end - state.time.start)
+  }
+  const first = messages.find((x) => x.role === "user")?.time.created
+  const assistant = messages.findLast((x) => x.role === "assistant")?.time.completed
+  if (!first || !assistant) return 0
+  return assistant - first
 }
 
 type ExecuteCall = { tool: string; status: "running" | "completed" | "error"; input?: Record<string, unknown> }

--- a/packages/tui/test/subagent-duration.test.ts
+++ b/packages/tui/test/subagent-duration.test.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "bun:test"
+import type { AssistantMessage, Message, ToolPart, UserMessage } from "@opencode-ai/sdk/v2"
+import { subagentDuration } from "../src/routes/session"
+
+let nextID = 0
+
+function userMessage(created: number): UserMessage {
+  return {
+    id: `msg_u${nextID++}`,
+    sessionID: "ses_test",
+    role: "user",
+    time: { created },
+    agent: "subagent",
+    model: { providerID: "test", modelID: "test" },
+  }
+}
+
+function assistantMessage(created: number, completed?: number): AssistantMessage {
+  return {
+    id: `msg_a${nextID++}`,
+    sessionID: "ses_test",
+    role: "assistant",
+    time: { created, completed },
+    parentID: "msg_parent",
+    modelID: "test",
+    providerID: "test",
+    mode: "build",
+    agent: "subagent",
+    path: { cwd: "/", root: "/" },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+  }
+}
+
+function completedState(start: number, end: number): ToolPart["state"] {
+  return {
+    status: "completed",
+    input: {},
+    output: "",
+    title: "",
+    metadata: {},
+    time: { start, end },
+  }
+}
+
+test("uses the tool part time range for completed subagents", () => {
+  const messages: Message[] = []
+  expect(subagentDuration(completedState(1_000_000, 1_000_000 + 3_660_000), messages)).toBe(3_660_000)
+})
+
+test("prefers tool part time over the message scan when both are available", () => {
+  const messages: Message[] = [userMessage(1_000), assistantMessage(2_000, 60_000)]
+  expect(subagentDuration(completedState(10_000, 42_000), messages)).toBe(32_000)
+})
+
+test("falls back to the message scan when the part has no completed time", () => {
+  const state: ToolPart["state"] = {
+    status: "running",
+    input: {},
+    title: "",
+    time: { start: 1_000 },
+  }
+  const messages: Message[] = [userMessage(1_000), assistantMessage(2_000, 61_000)]
+  expect(subagentDuration(state, messages)).toBe(60_000)
+})
+
+test("returns 0 when the first user message fell out of the synced window and no part time exists", () => {
+  const state: ToolPart["state"] = {
+    status: "running",
+    input: {},
+    title: "",
+    time: { start: 1_000 },
+  }
+  const messages: Message[] = Array.from({ length: 100 }, (_, index) => assistantMessage(index, index + 1))
+  expect(messages.find((x) => x.role === "user")).toBeUndefined()
+  expect(subagentDuration(state, messages)).toBe(0)
+})


### PR DESCRIPTION
### Issue for this PR

Closes #44361

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The subagent duration in the TUI computed `assistant time.completed - first user time.created` by scanning the child session's messages. The sync layer only pulls the latest page of messages (`session.messages({ limit: 100 })`, newest-first), so once a subagent runs long enough to produce >100 messages, the first user message falls out of the synced window, `first` is `undefined`, and the UI shows `0ms` — which is why the symptom only appears for runs over ~60 minutes.

The tool part already carries the full run window in `state.time.{start,end}` for completed subagents, independent of the sync window. This PR adds a `subagentDuration(state, messages)` helper that prefers the tool part's time range when the part is `completed`, and falls back to the message scan otherwise (running/errored parts have no end time yet).

### How did you verify your code works?

- Added `packages/tui/test/subagent-duration.test.ts` with 4 regression cases:
  - completed part time is used when the synced message page is empty (the original repro: >100 messages, `0ms` before)
  - part time is preferred over the message scan when both are available
  - falls back to the message scan for non-completed parts
  - returns `0` when the window fell out of sync and no part time exists (running/error state)
- `bun test test/subagent-duration.test.ts` → 4 pass, 0 fail
- `bunx tsgo --noEmit` (packages/tui) → clean

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
