### PR TITLE
fix(app): increase open-in icon size

### DIFF
--- a/packages/app/src/components/session/open-in-app-v2.tsx
+++ b/packages/app/src/components/session/open-in-app-v2.tsx
@@ -31,7 +31,10 @@ export function OpenInAppV2(props: { directory: () => string }) {
             disabled={state.opening()}
             aria-label={language.t("session.header.open.ariaLabel", { app: state.current().label })}
           >
-            <Show when={state.opening()} fallback={<AppIcon id={state.current().icon} class="size-[18px]" />}>
+            <Show
+              when={state.opening()}
+              fallback={<AppIcon id={state.current().icon} style={{ width: "20px", height: "20px" }} />}
+            >
               <Spinner class="size-3.5" />
             </Show>
           </SplitButtonV2Action>


### PR DESCRIPTION
Increases the selected app icon in the V2 Open in split button from 18px to 20px while leaving dropdown icons unchanged. Uses inline dimensions to override the shared 16px split-button rule. Testing: bun typecheck (packages/app); repository pre-push typecheck.