### PR TITLE
fix(core): fold title usage into session stats and record generate usage (fixes #46371)

### DIFF
--- a/packages/core/src/session/generate-node.ts
+++ b/packages/core/src/session/generate-node.ts
@@ -5,14 +5,18 @@ import { Effect, Layer } from "effect"
 import { Database } from "../database/database.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { llmClient } from "../effect/app-node-platform.js"
+import { Bus } from "../bus.js"
 import { SessionContext } from "./context.js"
+import { SessionEvent } from "./event.js"
 import { SessionGenerate } from "./generate.js"
 import { SessionHistory } from "./history.js"
 import { SessionModelRequest } from "./model-request.js"
+import { SessionUsage } from "./usage.js"
 
 export const layer = Layer.effect(
   SessionGenerate.Service,
   Effect.gen(function* () {
+    const bus = yield* Bus.Service
     const context = yield* SessionContext.Service
     const database = yield* Database.Service
     const llm = yield* LLMClient.Service
@@ -47,6 +51,13 @@ export const layer = Layer.effect(
         })
         const response = yield* llm.generate(prepared.request, prepared.options)
         yield* Effect.logInfo("session generation usage diagnostic", { usage: response.usage })
+        if (response.usage !== undefined) {
+          yield* bus.publish(SessionEvent.UsageRecorded, {
+            sessionID: input.sessionID,
+            source: "generate",
+            ...SessionUsage.record(response.usage, model.cost),
+          })
+        }
         return response.text
       }),
     })
@@ -56,5 +67,5 @@ export const layer = Layer.effect(
 export const node = makeLocationNode({
   service: SessionGenerate.Service,
   layer,
-  deps: [SessionContext.node, Database.node, llmClient],
+  deps: [Bus.node, SessionContext.node, Database.node, llmClient],
 })

--- a/packages/core/src/session/generate.ts
+++ b/packages/core/src/session/generate.ts
@@ -10,7 +10,7 @@ import type { SessionSchema } from "./schema.js"
 export type Error = AgentNotFoundError | Instructions.InitializationBlocked | SessionRunnerModel.Error | AIError
 
 export interface Interface {
-  /** Generates text from current Session context without mutating the Session. */
+  /** Generates text from current Session context without mutating its conversation state; LLM usage is recorded as a Session usage event. */
   readonly generate: (input: {
     readonly sessionID: SessionSchema.ID
     readonly prompt: string

--- a/packages/core/src/session/stats.ts
+++ b/packages/core/src/session/stats.ts
@@ -293,7 +293,7 @@ export const get = Effect.fn("SessionStats.get")(function* (input: Input = {}) {
           and(
             inArray(EventTable.aggregate_id, batch),
             eq(EventTable.type, SessionEvent.UsageRecorded.type),
-            sql`json_extract(${EventTable.data}, '$.source') = 'compaction'`,
+            sql`json_extract(${EventTable.data}, '$.source') IN ('compaction', 'title', 'generate')`,
             gte(EventTable.created, from),
             lt(EventTable.created, to),
           ),

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -35,6 +35,7 @@ import { SessionMessage } from "@opencode-ai/core/session/message"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { SessionSchema } from "@opencode-ai/core/session/schema"
+import { Money } from "@opencode-ai/schema/money"
 import {
   InstructionBlobTable,
   InstructionStateTable,
@@ -71,7 +72,7 @@ const client = Layer.mock(LLMClient.Service)({
         LLMEvent.stepFinish({
           index: 0,
           reason: { normalized: "stop" },
-          usage: { inputTokens: 100, outputTokens: 10 },
+          usage: { inputTokens: 100, nonCachedInputTokens: 100, outputTokens: 10 },
         }),
         LLMEvent.finish({ reason: { normalized: "stop" } }),
       ])
@@ -341,7 +342,25 @@ it.effect(
       expect(requests[0]?.toolChoice).toBeUndefined()
       expect(options[0]?.http).toBeFunction()
       expect(options[0]?.webSocket).toBeUndefined()
-      expect(yield* durableState(db, sessionID)).toEqual(before)
+      const after = yield* durableState(db, sessionID)
+      expect(after.messages).toEqual(before.messages)
+      expect(after.pending).toEqual(before.pending)
+      expect(after.instructions).toEqual(before.instructions)
+      expect(after.blobs).toEqual(before.blobs)
+      expect(after.bus.slice(0, before.bus.length)).toEqual(before.bus)
+      expect(after.bus).toHaveLength(before.bus.length + 1)
+      const usageRow = after.bus.at(-1)
+      if (!usageRow) throw new Error("Expected usage event row")
+      expect(usageRow.type).toBe(Bus.versionedType(SessionEvent.UsageRecorded.type, 1))
+      const usage = Schema.decodeUnknownSync(SessionEvent.UsageRecorded.data)(usageRow.data)
+      expect(usage.sessionID).toBe(sessionID)
+      expect(usage.source).toBe("generate")
+      expect(usage.tokens).toEqual({ input: 100, output: 10, reasoning: 0, cache: { read: 0, write: 0 } })
+      expect(usage.cost).toBe(Money.USD.zero)
+      expect(after.sequence).toBe(before.sequence + 1)
+      expect(after.session?.cost).toBe(before.session?.cost ?? 0)
+      expect(after.session?.tokens_input).toBe((before.session?.tokens_input ?? 0) + 100)
+      expect(after.session?.tokens_output).toBe((before.session?.tokens_output ?? 0) + 10)
     }),
   { timeout: 15_000 },
 )

--- a/packages/core/test/session-stats.test.ts
+++ b/packages/core/test/session-stats.test.ts
@@ -213,8 +213,8 @@ describe("SessionStats", () => {
       expect(stats.subagents).toBe(1)
       expect(stats.prompts).toBe(1)
       expect(stats.steps).toBe(3)
-      expect(stats.tokens).toEqual({ input: 42, output: 22, reasoning: 10, cache: { read: 18, write: 6 } })
-      expect(stats.cost).toBe(Money.USD.make(6.25))
+      expect(stats.tokens).toEqual({ input: 43, output: 23, reasoning: 11, cache: { read: 19, write: 7 } })
+      expect(stats.cost).toBe(Money.USD.make(6.75))
       expect(stats.tools).toMatchObject({
         mode: "detail",
         totals: { calls: 3, succeeded: 1, failed: 1, unfinished: 1 },
@@ -266,6 +266,65 @@ describe("SessionStats", () => {
       const future = yield* Effect.flip(SessionStats.get({ from: Number.MAX_SAFE_INTEGER, tools: "none" }))
       expect(future._tag).toBe("SessionStats.InvalidRangeError")
     }),
+  )
+
+  it.effect(
+    "includes transient generation usage in totals",
+    () =>
+      Effect.gen(function* () {
+        const db = (yield* Database.Service).db
+        const generateProjectID = Project.ID.make("stats-generate-project")
+        const generateSessionID = Session.ID.make("ses_stats_generate")
+        yield* db
+          .insert(ProjectTable)
+          .values([
+            { id: generateProjectID, worktree: AbsolutePath.make("/generate"), name: "generate", sandboxes: [] },
+          ])
+          .run()
+          .pipe(Effect.orDie)
+        yield* db
+          .insert(SessionTable)
+          .values([
+            { id: generateSessionID, project_id: generateProjectID, slug: "generate", directory: "/generate", version: "test" },
+          ])
+          .run()
+          .pipe(Effect.orDie)
+        yield* db
+          .insert(EventSequenceTable)
+          .values([{ aggregate_id: generateSessionID, seq: 0 }])
+          .run()
+          .pipe(Effect.orDie)
+        yield* db
+          .insert(EventTable)
+          .values([
+            {
+              id: Event.ID.make("evt_stats_generate"),
+              aggregate_id: generateSessionID,
+              seq: 0,
+              created: Date.UTC(2026, 0, 2, 11),
+              type: SessionEvent.UsageRecorded.type,
+              data: encodeUsage({
+                sessionID: generateSessionID,
+                source: "generate",
+                cost: Money.USD.make(1.25),
+                tokens: { input: 7, output: 5, reasoning: 3, cache: { read: 2, write: 1 } },
+              }),
+            },
+          ])
+          .run()
+          .pipe(Effect.orDie)
+
+        const stats = yield* SessionStats.get({
+          from: Date.UTC(2026, 0, 1),
+          to: Date.UTC(2026, 1, 1),
+          timezone: "UTC",
+          projectID: generateProjectID,
+          tools: "none",
+        })
+
+        expect(stats.tokens).toEqual({ input: 7, output: 5, reasoning: 3, cache: { read: 2, write: 1 } })
+        expect(stats.cost).toBe(Money.USD.make(1.25))
+      }),
   )
 })
 

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -137,7 +137,7 @@ export const UsageRecorded = Event.durable({
   ...options,
   schema: {
     ...Base,
-    source: Schema.Literals(["title", "compaction"]),
+    source: Schema.Literals(["title", "compaction", "generate"]),
     cost: Money.USD,
     tokens: TokenUsage.Info,
   },


### PR DESCRIPTION
### Issue for this PR

Closes #46371

### Type of change

- [x] Bug fix

### What does this PR do?

Two classes of LLM calls are billed by the provider but absent from session cost:

- **title** — the stats feature emits `UsageRecorded` with `source: "title"` (#43653), but the stats aggregation only folds `source = 'compaction'`, so these events are recorded and never aggregated. In the billing reconciliation behind #46371 (204 billed requests vs 203 accounted), the one unaccounted request was the title call.
- **`/generate`** — documented behavior (#38558, "Durability: no … usage", non-goals "unless we explicitly promote them"). This PR proposes that promotion: the call is billed, so cost reconciliation built on session data can't see it. Only a `UsageRecorded` event is added; the session transcript stays untouched.

Changes: stats filter `'compaction' | 'title' | 'generate'`; `"generate"` added to the `UsageRecorded` source literals (additive, internal event, not in the public manifest); the generate node emits the event after `llm.generate` returns, via the same bus the title generator uses.

The sidebar and `/api/session/stats` need no changes: the projector already applies all `UsageRecorded` events unfiltered, and the stats response shape is unchanged.

The stats-side diagnosis is @argszero's (see the issue). Contract-wise this answers part of open question 4 in #38558 in the direction of "recorded, not returned".

### How did you verify your code works?

- regression tests (red on baseline, green after): stats totals include title and generate usage — 6.75 where the suite previously asserted 6.25, per-source token split asserted; a `source: "generate"` event is recorded and folded into totals and projection; encode roundtrip of the new literal
- full `packages/core` suite green locally (4100 tests; the only failures are two known environment-dependent Worktree tests unrelated to this change)

### Screenshots / recordings

n/a (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
