### PR TITLE
fix: stabilize OAuth tests and Windows npm staging

### DIFF
--- a/packages/core/test/mcp-oauth.test.ts
+++ b/packages/core/test/mcp-oauth.test.ts
@@ -162,6 +162,6 @@ describe("MCP OAuth", () => {
   })
 
   test("rejects an invalid redirect URL", async () => {
-    await expect(authorize("not a URL")).rejects.toThrow("cannot be parsed as a URL")
+    await expect(authorize("not a URL")).rejects.toThrow(TypeError)
   })
 })

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -66,7 +66,7 @@ async function createRegistryFixture(directory: string) {
       exports: "./index.js",
     })
     await Bun.write(path.join(root, "package", "index.js"), `export const version = "${version}"\n`)
-    await Bun.$`tar -czf ${path.join(root, "package.tgz")} -C ${root} package`
+    await Bun.$`tar -czf package.tgz package`.cwd(root)
     tarballs.set(version, await Bun.file(path.join(root, "package.tgz")).bytes())
   }
   const state = { latest: "1.0.0" }

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -252,7 +252,7 @@ describe("Npm.add", () => {
         }
       }).pipe(Effect.scoped, Effect.provide(npmLayer(cache)), Effect.runPromise)
 
-      expect(entries.added.entrypoint).toEndWith("/index.js")
+      expect(entries.added.entrypoint).toBe(pathToFileURL(path.join(entries.added.directory, "index.js")).href)
       expect(entries.added.version).toBe(fixture.commit)
       expect(entries.cached).toEqual(entries.added)
       expect(entries.resolved).toEqual(entries.added)

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -231,7 +231,6 @@ describe("Npm.add", () => {
 
     expect(entries.tui.entrypoint).toEndWith("/tui.js")
     expect(entries.fallback.entrypoint).toEndWith("/index.js")
-    expect(await fs.realpath(entries.tui.directory)).toBe(await fs.realpath(path.join(tmp.path, "fixture-provider")))
   })
 
   test("installs and resolves named and unnamed Git packages with dependencies", async () => {
@@ -263,7 +262,7 @@ describe("Npm.add", () => {
       expect(entries.added.directory).toContain(path.join("npm", await Npm.cacheKey(spec)))
       expect(entries.added.directory).toContain("node_modules")
     }
-  }, 30_000)
+  })
 
   test("installs a Git package from an npm ::path: subdirectory", async () => {
     await using tmp = await tmpdir()

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -231,6 +231,7 @@ describe("Npm.add", () => {
 
     expect(entries.tui.entrypoint).toEndWith("/tui.js")
     expect(entries.fallback.entrypoint).toEndWith("/index.js")
+    expect(await fs.realpath(entries.tui.directory)).toBe(await fs.realpath(path.join(tmp.path, "fixture-provider")))
   })
 
   test("installs and resolves named and unnamed Git packages with dependencies", async () => {
@@ -262,7 +263,7 @@ describe("Npm.add", () => {
       expect(entries.added.directory).toContain(path.join("npm", await Npm.cacheKey(spec)))
       expect(entries.added.directory).toContain("node_modules")
     }
-  })
+  }, 30_000)
 
   test("installs a Git package from an npm ::path: subdirectory", async () => {
     await using tmp = await tmpdir()

--- a/packages/server/test/fetch.test.ts
+++ b/packages/server/test/fetch.test.ts
@@ -3,7 +3,9 @@ import { createServer } from "node:http"
 import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
 import { Workspace } from "@opencode-ai/core/workspace"
 import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
-import { Effect } from "effect"
+import { Agent } from "@opencode-ai/schema/agent"
+import { Integration } from "@opencode-ai/schema/integration"
+import { Effect, Schedule, Schema } from "effect"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import { it } from "../../core/test/lib/effect"
 import { ServerFetch } from "../src/fetch"
@@ -58,19 +60,35 @@ function occupy(port: number, cancel = false) {
   })
 }
 
-const ready = (handler: Handler) =>
-  Effect.promise(() => handler(new Request("http://opencode.local/api/model/default")))
-
 const connectOpenAI = (handler: Handler) =>
-  Effect.promise(() =>
-    handler(
-      new Request("http://opencode.local/api/integration/openai/connect/oauth", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ methodID: "chatgpt-browser" }),
-      }),
-    ),
-  )
+  Effect.gen(function* () {
+    // Catalog endpoints no longer wait for plugin initialization.
+    yield* Effect.gen(function* () {
+      const response = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/integration")))
+      expect(response.status).toBe(200)
+      const body = Schema.decodeUnknownSync(Schema.Struct({ data: Schema.Array(Integration.Info) }))(
+        yield* Effect.promise(() => response.json()),
+      )
+      return body.data.some(
+        (integration) =>
+          integration.id === "openai" &&
+          integration.methods.some((method) => method.type === "oauth" && method.id === "chatgpt-browser"),
+      )
+    }).pipe(
+      Effect.filterOrFail((ready) => ready),
+      Effect.retry(Schedule.spaced("10 millis")),
+      Effect.timeout("2 seconds"),
+    )
+    return yield* Effect.promise(() =>
+      handler(
+        new Request("http://opencode.local/api/integration/openai/connect/oauth", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ methodID: "chatgpt-browser" }),
+        }),
+      ),
+    )
+  })
 
 const workspaceDriver = WorkspaceDriver.make({
   create: ({ workspaceID }) => Effect.succeed({ binding: { workspaceID } }),
@@ -189,7 +207,6 @@ it.live("cancels a stale OpenAI OAuth callback server before falling back", () =
   Effect.gen(function* () {
     const requests = yield* occupy(1455, true)
     const handler = yield* ServerFetch.make(options)
-    yield* ready(handler)
     const response = yield* connectOpenAI(handler)
 
     expect(response.status).toBe(200)
@@ -203,7 +220,6 @@ it.live("falls back to port 1457 when OpenAI OAuth port 1455 remains busy", () =
   Effect.gen(function* () {
     const requests = yield* occupy(1455)
     const handler = yield* ServerFetch.make(options)
-    yield* ready(handler)
     const response = yield* connectOpenAI(handler)
 
     expect(response.status).toBe(200)
@@ -220,7 +236,6 @@ it.live(
       yield* occupy(1455)
       yield* occupy(1457)
       const handler = yield* ServerFetch.make(options)
-      yield* ready(handler)
       const response = yield* connectOpenAI(handler)
 
       expect(response.status).toBe(400)
@@ -439,7 +454,22 @@ it.live("routes pending requests by Session without loading an instance", () =>
     expect(yield* Effect.promise(() => globalForms.json())).toMatchObject({ data: [{ title: "Global form" }] })
 
     // Agent permission policy is installed by plugin activation.
-    expect((yield* ready(handler)).status).toBe(200)
+    yield* Effect.gen(function* () {
+      const response = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/agent")))
+      expect(response.status).toBe(200)
+      const body = Schema.decodeUnknownSync(Schema.Struct({ data: Schema.Array(Agent.Info) }))(
+        yield* Effect.promise(() => response.json()),
+      )
+      return body.data.some(
+        (agent) =>
+          agent.id === "build" &&
+          agent.permissions.some((rule) => rule.action === "shell" && rule.resource === "*" && rule.effect === "ask"),
+      )
+    }).pipe(
+      Effect.filterOrFail((ready) => ready),
+      Effect.retry(Schedule.spaced("10 millis")),
+      Effect.timeout("2 seconds"),
+    )
     const createdPermission = yield* Effect.promise(() =>
       handler(
         new Request(`http://opencode.local/api/session/${created.data.id}/permission`, {

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -133,13 +133,10 @@ const resolveEntryPoint = (name: string, dir: string, subpaths: readonly string[
 interface ArboristNode {
   name: string
   path: string
-  realpath: string
-  isLink: boolean
 }
 
 interface ArboristTree {
   edgesOut: Map<string, { to?: ArboristNode }>
-  inventory: { values(): IterableIterator<ArboristNode> }
 }
 
 const PackageJson = Schema.Struct({
@@ -300,13 +297,7 @@ const layer = Layer.effect(
           installed ? [] : subpaths,
         )
         if (!installed && !result.entrypoint) return yield* new InstallFailedError({ add: [pkg], dir: staging })
-        const links =
-          process.platform === "win32"
-            ? Array.from(tree.inventory.values()).filter(
-                (node) => node.isLink && FSUtil.contains(staging, node.path) && FSUtil.contains(staging, node.realpath),
-              )
-            : []
-        return { name: installedNameValue, result, links }
+        return { name: installedNameValue, result }
       }).pipe(Effect.onError(() => remove(staging, dir).pipe(Effect.ignore)))
 
       if (active) {
@@ -320,22 +311,6 @@ const layer = Layer.effect(
       const completedAt = yield* Clock.currentTimeMillis
       const newest = Number((yield* generations(dir)).at(-1) ?? 0)
       const generation = path.join(dir, String(Math.max(completedAt, newest + 1)))
-      // Windows junctions use absolute targets, so internal links must follow the published generation.
-      if (staged.links.length > 0) {
-        const { unlink, symlink } = yield* Effect.promise(() => import("node:fs/promises"))
-        yield* Effect.forEach(
-          staged.links,
-          (link) =>
-            Effect.tryPromise({
-              try: async () => {
-                await unlink(link.path)
-                await symlink(path.join(generation, path.relative(staging, link.realpath)), link.path, "junction")
-              },
-              catch: (cause) => new InstallFailedError({ dir, cause }),
-            }),
-          { discard: true },
-        )
-      }
       yield* rename(staging, generation, dir)
       return yield* entry(
         generation,

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -293,7 +293,8 @@ const layer = Layer.effect(
           installedNameValue,
           installed?.path ?? path.join(staging, "node_modules", installedNameValue),
           target,
-          subpaths,
+          // Resolve installed entrypoints after rename so Bun cannot hold the staging directory open on Windows.
+          installed ? [] : subpaths,
         )
         if (!installed && !result.entrypoint) return yield* new InstallFailedError({ add: [pkg], dir: staging })
         return { name: installedNameValue, result }

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -133,10 +133,13 @@ const resolveEntryPoint = (name: string, dir: string, subpaths: readonly string[
 interface ArboristNode {
   name: string
   path: string
+  realpath: string
+  isLink: boolean
 }
 
 interface ArboristTree {
   edgesOut: Map<string, { to?: ArboristNode }>
+  inventory: { values(): IterableIterator<ArboristNode> }
 }
 
 const PackageJson = Schema.Struct({
@@ -297,7 +300,13 @@ const layer = Layer.effect(
           installed ? [] : subpaths,
         )
         if (!installed && !result.entrypoint) return yield* new InstallFailedError({ add: [pkg], dir: staging })
-        return { name: installedNameValue, result }
+        const links =
+          process.platform === "win32"
+            ? Array.from(tree.inventory.values()).filter(
+                (node) => node.isLink && FSUtil.contains(staging, node.path) && FSUtil.contains(staging, node.realpath),
+              )
+            : []
+        return { name: installedNameValue, result, links }
       }).pipe(Effect.onError(() => remove(staging, dir).pipe(Effect.ignore)))
 
       if (active) {
@@ -311,6 +320,22 @@ const layer = Layer.effect(
       const completedAt = yield* Clock.currentTimeMillis
       const newest = Number((yield* generations(dir)).at(-1) ?? 0)
       const generation = path.join(dir, String(Math.max(completedAt, newest + 1)))
+      // Windows junctions use absolute targets, so internal links must follow the published generation.
+      if (staged.links.length > 0) {
+        const { unlink, symlink } = yield* Effect.promise(() => import("node:fs/promises"))
+        yield* Effect.forEach(
+          staged.links,
+          (link) =>
+            Effect.tryPromise({
+              try: async () => {
+                await unlink(link.path)
+                await symlink(path.join(generation, path.relative(staging, link.realpath)), link.path, "junction")
+              },
+              catch: (cause) => new InstallFailedError({ dir, cause }),
+            }),
+          { discard: true },
+        )
+      }
       yield* rename(staging, generation, dir)
       return yield* entry(
         generation,


### PR DESCRIPTION
## Summary
Keep the confirmed, limited CI fixes without expanding into Windows junction repair.

- Assert TypeError for an invalid OAuth redirect instead of Bun-specific error wording.
- Wait for the actual OpenAI OAuth method and configured agent permission rule before testing their behavior. Catalog reads no longer wait for plugin initialization.
- Create registry fixture tarballs using a relative archive path so GNU tar does not interpret a Windows drive letter as a remote host.
- Defer entrypoint resolution for successfully staged npm installs until after the staging directory is renamed. The pre-rename entrypoint was unused; avoiding it prevents Bun resolver handles from blocking the rename on Windows. Preserve metadata reads, revision comparison, requested subpaths, and the missing-node validation fallback.
- Assert that Git installs return an entrypoint under their published package directory.

The later Windows junction-repair change has been reverted. No test skips, mutation retries, permission-policy changes, dependency changes, or schema-comment changes.

## Validation
Bun 1.4.0 on macOS, for the retained changes:
- Full core suite: 4,063 passed, 40 skipped.
- Full server suite: 52 passed, 3 skipped.
- Fetch suite repeated five times: 60 passed.
- MCP OAuth suite: 6 passed.
- Npm suite: 13 passed.
- Util suite: 37 passed.
- Core, server, and util typechecks passed.
- git diff --check passed. Changed test files pass Prettier; existing formatting differences in util/npm.ts were left untouched.

## Remaining Failures
The retained changes passed the Windows server suite and resolved the npm EPERM rename and tar-path errors. Two Windows Git dependency tests still fail because directory links point at the old staging location. Those are intentionally deferred.

The last run of the retained code also reported a Linux module-resolution error in the unchanged tool-edit test; that test and the full core suite pass locally. This PR does not claim all CI checks are green.