### PR TITLE
fix(app): follow file tree order in review navigation

### DIFF
--- a/packages/app/src/session/files/file-tree-v2-model.test.ts
+++ b/packages/app/src/session/files/file-tree-v2-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { buildFileTreeV2Model, flattenFileTreeV2, flattenLiveFileTreeV2 } from "./file-tree-v2-model"
+import { buildFileTreeV2Model, flattenFileTreeV2, flattenLiveFileTreeV2, sortFileTreeV2Paths } from "./file-tree-v2-model"
 import type { FileNode } from "@/runtime/server/types"
 
 describe("buildFileTreeV2Model", () => {
@@ -42,6 +42,33 @@ describe("buildFileTreeV2Model", () => {
     const model = buildFileTreeV2Model([file])
 
     expect(flattenFileTreeV2(model, () => true)).toHaveLength(131)
+  })
+})
+
+describe("sortFileTreeV2Paths", () => {
+  test("orders navigation depth-first with directories before sibling files", () => {
+    const paths = ["README.md", "src/a.ts", "src/lib/z.ts", "docs/guide.md", "src/lib/b.ts"]
+
+    expect(sortFileTreeV2Paths(paths)).toEqual([
+      "docs/guide.md",
+      "src/lib/b.ts",
+      "src/lib/z.ts",
+      "src/a.ts",
+      "README.md",
+    ])
+    expect(paths[0]).toBe("README.md")
+  })
+
+  test("preserves original paths for selection", () => {
+    expect(sortFileTreeV2Paths(["README.md", "src\\lib\\a.ts", "/docs//guide.md/"])).toEqual([
+      "/docs//guide.md/",
+      "src\\lib\\a.ts",
+      "README.md",
+    ])
+  })
+
+  test("handles an empty file list", () => {
+    expect(sortFileTreeV2Paths([])).toEqual([])
   })
 })
 

--- a/packages/app/src/session/files/file-tree-v2-model.ts
+++ b/packages/app/src/session/files/file-tree-v2-model.ts
@@ -76,6 +76,12 @@ export function flattenFileTreeV2(model: FileTreeV2Model, expanded: (path: strin
   return rows
 }
 
+export function sortFileTreeV2Paths(paths: readonly string[]) {
+  return flattenFileTreeV2(buildFileTreeV2Model(paths), () => true)
+    .filter((row) => row.node.type === "file")
+    .map((row) => row.node.originalPath)
+}
+
 export function flattenLiveFileTreeV2(
   children: (path: string) => readonly FileNode[],
   expanded: (path: string) => boolean,

--- a/packages/app/src/session/review/panel.tsx
+++ b/packages/app/src/session/review/panel.tsx
@@ -18,6 +18,7 @@ import type {
   SessionReviewLineComment,
 } from "@opencode-ai/session-ui/session-review"
 import FileTreeV2 from "@/session/files/file-tree-v2"
+import { sortFileTreeV2Paths } from "@/session/files/file-tree-v2-model"
 import { useLanguage } from "@/runtime/i18n/language"
 import { useWorkspaceLocation } from "@/workspaces/location"
 import { useServerSDK } from "@/runtime/server/client"
@@ -83,6 +84,9 @@ export function ReviewPanelView(
     ),
   )
   const searching = createMemo(() => props.state.filter().trim().length > 0)
+  const navigationFiles = createMemo(() =>
+    searching() || props.fileList === "flat" ? filteredFiles() : sortFileTreeV2Paths(filteredFiles()),
+  )
   const kinds = createMemo(() => reviewDiffKinds(diffs()))
   // Changes-only trees omit "M" — every row is already a change; A/D stay visible.
   const treeKinds = createMemo(() => new Map([...kinds()].filter(([, kind]) => kind !== "mix")))
@@ -93,7 +97,7 @@ export function ReviewPanelView(
     if (focus && diffs().some((diff) => diff.file === focus.file)) return focus.file
     const active = props.activeFile
     if (searching()) return active
-    const files = filteredFiles()
+    const files = navigationFiles()
     if (active && files.includes(active)) return active
     return files[0]
   })
@@ -141,7 +145,7 @@ export function ReviewPanelView(
         />
       }
       activeFile={activeDiff()}
-      files={filteredFiles()}
+      files={navigationFiles()}
       onSelectFile={props.onSelectFile}
       diffStyle={props.diffStyle}
       onDiffStyleChange={props.onDiffStyleChange}


### PR DESCRIPTION
## Summary
- Make the review pane's previous/next buttons and arrow keys follow the file tree's depth-first, directories-first ordering instead of incoming diff order.
- Use the same order for the default selected file, while preserving flat-list and search-result ordering.
- Add regression tests for nested ordering, original path preservation, and empty lists.

## Validation
- 15 focused file-tree and review tests passed.
- App typecheck and production build passed.
- Repository pre-push typechecks passed using Bun 1.4.0.
- The production review-pane benchmark timed out before and after the change without reporting metrics; performance comparison is unavailable.

## Scope
Only the three review-navigation implementation/test files are included. Unrelated workspace changes are excluded.