### PR TITLE
fix(app): discover server projects in fresh clients

### DIFF
--- a/packages/app/e2e/regression/home-server-project-discovery.spec.ts
+++ b/packages/app/e2e/regression/home-server-project-discovery.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test, type Page } from "@playwright/test"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible } from "../utils/waits"
+
+const directoryA = "C:/OpenCode/ProjectA"
+const directoryB = "C:/OpenCode/ProjectB"
+const projects = [
+  {
+    id: "proj_discovery_a",
+    worktree: directoryA,
+    vcs: "git",
+    name: "Project A",
+    time: { created: 1_700_000_000_000, updated: 1_700_000_000_000 },
+    sandboxes: [],
+  },
+  {
+    id: "proj_discovery_b",
+    worktree: directoryB,
+    vcs: "git",
+    name: "Project B",
+    time: { created: 1_700_000_000_000, updated: 1_700_000_000_000 },
+    sandboxes: [],
+  },
+]
+const sessions = [
+  {
+    id: "ses_discovery_a",
+    projectID: projects[0]!.id,
+    directory: directoryA,
+    title: "Session in Project A",
+    time: { created: 1_700_000_000_000, updated: 1_700_000_000_002 },
+  },
+  {
+    id: "ses_discovery_b",
+    projectID: projects[1]!.id,
+    directory: directoryB,
+    title: "Session in Project B",
+    time: { created: 1_700_000_000_000, updated: 1_700_000_000_001 },
+  },
+]
+
+async function configure(page: Page) {
+  await mockOpenCodeServer(page, {
+    directory: directoryA,
+    project: projects[0],
+    projects,
+    provider: { all: [], connected: [], default: {} },
+    sessions,
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.addInitScript(() => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+  })
+}
+
+function projectRow(page: Page, name: string) {
+  return page.locator('[data-component="home-project-row"]').filter({ hasText: name })
+}
+
+function sessionRow(page: Page, title: string) {
+  return page.locator('[data-component="home-session-row"]').filter({ hasText: title })
+}
+
+test("discovers server projects and sessions without leaking local project state across clients", async ({
+  page,
+  browser,
+}) => {
+  await configure(page)
+  await page.goto("/")
+
+  await expectAppVisible(projectRow(page, "Project A"))
+  await expectAppVisible(projectRow(page, "Project B"))
+  await expectAppVisible(sessionRow(page, "Session in Project A"))
+  await expectAppVisible(sessionRow(page, "Session in Project B"))
+
+  const projectA = projectRow(page, "Project A").locator("..")
+  await projectA.hover()
+  await projectA.locator('[data-action="home-project-new-session"]').click()
+  await expect(page).toHaveURL(/\/new-session\?draftId=/)
+
+  await page.goto("/")
+  await expectAppVisible(projectRow(page, "Project B"))
+
+  const projectB = projectRow(page, "Project B").locator("..")
+  await projectB.hover()
+  await projectB.locator('[data-action="home-project-menu"]').click()
+  await page.getByRole("menuitem", { name: "Close", exact: true }).click()
+  await expect(projectRow(page, "Project B")).toHaveCount(0)
+
+  const second = await browser.newPage()
+  try {
+    await configure(second)
+    await second.goto(process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3000")
+    await expectAppVisible(projectRow(second, "Project B"))
+    await expectAppVisible(sessionRow(second, "Session in Project B"))
+  } finally {
+    await second.close()
+  }
+})

--- a/packages/app/e2e/user-story/model-selection-flow.spec.ts
+++ b/packages/app/e2e/user-story/model-selection-flow.spec.ts
@@ -63,10 +63,13 @@ test("creates a session in a new project, connects OpenCode Go, and selects its 
       path ? [] : [{ name: "NewProject", path: "NewProject", absolute: directory, type: "directory", ignored: false }],
     findFiles: () => ["NewProject"],
   })
-  await page.addInitScript(() => {
+  await page.addInitScript((directory) => {
     localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
-    localStorage.setItem("opencode.global.dat:server", JSON.stringify({ projects: { local: [] } }))
-  })
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({ projects: { local: [] }, hiddenProjects: { local: [directory] } }),
+    )
+  }, directory)
 
   await page.goto("/")
   const addProject = page.locator('[data-action="home-add-project-row"]')

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -11,6 +11,7 @@ export interface MockServerConfig {
   onInstanceDispose?: () => void
   directory: string
   project: unknown
+  projects?: unknown[]
   sessions: ({ id: string } & Record<string, unknown>)[]
   pageMessages: (sessionId: string, limit: number, before?: string) => { items: unknown[]; cursor?: string }
   vcsDiff?: unknown[]
@@ -33,6 +34,7 @@ export interface MockServerConfig {
 export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
   const cursors = new Map<string, string>()
   let nextCursor = 0
+  const projects = config.projects ?? [config.project]
   const staticRoutes: Record<string, unknown> = {
     "/path": {
       state: config.directory,
@@ -41,7 +43,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
       directory: config.directory,
       home: "C:/OpenCode",
     },
-    "/project": [config.project],
+    "/project": projects,
     "/project/current": config.project,
     "/agent": [{ name: "build", mode: "primary" }],
     "/vcs": { branch: "main", default_branch: "main" },
@@ -149,7 +151,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
       config.onConnectKey?.({ integrationID: integrationConnect, body: route.request().postDataJSON() })
       return route.fulfill({ status: 204, headers: { "access-control-allow-origin": "*" } })
     }
-    if (path === "/api/project") return json(route, [config.project])
+    if (path === "/api/project") return json(route, projects)
     if (path === "/api/project/current")
       return json(route, { id: (config.project as { id?: string }).id, directory: config.directory })
     if (path.startsWith("/api/project/") && route.request().method() === "PATCH") return json(route, config.project)

--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -5,6 +5,7 @@ import type { Config, OpencodeClient, Project } from "@opencode-ai/sdk/v2/client
 import type { AgentApi, CatalogApi, CommandApi, ReferenceApi } from "@opencode-ai/client/promise"
 import type { NormalizedProviderListResponse } from "@opencode-ai/session-ui/context"
 import {
+  bootstrapGlobalResult,
   bootstrapDirectory,
   loadAgentsQuery,
   loadCommands,
@@ -180,6 +181,16 @@ describe("bootstrapDirectory", () => {
     await new Promise((resolve) => setTimeout(resolve, 80))
 
     expect(store.status).toBe("complete")
+  })
+})
+
+describe("bootstrapGlobalResult", () => {
+  const fulfilled = { status: "fulfilled", value: undefined } as const
+  const rejected = { status: "rejected", reason: new Error("failed") } as const
+
+  test("marks projects ready only when the project request fulfilled", () => {
+    expect(bootstrapGlobalResult([fulfilled, fulfilled, fulfilled, fulfilled])).toEqual({ projects: true })
+    expect(bootstrapGlobalResult([fulfilled, fulfilled, fulfilled, rejected])).toEqual({ projects: false })
   })
 })
 

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -89,6 +89,10 @@ function runAll(list: Array<() => Promise<unknown>>) {
   return Promise.allSettled(list.map((item) => item()))
 }
 
+export function bootstrapGlobalResult(results: PromiseSettledResult<unknown>[]) {
+  return { projects: results[3]?.status === "fulfilled" }
+}
+
 function showErrors(input: {
   errors: unknown[]
   title: string
@@ -163,7 +167,7 @@ export async function bootstrapGlobal(input: {
         .fetchQuery(loadProjectsQuery(input.scope, input.serverAPI.project))
         .then((data) => input.setGlobalStore("project", data)),
   ]
-  await runAll(slow)
+  return bootstrapGlobalResult(await runAll(slow))
   // showErrors({
   //   errors: errors(),
   //   title: input.requestFailedTitle,

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -1,7 +1,13 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createEffect, createMemo, createRoot } from "solid-js"
 import { createStore } from "solid-js/store"
-import { createServerProjects, RECENTLY_CLOSED_DISPLAY_LIMIT, ServerConnection, useServer } from "./server"
+import {
+  createServerProjects,
+  RECENTLY_CLOSED_DISPLAY_LIMIT,
+  ServerConnection,
+  useServer,
+  visibleProjectEntries,
+} from "./server"
 import { pathKey } from "@/utils/path-key"
 import { useServerHealth } from "@/utils/server-health"
 import { createServerSdkContext } from "./server-sdk"
@@ -110,6 +116,11 @@ function createServerCtx(
   const sdk = createServerSdkContext(conn, scope)
   const sync = createServerSyncContext(sdk)
 
+  createEffect(() => {
+    if (!sync.projectsReady) return
+    projects.reconcileHidden(sync.data.project.map((project) => project.worktree))
+  })
+
   function enrich(project: { worktree: string; expanded: boolean }) {
     const [childStore] = sync.child(project.worktree, { bootstrap: false })
     const projectID = childStore.project
@@ -127,7 +138,9 @@ function createServerCtx(
     return base
   }
 
-  const projectsList = createMemo(() => projects.list().map(enrich))
+  const projectsList = createMemo(() =>
+    visibleProjectEntries(projects.list(), sync.data.project, projects.hidden()).map(enrich),
+  )
   const recentlyClosedList = createMemo(() => {
     const known = new Set(sync.data.project.map((project) => pathKey(project.worktree)))
     return projects

--- a/packages/app/src/context/server-sync.tsx
+++ b/packages/app/src/context/server-sync.tsx
@@ -320,7 +320,7 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
   const bootstrap = useQuery(() => ({
     queryKey: [serverSDK.scope, "bootstrap"],
     queryFn: async () => {
-      await bootstrapGlobal({
+      const result = await bootstrapGlobal({
         serverSDK: serverSDK.client,
         serverAPI: serverSDK.api,
         protocol: serverSDK.protocol,
@@ -332,7 +332,7 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
         queryClient,
       })
       bootedAt = Date.now()
-      return bootedAt
+      return { bootedAt, projects: result.projects }
     },
   }))
 
@@ -675,6 +675,9 @@ export function createServerSyncContextInner(serverSDK: ServerSDK) {
     set,
     get ready() {
       return globalStore.ready
+    },
+    get projectsReady() {
+      return bootstrap.data?.projects === true
     },
     get error() {
       return globalStore.error

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import {
+  clearServerProjectScope,
   createServerProjects,
   migrateCanonicalLocalServerState,
   nextServerAfterRemoval,
   resolveServerList,
   ServerConnection,
+  visibleProjectEntries,
 } from "./server"
 import { ServerScope } from "@/utils/server-scope"
 
@@ -197,6 +199,163 @@ describe("createServerProjects", () => {
       dispose()
     })
   })
+
+  test("keeps hidden projects isolated per server and restores them when reopened", () => {
+    createRoot((dispose) => {
+      const [store, setStore] = createStore({
+        projects: {},
+        lastProject: {},
+        recentlyClosed: {},
+        hiddenProjects: {},
+      })
+      const local = createServerProjects({ scope: () => ServerScope.local, store, setStore })
+      const remote = createServerProjects({ scope: () => "https://debian.example" as ServerScope, store, setStore })
+
+      remote.close("/repo")
+      expect(remote.hidden()).toEqual(["/repo"])
+      expect(local.hidden()).toEqual([])
+
+      remote.open("/repo/")
+      expect(remote.hidden()).toEqual([])
+      dispose()
+    })
+  })
+
+  test("normalizes bookmark mutations and removes every duplicate on close", () => {
+    createRoot((dispose) => {
+      const [store, setStore] = createStore({
+        projects: {
+          local: [
+            { worktree: "/repo", expanded: true },
+            { worktree: "/repo/", expanded: false },
+          ],
+        },
+        lastProject: {},
+        recentlyClosed: {},
+        hiddenProjects: {},
+      })
+      const projects = createServerProjects({ scope: () => ServerScope.local, store, setStore })
+
+      projects.open("/repo/")
+      expect(projects.list()).toHaveLength(2)
+
+      projects.close("/repo")
+      expect(projects.list()).toEqual([])
+      expect(projects.hidden()).toEqual(["/repo"])
+      dispose()
+    })
+  })
+
+  test("prunes hidden projects against current server discovery", () => {
+    createRoot((dispose) => {
+      const [store, setStore] = createStore({
+        projects: {},
+        lastProject: {},
+        recentlyClosed: {},
+        hiddenProjects: { local: ["/repo/a", "/repo/b", "/repo/b/"] },
+      })
+      const projects = createServerProjects({ scope: () => ServerScope.local, store, setStore })
+
+      projects.reconcileHidden(["/repo/b"])
+      expect(projects.hidden()).toEqual(["/repo/b"])
+      dispose()
+    })
+  })
+})
+
+describe("clearServerProjectScope", () => {
+  test("clears every organization bucket for a removed remote server", () => {
+    const scope = ServerScope.fromServerKey(ServerConnection.Key.make("https://opencode.example.com"))
+    const [store, setStore] = createStore({
+      projects: { [scope]: [{ worktree: "/repo", expanded: true }], local: [{ worktree: "/local", expanded: true }] },
+      lastProject: { [scope]: "/repo", local: "/local" },
+      recentlyClosed: { [scope]: ["/closed"], local: ["/local-closed"] },
+      hiddenProjects: { [scope]: ["/hidden"], local: ["/local-hidden"] },
+    })
+
+    clearServerProjectScope({ scope, store, setStore })
+
+    expect(store).toEqual({
+      projects: { local: [{ worktree: "/local", expanded: true }] },
+      lastProject: { local: "/local" },
+      recentlyClosed: { local: ["/local-closed"] },
+      hiddenProjects: { local: ["/local-hidden"] },
+    })
+  })
+
+  test("does not clear the shared canonical local bucket", () => {
+    const [store, setStore] = createStore({
+      projects: { local: [{ worktree: "/local", expanded: true }] },
+      lastProject: { local: "/local" },
+      recentlyClosed: { local: ["/closed"] },
+      hiddenProjects: { local: ["/hidden"] },
+    })
+
+    clearServerProjectScope({ scope: ServerScope.local, store, setStore })
+    expect(store.projects.local).toHaveLength(1)
+    expect(store.hiddenProjects.local).toEqual(["/hidden"])
+  })
+})
+
+describe("visibleProjectEntries", () => {
+  test("discovers server projects for a fresh client", () => {
+    expect(visibleProjectEntries([], [{ worktree: "/repo/a" }, { worktree: "/repo/b" }], [])).toEqual([
+      { worktree: "/repo/a", expanded: false },
+      { worktree: "/repo/b", expanded: false },
+    ])
+  })
+
+  test("keeps remaining server projects after the first bookmark", () => {
+    expect(
+      visibleProjectEntries(
+        [{ worktree: "/repo/a", expanded: true }],
+        [{ worktree: "/repo/a" }, { worktree: "/repo/b" }],
+        [],
+      ),
+    ).toEqual([
+      { worktree: "/repo/a", expanded: true },
+      { worktree: "/repo/b", expanded: false },
+    ])
+  })
+
+  test("dedupes normalized paths while preserving bookmark order", () => {
+    expect(
+      visibleProjectEntries(
+        [
+          { worktree: "/repo/b", expanded: true },
+          { worktree: "/repo/a/", expanded: false },
+        ],
+        [{ worktree: "/repo/a" }, { worktree: "/repo/c" }, { worktree: "/repo/b/" }],
+        [],
+      ),
+    ).toEqual([
+      { worktree: "/repo/b", expanded: true },
+      { worktree: "/repo/a/", expanded: false },
+      { worktree: "/repo/c", expanded: false },
+    ])
+  })
+
+  test("filters hidden discoveries without hiding explicit bookmarks", () => {
+    expect(
+      visibleProjectEntries(
+        [{ worktree: "/repo/a", expanded: true }],
+        [{ worktree: "/repo/a" }, { worktree: "/repo/b" }],
+        ["/repo/a/", "/repo/b/"],
+      ),
+    ).toEqual([{ worktree: "/repo/a", expanded: true }])
+  })
+
+  test("ignores malformed persisted hidden entries", () => {
+    expect(visibleProjectEntries([], [{ worktree: "/repo/a" }], [null, 42, "/repo/b"] as unknown as string[])).toEqual([
+      { worktree: "/repo/a", expanded: false },
+    ])
+  })
+
+  test("preserves explicit local bookmarks that are absent from server discovery", () => {
+    expect(visibleProjectEntries([{ worktree: "/manual", expanded: true }], [], [])).toEqual([
+      { worktree: "/manual", expanded: true },
+    ])
+  })
 })
 
 describe("migrateCanonicalLocalServerState", () => {
@@ -240,6 +399,38 @@ describe("migrateCanonicalLocalServerState", () => {
         ],
       },
       lastProject: { local: "/local" },
+    })
+  })
+
+  test("moves hidden projects from a canonical web bucket into local scope", () => {
+    expect(
+      migrateCanonicalLocalServerState(
+        {
+          hiddenProjects: {
+            local: ["/local-hidden"],
+            "https://opencode.example.com": ["/local-hidden/", "/remote-hidden"],
+          },
+        },
+        ServerConnection.Key.make("https://opencode.example.com"),
+      ),
+    ).toEqual({
+      hiddenProjects: { local: ["/local-hidden", "/remote-hidden"] },
+    })
+  })
+
+  test("drops malformed hidden projects during canonical migration", () => {
+    expect(
+      migrateCanonicalLocalServerState(
+        {
+          hiddenProjects: {
+            local: ["/local-hidden", null],
+            "https://opencode.example.com": [42, "/remote-hidden"],
+          },
+        },
+        ServerConnection.Key.make("https://opencode.example.com"),
+      ),
+    ).toEqual({
+      hiddenProjects: { local: ["/local-hidden", "/remote-hidden"] },
     })
   })
 })

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -1,6 +1,6 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { type Accessor, batch, createMemo } from "solid-js"
-import { createStore, type SetStoreFunction, type Store } from "solid-js/store"
+import { createStore, reconcile, type SetStoreFunction, type Store } from "solid-js/store"
 import { Persist, persisted } from "@/utils/persist"
 import { pathKey } from "@/utils/path-key"
 import { ServerScope } from "@/utils/server-scope"
@@ -11,6 +11,33 @@ type ServerProjectState = {
   projects: Record<string, StoredProject[]>
   lastProject: Record<string, string>
   recentlyClosed: Record<string, string[]>
+  hiddenProjects?: Record<string, string[]>
+}
+
+const stringList = (value: unknown): string[] =>
+  Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []
+
+export function clearServerProjectScope<T extends ServerProjectState>(input: {
+  scope: ServerScope
+  store: Store<T>
+  setStore: SetStoreFunction<T>
+}) {
+  if (input.scope === ServerScope.local) return
+  const setStore = input.setStore as unknown as SetStoreFunction<ServerProjectState>
+  const projects = { ...input.store.projects }
+  const lastProject = { ...input.store.lastProject }
+  const recentlyClosed = { ...input.store.recentlyClosed }
+  const hiddenProjects = { ...input.store.hiddenProjects }
+  delete projects[input.scope]
+  delete lastProject[input.scope]
+  delete recentlyClosed[input.scope]
+  delete hiddenProjects[input.scope]
+  batch(() => {
+    setStore("projects", reconcile(projects))
+    setStore("lastProject", reconcile(lastProject))
+    setStore("recentlyClosed", reconcile(recentlyClosed))
+    setStore("hiddenProjects", reconcile(hiddenProjects))
+  })
 }
 const HEALTH_POLL_INTERVAL_MS = 10_000
 // The store retains more history than is displayed. Consumers filter recently closed entries
@@ -47,9 +74,16 @@ export function migrateCanonicalLocalServerState(value: unknown, canonicalLocalS
   if (!isRecord(value)) return value
   const projects = isRecord(value.projects) ? value.projects : undefined
   const lastProject = isRecord(value.lastProject) ? value.lastProject : undefined
+  const hiddenProjects = isRecord(value.hiddenProjects) ? value.hiddenProjects : undefined
   const previousProjects = projects?.[canonicalLocalServer]
   const previousLastProject = lastProject?.[canonicalLocalServer]
-  if (!Array.isArray(previousProjects) && typeof previousLastProject !== "string") return value
+  const previousHiddenProjects = hiddenProjects?.[canonicalLocalServer]
+  if (
+    !Array.isArray(previousProjects) &&
+    typeof previousLastProject !== "string" &&
+    !Array.isArray(previousHiddenProjects)
+  )
+    return value
 
   const next = { ...value }
   if (projects && Array.isArray(previousProjects)) {
@@ -73,7 +107,46 @@ export function migrateCanonicalLocalServerState(value: unknown, canonicalLocalS
     delete nextLastProject[canonicalLocalServer]
     next.lastProject = nextLastProject
   }
+  if (hiddenProjects && Array.isArray(previousHiddenProjects)) {
+    const local = stringList(hiddenProjects.local)
+    const keys = new Set(local.map(pathKey))
+    const migrated = stringList(previousHiddenProjects).filter((directory) => {
+      const key = pathKey(directory)
+      if (keys.has(key)) return false
+      keys.add(key)
+      return true
+    })
+    const nextHiddenProjects: Record<string, unknown> = { ...hiddenProjects, local: [...local, ...migrated] }
+    delete nextHiddenProjects[canonicalLocalServer]
+    next.hiddenProjects = nextHiddenProjects
+  }
   return next
+}
+
+export function visibleProjectEntries(
+  bookmarked: ReadonlyArray<StoredProject>,
+  server: ReadonlyArray<{ worktree: string }>,
+  hidden: ReadonlyArray<string>,
+) {
+  const seen = new Set<string>()
+  const result: StoredProject[] = []
+
+  for (const project of bookmarked) {
+    const key = pathKey(project.worktree)
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(project)
+  }
+
+  const blocked = new Set(stringList(hidden).map(pathKey))
+  for (const project of server) {
+    const key = pathKey(project.worktree)
+    if (seen.has(key) || blocked.has(key)) continue
+    seen.add(key)
+    result.push({ worktree: project.worktree, expanded: false })
+  }
+
+  return result
 }
 
 export function createServerProjects<T extends ServerProjectState>(input: {
@@ -84,20 +157,41 @@ export function createServerProjects<T extends ServerProjectState>(input: {
   const setStore = input.setStore as unknown as SetStoreFunction<ServerProjectState>
   const current = () => input.store.projects[input.scope()] ?? []
   const currentClosed = () => input.store.recentlyClosed?.[input.scope()] ?? []
+  const currentHidden = () => stringList(input.store.hiddenProjects?.[input.scope()])
+  const projectIndex = (directory: string) => {
+    const key = pathKey(directory)
+    return current().findIndex((project) => pathKey(project.worktree) === key)
+  }
+  const setHidden = (scope: ServerScope, directories: string[]) => {
+    if (!input.store.hiddenProjects) {
+      setStore("hiddenProjects", { [scope]: directories })
+      return
+    }
+    setStore("hiddenProjects", scope, directories)
+  }
   const remove = (directory: string) => {
+    const key = pathKey(directory)
     setStore(
       "projects",
       input.scope(),
-      current().filter((project) => project.worktree !== directory),
+      current().filter((project) => pathKey(project.worktree) !== key),
     )
   }
   return {
     list: current,
     recentlyClosed: currentClosed,
+    hidden: currentHidden,
     remove,
     open(directory: string) {
       const scope = input.scope()
       const key = pathKey(directory)
+      const hidden = currentHidden()
+      if (hidden.some((worktree) => pathKey(worktree) === key)) {
+        setHidden(
+          scope,
+          hidden.filter((worktree) => pathKey(worktree) !== key),
+        )
+      }
       const closed = currentClosed()
       if (closed.some((worktree) => pathKey(worktree) === key)) {
         setStore(
@@ -106,7 +200,7 @@ export function createServerProjects<T extends ServerProjectState>(input: {
           closed.filter((worktree) => pathKey(worktree) !== key),
         )
       }
-      if (current().some((project) => project.worktree === directory)) return
+      if (projectIndex(directory) !== -1) return
       setStore("projects", scope, [{ worktree: directory, expanded: true }, ...current()])
     },
     // User-initiated close: removes the project and records it in recently closed.
@@ -114,22 +208,36 @@ export function createServerProjects<T extends ServerProjectState>(input: {
     close(directory: string) {
       remove(directory)
       const key = pathKey(directory)
+      setHidden(input.scope(), [directory, ...currentHidden().filter((worktree) => pathKey(worktree) !== key)])
       const closed = [directory, ...currentClosed().filter((worktree) => pathKey(worktree) !== key)].slice(
         0,
         RECENTLY_CLOSED_HISTORY_LIMIT,
       )
       setStore("recentlyClosed", input.scope(), closed)
     },
+    reconcileHidden(discovered: string[]) {
+      const known = new Set(discovered.map(pathKey))
+      const seen = new Set<string>()
+      const current = currentHidden()
+      const next = current.filter((worktree) => {
+        const key = pathKey(worktree)
+        if (!known.has(key) || seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+      if (next.length === current.length && next.every((worktree, index) => worktree === current[index])) return
+      setHidden(input.scope(), next)
+    },
     expand(directory: string) {
-      const index = current().findIndex((project) => project.worktree === directory)
+      const index = projectIndex(directory)
       if (index !== -1) setStore("projects", input.scope(), index, "expanded", true)
     },
     collapse(directory: string) {
-      const index = current().findIndex((project) => project.worktree === directory)
+      const index = projectIndex(directory)
       if (index !== -1) setStore("projects", input.scope(), index, "expanded", false)
     },
     move(directory: string, toIndex: number) {
-      const fromIndex = current().findIndex((project) => project.worktree === directory)
+      const fromIndex = projectIndex(directory)
       if (fromIndex === -1 || fromIndex === toIndex) return
       const next = [...current()]
       const [item] = next.splice(fromIndex, 1)
@@ -270,6 +378,7 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
         projects: {} as Record<string, StoredProject[]>,
         lastProject: {} as Record<string, string>,
         recentlyClosed: {} as Record<string, string[]>,
+        hiddenProjects: {} as Record<string, string[]>,
       }),
     )
 
@@ -306,8 +415,11 @@ export const { use: useServer, provider: ServerProvider } = createSimpleContext(
     function remove(key: ServerConnection.Key) {
       const next = nextServerAfterRemoval(allServers(), key, props.defaultServer)
       const list = store.list.filter((x) => url(x) !== key)
+      const removedScope = scope(key)
       batch(() => {
         setStore("list", list)
+        clearServerProjectScope({ scope: removedScope, store, setStore })
+        projectStores.delete(key)
         if (state.active === key) setState("active", next)
       })
     }

--- a/packages/app/src/pages/home/home-session-records.ts
+++ b/packages/app/src/pages/home/home-session-records.ts
@@ -1,0 +1,28 @@
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import type { LocalProject } from "@/context/layout"
+import { compareSessionTime, displayName, projectForSession } from "@/pages/layout/helpers"
+import { pathKey } from "@/utils/path-key"
+
+export function buildHomeSessionRecords(input: {
+  sessions: () => Session[]
+  projectDirectories: () => string[]
+  projects: () => LocalProject[]
+  projectByID: () => Map<string, LocalProject>
+}) {
+  const directories = new Set(input.projectDirectories().map(pathKey))
+  const sessions = input.sessions().filter((session) => directories.has(pathKey(session.directory)))
+  return [...new Map(sessions.map((session) => [session.id, session] as const)).values()]
+    .sort(compareSessionTime)
+    .flatMap((session) => {
+      const directory = pathKey(session.directory)
+      const project =
+        input
+          .projects()
+          .find(
+            (item) =>
+              pathKey(item.worktree) === directory || item.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
+          ) ?? projectForSession(session, input.projects(), input.projectByID())
+      if (!project) return []
+      return { session, project, projectName: displayName(project) }
+    })
+}

--- a/packages/app/src/pages/home/home-sessions-controller.test.ts
+++ b/packages/app/src/pages/home/home-sessions-controller.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test"
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import type { LocalProject } from "@/context/layout"
+import { visibleProjectEntries } from "@/context/server"
+import { buildHomeSessionRecords } from "./home-session-records"
+
+describe("buildHomeSessionRecords", () => {
+  test("shows sessions for projects discovered from the server", () => {
+    const projects = visibleProjectEntries([], [{ worktree: "/repo/b" }], []) as LocalProject[]
+    const sessions = [
+      {
+        id: "ses_server_project",
+        directory: "/repo/b",
+        time: { created: 1, updated: 2 },
+      } as Session,
+    ]
+
+    const records = buildHomeSessionRecords({
+      sessions: () => sessions,
+      projectDirectories: () => projects.map((project) => project.worktree),
+      projects: () => projects,
+      projectByID: () => new Map(),
+    })
+
+    expect(records).toHaveLength(1)
+    expect(records[0]?.session.id).toBe("ses_server_project")
+    expect(records[0]?.project.worktree).toBe("/repo/b")
+  })
+})

--- a/packages/app/src/pages/home/home-sessions-controller.tsx
+++ b/packages/app/src/pages/home/home-sessions-controller.tsx
@@ -15,13 +15,14 @@ import type { LocalProject } from "@/context/layout"
 import { useLanguage } from "@/context/language"
 import { ServerConnection } from "@/context/server"
 import { sessionHasOpenTab, useTabs } from "@/context/tabs"
-import { compareSessionTime, displayName, errorMessage, projectForSession } from "@/pages/layout/helpers"
+import { errorMessage, projectForSession } from "@/pages/layout/helpers"
 import { useSessionTabAvatarState } from "@/pages/layout/project-avatar-state"
 import { pathKey } from "@/utils/path-key"
 import { showToast } from "@/utils/toast"
 import { Binary } from "@opencode-ai/core/util/binary"
 import { archiveHomeSession } from "../home-session-archive"
 import type { HomeController } from "./home-controller"
+import { buildHomeSessionRecords } from "./home-session-records"
 
 const HOME_SESSION_LIMIT = 64
 export type HomeSessionRecord = {
@@ -245,30 +246,6 @@ export function createHomeSessionsController(home: HomeController) {
 
 function directories(project: LocalProject) {
   return [project.worktree, ...(project.sandboxes ?? [])]
-}
-
-function buildHomeSessionRecords(input: {
-  sessions: () => Session[]
-  projectDirectories: () => string[]
-  projects: () => LocalProject[]
-  projectByID: () => Map<string, LocalProject>
-}) {
-  const directories = new Set(input.projectDirectories().map(pathKey))
-  const sessions = input.sessions().filter((session) => directories.has(pathKey(session.directory)))
-  return [...new Map(sessions.map((session) => [session.id, session] as const)).values()]
-    .sort(compareSessionTime)
-    .flatMap((session) => {
-      const directory = pathKey(session.directory)
-      const project =
-        input
-          .projects()
-          .find(
-            (item) =>
-              pathKey(item.worktree) === directory || item.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
-          ) ?? projectForSession(session, input.projects(), input.projectByID())
-      if (!project) return []
-      return { session, project, projectName: displayName(project) }
-    })
 }
 
 export function homeSessionSearchKey(record: HomeSessionRecord) {


### PR DESCRIPTION
### Issue for this PR

Closes #13626

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

A fresh web client currently depends on browser-local bookmarks, so projects and their sessions can be missing even though the connected server already knows them.

This change merges server-discovered projects into the local project list while keeping browser organization local: bookmarks retain their order, server projects are appended and path-deduplicated, and closing a discovered project stores a per-server local hidden marker. Hidden state is sanitized, pruned only after a successful project request, and removed when its saved remote server is deleted.

This follows the direction from #41154 and fixes its first-bookmark transition: opening project A no longer makes the remaining server project B disappear. It does not add server-side profile storage, credential transfer, or browser-storage export.

Related: #41412, #44073.

### How did you verify your code works?

- `bun run test:unit` — 739 passed
- `bun run test:browser` — 41 passed
- `bun run typecheck` — passed
- `bun run build` — passed
- focused Playwright regression matrix — 10 passed, including separate browser contexts against the same server
- Prettier, `git diff --check`, and the repository pre-push monorepo typecheck — passed

### Screenshots / recordings

Not applicable: this changes project discovery and persistence behavior without changing visual styling. The cross-client flow is covered by `home-server-project-discovery.spec.ts`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
