### PR TITLE
test(server): wait for plugin readiness

### DIFF
--- a/packages/server/test/fetch.test.ts
+++ b/packages/server/test/fetch.test.ts
@@ -60,19 +60,25 @@ function occupy(port: number, cancel = false) {
 
 const ready = (handler: Handler) =>
   Effect.promise(async () => {
-    const response = await handler(new Request("http://opencode.local/api/plugin"))
-    const body: unknown = await response.json()
-    if (!response.ok || typeof body !== "object" || body === null || !("data" in body) || !Array.isArray(body.data))
-      throw new Error("Expected a plugin list response")
-    const ids = new Set(
-      body.data.flatMap((plugin) =>
-        typeof plugin === "object" && plugin !== null && "id" in plugin && typeof plugin.id === "string"
-          ? [plugin.id]
-          : [],
-      ),
+    const integration = await handler(new Request("http://opencode.local/api/integration/openai"))
+    const agent = await handler(new Request("http://opencode.local/api/agent/build"))
+    const body: unknown = await integration.json()
+    if (
+      !integration.ok ||
+      !agent.ok ||
+      typeof body !== "object" ||
+      body === null ||
+      !("data" in body) ||
+      typeof body.data !== "object" ||
+      body.data === null ||
+      !("methods" in body.data) ||
+      !Array.isArray(body.data.methods) ||
+      !body.data.methods.some(
+        (method) => typeof method === "object" && method !== null && "id" in method && method.id === "chatgpt-browser",
+      )
     )
-    if (!ids.has("opencode.agent") || !ids.has("opencode.provider.openai")) throw new Error("Plugins not ready")
-    return response
+      throw new Error("Plugins not ready")
+    return integration
   }).pipe(Effect.retry(Schedule.spaced("10 millis")), Effect.timeout("2 seconds"))
 
 const connectOpenAI = (handler: Handler) =>

--- a/packages/server/test/fetch.test.ts
+++ b/packages/server/test/fetch.test.ts
@@ -3,7 +3,9 @@ import { createServer } from "node:http"
 import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
 import { Workspace } from "@opencode-ai/core/workspace"
 import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
-import { Effect, Schedule } from "effect"
+import { Agent } from "@opencode-ai/schema/agent"
+import { Integration } from "@opencode-ai/schema/integration"
+import { Effect, Schedule, Schema } from "effect"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import { it } from "../../core/test/lib/effect"
 import { ServerFetch } from "../src/fetch"
@@ -58,39 +60,35 @@ function occupy(port: number, cancel = false) {
   })
 }
 
-const ready = (handler: Handler) =>
-  Effect.promise(async () => {
-    const integration = await handler(new Request("http://opencode.local/api/integration/openai"))
-    const agent = await handler(new Request("http://opencode.local/api/agent/build"))
-    const body: unknown = await integration.json()
-    if (
-      !integration.ok ||
-      !agent.ok ||
-      typeof body !== "object" ||
-      body === null ||
-      !("data" in body) ||
-      typeof body.data !== "object" ||
-      body.data === null ||
-      !("methods" in body.data) ||
-      !Array.isArray(body.data.methods) ||
-      !body.data.methods.some(
-        (method) => typeof method === "object" && method !== null && "id" in method && method.id === "chatgpt-browser",
-      )
-    )
-      throw new Error("Plugins not ready")
-    return integration
-  }).pipe(Effect.retry(Schedule.spaced("10 millis")), Effect.timeout("2 seconds"))
-
 const connectOpenAI = (handler: Handler) =>
-  Effect.promise(() =>
-    handler(
-      new Request("http://opencode.local/api/integration/openai/connect/oauth", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ methodID: "chatgpt-browser" }),
-      }),
-    ),
-  )
+  Effect.gen(function* () {
+    // Catalog endpoints no longer wait for plugin initialization.
+    yield* Effect.gen(function* () {
+      const response = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/integration")))
+      expect(response.status).toBe(200)
+      const body = Schema.decodeUnknownSync(Schema.Struct({ data: Schema.Array(Integration.Info) }))(
+        yield* Effect.promise(() => response.json()),
+      )
+      return body.data.some(
+        (integration) =>
+          integration.id === "openai" &&
+          integration.methods.some((method) => method.type === "oauth" && method.id === "chatgpt-browser"),
+      )
+    }).pipe(
+      Effect.filterOrFail((ready) => ready),
+      Effect.retry(Schedule.spaced("10 millis")),
+      Effect.timeout("2 seconds"),
+    )
+    return yield* Effect.promise(() =>
+      handler(
+        new Request("http://opencode.local/api/integration/openai/connect/oauth", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ methodID: "chatgpt-browser" }),
+        }),
+      ),
+    )
+  })
 
 const workspaceDriver = WorkspaceDriver.make({
   create: ({ workspaceID }) => Effect.succeed({ binding: { workspaceID } }),
@@ -209,7 +207,6 @@ it.live("cancels a stale OpenAI OAuth callback server before falling back", () =
   Effect.gen(function* () {
     const requests = yield* occupy(1455, true)
     const handler = yield* ServerFetch.make(options)
-    yield* ready(handler)
     const response = yield* connectOpenAI(handler)
 
     expect(response.status).toBe(200)
@@ -223,7 +220,6 @@ it.live("falls back to port 1457 when OpenAI OAuth port 1455 remains busy", () =
   Effect.gen(function* () {
     const requests = yield* occupy(1455)
     const handler = yield* ServerFetch.make(options)
-    yield* ready(handler)
     const response = yield* connectOpenAI(handler)
 
     expect(response.status).toBe(200)
@@ -240,7 +236,6 @@ it.live(
       yield* occupy(1455)
       yield* occupy(1457)
       const handler = yield* ServerFetch.make(options)
-      yield* ready(handler)
       const response = yield* connectOpenAI(handler)
 
       expect(response.status).toBe(400)
@@ -459,7 +454,22 @@ it.live("routes pending requests by Session without loading an instance", () =>
     expect(yield* Effect.promise(() => globalForms.json())).toMatchObject({ data: [{ title: "Global form" }] })
 
     // Agent permission policy is installed by plugin activation.
-    expect((yield* ready(handler)).status).toBe(200)
+    yield* Effect.gen(function* () {
+      const response = yield* Effect.promise(() => handler(new Request("http://opencode.local/api/agent")))
+      expect(response.status).toBe(200)
+      const body = Schema.decodeUnknownSync(Schema.Struct({ data: Schema.Array(Agent.Info) }))(
+        yield* Effect.promise(() => response.json()),
+      )
+      return body.data.some(
+        (agent) =>
+          agent.id === "build" &&
+          agent.permissions.some((rule) => rule.action === "shell" && rule.resource === "*" && rule.effect === "ask"),
+      )
+    }).pipe(
+      Effect.filterOrFail((ready) => ready),
+      Effect.retry(Schedule.spaced("10 millis")),
+      Effect.timeout("2 seconds"),
+    )
     const createdPermission = yield* Effect.promise(() =>
       handler(
         new Request(`http://opencode.local/api/session/${created.data.id}/permission`, {

--- a/packages/server/test/fetch.test.ts
+++ b/packages/server/test/fetch.test.ts
@@ -60,17 +60,18 @@ function occupy(port: number, cancel = false) {
 
 const ready = (handler: Handler) =>
   Effect.promise(async () => {
-    const response = await handler(new Request("http://opencode.local/api/model/default"))
+    const response = await handler(new Request("http://opencode.local/api/plugin"))
     const body: unknown = await response.json()
-    if (
-      !response.ok ||
-      typeof body !== "object" ||
-      body === null ||
-      !("data" in body) ||
-      body.data === undefined ||
-      body.data === null
+    if (!response.ok || typeof body !== "object" || body === null || !("data" in body) || !Array.isArray(body.data))
+      throw new Error("Expected a plugin list response")
+    const ids = new Set(
+      body.data.flatMap((plugin) =>
+        typeof plugin === "object" && plugin !== null && "id" in plugin && typeof plugin.id === "string"
+          ? [plugin.id]
+          : [],
+      ),
     )
-      throw new Error("Plugins not ready")
+    if (!ids.has("opencode.agent") || !ids.has("opencode.provider.openai")) throw new Error("Plugins not ready")
     return response
   }).pipe(Effect.retry(Schedule.spaced("10 millis")), Effect.timeout("2 seconds"))
 

--- a/packages/server/test/fetch.test.ts
+++ b/packages/server/test/fetch.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http"
 import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
 import { Workspace } from "@opencode-ai/core/workspace"
 import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
-import { Effect } from "effect"
+import { Effect, Schedule } from "effect"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import { it } from "../../core/test/lib/effect"
 import { ServerFetch } from "../src/fetch"
@@ -59,7 +59,20 @@ function occupy(port: number, cancel = false) {
 }
 
 const ready = (handler: Handler) =>
-  Effect.promise(() => handler(new Request("http://opencode.local/api/model/default")))
+  Effect.promise(async () => {
+    const response = await handler(new Request("http://opencode.local/api/model/default"))
+    const body: unknown = await response.json()
+    if (
+      !response.ok ||
+      typeof body !== "object" ||
+      body === null ||
+      !("data" in body) ||
+      body.data === undefined ||
+      body.data === null
+    )
+      throw new Error("Plugins not ready")
+    return response
+  }).pipe(Effect.retry(Schedule.spaced("10 millis")), Effect.timeout("2 seconds"))
 
 const connectOpenAI = (handler: Handler) =>
   Effect.promise(() =>


### PR DESCRIPTION
### Issue for this PR

Regression from nonblocking model endpoints; no linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Wait for the actual OpenAI OAuth method and configured build-agent permission rule before testing their behavior. Catalog reads no longer wait for plugin initialization.

This extracts the focused server-test fix already validated in #46545 so it can land independently of that PR's unrelated npm changes.

### How did you verify your code works?

Server package typecheck and repository pre-push typecheck pass. The identical server test change passed the full Linux and Windows server suites in #46545. Tests left to CI here.

### Screenshots / recordings

N/A (test-only change).

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR