### PR TITLE
fix: stabilize cross-platform unit tests

### DIFF
--- a/packages/core/test/mcp-oauth.test.ts
+++ b/packages/core/test/mcp-oauth.test.ts
@@ -162,6 +162,6 @@ describe("MCP OAuth", () => {
   })
 
   test("rejects an invalid redirect URL", async () => {
-    await expect(authorize("not a URL")).rejects.toThrow("cannot be parsed as a URL")
+    await expect(authorize("not a URL")).rejects.toThrow(TypeError)
   })
 })

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -66,7 +66,7 @@ async function createRegistryFixture(directory: string) {
       exports: "./index.js",
     })
     await Bun.write(path.join(root, "package", "index.js"), `export const version = "${version}"\n`)
-    await Bun.$`tar -czf ${path.join(root, "package.tgz")} -C ${root} package`
+    await Bun.$`tar -czf package.tgz package`.cwd(root)
     tarballs.set(version, await Bun.file(path.join(root, "package.tgz")).bytes())
   }
   const state = { latest: "1.0.0" }

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -252,7 +252,7 @@ describe("Npm.add", () => {
         }
       }).pipe(Effect.scoped, Effect.provide(npmLayer(cache)), Effect.runPromise)
 
-      expect(entries.added.entrypoint).toEndWith("/index.js")
+      expect(entries.added.entrypoint).toBe(pathToFileURL(path.join(entries.added.directory, "index.js")).href)
       expect(entries.added.version).toBe(fixture.commit)
       expect(entries.cached).toEqual(entries.added)
       expect(entries.resolved).toEqual(entries.added)

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -293,7 +293,8 @@ const layer = Layer.effect(
           installedNameValue,
           installed?.path ?? path.join(staging, "node_modules", installedNameValue),
           target,
-          subpaths,
+          // Resolve installed entrypoints after rename so Bun cannot hold the staging directory open on Windows.
+          installed ? [] : subpaths,
         )
         if (!installed && !result.entrypoint) return yield* new InstallFailedError({ add: [pkg], dir: staging })
         return { name: installedNameValue, result }

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -133,10 +133,13 @@ const resolveEntryPoint = (name: string, dir: string, subpaths: readonly string[
 interface ArboristNode {
   name: string
   path: string
+  realpath: string
+  isLink: boolean
 }
 
 interface ArboristTree {
   edgesOut: Map<string, { to?: ArboristNode }>
+  inventory: { values(): IterableIterator<ArboristNode> }
 }
 
 const PackageJson = Schema.Struct({
@@ -297,7 +300,13 @@ const layer = Layer.effect(
           installed ? [] : subpaths,
         )
         if (!installed && !result.entrypoint) return yield* new InstallFailedError({ add: [pkg], dir: staging })
-        return { name: installedNameValue, result }
+        const links =
+          process.platform === "win32"
+            ? Array.from(tree.inventory.values()).filter(
+                (node) => node.isLink && FSUtil.contains(staging, node.path) && FSUtil.contains(staging, node.realpath),
+              )
+            : []
+        return { name: installedNameValue, result, links }
       }).pipe(Effect.onError(() => remove(staging, dir).pipe(Effect.ignore)))
 
       if (active) {
@@ -311,6 +320,22 @@ const layer = Layer.effect(
       const completedAt = yield* Clock.currentTimeMillis
       const newest = Number((yield* generations(dir)).at(-1) ?? 0)
       const generation = path.join(dir, String(Math.max(completedAt, newest + 1)))
+      // Windows junctions use absolute targets, so rebase internal links before publishing the generation.
+      if (staged.links.length > 0) {
+        const { unlink, symlink } = yield* Effect.promise(() => import("node:fs/promises"))
+        yield* Effect.forEach(
+          staged.links,
+          (link) =>
+            Effect.tryPromise({
+              try: async () => {
+                await unlink(link.path)
+                await symlink(path.join(generation, path.relative(staging, link.realpath)), link.path, "junction")
+              },
+              catch: (cause) => new InstallFailedError({ dir, cause }),
+            }),
+          { discard: true },
+        ).pipe(Effect.onError(() => remove(staging, dir).pipe(Effect.ignore)))
+      }
       yield* rename(staging, generation, dir)
       return yield* entry(
         generation,


### PR DESCRIPTION
### Issue for this PR

CI regressions from live package updates; no linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

- accept platform-specific `TypeError` messages for invalid MCP OAuth redirects
- create npm fixture archives from relative paths on Windows
- defer staged entrypoint resolution until after generation publication
- rebase internal Windows junction targets before renaming the staging directory

This retains the confirmed fixes from #46545 and completes its deferred Windows junction repair. External links and Unix symlinks remain unchanged.

### How did you verify your code works?

`core` and `util` package typechecks pass. Repository pre-push typecheck passes. Tests left to CI.

### Screenshots / recordings

N/A.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR