### PR TITLE
fix: page the session list in-process when no pager is found

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -642,6 +642,7 @@
         "ignore": "7.0.5",
         "immer": "11.1.4",
         "jsonc-parser": "3.3.1",
+        "less-pager-mini": "1.15.2",
         "mime-types": "3.0.2",
         "minimatch": "10.0.3",
         "npm-package-arg": "13.0.2",
@@ -3286,6 +3287,8 @@
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "char-width": ["char-width@1.0.0", "", {}, "sha512-d82CdiyM1U6MNtiUOu9bOTCqu95x3dFz9q3frXwe/1+YnavIDEiLryaD7cgYziGzcXqNU27x8kvJ7FAj8NthVg=="],
+
     "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
 
     "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
@@ -4216,6 +4219,8 @@
 
     "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
 
+    "less-pager-mini": ["less-pager-mini@1.15.2", "", { "dependencies": { "char-width": "^1.0.0", "posix-regex": "^1.0.1", "shell-glob": "^1.2.0" }, "bin": { "lmn": "dist/cli.js" } }, "sha512-LKu9POTWgIWg1TTTZ6gVPeEKHVHgKexUpHS/E4fu1Y1pqlPXq8A/vf5FKJ4ASyz+GpmR/vLGcxODHRDz62tTnA=="],
+
     "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
 
     "lightningcss": ["lightningcss@1.30.1", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-darwin-arm64": "1.30.1", "lightningcss-darwin-x64": "1.30.1", "lightningcss-freebsd-x64": "1.30.1", "lightningcss-linux-arm-gnueabihf": "1.30.1", "lightningcss-linux-arm64-gnu": "1.30.1", "lightningcss-linux-arm64-musl": "1.30.1", "lightningcss-linux-x64-gnu": "1.30.1", "lightningcss-linux-x64-musl": "1.30.1", "lightningcss-win32-arm64-msvc": "1.30.1", "lightningcss-win32-x64-msvc": "1.30.1" } }, "sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg=="],
@@ -4746,6 +4751,8 @@
 
     "poe-oauth": ["poe-oauth@0.0.8", "", {}, "sha512-zlaRVLR6vuxBIYUkZoTIVo3f8h3qd27gv9Ms+kmGiYEiiV4TdccddTdNcGyI0DnuJ9tVi+5LP3Bvzez59IFbjw=="],
 
+    "posix-regex": ["posix-regex@1.0.1", "", {}, "sha512-a1DYMmlirjX2fHsiznUMQ+/Tp7JJaYiOHkvVhRR8fOARTrGW5QNvtWf+QlLlbcizsrTzoyOPyGe8LyhjtjVb7A=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
@@ -5055,6 +5062,8 @@
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "shell-glob": ["shell-glob@1.2.0", "", {}, "sha512-1yXrIgj8KMWaw1tEVLmK1gMRlVh3Q0UhqVtLS728kEJT2UATVtFRjk1iZE43UAqTIHrTNrkSPqz4aXFwBpc5og=="],
 
     "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
 

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -128,6 +128,7 @@
     "ignore": "7.0.5",
     "immer": "11.1.4",
     "jsonc-parser": "3.3.1",
+    "less-pager-mini": "1.15.2",
     "mime-types": "3.0.2",
     "minimatch": "10.0.3",
     "npm-package-arg": "13.0.2",

--- a/packages/opencode/src/cli/cmd/session.ts
+++ b/packages/opencode/src/cli/cmd/session.ts
@@ -14,31 +14,32 @@ import { EOL } from "os"
 import path from "path"
 import { which } from "@opencode-ai/core/util/which"
 
-function pagerCmd(): string[] {
-  const lessOptions = ["-R", "-S"]
+const LESS_OPTIONS = ["-R", "-S"]
+
+function pagerCmd(): string[] | undefined {
   if (process.platform !== "win32") {
-    return ["less", ...lessOptions]
+    return ["less", ...LESS_OPTIONS]
   }
 
   // user could have less installed via other options
   const lessOnPath = which("less")
   if (lessOnPath) {
-    if (Filesystem.stat(lessOnPath)?.size) return [lessOnPath, ...lessOptions]
+    if (Filesystem.stat(lessOnPath)?.size) return [lessOnPath, ...LESS_OPTIONS]
   }
 
   if (Flag.OPENCODE_GIT_BASH_PATH) {
     const less = path.join(Flag.OPENCODE_GIT_BASH_PATH, "..", "..", "usr", "bin", "less.exe")
-    if (Filesystem.stat(less)?.size) return [less, ...lessOptions]
+    if (Filesystem.stat(less)?.size) return [less, ...LESS_OPTIONS]
   }
 
   const git = which("git")
   if (git) {
     const less = path.join(git, "..", "..", "usr", "bin", "less.exe")
-    if (Filesystem.stat(less)?.size) return [less, ...lessOptions]
+    if (Filesystem.stat(less)?.size) return [less, ...LESS_OPTIONS]
   }
 
-  // Fall back to Windows built-in more (via cmd.exe)
-  return ["cmd", "/c", "more"]
+  // No pager found, fall back to in-process pager.
+  return undefined
 }
 
 export const SessionCommand = cmd({
@@ -94,7 +95,17 @@ export const SessionListCommand = effectCmd({
 
     if (shouldPaginate) {
       yield* Effect.promise(async () => {
-        const proc = Process.spawn(pagerCmd(), {
+        const cmd = pagerCmd()
+
+        // in-process pager (fallback)
+        if (cmd === undefined) {
+          const { default: pager } = await import("less-pager-mini")
+          await pager(output, LESS_OPTIONS)
+          return
+        }
+
+        // local pager
+        const proc = Process.spawn(cmd, {
           stdin: "pipe",
           stdout: "inherit",
           stderr: "inherit",


### PR DESCRIPTION
### Issue for this PR

Closes #38977

### Type of change

- [x] Bug fix

### What does this PR do?

pagerCmd() returned ["cmd", "/c", "more"] when it couldn't find less on Windows. more has no scroll back and no search, which is the complaint in #38977. It now returns undefined when nothing is found, and the caller pages in process with [less-pager-mini](https://github.com/dawsonhuang0/Less-Pager-Mini) instead. Every path that finds a real pager (unix, less on PATH, Git Bash, OPENCODE_GIT_BASH_PATH) is untouched.

### How did you verify your code works?

1. Make less unreachable by all three lookups: not on PATH, and not at Git\usr\bin\less.exe. I have Git installed but less isn't in PATH so I renamed Git's copy to `less.exe1`.
2. Open Opencode from Windows terminal.
3. Start a session by sending "hi" to an agent.
4. Run `opencode session list` in new terminal window.
5. Session list pages correctly.

### Screenshots / recordings

<img width="1538" height="762" alt="Screenshot 2026-09-01 222945" src="https://github.com/user-attachments/assets/d9fa3cbf-706b-463f-89ff-eacc982a4695" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
