### PR TITLE
fix(tui): mini defer prompt echo until delivery

### DIFF
--- a/packages/tui/src/mini/demo.ts
+++ b/packages/tui/src/mini/demo.ts
@@ -947,6 +947,16 @@ export function createRunDemo(input: Input) {
 
     clearSubagent(state.footer)
 
+    if (line.mode !== "shell" && ["/help", "/permission", "/form", "/fmt"].includes(cmd)) {
+      state.footer.append({
+        kind: "user",
+        text: line.text,
+        phase: "start",
+        source: "system",
+        messageID: line.messageID,
+      })
+    }
+
     if (cmd === "/help") {
       intro(state)
       return true

--- a/packages/tui/src/mini/footer.command.tsx
+++ b/packages/tui/src/mini/footer.command.tsx
@@ -493,7 +493,7 @@ export function RunCommandMenuBody(props: {
             {
               action: "queued" as const,
               category: "Agent",
-              display: "View queued prompts",
+              display: "View pending prompts",
               footer: `${props.queued().length} pending`,
               keywords: props
                 .queued()
@@ -939,7 +939,7 @@ export function RunQueuedPromptSelectBody(props: {
   theme: Accessor<RunFooterTheme>
   prompts: Accessor<FooterQueuedPrompt[]>
   onClose: () => void
-  onSteer: (prompt: FooterQueuedPrompt) => void
+  onSelect: (prompt: FooterQueuedPrompt) => void
   onDelete: (prompt: FooterQueuedPrompt) => void
   onRows?: (rows: number) => void
   mono?: boolean
@@ -948,7 +948,7 @@ export function RunQueuedPromptSelectBody(props: {
     props.prompts().map((prompt) => ({
       category: "",
       display: prompt.prompt.text.replaceAll("\n", " "),
-      footer: "queued",
+      footer: prompt.delivery === "queue" ? "queued" : "steering",
       keywords: prompt.prompt.text,
       prompt,
     })),
@@ -957,7 +957,7 @@ export function RunQueuedPromptSelectBody(props: {
     entries,
     limit: SUBAGENT_LIST_ROWS,
     onClose: props.onClose,
-    onSelect: (item) => props.onSteer(item.prompt),
+    onSelect: (item) => props.onSelect(item.prompt),
     onRows: props.onRows,
   })
   const shortcuts = Keymap.useShortcuts()
@@ -967,7 +967,7 @@ export function RunQueuedPromptSelectBody(props: {
     commands: [
       {
         id: "queued_prompt.delete",
-        title: "Delete queued prompt",
+        title: "Delete pending prompt",
         group: "Prompt",
         run() {
           const item = controller.items()[controller.menu.selected()]
@@ -980,7 +980,7 @@ export function RunQueuedPromptSelectBody(props: {
 
   return (
     <PanelShell
-      title="Queued prompts"
+      title="Pending prompts"
       layout={controller.layout()}
       query={controller.query()}
       count={controller.items().length}
@@ -989,7 +989,12 @@ export function RunQueuedPromptSelectBody(props: {
       theme={props.theme}
       inputRef={controller.inputRef}
       onQuery={controller.setQuery}
-      hint={["enter steer", deleteShortcut() ? `${deleteShortcut()} delete` : undefined].filter(Boolean).join(" · ")}
+      hint={[
+        controller.items()[controller.menu.selected()]?.prompt.delivery === "steer" ? "enter queue" : "enter steer",
+        deleteShortcut() ? `${deleteShortcut()} delete` : undefined,
+      ]
+        .filter(Boolean)
+        .join(" · ")}
       mono={props.mono}
     >
       <RunFooterMenu
@@ -1000,7 +1005,7 @@ export function RunQueuedPromptSelectBody(props: {
         rows={controller.menu.rows}
         limit={controller.menu.limit()}
         compact={controller.layout().compact}
-        empty="No queued prompts"
+        empty="No pending prompts"
         border={false}
         paddingLeft={panelPad(props.mono)}
         paddingRight={panelPad(props.mono)}

--- a/packages/tui/src/mini/footer.ts
+++ b/packages/tui/src/mini/footer.ts
@@ -758,7 +758,7 @@ export class RunFooter implements FooterApi {
     const height = Math.max(
       1,
       Math.min(
-        desired + (this.startup() ? 2 : 0),
+        desired + (this.startup() ? 1 : 0),
         this.renderer.terminalHeight - (type === "prompt" && route === "composer" ? 1 : 0),
       ),
     )

--- a/packages/tui/src/mini/footer.view.tsx
+++ b/packages/tui/src/mini/footer.view.tsx
@@ -245,7 +245,7 @@ export function RunFooterView(props: RunFooterViewProps) {
     if (current) details.push(variant ? `${current} ${variant}` : current)
     if (contextUsage()) details.push(contextUsage())
     if (cost()) details.push(cost())
-    if (queue().length > 0) details.push(`${queue().length} queued`)
+    if (queuedPrompts().length > 0) details.push(`${queuedPrompts().length} pending`)
     if (activeTabs().length > 0) details.push(`${activeTabs().length} subagent${activeTabs().length === 1 ? "" : "s"}`)
     return details.join(props.mono ? " - " : " · ")
   })
@@ -323,7 +323,7 @@ export function RunFooterView(props: RunFooterViewProps) {
   }
 
   const openQueuedMenu = () => {
-    if (queue().length === 0) return
+    if (queuedPrompts().length === 0) return
     openRoute({ type: "queued-menu" })
   }
 
@@ -341,7 +341,7 @@ export function RunFooterView(props: RunFooterViewProps) {
         (error) => error,
       )
       if (!error) return true
-      props.onStatus(`failed to ${action === "cancel" ? "delete" : action} queued prompt: ${errorMessage(error)}`)
+      props.onStatus(`failed to ${action === "cancel" ? "delete" : action} pending prompt: ${errorMessage(error)}`)
       return false
     })
     return result ?? false
@@ -463,8 +463,8 @@ export function RunFooterView(props: RunFooterViewProps) {
 
     const items: Array<{ id: "queued" | "subagents" | "background"; key: string; label: string; expanded?: string }> =
       []
-    if (queue().length > 0 && queuedShortcut()) {
-      items.push({ id: "queued", key: queuedShortcut(), label: `${queue().length} queued` })
+    if (queuedPrompts().length > 0 && queuedShortcut()) {
+      items.push({ id: "queued", key: queuedShortcut(), label: `${queuedPrompts().length} pending` })
     }
     if (activeTabs().length > 0 && subagentShortcut()) {
       items.push({
@@ -590,11 +590,11 @@ export function RunFooterView(props: RunFooterViewProps) {
   }))
 
   Keymap.createLayer(() => ({
-    enabled: active().type === "prompt" && route().type === "composer" && queue().length > 0,
+    enabled: active().type === "prompt" && route().type === "composer" && queuedPrompts().length > 0,
     commands: [
       {
         id: "session.queued_prompts",
-        title: "View queued prompts",
+        title: "View pending prompts",
         group: "Prompt",
         run: openQueuedMenu,
       },
@@ -651,7 +651,7 @@ export function RunFooterView(props: RunFooterViewProps) {
   })
 
   createEffect(() => {
-    if (route().type !== "queued-menu" || queue().length > 0) return
+    if (route().type !== "queued-menu" || queuedPrompts().length > 0) return
     closePanel()
   })
 
@@ -694,9 +694,10 @@ export function RunFooterView(props: RunFooterViewProps) {
       gap={0}
       padding={0}
     >
+      {/* The renderer seeds the leading blank row that entrySplash includes in scrollback. */}
       <Show when={startup()}>
         {(layout) => (
-          <box id="mini-startup" height={2} flexShrink={0} paddingTop={1} flexDirection="row">
+          <box id="mini-startup" height={1} flexShrink={0} flexDirection="row">
             <Show when={layout().label.startsWith("\u25aa")}>
               <OneCellSpinner
                 animation={SEED_LAUNCH}
@@ -779,12 +780,13 @@ export function RunFooterView(props: RunFooterViewProps) {
                         <Match when={selectingQueued()}>
                           <RunQueuedPromptSelectBody
                             theme={theme}
-                            prompts={queue}
+                            prompts={queuedPrompts}
                             onClose={closePanel}
-                            onSteer={(item) => {
-                              void queuedPromptAction("steer", item.messageID).then((steered) => {
-                                if (steered) closePanel()
-                              })
+                            onSelect={async (item) => {
+                              if (
+                                await queuedPromptAction(item.delivery === "queue" ? "steer" : "queue", item.messageID)
+                              )
+                                closePanel()
                             }}
                             onDelete={(item) => {
                               void queuedPromptAction("cancel", item.messageID)
@@ -798,7 +800,7 @@ export function RunFooterView(props: RunFooterViewProps) {
                             theme={theme}
                             commands={props.commands}
                             subagents={tabs}
-                            queued={queue}
+                            queued={queuedPrompts}
                             variants={props.variants}
                             variantCycle={variantCycle()}
                             onClose={closePanel}

--- a/packages/tui/src/mini/runtime.queue.ts
+++ b/packages/tui/src/mini/runtime.queue.ts
@@ -21,7 +21,7 @@ export type QueueInput = {
   footer: FooterApi
   initialInput?: string
   trace?: Trace
-  onSend?: (prompt: RunPrompt, delivery: RunDelivery) => void
+  onSend?: (prompt: RunPrompt, emittedUser: boolean) => void
   onAdmissionError?: (prompt: RunPrompt, error: unknown) => void | Promise<void>
   onNewSession?: () => void | Promise<void>
   onCompact?: () => void | Promise<void>
@@ -172,7 +172,8 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
               break
             }
 
-            if (sent.mode !== "shell" && sent.text.trim()) {
+            const emittedUser = sent.mode !== "shell" && sent.command?.source === "skill" && !!sent.text.trim()
+            if (emittedUser) {
               const commit = {
                 kind: "user",
                 text: sent.text,
@@ -183,7 +184,7 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
               input.trace?.write("ui.commit", commit)
               input.footer.append(commit)
             }
-            input.onSend?.(sent, sent.delivery ?? "steer")
+            input.onSend?.(sent, emittedUser)
 
             if (state.closed) {
               break
@@ -278,7 +279,7 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
       const admission = state.admission
       admissionVersion += 1
       const delivery = prompt.delivery ?? "queue"
-      input.onSend?.(sent, delivery)
+      input.onSend?.(sent, false)
       admissions = admissions
         .then(() => admission)
         .then(() => input.admit(sent, delivery, admissionController.signal))

--- a/packages/tui/src/mini/runtime.ts
+++ b/packages/tui/src/mini/runtime.ts
@@ -391,11 +391,7 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
     onQueuedPromptAction: async (action, inboxID) => {
       if (!state.sessionID) return
       log?.write(`send.pending.${action}`, { sessionID: state.sessionID, inboxID })
-      if (action === "steer") {
-        await state.sdk.session.inbox.steer({ sessionID: state.sessionID, inboxID })
-        return
-      }
-      await state.sdk.session.inbox.cancel({ sessionID: state.sessionID, inboxID })
+      await state.sdk.session.inbox[action]({ sessionID: state.sessionID, inboxID })
     },
     onSubagentInterrupt: (sessionID) => {
       log?.write("send.subagent.interrupt", { sessionID })
@@ -889,10 +885,11 @@ async function runInteractiveRuntime(input: RunRuntimeInput, deps: RunRuntimeDep
       footer,
       initialInput: input.initialInput,
       trace: log,
-      onSend: (prompt, delivery) => {
+      onSend: (prompt, emittedUser) => {
         state.shown = true
         state.history.push({ ...prompt, delivery: undefined })
-        if (prompt.mode !== "shell" && delivery === "steer") {
+        // Pending inputs can still be cancelled; only replay rows already printed.
+        if (emittedUser) {
           rememberLocal({
             kind: "user",
             text: prompt.text,

--- a/packages/tui/src/mini/stream-v2.transport.ts
+++ b/packages/tui/src/mini/stream-v2.transport.ts
@@ -134,7 +134,7 @@ type State = {
   globalForms: MiniFormRequest[]
   view: FooterView
   messageIDs: Set<string>
-  // Optimistic text and pending steers can be visible before attachment delivery.
+  // Delivery can arrive before the admission response supplies the user content.
   promotedMessages: Set<string>
   imageIDs: Set<string>
   fragments: FragmentReconciler
@@ -564,8 +564,8 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
 
   let syncedPending: string[] | undefined
   const syncPending = () => {
-    const prompts = [...state.pending.values()].filter((item) => item.delivery === "queue")
-    const ids = prompts.map((item) => item.messageID)
+    const prompts = [...state.pending.values()]
+    const ids = prompts.map((item) => `${item.messageID}:${item.delivery}`)
     if (syncedPending?.length === ids.length && syncedPending.every((id, index) => id === ids[index])) return
     syncedPending = ids
     input.trace?.write("ui.patch", { pending: prompts.length })
@@ -580,11 +580,31 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       return render
     })
 
+  const renderUser = (
+    messageID: string,
+    text: string,
+    files: SessionMessageUser["files"],
+    skills: FooterQueuedPrompt["skills"],
+    render = true,
+  ) => {
+    const visible = state.messageIDs.has(messageID)
+    state.messageIDs.add(messageID)
+    const images = freshImages(userImageCommits(messageID, files), render)
+    if (!render) return
+    write([
+      ...(!visible ? skillCommits(messageID, skills) : []),
+      ...(!visible && text.trim()
+        ? [{ kind: "user", source: "system", text, phase: "start", messageID } as const]
+        : []),
+      ...images,
+    ])
+  }
+
   const mergePending = (item: SessionInboxInfo) => {
     const prompt = pendingPrompt(item)
     if (!prompt) return
     if (state.promotedMessages.has(prompt.messageID)) {
-      write(freshImages(userImageCommits(prompt.messageID, prompt.files)))
+      renderUser(prompt.messageID, prompt.prompt.text, prompt.files, prompt.skills)
       return
     }
     state.admitted.add(prompt.messageID)
@@ -688,25 +708,15 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
     ])
   }
 
-  const renderMessage = (message: SessionMessageInfo, render: boolean, reuseVisibleWait: boolean) => {
+  const renderMessage = (message: SessionMessageInfo, render: boolean) => {
     if (message.type === "user") {
       const waiting = state.wait?.messageID === message.id
       const admitted = state.admitted.delete(message.id)
       if (state.wait && (admitted || (waiting && state.wait.failureMessageID === message.id)))
         promoteWait(state.wait, false, message.id)
       if (state.pending.delete(message.id)) syncPending()
-      const visible = state.messageIDs.has(message.id) || (reuseVisibleWait && waiting)
-      state.messageIDs.add(message.id)
       state.promotedMessages.add(message.id)
-      const images = freshImages(userImageCommits(message.id, message.files), render)
-      if (!render) return
-      write([
-        ...(!visible ? skillCommits(message.id, message.skills) : []),
-        ...(!visible && message.text.trim()
-          ? [{ kind: "user", source: "system", text: message.text, phase: "start", messageID: message.id } as const]
-          : []),
-        ...images,
-      ])
+      renderUser(message.id, message.text, message.files, message.skills, render)
       return
     }
     if (message.type === "skill") {
@@ -837,7 +847,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
 
   const settleSession = async (client: OpenCodeClient) => {
     await client.session.wait({ sessionID: input.sessionID }, { signal: controller.signal })
-    for (const message of await projectedMessages(client, controller.signal)) renderMessage(message, true, true)
+    for (const message of await projectedMessages(client, controller.signal)) renderMessage(message, true)
     paintIdle(blockerStatus(state.view))
     await input.footer.idle()
   }
@@ -878,10 +888,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
     return permissions.map((request) => permissionTool(request, state.toolSources))
   }
 
-  const hydrate = async (
-    attempt: Attempt,
-    next: { render: boolean; reuseVisibleWait: boolean; reconnect?: boolean },
-  ) => {
+  const hydrate = async (attempt: Attempt, next: { render: boolean; reconnect?: boolean }) => {
     const client = attempt.client
     const options = { signal: attempt.signal }
     const [projected, pending, permissions, forms, globals, active] = await Promise.all([
@@ -909,7 +916,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
     syncPending()
     state.permissions = permissions
     pruneToolSources()
-    for (const message of projected) renderMessage(message, next.render, next.reuseVisibleWait)
+    for (const message of projected) renderMessage(message, next.render)
     state.permissions = await resolvePermissionSources(client, permissions, attempt)
     if (!current(attempt)) return
     pruneToolSources()
@@ -985,26 +992,14 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       return
     }
     if (event.type === "session.inbox.delivered") {
-      const waiting = state.wait?.messageID === event.data.inboxID
       if (state.wait) promoteWait(state.wait, true, event.data.inboxID)
       state.admitted.delete(event.data.inboxID)
       state.promotedMessages.add(event.data.inboxID)
       const pending = state.pending.get(event.data.inboxID)
       state.pending.delete(event.data.inboxID)
       syncPending()
-      const visible = state.messageIDs.has(event.data.inboxID)
-      if (waiting || pending) state.messageIDs.add(event.data.inboxID)
-      const commits = pending && !visible ? skillCommits(event.data.inboxID, pending.skills) : []
-      if (!waiting && pending && !visible && pending.prompt.text.trim())
-        commits.push({
-          kind: "user",
-          source: "system",
-          text: pending.prompt.text,
-          phase: "start",
-          messageID: event.data.inboxID,
-        })
-      if (pending) commits.push(...freshImages(userImageCommits(event.data.inboxID, pending.files)))
-      write(commits, { phase: "running", status: "waiting for assistant" })
+      if (pending) renderUser(pending.messageID, pending.prompt.text, pending.files, pending.skills)
+      write([], { phase: "running", status: "waiting for assistant" })
       return
     }
     if (event.type === "session.inbox.delivery.changed") {
@@ -1012,19 +1007,6 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       if (!pending) return
       state.pending.set(event.data.inboxID, { ...pending, delivery: event.data.delivery })
       syncPending()
-      if (event.data.delivery === "queue") return
-      if (state.messageIDs.has(event.data.inboxID)) return
-      state.messageIDs.add(event.data.inboxID)
-      write([
-        ...skillCommits(event.data.inboxID, pending.skills),
-        {
-          kind: "user",
-          source: "system",
-          text: pending.prompt.text,
-          phase: "start",
-          messageID: event.data.inboxID,
-        },
-      ])
       return
     }
     if (event.type === "session.inbox.cancelled") {
@@ -1460,7 +1442,6 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
             serializeHydration(attempt, () =>
               hydrate(attempt, {
                 render: state.initial ? input.replay === true : true,
-                reuseVisibleWait: !state.initial,
                 reconnect: !state.initial,
               }),
             ),
@@ -1630,7 +1611,7 @@ export async function createSessionTransport(input: StreamInput): Promise<Sessio
       state.activeCompaction = undefined
       state.shellEnded.clear()
       state.errors.clear()
-      await hydrate(attempt, { render: true, reuseVisibleWait: false })
+      await hydrate(attempt, { render: true })
     } catch (error) {
       failure = error
     } finally {

--- a/packages/tui/src/mini/types.ts
+++ b/packages/tui/src/mini/types.ts
@@ -97,7 +97,7 @@ export type FooterQueuedPrompt = {
   skills?: ReadonlyArray<{ id: string; name: string }>
 }
 
-export type QueuedPromptAction = "steer" | "cancel"
+export type QueuedPromptAction = "steer" | "queue" | "cancel"
 
 export type RunAgent = {
   id: string

--- a/packages/tui/test/mini/footer.test.ts
+++ b/packages/tui/test/mini/footer.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from "bun:test"
 import { createTestRenderer } from "@opentui/core/testing"
 import { CliRenderEvents, RGBA, TextRenderable } from "@opentui/core"
 import path from "node:path"
+import { Writable } from "node:stream"
 import { coalesceProgressCommit, resolveRunAgent, RunFooter } from "../../src/mini/footer"
 import { createRunDemo } from "../../src/mini/demo"
 import { resolveMiniSettings } from "../../src/mini/runtime.boot"
@@ -51,17 +52,32 @@ async function setup(
     mono?: boolean
     theme?: RunTuiConfig["theme"]
     startup?: { version: string; detail: string }
+    cursorRow?: number
     update?: (change: MiniSettingChange) => Promise<MiniSettings>
   } = {},
 ) {
   const mono = input.mono ?? true
+  const output: string[] = []
   const app = await createTestRenderer({
     width: 112,
     height: 24,
     screenMode: "split-footer",
     footerHeight: 4,
     externalOutputMode: "capture-stdout",
+    bufferedOutput: input.cursorRow ? "stdout" : "memory",
+    stdout: input.cursorRow
+      ? (new Writable({
+          write(chunk, _encoding, callback) {
+            output.push(chunk.toString())
+            callback()
+          },
+        }) as NodeJS.WriteStream)
+      : undefined,
   })
+  if (input.cursorRow) {
+    await app.renderer.setupTerminal()
+    await app.mockInput.pressKeys([`\x1b[${input.cursorRow};1R`])
+  }
   const footer = new RunFooter(app.renderer, {
     directory: () => "/project",
     findFiles: async () => [],
@@ -86,8 +102,24 @@ async function setup(
     onEditorOpen: async () => undefined,
     subscribeThemeSignal: () => () => {},
   })
-  return { ...app, footer }
+  return { ...app, footer, output }
 }
+
+test.each([1, 5, 24])("startup preserves the terminal prompt row from cursor row %s", async (cursorRow) => {
+  const app = await setup({ mono: false, startup: { version: "test", detail: "/project" }, cursorRow })
+  try {
+    await app.renderOnce()
+    app.footer.finishStartup()
+    await app.renderOnce()
+    // Inspect terminal cursor coordinates, not the footer-local render buffer.
+    const rows = Array.from(app.output.join("").matchAll(/\x1b\[(\d+);3H\x1b\[\?25h/g), (match) => Number(match[1]))
+    expect(rows.length).toBeGreaterThanOrEqual(2)
+    expect(new Set(rows).size).toBe(1)
+  } finally {
+    app.footer.destroy()
+    app.renderer.destroy()
+  }
+})
 
 test.each(["timer", "output", "close", "panel"] as const)(
   "startup stays editable and settles exactly once before %s",

--- a/packages/tui/test/mini/footer.view.test.tsx
+++ b/packages/tui/test/mini/footer.view.test.tsx
@@ -13,7 +13,6 @@ import {
   RunAgentSelectBody,
   RunCommandMenuBody,
   RunModelSelectBody,
-  RunQueuedPromptSelectBody,
   RunSettingsBody,
   RunSkillSelectBody,
   RunSubagentSelectBody,
@@ -33,6 +32,7 @@ import type {
   FooterView,
   MiniSettingChange,
   MiniSettings,
+  QueuedPromptAction,
   RunAgent,
   RunCommand,
   RunInput,
@@ -160,7 +160,7 @@ async function renderFooter(
     onStatus?: (status: string) => void
     onMiniSettingChange?: (change: MiniSettingChange) => void
     queuedPrompts?: FooterQueuedPrompt[]
-    onQueuedPromptAction?: (action: "steer" | "cancel", inboxID: string) => Promise<void>
+    onQueuedPromptAction?: (action: QueuedPromptAction, inboxID: string) => Promise<void>
   } = {},
 ) {
   const [view, setView] = createSignal<FooterView>(input.view ?? { type: "prompt" })
@@ -168,6 +168,7 @@ async function renderFooter(
     input.subagents ?? { tabs: [], details: {}, permissions: [], forms: [] },
   )
   const [state, setState] = footerState(input.state)
+  const [queuedPrompts, setQueuedPrompts] = createSignal(input.queuedPrompts ?? [])
   const config = { ...(input.tuiConfig ?? tuiConfig), animations: input.tuiConfig?.animations ?? false }
   const [miniSettings, setMiniSettings] = createSignal<MiniSettings>(input.miniSettings ?? resolveMiniSettings())
   function Harness() {
@@ -188,7 +189,7 @@ async function renderFooter(
           state={state}
           view={view}
           subagent={subagents}
-          queuedPrompts={() => input.queuedPrompts ?? []}
+          queuedPrompts={queuedPrompts}
           theme={input.theme ?? (() => RUN_THEME_FALLBACK)}
           tuiConfig={config}
           mono={input.mono ?? false}
@@ -231,6 +232,7 @@ async function renderFooter(
     setView,
     setState,
     setMiniSettings,
+    setQueuedPrompts,
     cleanup() {
       app.renderer.currentFocusedRenderable?.blur()
       app.renderer.currentFocusedEditor?.blur()
@@ -642,8 +644,7 @@ function footerStatusline(root: BoxRenderable | RootRenderable) {
 }
 
 function panelMenu(root: BoxRenderable | RootRenderable) {
-  const panel = child(child(root, 0), 0)
-  const content = child(panel, 0)
+  const content = boxPath(root, "InputRenderable")!.at(-2)!
   return child(content.getChildren().at(-1) as BoxRenderable, 0)
 }
 
@@ -1307,52 +1308,58 @@ test("direct subagent panel closes when moving up from the first item", async ()
   }
 })
 
-test("direct queued panel steers and deletes selected prompts", async () => {
-  const [prompts] = createSignal([
-    {
-      messageID: "m-1",
-      prompt: { text: "fix the auth test", parts: [] },
-      delivery: "queue" as const,
+test.each(["queue", "steer"] as const)("direct footer toggles and deletes pending %s prompts", async (delivery) => {
+  const actions: string[] = []
+  const app = await renderFooter({
+    height: RUN_SUBAGENT_PANEL_ROWS,
+    state: { phase: "running" },
+    queuedPrompts: [{ messageID: "m-1", prompt: { text: "follow up", parts: [] }, delivery }],
+    onQueuedPromptAction: async (action, inboxID) => {
+      actions.push(`${action}:${inboxID}`)
+      app.setQueuedPrompts((prompts) =>
+        action === "cancel" ? [] : prompts.map((prompt) => ({ ...prompt, delivery: action })),
+      )
     },
-  ])
-  const steered: string[] = []
-  const deleted: string[] = []
-
-  const app = await testRender(
-    () => (
-      <Keymap.Provider config={tuiConfig}>
-        <box width={100} height={RUN_SUBAGENT_PANEL_ROWS}>
-          <RunQueuedPromptSelectBody
-            theme={() => RUN_THEME_FALLBACK.footer}
-            prompts={prompts}
-            onClose={() => {}}
-            onSteer={(prompt) => steered.push(prompt.messageID)}
-            onDelete={(prompt) => deleted.push(prompt.messageID)}
-          />
-        </box>
-      </Keymap.Provider>
-    ),
-    { width: 100, height: RUN_SUBAGENT_PANEL_ROWS },
-  )
+  })
 
   try {
     await app.renderOnce()
+    expect(app.captureCharFrame()).toContain("ctrl+x q 1 pending")
+    app.mockInput.pressKey("ARROW_DOWN")
+    await app.renderOnce()
+    expect(app.captureCharFrame()).not.toContain("Pending prompts")
+
+    app.mockInput.pressKey("x", { ctrl: true })
+    app.mockInput.pressKey("q")
+    await app.renderOnce()
     const frame = app.captureCharFrame()
     const list = panelMenu(app.renderer.root)
-
-    expect(frame).toContain("Queued prompts")
-    expect(frame).toContain("fix the auth test")
-    expect(frame).toContain("queued")
-    expect(frame).toContain("enter steer · ctrl+d delete")
+    expect(frame).toContain("Pending prompts")
+    expect(frame).toContain("follow up")
+    expect(frame).toContain(delivery === "queue" ? "queued" : "steering")
+    expect(frame).toContain(`enter ${delivery === "queue" ? "steer" : "queue"} · ctrl+d delete`)
     expect(frame).not.toContain("┌")
     expect(frame).not.toContain("┃")
     expectPaletteList(list, 0)
     app.mockInput.pressEnter()
+    await Bun.sleep(0)
+    await app.renderOnce()
+    expect(actions).toEqual([`${delivery === "queue" ? "steer" : "queue"}:m-1`])
+    expect(app.captureCharFrame()).toContain("1 pending")
+
+    app.mockInput.pressKey("x", { ctrl: true })
+    app.mockInput.pressKey("q")
+    await app.renderOnce()
+    expect(app.captureCharFrame()).toContain(delivery === "queue" ? "steering" : "queued")
+    expect(app.captureCharFrame()).toContain(delivery === "queue" ? "enter queue" : "enter steer")
     app.mockInput.pressKey("d", { ctrl: true })
-    expect(steered).toEqual(["m-1"])
-    expect(deleted).toEqual(["m-1"])
+    await Bun.sleep(0)
+    await app.renderOnce()
+    expect(actions.at(-1)).toBe("cancel:m-1")
+    expect(app.captureCharFrame()).not.toContain("Pending prompts")
+    expect(app.captureCharFrame()).not.toContain("1 pending")
   } finally {
-    app.renderer.destroy()
+    app.cleanup()
   }
 })
 
@@ -1360,6 +1367,7 @@ test("direct footer steers the oldest queued prompt from an empty composer", asy
   const steered: string[] = []
   const app = await renderFooter({
     queuedPrompts: [
+      { messageID: "m-steering", prompt: { text: "already steering", parts: [] }, delivery: "steer" },
       { messageID: "m-1", prompt: { text: "first", parts: [] }, delivery: "queue" },
       { messageID: "m-2", prompt: { text: "second", parts: [] }, delivery: "queue" },
     ],
@@ -1377,6 +1385,38 @@ test("direct footer steers the oldest queued prompt from an empty composer", asy
     app.mockInput.pressEnter()
     await Bun.sleep(0)
     expect(steered).toEqual(["m-1"])
+    app.setQueuedPrompts((prompts) => prompts.filter((prompt) => prompt.delivery === "steer"))
+    app.mockInput.pressEnter()
+    await Bun.sleep(0)
+    expect(steered).toEqual(["m-1"])
+  } finally {
+    app.cleanup()
+  }
+})
+
+test("direct footer preserves steer and queue submission shortcuts while busy", async () => {
+  const submitted: RunPrompt[] = []
+  const app = await renderFooter({
+    state: { phase: "running" },
+    onSubmit: (prompt) => {
+      submitted.push(prompt)
+      return true
+    },
+  })
+
+  try {
+    await app.renderOnce()
+    await app.mockInput.typeText("steer now")
+    app.mockInput.pressEnter()
+    await Bun.sleep(0)
+    await app.mockInput.typeText("queue later")
+    app.mockInput.pressKey("x", { ctrl: true })
+    app.mockInput.pressEnter()
+    await Bun.sleep(0)
+    expect(submitted).toEqual([
+      { text: "steer now", parts: [], delivery: "steer" },
+      { text: "queue later", parts: [], delivery: "queue" },
+    ])
   } finally {
     app.cleanup()
   }
@@ -1795,7 +1835,7 @@ test.skip("direct footer clears the synthetic skills draft when the panel closes
   }
 })
 
-test("direct footer shows authoritative queued work while running", async () => {
+test("direct footer counts queued and steering work while running", async () => {
   const app = await renderFooter({
     width: 160,
     state: { phase: "running" },
@@ -1806,7 +1846,10 @@ test("direct footer shows authoritative queued work while running", async () => 
       permissions: [],
       forms: [],
     },
-    queuedPrompts: [{ messageID: "m-queued", prompt: { text: "follow up", parts: [] }, delivery: "queue" }],
+    queuedPrompts: [
+      { messageID: "m-queued", prompt: { text: "follow up", parts: [] }, delivery: "queue" },
+      { messageID: "m-steering", prompt: { text: "steer now", parts: [] }, delivery: "steer" },
+    ],
   })
 
   try {
@@ -1814,7 +1857,7 @@ test("direct footer shows authoritative queued work while running", async () => 
     const frame = app.captureCharFrame()
     const transparent = RGBA.fromValues(0, 0, 0, 0).toInts()
     const statusline = footerStatusline(app.renderer.root)
-    expect(frame).toContain("esc stop · ctrl+x q 1 queued · ↓ 1 subagent · ctrl+b background · Build")
+    expect(frame).toContain("esc stop · ctrl+x q 2 pending · ↓ 1 subagent · ctrl+b background · Build")
     expect(frame).toMatch(/opencode · ctrl\+p menu *$/m)
     expect(frame).not.toContain("1 agent")
     expect(statusline.backgroundColor.toInts()).toEqual(transparent)
@@ -2061,7 +2104,7 @@ test.each(["ctrl+g", "none"])("context actions use only configured bindings (%s)
     expect(frame).toContain(
       queued === "none"
         ? "ctrl+i interrupt · ctrl+j 1 subagent · Build · gpt-5 · ctrl+y menu"
-        : "ctrl+i interrupt · ctrl+g 1 queued · ctrl+j 1 subagent · Build · gpt-5 · ctrl+y menu",
+        : "ctrl+i interrupt · ctrl+g 1 pending · ctrl+j 1 subagent · Build · gpt-5 · ctrl+y menu",
     )
     for (const hidden of ["ctrl+b", "ctrl+x", "ctrl+p", "esc", "↓"]) expect(frame).not.toContain(hidden)
   } finally {

--- a/packages/tui/test/mini/runtime.queue.test.ts
+++ b/packages/tui/test/mini/runtime.queue.test.ts
@@ -100,15 +100,7 @@ describe("run runtime queue", () => {
 
     expect(created).toBe(1)
     expect(seen).toEqual(["hello"])
-    expect(ui.commits).toEqual([
-      {
-        kind: "user",
-        text: "hello",
-        phase: "start",
-        source: "system",
-        messageID: expect.any(String),
-      },
-    ])
+    expect(ui.commits).toEqual([])
   })
 
   test("treats /compact as a local compaction command", async () => {
@@ -133,7 +125,7 @@ describe("run runtime queue", () => {
 
     expect(compacted).toBe(1)
     expect(seen).toEqual(["hello"])
-    expect(ui.commits.map((item) => item.text)).toEqual(["hello"])
+    expect(ui.commits).toEqual([])
   })
 
   test("keeps prompts submitted after an in-flight /compact behind the compaction barrier", async () => {
@@ -256,15 +248,47 @@ describe("run runtime queue", () => {
     })
 
     expect(seen).toEqual(["  hello  "])
+    expect(ui.commits).toEqual([])
+  })
+
+  test("skill commands retain their local input echo", async () => {
+    const ui = createFooterApiFixture()
+    const task = runPromptQueue({
+      footer: ui.api,
+      onSend: (_prompt, emittedUser) => expect(emittedUser).toBe(true),
+      run: async () => ui.api.close(),
+    })
+
+    ui.submit({ text: "/review", parts: [], command: { name: "review", arguments: "", source: "skill" } })
+    await task
     expect(ui.commits).toEqual([
       {
         kind: "user",
-        text: "  hello  ",
+        text: "/review",
         phase: "start",
         source: "system",
         messageID: expect.any(String),
       },
     ])
+  })
+
+  test("demo commands own their local input echo", async () => {
+    const { createRunDemo } = await import("../../src/mini/demo")
+    const ui = createFooterApiFixture()
+    const demo = createRunDemo({ sessionID: "ses_demo", thinking: false, footer: ui.api })
+    expect(await demo.prompt({ text: "ordinary prompt", parts: [] })).toBe(false)
+    expect(ui.commits).toEqual([])
+    const task = runPromptQueue({
+      footer: ui.api,
+      run: async (prompt) => {
+        expect(await demo.prompt(prompt)).toBe(true)
+        ui.api.close()
+      },
+    })
+
+    ui.submit("/help")
+    await task
+    expect(ui.commits.filter((commit) => commit.kind === "user")).toMatchObject([{ text: "/help" }])
   })
 
   test("durably admits in-flight follow-ups in submission order", async () => {
@@ -290,7 +314,7 @@ describe("run runtime queue", () => {
     ui.submit("three")
     while (admitted.length < 3) await Bun.sleep(0)
     expect(admitted).toEqual(["one:steer", "two:queue", "three:queue"])
-    expect(ui.commits.map((item) => item.text)).toEqual(["one"])
+    expect(ui.commits).toEqual([])
 
     gate.resolve()
     await task
@@ -299,10 +323,12 @@ describe("run runtime queue", () => {
   test("preserves explicit steer and queue delivery for in-flight prompts", async () => {
     const ui = createFooterApiFixture()
     const admitted: string[] = []
+    const emitted: boolean[] = []
     const gate = Promise.withResolvers<void>()
 
     const task = runPromptQueue({
       footer: ui.api,
+      onSend: (_prompt, emittedUser) => emitted.push(emittedUser),
       run: async (_input, _signal, onAdmitted) => {
         onAdmitted()
         await gate.promise
@@ -318,6 +344,8 @@ describe("run runtime queue", () => {
     ui.submit("three", undefined, "queue")
     while (admitted.length < 2) await Bun.sleep(0)
     expect(admitted).toEqual(["two:steer", "three:queue"])
+    expect(emitted).toEqual([false, false, false])
+    expect(ui.commits).toEqual([])
 
     gate.resolve()
     await task

--- a/packages/tui/test/mini/stream-v2.transport.test.ts
+++ b/packages/tui/test/mini/stream-v2.transport.test.ts
@@ -13,6 +13,7 @@ import {
   type ToolContent,
 } from "@opencode-ai/client/promise"
 import { createSessionTransport } from "../../src/mini/stream-v2.transport"
+import { runPromptQueue } from "../../src/mini/runtime.queue"
 import { entryBody } from "../../src/mini/entry.body"
 import type { StreamCommit } from "../../src/mini/types"
 import { createFooterApiFixture } from "./fixture/footer-api"
@@ -228,7 +229,84 @@ afterEach(() => {
 })
 
 describe("V2 mini transport", () => {
-  test.each(["before", "after"])("renders materialized prompt images when delivery is %s the ack", async (order) => {
+  test.each(["steer", "queue"] as const)("cancels the first local %s after attaching while busy", async (delivery) => {
+    const events = feed()
+    events.push(connected())
+    const inbox: SessionInboxInfo[] = []
+    const idle = defer()
+    const admitted = defer()
+    const client = sdk({
+      streams: [events],
+      active: () => ({ ses_1: { type: "running" } }),
+      messages: { ses_1: [] },
+      pending: { ses_1: inbox },
+      wait: () => idle.promise,
+    })
+    spyOn(client.session, "prompt").mockImplementation((request) => {
+      const item = { ...promptAdmission(request), payload: { text: request.text } }
+      inbox.push(item)
+      return ok(item) as never
+    })
+    const ui = footer()
+    const live: StreamCommit[] = []
+    const transport = await createSessionTransport({
+      sdk: client,
+      sessionID: "ses_1",
+      thinking: false,
+      replay: true,
+      footer: ui.api,
+      onCommit: (commit) => live.push(commit),
+    })
+    const queue = runPromptQueue({
+      footer: ui.api,
+      onSend: (_prompt, emittedUser) => {
+        if (emittedUser) live.push(ui.commits.at(-1)!)
+      },
+      run: (prompt, signal, onAdmitted) =>
+        transport.runPromptTurn(
+          { agent: undefined, model: undefined, variant: undefined, prompt, files: [], includeFiles: false, signal },
+          () => {
+            onAdmitted()
+            admitted.resolve()
+          },
+        ),
+      admit: async () => {
+        throw new Error("unexpected follow-up")
+      },
+      settle: () => transport.waitForIdle(),
+    })
+    try {
+      ui.submit("cancel before delivery", undefined, delivery)
+      await admitted.promise
+      expect(ui.events.findLast((event) => event.type === "queued.prompts")?.prompts).toHaveLength(1)
+      expect(ui.commits).toEqual([])
+      const item = inbox.shift()!
+      events.push({
+        id: "evt_cancelled",
+        created: 3,
+        type: "session.inbox.cancelled",
+        durable: durable("ses_1", 1),
+        data: { sessionID: "ses_1", inboxID: item.id },
+      })
+      while (ui.events.findLast((event) => event.type === "queued.prompts")?.prompts.length !== 0) await Bun.sleep(0)
+      await transport.replayOnResize({
+        localRows: () => live.map((commit) => ({ commit })),
+        reset: async () => {
+          ui.commits.length = 0
+        },
+      })
+      expect(ui.events.findLast((event) => event.type === "stream.patch")?.patch.phase).toBe("running")
+      expect(ui.commits).toEqual([])
+      expect(live).toEqual([])
+    } finally {
+      idle.resolve()
+      ui.api.close()
+      await queue
+      await transport.close()
+    }
+  })
+
+  test.each(["admission", "delivery", "projection"])("renders user content once (%s first)", async (first) => {
     const events = feed()
     events.push(connected())
     const requested = defer()
@@ -263,7 +341,6 @@ describe("V2 mini transport", () => {
       footer: ui.api,
       onCommit: (commit) => live.push(commit),
     })
-    ui.api.append({ kind: "user", source: "system", text: pending.payload.text, messageID: pending.id, phase: "start" })
     const turn = transport.runPromptTurn(
       {
         agent: undefined,
@@ -289,11 +366,11 @@ describe("V2 mini transport", () => {
       admitted.resolve,
     )
     await requested.promise
-    if (order === "after") {
+    if (first === "admission") {
       ack.resolve()
       await admitted.promise
     }
-    expect(ui.commits.filter((commit) => commit.image)).toEqual([])
+    expect(ui.commits).toEqual([])
     events.push({
       id: "evt_delivered",
       created: 1,
@@ -303,6 +380,10 @@ describe("V2 mini transport", () => {
     })
     while (!ui.events.some((event) => event.type === "stream.patch" && event.patch.status === "waiting for assistant"))
       await Bun.sleep(0)
+    messages.push({ id: pending.id, type: "user", ...pending.payload, time: { created: 1 } })
+    if (first === "projection") {
+      await transport.replayOnResize({ localRows: () => [], reset: async () => {} })
+    }
     ack.resolve()
     await admitted.promise
 
@@ -320,8 +401,14 @@ describe("V2 mini transport", () => {
       }),
       expect.anything(),
     )
-    const images = ui.commits.filter((commit) => commit.image)
-    expect(images).toEqual([
+    const expected = [
+      {
+        kind: "user",
+        source: "system",
+        text: pending.payload.text,
+        messageID: pending.id,
+        phase: "start",
+      },
       {
         kind: "user",
         source: "system",
@@ -340,20 +427,19 @@ describe("V2 mini transport", () => {
         partID: "image:1",
         phase: "final",
       },
-    ])
-    messages.push({ id: pending.id, type: "user", ...pending.payload, time: { created: 1 } })
+    ] satisfies StreamCommit[]
+    expect(ui.commits).toEqual(expected)
     idle.resolve()
     await turn
 
-    expect(ui.commits.filter((commit) => commit.image)).toEqual(images)
-    expect(ui.commits.filter((commit) => commit.kind === "user" && !commit.image)).toHaveLength(1)
+    expect(ui.commits).toEqual(expected)
     await transport.replayOnResize({
       localRows: () => live.map((commit) => ({ commit })),
       reset: async () => {
         ui.commits.length = 0
       },
     })
-    expect(ui.commits.filter((commit) => commit.image)).toEqual(images)
+    expect(ui.commits).toEqual(expected)
     await transport.close()
   })
 
@@ -790,7 +876,7 @@ describe("V2 mini transport", () => {
     let admitted = false
     spyOn(client.session, "prompt").mockImplementation((request) => {
       admitted = true
-      return ok({ data: promptAdmission(request) }) as never
+      return ok(promptAdmission(request)) as never
     })
 
     const turn = transport.runPromptTurn({
@@ -850,11 +936,11 @@ describe("V2 mini transport", () => {
     settled.resolve()
     await turn
 
-    expect(ui.commits.map((item) => item.text)).toEqual(["ans", "wer"])
+    expect(ui.commits.map((item) => item.text)).toEqual(["hello", "ans", "wer"])
     await transport.close()
   })
 
-  test("shows durable pending delivery and appends queued input on promotion", async () => {
+  test.each(["queue", "steer"] as const)("keeps pending %s out of scrollback until delivery", async (delivery) => {
     const events = feed()
     events.push(connected())
     const client = sdk({
@@ -882,7 +968,7 @@ describe("V2 mini transport", () => {
             timeCreated: 2,
             type: "user",
             payload: { text: "remove me", files: [image] },
-            delivery: "queue",
+            delivery,
           },
         ],
       },
@@ -901,7 +987,7 @@ describe("V2 mini transport", () => {
 
     expect(pending()).toEqual([
       ["msg_queued", "queue"],
-      ["msg_cancelled", "queue"],
+      ["msg_cancelled", delivery],
     ])
     events.push({
       id: "evt_steered",
@@ -910,14 +996,13 @@ describe("V2 mini transport", () => {
       durable: durable("ses_1", 2),
       data: { sessionID: "ses_1", inboxID: "msg_queued", delivery: "steer" },
     })
-    while (!ui.commits.some((item) => item.messageID === "msg_queued")) await Bun.sleep(0)
+    while (pending()?.[0]?.[1] !== "steer") await Bun.sleep(0)
 
-    expect(ui.commits.filter((item) => item.messageID === "msg_queued")).toEqual([
-      expect.objectContaining({ kind: "system", partID: "skill:effect", text: '→ Skill "Effect"' }),
-      expect.objectContaining({ kind: "user", text: "follow up" }),
+    expect(pending()).toEqual([
+      ["msg_queued", "steer"],
+      ["msg_cancelled", delivery],
     ])
-    expect(pending()).toEqual([["msg_cancelled", "queue"]])
-    expect(ui.commits.some((commit) => commit.image)).toBe(false)
+    expect(ui.commits).toEqual([])
     events.push({
       id: "evt_queued",
       created: 4,
@@ -925,10 +1010,10 @@ describe("V2 mini transport", () => {
       durable: durable("ses_1", 3),
       data: { sessionID: "ses_1", inboxID: "msg_queued", delivery: "queue" },
     })
-    while (pending()?.length !== 2) await Bun.sleep(0)
+    while (pending()?.[0]?.[1] !== "queue") await Bun.sleep(0)
     expect(pending()).toEqual([
       ["msg_queued", "queue"],
-      ["msg_cancelled", "queue"],
+      ["msg_cancelled", delivery],
     ])
     events.push({
       id: "evt_cancelled",
@@ -939,6 +1024,7 @@ describe("V2 mini transport", () => {
     })
     while (pending()?.length !== 1) await Bun.sleep(0)
     expect(pending()).toEqual([["msg_queued", "queue"]])
+    expect(ui.commits).toEqual([])
     events.push({
       id: "evt_promoted",
       created: 6,
@@ -948,6 +1034,10 @@ describe("V2 mini transport", () => {
     })
     while (pending()?.length !== 0) await Bun.sleep(0)
     expect(ui.commits.filter((item) => item.messageID === "msg_queued")).toHaveLength(3)
+    expect(ui.commits.filter((commit) => !commit.image)).toEqual([
+      expect.objectContaining({ kind: "system", partID: "skill:effect", text: '→ Skill "Effect"' }),
+      expect.objectContaining({ kind: "user", text: "follow up" }),
+    ])
     expect(ui.commits.filter((commit) => commit.image)).toEqual([
       expect.objectContaining({ kind: "user", messageID: "msg_queued", image: "data:image/png;base64,cG5n" }),
     ])
@@ -963,14 +1053,16 @@ describe("V2 mini transport", () => {
         files: [],
         includeFiles: false,
       },
-      "queue",
+      delivery,
     )
     expect(client.session.switchAgent).toHaveBeenCalledWith({ sessionID: "ses_1", agent: "review" }, expect.anything())
     expect(client.session.switchModel).toHaveBeenCalledWith(
       { sessionID: "ses_1", model: { providerID: "test", id: "next", variant: "high" } },
       expect.anything(),
     )
-    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({ delivery: "queue" }), expect.anything())
+    expect(prompt).toHaveBeenCalledWith(expect.objectContaining({ delivery }), expect.anything())
+    expect(pending()).toEqual([["msg_next", delivery]])
+    expect(ui.commits.some((commit) => commit.messageID === "msg_next")).toBe(false)
     events.push({
       id: "evt_earlier_admission",
       created: 3,
@@ -983,7 +1075,11 @@ describe("V2 mini transport", () => {
       },
     })
     await Bun.sleep(10)
-    expect(pending()).toEqual([["msg_next", "queue"]])
+    expect(pending()).toEqual([
+      ["msg_next", delivery],
+      ["msg_earlier", "steer"],
+    ])
+    expect(ui.commits.some((commit) => commit.messageID === "msg_earlier")).toBe(false)
     await transport.close()
   })
 
@@ -1476,7 +1572,7 @@ describe("V2 mini transport", () => {
     await transport.close()
   })
 
-  test("does not duplicate the optimistic user row when reconnect hydration recovers a missed prompt", async () => {
+  test("renders the user row once when reconnect hydration recovers a missed delivery", async () => {
     const first = feed()
     const second = feed()
     first.push(connected("evt_connected_1"))
@@ -1511,7 +1607,6 @@ describe("V2 mini transport", () => {
       }),
     )
     const ui = footer()
-    ui.commits.push({ kind: "user", source: "system", text: "hello", phase: "start", messageID: "msg_prompt" })
     const transport = await createSessionTransport({
       sdk: client,
       sessionID: "ses_1",
@@ -1519,11 +1614,9 @@ describe("V2 mini transport", () => {
       footer: ui.api,
     })
     let admitted = false
-    // The generated method has conditional return types for throwOnError; this mock represents the successful branch.
-    // @ts-expect-error successful SDK response is valid for both modes at runtime
     spyOn(client.session, "prompt").mockImplementation((request) => {
       admitted = true
-      return ok({ data: promptAdmission(request) })
+      return ok(promptAdmission(request)) as never
     })
 
     const turn = transport.runPromptTurn({


### PR DESCRIPTION
Printing prompts before delivery leaves stale scrollback and replay rows when users cancel them. Keep queued and steering input in the pending menu until delivery so users can switch modes or cancel either kind.

Keep the prompt on the same terminal row when the startup splash closes to prevent a cursor jump.
