### PR TITLE
refactor(tui): sum cached and total tokens across all steps in turn summary

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1621,12 +1621,11 @@ function TurnTokenUsage(props: {
   }))
   const summary = createMemo(() => {
     const items = steps()
-    const last = items[items.length - 1]
     return {
       count: items.length,
       newTokens: items.reduce((sum, item) => sum + item.newTokens, 0),
-      cached: last?.cached ?? 0,
-      total: last?.total ?? 0,
+      cached: items.reduce((sum, item) => sum + item.cached, 0),
+      total: items.reduce((sum, item) => sum + item.total, 0),
       reuseDrops: items.filter((item) => item.reuseDrop !== undefined).length,
     }
   })


### PR DESCRIPTION
### Issue for this PR

Closes #46636

### Type of change

- [x] Refactor / code improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation

### What does this PR do?

The `+ Tokens` turn summary mixes two units on one line (#41922): `new` is
summed across all steps while `cached` and `total` are the last step's values.
Nothing on the line marks that difference, so the three numbers read as the
same kind of aggregate when they aren't. This makes all three turn-level sums;
the last step's context is still visible in the expanded table and on the
status bar.

### How did you verify your code works?

- `bun test test/cli/tui/session-rows.test.ts` in packages/tui — 24 pass, 0 fail

### Screenshots / recordings

Multi-step turn with `debug.turn_tokens` on (11 steps):
```
Build · GLM-5.3 Flash · 1m 47s

+ Tokens: 11 steps · 50,006 new · 2,456,768 cached · 2,506,774 total
```
`50,006 + 2,456,768 = 2,506,774`

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR