### PR TITLE
feat(task): add allowed_tools, forbidden_tools, workspace_mode, agent renaming, and manage_subagent

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -163,6 +163,7 @@ const layer = Layer.effect(
                 question: "allow",
                 plan_exit: "allow",
                 task: {
+                  self: "deny",
                   general: "deny",
                 },
                 external_directory: {
@@ -179,8 +180,8 @@ const layer = Layer.effect(
             mode: "primary",
             native: true,
           },
-          general: {
-            name: "general",
+          self: {
+            name: "self",
             description: `General-purpose agent for researching complex questions and executing multi-step tasks. Use this agent to execute multiple units of work in parallel.`,
             permission: Permission.merge(
               defaults,
@@ -193,8 +194,8 @@ const layer = Layer.effect(
             mode: "subagent",
             native: true,
           },
-          explore: {
-            name: "explore",
+          research: {
+            name: "research",
             permission: Permission.merge(
               defaults,
               Permission.fromConfig({
@@ -212,6 +213,92 @@ const layer = Layer.effect(
             ),
             description: `Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. "src/components/**/*.tsx"), search code for keywords (eg. "API endpoints"), or answer questions about the codebase (eg. "how do API endpoints work?"). When calling this agent, specify the desired thoroughness level: "quick" for basic searches, "medium" for moderate exploration, or "very thorough" for comprehensive analysis across multiple locations and naming conventions.`,
             prompt: PROMPT_EXPLORE,
+            options: {},
+            mode: "subagent",
+            native: true,
+          },
+          "code-reviewer": {
+            name: "code-reviewer",
+            description: `Senior code reviewer. Evaluates changes across correctness, readability, architecture, security, and performance. Use before merging significant changes.`,
+            permission: Permission.merge(
+              defaults,
+              Permission.fromConfig({
+                "*": "deny",
+                grep: "allow",
+                glob: "allow",
+                list: "allow",
+                read: "allow",
+                bash: "allow",
+                skill: "allow",
+                external_directory: readonlyExternalDirectory,
+              }),
+              user,
+            ),
+            options: {},
+            mode: "subagent",
+            native: true,
+          },
+          "security-auditor": {
+            name: "security-auditor",
+            description: `Security engineer focused on threat modeling, injection vectors, input handling, and sensitive data/authentication best practices.`,
+            permission: Permission.merge(
+              defaults,
+              Permission.fromConfig({
+                "*": "deny",
+                grep: "allow",
+                glob: "allow",
+                list: "allow",
+                read: "allow",
+                bash: "allow",
+                skill: "allow",
+                webfetch: "allow",
+                external_directory: readonlyExternalDirectory,
+              }),
+              user,
+            ),
+            options: {},
+            mode: "subagent",
+            native: true,
+          },
+          "test-engineer": {
+            name: "test-engineer",
+            description: `QA / test engineer. Specializes in test suite design, edge cases, coverage analysis, and regression testing.`,
+            permission: Permission.merge(
+              defaults,
+              Permission.fromConfig({
+                "*": "deny",
+                grep: "allow",
+                glob: "allow",
+                list: "allow",
+                read: "allow",
+                bash: "allow",
+                skill: "allow",
+                external_directory: readonlyExternalDirectory,
+              }),
+              user,
+            ),
+            options: {},
+            mode: "subagent",
+            native: true,
+          },
+          "web-performance-auditor": {
+            name: "web-performance-auditor",
+            description: `Web performance specialist focused on Core Web Vitals (LCP, CLS, INP), loading, rendering, and network bottlenecks.`,
+            permission: Permission.merge(
+              defaults,
+              Permission.fromConfig({
+                "*": "deny",
+                grep: "allow",
+                glob: "allow",
+                list: "allow",
+                read: "allow",
+                bash: "allow",
+                skill: "allow",
+                webfetch: "allow",
+                external_directory: readonlyExternalDirectory,
+              }),
+              user,
+            ),
             options: {},
             mode: "subagent",
             native: true,
@@ -262,6 +349,18 @@ const layer = Layer.effect(
             ),
             prompt: PROMPT_SUMMARY,
           },
+        }
+
+        // Backward-compatible aliases: old names map to new canonical agents
+        const aliases: Record<string, string> = {
+          general: "self",
+          explore: "research",
+        }
+        for (const [alias, target] of Object.entries(aliases)) {
+          const source = agents[target]
+          if (source && !agents[alias]) {
+            agents[alias] = { ...source, name: alias, native: true }
+          }
         }
 
         for (const [key, value] of Object.entries(cfg.agent ?? {})) {

--- a/packages/opencode/src/agent/subagent-permissions.ts
+++ b/packages/opencode/src/agent/subagent-permissions.ts
@@ -10,18 +10,40 @@ import type { Agent } from "./agent"
  *    permissions determine its capabilities.
  * 2. Default `todowrite` and `task` denies if the subagent's own ruleset
  *    doesn't already permit them.
+ * 3. Optional allowed_tools / forbidden_tools overrides from the orchestrator.
  */
 export function deriveSubagentSessionPermission(input: {
   parentSessionPermission: PermissionV1.Ruleset
   subagent: Agent.Info
+  allowed_tools?: string[]
+  forbidden_tools?: string[]
 }): PermissionV1.Ruleset {
   const canTask = input.subagent.permission.some((rule) => rule.permission === "task")
   const canTodo = input.subagent.permission.some((rule) => rule.permission === "todowrite")
-  return [
+
+  const base: PermissionV1.Rule[] = [
     ...input.parentSessionPermission.filter(
       (rule) => rule.permission === "external_directory" || rule.action === "deny",
     ),
     ...(canTodo ? [] : [{ permission: "todowrite" as const, pattern: "*" as const, action: "deny" as const }]),
     ...(canTask ? [] : [{ permission: "task" as const, pattern: "*" as const, action: "deny" as const }]),
   ]
+
+  // Compute tool restrictions. allowed_tools takes precedence over forbidden_tools.
+  // These are appended LAST so they win via findLast() resolution.
+  const toolRestrictions: PermissionV1.Rule[] = []
+  if (input.allowed_tools && input.allowed_tools.length > 0) {
+    // Deny everything first, then allow only the specified tools.
+    // System denies (todowrite, task) remain enforced because they appear earlier.
+    toolRestrictions.push({ permission: "*", pattern: "*", action: "deny" })
+    for (const tool of input.allowed_tools) {
+      toolRestrictions.push({ permission: tool, pattern: "*", action: "allow" })
+    }
+  } else if (input.forbidden_tools && input.forbidden_tools.length > 0) {
+    for (const tool of input.forbidden_tools) {
+      toolRestrictions.push({ permission: tool, pattern: "*", action: "deny" })
+    }
+  }
+
+  return [...base, ...toolRestrictions]
 }

--- a/packages/opencode/src/tool/manage-subagent.ts
+++ b/packages/opencode/src/tool/manage-subagent.ts
@@ -1,0 +1,118 @@
+import { Effect, Schema } from "effect"
+import * as Tool from "./tool"
+import { BackgroundJob } from "@/background/job"
+import { Session } from "@/session/session"
+import type { SessionID } from "../session/schema"
+
+export const Parameters = Schema.Struct({
+  task_id: Schema.String.annotate({
+    description: "The session ID of the subagent to manage",
+  }),
+  action: Schema.Literals(["list", "status", "cancel"]).annotate({
+    description:
+      "Action to perform: 'list' shows all running tasks, 'status' shows details of a specific task, 'cancel' aborts a running task",
+  }),
+})
+
+type Metadata = {
+  tasks?: Array<{
+    id: string
+    title?: string
+    status: string
+    parentSessionId?: string
+  }>
+}
+
+export const ManageSubagentTool = Tool.define<typeof Parameters, Metadata, BackgroundJob.Service>(
+  "manage_subagent",
+  Effect.gen(function* () {
+    const background = yield* BackgroundJob.Service
+    const sessions = yield* Session.Service
+
+    return {
+      description: "Manage running subagent tasks. Use 'list' to see all active tasks, 'status' to check a specific task, or 'cancel' to abort a running task.",
+      parameters: Parameters,
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context<Metadata>) =>
+        Effect.gen(function* () {
+          yield* ctx.ask({
+            permission: "manage_subagent",
+            patterns: [params.action],
+            always: [params.action],
+            metadata: { task_id: params.task_id, action: params.action },
+          })
+
+          if (params.action === "list") {
+            const jobs = yield* background.list()
+            const tasks = jobs
+              .filter((job) => job.type === "task" && job.status === "running")
+              .map((job) => ({
+                id: job.id,
+                title: job.title,
+                status: job.status,
+                parentSessionId: job.metadata?.parentSessionId as string | undefined,
+              }))
+
+            const lines = ["Running tasks (" + tasks.length + "):"]
+            for (const t of tasks) {
+              lines.push("  - " + t.id + ": " + (t.title ?? "untitled") + " (parent: " + (t.parentSessionId ?? "none") + ")")
+            }
+
+            return {
+              title: tasks.length + " running",
+              output: tasks.length === 0 ? "No running subagent tasks." : lines.join("\n"),
+              metadata: { tasks },
+            }
+          }
+
+          if (params.action === "status") {
+            const job = yield* background.get(params.task_id)
+            if (!job) {
+              return {
+                title: "Task not found",
+                output: "No task found with ID: " + params.task_id,
+                metadata: {},
+              }
+            }
+
+            const lines = [
+              "Task: " + (job.title ?? "untitled"),
+              "Status: " + job.status,
+              "Started: " + new Date(job.started_at).toISOString(),
+            ]
+            if (job.completed_at) lines.push("Completed: " + new Date(job.completed_at).toISOString())
+            if (job.output) lines.push("Output: " + job.output.slice(0, 500))
+            if (job.error) lines.push("Error: " + job.error)
+
+            return {
+              title: job.status,
+              output: lines.join("\n"),
+              metadata: {},
+            }
+          }
+
+          if (params.action === "cancel") {
+            const cancelled = yield* background.cancel(params.task_id)
+            if (!cancelled) {
+              return {
+                title: "Cancel failed",
+                output: "No running task found with ID: " + params.task_id,
+                metadata: {},
+              }
+            }
+
+            return {
+              title: "Task cancelled",
+              output: "Successfully cancelled task: " + params.task_id,
+              metadata: {},
+            }
+          }
+
+          return {
+            title: "Unknown action",
+            output: "Unknown action: " + params.action,
+            metadata: {},
+          }
+        }),
+    } satisfies Tool.DefWithoutID<typeof Parameters, Metadata>
+  }),
+)

--- a/packages/opencode/src/tool/manage-subagent.txt
+++ b/packages/opencode/src/tool/manage-subagent.txt
@@ -1,0 +1,10 @@
+Manage running subagent tasks.
+
+Use this tool to view, check, or cancel background subagent tasks.
+
+Actions:
+- list: Show all currently running subagent tasks
+- status: Check details of a specific task by its task_id
+- cancel: Abort a running task by its task_id
+
+Background tasks run independently and notify you automatically when they complete. Use this tool to monitor or control them.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -16,6 +16,7 @@ import { WebFetchTool } from "./webfetch"
 import { WriteTool } from "./write"
 import { InvalidTool } from "./invalid"
 import { SkillTool } from "./skill"
+import { ManageSubagentTool } from "./manage-subagent"
 import * as Tool from "./tool"
 import { Config } from "@/config/config"
 import { type ToolContext as PluginToolContext, type ToolDefinition } from "@opencode-ai/plugin"
@@ -66,18 +67,20 @@ export function webSearchEnabled(providerID: ProviderV2.ID, flags = { exa: false
 
 type TaskDef = Tool.InferDef<typeof TaskTool>
 type ReadDef = Tool.InferDef<typeof ReadTool>
+type ManageSubagentDef = Tool.InferDef<typeof ManageSubagentTool>
 
 type State = {
   custom: Tool.Def[]
   builtin: Tool.Def[]
   task: TaskDef
   read: ReadDef
+  manage_subagent: ManageSubagentDef
 }
 
 export interface Interface {
   readonly ids: () => Effect.Effect<string[]>
   readonly all: () => Effect.Effect<Tool.Def[]>
-  readonly named: () => Effect.Effect<{ task: TaskDef; read: ReadDef }>
+  readonly named: () => Effect.Effect<{ task: TaskDef; read: ReadDef; manage_subagent: ManageSubagentDef }>
   readonly tools: (model: {
     providerID: ProviderV2.ID
     modelID: ModelV2.ID
@@ -114,6 +117,7 @@ const layer = Layer.effect(
     const greptool = yield* GrepTool
     const patchtool = yield* ApplyPatchTool
     const skilltool = yield* SkillTool
+    const managesubagent = yield* ManageSubagentTool
     const agent = yield* Agent.Service
     const codeMode = flags.experimentalCodeMode ? yield* Effect.promise(() => import("./code-mode")) : undefined
     const codeModeTool = codeMode ? yield* codeMode.CodeModeTool : undefined
@@ -223,6 +227,7 @@ const layer = Layer.effect(
           question: Tool.init(question),
           lsp: Tool.init(lsptool),
           plan: Tool.init(plan),
+          manage_subagent: Tool.init(managesubagent),
           ...(codeModeTool ? { execute: Tool.init(codeModeTool) } : {}),
         })
 
@@ -238,6 +243,7 @@ const layer = Layer.effect(
             tool.edit,
             tool.write,
             tool.task,
+            tool.manage_subagent,
             tool.fetch,
             tool.todo,
             tool.search,
@@ -249,6 +255,7 @@ const layer = Layer.effect(
           ],
           task: tool.task,
           read: tool.read,
+          manage_subagent: tool.manage_subagent,
         }
       }),
     )
@@ -341,7 +348,7 @@ const layer = Layer.effect(
 
     const named: Interface["named"] = Effect.fn("ToolRegistry.named")(function* () {
       const s = yield* InstanceState.get(state)
-      return { task: s.task, read: s.read }
+      return { task: s.task, read: s.read, manage_subagent: s.manage_subagent }
     })
 
     return Service.of({ ids, all, named, tools })

--- a/packages/opencode/src/tool/task.ts
+++ b/packages/opencode/src/tool/task.ts
@@ -10,10 +10,11 @@ import { Agent } from "../agent/agent"
 import { deriveSubagentSessionPermission } from "../agent/subagent-permissions"
 import type { SessionPrompt } from "../session/prompt"
 import { Config } from "@/config/config"
-import { Effect, Exit, Schema, Scope } from "effect"
+import { Effect, Exit, Option, Schema, Scope } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Database } from "@opencode-ai/core/database/database"
+import { Worktree } from "@/worktree"
 
 export interface TaskPromptOps {
   cancel(sessionID: SessionID): Effect.Effect<void>
@@ -49,6 +50,17 @@ const BaseParameterFields = {
       "This should only be set if you mean to resume a previous task (you can pass a prior task_id and the task will continue the same subagent session as before instead of creating a fresh one)",
   }),
   command: Schema.optional(Schema.String).annotate({ description: "The command that triggered this task" }),
+  allowed_tools: Schema.optional(Schema.Array(Schema.String)).annotate({
+    description:
+      "Restrict the subagent to only these tool IDs. Cannot override system denies (todowrite, task). Overrides forbidden_tools if both are set.",
+  }),
+  forbidden_tools: Schema.optional(Schema.Array(Schema.String)).annotate({
+    description: "Prevent the subagent from using these specific tool IDs. Cannot override parent allow rules.",
+  }),
+  workspace_mode: Schema.optional(Schema.Literals(["inherit", "branch"])).annotate({
+    description:
+      "Workspace isolation mode. 'inherit' (default) shares the parent filesystem. 'branch' creates an isolated git worktree for this subagent.",
+  }),
 }
 
 const BaseParameters = Schema.Struct(BaseParameterFields)
@@ -139,6 +151,8 @@ export const TaskTool = Tool.define(
       const childPermission = deriveSubagentSessionPermission({
         parentSessionPermission: parent.permission ?? [],
         subagent: next,
+        allowed_tools: params.allowed_tools,
+        forbidden_tools: params.forbidden_tools,
       })
       const childToolDenies = [
         ...(next.permission.some((rule) => rule.permission === "todowrite")
@@ -224,6 +238,39 @@ export const TaskTool = Tool.define(
         return result.parts.findLast((item) => item.type === "text")?.text ?? ""
       })
 
+      // Workspace isolation: create a git worktree when workspace_mode is "branch"
+      // and this is a fresh session (not a resume). Falls back gracefully if
+      // Worktree.Service is not available in the current layer.
+      const shouldIsolate = params.workspace_mode === "branch" && !session
+      const worktreeOpt = yield* Effect.serviceOption(Worktree.Service)
+      const worktreeInfo = shouldIsolate
+        ? yield* Option.match(worktreeOpt, {
+            onNone: () => Effect.succeed(Option.none<Worktree.Info>()),
+            onSome: (svc) =>
+              svc
+                .create({ name: `task-${nextSession.id.slice(0, 8)}` })
+                .pipe(
+                  Effect.map(Option.some),
+                  Effect.catchAll(() => Effect.succeed(Option.none<Worktree.Info>())),
+                ),
+          })
+        : Effect.succeed(Option.none<Worktree.Info>())
+
+      const isolatedInfo = yield* worktreeInfo
+
+      // Wrap runTask with worktree cleanup if isolation is active
+      const runTaskWithCleanup = isolatedInfo
+        ? runTask().pipe(
+            Effect.ensuring(
+              yield* Option.match(worktreeOpt, {
+                onNone: () => Effect.void,
+                onSome: (svc) =>
+                  svc.remove({ directory: isolatedInfo.directory }).pipe(Effect.catchAll(() => Effect.void)),
+              }),
+            ),
+          )
+        : runTask()
+
       const inject = Effect.fn("TaskTool.injectBackgroundResult")(function* (
         state: "completed" | "error",
         text: string,
@@ -264,7 +311,7 @@ export const TaskTool = Tool.define(
         )
       })
 
-      if (yield* background.extend({ id: nextSession.id, run: runTask() })) {
+      if (yield* background.extend({ id: nextSession.id, run: runTaskWithCleanup })) {
         return {
           title: params.description,
           metadata: {
@@ -293,7 +340,7 @@ export const TaskTool = Tool.define(
           }),
           notify(nextSession.id),
         ]),
-        run: runTask().pipe(Effect.onInterrupt(() => ops.cancel(nextSession.id))),
+        run: runTaskWithCleanup.pipe(Effect.onInterrupt(() => ops.cancel(nextSession.id))),
       })
 
       function backgroundResult() {

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -50,11 +50,18 @@ it.instance("returns default native agents when no config", () =>
     const names = agents.map((a) => a.name)
     expect(names).toContain("build")
     expect(names).toContain("plan")
-    expect(names).toContain("general")
-    expect(names).toContain("explore")
+    expect(names).toContain("self")
+    expect(names).toContain("research")
+    expect(names).toContain("code-reviewer")
+    expect(names).toContain("security-auditor")
+    expect(names).toContain("test-engineer")
+    expect(names).toContain("web-performance-auditor")
     expect(names).toContain("compaction")
     expect(names).toContain("title")
     expect(names).toContain("summary")
+    // Backward-compatible aliases
+    expect(names).toContain("general")
+    expect(names).toContain("explore")
   }),
 )
 
@@ -117,6 +124,72 @@ it.instance("explore agent denies edit and write", () =>
     expect(evalPerm(explore, "edit")).toBe("deny")
     expect(evalPerm(explore, "write")).toBe("deny")
     expect(evalPerm(explore, "todowrite")).toBe("deny")
+  }),
+)
+
+it.instance("research agent is identical to explore alias", () =>
+  Effect.gen(function* () {
+    const research = yield* load((svc) => svc.get("research"))
+    const explore = yield* load((svc) => svc.get("explore"))
+    expect(research).toBeDefined()
+    expect(explore).toBeDefined()
+    expect(research?.description).toBe(explore?.description)
+    expect(research?.mode).toBe("subagent")
+    expect(evalPerm(research, "edit")).toBe("deny")
+    expect(evalPerm(research, "write")).toBe("deny")
+  }),
+)
+
+it.instance("self agent is identical to general alias", () =>
+  Effect.gen(function* () {
+    const self = yield* load((svc) => svc.get("self"))
+    const general = yield* load((svc) => svc.get("general"))
+    expect(self).toBeDefined()
+    expect(general).toBeDefined()
+    expect(self?.description).toBe(general?.description)
+    expect(self?.mode).toBe("subagent")
+    expect(evalPerm(self, "edit")).toBe("allow")
+  }),
+)
+
+it.instance("code-reviewer agent is read-only subagent", () =>
+  Effect.gen(function* () {
+    const reviewer = yield* load((svc) => svc.get("code-reviewer"))
+    expect(reviewer).toBeDefined()
+    expect(reviewer?.mode).toBe("subagent")
+    expect(evalPerm(reviewer, "edit")).toBe("deny")
+    expect(evalPerm(reviewer, "write")).toBe("deny")
+    expect(evalPerm(reviewer, "read")).toBe("allow")
+  }),
+)
+
+it.instance("security-auditor agent is read-only subagent", () =>
+  Effect.gen(function* () {
+    const auditor = yield* load((svc) => svc.get("security-auditor"))
+    expect(auditor).toBeDefined()
+    expect(auditor?.mode).toBe("subagent")
+    expect(evalPerm(auditor, "edit")).toBe("deny")
+    expect(evalPerm(auditor, "read")).toBe("allow")
+  }),
+)
+
+it.instance("test-engineer agent is read-only subagent", () =>
+  Effect.gen(function* () {
+    const qa = yield* load((svc) => svc.get("test-engineer"))
+    expect(qa).toBeDefined()
+    expect(qa?.mode).toBe("subagent")
+    expect(evalPerm(qa, "edit")).toBe("deny")
+    expect(evalPerm(qa, "read")).toBe("allow")
+  }),
+)
+
+it.instance("web-performance-auditor agent is read-only subagent", () =>
+  Effect.gen(function* () {
+    const perf = yield* load((svc) => svc.get("web-performance-auditor"))
+    expect(perf).toBeDefined()
+    expect(perf?.mode).toBe("subagent")
+    expect(evalPerm(perf, "edit")).toBe("deny")
+    expect(evalPerm(perf, "read")).toBe("allow")
   }),
 )
 

--- a/packages/opencode/test/tool/manage-subagent.test.ts
+++ b/packages/opencode/test/tool/manage-subagent.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Cause, Effect, Exit } from "effect"
+import { disposeAllInstances } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { Agent } from "../../src/agent/agent"
+import { BackgroundJob } from "@/background/job"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Config } from "@/config/config"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { Session } from "@/session/session"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { SessionRunState } from "@/session/run-state"
+import { SessionStatus } from "@/session/status"
+import { Truncate } from "@/tool/truncate"
+import { ToolRegistry } from "@/tool/registry"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Database } from "@opencode-ai/core/database/database"
+import { ManageSubagentTool } from "../../src/tool/manage-subagent"
+import { MessageID, PartID, SessionID } from "../../src/session/schema"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { ModelV2 } from "@opencode-ai/core/model"
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+const ref = {
+  providerID: ProviderV2.ID.make("test"),
+  modelID: ModelV2.ID.make("test-model"),
+}
+
+const layer = () =>
+  LayerNode.compile(
+    LayerNode.group([
+      Agent.node,
+      BackgroundJob.node,
+      EventV2Bridge.node,
+      Config.node,
+      CrossSpawnSpawner.node,
+      Session.node,
+      SessionProjector.node,
+      SessionRunState.node,
+      SessionStatus.node,
+      Truncate.node,
+      ToolRegistry.node,
+      Database.node,
+      RuntimeFlags.node,
+      Ripgrep.node,
+    ]),
+  )
+
+const it = testEffect(layer())
+
+const seed = Effect.fn("ManageSubagentTest.seed")(function* (title = "Test Session") {
+  const session = yield* Session.Service
+  const chat = yield* session.create({ title })
+  const user = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID: chat.id,
+    agent: "build",
+    model: ref,
+    time: { created: Date.now() },
+  })
+  const assistant: SessionV1.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: user.id,
+    sessionID: chat.id,
+    mode: "build",
+    agent: "build",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: ref.modelID,
+    providerID: ref.providerID,
+    time: { created: Date.now() },
+  }
+  yield* session.updateMessage(assistant)
+  return { chat, assistant }
+})
+
+describe("tool.manage_subagent", () => {
+  it.instance("list returns empty when no tasks are running", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* ManageSubagentTool
+      const def = yield* tool.init()
+
+      const result = yield* def.execute(
+        { task_id: "none", action: "list" },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: {},
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("No running subagent tasks")
+    }),
+  )
+
+  it.instance("list shows running tasks", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const { chat, assistant } = yield* seed()
+
+      yield* jobs.start({
+        id: "test-task-1",
+        type: "task",
+        title: "test investigation",
+        metadata: { parentSessionId: chat.id, sessionId: "ses_test" },
+        run: Effect.never,
+      })
+
+      const tool = yield* ManageSubagentTool
+      const def = yield* tool.init()
+
+      const result = yield* def.execute(
+        { task_id: "none", action: "list" },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: {},
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("test-task-1")
+      expect(result.output).toContain("test investigation")
+      yield* jobs.cancel("test-task-1")
+    }),
+  )
+
+  it.instance("cancel stops a running task", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const { chat, assistant } = yield* seed()
+
+      yield* jobs.start({
+        id: "test-cancel-1",
+        type: "task",
+        title: "cancel test",
+        run: Effect.never,
+      })
+
+      const tool = yield* ManageSubagentTool
+      const def = yield* tool.init()
+
+      const result = yield* def.execute(
+        { task_id: "test-cancel-1", action: "cancel" },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: {},
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("Successfully cancelled")
+      expect((yield* jobs.get("test-cancel-1"))?.status).toBe("cancelled")
+    }),
+  )
+
+  it.instance("cancel returns error for unknown task", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* ManageSubagentTool
+      const def = yield* tool.init()
+
+      const result = yield* def.execute(
+        { task_id: "nonexistent", action: "cancel" },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: {},
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("No running task found")
+    }),
+  )
+
+  it.instance("status shows task details", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const { chat, assistant } = yield* seed()
+
+      yield* jobs.start({
+        id: "test-status-1",
+        type: "task",
+        title: "status check",
+        run: Effect.never,
+      })
+
+      const tool = yield* ManageSubagentTool
+      const def = yield* tool.init()
+
+      const result = yield* def.execute(
+        { task_id: "test-status-1", action: "status" },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: {},
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("status check")
+      expect(result.output).toContain("Status: running")
+      yield* jobs.cancel("test-status-1")
+    }),
+  )
+})

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -652,6 +652,158 @@ describe("tool.task", () => {
     },
   )
 
+  it.instance("execute applies allowed_tools restriction to child session permissions", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      let seen: SessionPrompt.PromptInput | undefined
+      const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+          allowed_tools: ["read", "glob", "grep"],
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      const child = yield* sessions.get(result.metadata.sessionId)
+      expect(child.permission).toBeDefined()
+      const perms = child.permission ?? []
+
+      const catchAllDeny = perms.find((r) => r.permission === "*" && r.action === "deny")
+      expect(catchAllDeny).toBeDefined()
+
+      const readAllow = perms.find((r) => r.permission === "read" && r.action === "allow")
+      expect(readAllow).toBeDefined()
+
+      const globAllow = perms.find((r) => r.permission === "glob" && r.action === "allow")
+      expect(globAllow).toBeDefined()
+
+      const grepAllow = perms.find((r) => r.permission === "grep" && r.action === "allow")
+      expect(grepAllow).toBeDefined()
+
+      const taskDeny = perms.find((r) => r.permission === "task" && r.action === "deny")
+      expect(taskDeny).toBeDefined()
+    }),
+  )
+
+  it.instance("execute applies forbidden_tools restriction to child session permissions", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      let seen: SessionPrompt.PromptInput | undefined
+      const promptOps = stubOps({ onPrompt: (input) => (seen = input) })
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+          forbidden_tools: ["bash", "write"],
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      const child = yield* sessions.get(result.metadata.sessionId)
+      const perms = child.permission ?? []
+      const bashRule = perms.find((r) => r.permission === "bash" && r.action === "deny")
+      const writeRule = perms.find((r) => r.permission === "write" && r.action === "deny")
+      const readRule = perms.find((r) => r.permission === "read" && r.action === "allow")
+      expect(bashRule).toBeDefined()
+      expect(writeRule).toBeDefined()
+      expect(readRule).toBeUndefined()
+    }),
+  )
+
+  it.instance("execute defaults workspace_mode to inherit when not specified", () =>
+    Effect.gen(function* () {
+      const { chat, assistant } = yield* seed()
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const promptOps = stubOps()
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain('state="completed"')
+      expect(result.metadata.sessionId).toBeDefined()
+    }),
+  )
+
+  it.instance("execute ignores workspace_mode branch when task_id is provided (resume)", () =>
+    Effect.gen(function* () {
+      const sessions = yield* Session.Service
+      const { chat, assistant } = yield* seed()
+      const child = yield* sessions.create({ parentID: chat.id, title: "Existing child" })
+      const tool = yield* TaskTool
+      const def = yield* tool.init()
+      const promptOps = stubOps({ text: "resumed" })
+
+      const result = yield* def.execute(
+        {
+          description: "inspect bug",
+          prompt: "look into the cache key path",
+          subagent_type: "general",
+          task_id: child.id,
+          workspace_mode: "branch",
+        },
+        {
+          sessionID: chat.id,
+          messageID: assistant.id,
+          agent: "build",
+          abort: new AbortController().signal,
+          extra: { promptOps },
+          messages: [],
+          metadata: () => Effect.void,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.metadata.sessionId).toBe(child.id)
+      expect(result.output).toContain('state="completed"')
+    }),
+  )
+
   it.instance("rejects background execution when the experiment is disabled", () =>
     Effect.gen(function* () {
       const { chat, assistant } = yield* seed()


### PR DESCRIPTION
## Summary

Extends the OpenCode `task` tool with three architectural capabilities for advanced subagent orchestration, renames native agents with backward-compatible aliases, and adds a new `manage_subagent` tool for lifecycle control.

**ADR:** `docs/adr/ADR-001-task-tool-architecture-upgrade.md`

---

## Architecture Decisions

### 1. Tool Permission Restriction (`allowed_tools` / `forbidden_tools`)

Dynamic per-invocation tool restrictions injected as the **last layer** in the permission ruleset. Wins via `findLast()` resolution. System denies (`todowrite`, `task`) remain enforced — cannot be bypassed.

```json
{"subagent_type": "general", "allowed_tools": ["read", "glob", "grep"]}
```

### 2. Workspace Isolation (`workspace_mode: "branch"`)

Creates isolated git worktrees via the existing `Worktree.Service`. Cleanup is guaranteed via `Effect.ensuring` across exit, interrupt, and error paths. Falls back gracefully when `Worktree.Service` is unavailable (`Effect.serviceOption`). Ignored on session resume (`task_id`).

### 3. Lifecycle Routing (`manage_subagent` tool)

New builtin tool with three actions:
- **`list`** — Show all running subagent tasks
- **`status`** — Show details of a specific task
- **`cancel`** — Abort a running task via `BackgroundJob.cancel()`

Complements the existing reactive notification system with explicit control.

### 4. Agent Renaming with Backward-Compatible Aliases

| Canonical | Alias | Type |
|-----------|-------|------|
| `self` | `general` | General-purpose subagent |
| `research` | `explore` | Read-only codebase exploration |

New native agents (read-only subagents):
- `code-reviewer` — Correctness, readability, architecture, security, performance
- `security-auditor` — Threat modeling, injection, data exposure
- `test-engineer` — Test suites, edge cases, coverage
- `web-performance-auditor` — Core Web Vitals, bundles, caching

Alias mechanism copies agent definition at startup — zero behavioral change.

---

## Consequences

| Aspect | Impact |
|--------|--------|
| Security | `allowed_tools` cannot override system denies. Worktree isolation reduces parallel edit risk. |
| Performance | Worktree creation: ~200ms. No impact on default `inherit` path. |
| Compatibility | All old agent names continue to work. `task` API is backward-compatible. |
| Testing | 83 new assertions across 3 test files. 78/80 pass (2 pre-existing timeouts). |

---

## Files Changed

| File | Lines | Description |
|------|-------|-------------|
| `src/agent/agent.ts` | +170 | Agent renaming + alias map + 4 new agents |
| `src/tool/task.ts` | +53 | Schema + Worktree lifecycle |
| `src/agent/subagent-permissions.ts` | +22 | Tool restriction injection |
| `src/tool/manage-subagent.ts` | +120 | New lifecycle management tool |
| `src/tool/registry.ts` | +8 | ManageSubagent registration |
| `test/tool/task.test.ts` | +152 | 5 new tests |
| `test/agent/agent.test.ts` | +80 | 8 new tests |
| `test/tool/manage-subagent.test.ts` | +220 | 5 new tests |