### PR TITLE
fix(core): fail content-filtered and outputless length settlements

### DIFF
--- a/packages/core/src/session/generate-node.ts
+++ b/packages/core/src/session/generate-node.ts
@@ -1,6 +1,6 @@
 export * as SessionGenerateNode from "./generate-node.js"
 
-import { LLMClient, Message } from "@opencode-ai/ai"
+import { AIError, ContentPolicyError, InvalidProviderOutputError, LLMClient, Message } from "@opencode-ai/ai"
 import { Effect, Layer } from "effect"
 import { Database } from "../database/database.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
@@ -47,6 +47,16 @@ export const layer = Layer.effect(
         })
         const response = yield* llm.generate(prepared.request, prepared.options)
         yield* Effect.logInfo("session generation usage diagnostic", { usage: response.usage })
+        if (response.finishReason.normalized === "content-filter")
+          return yield* new AIError({
+            reason: new ContentPolicyError({ message: "Provider blocked the response" }),
+          })
+        if (response.finishReason.normalized === "length" && !response.text && response.toolCalls.length === 0)
+          return yield* new AIError({
+            reason: new InvalidProviderOutputError({
+              message: "The model reached its output limit before producing text or a tool call",
+            }),
+          })
         return response.text
       }),
     })

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -28,7 +28,7 @@ const asRecord = (value: unknown): Record<string, unknown> =>
 
 /** Immutable fold of the durable facts a step's writer has recorded so far. */
 export interface StepRecord {
-  /** The model produced visible output this attempt, which bars transparent retries and overflow recovery. */
+  /** The model produced durable output this attempt, which bars transparent retries and overflow recovery. */
   readonly outputStarted: boolean
   readonly providerFailed: boolean
   /** The step's recorded assistant failure, if any. */
@@ -93,6 +93,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
   let stepFailed = false
   let providerFailed = false
   let outputStarted = false
+  let usefulOutput = false
   let stepStreamed = false
   let stepFailure: SessionError.Error | undefined
   let stepSettlement: StepRecord["finish"]
@@ -400,9 +401,11 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         })
         return
       case "text-delta":
+        if (event.text.length > 0) usefulOutput = true
         yield* text.append(event.id, event.text, providerState(event.providerMetadata))
         return
       case "text-end":
+        if (event.text && event.text.length > 0) usefulOutput = true
         yield* text.end(event.id, providerState(event.providerMetadata), event.text)
         return
       case "reasoning-start":
@@ -443,6 +446,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         return
       case "tool-call": {
         outputStarted = true
+        usefulOutput = true
         const tool = tools.get(event.id) ?? (yield* startToolInput(event))
         if (toolInput.has(event.id)) yield* endToolInput(event)
         if (tool.name !== event.name)
@@ -530,6 +534,14 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         if (event.reason.normalized === "content-filter") {
           providerFailed = true
           yield* failAssistant({ type: "provider.content-filter", message: "Provider blocked the response" })
+          return
+        }
+        if (event.reason.normalized === "length" && !usefulOutput) {
+          providerFailed = true
+          yield* failAssistant({
+            type: "provider.invalid-output",
+            message: "The model reached its output limit before producing text or a tool call",
+          })
           return
         }
         return

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -63,18 +63,40 @@ const client = Layer.mock(LLMClient.Service)({
     Effect.sync(() => {
       requests.push(request)
       options.push(requestOptions)
-      const response = LLMResponse.fromEvents([
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.textStart({ id: "generate" }),
-        LLMEvent.textDelta({ id: "generate", text: "Transient answer" }),
-        LLMEvent.textEnd({ id: "generate" }),
-        LLMEvent.stepFinish({
-          index: 0,
-          reason: { normalized: "stop" },
-          usage: { inputTokens: 100, outputTokens: 10 },
-        }),
-        LLMEvent.finish({ reason: { normalized: "stop" } }),
-      ])
+      const prompt = request.messages
+        .at(-1)
+        ?.content.flatMap((part) => (part.type === "text" ? [part.text] : []))
+        .join("")
+      const events = (() => {
+        if (prompt === "Filtered privately")
+          return [
+            LLMEvent.stepStart({ index: 0 }),
+            LLMEvent.stepFinish({ index: 0, reason: { normalized: "content-filter", raw: "content_filtered" } }),
+            LLMEvent.finish({ reason: { normalized: "content-filter", raw: "content_filtered" } }),
+          ]
+        if (prompt === "Reason privately")
+          return [
+            LLMEvent.stepStart({ index: 0 }),
+            LLMEvent.reasoningStart({ id: "generate-reasoning" }),
+            LLMEvent.reasoningDelta({ id: "generate-reasoning", text: "Thinking without an answer" }),
+            LLMEvent.reasoningEnd({ id: "generate-reasoning" }),
+            LLMEvent.stepFinish({ index: 0, reason: { normalized: "length", raw: "max_tokens" } }),
+            LLMEvent.finish({ reason: { normalized: "length", raw: "max_tokens" } }),
+          ]
+        return [
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.textStart({ id: "generate" }),
+          LLMEvent.textDelta({ id: "generate", text: "Transient answer" }),
+          LLMEvent.textEnd({ id: "generate" }),
+          LLMEvent.stepFinish({
+            index: 0,
+            reason: { normalized: "stop" },
+            usage: { inputTokens: 100, outputTokens: 10 },
+          }),
+          LLMEvent.finish({ reason: { normalized: "stop" } }),
+        ]
+      })()
+      const response = LLMResponse.fromEvents(events)
       if (!response) throw new Error("Incomplete generate response")
       return response
     }),
@@ -344,6 +366,41 @@ it.effect(
       expect(requests[0]?.toolChoice).toBeUndefined()
       expect(options[0]?.http).toBeFunction()
       expect(options[0]?.webSocket).toBeUndefined()
+      expect(yield* durableState(db, sessionID)).toEqual(before)
+    }),
+  { timeout: 15_000 },
+)
+
+it.effect(
+  "fails transient generation when the provider filters or exhausts output before answering",
+  () =>
+    Effect.gen(function* () {
+      requests.length = 0
+      options.length = 0
+      instruction = "Initial context"
+      const { db, bus, instructions } = yield* setup
+      yield* InstructionState.prepare(db, bus, instructions, sessionID)
+      const before = yield* durableState(db, sessionID)
+      const generate = yield* SessionGenerate.Service
+
+      for (const failure of [
+        {
+          prompt: "Filtered privately",
+          reason: { _tag: "ContentPolicy", message: "Provider blocked the response" },
+        },
+        {
+          prompt: "Reason privately",
+          reason: {
+            _tag: "InvalidProviderOutput",
+            message: "The model reached its output limit before producing text or a tool call",
+          },
+        },
+      ]) {
+        const error = yield* generate.generate({ sessionID, prompt: failure.prompt }).pipe(Effect.flip)
+        expect(error).toMatchObject({ _tag: "AI.Error", reason: failure.reason })
+      }
+
+      expect(requests).toHaveLength(2)
       expect(yield* durableState(db, sessionID)).toEqual(before)
     }),
   { timeout: 15_000 },

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -625,3 +625,62 @@ test("content-filter finish preserves partial streamed text and never ends the s
     error: { type: "provider.content-filter" },
   })
 })
+
+test("reasoning-only length finish retains evidence and fails step closeout", async () => {
+  const { published, publisher } = capture()
+  await Effect.runPromise(
+    Effect.forEach(
+      [
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.reasoningStart({ id: "reasoning" }),
+        LLMEvent.reasoningDelta({ id: "reasoning", text: "Thinking without an answer" }),
+        LLMEvent.reasoningEnd({ id: "reasoning" }),
+        LLMEvent.stepFinish({ index: 0, reason: { normalized: "length", raw: "max_tokens" } }),
+      ],
+      (event) => publisher.publish(event),
+      { discard: true },
+    ),
+  )
+
+  expect(publisher.record()).toMatchObject({
+    outputStarted: true,
+    providerFailed: true,
+    failure: {
+      type: "provider.invalid-output",
+      message: "The model reached its output limit before producing text or a tool call",
+    },
+    finish: { finish: "length", rawFinish: "max_tokens" },
+  })
+  await Effect.runPromise(publisher.publishStepFailure())
+  expect(published.find((event) => event.type === "session.reasoning.ended.1")?.data).toMatchObject({
+    text: "Thinking without an answer",
+  })
+  expect(published.find((event) => event.type === "session.step.failed.1")?.data).toMatchObject({
+    rawFinish: "max_tokens",
+    error: { type: "provider.invalid-output" },
+  })
+})
+
+test("length finish remains successful after partial text", async () => {
+  const { publisher } = capture()
+  await Effect.runPromise(
+    Effect.forEach(
+      [
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.textStart({ id: "text" }),
+        LLMEvent.textDelta({ id: "text", text: "Partial answer" }),
+        LLMEvent.textEnd({ id: "text" }),
+        LLMEvent.stepFinish({ index: 0, reason: { normalized: "length", raw: "max_tokens" } }),
+      ],
+      (event) => publisher.publish(event),
+      { discard: true },
+    ),
+  )
+
+  expect(publisher.record()).toMatchObject({
+    outputStarted: true,
+    providerFailed: false,
+    finish: { finish: "length", rawFinish: "max_tokens" },
+  })
+  expect(publisher.record().failure).toBeUndefined()
+})


### PR DESCRIPTION
### Issue for this PR

Closes #46596

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Steps ending in `content_filtered`, or in `max_tokens` without any text or tool call, settled as succeeded with empty output. Users saw blank responses recorded as success, and the terminal filtered segment stayed in history, causing subsequent generations on the session to return empty text as well.

Two changes:

- `session.generate` raises `ContentPolicyError` on `content-filter` and `InvalidProviderOutputError` on `length` with no text/tool call, instead of returning empty text with HTTP 200.
- The runner publisher tracks useful output (text or tool call) separately from durable output: reasoning-only `length` keeps its reasoning and `rawFinish` for diagnosis but settles as `provider.invalid-output`. Truncated responses with partial text remain successful, so no valid output is lost.

### How did you verify your code works?

- Regression tests in `session-generate.test.ts` (content-filter, output-less length, partial text) and `session-runner-tool-events.test.ts` (reasoning-only length settlement).
- Full `packages/core` suite green (4,106 tests, 0 fail).
- Live with a private build: replaying a real session whose history ends in `content_filtered` now returns a visible 503 (`Provider blocked the response`) instead of a silent empty success; healthy sessions and the same history with the filtered segment removed still respond normally.
