### PR TITLE
fix(server): use renamed plugin activation wait

### DIFF
--- a/packages/server/src/handlers/plugin.ts
+++ b/packages/server/src/handlers/plugin.ts
@@ -17,7 +17,7 @@ export const PluginHandler = HttpApiBuilder.group(Api, "server.plugin", (handler
     .handle("plugin.check", (ctx) =>
       Effect.gen(function* () {
         const supervisor = yield* PluginSupervisor.Service
-        yield* supervisor.flush
+        yield* supervisor.awaitActivation
         const plugins = yield* Plugin.Service
         const inventory = yield* plugins.list()
         const targets = [


### PR DESCRIPTION
## Why

The `PluginSupervisor.flush` to `awaitActivation` rename missed the `plugin.check` HTTP handler. It still reads the removed property, causing plugin-update checks to fail at runtime and breaking Server, SDK, and CLI typechecking.

## What Changes

Use `supervisor.awaitActivation` in `plugin.check`, matching the already-migrated `plugin.update` handler. The existing plugin-update HTTP regression exercises the broken path.

## Scope

One missed call-site migration only. No readiness-policy change, compatibility alias, SDK feature, or HTTP contract change.

## Verification

Using Bun 1.4.0:

```sh
# packages/server
bun run ../core/script/test.ts test/plugin-update.test.ts
bun typecheck
bun run ../core/script/test.ts

# packages/sdk, then packages/cli
bun typecheck
```

Before the change, the existing plugin-update HTTP test failed with `Unexpected end of JSON input`, and Server typechecking reported the removed `flush` property plus cascading Effect errors. Afterward the test passed, the full Server suite passed **52 tests with 3 skipped**, and Server, SDK, and CLI typechecks passed. Diff checks passed.
