### PR TITLE
fix(cli): wait for consistent ACP model choices

### DIFF
--- a/packages/cli/src/acp/service.ts
+++ b/packages/cli/src/acp/service.ts
@@ -412,7 +412,11 @@ async function loadCatalog(client: OpenCodeClient, cwd: string): Promise<Catalog
       client.skill.list({ location }),
     ])
     const models = modelResult.data.filter((model) => model.enabled)
-    const defaultModel = defaultResult.data ?? models[0]
+    const preferred = defaultResult.data
+    // Parallel reads can straddle initialization; select only from this model list.
+    const defaultModel = preferred
+      ? models.find((model) => model.providerID === preferred.providerID && model.id === preferred.id)
+      : models[0]
     const agents = agentResult.data.filter((agent) => agent.mode !== "subagent" && !agent.hidden)
     const defaultAgent = agents.find((agent) => agent.mode === "primary") ?? agents[0]
     if (defaultModel && defaultAgent) {

--- a/packages/cli/test/acp/service-directory.test.ts
+++ b/packages/cli/test/acp/service-directory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import type { McpServer, SessionConfigOption } from "@agentclientprotocol/sdk"
 import { makeACPFixture, makeSession, secondModel } from "./service-fixture"
+import { flattenSelectOptions, requireSelectOption } from "./subprocess"
 
 describe("acp service directory behavior", () => {
   test("creates sessions from a catalog shared by concurrent callers in the same cwd", async () => {
@@ -71,6 +72,41 @@ describe("acp service directory behavior", () => {
       ["review", "verify"],
     ])
   })
+
+  test.each(["empty", "missing the default"])(
+    "retries when the model list is %s but the default is ready",
+    async (initial) => {
+      await using fixture = makeACPFixture({
+        fetch(request, context) {
+          if (
+            request.path === "/api/model" &&
+            context.requests.filter((request) => request.path === "/api/model").length === 1
+          ) {
+            return Response.json({
+              location: {
+                directory: "/workspace",
+                project: { id: "global", directory: "/workspace", canonical: "/workspace" },
+              },
+              data: initial === "empty" ? [] : [secondModel],
+            })
+          }
+          if (request.method === "POST" && request.path === "/api/session") {
+            return Response.json({ data: makeSession("ses_ready") })
+          }
+          return undefined
+        },
+      })
+
+      const session = await fixture.service.newSession({ cwd: "/workspace", mcpServers: [] })
+      const model = requireSelectOption(session.configOptions, "model")
+      const choices = flattenSelectOptions(model).map((option) => option.value)
+
+      expect(choices).toContain("test/second-model")
+      expect(choices).toContain("test/test-model")
+      expect(model.currentValue).toBe("test/test-model")
+      expect(fixture.requests.filter((request) => request.path === "/api/model")).toHaveLength(2)
+    },
+  )
 
   test("does not cache a failed catalog load", async () => {
     let modelCalls = 0


### PR DESCRIPTION
## Why

ACP can return an empty or incomplete model menu on startup even though its default model is available. The model list and default are read in parallel, so they can straddle plugin activation. The previous loader accepted the ready default and cached the older list.

## What Changes

Resolve the preferred default from the same enabled-model list used to build ACP's choices. If that list is empty or does not yet contain the default, use the existing retry loop instead of caching an inconsistent catalog.

| Startup Responses | Before | After |
| --- | --- | --- |
| Empty model list, ready default | Cache an empty menu | Retry the catalog read |
| Partial list missing the default | Advertise choices that omit the current model | Retry the catalog read |
| Consistent list and default | Use the catalog | Unchanged |
| No preferred default | Choose the first enabled model | Unchanged |

## Scope

Independent ACP bug fix extracted from #46496. The retry budget and catalog-sharing behavior are unchanged; no SDK instance-selection dependency.

The former shared build prerequisite landed independently in `43d09b9d75`; this PR now targets `v2` directly.

## Verification

Using Bun 1.4.0, from `packages/cli`:

```sh
bun typecheck
bun run test test/acp/service-directory.test.ts test/acp/config-options.subprocess.test.ts
bun run test
```

After rebasing onto `v2` at `e2e82f18e2`, the full CLI suite passed **264 tests** and the ACP service-directory/subprocess slice passed **10 tests**. Range-diff confirms the two-file patch is unchanged. Both deterministic regressions failed before the fix when first introduced.

CLI typechecking, formatting, and diff checks passed. The normal pre-push workspace typecheck passed all **33 tasks**.

The previous head's CI passed Windows and the Linux unit suites; its only failure was the generated-documentation check, which upstream fixed in #46678. Rebased again onto `v2` at `c8f81c8b83` with an identical patch; the ACP service-directory and subprocess tests passed **10/10** and CLI typechecking passed.
