### PR TITLE
test(sdk): wait for configured providers

### DIFF
--- a/packages/sdk/test/embedded.test.ts
+++ b/packages/sdk/test/embedded.test.ts
@@ -6,10 +6,9 @@ import { OpenAIChat } from "@opencode-ai/ai/protocols"
 import { TestLLM } from "@opencode-ai/ai/testing"
 import { llmClient } from "@opencode-ai/core/effect/app-node-platform"
 import { makeMemoryDriver } from "@opencode-ai/core/environment/index"
-import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
-import { Deferred, Effect, Fiber, Latch, Layer, Option, Ref, Schema, Stream } from "effect"
+import { Deferred, Effect, Fiber, Latch, Layer, Option, Ref, Schedule, Schema, Stream } from "effect"
 import { testEffect } from "../../core/test/lib/effect"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
 import type { OpenCodeEvent } from "../src/effect"
@@ -36,21 +35,11 @@ const location = (fixture: Fixture) =>
   fixture.sdk.Location.Ref.make({ directory: fixture.sdk.AbsolutePath.make(fixture.directory) })
 
 for (const selection of ["explicit", "default"] as const) {
-  it.live(`first generate.text waits for inline providers with ${selection} model selection`, () =>
+  it.live(`generate.text uses inline providers with ${selection} model selection`, () =>
     withEmbedded("opencode-embedded-generate-", (fixture) =>
       Effect.gen(function* () {
-        const release = yield* Latch.make()
         const llm = yield* TestLLM.Test.pipe(
           Effect.provide(TestLLM.testLayer({ fallback: TestLLM.text("ready", "answer") })),
-        )
-        const supervisor = PluginSupervisor.node.mapLayer((layer) =>
-          Layer.effect(
-            PluginSupervisor.Service,
-            Effect.gen(function* () {
-              const plugins = yield* PluginSupervisor.Service
-              return { awaitActivation: release.open.pipe(Effect.andThen(plugins.awaitActivation)) }
-            }),
-          ).pipe(Layer.provide(layer)),
         )
         const opencode = yield* fixture.sdk.OpenCode.create(
           {
@@ -72,14 +61,19 @@ for (const selection of ["explicit", "default"] as const) {
             fs: { filewatcher: false },
           },
           {
-            overrides: [
-              llmClient.replace(Layer.succeed(LLMClient.Service, llm)),
-              PluginSupervisor.node.replace(supervisor),
-            ],
+            overrides: [llmClient.replace(Layer.succeed(LLMClient.Service, llm))],
           },
         )
-        // Hold provider activation until the request reaches readiness, regardless of startup speed.
-        yield* opencode.plugin({ id: "gate-catalog", effect: () => release.await })
+        // Catalog reads no longer wait for plugin initialization.
+        yield* opencode.model.list({ location: location(fixture) }).pipe(
+          Effect.filterOrFail((result) =>
+            result.data.some(
+              (model) => model.providerID === "custom" && model.id === "fictional-chat" && model.enabled,
+            ),
+          ),
+          Effect.retry(Schedule.spaced("10 millis")),
+          Effect.timeout("2 seconds"),
+        )
 
         const result = yield* opencode.generate.text({
           prompt: "Say ready",
@@ -497,6 +491,11 @@ it.live("embedded client exposes plugin-backed web search", () =>
             })
           }),
       })
+      yield* opencode.websearch.providers({ location: location(fixture) }).pipe(
+        Effect.filterOrFail((result) => result.data.some((provider) => provider.id === providerID)),
+        Effect.retry(Schedule.spaced("10 millis")),
+        Effect.timeout("2 seconds"),
+      )
 
       const result = yield* opencode.websearch.query({
         query: "opencode",


### PR DESCRIPTION
## Why

Existing SDK generation and websearch tests assume catalog operations wait for plugin initialization. Upstream made these operations nonblocking, so the old forced supervisor gate and immediate query can fail before the configured provider is available.

## What Changes

The two generation cases wait for their exact enabled inline model, then still assert explicit/default selection, the generated response, and exactly one model request. The websearch case waits for its provider in the same Location before asserting the query result.

Remove the obsolete supervisor gate rather than restoring blocking production behavior. Readiness waits are bounded and observe actual provider inventory, not a fixed sleep.

## Scope

Test-only adaptation extracted from #46496, following the same nonblocking-catalog change addressed for Server fixtures in #46567. This does not depend on session-selected SDK instances or strict Core activation waits.

The former shared build prerequisite landed independently in `43d09b9d75`; this PR now targets `v2` directly.

## Verification

Using Bun 1.4.0, from `packages/sdk`:

```sh
# Run the focused command five times with fresh test homes
bun run ../core/script/test.ts --timeout 5000 ./test/embedded.test.ts --test-name-pattern '^(generate\.text uses inline providers with (explicit|default) model selection|embedded client exposes plugin-backed web search)$'
bun run ../core/script/test.ts --timeout 5000 ./test
bun typecheck
```

All three affected cases failed at runtime before the change. Afterward they passed **15/15** repeated runs. Full SDK suite: **25 passed, 1 failed**. The failure is the unchanged cancellation assertion at `test/promise.test.ts:73`: the aborted iterator completes instead of rejecting with `ClientError/Transport`. That assertion was also reproduced before these edits.

These results were reproduced after rebasing onto `v2` at `e2e82f18e2`. SDK typechecking and diff checks passed; range-diff confirms that the fixture patch is unchanged by the rebase. The normal pre-push workspace typecheck passed all **33 tasks**.

At the rebased head, run `33550743501` passed Windows CI and the Linux unit suites. Linux failed only the generated-documentation check: the website OpenAPI copies in base `v2` omit the diagnostic `ref` added in #46594. This test-only PR does not change those documents or their generator inputs.
