### PR TITLE
test(core): reproduce OAuth refresh omission during batching

### DIFF
--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -7,6 +7,7 @@ import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Bus } from "@opencode-ai/core/bus"
 import { Integration } from "@opencode-ai/core/integration"
+import { State } from "@opencode-ai/core/state"
 import { testEffect } from "./lib/effect"
 
 const it = testEffect(AppNodeBuilder.build(LayerNode.group([Integration.node, Credential.node, Bus.node])))
@@ -259,6 +260,56 @@ describe("Integration", () => {
           value: Credential.Key.make({ type: "key", key: "secret" }),
         }),
       ])
+    }),
+  )
+
+  it.effect("refreshes an expired OAuth credential during batched registration", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const credentials = yield* Credential.Service
+      yield* TestClock.setTime(1_000)
+      const integrationID = Integration.ID.make("opencode")
+      const methodID = Integration.MethodID.make("device")
+      const stored = yield* credentials.create({
+        integrationID,
+        label: "Work",
+        value: Credential.OAuth.make({ type: "oauth", methodID, access: "expired", refresh: "refresh", expires: 1 }),
+      })
+      const connection = { type: "credential" as const, id: stored.id, label: "Work" }
+      let refreshes = 0
+
+      // Plugin.activate batches setup. The plugin registers its method, then
+      // resolves its saved connection before the enclosing batch completes.
+      const during = yield* State.batch(
+        Effect.gen(function* () {
+          yield* integrations.transform((draft) =>
+            draft.method.update({
+              integrationID,
+              method: { id: methodID, type: "oauth", label: "Device" },
+              authorize: () => Effect.die(new Error("unused authorize")),
+              refresh: (credential) =>
+                Effect.sync(() => {
+                  refreshes++
+                  return { ...credential, access: "fresh", expires: Number.MAX_SAFE_INTEGER }
+                }),
+            }),
+          )
+          const resolved = yield* integrations.connection.resolve(connection)
+          return { resolved, persisted: (yield* credentials.get(stored.id))?.value, refreshes }
+        }),
+      )
+
+      // The same method works after batch completion; neither the stored
+      // connection nor the refresh implementation needs to be replaced.
+      expect(yield* integrations.connection.resolve(connection)).toMatchObject({ type: "oauth", access: "fresh" })
+      expect((yield* credentials.get(stored.id))?.value).toMatchObject({ access: "fresh" })
+      expect(refreshes).toBe(1)
+
+      expect(during).toMatchObject({
+        resolved: { type: "oauth", access: "fresh" },
+        persisted: { access: "fresh" },
+        refreshes: 1,
+      })
     }),
   )
 


### PR DESCRIPTION
## Why

A plugin can await registration of its OAuth refresh implementation and then resolve its saved connection during the same activation batch. The resolver reads the old published registry, misses the refresh implementation, and returns the expired access token unchanged.

For Console, that token can make the initial provider-configuration request fail with 401. The plugin logs the failure and captures no remote provider inventory, so account-provided models can disappear or a session can fail with `Model unavailable`. This is not a server-side account lockout. Completing the activation batch does not retry the failed inventory fetch, so simply waiting need not recover it.

## What Changes

**Reproducer only, intentionally failing.** One test uses the production Integration, Credential, and State implementations to register and resolve inside `State.batch`, matching the ordering used by plugin activation.

The same test resolves the same connection again after the batch as a passing control:

| Observation | During the batch | After the batch |
| --- | --- | --- |
| Returned access token | `expired` | `fresh` |
| Persisted access token | `expired` | `fresh` |
| Refresh callback invocations so far | 0 | 1 |

The final assertion requires the during-batch resolution to have returned and persisted a fresh credential. It fails on current `v2`, after the after-batch control assertions pass. The test clock explicitly places the stored credential in the past.

## Scope

No production changes and no proposed fix. This branch is based directly on `v2`, independently of #45810; it includes neither `State.resolve()` nor `State.flush()`.

The test isolates the registration-visibility failure. It does not run the Console plugin, issue the subsequent HTTP request, or exercise UI rendering. All token values and the refresh callback are synthetic; no real credentials or external network are used.

## Verification

From `packages/core`, using Bun 1.4.0:

```sh
bun run test test/integration.test.ts --test-name-pattern 'during batched registration'
bun run test test/integration.test.ts --test-name-pattern 'during batched registration' --rerun-each 20
bun run test test/integration.test.ts
bun typecheck
```

- The reproducer fails as intended, consistently **20/20** times, with zero refresh calls and an expired returned/persisted credential inside the batch.
- The post-batch control succeeds before each failing assertion, using the same registered method and saved connection.
- Complete Integration suite: **13 passed, 1 intentionally failed**.
- Core typechecking, formatting, and whitespace checks pass. The only changed file is `packages/core/test/integration.test.ts`.
- The unmodified pre-push hook passed all **33 repository typecheck tasks**.
