### PR TITLE
test(tui): stabilize scroll fixture readiness

### DIFF
--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -922,8 +922,9 @@ test("error investigations repeatedly seed editable home drafts without creating
 })
 
 test("shows jump to latest after scrolling one line above the final message", async () => {
+  await using state = await tmpdir()
   const session = {
-    id: "dummy",
+    id: "ses_scroll",
     title: "Demo session",
     projectID: "project",
     location: { directory },
@@ -942,14 +943,15 @@ test("shows jump to latest after scrolling one line above the final message", as
   await using setup = await createAppFixture({
     width: 80,
     height: 20,
+    state: state.path,
     config: { animations: false, keybinds: { "session.line.up": "f6", "session.line.down": "f7" } },
-    args: { sessionID: "dummy" },
+    args: { sessionID: "ses_scroll" },
     fetch: (url) => {
       if (url.pathname === "/api/session") return json({ data: [session], cursor: {} })
-      if (url.pathname === "/api/session/dummy") return json({ data: session })
-      if (url.pathname === "/api/session/dummy/message") return json({ data: messages.toReversed(), cursor: {} })
-      if (url.pathname === "/api/session/dummy/inbox") return json({ data: [] })
-      if (url.pathname === "/api/session/dummy/permission") return json({ data: [] })
+      if (url.pathname === "/api/session/ses_scroll") return json({ data: session })
+      if (url.pathname === "/api/session/ses_scroll/message") return json({ data: messages.toReversed(), cursor: {} })
+      if (url.pathname === "/api/session/ses_scroll/inbox") return json({ data: [] })
+      if (url.pathname === "/api/session/ses_scroll/permission") return json({ data: [] })
     },
   })
 

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -955,7 +955,8 @@ test("shows jump to latest after scrolling one line above the final message", as
     },
   })
 
-  await setup.waitForFrame((frame) => frame.includes("Final visible message"))
+  // Persisting the tab adds a layout row, so wait for it before measuring the transcript.
+  await setup.waitForFrame((frame) => frame.includes(session.title) && frame.includes("Final visible message"))
   const findScrollBox = (root: Renderable): ScrollBoxRenderable | undefined =>
     root instanceof ScrollBoxRenderable && root.getRenderable("message-7")
       ? root


### PR DESCRIPTION
## Why

The jump-to-latest fixture uses `dummy` as a stored Session ID. The TUI reserves that value for its placeholder Session and excludes it from current-session retention. With the new family-cache eviction policy, this fixture can lose its transcript before the first expected frame appears.

Using an ordinary Session ID also activates asynchronous tab registration. The transcript can become visible before that tab bar adds its layout row, so scrolling immediately can race a viewport resize.

## What Changes

Use the non-placeholder `ses_scroll` fixture ID consistently in the Session record, startup arguments, and API paths.

Give the fixture its own temporary state directory so its now-ordinary Session tab cannot leak into later tests.

Wait for both the tab title and the final message before measuring the viewport and pressing F6. This keeps tab-bar startup outside the one-line scrolling assertion.

Keep production cache behavior, every assertion, and all timing budgets unchanged.

## Scope

One test-file correction for the cache-retention change in `7730cec123`. The corresponding Home-fixture repair landed independently in #46618 and is not repeated here. No SDK or Core feature changes, test skips, or production UI changes.

## Verification

Using Bun 1.4.0 and OpenTUI 0.5.9 on macOS, from `packages/tui`:

```sh
bun run test test/app-lifecycle.test.tsx --test-name-pattern 'shows jump to latest' --rerun-each 500
bun run test
bun typecheck
```

The text-only readiness wait reproduced the Windows geometry assertion in **6/100 local runs**. Failure-only probes showed content height unchanged at 32, scroll position moving correctly from 20 to 19, and the viewport shrinking from 12 to 11 rows as the tab appeared. The resulting distance was two rows from the new bottom, not one.

After waiting for the tab frame and removing all probes, **500/500 repetitions passed**. The full TUI suite finished with **1,204 passed, 4 skipped, 0 failed**, including 107,128 assertions across 127 files. Typechecking, formatting, and diff checks passed.

The initial investigation also reproduced all 17 Home failures locally, now fixed by #46618 and excluded from this diff.

High-repetition runs still log pending tab-persistence cleanup warnings after temporary fixture-state removal, including on passing iterations. Those warnings were not suppressed, and production storage lifecycle behavior is unchanged.

Linux and Windows validation is left to CI. The final diff is one test file, **10 insertions and 7 deletions**. All original geometry and clipping assertions and wait budgets remain intact.
