### PR TITLE
refactor(client): centralize service handoff in stop

### DIFF
--- a/packages/client/src/effect/service.ts
+++ b/packages/client/src/effect/service.ts
@@ -103,16 +103,12 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
         return yield* Effect.fail(new Error("Background service failed to start"))
       if (compatible) return Option.none<LocalService>()
       yield* announce("version-mismatch", service.version)
-      if (!service.legacy && service.state === "ready")
-        yield* Effect.tryPromise(() =>
-          PtyHandoff.prepare(options.file ?? fallback(), service.info, timing.requestTimeout),
-        )
-      else {
-        if (!service.legacy)
-          yield* Effect.logWarning("Background service is not ready; replacement cannot preserve persistent terminals")
-        yield* Effect.tryPromise(() => PtyHandoff.clear(options.file ?? fallback()))
-      }
-      yield* terminate(service.info, options, timing).pipe(Effect.ignore)
+      if (!service.legacy && service.state !== "ready")
+        yield* Effect.logWarning("Background service is not ready; replacement cannot preserve persistent terminals")
+      yield* stop({
+        file: options.file,
+        pty: !service.legacy && service.state === "ready" ? "handoff" : "clear",
+      }).pipe(Effect.ignore)
       lastSpawn = 0
       return Option.none<LocalService>()
     } else if (lastSpawn === 0 && info !== undefined) lastSpawn = Date.now()
@@ -145,8 +141,12 @@ export const ensure = Effect.fn("service.ensure")(function* (options: EnsureOpti
 
 /** Stop the registered local service. */
 export const stop = Effect.fn("service.stop")(function* (options: StopOptions = {}) {
-  yield* Effect.tryPromise(() => PtyHandoff.clear(options.file ?? fallback()))
   const info = yield* read(options.file)
+  if (options.pty === "handoff" && info !== undefined)
+    yield* Effect.tryPromise(() =>
+      PtyHandoff.prepare(options.file ?? fallback(), info, defaultEnsureTiming.requestTimeout),
+    )
+  else yield* Effect.tryPromise(() => PtyHandoff.clear(options.file ?? fallback()))
   if (info !== undefined) yield* terminate(info, options, defaultEnsureTiming)
 })
 

--- a/packages/client/src/promise/service.ts
+++ b/packages/client/src/promise/service.ts
@@ -84,14 +84,12 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
         if (compatible && service.state === "failed") throw new Error("Background service failed to start")
         if (!compatible) {
           announce("version-mismatch", service.version)
-          if (!service.legacy && service.state === "ready")
-            await PtyHandoff.prepare(options.file ?? fallback(), service.info, timing.requestTimeout)
-          else {
-            if (!service.legacy)
-              console.warn("Background service is not ready; replacement cannot preserve persistent terminals")
-            await PtyHandoff.clear(options.file ?? fallback())
-          }
-          await terminate(service.info, options, timing).catch(() => undefined)
+          if (!service.legacy && service.state !== "ready")
+            console.warn("Background service is not ready; replacement cannot preserve persistent terminals")
+          await stop({
+            file: options.file,
+            pty: !service.legacy && service.state === "ready" ? "handoff" : "clear",
+          }).catch(() => undefined)
           lastSpawn = 0
         }
       } else {
@@ -119,8 +117,10 @@ export async function ensure(options: EnsureOptions = {}): Promise<Endpoint> {
 
 /** Stop the registered local service. */
 export async function stop(options: StopOptions = {}) {
-  await PtyHandoff.clear(options.file ?? fallback())
   const info = await read(options.file)
+  if (options.pty === "handoff" && info !== undefined)
+    await PtyHandoff.prepare(options.file ?? fallback(), info, defaultEnsureTiming.requestTimeout)
+  else await PtyHandoff.clear(options.file ?? fallback())
   if (info !== undefined) await terminate(info, options, defaultEnsureTiming)
 }
 

--- a/packages/client/src/service.ts
+++ b/packages/client/src/service.ts
@@ -38,6 +38,8 @@ export type EnsureOptions = DiscoverOptions & {
 export type StopOptions = {
   /** Absolute registration file path. Defaults to the XDG state directory. */
   readonly file?: string
+  /** How to handle persistent terminals before stopping the service. */
+  readonly pty?: "clear" | "handoff"
 }
 
 /** Contents of the local service registration file. */


### PR DESCRIPTION
## Summary

- add an explicit `pty` policy to `Service.stop()`
- keep clearing handoff state as the default stop behavior
- allow callers to prepare a PTY handoff before stopping
- route version-mismatch termination through the shared stop operation
- keep Effect and Promise service implementations aligned

## Testing

- not run per request
- formatted changed files
- `git diff --check`