### PR TITLE
refactor(tui): use OpenTUI Dynamic in session view

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -14,7 +14,6 @@ import {
   untrack,
   useContext,
 } from "solid-js"
-import { Dynamic } from "solid-js/web"
 import path from "node:path"
 import { mkdir, writeFile } from "node:fs/promises"
 import { useRoute, useRouteData } from "../../context/route"
@@ -40,7 +39,7 @@ import type {
 import { useLocal } from "../../context/local"
 import { Locale } from "../../util/locale"
 import { webSearchProviderLabel } from "../../util/tool-display"
-import { useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
+import { Dynamic, useRenderer, useTerminalDimensions, type JSX } from "@opentui/solid"
 import { useSDK } from "../../context/sdk"
 import { useEditorContext } from "../../context/editor"
 import { openEditor } from "../../editor"


### PR DESCRIPTION
### What does this PR do?

Import the session view's `Dynamic` component from `@opentui/solid` rather than `solid-js/web`. This keeps the terminal view on its renderer's implementation instead of selecting Solid Web's browser/server implementation through runtime conditions.

One file, import change only. No new tests, dependencies, build settings, or dev-script changes.

Split out of #46644 so the renderer cleanup can be reviewed independently of the Bedrock dev-runtime fix. This is not required to fix Bedrock decoding. A primitive-level reproduction showed the server version does not react to component selection changes, but no user-visible session-view regression was established; the view selects function components from each part's type.

### Verification

- `bun typecheck` in `packages/tui`: passed.
- `bun test --timeout 30000 --only-failures` in `packages/tui`: 193 passed, 1 skipped, 0 failed.
- `git diff --check`: passed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
