### PR TITLE
fix(tui): show session scrollbar by default for long chats

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -263,7 +263,7 @@ export function Session() {
   const [timestamps, setTimestamps] = kv.signal<"hide" | "show">("timestamps", "hide")
   const [showDetails, setShowDetails] = kv.signal("tool_details_visibility", true)
   const [showAssistantMetadata, _setShowAssistantMetadata] = kv.signal("assistant_metadata_visibility", true)
-  const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", false)
+  const [showScrollbar, setShowScrollbar] = kv.signal("scrollbar_visible", true)
   const [diffWrapMode] = kv.signal<"word" | "none">("diff_wrap_mode", "word")
   const [_animationsEnabled, _setAnimationsEnabled] = kv.signal("animations_enabled", true)
   const [showGenericToolOutput, setShowGenericToolOutput] = kv.signal("generic_tool_output_visibility", false)


### PR DESCRIPTION
### Issue for this PR

Closes #46654

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The session scrollbar is currently hidden by default, which makes long chats harder to navigate with a mouse or trackpad.

This PR makes the session scrollbar visible by default when the session content overflows. Short chats remain without a visible scrollbar.

The existing scrollbar toggle and saved user preference are preserved.

### How did you verify your code works?

I tested the TUI with long and short sessions and verified that:

- Long sessions show the scrollbar by default.
- Short sessions do not show an unnecessary scrollbar.
- The existing scrollbar toggle still works.
- The change does not affect keyboard-based scrolling.

### Screenshots / recordings

[Add a screenshot or recording showing the scrollbar visible in a long chat.]

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR