### PR TITLE
fix(opencode): bound apply patch diff metadata

### DIFF
--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -14,6 +14,17 @@ import DESCRIPTION from "./apply_patch.txt"
 import { FileSystem } from "@opencode-ai/core/filesystem"
 import { Format } from "../format"
 import * as Bom from "@/util/bom"
+import { isBinaryFile } from "@/util/binary"
+
+const MAX_DELETE_DIFF_BYTES = 1024 * 1024
+
+function omittedDeleteDiff(filePath: string, size: number) {
+  return [
+    `Index: ${filePath}`,
+    "===================================================================",
+    `Binary or oversized file deleted (${size} bytes; content diff omitted)`,
+  ].join("\n")
+}
 
 export const Parameters = Schema.Struct({
   patchText: Schema.String.annotate({ description: "The full patch text that describes all changes to be made" }),
@@ -159,23 +170,28 @@ export const ApplyPatchTool = Tool.define(
           }
 
           case "delete": {
-            const source = yield* Bom.readFile(afs, filePath).pipe(
-              Effect.catch((error) =>
-                Effect.fail(
-                  new Error(
-                    `apply_patch verification failed: ${error instanceof Error ? error.message : String(error)}`,
-                  ),
-                ),
-              ),
-            )
-            const contentToDelete = source.text
-            const deleteDiff = trimDiff(createTwoFilesPatch(filePath, filePath, contentToDelete, ""))
+            const stat = yield* afs.stat(filePath).pipe(Effect.catch(() => Effect.succeed(undefined)))
+            if (!stat || stat.type === "Directory") {
+              return yield* Effect.fail(
+                new Error(`apply_patch verification failed: Failed to read file to delete: ${filePath}`),
+              )
+            }
+            const size = Number(stat.size)
+            const knownBinary = isBinaryFile(filePath, new Uint8Array())
+            const bytes = !knownBinary && size <= MAX_DELETE_DIFF_BYTES ? yield* afs.readFile(filePath) : undefined
+            const omit = knownBinary || size > MAX_DELETE_DIFF_BYTES || isBinaryFile(filePath, bytes ?? new Uint8Array())
+            const source = omit
+              ? { bom: false, text: "" }
+              : Bom.split(new TextDecoder("utf-8", { ignoreBOM: true }).decode(bytes))
+            const deleteDiff = omit
+              ? omittedDeleteDiff(filePath, size)
+              : trimDiff(createTwoFilesPatch(filePath, filePath, source.text, ""))
 
-            const deletions = contentToDelete.split("\n").length
+            const deletions = omit ? 0 : source.text.split("\n").length
 
             fileChanges.push({
               filePath,
-              oldContent: contentToDelete,
+              oldContent: source.text,
               newContent: "",
               type: "delete",
               diff: deleteDiff,

--- a/packages/opencode/src/tool/apply_patch.ts
+++ b/packages/opencode/src/tool/apply_patch.ts
@@ -16,14 +16,31 @@ import { Format } from "../format"
 import * as Bom from "@/util/bom"
 import { isBinaryFile } from "@/util/binary"
 
-const MAX_DELETE_DIFF_BYTES = 1024 * 1024
+const MAX_DIFF_BYTES = 1024 * 1024
+const MAX_TOTAL_DIFF_BYTES = 2 * MAX_DIFF_BYTES
 
-function omittedDeleteDiff(filePath: string, size: number) {
+function omittedDiff(filePath: string, size: number, reason: string) {
   return [
     `Index: ${filePath}`,
     "===================================================================",
-    `Binary or oversized file deleted (${size} bytes; content diff omitted)`,
+    `${reason} deleted (${size} bytes; content diff omitted)`,
   ].join("\n")
+}
+
+function boundDiff(diff: string, maxBytes: number) {
+  const bytes = Buffer.byteLength(diff, "utf8")
+  if (bytes <= maxBytes) return diff
+  let kept = ""
+  let used = 0
+  // Truncate at line boundaries so consumers never see a half-written hunk.
+  // A single line larger than the cap is dropped entirely in favor of the marker.
+  for (const line of diff.split("\n")) {
+    const size = Buffer.byteLength(line, "utf8") + 1
+    if (used + size > maxBytes) break
+    kept += `${line}\n`
+    used += size
+  }
+  return `${kept}\n[diff truncated: showing first ${used} of ${bytes} bytes]`
 }
 
 export const Parameters = Schema.Struct({
@@ -78,8 +95,6 @@ export const ApplyPatchTool = Tool.define(
         bom: boolean
       }> = []
 
-      let totalDiff = ""
-
       for (const hunk of hunks) {
         const filePath = path.resolve(instance.directory, hunk.path)
         yield* assertExternalDirectoryEffect(ctx, filePath)
@@ -109,8 +124,6 @@ export const ApplyPatchTool = Tool.define(
               deletions,
               bom: next.bom,
             })
-
-            totalDiff += diff + "\n"
             break
           }
 
@@ -164,8 +177,6 @@ export const ApplyPatchTool = Tool.define(
               deletions,
               bom,
             })
-
-            totalDiff += diff + "\n"
             break
           }
 
@@ -178,13 +189,14 @@ export const ApplyPatchTool = Tool.define(
             }
             const size = Number(stat.size)
             const knownBinary = isBinaryFile(filePath, new Uint8Array())
-            const bytes = !knownBinary && size <= MAX_DELETE_DIFF_BYTES ? yield* afs.readFile(filePath) : undefined
-            const omit = knownBinary || size > MAX_DELETE_DIFF_BYTES || isBinaryFile(filePath, bytes ?? new Uint8Array())
+            const oversized = size > MAX_DIFF_BYTES
+            const bytes = knownBinary || oversized ? undefined : yield* afs.readFile(filePath)
+            const omit = knownBinary || oversized || isBinaryFile(filePath, bytes ?? new Uint8Array())
             const source = omit
               ? { bom: false, text: "" }
               : Bom.split(new TextDecoder("utf-8", { ignoreBOM: true }).decode(bytes))
             const deleteDiff = omit
-              ? omittedDeleteDiff(filePath, size)
+              ? omittedDiff(filePath, size, oversized ? "oversized file" : "binary file")
               : trimDiff(createTwoFilesPatch(filePath, filePath, source.text, ""))
 
             const deletions = omit ? 0 : source.text.split("\n").length
@@ -199,15 +211,18 @@ export const ApplyPatchTool = Tool.define(
               deletions,
               bom: source.bom,
             })
-
-            totalDiff += deleteDiff + "\n"
             break
           }
         }
       }
 
+      // Final safety net: bound every per-file diff and the combined diff so no
+      // change type can persist pathological content in metadata.
+      const bounded = fileChanges.map((change) => ({ ...change, diff: boundDiff(change.diff, MAX_DIFF_BYTES) }))
+      const totalDiff = boundDiff(bounded.map((change) => `${change.diff}\n`).join(""), MAX_TOTAL_DIFF_BYTES)
+
       // Build per-file metadata for UI rendering (used for both permission and result)
-      const files = fileChanges.map((change) => ({
+      const files = bounded.map((change) => ({
         filePath: change.filePath,
         relativePath: path.relative(instance.worktree, change.movePath ?? change.filePath).replaceAll("\\", "/"),
         type: change.type,

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -9,6 +9,7 @@ import { InstanceState } from "@/effect/instance-state"
 import { assertExternalDirectoryEffect } from "./external-directory"
 import { Instruction } from "../session/instruction"
 import { isPdfAttachment, sniffAttachmentMime } from "@/util/media"
+import { isBinaryFile } from "@/util/binary"
 
 const DEFAULT_READ_LIMIT = 2000
 const MAX_LINE_LENGTH = 2000
@@ -178,53 +179,6 @@ export const ReadTool = Tool.define<
 
       return { raw, count: flags.count, cut: flags.cut, more: flags.more, offset: opts.offset }
     })
-
-    const isBinaryFile = (filepath: string, bytes: Uint8Array) => {
-      const ext = path.extname(filepath).toLowerCase()
-      switch (ext) {
-        case ".zip":
-        case ".tar":
-        case ".gz":
-        case ".exe":
-        case ".dll":
-        case ".so":
-        case ".class":
-        case ".jar":
-        case ".war":
-        case ".7z":
-        case ".doc":
-        case ".docx":
-        case ".xls":
-        case ".xlsx":
-        case ".ppt":
-        case ".pptx":
-        case ".odt":
-        case ".ods":
-        case ".odp":
-        case ".bin":
-        case ".dat":
-        case ".obj":
-        case ".o":
-        case ".a":
-        case ".lib":
-        case ".wasm":
-        case ".pyc":
-        case ".pyo":
-          return true
-      }
-
-      if (bytes.length === 0) return false
-
-      let nonPrintableCount = 0
-      for (let i = 0; i < bytes.length; i++) {
-        if (bytes[i] === 0) return true
-        if (bytes[i] < 9 || (bytes[i] > 13 && bytes[i] < 32)) {
-          nonPrintableCount++
-        }
-      }
-
-      return nonPrintableCount / bytes.length > 0.3
-    }
 
     const run = Effect.fn("ReadTool.execute")(function* (
       params: Schema.Schema.Type<typeof Parameters>,

--- a/packages/opencode/src/util/binary.ts
+++ b/packages/opencode/src/util/binary.ts
@@ -1,0 +1,45 @@
+import path from "path"
+
+const extensions = new Set([
+  ".zip",
+  ".tar",
+  ".gz",
+  ".exe",
+  ".dll",
+  ".so",
+  ".class",
+  ".jar",
+  ".war",
+  ".7z",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".ppt",
+  ".pptx",
+  ".odt",
+  ".ods",
+  ".odp",
+  ".bin",
+  ".dat",
+  ".obj",
+  ".o",
+  ".a",
+  ".lib",
+  ".wasm",
+  ".pyc",
+  ".pyo",
+])
+
+export function isBinaryFile(filepath: string, bytes: Uint8Array) {
+  if (extensions.has(path.extname(filepath).toLowerCase())) return true
+  if (bytes.length === 0) return false
+
+  let nonPrintableCount = 0
+  for (const byte of bytes) {
+    if (byte === 0) return true
+    if (byte < 9 || (byte > 13 && byte < 32)) nonPrintableCount++
+  }
+
+  return nonPrintableCount / bytes.length > 0.3
+}

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -75,6 +75,7 @@ const makeCtx = () => {
 
 const readText = (filepath: string) => Effect.promise(() => fs.readFile(filepath, "utf-8"))
 const writeText = (filepath: string, content: string) => Effect.promise(() => fs.writeFile(filepath, content, "utf-8"))
+const writeBytes = (filepath: string, content: Uint8Array) => Effect.promise(() => fs.writeFile(filepath, content))
 const makeDir = (dir: string) => Effect.promise(() => fs.mkdir(dir, { recursive: true }))
 
 const expectFailure = <A, E, R>(effect: Effect.Effect<A, E, R>, message?: string) =>
@@ -363,6 +364,48 @@ describe("tool.apply_patch freeform", () => {
       const patchText = "*** Begin Patch\n*** Delete File: dir\n*** End Patch"
 
       yield* expectFailure(execute({ patchText }, ctx))
+    }),
+  )
+
+  it.instance("deletes binary files without embedding their contents in metadata", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx, calls } = makeCtx()
+      const target = path.join(test.directory, "archive.zip")
+      const content = new Uint8Array(128 * 1024)
+      content.set([0x50, 0x4b, 0x03, 0x04])
+      yield* writeBytes(target, content)
+
+      const result = yield* execute(
+        { patchText: "*** Begin Patch\n*** Delete File: archive.zip\n*** End Patch" },
+        ctx,
+      )
+
+      expect(result.metadata.diff.length).toBeLessThan(1024)
+      expect(result.metadata.files[0]?.patch.length).toBeLessThan(1024)
+      expect(calls[0]?.metadata.diff.length).toBeLessThan(1024)
+      expect(calls[0]?.metadata.files[0]?.patch.length).toBeLessThan(1024)
+      yield* expectReadFailure(target)
+    }),
+  )
+
+  it.instance("deletes oversized text files without embedding their contents in metadata", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx, calls } = makeCtx()
+      const target = path.join(test.directory, "large.txt")
+      yield* writeText(target, "x".repeat(1024 * 1024 + 1))
+
+      const result = yield* execute(
+        { patchText: "*** Begin Patch\n*** Delete File: large.txt\n*** End Patch" },
+        ctx,
+      )
+
+      expect(result.metadata.diff.length).toBeLessThan(1024)
+      expect(result.metadata.files[0]?.patch.length).toBeLessThan(1024)
+      expect(calls[0]?.metadata.diff.length).toBeLessThan(1024)
+      expect(calls[0]?.metadata.files[0]?.patch.length).toBeLessThan(1024)
+      yield* expectReadFailure(target)
     }),
   )
 

--- a/packages/opencode/test/tool/apply_patch.test.ts
+++ b/packages/opencode/test/tool/apply_patch.test.ts
@@ -2,6 +2,8 @@ import { describe, expect } from "bun:test"
 import path from "path"
 import * as fs from "fs/promises"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Cause, Effect, Exit, Layer, Schema } from "effect"
 import { ApplyPatchTool } from "../../src/tool/apply_patch"
@@ -10,14 +12,26 @@ import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Format } from "../../src/format"
 import { Agent } from "../../src/agent/agent"
 import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { MessageV2 } from "../../src/session/message-v2"
+import { Session as SessionNs } from "@/session/session"
 import { Truncate } from "@/tool/truncate"
 import { TestInstance } from "../fixture/fixture"
-import { SessionID, MessageID } from "../../src/session/schema"
+import { SessionID, MessageID, PartID } from "../../src/session/schema"
 import { testEffect } from "../lib/effect"
 
 const it = testEffect(
   LayerNode.compile(
-    LayerNode.group([LSP.node, FSUtil.node, Format.node, EventV2Bridge.node, Truncate.node, Agent.node]),
+    LayerNode.group([
+      LSP.node,
+      FSUtil.node,
+      Format.node,
+      EventV2Bridge.node,
+      Truncate.node,
+      Agent.node,
+      SessionNs.node,
+      MessageV2.node,
+      SessionProjector.node,
+    ]),
   ),
 )
 
@@ -376,10 +390,7 @@ describe("tool.apply_patch freeform", () => {
       content.set([0x50, 0x4b, 0x03, 0x04])
       yield* writeBytes(target, content)
 
-      const result = yield* execute(
-        { patchText: "*** Begin Patch\n*** Delete File: archive.zip\n*** End Patch" },
-        ctx,
-      )
+      const result = yield* execute({ patchText: "*** Begin Patch\n*** Delete File: archive.zip\n*** End Patch" }, ctx)
 
       expect(result.metadata.diff.length).toBeLessThan(1024)
       expect(result.metadata.files[0]?.patch.length).toBeLessThan(1024)
@@ -396,10 +407,7 @@ describe("tool.apply_patch freeform", () => {
       const target = path.join(test.directory, "large.txt")
       yield* writeText(target, "x".repeat(1024 * 1024 + 1))
 
-      const result = yield* execute(
-        { patchText: "*** Begin Patch\n*** Delete File: large.txt\n*** End Patch" },
-        ctx,
-      )
+      const result = yield* execute({ patchText: "*** Begin Patch\n*** Delete File: large.txt\n*** End Patch" }, ctx)
 
       expect(result.metadata.diff.length).toBeLessThan(1024)
       expect(result.metadata.files[0]?.patch.length).toBeLessThan(1024)
@@ -407,6 +415,171 @@ describe("tool.apply_patch freeform", () => {
       expect(calls[0]?.metadata.files[0]?.patch.length).toBeLessThan(1024)
       yield* expectReadFailure(target)
     }),
+  )
+
+  it.instance("deletes a 64 MiB file without embedding its contents in metadata", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx, calls } = makeCtx()
+      const target = path.join(test.directory, "huge_blob")
+      const content = new Uint8Array(64 * 1024 * 1024)
+      content.set([0x50, 0x4b, 0x03, 0x04])
+      yield* writeBytes(target, content)
+
+      const result = yield* execute({ patchText: "*** Begin Patch\n*** Delete File: huge_blob\n*** End Patch" }, ctx)
+
+      expect(result.metadata.diff).toContain("content diff omitted")
+      expect(result.metadata.diff).toContain("oversized file")
+      expect(result.metadata.diff).toContain("67108864")
+      expect(Buffer.byteLength(result.metadata.diff)).toBeLessThan(4096)
+      expect(Buffer.byteLength(result.metadata.files[0]?.patch ?? "")).toBeLessThan(4096)
+      expect(calls[0]?.metadata.diff).toBe(result.metadata.diff)
+      yield* expectReadFailure(target)
+    }),
+  )
+
+  it.instance("omits diffs for binary content without a binary extension", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx } = makeCtx()
+      const target = path.join(test.directory, "blob")
+      const content = new Uint8Array(16 * 1024).fill(0x41)
+      content[0] = 0
+      content[1] = 0
+      yield* writeBytes(target, content)
+
+      const result = yield* execute({ patchText: "*** Begin Patch\n*** Delete File: blob\n*** End Patch" }, ctx)
+
+      expect(result.metadata.diff).toContain("binary file")
+      expect(result.metadata.diff).toContain("content diff omitted")
+      expect(result.metadata.diff).toContain("16384")
+      expect(result.metadata.diff).not.toContain("AAAA")
+      yield* expectReadFailure(target)
+    }),
+  )
+
+  it.instance(
+    "bounds metadata across a multi-file patch with mixed sizes",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const { ctx, calls } = makeCtx()
+        const bigPath = path.join(test.directory, "big.txt")
+        const keepPath = path.join(test.directory, "keep.txt")
+        yield* writeText(bigPath, `${"x".repeat(2 * 1024 * 1024)}\n`)
+        yield* writeText(keepPath, "keep me\n")
+
+        const patchText = "*** Begin Patch\n*** Delete File: big.txt\n*** Delete File: keep.txt\n*** End Patch"
+
+        const result = yield* execute({ patchText }, ctx)
+
+        expect(result.metadata.files).toHaveLength(2)
+        const big = result.metadata.files.find((f) => f.relativePath === "big.txt")
+        const keep = result.metadata.files.find((f) => f.relativePath === "keep.txt")
+        expect(big?.patch).toContain("content diff omitted")
+        expect(keep?.patch).toContain("-keep me")
+        expect(Buffer.byteLength(result.metadata.diff)).toBeLessThan(8192)
+        expect(calls[0]?.metadata.diff).toBe(result.metadata.diff)
+        yield* expectReadFailure(bigPath)
+        yield* expectReadFailure(keepPath)
+      }),
+    { git: true },
+  )
+
+  it.instance("truncates the combined diff when per-file diffs exceed the aggregate cap", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx } = makeCtx()
+      const chunk = "y".repeat(900 * 1024)
+      const patchText = `*** Begin Patch\n*** Add File: a.txt\n+${chunk}\n*** Add File: b.txt\n+${chunk}\n*** Add File: c.txt\n+${chunk}\n*** End Patch`
+
+      const result = yield* execute({ patchText }, ctx)
+
+      expect(result.metadata.files).toHaveLength(3)
+      expect(Buffer.byteLength(result.metadata.diff)).toBeLessThanOrEqual(2 * 1024 * 1024 + 512)
+      expect(result.metadata.diff).toContain("[diff truncated")
+      for (const file of result.metadata.files) {
+        expect(file.patch).toContain("yyy")
+        expect(Buffer.byteLength(file.patch)).toBeLessThanOrEqual(1024 * 1024)
+      }
+    }),
+  )
+
+  it.instance("bounds the diff when updating a pathological single-line file", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const { ctx } = makeCtx()
+      const target = path.join(test.directory, "one_line.txt")
+      const giant = "x".repeat(2 * 1024 * 1024)
+      yield* writeText(target, `${giant}\n`)
+
+      const patchText = `*** Begin Patch\n*** Update File: one_line.txt\n@@\n-${giant}\n+replaced\n*** End Patch`
+
+      const result = yield* execute({ patchText }, ctx)
+
+      expect(result.metadata.files).toHaveLength(1)
+      const file = result.metadata.files[0]
+      expect(file?.patch).toContain("[diff truncated")
+      expect(file?.patch.includes("x".repeat(1000))).toBe(false)
+      expect(Buffer.byteLength(result.metadata.diff)).toBeLessThan(4096)
+      expect(yield* readText(target)).toBe("replaced\n")
+    }),
+  )
+
+  it.instance(
+    "persists bounded apply_patch metadata and reloads it through the session store",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const { ctx } = makeCtx()
+        const target = path.join(test.directory, "blob")
+        const content = new Uint8Array(16 * 1024).fill(0x41)
+        content[0] = 0
+        content[1] = 0
+        yield* writeBytes(target, content)
+
+        const result = yield* execute({ patchText: "*** Begin Patch\n*** Delete File: blob\n*** End Patch" }, ctx)
+
+        const session = yield* SessionNs.Service
+        const created = yield* session.create({})
+        const messageID = MessageID.ascending()
+        yield* session.updateMessage({
+          id: messageID,
+          sessionID: created.id,
+          role: "user",
+          time: { created: Date.now() },
+          agent: "test",
+          model: { providerID: "test", modelID: "test" },
+          tools: {},
+          mode: "",
+        } as unknown as SessionV1.Info)
+        yield* session.updatePart({
+          id: PartID.ascending(),
+          sessionID: created.id,
+          messageID,
+          type: "tool",
+          callID: "call_apply_patch",
+          tool: "apply_patch",
+          state: {
+            status: "completed",
+            input: { patchText: "*** Begin Patch\n*** Delete File: blob\n*** End Patch" },
+            output: result.output,
+            title: result.title,
+            metadata: result.metadata,
+            time: { start: Date.now(), end: Date.now() },
+          },
+        })
+
+        const page = yield* MessageV2.page({ sessionID: created.id, limit: 10 })
+        const toolPart = page.items.flatMap((item) => item.parts).find((part) => part.type === "tool")
+        expect(toolPart).toBeDefined()
+        const state = (toolPart as SessionV1.ToolPart).state
+        expect(state.status).toBe("completed")
+        const persisted = Buffer.byteLength(JSON.stringify(state))
+        expect(persisted).toBeLessThan(8192)
+        expect(JSON.stringify(state)).toContain("content diff omitted")
+      }),
+    { git: true },
   )
 
   it.instance("rejects invalid hunk header", () =>


### PR DESCRIPTION
# fix(opencode): bound apply patch diff metadata

Closes #41733. Builds on and supersedes #41734.

## Root cause

`apply_patch` persisted every file diff twice in tool metadata: once in
`metadata.diff` (combined) and once in `metadata.files[].patch`. For a delete,
the "diff" is the entire old file content, so deleting one large or binary file
(for example a 64 MiB archive or a `.bin` blob full of NUL bytes) wrote
hundreds of megabytes of binary text into:

- the permission request metadata,
- the completed tool part (`part` table),
- every durable `message.part.updated.1` event emitted while the part streamed
  (`event` table).

In real sessions this grew `opencode.db` past 2.5 GiB, and the Desktop sidecar
died with exit code 5 while rehydrating the session, which surfaced in the UI
as `TypeError: Failed to fetch` in `fetchMessages/loadMessages`.

#41734 already stops the worst case for deletes by checking the extension,
file size, and a content sniff before reading. This PR keeps that behavior and
closes the remaining holes:

- Only deletes were protected. An `add`/`update`/`move` can still produce a
  pathological diff (for example a single-line file with no newlines, where
  `diffLines` treats the whole blob as one change).
- The combined `metadata.diff` was unbounded regardless of per-file limits, so
  a multi-file patch could still aggregate gigabytes.
- The omission marker did not say why content was omitted.

## What this PR does

1. Commit 1 (from #41734): extract `isBinaryFile` into
   `packages/opencode/src/util/binary.ts`, and for deletes check extension,
   `stat.size`, and content NUL/printable ratio before reading; omit the
   content diff when binary or larger than 1 MiB.
2. Commit 2: add a final safety net for every change type. Each per-file diff
   is bounded to `MAX_DIFF_BYTES` (1 MiB) and the combined diff to
   `MAX_TOTAL_DIFF_BYTES` (2 MiB), with explicit markers:
   - `binary file deleted (N bytes; content diff omitted)`
   - `oversized file deleted (N bytes; content diff omitted)`
   - `[diff truncated: showing first N of M bytes]`

Truncation happens at line boundaries, so consumers never see a half-written
hunk; a single line larger than the cap is dropped entirely in favor of the
marker. The metadata always stays valid UTF-8 and JSON-encodable. The UI
degrades to a short marker instead of a crash; the actual file operation
result is unchanged.

## Tests

`packages/opencode/test/tool/apply_patch.test.ts`, 35 passing:

- deletes a 64 MiB file without embedding its contents in metadata (marker
  contains the exact byte count, both result and permission metadata bounded,
  file removed)
- omits diffs for binary content without a binary extension (content sniffing,
  not just extensions)
- bounds metadata across a multi-file patch with mixed sizes (small file keeps
  its real diff, large file gets the marker, permission metadata equals result
  metadata)
- truncates the combined diff when per-file diffs exceed the aggregate cap
  (per-file diffs stay intact, combined diff capped at 2 MiB + marker)
- persists bounded apply_patch metadata and reloads it through the session
  store (`Session.updatePart` -> SQLite -> `MessageV2.page`; persisted tool
  state stays under 8 KiB)
- all pre-existing tests, including the #41734 binary/oversized delete cases
  and the `PermissionV1` JSON-encodability check

Verification commands (from `packages/opencode`):

```
bun test test/tool/apply_patch.test.ts --timeout 60000
bun test test/tool/read.test.ts --timeout 60000
bun typecheck
```

## Compatibility risks

- `metadata.diff` and `metadata.files[].patch` can now contain omission
  markers instead of full content. Consumers that parse these strings as
  unified diffs (UI diff renderers, external tooling reading tool metadata)
  will see a short `Index:`-style block or a truncated diff with an explicit
  marker. No schema change: both fields remain strings.
- `deletions` is `0` for omitted deletes (we intentionally do not read the
  file just to count lines). Consumers relying on exact deletion line counts
  for deleted oversized/binary files will see 0; the byte size is in the
  marker.
- Existing sessions written by older versions keep their oversized rows; the
  fix is write-side only and does not migrate data.

## Migration plan for existing databases

The fix prevents new bloat. Databases already affected need a one-time
cleanup, run with the server stopped:

```sql
-- 1. Inspect oversized tool parts first
SELECT id, length(data) FROM part
WHERE type = 'tool' AND length(data) > 1000000
ORDER BY length(data) DESC;

-- 2a. Surgical: replace the combined diff only
-- (keeps the file list, diagnostics, and output)
UPDATE part
SET data = json_set(data, '$.state.metadata.diff',
  '[removed: oversized or binary delete diff]')
WHERE id IN (...);

-- 2b. Nuclear: parts still oversized after 2a carry bloat inside
-- state.metadata.files[].patch. Replace the whole metadata block
-- (loses the per-file list and diagnostics; keeps output).
-- Review the ids from step 1 first; narrow the WHERE to those ids
-- if any legitimate large-output parts show up.
UPDATE part
SET data = json_set(data, '$.state.metadata',
  json_object('diff', '[removed: oversized apply_patch metadata]'))
WHERE type = 'tool' AND length(data) > 1000000;

DELETE FROM event WHERE type = 'message.part.updated.1';
VACUUM;
```

Longer term, bounded event-log compaction would help every tool, not just
`apply_patch` (see #33356 and the closed #36710, closed only by automated
cleanup criteria, plus #40861/#42771 which address related summary-diff
payloads). Happy to split that into a separate PR if preferred.
