### PR TITLE
feat(session-ui): expose reasoning and tool details behind collapsible block

### DIFF
--- a/packages/app/src/pages/session/timeline/reasoning-visibility.test.ts
+++ b/packages/app/src/pages/session/timeline/reasoning-visibility.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, mock, test } from "bun:test"
+import type { SessionMessageInfo } from "@opencode-ai/client/promise"
+import { normalizeSessionMessages } from "@/utils/session-message"
+
+// The real module pulls in a Vite worker import (markdown.worker.ts?worker&url)
+// that cannot resolve outside a bundler. These stubs mirror the actual exported
+// renderable() and groupParts() logic for the part types exercised in these tests.
+mock.module("@opencode-ai/session-ui/message-part", () => ({
+  renderable: (part: { type: string; text?: string; tool?: string; state?: { status?: string } }, showReasoning?: boolean) => {
+    if (part.type === "tool") {
+      if (part.tool === "question") return part.state?.status !== "pending" && part.state?.status !== "running"
+      return true
+    }
+    if (part.type === "text") return !!part.text?.trim()
+    if (part.type === "reasoning") return (showReasoning ?? true) && !!part.text?.trim()
+    return false
+  },
+  groupParts: (refs: Array<{ messageID: string; part: { id: string } }>) =>
+    refs.map((ref) => ({
+      type: "part" as const,
+      key: ref.part.id,
+      ref: { messageID: ref.messageID, partID: ref.part.id },
+    })),
+}))
+
+const { Timeline, TimelineRow } = await import("./rows")
+
+describe("reasoning visibility in timeline rows", () => {
+  test("hides reasoning parts when showReasoningSummaries is false", () => {
+    const source = [
+      { id: "msg_1", type: "user", text: "first", time: { created: 1 } },
+      {
+        id: "msg_2",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [{ type: "reasoning", text: "thinking process" }],
+        time: { created: 2, completed: 3 },
+      },
+    ] satisfies SessionMessageInfo[]
+    const normalized = normalizeSessionMessages("ses_1", source)
+    const messages = new Map(normalized.messages.map((message) => [message.id, message]))
+
+    const result = Timeline.constructSessionMessageRows(
+      source,
+      (messageID) => messages.get(messageID),
+      (messageID) => normalized.parts.get(messageID) ?? [],
+      false,
+      "idle",
+      true,
+      normalized.messages.filter((message) => message.role === "user"),
+    )
+
+    expect(result.rows.map(TimelineRow.key)).toEqual(["user-message:msg_1"])
+  })
+
+  test("shows reasoning parts when showReasoningSummaries is true", () => {
+    const source = [
+      { id: "msg_1", type: "user", text: "first", time: { created: 1 } },
+      {
+        id: "msg_2",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [{ type: "reasoning", text: "let me think about this" }],
+        time: { created: 2, completed: 3 },
+      },
+      {
+        id: "msg_3",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [{ type: "text", text: "answer" }],
+        time: { created: 4, completed: 5 },
+      },
+    ] satisfies SessionMessageInfo[]
+    const normalized = normalizeSessionMessages("ses_1", source)
+    const messages = new Map(normalized.messages.map((message) => [message.id, message]))
+
+    const result = Timeline.constructSessionMessageRows(
+      source,
+      (messageID) => messages.get(messageID),
+      (messageID) => normalized.parts.get(messageID) ?? [],
+      true,
+      "idle",
+      true,
+      normalized.messages.filter((message) => message.role === "user"),
+    )
+
+    expect(result.rows.map(TimelineRow.key)).toEqual([
+      "user-message:msg_1",
+      "assistant-part:msg_1:msg_2:reasoning:0",
+      "assistant-part:msg_1:msg_3:text:0",
+    ])
+  })
+
+  test("reasoning parts are shown as AssistantPart rows for toggle rendering", () => {
+    const source = [
+      { id: "msg_1", type: "user", text: "first", time: { created: 1 } },
+      {
+        id: "msg_2",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [
+          { type: "reasoning", text: "analyzing the problem" },
+          { type: "text", text: "solution" },
+        ],
+        time: { created: 2, completed: 3 },
+      },
+    ] satisfies SessionMessageInfo[]
+    const normalized = normalizeSessionMessages("ses_1", source)
+    const messages = new Map(normalized.messages.map((message) => [message.id, message]))
+
+    const result = Timeline.constructSessionMessageRows(
+      source,
+      (messageID) => messages.get(messageID),
+      (messageID) => normalized.parts.get(messageID) ?? [],
+      true,
+      "idle",
+      true,
+      normalized.messages.filter((message) => message.role === "user"),
+    )
+
+    const reasoningRow = result.rows.find(
+      (row): row is InstanceType<typeof TimelineRow.AssistantPart> =>
+        row._tag === "AssistantPart" && row.group.type === "part" && row.group.key.includes("reasoning"),
+    )
+    expect(reasoningRow).toBeDefined()
+    expect(reasoningRow!.group.type).toBe("part")
+  })
+
+  test("showThinking row appears during busy status with no reasoning parts yet", () => {
+    const source = [
+      { id: "msg_1", type: "user", text: "first", time: { created: 1 } },
+    ] satisfies SessionMessageInfo[]
+    const normalized = normalizeSessionMessages("ses_1", source)
+
+    const result = Timeline.constructSessionMessageRows(
+      source,
+      () => normalized.messages.find((m) => m.id === "msg_1"),
+      () => [],
+      true,
+      "busy",
+      true,
+      normalized.messages.filter((message) => message.role === "user"),
+    )
+
+    const thinkingRow = result.rows.find((row) => row._tag === "Thinking")
+    expect(thinkingRow).toBeDefined()
+  })
+})

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -1758,17 +1758,32 @@ PART_MAPPING["text"] = function TextPartDisplay(props) {
 
 PART_MAPPING["reasoning"] = function ReasoningPartDisplay(props) {
   const data = useData()
+  const i18n = useI18n()
   const part = () => props.part as ReasoningPart
   const streaming = createMemo(
     () => props.message.role === "assistant" && typeof (props.message as AssistantMessage).time.completed !== "number",
   )
   const text = () => readPartText(data.store.part_text_accum_delta, part())
+  const pending = () => streaming()
 
   return (
     <Show when={text()}>
-      <div data-component="reasoning-part" data-timeline-part-id={part().id}>
-        <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />
-      </div>
+      <BasicTool
+        icon="brain"
+        status={pending() ? "running" : undefined}
+        defaultOpen={false}
+        open={props.toolOpen}
+        onOpenChange={props.onToolOpenChange}
+        allowOpenWhilePending
+        trigger={{
+          title: i18n.t("ui.sessionTurn.status.thinking"),
+          subtitle: undefined,
+        }}
+      >
+        <div data-component="reasoning-part" data-timeline-part-id={part().id}>
+          <PacedMarkdown text={text()} cacheKey={part().id} streaming={streaming()} />
+        </div>
+      </BasicTool>
     </Show>
   )
 }
@@ -1915,7 +1930,6 @@ ToolRegistry.register({
     return (
       <BasicTool
         {...props}
-        hideDetails
         icon="window-cursor"
         trigger={
           <div data-slot="basic-tool-tool-info-structured">
@@ -1943,7 +1957,19 @@ ToolRegistry.register({
             </Show>
           </div>
         }
-      />
+      >
+        <Show when={props.output}>
+          <div
+            data-component="tool-output"
+            data-scrollable
+            tabIndex={0}
+            role="region"
+            aria-label={i18n.t("ui.scrollView.ariaLabel")}
+          >
+            <Markdown text={props.output!} />
+          </div>
+        </Show>
+      </BasicTool>
     )
   },
 })
@@ -2016,7 +2042,7 @@ ToolRegistry.register({
       open()
     }
     const navigateKey = (event: KeyboardEvent) => {
-      if (!clickable() || href()) return
+      if (!clickable()) return
       if (event.key !== "Enter" && event.key !== " ") return
       event.preventDefault()
       open()
@@ -2059,9 +2085,20 @@ ToolRegistry.register({
           </div>
         </div>
         <Show when={clickable()}>
-          <div data-component="task-tool-action">
+          <a
+            data-component="task-tool-action"
+            href={href()}
+            onClick={(e) => {
+              e.stopPropagation()
+              navigate(e)
+            }}
+            onKeyDown={(e) => {
+              e.stopPropagation()
+              navigateKey(e)
+            }}
+          >
             <Icon name="square-arrow-top-right" size="small" />
-          </div>
+          </a>
         </Show>
       </div>
     )
@@ -2071,13 +2108,20 @@ ToolRegistry.register({
         icon="task"
         status={props.status}
         trigger={trigger()}
-        hideDetails
-        triggerAsLink
-        triggerHref={href()}
         clickable={clickable()}
-        onTriggerClick={navigate}
-        onTriggerKeyDown={navigateKey}
-      />
+      >
+        <Show when={props.output}>
+          <div
+            data-component="tool-output"
+            data-scrollable
+            tabIndex={0}
+            role="region"
+            aria-label={i18n.t("ui.scrollView.ariaLabel")}
+          >
+            <Markdown text={props.output!} />
+          </div>
+        </Show>
+      </BasicTool>
     )
   },
 })
@@ -2637,6 +2681,20 @@ ToolRegistry.register({
       </div>
     )
 
-    return <BasicTool icon="brain" status={props.status} trigger={trigger()} hideDetails />
+    return (
+      <BasicTool icon="brain" status={props.status} trigger={trigger()}>
+        <Show when={props.output}>
+          <div
+            data-component="tool-output"
+            data-scrollable
+            tabIndex={0}
+            role="region"
+            aria-label={i18n.t("ui.scrollView.ariaLabel")}
+          >
+            <Markdown text={props.output!} />
+          </div>
+        </Show>
+      </BasicTool>
+    )
   },
 })

--- a/packages/session-ui/src/components/message-part.tsx
+++ b/packages/session-ui/src/components/message-part.tsx
@@ -2056,7 +2056,23 @@ ToolRegistry.register({
           "--task-agent-legacy-color": tone(),
         }}
       >
-        <div data-component="task-tool-surface">
+        <div
+          data-component="task-tool-surface"
+          role={clickable() ? "button" : undefined}
+          tabIndex={clickable() ? 0 : undefined}
+          onClick={(e) => {
+            if (clickable()) {
+              e.stopPropagation()
+              navigate(e)
+            }
+          }}
+          onKeyDown={(e) => {
+            if (clickable()) {
+              e.stopPropagation()
+              navigateKey(e)
+            }
+          }}
+        >
           <div data-slot="basic-tool-tool-info-structured">
             <div data-slot="basic-tool-tool-info-main">
               <Show
@@ -2105,8 +2121,8 @@ ToolRegistry.register({
 
     return (
       <BasicTool
+        {...props}
         icon="task"
-        status={props.status}
         trigger={trigger()}
         clickable={clickable()}
       >

--- a/packages/session-ui/src/components/part-default-open.test.ts
+++ b/packages/session-ui/src/components/part-default-open.test.ts
@@ -44,6 +44,26 @@ describe("partDefaultOpen", () => {
   test("preserves shell defaults", () => {
     expect(partDefaultOpen(tool("shell", {}), true, false)).toBe(true)
   })
+
+  test("returns undefined for reasoning parts (not a tool)", () => {
+    expect(partDefaultOpen(reasoning("thinking content"), false, false)).toBeUndefined()
+  })
+
+  test("returns undefined for text parts", () => {
+    expect(partDefaultOpen(text("hello"), false, false)).toBeUndefined()
+  })
+
+  test("returns undefined for webfetch tool (no special default)", () => {
+    expect(partDefaultOpen(tool("webfetch", {}), false, false)).toBeUndefined()
+  })
+
+  test("returns undefined for skill tool (no special default)", () => {
+    expect(partDefaultOpen(tool("skill", {}), false, false)).toBeUndefined()
+  })
+
+  test("returns undefined for task tool (no special default)", () => {
+    expect(partDefaultOpen(tool("task", {}), false, false)).toBeUndefined()
+  })
 })
 
 function tool(name: string, metadata: Record<string, unknown>): PartType {
@@ -62,5 +82,27 @@ function tool(name: string, metadata: Record<string, unknown>): PartType {
       metadata,
       time: { start: 0, end: 1 },
     },
+  }
+}
+
+function reasoning(text: string): PartType {
+  return {
+    id: "part_reasoning",
+    sessionID: "session",
+    messageID: "message",
+    type: "reasoning",
+    text,
+    time: { start: 0, end: 1 },
+  }
+}
+
+function text(text: string): PartType {
+  return {
+    id: "part_text",
+    sessionID: "session",
+    messageID: "message",
+    type: "text",
+    text,
+    time: { start: 0, end: 1 },
   }
 }


### PR DESCRIPTION
### Issue for this PR

Closes #21549, #21548

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

1. Wraps model reasoning parts in a collapsible `BasicTool` card titled "Thinking" with brain icon and live status.
2. Sets `allowOpenWhilePending` on reasoning cards so users can expand thinking output while the assistant streams.
3. Preserves user open/close toggle state across virtualized list scroll and remounts via `props.toolOpen` and `props.onToolOpenChange`.
4. Enables collapsible output viewing for `webfetch`, `task`, and `skill` tools while keeping direct task subsession navigation on the arrow action link.
5. Adds tests for reasoning visibility and default open state.

### How did you verify your code works?

- Ran `bun test packages/app/src/pages/session/timeline/reasoning-visibility.test.ts`.
- Ran `bun turbo run typecheck`.
- Tested expanding reasoning while streaming and after scrolling.

### Screenshots / recordings

_N/A_

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR