### PR TITLE
fix(app): improve path separator handling and directory tab completion in project picker

### DIFF
--- a/packages/app/src/components/dialog-select-directory-v2.tsx
+++ b/packages/app/src/components/dialog-select-directory-v2.tsx
@@ -162,7 +162,7 @@ export function DialogSelectDirectoryV2(props: DialogSelectDirectoryV2Props) {
     setSuggestionsOpen(false)
     setActiveSuggestion(-1)
     setRoot(value)
-    setInput(displayPickerPath(value, value, home()))
+    setInput(displayPickerPath(value, "", home()))
     listings.clear()
     advanced.clear()
     tree?.resetPaths([])
@@ -172,19 +172,6 @@ export function DialogSelectDirectoryV2(props: DialogSelectDirectoryV2Props) {
     setLoading(false)
   }
 
-  function complete() {
-    const items = currentSuggestions()
-    const match = items[activeSuggestion()] ?? items[0]
-    if (!match) return
-    const value = displayPickerPath(match.absolute, input(), home())
-    setInput(match.type === "directory" && !value.endsWith("/") ? value + "/" : value)
-    if (match.type === "file") {
-      setSelected(policy.selection(root(), pickerFileSearchQuery(root(), match.absolute, home())) ?? "")
-      setSuggestionsOpen(false)
-      setActiveSuggestion(-1)
-    }
-  }
-
   function chooseSuggestion(suggestion: { absolute: string; type: "file" | "directory" }) {
     if (suggestion.type === "directory") {
       void navigate(suggestion.absolute)
@@ -192,8 +179,7 @@ export function DialogSelectDirectoryV2(props: DialogSelectDirectoryV2Props) {
     }
     setInput(displayPickerPath(suggestion.absolute, input(), home()))
     setSelected(policy.selection(root(), pickerFileSearchQuery(root(), suggestion.absolute, home())) ?? "")
-    setSuggestionsOpen(false)
-    setActiveSuggestion(-1)
+    resolve()
   }
 
   function moveSuggestion(delta: -1 | 1) {
@@ -212,9 +198,9 @@ export function DialogSelectDirectoryV2(props: DialogSelectDirectoryV2Props) {
     Enter: () => {
       const suggestion = activeSuggestionValue()
       if (suggestion) chooseSuggestion(suggestion)
-      if (!suggestion) void navigate(input())
+      else void navigate(input())
     },
-    Tab: complete,
+    Tab: () => moveSuggestion(1),
   }
 
   function handleInputKey(event: KeyboardEvent) {

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -8,7 +8,14 @@ import { createMemo, createResource, createSignal } from "solid-js"
 import { useLanguage } from "@/context/language"
 import { ServerConnection } from "@/context/server"
 import { useGlobal } from "@/context/global"
-import { cleanPickerInput, createDirectorySearch, displayPickerPath } from "./directory-picker-domain"
+import {
+  cleanPickerInput,
+  createDirectorySearch,
+  displayPickerPath,
+  pickerAbsoluteInput,
+  pickerTabCompletions,
+  pickerTabTargetDirectory,
+} from "./directory-picker-domain"
 import type { Path } from "@opencode-ai/sdk/v2/client"
 
 interface DialogSelectDirectoryProps {
@@ -58,6 +65,7 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
 
   const [filter, setFilter] = createSignal("")
   let list: ListRef | undefined
+  let cycle: { items: string[]; index: number } | undefined
 
   const missingHome = createMemo(() => !sync.data.path.home)
   const [fallbackPath] = createResource(
@@ -147,17 +155,71 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
           group.category === "recent" ? language.t("home.recentProjects") : language.t("command.project.open")
         }
         ref={(r) => (list = r)}
-        onFilter={(value) => setFilter(cleanPickerInput(value))}
-        onKeyEvent={(e, item) => {
-          if (e.key !== "Tab") return
-          if (e.shiftKey) return
-          if (!item) return
+        onFilter={(value) => {
+          const cleaned = cleanPickerInput(value)
+          if (cycle && cleaned !== cycle.items[cycle.index]) {
+            cycle = undefined
+          }
+          setFilter(cleaned)
+        }}
+        onKeyEvent={async (e, item) => {
+          if (e.key === "Tab" && !e.shiftKey) {
+            e.preventDefault()
+            e.stopPropagation()
 
-          e.preventDefault()
-          e.stopPropagation()
+            const current = filter()
+            if (cycle && cycle.items.length > 0 && current === cycle.items[cycle.index]) {
+              cycle.index = (cycle.index + 1) % cycle.items.length
+              list?.setFilter(cycle.items[cycle.index])
+              return
+            }
 
-          const value = displayPickerPath(item.absolute, filter(), home())
-          list?.setFilter(value.endsWith("/") ? value : value + "/")
+            const target = pickerTabTargetDirectory({
+              input: current,
+              home: home(),
+              base: start(),
+            })
+
+            const entries = await sdk.api.file
+              .list({ location: { directory: target } })
+              .then((result) =>
+                result.data
+                  .filter((entry) => entry.type === "directory")
+                  .map((entry) => getFilename(entry.path.replace(/[\\/]+$/, ""))),
+              )
+              .catch(() => [])
+
+            // Bail if the user typed while the async list was in flight.
+            if (filter() !== current) return
+
+            const completions = pickerTabCompletions({
+              input: current,
+              home: home(),
+              base: start(),
+              directories: entries,
+            })
+
+            if (completions.length === 0) return
+
+            if (completions.length > 1) {
+              cycle = {
+                items: completions,
+                index: 0,
+              }
+            } else {
+              cycle = undefined
+            }
+            list?.setFilter(completions[0])
+            return
+          }
+
+          if (e.key === "Enter" && !e.isComposing && !item) {
+            const current = filter()
+            if (!current) return
+            e.preventDefault()
+            const absolute = pickerAbsoluteInput(current, home(), start() ?? home())
+            resolve(absolute)
+          }
         }}
         onSelect={(path) => {
           if (!path) return

--- a/packages/app/src/components/dialog-select-directory.tsx
+++ b/packages/app/src/components/dialog-select-directory.tsx
@@ -15,6 +15,7 @@ import {
   pickerAbsoluteInput,
   pickerTabCompletions,
   pickerTabTargetDirectory,
+  trimPickerPath,
 } from "./directory-picker-domain"
 import type { Path } from "@opencode-ai/sdk/v2/client"
 
@@ -174,13 +175,13 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
               return
             }
 
-            const target = pickerTabTargetDirectory({
+            let target = pickerTabTargetDirectory({
               input: current,
               home: home(),
               base: start(),
             })
 
-            const entries = await sdk.api.file
+            let entries = await sdk.api.file
               .list({ location: { directory: target } })
               .then((result) =>
                 result.data
@@ -192,12 +193,51 @@ export function DialogSelectDirectory(props: DialogSelectDirectoryProps) {
             // Bail if the user typed while the async list was in flight.
             if (filter() !== current) return
 
-            const completions = pickerTabCompletions({
+            let completions = pickerTabCompletions({
               input: current,
               home: home(),
               base: start(),
               directories: entries,
             })
+
+            // When pressing tab on an exact single directory without trailing slash,
+            // shift into that directory to complete its subdirectories.
+            const isWindows =
+              /^[A-Za-z]:\//.test(trimPickerPath(home())) ||
+              (start() ? /^[A-Za-z]:\//.test(trimPickerPath(start()!)) : false) ||
+              current.includes("\\")
+            const sep = current.includes("\\") || (isWindows && !current.includes("/")) ? "\\" : "/"
+
+            if (
+              completions.length === 1 &&
+              completions[0] === current &&
+              !current.endsWith("/") &&
+              !current.endsWith("\\")
+            ) {
+              target = pickerTabTargetDirectory({
+                input: `${current}${sep}`,
+                home: home(),
+                base: start(),
+              })
+
+              entries = await sdk.api.file
+                .list({ location: { directory: target } })
+                .then((result) =>
+                  result.data
+                    .filter((entry) => entry.type === "directory")
+                    .map((entry) => getFilename(entry.path.replace(/[\\/]+$/, ""))),
+                )
+                .catch(() => [])
+
+              if (filter() !== current) return
+
+              completions = pickerTabCompletions({
+                input: `${current}${sep}`,
+                home: home(),
+                base: start(),
+                directories: entries,
+              })
+            }
 
             if (completions.length === 0) return
 

--- a/packages/app/src/components/directory-picker-domain.test.ts
+++ b/packages/app/src/components/directory-picker-domain.test.ts
@@ -406,14 +406,14 @@ test("pickerTabTargetDirectory determines the absolute directory to list for Tab
 test("pickerTabCompletions completes folders up to next slash and supports cycling", () => {
   const homeDirs = ["Documents", "Downloads", "Desktop", "Music", "Pictures"]
 
-  // Prefix match in home directory
+  // Prefix match in home directory (no trailing slash added)
   expect(
     pickerTabCompletions({
       input: "~/Doc",
       home: "/home/luke",
       directories: homeDirs,
     }),
-  ).toEqual(["~/Documents/"])
+  ).toEqual(["~/Documents"])
 
   // Multiple matches returned in alphabetical order for cycling
   expect(
@@ -422,9 +422,9 @@ test("pickerTabCompletions completes folders up to next slash and supports cycli
       home: "/home/luke",
       directories: homeDirs,
     }),
-  ).toEqual(["~/Desktop/", "~/Documents/", "~/Downloads/"])
+  ).toEqual(["~/Desktop", "~/Documents", "~/Downloads"])
 
-  // Empty prefix inside directory expands all child folders
+  // When user adds trailing slash, expands all child folders
   const docDirs = ["work", "personal", "archive"]
   expect(
     pickerTabCompletions({
@@ -432,7 +432,7 @@ test("pickerTabCompletions completes folders up to next slash and supports cycli
       home: "/home/luke",
       directories: docDirs,
     }),
-  ).toEqual(["~/Documents/archive/", "~/Documents/personal/", "~/Documents/work/"])
+  ).toEqual(["~/Documents/archive", "~/Documents/personal", "~/Documents/work"])
 
   // Prefix inside subfolder
   expect(
@@ -441,41 +441,41 @@ test("pickerTabCompletions completes folders up to next slash and supports cycli
       home: "/home/luke",
       directories: docDirs,
     }),
-  ).toEqual(["~/Documents/work/"])
+  ).toEqual(["~/Documents/work"])
 
-  // Windows backslash path preserves backslashes
+  // Windows backslash path preserves backslashes without trailing slash
   expect(
     pickerTabCompletions({
       input: "C:\\Users\\luke\\D",
       home: "C:/Users/luke",
       directories: homeDirs,
     }),
-  ).toEqual(["C:\\Users\\luke\\Desktop\\", "C:\\Users\\luke\\Documents\\", "C:\\Users\\luke\\Downloads\\"])
+  ).toEqual(["C:\\Users\\luke\\Desktop", "C:\\Users\\luke\\Documents", "C:\\Users\\luke\\Downloads"])
 
-  // Multi-step tab navigation: single match completes folder with trailing slash,
-  // then next step targets the completed folder to explore its subdirectories
+  // Multi-step tab navigation:
+  // 1. Single match completes folder without trailing slash
   const dir1Children = ["Dir2"]
   const firstStep = pickerTabCompletions({
     input: "/Dir1/Di",
     home: "/home/luke",
     directories: dir1Children,
   })
-  expect(firstStep).toEqual(["/Dir1/Dir2/"])
+  expect(firstStep).toEqual(["/Dir1/Dir2"])
 
-  // Next tab targets /Dir1/Dir2 directly because input ends with /
+  // 2. When user adds slash (or re-presses tab), targets /Dir1/Dir2/ to explore subdirectories
   const nextTarget = pickerTabTargetDirectory({
-    input: firstStep[0],
+    input: `${firstStep[0]}/`,
     home: "/home/luke",
   })
   expect(nextTarget).toBe("/Dir1/Dir2")
 
   const dir2Children = ["subA", "subB"]
   const secondStep = pickerTabCompletions({
-    input: firstStep[0],
+    input: `${firstStep[0]}/`,
     home: "/home/luke",
     directories: dir2Children,
   })
-  expect(secondStep).toEqual(["/Dir1/Dir2/subA/", "/Dir1/Dir2/subB/"])
+  expect(secondStep).toEqual(["/Dir1/Dir2/subA", "/Dir1/Dir2/subB"])
 
   // Tilde alone expands all home directories
   expect(
@@ -484,5 +484,5 @@ test("pickerTabCompletions completes folders up to next slash and supports cycli
       home: "/home/luke",
       directories: ["Desktop", "Documents"],
     }),
-  ).toEqual(["~/Desktop/", "~/Documents/"])
+  ).toEqual(["~/Desktop", "~/Documents"])
 })

--- a/packages/app/src/components/directory-picker-domain.test.ts
+++ b/packages/app/src/components/directory-picker-domain.test.ts
@@ -20,6 +20,7 @@ import {
   pickerParent,
   pickerRoot,
   pickerAbsoluteInput,
+  normalizePickerPath,
 } from "./directory-picker-domain"
 
 test("maps server directory entries into Pierre paths", () => {
@@ -95,9 +96,7 @@ test("preserves POSIX case while matching Windows drives case-insensitively", ()
 })
 
 test("displays paths using the selected server path format", () => {
-  expect(displayPickerPath("C:/Users/luke/repos", "C:/Users/luke/repos", "C:/Users/luke")).toBe(
-    "C:\\Users\\luke\\repos",
-  )
+  expect(displayPickerPath("C:/Users/luke/repos", "C:/Users/luke/repos", "C:/Users/luke")).toBe("C:/Users/luke/repos")
   expect(displayPickerPath("C:/Users/luke/repos", "C:\\Users\\luke\\repos", "C:/Users/luke")).toBe(
     "C:\\Users\\luke\\repos",
   )
@@ -307,4 +306,53 @@ test("returns absolute directories and relative files", () => {
   expect(selectedTreePath("/home/luke/repo", "src/index.ts", "file")).toBe("src/index.ts")
   expect(selectedTreePath("/home/luke/repo/src", "index.ts", "file", "/home/luke/repo")).toBe("src/index.ts")
   expect(selectedTreePath("/home/luke/repo", "src/", "file")).toBeUndefined()
+})
+
+test("preserves forward-slash input style on Windows paths", () => {
+  // User typed forward slashes → display preserves them
+  expect(displayPickerPath("C:/Users/luke/projects", "C:/Users/luke/pro", "C:/Users/luke")).toBe(
+    "C:/Users/luke/projects",
+  )
+  expect(displayPickerPath("C:/Users/luke/projects", "C:/Users/luke/projects", "C:/Users/luke")).toBe(
+    "C:/Users/luke/projects",
+  )
+})
+
+test("preserves backslash input style on Windows paths", () => {
+  // User typed backslashes → display preserves them
+  expect(displayPickerPath("C:/Users/luke/projects", "C:\\Users\\luke\\pro", "C:/Users/luke")).toBe(
+    "C:\\Users\\luke\\projects",
+  )
+  expect(displayPickerPath("C:/Users/luke/projects", "C:\\Users\\luke\\projects", "C:/Users/luke")).toBe(
+    "C:\\Users\\luke\\projects",
+  )
+})
+
+test("defaults to backslash display for empty input on Windows", () => {
+  // Empty input (initial navigation) → backslash on Windows
+  expect(displayPickerPath("C:/Users/luke/projects", "", "C:/Users/luke")).toBe("C:\\Users\\luke\\projects")
+})
+
+test("preserves UNC path separator style from input", () => {
+  // UNC paths without a tilde-convertible home keep their separators
+  expect(displayPickerPath("//Server/Share/repo", "//Server/Share/repo", "//Other")).toBe("//Server/Share/repo")
+  expect(displayPickerPath("//Server/Share/repo", "\\\\Server\\Share\\repo", "//Other")).toBe(
+    "\\\\Server\\Share\\repo",
+  )
+})
+
+test("normalizes backslash input to forward slash for internal search", () => {
+  // normalizePickerPath always converts \ to /
+  expect(normalizePickerPath("C:\\Users\\luke\\projects")).toBe("C:/Users/luke/projects")
+  expect(normalizePickerPath("C:/Users/luke/projects")).toBe("C:/Users/luke/projects")
+  expect(normalizePickerPath("\\\\Server\\Share\\repo")).toBe("//Server/Share/repo")
+})
+
+test("pickerAbsoluteInput resolves Windows backslash relative paths", () => {
+  expect(pickerAbsoluteInput("src\\components", "C:/Users/luke", "C:/Users/luke/repo")).toBe(
+    "C:/Users/luke/repo/src/components",
+  )
+  expect(pickerAbsoluteInput("C:\\Users\\luke\\projects", "C:/Users/luke", "C:/Users/luke/repo")).toBe(
+    "C:/Users/luke/projects",
+  )
 })

--- a/packages/app/src/components/directory-picker-domain.test.ts
+++ b/packages/app/src/components/directory-picker-domain.test.ts
@@ -21,6 +21,9 @@ import {
   pickerRoot,
   pickerAbsoluteInput,
   normalizePickerPath,
+  splitPickerPath,
+  pickerTabTargetDirectory,
+  pickerTabCompletions,
 } from "./directory-picker-domain"
 
 test("maps server directory entries into Pierre paths", () => {
@@ -308,6 +311,22 @@ test("returns absolute directories and relative files", () => {
   expect(selectedTreePath("/home/luke/repo", "src/", "file")).toBeUndefined()
 })
 
+test("resolves directory suggestion as the native project path", () => {
+  const directory = pickerMode("directory")
+  expect(directory.result("/home/luke/projects/myapp", "", true)).toBe("/home/luke/projects/myapp")
+  expect(directory.result("C:/Users/luke/projects", "", true)).toBe("C:\\Users\\luke\\projects")
+  expect(directory.result("//Server/Share/repo", "", true)).toBe("\\\\Server\\Share\\repo")
+  expect(directory.result("/home/luke/projects/myapp", "", false)).toBeUndefined()
+})
+
+test("resolves file suggestion through query scoping and selection", () => {
+  const file = pickerMode("file", "/home/luke/repos")
+  const query = pickerFileSearchQuery("/home/luke/repos", "/home/luke/repos/src/index.ts", "/home/luke")
+  expect(query).toBe("src/index.ts")
+  expect(file.selection("/home/luke/repos", query)).toBe("src/index.ts")
+  expect(file.result("/home/luke/repos", query)).toBe("src/index.ts")
+})
+
 test("preserves forward-slash input style on Windows paths", () => {
   // User typed forward slashes → display preserves them
   expect(displayPickerPath("C:/Users/luke/projects", "C:/Users/luke/pro", "C:/Users/luke")).toBe(
@@ -355,4 +374,115 @@ test("pickerAbsoluteInput resolves Windows backslash relative paths", () => {
   expect(pickerAbsoluteInput("C:\\Users\\luke\\projects", "C:/Users/luke", "C:/Users/luke/repo")).toBe(
     "C:/Users/luke/projects",
   )
+})
+
+test("splitPickerPath decomposes path into directory head and completion tail", () => {
+  expect(splitPickerPath("")).toEqual({ head: "", tail: "" })
+  expect(splitPickerPath("~")).toEqual({ head: "~/", tail: "" })
+  expect(splitPickerPath("~/")).toEqual({ head: "~/", tail: "" })
+  expect(splitPickerPath("~/Doc")).toEqual({ head: "~/", tail: "Doc" })
+  expect(splitPickerPath("~/Documents/")).toEqual({ head: "~/Documents/", tail: "" })
+  expect(splitPickerPath("~/Documents/wo")).toEqual({ head: "~/Documents/", tail: "wo" })
+  expect(splitPickerPath("/")).toEqual({ head: "/", tail: "" })
+  expect(splitPickerPath("/usr/loc")).toEqual({ head: "/usr/", tail: "loc" })
+  expect(splitPickerPath("C:\\Users\\luke\\")).toEqual({ head: "C:\\Users\\luke\\", tail: "" })
+  expect(splitPickerPath("C:\\Users\\luke\\Do")).toEqual({ head: "C:\\Users\\luke\\", tail: "Do" })
+  expect(splitPickerPath("src/co")).toEqual({ head: "src/", tail: "co" })
+  expect(splitPickerPath("co")).toEqual({ head: "", tail: "co" })
+})
+
+test("pickerTabTargetDirectory determines the absolute directory to list for Tab", () => {
+  expect(pickerTabTargetDirectory({ input: "", home: "/home/luke", base: "/home/luke" })).toBe("/home/luke")
+  expect(pickerTabTargetDirectory({ input: "~", home: "/home/luke" })).toBe("/home/luke")
+  expect(pickerTabTargetDirectory({ input: "~/Doc", home: "/home/luke" })).toBe("/home/luke")
+  expect(pickerTabTargetDirectory({ input: "~/Documents/w", home: "/home/luke" })).toBe("/home/luke/Documents")
+  expect(pickerTabTargetDirectory({ input: "/usr/loc", home: "/home/luke" })).toBe("/usr")
+  expect(pickerTabTargetDirectory({ input: "C:\\Users\\luke\\Do", home: "C:/Users/luke" })).toBe("C:/Users/luke")
+  expect(pickerTabTargetDirectory({ input: "src/co", home: "/home/luke", base: "/home/luke/repo" })).toBe(
+    "/home/luke/repo/src",
+  )
+})
+
+test("pickerTabCompletions completes folders up to next slash and supports cycling", () => {
+  const homeDirs = ["Documents", "Downloads", "Desktop", "Music", "Pictures"]
+
+  // Prefix match in home directory
+  expect(
+    pickerTabCompletions({
+      input: "~/Doc",
+      home: "/home/luke",
+      directories: homeDirs,
+    }),
+  ).toEqual(["~/Documents/"])
+
+  // Multiple matches returned in alphabetical order for cycling
+  expect(
+    pickerTabCompletions({
+      input: "~/D",
+      home: "/home/luke",
+      directories: homeDirs,
+    }),
+  ).toEqual(["~/Desktop/", "~/Documents/", "~/Downloads/"])
+
+  // Empty prefix inside directory expands all child folders
+  const docDirs = ["work", "personal", "archive"]
+  expect(
+    pickerTabCompletions({
+      input: "~/Documents/",
+      home: "/home/luke",
+      directories: docDirs,
+    }),
+  ).toEqual(["~/Documents/archive/", "~/Documents/personal/", "~/Documents/work/"])
+
+  // Prefix inside subfolder
+  expect(
+    pickerTabCompletions({
+      input: "~/Documents/w",
+      home: "/home/luke",
+      directories: docDirs,
+    }),
+  ).toEqual(["~/Documents/work/"])
+
+  // Windows backslash path preserves backslashes
+  expect(
+    pickerTabCompletions({
+      input: "C:\\Users\\luke\\D",
+      home: "C:/Users/luke",
+      directories: homeDirs,
+    }),
+  ).toEqual(["C:\\Users\\luke\\Desktop\\", "C:\\Users\\luke\\Documents\\", "C:\\Users\\luke\\Downloads\\"])
+
+  // Multi-step tab navigation: single match completes folder with trailing slash,
+  // then next step targets the completed folder to explore its subdirectories
+  const dir1Children = ["Dir2"]
+  const firstStep = pickerTabCompletions({
+    input: "/Dir1/Di",
+    home: "/home/luke",
+    directories: dir1Children,
+  })
+  expect(firstStep).toEqual(["/Dir1/Dir2/"])
+
+  // Next tab targets /Dir1/Dir2 directly because input ends with /
+  const nextTarget = pickerTabTargetDirectory({
+    input: firstStep[0],
+    home: "/home/luke",
+  })
+  expect(nextTarget).toBe("/Dir1/Dir2")
+
+  const dir2Children = ["subA", "subB"]
+  const secondStep = pickerTabCompletions({
+    input: firstStep[0],
+    home: "/home/luke",
+    directories: dir2Children,
+  })
+  expect(secondStep).toEqual(["/Dir1/Dir2/subA/", "/Dir1/Dir2/subB/"])
+
+  // Tilde alone expands all home directories
+  expect(
+    pickerTabCompletions({
+      input: "~",
+      home: "/home/luke",
+      directories: ["Desktop", "Documents"],
+    }),
+  ).toEqual(["~/Desktop/", "~/Documents/"])
 })

--- a/packages/app/src/components/directory-picker-domain.ts
+++ b/packages/app/src/components/directory-picker-domain.ts
@@ -331,6 +331,52 @@ export function displayPickerPath(path: string, input: string, home: string) {
   return pickerTilde(value, home) || value
 }
 
+export function splitPickerPath(input: string) {
+  const trimmed = cleanPickerInput(input)
+  if (trimmed === "~") return { head: "~/", tail: "" }
+  const lastSlash = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"))
+  if (lastSlash === -1) {
+    return { head: "", tail: trimmed }
+  }
+  return {
+    head: trimmed.slice(0, lastSlash + 1),
+    tail: trimmed.slice(lastSlash + 1),
+  }
+}
+
+export function pickerTabTargetDirectory(args: { input: string; home: string; base?: string }) {
+  const { head } = splitPickerPath(args.input)
+  const target = head || (args.input.startsWith("~") ? "~" : "")
+  if (!target) {
+    return args.base ? trimPickerPath(args.base) : trimPickerPath(args.home)
+  }
+  return pickerAbsoluteInput(target, args.home, args.base || args.home)
+}
+
+export function pickerTabCompletions(args: {
+  input: string
+  home: string
+  base?: string
+  directories: string[]
+}): string[] {
+  const { head, tail } = splitPickerPath(args.input)
+  const isWindows =
+    /^[A-Za-z]:\//.test(trimPickerPath(args.home)) ||
+    (args.base ? /^[A-Za-z]:\//.test(trimPickerPath(args.base)) : false) ||
+    head.includes("\\")
+  const sep = head.includes("\\") || (isWindows && !head.includes("/")) ? "\\" : "/"
+
+  const needle = tail.toLowerCase()
+  const matching = args.directories
+    .filter((name) => !needle || name.toLowerCase().startsWith(needle))
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }))
+
+  const candidates = matching
+
+  const prefix = head || (args.input.startsWith("~") ? `~${sep}` : "")
+  return candidates.map((name) => `${prefix}${name}${sep}`)
+}
+
 export function createDirectorySearch(args: { sdk: ServerSDK; base: () => string | undefined; home: () => string }) {
   const cache = new Map<string, Promise<Array<{ name: string; absolute: string }>>>()
   let current = 0

--- a/packages/app/src/components/directory-picker-domain.ts
+++ b/packages/app/src/components/directory-picker-domain.ts
@@ -317,7 +317,17 @@ function pickerTilde(absolute: string, home: string) {
 
 export function displayPickerPath(path: string, input: string, home: string) {
   const value = trimPickerPath(path)
-  if (/^[A-Za-z]:\//.test(trimPickerPath(home)) || /^[A-Za-z]:\//.test(value)) return value.replaceAll("/", "\\")
+  const isWindows =
+    /^[A-Za-z]:\//.test(trimPickerPath(home)) ||
+    /^[A-Za-z]:\//.test(value) ||
+    value.startsWith("//")
+  if (isWindows) {
+    // Preserve the user's separator style from their input so completion
+    // does not silently replace displayed separators. Empty input defaults
+    // to backslash (existing Windows behaviour for initial navigation).
+    if (input.length > 0 && !input.includes("\\")) return value
+    return value.replaceAll("/", "\\")
+  }
   return pickerTilde(value, home) || value
 }
 

--- a/packages/app/src/components/directory-picker-domain.ts
+++ b/packages/app/src/components/directory-picker-domain.ts
@@ -374,7 +374,7 @@ export function pickerTabCompletions(args: {
   const candidates = matching
 
   const prefix = head || (args.input.startsWith("~") ? `~${sep}` : "")
-  return candidates.map((name) => `${prefix}${name}${sep}`)
+  return candidates.map((name) => `${prefix}${name}`)
 }
 
 export function createDirectorySearch(args: { sdk: ServerSDK; base: () => string | undefined; home: () => string }) {


### PR DESCRIPTION
### Issue for this PR

#46661 

### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

1. Preserves user-typed separator style (`/` vs `\`) on Windows and UNC paths in `displayPickerPath` so autocomplete does not rewrite typed separators.
2. Adds Tab folder completion and cycling in `DialogSelectDirectory` via `pickerTabTargetDirectory` and `pickerTabCompletions`.
3. Supports direct Enter submission for typed unselected paths.
4. Adds domain tests covering POSIX, Windows drives, UNC paths, path splitting, and Tab completion cycling.

### How did you verify your code works?

- Ran `bun test packages/app/src/components/directory-picker-domain.test.ts` (34 passed).
- Ran `bun turbo run typecheck`.
- Tested Tab cycling, Enter submission, and separator preservation on Windows.

### Screenshots / recordings

Previous behavior on windows (and had no tab completion)
<img width="749" height="210" alt="2026-09-01_21-57" src="https://github.com/user-attachments/assets/b531f9ed-ac4c-4db5-88f3-103be336690b" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR