### PR TITLE
feat(tui): add read-only file preview dialog

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -45,6 +45,7 @@ import { DialogMcp } from "./component/dialog-mcp"
 import { DialogStatus } from "./component/dialog-status"
 import { DialogDebug } from "./component/dialog-debug"
 import { DialogThemeList } from "./component/dialog-theme-list"
+import { DialogPreview } from "./component/dialog-preview"
 import { DialogHelp } from "./ui/dialog-help"
 import { DialogAgent } from "./component/dialog-agent"
 import { DialogSessionList } from "./component/dialog-session-list"
@@ -615,6 +616,15 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         slashName: "workspaces",
         run: () => {
           dialog.replace(() => <DialogWorkspaceList />)
+        },
+      },
+      {
+        name: "preview.open",
+        title: "Preview file",
+        category: "Workspace",
+        slashName: "preview",
+        run: () => {
+          dialog.replace(() => <DialogPreview />)
         },
       },
       ...Array.from({ length: 9 }, (_, i) => ({

--- a/packages/tui/src/component/dialog-preview.tsx
+++ b/packages/tui/src/component/dialog-preview.tsx
@@ -1,0 +1,161 @@
+import { ScrollBoxRenderable, TextAttributes } from "@opentui/core"
+import { useTerminalDimensions } from "@opentui/solid"
+import { Show, Switch, Match, createResource, createSignal, onCleanup } from "solid-js"
+import { DialogSelect } from "../ui/dialog-select"
+import { useDialog } from "../ui/dialog"
+import { useProject } from "../context/project"
+import { useSDK } from "../context/sdk"
+import { useTheme } from "../context/theme"
+import { useBindings } from "../keymap"
+import { filetype } from "../util/filetype"
+
+type PreviewContent = { kind: "text"; text: string } | { kind: "binary" } | { kind: "error" }
+
+export function DialogPreview() {
+  const sdk = useSDK()
+  const dialog = useDialog()
+  const project = useProject()
+  const [query, setQuery] = createSignal("")
+
+  const [files] = createResource(
+    () => ({ query: query() }),
+    async (input) => {
+      const result = await sdk.client.find.files({
+        query: input.query,
+        type: "file",
+        limit: 50,
+        workspace: project.workspace.current(),
+      })
+      if (result.error) return []
+      return result.data ?? []
+    },
+  )
+
+  return (
+    <DialogSelect
+      title="Preview file"
+      placeholder="Search files"
+      skipFilter
+      options={(files.latest ?? []).map((value) => ({ title: value, value }))}
+      onFilter={setQuery}
+      onSelect={(option) => {
+        dialog.replace(() => <DialogPreviewFile path={option.value} />)
+      }}
+    />
+  )
+}
+
+export function DialogPreviewFile(props: { path: string }) {
+  const sdk = useSDK()
+  const dialog = useDialog()
+  const project = useProject()
+  const { theme, syntax } = useTheme()
+  const dimensions = useTerminalDimensions()
+
+  dialog.setSize("xlarge")
+  onCleanup(() => dialog.setSize("medium"))
+
+  const [content] = createResource(
+    () => ({ path: props.path, workspace: project.workspace.current() }),
+    async (input): Promise<PreviewContent> => {
+      const result = await sdk.client.file.read({ path: input.path, workspace: input.workspace })
+      if (result.error) return { kind: "error" }
+      if (result.data.type === "binary") return { kind: "binary" }
+      return { kind: "text", text: result.data.content }
+    },
+  )
+
+  let scroll: ScrollBoxRenderable | undefined
+  useBindings(() => ({
+    bindings: [
+      { key: "j,down", desc: "Scroll down", group: "Preview", cmd: () => scroll?.scrollBy(1) },
+      { key: "k,up", desc: "Scroll up", group: "Preview", cmd: () => scroll?.scrollBy(-1) },
+      { key: "pagedown", desc: "Page down", group: "Preview", cmd: () => scroll?.scrollBy(10) },
+      { key: "pageup", desc: "Page up", group: "Preview", cmd: () => scroll?.scrollBy(-10) },
+      { key: "g", desc: "Scroll to top", group: "Preview", cmd: () => scroll?.scrollTo(0) },
+      {
+        key: "shift+g",
+        desc: "Scroll to bottom",
+        group: "Preview",
+        cmd: () => scroll?.scrollTo(Number.MAX_SAFE_INTEGER),
+      },
+    ],
+  }))
+
+  const isMarkdown = () => filetype(props.path) === "markdown"
+  const text = () => {
+    const item = content()
+    return item?.kind === "text" ? item.text : undefined
+  }
+
+  return (
+    <box gap={1} paddingBottom={1}>
+      <box paddingLeft={4} paddingRight={4} flexDirection="row" justifyContent="space-between">
+        <text fg={theme.text} attributes={TextAttributes.BOLD}>
+          {props.path}
+        </text>
+        <text fg={theme.textMuted} onMouseUp={() => dialog.clear()}>
+          esc
+        </text>
+      </box>
+      <Switch>
+        <Match when={content.loading}>
+          <box paddingLeft={4} paddingTop={1}>
+            <text fg={theme.textMuted}>Loading...</text>
+          </box>
+        </Match>
+        <Match when={content()?.kind === "error"}>
+          <box paddingLeft={4} paddingTop={1}>
+            <text fg={theme.textMuted}>Failed to load file</text>
+          </box>
+        </Match>
+        <Match when={content()?.kind === "binary"}>
+          <box paddingLeft={4} paddingTop={1}>
+            <text fg={theme.textMuted}>Binary file — text preview not available</text>
+          </box>
+        </Match>
+        <Match when={text() !== undefined}>
+          <scrollbox
+            paddingLeft={1}
+            paddingRight={3}
+            scrollbarOptions={{ visible: false }}
+            ref={(r: ScrollBoxRenderable) => (scroll = r)}
+            maxHeight={Math.floor(dimensions().height * 0.55)}
+          >
+            <Show when={text()?.trim() === ""}>
+              <box paddingLeft={3} paddingTop={1}>
+                <text fg={theme.textMuted}>Empty file</text>
+              </box>
+            </Show>
+            <Show
+              when={isMarkdown()}
+              fallback={
+                <line_number fg={theme.textMuted} minWidth={4} paddingRight={1}>
+                  <code
+                    conceal={false}
+                    fg={theme.text}
+                    filetype={filetype(props.path)}
+                    syntaxStyle={syntax()}
+                    content={text() ?? ""}
+                  />
+                </line_number>
+              }
+            >
+              <box paddingLeft={2}>
+                <markdown
+                  syntaxStyle={syntax()}
+                  streaming={false}
+                  internalBlockMode="top-level"
+                  content={text() ?? ""}
+                  tableOptions={{ style: "grid" }}
+                  fg={theme.markdownText}
+                  bg={theme.background}
+                />
+              </box>
+            </Show>
+          </scrollbox>
+        </Match>
+      </Switch>
+    </box>
+  )
+}

--- a/packages/tui/test/cli/tui/dialog-preview.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-preview.test.tsx
@@ -1,0 +1,137 @@
+/** @jsxImportSource @opentui/solid */
+import { test } from "bun:test"
+import { createDefaultOpenTuiKeymap } from "@opentui/keymap/opentui"
+import { testRender, useRenderer } from "@opentui/solid"
+import { onCleanup } from "solid-js"
+import { DialogProvider } from "../../../src/ui/dialog"
+import { DialogPreview, DialogPreviewFile } from "../../../src/component/dialog-preview"
+import { ProjectProvider } from "../../../src/context/project"
+import { SDKProvider } from "../../../src/context/sdk"
+import { ThemeProvider } from "../../../src/context/theme"
+import { ToastProvider } from "../../../src/ui/toast"
+import { KVProvider } from "../../../src/context/kv"
+import { TuiConfigProvider } from "../../../src/config"
+import { OpencodeKeymapProvider, registerOpencodeKeymap } from "../../../src/keymap"
+import { TestTuiContexts } from "../../fixture/tui-environment"
+import { createEventSource, createFetch, directory, json } from "../../fixture/tui-sdk"
+import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
+
+async function waitUntilFrame(
+  app: { captureCharFrame(): string },
+  predicate: (frame: string) => boolean,
+  timeout = 3000,
+) {
+  const start = Date.now()
+  while (!predicate(app.captureCharFrame())) {
+    if (Date.now() - start > timeout) throw new Error("timed out waiting for frame content")
+    await Bun.sleep(10)
+  }
+}
+
+async function mountPreview(input: { path?: string; find?: string[]; content?: unknown; status?: number } = {}) {
+  const events = createEventSource()
+  const calls = createFetch((url) => {
+    if (url.pathname === "/find/file" && input.find) return json(input.find)
+    if (url.pathname === "/file/content" && input.content !== undefined)
+      return json(input.content, { status: input.status })
+    return undefined
+  }, events)
+
+  function Harness() {
+    const renderer = useRenderer()
+    const keymap = createDefaultOpenTuiKeymap(renderer)
+    const resolvedConfig = createTuiResolvedConfig({ leader_timeout: 1000 })
+    const off = registerOpencodeKeymap(keymap, renderer, resolvedConfig)
+    onCleanup(off)
+
+    return (
+      <TestTuiContexts>
+        <OpencodeKeymapProvider keymap={keymap}>
+          <TuiConfigProvider config={resolvedConfig}>
+            <KVProvider>
+              <ThemeProvider mode="dark">
+                <ToastProvider>
+                  <SDKProvider url="http://test" directory={directory} events={events.source} fetch={calls.fetch}>
+                    <ProjectProvider>
+                      <DialogProvider>
+                        {input.path !== undefined ? <DialogPreviewFile path={input.path} /> : <DialogPreview />}
+                      </DialogProvider>
+                    </ProjectProvider>
+                  </SDKProvider>
+                </ToastProvider>
+              </ThemeProvider>
+            </KVProvider>
+          </TuiConfigProvider>
+        </OpencodeKeymapProvider>
+      </TestTuiContexts>
+    )
+  }
+
+  return testRender(() => <Harness />, { kittyKeyboard: true })
+}
+
+test("renders markdown files as markdown", async () => {
+  const app = await mountPreview({
+    path: "README.md",
+    content: { type: "text", content: "# Hello Preview\n\nSome body text." },
+  })
+  try {
+    await waitUntilFrame(app, (frame) => frame.includes("Hello Preview"))
+    await waitUntilFrame(app, (frame) => frame.includes("Some body text."))
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("renders code files with syntax highlighting", async () => {
+  const app = await mountPreview({
+    path: "src/example.ts",
+    content: { type: "text", content: "export const preview_marker = 1\n" },
+  })
+  try {
+    await waitUntilFrame(app, (frame) => frame.includes("preview_marker"))
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("shows a notice for binary files", async () => {
+  const app = await mountPreview({
+    path: "assets/logo.png",
+    content: { type: "binary", content: "aGk=", encoding: "base64", mimeType: "image/png" },
+  })
+  try {
+    await waitUntilFrame(app, (frame) => frame.includes("Binary file"))
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("shows a notice when the file fails to load", async () => {
+  const app = await mountPreview({
+    path: "docs/missing.md",
+    content: { message: "Bad request" },
+    status: 400,
+  })
+  try {
+    await waitUntilFrame(app, (frame) => frame.includes("Failed to load file"))
+  } finally {
+    app.renderer.destroy()
+  }
+})
+
+test("picker opens a preview for the selected file", async () => {
+  const app = await mountPreview({
+    find: ["README.md", "docs/guide.md"],
+    content: { type: "text", content: "# From the picker\n\nPicker body." },
+  })
+  try {
+    await waitUntilFrame(app, (frame) => frame.includes("README.md"))
+    await waitUntilFrame(app, (frame) => frame.includes("docs/guide.md"))
+    app.mockInput.pressEnter()
+    await waitUntilFrame(app, (frame) => frame.includes("From the picker"))
+    await waitUntilFrame(app, (frame) => frame.includes("Picker body."))
+  } finally {
+    app.renderer.destroy()
+  }
+})


### PR DESCRIPTION
### Issue for this PR

Refs #43598 — this is a draft prototype for the design discussion; will switch to `Closes` if the direction is approved.

### Type of change

- [x] New feature

### What does this PR do?

Adds a read-only file preview to the TUI, as proposed in #43598:

- `/preview` opens a file picker backed by the same server-side search the `@` mention uses
- `.md` files render as markdown, other text files show with syntax highlighting, binary files show a notice
- `esc` closes; `j/k/up/down/pgup/pgdn/g/G` scroll
- Files over 512KB show a "too large" notice instead of being loaded into the render loop

Design choices: reuses `/find/file` + `DialogSelect` so ranking matches `@` mentions (no client-side search logic), reads content via the existing `/file/content` endpoint (it already classifies text vs binary), and renders with opentui's built-in `<markdown>` element — zero new dependencies.

Note: #43599 is another draft prototype for the same issue. Neither has received maintainer direction yet — happy to coordinate, or close this one if the core team prefers that approach.

### How did you verify your code works?

- 6 render-level tests in `packages/tui/test/cli/tui/dialog-preview.test.tsx` (markdown, code, binary, oversized, error, and a picker end-to-end flow). `bun test` in `packages/tui`: 199 pass, 0 fail.
- `bun typecheck` passes for all packages, oxlint clean on touched files.

### Screenshots / recordings

https://gist.github.com/xxxiaocat/095d822983c36b1bf9d702b137ffbc43 (asciinema cast: `/preview` → filter `readme` → select → markdown preview → scroll → `esc`)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
