### PR TITLE
feat(app): add session history sidebar

### DIFF
--- a/docs/plans/2026-08-31-001-feat-session-history-tree-plan.md
+++ b/docs/plans/2026-08-31-001-feat-session-history-tree-plan.md
@@ -1,0 +1,180 @@
+---
+title: Session History Tree - Plan
+type: feat
+date: 2026-08-31
+topic: session-history-tree
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: requirements-only
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+# Session History Tree - Plan
+
+## Goal Capsule
+
+- **Objective:** Replace the OpenCode desktop/web app's titlebar session tabs with a left tree of chat history grouped by project, so several chats can run while one conversation is on screen.
+- **Product authority:** This Product Contract. Adjacent chrome (Home, split views, TUI) is not active scope.
+- **Open blockers:** None. Remaining questions are deferred to planning.
+
+---
+
+## Product Contract
+
+### Summary
+
+Ship a project-grouped chat history tree as the app's session chrome.
+The tree is history with running vs inactive status, not an open-tab strip.
+Several chats can run at once; the canvas shows one.
+
+### Problem Frame
+
+The default app is built around a horizontal tab strip of "open" sessions.
+That model does not match how people already think about this product: a list of chats under each project, some running, most idle.
+Tabs also hide other projects' chats until you hunt for them, which fights parallel work across projects.
+The leftover project icon rail on the old layout only shows one project's list at a time.
+
+### Key Decisions
+
+- Tree chrome, not a selected-project rail or a hover overlay.
+  (session-settled: user-directed — chosen over rail+list and overlay tree: all projects' chats stay visible without switching the rail)
+  Governs R1, R2.
+- History with running/inactive status, not an open-tab set.
+  (session-settled: user-directed — chosen over titlebar-equivalent open tabs: there is no close-the-tab concept)
+  Governs R5, R6.
+- One conversation on screen; parallel means concurrent runs, not split panes.
+  (session-settled: user-directed — chosen over split canvas)
+  Governs R7, R8.
+- Ship the tree for everyone. No settings flag, and do not keep A/B/C as live options.
+  (session-settled: user-directed — chosen over a three-variant enum and a current-vs-tree toggle)
+  Governs R4.
+
+### Actors
+
+- A1. Person using the OpenCode desktop or web app, often with more than one project and more than one chat in flight.
+
+### Requirements
+
+**Chrome**
+
+- R1. A persistent left tree lists chats nested under their project names, for every project that has chats in the list.
+- R2. The titlebar does not list sessions, and the project icon rail is not part of this chrome.
+- R3. Each project in the tree offers a way to start a new chat in that project without leaving the tree.
+- R4. This tree is the session chrome. There is no settings control to restore titlebar tabs or to pick among the explored rail/overlay sketches.
+
+**History and running work**
+
+- R5. The tree is chat history. A row is a chat, not an "open tab" that the user must close to remove from the list.
+- R6. A chat is either running or inactive. Inactive rows stay cheap enough that a long history remains usable.
+- R7. Selecting a row shows that chat in the single session canvas.
+- R8. Selecting another row does not stop chats that are still running.
+
+**Parallel**
+
+- R9. Only one conversation is visible at a time.
+
+```mermaid
+flowchart LR
+  subgraph window [App window]
+    titlebar[Slim titlebar without session tabs]
+    subgraph tree [History tree]
+      p1[Project]
+      c1[Running chat]
+      c2[Inactive chat]
+      p2[Other project]
+      c3[Chat]
+    end
+    canvas[One session canvas]
+  end
+  titlebar --- tree
+  tree --- canvas
+```
+
+### Key Flows
+
+- F1. Jump between two running chats
+  - **Trigger:** A1 has two chats running in the same or different projects.
+  - **Actors:** A1
+  - **Steps:** A1 selects the other running row in the tree. The canvas shows that chat. The first chat keeps running.
+  - **Covered by:** R1, R7, R8, R9
+- F2. Open an inactive chat
+  - **Trigger:** A1 selects a history row that is not running and may not be loaded.
+  - **Actors:** A1
+  - **Steps:** The canvas shows that chat. Other running chats continue.
+  - **Covered by:** R5, R6, R7, R8
+- F3. Start a new chat while another runs
+  - **Trigger:** A1 starts a new chat from a project in the tree.
+  - **Actors:** A1
+  - **Steps:** A new row appears under that project. The canvas shows the new chat. Existing running chats continue.
+  - **Covered by:** R3, R7, R8
+- F4. Scan a long project history
+  - **Trigger:** A project has more chats than fit on screen.
+  - **Actors:** A1
+  - **Steps:** A1 scrolls the tree. Off-screen inactive rows stay cheap per R6.
+  - **Covered by:** R1, R5, R6
+
+### Acceptance Examples
+
+- AE1. Two running chats, one canvas
+  - **Covers R7, R8, R9.**
+  - **Given:** Chat A and chat B are both running.
+  - **When:** A1 selects B in the tree.
+  - **Then:** The canvas shows B, A is still running, and A remains in the tree as running.
+- AE2. Inactive chat is still in the tree
+  - **Covers R5, R6.**
+  - **Given:** A chat finished and is not loaded.
+  - **When:** A1 looks at its project in the tree.
+  - **Then:** The chat is still listed, marked inactive, and selecting it shows it.
+- AE3. Closing is not how a chat leaves the list
+  - **Covers R2, R5.**
+  - **Given:** A1 is looking at a chat.
+  - **When:** A1 switches to another chat.
+  - **Then:** The previous chat stays in the tree. There is no titlebar tab to close.
+- AE4. New chat under the chosen project
+  - **Covers R3, R1.**
+  - **Given:** Projects P and Q are in the tree.
+  - **When:** A1 starts a new chat from P.
+  - **Then:** The new row is under P, not Q, and the canvas shows it.
+- AE5. Other project's chats stay visible
+  - **Covers R1, R8.**
+  - **Given:** P has a running chat and Q has an inactive chat.
+  - **When:** A1 is viewing P's chat.
+  - **Then:** Q's chat remains listed under Q without switching a project rail.
+
+### Scope Boundaries
+
+**Deferred for later**
+
+- Split canvas so two conversations are on screen at once.
+- Shipping the rail+list or overlay-tree sketches as settings options.
+- TUI session sidebar.
+
+**Outside this product's identity**
+
+- A settings flag to keep titlebar tabs. The tree is the chrome, not an experiment.
+- Treating chats as browser tabs that vanish when "closed."
+
+### Dependencies / Assumptions
+
+- The change targets the current default desktop/web app chrome, not TUI.
+- Mobile uses the same tree, collapsed until opened.
+- Git workspaces, if shown, nest under their project in this tree rather than becoming a second grouping axis.
+- Home remains a place to browse projects and chats; it is not replaced by the tree.
+- Existing session delete/archive is how a row leaves the tree. Switching away from a chat does not remove it.
+- The existing "New interface" layout toggle is a different, already-shipping concern. This work does not add a second layout flag.
+
+### Outstanding Questions
+
+**Deferred to Planning**
+
+- How running vs inactive is shown (dot, label, section, filter).
+- What remains in the slim titlebar besides window chrome (Home, search, status).
+- What happens to persisted tab-strip state and to copy that currently describes the app as built around tabs.
+- How far virtualization goes on first ship.
+
+### Sources / Research
+
+- Default v2 chrome is a titlebar session tab strip. In-app help still says the desktop app is built around tabs (`packages/app/src/i18n/en.ts`, `help.tabs.*`).
+- Legacy layout already lists sessions under one selected project next to a 64px project rail (`packages/app/src/pages/layout/sidebar-shell.tsx`, `sidebar-project.tsx`).
+- The tree content is that history list for every project at once, not the titlebar's open-tab store (`packages/app/src/context/tabs.tsx`).
+- Directional chrome sketches compared tree vs rail+list vs overlay; tree was chosen. Scratch only, not a spec: the local visual probe at session time.

--- a/packages/app/e2e/performance/timeline/first-navigation-benchmark.spec.ts
+++ b/packages/app/e2e/performance/timeline/first-navigation-benchmark.spec.ts
@@ -1,4 +1,4 @@
-import { expectSessionTitle } from "../../utils/waits"
+import { expectSessionTitle, sessionHistoryRow } from "../../utils/waits"
 import { benchmark, expect } from "../benchmark"
 import { measureFirstNavigation } from "./first-navigation-probe"
 import { fixture } from "./session-timeline-stress.fixture"
@@ -6,26 +6,25 @@ import {
   installStressSessionTabs,
   installTimelineSettings,
   mockStressTimeline,
-  stressDraftHref,
   stressSessionHref,
 } from "./timeline-test-helpers"
 import { waitForStableTimeline } from "./session-tab-switch-probe"
 
 const contentSelector = '[data-message-id], [data-component="prompt-input"]'
-const draftID = "draft_first_navigation"
 
 benchmark.describe("performance: first navigation paint", () => {
   benchmark("opens an unvisited session tab without a blank frame", async ({ page, report }) => {
     await setup(page)
     const href = stressSessionHref(fixture.targetID)
+    const row = sessionHistoryRow(page, fixture.targetID)
     const result = await measureFirstNavigation(page, {
-      href,
+      triggerSelector: `[data-component="session-history-row"][data-session-id="${fixture.targetID}"]`,
       destinationPath: href,
       sourceSelector: messageSelector(fixture.expected.sourceMessageIDs.at(-1)!),
       destinationSelector: messageSelector(fixture.expected.targetMessageIDs.at(-1)!),
       contentSelector,
       navigate: async () => {
-        await page.locator(`[data-slot="titlebar-tabs"] a[href="${href}"]`).first().click()
+        await row.click()
         await expectSessionTitle(page, fixture.expected.targetTitle)
       },
     })
@@ -35,16 +34,16 @@ benchmark.describe("performance: first navigation paint", () => {
   })
 
   benchmark("opens the new session page before its lazy module is used", async ({ page, report }) => {
-    await setup(page, draftID)
-    const href = stressDraftHref(draftID)
+    await setup(page)
+    const trigger = page.locator('[data-action="sidebar-new-session"]')
     const result = await measureFirstNavigation(page, {
-      href,
-      destinationPath: href,
+      triggerSelector: '[data-action="sidebar-new-session"]',
+      destinationPath: "/new-session",
       sourceSelector: messageSelector(fixture.expected.sourceMessageIDs.at(-1)!),
       destinationSelector: '[data-component="prompt-input"]',
       contentSelector,
       navigate: async () => {
-        await page.locator(`[data-slot="titlebar-tabs"] a[href="${href}"]`).first().click()
+        await trigger.click()
         await expect(page.locator('[data-component="prompt-input"]')).toBeVisible()
       },
     })
@@ -57,7 +56,7 @@ benchmark.describe("performance: first navigation paint", () => {
     await setup(page)
     const href = stressSessionHref(fixture.childID)
     const result = await measureFirstNavigation(page, {
-      href,
+      triggerSelector: `a[href="${href}"]`,
       destinationPath: href,
       sourceSelector: messageSelector(fixture.expected.sourceMessageIDs.at(-1)!),
       destinationSelector: messageSelector(fixture.expected.childMessageIDs.at(-1)!),
@@ -73,10 +72,10 @@ benchmark.describe("performance: first navigation paint", () => {
   })
 })
 
-async function setup(page: Parameters<typeof mockStressTimeline>[0], draft?: string) {
+async function setup(page: Parameters<typeof mockStressTimeline>[0]) {
   await mockStressTimeline(page)
   await installTimelineSettings(page)
-  await installStressSessionTabs(page, draft ? { draftID: draft } : undefined)
+  await installStressSessionTabs(page)
   await page.goto(stressSessionHref(fixture.sourceID))
   await expectSessionTitle(page, fixture.expected.sourceTitle)
   await waitForStableTimeline(page, fixture.expected.sourceMessageIDs.at(-1)!)

--- a/packages/app/e2e/performance/timeline/first-navigation-probe.ts
+++ b/packages/app/e2e/performance/timeline/first-navigation-probe.ts
@@ -9,7 +9,7 @@ type FirstNavigationProbe = {
 export async function measureFirstNavigation(
   page: Page,
   input: {
-    href: string
+    triggerSelector: string
     destinationPath: string
     sourceSelector: string
     destinationSelector: string
@@ -18,7 +18,7 @@ export async function measureFirstNavigation(
   },
 ) {
   await page.evaluate(
-    ({ href, destinationPath, sourceSelector, destinationSelector, contentSelector }) => {
+    ({ triggerSelector, destinationPath, sourceSelector, destinationSelector, contentSelector }) => {
       const samples: FirstNavigationSample[] = []
       let started: number | undefined
       let running = true
@@ -36,7 +36,10 @@ export async function measureFirstNavigation(
             samples.push({
               observedAtMs: performance.now() - started,
               source: visible(sourceSelector),
-              destination: `${location.pathname}${location.search}` === destinationPath && visible(destinationSelector),
+              destination:
+                (location.pathname === destinationPath ||
+                  `${location.pathname}${location.search}` === destinationPath) &&
+                visible(destinationSelector),
               content: visible(contentSelector),
               pathname: `${location.pathname}${location.search}`,
               center: document.elementFromPoint(innerWidth / 2, innerHeight / 2)?.textContent?.slice(0, 80),
@@ -48,8 +51,8 @@ export async function measureFirstNavigation(
       document.addEventListener(
         "click",
         (event) => {
-          const link = event.target instanceof Element ? event.target.closest("a") : undefined
-          if (link?.getAttribute("href") !== href) return
+          const target = event.target instanceof Element ? event.target : undefined
+          if (!target?.closest(triggerSelector)) return
           started = performance.now()
           sample()
         },
@@ -63,7 +66,7 @@ export async function measureFirstNavigation(
       }
     },
     {
-      href: input.href,
+      triggerSelector: input.triggerSelector,
       destinationPath: input.destinationPath,
       sourceSelector: input.sourceSelector,
       destinationSelector: input.destinationSelector,

--- a/packages/app/e2e/performance/timeline/home-tab-navigation-benchmark.spec.ts
+++ b/packages/app/e2e/performance/timeline/home-tab-navigation-benchmark.spec.ts
@@ -1,5 +1,5 @@
 import { benchmark, expect } from "../benchmark"
-import { expectSessionTitle } from "../../utils/waits"
+import { expectSessionTitle, sessionHistoryRow } from "../../utils/waits"
 import { measureNavigationMilestones } from "./navigation-milestones"
 import { fixture } from "./session-timeline-stress.fixture"
 import {
@@ -13,18 +13,18 @@ import { waitForStableTimeline } from "./session-tab-switch-probe"
 const homeRow = '[data-component="home-session-row"]'
 const homeShell = '[data-component="home-session-search"]'
 
-benchmark.describe("performance: home and tab navigation", () => {
-  benchmark("opens a home session and paints its titlebar tab", async ({ page, report }) => {
+benchmark.describe("performance: home and session navigation", () => {
+  benchmark("opens a home session and paints its history row", async ({ page, report }) => {
     await setup(page, [])
     await page.goto("/")
     const row = page.locator(homeRow).filter({ hasText: fixture.expected.targetTitle }).first()
     await expect(row).toBeVisible()
-    const href = stressSessionHref(fixture.targetID)
+    const historyRow = `[data-component="session-history-row"][data-session-id="${fixture.targetID}"]`
     const result = await measureNavigationMilestones(page, {
       triggerSelector: homeRow,
       milestones: {
         content: { selector: messageSelector(fixture.expected.targetMessageIDs.at(-1)!) },
-        tab: { selector: `[data-slot="titlebar-tabs"] a[href="${href}"]` },
+        row: { selector: `${historyRow}[aria-current="page"]` },
       },
       navigate: async () => {
         await row.click()
@@ -32,9 +32,7 @@ benchmark.describe("performance: home and tab navigation", () => {
       },
     })
     report(result)
-    await expect(page.locator(`[data-slot="titlebar-tabs"] a[href="${href}"]`)).toContainText(
-      fixture.expected.targetTitle,
-    )
+    await expect(sessionHistoryRow(page, fixture.targetID)).toHaveAttribute("aria-current", "page")
   })
 
   benchmark("stages the review body after cold session content", async ({ page, report }) => {
@@ -78,24 +76,23 @@ benchmark.describe("performance: home and tab navigation", () => {
     await expect(page.locator('[data-component="session-review"]')).toBeVisible()
   })
 
-  benchmark("closes the only session tab and paints home", async ({ page, report }) => {
+  benchmark("returns home from a session and paints the session list", async ({ page, report }) => {
     await setup(page, [fixture.sourceID])
     const href = stressSessionHref(fixture.sourceID)
     await page.goto(href)
     await expectSessionTitle(page, fixture.expected.sourceTitle)
     await waitForStableTimeline(page, fixture.expected.sourceMessageIDs.at(-1)!)
-    const tab = page.locator(`[data-slot="titlebar-tabs"] a[href="${href}"]`).first()
-    const close = tab.locator("..").locator('[data-component="icon-button-v2"]')
-    await expect(close).toBeVisible()
+    const row = sessionHistoryRow(page, fixture.sourceID)
+    await expect(row).toBeVisible()
     const result = await measureNavigationMilestones(page, {
-      triggerSelector: '[data-slot="titlebar-tabs"] [data-component="icon-button-v2"]',
+      triggerSelector: `[data-component="session-history-row"][data-session-id="${fixture.sourceID}"]`,
       milestones: {
         home: { selector: homeShell },
         row: { selector: homeRow },
-        tabRemoved: { selector: `[data-slot="titlebar-tabs"] a[href="${href}"]`, visible: false },
       },
       navigate: async () => {
-        await close.click()
+        await row.click()
+        await page.goto("/")
         await expect(page).toHaveURL("/")
       },
     })

--- a/packages/app/e2e/performance/timeline/session-parent-hydration-benchmark.spec.ts
+++ b/packages/app/e2e/performance/timeline/session-parent-hydration-benchmark.spec.ts
@@ -153,7 +153,7 @@ async function trial(page: Page, mode: ParentHydrationBenchmarkMode) {
     lastID,
     requiredPartID: lastPartID,
     requireBottomAnchor: false,
-    href,
+    triggerSelector: `a[href="${href}"]`,
     switch: async () => {
       await page.locator("#parent-hydration-target").click()
       await expectSessionTitle(page, target.title)

--- a/packages/app/e2e/performance/timeline/session-tab-flash.spec.ts
+++ b/packages/app/e2e/performance/timeline/session-tab-flash.spec.ts
@@ -1,5 +1,5 @@
 import { benchmark, expect } from "../benchmark"
-import { expectSessionTitle } from "../../utils/waits"
+import { expectSessionTitle, sessionHistoryRow, switchHistorySession } from "../../utils/waits"
 import { fixture } from "./session-timeline-stress.fixture"
 import {
   collectCachedRepaintTrace,
@@ -23,25 +23,18 @@ benchmark("samples cached session repaint after the click", async ({ page, repor
   await page.goto(stressSessionHref(fixture.targetID))
   await expectSessionTitle(page, fixture.expected.targetTitle)
   await waitForStableTimeline(page, fixture.expected.targetMessageIDs.at(-1)!)
-  await page
-    .locator(`[data-slot="titlebar-tabs"] a[href="${stressSessionHref(fixture.sourceID)}"]`)
-    .first()
-    .click()
-  await expectSessionTitle(page, fixture.expected.sourceTitle)
+  await switchHistorySession(page, fixture.sourceID, fixture.expected.sourceTitle)
   await waitForStableTimeline(page, fixture.expected.sourceMessageIDs.at(-1)!)
 
   await installCachedRepaintProbe(page, {
-    targetHref: stressSessionHref(fixture.targetID),
+    targetSessionID: fixture.targetID,
     destination: fixture.messages[fixture.targetID].map((message) => message.info.id),
     source: fixture.messages[fixture.sourceID].map((message) => message.info.id),
     last: fixture.expected.targetMessageIDs.at(-1)!,
     windowMs: 1_000,
   })
 
-  await page
-    .locator(`[data-slot="titlebar-tabs"] a[href="${stressSessionHref(fixture.targetID)}"]`)
-    .first()
-    .click()
+  await sessionHistoryRow(page, fixture.targetID).click()
   await Promise.all([expectSessionTitle(page, fixture.expected.targetTitle), waitForCachedRepaintWindow(page, 1_000)])
   const result = await collectCachedRepaintTrace(page)
   report(compressCachedRepaintTrace(result))

--- a/packages/app/e2e/performance/timeline/session-tab-repaint-probe.ts
+++ b/packages/app/e2e/performance/timeline/session-tab-repaint-probe.ts
@@ -25,9 +25,9 @@ type CachedRepaintTrace = {
 
 export async function installCachedRepaintProbe(
   page: Page,
-  input: { targetHref: string; destination: string[]; source: string[]; last: string; windowMs: number },
+  input: { targetSessionID: string; destination: string[]; source: string[]; last: string; windowMs: number },
 ) {
-  await page.evaluate(({ targetHref, destination, source, last, windowMs }) => {
+  await page.evaluate(({ targetSessionID, destination, source, last, windowMs }) => {
     const destinationIDs = new Set(destination)
     const sourceIDs = new Set(source)
     const nodeIDs = new WeakMap<Node, number>()
@@ -154,8 +154,9 @@ export async function installCachedRepaintProbe(
     document.addEventListener(
       "click",
       (event) => {
-        const link = event.target instanceof Element ? event.target.closest("a") : undefined
-        if (link?.getAttribute("href") !== targetHref) return
+        const row =
+          event.target instanceof Element ? event.target.closest("[data-component=session-history-row]") : undefined
+        if (row?.getAttribute("data-session-id") !== targetSessionID) return
         state.startedAtPerformanceMs = performance.now()
         state.running = true
         requestAnimationFrame(sample)

--- a/packages/app/e2e/performance/timeline/session-tab-switch-benchmark.spec.ts
+++ b/packages/app/e2e/performance/timeline/session-tab-switch-benchmark.spec.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@playwright/test"
-import { expectSessionTitle } from "../../utils/waits"
+import { expectSessionTitle, switchHistorySession } from "../../utils/waits"
 import { benchmark, expect, withBenchmarkPage } from "../benchmark"
 import { fixture } from "./session-timeline-stress.fixture"
 import {
@@ -66,7 +66,7 @@ async function trial(
     await page.goto(stressSessionHref(fixture.targetID))
     await expectSessionTitle(page, fixture.expected.targetTitle)
     await waitForStableTimeline(page, fixture.expected.targetMessageIDs.at(-1)!)
-    await switchSession(page, fixture.sourceID, fixture.expected.sourceTitle)
+    await switchHistorySession(page, fixture.sourceID, fixture.expected.sourceTitle)
   } else {
     await page.goto(stressSessionHref(fixture.sourceID))
     await expectSessionTitle(page, fixture.expected.sourceTitle)
@@ -80,13 +80,12 @@ async function trial(
   const destinationIDs = fixture.messages[fixture.targetID].map((message) => message.info.id)
   const sourceIDs = fixture.messages[fixture.sourceID].map((message) => message.info.id)
   const lastID = fixture.expected.targetMessageIDs.at(-1)!
-  const href = stressSessionHref(fixture.targetID)
   const result = await measureSessionSwitch(page, {
     destinationIDs,
     sourceIDs,
     lastID,
-    href,
-    switch: () => switchSession(page, fixture.targetID, fixture.expected.targetTitle),
+    triggerSelector: `[data-component="session-history-row"][data-session-id="${fixture.targetID}"]`,
+    switch: () => switchHistorySession(page, fixture.targetID, fixture.expected.targetTitle),
   })
   return result
 }
@@ -120,14 +119,6 @@ function summarizeReviewPane(results: Record<"closed" | "open", Record<"cold" | 
       summarize(values as Record<"cold" | "hot", Result[]>),
     ]),
   )
-}
-
-async function switchSession(page: Page, sessionID: string, title: string) {
-  const href = stressSessionHref(sessionID)
-  const tab = page.locator(`[data-slot="titlebar-tabs"] a[href="${href}"]`).first()
-  await expect(tab).toBeVisible()
-  await tab.click()
-  await expectSessionTitle(page, title)
 }
 
 async function openReviewPane(page: Page) {

--- a/packages/app/e2e/performance/timeline/session-tab-switch-probe.ts
+++ b/packages/app/e2e/performance/timeline/session-tab-switch-probe.ts
@@ -14,10 +14,10 @@ async function installSessionSwitchProbe(
     lastID: string
     requiredPartID?: string
     requireBottomAnchor?: boolean
-    href: string
+    triggerSelector: string
   },
 ) {
-  await page.evaluate(({ destinationIDs, sourceIDs, lastID, requiredPartID, requireBottomAnchor, href }) => {
+  await page.evaluate(({ destinationIDs, sourceIDs, lastID, requiredPartID, requireBottomAnchor, triggerSelector }) => {
     const destination = new Set(destinationIDs)
     const source = new Set(sourceIDs)
     const samples: SessionSwitchSample[] = []
@@ -110,8 +110,8 @@ async function installSessionSwitchProbe(
     document.addEventListener(
       "click",
       (event) => {
-        const link = event.target instanceof Element ? event.target.closest("a") : undefined
-        if (link?.getAttribute("href") !== href) return
+        const target = event.target instanceof Element ? event.target : undefined
+        if (!target?.closest(triggerSelector)) return
         started = performance.now()
         for (const [name, selector] of Object.entries(reviewLevels)) {
           initialReviewNodes[name] = document.querySelector(selector)
@@ -167,7 +167,7 @@ export async function measureSessionSwitch(
     lastID: string
     requiredPartID?: string
     requireBottomAnchor?: boolean
-    href: string
+    triggerSelector: string
     switch: () => Promise<void>
   },
 ) {

--- a/packages/app/e2e/performance/unit/session-tab-switch-probe.test.ts
+++ b/packages/app/e2e/performance/unit/session-tab-switch-probe.test.ts
@@ -21,7 +21,7 @@ function input(run: () => Promise<void>) {
     destinationIDs: ["destination"],
     sourceIDs: ["source"],
     lastID: "destination",
-    href: "/session/destination",
+    triggerSelector: 'a[href="/session/destination"]',
     switch: run,
   }
 }

--- a/packages/app/e2e/regression/session-rename.spec.ts
+++ b/packages/app/e2e/regression/session-rename.spec.ts
@@ -52,7 +52,9 @@ for (const commit of ["Enter", "blur", "click outside"]) {
     if (commit === "blur") await input.press("Tab")
     if (commit === "click outside") await page.getByRole("textbox", { name: "Prompt", exact: true }).click()
     await expect(page.getByRole("heading", { name: "Renamed session", exact: true })).toBeVisible()
-    await expect(page.locator('[data-slot="titlebar-tabs"] a').filter({ hasText: "Renamed session" })).toBeVisible()
+    await expect(
+      page.locator('[data-component="session-history-row"]').filter({ hasText: "Renamed session" }),
+    ).toBeVisible()
     await page.reload()
     await expect(page.getByRole("heading", { name: "Renamed session", exact: true })).toBeVisible()
   })
@@ -81,7 +83,7 @@ test("keeps the draft when saving the session heading fails", async ({ page }) =
   await expect(input).toBeEnabled()
   await expect(input).toHaveValue("Retry this title")
   await expect(
-    page.locator('[data-slot="titlebar-tabs"] a').filter({ hasText: fixture.expected.targetTitle }),
+    page.locator('[data-component="session-history-row"]').filter({ hasText: fixture.expected.targetTitle }),
   ).toBeVisible()
 })
 
@@ -93,49 +95,4 @@ test("does not save an empty session heading", async ({ page }) => {
   await expect(page.getByRole("heading", { name: fixture.expected.targetTitle, exact: true })).toBeVisible()
   await page.reload()
   await expect(page.getByRole("heading", { name: fixture.expected.targetTitle, exact: true })).toBeVisible()
-})
-
-test("renames and closes the session tab from its context menu", async ({ page }) => {
-  const tab = page.locator('[data-slot="titlebar-tabs"] a').filter({ hasText: fixture.expected.targetTitle })
-  await tab.click({ button: "right" })
-  await expect(page.getByRole("menuitem", { name: "Rename", exact: true })).toBeVisible()
-  await page.keyboard.press("Escape")
-  await expect(page.getByRole("menuitem", { name: "Rename", exact: true })).toBeHidden()
-  await expect(tab).toBeFocused()
-  await tab.press("Shift+F10")
-  await page.getByRole("menuitem", { name: "Rename", exact: true }).click()
-  const input = page.locator('[data-slot="tab-title"][contenteditable="true"]')
-  await expect(input).toBeFocused()
-  await input.fill("Renamed from tab")
-  await input.press("Enter")
-  await expect(page.getByRole("heading", { name: "Renamed from tab", exact: true })).toBeVisible()
-  await page.reload()
-  await expect(page.getByRole("heading", { name: "Renamed from tab", exact: true })).toBeVisible()
-  const renamed = page.locator('[data-slot="titlebar-tabs"] a').filter({ hasText: "Renamed from tab" })
-  await renamed.click({ button: "right" })
-  await page.getByRole("menuitem", { name: "Close tab", exact: true }).click()
-  await expect(renamed).toBeHidden()
-  await page.getByRole("button", { name: "Home", exact: true }).click()
-  await expect(
-    page.locator('[data-component="home-session-row"]').filter({ hasText: "Renamed from tab" }),
-  ).toBeVisible()
-})
-
-test("renames an inactive tab without switching sessions", async ({ page }) => {
-  await page.getByRole("button", { name: "Home", exact: true }).click()
-  await page.locator('[data-component="home-session-row"]').filter({ hasText: fixture.expected.sourceTitle }).click()
-  await expect(page.getByRole("heading", { name: fixture.expected.sourceTitle, exact: true })).toBeVisible()
-  const tab = page.locator('[data-slot="titlebar-tabs"] a').filter({ hasText: fixture.expected.targetTitle })
-  await tab.click({ button: "right" })
-  await page.getByRole("menuitem", { name: "Rename", exact: true }).click()
-  const input = page.locator('[data-slot="tab-title"][contenteditable="true"]')
-  await expect(input).toBeFocused()
-  await input.fill("Inactive tab renamed")
-  await input.press("Tab")
-  await expect(page.getByRole("heading", { name: fixture.expected.sourceTitle, exact: true })).toBeVisible()
-  await expect(page).toHaveURL(new RegExp(`/session/${fixture.sourceID}$`))
-  await page.locator('[data-slot="titlebar-tabs"] a').filter({ hasText: "Inactive tab renamed" }).click()
-  await expect(page.getByRole("heading", { name: "Inactive tab renamed", exact: true })).toBeVisible()
-  await page.reload()
-  await expect(page.getByRole("heading", { name: "Inactive tab renamed", exact: true })).toBeVisible()
 })

--- a/packages/app/e2e/regression/session-todo-dock-navigation.spec.ts
+++ b/packages/app/e2e/regression/session-todo-dock-navigation.spec.ts
@@ -1,7 +1,7 @@
 import { base64Encode } from "@opencode-ai/core/util/encode"
 import { expect, test, type Page } from "@playwright/test"
 import { mockOpenCodeServer } from "../utils/mock-server"
-import { expectSessionTitle } from "../utils/waits"
+import { expectSessionTitle, switchHistorySession } from "../utils/waits"
 
 const directory = "C:/OpenCode/TodoDockNavigation"
 const projectID = "proj_todo_dock_navigation"
@@ -83,11 +83,11 @@ test("animates todo lifecycle without replaying it across session tabs", async (
   await expect(dock.locator('[data-state="in_progress"]')).toHaveCount(1)
   expect((await opening).some((sample) => sample.opacity > 0.05 && sample.opacity < 0.95)).toBe(true)
 
-  await switchSession(page, otherID, otherTitle)
+  await switchHistorySession(page, otherID, otherTitle)
   await expect(dock).toHaveCount(0)
 
   const returningOpen = sampleDock(page, 700)
-  await switchSession(page, sourceID, sourceTitle)
+  await switchHistorySession(page, sourceID, sourceTitle)
   const openSamples = (await returningOpen).filter((sample) => sample.present)
   expect(openSamples.length).toBeGreaterThan(0)
   expect(openSamples[0]!.opacity).toBeGreaterThan(0.98)
@@ -103,9 +103,9 @@ test("animates todo lifecycle without replaying it across session tabs", async (
   todos[sourceID] = []
   events.push(todoEvent(sourceID, []))
 
-  await switchSession(page, otherID, otherTitle)
+  await switchHistorySession(page, otherID, otherTitle)
   const returningEmpty = sampleDock(page, 700)
-  await switchSession(page, sourceID, sourceTitle)
+  await switchHistorySession(page, sourceID, sourceTitle)
   await expect(dock).toHaveCount(0)
   expect((await returningEmpty).every((sample) => !sample.present)).toBe(true)
 })
@@ -155,19 +155,6 @@ async function configurePage(page: Page) {
     },
     { directory, dirBase64: base64Encode(directory), server, sessionIDs: [sourceID, otherID] },
   )
-}
-
-function sessionHref(sessionID: string) {
-  const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
-  return `/server/${base64Encode(server)}/session/${sessionID}`
-}
-
-async function switchSession(page: Page, sessionID: string, title: string) {
-  const href = sessionHref(sessionID)
-  const tab = page.locator(`[data-slot="titlebar-tabs"] a[href="${href}"]`).first()
-  await expect(tab).toBeVisible()
-  await tab.click()
-  await expectSessionTitle(page, title)
 }
 
 function sampleDock(page: Page, duration: number) {

--- a/packages/app/e2e/smoke/session-timeline.spec.ts
+++ b/packages/app/e2e/smoke/session-timeline.spec.ts
@@ -3,7 +3,7 @@ import { base64Encode } from "@opencode-ai/core/util/encode"
 import { fixture, pageMessages } from "./session-timeline.fixture"
 import { trackPageErrors, expectNoSmokeErrors } from "../utils/errors"
 import { mockOpenCodeServer } from "../utils/mock-server"
-import { APP_READY_TIMEOUT, expectAppVisible, expectSessionTitle } from "../utils/waits"
+import { APP_READY_TIMEOUT, expectAppVisible, expectSessionTitle, switchHistorySession } from "../utils/waits"
 
 const forbiddenText = ["Load details", "Show earlier steps"]
 
@@ -143,7 +143,7 @@ test.describe("smoke: session timeline", () => {
 
     await page.goto(`/${base64Encode(fixture.directory)}/session/${fixture.targetID}`)
     await expectSessionTitle(page, fixture.expected.targetTitle)
-    await switchTitlebarSession(page, fixture.sourceID, fixture.expected.sourceTitle)
+    await switchHistorySession(page, fixture.sourceID, fixture.expected.sourceTitle)
 
     const destination = fixture.messages[fixture.targetID].map((message) => message.info.id)
     const last = fixture.expected.targetMessageIDs.at(-1)!
@@ -216,7 +216,7 @@ test.describe("smoke: session timeline", () => {
       { destination, last },
     )
 
-    await switchTitlebarSession(page, fixture.targetID, fixture.expected.targetTitle)
+    await switchHistorySession(page, fixture.targetID, fixture.expected.targetTitle)
     await page.waitForFunction(() =>
       (
         window as Window & { __sessionTabPaint?: { samples: Array<{ ids: string[] }> } }
@@ -301,7 +301,7 @@ test.describe("smoke: session timeline", () => {
       { destination, last },
     )
 
-    await switchTitlebarSession(page, fixture.targetID, fixture.expected.targetTitle)
+    await switchHistorySession(page, fixture.targetID, fixture.expected.targetTitle)
     await page.waitForFunction(() =>
       (window as Window & { __coldTabSamples?: Array<{ destination: boolean }> }).__coldTabSamples?.some(
         (sample) => sample.destination,
@@ -725,14 +725,6 @@ async function selectHomeProject(page: Page, projectName: string) {
 async function navigateToSession(page: Page, directory: string, sessionId: string, expectedTitle: string) {
   await page.goto(`/${base64Encode(directory)}/session/${sessionId}`)
   await expectSessionTitle(page, expectedTitle)
-}
-
-async function switchTitlebarSession(page: Page, sessionID: string, title: string) {
-  const href = `/server/${base64Encode(fixture.serverKey)}/session/${sessionID}`
-  const tab = page.locator(`[data-slot="titlebar-tabs"] a[href="${href}"]`).first()
-  await expect(tab).toBeVisible()
-  await tab.click()
-  await expectSessionTitle(page, title)
 }
 
 async function expectSessionReady(page: Page) {

--- a/packages/app/e2e/utils/waits.ts
+++ b/packages/app/e2e/utils/waits.ts
@@ -9,3 +9,18 @@ export async function expectAppVisible(locator: Locator) {
 export async function expectSessionTitle(page: Page, title: string) {
   await expectAppVisible(page.getByRole("heading", { name: title }))
 }
+
+export function sessionHistoryRow(page: Page, sessionID: string) {
+  return page.locator(`[data-component="session-history-row"][data-session-id="${sessionID}"]`)
+}
+
+export function draftHistoryRow(page: Page, draftID: string) {
+  return page.locator(`[data-component="session-history-row"][data-draft-id="${draftID}"]`)
+}
+
+export async function switchHistorySession(page: Page, sessionID: string, title: string) {
+  const row = sessionHistoryRow(page, sessionID)
+  await expect(row).toBeVisible()
+  await row.click()
+  await expectSessionTitle(page, title)
+}

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -39,6 +39,9 @@ export type PromptInputV2ComposerProps = {
   borderUnderlay?: boolean
 }
 
+export const PROMPT_INPUT_V2_SURFACE_CLASS =
+  "[&_[data-component=prompt-input-v2]]:bg-v2-background-bg-layer-01 [&_[data-component=prompt-input-v2]]:shadow-[inset_0_0_0_0.5px_var(--v2-border-border-muted),var(--v2-elevation-raised)]"
+
 export type PromptInputV2ControllerProps = Omit<PromptInputProps, "class" | "submission">
 export type PromptInputV2ComposerController = PromptInputV2Interaction & {
   readonly model: PromptInputProps["controls"]["model"]

--- a/packages/app/src/components/session/session-changes-toggle.tsx
+++ b/packages/app/src/components/session/session-changes-toggle.tsx
@@ -1,0 +1,51 @@
+import { Show } from "solid-js"
+import { Icon } from "@opencode-ai/ui/v2/icon"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
+import { reviewTooltipKeybind } from "@/components/command-tooltip-keybind"
+import { useCommand } from "@/context/command"
+import { useLanguage } from "@/context/language"
+import { useSettings } from "@/context/settings"
+import { useSessionLayout } from "@/pages/session/session-layout"
+
+export function SessionChangesToggle() {
+  const language = useLanguage()
+  const command = useCommand()
+  const settings = useSettings()
+  const { params, view } = useSessionLayout()
+  const opened = () => view().reviewPanel.opened()
+  const keybind = reviewTooltipKeybind(command)
+
+  return (
+    <Show when={settings.general.newLayoutDesigns() && params.id}>
+      <TooltipV2
+        class="shrink-0"
+        placement="bottom"
+        value={
+          <>
+            {language.t("session.review.change.other")}
+            <Show when={keybind.length > 0}>
+              <KeybindV2 keys={keybind} variant="neutral" />
+            </Show>
+          </>
+        }
+      >
+        <IconButtonV2
+          type="button"
+          variant="ghost-muted"
+          size="large"
+          class="shrink-0"
+          icon={<Icon name="review" />}
+          state={opened() ? "pressed" : undefined}
+          data-expanded={opened() || undefined}
+          aria-pressed={opened()}
+          aria-expanded={opened()}
+          aria-controls="review-panel"
+          aria-label={language.t("session.review.change.other")}
+          onClick={() => view().reviewPanel.toggle()}
+        />
+      </TooltipV2>
+    </Show>
+  )
+}

--- a/packages/app/src/components/session/session-header.tsx
+++ b/packages/app/src/components/session/session-header.tsx
@@ -10,7 +10,6 @@ import { Tooltip, TooltipKeybind } from "@opencode-ai/ui/tooltip"
 import { getFilename } from "@opencode-ai/core/util/path"
 import { createEffect, createMemo, createSignal, For, onMount, Show } from "solid-js"
 import { createStore } from "solid-js/store"
-import { createMediaQuery } from "@solid-primitives/media"
 import { Portal } from "solid-js/web"
 import { useCommand } from "@/context/command"
 import { useLanguage } from "@/context/language"
@@ -27,11 +26,6 @@ import { decode64 } from "@/utils/base64"
 import { fileManagerApp } from "@/utils/file-manager"
 import { Persist, persisted } from "@/utils/persist"
 import { StatusPopover, StatusPopoverV2 } from "../status-popover"
-import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
-import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
-import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
-import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
-import { reviewTooltipKeybind } from "../command-tooltip-keybind"
 import { useTitlebarRightMount } from "../titlebar"
 
 const OPEN_APPS = [
@@ -164,7 +158,6 @@ export function SessionHeader() {
   const isV2 = settings.general.newLayoutDesigns
   const search = settings.visibility.search
   const status = settings.visibility.status
-  const isDesktop = createMediaQuery("(min-width: 768px)")
 
   const [exists, setExists] = createStore<Partial<Record<OpenApp, boolean>>>({
     finder: true,
@@ -234,15 +227,6 @@ export function SessionHeader() {
   const tint = createMemo(() =>
     messageAgentColor(params.id ? sync().data.message[params.id] : undefined, sync().data.agent),
   )
-  const v2ActionsState = createMemo<SessionHeaderV2ActionsState>(() => ({
-    statusVisible: status(),
-    statusLabel: language.t("status.popover.trigger"),
-    reviewLabel: language.t("command.review.toggle"),
-    reviewKeybind: reviewTooltipKeybind(command),
-    reviewVisible: isDesktop(),
-    reviewOpened: view().reviewPanel.opened(),
-    onReviewToggle: () => view().reviewPanel.toggle(),
-  }))
 
   const selectApp = (app: OpenApp) => {
     if (!options().some((item) => item.id === app)) return
@@ -319,7 +303,7 @@ export function SessionHeader() {
           </Portal>
         )}
       </Show>
-      <Show when={rightMount()} keyed>
+      <Show when={!isV2() && rightMount()} keyed>
         {(mount) => (
           <Portal mount={mount}>
             <Show
@@ -507,62 +491,32 @@ export function SessionHeader() {
                 </div>
               }
             >
-              <SessionHeaderV2Actions state={v2ActionsState()} />
+              <SessionHeaderV2Actions />
             </Show>
           </Portal>
         )}
+      </Show>
+      <Show when={isV2()}>
+        <div class="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-end p-3">
+          <div class="pointer-events-auto">
+            <SessionHeaderV2Actions />
+          </div>
+        </div>
       </Show>
     </>
   )
 }
 
-type SessionHeaderV2ActionsState = {
-  statusVisible: boolean
-  statusLabel: string
-  reviewLabel: string
-  reviewKeybind: string[]
-  reviewVisible: boolean
-  reviewOpened: boolean
-  onReviewToggle: () => void
-}
-
-function SessionHeaderV2Actions(props: { state: SessionHeaderV2ActionsState }) {
+function SessionHeaderV2Actions() {
   const language = useLanguage()
+  const settings = useSettings()
+  const status = settings.visibility.status
 
   return (
-    <div class="flex items-center gap-2">
-      <Show when={props.state.statusVisible}>
-        <Tooltip placement="bottom" value={props.state.statusLabel}>
-          <StatusPopoverV2 />
-        </Tooltip>
-      </Show>
-      <Show when={props.state.reviewVisible}>
-        <TooltipV2
-          class="shrink-0"
-          placement="bottom"
-          value={
-            <>
-              {props.state.reviewLabel}
-              <Show when={props.state.reviewKeybind.length > 0}>
-                <KeybindV2 keys={props.state.reviewKeybind} variant="neutral" />
-              </Show>
-            </>
-          }
-        >
-          <IconButtonV2
-            type="button"
-            variant="ghost-muted"
-            size="large"
-            class="!w-9 shrink-0"
-            state={props.state.reviewOpened ? "pressed" : undefined}
-            onClick={props.state.onReviewToggle}
-            aria-label={props.state.reviewLabel}
-            aria-expanded={props.state.reviewOpened}
-            aria-controls="review-panel"
-            icon={<IconV2 name="sidebar-right" />}
-          />
-        </TooltipV2>
-      </Show>
-    </div>
+    <Show when={status()}>
+      <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
+        <StatusPopoverV2 />
+      </Tooltip>
+    </Show>
   )
 }

--- a/packages/app/src/components/titlebar.tsx
+++ b/packages/app/src/components/titlebar.tsx
@@ -28,13 +28,12 @@ import { useLanguage } from "@/context/language"
 import { useSettings } from "@/context/settings"
 import { WindowsAppMenu } from "./windows-app-menu"
 import { applyPath, backPath, forwardPath } from "./titlebar-history"
-import { TitlebarTabStrip } from "@/components/titlebar-tab-strip"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { createMediaQuery } from "@solid-primitives/media"
 import { readSessionTabsRemovedDetail, SESSION_TABS_REMOVED_EVENT } from "@/components/titlebar-session-events"
 import { useGlobal } from "@/context/global"
 import { ServerConnection, useServer } from "@/context/server"
-import { tabKey, useTabs } from "@/context/tabs"
+import { useTabs } from "@/context/tabs"
 import type { PromptSession } from "@/context/prompt"
 import "./titlebar.css"
 import { newTabTooltipKeybind } from "./command-tooltip-keybind"
@@ -356,8 +355,6 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
               ].filter((v) => v !== undefined)
             })
 
-            const [tabsAreOverflowing, setTabsAreOverflowing] = createSignal(false)
-
             return (
               <div
                 class="h-full flex-1 overflow-hidden flex flex-row items-center gap-1.5 px-2 md:pr-3"
@@ -371,6 +368,19 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                 <ChannelIndicator debugTools={props.debugTools} />
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} variant="v2" />
+                </Show>
+                <Show when={mobile()}>
+                  <IconButtonV2
+                    type="button"
+                    variant="ghost-muted"
+                    size="large"
+                    class="!w-9 shrink-0"
+                    icon={<IconV2 name="menu" />}
+                    state={layout.mobileSidebar.opened() ? "pressed" : undefined}
+                    onClick={() => layout.mobileSidebar.toggle()}
+                    aria-label={language.t("sidebar.menu.toggle")}
+                    aria-expanded={layout.mobileSidebar.opened()}
+                  />
                 </Show>
                 <TooltipV2
                   placement="bottom"
@@ -394,22 +404,6 @@ export function Titlebar(props: { update?: TitlebarUpdate; debugTools?: { visibl
                     aria-pressed={layout.route().type === "home"}
                   />
                 </TooltipV2>
-
-                <TitlebarTabStrip
-                  tabs={tabsStore}
-                  currentTab={currentTab}
-                  forceTruncate={tabsAreOverflowing()}
-                  onOverflowChange={setTabsAreOverflowing}
-                  onNavigate={(tab, el) => {
-                    tabs.select(tab)
-                    el?.scrollIntoView({ behavior: "instant" })
-                  }}
-                  onClose={(tab) => {
-                    const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
-                    if (index !== -1) tabsStoreActions.closeTab(index)
-                  }}
-                  onReorder={(keys) => tabsStoreActions.reorder(keys)}
-                />
                 <TooltipV2
                   placement="bottom"
                   value={

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -296,6 +296,9 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         mobileSidebar: {
           opened: false,
         },
+        historyTree: {
+          opened: true,
+        },
         sessionTabs: {} as Record<string, SessionTabs>,
         sessionView: {} as Record<string, SessionView>,
         handoff: {
@@ -761,6 +764,30 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         },
         toggle() {
           setStore("mobileSidebar", "opened", (x) => !x)
+        },
+      },
+      historyTree: {
+        opened: createMemo(() => store.historyTree?.opened ?? true),
+        open() {
+          if (!store.historyTree) {
+            setStore("historyTree", { opened: true })
+            return
+          }
+          setStore("historyTree", "opened", true)
+        },
+        close() {
+          if (!store.historyTree) {
+            setStore("historyTree", { opened: false })
+            return
+          }
+          setStore("historyTree", "opened", false)
+        },
+        toggle() {
+          if (!store.historyTree) {
+            setStore("historyTree", { opened: false })
+            return
+          }
+          setStore("historyTree", "opened", !(store.historyTree.opened ?? true))
         },
       },
       pendingMessage: {

--- a/packages/app/src/context/tabs.test.ts
+++ b/packages/app/src/context/tabs.test.ts
@@ -4,6 +4,7 @@ import { createTabMemory } from "./tab-memory"
 import { nextTabAfterClose, pushClosedTab, removeClosedTabs, takeClosedTab, type ClosedTab } from "./closed-tabs"
 import type { SessionTab, Tab } from "./tabs"
 import { migrateTabs } from "./tab-migration"
+import { existingUnusedDraft } from "./unused-draft"
 import type { ServerConnection } from "./server"
 
 const server = "local\nhttp://localhost:4096" as ServerConnection.Key
@@ -121,5 +122,28 @@ describe("closed tab stack", () => {
     expect(nextTabAfterClose(tabs, 1, false)).toBeUndefined()
     expect(nextTabAfterClose(tabs, 1, true)).toEqual(sessionTab("c"))
     expect(nextTabAfterClose([sessionTab("a")], 0, true)).toBeNull()
+  })
+})
+
+describe("unused drafts", () => {
+  const draft = (id: string, directory = "/opencode"): Tab => ({
+    type: "draft",
+    draftID: id,
+    server,
+    directory,
+  })
+
+  test("reuses a draft for the same directory before any other unused draft", () => {
+    const tabs = [sessionTab("a"), draft("one", "/a"), draft("two", "/b")]
+    expect(existingUnusedDraft(tabs, { server, directory: "/b" })?.draftID).toBe("two")
+  })
+
+  test("falls back to the first unused draft when no directory matches", () => {
+    const tabs = [draft("one", "/a"), sessionTab("a")]
+    expect(existingUnusedDraft(tabs, { server, directory: "/b" })?.draftID).toBe("one")
+  })
+
+  test("returns nothing when there is no unused draft", () => {
+    expect(existingUnusedDraft([sessionTab("a")], { server, directory: "/a" })).toBeUndefined()
   })
 })

--- a/packages/app/src/context/tabs.tsx
+++ b/packages/app/src/context/tabs.tsx
@@ -13,6 +13,7 @@ import { createTabMemory } from "./tab-memory"
 import { nextTabAfterClose, pushClosedTab, removeClosedTabs, takeClosedTab, type ClosedTab } from "./closed-tabs"
 import { createDraftPromptSession, type PromptModel } from "./prompt-state"
 import { migrateTabs } from "./tab-migration"
+import { existingUnusedDraft } from "./unused-draft"
 
 export type SessionTab = {
   type: "session"
@@ -176,6 +177,18 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
       if (draftID) removeDraftPersisted(draftID)
     }
 
+    const discardUnusedDrafts = (keep?: string) => {
+      const removed = store.filter((tab) => tab.type === "draft" && tab.draftID !== keep)
+      if (removed.length === 0) return
+      setStore((tabs) => tabs.filter((tab) => tab.type !== "draft" || tab.draftID === keep))
+      if (recent.key && removed.some((tab) => tabKey(tab) === recent.key)) setRecentKey(undefined)
+      for (const tab of removed) {
+        memory.remove(tabKey(tab))
+        removeInfo(tabKey(tab))
+        if (tab.type === "draft") removeDraftPersisted(tab.draftID)
+      }
+    }
+
     const actions = {
       addSessionTab: (tab: Omit<SessionTab, "type">) => {
         const next = { type: "session" as const, ...tab }
@@ -206,7 +219,21 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
         if (!tab || tab.type !== "draft") throw new Error(`Draft not found: ${draftID}`)
         return tab
       },
+      discardUnusedDrafts,
       async newDraft(draft: Omit<DraftTab, "type" | "draftID">, prompt?: string, model?: PromptModel) {
+        const existing = prompt ? undefined : existingUnusedDraft(store, draft)
+        if (existing) {
+          discardUnusedDrafts(existing.draftID)
+          await startTransition(() => {
+            setStore(
+              (tab) => tab.type === "draft" && tab.draftID === existing.draftID,
+              produce((tab) => Object.assign(tab, draft)),
+            )
+            navigate(draftHref(existing.draftID))
+          })
+          return { ...existing, ...draft }
+        }
+        discardUnusedDrafts()
         const draftID = uuid()
         const tab = { type: "draft" as const, draftID, ...draft }
         memory.ensure(tabKey(tab), "prompt", () => createDraftPromptSession(draftID, { prompt, model }))

--- a/packages/app/src/context/unused-draft.ts
+++ b/packages/app/src/context/unused-draft.ts
@@ -1,0 +1,6 @@
+import type { DraftTab, Tab } from "./tabs"
+
+export function existingUnusedDraft(tabs: Tab[], next: Pick<DraftTab, "server" | "directory">) {
+  const drafts = tabs.filter((tab): tab is DraftTab => tab.type === "draft")
+  return drafts.find((tab) => tab.server === next.server && tab.directory === next.directory) ?? drafts[0]
+}

--- a/packages/app/src/i18n/am.ts
+++ b/packages/app/src/i18n/am.ts
@@ -860,6 +860,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ማሳወቂያዎችን አጽዳ",
   "sidebar.empty.title": "ምንም ክፍት ፕሮጀክቶች የሉም",
   "sidebar.empty.description": "ለመጀመር ፕሮጀክት ይክፈቱ",
+  "sidebar.history.runningChat": "በሂደት ላይ: {{title}}",
   "debugBar.ariaLabel": "የልማት አፈጻጸም ምርመራዎች",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ar.ts
+++ b/packages/app/src/i18n/ar.ts
@@ -827,6 +827,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "مسح الإشعارات",
   "sidebar.empty.title": "لا توجد مشاريع مفتوحة",
   "sidebar.empty.description": "افتح مشروعًا للبدء",
+  "sidebar.history.runningChat": "جارٍ التشغيل: {{title}}",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "سطح المكتب",
   "settings.section.server": "الخادم",

--- a/packages/app/src/i18n/az.ts
+++ b/packages/app/src/i18n/az.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Bildirişləri təmizlə",
   "sidebar.empty.title": "Heç bir layihə açılmayıb",
   "sidebar.empty.description": "Başlamaq üçün bir layihə açın",
+  "sidebar.history.runningChat": "İşləyir: {{title}}",
   "debugBar.ariaLabel": "Tərtibatçı performans diaqnostikası",
   "debugBar.na": "yox",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/bg.ts
+++ b/packages/app/src/i18n/bg.ts
@@ -882,6 +882,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Изчистване на известията",
   "sidebar.empty.title": "Няма отворени проекти",
   "sidebar.empty.description": "Отворете проект, за да започнете",
+  "sidebar.history.runningChat": "Изпълнява се: {{title}}",
   "debugBar.ariaLabel": "Диагностика на ефективността на разработката",
   "debugBar.na": "няма",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/bn.ts
+++ b/packages/app/src/i18n/bn.ts
@@ -876,6 +876,7 @@ export const dict: Record<string, string> = {
   "sidebar.project.clearNotifications": "বিজ্ঞপ্তিগুলি সাফ করুন",
   "sidebar.empty.title": "কোনো প্রকল্প খোলা নেই",
   "sidebar.empty.description": "শুরু করতে একটি প্রকল্প খুলুন",
+  "sidebar.history.runningChat": "চলছে: {{title}}",
   "debugBar.ariaLabel": "উন্নয়ন কর্মক্ষমতা ডায়গনিস্টিক",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "এনএভি",

--- a/packages/app/src/i18n/br.ts
+++ b/packages/app/src/i18n/br.ts
@@ -830,6 +830,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Limpar notificações",
   "sidebar.empty.title": "Nenhum projeto aberto",
   "sidebar.empty.description": "Abra um projeto para começar",
+  "sidebar.history.runningChat": "Em execução: {{title}}",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Desktop",
   "settings.section.server": "Servidor",

--- a/packages/app/src/i18n/bs.ts
+++ b/packages/app/src/i18n/bs.ts
@@ -891,6 +891,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Očisti obavijesti",
   "sidebar.empty.title": "Nema otvorenih projekata",
   "sidebar.empty.description": "Otvori projekat za početak",
+  "sidebar.history.runningChat": "U toku: {{title}}",
 
   "app.name.desktop": "OpenCode Desktop",
 

--- a/packages/app/src/i18n/ca.ts
+++ b/packages/app/src/i18n/ca.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Esborra les notificacions",
   "sidebar.empty.title": "No hi ha projectes oberts",
   "sidebar.empty.description": "Obriu un projecte per començar",
+  "sidebar.history.runningChat": "En execució: {{title}}",
   "debugBar.ariaLabel": "Diagnòstic de rendiment del desenvolupament",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/cs.ts
+++ b/packages/app/src/i18n/cs.ts
@@ -882,6 +882,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Vymazat oznámení",
   "sidebar.empty.title": "Nejsou otevřeny žádné projekty",
   "sidebar.empty.description": "Chcete-li začít, otevřete projekt",
+  "sidebar.history.runningChat": "Běží: {{title}}",
   "debugBar.ariaLabel": "Diagnostika vývoje výkonnosti",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/da.ts
+++ b/packages/app/src/i18n/da.ts
@@ -768,6 +768,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Ryd notifikationer",
   "sidebar.empty.title": "Ingen åbne projekter",
   "sidebar.empty.description": "Åbn et projekt for at komme i gang",
+  "sidebar.history.runningChat": "Kører: {{title}}",
 
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Desktop",

--- a/packages/app/src/i18n/de.ts
+++ b/packages/app/src/i18n/de.ts
@@ -721,6 +721,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Benachrichtigungen löschen",
   "sidebar.empty.title": "Keine Projekte geöffnet",
   "sidebar.empty.description": "Öffnen Sie ein Projekt, um loszulegen",
+  "sidebar.history.runningChat": "Läuft: {{title}}",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Desktop",
   "settings.section.server": "Server",

--- a/packages/app/src/i18n/dv.ts
+++ b/packages/app/src/i18n/dv.ts
@@ -890,6 +890,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ނޮޓިފިކޭޝަންތައް ސާފުކުރުން",
   "sidebar.empty.title": "އެއްވެސް މަޝްރޫއެއް ނުހުޅުވޭ",
   "sidebar.empty.description": "ފަށަން ޕްރޮޖެކްޓެއް ހުޅުވާށެވެ",
+  "sidebar.history.runningChat": "ހިންގަވަމުން: {{title}}",
   "debugBar.ariaLabel": "ޑިވެލޮޕްމަންޓް ޕާފޯމަންސް ޑައިގްނޯސްޓިކްސް",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV އެވެ",

--- a/packages/app/src/i18n/dz.ts
+++ b/packages/app/src/i18n/dz.ts
@@ -891,6 +891,7 @@ export const dict: Record<string, string> = {
   "sidebar.project.clearNotifications": "བརྡ་བསྐུལ་ཚུ་གསལ་བཟོ།",
   "sidebar.empty.title": "ལས་འགུལ་ཁ་ཕྱེ་མེད།",
   "sidebar.empty.description": "འགོ་བཙུགས་ནིའི་དོན་ལུ་ལས་འགུལ་ཅིག་ཁ་ཕྱེ།",
+  "sidebar.history.runningChat": "འཁོར་བཞིན་པ: {{title}}",
   "debugBar.ariaLabel": "གོང་འཕེལ་གྱི་ལས་དོན་བརྟག་དཔྱད།",
   "debugBar.na": "ན/ཨེ།",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/el.ts
+++ b/packages/app/src/i18n/el.ts
@@ -885,6 +885,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Διαγραφή ειδοποιήσεων",
   "sidebar.empty.title": "Δεν υπάρχουν ανοιχτά έργα",
   "sidebar.empty.description": "Ανοίξτε ένα έργο για να ξεκινήσετε",
+  "sidebar.history.runningChat": "Σε εξέλιξη: {{title}}",
   "debugBar.ariaLabel": "Διαγνωστικά απόδοσης ανάπτυξης",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -854,6 +854,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Clear notifications",
   "sidebar.empty.title": "No projects open",
   "sidebar.empty.description": "Open a project to get started",
+  "sidebar.history.runningChat": "Running: {{title}}",
 
   "debugBar.ariaLabel": "Development performance diagnostics",
   "debugBar.na": "n/a",

--- a/packages/app/src/i18n/es.ts
+++ b/packages/app/src/i18n/es.ts
@@ -896,6 +896,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Borrar notificaciones",
   "sidebar.empty.title": "No hay proyectos abiertos",
   "sidebar.empty.description": "Abre un proyecto para empezar",
+  "sidebar.history.runningChat": "En curso: {{title}}",
 
   "app.name.desktop": "OpenCode Desktop",
 

--- a/packages/app/src/i18n/et.ts
+++ b/packages/app/src/i18n/et.ts
@@ -872,6 +872,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Tühjenda märguanded",
   "sidebar.empty.title": "Avatud projekte pole",
   "sidebar.empty.description": "Alustamiseks avage projekt",
+  "sidebar.history.runningChat": "Töös: {{title}}",
   "debugBar.ariaLabel": "Arendustegevuse diagnostika",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/fa.ts
+++ b/packages/app/src/i18n/fa.ts
@@ -875,6 +875,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "پرامپت ها را پاک کنید",
   "sidebar.empty.title": "هیچ پروژه ای باز نشده است",
   "sidebar.empty.description": "برای شروع یک پروژه باز کنید",
+  "sidebar.history.runningChat": "در حال اجرا: {{title}}",
   "debugBar.ariaLabel": "تشخیص عملکرد توسعه",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/fi.ts
+++ b/packages/app/src/i18n/fi.ts
@@ -776,6 +776,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Tyhjennä ilmoitukset",
   "sidebar.empty.title": "Ei avoimia projekteja",
   "sidebar.empty.description": "Aloita avaamalla projekti",
+  "sidebar.history.runningChat": "Käynnissä: {{title}}",
   "debugBar.ariaLabel": "Kehityksen suorituskyvyn diagnostiikka",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/fo.ts
+++ b/packages/app/src/i18n/fo.ts
@@ -877,6 +877,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Rudda fráboðanir",
   "sidebar.empty.title": "Ongar verkætlanir lata upp",
   "sidebar.empty.description": "Opna eina verkætlan fyri at koma í gongd",
+  "sidebar.history.runningChat": "Koyrir: {{title}}",
   "debugBar.ariaLabel": "Menningar avriksdiagnostikk",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/fr.ts
+++ b/packages/app/src/i18n/fr.ts
@@ -835,6 +835,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Effacer les notifications",
   "sidebar.empty.title": "Aucun projet ouvert",
   "sidebar.empty.description": "Ouvrez un projet pour commencer",
+  "sidebar.history.runningChat": "En cours : {{title}}",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Application de bureau",
   "settings.section.server": "Serveur",

--- a/packages/app/src/i18n/hi.ts
+++ b/packages/app/src/i18n/hi.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "सूचनाएँ साफ़ करें",
   "sidebar.empty.title": "कोई प्रोजेक्ट खुला नहीं",
   "sidebar.empty.description": "आरंभ करने के लिए एक प्रोजेक्ट खोलें",
+  "sidebar.history.runningChat": "चल रहा है: {{title}}",
   "debugBar.ariaLabel": "विकास प्रदर्शन निदान",
   "debugBar.na": "एन/ए",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/hr.ts
+++ b/packages/app/src/i18n/hr.ts
@@ -885,6 +885,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Očistite obavijesti",
   "sidebar.empty.title": "Nema otvorenih projekata",
   "sidebar.empty.description": "Otvorite projekt da biste započeli",
+  "sidebar.history.runningChat": "U tijeku: {{title}}",
   "debugBar.ariaLabel": "Dijagnostika izvedbe razvoja",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/hu.ts
+++ b/packages/app/src/i18n/hu.ts
@@ -884,6 +884,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Értesítések törlése",
   "sidebar.empty.title": "Nincs nyitott projekt",
   "sidebar.empty.description": "A kezdéshez nyisson meg egy projektet",
+  "sidebar.history.runningChat": "Fut: {{title}}",
   "debugBar.ariaLabel": "Fejlesztési teljesítmény diagnosztika",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/hy.ts
+++ b/packages/app/src/i18n/hy.ts
@@ -883,6 +883,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Մաքրել ծանուցումները",
   "sidebar.empty.title": "Ոչ մի նախագիծ բաց",
   "sidebar.empty.description": "Բացեք նախագիծ՝ սկսելու համար",
+  "sidebar.history.runningChat": "Աշխատում է: {{title}}",
   "debugBar.ariaLabel": "Զարգացման կատարողականի ախտորոշում",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/id.ts
+++ b/packages/app/src/i18n/id.ts
@@ -953,6 +953,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Hapus notifikasi",
   "sidebar.empty.title": "Tidak ada proyek terbuka",
   "sidebar.empty.description": "Buka proyek untuk memulai",
+  "sidebar.history.runningChat": "Berjalan: {{title}}",
 
   "debugBar.ariaLabel": "Diagnostik kinerja pengembangan",
   "debugBar.na": "n/a",

--- a/packages/app/src/i18n/is.ts
+++ b/packages/app/src/i18n/is.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Hreinsaðu tilkynningar",
   "sidebar.empty.title": "Engin verkefni opin",
   "sidebar.empty.description": "Opnaðu verkefni til að byrja",
+  "sidebar.history.runningChat": "Í gangi: {{title}}",
   "debugBar.ariaLabel": "Þróunarárangursgreiningar",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/it.ts
+++ b/packages/app/src/i18n/it.ts
@@ -796,6 +796,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Cancella notifiche",
   "sidebar.empty.title": "Nessun progetto aperto",
   "sidebar.empty.description": "Apri un progetto per iniziare",
+  "sidebar.history.runningChat": "In esecuzione: {{title}}",
   "debugBar.ariaLabel": "Diagnostica delle prestazioni di sviluppo",
   "debugBar.na": "n/d",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ja.ts
+++ b/packages/app/src/i18n/ja.ts
@@ -815,6 +815,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "通知をクリア",
   "sidebar.empty.title": "開いているプロジェクトはありません",
   "sidebar.empty.description": "プロジェクトを開いて始めましょう",
+  "sidebar.history.runningChat": "実行中: {{title}}",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "デスクトップ",
   "settings.section.server": "サーバー",

--- a/packages/app/src/i18n/ka.ts
+++ b/packages/app/src/i18n/ka.ts
@@ -876,6 +876,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "შეტყობინებების გასუფთავება",
   "sidebar.empty.title": "პროექტები არ არის გახსნილი",
   "sidebar.empty.description": "გახსენით პროექტი დასაწყებად",
+  "sidebar.history.runningChat": "მიმდინარეობს: {{title}}",
   "debugBar.ariaLabel": "განვითარების შესრულების დიაგნოსტიკა",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/km.ts
+++ b/packages/app/src/i18n/km.ts
@@ -873,6 +873,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ជម្រះការជូនដំណឹង",
   "sidebar.empty.title": "គ្មានគម្រោងបើកទេ។",
   "sidebar.empty.description": "បើកគម្រោងដើម្បីចាប់ផ្តើម",
+  "sidebar.history.runningChat": "កំពុងដំណើរការ: {{title}}",
   "debugBar.ariaLabel": "ការវិនិច្ឆ័យដំណើរការអភិវឌ្ឍន៍",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ko.ts
+++ b/packages/app/src/i18n/ko.ts
@@ -1016,6 +1016,7 @@ export const dict = {
 
   "sidebar.empty.title": "열린 프로젝트 없음",
   "sidebar.empty.description": "프로젝트를 열어 시작하세요",
+  "sidebar.history.runningChat": "실행 중: {{title}}",
 
   "settings.general.section.advanced": "고급",
   "settings.general.row.shell.title": "터미널 셸",

--- a/packages/app/src/i18n/lo.ts
+++ b/packages/app/src/i18n/lo.ts
@@ -871,6 +871,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ລຶບການແຈ້ງເຕືອນ",
   "sidebar.empty.title": "ບໍ່ມີໂຄງການເປີດ",
   "sidebar.empty.description": "ເປີດໂຄງການເພື່ອເລີ່ມຕົ້ນ",
+  "sidebar.history.runningChat": "ກຳລັງເຮັດວຽກ: {{title}}",
   "debugBar.ariaLabel": "ການວິນິດໄສປະສິດທິພາບການພັດທະນາ",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/lt.ts
+++ b/packages/app/src/i18n/lt.ts
@@ -890,6 +890,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Išvalyti pranešimus",
   "sidebar.empty.title": "Jokių atvirų projektų",
   "sidebar.empty.description": "Norėdami pradėti, atidarykite projektą",
+  "sidebar.history.runningChat": "Vykdoma: {{title}}",
   "debugBar.ariaLabel": "Vystymosi veiklos diagnostika",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/lv.ts
+++ b/packages/app/src/i18n/lv.ts
@@ -882,6 +882,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Notīrīt paziņojumus",
   "sidebar.empty.title": "Nav atvērts neviens projekts",
   "sidebar.empty.description": "Atveriet projektu, lai sāktu",
+  "sidebar.history.runningChat": "Darbojas: {{title}}",
   "debugBar.ariaLabel": "Izstrādes veiktspējas diagnostika",
   "debugBar.na": "nav",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/mk.ts
+++ b/packages/app/src/i18n/mk.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Исчистете ги известувањата",
   "sidebar.empty.title": "Нема отворени проекти",
   "sidebar.empty.description": "Отворете проект за да започнете",
+  "sidebar.history.runningChat": "Се извршува: {{title}}",
   "debugBar.ariaLabel": "Дијагностика на перформансите на развојот",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/mn.ts
+++ b/packages/app/src/i18n/mn.ts
@@ -884,6 +884,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Мэдэгдлийг арилгах",
   "sidebar.empty.title": "Нээлттэй төсөл байхгүй",
   "sidebar.empty.description": "Эхлэхийн тулд төсөл нээнэ үү",
+  "sidebar.history.runningChat": "Ажиллаж байна: {{title}}",
   "debugBar.ariaLabel": "Хөгжлийн гүйцэтгэлийн оношлогоо",
   "debugBar.na": "үгүй",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ms.ts
+++ b/packages/app/src/i18n/ms.ts
@@ -876,6 +876,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Kosongkan notifikasi",
   "sidebar.empty.title": "Tiada projek dibuka",
   "sidebar.empty.description": "Buka projek untuk bermula",
+  "sidebar.history.runningChat": "Sedang berjalan: {{title}}",
   "debugBar.ariaLabel": "Diagnostik prestasi pembangunan",
   "debugBar.na": "tiada",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/my.ts
+++ b/packages/app/src/i18n/my.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "အကြောင်းကြားချက်များကို ရှင်းလင်းပါ။",
   "sidebar.empty.title": "မည်သည့်ပရောဂျက်မှ ဖွင့်ထားခြင်းမရှိပါ။",
   "sidebar.empty.description": "စတင်ရန် ပရောဂျက်တစ်ခုကို ဖွင့်ပါ။",
+  "sidebar.history.runningChat": "လုပ်ဆောင်နေသည်: {{title}}",
   "debugBar.ariaLabel": "ဖွံ့ဖြိုးတိုးတက်မှု စွမ်းဆောင်ရည် အဖြေရှာခြင်း",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ne.ts
+++ b/packages/app/src/i18n/ne.ts
@@ -877,6 +877,7 @@ export const dict: Record<string, string> = {
   "sidebar.project.clearNotifications": "सूचनाहरू खाली गर्नुहोस्",
   "sidebar.empty.title": "कुनै पनि आयोजना खुलेका छैनन्",
   "sidebar.empty.description": "सुरु गर्न एउटा परियोजना खोल्नुहोस्",
+  "sidebar.history.runningChat": "चलिरहेको: {{title}}",
   "debugBar.ariaLabel": "विकास प्रदर्शन निदान",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/nl.ts
+++ b/packages/app/src/i18n/nl.ts
@@ -886,6 +886,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Meldingen wissen",
   "sidebar.empty.title": "Geen projecten geopend",
   "sidebar.empty.description": "Open een project om aan de slag te gaan",
+  "sidebar.history.runningChat": "Actief: {{title}}",
   "debugBar.ariaLabel": "Diagnostiek voor ontwikkelprestaties",
   "debugBar.na": "n.v.t.",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/no.ts
+++ b/packages/app/src/i18n/no.ts
@@ -1229,6 +1229,7 @@ export const dict = {
 
   "sidebar.empty.title": "Ingen åpne prosjekter",
   "sidebar.empty.description": "Åpne et prosjekt for å komme i gang",
+  "sidebar.history.runningChat": "Kjører: {{title}}",
 
   "settings.general.section.advanced": "Avansert",
   "settings.general.row.shell.title": "Terminalskall",

--- a/packages/app/src/i18n/pa.ts
+++ b/packages/app/src/i18n/pa.ts
@@ -884,6 +884,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "نوٹیفکیشن صاف کرو",
   "sidebar.empty.title": "کوئی پروجیکٹ نئیں کھلیا",
   "sidebar.empty.description": "شروع کرن لئی کوئی پروجیکٹ کھولو",
+  "sidebar.history.runningChat": "ਚੱਲ ਰਿਹਾ ਹੈ: {{title}}",
   "debugBar.ariaLabel": "ترقی دی کارکردگی دی تشخیص",
   "debugBar.na": "لاگو نئیں",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/pl.ts
+++ b/packages/app/src/i18n/pl.ts
@@ -831,6 +831,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Wyczyść powiadomienia",
   "sidebar.empty.title": "Brak otwartych projektów",
   "sidebar.empty.description": "Otwórz projekt, aby rozpocząć",
+  "sidebar.history.runningChat": "Uruchomiono: {{title}}",
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Aplikacja komputerowa",
   "settings.section.server": "Serwer",

--- a/packages/app/src/i18n/ro.ts
+++ b/packages/app/src/i18n/ro.ts
@@ -881,6 +881,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Șterge notificările",
   "sidebar.empty.title": "Niciun proiect deschis",
   "sidebar.empty.description": "Deschide un proiect pentru a începe",
+  "sidebar.history.runningChat": "În execuție: {{title}}",
   "debugBar.ariaLabel": "Diagnosticare performanță dezvoltare",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/ru.ts
+++ b/packages/app/src/i18n/ru.ts
@@ -894,6 +894,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Очистить уведомления",
   "sidebar.empty.title": "Нет открытых проектов",
   "sidebar.empty.description": "Откройте проект, чтобы начать",
+  "sidebar.history.runningChat": "Выполняется: {{title}}",
 
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "Приложение",

--- a/packages/app/src/i18n/si.ts
+++ b/packages/app/src/i18n/si.ts
@@ -874,6 +874,7 @@ export const dict: Record<string, string> = {
   "sidebar.project.clearNotifications": "දැනුම්දීම් හිස් කරන්න",
   "sidebar.empty.title": "ව්‍යාපෘති විවෘත නැත",
   "sidebar.empty.description": "ආරම්භ කිරීමට ව්‍යාපෘතියක් විවෘත කරන්න",
+  "sidebar.history.runningChat": "ක්‍රියාත්මක වෙමින්: {{title}}",
   "debugBar.ariaLabel": "සංවර්ධන කාර්ය සාධන රෝග විනිශ්චය",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sk.ts
+++ b/packages/app/src/i18n/sk.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Vymazať oznámenia",
   "sidebar.empty.title": "Nie sú otvorené žiadne projekty",
   "sidebar.empty.description": "Otvorte projekt pre začiatok",
+  "sidebar.history.runningChat": "Beží: {{title}}",
   "debugBar.ariaLabel": "Diagnostika výkonu vývoja",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sl.ts
+++ b/packages/app/src/i18n/sl.ts
@@ -881,6 +881,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Počisti obvestila",
   "sidebar.empty.title": "Ni odprtih projektov",
   "sidebar.empty.description": "Za začetek odprite projekt",
+  "sidebar.history.runningChat": "V teku: {{title}}",
   "debugBar.ariaLabel": "Diagnostika uspešnosti razvoja",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sq.ts
+++ b/packages/app/src/i18n/sq.ts
@@ -879,6 +879,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Pastro njoftimet",
   "sidebar.empty.title": "Asnjë projekt i hapur",
   "sidebar.empty.description": "Hapni një projekt për të filluar",
+  "sidebar.history.runningChat": "Në progres: {{title}}",
   "debugBar.ariaLabel": "Diagnostifikimi i performancës së zhvillimit",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sr.ts
+++ b/packages/app/src/i18n/sr.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Обришите обавештења",
   "sidebar.empty.title": "Нема отворених пројеката",
   "sidebar.empty.description": "Отворите пројекат да бисте започели",
+  "sidebar.history.runningChat": "У току: {{title}}",
   "debugBar.ariaLabel": "Дијагностика перформанси развоја",
   "debugBar.na": "н/а",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/sv.ts
+++ b/packages/app/src/i18n/sv.ts
@@ -881,6 +881,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Rensa aviseringar",
   "sidebar.empty.title": "Inga projekt öppna",
   "sidebar.empty.description": "Öppna ett projekt för att komma igång",
+  "sidebar.history.runningChat": "Körs: {{title}}",
   "debugBar.ariaLabel": "Utvecklingsprestandadiagnostik",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/tg.ts
+++ b/packages/app/src/i18n/tg.ts
@@ -880,6 +880,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Огоҳиҳоро тоза кунед",
   "sidebar.empty.title": "Ягон лоиҳа кушода нест",
   "sidebar.empty.description": "Барои оғоз кардани лоиҳа лоиҳа кушоед",
+  "sidebar.history.runningChat": "Иҷро шуда истодааст: {{title}}",
   "debugBar.ariaLabel": "Ташхиси самаранокии рушд",
   "debugBar.na": "не",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/th.ts
+++ b/packages/app/src/i18n/th.ts
@@ -878,6 +878,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "ล้างการแจ้งเตือน",
   "sidebar.empty.title": "ไม่มีโปรเจกต์ที่เปิดอยู่",
   "sidebar.empty.description": "เปิดโปรเจกต์เพื่อเริ่มต้น",
+  "sidebar.history.runningChat": "กำลังทำงาน: {{title}}",
 
   "app.name.desktop": "OpenCode Desktop",
 

--- a/packages/app/src/i18n/tk.ts
+++ b/packages/app/src/i18n/tk.ts
@@ -877,6 +877,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Duýduryşlary arassalaň",
   "sidebar.empty.title": "Taslama açylmaýar",
   "sidebar.empty.description": "Başlamak üçin taslama açyň",
+  "sidebar.history.runningChat": "Işleýär: {{title}}",
   "debugBar.ariaLabel": "Ösüş öndürijiligini anyklaýyş",
   "debugBar.na": "n / a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/tr.ts
+++ b/packages/app/src/i18n/tr.ts
@@ -896,6 +896,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Bildirimleri temizle",
   "sidebar.empty.title": "Açık proje yok",
   "sidebar.empty.description": "Başlamak için bir proje açın",
+  "sidebar.history.runningChat": "Çalışıyor: {{title}}",
 
   "app.name.desktop": "OpenCode Masaüstü",
 

--- a/packages/app/src/i18n/uk.ts
+++ b/packages/app/src/i18n/uk.ts
@@ -966,6 +966,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Очистити сповіщення",
   "sidebar.empty.title": "Немає відкритих проєктів",
   "sidebar.empty.description": "Відкрийте проєкт, щоб почати",
+  "sidebar.history.runningChat": "Виконується: {{title}}",
 
   "debugBar.ariaLabel": "Діагностика продуктивності розробки",
   "debugBar.na": "н/д",

--- a/packages/app/src/i18n/ur.ts
+++ b/packages/app/src/i18n/ur.ts
@@ -887,6 +887,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "اطلاعات کو صاف کریں۔",
   "sidebar.empty.title": "کوئی پروجیکٹ نہیں کھلا۔",
   "sidebar.empty.description": "شروع کرنے کے لیے ایک پروجیکٹ کھولیں۔",
+  "sidebar.history.runningChat": "چل رہا ہے: {{title}}",
   "debugBar.ariaLabel": "ترقیاتی کارکردگی کی تشخیص",
   "debugBar.na": "n/a",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/uz.ts
+++ b/packages/app/src/i18n/uz.ts
@@ -884,6 +884,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Bildirishnomalarni tozalash",
   "sidebar.empty.title": "Hech qanday loyiha ochiq emas",
   "sidebar.empty.description": "Boshlash uchun loyihani oching",
+  "sidebar.history.runningChat": "Ishlamoqda: {{title}}",
   "debugBar.ariaLabel": "Rivojlanish samaradorligi diagnostikasi",
   "debugBar.na": "yo'q",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/vi.ts
+++ b/packages/app/src/i18n/vi.ts
@@ -888,6 +888,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "Xóa thông báo",
   "sidebar.empty.title": "Không có dự án nào mở",
   "sidebar.empty.description": "Mở một dự án để bắt đầu",
+  "sidebar.history.runningChat": "Đang chạy: {{title}}",
   "debugBar.ariaLabel": "Chẩn đoán hiệu suất phát triển",
   "debugBar.na": "không có",
   "debugBar.nav.label": "NAV",

--- a/packages/app/src/i18n/zh.ts
+++ b/packages/app/src/i18n/zh.ts
@@ -874,6 +874,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "清除通知",
   "sidebar.empty.title": "没有打开的项目",
   "sidebar.empty.description": "打开一个项目以开始使用",
+  "sidebar.history.runningChat": "正在运行：{{title}}",
 
   "app.name.desktop": "OpenCode Desktop",
 

--- a/packages/app/src/i18n/zht.ts
+++ b/packages/app/src/i18n/zht.ts
@@ -871,6 +871,7 @@ export const dict = {
   "sidebar.project.clearNotifications": "清除通知",
   "sidebar.empty.title": "未開啟任何專案",
   "sidebar.empty.description": "開啟專案以開始使用",
+  "sidebar.history.runningChat": "正在執行：{{title}}",
 
   "app.name.desktop": "OpenCode Desktop",
   "settings.section.desktop": "桌面",

--- a/packages/app/src/pages/layout-new.tsx
+++ b/packages/app/src/pages/layout-new.tsx
@@ -1,10 +1,12 @@
-import { createEffect, Suspense, type ParentProps } from "solid-js"
+import { createEffect, Show, Suspense, type ParentProps } from "solid-js"
 import { createStore } from "solid-js/store"
 import { DebugBar } from "@/components/debug-bar"
-import { TabsInfoPopup } from "@/components/help-button"
-import { Titlebar, type TitlebarUpdate } from "@/components/titlebar"
+import { type TitlebarUpdate } from "@/components/titlebar"
+import { WindowsAppMenu } from "@/components/windows-app-menu"
+import { useCommand } from "@/context/command"
 import { usePlatform } from "@/context/platform"
 import { setV2Toast, ToastRegion } from "@/utils/toast"
+import { SessionHistoryTree } from "@/pages/session-history-tree"
 
 export default function NewLayout(props: ParentProps) {
   const platform = usePlatform()
@@ -14,9 +16,9 @@ export default function NewLayout(props: ParentProps) {
 
   const update: TitlebarUpdate = {
     version: () => {
-      const state = platform.updater?.state()
-      if (state?.status !== "ready") return
-      return state.version
+      const current = platform.updater?.state()
+      if (current?.status !== "ready") return
+      return current.version
     },
     installing: () => platform.updater?.state().status === "installing",
     install: () => void platform.updater?.install(),
@@ -30,20 +32,52 @@ export default function NewLayout(props: ParentProps) {
         "padding-bottom": "env(safe-area-inset-bottom, 0px)",
       }}
     >
-      <Titlebar
-        update={update}
-        debugTools={
-          import.meta.env.DEV
-            ? { visible: state.debugTools, toggle: () => setState("debugTools", (value) => !value) }
-            : undefined
-        }
-      />
-      <main class="flex-1 min-h-0 min-w-0 overflow-x-hidden flex flex-col items-start contain-strict">
-        <Suspense>{props.children}</Suspense>
-      </main>
-      {import.meta.env.DEV && state.debugTools && <DebugBar inline />}
-      <TabsInfoPopup />
+      <WindowChrome />
+      <div class="relative flex min-h-0 min-w-0 flex-1">
+        <SessionHistoryTree update={update} />
+        <main class="flex min-h-0 min-w-0 flex-1 flex-col items-start overflow-x-hidden contain-strict">
+          <Suspense>{props.children}</Suspense>
+        </main>
+      </div>
+      <Show when={import.meta.env.DEV}>
+        <div class="flex shrink-0 items-center gap-2 px-2 py-1">
+          <Show when={import.meta.env.VITE_OPENCODE_CHANNEL === "dev"}>
+            <button
+              type="button"
+              class="bg-icon-interactive-base text-[#FFF] font-medium px-2 rounded-sm uppercase font-mono cursor-pointer"
+              onClick={() => setState("debugTools", (value) => !value)}
+              aria-label="Toggle debug tools"
+              aria-pressed={state.debugTools}
+            >
+              DEV
+            </button>
+          </Show>
+          <Show when={state.debugTools}>
+            <DebugBar inline />
+          </Show>
+        </div>
+      </Show>
       <ToastRegion v2 />
+    </div>
+  )
+}
+
+function WindowChrome() {
+  const platform = usePlatform()
+  const command = useCommand()
+  const windows = platform.platform === "desktop" && platform.os === "windows"
+  const linux = platform.platform === "desktop" && platform.os === "linux"
+
+  return (
+    <div
+      class="pointer-events-none absolute inset-x-0 top-0 z-50 flex h-9 items-center gap-1.5 px-2"
+      data-tauri-drag-region
+    >
+      <Show when={windows || linux}>
+        <div class="pointer-events-auto">
+          <WindowsAppMenu command={command} platform={platform} variant="v2" />
+        </div>
+      </Show>
     </div>
   )
 }

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -21,6 +21,8 @@ import {
   latestRootSession,
   sortedRootSessions,
   toggleHomeProjectSelection,
+  historyTreeGroups,
+  historyTreeProjectForDirectory,
 } from "./helpers"
 import { pathKey } from "@/utils/path-key"
 import { ServerConnection } from "@/context/server"
@@ -343,5 +345,66 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+})
+
+describe("history tree groups", () => {
+  test("nests root sessions under their project and skips children and archives", () => {
+    const opencode = { worktree: "/opencode", name: "opencode" }
+    const tracker = { worktree: "/tracker", name: "Tracker", sandboxes: ["/tracker/.worktrees/sim"] }
+    const groups = historyTreeGroups(
+      [opencode, tracker],
+      [
+        session({ id: "child", directory: "/opencode", parentID: "parent", time: { created: 9, updated: 9 } }),
+        session({
+          id: "archived",
+          directory: "/opencode",
+          time: { created: 8, updated: 8, archived: 8 },
+        }),
+        session({ id: "cost", directory: "/opencode", title: "Cost calculator", time: { created: 2, updated: 4 } }),
+        session({ id: "flaky", directory: "/opencode", title: "Fix flaky", time: { created: 1, updated: 3 } }),
+        session({
+          id: "sim",
+          directory: "/tracker/.worktrees/sim",
+          title: "Simulator",
+          time: { created: 5, updated: 5 },
+        }),
+      ],
+    )
+
+    expect(groups.map((group) => group.projectName)).toEqual(["opencode", "Tracker"])
+    expect(groups[0]!.sessions.map((item) => item.id)).toEqual(["cost", "flaky"])
+    expect(groups[1]!.sessions.map((item) => item.id)).toEqual(["sim"])
+  })
+
+  test("assigns a nested directory to the longest matching project", () => {
+    const root = { worktree: "/src", name: "src" }
+    const nested = { worktree: "/src/app", name: "app" }
+    const groups = historyTreeGroups(
+      [root, nested],
+      [session({ id: "inner", directory: "/src/app/lib", time: { created: 1, updated: 1 } })],
+    )
+    expect(historyTreeProjectForDirectory([root, nested], "/src/app/lib")?.name).toBe("app")
+    expect(groups[0]!.sessions.map((item) => item.id)).toEqual([])
+    expect(groups[1]!.sessions.map((item) => item.id)).toEqual(["inner"])
+  })
+
+  test("nests a worktree path under its project even without a sandbox list", () => {
+    const groups = historyTreeGroups(
+      [{ worktree: "/tracker", name: "Tracker" }],
+      [session({ id: "sim", directory: "/tracker/.worktrees/sim", time: { created: 1, updated: 1 } })],
+    )
+    expect(groups[0]!.sessions.map((item) => item.id)).toEqual(["sim"])
+  })
+
+  test("keeps projects with no chats so a new session can still start there", () => {
+    const groups = historyTreeGroups([{ worktree: "/empty", name: "empty" }], [])
+    expect(groups).toEqual([
+      {
+        project: { worktree: "/empty", name: "empty" },
+        projectName: "empty",
+        sessions: [],
+      },
+    ])
   })
 })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -49,6 +49,51 @@ export const childSessionOnPath = (sessions: Session[] | undefined, rootID: stri
 export const displayName = (project: { name?: string; worktree: string }) =>
   project.name || getFilename(project.worktree) || project.worktree
 
+export type HistoryTreeProject = { worktree: string; name?: string; sandboxes?: string[] }
+
+export type HistoryTreeGroup<T extends HistoryTreeProject = HistoryTreeProject> = {
+  project: T
+  projectName: string
+  sessions: Session[]
+}
+
+export function projectOwnsDirectory(project: HistoryTreeProject, directory: string) {
+  const dir = pathKey(directory)
+  const root = pathKey(project.worktree)
+  if (dir === root) return true
+  if (project.sandboxes?.some((sandbox) => pathKey(sandbox) === dir)) return true
+  return dir.startsWith(`${root}/`)
+}
+
+export function historyTreeProjectForDirectory<T extends HistoryTreeProject>(projects: T[], directory: string) {
+  return projects
+    .filter((project) => projectOwnsDirectory(project, directory))
+    .sort((left, right) => pathKey(right.worktree).length - pathKey(left.worktree).length)[0]
+}
+
+export function historyTreeGroups<T extends HistoryTreeProject>(
+  projects: T[],
+  sessions: Session[],
+): HistoryTreeGroup<T>[] {
+  const buckets = new Map(
+    projects.map((project) => [
+      pathKey(project.worktree),
+      { project, projectName: displayName(project), sessions: [] as Session[] },
+    ]),
+  )
+  for (const session of sessions) {
+    if (session.parentID) continue
+    if (session.time?.archived) continue
+    const project = historyTreeProjectForDirectory(projects, session.directory)
+    if (!project) continue
+    buckets.get(pathKey(project.worktree))?.sessions.push(session)
+  }
+  return [...buckets.values()].map((group) => ({
+    ...group,
+    sessions: group.sessions.sort(compareSessionTime),
+  }))
+}
+
 export function toggleHomeProjectSelection(
   current: HomeProjectSelection | undefined,
   server: ServerConnection.Key,

--- a/packages/app/src/pages/layout/history-tree-chrome.test.ts
+++ b/packages/app/src/pages/layout/history-tree-chrome.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test"
+import {
+  HISTORY_TREE_AFTER,
+  HISTORY_TREE_CARD_INSET,
+  HISTORY_TREE_ICON,
+  HISTORY_TREE_SIDEBAR_INSET,
+  HISTORY_TREE_TITLE_PAD,
+  MAC_TRAFFIC_LIGHTS_WIDTH,
+  historyTreeChromeOnCard,
+  historyTreeCollapsedStart,
+  historyTreeTitlePadding,
+  historyTreeTitleShift,
+  historyTreeWindowChromeStart,
+  historyTreeWindowToggle,
+} from "./history-tree-chrome"
+
+describe("history tree chrome", () => {
+  test("collapsed start sits after traffic lights on mac and on the card inset elsewhere", () => {
+    expect(historyTreeCollapsedStart(true)).toBe(MAC_TRAFFIC_LIGHTS_WIDTH)
+    expect(historyTreeCollapsedStart(false)).toBe(HISTORY_TREE_CARD_INSET)
+  })
+
+  test("window chrome stays put in the title inset so toggling does not shift it", () => {
+    expect(historyTreeWindowChromeStart(false)).toBe(HISTORY_TREE_CARD_INSET + HISTORY_TREE_TITLE_PAD)
+    expect(historyTreeWindowChromeStart(true)).toBe(MAC_TRAFFIC_LIGHTS_WIDTH)
+  })
+
+  test("tree rows keep the same gutter when the header clears the traffic lights", () => {
+    expect(HISTORY_TREE_SIDEBAR_INSET).toBe(historyTreeWindowChromeStart(false))
+    expect(HISTORY_TREE_SIDEBAR_INSET).not.toBe(historyTreeWindowChromeStart(true))
+  })
+
+  test("chrome sits on the card when the tree is a drawer or collapsed", () => {
+    expect(historyTreeChromeOnCard(true, true)).toBe(true)
+    expect(historyTreeChromeOnCard(true, false)).toBe(true)
+    expect(historyTreeChromeOnCard(false, true)).toBe(false)
+    expect(historyTreeChromeOnCard(false, false)).toBe(true)
+  })
+
+  test("title shift lands after the in-window toggle", () => {
+    const cluster = HISTORY_TREE_ICON + HISTORY_TREE_AFTER
+    expect(HISTORY_TREE_CARD_INSET + HISTORY_TREE_TITLE_PAD + historyTreeTitleShift(false)).toBe(
+      historyTreeWindowChromeStart(false) + cluster,
+    )
+    expect(HISTORY_TREE_CARD_INSET + HISTORY_TREE_TITLE_PAD + historyTreeTitleShift(true)).toBe(
+      historyTreeWindowChromeStart(true) + cluster,
+    )
+    expect(historyTreeTitlePadding(false, false)).toBe(HISTORY_TREE_TITLE_PAD)
+    expect(historyTreeTitlePadding(true, false)).toBe(HISTORY_TREE_TITLE_PAD + historyTreeTitleShift(false))
+  })
+
+  test("session title hosts the tree toggle on compact sessions, not a drawer menu", () => {
+    expect(historyTreeWindowToggle({ mobile: true, treeOpened: false, session: true })).toBe(false)
+    expect(historyTreeWindowToggle({ mobile: true, treeOpened: true, session: true })).toBe(false)
+    expect(historyTreeWindowToggle({ mobile: true, treeOpened: false, session: false })).toBe(true)
+    expect(historyTreeWindowToggle({ mobile: false, treeOpened: false, session: true })).toBe(true)
+    expect(historyTreeWindowToggle({ mobile: false, treeOpened: true, session: true })).toBe(false)
+  })
+})

--- a/packages/app/src/pages/layout/history-tree-chrome.ts
+++ b/packages/app/src/pages/layout/history-tree-chrome.ts
@@ -1,0 +1,50 @@
+export const HISTORY_TREE_OPEN_WIDTH = 244
+export const HISTORY_TREE_CARD_INSET = 8
+export const HISTORY_TREE_HEADER = 48
+export const HISTORY_TREE_ICON = 28
+export const HISTORY_TREE_ICON_GAP = 4
+export const HISTORY_TREE_AFTER = 4
+export const HISTORY_TREE_TITLE_PAD = 10
+export const MAC_TRAFFIC_LIGHTS_WIDTH = 84
+export const HISTORY_TREE_EASE = "cubic-bezier(0.23, 1, 0.32, 1)"
+export const HISTORY_TREE_MS = 220
+
+export function historyTreeMacLights(platform: { platform: string; os?: string; windowFullscreen?: () => boolean }) {
+  return platform.platform === "desktop" && platform.os === "macos" && !platform.windowFullscreen?.()
+}
+
+export function historyTreeCollapsedStart(macLights: boolean) {
+  if (macLights) return MAC_TRAFFIC_LIGHTS_WIDTH
+  return HISTORY_TREE_CARD_INSET
+}
+
+export function historyTreeWindowChromeStart(macLights: boolean) {
+  if (macLights) return MAC_TRAFFIC_LIGHTS_WIDTH
+  return HISTORY_TREE_CARD_INSET + HISTORY_TREE_TITLE_PAD
+}
+
+// Tree rows keep a fixed gutter; only the header row shifts to clear the macOS traffic lights.
+export const HISTORY_TREE_SIDEBAR_INSET = HISTORY_TREE_CARD_INSET + HISTORY_TREE_TITLE_PAD
+
+export function historyTreeChromeOnCard(mobile: boolean, treeOpened: boolean) {
+  if (mobile) return true
+  return !treeOpened
+}
+
+export function historyTreeTitleShift(macLights: boolean) {
+  const cluster = HISTORY_TREE_ICON + HISTORY_TREE_AFTER
+  return historyTreeWindowChromeStart(macLights) + cluster - HISTORY_TREE_CARD_INSET - HISTORY_TREE_TITLE_PAD
+}
+
+export function historyTreeTitlePadding(collapsed: boolean, macLights: boolean) {
+  if (!collapsed) return HISTORY_TREE_TITLE_PAD
+  return HISTORY_TREE_TITLE_PAD + historyTreeTitleShift(macLights)
+}
+
+export function historyTreeWindowToggle(input: { mobile: boolean; treeOpened: boolean; session: boolean }) {
+  if (input.treeOpened) return false
+  // Compact sessions keep the toggle in the title bar, same as the collapsed
+  // desktop tree. Home still needs the in-window control.
+  if (input.mobile && input.session) return false
+  return true
+}

--- a/packages/app/src/pages/layout/session-chrome.ts
+++ b/packages/app/src/pages/layout/session-chrome.ts
@@ -1,0 +1,242 @@
+import { makeEventListener } from "@solid-primitives/event-listener"
+import { useLocation, useNavigate } from "@solidjs/router"
+import { createEffect, createResource, untrack, on } from "solid-js"
+import { createStore } from "solid-js/store"
+import { applyPath, backPath, forwardPath } from "@/components/titlebar-history"
+import { readSessionTabsRemovedDetail, SESSION_TABS_REMOVED_EVENT } from "@/components/titlebar-session-events"
+import { useCommand } from "@/context/command"
+import { useGlobal } from "@/context/global"
+import { LayoutRoute, useLayout } from "@/context/layout"
+import { useLanguage } from "@/context/language"
+import type { PromptSession } from "@/context/prompt"
+import { ServerConnection, useServer } from "@/context/server"
+import { useTabs } from "@/context/tabs"
+import { normalizeSessionInfo } from "@/utils/session"
+
+export function useV2SessionChrome() {
+  const layout = useLayout()
+  const global = useGlobal()
+  const server = useServer()
+  const tabs = useTabs()
+  const command = useCommand()
+  const language = useLanguage()
+  const navigate = useNavigate()
+  const location = useLocation()
+  const tabsStore = tabs.store
+  const [history, setHistory] = createStore({
+    stack: [] as string[],
+    index: 0,
+    action: undefined as "back" | "forward" | undefined,
+  })
+  const path = () => `${location.pathname}${location.search}${location.hash}`
+
+  createEffect(() => {
+    const current = path()
+    untrack(() => {
+      const next = applyPath(history, current)
+      if (next === history) return
+      setHistory(next)
+    })
+  })
+
+  const back = () => {
+    const next = backPath(history)
+    if (!next) return
+    setHistory(next.state)
+    navigate(next.to)
+  }
+
+  const forward = () => {
+    const next = forwardPath(history)
+    if (!next) return
+    setHistory(next.state)
+    navigate(next.to)
+  }
+
+  command.register(() => [
+    {
+      id: "common.goBack",
+      title: language.t("common.goBack"),
+      category: language.t("command.category.view"),
+      keybind: "mod+[",
+      onSelect: back,
+    },
+    {
+      id: "common.goForward",
+      title: language.t("common.goForward"),
+      category: language.t("command.category.view"),
+      keybind: "mod+]",
+      onSelect: forward,
+    },
+  ])
+
+  const [session] = createResource(
+    () => {
+      const route = layout.route()
+      if (route.type !== "session") return undefined
+      const conn = global.servers.list().find((item) => ServerConnection.key(item) === (route.server ?? server.key))
+      return conn ? { route, sdk: global.ensureServerCtx(conn).sdk } : undefined
+    },
+    ({ route, sdk }) =>
+      sdk.api.session
+        .get({ sessionID: route.sessionId })
+        .then(normalizeSessionInfo)
+        .catch(() => {}),
+  )
+
+  const matchRoute = (route: LayoutRoute) => {
+    if (route.type === "home") return
+    if (route.type === "draft") {
+      return tabsStore.find((item) => item.type === "draft" && item.draftID === route.draftID)
+    }
+    if (route.type !== "session") return
+    const main = tabsStore.find(
+      (item) => item.type === "session" && item.server === route.server && item.sessionId === route.sessionId,
+    )
+    if (main) return main
+    const current = session()
+    if (!current?.parentID) return
+    return tabsStore.find(
+      (item) => item.type === "session" && item.server === route.server && item.sessionId === current.parentID,
+    )
+  }
+
+  const currentTab = () => matchRoute(layout.route())
+
+  createEffect(
+    on(
+      () => [layout.route().type, tabs.ready()] as const,
+      ([type, ready]) => {
+        if (!ready) return
+        if (type === "session" || type === "home") tabs.discardUnusedDrafts()
+      },
+    ),
+  )
+
+  createEffect(() => {
+    const route = layout.route()
+    if (!tabs.ready()) return
+    const tab = currentTab()
+    if (tab) {
+      tabs.remember(tab)
+      return
+    }
+    if (route.type !== "session") return
+    const current = session()
+    if (!current) return
+    tabs.addSessionTab({ server: route.server ?? server.key, sessionId: current.parentID ?? current.id })
+  })
+
+  makeEventListener(window, SESSION_TABS_REMOVED_EVENT, (event) => {
+    const detail = readSessionTabsRemovedDetail(event)
+    if (!detail) return
+    tabs.removeSessions(detail)
+  })
+
+  const openNewTab = () => {
+    const route = layout.route()
+    const activeSession = session()
+    if (route.type === "session" && activeSession) {
+      const model = untrack(() =>
+        tabs
+          .stateValue<PromptSession>(
+            { type: "session", server: route.server ?? server.key, sessionId: activeSession.id },
+            "prompt",
+          )
+          ?.model.current(),
+      )
+      void tabs.newDraft({ server: route.server ?? server.key, directory: activeSession.directory }, "", model)
+      return
+    }
+
+    const activeTab = currentTab()
+    if (activeTab?.type === "draft") {
+      const model = untrack(() => tabs.stateValue<PromptSession>(activeTab, "prompt")?.model.current())
+      void tabs.newDraft({ server: activeTab.server, directory: activeTab.directory }, "", model)
+      return
+    }
+
+    if (route.type === "home") {
+      const selection = layout.home.selection()
+      const conn = global.servers.list().find((item) => ServerConnection.key(item) === selection.server)
+      const project = conn
+        ? global
+            .ensureServerCtx(conn)
+            .projects.list()
+            .find((item) => item.worktree === selection.directory)
+        : undefined
+      if (conn && project) {
+        void tabs.newDraft({ server: ServerConnection.key(conn), directory: project.worktree }, "")
+        return
+      }
+    }
+
+    const current = layout.projects.list()[0]
+    if (current) {
+      void tabs.newDraft({ server: server.key, directory: current.worktree }, "")
+      return
+    }
+
+    const fallback = global.servers.list().flatMap((conn) => {
+      const project = global.ensureServerCtx(conn).projects.list()[0]
+      return project ? [{ server: ServerConnection.key(conn), project }] : []
+    })[0]
+    if (!fallback) return
+    void tabs.newDraft({ server: fallback.server, directory: fallback.project.worktree }, "")
+  }
+
+  const toggleHome = () => tabs.toggleHome({ home: layout.route().type === "home", current: currentTab() })
+
+  command.register("titlebar-home", () => [
+    {
+      id: "home.toggle",
+      title: language.t("home.title"),
+      category: language.t("command.category.view"),
+      hidden: true,
+      onSelect: toggleHome,
+    },
+  ])
+
+  command.register("sidebar", () => [
+    {
+      id: "sidebar.toggle",
+      title: language.t("command.sidebar.toggle"),
+      category: language.t("command.category.view"),
+      keybind: "mod+b",
+      onSelect: () => layout.historyTree.toggle(),
+    },
+  ])
+
+  command.register("tabs", () => {
+    const current = currentTab()
+    return [
+      {
+        id: "tab.new",
+        category: "tab",
+        title: language.t("command.session.new"),
+        keybind: "mod+t,mod+n",
+        hidden: true,
+        onSelect: openNewTab,
+      },
+      current && {
+        id: "tab.close",
+        category: "tab",
+        title: language.t("command.tab.close"),
+        keybind: "mod+w",
+        hidden: true,
+        onSelect: () => {
+          tabs.closeTab(tabsStore.findIndex((tab) => current === tab))
+        },
+      },
+      {
+        id: "tab.reopenClosed",
+        category: language.t("command.category.file"),
+        title: language.t("command.tab.reopenClosed"),
+        keybind: "mod+shift+t",
+        onSelect: () => tabs.reopenClosedTab(),
+      },
+    ].filter((item) => item !== undefined)
+  })
+
+  return { openNewTab, toggleHome, currentTab }
+}

--- a/packages/app/src/pages/new-session/new-session-view.tsx
+++ b/packages/app/src/pages/new-session/new-session-view.tsx
@@ -7,7 +7,7 @@ import { Show, createMemo, createSignal, type Accessor } from "solid-js"
 import { createStore } from "solid-js/store"
 import { Portal } from "solid-js/web"
 import createPresence from "solid-presence"
-import { PromptInputV2Composer } from "@/components/prompt-input-v2"
+import { PromptInputV2Composer, PROMPT_INPUT_V2_SURFACE_CLASS } from "@/components/prompt-input-v2"
 import { PromptGitStatus, PromptWorkspaceSelector } from "@/components/prompt-workspace-selector"
 import {
   PromptProjectAddButton,
@@ -35,13 +35,13 @@ export function NewSessionView(props: {
     <div class="@container relative flex flex-col min-h-0 h-full flex-1">
       <div
         data-component="session-new-design"
-        class="relative flex-1 min-h-0 overflow-hidden rounded-[10px] bg-v2-background-bg-deep"
+        class="relative flex-1 min-h-0 overflow-hidden rounded-[10px] bg-v2-background-bg-base shadow-[var(--v2-elevation-raised)]"
       >
         <div class="absolute inset-x-0 top-[25.375%] flex justify-center px-6">
           <div class={NEW_SESSION_CONTENT_WIDTH}>
             <WordmarkV2 class="h-auto w-full text-v2-background-bg-inverse" />
             <div class="mt-8 flex flex-col gap-8">
-              <PromptInputV2Composer controller={props.input} />
+              <PromptInputV2Composer controller={props.input} class={PROMPT_INPUT_V2_SURFACE_CLASS} />
               <Show when={props.project.empty()}>
                 <PromptProjectAddButton controller={props.project} />
               </Show>
@@ -77,17 +77,25 @@ export function NewSessionView(props: {
 export function NewSessionStatus(props: { mount: Accessor<HTMLElement | null>; visible: Accessor<boolean> }) {
   const language = useLanguage()
 
+  const popover = (
+    <Show when={props.visible()}>
+      <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
+        <StatusPopoverV2 />
+      </Tooltip>
+    </Show>
+  )
+
   return (
-    <Show when={props.mount()} keyed>
-      {(mount) => (
-        <Portal mount={mount}>
-          <Show when={props.visible()}>
-            <Tooltip placement="bottom" value={language.t("status.popover.trigger")}>
-              <StatusPopoverV2 />
-            </Tooltip>
-          </Show>
-        </Portal>
-      )}
+    <Show
+      when={props.mount()}
+      keyed
+      fallback={
+        <div class="pointer-events-none absolute inset-x-0 top-0 z-20 flex justify-end p-3">
+          <div class="pointer-events-auto">{popover}</div>
+        </div>
+      }
+    >
+      {(mount) => <Portal mount={mount}>{popover}</Portal>}
     </Show>
   )
 }

--- a/packages/app/src/pages/session-history-tree.tsx
+++ b/packages/app/src/pages/session-history-tree.tsx
@@ -1,0 +1,503 @@
+import type { Session } from "@opencode-ai/sdk/v2/client"
+import { Logo } from "@opencode-ai/ui/logo"
+import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
+import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { MenuV2 } from "@opencode-ai/ui/v2/menu-v2"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
+import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
+import { createMediaQuery } from "@solid-primitives/media"
+import { useQuery } from "@tanstack/solid-query"
+import { For, Show, createMemo, startTransition } from "solid-js"
+import { createStore, produce } from "solid-js/store"
+import { useDirectoryPicker } from "@/components/directory-picker"
+import { newTabTooltipKeybind } from "@/components/command-tooltip-keybind"
+import { useSettingsCommand } from "@/components/settings-dialog"
+import { type TitlebarUpdate } from "@/components/titlebar"
+import {
+  loadHomeSessionIndex,
+  retainHomeSessions,
+  type HomeSessionEvents,
+} from "@/context/global-sync/home-session-index"
+import { useCommand } from "@/context/command"
+import { useLanguage } from "@/context/language"
+import { useLayout, type LocalProject } from "@/context/layout"
+import { usePlatform } from "@/context/platform"
+import { ServerConnection } from "@/context/server"
+import { useTabs } from "@/context/tabs"
+import { createHomeController } from "@/pages/home/home-controller"
+import { archiveHomeSession } from "@/pages/home-session-archive"
+import { historyTreeGroups, errorMessage, homeProjectDirectories } from "@/pages/layout/helpers"
+import {
+  HISTORY_TREE_CARD_INSET,
+  HISTORY_TREE_HEADER,
+  HISTORY_TREE_OPEN_WIDTH,
+  HISTORY_TREE_SIDEBAR_INSET,
+  historyTreeMacLights,
+  historyTreeWindowChromeStart,
+  historyTreeWindowToggle,
+} from "@/pages/layout/history-tree-chrome"
+import { useV2SessionChrome } from "@/pages/layout/session-chrome"
+import { SessionTabAvatar } from "@/pages/layout/session-tab-avatar"
+import { useSessionTabAvatarState } from "@/pages/layout/project-avatar-state"
+import { pathKey } from "@/utils/path-key"
+import { sessionTitle } from "@/utils/session-title"
+import { showToast } from "@/utils/toast"
+import { Binary } from "@opencode-ai/core/util/binary"
+
+const TREE_SESSION_LIMIT = 64
+const TREE_GUTTER = "flex size-4 shrink-0 items-center justify-center"
+const TREE_ROW = "flex h-8 w-full min-w-0 items-center gap-2"
+const TREE_BUTTON =
+  "rounded-[6px] text-left text-[13px] font-[440] leading-4 tracking-[-0.04px] text-v2-text-text-base hover:bg-v2-overlay-simple-overlay-hover"
+// Row pills span the whole track, so 6px of lead padding puts glyphs on the same column as the
+// 28px toggle button's centered icon, and trailing actions mirror it from the pill's end edge.
+const TREE_PAD = "ps-1.5 pe-2"
+const TREE_PAD_ACTION = "ps-1.5 pe-8"
+const TREE_PAD_SESSION = "ps-[30px] pe-8"
+const TREE_ACTION = "absolute end-0 top-1/2 -translate-y-1/2"
+const TREE_TRACK = {
+  "padding-inline-start": `${HISTORY_TREE_SIDEBAR_INSET}px`,
+  "padding-inline-end": `${HISTORY_TREE_SIDEBAR_INSET}px`,
+}
+const TREE_FADE =
+  "transition-[opacity,transform] duration-[220ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:duration-[0ms]"
+const TREE_TOGGLE =
+  "transition-transform duration-[160ms] ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97] motion-reduce:transform-none"
+
+export function SessionHistoryTree(props: { update?: TitlebarUpdate }) {
+  const language = useLanguage()
+  const layout = useLayout()
+  const tabs = useTabs()
+  const command = useCommand()
+  const platform = usePlatform()
+  const openSettings = useSettingsCommand()
+  const chrome = useV2SessionChrome()
+  const home = createHomeController()
+  const pickDirectory = useDirectoryPicker()
+  const mobile = createMediaQuery("(max-width: 767px)")
+  const [collapsed, setCollapsed] = createStore<Record<string, boolean>>({})
+  const cache = () => home.server.focusedSync().homeSessions
+  const sessionEventLoad = useQuery(() => ({
+    queryKey: cache().eventsKey,
+    queryFn: async (): Promise<HomeSessionEvents> => ({ sequence: 0, entries: [] }),
+    initialData: { sequence: 0, entries: [] } satisfies HomeSessionEvents,
+    enabled: false,
+  }))
+  const sessionLoad = useQuery(() => ({
+    queryKey: cache().indexKey,
+    enabled: !!home.server.focusedContext(),
+    queryFn: async ({ signal }) => {
+      const ctx = home.server.focusedContext()
+      if (!ctx) return { sessions: [], eventSequence: 0 }
+      const eventSequence = cache().eventSequence()
+      const index = await loadHomeSessionIndex(
+        (input, options) => ctx.sdk.client.v2.session.list(input, options),
+        eventSequence,
+        signal,
+      )
+      cache().complete(eventSequence)
+      return index
+    },
+    retry: false,
+    staleTime: 30_000,
+    refetchOnMount: true,
+    refetchOnReconnect: true,
+  }))
+  const sessions = createMemo(() =>
+    retainHomeSessions(cache().sessions(sessionLoad.data, sessionEventLoad.data), TREE_SESSION_LIMIT, Date.now()),
+  )
+  const projects = createMemo(() => home.project.list())
+  const groups = createMemo(() => historyTreeGroups(projects(), sessions()))
+  const route = () => layout.route()
+  const railOpen = () => layout.historyTree.opened()
+  const macLights = () => historyTreeMacLights(platform)
+  const chromeStart = () => historyTreeWindowChromeStart(macLights())
+  const headerPad = () => ({ ...TREE_TRACK, "padding-inline-start": `${chromeStart()}px` })
+  const overlayToggle = () =>
+    historyTreeWindowToggle({
+      mobile: mobile(),
+      treeOpened: layout.historyTree.opened(),
+      session: route().type === "session",
+    })
+  const fadeClass = () => ({
+    [TREE_FADE]: true,
+    "opacity-100 [transform:translateX(0)]": railOpen(),
+    "pointer-events-none opacity-0 [transform:translateX(-8px)] rtl:[transform:translateX(8px)]": !railOpen(),
+  })
+  const conn = () => home.server.focused()
+  const canAddProject = createMemo(() => {
+    const current = conn()
+    return !!current && home.server.health(current)?.healthy !== false
+  })
+
+  const openSession = (session: Session) => {
+    const current = conn()
+    const ctx = home.server.focusedContext()
+    if (!current || !ctx) return
+    ctx.projects.open(session.directory)
+    ctx.projects.touch(session.directory)
+    void startTransition(() => {
+      const tab = tabs.addSessionTab({ server: ServerConnection.key(current), sessionId: session.id })
+      tabs.select(tab)
+    })
+  }
+
+  const openNew = (project: LocalProject) => {
+    const current = conn()
+    if (!current) return
+    setCollapsed(pathKey(project.worktree), false)
+    home.project.openProjectNewSession(current, project.worktree)
+  }
+
+  const addProject = () => {
+    const current = conn()
+    if (!current || home.server.health(current)?.healthy === false) return
+    pickDirectory({
+      server: current,
+      title: language.t("command.project.open"),
+      multiple: true,
+      onSelect: (result) => {
+        const directories = homeProjectDirectories(result)
+        if (directories.length === 0) return
+        home.project.add(current, directories)
+        for (const directory of directories) setCollapsed(pathKey(directory), false)
+      },
+    })
+  }
+
+  const selectedSession = () => {
+    const current = route()
+    if (current.type !== "session") return
+    return current.sessionId
+  }
+
+  const openHelp = () => platform.openExternal("https://opencode.ai/desktop-feedback")
+
+  const archiveSession = async (session: Session) => {
+    const current = conn()
+    const ctx = home.server.focusedContext()
+    if (!current || !ctx) return
+    const [, setStore] = ctx.sync.child(session.directory)
+    if ((await ctx.sdk.protocol) !== "v1") return
+    await archiveHomeSession({
+      server: ServerConnection.key(current),
+      session,
+      archive: (sessionID) =>
+        ctx.sdk.client.session.update({
+          sessionID,
+          directory: session.directory,
+          time: { archived: Date.now() },
+        }),
+      remove: () => {
+        setStore(
+          produce((draft) => {
+            const match = Binary.search(draft.session, session.id, (item) => item.id)
+            if (match.found) draft.session.splice(match.index, 1)
+          }),
+        )
+        cache().remove(session.id)
+      },
+      onError: (cause) =>
+        showToast({
+          title: language.t("common.requestFailed"),
+          description: errorMessage(cause, language.t("common.requestFailed")),
+        }),
+    })
+  }
+
+  return (
+    <>
+      <nav
+        data-slot="session-history-tree"
+        aria-label={language.t("sidebar.nav.projectsAndSessions")}
+        style={{ width: railOpen() ? `${HISTORY_TREE_OPEN_WIDTH}px` : "0px" }}
+        class="flex h-full min-h-0 shrink-0 flex-col overflow-hidden bg-v2-background-bg-deep pt-2 transition-[width] duration-[220ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:duration-[0ms]"
+      >
+        <div class="flex h-full min-h-0 w-[244px] shrink-0 flex-col">
+          <Show when={railOpen()}>
+            <div class="flex h-12 shrink-0 items-center gap-2" style={headerPad()} classList={fadeClass()}>
+              <TooltipV2
+                class="inline-flex shrink-0 items-center"
+                placement="right"
+                value={
+                  <>
+                    {language.t("command.sidebar.toggle")}
+                    <KeybindV2 keys={command.keybindParts("sidebar.toggle")} variant="neutral" />
+                  </>
+                }
+              >
+                <IconButtonV2
+                  type="button"
+                  data-action="sidebar-toggle"
+                  variant="ghost-muted"
+                  size="large"
+                  class={TREE_TOGGLE}
+                  icon={<IconV2 name="sidebar-right" />}
+                  aria-label={language.t("command.sidebar.toggle")}
+                  aria-expanded={layout.historyTree.opened()}
+                  onClick={() => layout.historyTree.toggle()}
+                />
+              </TooltipV2>
+              <Logo class="h-3.5 w-auto min-w-0 shrink opacity-60" aria-hidden="true" />
+            </div>
+          </Show>
+          <Show when={railOpen()}>
+            <div class="shrink-0 pb-2" style={TREE_TRACK} classList={fadeClass()}>
+              <TooltipV2
+                placement="right"
+                value={
+                  <>
+                    {language.t("command.session.new")}
+                    <KeybindV2 keys={newTabTooltipKeybind(command)} variant="neutral" />
+                  </>
+                }
+              >
+                <button
+                  type="button"
+                  data-action="sidebar-new-session"
+                  class={`${TREE_ROW} ${TREE_BUTTON} ${TREE_PAD}`}
+                  classList={{ "bg-v2-overlay-simple-overlay-hover": route().type === "draft" }}
+                  aria-pressed={route().type === "draft"}
+                  aria-label={language.t("command.session.new")}
+                  onClick={() => {
+                    chrome.openNewTab()
+                  }}
+                >
+                  <span class={TREE_GUTTER}>
+                    <IconV2 name="plus" class="size-4 text-v2-icon-icon-muted" />
+                  </span>
+                  <span class="min-w-0 truncate">{language.t("command.session.new")}</span>
+                </button>
+              </TooltipV2>
+            </div>
+          </Show>
+          <Show when={railOpen()}>
+            <div class="flex min-h-0 flex-1 flex-col" classList={fadeClass()}>
+              <div class="min-h-0 flex-1 overflow-y-auto py-1 no-scrollbar" style={TREE_TRACK}>
+                <div class={`${TREE_ROW} justify-between ps-1.5`}>
+                  <div class="min-w-0 truncate text-[12px] font-[440] leading-4 tracking-[-0.04px] text-v2-text-text-muted">
+                    {language.t("home.projects")}
+                  </div>
+                  <TooltipV2
+                    class="flex shrink-0 items-center"
+                    placement="right"
+                    value={language.t("home.project.add")}
+                  >
+                    <IconButtonV2
+                      type="button"
+                      data-action="sidebar-add-project"
+                      variant="ghost-muted"
+                      size="large"
+                      icon={<IconV2 name="folder-add-left" />}
+                      disabled={!canAddProject()}
+                      aria-label={language.t("home.project.add")}
+                      onClick={addProject}
+                    />
+                  </TooltipV2>
+                </div>
+                <For each={groups()}>
+                  {(group) => {
+                    const key = pathKey(group.project.worktree)
+                    const open = () => collapsed[key] !== true
+                    return (
+                      <div class="mb-2 flex flex-col gap-1">
+                        <div class="group/project relative">
+                          <button
+                            type="button"
+                            class={`${TREE_ROW} ${TREE_BUTTON} ${TREE_PAD_ACTION}`}
+                            aria-expanded={open()}
+                            onClick={() => setCollapsed(key, open())}
+                          >
+                            <span class={TREE_GUTTER}>
+                              <IconV2 name="folder" class="size-4 text-v2-icon-icon-muted" />
+                            </span>
+                            <span class="min-w-0 truncate text-v2-text-text-muted">{group.projectName}</span>
+                          </button>
+                          <div class={TREE_ACTION}>
+                            <TooltipV2 placement="right" value={language.t("command.session.new")}>
+                              <IconButtonV2
+                                type="button"
+                                data-action="sidebar-project-new-session"
+                                variant="ghost-muted"
+                                size="large"
+                                class="md:opacity-0 md:group-hover/project:opacity-100 focus-visible:opacity-100"
+                                icon={<IconV2 name="plus" />}
+                                aria-label={language.t("command.session.new")}
+                                onClick={() => openNew(group.project)}
+                              />
+                            </TooltipV2>
+                          </div>
+                        </div>
+                        <Show when={open()}>
+                          <div class="flex flex-col gap-0.5">
+                            <For each={group.sessions}>
+                              {(session) => (
+                                <HistoryTreeRow
+                                  project={group.project}
+                                  server={() => home.selection.value().server}
+                                  session={session}
+                                  selected={selectedSession() === session.id}
+                                  onOpen={() => openSession(session)}
+                                  onArchive={() => archiveSession(session)}
+                                />
+                              )}
+                            </For>
+                          </div>
+                        </Show>
+                      </div>
+                    )
+                  }}
+                </For>
+              </div>
+              <div class="flex shrink-0 flex-col pb-3 pt-1" style={TREE_TRACK}>
+                <Show when={props.update?.version() || props.update?.installing()}>
+                  <button
+                    type="button"
+                    class={`${TREE_ROW} ${TREE_BUTTON} ${TREE_PAD}`}
+                    disabled={props.update?.installing()}
+                    aria-busy={props.update?.installing()}
+                    aria-label={language.t("toast.update.action.installRestart")}
+                    onClick={() => props.update?.install()}
+                  >
+                    <span class="min-w-0 truncate text-v2-text-text-accent">{language.t("titlebar.update")}</span>
+                  </button>
+                </Show>
+                <button type="button" class={`${TREE_ROW} ${TREE_BUTTON} ${TREE_PAD}`} onClick={openSettings}>
+                  <span class={TREE_GUTTER}>
+                    <IconV2 name="settings-gear" class="size-4 text-v2-icon-icon-muted" />
+                  </span>
+                  <span class="min-w-0 truncate text-v2-text-text-muted">{language.t("sidebar.settings")}</span>
+                </button>
+                <button type="button" class={`${TREE_ROW} ${TREE_BUTTON} ${TREE_PAD}`} onClick={openHelp}>
+                  <span class={TREE_GUTTER}>
+                    <IconV2 name="help" class="size-4 text-v2-icon-icon-muted" />
+                  </span>
+                  <span class="min-w-0 truncate text-v2-text-text-muted">{language.t("sidebar.help")}</span>
+                </button>
+              </div>
+            </div>
+          </Show>
+        </div>
+      </nav>
+      <Show when={overlayToggle()}>
+        <div
+          data-slot="history-tree-window-chrome"
+          class="pointer-events-none absolute z-20 flex shrink-0 items-center md:z-40"
+          style={{
+            top: `${HISTORY_TREE_CARD_INSET}px`,
+            height: `${HISTORY_TREE_HEADER}px`,
+            "inset-inline-start": `${chromeStart()}px`,
+          }}
+        >
+          <div class="pointer-events-auto shrink-0">
+            <TooltipV2
+              class="inline-flex shrink-0 items-center"
+              placement="right"
+              value={
+                <>
+                  {language.t("command.sidebar.toggle")}
+                  <KeybindV2 keys={command.keybindParts("sidebar.toggle")} variant="neutral" />
+                </>
+              }
+            >
+              <IconButtonV2
+                type="button"
+                data-action="sidebar-toggle"
+                variant="ghost-muted"
+                size="large"
+                class={TREE_TOGGLE}
+                icon={<IconV2 name="sidebar-right" />}
+                aria-label={language.t("command.sidebar.toggle")}
+                aria-expanded={layout.historyTree.opened()}
+                onClick={() => layout.historyTree.toggle()}
+              />
+            </TooltipV2>
+          </div>
+        </div>
+      </Show>
+    </>
+  )
+}
+
+function HistoryTreeRow(props: {
+  project: LocalProject
+  server: () => ServerConnection.Key
+  session: Session
+  selected: boolean
+  onOpen: () => void
+  onArchive: () => void
+}) {
+  const language = useLanguage()
+  const avatar = useSessionTabAvatarState(
+    props.server,
+    () => props.session.directory,
+    () => props.session.id,
+  )
+  const title = () => sessionTitle(props.session.title) || props.session.id
+  const menu = () => <SessionHistoryRowMenuItems onArchive={props.onArchive} />
+
+  return (
+    <div class="group/session relative">
+      <MenuV2.Context>
+        <MenuV2.Context.Trigger as="div" class="contents">
+          <button
+            type="button"
+            data-component="session-history-row"
+            data-session-id={props.session.id}
+            aria-current={props.selected ? "page" : undefined}
+            class={`${TREE_ROW} ${TREE_BUTTON} ${TREE_PAD_SESSION}`}
+            classList={{ "bg-v2-overlay-simple-overlay-hover": props.selected }}
+            aria-label={avatar.loading() ? language.t("sidebar.history.runningChat", { title: title() }) : undefined}
+            onClick={props.onOpen}
+          >
+            <span class={TREE_GUTTER}>
+              <SessionTabAvatar
+                project={props.project}
+                directory={props.session.directory}
+                sessionId={props.session.id}
+                server={props.server()}
+                revealProjectOnHover={false}
+              />
+            </span>
+            <span class="min-w-0 truncate">{title()}</span>
+          </button>
+        </MenuV2.Context.Trigger>
+        <MenuV2.Context.Portal>
+          <MenuV2.Context.Content>{menu()}</MenuV2.Context.Content>
+        </MenuV2.Context.Portal>
+      </MenuV2.Context>
+      <div class={TREE_ACTION}>
+        <MenuV2 placement="bottom-end" gutter={4}>
+          <TooltipV2 placement="right" value={language.t("common.moreOptions")}>
+            <MenuV2.Trigger
+              as={IconButtonV2}
+              type="button"
+              data-action="session-history-more"
+              variant="ghost-muted"
+              size="large"
+              class="md:opacity-0 md:group-hover/session:opacity-100 focus-visible:opacity-100 data-[expanded]:opacity-100"
+              icon={<IconV2 name="outline-dots" />}
+              aria-label={language.t("common.moreOptions")}
+              onPointerDown={(event: PointerEvent) => event.stopPropagation()}
+            />
+          </TooltipV2>
+          <MenuV2.Portal>
+            <MenuV2.Content>{menu()}</MenuV2.Content>
+          </MenuV2.Portal>
+        </MenuV2>
+      </div>
+    </div>
+  )
+}
+
+function SessionHistoryRowMenuItems(props: { onArchive: () => void }) {
+  const language = useLanguage()
+  return (
+    <MenuV2.Item data-action="session-history-archive" onSelect={() => void props.onArchive()}>
+      <span class="flex items-center gap-2">
+        <IconV2 name="archive" class="size-4 shrink-0 text-v2-icon-icon-muted" />
+        <span>{language.t("common.archive")}</span>
+      </span>
+    </MenuV2.Item>
+  )
+}

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -59,7 +59,11 @@ import { useSync } from "@/context/sync"
 import { useTabs } from "@/context/tabs"
 import { TerminalProvider, useTerminal } from "@/context/terminal"
 import { PromptInput } from "@/components/prompt-input"
-import { PromptInputV2Composer, usePromptInputV2Controller } from "@/components/prompt-input-v2"
+import {
+  PromptInputV2Composer,
+  PROMPT_INPUT_V2_SURFACE_CLASS,
+  usePromptInputV2Controller,
+} from "@/components/prompt-input-v2"
 import { useSettingsCommand } from "@/components/settings-dialog"
 import { setCursorPosition } from "@/components/prompt-input/editor-dom"
 import { promptLength } from "@/components/prompt-input/history"
@@ -665,12 +669,14 @@ export default function Page() {
     list.push("turn")
     return list
   })
-  const mobileChanges = createMemo(() => !isDesktop() && store.mobileTab === "changes")
+  const mobileChanges = createMemo(
+    () => !isDesktop() && (newSessionDesign() ? view().reviewPanel.opened() : store.mobileTab === "changes"),
+  )
   const wantsReview = createMemo(() =>
     isDesktop()
       ? desktopFileTreeOpen() ||
         (desktopReviewOpen() && (activeTab() === "review" || (newSessionDesign() && !!activeFileTab())))
-      : store.mobileTab === "changes",
+      : mobileChanges(),
   )
   const vcsMode = createMemo<VcsMode | undefined>(() => {
     const mode = reviewMode()
@@ -2049,9 +2055,19 @@ export default function Page() {
       </Tabs.List>
     </Tabs>
   )
-  const mobileTabsBottom = createMemo(
-    () => !isDesktop() && settings.general.newLayoutDesigns() && settings.general.mobileTitlebarPosition() === "bottom",
-  )
+  const compactChangesCover = () =>
+    newSessionDesign() && mobileChanges()
+      ? reviewContent({
+          diffStyle: "unified",
+          classes: {
+            root: "h-full pb-8 [&_[data-slot=session-review-list]]:pb-0",
+            header: "px-4 !h-16 !pb-4",
+            container: "px-4",
+          },
+          loadingClass: "px-4 py-4 text-text-weak",
+          emptyClass: "h-full pb-64 -mt-4 flex flex-col items-center justify-center text-center gap-6",
+        })
+      : undefined
 
   const sessionErrorFallback = (error: unknown, reset: () => void) => {
     createEffect(on(sessionKey, reset, { defer: true }))
@@ -2061,12 +2077,9 @@ export default function Page() {
   const sessionPanelContent = () => (
     <>
       {sessionSync() ?? ""}
-      <Show when={!isDesktop() && !!params.id && settings.general.newLayoutDesigns() && !mobileTabsBottom()}>
-        {mobileTabs(true)}
-      </Show>
       <div class="flex-1 min-h-0 overflow-hidden">
         <Switch>
-          <Match when={params.id && mobileChanges()}>
+          <Match when={params.id && mobileChanges() && !newSessionDesign()}>
             <div class="relative h-full overflow-hidden">
               {reviewContent({
                 diffStyle: "unified",
@@ -2118,6 +2131,7 @@ export default function Page() {
                   setScrollToEnd={(fn) => {
                     scrollToEnd = fn
                   }}
+                  cover={compactChangesCover()}
                 />
               )}
             </Show>
@@ -2234,7 +2248,13 @@ export default function Page() {
                         setFollowup("paused", id, true)
                       },
                     })
-                    return <PromptInputV2Composer controller={controller} borderUnderlay />
+                    return (
+                      <PromptInputV2Composer
+                        controller={controller}
+                        borderUnderlay
+                        class={PROMPT_INPUT_V2_SURFACE_CLASS}
+                      />
+                    )
                   }}
                 </Show>
               }
@@ -2242,7 +2262,6 @@ export default function Page() {
           )
         }}
       </Show>
-      <Show when={!!params.id && mobileTabsBottom()}>{mobileTabs(true, true)}</Show>
     </>
   )
 

--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -33,6 +33,8 @@ import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
+import { KeybindV2 } from "@opencode-ai/ui/v2/keybind-v2"
+import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { MenuV2 } from "@opencode-ai/ui/v2/menu-v2"
 import { Dialog } from "@opencode-ai/ui/dialog"
@@ -59,14 +61,24 @@ import { Popover as KobaltePopover } from "@kobalte/core/popover"
 import { normalize } from "@opencode-ai/session-ui/session-diff"
 import { useFileComponent } from "@opencode-ai/ui/context/file"
 import { shouldMarkBoundaryGesture, normalizeWheelDelta } from "@/pages/session/message-gesture"
+import { SessionChangesToggle } from "@/components/session/session-changes-toggle"
 import { SessionContextUsage } from "@/components/session-context-usage"
+import { createMediaQuery } from "@solid-primitives/media"
 import { useDialog } from "@opencode-ai/ui/context/dialog"
+import { useCommand } from "@/context/command"
 import { useLanguage } from "@/context/language"
+import { useLayout } from "@/context/layout"
 import { useSessionKey } from "@/pages/session/session-layout"
 import { useSessionArchive } from "@/pages/session/session-archive"
 import { useServerSDK } from "@/context/server-sdk"
 import { usePlatform } from "@/context/platform"
 import { useSettings } from "@/context/settings"
+import {
+  HISTORY_TREE_TITLE_PAD,
+  historyTreeChromeOnCard,
+  historyTreeMacLights,
+  historyTreeTitlePadding,
+} from "@/pages/layout/history-tree-chrome"
 import { legacySessionHref, requireServerKey, sessionHref } from "@/utils/session-route"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
@@ -255,6 +267,7 @@ export function MessageTimeline(props: {
   setRevealMessage?: (fn: (id: string) => void) => void
   setScrollToEnd?: (fn: () => void) => void
   setHistoryAnchor?: (handlers: { capture: () => void; restore: (done: boolean) => void }) => void
+  cover?: JSX.Element
 }) {
   let touchGesture: number | undefined
 
@@ -266,12 +279,23 @@ export function MessageTimeline(props: {
   const dialog = useDialog()
   const sessionArchive = useSessionArchive()
   const language = useLanguage()
+  const command = useCommand()
   const { params, sessionKey } = useSessionKey()
   const ownerSessionKey = sessionKey()
   const cached = timelineCache.get(ownerSessionKey)
   const initialMeasurements = cached?.measurements
   const coldBottomMount = !initialMeasurements?.length && props.shouldAnchorBottom()
   const platform = usePlatform()
+  const layout = useLayout()
+  const mobile = createMediaQuery("(max-width: 767px)")
+  const titlePadding = () => {
+    if (mobile()) return HISTORY_TREE_TITLE_PAD
+    return historyTreeTitlePadding(
+      historyTreeChromeOnCard(mobile(), layout.historyTree.opened()),
+      historyTreeMacLights(platform),
+    )
+  }
+  const titleToggle = () => settings.general.newLayoutDesigns() && mobile() && !layout.historyTree.opened()
 
   const [listRoot, setListRoot] = createSignal<HTMLDivElement>()
   const sessionID = createMemo(() => params.id)
@@ -329,7 +353,10 @@ export function MessageTimeline(props: {
     if (value) return value
     return language.t("command.session.new")
   })
-  const showHeader = createMemo(() => !!(titleValue() || parentID()))
+  const showHeader = createMemo(() => {
+    if (titleToggle()) return true
+    return !!(titleValue() || parentID())
+  })
   const projection = createTimelineProjection({
     messages: sessionMessages,
     userMessages: () => props.userMessages,
@@ -1298,58 +1325,60 @@ export function MessageTimeline(props: {
 
   return (
     <div class="relative w-full h-full min-w-0">
-      <div
-        class="absolute left-1/2 -translate-x-1/2 z-[60] pointer-events-none transition-all duration-200 ease-out"
-        classList={{
-          "bottom-8": settings.general.newLayoutDesigns(),
-          "bottom-6": !settings.general.newLayoutDesigns(),
-          "opacity-100 translate-y-0 scale-100": props.scroll.overflow && props.scroll.jump,
-          "opacity-0 translate-y-2 pointer-events-none": !props.scroll.overflow || !props.scroll.jump,
-          "scale-[0.8]": (!props.scroll.overflow || !props.scroll.jump) && settings.general.newLayoutDesigns(),
-          "scale-95": (!props.scroll.overflow || !props.scroll.jump) && !settings.general.newLayoutDesigns(),
-        }}
-      >
-        <Show
-          when={settings.general.newLayoutDesigns()}
-          fallback={
+      <Show when={!props.cover}>
+        <div
+          class="absolute left-1/2 -translate-x-1/2 z-[60] pointer-events-none transition-all duration-200 ease-out"
+          classList={{
+            "bottom-8": settings.general.newLayoutDesigns(),
+            "bottom-6": !settings.general.newLayoutDesigns(),
+            "opacity-100 translate-y-0 scale-100": props.scroll.overflow && props.scroll.jump,
+            "opacity-0 translate-y-2 pointer-events-none": !props.scroll.overflow || !props.scroll.jump,
+            "scale-[0.8]": (!props.scroll.overflow || !props.scroll.jump) && settings.general.newLayoutDesigns(),
+            "scale-95": (!props.scroll.overflow || !props.scroll.jump) && !settings.general.newLayoutDesigns(),
+          }}
+        >
+          <Show
+            when={settings.general.newLayoutDesigns()}
+            fallback={
+              <button
+                type="button"
+                aria-label={language.t("session.messages.jumpToLatest")}
+                class="pointer-events-auto flex items-center justify-center w-10 h-8 bg-transparent border-none cursor-pointer p-0 group"
+                onClick={props.onResumeScroll}
+              >
+                <div
+                  class="flex items-center justify-center w-8 h-6 rounded-[6px] border border-border-weaker-base bg-[color-mix(in_srgb,var(--surface-raised-stronger-non-alpha)_80%,transparent)] backdrop-blur-[0.75px] transition-colors group-hover:border-[var(--border-weak-base)] group-hover:[--icon-base:var(--icon-hover)]"
+                  style={{
+                    "box-shadow":
+                      "0 51px 60px 0 rgba(0,0,0,0.10), 0 15px 18px 0 rgba(0,0,0,0.12), 0 6.386px 7.513px 0 rgba(0,0,0,0.12), 0 2.31px 2.717px 0 rgba(0,0,0,0.20)",
+                  }}
+                >
+                  <Icon name="arrow-down-to-line" size="small" />
+                </div>
+              </button>
+            }
+          >
             <button
               type="button"
               aria-label={language.t("session.messages.jumpToLatest")}
-              class="pointer-events-auto flex items-center justify-center w-10 h-8 bg-transparent border-none cursor-pointer p-0 group"
+              class="pointer-events-auto flex items-center justify-center w-8 h-7 px-2 py-1.5 rounded-lg border-none cursor-pointer text-v2-text-text-base backdrop-blur-[2px]"
+              style={{
+                background: "color-mix(in srgb, var(--v2-background-bg-base) 92%, transparent)",
+                "box-shadow": "var(--v2-elevation-raised), 0px 2px 8px var(--v2-background-bg-base)",
+              }}
               onClick={props.onResumeScroll}
             >
-              <div
-                class="flex items-center justify-center w-8 h-6 rounded-[6px] border border-border-weaker-base bg-[color-mix(in_srgb,var(--surface-raised-stronger-non-alpha)_80%,transparent)] backdrop-blur-[0.75px] transition-colors group-hover:border-[var(--border-weak-base)] group-hover:[--icon-base:var(--icon-hover)]"
-                style={{
-                  "box-shadow":
-                    "0 51px 60px 0 rgba(0,0,0,0.10), 0 15px 18px 0 rgba(0,0,0,0.12), 0 6.386px 7.513px 0 rgba(0,0,0,0.12), 0 2.31px 2.717px 0 rgba(0,0,0,0.20)",
-                }}
-              >
-                <Icon name="arrow-down-to-line" size="small" />
-              </div>
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path
+                  d="M12.3333 8.66665L8 13L3.66667 8.66665M8 12.6667V2.83332"
+                  stroke="currentColor"
+                  stroke-linecap="square"
+                />
+              </svg>
             </button>
-          }
-        >
-          <button
-            type="button"
-            aria-label={language.t("session.messages.jumpToLatest")}
-            class="pointer-events-auto flex items-center justify-center w-8 h-7 px-2 py-1.5 rounded-lg border-none cursor-pointer text-v2-text-text-base backdrop-blur-[2px]"
-            style={{
-              background: "color-mix(in srgb, var(--v2-background-bg-base) 92%, transparent)",
-              "box-shadow": "var(--v2-elevation-raised), 0px 2px 8px var(--v2-background-bg-base)",
-            }}
-            onClick={props.onResumeScroll}
-          >
-            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path
-                d="M12.3333 8.66665L8 13L3.66667 8.66665M8 12.6667V2.83332"
-                stroke="currentColor"
-                stroke-linecap="square"
-              />
-            </svg>
-          </button>
-        </Show>
-      </div>
+          </Show>
+        </div>
+      </Show>
       <ScrollView
         viewportRef={bindListRoot}
         onWheel={handleListWheel}
@@ -1379,10 +1408,12 @@ export function MessageTimeline(props: {
               "w-full": true,
               "pb-4": true,
               "pr-3": true,
-              "pl-2.5": settings.general.newLayoutDesigns(),
               "pl-2 md:pl-4": !settings.general.newLayoutDesigns(),
+              "transition-[padding-inline-start] duration-[220ms] ease-[cubic-bezier(0.23,1,0.32,1)] motion-reduce:duration-[0ms]":
+                settings.general.newLayoutDesigns(),
               "md:max-w-200 md:mx-auto 2xl:max-w-[1000px]": props.centered && !settings.general.newLayoutDesigns(),
             }}
+            style={settings.general.newLayoutDesigns() ? { "padding-inline-start": `${titlePadding()}px` } : undefined}
           >
             <div class="h-12 w-full flex items-center justify-between gap-2">
               <div
@@ -1391,6 +1422,30 @@ export function MessageTimeline(props: {
                   "pr-3": !settings.general.newLayoutDesigns(),
                 }}
               >
+                <Show when={titleToggle()}>
+                  <TooltipV2
+                    class="inline-flex shrink-0 items-center"
+                    placement="right"
+                    value={
+                      <>
+                        {language.t("command.sidebar.toggle")}
+                        <KeybindV2 keys={command.keybindParts("sidebar.toggle")} variant="neutral" />
+                      </>
+                    }
+                  >
+                    <IconButtonV2
+                      type="button"
+                      data-action="sidebar-toggle"
+                      variant="ghost-muted"
+                      size="large"
+                      class="shrink-0 transition-transform duration-[160ms] ease-[cubic-bezier(0.23,1,0.32,1)] active:scale-[0.97] motion-reduce:transform-none"
+                      icon={<IconV2 name="sidebar-right" />}
+                      aria-label={language.t("command.sidebar.toggle")}
+                      aria-expanded={layout.historyTree.opened()}
+                      onClick={() => layout.historyTree.toggle()}
+                    />
+                  </TooltipV2>
+                </Show>
                 <div class="flex items-center min-w-0 flex-1 w-full">
                   <Show when={parentID()}>
                     <button
@@ -1417,8 +1472,15 @@ export function MessageTimeline(props: {
                           data-slot="session-title-child"
                           classList={{
                             "truncate text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-base": true,
-                            "w-fit rounded-[6px] px-2 py-1 hover:bg-v2-overlay-simple-overlay-hover":
+                            "w-fit rounded-[6px] py-1 hover:bg-v2-overlay-simple-overlay-hover":
                               settings.general.newLayoutDesigns(),
+                            "px-2":
+                              settings.general.newLayoutDesigns() &&
+                              (titleToggle() || !historyTreeChromeOnCard(mobile(), layout.historyTree.opened())),
+                            "pe-2":
+                              settings.general.newLayoutDesigns() &&
+                              !titleToggle() &&
+                              historyTreeChromeOnCard(mobile(), layout.historyTree.opened()),
                             "grow-1 min-w-0": !settings.general.newLayoutDesigns(),
                           }}
                           onClick={openTitleEditor}
@@ -1437,8 +1499,14 @@ export function MessageTimeline(props: {
                         classList={{
                           "block text-[13px] font-[530] leading-4 tracking-[-0.04px] text-v2-text-text-base": true,
                           "w-full flex-1 grow-1 min-w-0 pl-1 -ml-1 rounded-[6px]": !settings.general.newLayoutDesigns(),
-                          "field-sizing-content self-start rounded-[6px] px-2 py-1 ":
-                            settings.general.newLayoutDesigns(),
+                          "field-sizing-content self-start rounded-[6px] py-1": settings.general.newLayoutDesigns(),
+                          "px-2":
+                            settings.general.newLayoutDesigns() &&
+                            (titleToggle() || !historyTreeChromeOnCard(mobile(), layout.historyTree.opened())),
+                          "pe-2":
+                            settings.general.newLayoutDesigns() &&
+                            !titleToggle() &&
+                            historyTreeChromeOnCard(mobile(), layout.historyTree.opened()),
                         }}
                         style={{
                           "--inline-input-shadow": settings.general.newLayoutDesigns()
@@ -1478,6 +1546,7 @@ export function MessageTimeline(props: {
                       placement="bottom"
                       buttonAppearance={settings.general.newLayoutDesigns() ? "v2" : "default"}
                     />
+                    <SessionChangesToggle />
                     <Show when={!parentID()}>
                       <Show
                         when={settings.general.newLayoutDesigns()}
@@ -1842,6 +1911,14 @@ export function MessageTimeline(props: {
           </Show>
         </div>
       </ScrollView>
+      <Show when={props.cover}>
+        <div
+          class="absolute inset-x-0 bottom-0 z-[70] overflow-hidden bg-v2-background-bg-base"
+          style={{ top: showHeader() ? "48px" : "0px" }}
+        >
+          {props.cover}
+        </div>
+      </Show>
     </div>
   )
 }


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds a persistent project and session sidebar to the v2 layout. It replaces the floating session tabs, keeps controls aligned, and collapses back into the session title bar without changing the active session.

### How did you verify your code works?

- `packages/app`: `bun typecheck`
- `packages/app`: 52 focused layout, navigation, and tab tests
- Browser: expanded and collapsed sidebar, session switching, compact title controls, and Changes view

### Screenshots / recordings

Expanded sidebar:

![Expanded session history sidebar](https://raw.githubusercontent.com/0kzh/opencode/f5da42669687d1dd537776efcad0d44ee81be8f3/sidebar-expanded.png)

Collapsed sidebar:

![Collapsed sidebar with session title controls](https://raw.githubusercontent.com/0kzh/opencode/f5da42669687d1dd537776efcad0d44ee81be8f3/sidebar-collapsed.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
