### PR TITLE
fix(opencode): allow none reasoning effort in Bedrock SDK

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1778,9 +1778,6 @@ function reasoningEffort(model: Provider.Model, effort: string) {
           },
         }
       if (model.api.id.includes("anthropic")) return
-      // The SDK's maxReasoningEffort schema excludes "none".
-      if (effort === "none" && model.api.id.includes("openai.gpt-5.6-"))
-        return { additionalModelRequestFields: { reasoning: { effort } } }
       return { reasoningConfig: { type: "enabled", maxReasoningEffort: effort } }
     case "@ai-sdk/gateway":
       if (model.id.includes("anthropic")) return { thinking: { type: "adaptive", display: "summarized" }, effort }

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1778,6 +1778,9 @@ function reasoningEffort(model: Provider.Model, effort: string) {
           },
         }
       if (model.api.id.includes("anthropic")) return
+      // The SDK's maxReasoningEffort schema excludes "none".
+      if (effort === "none" && model.api.id.includes("openai.gpt-5.6-"))
+        return { additionalModelRequestFields: { reasoning: { effort } } }
       return { reasoningConfig: { type: "enabled", maxReasoningEffort: effort } }
     case "@ai-sdk/gateway":
       if (model.id.includes("anthropic")) return { thinking: { type: "adaptive", display: "summarized" }, effort }

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -3717,6 +3717,39 @@ describe("ProviderTransform.reasoningVariants", () => {
     )
   })
 
+  test.each(["luna", "sol", "terra"])("sends Bedrock GPT-5.6 %s none effort through native fields", async (name) => {
+    const item = target("@ai-sdk/amazon-bedrock", `global.openai.gpt-5.6-${name}`)
+    const variants = ProviderTransform.reasoningVariants(
+      model([{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }]),
+      item,
+    )
+    for (const effort of ["low", "medium", "high", "xhigh", "max"]) {
+      expect(variants?.[effort]).toEqual({ reasoningConfig: { type: "enabled", maxReasoningEffort: effort } })
+    }
+    const sent: unknown[] = []
+    const provider = createAmazonBedrock({
+      apiKey: "test-key",
+      region: "us-east-1",
+      fetch: Object.assign(
+        async (...args: Parameters<typeof fetch>) => {
+          sent.push(JSON.parse(String(args[1]?.body)))
+          return Response.json({
+            output: { message: { role: "assistant", content: [{ text: "ok" }] } },
+            stopReason: "end_turn",
+            usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          })
+        },
+        { preconnect: () => undefined },
+      ),
+    })
+    await generateText({
+      model: provider(item.api.id),
+      prompt: "hi",
+      providerOptions: ProviderTransform.providerOptions(item, variants?.none ?? {}),
+    })
+    expect(sent).toEqual([expect.objectContaining({ additionalModelRequestFields: { reasoning: { effort: "none" } } })])
+  })
+
   test("combines effort with extended thinking for Claude Opus 4.5", () => {
     expect(
       ProviderTransform.reasoningVariants(

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -6,7 +6,7 @@ import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { generateText, jsonSchema, type ModelMessage } from "ai"
-import { createAmazonBedrock } from "@ai-sdk/amazon-bedrock"
+import { createAmazonBedrock, type AmazonBedrockLanguageModelOptions } from "@ai-sdk/amazon-bedrock"
 import { createAnthropic } from "@ai-sdk/anthropic"
 import { createVertexAnthropic } from "@ai-sdk/google-vertex/anthropic"
 
@@ -3717,7 +3717,7 @@ describe("ProviderTransform.reasoningVariants", () => {
     )
   })
 
-  test.each(["luna", "sol", "terra"])("sends Bedrock GPT-5.6 %s none effort through native fields", async (name) => {
+  test.each(["luna", "sol", "terra"])("serializes Bedrock GPT-5.6 %s none effort", async (name) => {
     const item = target("@ai-sdk/amazon-bedrock", `global.openai.gpt-5.6-${name}`)
     const variants = ProviderTransform.reasoningVariants(
       model([{ type: "effort", values: ["none", "low", "medium", "high", "xhigh", "max"] }]),
@@ -3726,6 +3726,9 @@ describe("ProviderTransform.reasoningVariants", () => {
     for (const effort of ["low", "medium", "high", "xhigh", "max"]) {
       expect(variants?.[effort]).toEqual({ reasoningConfig: { type: "enabled", maxReasoningEffort: effort } })
     }
+    expect(variants?.none).toEqual({
+      reasoningConfig: { type: "enabled", maxReasoningEffort: "none" },
+    } satisfies AmazonBedrockLanguageModelOptions)
     const sent: unknown[] = []
     const provider = createAmazonBedrock({
       apiKey: "test-key",

--- a/patches/@ai-sdk%2Famazon-bedrock@4.0.166.patch
+++ b/patches/@ai-sdk%2Famazon-bedrock@4.0.166.patch
@@ -1,8 +1,16 @@
 diff --git a/dist/index.d.mts b/dist/index.d.mts
-index d194ae227fd1223ba44c8c5157b1bb72b1bab273..2e046db0a365c27659ffcec08782c7c26845c1fa 100644
+index d194ae227fd1223ba44c8c5157b1bb72b1bab273..db7fdb1b6f4e617baa40539ccef718735d2e9e81 100644
 --- a/dist/index.d.mts
 +++ b/dist/index.d.mts
-@@ -61,6 +61,12 @@ declare const amazonBedrockLanguageModelOptions: z.ZodObject<{
+@@ -51,6 +51,7 @@ declare const amazonBedrockLanguageModelOptions: z.ZodObject<{
+         type: z.ZodOptional<z.ZodUnion<readonly [z.ZodLiteral<"enabled">, z.ZodLiteral<"disabled">, z.ZodLiteral<"adaptive">]>>;
+         budgetTokens: z.ZodOptional<z.ZodNumber>;
+         maxReasoningEffort: z.ZodOptional<z.ZodEnum<{
++            none: "none";
+             low: "low";
+             medium: "medium";
+             high: "high";
+@@ -61,6 +62,12 @@ declare const amazonBedrockLanguageModelOptions: z.ZodObject<{
              omitted: "omitted";
              summarized: "summarized";
          }>>;
@@ -16,10 +24,18 @@ index d194ae227fd1223ba44c8c5157b1bb72b1bab273..2e046db0a365c27659ffcec08782c7c2
      anthropicBeta: z.ZodOptional<z.ZodArray<z.ZodString>>;
      serviceTier: z.ZodOptional<z.ZodEnum<{
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index d194ae227fd1223ba44c8c5157b1bb72b1bab273..2e046db0a365c27659ffcec08782c7c26845c1fa 100644
+index d194ae227fd1223ba44c8c5157b1bb72b1bab273..db7fdb1b6f4e617baa40539ccef718735d2e9e81 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
-@@ -61,6 +61,12 @@ declare const amazonBedrockLanguageModelOptions: z.ZodObject<{
+@@ -51,6 +51,7 @@ declare const amazonBedrockLanguageModelOptions: z.ZodObject<{
+         type: z.ZodOptional<z.ZodUnion<readonly [z.ZodLiteral<"enabled">, z.ZodLiteral<"disabled">, z.ZodLiteral<"adaptive">]>>;
+         budgetTokens: z.ZodOptional<z.ZodNumber>;
+         maxReasoningEffort: z.ZodOptional<z.ZodEnum<{
++            none: "none";
+             low: "low";
+             medium: "medium";
+             high: "high";
+@@ -61,6 +62,12 @@ declare const amazonBedrockLanguageModelOptions: z.ZodObject<{
              omitted: "omitted";
              summarized: "summarized";
          }>>;
@@ -33,14 +49,16 @@ index d194ae227fd1223ba44c8c5157b1bb72b1bab273..2e046db0a365c27659ffcec08782c7c2
      anthropicBeta: z.ZodOptional<z.ZodArray<z.ZodString>>;
      serviceTier: z.ZodOptional<z.ZodEnum<{
 diff --git a/dist/index.js b/dist/index.js
-index 2047c91971c23f72dd3cd0c069614f37a30e45f3..9e9ccc26b711eb9ad2722bf1dd4b2e931e528776 100644
+index 2047c91971c23f72dd3cd0c069614f37a30e45f3..ede62d091e3d17fd6130e77a6a209ee0af2a7c20 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -95,7 +95,10 @@ var amazonBedrockLanguageModelOptions = import_v4.z.object({
+@@ -94,8 +94,11 @@ var amazonBedrockLanguageModelOptions = import_v4.z.object({
+       import_v4.z.literal("adaptive")
      ]).optional(),
      budgetTokens: import_v4.z.number().optional(),
-     maxReasoningEffort: import_v4.z.enum(["low", "medium", "high", "xhigh", "max"]).optional(),
+-    maxReasoningEffort: import_v4.z.enum(["low", "medium", "high", "xhigh", "max"]).optional(),
 -    display: import_v4.z.enum(["omitted", "summarized"]).optional()
++    maxReasoningEffort: import_v4.z.enum(["none", "low", "medium", "high", "xhigh", "max"]).optional(),
 +    display: import_v4.z.enum(["omitted", "summarized"]).optional(),
 +    blockBinding: import_v4.z.object({
 +      prefixMismatchBehavior: import_v4.z.enum(["error", "drop_block"])
@@ -88,14 +106,16 @@ index 2047c91971c23f72dd3cd0c069614f37a30e45f3..9e9ccc26b711eb9ad2722bf1dd4b2e93
          };
        }
 diff --git a/dist/index.mjs b/dist/index.mjs
-index 5a669504cb3b21f20788956bc9c22529c1498c35..000114dfe76cba25ddfe693f042232810026c229 100644
+index 5a669504cb3b21f20788956bc9c22529c1498c35..bcbcd768759a4e412657795d6db75e21d4e64c09 100644
 --- a/dist/index.mjs
 +++ b/dist/index.mjs
-@@ -84,7 +84,10 @@ var amazonBedrockLanguageModelOptions = z.object({
+@@ -83,8 +83,11 @@ var amazonBedrockLanguageModelOptions = z.object({
+       z.literal("adaptive")
      ]).optional(),
      budgetTokens: z.number().optional(),
-     maxReasoningEffort: z.enum(["low", "medium", "high", "xhigh", "max"]).optional(),
+-    maxReasoningEffort: z.enum(["low", "medium", "high", "xhigh", "max"]).optional(),
 -    display: z.enum(["omitted", "summarized"]).optional()
++    maxReasoningEffort: z.enum(["none", "low", "medium", "high", "xhigh", "max"]).optional(),
 +    display: z.enum(["omitted", "summarized"]).optional(),
 +    blockBinding: z.object({
 +      prefixMismatchBehavior: z.enum(["error", "drop_block"])


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Extend the existing `@ai-sdk/amazon-bedrock@4.0.166` dependency patch to accept `none` in `reasoningConfig.maxReasoningEffort`.

The SDK's effort enum currently rejects `none` before making an AWS request, even though GPT-5.6 supports it. Its existing serializer already maps the effort to `additionalModelRequestFields.reasoning.effort` for GPT models. Add the missing enum value in both ESM and CommonJS runtime bundles and their TypeScript declarations; no serializer changes are needed.

The previous OpenCode transform workaround is removed. `src/provider/transform.ts` is identical to the PR base. Preserve the existing Anthropic block-binding patch; leave variant generation, defaults, summary settings, Mantle, and configuration merging unchanged. No package-version, lockfile, or catalog changes. As with the SDK's other effort values, adding a value to its shared schema does not assert that every Bedrock model supports it.

AWS documents `none` as a supported GPT-5.6 effort, so removing it from models.dev would incorrectly narrow the model's capabilities: https://aws.amazon.com/blogs/machine-learning/get-started-with-openai-gpt-5-6-sol-terra-and-luna-on-amazon-bedrock/

### How did you verify your code works?

- One parameterized regression in the existing transform test file checks the unchanged `maxReasoningEffort: "none"` variant against the SDK's public TypeScript type and exercises actual SDK request serialization for global Luna, Sol, and Terra. It also checks the other five variant mappings remain unchanged.
- With the transform workaround removed, all three regression cases failed before the SDK patch with `invalid bedrock provider options`; all passed afterward.
- Separate ESM and CommonJS probes confirmed the existing serializer emits `additionalModelRequestFields.reasoning.effort: "none"`.
- `bun test test/provider --timeout 30000 --only-failures`: 589 passed, 0 failed.
- `packages/core`: `bun test test/plugin --timeout 30000 --only-failures`: 227 passed, 0 failed.
- Nine live source-CLI checks in `us-east-1` passed: all six efforts for global Luna, `none` for global Sol and Terra, and `none` for Mantle Luna. Each returned `OK`, completed normally, and emitted no error events. Checks used isolated configuration/data and disabled tools; the temporary live harness is not part of the PR.
- `bun typecheck` in `packages/opencode` and `packages/core`: passed.
- `bun install --frozen-lockfile`: passed with the updated patch, without lockfile changes.
- Prettier and `git diff --check`: passed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
