### PR TITLE
test(opencode): fix session tools test typecheck and runtime

### DIFF
--- a/packages/opencode/test/session/tools.test.ts
+++ b/packages/opencode/test/session/tools.test.ts
@@ -14,6 +14,7 @@ import { Tool } from "@/tool/tool"
 import { ToolRegistry } from "@/tool/registry"
 import { Truncate } from "@/tool/truncate"
 import { Plugin } from "@/plugin"
+import { RuntimeFlags } from "@/effect/runtime-flags"
 import { Effect, Layer, Schema } from "effect"
 import { testEffect } from "../lib/effect"
 
@@ -37,6 +38,7 @@ const model = {
 function fakeMcp() {
   return MCP.Service.of({
     tools: () => Effect.succeed({}),
+    clients: () => Effect.succeed({}),
   } as Partial<MCP.Interface> as MCP.Interface)
 }
 
@@ -64,6 +66,7 @@ const layer = Layer.mergeAll(
   Layer.succeed(Permission.Service, fakePermission),
   Layer.succeed(MCP.Service, fakeMcp()),
   Layer.succeed(Truncate.Service, fakeTruncate),
+  RuntimeFlags.layer(),
   Layer.succeed(
     ToolRegistry.Service,
     ToolRegistry.Service.of({
@@ -135,7 +138,7 @@ it.effect("preserves running tool start time across metadata updates", () =>
     const tools = yield* SessionTools.resolve({
       agent,
       model,
-      session: { id: sessionID, permission: [] } as Session.Info,
+      session: { id: sessionID, permission: [] } as unknown as Session.Info,
       processor,
       bypassAgentCheck: false,
       messages: [],
@@ -150,6 +153,7 @@ it.effect("preserves running tool start time across metadata updates", () =>
         {
           toolCallId: callID,
           abortSignal: new AbortController().signal,
+          messages: [],
         },
       ),
     )


### PR DESCRIPTION
## Summary

`dev` typecheck has been red since #32596 landed (https://github.com/anomalyco/opencode/actions?query=branch%3Adev+workflow%3Atypecheck). That PR was authored against an older API and its new `test/session/tools.test.ts` no longer typechecks or runs against current `dev`:

- `SessionTools.resolve` now requires `RuntimeFlags.Service`, which the test layer did not provide
- `Session.Info` grew enough fields that the partial `as Session.Info` cast is rejected; needs `as unknown as`
- `ToolExecutionOptions` now requires `messages`
- At runtime, `resolve` calls `mcp.clients()`, which the fake MCP service did not implement

## Change

Test-only. Add `RuntimeFlags.layer()` to the layer, stub `clients()` on the fake MCP, cast the partial session through `unknown`, and pass `messages: []` to `execute`.

## Verification

- `bun typecheck` in `packages/opencode`: 0 errors
- `bun test test/session/tools.test.ts`: passes
- Reverting the one-line `src/session/tools.ts` fix from #32596 makes the test fail again, so it still guards the regression it was written for