### PR TITLE
fix(app): show review diffs for non-git VCS backends

### DIFF
--- a/packages/app/src/runtime/server/global-sync/utils.test.ts
+++ b/packages/app/src/runtime/server/global-sync/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
-import type { AgentListOutput, ModelListOutput, ProviderListOutput } from "@opencode-ai/client/promise"
-import { directoryKey, normalizeAgentList, normalizeProviderList } from "./utils"
+import type { AgentListOutput, ModelListOutput, Project, ProviderListOutput } from "@opencode-ai/client/promise"
+import { directoryKey, normalizeAgentList, normalizeProjectInfo, normalizeProviderList } from "./utils"
 
 describe("normalizeAgentList", () => {
   test("adapts current agents to the app agent shape", () => {
@@ -82,6 +82,15 @@ describe("normalizeProviderList", () => {
       cost: { input: 1, output: 2 },
       variants: { high: {} },
     })
+  })
+})
+
+describe("normalizeProjectInfo", () => {
+  test("keeps the project VCS backend", () => {
+    const project = { id: "prj", canonical: "/repo", time: { created: 1, updated: 1 }, sandboxes: [] }
+    expect(normalizeProjectInfo({ ...project, vcs: "git" } as Project).vcs).toBe("git")
+    expect(normalizeProjectInfo({ ...project, vcs: "hg" } as Project).vcs).toBe("hg")
+    expect(normalizeProjectInfo(project as Project).vcs).toBeUndefined()
   })
 })
 

--- a/packages/app/src/runtime/server/global-sync/utils.ts
+++ b/packages/app/src/runtime/server/global-sync/utils.ts
@@ -135,6 +135,5 @@ export function normalizeProjectInfo(project: Project | CurrentProject): Project
     ...project,
     worktree,
     worktrees: "worktrees" in project ? project.worktrees : [{ directory: worktree }],
-    vcs: project.vcs === "git" ? "git" : undefined,
   }
 }

--- a/packages/app/src/session/review/model.ts
+++ b/packages/app/src/session/review/model.ts
@@ -55,9 +55,9 @@ export function createSessionReview(input: {
   const options = createMemo<ChangeMode[]>(() => {
     const list: ChangeMode[] = []
     const project = input.session.project()
-    if (project?.vcs === "git") list.push("git")
+    if (project?.vcs) list.push("git")
     if (
-      project?.vcs === "git" &&
+      project?.vcs &&
       vcs()?.branch.current &&
       vcs()?.branch.default &&
       vcs()?.branch.current !== vcs()?.branch.default
@@ -94,7 +94,7 @@ export function createSessionReview(input: {
     const value = vcsMode()
     return {
       queryKey: [...vcsKey(), value] as const,
-      enabled: server.connection.status() === "connected" && wantsReview() && input.session.project()?.vcs === "git",
+      enabled: server.connection.status() === "connected" && wantsReview() && !!input.session.project()?.vcs,
       refetchOnMount: "always" as const,
       refetchOnWindowFocus: true,
       queryFn: value
@@ -110,7 +110,7 @@ export function createSessionReview(input: {
   })
   const detailsQuery = createQuery(() => ({
     queryKey: [server.scope, "session-details", input.session.workspace.directory()] as const,
-    enabled: state.detailsOpen && server.connection.status() === "connected" && input.session.project()?.vcs === "git",
+    enabled: state.detailsOpen && server.connection.status() === "connected" && !!input.session.project()?.vcs,
     queryFn: () =>
       server.api.vcs
         .diff({ location: { directory: input.session.workspace.directory() }, mode: "working" })
@@ -413,7 +413,7 @@ export function createSessionReview(input: {
       tab: () => state.mobileTab,
     },
     mode,
-    noGit: createMemo(() => !!input.session.project() && input.session.project()?.vcs !== "git"),
+    noGit: createMemo(() => !!input.session.project() && !input.session.project()?.vcs),
     open,
     openFile,
     options,

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -165,7 +165,7 @@ export function SessionScreen(props: { session: SessionModel }) {
                         baseBranch={
                           session.shared.data.location.vcs.info({ directory: project().worktree })?.branch.current
                         }
-                        diffs={project().vcs === "git" ? review.details.diffs() : []}
+                        diffs={project().vcs ? review.details.diffs() : []}
                         sessionID={session.identity.params.id ?? ""}
                         moveEligible={composer.workspaceMoveEligible()}
                         moveDismissed={store.mobileMoveDismissed}


### PR DESCRIPTION
### Issue for this PR

Fixes #46472

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes the session review panel work for non-git VCS backends — Mercurial or any plugin-registered one.

`normalizeProjectInfo` rewrote every backend except git to `undefined`, and the review model gated its diff queries on `vcs === "git"`, so the panel never left the empty state even though the server already returns those diffs. Dropped the rewrite and changed the five gates to check for any backend instead.

### How did you verify your code works?

- Opened the review panel on a Mercurial repository — file list and diff show up. 
- Added a unit test for `normalizeProjectInfo`.

### Screenshots / recordings

**Before**
<img width="1168" height="624" alt="before" src="https://github.com/user-attachments/assets/81cfca64-cf6d-432d-8489-e0dd3e83da5d" />
<img width="335" height="560" alt="before2" src="https://github.com/user-attachments/assets/c28cd257-03ef-4631-aa3f-6c392b5aa62b" />

**After**
<img width="1168" height="626" alt="after" src="https://github.com/user-attachments/assets/8ab1d97e-e047-4883-8b9f-ece68470c9d1" />
<img width="335" height="560" alt="before2" src="https://github.com/user-attachments/assets/79c67f31-21d9-4adb-8fd1-2da66561c3e2" />


### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR