### PR TITLE
test(client): cover session background

### DIFF
--- a/packages/client/test/effect.test.ts
+++ b/packages/client/test/effect.test.ts
@@ -230,6 +230,7 @@ test("session methods retain decoded Effect inputs and outputs", async () => {
       .log({ sessionID: Session.ID.make("ses_test"), after: Event.Seq.make(0) })
       .pipe(Stream.runCollect)
     const interrupted = yield* client.session.interrupt({ sessionID: Session.ID.make("ses_test") })
+    yield* client.session.background({ sessionID: Session.ID.make("ses_test") })
     const message = yield* client.session.message({
       sessionID: Session.ID.make("ses_test"),
       messageID: SessionMessage.ID.make("msg_model"),
@@ -253,6 +254,7 @@ test("session methods retain decoded Effect inputs and outputs", async () => {
   expect(result.context).toEqual([])
   expect(logQueries[0]).toEqual({ after: "0" })
   expect(requests).toContainEqual({ method: "POST", url: "http://localhost:3000/api/session/ses_test/view" })
+  expect(requests).toContainEqual({ method: "POST", url: "http://localhost:3000/api/session/ses_test/background" })
   const logged = Array.from(result.log)
   expect(logged.map((item) => item.type)).toEqual(["session.model.selected", "log.synced"])
   expect(logged[0]?.type === "session.model.selected" && logged[0].created).toBe(1_717_171_717_000)

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -818,6 +818,7 @@ test("session methods use the public HTTP contract", async () => {
   const log = []
   for await (const item of client.session.log({ sessionID: "ses_test", after: 0 })) log.push(item)
   const interrupted = await client.session.interrupt({ sessionID: "ses_test", continue: true })
+  await client.session.background({ sessionID: "ses_test" })
   const message = await client.session.message({ sessionID: "ses_test", messageID: "msg_model" })
 
   expect(page.cursor.next).toBe("next")
@@ -846,6 +847,7 @@ test("session methods use the public HTTP contract", async () => {
     ["GET", "http://localhost:3000/api/session/ses_test/context"],
     ["GET", "http://localhost:3000/api/experimental/session/ses_test/log?after=0"],
     ["POST", "http://localhost:3000/api/session/ses_test/interrupt?continue=true"],
+    ["POST", "http://localhost:3000/api/session/ses_test/background"],
     ["GET", "http://localhost:3000/api/session/ses_test/message/msg_model"],
   ])
   const viewBody = requests.find((request) => request.url.endsWith("/api/session/ses_test/view"))?.init?.body


### PR DESCRIPTION
Tests the existing v2 `session.background` route through both public clients.

Tests: client tests and typecheck.