### PR TITLE
feat(sdk): expose session background type

### DIFF
--- a/packages/sdk/src/effect/opencode.ts
+++ b/packages/sdk/src/effect/opencode.ts
@@ -8,12 +8,13 @@ import { FetchHttpClient } from "effect/unstable/http"
 import { EmbeddedHost } from "../internal/host"
 
 export type { LogEntry, LogLevel, LogOptions, LogWriter } from "../logging"
+export type SessionClient = OpenCodeClient["session"]
 
 export type CreateOptions = EmbeddedHost.CreateOptions
 export type EmbedOptions = EmbeddedHost.EmbedOptions
 
 export type Interface = Omit<OpenCodeClient, "plugin" | "workspace"> & {
-  readonly sessions: OpenCodeClient["session"]
+  readonly sessions: SessionClient
   readonly events: OpenCodeClient["event"]
   readonly workspace: {
     readonly create: Workspace.Interface["create"]

--- a/packages/sdk/src/effect/opencode.ts
+++ b/packages/sdk/src/effect/opencode.ts
@@ -8,7 +8,9 @@ import { FetchHttpClient } from "effect/unstable/http"
 import { EmbeddedHost } from "../internal/host"
 
 export type { LogEntry, LogLevel, LogOptions, LogWriter } from "../logging"
-export type SessionClient = OpenCodeClient["session"]
+export type SessionClient = OpenCodeClient["session"] & {
+  readonly background: OpenCodeClient["session"]["background"]
+}
 
 export type CreateOptions = EmbeddedHost.CreateOptions
 export type EmbedOptions = EmbeddedHost.EmbedOptions

--- a/packages/sdk/src/opencode.ts
+++ b/packages/sdk/src/opencode.ts
@@ -4,5 +4,6 @@ export type { LogEntry, LogLevel, LogOptions, LogWriter } from "./logging"
 
 export type CreateOptions = PromiseSdk.CreateOptions
 export type Interface = PromiseSdk.Interface
+export type SessionClient = PromiseSdk.SessionClient
 
 export const create = (options: CreateOptions = {}) => PromiseSdk.create(options)

--- a/packages/sdk/src/promise.ts
+++ b/packages/sdk/src/promise.ts
@@ -5,7 +5,9 @@ import type { Plugin } from "@opencode-ai/plugin"
 import { Effect } from "effect"
 import { EmbeddedHost } from "./internal/host"
 
-export type SessionClient = OpenCodeClient["session"]
+export type SessionClient = OpenCodeClient["session"] & {
+  readonly background: OpenCodeClient["session"]["background"]
+}
 
 export interface CreateOptions extends Omit<EmbeddedHost.CreateOptions, "workspaceProviders"> {
   readonly plugins?: ReadonlyArray<Plugin.Plugin>

--- a/packages/sdk/src/promise.ts
+++ b/packages/sdk/src/promise.ts
@@ -5,12 +5,14 @@ import type { Plugin } from "@opencode-ai/plugin"
 import { Effect } from "effect"
 import { EmbeddedHost } from "./internal/host"
 
+export type SessionClient = OpenCodeClient["session"]
+
 export interface CreateOptions extends Omit<EmbeddedHost.CreateOptions, "workspaceProviders"> {
   readonly plugins?: ReadonlyArray<Plugin.Plugin>
 }
 
 export type Interface = Omit<OpenCodeClient, "plugin"> & {
-  readonly sessions: OpenCodeClient["session"]
+  readonly sessions: SessionClient
   readonly events: OpenCodeClient["event"]
   readonly plugin: ((plugin: Plugin.Plugin) => Promise<void>) & OpenCodeClient["plugin"]
   readonly close: () => Promise<void>

--- a/packages/sdk/test/embedded.test.ts
+++ b/packages/sdk/test/embedded.test.ts
@@ -11,7 +11,7 @@ import { WorkspaceDriver } from "@opencode-ai/core/workspace/driver"
 import { Deferred, Effect, Fiber, Latch, Layer, Option, Schedule, Stream } from "effect"
 import { testEffect } from "../../core/test/lib/effect"
 import { tmpdir } from "../../core/test/fixture/tmpdir"
-import type { OpenCodeEvent } from "../src/effect"
+import type { OpenCode, OpenCodeEvent } from "../src/effect"
 
 const it = testEffect(Layer.empty)
 type Sdk = typeof import("../src/effect")
@@ -100,13 +100,14 @@ it.live(
     withEmbedded("opencode-embedded-", (fixture) =>
       Effect.gen(function* () {
         const opencode = yield* fixture.sdk.OpenCode.create({ events: { persist: true } })
+        const sessions: OpenCode.SessionClient = opencode.sessions
         const id = sessionID(fixture)
         const model = fixture.sdk.Model.Ref.make({
           id: fixture.sdk.Model.ID.make("embedded"),
           providerID: fixture.sdk.Provider.ID.make("test"),
         })
 
-        const created = yield* opencode.sessions.create({
+        const created = yield* sessions.create({
           id,
           agent: fixture.sdk.Agent.ID.make("build"),
           location: location(fixture),

--- a/packages/sdk/test/embedded.test.ts
+++ b/packages/sdk/test/embedded.test.ts
@@ -112,6 +112,7 @@ it.live(
           agent: fixture.sdk.Agent.ID.make("build"),
           location: location(fixture),
         })
+        yield* sessions.background({ sessionID: id })
         yield* opencode.sessions.switchModel({ sessionID: id, model })
         const selected = yield* opencode.sessions.get({ sessionID: id })
         const page = yield* opencode.sessions.list({ directory: fixture.sdk.AbsolutePath.make(fixture.directory) })

--- a/packages/sdk/test/promise.test.ts
+++ b/packages/sdk/test/promise.test.ts
@@ -17,6 +17,7 @@ test("Promise host uses the embedded router", async () => {
     const location = { directory: directory.path }
     const sessions: OpenCode.SessionClient = opencode.sessions
     const session = await sessions.create({ location })
+    await sessions.background({ sessionID: session.id })
     const selected = await opencode.sessions.get({ sessionID: session.id })
     const page = await opencode.sessions.list({ directory: directory.path })
     const events = Array.fromAsync(opencode.sessions.log({ sessionID: session.id }))

--- a/packages/sdk/test/promise.test.ts
+++ b/packages/sdk/test/promise.test.ts
@@ -15,7 +15,8 @@ test("Promise host uses the embedded router", async () => {
 
   try {
     const location = { directory: directory.path }
-    const session = await opencode.sessions.create({ location })
+    const sessions: OpenCode.SessionClient = opencode.sessions
+    const session = await sessions.create({ location })
     const selected = await opencode.sessions.get({ sessionID: session.id })
     const page = await opencode.sessions.list({ directory: directory.path })
     const events = Array.fromAsync(opencode.sessions.log({ sessionID: session.id }))


### PR DESCRIPTION
Makes `sessions.background` discoverable in both SDK type declarations.