### PR TITLE
fix(app): apply safe-area sizing to iOS home-screen apps

### DIFF
--- a/packages/app/src/entry.tsx
+++ b/packages/app/src/entry.tsx
@@ -73,6 +73,7 @@ if (root instanceof HTMLElement && root.dataset.opencodeMounted === undefined) {
     const auth = authFromToken(new URLSearchParams(location.search).get("auth_token"))
     clearAuthToken()
     const standalone = isStandalone()
+    root.dataset.standalone = String(standalone)
     if (standalone) restorePwaRoute()
     const server: ServerConnection.Http = {
       type: "http",

--- a/packages/app/src/index.css
+++ b/packages/app/src/index.css
@@ -32,6 +32,11 @@
   }
 }
 
+/* iOS can report navigator.standalone without matching display-mode. */
+#root[data-standalone="true"] {
+  height: 100vh;
+}
+
 @layer components {
   [data-slot="session-side-panel-presence"][data-opened="true"] {
     animation: terminal-panel-presence-in 240ms cubic-bezier(0.22, 1, 0.36, 1);

--- a/packages/app/test-browser/pwa-route.test.ts
+++ b/packages/app/test-browser/pwa-route.test.ts
@@ -19,6 +19,18 @@ test("normal browser windows are not standalone", () => {
   expect(isStandalone()).toBe(false)
 })
 
+test("detects iOS home-screen apps when the standalone media query does not match", () => {
+  const descriptor = Object.getOwnPropertyDescriptor(navigator, "standalone")
+  Object.defineProperty(navigator, "standalone", { configurable: true, value: true })
+  try {
+    expect(window.matchMedia("(display-mode: standalone)").matches).toBe(false)
+    expect(isStandalone()).toBe(true)
+  } finally {
+    if (descriptor) Object.defineProperty(navigator, "standalone", descriptor)
+    if (!descriptor) Reflect.deleteProperty(navigator, "standalone")
+  }
+})
+
 test("restores the last PWA route including query and hash without adding history", () => {
   window.history.replaceState({ retained: true }, "", "http://localhost/")
   const length = window.history.length


### PR DESCRIPTION
### Issue for this PR

Reported during on-device iPhone debugging; no linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

On an installed iPhone PWA, `navigator.standalone` was true while `(display-mode: standalone)` was false. Our CSS-only detection missed the existing `100vh` workaround, leaving the root 62px short and a large bottom gap.

Expose the existing JavaScript standalone detection on the root and use it as a CSS fallback. Keep the media-query rule and existing safe-area padding. This PR contains only the layout fix; API-only authentication is separate in #46702.

### How did you verify your code works?

- On a physical iPhone 16 Pro running iOS 26.6, applied the exact root attribute/CSS change to the open PWA without restarting its server: root height changed from 812px to the full 874px. The 62px top and 34px bottom safe-area padding remained intact.
- Bun 1.4.0: `bun test --conditions=browser --preload ./happydom.ts ./test-browser/pwa-route.test.ts` in `packages/app`: 6 passed.
- `bun typecheck` in `packages/app`, `git diff --check`, and the unmodified pre-push hook's 33 typecheck tasks passed.

### Screenshots / recordings

The on-device scenario was Home (`/`) at 402 x 874 CSS pixels. Before/after measurements are recorded above; the original PWA page was closed before a privacy-safe screenshot pair could be captured.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
