### PR TITLE
fix(client): retry transient prompt admissions

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -29,6 +29,7 @@ import type {
   SessionMessageAssistantTool,
   SessionInfo,
   SessionInboxInfo,
+  SessionInboxUser,
   SessionInboxCompaction,
   ShellInfo,
   SkillInfo,
@@ -44,13 +45,32 @@ import {
   isFormAlreadySettledError,
   isFormNotFoundError,
   isPermissionNotFoundError,
+  isConflictError,
+  isSessionNotFoundError,
   type SessionPromptInput,
 } from "../promise"
-import { createStore, produce, reconcile } from "solid-js/store"
+import { createStore, produce, reconcile, unwrap } from "solid-js/store"
+import { promptFailure } from "./prompt-retry"
 import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
 import { batch, createEffect, createMemo, createSignal, onCleanup } from "solid-js"
 
 export type DataSessionStatus = "idle" | "running"
+export type PromptSubmission = {
+  readonly id: string
+  readonly sessionID: string
+  readonly status: "sending" | "retrying" | "failed"
+  readonly attempt: number
+}
+
+export class PromptSubmissionError extends Error {
+  constructor(
+    readonly reason: "cancelled" | "failed",
+    readonly sessionID: string,
+    readonly id: string,
+  ) {
+    super(reason === "cancelled" ? "Prompt submission cancelled" : "Could not confirm prompt delivery")
+  }
+}
 type OpenCodeEventMap = { [Type in OpenCodeEvent["type"]]: Extract<OpenCodeEvent, { type: Type }> }
 
 export type CreateDataInput = {
@@ -65,6 +85,9 @@ export type CreateDataInput = {
   }
   readonly connection?: {
     readonly status: () => "connected" | "connecting" | "reconnecting"
+  }
+  readonly log?: {
+    readonly info?: (message: string, data?: Readonly<Record<string, unknown>>) => void
   }
 }
 
@@ -212,6 +235,7 @@ export function createData(config: CreateDataInput) {
   })
 
   const [defaultLocation, setDefaultLocation] = createSignal<LocationRef>({ directory: config.directory })
+  const [submissions, setSubmissions] = createStore<Record<string, PromptSubmission | undefined>>({})
   const sessions = createMemo(() =>
     Object.values(store.session.info).toSorted((a, b) => b.time.updated - a.time.updated),
   )
@@ -308,6 +332,23 @@ export function createData(config: CreateDataInput) {
   // submission order. Each waits for the previous POST to settle, so one
   // failure does not block the next.
   const sending = new Map<string, Promise<unknown>>()
+  const prompts = new Map<
+    string,
+    {
+      sessionID: string
+      delivery: SessionInbox.Delivery
+      attempted: boolean
+      stopped: boolean
+      signal: AbortSignal
+      accepted?: SessionInboxUser
+      confirmation?: Promise<SessionInboxUser | undefined>
+      acknowledge: (item: SessionInboxUser) => void
+      stop: () => void
+      retry: () => Promise<SessionInboxUser>
+      request?: Promise<SessionInboxUser>
+    }
+  >()
+  onCleanup(() => prompts.forEach((entry) => entry.stop()))
   const messageLoads = new Map<string, Promise<unknown>>()
   const compacting = new Map<string, { id: string; observed: Set<string>; request: Promise<SessionInboxCompaction> }>()
   onCleanup(() => compacting.clear())
@@ -323,11 +364,19 @@ export function createData(config: CreateDataInput) {
   }
 
   // Capture creation before settlement clears its entry, so dependent RPCs still see a failed create.
-  function sendAdmission<Value>(sessionID: string, send: () => Promise<Value>, gate?: Promise<unknown>) {
+  function sendAdmission<Value>(
+    sessionID: string,
+    send: () => Promise<Value>,
+    gate?: Promise<unknown>,
+    cancelled?: Promise<never>,
+  ) {
     const created = creating.get(sessionID)
     const previous = sending.get(sessionID)
     const request = Promise.resolve()
-      .then(() => Promise.all([gate, created, previous]))
+      .then(() => {
+        const ready = Promise.all([gate, created, previous])
+        return cancelled ? Promise.race([ready, cancelled]) : ready
+      })
       .then(send)
     track(
       sending,
@@ -521,6 +570,9 @@ export function createData(config: CreateDataInput) {
   }
 
   function removeSession(sessionID: string) {
+    prompts.forEach((entry) => {
+      if (entry.sessionID === sessionID) entry.stop()
+    })
     activeUpdates?.set(sessionID, undefined)
     store.session.pending[sessionID]?.forEach((item) => outbox.delete(item.id))
     messageIndex.delete(sessionID)
@@ -706,6 +758,42 @@ export function createData(config: CreateDataInput) {
         return
       }
       case "session.inbox.delivered": {
+        const item = store.session.pending[event.data.sessionID]?.find((item) => item.id === event.data.inboxID)
+        const entry = prompts.get(event.data.inboxID)
+        if (item?.type === "user" && !outbox.has(item.id)) entry?.acknowledge(item)
+        if (entry && !entry.accepted && !entry.confirmation) {
+          // Delivery proves acceptance, not the contents of an optimistic row.
+          // Fetch the exact projected message when its enqueue echo was missed.
+          entry.confirmation = api()
+            .session.message(
+              {
+                sessionID: event.data.sessionID,
+                messageID: event.data.inboxID,
+              },
+              { signal: entry.signal },
+            )
+            .then((row) => {
+              if (entry.stopped || row.type !== "user") return
+              outbox.delete(row.id)
+              removePending(event.data.sessionID, row.id)
+              message.update(event.data.sessionID, (draft, index) => {
+                const position = index.get(row.id)
+                if (position !== undefined) draft[position] = row
+              })
+              const { id, type, time, ...payload } = row
+              const result = {
+                id,
+                type,
+                sessionID: event.data.sessionID,
+                timeCreated: time.created,
+                payload,
+                delivery: entry.delivery,
+              }
+              entry.acknowledge(result)
+              return result
+            })
+            .catch(() => undefined)
+        }
         const admitted = store.session.input[event.data.sessionID]?.includes(event.data.inboxID) ?? false
         removePending(event.data.sessionID, event.data.inboxID)
         message.update(event.data.sessionID, (draft, index) => {
@@ -725,11 +813,19 @@ export function createData(config: CreateDataInput) {
         updatePending(event.data.sessionID, event.data.inboxID, event.data.delivery)
         return
       case "session.inbox.cancelled": {
+        prompts.get(event.data.inboxID)?.stop()
         retractLocal(event.data.sessionID, event.data.inboxID)
         compacting.get(event.data.sessionID)?.observed.add(event.data.inboxID)
         return
       }
       case "session.inbox.enqueued": {
+        if (event.data.item.type === "user")
+          prompts.get(event.data.inboxID)?.acknowledge({
+            id: event.data.inboxID,
+            sessionID: event.data.sessionID,
+            timeCreated: event.created,
+            ...event.data.item,
+          })
         outbox.delete(event.data.inboxID)
         admitLocal({
           id: event.data.inboxID,
@@ -1330,6 +1426,18 @@ export function createData(config: CreateDataInput) {
         },
       },
       pending: {
+        async cancel(sessionID: string, inboxID: string) {
+          const active = prompts.get(inboxID)
+          const entry = active?.sessionID === sessionID ? active : undefined
+          entry?.stop()
+          if (entry && !entry.attempted) return
+          await api()
+            .session.inbox.cancel({ sessionID, inboxID })
+            .catch((error: unknown) => {
+              if (entry && (isConflictError(error) || isSessionNotFoundError(error))) return
+              throw error
+            })
+        },
         list(sessionID: string) {
           return store.session.pending[sessionID] ?? []
         },
@@ -1337,7 +1445,10 @@ export function createData(config: CreateDataInput) {
           return sync.run(`session.pending:${sessionID}`, async () => {
             const pending = await api().session.inbox.list({ sessionID })
             // A positive read acknowledges admission even when its SSE echo is delayed.
-            pending.forEach((item) => outbox.delete(item.id))
+            pending.forEach((item) => {
+              outbox.delete(item.id)
+              if (item.type === "user") prompts.get(item.id)?.acknowledge(item)
+            })
             // Compactions also coalesce by Session, not just by the proposed ID.
             if (pending.some((item) => item.type === "compaction"))
               store.session.pending[sessionID]
@@ -1463,14 +1574,28 @@ export function createData(config: CreateDataInput) {
         compacting.set(input.sessionID, { id, observed, request })
         return request
       },
-      // Optimistic prompt admission: render the prompt immediately under a
-      // client-minted ID, send it, and let the durable inbox.enqueued echo
-      // upsert that same ID with the server's payload. Server admission is
-      // idempotent per ID, so retrying with the identical payload cannot
-      // double-admit.
-      prompt(input: SessionPromptInput & { gate?: Promise<unknown>; prepare?: () => Promise<unknown> }) {
-        const { gate, prepare, ...request } = input
+      submission: {
+        get(sessionID: string, id: string) {
+          const entry = submissions[id]
+          return entry?.sessionID === sessionID ? entry : undefined
+        },
+        retry(sessionID: string, id: string) {
+          const entry = prompts.get(id)
+          if (!entry || entry.sessionID !== sessionID) return Promise.reject(new Error("Prompt submission not found"))
+          return entry.retry()
+        },
+      },
+      // Keep a single captured payload and ID through automatic and manual retries.
+      prompt(
+        input: SessionPromptInput & { gate?: Promise<unknown>; prepare?: () => Promise<unknown>; model?: ModelRef },
+      ) {
+        const { gate, prepare, model, ...value } = input
+        const request = structuredClone(unwrap(value))
+        const selection = model && { ...model }
         const id = request.id ?? SessionMessage.ID.create()
+        const existing = prompts.get(id)
+        if (existing?.sessionID === request.sessionID) return existing.retry()
+        if (existing) return Promise.reject(new Error("Prompt submission belongs to another session"))
         // A retry may reuse an ID that is already rendered — and possibly
         // already durable. Admit optimistically only for new IDs so a failed
         // retry cannot roll back acknowledged state.
@@ -1495,19 +1620,153 @@ export function createData(config: CreateDataInput) {
             },
           })
         }
-        return sendAdmission(
-          request.sessionID,
-          async () => {
-            await prepare?.()
-            return api().session.prompt({ ...request, id })
+        const abort = new AbortController()
+        const cancelled = Promise.withResolvers<never>()
+        const acknowledged = Promise.withResolvers<SessionInboxUser>()
+        let wake: (() => void) | undefined
+        let prepared = false
+        const entry: NonNullable<ReturnType<typeof prompts.get>> = {
+          sessionID: request.sessionID,
+          delivery: request.delivery ?? "steer",
+          attempted: !fresh,
+          stopped: false,
+          signal: abort.signal,
+          acknowledge(item) {
+            if (entry.stopped || item.sessionID !== entry.sessionID) return
+            entry.accepted = item
+            outbox.delete(id)
+            acknowledged.resolve(item)
+            wake?.()
+            setSubmissions(id, undefined)
+            if (!entry.request) prompts.delete(id)
           },
-          gate,
-        ).catch((error) => {
-          // Roll back only rows this call admitted and the server has not
-          // acknowledged: anything else is server state.
-          if (fresh && outbox.delete(id)) retractLocal(request.sessionID, id)
-          throw error
-        })
+          stop() {
+            if (entry.stopped) return
+            entry.stopped = true
+            abort.abort()
+            cancelled.reject(new PromptSubmissionError("cancelled", request.sessionID, id))
+            wake?.()
+            if (fresh && outbox.delete(id)) retractLocal(request.sessionID, id)
+            setSubmissions(id, undefined)
+            prompts.delete(id)
+          },
+          retry() {
+            if (entry.request) return entry.request
+            let stage = "waiting"
+            let attempt = 0
+            let modelSet = !selection
+            const log = (outcome: string, extra?: Readonly<Record<string, unknown>>) =>
+              config.log?.info?.("prompt submission", {
+                sessionID: request.sessionID,
+                messageID: id,
+                stage,
+                attempt,
+                outcome,
+                ...extra,
+              })
+            setSubmissions(id, { id, sessionID: request.sessionID, status: "sending", attempt })
+            log("started")
+            entry.request = sendAdmission(
+              request.sessionID,
+              async () => {
+                if (entry.stopped) throw new PromptSubmissionError("cancelled", request.sessionID, id)
+                if (!prepared) {
+                  stage = "prepare"
+                  await Promise.race([Promise.resolve().then(prepare), cancelled.promise])
+                  prepared = true
+                }
+                for (;;) {
+                  if (entry.stopped) throw new PromptSubmissionError("cancelled", request.sessionID, id)
+                  if (entry.accepted) return entry.accepted
+                  attempt += 1
+                  setSubmissions(id, { id, sessionID: request.sessionID, status: "sending", attempt })
+                  try {
+                    if (!modelSet && selection) {
+                      stage = "model"
+                      log("attempt")
+                      await Promise.race([
+                        api().session.switchModel(
+                          { sessionID: request.sessionID, model: selection },
+                          { signal: abort.signal },
+                        ),
+                        cancelled.promise,
+                      ])
+                      modelSet = true
+                    }
+                    if (entry.stopped) throw new PromptSubmissionError("cancelled", request.sessionID, id)
+                    if (entry.accepted) return entry.accepted
+                    stage = "prompt"
+                    entry.attempted = true
+                    log("attempt")
+                    return await Promise.race([
+                      api().session.prompt({ ...request, id }, { signal: abort.signal }),
+                      acknowledged.promise,
+                      cancelled.promise,
+                    ])
+                  } catch (error) {
+                    if (entry.stopped) throw new PromptSubmissionError("cancelled", request.sessionID, id)
+                    if (entry.accepted) return entry.accepted
+                    const confirmed =
+                      entry.confirmation && (await Promise.race([entry.confirmation, cancelled.promise]))
+                    if (confirmed) return confirmed
+                    const failure = promptFailure(error)
+                    const retryable = failure.retryable || entry.confirmation !== undefined
+                    log("rejected", { ...failure, retryable })
+                    if (!retryable) throw error
+                    const delay = [250, 750, 1500][attempt - 1]
+                    if (delay === undefined) {
+                      setSubmissions(id, { id, sessionID: request.sessionID, status: "failed", attempt })
+                      throw new PromptSubmissionError("failed", request.sessionID, id)
+                    }
+                    setSubmissions(id, { id, sessionID: request.sessionID, status: "retrying", attempt })
+                    log("retrying", { delay })
+                    await new Promise<void>((resolve) => {
+                      const timer = setTimeout(resolve, delay)
+                      wake = () => {
+                        clearTimeout(timer)
+                        resolve()
+                      }
+                    })
+                    wake = undefined
+                  }
+                }
+              },
+              gate,
+              cancelled.promise,
+            )
+              .then((item) => {
+                log("accepted")
+                if (entry.confirmation) {
+                  outbox.delete(id)
+                  removePending(request.sessionID, id)
+                  message.update(request.sessionID, (draft, index) => {
+                    const position = index.get(id)
+                    if (position !== undefined)
+                      draft[position] = { id, type: "user", ...item.payload, time: draft[position].time }
+                  })
+                }
+                abort.abort()
+                setSubmissions(id, undefined)
+                prompts.delete(id)
+                return item
+              })
+              .catch((error: unknown) => {
+                log(error instanceof PromptSubmissionError && error.reason === "cancelled" ? "cancelled" : "failed")
+                if (!(error instanceof PromptSubmissionError) || error.reason !== "failed") {
+                  if (fresh && outbox.delete(id)) retractLocal(request.sessionID, id)
+                  setSubmissions(id, undefined)
+                  prompts.delete(id)
+                }
+                throw error
+              })
+              .finally(() => {
+                entry.request = undefined
+              })
+            return entry.request
+          },
+        }
+        prompts.set(id, entry)
+        return entry.retry()
       },
       sync(sessionID: string, options?: { children?: boolean }) {
         return sync.run(options?.children ? `session.family:${sessionID}` : `session:${sessionID}`, async () => {
@@ -1551,6 +1810,15 @@ export function createData(config: CreateDataInput) {
           return sync.run(`session.message:${sessionID}`, async () => {
             const response = await api().message.list({ sessionID, limit: messagePageLimit, order: "desc" })
             const fetched = response.data.toReversed()
+            fetched.forEach((item) => {
+              if (item.type !== "user") return
+              outbox.delete(item.id)
+              removePending(sessionID, item.id)
+              const entry = prompts.get(item.id)
+              if (entry?.sessionID !== sessionID) return
+              const { id, type, time, ...payload } = item
+              entry.acknowledge({ id, type, sessionID, timeCreated: time.created, payload, delivery: entry.delivery })
+            })
             // Same protection as the pending sync: a re-fetch racing an
             // admission must not wipe its local transcript row.
             const ids = new Set(fetched.map((item) => item.id))

--- a/packages/client/src/solid/prompt-retry.ts
+++ b/packages/client/src/solid/prompt-retry.ts
@@ -1,0 +1,28 @@
+import { ClientError, isServiceUnavailableError } from "../promise"
+
+// Preparation can wrap the transport failure. Classify the cause without
+// retaining its message or payload in submission diagnostics.
+export function promptFailure(error: unknown): { retryable: boolean; reason: string; status?: number } {
+  if (error instanceof Error && !(error instanceof ClientError) && error.cause) return promptFailure(error.cause)
+  if (isServiceUnavailableError(error)) return { retryable: true, reason: "ServiceUnavailable", status: 503 }
+  if (!(error instanceof ClientError)) return { retryable: false, reason: "Rejected" }
+  if (error.reason === "Transport") {
+    const aborted = error.cause instanceof Error && error.cause.name === "AbortError"
+    return { retryable: !aborted, reason: aborted ? "Aborted" : "Transport" }
+  }
+  // A successful admission response can be truncated after the server commits.
+  if (error.reason === "MalformedResponse") return { retryable: true, reason: error.reason }
+  const status =
+    error.reason === "UnexpectedStatus" &&
+    typeof error.cause === "object" &&
+    error.cause !== null &&
+    "status" in error.cause &&
+    typeof error.cause.status === "number"
+      ? error.cause.status
+      : undefined
+  return {
+    retryable: status !== undefined && [408, 429, 500, 502, 503, 504].includes(status),
+    reason: error.reason,
+    status,
+  }
+}

--- a/packages/client/test/solid-compaction.test.ts
+++ b/packages/client/test/solid-compaction.test.ts
@@ -190,7 +190,8 @@ test.each(["compaction", "canonical compaction", "user"])(
     await fixture.data.session.pending.sync(sessionID)
     expect(fixture.data.session.pending.list(sessionID)).toEqual([durable])
     fixture.response.resolve(new Response("Lost response", { status: 500 }))
-    expect(await result).toBeInstanceOf(Error)
+    if (type === "user") expect(await result).toEqual(durable)
+    else expect(await result).toBeInstanceOf(Error)
     expect(fixture.data.session.pending.list(sessionID)).toEqual([durable])
     if (type === "user")
       expect(fixture.data.session.message.list(sessionID)).toMatchObject([{ id, type: "user", text: "Follow up" }])
@@ -207,7 +208,8 @@ test("keeps one event listener and removes it when the data owner is disposed du
   expect(fixture.listeners.size).toBe(0)
   gate.resolve()
   fixture.response.resolve(Response.json({ data: item("msg_canonical") }))
-  await Promise.all([first, compact])
+  await expect(first).rejects.toMatchObject({ reason: "cancelled" })
+  await compact
   expect(fixture.listeners.size).toBe(0)
 })
 

--- a/packages/client/test/solid-prompt-retry.test.ts
+++ b/packages/client/test/solid-prompt-retry.test.ts
@@ -1,0 +1,376 @@
+import { expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createData, type CreateDataInput } from "../src/solid"
+import { OpenCode, type OpenCodeEvent, type SessionInboxUser } from "../src/promise"
+
+test("retries transient admission with the same ID and captured body", async () => {
+  const bodies: string[] = []
+  using fixture = setup(async (request) => {
+    bodies.push(await request.text())
+    if (bodies.length === 1) return new Response(null, { status: 503 })
+    return Response.json({ data: item(JSON.parse(bodies[0]).id) })
+  })
+  const input = { sessionID, text: "Original", files: [{ uri: "file:///original.txt" }] }
+  const sent = fixture.data.session.prompt(input).catch((error: unknown) => error)
+  input.text = "Changed"
+  input.files[0].uri = "file:///changed.txt"
+  await wait(() => bodies.length === 2)
+  expect(await sent).toMatchObject({ type: "user" })
+  expect(bodies[1]).toBe(bodies[0])
+  expect(JSON.parse(bodies[0])).toMatchObject({ text: "Original", files: [{ uri: "file:///original.txt" }] })
+  expect(fixture.data.session.message.list(sessionID)).toHaveLength(1)
+})
+
+test("retries model selection but runs arbitrary preparation once and preserves admission ordering", async () => {
+  const calls: string[] = []
+  let modelCalls = 0
+  let promptCalls = 0
+  using fixture = setup(async (request) => {
+    const rpc = request.url.split("/").at(-1)
+    const body = await request.json()
+    calls.push(rpc === "prompt" ? body.text : rpc)
+    if (rpc === "model") {
+      modelCalls += 1
+      return new Response(null, { status: modelCalls === 1 ? 503 : 204 })
+    }
+    if (body.text === "First" && ++promptCalls === 1) throw new Error("Connection reset")
+    return Response.json({ data: item(body.id) })
+  })
+  let preparations = 0
+  const first = fixture.data.session.prompt({
+    sessionID,
+    text: "First",
+    model: { providerID: "demo", id: "model" },
+    prepare: async () => {
+      preparations += 1
+    },
+  })
+  const second = fixture.data.session.prompt({ sessionID, text: "Second" })
+  await Promise.all([first, second])
+  expect(preparations).toBe(1)
+  expect(calls).toEqual(["model", "model", "First", "First", "Second"])
+})
+
+test.each([400, 401, 404, 409, 422])("does not retry definitive HTTP %i rejection", async (status) => {
+  let calls = 0
+  using fixture = setup(async () => {
+    calls += 1
+    return Response.json({ message: "Invalid request" }, { status })
+  })
+  await expect(fixture.data.session.prompt({ sessionID, text: "Invalid" })).rejects.toBeDefined()
+  expect(calls).toBe(1)
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([])
+})
+
+test("an internal server error is ambiguous and retries the original admission", async () => {
+  let calls = 0
+  using fixture = setup(async (request) => {
+    calls += 1
+    if (calls === 1) return new Response(null, { status: 500 })
+    return Response.json({ data: item((await request.json()).id) })
+  })
+  expect(await fixture.data.session.prompt({ sessionID, id: "msg_500", text: "Retry" })).toMatchObject({
+    id: "msg_500",
+  })
+  expect(calls).toBe(2)
+})
+
+test("cancelling an existing admission reaches the server even while its local retry is gated", async () => {
+  const methods: string[] = []
+  using fixture = setup(async (request) => {
+    methods.push(request.method)
+    return new Response(null, { status: 204 })
+  })
+  fixture.enqueue("msg_existing")
+  const gate = Promise.withResolvers<void>()
+  const sent = fixture.data.session
+    .prompt({ sessionID, id: "msg_existing", text: "Retry", gate: gate.promise })
+    .catch((error: unknown) => error)
+  await fixture.data.session.pending.cancel(sessionID, "msg_existing")
+  expect(await sent).toMatchObject({ reason: "cancelled" })
+  expect(methods).toEqual(["DELETE"])
+  gate.resolve()
+})
+
+test("keeps an exhausted submission visible and manual retry reuses its identity", async () => {
+  const ids: string[] = []
+  const models: string[] = []
+  using fixture = setup(async (request) => {
+    const body = await request.json()
+    if (request.url.endsWith("/model")) {
+      models.push(body.model.id)
+      return new Response(null, { status: 204 })
+    }
+    ids.push(body.id)
+    if (ids.length <= 4) return new Response(null, { status: 502 })
+    return Response.json({ data: item(body.id) })
+  })
+  await expect(
+    fixture.data.session.prompt({ sessionID, text: "Keep me", model: { providerID: "demo", id: "original" } }),
+  ).rejects.toMatchObject({ reason: "failed" })
+  expect(ids).toHaveLength(4)
+  expect(fixture.data.session.submission.get(sessionID, ids[0])).toMatchObject({ status: "failed", attempt: 4 })
+  expect(fixture.data.session.message.list(sessionID)).toMatchObject([{ id: ids[0], text: "Keep me" }])
+  await fixture.api.session.switchModel({ sessionID, model: { providerID: "demo", id: "different" } })
+  await fixture.data.session.submission.retry(sessionID, ids[0])
+  expect(ids).toHaveLength(5)
+  expect(new Set(ids).size).toBe(1)
+  expect(models).toEqual(["original", "different", "original"])
+  expect(fixture.data.session.submission.get(sessionID, ids[0])).toBeUndefined()
+})
+
+test("an enqueue acknowledgement settles a lost response without another POST", async () => {
+  const requested = Promise.withResolvers<string>()
+  let calls = 0
+  using fixture = setup(async (request) => {
+    calls += 1
+    requested.resolve((await request.json()).id)
+    return new Promise((_, reject) =>
+      request.signal.addEventListener("abort", () => reject(new Error("Closed")), { once: true }),
+    )
+  })
+  const sent = fixture.data.session.prompt({ sessionID, text: "Accepted" })
+  const id = await requested.promise
+  fixture.enqueue(id)
+  expect(await sent).toEqual(item(id))
+  expect(calls).toBe(1)
+  expect(fixture.data.session.submission.get(sessionID, id)).toBeUndefined()
+})
+
+test("another session can send while one session is retrying", async () => {
+  const calls: string[] = []
+  using fixture = setup(async (request) => {
+    const body = await request.json()
+    calls.push(body.text)
+    if (body.text === "Blocked") return new Response(null, { status: 503 })
+    return Response.json({ data: { ...item(body.id), sessionID: "ses_other" } })
+  })
+  const first = fixture.data.session
+    .prompt({ sessionID, id: "msg_blocked", text: "Blocked" })
+    .catch((error: unknown) => error)
+  await wait(() => fixture.data.session.submission.get(sessionID, "msg_blocked")?.status === "retrying")
+  await fixture.data.session.prompt({ sessionID: "ses_other", text: "Independent" })
+  expect(calls).toEqual(["Blocked", "Independent"])
+  fixture.dispose()
+  expect(await first).toMatchObject({ reason: "cancelled" })
+})
+
+test("a projected message acknowledges delivery even when the enqueue event was missed", async () => {
+  const requested = Promise.withResolvers<string>()
+  using fixture = setup(async (request) => {
+    if (request.method === "GET")
+      return Response.json({
+        data: [
+          { id: "msg_answer", type: "assistant", time: { created: 30 }, content: [] },
+          { id: await requested.promise, type: "user", text: "Canonical text", time: { created: 25 } },
+        ],
+        cursor: {},
+      })
+    requested.resolve((await request.json()).id)
+    return new Promise((_, reject) =>
+      request.signal.addEventListener("abort", () => reject(new Error("Closed")), { once: true }),
+    )
+  })
+  const sent = fixture.data.session.prompt({ sessionID, text: "Original text" })
+  await requested.promise
+  await fixture.data.session.message.sync(sessionID)
+  expect(await sent).toMatchObject({ payload: { text: "Canonical text" }, timeCreated: 25 })
+  expect(fixture.data.session.submission.get(sessionID, await requested.promise)).toBeUndefined()
+  fixture.emit({
+    id: "evt_delivered",
+    created: 25,
+    type: "session.inbox.delivered",
+    durable: { aggregateID: sessionID, seq: 2, version: 1 },
+    data: { sessionID, inboxID: await requested.promise, messageID: await requested.promise },
+  })
+  expect(fixture.data.session.input.list(sessionID)).toEqual([])
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([])
+  expect(fixture.data.session.message.list(sessionID).map((row) => row.id)).toEqual([
+    await requested.promise,
+    "msg_answer",
+  ])
+  fixture.data.session.evict(sessionID)
+  expect(fixture.data.session.message.list(sessionID)).toEqual([])
+})
+
+test("delivery without an enqueue echo confirms canonical content rather than the optimistic placeholder", async () => {
+  const requested = Promise.withResolvers<string>()
+  using fixture = setup(async (request) => {
+    if (request.method === "GET")
+      return Response.json({
+        data: { id: await requested.promise, type: "user", text: "Canonical text", time: { created: 25 } },
+      })
+    requested.resolve((await request.json()).id)
+    return new Promise((_, reject) =>
+      request.signal.addEventListener("abort", () => reject(new Error("Closed")), { once: true }),
+    )
+  })
+  const sent = fixture.data.session.prompt({ sessionID, text: "Original text" })
+  const id = await requested.promise
+  fixture.emit({
+    id: "evt_delivered",
+    created: 25,
+    type: "session.inbox.delivered",
+    durable: { aggregateID: sessionID, seq: 2, version: 1 },
+    data: { sessionID, inboxID: id, messageID: id },
+  })
+  expect(await sent).toMatchObject({ payload: { text: "Canonical text" }, timeCreated: 25 })
+  expect(fixture.data.session.pending.list(sessionID)).toEqual([])
+})
+
+test("a cancellation echo stops retries without resurrecting the prompt", async () => {
+  let calls = 0
+  using fixture = setup(async () => {
+    calls += 1
+    return new Response(null, { status: 503 })
+  })
+  const sent = fixture.data.session
+    .prompt({ sessionID, id: "msg_cancelled", text: "Cancel" })
+    .catch((error: unknown) => error)
+  await wait(() => fixture.data.session.submission.get(sessionID, "msg_cancelled")?.status === "retrying")
+  fixture.emit({
+    id: "evt_cancel",
+    created: 20,
+    type: "session.inbox.cancelled",
+    durable: { aggregateID: sessionID, seq: 2, version: 1 },
+    data: { sessionID, inboxID: "msg_cancelled" },
+  })
+  expect(await sent).toMatchObject({ reason: "cancelled" })
+  expect(fixture.data.session.message.list(sessionID)).toEqual([])
+  expect(calls).toBe(1)
+})
+
+test("does not retry arbitrary preparation callbacks", async () => {
+  let calls = 0
+  using fixture = setup(async () => {
+    calls += 1
+    return new Response(null, { status: 503 })
+  })
+  let prepared = 0
+  await expect(
+    fixture.data.session.prompt({
+      sessionID,
+      text: "Prepare",
+      prepare: async () => {
+        prepared += 1
+        throw new Error("Preparation failed")
+      },
+    }),
+  ).rejects.toThrow("Preparation failed")
+  expect(prepared).toBe(1)
+  expect(calls).toBe(0)
+})
+
+test("cancellation interrupts backoff and releases a following submission", async () => {
+  const calls: string[] = []
+  using fixture = setup(async (request) => {
+    if (request.method === "DELETE") return new Response(null, { status: 204 })
+    const body = await request.json()
+    calls.push(body.text)
+    if (body.text === "Cancel me") return new Response(null, { status: 503 })
+    return Response.json({ data: item(body.id) })
+  })
+  const first = fixture.data.session
+    .prompt({ sessionID, id: "msg_cancel", text: "Cancel me" })
+    .catch((error: unknown) => error)
+  const second = fixture.data.session.prompt({ sessionID, text: "Next" })
+  await wait(() => fixture.data.session.submission.get(sessionID, "msg_cancel")?.status === "retrying")
+  await fixture.data.session.pending.cancel(sessionID, "msg_cancel")
+  expect(await first).toMatchObject({ reason: "cancelled" })
+  await second
+  expect(calls).toEqual(["Cancel me", "Next"])
+})
+
+test("disposal stops a prompt waiting behind a gate without sending it", async () => {
+  let calls = 0
+  using fixture = setup(async () => {
+    calls += 1
+    return Response.json({ data: item("msg_disposed") })
+  })
+  const gate = Promise.withResolvers<void>()
+  const sent = fixture.data.session
+    .prompt({ sessionID, text: "Never send", gate: gate.promise })
+    .catch((error: unknown) => error)
+  fixture.dispose()
+  expect(await sent).toMatchObject({ reason: "cancelled" })
+  gate.resolve()
+  await Bun.sleep(10)
+  expect(calls).toBe(0)
+})
+
+test("diagnostics exclude prompt data and raw error messages", async () => {
+  let calls = 0
+  using fixture = setup(async (request) => {
+    calls += 1
+    if (calls === 1) throw new Error("private transport details")
+    return Response.json({ data: item((await request.json()).id) })
+  })
+  await fixture.data.session.prompt({ sessionID, text: "private prompt", metadata: { private: "private metadata" } })
+  expect(fixture.logs).toContainEqual(expect.objectContaining({ stage: "prompt", outcome: "retrying", attempt: 1 }))
+  expect(fixture.logs).toContainEqual(expect.objectContaining({ stage: "prompt", outcome: "accepted", attempt: 2 }))
+  expect(JSON.stringify(fixture.logs)).not.toContain("private")
+})
+
+const sessionID = "ses_retry"
+const item = (id: string): SessionInboxUser => ({
+  id,
+  sessionID,
+  type: "user",
+  payload: { text: "Accepted" },
+  delivery: "steer",
+  timeCreated: 10,
+})
+
+function setup(handle: (request: Request) => Promise<Response>) {
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
+  const logs: Readonly<Record<string, unknown>>[] = []
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => handle(input instanceof Request ? input : new Request(input, init)),
+  })
+  const root = createRoot((dispose) => ({
+    data: createData({
+      api: () => api,
+      directory: "/project",
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
+      log: {
+        info: (_message, data) => {
+          if (data) logs.push(data)
+        },
+      },
+    }),
+    dispose,
+  }))
+  const emit = (details: OpenCodeEvent) => listeners.forEach((listener) => listener({ name: details.type, details }))
+  return {
+    data: root.data,
+    api,
+    dispose: root.dispose,
+    [Symbol.dispose]: root.dispose,
+    logs,
+    emit,
+    enqueue(id: string) {
+      emit({
+        id: "evt_enqueue",
+        created: 10,
+        type: "session.inbox.enqueued",
+        durable: { aggregateID: sessionID, seq: 1, version: 1 },
+        data: { sessionID, inboxID: id, item: { type: "user", payload: { text: "Accepted" }, delivery: "steer" } },
+      })
+    },
+  }
+}
+
+async function wait(predicate: () => boolean) {
+  for (let attempt = 0; attempt < 200; attempt++) {
+    if (predicate()) return
+    await Bun.sleep(5)
+  }
+  throw new Error("Timed out waiting for submission")
+}

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -53,6 +53,7 @@ import { useConfig } from "../../config"
 import { usePromptMove } from "./move"
 import { resolvePastedAttachments } from "./local-attachment"
 import { locationKey, useData } from "../../context/data"
+import { PromptSubmissionError } from "@opencode-ai/client/solid"
 import { useLocation } from "../../context/location"
 import { Keymap, type KeymapCommand } from "../../context/keymap"
 import { abbreviateHome } from "../../runtime"
@@ -1349,10 +1350,9 @@ export function Prompt(props: PromptProps) {
           }
         }
       }
-      // The data layer admits optimistically: the prompt renders immediately
-      // and rolls back if the server rejects it, so submission does not wait
-      // on the network. On rejection the row is already rolled back; restore
-      // the composer unless the user has started typing something new.
+      // Admission owns retries and their identity. Definitive failures restore
+      // the draft; uncertain outcomes remain on the original retryable row.
+      let cancelCommit: (() => void) | undefined
       data.session
         .prompt({
           sessionID: target,
@@ -1361,19 +1361,18 @@ export function Prompt(props: PromptProps) {
           agents: entry.agents,
           skills: entry.skills?.length ? entry.skills : undefined,
           delivery,
+          model,
           gate: newSession?.gate,
-          prepare: () => {
-            // Commit the captured selection after earlier admissions, including
-            // compaction setup. Cached state may still precede their SSE echoes;
-            // the server makes an unchanged selection a no-op.
-            const cancelCommit = local.model.trackSessionCommit(target, model)
-            return client.api.session.switchModel({ sessionID: target, model }).catch((error) => {
-              cancelCommit()
-              throw new Error(`Failed to switch model: ${errorMessage(error)}`, { cause: error })
-            })
+          prepare: async () => {
+            // Track selection after earlier admissions. The data layer owns
+            // the retryable model commit and skips it once it succeeds.
+            cancelCommit = local.model.trackSessionCommit(target, model)
           },
         })
         .catch((error) => {
+          cancelCommit?.()
+          // Unknown outcomes retain their original admission ID for explicit retry.
+          if (error instanceof PromptSubmissionError) return
           if (newSession) return newSession.recover(error)
           toast.show({ title: "Failed to send prompt", message: errorMessage(error), variant: "error" })
           restoreEntry()

--- a/packages/tui/src/context/data.tsx
+++ b/packages/tui/src/context/data.tsx
@@ -3,6 +3,7 @@ import type { Plugin } from "@opencode-ai/plugin/tui"
 import { createStore } from "solid-js/store"
 import { createSimpleContext } from "./helper"
 import { useClient } from "./client"
+import { useLog } from "./log"
 
 export { locationKey } from "@opencode-ai/client/solid"
 export type { FormWithLocation } from "@opencode-ai/client/solid"
@@ -11,11 +12,13 @@ export const { use: useData, provider: DataProvider } = createSimpleContext({
   name: "Data",
   init: (props: { directory: string }) => {
     const client = useClient()
+    const log = useLog({ component: "prompt" })
     const data = createData({
       api: () => client.api,
       event: client.event,
       connection: client.connection,
       directory: props.directory,
+      log,
     })
     data satisfies Plugin.Context["data"]
     const [generatingTitles, setGeneratingTitles] = createStore<Record<string, boolean | undefined>>({})

--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -21,6 +21,8 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { useRoute, useRouteData } from "../../context/route"
 import { createStore } from "solid-js/store"
 import { useData } from "../../context/data"
+import { PromptSubmissionError } from "@opencode-ai/client/solid"
+import { PromptSubmissionStatus } from "./prompt-submission"
 import { SplitBorder } from "../../ui/border"
 import { useTuiPaths, useTuiTerminalEnvironment } from "../../context/runtime"
 import { Spinner, SPINNER_FRAMES } from "../../component/spinner"
@@ -124,7 +126,7 @@ const BACKGROUND_TOOL_HINT_DELAY = 3_000
 // The tail comfortably overfills a tall viewport; older rows mount as the reader approaches them.
 const TRANSCRIPT_TAIL_ROWS = 40
 const TRANSCRIPT_BACKFILL_CHUNK = 60
-type PendingAction = "steer" | "queue" | "cancel"
+type PendingAction = "steer" | "queue" | "cancel" | "retry"
 
 const context = createContext<{
   /** Content width: terminal width minus vertical tabs, sidebar, and padding. */
@@ -570,16 +572,19 @@ export function Session(props: {
   const mutatePending = async (action: PendingAction, inboxID: string) => {
     const result = await runPendingAction(inboxID, async () => {
       const request =
-        action === "steer"
-          ? client.api.session.inbox.steer({ sessionID: route.sessionID, inboxID })
-          : action === "queue"
-            ? client.api.session.inbox.queue({ sessionID: route.sessionID, inboxID })
-            : client.api.session.inbox.cancel({ sessionID: route.sessionID, inboxID })
+        action === "retry"
+          ? data.session.submission.retry(route.sessionID, inboxID)
+          : action === "steer"
+            ? client.api.session.inbox.steer({ sessionID: route.sessionID, inboxID })
+            : action === "queue"
+              ? client.api.session.inbox.queue({ sessionID: route.sessionID, inboxID })
+              : data.session.pending.cancel(route.sessionID, inboxID)
       const error = await request.then(
         () => undefined,
         (error) => error,
       )
       if (!error) return true
+      if (error instanceof PromptSubmissionError) return false
       const label = action === "cancel" ? "delete" : action
       toast.show({ title: `Failed to ${label} pending prompt`, message: errorMessage(error), variant: "error" })
       return false
@@ -591,12 +596,14 @@ export function Session(props: {
       <DialogSelect
         title="Queued prompts"
         options={queuedPrompts().map((prompt, index) => ({
-          title: prompt.text,
+          title: `${data.session.submission.get(route.sessionID, prompt.id)?.status === "failed" ? "Send not confirmed: " : ""}${prompt.text}`,
           value: prompt.id,
           footer: `${index + 1} of ${queuedPrompts().length}`,
         }))}
         onSelect={(option) => {
-          void mutatePending("steer", option.value).then((steered) => {
+          const state = data.session.submission.get(route.sessionID, option.value)
+          if (state && state.status !== "failed") return
+          void mutatePending(state ? "retry" : "steer", option.value).then((steered) => {
             if (steered) dialog.clear()
           })
         }}
@@ -612,7 +619,7 @@ export function Session(props: {
             },
           },
         ]}
-        footerHints={[{ title: "steer", label: "enter" }]}
+        footerHints={[{ title: "steer / retry", label: "enter" }]}
       />
     ))
   const unavailable = (feature: string) => {
@@ -1267,6 +1274,21 @@ export function Session(props: {
       },
     },
     {
+      title: "Retry failed prompt",
+      id: "session.retry_prompt",
+      group: "Prompt",
+      enabled: pendingUsers().some(
+        (item) => data.session.submission.get(route.sessionID, item.id)?.status === "failed",
+      ),
+      run: () => {
+        const item = pendingUsers().find(
+          (item) => data.session.submission.get(route.sessionID, item.id)?.status === "failed",
+        )
+        if (item) void mutatePending("retry", item.id)
+        dialog.clear()
+      },
+    },
+    {
       title: "View queued prompts",
       id: "session.queued_prompts",
       group: "Prompt",
@@ -1441,7 +1463,7 @@ export function Session(props: {
             </box>
             <box flexShrink={0}>
               <Show when={!composer.open && !disabled() && queuedPrompts().length > 0}>
-                <QueuedPromptDock prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
+                <QueuedPromptDock sessionID={route.sessionID} prompts={queuedPrompts()} onOpen={openQueuedPrompts} />
               </Show>
               <Slot path="session.composer.top" input={{ sessionID: route.sessionID }} />
               <Composer
@@ -2372,6 +2394,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
   const [hover, setHover] = createSignal(false)
   const color = createMemo(() => local.agent.color(data.session.get(ctx.sessionID)?.agent ?? "build"))
   const delivery = createMemo(() => ctx.pendingDelivery(props.message.id))
+  const submission = createMemo(() => data.session.submission.get(ctx.sessionID, props.message.id))
   const dialog = useDialog()
   const renderer = useRenderer()
   const promptRef = usePromptRef()
@@ -2398,6 +2421,23 @@ function UserMessage(props: { message: SessionMessageUser }) {
           }}
           onMouseUp={() => {
             if (renderer.getSelection()?.getSelectedText()) return
+            if (submission()) {
+              dialog.replace(() => (
+                <DialogSelect
+                  title="Prompt submission"
+                  options={[
+                    ...(submission()?.status === "failed" ? [{ title: "Retry send", value: "retry" as const }] : []),
+                    { title: "Cancel send", value: "cancel" as const },
+                  ]}
+                  onSelect={(option) => {
+                    void ctx.mutatePending(option.value, props.message.id).then((ok) => {
+                      if (ok) dialog.clear()
+                    })
+                  }}
+                />
+              ))
+              return
+            }
             if (delivery() === "steer") {
               dialog.replace(() => (
                 <DialogSelect
@@ -2428,6 +2468,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
           flexShrink={0}
         >
           <text fg={theme.text.default}>{props.message.text}</text>
+          <PromptSubmissionStatus sessionID={ctx.sessionID} messageID={props.message.id} />
           <Show when={skills().length}>
             <box flexDirection="row" paddingTop={1} gap={1} flexWrap="wrap">
               <For each={skills()}>
@@ -2482,7 +2523,7 @@ function UserMessage(props: { message: SessionMessageUser }) {
   )
 }
 
-function QueuedPromptDock(props: { prompts: { id: string; text: string }[]; onOpen: () => void }) {
+function QueuedPromptDock(props: { sessionID: string; prompts: { id: string; text: string }[]; onOpen: () => void }) {
   const theme = useTheme("elevated")
   const [hover, setHover] = createSignal(false)
   const next = createMemo(() => props.prompts[0]?.text.replaceAll("\n", " "))
@@ -2503,12 +2544,15 @@ function QueuedPromptDock(props: { prompts: { id: string; text: string }[]; onOp
         paddingLeft={2}
         paddingRight={1}
         backgroundColor={hover() ? theme.raise(theme.background.default) : theme.background.default}
-        flexDirection="row"
+        flexDirection="column"
       >
         <text fg={theme.text.subdued} wrapMode="none" truncate flexGrow={1} flexShrink={1} minWidth={0}>
           <span style={{ fg: theme.text.default }}>{props.prompts.length} queued</span>
           <Show when={next()}>{(text) => <> · {text()}</>}</Show>
         </text>
+        <Show when={props.prompts[0]}>
+          {(prompt) => <PromptSubmissionStatus sessionID={props.sessionID} messageID={prompt().id} />}
+        </Show>
       </box>
     </box>
   )

--- a/packages/tui/src/routes/session/prompt-submission.tsx
+++ b/packages/tui/src/routes/session/prompt-submission.tsx
@@ -1,0 +1,60 @@
+import { createMemo, Show } from "solid-js"
+import { PromptSubmissionError } from "@opencode-ai/client/solid"
+import { useData } from "../../context/data"
+import { useTheme } from "../../context/theme"
+import { useToast } from "../../ui/toast"
+import { errorMessage } from "../../util/error"
+
+export function PromptSubmissionStatus(props: { sessionID: string; messageID: string }) {
+  const data = useData()
+  const theme = useTheme()
+  const toast = useToast()
+  const submission = createMemo(() => data.session.submission.get(props.sessionID, props.messageID))
+  const act = (action: "retry" | "cancel") => {
+    const request =
+      action === "retry"
+        ? data.session.submission.retry(props.sessionID, props.messageID)
+        : data.session.pending.cancel(props.sessionID, props.messageID)
+    void request.catch((error: unknown) => {
+      if (error instanceof PromptSubmissionError) return
+      toast.show({ title: "Prompt submission failed", message: errorMessage(error), variant: "error" })
+    })
+  }
+  return (
+    <Show when={submission()}>
+      {(state) => (
+        <box flexDirection="row" gap={2} flexWrap="wrap" paddingTop={1}>
+          <text fg={state().status === "failed" ? theme.text.feedback.error.default : theme.text.subdued}>
+            {state().status === "failed"
+              ? "Send not confirmed"
+              : state().status === "retrying"
+                ? `Retrying send (attempt ${state().attempt + 1}/4)`
+                : "Sending..."}
+          </text>
+          <Show when={state().status === "failed"}>
+            <text
+              fg={theme.text.action.primary.default}
+              onMouseUp={(event) => {
+                if (event.button !== 0) return
+                event.stopPropagation()
+                act("retry")
+              }}
+            >
+              retry
+            </text>
+          </Show>
+          <text
+            fg={theme.text.action.primary.default}
+            onMouseUp={(event) => {
+              if (event.button !== 0) return
+              event.stopPropagation()
+              act("cancel")
+            }}
+          >
+            cancel
+          </text>
+        </box>
+      )}
+    </Show>
+  )
+}

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -3198,9 +3198,9 @@ test("admits prompts optimistically and reconciles with the durable echo", async
     expect(echoed.time.created).toBe(5)
     expect(echoed.files).toEqual([echoFile])
 
-    // A late transport failure after the echo must not delete acknowledged state.
+    // The durable echo settles admission even when its HTTP response is lost.
     release(json({ _tag: "UnknownError", message: "response lost" }, { status: 500 }))
-    expect(await settled).toBeDefined()
+    expect(await settled).toBeUndefined()
     expect(sync.session.pending.list(sessionID).map((item) => item.id)).toEqual([messageID])
     expect(sync.session.message.list(sessionID).map((message) => message.id)).toEqual([messageID])
   } finally {

--- a/packages/tui/test/prompt-retry.test.tsx
+++ b/packages/tui/test/prompt-retry.test.tsx
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test"
+import { createTestRenderer } from "@opentui/core/testing"
+import { TextareaRenderable } from "@opentui/core"
+import { Effect, FileSystem } from "effect"
+import { Global } from "@opencode-ai/util/global"
+import { createEventStream, createFetch, directory, json } from "./fixture/tui-client"
+import { tmpdir } from "./fixture/fixture"
+
+test.each(["steer", "queue"] as const)(
+  "retains and retries an unconfirmed %s with the original ID",
+  async (delivery) => {
+    await using state = await tmpdir()
+    const setup = await createTestRenderer({ width: 80, height: 30, useThread: false, kittyKeyboard: true })
+    setup.renderer.start()
+    const ready = Promise.withResolvers<void>()
+    const retrying = Promise.withResolvers<void>()
+    const exhausted = Promise.withResolvers<void>()
+    const accepted = Promise.withResolvers<void>()
+    const events = createEventStream()
+    const sessionID = `ses_retry_${delivery}`
+    const location = { directory, project: { id: "project", directory, canonical: directory } }
+    const bodies: string[] = []
+    const calls = createFetch(async (url, request) => {
+      if (url.pathname === `/api/session/${sessionID}`)
+        return json({
+          data: {
+            id: sessionID,
+            projectID: "project",
+            title: "Prompt retry",
+            agent: "build",
+            model: { providerID: "demo", id: "model" },
+            location: { directory },
+            cost: 0,
+            tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+            time: { created: 0, updated: 0 },
+          },
+        })
+      if (url.pathname === `/api/session/${sessionID}/message`) return json({ data: [], cursor: {} })
+      if (url.pathname === `/api/session/${sessionID}/inbox` || url.pathname === `/api/session/${sessionID}/permission`)
+        return json({ data: [] })
+      if (url.pathname === "/api/agent")
+        return json({ location, data: [{ id: "build", mode: "primary", hidden: false, permissions: [] }] })
+      if (url.pathname === "/api/provider") return json({ location, data: [{ id: "demo", name: "Demo" }] })
+      if (url.pathname === "/api/model")
+        return json({ location, data: [{ id: "model", providerID: "demo", name: "Demo Model", variants: [] }] })
+      if (url.pathname === `/api/session/${sessionID}/prompt`) {
+        const text = await request.text()
+        bodies.push(text)
+        if (bodies.length <= 4) return new Response(null, { status: 503 })
+        const body = JSON.parse(text)
+        const item = { type: "user" as const, payload: { text: body.text }, delivery }
+        events.emit({
+          id: "evt_accepted",
+          created: 10,
+          type: "session.inbox.enqueued",
+          durable: { aggregateID: sessionID, seq: 1, version: 1 },
+          data: { sessionID, inboxID: body.id, item },
+        })
+        return json({ data: { id: body.id, sessionID, timeCreated: 10, ...item } })
+      }
+      return undefined
+    }, events)
+    const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+    const { run } = await import("../src/app")
+    const task = Effect.runPromise(
+      run({
+        app: { name: "test", version: "test", channel: "test" },
+        server: { endpoint: { url: server.url.toString() } },
+        config: {
+          get: async () => ({ animations: false, keybinds: { "prompt.queue": "f6" } }),
+          update: async () => ({}),
+        },
+        packages: { resolve: async () => undefined },
+        terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+        args: { sessionID },
+        log: (_level, message, tags) => {
+          if (message !== "prompt submission") return
+          if (tags.outcome === "retrying") retrying.resolve()
+          if (tags.outcome === "failed") exhausted.resolve()
+          if (tags.outcome === "accepted") accepted.resolve()
+        },
+      }).pipe(Effect.provide(Global.layerWith({ state: state.path })), Effect.provide(FileSystem.layerNoop({}))),
+    )
+    try {
+      await ready.promise
+      await setup.waitForFrame((frame) => frame.includes("Demo Model"))
+      await setup.mockInput.typeText("Please keep this prompt")
+      if (delivery === "queue") setup.mockInput.pressKey("F6")
+      else setup.mockInput.pressEnter()
+      await retrying.promise
+      await setup.waitForFrame((frame) => frame.includes("Retrying send"))
+      await exhausted.promise
+      const failed = await setup.waitForFrame((frame) => frame.includes("Send not confirmed"))
+      expect(failed).toContain("Please keep this prompt")
+      const input = setup.renderer.currentFocusedRenderable
+      expect(input).toBeInstanceOf(TextareaRenderable)
+      if (!(input instanceof TextareaRenderable)) throw new Error("composer is not focused")
+      expect(input.plainText).toBe("")
+      expect(bodies).toHaveLength(4)
+
+      const lines = failed.split("\n")
+      const row = lines.findIndex((line) => line.includes("retry") && line.includes("cancel"))
+      await setup.mockMouse.click(lines[row].indexOf("retry"), row)
+      await accepted.promise
+      await setup.waitForFrame((frame) => !frame.includes("Send not confirmed") && !frame.includes("Retrying send"))
+      expect(bodies).toHaveLength(5)
+      expect(new Set(bodies).size).toBe(1)
+      expect(JSON.parse(bodies[0]).delivery).toBe(delivery)
+      expect(input.plainText).toBe("")
+    } finally {
+      setup.renderer.destroy()
+      await task
+      await server.stop()
+    }
+  },
+)


### PR DESCRIPTION
## Why

A transient failure while selecting the model or admitting a prompt currently removes its optimistic row immediately. The client never retries, even though the server supports idempotent prompt admission by message ID. A lost HTTP response can also report failure after the server has already acknowledged the prompt.

This is separate from #46681: that PR preserves drafts after failure; this one retries temporary admission failures and retains an unconfirmed submission's identity.

## What Changes

| Outcome | Behavior |
| --- | --- |
| Transport failure, truncated JSON response, or HTTP 408/429/500/502/503/504 | Retry up to four total attempts with 250/750/1500ms backoff |
| Model-selection failure | Retry that idempotent operation before attempting admission |
| Arbitrary preparation callback fails | Do not rerun arbitrary side effects |
| Durable acknowledgement arrives before the HTTP response | Treat admission as confirmed instead of restoring a duplicate draft |
| Retry budget exhausted | Keep the original row with **Send not confirmed**, **retry**, and **cancel** |
| Explicit retry | Reuse the captured payload, message ID, and model selection |
| Cancellation or client disposal | Stop further attempts and release the pending send chain |

Retries stay inside the existing per-session admission chain, so later prompts and compactions cannot overtake them. Other sessions continue independently. Steered messages and the queued-prompt dock both show send status; failed sends can also be retried from the command palette.

Submission logs include session/message IDs, stage, attempt, outcome, backoff, and sanitized failure category/status. They do not include prompt text, attachments, metadata, or raw error messages.

Canonical message reads also retire stale optimistic pending state. This keeps a delayed delivery event from moving the user bubble below its answer, and delivery-only confirmation reads the exact server message rather than returning an optimistic placeholder as canonical content.

## Demo

The same OpenCode Drive fixture runs against base `c8f81c8b83` and fix `80cad95022`. Both use the real TUI and an isolated server with a simulated model. The proxy drops the pending connection, holds the same 1.2-second checkpoint, then heals. The before case restores the draft without sending; the after case retries automatically and receives one response without re-entry. The clips are trimmed and synchronized, with equal final-state holds.

https://github.com/user-attachments/assets/1b9f2ab1-d82a-4cab-8f63-208a3cb3838d

## Scope

Normal user-prompt admission and its captured model selection only. This does not add generic POST retries, rerun shell commands, change provider-generation retry policy, or introduce a disk-backed outbox. Definitive rejections still use the existing draft-recovery path, complemented by #46681.

Cancellation stops local retrying and requests cancellation of any server inbox item. It cannot undo a prompt already delivered to the runner.

## Verification

```sh
# packages/client
bun run test
bun typecheck

# packages/tui
bun run test test/prompt-retry.test.tsx test/compact-admission.test.tsx test/cli/tui/data.test.tsx
bun run test
bun typecheck
```

The same-ID transient retry test fails against the base revision and passes with this change. Tests cover payload capture, model/preparation ordering, concurrent sessions, exhausted/manual retries, acknowledgement recovery, cancellation/disposal, and log redaction. Real OpenCode Drive checks use an isolated server and simulated model, never the live user server.

- Client suite: 163 passed.
- Focused TUI admission/retry suite: 52 passed.
- Full TUI suite: 1,175 passed, 4 skipped, 0 failed.
- Client and TUI typechecks passed; repository pre-push typechecks passed.
- Drive covers steered sends at 120 columns, queued sends at 80, exhaustion and manual retry at 80, and cancellation during backoff at 120.
- In the lost-acknowledgement case, the server accepted the first prompt before the connection dropped. The same ID was retried against Core; verification found one durable user message, one model execution, an empty inbox, and the user bubble before its answer.
