### PR TITLE
fix(core): copy models.dev snapshot without structuredClone

### DIFF
--- a/packages/core/src/plugin/models-dev.ts
+++ b/packages/core/src/plugin/models-dev.ts
@@ -78,7 +78,13 @@ function copy<T>(value: T): T {
   if (Array.isArray(value)) return value.map(copy) as T
   if (value !== null && typeof value === "object") {
     const result: Record<string, unknown> = {}
-    for (const key in value) result[key] = copy((value as Record<string, unknown>)[key])
+    for (const key of Object.keys(value)) {
+      const copied = copy((value as Record<string, unknown>)[key])
+      // Assigning this key would set the prototype rather than an own property, unlike structuredClone.
+      if (key === "__proto__")
+        Object.defineProperty(result, key, { value: copied, enumerable: true, writable: true, configurable: true })
+      else result[key] = copied
+    }
     return result as T
   }
   return value

--- a/packages/core/src/plugin/models-dev.ts
+++ b/packages/core/src/plugin/models-dev.ts
@@ -37,7 +37,7 @@ export const ModelsDevPlugin = define({
         })
         for (const model of provider.models) {
           if (model.status === "deprecated") continue
-          catalog.model.update(provider.info.id, model.id, (draft) => Object.assign(draft, structuredClone(model)))
+          catalog.model.update(provider.info.id, model.id, (draft) => Object.assign(draft, copy(model)))
         }
       }
     })
@@ -65,8 +65,21 @@ function environmentNames(provider: ModelsDev.Snapshot) {
 }
 
 function snapshots(data: readonly ModelsDev.Snapshot[]) {
-  return structuredClone(data).filter(
+  return copy(data).filter(
     // These deprecated aliases are replaced by the canonical Azure and Google Vertex providers.
     (provider) => provider.info.id !== "azure-cognitive-services" && provider.info.id !== "google-vertex-anthropic",
   )
+}
+
+// The catalog owns and mutates its model records, so every rebuild needs fresh copies of the
+// thousands of snapshot models. Snapshot data is plain JSON, and a direct copy is an order of
+// magnitude faster than structuredClone's general graph walk on the startup path.
+function copy<T>(value: T): T {
+  if (Array.isArray(value)) return value.map(copy) as T
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {}
+    for (const key in value) result[key] = copy((value as Record<string, unknown>)[key])
+    return result as T
+  }
+  return value
 }

--- a/packages/core/test/plugin/models-dev.test.ts
+++ b/packages/core/test/plugin/models-dev.test.ts
@@ -411,6 +411,60 @@ describe("ModelsDevPlugin", () => {
     ),
   )
 
+  it.effect("copies model request bodies without reinterpreting literal __proto__ keys", () =>
+    Effect.gen(function* () {
+      const integrations = yield* Integration.Service
+      const catalog = yield* Catalog.Service
+      const providerID = Provider.ID.make("acme")
+      const modelID = Model.ID.make("gpt-5.4")
+      // A JSON body may legitimately contain a "__proto__" key; both copy stages must keep it as an own property.
+      const body = JSON.parse('{"__proto__":{"service_tier":"priority"},"keep":true}') as Record<string, unknown>
+      const snapshot = {
+        info: {
+          id: providerID,
+          name: "Acme",
+          activation: "auto",
+          package: Provider.aisdk("@ai-sdk/openai-compatible"),
+        },
+        environment: [],
+        models: [
+          {
+            id: modelID,
+            modelID,
+            providerID,
+            name: "GPT-5.4",
+            capabilities: { tools: true, input: [], output: [] },
+            variants: [],
+            time: { released: Date.parse("2026-01-01") },
+            cost: [],
+            status: "active",
+            enabled: true,
+            limit: { context: 1_050_000, output: 128_000 },
+            body,
+          },
+        ],
+      } satisfies ModelsDev.Snapshot
+      yield* ModelsDevPlugin.effect(
+        host({
+          catalog: catalogHost(catalog),
+          integration: integrationHost(integrations),
+        }),
+      ).pipe(
+        Effect.provideService(
+          ModelsDev.Service,
+          ModelsDev.Service.of({ get: () => Effect.succeed([snapshot]), refresh: () => Effect.void }),
+        ),
+      )
+
+      const copied = (yield* catalog.model.get(providerID, modelID))?.body
+      expect(copied).not.toBe(body)
+      expect(Object.hasOwn(copied ?? {}, "__proto__")).toBe(true)
+      expect(Object.keys(copied ?? {})).toEqual(["__proto__", "keep"])
+      expect(JSON.stringify(copied)).toBe(JSON.stringify(body))
+      expect(copied).not.toHaveProperty("service_tier")
+    }),
+  )
+
   it.effect("omits legacy provider aliases", () =>
     Effect.gen(function* () {
       const integrations = yield* Integration.Service


### PR DESCRIPTION
## Why

The models.dev plugin registers every snapshot model into the catalog, and the catalog owns and mutates those records, so each run needs fresh copies. It made them with `structuredClone` **per model** — about 6,300 calls over 3.6 MB of data — costing roughly 40 ms every time the catalog callback runs. During a cold start that callback runs more than once, so this was the single most expensive piece of catalog work on the startup path.

## What Changes

Snapshot data is Schema-decoded plain JSON (strings, branded numbers, nested records, arrays), so a small recursive copy produces identical fresh objects without `structuredClone`'s general graph walk. The same helper replaces the one-time whole-snapshot clone in `snapshots(...)`.

The copy walks own keys only and defines a literal `__proto__` key explicitly, since plain assignment would set the prototype instead of an own property and a second copy would then hoist those nested fields into the request body. This matches `structuredClone`'s behavior for JSON bodies that contain that key.

| | per catalog callback run |
| --- | --- |
| Before | 39–55 ms (median ≈ 41) |
| After | 6–11 ms (median ≈ 7) |

Measured inside a real `opencode serve` process with an isolated HOME, five servers per revision, each running the callback twice during startup.

Isolated comparison on the bundled snapshot (6,279 models): `structuredClone` per model 28.8 ms; whole-snapshot `structuredClone` 18.0 ms; `Object.fromEntries` copy 9.7 ms; recursive plain copy with the `__proto__` guard 2.9 ms. The cost is data volume, not call overhead, which is why cloning once was not enough.

## Scope

One file. Catalog semantics are unchanged: every rebuild still gets fresh, independently mutable copies of the snapshot. No public interface changes. Independent of the State materialization stack (#46610 → #46682 → #46631); it reduces catalog rebuild cost under any State design.

## Verification

```sh
# packages/core
bun typecheck
bun run test test/catalog.test.ts test/plugin/models-dev.test.ts test/provider.test.ts
```

- Typecheck passes; catalog, models.dev, and provider tests: **24 passed, 0 failed**.
- New regression `copies model request bodies without reinterpreting literal __proto__ keys` fails on the initial `for...in` copy and passes with the guard.
- In-process timing above was collected with a temporary `performance.now()` around the callback on both revisions; the timing code is not in the diff.
- The pre-push hook passed all **33 repository typecheck tasks**.
