### PR TITLE
fix(desktop): open PowerShell in the project directory on Windows

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -8,6 +8,7 @@ import { parseDesktopNativeBundle, type DesktopNativeBundle } from "@opencode-ai
 
 import type { FatalRendererError, ServerReadyData, TitlebarTheme } from "../preload/types"
 import { runDesktopMenuAction } from "./desktop-menu-actions"
+import { isPowerShellApp, openPowerShellWindow } from "./windows-terminal"
 import { setForceFocus } from "./debug"
 import { assertAttachmentBudget, createPickedFileAuthorizations } from "./attachment-picker"
 import { getStore, removeStoreFileIfEmpty } from "./store"
@@ -218,6 +219,10 @@ export function registerIpcHandlers(deps: Deps) {
 
   ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {
     if (!app) return shell.openPath(path)
+    if (process.platform === "win32" && isPowerShellApp(app)) {
+      await openPowerShellWindow(app, path)
+      return
+    }
     await new Promise<void>((resolve, reject) => {
       const [cmd, args] =
         process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)

--- a/packages/desktop/src/main/windows-terminal.test.ts
+++ b/packages/desktop/src/main/windows-terminal.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildPowerShellLocationCommand,
+  encodePowerShellCommand,
+  isPowerShellApp,
+} from "./windows-terminal"
+
+describe("isPowerShellApp", () => {
+  test("detects bare powershell names", () => {
+    expect(isPowerShellApp("powershell")).toBe(true)
+    expect(isPowerShellApp("pwsh")).toBe(true)
+  })
+
+  test("detects powershell executable names", () => {
+    expect(isPowerShellApp("powershell.exe")).toBe(true)
+    expect(isPowerShellApp("pwsh.exe")).toBe(true)
+  })
+
+  test("detects resolved full paths", () => {
+    expect(isPowerShellApp("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")).toBe(true)
+    expect(isPowerShellApp("C:\\Program Files\\PowerShell\\7\\pwsh.exe")).toBe(true)
+  })
+
+  test("is case-insensitive", () => {
+    expect(isPowerShellApp("PowerShell.EXE")).toBe(true)
+    expect(isPowerShellApp("PWSH")).toBe(true)
+  })
+
+  test("rejects other executables", () => {
+    expect(isPowerShellApp("cmd.exe")).toBe(false)
+    expect(isPowerShellApp("code")).toBe(false)
+    expect(isPowerShellApp("C:\\Program Files\\Microsoft VS Code\\Code.exe")).toBe(false)
+  })
+})
+
+describe("buildPowerShellLocationCommand", () => {
+  test("sets the literal working directory", () => {
+    expect(buildPowerShellLocationCommand("C:\\Projects\\demo")).toBe(
+      "Set-Location -LiteralPath 'C:\\Projects\\demo'",
+    )
+  })
+
+  test("escapes single quotes by doubling them", () => {
+    expect(buildPowerShellLocationCommand("C:\\Users\\owner's\\project")).toBe(
+      "Set-Location -LiteralPath 'C:\\Users\\owner''s\\project'",
+    )
+  })
+
+  test("keeps non-ascii paths intact", () => {
+    expect(buildPowerShellLocationCommand("C:\\Users\\山田\\プロジェクト")).toBe(
+      "Set-Location -LiteralPath 'C:\\Users\\山田\\プロジェクト'",
+    )
+  })
+})
+
+describe("encodePowerShellCommand", () => {
+  test("round-trips through utf-16le base64", () => {
+    const command = "Set-Location -LiteralPath 'C:\\Projects\\path with spaces'"
+    const decoded = Buffer.from(encodePowerShellCommand(command), "base64").toString("utf16le")
+    expect(decoded).toBe(command)
+  })
+
+  test("contains only cmd-safe base64 characters", () => {
+    const encoded = encodePowerShellCommand("Set-Location -LiteralPath 'C:\\100% & done; `more' \"$x\"")
+    expect(encoded).toMatch(/^[A-Za-z0-9+/=]+$/)
+  })
+
+  test("round-trips non-ascii paths", () => {
+    const command = buildPowerShellLocationCommand("C:\\Users\\山田\\プロジェクト")
+    const decoded = Buffer.from(encodePowerShellCommand(command), "base64").toString("utf16le")
+    expect(decoded).toBe(command)
+  })
+})

--- a/packages/desktop/src/main/windows-terminal.ts
+++ b/packages/desktop/src/main/windows-terminal.ts
@@ -1,0 +1,32 @@
+import { spawn } from "node:child_process"
+import { basename } from "node:path"
+
+const POWERSHELL_EXECUTABLES = new Set(["powershell", "powershell.exe", "pwsh", "pwsh.exe"])
+
+export function isPowerShellApp(appPath: string): boolean {
+  return POWERSHELL_EXECUTABLES.has(basename(appPath).toLowerCase())
+}
+
+export function buildPowerShellLocationCommand(targetPath: string): string {
+  return `Set-Location -LiteralPath '${targetPath.replace(/'/g, "''")}'`
+}
+
+export function encodePowerShellCommand(command: string): string {
+  return Buffer.from(command, "utf16le").toString("base64")
+}
+
+export function openPowerShellWindow(appPath: string, targetPath: string): Promise<void> {
+  const encoded = encodePowerShellCommand(buildPowerShellLocationCommand(targetPath))
+  return new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      "cmd.exe",
+      ["/d", "/c", "start", "", appPath, "-NoExit", "-EncodedCommand", encoded],
+      { stdio: "ignore" },
+    )
+    child.once("error", reject)
+    child.once("spawn", () => {
+      child.unref()
+      resolve()
+    })
+  })
+}


### PR DESCRIPTION
### Issue for this PR

Closes #39851
Closes #40045
Closes #40277
Closes #48799

### Type of change

- [x] Bug fix

### What does this PR do?

On Windows, "Open in → PowerShell" fails with CommandNotFoundException: the open-path handler runs `execFile(app, [path])`, and PowerShell treats the project directory as a command to execute.

This adds a PowerShell-specific launch path on win32. The shell opens in its own console window via `cmd.exe /d /c start`, and the working directory is applied with `Set-Location -LiteralPath '<path>'` passed as a UTF-16LE Base64 `-EncodedCommand`. The path therefore never passes through the CMD or PowerShell parsers, so spaces, single quotes, `%VAR%`, and non-ASCII paths are all safe. Other apps and platforms keep the existing `execFile` behavior.

I looked at #40067 first, but `spawn(cwd, detached)` doesn't surface a console window on Windows (as noted on #40045), so I went with `start` in a new console instead.

The helpers (app detection, quote escaping, Base64 encoding) are in `windows-terminal.ts` with unit tests.

### How did you verify your code works?

Verified in the Electron dev build (bun dev) on Windows 11.

"Open in → PowerShell" opened a new PowerShell window in the correct directory for all of these project paths:

- `C:\Projects\simple`
- `C:\path with spaces` (spaces)
- `C:\owner's project` (single quote)
- `C:\100% complete` (percent chars, CMD expansion)
- `C:\あああ` (non-ASCII)

`bun test packages/desktop`: 83 pass (11 new). Full repo `bun turbo typecheck`: 30/30 pass.

### Screenshots / recordings

_Not a UI change (main-process IPC only)._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR