### PR TITLE
fix(app): keep new local sessions in the selected directory

### DIFF
--- a/packages/app/src/new-session/workspace/controller.test.ts
+++ b/packages/app/src/new-session/workspace/controller.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import {
-  normalizeNewSessionWorktree,
-  resolveNewSessionBranch,
-  resolveNewSessionGit,
-  resolveNewSessionWorktree,
-} from "./controller"
+import { resolveNewSessionBranch, resolveNewSessionGit, resolveNewSessionWorktree } from "./controller"
 
 describe("new session workspace selection", () => {
   test("uses main when the workspace bar is unavailable", () => {
@@ -12,8 +7,6 @@ describe("new session workspace selection", () => {
       resolveNewSessionWorktree({
         enabled: false,
         selected: "/project/feature",
-        directory: "/project/feature",
-        projectWorktree: "/project",
       }),
     ).toBe("main")
   })
@@ -22,31 +15,21 @@ describe("new session workspace selection", () => {
     expect(
       resolveNewSessionWorktree({
         enabled: true,
-        directory: "/project/feature",
-        projectWorktree: "/project",
         fallback: "create",
       }),
     ).toBe("create")
     expect(
       resolveNewSessionWorktree({
         enabled: true,
-        directory: "/project/feature",
-        projectWorktree: "/project",
         fallback: "main",
       }),
-    ).toBe("/project")
-  })
-
-  test("normalizes main to the project root outside the main worktree", () => {
-    expect(normalizeNewSessionWorktree("main", "/project/feature", "/project")).toBe("/project")
-    expect(normalizeNewSessionWorktree("main", "/project", "/project")).toBe("main")
-  })
-
-  test("treats equivalent Windows roots as the main worktree", () => {
-    expect(
-      resolveNewSessionWorktree({ enabled: true, directory: "C:\\Repo\\", projectWorktree: "c:/repo" }),
     ).toBe("main")
-    expect(normalizeNewSessionWorktree("main", "C:\\Repo\\", "c:/repo")).toBe("main")
+  })
+
+  test("keeps local selection when the cached project path is stale", () => {
+    const input = { enabled: true, directory: "C:/Projects/repo", projectWorktree: "D:/Projects/repo" }
+    expect(resolveNewSessionWorktree(input)).toBe("main")
+    expect(resolveNewSessionWorktree({ ...input, selected: "/worktree" })).toBe("/worktree")
   })
 
   test("resolves the branch from the active location", () => {

--- a/packages/app/src/new-session/workspace/controller.ts
+++ b/packages/app/src/new-session/workspace/controller.ts
@@ -11,27 +11,15 @@ import { normalizeProjectInfo } from "@/runtime/server/global-sync/utils"
 import {
   isWorkspaceDirectory,
   isWorkspaceSelection,
-  sameDirectory,
   workspaceDefaultSelection,
   workspaceDirectories,
   workspaceSelectionDestination,
 } from "@/workspaces/paths"
 
-export function resolveNewSessionWorktree(input: {
-  enabled: boolean
-  selected?: string
-  directory: string
-  projectWorktree?: string
-  fallback?: string
-}) {
+export function resolveNewSessionWorktree(input: { enabled: boolean; selected?: string; fallback?: string }) {
   if (!input.enabled) return "main"
   if (input.selected) return input.selected
-  return normalizeNewSessionWorktree(input.fallback ?? "main", input.directory, input.projectWorktree)
-}
-
-export function normalizeNewSessionWorktree(value: string, directory: string, projectWorktree?: string) {
-  if (value === "main" && projectWorktree && !sameDirectory(directory, projectWorktree)) return projectWorktree
-  return value
+  return input.fallback ?? "main"
 }
 
 export function resolveNewSessionBranch(input: {
@@ -92,8 +80,6 @@ export function createNewSessionWorkspaceController(input: {
     resolveNewSessionWorktree({
       enabled: visible(),
       selected: selected(),
-      directory: sdk().directory,
-      projectWorktree: currentProject()?.worktree,
       fallback: fallback(),
     }),
   )
@@ -145,7 +131,7 @@ export function createNewSessionWorkspaceController(input: {
       remember,
       set: (worktree: string) => {
         input.setSelectedBranch(undefined)
-        input.setSelectedWorktree(normalizeNewSessionWorktree(worktree, sdk().directory, currentProject()?.worktree))
+        input.setSelectedWorktree(worktree)
         remember(worktree)
       },
       create: (branch: string) => {


### PR DESCRIPTION
- Keep new Local sessions in the folder selected for the draft, rather than substituting the project's cached canonical path.
- Preserve explicit workspace choices and new-workspace defaults. Existing session history is unchanged.
- Scope: new-session directory selection. The issue references include broader reports; this does not relocate existing sessions, separate clone histories, or resolve unrelated defects within multi-issue reports.

```mermaid
flowchart LR
  Open["Open C:/Projects/repo"] --> Local["Local session"]
  Local --> Fixed["Create session in C:/Projects/repo"]
  Local -. "previous behavior" .-> Stale["Cached canonical: D:/Projects/repo"]
```

| Viewport | Before | After |
| --- | --- | --- |
| Desktop | ![](https://github.com/user-attachments/assets/48f080e1-5c09-48ce-85ab-3b1b0b8eb0ec) | ![](https://github.com/user-attachments/assets/dc9e1457-87ad-4afb-8db9-ffb39eedcec1) |
| Mobile | ![](https://github.com/user-attachments/assets/362708f5-1533-4a3b-80ea-2f37e0513ddd) | ![](https://github.com/user-attachments/assets/15f92837-48a8-4694-b7e2-c9cc80f7886b) |

- Screenshots use the production UI with an isolated API fixture: the old directory fails admission; the selected directory accepts it.

| Production Home -> new session, Windows Chromium | Before (`74eda7f950`) | After |
| --- | ---: | ---: |
| Ready, median | 143.10 ms | 200.30 ms |
| Ready, p95 | 194.30 ms | 225.60 ms |
| Stable, median | 174.20 ms | 225.90 ms |
| Stable, p95 | 224.40 ms | 255.90 ms |

- Three serial samples per build; diagnostic measurements, not a performance claim.

<details>
<summary>Issue references: 57 related reports, including 22 already closed</summary>

- Fixes #6696
- Fixes #12918
- Fixes #17940
- Fixes #23248
- Fixes #29714
- Fixes #29823
- Fixes #29825
- Fixes #30005
- Fixes #30462
- Fixes #30697
- Fixes #30750
- Fixes #31063
- Fixes #31074
- Fixes #31401
- Fixes #31869
- Fixes #31888
- Fixes #32785
- Fixes #32803
- Fixes #32847
- Fixes #33313
- Fixes #33359
- Fixes #33615
- Fixes #33909
- Fixes #33995
- Fixes #34373
- Fixes #34737
- Fixes #35240
- Fixes #35297
- Fixes #35427
- Fixes #35491
- Fixes #35674
- Fixes #35714
- Fixes #35851
- Fixes #35873
- Fixes #36004
- Fixes #36150
- Fixes #37697
- Fixes #38013
- Fixes #38151
- Fixes #38578
- Fixes #39471
- Fixes #39836
- Fixes #40222
- Fixes #40336
- Fixes #40596
- Fixes #40677
- Fixes #40699
- Fixes #40986
- Fixes #41420
- Fixes #42315
- Fixes #43192
- Fixes #44073
- Fixes #44101
- Fixes #44538
- Fixes #45392
- Fixes #45559
- Fixes #46330

</details>
