### PR TITLE
feat(core): add hidden glob option

### DIFF
--- a/packages/core/src/filesystem.ts
+++ b/packages/core/src/filesystem.ts
@@ -37,6 +37,7 @@ export const DEFAULT_SEARCH_TIMEOUT_MS = 30_000
 export class GlobInput extends Schema.Class<GlobInput>("FileSystem.GlobInput")({
   pattern: Schema.String,
   path: Schema.optionalKey(RelativePath),
+  hidden: Schema.optionalKey(Schema.Boolean),
   limit: Schema.optionalKey(PositiveInt),
 }) {}
 

--- a/packages/core/src/tool/plugin/glob.ts
+++ b/packages/core/src/tool/plugin/glob.ts
@@ -19,6 +19,9 @@ export const Input = Schema.Struct({
   path: Schema.optionalKey(RelativePath).annotate({
     description: "Directory to search. Defaults to the current working directory.",
   }),
+  hidden: FileSystem.GlobInput.fields.hidden.annotate({
+    description: "Include hidden files and directories (default: false).",
+  }),
   limit: FileSystem.GlobInput.fields.limit.annotate({
     description: `Maximum number of matching files to return (default: ${FileSystem.DEFAULT_SEARCH_LIMIT})`,
   }),
@@ -76,6 +79,7 @@ export const Plugin = {
                 metadata: {
                   root: searchPath ?? ".",
                   path: searchPath,
+                  hidden: input.hidden,
                   limit: input.limit,
                 },
                 sessionID: context.sessionID,
@@ -97,6 +101,7 @@ export const Plugin = {
                 .glob({
                   cwd: root,
                   pattern: input.pattern,
+                  hidden: input.hidden,
                   limit: limit + 1,
                 })
                 .pipe(


### PR DESCRIPTION
## Summary
- expose a `hidden` option on the glob tool
- forward the option through the filesystem input to ripgrep
- preserve the existing default behavior when omitted

## Testing
- `bun test test/ripgrep.test.ts test/tool-search.test.ts`
- `bun typecheck`