### PR TITLE
docs(zen): add Claude Fable 5.1

### DIFF
--- a/packages/web/src/content/docs/ar/zen.mdx
+++ b/packages/web/src/content/docs/ar/zen.mdx
@@ -75,6 +75,7 @@ OpenCode Zen هي بوابة AI تتيح لك الوصول إلى هذه الن�
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -162,6 +163,7 @@ https://opencode.ai/zen/v1/models
 | DeepSeek V4 Pro (Peak)            | $1.32   | $3.96   | $0.044          | -               |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22   | $0.66   | $0.007          | -               |
 | DeepSeek V4 Flash (Peak)          | $0.44   | $1.32   | $0.014          | -               |
+| Claude Fable 5.1                  | $10.00  | $50.00  | $0.25           | $12.50          |
 | Claude Fable 5                    | $10.00  | $50.00  | $1.00           | $12.50          |
 | Claude Opus 5                     | $5.00   | $25.00  | $0.50           | $6.25           |
 | Claude Opus 4.8                   | $5.00   | $25.00  | $0.50           | $6.25           |

--- a/packages/web/src/content/docs/bs/zen.mdx
+++ b/packages/web/src/content/docs/bs/zen.mdx
@@ -80,6 +80,7 @@ Našim modelima možete pristupiti i preko sljedećih API endpointa.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -169,6 +170,7 @@ Podržavamo pay-as-you-go model. Ispod su cijene **po 1M tokena**.
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/da/zen.mdx
+++ b/packages/web/src/content/docs/da/zen.mdx
@@ -80,6 +80,7 @@ Du kan også få adgang til vores modeller gennem følgende API-endpoints.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -169,6 +170,7 @@ Vi understøtter en pay-as-you-go-model. Nedenfor er priserne **pr. 1M tokens**.
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/de/zen.mdx
+++ b/packages/web/src/content/docs/de/zen.mdx
@@ -71,6 +71,7 @@ Du kannst auch über die folgenden API-Endpunkte auf unsere Modelle zugreifen.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -158,6 +159,7 @@ Wir unterstützen ein Pay-as-you-go-Modell. Unten findest du die Preise **pro 1M
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/es/zen.mdx
+++ b/packages/web/src/content/docs/es/zen.mdx
@@ -80,6 +80,7 @@ También puedes acceder a nuestros modelos a través de los siguientes endpoints
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -169,6 +170,7 @@ Admitimos un modelo de pago por uso. A continuación se muestran los precios **p
 | DeepSeek V4 Pro (Peak)            | $1.32   | $3.96   | $0.044           | -                  |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22   | $0.66   | $0.007           | -                  |
 | DeepSeek V4 Flash (Peak)          | $0.44   | $1.32   | $0.014           | -                  |
+| Claude Fable 5.1                  | $10.00  | $50.00  | $0.25            | $12.50             |
 | Claude Fable 5                    | $10.00  | $50.00  | $1.00            | $12.50             |
 | Claude Opus 5                     | $5.00   | $25.00  | $0.50            | $6.25              |
 | Claude Opus 4.8                   | $5.00   | $25.00  | $0.50            | $6.25              |

--- a/packages/web/src/content/docs/fr/zen.mdx
+++ b/packages/web/src/content/docs/fr/zen.mdx
@@ -71,6 +71,7 @@ Vous pouvez également accéder à nos modèles via les points de terminaison AP
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -158,6 +159,7 @@ Nous prenons en charge un modèle de paiement à l'utilisation. Vous trouverez c
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/it/zen.mdx
+++ b/packages/web/src/content/docs/it/zen.mdx
@@ -80,6 +80,7 @@ Puoi anche accedere ai nostri modelli tramite i seguenti endpoint API.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -169,6 +170,7 @@ Supportiamo un modello pay-as-you-go. Qui sotto trovi i prezzi **per 1M token**.
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/ja/zen.mdx
+++ b/packages/web/src/content/docs/ja/zen.mdx
@@ -71,6 +71,7 @@ OpenCode Zen は、OpenCode のほかのプロバイダーと同じように動�
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -158,6 +159,7 @@ https://opencode.ai/zen/v1/models
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/ko/zen.mdx
+++ b/packages/web/src/content/docs/ko/zen.mdx
@@ -71,6 +71,7 @@ OpenCode Zen은 OpenCode의 다른 provider와 똑같이 작동합니다.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -158,6 +159,7 @@ https://opencode.ai/zen/v1/models
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/nb/zen.mdx
+++ b/packages/web/src/content/docs/nb/zen.mdx
@@ -80,6 +80,7 @@ Du kan også få tilgang til modellene våre gjennom følgende API-endepunkter.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -169,6 +170,7 @@ Vi støtter en pay-as-you-go-modell. Nedenfor er prisene **per 1M tokens**.
 | DeepSeek V4 Pro (Peak)            | $1.32   | $3.96   | $0.044        | -               |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22   | $0.66   | $0.007        | -               |
 | DeepSeek V4 Flash (Peak)          | $0.44   | $1.32   | $0.014        | -               |
+| Claude Fable 5.1                  | $10.00  | $50.00  | $0.25         | $12.50          |
 | Claude Fable 5                    | $10.00  | $50.00  | $1.00         | $12.50          |
 | Claude Opus 5                     | $5.00   | $25.00  | $0.50         | $6.25           |
 | Claude Opus 4.8                   | $5.00   | $25.00  | $0.50         | $6.25           |

--- a/packages/web/src/content/docs/pl/zen.mdx
+++ b/packages/web/src/content/docs/pl/zen.mdx
@@ -80,6 +80,7 @@ Możesz też uzyskać dostęp do naszych modeli przez poniższe endpointy API.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -169,6 +170,7 @@ Obsługujemy model pay-as-you-go. Poniżej znajdują się ceny **za 1M tokenów*
 | DeepSeek V4 Pro (Peak)            | $1.32   | $3.96   | $0.044         | -              |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22   | $0.66   | $0.007         | -              |
 | DeepSeek V4 Flash (Peak)          | $0.44   | $1.32   | $0.014         | -              |
+| Claude Fable 5.1                  | $10.00  | $50.00  | $0.25          | $12.50         |
 | Claude Fable 5                    | $10.00  | $50.00  | $1.00          | $12.50         |
 | Claude Opus 5                     | $5.00   | $25.00  | $0.50          | $6.25          |
 | Claude Opus 4.8                   | $5.00   | $25.00  | $0.50          | $6.25          |

--- a/packages/web/src/content/docs/pt-br/zen.mdx
+++ b/packages/web/src/content/docs/pt-br/zen.mdx
@@ -71,6 +71,7 @@ Você também pode acessar nossos modelos pelos seguintes endpoints de API.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -158,6 +159,7 @@ Oferecemos um modelo pay-as-you-go. Abaixo estão os preços **por 1M tokens**.
 | DeepSeek V4 Pro (Peak)            | $1.32   | $3.96   | $0.044           | -                |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22   | $0.66   | $0.007           | -                |
 | DeepSeek V4 Flash (Peak)          | $0.44   | $1.32   | $0.014           | -                |
+| Claude Fable 5.1                  | $10.00  | $50.00  | $0.25            | $12.50           |
 | Claude Fable 5                    | $10.00  | $50.00  | $1.00            | $12.50           |
 | Claude Opus 5                     | $5.00   | $25.00  | $0.50            | $6.25            |
 | Claude Opus 4.8                   | $5.00   | $25.00  | $0.50            | $6.25            |

--- a/packages/web/src/content/docs/ru/zen.mdx
+++ b/packages/web/src/content/docs/ru/zen.mdx
@@ -80,6 +80,7 @@ OpenCode Zen работает как любой другой провайдер 
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -169,6 +170,7 @@ https://opencode.ai/zen/v1/models
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/th/zen.mdx
+++ b/packages/web/src/content/docs/th/zen.mdx
@@ -73,6 +73,7 @@ OpenCode Zen ทำงานเหมือน provider อื่น ๆ ใน 
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -160,6 +161,7 @@ https://opencode.ai/zen/v1/models
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/tr/zen.mdx
+++ b/packages/web/src/content/docs/tr/zen.mdx
@@ -71,6 +71,7 @@ Modellerimize aşağıdaki API uç noktaları aracılığıyla da erişebilirsin
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -158,6 +159,7 @@ Kullandıkça öde modelini destekliyoruz. Aşağıda **1M token başına** fiya
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -80,6 +80,7 @@ You can also access our models through the following API endpoints.
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -169,6 +170,7 @@ We support a pay-as-you-go model. Below are the prices **per 1M tokens**.
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044      | -            |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007      | -            |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014      | -            |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25       | $12.50       |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00       | $12.50       |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50       | $6.25        |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50       | $6.25        |

--- a/packages/web/src/content/docs/zh-cn/zen.mdx
+++ b/packages/web/src/content/docs/zh-cn/zen.mdx
@@ -71,6 +71,7 @@ OpenCode Zen 的工作方式与 OpenCode 中的任何其他提供商相同。
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -158,6 +159,7 @@ https://opencode.ai/zen/v1/models
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044   | -        |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007   | -        |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014   | -        |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25    | $12.50   |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00    | $12.50   |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50    | $6.25    |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50    | $6.25    |

--- a/packages/web/src/content/docs/zh-tw/zen.mdx
+++ b/packages/web/src/content/docs/zh-tw/zen.mdx
@@ -75,6 +75,7 @@ OpenCode Zen 的運作方式和 OpenCode 中的其他供應商一樣。
 | GPT 5                           | gpt-5                           | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Codex                     | gpt-5-codex                     | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | GPT 5 Nano                      | gpt-5-nano                      | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
+| Claude Fable 5.1                | claude-fable-5-1                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Fable 5                  | claude-fable-5                  | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 5                   | claude-opus-5                   | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Opus 4.8                 | claude-opus-4-8                 | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
@@ -163,6 +164,7 @@ https://opencode.ai/zen/v1/models
 | DeepSeek V4 Pro (Peak)            | $1.32  | $3.96   | $0.044   | -        |
 | DeepSeek V4 Flash (Off-Peak)      | $0.22  | $0.66   | $0.007   | -        |
 | DeepSeek V4 Flash (Peak)          | $0.44  | $1.32   | $0.014   | -        |
+| Claude Fable 5.1                  | $10.00 | $50.00  | $0.25    | $12.50   |
 | Claude Fable 5                    | $10.00 | $50.00  | $1.00    | $12.50   |
 | Claude Opus 5                     | $5.00  | $25.00  | $0.50    | $6.25    |
 | Claude Opus 4.8                   | $5.00  | $25.00  | $0.50    | $6.25    |


### PR DESCRIPTION
Add Claude Fable 5.1 to the Zen documentation across all supported languages.