### PR TITLE
feat(app): reorganize session navigation controls

### DIFF
--- a/packages/app/e2e/regression/session-header-controls.spec.ts
+++ b/packages/app/e2e/regression/session-header-controls.spec.ts
@@ -13,6 +13,13 @@ for (const direction of ["ltr", "rtl"] as const) {
       pageMessages,
     })
     await installStressSessionTabs(page)
+    await page.addInitScript(() => {
+      const settings = JSON.parse(localStorage.getItem("settings.v3") ?? "{}")
+      localStorage.setItem(
+        "settings.v3",
+        JSON.stringify({ ...settings, general: { ...settings.general, showStatus: true } }),
+      )
+    })
     await page.goto(stressSessionHref(fixture.targetID))
     const header = page.locator("[data-session-title]")
     const more = header.getByRole("button", { name: "More options", exact: true })
@@ -22,7 +29,8 @@ for (const direction of ["ltr", "rtl"] as const) {
     await page.evaluate((direction) => document.documentElement.setAttribute("dir", direction), direction)
     await expect(review).toBeVisible()
     await expect(details).toBeVisible()
-    await expect(page.locator('[data-slot="titlebar-v2"]').getByRole("button", { name: "Status" })).toHaveCount(0)
+    const status = page.locator('[data-slot="titlebar-v2"]').getByRole("button", { name: "Status" })
+    await expect(status).toBeVisible()
     await expect
       .poll(async () => {
         const boxes = await Promise.all(
@@ -47,23 +55,15 @@ for (const direction of ["ltr", "rtl"] as const) {
     await expect(review).toHaveAttribute("aria-expanded", "false")
 
     await more.click()
-    const status = page.getByRole("menuitem", { name: "Server status", exact: true })
+    await expect(page.getByRole("menuitem", { name: "Server status", exact: true })).toHaveCount(0)
+    await page.keyboard.press("Escape")
     await status.click()
-    const dialog = page.getByRole("dialog", { name: "Server status", exact: true })
-    const mcp = dialog.getByRole("tab", { name: "MCP", exact: true })
-    const plugins = dialog.getByRole("tab", { name: "Plugins", exact: true })
+    const mcp = page.getByRole("tab", { name: "MCP", exact: true })
+    const plugins = page.getByRole("tab", { name: "Plugins", exact: true })
     await expect(mcp).toHaveAttribute("aria-selected", "true")
     await plugins.click()
     await expect(plugins).toHaveAttribute("aria-selected", "true")
     await page.keyboard.press("Escape")
-    await expect(dialog).toBeHidden()
-
-    await more.click()
-    await page.keyboard.press("s")
-    await expect(status).toBeFocused()
-    await page.keyboard.press("Enter")
-    await expect(mcp).toBeVisible()
-    await page.keyboard.press("Tab")
-    await expect(mcp).toBeFocused()
+    await expect(mcp).toBeHidden()
   })
 }

--- a/packages/app/e2e/regression/session-header-controls.spec.ts
+++ b/packages/app/e2e/regression/session-header-controls.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from "@playwright/test"
+import { fixture, pageMessages } from "../performance/timeline/session-timeline-stress.fixture"
+import { installStressSessionTabs, stressSessionHref } from "../performance/timeline/timeline-test-helpers"
+import { mockOpenCodeServer } from "../utils/mock-server"
+
+for (const direction of ["ltr", "rtl"] as const) {
+  test(`session header groups controls and exposes server status in ${direction}`, async ({ page }) => {
+    await mockOpenCodeServer(page, {
+      directory: fixture.directory,
+      project: fixture.project,
+      sessions: fixture.sessions,
+      provider: fixture.provider,
+      pageMessages,
+    })
+    await installStressSessionTabs(page)
+    await page.goto(stressSessionHref(fixture.targetID))
+    const header = page.locator("[data-session-title]")
+    const more = header.getByRole("button", { name: "More options", exact: true })
+    const review = header.getByRole("button", { name: "Toggle review", exact: true })
+    const details = header.getByRole("button", { name: "Session details", exact: true })
+    await expect(header.getByRole("heading")).toHaveText(fixture.expected.targetTitle)
+    await page.evaluate((direction) => document.documentElement.setAttribute("dir", direction), direction)
+    await expect(review).toBeVisible()
+    await expect(details).toBeVisible()
+    await expect(page.locator('[data-slot="titlebar-v2"]').getByRole("button", { name: "Status" })).toHaveCount(0)
+    await expect
+      .poll(async () => {
+        const boxes = await Promise.all(
+          [header.getByRole("heading"), more, review, details].map((button) => button.boundingBox()),
+        )
+        const [title, menu, sidebar, summary] = boxes
+        if (!title || !menu || !sidebar || !summary) return false
+        return direction === "ltr"
+          ? Math.abs(title.x + title.width - menu.x) <= 1 &&
+              menu.x + menu.width <= summary.x &&
+              summary.x + summary.width <= sidebar.x
+          : Math.abs(menu.x + menu.width - title.x) <= 1 &&
+              sidebar.x + sidebar.width <= summary.x &&
+              summary.x + summary.width <= menu.x
+      })
+      .toBe(true)
+
+    await review.click()
+    await expect(review).toHaveAttribute("aria-expanded", "true")
+    await expect(page.locator("#review-panel")).toBeVisible()
+    await review.click()
+    await expect(review).toHaveAttribute("aria-expanded", "false")
+
+    await more.click()
+    const status = page.getByRole("menuitem", { name: "Server status", exact: true })
+    await status.click()
+    const dialog = page.getByRole("dialog", { name: "Server status", exact: true })
+    const mcp = dialog.getByRole("tab", { name: "MCP", exact: true })
+    const plugins = dialog.getByRole("tab", { name: "Plugins", exact: true })
+    await expect(mcp).toHaveAttribute("aria-selected", "true")
+    await plugins.click()
+    await expect(plugins).toHaveAttribute("aria-selected", "true")
+    await page.keyboard.press("Escape")
+    await expect(dialog).toBeHidden()
+
+    await more.click()
+    await page.keyboard.press("s")
+    await expect(status).toBeFocused()
+    await page.keyboard.press("Enter")
+    await expect(mcp).toBeVisible()
+    await page.keyboard.press("Tab")
+    await expect(mcp).toBeFocused()
+  })
+}

--- a/packages/app/e2e/regression/subagent-child-navigation.spec.ts
+++ b/packages/app/e2e/regression/subagent-child-navigation.spec.ts
@@ -22,8 +22,7 @@ test("navigates to a subagent child session missing from the session list", asyn
   await expectSessionTitle(page, taskDescription)
   await expect(page.getByRole("heading", { name: parentTitle })).toHaveCount(0)
 
-  const titlebarRight = page.locator("#opencode-titlebar-right")
-  await expect(titlebarRight.getByRole("button", { name: "Toggle review" })).toHaveCount(1)
+  await expect(page.getByRole("button", { name: "Toggle review", exact: true })).toBeVisible()
 })
 
 test("returns to the parent session with Escape", async ({ page }) => {

--- a/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
+++ b/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
@@ -146,6 +146,8 @@ test("vertical tabs show project details, resize, and navigate", async ({ page }
   await expect(tabB.locator('[data-slot="tab-project"]')).toHaveText("tab-project")
   await expect(sidebar.getByRole("button", { name: "Home", exact: true })).toHaveText("Home")
   await expect(sidebar.getByRole("button", { name: "New session" })).toBeVisible()
+  await expect(sidebar.locator('[data-slot="vertical-tabs-footer"]')).toBeVisible()
+  await expect(page.locator('[data-slot="titlebar-v2"]')).toBeHidden()
   await expect
     .poll(async () => {
       const button = await sidebar.getByRole("button", { name: "New session" }).boundingBox()

--- a/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
+++ b/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
@@ -121,7 +121,10 @@ test("vertical tabs show project details, resize, and navigate", async ({ page }
   await mockServer(page)
   await page.addInitScript(
     ({ server, sessionA, sessionB }) => {
-      localStorage.setItem("settings.v3", JSON.stringify({ appearance: { tabLayout: "vertical" } }))
+      localStorage.setItem(
+        "settings.v3",
+        JSON.stringify({ appearance: { tabLayout: "vertical" }, general: { showStatus: true } }),
+      )
       localStorage.setItem(
         "opencode.window.browser.dat:tabs",
         JSON.stringify([
@@ -147,6 +150,15 @@ test("vertical tabs show project details, resize, and navigate", async ({ page }
   await expect(sidebar.getByRole("button", { name: "Home", exact: true })).toHaveText("Home")
   await expect(sidebar.getByRole("button", { name: "New session" })).toBeVisible()
   await expect(sidebar.locator('[data-slot="vertical-tabs-footer"]')).toBeVisible()
+  const status = sidebar.getByRole("button", { name: "Status", exact: true })
+  await expect(status).toBeVisible()
+  await expect
+    .poll(async () => {
+      const bounds = await sidebar.boundingBox()
+      const button = await status.boundingBox()
+      return !!bounds && !!button && bounds.x + bounds.width - button.x - button.width <= 12
+    })
+    .toBe(true)
   await expect(page.locator('[data-slot="titlebar-v2"]')).toBeHidden()
   await expect
     .poll(async () => {

--- a/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
+++ b/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
@@ -145,6 +145,13 @@ test("vertical tabs show project details, resize, and navigate", async ({ page }
   await expect(tabB).toContainText(sessionB.title)
   await expect(tabB.locator('[data-slot="tab-project"]')).toHaveText("tab-project")
   await expect(sidebar.getByRole("button", { name: "New session" })).toBeVisible()
+  await expect
+    .poll(async () => {
+      const button = await sidebar.getByRole("button", { name: "New session" }).boundingBox()
+      const tab = await tabA.boundingBox()
+      return !!button && !!tab && button.y + button.height < tab.y
+    })
+    .toBe(true)
   await expect(page.locator('[data-slot="titlebar-tabs"]')).toHaveCount(0)
 
   const handle = sidebar.locator('[data-component="resize-handle"]')

--- a/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
+++ b/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
@@ -144,6 +144,7 @@ test("vertical tabs show project details, resize, and navigate", async ({ page }
   await expect(tabA).toContainText(sessionA.title)
   await expect(tabB).toContainText(sessionB.title)
   await expect(tabB.locator('[data-slot="tab-project"]')).toHaveText("tab-project")
+  await expect(sidebar.getByRole("button", { name: "Home", exact: true })).toHaveText("Home")
   await expect(sidebar.getByRole("button", { name: "New session" })).toBeVisible()
   await expect
     .poll(async () => {

--- a/packages/app/src/session/header/session-header-actions.tsx
+++ b/packages/app/src/session/header/session-header-actions.tsx
@@ -1,11 +1,10 @@
-import { Show, type JSX } from "solid-js"
+import { Show } from "solid-js"
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Keybind } from "@opencode-ai/ui/keybind"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 
 export type SessionHeaderActionsState = {
-  status?: { label: string; content: () => JSX.Element }
   reviewLabel: string
   reviewKeybind: string[]
   reviewVisible: boolean
@@ -16,13 +15,6 @@ export type SessionHeaderActionsState = {
 export function SessionHeaderActions(props: { state: SessionHeaderActionsState }) {
   return (
     <div class="flex items-center gap-2">
-      <Show when={props.state.status}>
-        {(status) => (
-          <Tooltip appearance="standard" placement="bottom" value={status().label}>
-            {status().content()}
-          </Tooltip>
-        )}
-      </Show>
       <Show when={props.state.reviewVisible}>
         <Tooltip
           class="shrink-0"
@@ -40,7 +32,7 @@ export function SessionHeaderActions(props: { state: SessionHeaderActionsState }
             type="button"
             variant="ghost-muted"
             size="large"
-            class="!w-9 shrink-0"
+            class="shrink-0"
             state={props.state.reviewOpened ? "pressed" : undefined}
             onClick={props.state.onReviewToggle}
             aria-label={props.state.reviewLabel}

--- a/packages/app/src/session/header/session-header.tsx
+++ b/packages/app/src/session/header/session-header.tsx
@@ -2,27 +2,18 @@ import { createMemo } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
 import { useCommand } from "@/shell/commands/command"
 import { useLanguage } from "@/runtime/i18n/language"
-import { useSettings } from "@/settings/model"
 import { useSessionLayout } from "@/session/session-layout"
 import { reviewTooltipKeybind } from "@/shell/commands/tooltip-keybind"
-import { StatusPopover } from "@/shell/status/status-popover"
-import { TitlebarRight } from "@/shell/titlebar/right-slot"
 import { SessionHeaderActions, type SessionHeaderActionsState } from "./session-header-actions"
 
 export function SessionHeader() {
   const command = useCommand()
   const language = useLanguage()
-  const settings = useSettings()
   const { view } = useSessionLayout()
 
-  const status = settings.visibility.status
   const isDesktop = createMediaQuery("(min-width: 768px)")
 
   const actions = createMemo<SessionHeaderActionsState>(() => ({
-    status:
-      isDesktop() && status()
-        ? { label: language.t("status.popover.trigger"), content: () => <StatusPopover /> }
-        : undefined,
     reviewLabel: language.t("command.review.toggle"),
     reviewKeybind: reviewTooltipKeybind(command),
     reviewVisible: isDesktop(),
@@ -30,9 +21,5 @@ export function SessionHeader() {
     onReviewToggle: () => view().reviewPanel.toggle(),
   }))
 
-  return (
-    <TitlebarRight>
-      <SessionHeaderActions state={actions()} />
-    </TitlebarRight>
-  )
+  return <SessionHeaderActions state={actions()} />
 }

--- a/packages/app/src/session/header/session-header.tsx
+++ b/packages/app/src/session/header/session-header.tsx
@@ -1,14 +1,19 @@
-import { createMemo } from "solid-js"
+import { createMemo, Show } from "solid-js"
 import { createMediaQuery } from "@solid-primitives/media"
 import { useCommand } from "@/shell/commands/command"
 import { useLanguage } from "@/runtime/i18n/language"
+import { useSettings } from "@/settings/model"
 import { useSessionLayout } from "@/session/session-layout"
 import { reviewTooltipKeybind } from "@/shell/commands/tooltip-keybind"
+import { StatusPopover } from "@/shell/status/status-popover"
+import { TitlebarRight } from "@/shell/titlebar/right-slot"
+import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { SessionHeaderActions, type SessionHeaderActionsState } from "./session-header-actions"
 
 export function SessionHeader() {
   const command = useCommand()
   const language = useLanguage()
+  const settings = useSettings()
   const { view } = useSessionLayout()
 
   const isDesktop = createMediaQuery("(min-width: 768px)")
@@ -21,5 +26,16 @@ export function SessionHeader() {
     onReviewToggle: () => view().reviewPanel.toggle(),
   }))
 
-  return <SessionHeaderActions state={actions()} />
+  return (
+    <>
+      <TitlebarRight>
+        <Show when={isDesktop() && settings.visibility.status()}>
+          <Tooltip appearance="standard" placement="bottom" value={language.t("status.popover.trigger")}>
+            <StatusPopover />
+          </Tooltip>
+        </Show>
+      </TitlebarRight>
+      <SessionHeaderActions state={actions()} />
+    </>
+  )
 }

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -12,7 +12,6 @@ import {
 } from "solid-js"
 import { createStore } from "solid-js/store"
 import { ResizeHandle } from "@opencode-ai/ui/resize-handle"
-import { SessionHeader } from "@/session/header/session-header"
 import { MessageTimeline, SessionSummaryPanel } from "@/session/timeline/message-timeline"
 import { useServer } from "@/runtime/server/current"
 import { projectForSession } from "@/shell/layout/helpers"
@@ -273,7 +272,6 @@ export function SessionScreen(props: { session: SessionModel }) {
 
   return (
     <>
-      <SessionHeader />
       <div class="flex-1 min-h-0 flex flex-col gap-2 px-2 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]">
         <div ref={screen.panel.ref} class="relative flex-1 min-h-0 flex flex-col md:flex-row gap-2">
           <div

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -32,6 +32,9 @@ import { parseCommentNote, readPromptPresentation } from "@/composer/comment-not
 import { useCommand } from "@/shell/commands/command"
 import { useSettings } from "@/settings/model"
 import { SessionTitleHeader } from "../session-identity-header"
+import { SessionHeader } from "@/session/header/session-header"
+import { StatusDialog } from "@/shell/status/status-popover"
+import { useDialog } from "@opencode-ai/ui/context/dialog"
 
 type BackgroundTask = {
   id: string
@@ -465,13 +468,16 @@ function MessageTimelineView(
     setScrollToEnd: props.setScrollToEnd,
   })
   const VirtualizedTimeline = virtualized.View
+  const dialog = useDialog()
   const [title, setTitle] = createStore({
     draft: "",
     editing: false,
     menuOpen: false,
     pendingRename: false,
+    pendingStatus: false,
   })
   let titleRef: HTMLInputElement | undefined
+  let menuRef: HTMLButtonElement | undefined
 
   createEffect(
     on(
@@ -482,6 +488,7 @@ function MessageTimelineView(
           editing: false,
           menuOpen: false,
           pendingRename: false,
+          pendingStatus: false,
         }),
       { defer: true },
     ),
@@ -732,6 +739,71 @@ function MessageTimelineView(
                       />
                     </Show>
                   </Show>
+                  <Show when={sessionID()} keyed>
+                    {(id) => (
+                      <Menu
+                        gutter={6}
+                        placement="bottom-end"
+                        open={title.menuOpen}
+                        onOpenChange={(open) => setTitle("menuOpen", open)}
+                      >
+                        <Menu.Trigger
+                          as={IconButton}
+                          ref={(element: HTMLButtonElement) => {
+                            menuRef = element
+                          }}
+                          icon={<Icon name="outline-dots" />}
+                          variant="ghost-muted"
+                          size="large"
+                          class="shrink-0"
+                          aria-label={language.t("common.moreOptions")}
+                          aria-expanded={title.menuOpen}
+                        />
+                        <Menu.Portal>
+                          <Menu.Content
+                            style={{ "min-width": "160px" }}
+                            onCloseAutoFocus={(event) => {
+                              if (title.pendingStatus) {
+                                event.preventDefault()
+                                setTitle("pendingStatus", false)
+                                menuRef?.focus()
+                                void dialog.show(() => <StatusDialog />)
+                                return
+                              }
+                              if (!title.pendingRename) return
+                              event.preventDefault()
+                              setTitle("pendingRename", false)
+                              openTitleEditor()
+                            }}
+                          >
+                            <Show when={!parentID()}>
+                              <Menu.Item
+                                onSelect={() => {
+                                  setTitle("pendingRename", true)
+                                  setTitle("menuOpen", false)
+                                }}
+                              >
+                                {language.t("common.rename")}
+                              </Menu.Item>
+                              <Menu.Item onSelect={() => void props.action.export(id)}>
+                                {language.t("common.export")}...
+                              </Menu.Item>
+                            </Show>
+                            <Menu.Item onSelect={() => setTitle({ pendingStatus: true, menuOpen: false })}>
+                              {language.t("settings.general.row.showStatus.title")}
+                            </Menu.Item>
+                            <Show when={!parentID()}>
+                              {/* TODO: Need a session archive API. */}
+                              <Menu.Separator />
+                              <Menu.Item onSelect={() => props.action.showDelete(id)}>
+                                {language.t("common.delete")}...
+                              </Menu.Item>
+                            </Show>
+                          </Menu.Content>
+                        </Menu.Portal>
+                      </Menu>
+                    )}
+                  </Show>
                 </div>
               </div>
               <Show when={sessionID()} keyed>
@@ -775,56 +847,7 @@ function MessageTimelineView(
                         </Popover>
                       )}
                     </Show>
-                    <Show when={!parentID()}>
-                      <Menu
-                        gutter={6}
-                        placement="bottom-end"
-                        open={title.menuOpen}
-                        onOpenChange={(open) => {
-                          setTitle("menuOpen", open)
-                          if (open) return
-                        }}
-                      >
-                        <Menu.Trigger
-                          as={IconButton}
-                          icon={<Icon name="outline-dots" />}
-                          variant="ghost-muted"
-                          size="large"
-                          aria-label={language.t("common.moreOptions")}
-                          aria-expanded={title.menuOpen}
-                        />
-                        <Menu.Portal>
-                          <Menu.Content
-                            style={{ width: "120px", "min-width": "120px" }}
-                            onCloseAutoFocus={(event) => {
-                              if (title.pendingRename) {
-                                event.preventDefault()
-                                setTitle("pendingRename", false)
-                                openTitleEditor()
-                                return
-                              }
-                            }}
-                          >
-                            <Menu.Item
-                              onSelect={() => {
-                                setTitle("pendingRename", true)
-                                setTitle("menuOpen", false)
-                              }}
-                            >
-                              {language.t("common.rename")}
-                            </Menu.Item>
-                            <Menu.Item onSelect={() => void props.action.export(id)}>
-                              {language.t("common.export")}...
-                            </Menu.Item>
-                            {/* TODO: Need a session archive API. */}
-                            <Menu.Separator />
-                            <Menu.Item onSelect={() => props.action.showDelete(id)}>
-                              {language.t("common.delete")}...
-                            </Menu.Item>
-                          </Menu.Content>
-                        </Menu.Portal>
-                      </Menu>
-                    </Show>
+                    <SessionHeader />
                   </div>
                 )}
               </Show>

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -33,8 +33,6 @@ import { useCommand } from "@/shell/commands/command"
 import { useSettings } from "@/settings/model"
 import { SessionTitleHeader } from "../session-identity-header"
 import { SessionHeader } from "@/session/header/session-header"
-import { StatusDialog } from "@/shell/status/status-popover"
-import { useDialog } from "@opencode-ai/ui/context/dialog"
 
 type BackgroundTask = {
   id: string
@@ -468,16 +466,13 @@ function MessageTimelineView(
     setScrollToEnd: props.setScrollToEnd,
   })
   const VirtualizedTimeline = virtualized.View
-  const dialog = useDialog()
   const [title, setTitle] = createStore({
     draft: "",
     editing: false,
     menuOpen: false,
     pendingRename: false,
-    pendingStatus: false,
   })
   let titleRef: HTMLInputElement | undefined
-  let menuRef: HTMLButtonElement | undefined
 
   createEffect(
     on(
@@ -488,7 +483,6 @@ function MessageTimelineView(
           editing: false,
           menuOpen: false,
           pendingRename: false,
-          pendingStatus: false,
         }),
       { defer: true },
     ),
@@ -749,9 +743,6 @@ function MessageTimelineView(
                       >
                         <Menu.Trigger
                           as={IconButton}
-                          ref={(element: HTMLButtonElement) => {
-                            menuRef = element
-                          }}
                           icon={<Icon name="outline-dots" />}
                           variant="ghost-muted"
                           size="large"
@@ -763,13 +754,6 @@ function MessageTimelineView(
                           <Menu.Content
                             style={{ "min-width": "160px" }}
                             onCloseAutoFocus={(event) => {
-                              if (title.pendingStatus) {
-                                event.preventDefault()
-                                setTitle("pendingStatus", false)
-                                menuRef?.focus()
-                                void dialog.show(() => <StatusDialog />)
-                                return
-                              }
                               if (!title.pendingRename) return
                               event.preventDefault()
                               setTitle("pendingRename", false)
@@ -789,9 +773,6 @@ function MessageTimelineView(
                                 {language.t("common.export")}...
                               </Menu.Item>
                             </Show>
-                            <Menu.Item onSelect={() => setTitle({ pendingStatus: true, menuOpen: false })}>
-                              {language.t("settings.general.row.showStatus.title")}
-                            </Menu.Item>
                             <Show when={!parentID()}>
                               {/* TODO: Need a session archive API. */}
                               <Menu.Separator />

--- a/packages/app/src/shell/shell.tsx
+++ b/packages/app/src/shell/shell.tsx
@@ -65,7 +65,7 @@ export default function Layout(props: ParentProps) {
             <aside
               ref={(element) => setState("tabsMount", element)}
               data-slot="vertical-tabs-sidebar"
-              class="relative flex min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]"
+              class="relative flex h-full min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]"
               style={{
                 width: `${state.tabsWidth}px`,
                 "padding-bottom": "max(8px, env(safe-area-inset-bottom, 0px))",

--- a/packages/app/src/shell/status/status-popover.tsx
+++ b/packages/app/src/shell/status/status-popover.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Popover } from "@opencode-ai/ui/popover"
+import { Dialog, DialogHeader, DialogTitle } from "@opencode-ai/ui/dialog"
 import { Suspense, createMemo, createSignal, lazy, Show, type JSX } from "solid-js"
 import { useLanguage } from "@/runtime/i18n/language"
 import { useGlobal } from "@/runtime/server/runtime"
@@ -9,6 +10,20 @@ import { useData, useServer } from "@/runtime/server/current"
 import { useWorkspaceLocation } from "@/workspaces/location"
 
 const Body = lazy(() => import("./body").then((x) => ({ default: x.StatusPopoverBody })))
+
+export function StatusDialog() {
+  const language = useLanguage()
+  return (
+    <Dialog fit class="w-[360px] max-w-[calc(100vw-32px)]">
+      <DialogHeader>
+        <DialogTitle>{language.t("settings.general.row.showStatus.title")}</DialogTitle>
+      </DialogHeader>
+      <StatusPopoverBody shown>
+        <Body shown embedded />
+      </StatusPopoverBody>
+    </Dialog>
+  )
+}
 
 export function StatusPopover() {
   const language = useLanguage()

--- a/packages/app/src/shell/status/status-popover.tsx
+++ b/packages/app/src/shell/status/status-popover.tsx
@@ -1,29 +1,16 @@
 import { Icon } from "@opencode-ai/ui/icon"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Popover } from "@opencode-ai/ui/popover"
-import { Dialog, DialogHeader, DialogTitle } from "@opencode-ai/ui/dialog"
 import { Suspense, createMemo, createSignal, lazy, Show, type JSX } from "solid-js"
 import { useLanguage } from "@/runtime/i18n/language"
 import { useGlobal } from "@/runtime/server/runtime"
 import { hasNonBlockingServiceIssue, hasServiceNeedingAttention, serverStatusDotClass } from "./indicator"
 import { useData, useServer } from "@/runtime/server/current"
 import { useWorkspaceLocation } from "@/workspaces/location"
+import { useSettings } from "@/settings/model"
+import { createMediaQuery } from "@solid-primitives/media"
 
 const Body = lazy(() => import("./body").then((x) => ({ default: x.StatusPopoverBody })))
-
-export function StatusDialog() {
-  const language = useLanguage()
-  return (
-    <Dialog fit class="w-[360px] max-w-[calc(100vw-32px)]">
-      <DialogHeader>
-        <DialogTitle>{language.t("settings.general.row.showStatus.title")}</DialogTitle>
-      </DialogHeader>
-      <StatusPopoverBody shown>
-        <Body shown embedded />
-      </StatusPopoverBody>
-    </Dialog>
-  )
-}
 
 export function StatusPopover() {
   const language = useLanguage()
@@ -31,6 +18,8 @@ export function StatusPopover() {
   const global = useGlobal()
   const data = useData()
   const sdk = useWorkspaceLocation()
+  const settings = useSettings()
+  const desktop = createMediaQuery("(min-width: 768px)")
   const [shown, setShown] = createSignal(false)
   const serverHealth = () => global.servers.health[server.key]?.healthy
   const mcp = () => data.location.mcp.server.list({ directory: sdk().directory })
@@ -52,6 +41,8 @@ export function StatusPopover() {
     serverHealth: serverHealth(),
     attention: attention(),
     issue: issue(),
+    placement: desktop() && settings.appearance.tabLayout() === "vertical" ? "top-start" : "bottom-end",
+    shift: desktop() && settings.appearance.tabLayout() === "vertical" ? 0 : -168,
     label: language.t("status.popover.trigger"),
     onOpenChange: setShown,
     body: () => (
@@ -70,6 +61,8 @@ type StatusPopoverState = {
   serverHealth: boolean | undefined
   attention: boolean
   issue: boolean
+  placement: "top-start" | "bottom-end"
+  shift: number
   label: string
   onOpenChange: (value: boolean) => void
   body: () => JSX.Element
@@ -92,8 +85,8 @@ function StatusPopoverView(props: { state: StatusPopoverState }) {
     class:
       "[&_[data-slot=popover-body]]:p-0 w-[360px] max-w-[calc(100vw-40px)] bg-transparent border-0 shadow-none rounded-xl",
     gutter: 4,
-    placement: "bottom-end" as const,
-    shift: -168,
+    placement: props.state.placement,
+    shift: props.state.shift,
   }
 
   return (

--- a/packages/app/src/shell/titlebar/tab-nav.css
+++ b/packages/app/src/shell/titlebar/tab-nav.css
@@ -86,6 +86,10 @@
   gap: 2px;
 }
 
+[data-slot="vertical-tabs-sidebar"] [data-titlebar-tab-list][data-orientation="vertical"] {
+  gap: 4px;
+}
+
 [data-titlebar-tab-slot] {
   --tab-separator: var(--v2-background-bg-layer-03);
   position: relative;

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -438,7 +438,7 @@ export function Titlebar(props: {
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} />
                 </Show>
-                <Show when={!mobile() && !macVerticalTabs()}>{homeButton()}</Show>
+                <Show when={!mobile() && !props.verticalTabs}>{homeButton()}</Show>
 
                 <Show
                   when={!mobile()}
@@ -632,8 +632,8 @@ export function Titlebar(props: {
                                   <TitlebarRightMount />
                                 </div>
                               </div>
-                              {homeButton(true)}
                             </Show>
+                            {homeButton(true)}
                             <button
                               type="button"
                               data-action="vertical-tabs-new-session"

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -627,11 +627,7 @@ export function Titlebar(props: {
                                 class="relative w-full shrink-0"
                                 style={{ height: `${macTrafficLightsTopClearance / zoom()}px` }}
                                 data-tauri-drag-region
-                              >
-                                <div class="absolute right-0 top-0 flex h-full items-center [app-region:no-drag]">
-                                  <TitlebarRightMount />
-                                </div>
-                              </div>
+                              ></div>
                             </Show>
                             {homeButton(true)}
                             <button
@@ -665,6 +661,9 @@ export function Titlebar(props: {
                               <div class="absolute bottom-0 left-0 flex h-9 items-center">
                                 <ChannelIndicator debugTools={props.debugTools} />
                               </div>
+                              <div class="absolute bottom-0 right-0 flex h-9 items-center">
+                                <TitlebarRightMount />
+                              </div>
                             </div>
                           </Portal>
                         )}
@@ -675,7 +674,7 @@ export function Titlebar(props: {
                 <Show when={!mobile()}>
                   <div class="flex-1" />
                 </Show>
-                <TitlebarRight state={rightState()} mount={!macVerticalTabs()} />
+                <TitlebarRight state={rightState()} mount={!props.verticalTabs} />
               </div>
             )
           }}

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -107,7 +107,7 @@ export function Titlebar(props: {
   const rightState = createMemo<TitlebarRightState>(() => ({
     update: updateState(),
   }))
-  const hideMacVerticalTitlebar = createMemo(() => macVerticalTabs() && !updateState().visible)
+  const hideVerticalTitlebar = createMemo(() => !!props.verticalTabs && !windows())
 
   const back = () => {
     const next = backPath(history)
@@ -143,7 +143,7 @@ export function Titlebar(props: {
   return (
     <header
       data-slot="titlebar-v2"
-      hidden={hideMacVerticalTitlebar()}
+      hidden={hideVerticalTitlebar()}
       classList={{
         "shrink-0 relative flex flex-row h-9 bg-v2-background-bg-deep overflow-visible": true,
         "order-last": bottom(),
@@ -432,7 +432,7 @@ export function Titlebar(props: {
                   "md:pl-4": !macTrafficLights(),
                 }}
               >
-                <Show when={!mobile() && !macVerticalTabs()}>
+                <Show when={!mobile() && !props.verticalTabs}>
                   <ChannelIndicator debugTools={props.debugTools} />
                 </Show>
                 <Show when={windows() || linux()}>
@@ -626,7 +626,7 @@ export function Titlebar(props: {
                               <div
                                 class="relative w-full shrink-0"
                                 style={{ height: `${macTrafficLightsTopClearance / zoom()}px` }}
-                                data-tauri-drag-region={hideMacVerticalTitlebar() ? true : undefined}
+                                data-tauri-drag-region
                               >
                                 <div class="absolute right-0 top-0 flex h-full items-center [app-region:no-drag]">
                                   <TitlebarRightMount />
@@ -661,13 +661,11 @@ export function Titlebar(props: {
                                 onReorder={(keys) => tabsStoreActions.reorder(keys)}
                               />
                             </div>
-                            <Show when={macVerticalTabs()}>
-                              <div data-slot="vertical-tabs-footer" class="relative mt-auto h-9 w-full shrink-0">
-                                <div class="absolute bottom-0 left-0 flex h-9 items-center">
-                                  <ChannelIndicator debugTools={props.debugTools} />
-                                </div>
+                            <div data-slot="vertical-tabs-footer" class="relative mt-auto h-9 w-full shrink-0">
+                              <div class="absolute bottom-0 left-0 flex h-9 items-center">
+                                <ChannelIndicator debugTools={props.debugTools} />
                               </div>
-                            </Show>
+                            </div>
                           </Portal>
                         )}
                       </Show>

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -37,6 +37,7 @@ const windowsTitlebarHeight = 44 // Includes the content inset; matches the nati
 const minTitlebarZoom = 0.25
 const windowsControlsBaseWidth = 138 // 3 native Windows caption buttons at 46px each.
 const macTrafficLightsBaseWidth = 84
+const macTrafficLightsTopClearance = 28
 
 export type TitlebarUpdate = {
   version: string | undefined
@@ -624,7 +625,7 @@ export function Titlebar(props: {
                             <Show when={macVerticalTabs()}>
                               <div
                                 class="relative w-full shrink-0"
-                                style={{ height: `${(titlebarHeight - 8) / zoom()}px` }}
+                                style={{ height: `${macTrafficLightsTopClearance / zoom()}px` }}
                                 data-tauri-drag-region={hideMacVerticalTitlebar() ? true : undefined}
                               >
                                 <div class="absolute right-0 top-0 flex h-full items-center [app-region:no-drag]">

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -63,6 +63,7 @@ export function Titlebar(props: {
   const windows = createMemo(() => platform.platform === "desktop" && platform.os === "windows")
   const linux = createMemo(() => platform.platform === "desktop" && platform.os === "linux")
   const macTrafficLights = createMemo(() => mac() && !platform.windowFullscreen?.())
+  const macVerticalTabs = createMemo(() => mac() && !!props.verticalTabs)
   const zoom = () => platform.webviewZoom?.() ?? 1
   const titlebarZoom = () => (windows() ? Math.max(zoom(), minTitlebarZoom) : zoom())
   const minHeight = () => {
@@ -105,6 +106,7 @@ export function Titlebar(props: {
   const rightState = createMemo<TitlebarRightState>(() => ({
     update: updateState(),
   }))
+  const hideMacVerticalTitlebar = createMemo(() => macVerticalTabs() && !updateState().visible)
 
   const back = () => {
     const next = backPath(history)
@@ -140,6 +142,7 @@ export function Titlebar(props: {
   return (
     <header
       data-slot="titlebar-v2"
+      hidden={hideMacVerticalTitlebar()}
       classList={{
         "shrink-0 relative flex flex-row h-9 bg-v2-background-bg-deep overflow-visible": true,
         "order-last": bottom(),
@@ -311,6 +314,48 @@ export function Titlebar(props: {
               }
             }
             const toggleHome = () => tabs.toggleHome({ home: layout.route().type === "home", current: currentTab() })
+            const homeButton = (vertical = false) => (
+              <Show
+                when={vertical}
+                fallback={
+                  <Tooltip
+                    placement="bottom"
+                    value={
+                      <>
+                        {language.t("home.title")}
+                        <Keybind keys={command.keybindParts("home.toggle")} variant="neutral" />
+                      </>
+                    }
+                    class="shrink-0"
+                  >
+                    <IconButton
+                      type="button"
+                      variant="ghost-muted"
+                      size="large"
+                      class="!w-9 shrink-0"
+                      icon={<Icon name="grid-plus" />}
+                      state={layout.route().type === "home" ? "pressed" : undefined}
+                      onClick={toggleHome}
+                      aria-label={language.t("home.title")}
+                      aria-pressed={layout.route().type === "home"}
+                    />
+                  </Tooltip>
+                }
+              >
+                <button
+                  type="button"
+                  data-action="vertical-tabs-home"
+                  data-state={layout.route().type === "home" ? "pressed" : undefined}
+                  class="mb-1 flex h-7 w-full shrink-0 items-center gap-1.5 rounded-[6px] px-1.5 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 hover:text-v2-text-text-base data-[state=pressed]:bg-v2-background-bg-layer-02 data-[state=pressed]:text-v2-text-text-base"
+                  onClick={toggleHome}
+                  aria-label={language.t("home.title")}
+                  aria-pressed={layout.route().type === "home"}
+                >
+                  <Icon name="grid-plus" />
+                  {language.t("home.title")}
+                </button>
+              </Show>
+            )
 
             command.register("titlebar-home", () => [
               {
@@ -386,36 +431,13 @@ export function Titlebar(props: {
                   "md:pl-4": !macTrafficLights(),
                 }}
               >
-                <Show when={!mobile()}>
+                <Show when={!mobile() && !macVerticalTabs()}>
                   <ChannelIndicator debugTools={props.debugTools} />
                 </Show>
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} />
                 </Show>
-                <Show when={!mobile()}>
-                  <Tooltip
-                    placement="bottom"
-                    value={
-                      <>
-                        {language.t("home.title")}
-                        <Keybind keys={command.keybindParts("home.toggle")} variant="neutral" />
-                      </>
-                    }
-                    class="shrink-0"
-                  >
-                    <IconButton
-                      type="button"
-                      variant="ghost-muted"
-                      size="large"
-                      class="!w-9 shrink-0"
-                      icon={<Icon name="grid-plus" />}
-                      state={layout.route().type === "home" ? "pressed" : undefined}
-                      onClick={toggleHome}
-                      aria-label={language.t("home.title")}
-                      aria-pressed={layout.route().type === "home"}
-                    />
-                  </Tooltip>
-                </Show>
+                <Show when={!mobile() && !macVerticalTabs()}>{homeButton()}</Show>
 
                 <Show
                   when={!mobile()}
@@ -595,31 +617,56 @@ export function Titlebar(props: {
                     {(vertical) => (
                       <Show when={vertical().mount} keyed>
                         {(mount) => (
-                          <Portal mount={mount}>
-                            <TitlebarTabStrip
-                              orientation="vertical"
-                              tabs={tabsStore}
-                              currentTab={currentTab()}
-                              onNavigate={(tab, el) => {
-                                tabs.select(tab)
-                                el?.scrollIntoView({ behavior: "instant", block: "nearest" })
-                              }}
-                              onClose={(tab) => {
-                                const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
-                                if (index !== -1) tabsStoreActions.closeTab(index)
-                              }}
-                              onReorder={(keys) => tabsStoreActions.reorder(keys)}
-                            />
+                          <Portal
+                            mount={mount}
+                            ref={(element) => (element.className = "flex size-full min-h-0 flex-col")}
+                          >
+                            <Show when={macVerticalTabs()}>
+                              <div
+                                class="relative w-full shrink-0"
+                                style={{ height: `${(titlebarHeight - 8) / zoom()}px` }}
+                                data-tauri-drag-region={hideMacVerticalTitlebar() ? true : undefined}
+                              >
+                                <div class="absolute right-0 top-0 flex h-full items-center [app-region:no-drag]">
+                                  <TitlebarRightMount />
+                                </div>
+                              </div>
+                              {homeButton(true)}
+                            </Show>
                             <button
                               type="button"
                               data-action="vertical-tabs-new-session"
-                              class="mt-1 flex h-7 w-full shrink-0 items-center gap-1.5 rounded-[6px] px-1.5 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 hover:text-v2-text-text-base"
+                              class="flex h-7 w-full shrink-0 items-center gap-1.5 rounded-[6px] px-1.5 text-[13px] leading-4 text-v2-text-text-faint hover:bg-v2-background-bg-layer-02 hover:text-v2-text-text-base"
                               onClick={openNewTab}
                               aria-label={language.t("command.session.new")}
                             >
                               <Icon name="plus" />
                               {language.t("command.session.new")}
                             </button>
+                            <div class="my-1 h-px w-full shrink-0 bg-v2-border-border-muted" aria-hidden="true" />
+                            <div class="flex min-h-0 flex-1 flex-col gap-1">
+                              <TitlebarTabStrip
+                                orientation="vertical"
+                                tabs={tabsStore}
+                                currentTab={currentTab()}
+                                onNavigate={(tab, el) => {
+                                  tabs.select(tab)
+                                  el?.scrollIntoView({ behavior: "instant", block: "nearest" })
+                                }}
+                                onClose={(tab) => {
+                                  const index = tabsStore.findIndex((item) => tabKey(item) === tabKey(tab))
+                                  if (index !== -1) tabsStoreActions.closeTab(index)
+                                }}
+                                onReorder={(keys) => tabsStoreActions.reorder(keys)}
+                              />
+                            </div>
+                            <Show when={macVerticalTabs()}>
+                              <div data-slot="vertical-tabs-footer" class="relative mt-auto h-9 w-full shrink-0">
+                                <div class="absolute bottom-0 left-0 flex h-9 items-center">
+                                  <ChannelIndicator debugTools={props.debugTools} />
+                                </div>
+                              </div>
+                            </Show>
                           </Portal>
                         )}
                       </Show>
@@ -629,7 +676,7 @@ export function Titlebar(props: {
                 <Show when={!mobile()}>
                   <div class="flex-1" />
                 </Show>
-                <TitlebarRight state={rightState()} />
+                <TitlebarRight state={rightState()} mount={!macVerticalTabs()} />
               </div>
             )
           }}
@@ -652,13 +699,15 @@ type TitlebarRightState = {
   update: TitlebarUpdatePillState
 }
 
-function TitlebarRight(props: { state: TitlebarRightState }) {
+function TitlebarRight(props: { state: TitlebarRightState; mount?: boolean }) {
   return (
     <div class="relative z-20 flex shrink-0 items-center justify-end gap-0 overflow-visible">
       <Show when={props.state.update.visible}>
         <TitlebarUpdateIconButton state={props.state.update} />
       </Show>
-      <TitlebarRightMount />
+      <Show when={props.mount !== false}>
+        <TitlebarRightMount />
+      </Show>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- place the session overflow menu beside the session title and keep server status as a dedicated button
- keep session details followed by the right-panel toggle at the outer edge
- place full-width Home and New session rows above vertical tabs and preserve fixed macOS traffic-light clearance
- remove the vertical-tabs topbar outside Windows and move the channel label to the footer
- place server status at the bottom-right of the vertical sidebar

## Before / After

| Before | After |
| --- | --- |
| ![Before: session navigation controls before reorganization](https://github.com/user-attachments/assets/179f9015-0afa-474b-8b83-6f4f2d63deb8) | ![After: server status in the bottom-right of vertical tabs](https://github.com/user-attachments/assets/c637bc35-f8f9-432b-b0c3-65cf691aaa0d) |

## Validation

- `bun typecheck` (`packages/app`)
- `bun run typecheck:e2e` (`packages/app`)
- `bun test --conditions=solid --preload ./happydom.ts ./src/shell/titlebar ./src/shell/status` (`packages/app`)
- `PLAYWRIGHT_BUILD=1 PLAYWRIGHT_PORT=4484 bunx playwright test e2e/regression/session-header-controls.spec.ts e2e/regression/tab-navigate-mousedown.spec.ts --workers=1 --retries=0 --reporter=line` (`packages/app`)
- focused vertical-tabs regression after making Home full width
- production tab-switch benchmark, warm cache/review closed: 33.0ms first correct, 49.9ms stable
