### PR TITLE
fix(app): shrink new session tab

### DIFF
--- a/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
+++ b/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
@@ -30,7 +30,9 @@ test("new session tab hugs its content", async ({ page }) => {
   const sessionTab = page.locator(`[data-titlebar-tab-slot]:has(a[href="${href}"])`)
   const draftTab = page.locator('[data-titlebar-tab-slot]:has(a[href^="/new-session?draftId="])')
   await expect(draftTab).toContainText("New session")
-  expect((await draftTab.boundingBox())?.width).toBeLessThan((await sessionTab.boundingBox())?.width ?? 0)
+  const width = (await draftTab.boundingBox())?.width ?? 0
+  expect(width).toBeGreaterThan(100)
+  expect(width).toBeLessThan((await sessionTab.boundingBox())?.width ?? 0)
 })
 
 test("pressing mouse down on a tab navigates before mouse up", async ({ page }) => {

--- a/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
+++ b/packages/app/e2e/regression/tab-navigate-mousedown.spec.ts
@@ -9,6 +9,30 @@ const sessionB = session("ses_tab_b", "Tab B session")
 const sessionC = session("ses_tab_c", "Tab C session")
 const unresolvedSessionID = "ses_tab_unresolved"
 
+test("new session tab hugs its content", async ({ page }) => {
+  await mockServer(page)
+  await page.addInitScript(
+    ({ server, sessionID, directory }) => {
+      localStorage.setItem(
+        "opencode.window.browser.dat:tabs",
+        JSON.stringify([
+          { type: "session", server, sessionId: sessionID },
+          { type: "draft", server, directory, draftID: "draft_tab_width" },
+        ]),
+      )
+    },
+    { server, sessionID: sessionA.id, directory: sessionA.directory },
+  )
+
+  const href = `/server/${base64Encode(server)}/session/${sessionA.id}`
+  await page.goto(href)
+
+  const sessionTab = page.locator(`[data-titlebar-tab-slot]:has(a[href="${href}"])`)
+  const draftTab = page.locator('[data-titlebar-tab-slot]:has(a[href^="/new-session?draftId="])')
+  await expect(draftTab).toContainText("New session")
+  expect((await draftTab.boundingBox())?.width).toBeLessThan((await sessionTab.boundingBox())?.width ?? 0)
+})
+
 test("pressing mouse down on a tab navigates before mouse up", async ({ page }) => {
   await mockServer(page)
   await page.addInitScript(

--- a/packages/app/src/shell/titlebar/tab-nav.tsx
+++ b/packages/app/src/shell/titlebar/tab-nav.tsx
@@ -431,7 +431,7 @@ export function DraftTabItem(props: {
           props.onNavigate()
         }}
         class="flex h-full min-w-0 flex-row items-center gap-1.5 text-[13px] font-medium text-v2-text-text-faint group-data-[active='true']:text-v2-text-text-base [-webkit-user-drag:none]"
-        classList={{ "flex-1": props.orientation === "vertical", "flex-none pe-5": props.orientation !== "vertical" }}
+        classList={{ "flex-1": props.orientation === "vertical", "flex-none pe-10": props.orientation !== "vertical" }}
       >
         <span class="flex size-4 shrink-0 items-center justify-center">
           <Icon name="edit" />

--- a/packages/app/src/shell/titlebar/tab-nav.tsx
+++ b/packages/app/src/shell/titlebar/tab-nav.tsx
@@ -393,8 +393,11 @@ export function DraftTabItem(props: {
       data-active={props.active}
       data-dragging={props.dragging}
       data-state={props.active || props.pressed ? "pressed" : undefined}
-      class="group relative flex h-7 w-full min-w-0 flex-row items-center gap-1.5 overflow-hidden rounded-[6px] px-1.5 [container-type:inline-size] whitespace-nowrap"
-      classList={{ invisible: props.hidden }}
+      class="group relative flex h-7 min-w-0 flex-row items-center gap-1.5 overflow-hidden rounded-[6px] px-1.5 whitespace-nowrap"
+      classList={{
+        invisible: props.hidden,
+        "w-full [container-type:inline-size]": props.orientation === "vertical",
+      }}
       onMouseDown={(event) => {
         if (event.button !== MIDDLE_MOUSE_BUTTON) return
         event.preventDefault()
@@ -427,14 +430,16 @@ export function DraftTabItem(props: {
           if (props.suppressNavigation) return
           props.onNavigate()
         }}
-        class="flex h-full min-w-0 flex-1 flex-row items-center gap-1.5 text-[13px] font-medium text-v2-text-text-faint group-data-[active='true']:text-v2-text-text-base [-webkit-user-drag:none]"
+        class="flex h-full min-w-0 flex-row items-center gap-1.5 text-[13px] font-medium text-v2-text-text-faint group-data-[active='true']:text-v2-text-text-base [-webkit-user-drag:none]"
+        classList={{ "flex-1": props.orientation === "vertical", "flex-none pe-5": props.orientation !== "vertical" }}
       >
         <span class="flex size-4 shrink-0 items-center justify-center">
           <Icon name="edit" />
         </span>
         <span
           data-titlebar-tab-title
-          class="min-w-0 flex-1 overflow-hidden text-clip whitespace-nowrap outline-none leading-4"
+          class="min-w-0 overflow-hidden text-clip whitespace-nowrap outline-none leading-4"
+          classList={{ "flex-1": props.orientation === "vertical", "flex-none": props.orientation !== "vertical" }}
         >
           {props.title}
         </span>

--- a/packages/app/src/shell/titlebar/tab-strip.tsx
+++ b/packages/app/src/shell/titlebar/tab-strip.tsx
@@ -212,7 +212,7 @@ function DraftTabSlot(props: {
       data-orientation={props.orientation}
       class="relative flex"
       classList={{
-        "w-56 min-w-7 max-w-56 flex-shrink": props.orientation === "horizontal",
+        "w-max min-w-7 max-w-56 shrink-0": props.orientation === "horizontal",
         "w-full shrink-0": props.orientation === "vertical",
       }}
     >


### PR DESCRIPTION
## Summary

- size horizontal new-session tabs to their icon and label instead of the standard session-tab width
- preserve the full label, close-control fade space, and existing vertical tab layout
- add browser regression coverage for the compact draft-tab width

## Before / After

| Before | After |
| --- | --- |
| ![Before: New session tab uses the full standard tab width](https://github.com/user-attachments/assets/996d396e-a961-4138-a7cb-6eee7164ea22) | ![After: New session tab hugs its icon, label, and close control](https://github.com/user-attachments/assets/de687dd0-cd58-463e-90a0-16fd0033fd49) |

## Validation

- `PLAYWRIGHT_PORT=3177 bun run test:e2e -- e2e/regression/tab-navigate-mousedown.spec.ts` (7 passed)
- `bun typecheck`
- `bun run typecheck:e2e`

## Issues

- https://linear.app/anomalyco/issue/OCD-150/reduce-the-width-of-the-new-session-tab-to-hug-the-content-when-there
- https://github.com/anomalyco/opencontrol/issues/198
