### PR TITLE
fix(ui): update summary panel icon

### DIFF
--- a/packages/ui/src/icons/icon/icon.tsx
+++ b/packages/ui/src/icons/icon/icon.tsx
@@ -134,7 +134,7 @@ const icons = {
   },
   "window-analytics": {
     viewBox: "0 0 16 16",
-    body: `<g transform="translate(1 2)"><path d="M7 4H11M7 8H11M0.5 0.5V11.5H13.5V0.5H0.5ZM3.5 3.5H4.5V4.5H3.5V3.5ZM3.5 7.5H4.5V8.5H3.5V7.5Z" stroke="currentColor" stroke-miterlimit="10" stroke-linecap="square"/></g>`,
+    body: `<path d="M14.5 9.8333V13.5H1.5V2.5H7.1667M9.5 2.5V7.5H14.5V2.5H9.5Z" stroke="currentColor" stroke-miterlimit="10" stroke-linecap="square"/>`,
   },
   trash: {
     viewBox: "0 0 20 20",


### PR DESCRIPTION
## Summary

- replace the summary panel trigger artwork with the latest supplied SVG
- preserve the existing icon name, viewport, sizing, and theme-aware color

## Before / After

| Before | After |
| --- | --- |
| ![Before: previous summary panel icon](https://github.com/user-attachments/assets/7c885ddf-cc48-4215-a435-4e32f471693f) | ![After: latest summary panel icon](https://github.com/user-attachments/assets/92ee96c6-929c-45c4-887d-c9019f9e659e) |

## Validation

- `bun typecheck` (`packages/ui`)
- `bun test` (`packages/ui`, 47 passed)
- pre-push workspace typecheck (33 tasks passed)

Linear: https://linear.app/anomalyco/issue/OCD-152/replace-the-summary-panel-icon-with-the-latest-one

Synced issue: https://github.com/anomalyco/opencontrol/issues/200
