### PR TITLE
fix(app): contain composer horizontal overflow

### DIFF
--- a/packages/app/e2e/regression/composer-command-draft.spec.ts
+++ b/packages/app/e2e/regression/composer-command-draft.spec.ts
@@ -8,7 +8,8 @@ const projectID = "proj_composer_editing"
 const sessionID = "ses_composer_editing"
 const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
 
-test("preserves the draft when a populated command menu triggers a built-in", async ({ page }) => {
+test("keeps a narrow session composer contained when invoking a built-in", async ({ page }) => {
+  await page.setViewportSize({ width: 800, height: 600 })
   await mockOpenCodeServer(page, {
     directory,
     project: {
@@ -40,6 +41,8 @@ test("preserves the draft when a populated command menu triggers a built-in", as
     .poll(() => input.evaluate((element) => getComputedStyle(element, "::before").content))
     .toBe(`"${String.fromCodePoint(0x200b)}"`)
   await expectAppVisible(composer)
+  await expect(page.locator('[data-slot="session-chat-panel"]')).toHaveCSS("min-width", "0px")
+  await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= innerWidth)).toBe(true)
 
   await input.fill("keep me")
   await composer.getByRole("button", { name: "Add images and files" }).click()

--- a/packages/app/src/session/screen.tsx
+++ b/packages/app/src/session/screen.tsx
@@ -278,7 +278,8 @@ export function SessionScreen(props: { session: SessionModel }) {
         <div ref={screen.panel.ref} class="relative flex-1 min-h-0 flex flex-col md:flex-row gap-2">
           <div
             classList={{
-              "@container relative z-10 shrink-0 flex flex-col min-h-0 h-full flex-1 md:flex-none transition-[width]": true,
+              "@container relative z-10 min-w-0 shrink-0 flex flex-col min-h-0 h-full flex-1 md:flex-none transition-[width]":
+                true,
               "duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
                 !screen.size.active() && sidePresence.animate(),
               "transition-none": screen.size.active() || !sidePresence.animate(),


### PR DESCRIPTION
## Summary

- allow the Session chat pane to shrink below the composer's intrinsic control width
- prevent the composer from widening the split Session layout and causing horizontal overscroll
- cover the narrow Session route with layout and document overflow assertions

## Before / After

| Before | After |
| --- | --- |
| ![Before: composer expands the chat pane beyond its assigned split width](https://github.com/user-attachments/assets/0eda7607-f2bd-4585-8a97-48c19e2718c2) | ![After: composer remains contained within the assigned chat pane width](https://github.com/user-attachments/assets/a5ee69fa-7175-4155-bc6b-0f805356e3d3) |

## Validation

- `bun run test:e2e composer-command-draft.spec.ts --reporter=line`
- `bun typecheck` (`packages/app`)
- `bun run typecheck:e2e` (`packages/app`)
- repository pre-push `bun typecheck` (39 packages)

Fixes [OCD-146](https://linear.app/anomalyco/issue/OCD-146/horizontal-over-scroll-in-the-composer)
Synced report: [anomalyco/opencontrol#194](https://github.com/anomalyco/opencontrol/issues/194)
