### PR TITLE
fix(provider): default a stream-idle timeout for openai-compatible providers

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -34,6 +34,24 @@ import { ProviderError } from "./error"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 300_000
 
+// Stream-idle guard default for @ai-sdk/openai-compatible providers. Named providers
+// (openai, anthropic, ...) receive timeout defaults, but custom openai-compatible
+// providers did not, so a backend that stalls mid-stream would hang the session
+// indefinitely (issue #46581). Overridable via provider options.chunkTimeout.
+const OPENAI_COMPATIBLE_CHUNK_TIMEOUT_DEFAULT = 300_000
+
+/**
+ * Apply the defaults @ai-sdk/openai-compatible model options need. Extracted as a
+ * pure, exported function so the defaulting behavior is unit-testable in isolation.
+ * Mutates and returns `options`; a no-op for other providers.
+ */
+export function applyOpenAICompatibleDefaults(npm: string, options: Record<string, any>) {
+  if (!npm.includes("@ai-sdk/openai-compatible")) return options
+  if (options["includeUsage"] !== false) options["includeUsage"] = true
+  if (options["chunkTimeout"] === undefined) options["chunkTimeout"] = OPENAI_COMPATIBLE_CHUNK_TIMEOUT_DEFAULT
+  return options
+}
+
 function wrapSSE(res: Response, ms: number, ctl: AbortController) {
   if (typeof ms !== "number" || ms <= 0) return res
   if (!res.body) return res
@@ -1748,9 +1766,7 @@ const layer = Layer.effect(
           delete options.fetch
         }
 
-        if (model.api.npm.includes("@ai-sdk/openai-compatible") && options["includeUsage"] !== false) {
-          options["includeUsage"] = true
-        }
+        applyOpenAICompatibleDefaults(model.api.npm, options)
 
         const baseURL = iife(() => {
           let url =

--- a/packages/opencode/test/provider/openai-compatible-defaults.test.ts
+++ b/packages/opencode/test/provider/openai-compatible-defaults.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { applyOpenAICompatibleDefaults } from "@/provider/provider"
+
+// Regression tests for the default stream-idle guard on @ai-sdk/openai-compatible
+// providers (issue #46581). Without a default chunkTimeout, a backend that stalls
+// mid-stream hangs the session indefinitely; named providers already default a
+// timeout, custom openai-compatible ones did not.
+
+test("defaults chunkTimeout for openai-compatible when unset", () => {
+  const options = applyOpenAICompatibleDefaults("@ai-sdk/openai-compatible", {})
+  expect(typeof options.chunkTimeout).toBe("number")
+  expect(options.chunkTimeout).toBeGreaterThan(0)
+  expect(options.includeUsage).toBe(true)
+})
+
+test("does not override an explicitly configured chunkTimeout", () => {
+  const options = applyOpenAICompatibleDefaults("@ai-sdk/openai-compatible", { chunkTimeout: 5_000 })
+  expect(options.chunkTimeout).toBe(5_000)
+})
+
+test("does not override an explicit includeUsage=false", () => {
+  const options = applyOpenAICompatibleDefaults("@ai-sdk/openai-compatible", { includeUsage: false })
+  expect(options.includeUsage).toBe(false)
+})
+
+test("leaves non-openai-compatible providers untouched", () => {
+  const options = applyOpenAICompatibleDefaults("@ai-sdk/anthropic", {})
+  expect(options.chunkTimeout).toBeUndefined()
+  expect(options.includeUsage).toBeUndefined()
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #46581

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Custom `@ai-sdk/openai-compatible` providers never got a `chunkTimeout` or `headerTimeout` default. `wrapSSE()` is a no-op when `chunkTimeout` is unset (`if (typeof ms !== "number" || ms <= 0) return res`), so these providers stream with no idle guard at all — a backend that stalls mid-stream hangs the session indefinitely. Named providers (`openai`, `anthropic`) already default a timeout; this gives openai-compatible providers the same protection via an overridable `chunkTimeout` default (300s, matching the header-timeout default).

I moved the existing inline `includeUsage` defaulting into a small exported `applyOpenAICompatibleDefaults()` and added the `chunkTimeout` default there. `includeUsage` behavior is unchanged.

This covers the stream-stall mode (no SSE bytes for the timeout window). The other mode in #46581 — the stream closing on `[DONE]` while the AI SDK's `fullStream` still awaits a usage chunk — is not addressed here, because a byte-idle timeout can't fire once the final byte has arrived; that one needs a change at the AI-SDK adapter and I'd rather keep it separate.

I hit this running unattended `opencode run` sessions against a local llama.cpp server; a couple stalled and hung until an external timeout. Forensics are in the comment on #46581.

### How did you verify your code works?

- New `test/provider/openai-compatible-defaults.test.ts`: default applied for openai-compatible, not applied to other providers, never overrides an explicit `chunkTimeout`, preserves `includeUsage: false`.
- `test/provider/header-timeout.test.ts` already verifies that a set `chunkTimeout` turns a stalled SSE stream into a `ResponseStreamError`; this change makes that apply by default.
- Full `test/provider/` suite passes (593 tests). `typecheck` and prettier clean.

### Screenshots / recordings

n/a — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
