### PR TITLE
fix(ui): make comment cancel action ghost

### DIFF
--- a/packages/session-ui/component-tests/line-comment-v2.spec.ts
+++ b/packages/session-ui/component-tests/line-comment-v2.spec.ts
@@ -1,0 +1,6 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+story("renders the line comment cancel action as a ghost button", async ({ mount }) => {
+  const root = await mount("ui-line-comment--editor-filled")
+  await expect(root.getByRole("button", { name: "Cancel" })).toHaveAttribute("data-variant", "ghost")
+})

--- a/packages/ui/src/data-display/line-comment/line-comment.stories.tsx
+++ b/packages/ui/src/data-display/line-comment/line-comment.stories.tsx
@@ -3,7 +3,7 @@ import { createSignal } from "solid-js"
 import { LineCommentEditor, LineComment, LineCommentOverflowIcon } from "./line-comment"
 
 const docs = `### Overview
-Line comment **display** and **editor** cards aligned with OpenCode line-comment specs (raised \`#FAFAFA\` surface, footer line context, \`Button\` neutral + contrast actions).
+Line comment **display** and **editor** cards aligned with OpenCode line-comment specs (raised \`#FAFAFA\` surface, footer line context, \`Button\` ghost + contrast actions).
 
 ### Display
 - \`LineComment\`: column stack (body + meta) beside optional \`actions\` (overflow).

--- a/packages/ui/src/data-display/line-comment/line-comment.tsx
+++ b/packages/ui/src/data-display/line-comment/line-comment.tsx
@@ -294,7 +294,7 @@ export function LineCommentEditor(props: LineCommentEditorProps) {
         <div data-slot="line-comment-v2-footer">
           <div data-slot="line-comment-v2-footer-meta">{local.selection}</div>
           <div data-slot="line-comment-v2-footer-actions">
-            <Button type="button" size="normal" variant="neutral" onClick={() => local.onCancel()}>
+            <Button type="button" size="normal" variant="ghost" onClick={() => local.onCancel()}>
               {local.cancelLabel ?? i18n.t("ui.lineComment.cancel")}
             </Button>
             <Button type="button" size="normal" variant="contrast" disabled={!canSubmit()} onClick={submit}>


### PR DESCRIPTION
## Summary

- render the comment editor's cancel action with the ghost button variant
- document and test the ghost/contrast action pairing in the shared line comment story

## Before / After

| Before | After |
| --- | --- |
| ![Before: comment editor with a bordered neutral Cancel button](https://github.com/user-attachments/assets/74710da7-e4b4-4b68-8a57-53a9d23c8289) | ![After: comment editor with a borderless ghost Cancel button](https://github.com/user-attachments/assets/757cce07-c901-43f2-95a9-f77b74048f35) |

## Validation

- `bun typecheck` (`packages/ui`)
- `bun typecheck` (`packages/session-ui`)
- `bun run test:components component-tests/line-comment-v2.spec.ts` (`packages/session-ui`)
- repository pre-push typecheck (39 packages)

Closes anomalyco/opencontrol#201
Linear: [OCD-153](https://linear.app/anomaly/issue/OCD-153)
