### PR TITLE
fix(ui): use ghost comment cancel button

### DIFF
--- a/packages/session-ui/component-tests/line-comment-v2.spec.ts
+++ b/packages/session-ui/component-tests/line-comment-v2.spec.ts
@@ -1,0 +1,6 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+story("renders the line comment cancel action as a ghost button", async ({ mount }) => {
+  const root = await mount("ui-line-comment--editor-filled")
+  await expect(root.getByRole("button", { name: "Cancel" })).toHaveAttribute("data-variant", "ghost")
+})

--- a/packages/ui/src/data-display/line-comment/line-comment.stories.tsx
+++ b/packages/ui/src/data-display/line-comment/line-comment.stories.tsx
@@ -3,7 +3,7 @@ import { createSignal } from "solid-js"
 import { LineCommentEditor, LineComment, LineCommentOverflowIcon } from "./line-comment"
 
 const docs = `### Overview
-Line comment **display** and **editor** cards aligned with OpenCode line-comment specs (raised \`#FAFAFA\` surface, footer line context, \`Button\` neutral + contrast actions).
+Line comment **display** and **editor** cards aligned with OpenCode line-comment specs (raised \`#FAFAFA\` surface, footer line context, \`Button\` ghost + contrast actions).
 
 ### Display
 - \`LineComment\`: column stack (body + meta) beside optional \`actions\` (overflow).

--- a/packages/ui/src/data-display/line-comment/line-comment.tsx
+++ b/packages/ui/src/data-display/line-comment/line-comment.tsx
@@ -294,7 +294,7 @@ export function LineCommentEditor(props: LineCommentEditorProps) {
         <div data-slot="line-comment-v2-footer">
           <div data-slot="line-comment-v2-footer-meta">{local.selection}</div>
           <div data-slot="line-comment-v2-footer-actions">
-            <Button type="button" size="normal" variant="neutral" onClick={() => local.onCancel()}>
+            <Button type="button" size="normal" variant="ghost" onClick={() => local.onCancel()}>
               {local.cancelLabel ?? i18n.t("ui.lineComment.cancel")}
             </Button>
             <Button type="button" size="normal" variant="contrast" disabled={!canSubmit()} onClick={submit}>


### PR DESCRIPTION
## Summary

- render the V2 line-comment Cancel action as a ghost button
- align the component documentation and cover the variant with a focused Storybook test

## Before / After

| Before | After |
| --- | --- |
| ![Before: outlined neutral Cancel button](https://github.com/user-attachments/assets/c18d9aa5-7351-4f3e-9262-65282e95bc02) | ![After: ghost Cancel button](https://github.com/user-attachments/assets/04c659df-89a7-4ec7-8f2e-f642fc0aca4d) |

## Validation

- `bun run test:components -- line-comment-v2.spec.ts` (`packages/session-ui`)
- `bun typecheck` (`packages/ui`)
- `bun typecheck` (`packages/session-ui`)

Fixes anomalyco/opencontrol#201
Linear: https://linear.app/anomalyco/issue/OCD-153/make-the-cancel-button-on-comments-a-ghost-button
