### PR TITLE
fix(app): show subagent tab activity

### DIFF
--- a/packages/app/e2e/regression/remote-tab-busy.spec.ts
+++ b/packages/app/e2e/regression/remote-tab-busy.spec.ts
@@ -31,8 +31,8 @@ test("tab busy indicator reflects activity in the tab session family", async ({ 
 
   // The parent is idle, but its tab remains active while the background child runs.
   const tabB = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefB}"])`)
-  await tabB.screenshot({ path: info.outputPath("subagent-tab-activity.png") })
   await expect(tabB.locator('[data-component="session-progress-indicator-v2"]')).toBeVisible()
+  await tabB.screenshot({ path: info.outputPath("subagent-tab-activity.png") })
 
   const tabA = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefA}"])`)
   await expect(tabA.locator("[data-titlebar-tab-title]")).toHaveText(sessionA.title)

--- a/packages/app/e2e/regression/remote-tab-busy.spec.ts
+++ b/packages/app/e2e/regression/remote-tab-busy.spec.ts
@@ -6,8 +6,9 @@ const serverA = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${p
 const serverB = "http://127.0.0.1:4097"
 const sessionA = session("ses_server_a", "C:/server-a", "Server A session")
 const sessionB = session("ses_server_b", "/home/server-b", "Server B session")
+const childB = { ...session("ses_server_b_child", sessionB.directory, "Server B subagent"), parentID: sessionB.id }
 
-test("tab busy indicator reflects the tab server's own session status", async ({ page }) => {
+test("tab busy indicator reflects activity in the tab session family", async ({ page }, info) => {
   await mockServers(page)
   await page.addInitScript(
     ({ serverA, serverB, sessionA, sessionB }) => {
@@ -28,9 +29,10 @@ test("tab busy indicator reflects the tab server's own session status", async ({
   await page.goto(hrefA)
   await expect(page.getByText(sessionA.title).first()).toBeVisible()
 
-  // Session B is busy on server B while server A stays the active server, so the
-  // busy indicator must come from the tab server's status, not the active server's.
+  // Session B's child is busy on server B while server A stays the active server, so the
+  // busy indicator must include subagent activity from the tab server.
   const tabB = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefB}"])`)
+  await tabB.screenshot({ path: info.outputPath("subagent-tab-activity.png") })
   await expect(tabB.locator('[data-component="session-progress-indicator-v2"]')).toBeVisible()
 
   const tabA = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefA}"])`)
@@ -60,8 +62,12 @@ async function mockServers(page: Page) {
     if (url.pathname === "/api/event") return sse(route)
     if (url.pathname === "/api/health") return json(route, { pid: 1 })
     if (url.pathname === "/api/session/active")
-      return json(route, { data: url.origin === serverB ? { [sessionB.id]: { type: "running" } } : {} })
-    if (url.pathname === "/api/session") return json(route, { data: [currentSession(current)], cursor: {} })
+      return json(route, { data: url.origin === serverB ? { [childB.id]: { type: "running" } } : {} })
+    if (url.pathname === "/api/session")
+      return json(route, {
+        data: url.origin === serverB ? [currentSession(current), currentSession(childB)] : [currentSession(current)],
+        cursor: {},
+      })
     if (url.pathname === `/api/session/${current.id}`) return json(route, { data: currentSession(current) })
     if (url.pathname === `/api/session/${current.id}/message`) return json(route, { data: [], cursor: {} })
     if (["/api/agent", "/api/provider", "/api/model", "/api/command", "/api/reference"].includes(url.pathname))

--- a/packages/app/e2e/regression/remote-tab-busy.spec.ts
+++ b/packages/app/e2e/regression/remote-tab-busy.spec.ts
@@ -26,11 +26,10 @@ test("tab busy indicator reflects activity in the tab session family", async ({ 
 
   const hrefA = `/server/${base64Encode(serverA)}/session/${sessionA.id}`
   const hrefB = `/server/${base64Encode(serverB)}/session/${sessionB.id}`
-  await page.goto(hrefA)
-  await expect(page.getByText(sessionA.title).first()).toBeVisible()
+  await page.goto(hrefB)
+  await expect(page.getByText(sessionB.title).first()).toBeVisible()
 
-  // Session B's child is busy on server B while server A stays the active server, so the
-  // busy indicator must include subagent activity from the tab server.
+  // The parent is idle, but its tab remains active while the background child runs.
   const tabB = page.locator(`[data-titlebar-tab-slot]:has(a[href="${hrefB}"])`)
   await tabB.screenshot({ path: info.outputPath("subagent-tab-activity.png") })
   await expect(tabB.locator('[data-component="session-progress-indicator-v2"]')).toBeVisible()

--- a/packages/app/src/shell/layout/project-avatar-state.ts
+++ b/packages/app/src/shell/layout/project-avatar-state.ts
@@ -42,6 +42,10 @@ export function useSessionTabAvatarState(
     const data = serverCtx()?.data
     if (!data) return false
     if (needsAttention()) return false
+    if (root?.())
+      return data.session
+        .list()
+        .some((session) => data.session.root(session.id) === sessionId() && data.session.status(session.id) === "running")
     return data.session.status(sessionId()) === "running"
   })
   return { unread, loading }

--- a/packages/app/src/shell/layout/session-tab-avatar.tsx
+++ b/packages/app/src/shell/layout/session-tab-avatar.tsx
@@ -16,6 +16,7 @@ export function SessionTabAvatar(props: {
   const state = useSessionTabAvatarState(
     () => props.server,
     () => props.sessionId,
+    () => true,
   )
   return (
     <SessionTabAvatarView


### PR DESCRIPTION
## Summary

- aggregate titlebar tab activity across the root session and its loaded descendants
- mark session tab avatars as root-session indicators
- cover an idle parent with a running background subagent in the multi-server tab fixture

## Before / After

| Before | After |
| --- | --- |
| ![Before: idle parent tab hides the running subagent radar](https://github.com/user-attachments/assets/0d3c6240-611c-4d53-a6a7-3b80e1f05887) | ![After: idle parent tab shows the running subagent radar](https://github.com/user-attachments/assets/97c54c31-801c-4dcd-8406-eba4f631c61f) |

## Validation

- `bun run test:e2e -- e2e/regression/remote-tab-busy.spec.ts --workers=1`
- `bun typecheck` (`packages/app`)
- `bun run typecheck:e2e` (`packages/app`)
- repository pre-push `bun typecheck` with Bun 1.4.0

Fixes OCD-164.

Linear: https://linear.app/anomalyco/issue/OCD-164/radar-not-showing-in-main-tab-even-though-sub-agents-are-running
Synced issue: https://github.com/anomalyco/opencontrol/issues/212
