### PR TITLE
test(app): cover background hint lifetime

### DIFF
--- a/packages/app/test-browser/animated-presence-state.test.ts
+++ b/packages/app/test-browser/animated-presence-state.test.ts
@@ -1,6 +1,8 @@
-import { expect, test } from "bun:test"
+import { afterEach, expect, test, vi } from "bun:test"
 import { createAnimatedPresence } from "../src/runtime/animated-presence"
 import { batch, createRoot, createSignal } from "solid-js"
+
+afterEach(() => vi.useRealTimers())
 
 test("animates visibility changes without animating initial presence", () => {
   createRoot((dispose) => {
@@ -63,6 +65,44 @@ test("does not animate visibility changes across identities", () => {
 
     setValue("visible")
     expect(presence.animate()).toBe(true)
+    dispose()
+  })
+})
+
+test("holds brief appearances until the minimum duration expires", () => {
+  vi.useFakeTimers()
+  createRoot((dispose) => {
+    const [value, setValue] = createSignal<string>()
+    const presence = createAnimatedPresence(value, () => null, undefined, 1000)
+
+    setValue("shell")
+    vi.advanceTimersByTime(100)
+    setValue(undefined)
+    expect(presence.show()).toBe(true)
+    expect(presence.value()).toBe("shell")
+
+    vi.advanceTimersByTime(899)
+    expect(presence.show()).toBe(true)
+    vi.advanceTimersByTime(1)
+    expect(presence.show()).toBe(false)
+    expect(presence.animate()).toBe(true)
+    dispose()
+  })
+})
+
+test("clears held appearances when identity changes", () => {
+  vi.useFakeTimers()
+  createRoot((dispose) => {
+    const [identity, setIdentity] = createSignal("session-a")
+    const [value, setValue] = createSignal<string>("shell")
+    const presence = createAnimatedPresence(value, () => null, identity, 1000)
+
+    setValue(undefined)
+    expect(presence.show()).toBe(true)
+    setIdentity("session-b")
+    expect(presence.show()).toBe(false)
+    expect(presence.animate()).toBe(false)
+    expect(presence.value()).toBeUndefined()
     dispose()
   })
 })


### PR DESCRIPTION
## Summary

- cover the one-second minimum lifetime for short-lived Move to background hints
- verify session changes immediately clear held hints instead of leaking timeline state
- preserve the existing background-task summary lifetime coverage

This is focused regression coverage for the OCD-161 behavior shipped in #46715.

Issue: https://linear.app/anomalyco/issue/OCD-161/update-move-to-background-in-summary-panel-and-how-it-displays-in-the
Synced issue: https://github.com/anomalyco/opencontrol/issues/209

## Before / After

| Before | After |
| --- | --- |
| ![Before: background work is in the summary panel but the timeline hint has already disappeared](https://github.com/user-attachments/assets/e933e8dc-80b7-4c3d-b08c-405eb354c18b) | ![After: background work is in the summary panel and the timeline hint remains readable during its minimum lifetime](https://github.com/user-attachments/assets/4f9ae466-e421-4c14-b493-6cf6671c02d5) |

Both production-fixture captures use the same route, session state, 1440x900 viewport, and 500 ms delay after a blocking subagent moves to the background. Before is `ddda404d99`, immediately before implementation PR #46715; After is the current PR state. The implementation itself merged in #46715.

Implementation recording: https://github.com/user-attachments/assets/70642073-6607-4a11-b98b-a2556fb50b3e

## Validation

- `bun test --conditions=browser --preload ./happydom.ts ./test-browser/animated-presence-state.test.ts ./test-browser/session-background.test.ts` (8 pass)
- `bun typecheck` from `packages/app`
- pre-push `bun turbo typecheck --concurrency=3` (33/33)

## Visual Verification

- Route: `/server/aHR0cDovLzEyNy4wLjAuMTozNDE1MA/session/ses_timeline_stability`
- Viewport: 1440x900
- State: backgrounded subagent remains busy, Session details is open, capture occurs 500 ms after handoff
- Both screenshots were inspected at identical dimensions and contain only deterministic fixture data
