### PR TITLE
fix(session-ui): tighten compact disclosure spacing

### DIFF
--- a/packages/session-ui/component-tests/tool-group.spec.ts
+++ b/packages/session-ui/component-tests/tool-group.spec.ts
@@ -74,6 +74,12 @@ story("summarizes subagents as Agent while retaining their card titles", async (
   await expect(
     group.locator('[data-component="context-tool-group-trigger"] [data-slot="basic-tool-tool-title"]'),
   ).toHaveText("4 Shell, Read, Agent")
+  const gap = await group.evaluate((element) => {
+    const title = element.querySelector('[data-component="context-tool-group-trigger"]')!.getBoundingClientRect()
+    const arrow = element.querySelector('[data-slot="collapsible-arrow-icon"]')!.getBoundingClientRect()
+    return arrow.left - title.right
+  })
+  expect(gap).toBeLessThanOrEqual(12)
   await expect(group.locator('[data-component="task-tool-title"]')).toHaveText(["General", "Explore"])
 })
 

--- a/packages/session-ui/component-tests/tool-group.spec.ts
+++ b/packages/session-ui/component-tests/tool-group.spec.ts
@@ -79,7 +79,7 @@ story("summarizes subagents as Agent while retaining their card titles", async (
     const arrow = element.querySelector('[data-slot="collapsible-arrow-icon"]')!.getBoundingClientRect()
     return arrow.left - title.right
   })
-  expect(gap).toBeLessThanOrEqual(12)
+  expect(gap).toBeLessThanOrEqual(8)
   await expect(group.locator('[data-component="task-tool-title"]')).toHaveText(["General", "Explore"])
 })
 

--- a/packages/session-ui/src/components/basic-tool.css
+++ b/packages/session-ui/src/components/basic-tool.css
@@ -173,6 +173,10 @@
 [data-component="collapsible"].tool-collapsible[data-compact="true"] > [data-slot="collapsible-trigger"] {
   height: 28px;
 
+  [data-slot="collapsible-arrow"] {
+    width: 16px;
+  }
+
   [data-component="tool-trigger"],
   [data-slot="basic-tool-tool-info-main"] {
     gap: 6px;

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -690,7 +690,7 @@
 }
 
 [data-component="context-tool-group-trigger"] {
-  width: 100%;
+  width: auto;
   min-height: 24px;
   display: flex;
   align-items: center;

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -690,7 +690,7 @@
 }
 
 [data-component="context-tool-group-trigger"] {
-  width: auto;
+  width: 100%;
   min-height: 24px;
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

- reduce the disclosure affordance width on compact timeline blocks
- bring Thought and grouped Used chevrons in line with the Questions spacing
- cover the grouped-tool text-to-chevron distance with a geometry assertion

## Before / After

| Before | After |
| --- | --- |
| ![Before: grouped tool chevron sits far from its label](https://github.com/user-attachments/assets/f90964b9-5ac3-4407-91bf-64923da78e7f) | ![After: grouped tool chevron sits close to its label](https://github.com/user-attachments/assets/748529bf-d328-4756-9649-2d6609ea8394) |

## Issues

- https://linear.app/anomalyco/issue/OCD-163/the-chevron-arrow-feels-too-far-away-from-the-blocks
- Fixes anomalyco/opencontrol#211

## Validation

- `bun typecheck` (`packages/session-ui`)
- `PLAYWRIGHT_STORYBOOK_PORT=6013 bun run test:components -- tool-group.spec.ts --workers=1` (`packages/session-ui`, 5 passed)
- pre-push monorepo typecheck (33 packages)
