### PR TITLE
fix(session-ui): tighten tool group chevrons

### DIFF
--- a/packages/session-ui/component-tests/tool-group.spec.ts
+++ b/packages/session-ui/component-tests/tool-group.spec.ts
@@ -77,6 +77,19 @@ story("summarizes subagents as Agent while retaining their card titles", async (
   await expect(group.locator('[data-component="task-tool-title"]')).toHaveText(["General", "Explore"])
 })
 
+story("matches the question label-to-chevron spacing", async ({ mount }) => {
+  const root = await mount("current-session-research-agents--agent-research", { args: { scenario: "workflow" } })
+  const grouped = root.locator('[data-component="collapsed-tool-group"]').first()
+  const question = root.locator('[data-timeline-part-id="tool_family_question"]')
+  const gap = (node: Element) => {
+    const label = node.querySelector('[data-slot="basic-tool-tool-info"]')!.getBoundingClientRect()
+    const chevron = node.querySelector('[data-slot="collapsible-arrow-icon"]')!.getBoundingClientRect()
+    return chevron.left - label.right
+  }
+
+  await expect.poll(() => grouped.evaluate(gap)).toBe(await question.evaluate(gap))
+})
+
 for (const width of [840, 390]) {
   story(`keeps grouped cards inside their trigger bounds at ${width}px`, async ({ mount, page }) => {
     await page.setViewportSize({ width, height: 600 })

--- a/packages/session-ui/src/components/message-part.css
+++ b/packages/session-ui/src/components/message-part.css
@@ -730,6 +730,10 @@
 
 [data-component="collapsed-tool-group"] > [data-component="collapsible"].tool-collapsible {
   --tool-content-gap: 8px;
+
+  > [data-slot="collapsible-trigger"] [data-component="tool-trigger"] {
+    gap: 0;
+  }
 }
 
 [data-component="context-tool-group-list"] {


### PR DESCRIPTION
## Summary

- remove the extra outer gap between grouped tool labels and their chevrons
- match the established answered-question disclosure spacing
- cover the production timeline geometry with a focused component test

## Before / After

| Before | After |
| --- | --- |
| ![Before: grouped tool chevrons sit farther from their labels than the question chevron](https://github.com/user-attachments/assets/2e81b48a-6f60-485c-99b8-03e381767807) | ![After: grouped tool chevrons match the question label spacing](https://github.com/user-attachments/assets/2bc507bb-0d25-4d0b-91a8-f0bfe79d26c6) |

## Validation

- `bun typecheck` (`packages/session-ui`)
- `bun typecheck` (`packages/app`)
- `PLAYWRIGHT_STORYBOOK_URL=http://127.0.0.1:6103 bun run test:components -- tool-group.spec.ts` (6 passed)
- repository pre-push typecheck (33 packages passed)

## Issues

- https://linear.app/anomalyco/issue/OCD-163/the-chevron-arrow-feels-too-far-away-from-the-blocks
- https://github.com/anomalyco/opencontrol/issues/211
