### PR TITLE
fix(app): reuse hydrated composer history blobs

### DIFF
--- a/packages/app/e2e/performance/composer-history/README.md
+++ b/packages/app/e2e/performance/composer-history/README.md
@@ -1,0 +1,37 @@
+# Composer History Hydration
+
+Manual benchmark for an empty destination composer. Runs the production
+`ComposerEditor`, `createComposerEditor`, `createComposerHistory`, persistence
+codec, and browser IndexedDB draft store. It does not run the surrounding app
+shell or native desktop IPC.
+
+Workload: 100 normal prompts with realistic review instructions/code and 100
+shell commands. Separate cases have no images, 50 unique screenshots, or 50
+references to 5 screenshots. The fixture generates valid 1440 x 900 PNG code
+screenshots before timing and reports their exact byte sizes. Each isolated
+browser context measures a cold URL-cache mount followed by a warm remount.
+The database was just seeded; this does not simulate a cold disk cache.
+
+`historyReadyMs` measures the mount action until both production history stores
+are populated. This is history availability, not time to first editable input
+(input can be usable before history finishes). The benchmark then verifies
+ArrowUp recall and a decoded screenshot in the real editor. `recallObservedMs`
+includes Playwright action/assertion overhead and is reported separately.
+`mountRecallObservedMs` includes the mount, readiness checks, keyboard action,
+and correct text/image completion; it also includes Playwright overhead.
+IndexedDB reads and blob sizes are mechanism metrics, not desktop IPC bytes or
+process memory. No timing threshold is enforced.
+
+From `packages/app`, set `OPENCODE_HISTORY_BUILD` and
+`OPENCODE_HISTORY_OUTPUT` to artifact directories outside Git, then run:
+
+```sh
+bun x vite build --config e2e/performance/composer-history/vite.config.ts
+bun x playwright test --config e2e/performance/composer-history/playwright.config.ts --repeat-each=20
+```
+
+The preview server owns port 4783 and is stopped by Playwright. Preserve each
+build and its revision/hash for comparisons. `BENCHMARK` JSON lines contain all
+raw samples. Optional Chrome traces use the existing
+`OPENCODE_PERFORMANCE_TRACE_DIR` setting; keep trace runs separate from clean
+timing. Screenshots are captured after timing on the first repeat only.

--- a/packages/app/e2e/performance/composer-history/composer-history.bench.ts
+++ b/packages/app/e2e/performance/composer-history/composer-history.bench.ts
@@ -3,11 +3,14 @@ import { benchmark, expect } from "../benchmark"
 benchmark.use({ traceScope: "page" })
 for (const shape of ["text", "unique", "repeated"]) {
   benchmark(`composer global history: ${shape}, cold and warm mounts`, async ({ page, report }, testInfo) => {
+    const errors: string[] = []
+    page.on("pageerror", (error) => errors.push(error.message))
     await page.goto(`/?shape=${shape}`)
     const button = page.getByRole("button", { name: "Mount empty composer", exact: true })
     const input = page.getByRole("textbox", { name: "Prompt", exact: true })
     const samples = []
     for (const cache of ["cold", "warm"]) {
+      const mountStarted = performance.now()
       await button.click()
       await expect(page.getByTestId("history-ready")).toHaveText("ready")
       await expect(input).toBeEditable()
@@ -20,10 +23,25 @@ for (const shape of ["text", "unique", "repeated"]) {
       await expect(input).toContainText("Review the retry policy in src/network/request-0.ts.")
       const images = page.getByRole("img", { name: "request-0.png", exact: true })
       await expect(images).toHaveCount(shape === "text" ? 0 : 1)
-      if (shape !== "text") await expect.poll(() => images.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth === 1440)).toBe(true)
-      samples.push({ cache, ...result, recallObservedMs: performance.now() - start })
+      if (shape !== "text")
+        await expect
+          .poll(() => images.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth === 1440))
+          .toBe(true)
+      samples.push({
+        cache,
+        ...result,
+        recallObservedMs: performance.now() - start,
+        mountRecallObservedMs: performance.now() - mountStarted,
+      })
     }
-    report({ samples }, { browser: page.context().browser()!.version(), scope: "production composer editor/history, browser IndexedDB; no native IPC" })
+    expect(errors).toEqual([])
+    report(
+      { samples },
+      {
+        browser: page.context().browser()!.version(),
+        scope: "production composer editor/history, browser IndexedDB; no native IPC",
+      },
+    )
     if (testInfo.repeatEachIndex === 0) await page.screenshot({ path: testInfo.outputPath(`${shape}.png`) })
   })
 }

--- a/packages/app/e2e/performance/composer-history/composer-history.bench.ts
+++ b/packages/app/e2e/performance/composer-history/composer-history.bench.ts
@@ -10,6 +10,7 @@ for (const shape of ["text", "unique", "repeated"]) {
     const input = page.getByRole("textbox", { name: "Prompt", exact: true })
     const samples = []
     for (const cache of ["cold", "warm"]) {
+      await expect(button).toBeEnabled()
       const mountStarted = performance.now()
       await button.click()
       await expect(page.getByTestId("history-ready")).toHaveText("ready")

--- a/packages/app/e2e/performance/composer-history/composer-history.bench.ts
+++ b/packages/app/e2e/performance/composer-history/composer-history.bench.ts
@@ -1,0 +1,29 @@
+import { benchmark, expect } from "../benchmark"
+
+benchmark.use({ traceScope: "page" })
+for (const shape of ["text", "unique", "repeated"]) {
+  benchmark(`composer global history: ${shape}, cold and warm mounts`, async ({ page, report }, testInfo) => {
+    await page.goto(`/?shape=${shape}`)
+    const button = page.getByRole("button", { name: "Mount empty composer", exact: true })
+    const input = page.getByRole("textbox", { name: "Prompt", exact: true })
+    const samples = []
+    for (const cache of ["cold", "warm"]) {
+      await button.click()
+      await expect(page.getByTestId("history-ready")).toHaveText("ready")
+      await expect(input).toBeEditable()
+      await expect(input).toBeEmpty()
+      const result = JSON.parse((await page.getByTestId("history-result").textContent())!)
+      expect(result.documents).toBe(2)
+      expect(result.historyReadyMs).toBeGreaterThan(0)
+      const start = performance.now()
+      await input.press("ArrowUp")
+      await expect(input).toContainText("Review the retry policy in src/network/request-0.ts.")
+      const images = page.getByRole("img", { name: "request-0.png", exact: true })
+      await expect(images).toHaveCount(shape === "text" ? 0 : 1)
+      if (shape !== "text") await expect.poll(() => images.evaluate((image: HTMLImageElement) => image.complete && image.naturalWidth === 1440)).toBe(true)
+      samples.push({ cache, ...result, recallObservedMs: performance.now() - start })
+    }
+    report({ samples }, { browser: page.context().browser()!.version(), scope: "production composer editor/history, browser IndexedDB; no native IPC" })
+    if (testInfo.repeatEachIndex === 0) await page.screenshot({ path: testInfo.outputPath(`${shape}.png`) })
+  })
+}

--- a/packages/app/e2e/performance/composer-history/fixture.tsx
+++ b/packages/app/e2e/performance/composer-history/fixture.tsx
@@ -1,0 +1,134 @@
+import { createEffect, Show } from "solid-js"
+import { createStore } from "solid-js/store"
+import { render } from "solid-js/web"
+import { PlatformProvider, type Platform } from "@/runtime/platform/platform"
+import { createBrowserDraftStore } from "@/runtime/persistence/drafts"
+import { createComposerHistory } from "@/composer/history/store"
+import { ComposerEditor } from "@/composer/editor/editor"
+import { createComposerEditor } from "@/composer/editor/interaction"
+import type { ComposerPersistedState } from "@/composer/types"
+import "@/index.css"
+
+const shape = new URLSearchParams(location.search).get("shape") ?? "text"
+const normal = Array.from({ length: 100 }, (_, index) => {
+  const content = `Review the retry policy in src/network/request-${index}.ts. Preserve cancellation and the existing error messages.\n\n` +
+    `The request should stop after three attempts. Add coverage for a 429 response, a connection reset, and a successful retry. Verify that only idempotent requests are retried.\n\n` +
+    `Report ${index}:\n\`\`\`ts\nexport async function request(input: Request) {\n  const response = await fetch(input)\n  if (!response.ok) throw new Error(response.statusText)\n  return response.json()\n}\n\`\`\``
+  return {
+    prompt: [
+      { type: "text", content, start: 0, end: content.length },
+      ...(shape !== "text" && index % 2 === 0 ? [{
+        type: "image", id: `attachment-${index}`, filename: `request-${index}.png`, mime: "image/png",
+        blob: { id: `screenshot-${shape === "repeated" ? index % 10 : index}` },
+      }] : []),
+    ],
+    comments: [],
+  }
+})
+const shell = Array.from({ length: 100 }, (_, index) => {
+  const content = `bun test src/network/request-${index}.test.ts --timeout 30000`
+  return { prompt: [{ type: "text", content, start: 0, end: content.length }], comments: [] }
+})
+
+// Seed only this Playwright context, before opening the production draft store.
+const request = indexedDB.open("opencode-drafts", 1)
+request.onupgradeneeded = () => {
+  request.result.createObjectStore("documents")
+  request.result.createObjectStore("blobs")
+}
+const db = await new Promise<IDBDatabase>((resolve, reject) => {
+  request.onsuccess = () => resolve(request.result)
+  request.onerror = () => reject(request.error)
+})
+const ids = [...new Set(normal.flatMap((entry) => entry.prompt.flatMap((part) => "blob" in part ? [part.blob.id] : [])))]
+const screenshots: { id: string; blob: Blob }[] = []
+for (const id of ids) {
+  const canvas = document.createElement("canvas")
+  canvas.width = 1440
+  canvas.height = 900
+  const context = canvas.getContext("2d")!
+  context.fillStyle = "#15191f"
+  context.fillRect(0, 0, canvas.width, canvas.height)
+  context.font = "16px monospace"
+  context.fillStyle = "#b8c8d8"
+  context.fillText(`request.ts - ${id}`, 30, 35)
+  for (let line = 0; line < 38; line++) {
+    context.fillStyle = line % 3 ? "#a8c7ba" : "#d4a882"
+    context.fillText(`${String(line + 1).padStart(3)}  const response${line} = await fetch('/api/request/${id}/${line}', { signal, headers });`, 30, 70 + line * 20)
+  }
+  const blob = await new Promise<Blob>((resolve) => canvas.toBlob((blob) => resolve(blob!), "image/png"))
+  screenshots.push({ id, blob })
+}
+const transaction = db.transaction(["documents", "blobs"], "readwrite")
+transaction.objectStore("documents").put(JSON.stringify({ entries: normal }), "opencode.global.dat:prompt-history")
+transaction.objectStore("documents").put(JSON.stringify({ entries: shell }), "opencode.global.dat:prompt-history-shell")
+screenshots.forEach(({ id, blob }) => transaction.objectStore("blobs").put(blob, id))
+await new Promise<void>((resolve, reject) => {
+  transaction.oncomplete = () => resolve()
+  transaction.onerror = () => reject(transaction.error)
+})
+db.close()
+
+const metrics = { reads: 0, blobBytes: 0, documents: 0 }
+const originalGet = IDBObjectStore.prototype.get
+IDBObjectStore.prototype.get = function (key) {
+  const request = originalGet.call(this, key)
+  if (this.name === "documents") metrics.documents++
+  if (this.name === "blobs") {
+    metrics.reads++
+    request.addEventListener("success", () => { metrics.blobBytes += request.result?.size ?? 0 })
+  }
+  return request
+}
+const platform: Platform = {
+  platform: "web", draftStore: createBrowserDraftStore(),
+  openExternal() {}, restart: async () => {}, notify: async () => {},
+}
+const [state, setState] = createStore({ mount: 0, ready: false, result: "" })
+const workload = {
+  shape, normalEntries: normal.length, shellEntries: shell.length,
+  imageReferences: shape === "text" ? 0 : 50, uniqueImages: ids.length,
+  storedImageBytes: screenshots.reduce((sum, item) => sum + item.blob.size, 0),
+  documentBytes: new TextEncoder().encode(JSON.stringify({ normal, shell })).length,
+  screenshotDimensions: [1440, 900],
+}
+let started = 0
+function mount() {
+  metrics.reads = 0
+  metrics.blobBytes = 0
+  metrics.documents = 0
+  setState({ ready: false, result: "" })
+  started = performance.now()
+  setState("mount", state.mount + 1)
+}
+function Destination() {
+  // Same history creation and editor mapping as createComposerModel. Destination draft is empty.
+  const history = createComposerHistory()
+  const store = createStore<ComposerPersistedState>({
+    prompt: [{ type: "text", content: "", start: 0, end: 0 }], cursor: 0, context: { items: [] },
+  })
+  const controller = createComposerEditor({
+    store, commands: () => [], context: () => [], searchContextFiles: () => [],
+    history: {
+      entries: (mode) => history.entries(mode).map((entry) => ({ prompt: entry.prompt, metadata: entry.comments })),
+      add: (prompt, mode) => history.add(prompt, mode, []),
+    },
+    view: { placeholder: () => "Empty destination composer", submit: { stopping: () => false, onSubmit() {}, onStop() {} } },
+  })
+  createEffect(() => {
+    if (history.entries("normal").length !== 100 || history.entries("shell").length !== 100) return
+    setState({ ready: true, result: JSON.stringify({ historyReadyMs: performance.now() - started, ...metrics, ...workload }) })
+  })
+  return <ComposerEditor controller={controller} />
+}
+render(() => (
+  <PlatformProvider value={platform}>
+      <main style={{ padding: "40px", width: "900px" }}>
+        <h1>Composer global history: {shape}</h1>
+        <button onClick={mount}>Mount empty composer</button>
+        <output data-testid="history-ready">{state.ready ? "ready" : "idle"}</output>
+        <pre data-testid="history-result">{state.result}</pre>
+        <Show when={state.mount} keyed>{() => <Destination />}</Show>
+      </main>
+  </PlatformProvider>
+), document.getElementById("root")!)

--- a/packages/app/e2e/performance/composer-history/fixture.tsx
+++ b/packages/app/e2e/performance/composer-history/fixture.tsx
@@ -1,3 +1,4 @@
+/// <reference types="vite/client" />
 import { createEffect, Show } from "solid-js"
 import { createStore } from "solid-js/store"
 import { render } from "solid-js/web"
@@ -11,16 +12,24 @@ import "@/index.css"
 
 const shape = new URLSearchParams(location.search).get("shape") ?? "text"
 const normal = Array.from({ length: 100 }, (_, index) => {
-  const content = `Review the retry policy in src/network/request-${index}.ts. Preserve cancellation and the existing error messages.\n\n` +
+  const content =
+    `Review the retry policy in src/network/request-${index}.ts. Preserve cancellation and the existing error messages.\n\n` +
     `The request should stop after three attempts. Add coverage for a 429 response, a connection reset, and a successful retry. Verify that only idempotent requests are retried.\n\n` +
     `Report ${index}:\n\`\`\`ts\nexport async function request(input: Request) {\n  const response = await fetch(input)\n  if (!response.ok) throw new Error(response.statusText)\n  return response.json()\n}\n\`\`\``
   return {
     prompt: [
       { type: "text", content, start: 0, end: content.length },
-      ...(shape !== "text" && index % 2 === 0 ? [{
-        type: "image", id: `attachment-${index}`, filename: `request-${index}.png`, mime: "image/png",
-        blob: { id: `screenshot-${shape === "repeated" ? index % 10 : index}` },
-      }] : []),
+      ...(shape !== "text" && index % 2 === 0
+        ? [
+            {
+              type: "image",
+              id: `attachment-${index}`,
+              filename: `request-${index}.png`,
+              mime: "image/png",
+              blob: { id: `screenshot-${shape === "repeated" ? index % 10 : index}` },
+            },
+          ]
+        : []),
     ],
     comments: [],
   }
@@ -40,7 +49,9 @@ const db = await new Promise<IDBDatabase>((resolve, reject) => {
   request.onsuccess = () => resolve(request.result)
   request.onerror = () => reject(request.error)
 })
-const ids = [...new Set(normal.flatMap((entry) => entry.prompt.flatMap((part) => "blob" in part ? [part.blob.id] : [])))]
+const ids = [
+  ...new Set(normal.flatMap((entry) => entry.prompt.flatMap((part) => (part.blob ? [part.blob.id] : [])))),
+]
 const screenshots: { id: string; blob: Blob }[] = []
 for (const id of ids) {
   const canvas = document.createElement("canvas")
@@ -54,7 +65,11 @@ for (const id of ids) {
   context.fillText(`request.ts - ${id}`, 30, 35)
   for (let line = 0; line < 38; line++) {
     context.fillStyle = line % 3 ? "#a8c7ba" : "#d4a882"
-    context.fillText(`${String(line + 1).padStart(3)}  const response${line} = await fetch('/api/request/${id}/${line}', { signal, headers });`, 30, 70 + line * 20)
+    context.fillText(
+      `${String(line + 1).padStart(3)}  const response${line} = await fetch('/api/request/${id}/${line}', { signal, headers });`,
+      30,
+      70 + line * 20,
+    )
   }
   const blob = await new Promise<Blob>((resolve) => canvas.toBlob((blob) => resolve(blob!), "image/png"))
   screenshots.push({ id, blob })
@@ -76,18 +91,26 @@ IDBObjectStore.prototype.get = function (key) {
   if (this.name === "documents") metrics.documents++
   if (this.name === "blobs") {
     metrics.reads++
-    request.addEventListener("success", () => { metrics.blobBytes += request.result?.size ?? 0 })
+    request.addEventListener("success", () => {
+      metrics.blobBytes += request.result?.size ?? 0
+    })
   }
   return request
 }
 const platform: Platform = {
-  platform: "web", draftStore: createBrowserDraftStore(),
-  openExternal() {}, restart: async () => {}, notify: async () => {},
+  platform: "web",
+  draftStore: createBrowserDraftStore(),
+  openExternal() {},
+  restart: async () => {},
+  notify: async () => {},
 }
 const [state, setState] = createStore({ mount: 0, ready: false, result: "" })
 const workload = {
-  shape, normalEntries: normal.length, shellEntries: shell.length,
-  imageReferences: shape === "text" ? 0 : 50, uniqueImages: ids.length,
+  shape,
+  normalEntries: normal.length,
+  shellEntries: shell.length,
+  imageReferences: shape === "text" ? 0 : 50,
+  uniqueImages: ids.length,
   storedImageBytes: screenshots.reduce((sum, item) => sum + item.blob.size, 0),
   documentBytes: new TextEncoder().encode(JSON.stringify({ normal, shell })).length,
   screenshotDimensions: [1440, 900],
@@ -105,30 +128,46 @@ function Destination() {
   // Same history creation and editor mapping as createComposerModel. Destination draft is empty.
   const history = createComposerHistory()
   const store = createStore<ComposerPersistedState>({
-    prompt: [{ type: "text", content: "", start: 0, end: 0 }], cursor: 0, context: { items: [] },
+    prompt: [{ type: "text", content: "", start: 0, end: 0 }],
+    cursor: 0,
+    context: { items: [] },
   })
   const controller = createComposerEditor({
-    store, commands: () => [], context: () => [], searchContextFiles: () => [],
+    store,
+    commands: () => [],
+    context: () => [],
+    searchContextFiles: () => [],
     history: {
       entries: (mode) => history.entries(mode).map((entry) => ({ prompt: entry.prompt, metadata: entry.comments })),
       add: (prompt, mode) => history.add(prompt, mode, []),
     },
-    view: { placeholder: () => "Empty destination composer", submit: { stopping: () => false, onSubmit() {}, onStop() {} } },
+    view: {
+      placeholder: () => "Empty destination composer",
+      submit: { stopping: () => false, onSubmit() {}, onStop() {} },
+    },
   })
   createEffect(() => {
     if (history.entries("normal").length !== 100 || history.entries("shell").length !== 100) return
-    setState({ ready: true, result: JSON.stringify({ historyReadyMs: performance.now() - started, ...metrics, ...workload }) })
+    setState({
+      ready: true,
+      result: JSON.stringify({ historyReadyMs: performance.now() - started, ...metrics, ...workload }),
+    })
   })
   return <ComposerEditor controller={controller} />
 }
-render(() => (
-  <PlatformProvider value={platform}>
+render(
+  () => (
+    <PlatformProvider value={platform}>
       <main style={{ padding: "40px", width: "900px" }}>
         <h1>Composer global history: {shape}</h1>
         <button onClick={mount}>Mount empty composer</button>
         <output data-testid="history-ready">{state.ready ? "ready" : "idle"}</output>
         <pre data-testid="history-result">{state.result}</pre>
-        <Show when={state.mount} keyed>{() => <Destination />}</Show>
+        <Show when={state.mount} keyed>
+          {(_mount) => <Destination />}
+        </Show>
       </main>
-  </PlatformProvider>
-), document.getElementById("root")!)
+    </PlatformProvider>
+  ),
+  document.getElementById("root")!,
+)

--- a/packages/app/e2e/performance/composer-history/fixture.tsx
+++ b/packages/app/e2e/performance/composer-history/fixture.tsx
@@ -112,7 +112,7 @@ const workload = {
   imageReferences: shape === "text" ? 0 : 50,
   uniqueImages: ids.length,
   storedImageBytes: screenshots.reduce((sum, item) => sum + item.blob.size, 0),
-  documentBytes: new TextEncoder().encode(JSON.stringify({ normal, shell })).length,
+  documentBytes: [normal, shell].reduce((sum, entries) => sum + new TextEncoder().encode(JSON.stringify({ entries })).length, 0),
   screenshotDimensions: [1440, 900],
 }
 let started = 0

--- a/packages/app/e2e/performance/composer-history/fixture.tsx
+++ b/packages/app/e2e/performance/composer-history/fixture.tsx
@@ -49,9 +49,7 @@ const db = await new Promise<IDBDatabase>((resolve, reject) => {
   request.onsuccess = () => resolve(request.result)
   request.onerror = () => reject(request.error)
 })
-const ids = [
-  ...new Set(normal.flatMap((entry) => entry.prompt.flatMap((part) => (part.blob ? [part.blob.id] : [])))),
-]
+const ids = [...new Set(normal.flatMap((entry) => entry.prompt.flatMap((part) => (part.blob ? [part.blob.id] : []))))]
 const screenshots: { id: string; blob: Blob }[] = []
 for (const id of ids) {
   const canvas = document.createElement("canvas")
@@ -112,7 +110,10 @@ const workload = {
   imageReferences: shape === "text" ? 0 : 50,
   uniqueImages: ids.length,
   storedImageBytes: screenshots.reduce((sum, item) => sum + item.blob.size, 0),
-  documentBytes: [normal, shell].reduce((sum, entries) => sum + new TextEncoder().encode(JSON.stringify({ entries })).length, 0),
+  documentBytes: [normal, shell].reduce(
+    (sum, entries) => sum + new TextEncoder().encode(JSON.stringify({ entries })).length,
+    0,
+  ),
   screenshotDimensions: [1440, 900],
 }
 let started = 0

--- a/packages/app/e2e/performance/composer-history/index.html
+++ b/packages/app/e2e/performance/composer-history/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><title>Composer history benchmark</title></head>
+  <body><div id="root"></div><script type="module" src="./fixture.tsx"></script></body>
+</html>

--- a/packages/app/e2e/performance/composer-history/index.html
+++ b/packages/app/e2e/performance/composer-history/index.html
@@ -1,5 +1,11 @@
 <!doctype html>
 <html lang="en">
-  <head><meta charset="UTF-8" /><title>Composer history benchmark</title></head>
-  <body><div id="root"></div><script type="module" src="./fixture.tsx"></script></body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Composer history benchmark</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./fixture.tsx"></script>
+  </body>
 </html>

--- a/packages/app/e2e/performance/composer-history/playwright.config.ts
+++ b/packages/app/e2e/performance/composer-history/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: ".",
+  testMatch: "composer-history.bench.ts",
+  workers: 1,
+  retries: 0,
+  timeout: 60_000,
+  reporter: "line",
+  outputDir: process.env.OPENCODE_HISTORY_OUTPUT,
+  use: { baseURL: "http://127.0.0.1:4783", viewport: { width: 1440, height: 900 }, trace: "off", video: "off" },
+  webServer: {
+    command: "bun x vite preview --config e2e/performance/composer-history/vite.config.ts --host 127.0.0.1 --port 4783 --strictPort",
+    url: "http://127.0.0.1:4783",
+    reuseExistingServer: false,
+  },
+})

--- a/packages/app/e2e/performance/composer-history/playwright.config.ts
+++ b/packages/app/e2e/performance/composer-history/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@playwright/test"
+import { fileURLToPath } from "node:url"
 
 export default defineConfig({
   testDir: ".",
@@ -10,7 +11,9 @@ export default defineConfig({
   outputDir: process.env.OPENCODE_HISTORY_OUTPUT,
   use: { baseURL: "http://127.0.0.1:4783", viewport: { width: 1440, height: 900 }, trace: "off", video: "off" },
   webServer: {
-    command: "bun x vite preview --config e2e/performance/composer-history/vite.config.ts --host 127.0.0.1 --port 4783 --strictPort",
+    cwd: fileURLToPath(new URL("../../../", import.meta.url)),
+    command:
+      "bun x vite preview --config e2e/performance/composer-history/vite.config.ts --host 127.0.0.1 --port 4783 --strictPort",
     url: "http://127.0.0.1:4783",
     reuseExistingServer: false,
   },

--- a/packages/app/e2e/performance/composer-history/vite.config.ts
+++ b/packages/app/e2e/performance/composer-history/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vite"
+import { fileURLToPath } from "node:url"
+import app from "../../../vite"
+
+export default defineConfig({
+  root: fileURLToPath(new URL(".", import.meta.url)),
+  publicDir: fileURLToPath(new URL("../../../public", import.meta.url)),
+  plugins: app,
+  build: { target: "esnext", outDir: process.env.OPENCODE_HISTORY_BUILD, emptyOutDir: true },
+})

--- a/packages/app/e2e/performance/composer-history/vite.config.ts
+++ b/packages/app/e2e/performance/composer-history/vite.config.ts
@@ -5,6 +5,6 @@ import app from "../../../vite"
 export default defineConfig({
   root: fileURLToPath(new URL(".", import.meta.url)),
   publicDir: fileURLToPath(new URL("../../../public", import.meta.url)),
-  plugins: app,
+  plugins: [app],
   build: { target: "esnext", outDir: process.env.OPENCODE_HISTORY_BUILD, emptyOutDir: true },
 })

--- a/packages/app/src/runtime/persistence/drafts.ts
+++ b/packages/app/src/runtime/persistence/drafts.ts
@@ -39,6 +39,19 @@ export async function createBlobReference(blob: Blob): Promise<BlobReference> {
 
 export function createDraftStore(driver: Driver): DraftStore {
   const versions = new Map<string, number>()
+  const loading = new Map<string, Promise<string | undefined>>()
+  const loadBlobUrl = (id: string) => {
+    const existing = urls.get(id)
+    if (existing) return existing
+    const pending = loading.get(id)
+    if (pending) return pending
+    const next = driver
+      .getBlob(id)
+      .then((blob) => (blob ? blobUrl(id, blob) : undefined))
+      .finally(() => loading.delete(id))
+    loading.set(id, next)
+    return next
+  }
   const putBlob = async (blob: Blob) => {
     const id = await driver.putBlob(blob)
     return { id, url: blobUrl(id, blob) }
@@ -71,8 +84,8 @@ export function createDraftStore(driver: Driver): DraftStore {
     if (item.blob && typeof item.blob === "object") {
       const ref = item.blob as Record<string, unknown>
       if (typeof ref.id === "string") {
-        const blob = await driver.getBlob(ref.id)
-        if (blob) return { ...item, blob: { id: ref.id, url: blobUrl(ref.id, blob) } }
+        const url = await loadBlobUrl(ref.id)
+        if (url) return { ...item, blob: { id: ref.id, url } }
       }
     }
     return Object.fromEntries(

--- a/packages/app/test-browser/draft-history-cache.test.ts
+++ b/packages/app/test-browser/draft-history-cache.test.ts
@@ -1,0 +1,130 @@
+import { expect, test } from "bun:test"
+import { resolveObjectURL } from "node:buffer"
+import { createDraftStore } from "@/runtime/persistence/drafts"
+
+function fixture(id: string, getBlob: () => Promise<Blob | null>) {
+  const documents = new Map([
+    ["history", JSON.stringify({ entries: [{ prompt: [{ type: "image", blob: { id } }] }] })],
+    ["draft", JSON.stringify({ prompt: [{ type: "image", blob: { id } }] })],
+  ])
+  const store = createDraftStore({
+    get: async (key) => documents.get(key) ?? null,
+    set: async (key, value) => void documents.set(key, value),
+    remove: async (key) => void documents.delete(key),
+    putBlob: async () => id,
+    getBlob,
+  })
+  return { store, documents }
+}
+
+test("deduplicates concurrent history and draft reads without invalidating either live reference", async () => {
+  const pending = Promise.withResolvers<Blob | null>()
+  const started = Promise.withResolvers<void>()
+  let reads = 0
+  const { store } = fixture("history-cache-concurrent", () => {
+    reads++
+    started.resolve()
+    return pending.promise
+  })
+  const history = store.getItem("history")
+  const draft = store.getItem("draft")
+  await started.promise
+  pending.resolve(new Blob(["shared screenshot"]))
+  const [saved, active] = await Promise.all([history, draft])
+  const reference = JSON.parse(saved!).entries[0].prompt[0].blob
+  expect(JSON.parse(active!).prompt[0].blob).toEqual(reference)
+  expect(reads).toBe(1)
+  await store.removeItem("history")
+  expect(await resolveObjectURL(reference.url)?.text()).toBe("shared screenshot")
+  expect(JSON.parse((await store.getItem("draft"))!).prompt[0].blob).toEqual(reference)
+  expect(reads).toBe(1)
+})
+
+test("hydrates repeated references once within one history document", async () => {
+  let reads = 0
+  const { store, documents } = fixture("history-cache-repeated", async () => {
+    reads++
+    return new Blob(["repeated screenshot"])
+  })
+  documents.set(
+    "history",
+    JSON.stringify({
+      entries: Array.from({ length: 100 }, () => ({
+        prompt: [{ type: "image", blob: { id: "history-cache-repeated" } }],
+      })),
+    }),
+  )
+  const value = JSON.parse((await store.getItem("history"))!)
+  expect(value.entries).toHaveLength(100)
+  expect(
+    new Set(value.entries.map((entry: { prompt: { blob: { url: string } }[] }) => entry.prompt[0].blob.url)).size,
+  ).toBe(1)
+  expect(reads).toBe(1)
+})
+
+test("reuses a live URL on remount but reads the latest document", async () => {
+  let reads = 0
+  const { store, documents } = fixture("history-cache-remount", async () => {
+    reads++
+    return new Blob(["saved screenshot"])
+  })
+  const first = JSON.parse((await store.getItem("history"))!)
+  const changed = JSON.parse(documents.get("history")!)
+  changed.entries[0].prompt.unshift({ type: "text", content: "new admission" })
+  documents.set("history", JSON.stringify(changed))
+  const second = JSON.parse((await store.getItem("history"))!)
+  expect(second.entries[0].prompt[0].content).toBe("new admission")
+  expect(second.entries[0].prompt[1].blob).toEqual(first.entries[0].prompt[0].blob)
+  expect(reads).toBe(1)
+})
+
+test("reuses a just-stored attachment without a round trip", async () => {
+  let reads = 0
+  const { store } = fixture("history-cache-put", async () => {
+    reads++
+    return new Blob(["unexpected read"])
+  })
+  const reference = await store.putBlob(new Blob(["pending admission"]))
+  expect(JSON.parse((await store.getItem("draft"))!).prompt[0].blob).toEqual(reference)
+  expect(reads).toBe(0)
+  expect(await resolveObjectURL(reference.url)?.text()).toBe("pending admission")
+})
+
+test("does not retain a missing blob result", async () => {
+  let reads = 0
+  const { store } = fixture("history-cache-missing", async () => (++reads === 1 ? null : new Blob(["arrived"])))
+  expect(JSON.parse((await store.getItem("draft"))!).prompt[0].blob.url).toBeUndefined()
+  expect(JSON.parse((await store.getItem("draft"))!).prompt[0].blob.url).toStartWith("blob:")
+  expect(reads).toBe(2)
+})
+
+test("retries after a failed blob read", async () => {
+  let reads = 0
+  const { store } = fixture("history-cache-failure", async () => {
+    if (++reads === 1) throw new Error("temporary storage failure")
+    return new Blob(["recovered"])
+  })
+  await expect(store.getItem("history")).rejects.toThrow("temporary storage failure")
+  expect(JSON.parse((await store.getItem("history"))!).entries[0].prompt[0].blob.url).toStartWith("blob:")
+  expect(reads).toBe(2)
+})
+
+test("keeps different blob IDs independent", async () => {
+  const reads: string[] = []
+  const store = createDraftStore({
+    get: async () => JSON.stringify(["history-cache-first", "history-cache-second"].map((id) => ({ blob: { id } }))),
+    set: async () => {},
+    remove: async () => {},
+    putBlob: async () => "unused",
+    getBlob: async (id) => {
+      reads.push(id)
+      return new Blob([id])
+    },
+  })
+  const value = JSON.parse((await store.getItem("history"))!)
+  expect(value[0].blob.url).not.toBe(value[1].blob.url)
+  expect(
+    await Promise.all(value.map((item: { blob: { url: string } }) => resolveObjectURL(item.blob.url)?.text())),
+  ).toEqual(reads)
+  expect(reads).toEqual(["history-cache-first", "history-cache-second"])
+})


### PR DESCRIPTION
## Problem

- Every composer mount hydrates both global history documents through the draft store `decode` path. For each image reference, `decode` called `driver.getBlob(id)` and only then consulted the module-level `urls` cache in `blobUrl`.
- Result: a mount with 50 screenshot references issued 50 IndexedDB blob reads and materialized ~12 MB of `Blob` objects, even when all 50 URLs were already live from a previous mount, and even when the 50 references pointed at only 5 distinct images.

## Change

`packages/app/src/runtime/persistence/drafts.ts`: consult the live URL map before reading, and coalesce concurrent reads of the same id.

```ts
const loading = new Map<string, Promise<string | undefined>>()
const loadBlobUrl = (id: string) => {
  const existing = urls.get(id)
  if (existing) return existing
  const pending = loading.get(id)
  if (pending) return pending
  const next = driver
    .getBlob(id)
    .then((blob) => (blob ? blobUrl(id, blob) : undefined))
    .finally(() => loading.delete(id))
  loading.set(id, next)
  return next
}
```

- No store setter, admission, or URL revocation behavior changed. Missing blobs and failed reads are not cached; the next decode retries.
- Adds `test-browser/draft-history-cache.test.ts` (concurrent history/draft reads, repeated references in one document, latest document after remount, just-stored attachments, missing blobs, failed reads, distinct ids).
- Adds the manual `e2e/performance/composer-history` benchmark (production `ComposerEditor`, `createComposerEditor`, `createComposerHistory`, persistence codec, browser IndexedDB draft store).

## Benchmark

- Workload: 100 normal + 100 shell history entries (two documents, 69–75 KB stored JSON). Image cases add 50 references to 1440×900 PNG screenshots (~244–249 KB each): `unique` = 50 distinct images (12.43 MB stored), `repeated` = 50 references to 5 images (1.22 MB stored). `text` has no images and acts as the control.
- Each isolated browser context mounts an empty composer cold (no live URLs), then remounts warm. Timing gate is both production history stores populated (`historyReadyMs`); the test then verifies ArrowUp recall and a decoded image before recording.
- Baseline `335e4ca` vs candidate `c8c0b4c`, frozen production bundles, counterbalanced ABBA order (baseline, candidate, candidate, baseline), 10 repeats per block, 20 samples per cell. Chromium 147, Windows.

### Mechanism (identical in all 20 samples per cell)

| Case | IndexedDB blob reads | Blob bytes read |
| --- | --- | --- |
| unique / cold | 50 → 50 | 12.43 MB → 12.43 MB |
| unique / warm | 50 → **0** | 12.43 MB → **0** |
| repeated / cold | 50 → **5** | 12.17 MB → **1.22 MB** |
| repeated / warm | 50 → **0** | 12.17 MB → **0** |
| text / cold, warm | 0 → 0 | 0 → 0 |

### History availability, `historyReadyMs` median (p95), baseline → candidate

| Case | Baseline | Candidate |
| --- | --- | --- |
| text / cold (control) | 48.8 (56.3) | 50.9 (77.1) |
| text / warm (control) | 26.8 (29.2) | 26.5 (28.9) |
| unique / cold | 71.6 (100.5) | 80.5 (140.0) |
| unique / warm | 33.2 (38.2) | 31.7 (36.4) |
| repeated / cold | 60.6 (72.9) | 61.7 (80.4) |
| repeated / warm | 33.6 (37.5) | 31.1 (35.0) |

- Latency did not move outside the band of the text control, which performs no blob reads in either build. The first candidate block was uniformly slower across every case including text (per-block medians below), which inflates the aggregate cold p95 values. No latency, FPS, or memory improvement is claimed from this run.
- `recallObservedMs` (ArrowUp → correct text and decoded image, includes Playwright overhead) also stayed within the control band.
- Blob reads on this path run concurrently, so wall time is bounded by the slowest read rather than the count; the win here is removed redundant IndexedDB work and transient `Blob` allocation, not a measured latency change.

<details>
<summary>Per-block <code>historyReadyMs</code> medians (10 samples each)</summary>

| Case | 0 baseline | 1 candidate | 2 candidate | 3 baseline |
| --- | --- | --- | --- | --- |
| text / cold | 46.5 | 57.4 | 50.2 | 52.6 |
| text / warm | 27.3 | 26.3 | 26.9 | 26.5 |
| unique / cold | 68.6 | 87.8 | 71.1 | 72.9 |
| unique / warm | 32.9 | 33.0 | 31.2 | 34.4 |
| repeated / cold | 57.0 | 62.1 | 61.1 | 61.5 |
| repeated / warm | 32.0 | 30.6 | 31.3 | 35.6 |

</details>

## Desktop path (Electron MessagePort + main-process SQLite)

Added after review to close the desktop evidence gap. Same workload and ABBA protocol, but every blob crosses the production desktop path: renderer `api.ts` → `ipc-client.ts` (Effect RPC, MessagePack) → Electron `MessagePort` → `IpcServerProtocolLive` → `storageHandlers` → `DesktopStorage` → `node:sqlite`.

- Isolated Electron 42.10.1 (Chrome 148.0.7778.280, Node 24.18.1) main running the production `DesktopStorage.layer`, storage/event RPC handlers, `RpcServer` + `IpcServerProtocolLive`, and the real preload; renderer runs the real `api.ts`, `ipc-client.ts`, `createDesktopStorage`, and the same production composer editor/history fixture. Fixture-owned `userData` per launch; seeded through `DraftsPutBlob`/`DraftsSet` and flushed to SQLite before the cold mount. No app shell, service, updater, or menus.
- Stored screenshots: 12.49 MB (`unique`, 50 images) / 1.22 MB (`repeated`, 5 images); documents 77 KB. Renderer bundles frozen per revision (baseline `drafts.ts` `c16694a7`, candidate `544f21dd`); main bundle, preload, and Electron shared. 10 repeats per block, 20 samples per cell, Windows.

### Per mount, main → renderer (identical in all 20 samples per cell)

| Case | `DraftsGetBlob` RPCs | Bytes over the MessagePort | Messages |
| --- | --- | --- | --- |
| unique / cold | 50 → 50 | 16.74 MB → 16.74 MB | 52 → 52 |
| unique / warm | 50 → **0** | 16.74 MB → **77.5 KB** | 52 → **2** |
| repeated / cold | 50 → **5** | 16.38 MB → **1.71 MB** | 52 → **7** |
| repeated / warm | 50 → **0** | 16.38 MB → **77.5 KB** | 52 → **2** |
| text / cold, warm | 0 → 0 | 69.2 KB → 69.2 KB | 2 → 2 |

12.49 MB of blobs cross as 16.66 MB because `RpcSerialization.layerMsgPack` uses the JSON codec, so `Schema.Uint8Array` travels as base64 inside MessagePack (×4/3). Pre-existing; not changed here.

### Median (p95), baseline → candidate

| Case | History available, ms | Mount → recalled text + decoded image, ms | Main CPU, ms | Main SQLite read + copy, ms | Renderer peak working set rise |
| --- | --- | --- | --- | --- | --- |
| text / cold (control) | 57 (67) → 64 (74) | 157 → 172 | 31 → 31 | 0 → 0 | +17 MB → +17 MB |
| text / warm (control) | 31 (37) → 35 (42) | 207 → 226 | 16 → 31 | 0 → 0 | +6 MB → +6 MB |
| unique / cold | 1141 (1266) → 1431 (1613) | 1262 → 1578 | 953 → 1218 | 32 → 39 | +297 MB → +294 MB |
| unique / warm | 778 (866) → **47 (59)** | 853 → **158** | 836 → **31** | 34 → **0** | +98 MB → **0** |
| repeated / cold | 1001 (1239) → **216 (296)** | 1142 → **435** | 844 → **235** | 18 → **3.8** | +281 MB → **+48 MB** |
| repeated / warm | 709 (878) → **49 (62)** | 800 → **143** | 750 → **32** | 18 → **0** | +94 MB → **0** |

- Main CPU is `process.cpuUsage()` user + system over the mount window (Windows ~16 ms tick). SQLite read + copy is the wall time inside `drafts.getBlob` (query plus `new Uint8Array(data).buffer`). Peak working set is the natural (no forced GC) `peakWorkingSetSize` increase of the renderer process above its pre-mount peak from `app.getAppMetrics()`; it shows the transient RSS spike of the base64 → string → `Uint8Array` → `slice` → `Blob` chain, not retained memory.
- `unique / cold` does identical work in both builds (50 reads, 16.74 MB). The candidate blocks ran ~25% slower, but main-only metrics for identical main work moved by the same ratio across blocks (SQLite read 28/33 → 39/39 ms; main CPU 875/1016 → 1156/1227 ms) and the text control moved the same direction, so this is machine drift during the middle ABBA blocks, not a build effect. Treat that row as unchanged.
- The recall step alone (ArrowUp → text + decoded 1440×900 image) is 15–20 ms slower in the candidate's warm cells (unique / warm 37 → 59 ms) because the key press now lands ~700 ms sooner and overlaps post-mount work that previously finished during the slow hydration. The user-visible total from mount to recalled image is the column above.
- Per-block medians for every cell are in the run artifacts; the warm and repeated improvements hold in both candidate blocks against both baseline blocks.

## Scope and limitations

- The browser benchmark covers the IndexedDB path; the desktop section covers the Electron MessagePort and main-process SQLite path without the app shell, background service, packaged build, or non-Windows platforms. Renderer allocations are not attributed by a profiler; blob bytes are never retained on the JS heap.
- The database is seeded immediately before each context, so cold here means no live object URLs, not a cold disk cache.
- Object URL revocation is intentionally out of scope. `clonePrompt` shallow-copies image parts and async submit later calls `blobDataUrl` on them, so unmount and document deletion are not safe last-consumer boundaries; that needs a separate ownership contract.
- Both history documents are still read on every mount; only blob hydration changed.
