### PR TITLE
fix(session-ui): reuse cached diff highlighting across remounts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -730,6 +730,7 @@
         "@types/bun": "catalog:",
         "@typescript/native-preview": "catalog:",
         "vite": "catalog:",
+        "vite-plugin-solid": "catalog:",
       },
     },
     "packages/simulation": {
@@ -6254,6 +6255,8 @@
     "@opencode-ai/posts/wrangler": ["wrangler@4.110.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260708.1", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260708.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260708.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg=="],
 
     "@opencode-ai/session-ui/vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
+
+    "@opencode-ai/session-ui/vite-plugin-solid": ["vite-plugin-solid@2.11.10", "", { "dependencies": { "@babel/core": "^7.23.3", "@types/babel__core": "^7.20.4", "babel-preset-solid": "^1.8.4", "merge-anything": "^5.1.7", "solid-refresh": "^0.6.3", "vitefu": "^1.0.4" }, "peerDependencies": { "@testing-library/jest-dom": "^5.16.6 || ^5.17.0 || ^6.*", "solid-js": "^1.7.2", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@testing-library/jest-dom"] }, "sha512-Yr1dQybmtDtDAHkii6hXuc1oVH9CPcS/Zb2jN/P36qqcrkNnVPsMTzQ06jyzFPFjj3U1IYKMVt/9ZqcwGCEbjw=="],
 
     "@opencode-ai/stats-app/vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -57,7 +57,8 @@
     "@tsconfig/node22": "catalog:",
     "@types/bun": "catalog:",
     "@typescript/native-preview": "catalog:",
-    "vite": "catalog:"
+    "vite": "catalog:",
+    "vite-plugin-solid": "catalog:"
   },
   "dependencies": {
     "@kobalte/core": "catalog:",

--- a/packages/session-ui/performance/highlighting/README.md
+++ b/packages/session-ui/performance/highlighting/README.md
@@ -24,6 +24,10 @@ plain first paint. Worker request counts and round-trip time describe the
 mechanism, not CPU time or desktop memory. Full reconstructed content is checked
 separately after timing. No forced GC or machine-dependent thresholds are used.
 
+`HIGHLIGHT_CORRECTNESS=1` runs the deterministic `*.correctness.ts` checks against
+the same fixture instead of the timed benchmarks: cache reuse across remounts and
+invalidation on content, theme, and worker option changes.
+
 Optional output settings: `HIGHLIGHT_RESULTS`, `HIGHLIGHT_SCREENSHOTS`,
 `OPENCODE_PERFORMANCE_RUN_ID`, and `OPENCODE_PERFORMANCE_TRACE_DIR` (separate
 diagnostic runs, not clean timing). `HIGHLIGHT_PORT` defaults to 4793. Preserve the

--- a/packages/session-ui/performance/highlighting/README.md
+++ b/packages/session-ui/performance/highlighting/README.md
@@ -1,0 +1,31 @@
+# Diff Highlighting
+
+Manual Chromium benchmark of the production `File` component, `normalize`, Pierre
+pool, and bundled workers. No OpenCode server, session, or stored data is used.
+
+From `packages/session-ui`, set `HIGHLIGHT_BUNDLE` to an external artifact
+directory, then run:
+
+```sh
+bun performance/highlighting/build.ts
+bun x playwright test --config performance/highlighting/playwright.config.ts --repeat-each 20
+```
+
+Each isolated page measures a cold mount, unmount/remount of the identical patch,
+and an edited patch under the same filename. The fixtures contain 120 or 1,200
+TypeScript route handlers with one changed line per ten handlers. Exact byte and
+line counts, bundle hash, source revision, and individual samples are reported
+through the existing performance reporter.
+
+`readyMs` ends when the viewer has called `onRendered`, its pool has settled,
+and `onPostRender` has committed the final worker result containing the expected
+edit. `firstReadyMs` records the earlier production callback, which can represent
+plain first paint. Worker request counts and round-trip time describe the
+mechanism, not CPU time or desktop memory. Full reconstructed content is checked
+separately after timing. No forced GC or machine-dependent thresholds are used.
+
+Optional output settings: `HIGHLIGHT_RESULTS`, `HIGHLIGHT_SCREENSHOTS`,
+`OPENCODE_PERFORMANCE_RUN_ID`, and `OPENCODE_PERFORMANCE_TRACE_DIR` (separate
+diagnostic runs, not clean timing). `HIGHLIGHT_PORT` defaults to 4793. Preserve the
+baseline build before product edits, then point `HIGHLIGHT_BUNDLE` at either frozen
+build to compare the same workload without rebuilding.

--- a/packages/session-ui/performance/highlighting/README.md
+++ b/packages/session-ui/performance/highlighting/README.md
@@ -29,3 +29,7 @@ Optional output settings: `HIGHLIGHT_RESULTS`, `HIGHLIGHT_SCREENSHOTS`,
 diagnostic runs, not clean timing). `HIGHLIGHT_PORT` defaults to 4793. Preserve the
 baseline build before product edits, then point `HIGHLIGHT_BUNDLE` at either frozen
 build to compare the same workload without rebuilding.
+
+`HIGHLIGHT_RETENTION=1` enables a separate post-unmount, forced-GC renderer-isolate
+heap diagnostic. Do not use that run for timing or describe it as desktop RAM;
+it excludes worker heaps and native/browser-process memory.

--- a/packages/session-ui/performance/highlighting/build.ts
+++ b/packages/session-ui/performance/highlighting/build.ts
@@ -1,0 +1,26 @@
+import { build } from "vite"
+import solid from "vite-plugin-solid"
+import path from "node:path"
+import { realpathSync } from "node:fs"
+import { createHash } from "node:crypto"
+
+const outDir = process.env.HIGHLIGHT_BUNDLE
+if (!outDir) throw new Error("Set HIGHLIGHT_BUNDLE to an external artifact directory")
+const ui = realpathSync(path.resolve(import.meta.dir, "../../node_modules/@opencode-ai/ui"))
+if (ui !== realpathSync(path.resolve(import.meta.dir, "../../../ui"))) throw new Error(`Wrong workspace source: ${ui}`)
+await build({
+  configFile: false,
+  logLevel: "warn",
+  root: import.meta.dir,
+  plugins: [solid()],
+  build: { outDir, emptyOutDir: true, sourcemap: true },
+  worker: { format: "es" },
+})
+const files = await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: outDir, onlyFiles: true }))
+const hash = createHash("sha256")
+for (const file of files.sort()) hash.update(file).update(new Uint8Array(await Bun.file(path.join(outDir, file)).arrayBuffer()))
+await Bun.write(path.join(outDir, "build.json"), JSON.stringify({
+  revision: Bun.spawnSync(["git", "rev-parse", "HEAD"]).stdout.toString().trim(),
+  sourceDiff: Bun.spawnSync(["git", "diff", "--", "src/components/session-diff.ts", "src/components/file.tsx", "src/pierre/worker.ts"]).stdout.toString(),
+  bundle: hash.digest("hex"), bun: Bun.version, ui,
+}, null, 2))

--- a/packages/session-ui/performance/highlighting/build.ts
+++ b/packages/session-ui/performance/highlighting/build.ts
@@ -8,6 +8,8 @@ const outDir = process.env.HIGHLIGHT_BUNDLE
 if (!outDir) throw new Error("Set HIGHLIGHT_BUNDLE to an external artifact directory")
 const ui = realpathSync(path.resolve(import.meta.dir, "../../node_modules/@opencode-ai/ui"))
 if (ui !== realpathSync(path.resolve(import.meta.dir, "../../../ui"))) throw new Error(`Wrong workspace source: ${ui}`)
+const util = realpathSync(path.resolve(import.meta.dir, "../../node_modules/@opencode-ai/util"))
+if (util !== realpathSync(path.resolve(import.meta.dir, "../../../util"))) throw new Error(`Wrong workspace source: ${util}`)
 await build({
   configFile: false,
   logLevel: "warn",
@@ -22,5 +24,5 @@ for (const file of files.sort()) hash.update(file).update(new Uint8Array(await B
 await Bun.write(path.join(outDir, "build.json"), JSON.stringify({
   revision: Bun.spawnSync(["git", "rev-parse", "HEAD"]).stdout.toString().trim(),
   sourceDiff: Bun.spawnSync(["git", "diff", "--", "src/components/session-diff.ts", "src/components/file.tsx", "src/pierre/worker.ts"]).stdout.toString(),
-  bundle: hash.digest("hex"), bun: Bun.version, ui,
+  bundle: hash.digest("hex"), bun: Bun.version, ui, util,
 }, null, 2))

--- a/packages/session-ui/performance/highlighting/cache.correctness.ts
+++ b/packages/session-ui/performance/highlighting/cache.correctness.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test"
+import type {} from "./viewer"
+
+test("reuses only matching patch, theme, and worker options", async ({ page }) => {
+  await page.goto("/")
+  await page.waitForFunction(() => !!window.highlighting)
+  const cold = await page.evaluate(() => window.highlighting.mount(1))
+  expect(cold.workerRequests).toBe(1)
+  expect(cold.cacheSize).toBe(1)
+  const first = await page.locator('[data-line="11"][data-line-type="change-addition"]').innerHTML()
+  await page.evaluate(() => window.highlighting.unmount())
+
+  const cached = await page.evaluate(() => window.highlighting.mount(1))
+  expect(cached.workerRequests).toBe(0)
+  expect(await page.locator('[data-line="11"][data-line-type="change-addition"]').innerHTML()).toBe(first)
+  await page.evaluate(() => window.highlighting.unmount())
+
+  const changed = await page.evaluate(() => window.highlighting.mount(2))
+  expect(changed.workerRequests).toBe(1)
+  await expect(page.locator('[data-line="11"][data-line-type="change-addition"]')).toContainText("status: 202")
+  await page.evaluate(() => window.highlighting.unmount())
+
+  await page.evaluate(() => window.highlighting.configure({ theme: "github-dark" }))
+  const themed = await page.evaluate(() => window.highlighting.mount(2))
+  expect(themed.workerRequests).toBe(1)
+  expect(themed.options.theme).toBe("github-dark")
+  expect(themed.cacheSize).toBe(1)
+  await page.evaluate(() => window.highlighting.unmount())
+
+  await page.evaluate(() => window.highlighting.configure({ tokenizeMaxLineLength: 1 }))
+  const plain = await page.evaluate(() => window.highlighting.mount(2))
+  expect(plain.workerRequests).toBe(1)
+  expect(plain.options.tokenizeMaxLineLength).toBe(1)
+  expect(await page.evaluate(() => window.highlighting.contents()!.after === window.highlighting.input.after[1])).toBe(true)
+})

--- a/packages/session-ui/performance/highlighting/index.html
+++ b/packages/session-ui/performance/highlighting/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en" data-color-scheme="light">
+  <head><meta charset="UTF-8" /><title>Diff highlighting benchmark</title></head>
+  <body><div id="root"></div><script type="module" src="./viewer.tsx"></script></body>
+</html>

--- a/packages/session-ui/performance/highlighting/playwright.config.ts
+++ b/packages/session-ui/performance/highlighting/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@playwright/test"
 
 export default defineConfig({
-  testDir: ".", testMatch: "*.bench.ts", workers: 1, retries: 0, maxFailures: 1, timeout: 120_000,
+  testDir: ".", testMatch: process.env.HIGHLIGHT_CORRECTNESS ? "*.correctness.ts" : "*.bench.ts", workers: 1, retries: 0, maxFailures: 1, timeout: 120_000,
   outputDir: process.env.HIGHLIGHT_RESULTS,
   reporter: [["line"]],
   use: { baseURL: `http://127.0.0.1:${process.env.HIGHLIGHT_PORT ?? 4793}`, viewport: { width: 1280, height: 800 } },

--- a/packages/session-ui/performance/highlighting/playwright.config.ts
+++ b/packages/session-ui/performance/highlighting/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: ".", testMatch: "*.bench.ts", workers: 1, retries: 0, maxFailures: 1, timeout: 120_000,
+  outputDir: process.env.HIGHLIGHT_RESULTS,
+  reporter: [["line"]],
+  use: { baseURL: `http://127.0.0.1:${process.env.HIGHLIGHT_PORT ?? 4793}`, viewport: { width: 1280, height: 800 } },
+  webServer: {
+    command: "bun serve.ts",
+    url: `http://127.0.0.1:${process.env.HIGHLIGHT_PORT ?? 4793}`,
+    reuseExistingServer: false,
+  },
+})

--- a/packages/session-ui/performance/highlighting/serve.ts
+++ b/packages/session-ui/performance/highlighting/serve.ts
@@ -1,0 +1,11 @@
+import path from "node:path"
+
+const root = process.env.HIGHLIGHT_BUNDLE
+if (!root) throw new Error("Set HIGHLIGHT_BUNDLE")
+Bun.serve({
+  hostname: "127.0.0.1", port: Number(process.env.HIGHLIGHT_PORT ?? 4793),
+  fetch(request) {
+    const pathname = new URL(request.url).pathname
+    return new Response(Bun.file(path.join(root, pathname === "/" ? "index.html" : pathname)))
+  },
+})

--- a/packages/session-ui/performance/highlighting/viewer.bench.ts
+++ b/packages/session-ui/performance/highlighting/viewer.bench.ts
@@ -22,7 +22,16 @@ for (const large of [false, true]) {
     })
     expect(complete).toBe(true)
     expect(errors).toEqual([])
-    report({ cold, remount, changed }, {
+    const retention = await (async () => {
+      if (!process.env.HIGHLIGHT_RETENTION) return
+      await page.evaluate(() => window.highlighting.unmount())
+      const session = await page.context().newCDPSession(page)
+      await session.send("HeapProfiler.collectGarbage")
+      const heap = await session.send("Runtime.getHeapUsage")
+      await session.detach()
+      return heap
+    })()
+    report({ cold, remount, changed, retention }, {
       browser: browser.version(),
       dimensions: await page.evaluate(() => window.highlighting.dimensions),
       build: JSON.parse(await readFile(path.join(process.env.HIGHLIGHT_BUNDLE!, "build.json"), "utf8")),

--- a/packages/session-ui/performance/highlighting/viewer.bench.ts
+++ b/packages/session-ui/performance/highlighting/viewer.bench.ts
@@ -1,0 +1,32 @@
+import { benchmark, expect } from "../../../app/e2e/performance/benchmark"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+import type {} from "./viewer"
+
+for (const large of [false, true]) {
+  benchmark(large ? "large file" : "normalized diff remount", async ({ page, browser, report }, info) => {
+    const errors: string[] = []
+    page.on("pageerror", (error) => errors.push(error.message))
+    await page.goto(large ? "/?large" : "/")
+    await page.waitForFunction(() => !!window.highlighting)
+    const cold = await page.evaluate(() => window.highlighting.mount(1))
+    await expect(page.locator('[data-line="11"][data-line-type="change-addition"]')).toContainText("status: 201")
+    await page.evaluate(() => window.highlighting.unmount())
+    const remount = await page.evaluate(() => window.highlighting.mount(1))
+    await page.evaluate(() => window.highlighting.unmount())
+    const changed = await page.evaluate(() => window.highlighting.mount(2))
+    await expect(page.locator('[data-line="11"][data-line-type="change-addition"]')).toContainText("status: 202")
+    const complete = await page.evaluate(() => {
+      const contents = window.highlighting.contents()!
+      return contents.before === window.highlighting.input.before && contents.after === window.highlighting.input.after[1]
+    })
+    expect(complete).toBe(true)
+    expect(errors).toEqual([])
+    report({ cold, remount, changed }, {
+      browser: browser.version(),
+      dimensions: await page.evaluate(() => window.highlighting.dimensions),
+      build: JSON.parse(await readFile(path.join(process.env.HIGHLIGHT_BUNDLE!, "build.json"), "utf8")),
+    })
+    if (process.env.HIGHLIGHT_SCREENSHOTS) await page.screenshot({ path: path.join(process.env.HIGHLIGHT_SCREENSHOTS, `${large ? "large" : "diff"}-${info.repeatEachIndex}.png`) })
+  })
+}

--- a/packages/session-ui/performance/highlighting/viewer.tsx
+++ b/packages/session-ui/performance/highlighting/viewer.tsx
@@ -5,6 +5,7 @@ import type { RenderDiffOptions } from "@pierre/diffs"
 import { File } from "../../src/components/file"
 import { normalize, text } from "../../src/components/session-diff"
 import { getWorkerPool } from "../../src/pierre/worker"
+import "../../../ui/src/styles/theme.css"
 
 // This fixture uses the production component, normalizer, pool, and worker bundle.
 // Observe messages without replacing the worker or its implementation.

--- a/packages/session-ui/performance/highlighting/viewer.tsx
+++ b/packages/session-ui/performance/highlighting/viewer.tsx
@@ -1,0 +1,133 @@
+import { render } from "solid-js/web"
+import { createPatch } from "diff"
+import type { WorkerRequest, WorkerResponse, WorkerRenderingOptions } from "@pierre/diffs/worker"
+import type { RenderDiffOptions } from "@pierre/diffs"
+import { File } from "../../src/components/file"
+import { normalize, text } from "../../src/components/session-diff"
+import { getWorkerPool } from "../../src/pierre/worker"
+
+// This fixture uses the production component, normalizer, pool, and worker bundle.
+// Observe messages without replacing the worker or its implementation.
+const messages: { type: string; at: number; end?: number }[] = []
+const listening = new WeakSet<Worker>()
+const pending = new Map<string, (typeof messages)[number]>()
+const postMessage = Worker.prototype.postMessage
+Worker.prototype.postMessage = function (message: WorkerRequest, options?: StructuredSerializeOptions) {
+  if (!listening.has(this)) {
+    listening.add(this)
+    this.addEventListener("message", (event: MessageEvent<WorkerResponse>) => {
+      const item = pending.get(event.data.id)
+      if (item) item.end = performance.now()
+      pending.delete(event.data.id)
+    })
+  }
+  const item = { type: message.type, at: performance.now() }
+  messages.push(item)
+  pending.set(message.id, item)
+  postMessage.call(this, message, options)
+}
+
+function source(count: number, revision: number) {
+  return Array.from({ length: count }, (_, index) => {
+    const status = index % 10 === 0 ? 200 + revision : 200
+    return `export async function route${index}(request: Request, context: RouteContext) {
+  const account = await context.accounts.find(request.headers.get("account-id"))
+  if (!account) return new Response("Account not found", { status: 404 })
+  const payload = await request.json()
+  const record = await context.records.save({
+    accountId: account.id,
+    category: "route-${index}",
+    title: payload.title.trim(),
+    enabled: payload.enabled ?? true,
+  })
+  return Response.json({ id: record.id, status: ${status} })
+}
+`
+  }).join("\n")
+}
+
+const large = new URLSearchParams(location.search).has("large")
+const before = source(large ? 1200 : 120, 0)
+const inputs = [1, 2].map((revision) => {
+  const after = source(large ? 1200 : 120, revision)
+  return { file: "routes.ts", patch: createPatch("routes.ts", before, after, "", "", { context: Infinity }), after }
+})
+const host = document.getElementById("root")!
+let dispose: VoidFunction | undefined
+let active: ReturnType<typeof normalize> | undefined
+
+document.head.insertAdjacentHTML("beforeend", `<style>
+  :root { color-scheme: light; --font-family-mono: monospace; --font-size-small: 13px;
+    --color-background-stronger: white; --v2-background-bg-accent: #007acc; --v2-text-text-accent: #005a9e; }
+  body { margin: 16px; } #root { height: 760px; overflow: auto; }
+</style>`)
+
+type Measurement = {
+  readyMs: number
+  firstReadyMs: number
+  workerRequests: number
+  workerRoundTripMs: number
+  cacheSize: number
+  syntaxSpans: number
+  options: RenderDiffOptions
+}
+
+async function mount(revision: number) {
+  if (dispose) throw new Error("Unmount the previous viewer first")
+  const input = inputs[revision - 1]
+  const offset = messages.length
+  const start = performance.now()
+  active = normalize({ ...input, additions: large ? 120 : 12, deletions: large ? 120 : 12 })
+  const pool = getWorkerPool(large ? "none" : "word-alt")!
+  let firstReady = 0
+  let rendered = 0
+  let finish!: (value: Measurement) => void
+  const result = new Promise<Measurement>((resolve) => (finish = resolve))
+  const check = () => {
+    const stats = pool.getStats()
+    if (!firstReady || !rendered || stats.managerState !== "initialized" || stats.activeTasks || stats.queuedTasks || stats.busyWorkers) return
+    const work = messages.slice(offset).filter((item) => item.type === "diff")
+    if (work.some((item) => !item.end || rendered < item.end)) return
+    const root = host.querySelector("diffs-container")?.shadowRoot
+    if (!root?.querySelector("[data-line]")) return
+    if (!root.textContent?.includes(`status: ${200 + revision}`)) return
+    finish({
+      readyMs: performance.now() - start,
+      firstReadyMs: firstReady - start,
+      workerRequests: work.length,
+      workerRoundTripMs: work.reduce((sum, item) => sum + item.end! - item.at, 0),
+      cacheSize: stats.diffCacheSize,
+      syntaxSpans: root.querySelectorAll('[data-line] [style*="--syntax-"]').length,
+      options: pool.getDiffRenderOptions(),
+    })
+  }
+  const unsubscribe = pool.subscribeToStatChanges(check)
+  dispose = render(() => <File mode="diff" fileDiff={active!.fileDiff}
+    onRendered={() => { firstReady ||= performance.now(); check() }}
+    onPostRender={(_, __, phase) => {
+      if (phase === "unmount") return
+      rendered = performance.now()
+      queueMicrotask(check)
+    }} />, host)
+  const value = await result
+  unsubscribe()
+  return value
+}
+
+export const highlighting = {
+  mount,
+  configure(options: Partial<WorkerRenderingOptions>) { return getWorkerPool(large ? "none" : "word-alt")!.setRenderOptions(options) },
+  unmount() { dispose?.(); dispose = undefined; host.scrollTop = 0 },
+  contents() { return active && { before: text(active, "deletions"), after: text(active, "additions") } },
+  input: { before, after: inputs.map((input) => input.after) },
+  dimensions: {
+    functions: large ? 1200 : 120,
+    beforeBytes: new TextEncoder().encode(before).length,
+    afterBytes: new TextEncoder().encode(inputs[0].after).length,
+    patchBytes: new TextEncoder().encode(inputs[0].patch).length,
+    lines: before.split("\n").length - 1,
+  },
+}
+
+declare global { interface Window { highlighting: typeof highlighting } }
+window.highlighting = highlighting

--- a/packages/session-ui/performance/highlighting/viewer.tsx
+++ b/packages/session-ui/performance/highlighting/viewer.tsx
@@ -20,7 +20,7 @@ Worker.prototype.postMessage = function (message: WorkerRequest, options?: Trans
       const item = pending.get(event.data.id)
       if (item) item.end = performance.now()
       pending.delete(event.data.id)
-    })
+    }, { capture: true })
   }
   const item = { type: message.type, at: performance.now() }
   messages.push(item)

--- a/packages/session-ui/performance/highlighting/viewer.tsx
+++ b/packages/session-ui/performance/highlighting/viewer.tsx
@@ -92,7 +92,9 @@ async function mount(revision: number) {
     const root = host.querySelector("diffs-container")?.shadowRoot
     const edit = root?.querySelector('[data-line="11"][data-line-type="change-addition"]')
     if (!root || !edit?.textContent?.includes(`status: ${200 + revision}`)) return
-    const bounds = edit.getBoundingClientRect()
+    const range = document.createRange()
+    range.selectNodeContents(edit)
+    const bounds = range.getBoundingClientRect()
     if (bounds.top < host.getBoundingClientRect().top || bounds.bottom > host.getBoundingClientRect().bottom) return
     finish({
       readyMs: performance.now() - start,

--- a/packages/session-ui/performance/highlighting/viewer.tsx
+++ b/packages/session-ui/performance/highlighting/viewer.tsx
@@ -61,6 +61,7 @@ document.head.insertAdjacentHTML("beforeend", `<style>
   :root { color-scheme: light; --font-family-mono: monospace; --font-size-small: 13px;
     --color-background-stronger: white; --v2-background-bg-accent: #007acc; --v2-text-text-accent: #005a9e; }
   body { margin: 16px; } #root { height: 760px; overflow: auto; overflow-anchor: none; }
+  [data-slot="file-header"] { height: 40px; line-height: 40px; font: 13px system-ui; padding: 0 12px; }
 </style>`)
 
 type Measurement = {
@@ -107,13 +108,19 @@ async function mount(revision: number) {
     })
   }
   const unsubscribe = pool.subscribeToStatChanges(check)
-  dispose = render(() => <File mode="diff" fileDiff={active!.fileDiff}
-    onRendered={() => { firstReady ||= performance.now(); check() }}
-    onPostRender={(_, __, phase) => {
-      if (phase === "unmount") return
-      rendered = performance.now()
-      queueMicrotask(check)
-    }} />, host)
+  // Production surfaces place a header or earlier content above the diff inside a `[role="log"]` scroll content
+  // element. An empty diff element at scroll offset 0 makes Pierre's virtualizer anchor its bottom edge and scroll
+  // the host by the full content height once the first rows render.
+  dispose = render(() => <div role="log">
+    <div data-slot="file-header">{input.file}</div>
+    <File mode="diff" fileDiff={active!.fileDiff}
+      onRendered={() => { firstReady ||= performance.now(); check() }}
+      onPostRender={(_, __, phase) => {
+        if (phase === "unmount") return
+        rendered = performance.now()
+        queueMicrotask(check)
+      }} />
+  </div>, host)
   const value = await result
   unsubscribe()
   return value

--- a/packages/session-ui/performance/highlighting/viewer.tsx
+++ b/packages/session-ui/performance/highlighting/viewer.tsx
@@ -12,7 +12,7 @@ const messages: { type: string; at: number; end?: number }[] = []
 const listening = new WeakSet<Worker>()
 const pending = new Map<string, (typeof messages)[number]>()
 const postMessage = Worker.prototype.postMessage
-Worker.prototype.postMessage = function (message: WorkerRequest, options?: StructuredSerializeOptions) {
+Worker.prototype.postMessage = function (message: WorkerRequest, options?: Transferable[] | StructuredSerializeOptions) {
   if (!listening.has(this)) {
     listening.add(this)
     this.addEventListener("message", (event: MessageEvent<WorkerResponse>) => {
@@ -24,7 +24,7 @@ Worker.prototype.postMessage = function (message: WorkerRequest, options?: Struc
   const item = { type: message.type, at: performance.now() }
   messages.push(item)
   pending.set(message.id, item)
-  postMessage.call(this, message, options)
+  postMessage.call(this, message, Array.isArray(options) ? { transfer: options } : options)
 }
 
 function source(count: number, revision: number) {

--- a/packages/session-ui/performance/highlighting/viewer.tsx
+++ b/packages/session-ui/performance/highlighting/viewer.tsx
@@ -60,7 +60,7 @@ let active: ReturnType<typeof normalize> | undefined
 document.head.insertAdjacentHTML("beforeend", `<style>
   :root { color-scheme: light; --font-family-mono: monospace; --font-size-small: 13px;
     --color-background-stronger: white; --v2-background-bg-accent: #007acc; --v2-text-text-accent: #005a9e; }
-  body { margin: 16px; } #root { height: 760px; overflow: auto; }
+  body { margin: 16px; } #root { height: 760px; overflow: auto; overflow-anchor: none; }
 </style>`)
 
 type Measurement = {
@@ -90,8 +90,10 @@ async function mount(revision: number) {
     const work = messages.slice(offset).filter((item) => item.type === "diff")
     if (work.some((item) => !item.end || rendered < item.end)) return
     const root = host.querySelector("diffs-container")?.shadowRoot
-    if (!root?.querySelector("[data-line]")) return
-    if (!root.textContent?.includes(`status: ${200 + revision}`)) return
+    const edit = root?.querySelector('[data-line="11"][data-line-type="change-addition"]')
+    if (!root || !edit?.textContent?.includes(`status: ${200 + revision}`)) return
+    const bounds = edit.getBoundingClientRect()
+    if (bounds.top < host.getBoundingClientRect().top || bounds.bottom > host.getBoundingClientRect().bottom) return
     finish({
       readyMs: performance.now() - start,
       firstReadyMs: firstReady - start,

--- a/packages/session-ui/src/components/session-diff.test.ts
+++ b/packages/session-ui/src/components/session-diff.test.ts
@@ -127,6 +127,38 @@ describe("session diff", () => {
     expect(resolveFileDiff({ file: "b.ts", patch }).name).toBe("b.ts")
   })
 
+  test.each([
+    "@@ -1 +1 @@\n-old\n+new\n",
+    "--- a.ts\t\n+++ a.ts\t\n@@ -1 +1 @@\n-old\n+new\n",
+  ])("reuses a highlight identity for the same cached patch: %s", (patch) => {
+    const first = resolveFileDiff({ file: "a.ts", patch })
+    expect(first.cacheKey).toBeString()
+    expect(resolveFileDiff({ file: "a.ts", patch }).cacheKey).toBe(first.cacheKey)
+    expect(resolveFileDiff({ file: "b.ts", patch }).cacheKey).not.toBe(first.cacheKey)
+    expect(resolveFileDiff({ file: "a.ts", patch: patch.replace("+new", "+next") }).cacheKey).not.toBe(first.cacheKey)
+  })
+
+  test("keys preloaded content diffs by file name and content", () => {
+    const diff = { file: "a.ts", before: "one\n", after: "two\n", additions: 1, deletions: 1 }
+    const first = normalize(diff).fileDiff
+    expect(first.cacheKey).toBeString()
+    expect(normalize(diff).fileDiff.cacheKey).toBe(first.cacheKey)
+    expect(normalize({ ...diff, file: "a.py" }).fileDiff.cacheKey).not.toBe(first.cacheKey)
+    expect(normalize({ ...diff, after: "three\n" }).fileDiff.cacheKey).not.toBe(first.cacheKey)
+  })
+
+  test("does not reuse an evicted highlight identity for different content", () => {
+    const patch = "@@ -1 +1 @@\n-old\n+new\n"
+    const first = resolveFileDiff({ file: "evicted.ts", patch })
+    const keys = Array.from({ length: 20 }, (_, index) =>
+      resolveFileDiff({ file: "evicted.ts", patch: patch.replace("+new", `+new${index}`) }).cacheKey,
+    )
+    expect(keys).not.toContain(first.cacheKey)
+    const restored = resolveFileDiff({ file: "evicted.ts", patch })
+    expect(restored.additionLines).toEqual(first.additionLines)
+    expect(restored.cacheKey).toBeString()
+  })
+
   test("keeps capped header-only patches partial", () => {
     const fileDiff = resolveFileDiff({
       file: "a.ts",

--- a/packages/session-ui/src/components/session-diff.ts
+++ b/packages/session-ui/src/components/session-diff.ts
@@ -1,5 +1,6 @@
 import { parseDiffFromFile, parsePatchFiles, type FileDiffMetadata } from "@pierre/diffs"
 import { parsePatch } from "diff"
+import { checksum } from "@opencode-ai/util/encode"
 import type { FileDiffInfo } from "@opencode-ai/client/promise"
 import type { PresentationFileDiff } from "../file-presentation"
 
@@ -65,6 +66,8 @@ function fileDiffFromPatch(file: string, patch: string) {
   const value = contents
     ? fileDiffFromContent(file, contents.before, contents.after)
     : ((input ? parsePatchFiles(input)[0]?.files[0] : undefined) ?? emptyFileDiff(file))
+  // Complete patches already carry a content key from fileDiffFromContent; partial patches are keyed by the patch text.
+  value.cacheKey ??= highlightKey(key)
   patchFileDiffCache.set(key, value)
   while (patchFileDiffCache.size > diffCacheLimit) patchFileDiffCache.delete(patchFileDiffCache.keys().next().value!)
   return value
@@ -136,7 +139,16 @@ function patchInput(file: string, patch: string) {
 
 function fileDiffFromContent(file: string, before: string, after: string) {
   if (!before && !after) return emptyFileDiff(file)
-  return parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
+  const value = parseDiffFromFile({ name: file, contents: before }, { name: file, contents: after })
+  value.cacheKey = highlightKey(`${file}\0${before}\0${after}`)
+  return value
+}
+
+// Pierre reuses and dedups worker highlighting only for diffs that carry a cacheKey, and it treats diffs with equal
+// keys as the same target. Derive the key from every input that shapes the highlighted output: the file name selects
+// the language and the content selects the lines.
+function highlightKey(value: string) {
+  return `${value.length}:${checksum(value) ?? 0}`
 }
 
 function emptyFileDiff(file: string) {


### PR DESCRIPTION
Pierre's worker pool only reuses or dedups highlighted diff ASTs for diffs that carry a `cacheKey` (`getDiffResultCache`, `getDiffHighlightKey`, `areDiffTargetsEqual`). `normalize`/`resolveFileDiff` never set one, so every remount of the same patch posted a fresh worker request, re-tokenized the whole diff, and the pool's diff LRU stayed empty.

- `resolveFileDiff` now derives a content key (`length:fnv1a`) from the file name plus patch text, or from the file name plus before/after contents for complete patches and preloaded contents. Same input gives the same key; a different name or content gives a different key.
- Remounting a diff (tab switch, review re-open, transcript re-render) is served from the pool's LRU with zero worker messages; concurrent viewers of the same diff share one worker task.
- `normalize`, `completePatchContents`, and `ViewDiff` are unchanged.

```ts
// packages/session-ui/src/components/session-diff.ts
value.cacheKey ??= highlightKey(`${file}\0${patch}`)            // partial patches
value.cacheKey = highlightKey(`${file}\0${before}\0${after}`)   // complete / preloaded contents
```

```mermaid
sequenceDiagram
  participant V as File (diff)
  participant P as WorkerPoolManager
  participant W as Shiki worker
  Note over V,W: before: no cacheKey
  V->>P: render(fileDiff)
  P->>W: diff (whole patch)
  W-->>P: highlighted AST
  P-->>V: rerender
  V->>P: remount same fileDiff
  P->>W: diff (whole patch again)
  Note over V,W: after: content cacheKey
  V->>P: remount same fileDiff
  P-->>V: cached AST, 0 messages
```

## Benchmark

`packages/session-ui/performance/highlighting`: production `File` (diff mode, virtualized), `normalize`, `getWorkerPool`, bundled Pierre worker. TypeScript route-handler file, one edited line per ten handlers. Each isolated page: cold mount, unmount and remount of the identical patch, then an edited patch. `ready` = production `onRendered`, pool idle, and the final worker result committed by `onPostRender` with the expected edit visible. Chromium 147 headless, 1280x800, 20 serial pages per case, medians (p95). Baseline `32d4375b39` (benchmark commits only) vs candidate `2800c245ff`.

| Case | Phase | ready ms before | ready ms after | worker ms before | worker ms after | worker requests | pool cache |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 120 fn / 62 KB patch / 1,559 lines | remount | 632 (1115) | **68 (108)** | 595 | 0 | 1 → 0 | 0 → 1 |
| | cold | 1060 (1371) | 784 (1036) | 804 | 624 | 1 → 1 | 0 → 1 |
| | changed | 592 (915) | 478 (632) | 537 | 444 | 1 → 1 | 0 → 2 |
| 1,200 fn / 625 KB patch / 15,599 lines | remount | 6182 (8780) | **76 (148)** | 6139 | 0 | 1 → 0 | 0 → 1 |
| | cold | 6580 (9545) | 4815 (6738) | 6330 | 4596 | 1 → 1 | 0 → 1 |
| | changed | 5971 (9063) | 4797 (5786) | 5859 | 4691 | 1 → 1 | 0 → 2 |

- Only the remount rows are attributable to this change; cold and changed still post one worker request each and their deltas are run-to-run variance on a shared machine.
- Reconstructed before/after content is byte-equal to the inputs in every run; the correctness check also verifies identical innerHTML on remount and cache invalidation on content, theme, and worker option changes.
- The pool LRU (100 entries per pool) now actually retains highlighted diff results in the renderer; no memory measurement is claimed here.
