### PR TITLE
docs(ecosystem): add opencode-twg plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-twg](https://github.com/atlassian-labs/twg-plugins)                                      | Setup, authenticate, repair, and verify Atlassian Teamwork Graph CLI                               |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation addition for the community ecosystem plugins list.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-twg](https://github.com/atlassian-labs/twg-plugins) to the Plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

`opencode-twg` supplies OpenCode with canonical setup, authentication, repair, and verification guidance for Atlassian's Teamwork Graph CLI.

### How did you verify your code works?

Confirmed the repository link responds successfully and the updated MDX passes Prettier and `git diff --check`.

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
