### PR TITLE
fix(session-ui): render large diffs as plain text in the worker pool

### DIFF
--- a/packages/session-ui/performance/highlighting/README.md
+++ b/packages/session-ui/performance/highlighting/README.md
@@ -25,8 +25,9 @@ mechanism, not CPU time or desktop memory. Full reconstructed content is checked
 separately after timing. No forced GC or machine-dependent thresholds are used.
 
 `HIGHLIGHT_CORRECTNESS=1` runs the deterministic `*.correctness.ts` checks against
-the same fixture instead of the timed benchmarks: cache reuse across remounts and
-invalidation on content, theme, and worker option changes.
+the same fixture instead of the timed benchmarks: cache reuse across remounts,
+invalidation on content, theme, and worker option changes, and plain rendering of
+large diffs with complete reconstructed content.
 
 Optional output settings: `HIGHLIGHT_RESULTS`, `HIGHLIGHT_SCREENSHOTS`,
 `OPENCODE_PERFORMANCE_RUN_ID`, and `OPENCODE_PERFORMANCE_TRACE_DIR` (separate

--- a/packages/session-ui/performance/highlighting/plain.correctness.ts
+++ b/packages/session-ui/performance/highlighting/plain.correctness.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test"
+import type {} from "./viewer"
+
+test("renders large diffs as plain text without changing ordinary highlighting", async ({ page }) => {
+  await page.goto("/?large")
+  await page.waitForFunction(() => !!window.highlighting)
+  const large = await page.evaluate(() => window.highlighting.mount(1))
+  expect(large.options).toMatchObject({ lineDiffType: "none", maxLineDiffLength: 0, tokenizeMaxLineLength: 1 })
+  expect(large.syntaxSpans).toBe(0)
+  await expect(page.locator('[data-line="11"][data-line-type="change-addition"]')).toContainText("status: 201")
+  expect(await page.evaluate(() => window.highlighting.contents()!.after === window.highlighting.input.after[0])).toBe(true)
+
+  await page.goto("/")
+  await page.waitForFunction(() => !!window.highlighting)
+  const ordinary = await page.evaluate(() => window.highlighting.mount(1))
+  expect(ordinary.options).toMatchObject({ lineDiffType: "word-alt", maxLineDiffLength: 1000, tokenizeMaxLineLength: 1000 })
+  expect(ordinary.syntaxSpans).toBeGreaterThan(0)
+  await expect(page.locator('[data-line="11"][data-line-type="change-addition"]')).toContainText("status: 201")
+})

--- a/packages/session-ui/src/pierre/worker.ts
+++ b/packages/session-ui/src/pierre/worker.ts
@@ -22,6 +22,9 @@ function createPool(lineDiffType: "none" | "word-alt") {
     {
       theme: "OpenCode",
       lineDiffType,
+      // Pierre renders with the pool's options, not the viewer's, whenever the pool works. The "none" pool only
+      // serves diffs above the large-file threshold, so it carries the plain-text fallback the viewer requests.
+      ...(lineDiffType === "none" && { maxLineDiffLength: 0, tokenizeMaxLineLength: 1 }),
       preferredHighlighter: "shiki-wasm",
     },
   )


### PR DESCRIPTION
`DiffViewer` asks for a plain-text fallback above 500 KB (`largeOptions`: `lineDiffType: "none"`, `maxLineDiffLength: 0`, `tokenizeMaxLineLength: 1`), but Pierre's `DiffHunksRenderer.getRenderOptions` uses the worker pool's render options whenever the pool works. The dedicated `"none"` pool only carried `lineDiffType`, so every >500 KB diff was still fully Shiki-tokenized (1000-char line cap) on each mount, about 6 s in the worker for a 625 KB patch.

- The `"none"` pool now carries the plain-text options the viewer requests. It only serves diffs above the large-file threshold (`file.tsx` picks it via `large()`), so ordinary diffs keep `word-alt` intra-line diffs and full highlighting on the default pool.
- Large diffs render as plain text through the same worker path, with complete content, hunks, and line numbers intact. `largeOptions` in `file.tsx` stays as the no-pool fallback.

```ts
// packages/session-ui/src/pierre/worker.ts
{
  theme: "OpenCode",
  lineDiffType,
  ...(lineDiffType === "none" && { maxLineDiffLength: 0, tokenizeMaxLineLength: 1 }),
  preferredHighlighter: "shiki-wasm",
}
```

## Benchmark

`packages/session-ui/performance/highlighting`: production `File` (diff mode, virtualized), `normalize`, `getWorkerPool`, bundled Pierre worker. TypeScript route-handler file, one edited line per ten handlers. Each isolated page: cold mount, unmount and remount, then an edited patch. `ready` = production `onRendered`, pool idle, and the final worker result committed by `onPostRender` with the expected edit visible. Chromium 147 headless, 1280x800, 20 serial pages per case, medians (p95). Baseline `32d4375b39` (benchmark commits only) vs candidate `6e00f90629`.

| Case | Phase | ready ms before | ready ms after | worker ms before | worker ms after | syntax spans | tokenizeMaxLineLength |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1,200 fn / 625 KB patch / 15,599 lines | cold | 6580 (9545) | **432 (506)** | 6330 | 195 | 730 → 0 | 1000 → 1 |
| | remount | 6182 (8780) | **178 (203)** | 6139 | 157 | 730 → 0 | 1000 → 1 |
| | changed | 5971 (9063) | **228 (266)** | 5859 | 150 | 730 → 0 | 1000 → 1 |
| 120 fn / 62 KB patch / 1,559 lines (unchanged path) | cold | 1060 (1371) | 849 (931) | 804 | 625 | 730 → 730 | 1000 → 1000 |
| | remount | 632 (1115) | 493 (570) | 595 | 465 | 730 → 730 | 1000 → 1000 |
| | changed | 592 (915) | 514 (574) | 537 | 470 | 730 → 730 | 1000 → 1000 |

- The ordinary case uses the untouched `word-alt` pool; its deltas are run-to-run variance on a shared machine (the same shift appears in an unrelated candidate run), not an effect of this change.
- Reconstructed before/after content is byte-equal to the inputs in every run. The correctness check asserts plain options and zero syntax spans for the large fixture and full highlighting for the ordinary fixture.
- Visual change for >500 KB diffs only: plain text instead of syntax colors. This is the behavior `file.tsx` already intended.

| Before (625 KB diff) | After |
| --- | --- |
| ![](https://github.com/user-attachments/assets/179fe395-5609-4555-a767-6f437b7a9dcf) | ![](https://github.com/user-attachments/assets/34d49aa8-be9a-42b6-8a58-31c82a2639dc) |
