### PR TITLE
fix(desktop): publish native menu zoom changes

### DIFF
--- a/packages/desktop/src/main/native/menu-actions.ts
+++ b/packages/desktop/src/main/native/menu-actions.ts
@@ -1,6 +1,6 @@
 import { BrowserWindow } from "electron"
 import type { DesktopMenuAction } from "@opencode-ai/app/desktop-menu"
-import { updateTitlebar } from "../windows"
+import { setZoomFactor } from "../windows"
 
 export type DesktopMenuActionHandlers = Partial<{
   checkForUpdates: () => void
@@ -47,13 +47,13 @@ export function runDesktopMenuAction(
       win?.webContents.toggleDevTools()
       return
     case "view.resetZoom":
-      setZoom(win, 1)
+      if (win) setZoomFactor(win, 1)
       return
     case "view.zoomIn":
-      setZoom(win, (win?.webContents.getZoomFactor() ?? 1) + 0.2)
+      if (win) setZoomFactor(win, win.webContents.getZoomFactor() + 0.2)
       return
     case "view.zoomOut":
-      setZoom(win, (win?.webContents.getZoomFactor() ?? 1) - 0.2)
+      if (win) setZoomFactor(win, win.webContents.getZoomFactor() - 0.2)
       return
     case "view.toggleFullscreen":
       win?.setFullScreen(!win.isFullScreen())
@@ -80,10 +80,4 @@ export function runDesktopMenuAction(
       win?.webContents.selectAll()
       return
   }
-}
-
-function setZoom(win: BrowserWindow | null, value: number) {
-  if (!win) return
-  win.webContents.setZoomFactor(Math.min(Math.max(value, 0.2), 10))
-  updateTitlebar(win)
 }

--- a/packages/desktop/src/main/windows/appearance.ts
+++ b/packages/desktop/src/main/windows/appearance.ts
@@ -99,6 +99,11 @@ export function getPinchZoomEnabled() {
   return getStore().get(PINCH_ZOOM_ENABLED_KEY) === true
 }
 
+export function setZoomFactor(win: BrowserWindow, factor: number) {
+  win.webContents.setZoomFactor(clampZoom(factor))
+  updateZoom(win)
+}
+
 export function wireZoom(win: BrowserWindow) {
   pinchZoomEnabled.set(win, getPinchZoomEnabled())
   win.webContents.setZoomFactor(1)

--- a/packages/desktop/src/main/windows/index.ts
+++ b/packages/desktop/src/main/windows/index.ts
@@ -15,6 +15,7 @@ import {
   setDockIcon,
   setPinchZoomEnabled,
   setTitlebar,
+  setZoomFactor,
   updateTitlebar,
   windowAppearance,
   wireFullscreen,
@@ -44,6 +45,7 @@ export {
   setDockIcon,
   setPinchZoomEnabled,
   setTitlebar,
+  setZoomFactor,
   updateTitlebar,
 }
 

--- a/packages/desktop/src/renderer/window/zoom.ts
+++ b/packages/desktop/src/renderer/window/zoom.ts
@@ -46,6 +46,13 @@ const applyZoom = (next: number) => {
     })
 }
 
+// A renderer reload keeps the window's zoom, so seed the signal from main.
+void api.getZoomFactor().then((factor) => {
+  if (requestedZoom !== 1) return
+  requestedZoom = clamp(factor)
+  setWebviewZoom(requestedZoom)
+})
+
 api.onZoomFactorChanged((factor) => {
   requestedZoom = clamp(factor)
   setWebviewZoom(requestedZoom)


### PR DESCRIPTION
## Summary

- The native **View → Zoom In / Zoom Out / Actual Size** menu changed the window zoom factor without emitting `WindowZoomChanged`, so the renderer's `webviewZoom` signal stayed stale. Anything laid out from that signal (titlebar insets, native view bounds) drifted from the real zoom until the next keyboard or pinch zoom.
- Route the menu actions through one `setZoomFactor(win, factor)` in `windows/appearance.ts` that clamps, applies, updates the titlebar overlay, and publishes the event.
- Seed `webviewZoom` from `getZoomFactor()` on renderer start so a reload while zoomed does not reset the signal to `1`.

```mermaid
flowchart LR
    Menu[Native View menu] --> Set[setZoomFactor]
    Keys[Ctrl +/- keys] --> Set
    Pinch[zoom-changed] --> Set
    Set --> Titlebar[updateTitlebar]
    Set --> Event[WindowZoomChanged]
    Event --> Signal[renderer webviewZoom]
```
