### PR TITLE
docs(i18n): add Turkish policies translation and fix Turkish characters in share

### DIFF
--- a/packages/web/src/content/docs/tr/policies.mdx
+++ b/packages/web/src/content/docs/tr/policies.mdx
@@ -1,0 +1,137 @@
+---
+title: Politikalar
+description: OpenCode'un hangi yapılandırılmış kaynakları kullanabileceğini kontrol edin.
+---
+
+Politikalar, OpenCode'un adlandırılmış bir kaynak üzerinde bir eylem gerçekleştirip gerçekleştiremeyeceğini kontrol eder. Bu özellik deneyseldir ve `opencode.json` içindeki `experimental.policies` dizisiyle yapılandırılır.
+
+Politikalar [izinlerden](/docs/permissions) ayrıdır. İzinler bir oturum sırasında araçların neler yapabileceğini kontrol ederken, politikalar OpenCode'un bir LLM sağlayıcısı gibi bir kaynağı kullanıp kullanamayacağını kontrol eder.
+
+---
+
+## Yapılandırma
+
+Her politika ifadesinin üç alanı vardır:
+
+- `effect` — `"allow"` veya `"deny"` olabilir.
+- `action` — Kontrol edilen işlem.
+- `resource` — İfadenin geçerli olduğu kaynak kimliği veya joker karakter deseni.
+
+Örneğin, `openai` sağlayıcısının kullanımını reddetmek için:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "openai"
+      }
+    ]
+  }
+}
+```
+
+Politika tarafından reddedilen bir sağlayıcı, kimlik bilgisi olsa veya başka türlü doğru şekilde yapılandırılmış olsa bile model seçimi ve model kullanımı için kullanılamaz.
+
+---
+
+## Kullanılabilir politikalar
+
+OpenCode şu anda tek bir politika action'ını destekler:
+
+| Action           | Resource                       | Açıklama                                      |
+| ---------------- | ------------------------------ | --------------------------------------------- |
+| `provider.use`   | Sağlayıcı kimliği, örneğin `openai` | Bir LLM sağlayıcısının kullanımına izin verin veya reddedin. |
+
+Gelecekte daha fazla politika action'ı eklenebilir.
+
+---
+
+## Eşleştirme
+
+`resource` alanı joker karakter eşleştirmeyi destekler. Sıfır veya daha fazla karakteri eşleştirmek için `*`, tek bir karakteri eşleştirmek için `?` kullanın.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "company-*"
+      }
+    ]
+  }
+}
+```
+
+Bu, `company-us` ve `company-eu` gibi sağlayıcıları reddeder.
+
+---
+
+## Kural sırası
+
+Birden fazla ifade eşleştiğinde, son eşleşen ifade kazanır. Geniş kuralları başa, daha spesifik istisnaları ise onların arkasına koyun.
+
+Örneğin, yalnızca Anthropic'e izin vermek için:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "experimental": {
+    "policies": [
+      {
+        "effect": "deny",
+        "action": "provider.use",
+        "resource": "*"
+      },
+      {
+        "effect": "allow",
+        "action": "provider.use",
+        "resource": "anthropic"
+      }
+    ]
+  }
+}
+```
+
+Bir sağlayıcıyla eşleşen politika yoksa, sağlayıcının kullanımı varsayılan olarak izinlidir.
+
+Politikalar hem genel config'inizde hem de proje config'inde ayarlanabilir. Her iki konumdaki politikalar aynı sağlayıcıyla eşleşirse, genel politikanız proje politikasından öncelik alır. Bu, bir repository'nin genel olarak reddettiğiniz bir sağlayıcıyı yeniden etkinleştirmesini engeller.
+
+---
+
+## Sağlayıcı listeleri
+
+Sağlayıcı erişimini kontrol ederken eski `disabled_providers` ve `enabled_providers` ayarları yerine politikaları kullanın.
+
+`disabled_providers` yerine geçecek şekilde:
+
+```json title="opencode.json"
+{
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "openai" },
+      { "effect": "deny", "action": "provider.use", "resource": "google" }
+    ]
+  }
+}
+```
+
+`enabled_providers` yerine geçecek şekilde, önce tüm sağlayıcıları reddedin ve ardından seçilen sağlayıcılara izin verin:
+
+```json title="opencode.json"
+{
+  "experimental": {
+    "policies": [
+      { "effect": "deny", "action": "provider.use", "resource": "*" },
+      { "effect": "allow", "action": "provider.use", "resource": "anthropic" },
+      { "effect": "allow", "action": "provider.use", "resource": "openai" }
+    ]
+  }
+}
+```

--- a/packages/web/src/content/docs/tr/share.mdx
+++ b/packages/web/src/content/docs/tr/share.mdx
@@ -1,43 +1,43 @@
 ---
-title: Paylasim
-description: opencode konusmalarini genel baglantilarla paylasin.
+title: Paylaşım
+description: OpenCode konuşmalarınızı paylaşın.
 ---
 
-opencode'un paylasim ozelligi, konusmalariniz icin genel baglantilar olusturmanizi saglar. Boylece ekip arkadaslarinizla birlikte calisabilir veya diger kisilerden yardim alabilirsiniz.
+OpenCode'un paylaşım özelliği, konuşmalarınız için genel bağlantılar oluşturmanızı sağlar. Böylece ekip arkadaşlarınızla birlikte çalışabilir veya diğer kişilerden yardım alabilirsiniz.
 
 :::note
-Paylasilan konusmalar, baglantiya sahip herkes tarafindan gorulebilir.
+Paylaşılan konuşmalar, bağlantıya sahip herkes tarafından görülebilir.
 :::
 
 ---
 
-## Nasil calisir
+## Nasıl çalışır
 
-Bir konusmayi paylastiginizda opencode:
+Bir konuşmayı paylaştığınızda OpenCode:
 
-1. Oturumunuz icin benzersiz bir genel URL olusturur
-2. Konusma gecmisinizi sunucularimiza senkronize eder
-3. Konusmayi paylasim baglantisiyla erisilebilir hale getirir - `opncd.ai/s/<share-id>`
-
----
-
-## Paylasim
-
-opencode, konusmalarin nasil paylasilacagini kontrol eden uc farkli paylasim modu sunar:
+1. Oturumunuz için benzersiz bir genel URL oluşturur
+2. Konuşma geçmişinizi sunucularımıza senkronize eder
+3. Konuşmayı paylaşım bağlantısıyla erişilebilir hale getirir — `opncd.ai/s/<share-id>`
 
 ---
 
-### Manuel (varsayilan)
+## Paylaşım
 
-Varsayilan olarak opencode manuel paylasim modunu kullanir. Oturumlar otomatik paylasilmaz, ancak `/share` komutuyla manuel olarak paylasabilirsiniz:
+OpenCode, konuşmaların nasıl paylaşılacağını kontrol eden üç farklı paylaşım modu sunar:
+
+---
+
+### Manuel (varsayılan)
+
+Varsayılan olarak OpenCode manuel paylaşım modunu kullanır. Oturumlar otomatik paylaşılmaz, ancak `/share` komutuyla manuel olarak paylaşabilirsiniz:
 
 ```
 /share
 ```
 
-Bu komut benzersiz bir URL uretir ve panoya kopyalar.
+Bu komut benzersiz bir URL üretir ve panoya kopyalar.
 
-Manuel modu acikca ayarlamak icin [config dosyaniza](/docs/config) sunu ekleyin:
+Manuel modu açıkça ayarlamak için [config dosyanıza](/docs/config) şunu ekleyin:
 
 ```json title="opencode.json"
 {
@@ -48,9 +48,9 @@ Manuel modu acikca ayarlamak icin [config dosyaniza](/docs/config) sunu ekleyin:
 
 ---
 
-### Otomatik paylasim
+### Otomatik paylaşım
 
-Tum yeni konusmalar icin otomatik paylasimi acmak isterseniz, [config dosyanizda](/docs/config) `share` degerini `"auto"` yapin:
+Tüm yeni konuşmalar için otomatik paylaşımı açmak isterseniz, [config dosyanızda](/docs/config) `share` değerini `"auto"` yapın:
 
 ```json title="opencode.json"
 {
@@ -59,13 +59,13 @@ Tum yeni konusmalar icin otomatik paylasimi acmak isterseniz, [config dosyanizda
 }
 ```
 
-Otomatik paylasim acikken her yeni konusma otomatik olarak paylasilir ve bir baglanti olusturulur.
+Otomatik paylaşım açıkken her yeni konuşma otomatik olarak paylaşılır ve bir bağlantı oluşturulur.
 
 ---
 
-### Devre disi
+### Devre dışı
 
-Paylasimi tamamen kapatmak icin [config dosyanizda](/docs/config) `share` degerini `"disabled"` yapin:
+Paylaşımı tamamen kapatmak için [config dosyanızda](/docs/config) `share` değerini `"disabled"` yapın:
 
 ```json title="opencode.json"
 {
@@ -74,54 +74,54 @@ Paylasimi tamamen kapatmak icin [config dosyanizda](/docs/config) `share` degeri
 }
 ```
 
-Bunu belirli bir projede tum ekip icin zorunlu kilmak icin proje icindeki `opencode.json` dosyasina ekleyip Git'e commit edin.
+Bunu belirli bir projede tüm ekip için zorunlu kılmak için proje içindeki `opencode.json` dosyasına ekleyip Git'e commit edin.
 
 ---
 
-## Paylasimi kaldirma
+## Paylaşımı kaldırma
 
-Bir konusmanin paylasimini durdurmak ve genel erisimi kaldirmak icin:
+Bir konuşmanın paylaşımını durdurmak ve genel erişimi kaldırmak için:
 
 ```
 /unshare
 ```
 
-Bu komut paylasim baglantisini kaldirir ve konusmaya ait verileri siler.
+Bu komut paylaşım bağlantısını kaldırır ve konuşmaya ait verileri siler.
 
 ---
 
 ## Gizlilik
 
-Bir konusmayi paylasirken akilda tutulmasi gereken bazi noktalar vardir.
+Bir konuşmayı paylaşırken akılda tutulması gereken bazı noktalar vardır.
 
 ---
 
 ### Veri saklama
 
-Paylasilan konusmalar, siz acikca paylasimi kaldirana kadar erisilebilir kalir. Buna sunlar dahildir:
+Paylaşılan konuşmalar, siz açıkça paylaşımı kaldırana kadar erişilebilir kalır. Buna şunlar dahildir:
 
-- Tum konusma gecmisi
-- Tum mesajlar ve yanitlar
+- Tüm konuşma geçmişi
+- Tüm mesajlar ve yanıtlar
 - Oturum metaverisi
 
 ---
 
-### Oneriler
+### Öneriler
 
-- Hassas bilgi icermeyen konusmalari paylasin.
-- Paylasmadan once konusma icerigini gozden gecirin.
-- Is birligi bittiginde paylasimi kaldirin.
-- Tescilli kod veya gizli veri iceren konusmalari paylasmayin.
-- Hassas projelerde paylasimi tamamen kapatin.
+- Yalnızca hassas bilgi içermeyen konuşmaları paylaşın.
+- Paylaşmadan önce konuşma içeriğini gözden geçirin.
+- İş birliği bittiğinde paylaşımı kaldırın.
+- Tescilli kod veya gizli veri içeren konuşmaları paylaşmaktan kaçının.
+- Hassas projelerde paylaşımı tamamen kapatın.
 
 ---
 
-## Kurumsal kullanim
+## Kurumsal kullanım
 
-Kurumsal kurulumlarda paylasim ozelligi su sekillerde yapilandirilabilir:
+Kurumsal kurulumlarda paylaşım özelliği şu şekillerde yapılandırılabilir:
 
-- Guvenlik uyumu icin tamamen **devre disi** birakilabilir
-- Sadece SSO ile dogrulanan kullanicilarla **sinirlandirilabilir**
-- Kendi altyapinizda **self-hosted** olarak calistirilabilir
+- Güvenlik uyumu için tamamen **devre dışı** bırakılabilir
+- Yalnızca SSO ile doğrulanan kullanıcılarla **sınırlandırılabilir**
+- Kendi altyapınızda **self-hosted** olarak çalıştırılabilir
 
-Kurulusunuzda opencode kullanimi icin [daha fazla bilgi alin](/docs/enterprise).
+Kuruluşunuzda opencode kullanımı hakkında [daha fazla bilgi alın](/docs/enterprise).


### PR DESCRIPTION
### Issue for this PR

Closes #

_No linked issue — found by comparing `packages/web/src/content/docs/` root files against the `tr/` folder: `policies.mdx` has no Turkish translation (no locale has one yet), and `tr/share.mdx` is one of only 3 tr files written with ASCII Turkish instead of proper Turkish characters._

### Type of change

- [x] Documentation

### What does this PR do?

Two things, both scoped to Turkish docs:

1. **Adds the missing `tr/policies.mdx` translation.** The tr page currently falls back to English. Technical terms stay in English (policy, action, resource, provider, config) per existing tr conventions; JSON code blocks are untouched.
2. **Fixes `tr/share.mdx` characters.** The file was written entirely with ASCII Turkish ("Paylasim", "konusma", "baglanti") while 31 of 32 other tr pages use proper Turkish characters. Content and structure are unchanged — only character fixes, plus normalizing "opencode" casing and an em-dash to match the current English source.

### How did you verify your code works?

- `policies.mdx` structure is 1:1 with the English source: 10 code fences, 5 headings, 3 table rows — verified programmatically, and the JSON block contents diff clean
- `share.mdx` structure unchanged: 10 code fences, 10 headings, 1 note block before and after
- Terminology side-by-side checked against existing tr pages (`config.mdx`, `agents.mdx`, `go.mdx`): "joker karakter" for wildcard, "sağlayıcı" for provider, Evet/Hayır table style

### Screenshots / recordings

Not a UI code change; the rendered results will be at opencode.ai/docs/tr/policies/ and opencode.ai/docs/tr/share/ once merged.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR