### PR TITLE
fix(core): reuse the Code Mode catalog across tool snapshots

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,7 @@
     "fix-node-pty": "bun run script/fix-node-pty.ts",
     "benchmark:location": "bun run script/benchmark-location.ts",
     "benchmark:location-memory": "bun run script/benchmark-location-memory.ts",
+    "benchmark:tool-snapshot": "bun run script/benchmark-tool-snapshot.ts",
     "build": "bun run script/build.ts",
     "update-models-snapshot": "bun run script/update-models-snapshot.ts",
     "test": "bun run script/test.ts",

--- a/packages/core/script/benchmark-tool-snapshot.ts
+++ b/packages/core/script/benchmark-tool-snapshot.ts
@@ -1,0 +1,288 @@
+// Measures what one LLM step pays to snapshot the Location tool registry when a
+// large MCP inventory is registered: `Tool.snapshot` plus the Code Mode
+// instructions built from its catalog (the two per-step calls in
+// `SessionContext.select`). Tools are synthetic OpenAPI-shaped MCP registrations
+// with realistic descriptions and JSON schemas; nothing is executed.
+//
+//   bun run script/benchmark-tool-snapshot.ts [--tools 3242] [--iterations 20] [--json out.json]
+//
+// Per-iteration heap growth is sampled after a forced GC before the iteration and
+// without GC afterwards, so it approximates bytes allocated by that step. Retained
+// heap after all iterations is a separate forced-GC number.
+import fs from "fs/promises"
+import path from "path"
+import { heapStats } from "bun:jsc"
+import { Effect, Layer, Logger } from "effect"
+import type { JsonSchema } from "effect"
+import { AppNodeBuilder } from "../src/effect/app-node-builder"
+import { CodeModeInstructions } from "../src/codemode/instructions"
+import { Image } from "../src/image"
+import { Tool } from "../src/tool"
+
+const args = process.argv.slice(2)
+const flag = (name: string, fallback: number) => {
+  const index = args.indexOf(`--${name}`)
+  if (index === -1) return fallback
+  const value = Number(args[index + 1])
+  if (!Number.isInteger(value) || value < 1) {
+    console.error(`--${name} must be a positive integer`)
+    process.exit(1)
+  }
+  return value
+}
+const toolCount = flag("tools", 3242)
+const iterations = flag("iterations", 20)
+const jsonIndex = args.indexOf("--json")
+const jsonPath = jsonIndex === -1 ? undefined : args[jsonIndex + 1]
+
+const resources = [
+  "accounts",
+  "zones",
+  "dns_records",
+  "workers",
+  "scripts",
+  "kv_namespaces",
+  "r2_buckets",
+  "queues",
+  "pages_projects",
+  "access_apps",
+  "gateway_rules",
+  "load_balancers",
+  "tunnels",
+  "certificates",
+  "firewall_rules",
+  "rulesets",
+  "logpush_jobs",
+  "images",
+  "stream_videos",
+  "d1_databases",
+]
+const methods = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const
+
+const body = (index: number): JsonSchema.JsonSchema => ({
+  type: "object",
+  description: "Request body",
+  properties: {
+    name: { type: "string", description: "Human readable name for the resource", maxLength: 256 },
+    enabled: { type: "boolean", description: "Whether the resource is active" },
+    tags: { type: "array", description: "Labels attached to the resource", items: { type: "string" } },
+    ttl: { type: "integer", description: "Time to live in seconds", minimum: 60, maximum: 86400 },
+    mode: { type: "string", enum: ["off", "on", "custom"], description: "Operating mode" },
+    settings: {
+      type: "object",
+      description: "Nested configuration",
+      properties: {
+        region: { type: "string", description: "Deployment region such as WNAM or ENAM" },
+        retries: { type: "integer", description: "Retry budget", minimum: 0, maximum: 10 },
+        origins: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              address: { type: "string", description: "Origin host or IP" },
+              weight: { type: "number", description: "Traffic weight between 0 and 1" },
+            },
+            required: ["address"],
+          },
+        },
+      },
+    },
+    ...(index % 3 === 0 ? { comment: { type: "string", description: "Free form note" } } : {}),
+  },
+  required: ["name"],
+})
+
+const input = (method: (typeof methods)[number], index: number): JsonSchema.JsonSchema => ({
+  type: "object",
+  properties: {
+    account_id: { type: "string", description: "Account identifier", maxLength: 32 },
+    ...(index % 2 === 0 ? { zone_id: { type: "string", description: "Zone identifier", maxLength: 32 } } : {}),
+    ...(method === "GET"
+      ? {
+          page: { type: "integer", description: "Page number of paginated results", minimum: 1 },
+          per_page: { type: "integer", description: "Number of results per page", minimum: 5, maximum: 1000 },
+          order: { type: "string", enum: ["id", "name", "created_on", "modified_on"], description: "Sort field" },
+          direction: { type: "string", enum: ["asc", "desc"], description: "Sort direction" },
+          match: { type: "string", enum: ["any", "all"], description: "Whether to match all or any filter" },
+        }
+      : {}),
+    ...(method === "POST" || method === "PUT" || method === "PATCH" ? { body: body(index) } : {}),
+    ...(method !== "POST" && method !== "GET" ? { identifier: { type: "string", description: "Resource id" } } : {}),
+  },
+  required: ["account_id"],
+})
+
+const output: JsonSchema.JsonSchema = {
+  type: "object",
+  properties: {
+    success: { type: "boolean" },
+    errors: {
+      type: "array",
+      items: { type: "object", properties: { code: { type: "integer" }, message: { type: "string" } } },
+    },
+    messages: {
+      type: "array",
+      items: { type: "object", properties: { code: { type: "integer" }, message: { type: "string" } } },
+    },
+    result: { description: "Operation result" },
+    result_info: {
+      type: "object",
+      properties: {
+        page: { type: "integer" },
+        per_page: { type: "integer" },
+        count: { type: "integer" },
+        total_count: { type: "integer" },
+      },
+    },
+  },
+}
+
+const synthetic = (index: number) => {
+  const method = methods[index % methods.length]!
+  const resource = resources[index % resources.length]!
+  const child = resources[(index * 7 + 3) % resources.length]!
+  const single = method !== "GET" && method !== "POST"
+  const route = `/accounts/{account_id}/${resource}/${index}/${child}${single ? "/{identifier}" : ""}`
+  const verb =
+    method === "GET"
+      ? "get"
+      : method === "POST"
+        ? "post"
+        : method === "PUT"
+          ? "put"
+          : method === "PATCH"
+            ? "patch"
+            : "delete"
+  return {
+    name: `${verb}_${resource}_${index}_${child}`,
+    description: `${method} ${route}`,
+    input: input(method, index),
+  }
+}
+
+const bytes = new TextEncoder()
+const registryLayer = AppNodeBuilder.build(Tool.node, [
+  Image.node.replace(Layer.mock(Image.Service, { normalize: (_, content) => Effect.succeed(content) })),
+])
+
+const program = Effect.gen(function* () {
+  const registry = yield* Tool.Service
+  const inventory = Array.from({ length: toolCount }, (_, index) => synthetic(index))
+  const schemaBytes = inventory.reduce(
+    (total, tool) => total + bytes.encode(JSON.stringify(tool.input)).length + bytes.encode(tool.description).length,
+    0,
+  )
+  // Mirrors `McpTool` registration: one namespace, Code Mode enabled, JSON schema input and output.
+  yield* registry.transform((draft) => {
+    draft.namespace({ name: "cloudflare-api", description: "Cloudflare REST API" })
+    for (const tool of inventory) {
+      draft.add({
+        name: tool.name,
+        options: { namespace: "cloudflare-api", codemode: true },
+        description: tool.description,
+        input: { ...tool.input, type: "object", additionalProperties: false },
+        output,
+        execute: () => Effect.succeed({ output: null, content: "" }),
+      })
+    }
+    for (const name of ["read", "edit", "write", "shell", "glob", "grep"]) {
+      draft.add({
+        name,
+        options: { codemode: false },
+        description: `Built-in ${name} tool`,
+        input: { type: "object", properties: { path: { type: "string" } }, additionalProperties: false },
+        execute: () => Effect.succeed({ output: undefined, content: "" }),
+      })
+    }
+  })
+
+  const step = Effect.gen(function* () {
+    const started = performance.now()
+    const snapshot = yield* registry.snapshot([])
+    const snapshotMs = performance.now() - started
+    const instructions = CodeModeInstructions.make(snapshot.codeModeCatalog)
+    return { definitions: snapshot.definitions.length, instructions, snapshotMs }
+  })
+
+  const samples: Array<{ ms: number; snapshotMs: number; heapGrowth: number }> = []
+  let definitions = 0
+  for (let index = 0; index < iterations; index++) {
+    Bun.gc(true)
+    Bun.gc(true)
+    const before = heapStats().heapSize
+    const started = performance.now()
+    const result = yield* step
+    const ms = performance.now() - started
+    const heapGrowth = heapStats().heapSize - before
+    definitions = result.definitions
+    samples.push({ ms, snapshotMs: result.snapshotMs, heapGrowth })
+  }
+  Bun.gc(true)
+  Bun.gc(true)
+  const retained = process.memoryUsage().heapUsed
+  return { samples, definitions, schemaBytes, retained }
+}).pipe(Effect.scoped, Effect.provide(registryLayer), Effect.provide(Logger.layer([])))
+
+const result = await Effect.runPromise(program)
+
+const sorted = (values: ReadonlyArray<number>) => values.toSorted((a, b) => a - b)
+const percentile = (values: ReadonlyArray<number>, value: number) => {
+  const list = sorted(values)
+  return list[Math.min(Math.ceil(list.length * value) - 1, list.length - 1)] ?? 0
+}
+const mib = (value: number) => (value / 1024 / 1024).toFixed(2)
+const times = result.samples.map((sample) => sample.ms)
+const growth = result.samples.map((sample) => sample.heapGrowth)
+const warm = result.samples.slice(1)
+
+console.log(
+  `tools ${toolCount} (input schema + description bytes ${mib(result.schemaBytes)} MiB), direct definitions ${result.definitions}`,
+)
+console.log(`snapshot + instructions per step, ${iterations} iterations`)
+console.log(
+  `  first    ${times[0]!.toFixed(1)} ms (snapshot ${result.samples[0]!.snapshotMs.toFixed(1)} ms), heap growth ${mib(growth[0]!)} MiB`,
+)
+console.log(
+  `  warm     p50 ${percentile(
+    warm.map((sample) => sample.ms),
+    0.5,
+  ).toFixed(1)} ms, p95 ${percentile(
+    warm.map((sample) => sample.ms),
+    0.95,
+  ).toFixed(1)} ms, max ${Math.max(...warm.map((sample) => sample.ms)).toFixed(1)} ms`,
+)
+console.log(
+  `  warm     snapshot only p50 ${percentile(
+    warm.map((sample) => sample.snapshotMs),
+    0.5,
+  ).toFixed(1)} ms, p95 ${percentile(
+    warm.map((sample) => sample.snapshotMs),
+    0.95,
+  ).toFixed(1)} ms`,
+)
+console.log(
+  `  warm     heap growth p50 ${mib(
+    percentile(
+      warm.map((sample) => sample.heapGrowth),
+      0.5,
+    ),
+  )} MiB, p95 ${mib(
+    percentile(
+      warm.map((sample) => sample.heapGrowth),
+      0.95,
+    ),
+  )} MiB`,
+)
+console.log(`  retained heapUsed after forced GC ${mib(result.retained)} MiB`)
+
+if (jsonPath) {
+  await fs.mkdir(path.dirname(jsonPath), { recursive: true })
+  await fs.writeFile(
+    jsonPath,
+    JSON.stringify(
+      { revision: process.env.OPENCODE_BENCH_REVISION, bun: Bun.version, toolCount, iterations, ...result },
+      null,
+      2,
+    ),
+  )
+}

--- a/packages/core/script/benchmark-tool-snapshot.ts
+++ b/packages/core/script/benchmark-tool-snapshot.ts
@@ -5,10 +5,12 @@
 // with realistic descriptions and JSON schemas; nothing is executed.
 //
 //   bun run script/benchmark-tool-snapshot.ts [--tools 3242] [--iterations 20] [--json out.json]
+//   bun run script/benchmark-tool-snapshot.ts --tools 200 --iterations 128 --churn equivalent
+// `--churn membership` hides a different tool each step; `equivalent` changes only resources.
 //
 // Per-iteration heap growth is sampled after a forced GC before the iteration and
-// without GC afterwards, so it approximates bytes allocated by that step. Retained
-// heap after all iterations is a separate forced-GC number.
+// without GC afterwards. This is a growth proxy, not an allocation count: automatic GC
+// and heap accounting can hide allocations. Retention is a separate forced-GC number.
 import fs from "fs/promises"
 import path from "path"
 import { heapStats } from "bun:jsc"
@@ -18,6 +20,7 @@ import { AppNodeBuilder } from "../src/effect/app-node-builder"
 import { CodeModeInstructions } from "../src/codemode/instructions"
 import { Image } from "../src/image"
 import { Tool } from "../src/tool"
+import type { Permission } from "../src/permission"
 
 const args = process.argv.slice(2)
 const flag = (name: string, fallback: number) => {
@@ -34,6 +37,11 @@ const toolCount = flag("tools", 3242)
 const iterations = flag("iterations", 20)
 const jsonIndex = args.indexOf("--json")
 const jsonPath = jsonIndex === -1 ? undefined : args[jsonIndex + 1]
+const churnIndex = args.indexOf("--churn")
+const churn = churnIndex === -1 ? "none" : args[churnIndex + 1]
+if (churn !== "none" && churn !== "equivalent" && churn !== "membership") {
+  throw new Error("--churn must be equivalent or membership")
+}
 
 const resources = [
   "accounts",
@@ -196,31 +204,54 @@ const program = Effect.gen(function* () {
     }
   })
 
-  const step = Effect.gen(function* () {
-    const started = performance.now()
-    const snapshot = yield* registry.snapshot([])
-    const snapshotMs = performance.now() - started
-    const instructions = CodeModeInstructions.make(snapshot.codeModeCatalog)
-    return { definitions: snapshot.definitions.length, instructions, snapshotMs }
-  })
+  const step = (index: number) =>
+    Effect.gen(function* () {
+      const started = performance.now()
+      const rules: Permission.Ruleset =
+        churn === "none"
+          ? []
+          : [
+              {
+                action:
+                  churn === "membership"
+                    ? `cloudflare-api_${inventory[index % inventory.length]!.name}`
+                    : "cloudflare-api_*",
+                resource: churn === "membership" ? "*" : `project-${index}`,
+                effect: "deny",
+              },
+            ]
+      const snapshot = yield* registry.snapshot(rules)
+      const snapshotMs = performance.now() - started
+      const instructions = CodeModeInstructions.make(snapshot.codeModeCatalog)
+      return { definitions: snapshot.definitions.length, instructions, snapshotMs, catalog: snapshot.codeModeCatalog }
+    })
 
   const samples: Array<{ ms: number; snapshotMs: number; heapGrowth: number }> = []
+  const catalogs = new WeakSet<object>()
+  let rendered = 0
   let definitions = 0
+  Bun.gc(true)
+  Bun.gc(true)
+  const retainedBefore = process.memoryUsage().heapUsed
   for (let index = 0; index < iterations; index++) {
     Bun.gc(true)
     Bun.gc(true)
     const before = heapStats().heapSize
     const started = performance.now()
-    const result = yield* step
+    const result = yield* step(index)
     const ms = performance.now() - started
     const heapGrowth = heapStats().heapSize - before
+    if (result.catalog && !catalogs.has(result.catalog)) {
+      catalogs.add(result.catalog)
+      rendered++
+    }
     definitions = result.definitions
     samples.push({ ms, snapshotMs: result.snapshotMs, heapGrowth })
   }
   Bun.gc(true)
   Bun.gc(true)
   const retained = process.memoryUsage().heapUsed
-  return { samples, definitions, schemaBytes, retained }
+  return { samples, definitions, schemaBytes, retainedBefore, retained, rendered }
 }).pipe(Effect.scoped, Effect.provide(registryLayer), Effect.provide(Logger.layer([])))
 
 const result = await Effect.runPromise(program)
@@ -239,6 +270,7 @@ console.log(
   `tools ${toolCount} (input schema + description bytes ${mib(result.schemaBytes)} MiB), direct definitions ${result.definitions}`,
 )
 console.log(`snapshot + instructions per step, ${iterations} iterations`)
+console.log(`  churn ${churn}, distinct catalog instances ${result.rendered}`)
 console.log(
   `  first    ${times[0]!.toFixed(1)} ms (snapshot ${result.samples[0]!.snapshotMs.toFixed(1)} ms), heap growth ${mib(growth[0]!)} MiB`,
 )
@@ -274,13 +306,16 @@ console.log(
   )} MiB`,
 )
 console.log(`  retained heapUsed after forced GC ${mib(result.retained)} MiB`)
+console.log(
+  `  retained heapUsed before snapshots ${mib(result.retainedBefore)} MiB, delta ${mib(result.retained - result.retainedBefore)} MiB`,
+)
 
 if (jsonPath) {
   await fs.mkdir(path.dirname(jsonPath), { recursive: true })
   await fs.writeFile(
     jsonPath,
     JSON.stringify(
-      { revision: process.env.OPENCODE_BENCH_REVISION, bun: Bun.version, toolCount, iterations, ...result },
+      { revision: process.env.OPENCODE_BENCH_REVISION, bun: Bun.version, toolCount, iterations, churn, ...result },
       null,
       2,
     ),

--- a/packages/core/src/codemode/instructions.ts
+++ b/packages/core/src/codemode/instructions.ts
@@ -128,19 +128,8 @@ ${render(current)}`
 const key = Instructions.Key.make("core/codemode")
 const codec = Schema.toCodecJson(CodeModeCatalog.Summary)
 
-// Registry snapshots reuse one catalog instance until the registry changes, so its summary
-// is reused with it instead of being rebuilt for every step.
-const summaries = new WeakMap<CodeModeCatalog.Inventory, CodeModeCatalog.Summary>()
-const summarize = (inventory: CodeModeCatalog.Inventory) => {
-  const cached = summaries.get(inventory)
-  if (cached) return cached
-  const summary = CodeModeCatalog.summarize(inventory)
-  summaries.set(inventory, summary)
-  return summary
-}
-
 export const make = (inventory?: CodeModeCatalog.Inventory): Instructions.List => {
-  const catalog = inventory === undefined ? Instructions.removed : summarize(inventory)
+  const catalog = inventory === undefined ? Instructions.removed : CodeModeCatalog.summarize(inventory)
   return Instructions.make({
     key,
     codec,

--- a/packages/core/src/codemode/instructions.ts
+++ b/packages/core/src/codemode/instructions.ts
@@ -128,8 +128,19 @@ ${render(current)}`
 const key = Instructions.Key.make("core/codemode")
 const codec = Schema.toCodecJson(CodeModeCatalog.Summary)
 
+// Registry snapshots reuse one catalog instance until the registry changes, so its summary
+// is reused with it instead of being rebuilt for every step.
+const summaries = new WeakMap<CodeModeCatalog.Inventory, CodeModeCatalog.Summary>()
+const summarize = (inventory: CodeModeCatalog.Inventory) => {
+  const cached = summaries.get(inventory)
+  if (cached) return cached
+  const summary = CodeModeCatalog.summarize(inventory)
+  summaries.set(inventory, summary)
+  return summary
+}
+
 export const make = (inventory?: CodeModeCatalog.Inventory): Instructions.List => {
-  const catalog = inventory === undefined ? Instructions.removed : CodeModeCatalog.summarize(inventory)
+  const catalog = inventory === undefined ? Instructions.removed : summarize(inventory)
   return Instructions.make({
     key,
     codec,

--- a/packages/core/src/session/model-request.ts
+++ b/packages/core/src/session/model-request.ts
@@ -292,9 +292,10 @@ export const layer = Layer.effect(
       const registry = new Map(tools.definitions.map((tool) => [tool.name, tool]))
       // The definition objects we hand to hooks, mapped back to their tools. Hooks rename a
       // tool by moving its definition to a new key; recognizing the object recovers the tool.
+      // Nested schema edits must stay request-local, even when registrations share a schema.
       const given = new Map(
         tools.definitions.map(
-          (tool) => [{ description: tool.description, input: { ...tool.inputSchema } }, tool] as const,
+          (tool) => [{ description: tool.description, input: structuredClone(tool.inputSchema) }, tool] as const,
         ),
       )
       // Hooks mutate this record in place: edit descriptions and schemas, rename, or remove.

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -209,19 +209,16 @@ const layer = Layer.effect(
         ),
     })
 
-    // Every LLM step snapshots the registry, and rendering the Code Mode catalog is O(tools)
-    // (a TypeScript signature and search entry per tool). The catalog is a pure function of
-    // the registry generation and the permission ruleset, so it is rendered once per pair;
-    // `State` replaces its data object on every rebuild, which expires the entry.
-    const catalogs = new WeakMap<Data, Map<string, CodeModeCatalog.Inventory>>()
-    const catalog = (data: Data, rules: Permission.Ruleset, inventory: CodeModeTool.Inventory) => {
-      const key = JSON.stringify(rules)
-      const entries = catalogs.get(data) ?? new Map<string, CodeModeCatalog.Inventory>()
-      catalogs.set(data, entries)
-      const cached = entries.get(key)
-      if (cached) return cached
+    // Producers replace changed schemas/options and reload when source data (including schema
+    // conversion dependencies) changes. Keep only the last visible tool set per State generation:
+    // agent-only rule churn must not retain every historical catalog.
+    const catalogs = new WeakMap<Data, { key: string; value: CodeModeCatalog.Inventory }>()
+    const catalog = (data: Data, inventory: CodeModeTool.Inventory) => {
+      const key = JSON.stringify(Array.from(inventory.tools.keys()))
+      const cached = catalogs.get(data)
+      if (cached?.key === key) return cached.value
       const rendered = CodeModeTool.catalog(inventory)
-      entries.set(key, rendered)
+      catalogs.set(data, { key, value: rendered })
       return rendered
     }
 
@@ -249,7 +246,7 @@ const layer = Layer.effect(
                 ),
               )
             : undefined
-          const codeModeCatalog = codeModeEnabled ? catalog(data, rules, codeModeInventory) : undefined
+          const codeModeCatalog = codeModeEnabled ? catalog(data, codeModeInventory) : undefined
           return {
             ...(codeModeCatalog === undefined ? {} : { codeModeCatalog }),
             definitions: [

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -209,20 +209,37 @@ const layer = Layer.effect(
         ),
     })
 
+    // Every LLM step snapshots the registry, and rendering the Code Mode catalog is O(tools)
+    // (a TypeScript signature and search entry per tool). The catalog is a pure function of
+    // the registry generation and the permission ruleset, so it is rendered once per pair;
+    // `State` replaces its data object on every rebuild, which expires the entry.
+    const catalogs = new WeakMap<Data, Map<string, CodeModeCatalog.Inventory>>()
+    const catalog = (data: Data, rules: Permission.Ruleset, inventory: CodeModeTool.Inventory) => {
+      const key = JSON.stringify(rules)
+      const entries = catalogs.get(data) ?? new Map<string, CodeModeCatalog.Inventory>()
+      catalogs.set(data, entries)
+      const cached = entries.get(key)
+      if (cached) return cached
+      const rendered = CodeModeTool.catalog(inventory)
+      entries.set(key, rendered)
+      return rendered
+    }
+
     return Service.of({
       transform: state.transform,
       reload: state.reload,
       snapshot: Effect.fn("Tool.snapshot")((permissions) =>
         Effect.sync(() => {
+          const data = state.get()
           const active = new Map<string, Tool.Info>()
           const rules = permissions ?? []
-          for (const [name, tool] of state.get().tools) {
+          for (const [name, tool] of data.tools) {
             if (whollyDisabled(tool.options?.permission ?? name, rules)) continue
             active.set(name, tool)
           }
           const direct = new Map(Array.from(active).filter(([, tool]) => tool.options?.codemode === false))
           const codeModeTools = new Map(Array.from(active).filter(([, tool]) => tool.options?.codemode !== false))
-          const namespaces = state.get().namespaces
+          const namespaces = data.namespaces
           const codeModeInventory = { tools: codeModeTools, namespaces }
           const codeModeEnabled = !whollyDisabled("execute", rules)
           const codeModeTool = codeModeEnabled
@@ -232,7 +249,7 @@ const layer = Layer.effect(
                 ),
               )
             : undefined
-          const codeModeCatalog = codeModeEnabled ? CodeModeTool.catalog(codeModeInventory) : undefined
+          const codeModeCatalog = codeModeEnabled ? catalog(data, rules, codeModeInventory) : undefined
           return {
             ...(codeModeCatalog === undefined ? {} : { codeModeCatalog }),
             definitions: [

--- a/packages/core/test/codemode/instructions.test.ts
+++ b/packages/core/test/codemode/instructions.test.ts
@@ -24,6 +24,20 @@ const lookup: CodeModeCatalog.Tool = {
 }
 
 describe("CodeModeInstructions", () => {
+  it.effect("summarizes caller-owned inventories again when their contents change", () =>
+    Effect.gen(function* () {
+      const inventory = { tools: [echo] }
+      const first = yield* readInitial(CodeModeInstructions.make(inventory))
+      inventory.tools.push(lookup)
+      const changed = yield* readUpdate(CodeModeInstructions.make(inventory), first)
+      expect(changed.changed).toBe(true)
+      expect(changed.text).toContain(lookup.signature)
+      expect(yield* readInitial(CodeModeInstructions.make(inventory))).toEqual(
+        yield* readInitial(CodeModeInstructions.make({ tools: [echo, lookup] })),
+      )
+    }),
+  )
+
   it.effect("instructs the model not to call execute while the catalog is empty", () =>
     Effect.gen(function* () {
       const initialized = yield* readInitial(CodeModeInstructions.make({ tools: [] }))

--- a/packages/core/test/session-model-request.test.ts
+++ b/packages/core/test/session-model-request.test.ts
@@ -1,8 +1,93 @@
 import { describe, expect, test } from "bun:test"
-import { Message, ToolResultPart } from "@opencode-ai/ai"
-import { boundImages, unsupportedParts } from "@opencode-ai/core/session/model-request"
+import { LanguageModel, Message, ToolResultPart } from "@opencode-ai/ai"
+import { OpenAIChat } from "@opencode-ai/ai/protocols"
+import { Agent } from "@opencode-ai/core/agent"
+import { CodeModeInstructions } from "@opencode-ai/core/codemode/instructions"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Image } from "@opencode-ai/core/image"
+import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
+import { SessionMessage } from "@opencode-ai/core/session/message"
+import { boundImages, SessionModelRequest, unsupportedParts } from "@opencode-ai/core/session/model-request"
+import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
+import { SessionSchema } from "@opencode-ai/core/session/schema"
+import { Tool } from "@opencode-ai/core/tool"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Effect, Layer, Schema } from "effect"
+import { testEffect } from "./lib/effect"
+import { readInitial } from "./lib/instructions"
 
 const capabilities = (input: string[]) => ({ tools: true, input, output: ["text"] })
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Tool.node, SessionModelRequest.node, PluginHooks.node]), [
+    Image.node.replace(Layer.mock(Image.Service, { normalize: (_, content) => Effect.succeed(content) })),
+  ]),
+)
+
+it.effect("isolates nested context-hook tool schemas from registry catalogs and subsequent requests", () =>
+  Effect.gen(function* () {
+    const registry = yield* Tool.Service
+    const hooks = yield* PluginHooks.Service
+    const requests = yield* SessionModelRequest.Service
+    const input = { type: "object", properties: { value: { type: "string" } }, required: ["value"] }
+    yield* registry.transform((draft) => {
+      const tool = { name: "echo", description: "Echo", input, execute: () => Effect.succeed({ content: "ok" }) }
+      draft.add(tool)
+      draft.add({ ...tool, name: "direct", options: { codemode: false } })
+    })
+    const hook = yield* hooks.register("session", "context", (event) =>
+      Effect.sync(() => {
+        const direct = event.tools.direct
+        if (!direct) throw new Error("Missing direct tool")
+        Object.assign(direct.input.properties ?? {}, { value: { type: "number" } })
+      }),
+    )
+    const first = yield* registry.snapshot()
+    const instructions = yield* readInitial(CodeModeInstructions.make(first.codeModeCatalog))
+    const scope = {
+      session: Schema.decodeUnknownSync(SessionSchema.Info)({
+        id: "ses_schema_isolation",
+        projectID: "schema-isolation",
+        cost: 0,
+        tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+        time: { created: 0, updated: 0 },
+        location: { directory: "/project" },
+      }),
+      agentID: Agent.ID.make("build"),
+      model: SessionRunnerModel.resolved(
+        LanguageModel.make({ id: "fixture", provider: "test", route: OpenAIChat.route }),
+        { capabilities: capabilities(["text"]), cost: [], limit: { context: 200000, output: 32000 } },
+      ),
+      tools: first,
+    }
+    const prepared = yield* requests.prepare({ scope, transcript: { system: [], messages: [] } })
+    expect(prepared.request.tools?.find((tool) => tool.name === "direct")?.inputSchema.properties).toEqual({
+      value: { type: "number" },
+    })
+    expect(input.properties.value.type).toBe("string")
+    expect(first.definitions.find((tool) => tool.name === "direct")?.inputSchema.properties).toEqual({
+      value: { type: "string" },
+    })
+    yield* hook.dispose
+    const second = yield* registry.snapshot()
+    expect(yield* readInitial(CodeModeInstructions.make(second.codeModeCatalog))).toEqual(instructions)
+    const next = yield* requests.prepare({
+      scope: { ...scope, tools: second },
+      transcript: { system: [], messages: [] },
+    })
+    expect(next.request.tools?.find((tool) => tool.name === "direct")?.inputSchema.properties).toEqual({
+      value: { type: "string" },
+    })
+    const search = yield* second.execute({
+      sessionID: scope.session.id,
+      agent: scope.agentID,
+      messageID: SessionMessage.ID.make("msg_schema_isolation"),
+      call: { type: "tool-call", id: "search-isolation", name: "execute", input: { code: "return search({})" } },
+    })
+    expect(search.output).toMatchObject({ output: expect.stringContaining("value: string") })
+    expect(instructions.text).toContain("value: string")
+  }),
+)
 
 describe("SessionModelRequest.unsupportedParts", () => {
   test("replaces unsupported user media with a visible error", () => {

--- a/packages/core/test/tool-registry.test.ts
+++ b/packages/core/test/tool-registry.test.ts
@@ -714,9 +714,7 @@ describe("Tool", () => {
       for (let index = 0; index < 40; index++) {
         // Agent-only source changes need not rebuild Tool state.
         permissions = [{ action: "acme_*", resource: `project-${index}`, effect: "deny" }]
-        const reload = yield* agents.reload().pipe(Effect.forkChild({ startImmediately: true }))
-        yield* TestClock.adjust("500 millis")
-        yield* Fiber.join(reload)
+        yield* agents.reload()
         const agent = yield* agents.get(identity.agent)
         if (!agent) throw new Error("Missing fixture agent")
         const equivalent = yield* service.snapshot(agent.permissions)
@@ -773,9 +771,7 @@ describe("Tool", () => {
       ]) {
         source = changed.tool
         namespace = changed.namespace
-        const reload = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
-        yield* TestClock.adjust("500 millis")
-        yield* Fiber.join(reload)
+        yield* service.reload()
         const current = yield* service.snapshot()
         const fresh = CodeModeTool.catalog({
           tools: new Map([[`${source.options?.namespace}_echo`, source]]),
@@ -824,9 +820,7 @@ describe("Tool", () => {
       const first = yield* service.snapshot()
       expect(JSON.stringify(first.codeModeCatalog)).toContain("value: string")
       type = "number"
-      const reload = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
-      yield* TestClock.adjust("500 millis")
-      yield* Fiber.join(reload)
+      yield* service.reload()
       const second = yield* service.snapshot()
       expect(JSON.stringify(second.codeModeCatalog)).toContain("value: number")
       expect(JSON.stringify(first.codeModeCatalog)).toContain("value: string")

--- a/packages/core/test/tool-registry.test.ts
+++ b/packages/core/test/tool-registry.test.ts
@@ -658,6 +658,44 @@ describe("Tool", () => {
     }),
   )
 
+  it.effect("reuses the Code Mode catalog across snapshots until the registry or ruleset changes", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      yield* transform(service, { echo: make(), constant: constant("text") }, { namespace: "acme" })
+
+      const first = yield* service.snapshot()
+      const second = yield* service.snapshot([])
+      expect(second.codeModeCatalog).toBe(first.codeModeCatalog)
+      expect(codeModeListings(first.codeModeCatalog!).map((tool) => tool.path)).toEqual(["acme.constant", "acme.echo"])
+
+      // A ruleset that hides a tool yields its own catalog; the unfiltered one stays cached.
+      const denied = yield* service.snapshot([{ action: "acme_constant", resource: "*", effect: "deny" }])
+      expect(denied.codeModeCatalog).not.toBe(first.codeModeCatalog)
+      expect(codeModeListings(denied.codeModeCatalog!).map((tool) => tool.path)).toEqual(["acme.echo"])
+      expect((yield* service.snapshot()).codeModeCatalog).toBe(first.codeModeCatalog)
+
+      // Registry changes replace the state and therefore the catalog.
+      const scope = yield* Scope.make()
+      yield* service.transform((draft) => draft.add({ ...make(), name: "extra" })).pipe(Scope.provide(scope))
+      const extended = yield* service.snapshot()
+      expect(extended.codeModeCatalog).not.toBe(first.codeModeCatalog)
+      expect(codeModeListings(extended.codeModeCatalog!).map((tool) => tool.path)).toEqual([
+        "acme.constant",
+        "acme.echo",
+        "extra",
+      ])
+      expect((yield* service.snapshot()).codeModeCatalog).toBe(extended.codeModeCatalog)
+
+      yield* Scope.close(scope, Exit.void)
+      const restored = yield* service.snapshot()
+      expect(restored.codeModeCatalog).not.toBe(extended.codeModeCatalog)
+      expect(codeModeListings(restored.codeModeCatalog!).map((tool) => tool.path)).toEqual([
+        "acme.constant",
+        "acme.echo",
+      ])
+    }),
+  )
+
   it.effect("keeps execute available without Code Mode tools unless explicitly denied", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service

--- a/packages/core/test/tool-registry.test.ts
+++ b/packages/core/test/tool-registry.test.ts
@@ -7,11 +7,14 @@ import { Session } from "@opencode-ai/core/session"
 import { SessionMessage } from "@opencode-ai/core/session/message"
 import { State } from "@opencode-ai/core/state"
 import { Tool } from "@opencode-ai/core/tool"
+import { CodeModeTool } from "@opencode-ai/core/codemode/tool"
+import { CodeModeInstructions } from "@opencode-ai/core/codemode/instructions"
 import type { Info } from "@opencode-ai/schema/tool"
 import { codeModeListings, executeTool, toolDefinitions } from "./lib/tool"
 import { Deferred, Effect, Exit, Fiber, Layer, Logger, Schema, SchemaGetter, SchemaIssue, Scope } from "effect"
 import { z } from "zod"
 import { testEffect } from "./lib/effect"
+import { readInitial } from "./lib/instructions"
 
 const imageStore = Layer.mock(Image.Service, {
   normalize: (resource, content) => {
@@ -658,7 +661,7 @@ describe("Tool", () => {
     }),
   )
 
-  it.effect("reuses the Code Mode catalog across snapshots until the registry or ruleset changes", () =>
+  it.effect("reuses the last Code Mode catalog until the registry or visible tools change", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service
       yield* transform(service, { echo: make(), constant: constant("text") }, { namespace: "acme" })
@@ -668,11 +671,11 @@ describe("Tool", () => {
       expect(second.codeModeCatalog).toBe(first.codeModeCatalog)
       expect(codeModeListings(first.codeModeCatalog!).map((tool) => tool.path)).toEqual(["acme.constant", "acme.echo"])
 
-      // A ruleset that hides a tool yields its own catalog; the unfiltered one stays cached.
+      // Only the last visible set stays cached; an agent switch can replace it.
       const denied = yield* service.snapshot([{ action: "acme_constant", resource: "*", effect: "deny" }])
       expect(denied.codeModeCatalog).not.toBe(first.codeModeCatalog)
       expect(codeModeListings(denied.codeModeCatalog!).map((tool) => tool.path)).toEqual(["acme.echo"])
-      expect((yield* service.snapshot()).codeModeCatalog).toBe(first.codeModeCatalog)
+      expect((yield* service.snapshot()).codeModeCatalog).toEqual(first.codeModeCatalog)
 
       // Registry changes replace the state and therefore the catalog.
       const scope = yield* Scope.make()
@@ -693,6 +696,146 @@ describe("Tool", () => {
         "acme.constant",
         "acme.echo",
       ])
+    }),
+  )
+
+  it.effect("deduplicates equivalent visible sets without retaining historical permission catalogs", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      const agents = yield* Agent.Service
+      let permissions: Permission.Rule[] = []
+      yield* agents.transform((draft) =>
+        draft.update(identity.agent, (agent) => {
+          agent.permissions = permissions
+        }),
+      )
+      yield* transform(service, { echo: make(), constant: constant("text") }, { namespace: "acme" })
+      const first = yield* service.snapshot()
+      for (let index = 0; index < 40; index++) {
+        // Agent-only source changes need not rebuild Tool state.
+        permissions = [{ action: "acme_*", resource: `project-${index}`, effect: "deny" }]
+        const reload = yield* agents.reload().pipe(Effect.forkChild({ startImmediately: true }))
+        yield* TestClock.adjust("500 millis")
+        yield* Fiber.join(reload)
+        const agent = yield* agents.get(identity.agent)
+        if (!agent) throw new Error("Missing fixture agent")
+        const equivalent = yield* service.snapshot(agent.permissions)
+        expect(equivalent.codeModeCatalog).toBe(first.codeModeCatalog)
+      }
+      const rules: Permission.Rule[] = [{ action: "acme_constant", resource: "*", effect: "deny" }]
+      const denied = yield* service.snapshot(rules)
+      expect(codeModeListings(denied.codeModeCatalog!).map((entry) => entry.path)).toEqual(["acme.echo"])
+      expect((yield* service.snapshot(rules.map((rule) => ({ ...rule })))).codeModeCatalog).toBe(denied.codeModeCatalog)
+      rules.push({ action: "acme_*", resource: "*", effect: "ask" })
+      const restored = yield* service.snapshot(rules)
+      expect(restored.codeModeCatalog).toEqual(first.codeModeCatalog)
+      expect(restored.codeModeCatalog).not.toBe(first.codeModeCatalog)
+      expect((yield* service.snapshot(rules.toReversed())).codeModeCatalog).toEqual(denied.codeModeCatalog)
+      expect((yield* service.snapshot(rules.toReversed())).codeModeCatalog).not.toBe(denied.codeModeCatalog)
+      const search = yield* restored.execute({
+        ...call("execute"),
+        call: { type: "tool-call", id: "search-rules", name: "execute", input: { code: "return search({})" } },
+      })
+      expect(search.output).toMatchObject({ output: expect.stringContaining("tools.acme.constant") })
+      const filtered = yield* service.snapshot(rules.toReversed())
+      const hidden = yield* filtered.execute({
+        ...call("execute"),
+        call: { type: "tool-call", id: "search-filtered", name: "execute", input: { code: "return search({})" } },
+      })
+      expect(hidden.output).toMatchObject({ output: expect.not.stringContaining("tools.acme.constant") })
+    }).pipe(Effect.provide(AppNodeBuilder.build(Agent.node))),
+  )
+
+  it.effect("refreshes schema, description, namespace, and pin inputs on explicit reload", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      const original = {
+        ...make(),
+        input: { type: "object", properties: { value: { type: "string" } }, required: ["value"] },
+        output: { type: "string" },
+        options: { namespace: "acme" },
+      }
+      let source: Info = original
+      let namespace = { name: "acme", description: "Original namespace" }
+      yield* service.transform((draft) => {
+        draft.namespace(namespace)
+        draft.add(source)
+      })
+      const first = yield* service.snapshot()
+      const initial = yield* readInitial(CodeModeInstructions.make(first.codeModeCatalog))
+      for (const changed of [
+        { tool: { ...original, input: { type: "object", properties: { value: { type: "number" } } } }, namespace },
+        { tool: { ...original, output: { type: "number" } }, namespace },
+        { tool: { ...original, description: "Changed description" }, namespace },
+        { tool: original, namespace: { name: "acme", description: "Changed namespace" } },
+        { tool: { ...original, options: { namespace: "acme", pinned: true } }, namespace },
+        { tool: { ...original, options: { namespace: "other" } }, namespace: { name: "other", description: "Other" } },
+      ]) {
+        source = changed.tool
+        namespace = changed.namespace
+        const reload = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
+        yield* TestClock.adjust("500 millis")
+        yield* Fiber.join(reload)
+        const current = yield* service.snapshot()
+        const fresh = CodeModeTool.catalog({
+          tools: new Map([[`${source.options?.namespace}_echo`, source]]),
+          namespaces: new Map([[namespace.name, namespace]]),
+        })
+        expect(current.codeModeCatalog).not.toEqual(first.codeModeCatalog)
+        expect(current.codeModeCatalog).toEqual(fresh)
+        expect((yield* service.snapshot()).codeModeCatalog).toBe(current.codeModeCatalog)
+        expect(yield* readInitial(CodeModeInstructions.make(current.codeModeCatalog))).toEqual(
+          yield* readInitial(CodeModeInstructions.make(fresh)),
+        )
+        const search = yield* current.execute({
+          ...call("execute"),
+          call: {
+            type: "tool-call",
+            id: "search-reload",
+            name: "execute",
+            input: { code: "return search({}).items[0].signature" },
+          },
+        })
+        const entries = current.codeModeCatalog?.tools[0]
+        const entry = entries?.type === "namespace" ? entries.tools[0] : entries
+        if (entry?.type !== "tool") throw new Error("Missing catalog tool")
+        expect(search.output).toMatchObject({ output: entry.signature })
+      }
+      expect(yield* readInitial(CodeModeInstructions.make(first.codeModeCatalog))).toEqual(initial)
+    }),
+  )
+
+  it.effect("reevaluates lazy schema conversion when its producer reloads", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      let type = "string"
+      const input = {
+        "~standard": {
+          version: 1 as const,
+          vendor: "fixture",
+          validate: (value: unknown) => ({ value }),
+          jsonSchema: {
+            input: () => ({ type: "object", properties: { value: { type } }, required: ["value"] }),
+            output: () => ({}),
+          },
+        },
+      }
+      yield* service.transform((draft) => draft.add({ ...make(), input }))
+      const first = yield* service.snapshot()
+      expect(JSON.stringify(first.codeModeCatalog)).toContain("value: string")
+      type = "number"
+      const reload = yield* service.reload().pipe(Effect.forkChild({ startImmediately: true }))
+      yield* TestClock.adjust("500 millis")
+      yield* Fiber.join(reload)
+      const second = yield* service.snapshot()
+      expect(JSON.stringify(second.codeModeCatalog)).toContain("value: number")
+      expect(JSON.stringify(first.codeModeCatalog)).toContain("value: string")
+      const search = yield* second.execute({
+        ...call("execute"),
+        call: { type: "tool-call", id: "search-lazy", name: "execute", input: { code: "return search({})" } },
+      })
+      expect(search.output).toMatchObject({ output: expect.stringContaining("value: number") })
+      expect((yield* readInitial(CodeModeInstructions.make(second.codeModeCatalog))).text).toContain("value: number")
     }),
   )
 


### PR DESCRIPTION
`SessionContext.select` snapshots the Location tool registry for each LLM step. Reuse the rendered Code Mode catalog when the registry generation and visible Code Mode tool names are unchanged.

- Keep one catalog entry per generation, not every historical permission ruleset. Equivalent visible sets share the entry; switching to a different set rebuilds it.
- Continue to build request definitions, execution closures, and instruction summaries per snapshot. Search and execution keep their existing runtime path.
- Deep-copy input JSON schemas at `SessionModelRequest.prepare` so context-hook edits cannot mutate a shared direct/Code Mode registration.
- Preserve the documented plugin contract: replace changed schemas/options and reload after source changes, including external schema-conversion dependencies. This is not a guarantee against unsupported no-reload mutations, and it does not change execution authorization.

## Benchmark Provenance

Current head `cede3870d72e7528ae658eade38484e7f071190d` is based on v2 `57c02cd04b42ae122eab6b1d4e4d615be77ae150`. The conflict repair preserves the reviewed runtime changes and fixture, but upstream changed the State rebuild/reload path. **The earlier measurements below do not establish performance for the current base/head.** Only brief snapshot/churn smoke checks were rerun; no new benchmark campaign or current-head performance claim is included.

## Historical Measurements

Uncached v2 baseline `499e22bf5261856716142376a372f187396fe1b2`; measured candidate `8ef80a3b4256c71c65f67d2b58057c8c588bb67a`. Ranges below are the three per-run statistics, not pooled percentiles.

The fixture uses a real `Tool.Service` with 3242 or 200 synthetic OpenAPI-shaped MCP tools, shared output schemas, and six direct tools. Input schema plus description text is 3.04 MiB or 0.19 MiB. Three serial runs per revision, 20 steps each; warm means steps 2-20. Churn cases use 200 tools and 128 steps per run. Bun 1.4.0, Windows x64; the identical benchmark source was used on both measured revisions.

| Metric | Historical Baseline | Historical Candidate |
| --- | --- | --- |
| 3242 tools, warm step p50 | 159.9-191.2 ms | 3.8-4.7 ms |
| 3242 tools, warm step p95 | 171.0-247.9 ms | 5.5-7.3 ms |
| 3242 tools, first step | 211.0-244.2 ms | 213.1-245.3 ms |
| 3242 tools, catalog instances / 20 steps | 20 | 1 |
| 3242 tools, warm heap growth p50 (proxy) | 8.4-29.6 MiB | 0.00 MiB |
| 3242 tools, retained heap after forced GC | 57.5-72.0 MiB | 67.4-81.6 MiB |
| 200 tools, warm step p50 | 9.6-10.6 ms | 1.0-1.7 ms |
| 200 tools, first step | 19.9-23.5 ms | 22.7-31.6 ms |
| Equivalent-rule churn, warm step p50 | 10.2-10.9 ms | 0.8-1.7 ms |
| Equivalent-rule churn, catalog instances / 128 steps | 128 | 1 |
| Equivalent-rule churn, retained heap after forced GC | 49.1-50.0 MiB | 48.9 MiB |
| Distinct-membership churn, warm step p50 | 10.3-11.6 ms | 10.0-11.1 ms |
| Distinct-membership churn, retained heap after forced GC | 49.1-50.0 MiB | 49.1 MiB |

This trades bounded catalog retention for less repeated construction. **No general retained-memory reduction is claimed.** Distinct-membership churn rendered 128 catalogs on both measured revisions; the candidate kept only the latest entry.

Limitations: these were isolated Bun snapshot/instruction measurements, not desktop RAM or complete model-request latency. The request-schema clone was not timed. Per-step heap growth is a coarse proxy, not exact allocation; retained heap was measured separately after forced GC. Real Cloudflare schemas and live models/services were not used. Alternating distinct visible sets intentionally loses cache reuse.
