### PR TITLE
fix(app): release workspace catalogs when no tab or route holds them

### DIFF
--- a/packages/app/e2e/performance/README.md
+++ b/packages/app/e2e/performance/README.md
@@ -150,6 +150,8 @@ bunx playwright test --config e2e/performance/playwright.config.ts \
 
 `location-catalog-benchmark.spec.ts` restores one session tab per workspace for 5, 15, and 30 distinct directories. The mock serves every directory as its own location with the same 1,200-model catalog plus 8 agents with system prompts, 24 commands, and 12 skills with SKILL.md content. The scenario visits every tab, switches back to the first tab, closes every tab, pushes a `credential.switched` event, reopens one workspace from Home, and reconnects the event stream. Each phase records catalog requests by path and directory; the retained heap is sampled after an explicit GC between phases, so the visit and revisit timings are Playwright-observed diagnostics rather than clean latency samples. `LOCATION_CATALOG_DIRECTORIES` (default `5,15,30`) and `LOCATION_CATALOG_MODELS` (default 1,200) adjust the workload.
 
+The second case holds all first catalog responses until every tab has closed and the credential event has been handled. It then releases the responses while Home remains visible, waits for the catalog body readers to finish, samples retained heap, and reopens a workspace. This exposes late responses and event refreshes queued behind released reads. The browser probe retains only request counters, not payloads. `LOCATION_CATALOG_PENDING=0` selects the loaded case; `1` selects the pending case. Set `LOCATION_CATALOG_MEMORY=0` for separate timing runs with no forced GC. To compare frozen production bundles without rebuilding, set `CATALOGS_DIST` to the bundle directory and use `e2e/performance/playwright.catalogs.config.ts`.
+
 ## Chrome traces
 
 Set `OPENCODE_PERFORMANCE_TRACE_DIR` to emit a standard Chrome DevTools trace for every benchmark page automatically:

--- a/packages/app/e2e/performance/README.md
+++ b/packages/app/e2e/performance/README.md
@@ -148,6 +148,8 @@ bunx playwright test --config e2e/performance/playwright.config.ts \
 
 `PROVIDER_MEMORY_MODELS` defaults to 1,200 and `PROVIDER_MEMORY_SWITCHES` defaults to 10. Each sample records Chromium's `Runtime.getHeapUsage` and `Memory.getDOMCounters` after an explicit garbage collection. This measures retained state, not allocation peaks or normal GC timing. It does not include worker heaps, the Electron main/GPU processes, or the OpenCode server, and must not be reported as total desktop RAM. Use identical model counts and navigation sequences for before/after comparisons.
 
+`location-catalog-benchmark.spec.ts` restores one session tab per workspace for 5, 15, and 30 distinct directories. The mock serves every directory as its own location with the same 1,200-model catalog plus 8 agents with system prompts, 24 commands, and 12 skills with SKILL.md content. The scenario visits every tab, switches back to the first tab, closes every tab, pushes a `credential.switched` event, reopens one workspace from Home, and reconnects the event stream. Each phase records catalog requests by path and directory; the retained heap is sampled after an explicit GC between phases, so the visit and revisit timings are Playwright-observed diagnostics rather than clean latency samples. `LOCATION_CATALOG_DIRECTORIES` (default `5,15,30`) and `LOCATION_CATALOG_MODELS` (default 1,200) adjust the workload.
+
 ## Chrome traces
 
 Set `OPENCODE_PERFORMANCE_TRACE_DIR` to emit a standard Chrome DevTools trace for every benchmark page automatically:

--- a/packages/app/e2e/performance/playwright.catalogs.config.ts
+++ b/packages/app/e2e/performance/playwright.catalogs.config.ts
@@ -1,0 +1,13 @@
+import config from "./playwright.config"
+
+const port = Number(process.env.PLAYWRIGHT_PORT ?? 4795)
+export default {
+  ...config,
+  testMatch: "timeline/location-catalog-benchmark.spec.ts",
+  webServer: {
+    command: `bun x vite preview --outDir "${process.env.CATALOGS_DIST}" --host 127.0.0.1 --port ${port} --strictPort`,
+    url: `http://127.0.0.1:${port}`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+}

--- a/packages/app/e2e/performance/timeline/location-catalog-benchmark.spec.ts
+++ b/packages/app/e2e/performance/timeline/location-catalog-benchmark.spec.ts
@@ -9,6 +9,7 @@ import { installTimelineSettings, stressSessionHref } from "./timeline-test-help
 
 const counts = (process.env.LOCATION_CATALOG_DIRECTORIES ?? "5,15,30").split(",").map(Number)
 const modelCount = Number(process.env.LOCATION_CATALOG_MODELS ?? 1200)
+const memory = process.env.LOCATION_CATALOG_MEMORY !== "0"
 const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
 const catalogPaths = [
   "/api/model",
@@ -27,277 +28,309 @@ const homeSearch = '[data-component="home-session-search"]'
 const composerModel = '[data-action="composer-model"]'
 
 type Request = { path: string; directory: string | null }
-type CatalogWindow = Window & { __catalogReads: { pending: number; completed: number } }
+type CatalogWindow = Window & { __catalogReads?: { pending: number; completed: number } }
 
 benchmark.use({ viewport: { width: 1440, height: 900 }, video: "off", trace: "off", serviceWorkers: "block" })
 
-for (const pending of [false, true].filter((value) => !process.env.LOCATION_CATALOG_PENDING || Number(process.env.LOCATION_CATALOG_PENDING) === Number(value))) {
-for (const count of counts) {
-  benchmark(`location catalogs: ${pending ? "close before first response" : "visit and close"} ${count} workspaces`, async ({ page, report }, testInfo) => {
-    benchmark.setTimeout(300_000)
-    const catalog = createLocationCatalog(modelCount)
-    const directories = Array.from(
-      { length: count },
-      (_, index) => `C:/OpenCode/Workspace-${String(index).padStart(2, "0")}`,
-    )
-    const now = Date.now()
-    const sessions = directories.map((directory, index) => ({
-      ...fixture.sessions[0],
-      id: `ses_catalog_${String(index).padStart(2, "0")}`,
-      directory,
-      title: `Workspace ${index} review`,
-      time: { created: now - index * 60_000, updated: now - index * 60_000 },
-    }))
-    // Its session.created echo orders one deterministic read after event-driven catalog refreshes.
-    const marker = { ...fixture.sessions[0], id: "ses_catalog_marker", title: "Event marker" }
-    const pages = Object.fromEntries(
-      sessions.map((session) => [
-        session.id,
-        transcript.map((message) => ({ ...message, id: `${message.id}_${session.id}` })),
-      ]),
-    )
-    const requests: Request[] = []
-    const inflight = new Set<string>()
-    const errors: string[] = []
-    const bytes: Record<string, number> = {}
-    page.on("pageerror", (error) => errors.push(error.message))
-    page.on("request", (request) => {
-      const url = new URL(request.url())
-      if (!url.pathname.startsWith("/api/")) return
-      requests.push({ path: url.pathname, directory: url.searchParams.get("location[directory]") })
-      if (url.pathname !== "/api/event") inflight.add(request.url())
-    })
-    page.on("requestfinished", (request) => inflight.delete(request.url()))
-    page.on("requestfailed", (request) => inflight.delete(request.url()))
-    page.on("response", (response) => {
-      const url = new URL(response.url())
-      if (!url.pathname.startsWith("/api/")) return
-      if (!response.ok()) errors.push(`HTTP ${response.status()}: ${response.url()}`)
-      if (url.searchParams.get("location[directory]") !== directories[0] || !catalogPaths.includes(url.pathname)) return
-      if (bytes[url.pathname] !== undefined) return
-      bytes[url.pathname] = 0
-      void response
-        .body()
-        .then((body) => {
-          bytes[url.pathname] = body.byteLength
+for (const pending of [false, true].filter(
+  (value) => !process.env.LOCATION_CATALOG_PENDING || Number(process.env.LOCATION_CATALOG_PENDING) === Number(value),
+)) {
+  for (const count of counts) {
+    benchmark(
+      `location catalogs: ${pending ? "close before first response" : "visit and close"} ${count} workspaces`,
+      async ({ page, report }, testInfo) => {
+        benchmark.setTimeout(300_000)
+        const catalog = createLocationCatalog(modelCount)
+        const directories = Array.from(
+          { length: count },
+          (_, index) => `C:/OpenCode/Workspace-${String(index).padStart(2, "0")}`,
+        )
+        const now = Date.now()
+        const sessions = directories.map((directory, index) => ({
+          ...fixture.sessions[0],
+          id: `ses_catalog_${String(index).padStart(2, "0")}`,
+          directory,
+          title: `Workspace ${index} review`,
+          time: { created: now - index * 60_000, updated: now - index * 60_000 },
+        }))
+        // Its session.created echo orders one deterministic read after event-driven catalog refreshes.
+        const marker = { ...fixture.sessions[0], id: "ses_catalog_marker", title: "Event marker" }
+        const pages = Object.fromEntries(
+          sessions.map((session) => [
+            session.id,
+            transcript.map((message) => ({ ...message, id: `${message.id}_${session.id}` })),
+          ]),
+        )
+        const requests: Request[] = []
+        const inflight = new Set<string>()
+        const errors: string[] = []
+        const bytes: Record<string, number> = {}
+        page.on("pageerror", (error) => errors.push(error.message))
+        page.on("request", (request) => {
+          const url = new URL(request.url())
+          if (!url.pathname.startsWith("/api/")) return
+          requests.push({ path: url.pathname, directory: url.searchParams.get("location[directory]") })
+          if (url.pathname !== "/api/event") inflight.add(request.url())
         })
-        .catch(() => undefined)
-    })
+        page.on("requestfinished", (request) => inflight.delete(request.url()))
+        page.on("requestfailed", (request) => inflight.delete(request.url()))
+        page.on("response", (response) => {
+          const url = new URL(response.url())
+          if (!url.pathname.startsWith("/api/")) return
+          if (!response.ok()) errors.push(`HTTP ${response.status()}: ${response.url()}`)
+          if (url.searchParams.get("location[directory]") !== directories[0] || !catalogPaths.includes(url.pathname))
+            return
+          if (bytes[url.pathname] !== undefined) return
+          bytes[url.pathname] = 0
+          void response
+            .body()
+            .then((body) => {
+              bytes[url.pathname] = body.byteLength
+            })
+            .catch(() => undefined)
+        })
 
-    const gate = Promise.withResolvers<void>()
-    if (!pending) gate.resolve()
-    await page.addInitScript(({ paths, server }) => {
-      const reads = { pending: 0, completed: 0 }
-      ;(window as CatalogWindow).__catalogReads = reads
-      const watched = (url: string) => !!url && new URL(url).origin === server && paths.includes(new URL(url).pathname)
-      const fetch = window.fetch.bind(window)
-      window.fetch = (input, init) => {
-        if (watched(input instanceof Request ? input.url : String(input))) reads.pending++
-        return fetch(input, init)
-      }
-      const text = Response.prototype.text
-      Response.prototype.text = async function () {
-        const body = await text.call(this)
-        if (watched(this.url)) {
-          reads.pending--
-          reads.completed++
+        const gate = Promise.withResolvers<void>()
+        if (!pending) gate.resolve()
+        await page.addInitScript(
+          ({ paths, server }) => {
+            const reads = { pending: 0, completed: 0 }
+            ;(window as CatalogWindow).__catalogReads = reads
+            const watched = (url: string) =>
+              !!url && new URL(url).origin === server && paths.includes(new URL(url).pathname)
+            const fetch = window.fetch.bind(window)
+            Object.defineProperty(window, "fetch", {
+              configurable: true,
+              writable: true,
+              value: (input: RequestInfo | URL, init?: RequestInit) => {
+                if (watched(input instanceof Request ? input.url : String(input))) reads.pending++
+                return fetch(input, init)
+              },
+            })
+            const text = Response.prototype.text
+            Response.prototype.text = async function () {
+              const body = await text.call(this)
+              if (watched(this.url)) {
+                reads.pending--
+                reads.completed++
+              }
+              return body
+            }
+          },
+          { paths: catalogPaths, server },
+        )
+        const transport = await installSseTransport(page, { server })
+        await mockOpenCodeServer(page, {
+          directory: fixture.directory,
+          directories,
+          project: fixture.project,
+          provider: catalog.provider,
+          agents: catalog.agents,
+          commands: catalog.commands,
+          skills: catalog.skills,
+          sessions: [...sessions, marker],
+          pageMessages: (id) => ({ items: pages[id] ?? [] }),
+        })
+        await page.route("**/api/**", async (route) => {
+          const url = new URL(route.request().url())
+          if (
+            pending &&
+            catalogPaths.includes(url.pathname) &&
+            directories.includes(url.searchParams.get("location[directory]") ?? "")
+          )
+            await gate.promise
+          await route.fallback()
+        })
+        page.on("close", () => gate.resolve())
+        await installTimelineSettings(page)
+        await page.addInitScript(
+          ({ directories, sessionIDs, server }) => {
+            localStorage.setItem(
+              "opencode.global.dat:server",
+              JSON.stringify({
+                projects: { local: directories.map((worktree) => ({ worktree, expanded: false })) },
+                lastProject: {},
+              }),
+            )
+            localStorage.setItem(
+              "opencode.window.browser.dat:tabs",
+              JSON.stringify(sessionIDs.map((sessionId) => ({ type: "session", server, sessionId }))),
+            )
+          },
+          { directories, sessionIDs: sessions.map((session) => session.id), server },
+        )
+        const cdp = await page.context().newCDPSession(page)
+        // GC is an explicit retained-heap measurement between phases, not a readiness wait.
+        const retainedHeap = async () => {
+          if (!memory) return undefined
+          await cdp.send("HeapProfiler.collectGarbage")
+          return (await cdp.send("Runtime.getHeapUsage")).usedSize
         }
-        return body
-      }
-    }, { paths: catalogPaths, server })
-    const transport = await installSseTransport(page, { server })
-    await mockOpenCodeServer(page, {
-      directory: fixture.directory,
-      directories,
-      project: fixture.project,
-      provider: catalog.provider,
-      agents: catalog.agents,
-      commands: catalog.commands,
-      skills: catalog.skills,
-      sessions: [...sessions, marker],
-      pageMessages: (id) => ({ items: pages[id] ?? [] }),
-    })
-    await page.route("**/api/**", async (route) => {
-      const url = new URL(route.request().url())
-      if (pending && catalogPaths.includes(url.pathname) && directories.includes(url.searchParams.get("location[directory]") ?? "")) await gate.promise
-      await route.fallback()
-    })
-    page.on("close", () => gate.resolve())
-    await installTimelineSettings(page)
-    await page.addInitScript(
-      ({ directories, sessionIDs, server }) => {
-        localStorage.setItem(
-          "opencode.global.dat:server",
-          JSON.stringify({
-            projects: { local: directories.map((worktree) => ({ worktree, expanded: false })) },
-            lastProject: {},
-          }),
-        )
-        localStorage.setItem(
-          "opencode.window.browser.dat:tabs",
-          JSON.stringify(sessionIDs.map((sessionId) => ({ type: "session", server, sessionId }))),
-        )
-      },
-      { directories, sessionIDs: sessions.map((session) => session.id), server },
-    )
-    const cdp = await page.context().newCDPSession(page)
-    // GC is an explicit retained-heap measurement between phases, not a readiness wait.
-    const retainedHeap = async () => {
-      await cdp.send("HeapProfiler.collectGarbage")
-      return (await cdp.send("Runtime.getHeapUsage")).usedSize
-    }
-    const tab = (id: string) => page.locator(`[data-slot="titlebar-tabs"] a[href="${stressSessionHref(id)}"]`)
-    const catalogRequests = (from: number) =>
-      requests.slice(from).filter((request) => catalogPaths.includes(request.path))
-    const summarize = (list: Request[]) => ({
-      requests: list.length,
-      directories: [...new Set(list.map((request) => request.directory || "<default>"))].toSorted(),
-      byPath: Object.fromEntries(
-        catalogPaths.map((path) => [path, list.filter((request) => request.path === path).length]),
-      ),
-    })
+        const tab = (id: string) => page.locator(`[data-slot="titlebar-tabs"] a[href="${stressSessionHref(id)}"]`)
+        const catalogRequests = (from: number) =>
+          requests.slice(from).filter((request) => catalogPaths.includes(request.path))
+        const summarize = (list: Request[]) => ({
+          requests: list.length,
+          directories: [...new Set(list.map((request) => request.directory || "<default>"))].toSorted(),
+          byPath: Object.fromEntries(
+            catalogPaths.map((path) => [path, list.filter((request) => request.path === path).length]),
+          ),
+        })
 
-    await page.goto("/")
-    await expect(page.locator(homeSearch)).toBeVisible()
-    for (const session of sessions) await expect(tab(session.id)).toContainText(session.title)
-    const heapStart = await retainedHeap()
+        await page.goto("/")
+        await expect(page.locator(homeSearch)).toBeVisible()
+        for (const session of sessions) await expect(tab(session.id)).toContainText(session.title)
+        const heapStart = await retainedHeap()
 
-    // Visit every workspace once from its restored tab.
-    const visits = []
-    for (const session of sessions) {
-      const from = requests.length
-      const started = performance.now()
-      await tab(session.id).click()
-      await expectSessionTitle(page, session.title)
-      if (pending) {
-        await expect(page.getByRole("textbox", { name: "Prompt", exact: true })).toBeEditable()
-        await expect.poll(() => catalogRequests(from).filter((request) => request.directory === session.directory).map((request) => request.path).toSorted()).toEqual(catalogPaths.toSorted())
-      } else {
+        // Visit every workspace once from its restored tab.
+        const visits = []
+        for (const session of sessions) {
+          const from = requests.length
+          const started = performance.now()
+          await tab(session.id).click()
+          await expectSessionTitle(page, session.title)
+          if (pending) {
+            await expect(page.getByRole("textbox", { name: "Prompt", exact: true })).toBeEditable()
+            await expect
+              .poll(() =>
+                catalogRequests(from)
+                  .filter((request) => request.directory === session.directory)
+                  .map((request) => request.path)
+                  .toSorted(),
+              )
+              .toEqual(catalogPaths.toSorted())
+          } else {
+            await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+          }
+          visits.push({ ms: performance.now() - started, catalogRequests: catalogRequests(from).length })
+        }
+
+        // Switching back to an open tab must not reload its catalogs in either build.
+        const warmFrom = requests.length
+        await tab(sessions[0]!.id).click()
+        await expectSessionTitle(page, sessions[0]!.title)
+        if (!pending) await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+        const warmSwitch = summarize(catalogRequests(warmFrom))
+        const heapOpen = await retainedHeap()
+
+        // Close every tab; the last close lands on Home.
+        for (const session of sessions) {
+          const slot = page
+            .locator("[data-titlebar-tab-slot]")
+            .filter({ has: page.locator(`a[href="${stressSessionHref(session.id)}"]`) })
+          await slot.getByRole("button", { name: "Close tab", exact: true }).click()
+          await expect(slot).toHaveCount(0)
+        }
+        await expect(page).toHaveURL("/")
+        await expect(page.locator(homeSearch)).toBeVisible()
+        const heapClosed = await retainedHeap()
+
+        // A credential switch refreshes the model and provider catalogs the client still retains.
+        const credentialFrom = requests.length
+        const markerRead = page.waitForRequest(
+          (request) => new URL(request.url()).pathname === `/api/session/${marker.id}`,
+        )
+        await transport.burst([
+          {
+            id: "evt_catalog_credential",
+            created: now,
+            type: "credential.switched",
+            data: { integrationID: "opencode", credentialID: "credential" },
+          },
+          {
+            id: "evt_catalog_marker",
+            created: now,
+            type: "session.created",
+            durable: { aggregateID: marker.id, seq: 1, version: 1 },
+            data: {
+              sessionID: marker.id,
+              projectID: fixture.project.id,
+              location: { directory: fixture.directory },
+              slug: "event-marker",
+              version: "dev",
+            },
+          },
+        ] satisfies OpenCodeEvent[])
+        await markerRead
+        const readsAtRelease = catalogRequests(0).length
+        gate.resolve()
+        // The browser probe retains counters only, never response bodies or catalog objects.
+        // Waiting for decoded bodies and no pending catalog reads also covers event refreshes
+        // queued behind the gated first loads. Home remains the actual owning UI throughout.
+        await page.waitForFunction((minimum) => {
+          const reads = (window as CatalogWindow).__catalogReads
+          return reads && reads.completed >= minimum && reads.pending === 0
+        }, readsAtRelease)
+        await expect(page.locator(homeSearch)).toBeVisible()
+        await expect(page.locator('[data-slot="titlebar-tabs"] a[data-titlebar-tab-link]')).toHaveCount(0)
+        const credentialRefresh = summarize(catalogRequests(credentialFrom))
+        const heapRefreshed = await retainedHeap()
+
+        // Reopen a closed workspace from Home.
+        const revisit = sessions[0]!
+        const revisitFrom = requests.length
+        const revisitStarted = performance.now()
+        await page
+          .locator(`[data-component="home-session-row-container"][data-session-id="${revisit.id}"]`)
+          .locator('[data-component="home-session-row"]')
+          .click()
+        await expectSessionTitle(page, revisit.title)
         await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
-      }
-      visits.push({ ms: performance.now() - started, catalogRequests: catalogRequests(from).length })
-    }
+        const revisitMs = performance.now() - revisitStarted
+        const revisitRequests = summarize(catalogRequests(revisitFrom))
 
-    // Switching back to an open tab must not reload its catalogs in either build.
-    const warmFrom = requests.length
-    await tab(sessions[0]!.id).click()
-    await expectSessionTitle(page, sessions[0]!.title)
-    if (!pending) await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
-    const warmSwitch = summarize(catalogRequests(warmFrom))
-    const heapOpen = await retainedHeap()
+        // Reconnect refreshes the catalogs of the workspace on screen.
+        const connection = await transport.waitForConnection()
+        const reconnectFrom = requests.length
+        const reconnected = transport.waitForConnection({ after: connection.id })
+        await transport.close()
+        await reconnected
+        await expect
+          .poll(
+            () =>
+              catalogRequests(reconnectFrom).some(
+                (request) => request.path === "/api/model" && request.directory === revisit.directory,
+              ) && inflight.size === 0,
+          )
+          .toBe(true)
+        const reconnectRequests = summarize(catalogRequests(reconnectFrom))
+        await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
 
-    // Close every tab; the last close lands on Home.
-    for (const session of sessions) {
-      const slot = page
-        .locator("[data-titlebar-tab-slot]")
-        .filter({ has: page.locator(`a[href="${stressSessionHref(session.id)}"]`) })
-      await slot.getByRole("button", { name: "Close tab", exact: true }).click()
-      await expect(slot).toHaveCount(0)
-    }
-    await expect(page).toHaveURL("/")
-    await expect(page.locator(homeSearch)).toBeVisible()
-    const heapClosed = await retainedHeap()
-
-    // A credential switch refreshes the model and provider catalogs the client still retains.
-    const credentialFrom = requests.length
-    const markerRead = page.waitForRequest((request) => new URL(request.url()).pathname === `/api/session/${marker.id}`)
-    await transport.burst([
-      {
-        id: "evt_catalog_credential",
-        created: now,
-        type: "credential.switched",
-        data: { integrationID: "opencode", credentialID: "credential" },
-      },
-      {
-        id: "evt_catalog_marker",
-        created: now,
-        type: "session.created",
-        durable: { aggregateID: marker.id, seq: 1, version: 1 },
-        data: {
-          sessionID: marker.id,
-          projectID: fixture.project.id,
-          location: { directory: fixture.directory },
-          slug: "event-marker",
-          version: "dev",
-        },
-      },
-    ] satisfies OpenCodeEvent[])
-    await markerRead
-    const readsAtRelease = catalogRequests(0).length
-    gate.resolve()
-    // The browser probe retains counters only, never response bodies or catalog objects.
-    // Waiting for decoded bodies and no pending catalog reads also covers event refreshes
-    // queued behind the gated first loads. Home remains the actual owning UI throughout.
-    await page.waitForFunction((minimum) => {
-      const reads = (window as CatalogWindow).__catalogReads
-      return reads.completed >= minimum && reads.pending === 0
-    }, readsAtRelease)
-    await expect(page.locator(homeSearch)).toBeVisible()
-    await expect(page.locator('[data-slot="titlebar-tabs"] a[data-titlebar-tab-link]')).toHaveCount(0)
-    const credentialRefresh = summarize(catalogRequests(credentialFrom))
-    const heapRefreshed = await retainedHeap()
-
-    // Reopen a closed workspace from Home.
-    const revisit = sessions[0]!
-    const revisitFrom = requests.length
-    const revisitStarted = performance.now()
-    await page
-      .locator(`[data-component="home-session-row-container"][data-session-id="${revisit.id}"]`)
-      .locator('[data-component="home-session-row"]')
-      .click()
-    await expectSessionTitle(page, revisit.title)
-    await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
-    const revisitMs = performance.now() - revisitStarted
-    const revisitRequests = summarize(catalogRequests(revisitFrom))
-
-    // Reconnect refreshes the catalogs of the workspace on screen.
-    const connection = await transport.waitForConnection()
-    const reconnectFrom = requests.length
-    const reconnected = transport.waitForConnection({ after: connection.id })
-    await transport.close()
-    await reconnected
-    await expect
-      .poll(
-        () =>
-          catalogRequests(reconnectFrom).some(
-            (request) => request.path === "/api/model" && request.directory === revisit.directory,
-          ) && inflight.size === 0,
-      )
-      .toBe(true)
-    const reconnectRequests = summarize(catalogRequests(reconnectFrom))
-    await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
-
-    expect(errors).toEqual([])
-    expect(visits).toHaveLength(count)
-    report(
-      {
-        heap: { start: heapStart, open: heapOpen, closed: heapClosed, refreshed: heapRefreshed },
-        retainedAfterCloseBytes: heapClosed - heapStart,
-        retainedAfterRefreshBytes: heapRefreshed - heapStart,
-        visitCatalogRequests: visits.reduce((total, visit) => total + visit.catalogRequests, 0),
-        visitMs: visits.map((visit) => Math.round(visit.ms)),
-        warmSwitch,
-        credentialRefresh,
-        revisit: { ...revisitRequests, ms: Math.round(revisitMs) },
-        reconnect: reconnectRequests,
-        lateCatalogRequests: catalogRequests(0).length - readsAtRelease - revisitRequests.requests - reconnectRequests.requests,
-      },
-      {
-        directories: count,
-        pendingFirstResponse: pending,
-        models: modelCount,
-        agents: catalog.agents.length,
-        commands: catalog.commands.length,
-        skills: catalog.skills.length,
-        responseBytes: bytes,
-        transport: "playwright-route",
-        gc: "explicit between phases; visit and revisit timings are Playwright-observed diagnostics",
-        scope: "production app renderer main isolate; not total desktop RAM",
-        browser: page.context().browser()!.version(),
+        expect(errors).toEqual([])
+        expect(visits).toHaveLength(count)
+        report(
+          {
+            heap: { start: heapStart, open: heapOpen, closed: heapClosed, refreshed: heapRefreshed },
+            retainedAfterCloseBytes:
+              heapClosed === undefined || heapStart === undefined ? undefined : heapClosed - heapStart,
+            retainedAfterRefreshBytes:
+              heapRefreshed === undefined || heapStart === undefined ? undefined : heapRefreshed - heapStart,
+            visitCatalogRequests: visits.reduce((total, visit) => total + visit.catalogRequests, 0),
+            visitMs: visits.map((visit) => Math.round(visit.ms)),
+            warmSwitch,
+            credentialRefresh,
+            revisit: { ...revisitRequests, ms: Math.round(revisitMs) },
+            reconnect: reconnectRequests,
+            lateCatalogRequests:
+              catalogRequests(0).length - readsAtRelease - revisitRequests.requests - reconnectRequests.requests,
+          },
+          {
+            directories: count,
+            pendingFirstResponse: pending,
+            models: modelCount,
+            agents: catalog.agents.length,
+            commands: catalog.commands.length,
+            skills: catalog.skills.length,
+            responseBytes: bytes,
+            transport: "playwright-route",
+            gc: memory ? "explicit between phases; timing diagnostic only" : "natural; no forced GC",
+            scope: "production app renderer main isolate; not total desktop RAM",
+            browser: page.context().browser()!.version(),
+          },
+        )
+        if (testInfo.repeatEachIndex === 0) await page.screenshot({ path: testInfo.outputPath("revisit.png") })
+        await cdp.detach()
       },
     )
-    if (testInfo.repeatEachIndex === 0) await page.screenshot({ path: testInfo.outputPath("revisit.png") })
-    await cdp.detach()
-  })
-}
+  }
 }

--- a/packages/app/e2e/performance/timeline/location-catalog-benchmark.spec.ts
+++ b/packages/app/e2e/performance/timeline/location-catalog-benchmark.spec.ts
@@ -1,0 +1,255 @@
+import { benchmark, expect } from "../benchmark"
+import type { OpenCodeEvent } from "@opencode-ai/client/promise"
+import { mockOpenCodeServer } from "../../utils/mock-server"
+import { installSseTransport } from "../../utils/sse-transport"
+import { expectSessionTitle } from "../../utils/waits"
+import { fixture } from "./session-timeline-stress.fixture"
+import { createLocationCatalog } from "./location-catalog.fixture"
+import { installTimelineSettings, stressSessionHref } from "./timeline-test-helpers"
+
+const counts = (process.env.LOCATION_CATALOG_DIRECTORIES ?? "5,15,30").split(",").map(Number)
+const modelCount = Number(process.env.LOCATION_CATALOG_MODELS ?? 1200)
+const server = `http://${process.env.PLAYWRIGHT_SERVER_HOST ?? "127.0.0.1"}:${process.env.PLAYWRIGHT_SERVER_PORT ?? "4096"}`
+const catalogPaths = [
+  "/api/model",
+  "/api/provider",
+  "/api/agent",
+  "/api/command",
+  "/api/skill",
+  "/api/integration",
+  "/api/mcp",
+  "/api/mcp/resource",
+  "/api/reference",
+]
+// Four exchanges per workspace: the transcript is not the subject of this workload.
+const transcript = fixture.messages[fixture.sourceID].slice(0, 8)
+const homeSearch = '[data-component="home-session-search"]'
+const composerModel = '[data-action="composer-model"]'
+
+type Request = { path: string; directory: string | null }
+
+benchmark.use({ viewport: { width: 1440, height: 900 }, video: "off", trace: "off", serviceWorkers: "block" })
+
+for (const count of counts) {
+  benchmark(`location catalogs: visit and close ${count} workspaces`, async ({ page, report }, testInfo) => {
+    benchmark.setTimeout(300_000)
+    const catalog = createLocationCatalog(modelCount)
+    const directories = Array.from(
+      { length: count },
+      (_, index) => `C:/OpenCode/Workspace-${String(index).padStart(2, "0")}`,
+    )
+    const now = Date.now()
+    const sessions = directories.map((directory, index) => ({
+      ...fixture.sessions[0],
+      id: `ses_catalog_${String(index).padStart(2, "0")}`,
+      directory,
+      title: `Workspace ${index} review`,
+      time: { created: now - index * 60_000, updated: now - index * 60_000 },
+    }))
+    // Its session.created echo orders one deterministic read after event-driven catalog refreshes.
+    const marker = { ...fixture.sessions[0], id: "ses_catalog_marker", title: "Event marker" }
+    const pages = Object.fromEntries(
+      sessions.map((session) => [
+        session.id,
+        transcript.map((message) => ({ ...message, id: `${message.id}_${session.id}` })),
+      ]),
+    )
+    const requests: Request[] = []
+    const inflight = new Set<string>()
+    const errors: string[] = []
+    const bytes: Record<string, number> = {}
+    page.on("pageerror", (error) => errors.push(error.message))
+    page.on("request", (request) => {
+      const url = new URL(request.url())
+      if (!url.pathname.startsWith("/api/")) return
+      requests.push({ path: url.pathname, directory: url.searchParams.get("location[directory]") })
+      if (url.pathname !== "/api/event") inflight.add(request.url())
+    })
+    page.on("requestfinished", (request) => inflight.delete(request.url()))
+    page.on("requestfailed", (request) => inflight.delete(request.url()))
+    page.on("response", (response) => {
+      const url = new URL(response.url())
+      if (!url.pathname.startsWith("/api/")) return
+      if (!response.ok()) errors.push(`HTTP ${response.status()}: ${response.url()}`)
+      if (url.searchParams.get("location[directory]") !== directories[0] || !catalogPaths.includes(url.pathname)) return
+      if (bytes[url.pathname] !== undefined) return
+      bytes[url.pathname] = 0
+      void response
+        .body()
+        .then((body) => {
+          bytes[url.pathname] = body.byteLength
+        })
+        .catch(() => undefined)
+    })
+
+    const transport = await installSseTransport(page, { server })
+    await mockOpenCodeServer(page, {
+      directory: fixture.directory,
+      directories,
+      project: fixture.project,
+      provider: catalog.provider,
+      agents: catalog.agents,
+      commands: catalog.commands,
+      skills: catalog.skills,
+      sessions: [...sessions, marker],
+      pageMessages: (id) => ({ items: pages[id] ?? [] }),
+    })
+    await installTimelineSettings(page)
+    await page.addInitScript(
+      ({ directories, sessionIDs, server }) => {
+        localStorage.setItem(
+          "opencode.global.dat:server",
+          JSON.stringify({
+            projects: { local: directories.map((worktree) => ({ worktree, expanded: false })) },
+            lastProject: {},
+          }),
+        )
+        localStorage.setItem(
+          "opencode.window.browser.dat:tabs",
+          JSON.stringify(sessionIDs.map((sessionId) => ({ type: "session", server, sessionId }))),
+        )
+      },
+      { directories, sessionIDs: sessions.map((session) => session.id), server },
+    )
+    const cdp = await page.context().newCDPSession(page)
+    // GC is an explicit retained-heap measurement between phases, not a readiness wait.
+    const retainedHeap = async () => {
+      await cdp.send("HeapProfiler.collectGarbage")
+      return (await cdp.send("Runtime.getHeapUsage")).usedSize
+    }
+    const tab = (id: string) => page.locator(`[data-slot="titlebar-tabs"] a[href="${stressSessionHref(id)}"]`)
+    const catalogRequests = (from: number) =>
+      requests.slice(from).filter((request) => catalogPaths.includes(request.path))
+    const summarize = (list: Request[]) => ({
+      requests: list.length,
+      directories: [...new Set(list.map((request) => request.directory || "<default>"))].toSorted(),
+      byPath: Object.fromEntries(
+        catalogPaths.map((path) => [path, list.filter((request) => request.path === path).length]),
+      ),
+    })
+
+    await page.goto("/")
+    await expect(page.locator(homeSearch)).toBeVisible()
+    for (const session of sessions) await expect(tab(session.id)).toContainText(session.title)
+    const heapStart = await retainedHeap()
+
+    // Visit every workspace once from its restored tab.
+    const visits = []
+    for (const session of sessions) {
+      const from = requests.length
+      const started = performance.now()
+      await tab(session.id).click()
+      await expectSessionTitle(page, session.title)
+      await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+      visits.push({ ms: performance.now() - started, catalogRequests: catalogRequests(from).length })
+    }
+
+    // Switching back to an open tab must not reload its catalogs in either build.
+    const warmFrom = requests.length
+    await tab(sessions[0]!.id).click()
+    await expectSessionTitle(page, sessions[0]!.title)
+    await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+    const warmSwitch = summarize(catalogRequests(warmFrom))
+    const heapOpen = await retainedHeap()
+
+    // Close every tab; the last close lands on Home.
+    for (const session of sessions) {
+      const slot = page
+        .locator("[data-titlebar-tab-slot]")
+        .filter({ has: page.locator(`a[href="${stressSessionHref(session.id)}"]`) })
+      await slot.getByRole("button", { name: "Close tab", exact: true }).click()
+      await expect(slot).toHaveCount(0)
+    }
+    await expect(page).toHaveURL("/")
+    await expect(page.locator(homeSearch)).toBeVisible()
+    const heapClosed = await retainedHeap()
+
+    // A credential switch refreshes the model and provider catalogs the client still retains.
+    const credentialFrom = requests.length
+    const markerRead = page.waitForRequest((request) => new URL(request.url()).pathname === `/api/session/${marker.id}`)
+    await transport.burst([
+      {
+        id: "evt_catalog_credential",
+        created: now,
+        type: "credential.switched",
+        data: { integrationID: "opencode", credentialID: "credential" },
+      },
+      {
+        id: "evt_catalog_marker",
+        created: now,
+        type: "session.created",
+        durable: { aggregateID: marker.id, seq: 1, version: 1 },
+        data: {
+          sessionID: marker.id,
+          projectID: fixture.project.id,
+          location: { directory: fixture.directory },
+          slug: "event-marker",
+          version: "dev",
+        },
+      },
+    ] satisfies OpenCodeEvent[])
+    await markerRead
+    const credentialRefresh = summarize(catalogRequests(credentialFrom))
+    const heapRefreshed = await retainedHeap()
+
+    // Reopen a closed workspace from Home.
+    const revisit = sessions[0]!
+    const revisitFrom = requests.length
+    const revisitStarted = performance.now()
+    await page
+      .locator(`[data-component="home-session-row-container"][data-session-id="${revisit.id}"]`)
+      .locator('[data-component="home-session-row"]')
+      .click()
+    await expectSessionTitle(page, revisit.title)
+    await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+    const revisitMs = performance.now() - revisitStarted
+    const revisitRequests = summarize(catalogRequests(revisitFrom))
+
+    // Reconnect refreshes the catalogs of the workspace on screen.
+    const connection = await transport.waitForConnection()
+    const reconnectFrom = requests.length
+    const reconnected = transport.waitForConnection({ after: connection.id })
+    await transport.close()
+    await reconnected
+    await expect
+      .poll(
+        () =>
+          catalogRequests(reconnectFrom).some(
+            (request) => request.path === "/api/model" && request.directory === revisit.directory,
+          ) && inflight.size === 0,
+      )
+      .toBe(true)
+    const reconnectRequests = summarize(catalogRequests(reconnectFrom))
+    await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+
+    expect(errors).toEqual([])
+    expect(visits).toHaveLength(count)
+    report(
+      {
+        heap: { start: heapStart, open: heapOpen, closed: heapClosed, refreshed: heapRefreshed },
+        retainedAfterCloseBytes: heapClosed - heapStart,
+        retainedAfterRefreshBytes: heapRefreshed - heapStart,
+        visitCatalogRequests: visits.reduce((total, visit) => total + visit.catalogRequests, 0),
+        visitMs: visits.map((visit) => Math.round(visit.ms)),
+        warmSwitch,
+        credentialRefresh,
+        revisit: { ...revisitRequests, ms: Math.round(revisitMs) },
+        reconnect: reconnectRequests,
+      },
+      {
+        directories: count,
+        models: modelCount,
+        agents: catalog.agents.length,
+        commands: catalog.commands.length,
+        skills: catalog.skills.length,
+        responseBytes: bytes,
+        transport: "playwright-route",
+        gc: "explicit between phases; visit and revisit timings are Playwright-observed diagnostics",
+        scope: "production app renderer main isolate; not total desktop RAM",
+        browser: page.context().browser()!.version(),
+      },
+    )
+    if (testInfo.repeatEachIndex === 0) await page.screenshot({ path: testInfo.outputPath("revisit.png") })
+    await cdp.detach()
+  })
+}

--- a/packages/app/e2e/performance/timeline/location-catalog-benchmark.spec.ts
+++ b/packages/app/e2e/performance/timeline/location-catalog-benchmark.spec.ts
@@ -27,11 +27,13 @@ const homeSearch = '[data-component="home-session-search"]'
 const composerModel = '[data-action="composer-model"]'
 
 type Request = { path: string; directory: string | null }
+type CatalogWindow = Window & { __catalogReads: { pending: number; completed: number } }
 
 benchmark.use({ viewport: { width: 1440, height: 900 }, video: "off", trace: "off", serviceWorkers: "block" })
 
+for (const pending of [false, true].filter((value) => !process.env.LOCATION_CATALOG_PENDING || Number(process.env.LOCATION_CATALOG_PENDING) === Number(value))) {
 for (const count of counts) {
-  benchmark(`location catalogs: visit and close ${count} workspaces`, async ({ page, report }, testInfo) => {
+  benchmark(`location catalogs: ${pending ? "close before first response" : "visit and close"} ${count} workspaces`, async ({ page, report }, testInfo) => {
     benchmark.setTimeout(300_000)
     const catalog = createLocationCatalog(modelCount)
     const directories = Array.from(
@@ -82,6 +84,27 @@ for (const count of counts) {
         .catch(() => undefined)
     })
 
+    const gate = Promise.withResolvers<void>()
+    if (!pending) gate.resolve()
+    await page.addInitScript(({ paths, server }) => {
+      const reads = { pending: 0, completed: 0 }
+      ;(window as CatalogWindow).__catalogReads = reads
+      const watched = (url: string) => !!url && new URL(url).origin === server && paths.includes(new URL(url).pathname)
+      const fetch = window.fetch.bind(window)
+      window.fetch = (input, init) => {
+        if (watched(input instanceof Request ? input.url : String(input))) reads.pending++
+        return fetch(input, init)
+      }
+      const text = Response.prototype.text
+      Response.prototype.text = async function () {
+        const body = await text.call(this)
+        if (watched(this.url)) {
+          reads.pending--
+          reads.completed++
+        }
+        return body
+      }
+    }, { paths: catalogPaths, server })
     const transport = await installSseTransport(page, { server })
     await mockOpenCodeServer(page, {
       directory: fixture.directory,
@@ -94,6 +117,12 @@ for (const count of counts) {
       sessions: [...sessions, marker],
       pageMessages: (id) => ({ items: pages[id] ?? [] }),
     })
+    await page.route("**/api/**", async (route) => {
+      const url = new URL(route.request().url())
+      if (pending && catalogPaths.includes(url.pathname) && directories.includes(url.searchParams.get("location[directory]") ?? "")) await gate.promise
+      await route.fallback()
+    })
+    page.on("close", () => gate.resolve())
     await installTimelineSettings(page)
     await page.addInitScript(
       ({ directories, sessionIDs, server }) => {
@@ -140,7 +169,12 @@ for (const count of counts) {
       const started = performance.now()
       await tab(session.id).click()
       await expectSessionTitle(page, session.title)
-      await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+      if (pending) {
+        await expect(page.getByRole("textbox", { name: "Prompt", exact: true })).toBeEditable()
+        await expect.poll(() => catalogRequests(from).filter((request) => request.directory === session.directory).map((request) => request.path).toSorted()).toEqual(catalogPaths.toSorted())
+      } else {
+        await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+      }
       visits.push({ ms: performance.now() - started, catalogRequests: catalogRequests(from).length })
     }
 
@@ -148,7 +182,7 @@ for (const count of counts) {
     const warmFrom = requests.length
     await tab(sessions[0]!.id).click()
     await expectSessionTitle(page, sessions[0]!.title)
-    await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
+    if (!pending) await expect(page.locator(composerModel)).toContainText("Claude Opus 4.6")
     const warmSwitch = summarize(catalogRequests(warmFrom))
     const heapOpen = await retainedHeap()
 
@@ -189,6 +223,17 @@ for (const count of counts) {
       },
     ] satisfies OpenCodeEvent[])
     await markerRead
+    const readsAtRelease = catalogRequests(0).length
+    gate.resolve()
+    // The browser probe retains counters only, never response bodies or catalog objects.
+    // Waiting for decoded bodies and no pending catalog reads also covers event refreshes
+    // queued behind the gated first loads. Home remains the actual owning UI throughout.
+    await page.waitForFunction((minimum) => {
+      const reads = (window as CatalogWindow).__catalogReads
+      return reads.completed >= minimum && reads.pending === 0
+    }, readsAtRelease)
+    await expect(page.locator(homeSearch)).toBeVisible()
+    await expect(page.locator('[data-slot="titlebar-tabs"] a[data-titlebar-tab-link]')).toHaveCount(0)
     const credentialRefresh = summarize(catalogRequests(credentialFrom))
     const heapRefreshed = await retainedHeap()
 
@@ -235,9 +280,11 @@ for (const count of counts) {
         credentialRefresh,
         revisit: { ...revisitRequests, ms: Math.round(revisitMs) },
         reconnect: reconnectRequests,
+        lateCatalogRequests: catalogRequests(0).length - readsAtRelease - revisitRequests.requests - reconnectRequests.requests,
       },
       {
         directories: count,
+        pendingFirstResponse: pending,
         models: modelCount,
         agents: catalog.agents.length,
         commands: catalog.commands.length,
@@ -252,4 +299,5 @@ for (const count of counts) {
     if (testInfo.repeatEachIndex === 0) await page.screenshot({ path: testInfo.outputPath("revisit.png") })
     await cdp.detach()
   })
+}
 }

--- a/packages/app/e2e/performance/timeline/location-catalog.fixture.ts
+++ b/packages/app/e2e/performance/timeline/location-catalog.fixture.ts
@@ -1,0 +1,79 @@
+import { fixture } from "./session-timeline-stress.fixture"
+
+// A realistic large per-directory catalog: the provider-memory benchmark's 1,200-model
+// catalog plus agents with system prompts, slash commands, and skills with SKILL.md content.
+// Every directory serves the same payload, so distinct directories hold byte-identical catalogs.
+export function createLocationCatalog(models: number) {
+  const provider = fixture.provider.all[0]
+  const selected = provider.models["claude-opus-4-6"]
+  return {
+    provider: {
+      ...fixture.provider,
+      all: [
+        {
+          ...provider,
+          models: {
+            [selected.id]: selected,
+            ...Object.fromEntries(
+              Array.from({ length: models - 1 }, (_, index) => {
+                const id = `catalog-model-${index}`
+                return [
+                  id,
+                  {
+                    id,
+                    name: `Catalog model ${index}`,
+                    cost: { input: 1, output: 2 },
+                    limit: { context: 200_000, output: 8192 },
+                    variants: { high: { reasoningEffort: "high" } },
+                  },
+                ]
+              }),
+            ),
+          },
+        },
+      ],
+    },
+    agents: ["build", "plan", "explore", "review", "docs", "test", "refactor", "general"].map((id, index) => ({
+      id,
+      name: id[0]!.toUpperCase() + id.slice(1),
+      description: `${id} agent for ${prose(index, 120)}`,
+      mode: index < 2 ? "primary" : "subagent",
+      hidden: false,
+      color: "blue",
+      steps: 50,
+      system: prose(index * 7, 2_500),
+      request: { settings: { temperature: 0.2 }, headers: {}, body: {} },
+      permissions: [
+        { action: "edit", resource: "*", effect: "allow" },
+        { action: "bash", resource: "git *", effect: "ask" },
+        { action: "webfetch", resource: "*", effect: index % 2 === 0 ? "allow" : "deny" },
+      ],
+    })),
+    commands: Array.from({ length: 24 }, (_, index) => ({
+      name: `command-${index}`,
+      description: prose(index * 3, 90),
+    })),
+    skills: Array.from({ length: 12 }, (_, index) => ({
+      id: `skill-${index}`,
+      name: `skill-${index}`,
+      description: prose(index * 5, 140),
+      slash: true,
+      autoinvoke: false,
+      location: `.opencode/skills/skill-${index}/SKILL.md`,
+      content: `# Skill ${index}\n\n${prose(index * 11, 3_000)}`,
+    })),
+  }
+}
+
+const words = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel", "india", "juliet"]
+
+function prose(seed: number, length: number) {
+  let out = ""
+  let index = seed
+  while (out.length < length) {
+    out += (out ? " " : "") + words[index % words.length]
+    if (index % 13 === 0) out += ".\n\n"
+    index += 3
+  }
+  return out.slice(0, length)
+}

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -10,6 +10,11 @@ export interface MockServerConfig {
   integrationMethods?: Record<string, unknown[]>
   onConnectKey?: (input: { integrationID: string; body: unknown }) => void
   directory: string
+  // Directories served as their own locations. Requests for other directories resolve to `directory`.
+  directories?: string[]
+  agents?: unknown[]
+  commands?: unknown[]
+  skills?: unknown[]
   project: unknown
   sessions: ({ id: string } & Record<string, unknown>)[]
   pageMessages: (
@@ -207,22 +212,11 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
       )
       .handleAll({
         health: () => Effect.succeed({ healthy: true, version: "2.0.0", pid: 1 }),
-        reference: () =>
+        reference: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: [] }),
+        agent: (ctx) =>
           Effect.succeed({
-            location: {
-              directory: config.directory,
-              project: {
-                id: (config.project as { id?: string }).id,
-                directory: config.directory,
-                canonical: config.directory,
-              },
-            },
-            data: [],
-          }),
-        agent: () =>
-          Effect.succeed({
-            location: location(config),
-            data: [
+            location: location(config, ctx.request),
+            data: config.agents ?? [
               {
                 id: "build",
                 name: "Build",
@@ -233,14 +227,19 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
               },
             ],
           }),
-        provider: () => Effect.succeed({ location: location(config), data: currentProviders(providerConfig(config)) }),
-        model: () => Effect.succeed({ location: location(config), data: currentModels(providerConfig(config)) }),
-        modelDefault: () =>
-          Effect.succeed({ location: location(config), data: currentDefaultModel(providerConfig(config)) }),
-        integrationList: () => Effect.succeed({ location: location(config), data: [] }),
+        provider: (ctx) =>
+          Effect.succeed({ location: location(config, ctx.request), data: currentProviders(providerConfig(config)) }),
+        model: (ctx) =>
+          Effect.succeed({ location: location(config, ctx.request), data: currentModels(providerConfig(config)) }),
+        modelDefault: (ctx) =>
+          Effect.succeed({
+            location: location(config, ctx.request),
+            data: currentDefaultModel(providerConfig(config)),
+          }),
+        integrationList: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: [] }),
         integrationGet: (ctx) =>
           Effect.succeed({
-            location: location(config),
+            location: location(config, ctx.request),
             data: {
               id: ctx.params.integrationID,
               name: ctx.params.integrationID,
@@ -253,11 +252,12 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
             Effect.andThen(noContent),
           ),
         credentialRemove: () => noContent,
-        command: () => Effect.succeed({ location: location(config), data: [] }),
-        skill: () => Effect.succeed({ location: location(config), data: [] }),
-        plugin: () => Effect.succeed({ location: location(config), data: [] }),
-        mcp: () => Effect.succeed({ location: location(config), data: [] }),
-        mcpResource: () => Effect.succeed({ location: location(config), data: { resources: [], templates: [] } }),
+        command: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: config.commands ?? [] }),
+        skill: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: config.skills ?? [] }),
+        plugin: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: [] }),
+        mcp: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: [] }),
+        mcpResource: (ctx) =>
+          Effect.succeed({ location: location(config, ctx.request), data: { resources: [], templates: [] } }),
         projectList: () => {
           const project = config.project as typeof config.project & { canonical?: string; worktree?: string }
           return Effect.succeed([{ ...project, canonical: project.canonical ?? project.worktree ?? config.directory }])
@@ -286,27 +286,31 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
         },
         worktreeRemove: () => noContent,
         worktreeRefresh: () => noContent,
-        location: () => Effect.succeed(location(config)),
-        permissionRequests: () =>
+        location: (ctx) => Effect.succeed(location(config, ctx.request)),
+        permissionRequests: (ctx) =>
           Effect.succeed({
-            location: location(config),
+            location: location(config, ctx.request),
             data: (typeof config.permissions === "function" ? config.permissions() : (config.permissions ?? [])).map(
               currentPermission,
             ),
           }),
-        formRequests: () =>
+        formRequests: (ctx) =>
           Effect.succeed({
-            location: location(config),
+            location: location(config, ctx.request),
             data: typeof config.forms === "function" ? config.forms() : (config.forms ?? []),
           }),
-        vcs: () =>
-          Effect.succeed({ location: location(config), data: { branch: { current: "main", default: "main" } } }),
-        vcsStatus: () => Effect.succeed({ location: location(config), data: [] }),
-        vcsBranches: () => Effect.succeed({ location: location(config), data: config.vcsBranches ?? ["main"] }),
-        vcsDiff: () => Effect.succeed({ location: location(config), data: config.vcsDiff ?? [] }),
+        vcs: (ctx) =>
+          Effect.succeed({
+            location: location(config, ctx.request),
+            data: { branch: { current: "main", default: "main" } },
+          }),
+        vcsStatus: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: [] }),
+        vcsBranches: (ctx) =>
+          Effect.succeed({ location: location(config, ctx.request), data: config.vcsBranches ?? ["main"] }),
+        vcsDiff: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: config.vcsDiff ?? [] }),
         fsList: (ctx) =>
           Effect.promise(() => Promise.resolve(config.fileList?.(ctx.query.path ?? ""))).pipe(
-            Effect.map((data) => ({ location: location(config), data })),
+            Effect.map((data) => ({ location: location(config, ctx.request), data })),
           ),
         fsFind: (ctx) =>
           Effect.promise(() =>
@@ -315,7 +319,7 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
             ),
           ).pipe(
             Effect.map((entries) => ({
-              location: location(config),
+              location: location(config, ctx.request),
               data: Array.isArray(entries)
                 ? entries.map((entry) =>
                     typeof entry === "string"
@@ -331,9 +335,9 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
                 : entries,
             })),
           ),
-        shell: () => Effect.succeed({ location: location(config), data: [] }),
-        ptyConnectToken: () =>
-          Effect.succeed({ location: location(config), data: { ticket: "e2e-ticket", expires_in: 60 } }),
+        shell: (ctx) => Effect.succeed({ location: location(config, ctx.request), data: [] }),
+        ptyConnectToken: (ctx) =>
+          Effect.succeed({ location: location(config, ctx.request), data: { ticket: "e2e-ticket", expires_in: 60 } }),
         sessionList: (ctx) => {
           const sessions = config.sessions
             .filter((session) => {
@@ -500,10 +504,12 @@ function mockHandlers(config: MockServerConfig, state: { cursors: Map<string, st
   )
 }
 
-function location(config: MockServerConfig) {
+function location(config: MockServerConfig, request?: { url: string }) {
+  const requested = request ? new URL(request.url, "http://localhost").searchParams.get("location[directory]") : null
+  const directory = requested !== null && config.directories?.includes(requested) ? requested : config.directory
   return {
-    directory: config.directory,
-    project: { id: (config.project as { id?: string }).id, directory: config.directory, canonical: config.directory },
+    directory,
+    project: { id: (config.project as { id?: string }).id, directory, canonical: directory },
   }
 }
 

--- a/packages/app/src/providers/catalog/integrations.ts
+++ b/packages/app/src/providers/catalog/integrations.ts
@@ -1,11 +1,16 @@
 import { useServerSDK } from "@/runtime/server/client"
 import { useData } from "@/runtime/server/current"
-import { createEffect, type Accessor } from "solid-js"
+import { createEffect, onCleanup, type Accessor } from "solid-js"
 
 export function useIntegrations(directory: Accessor<string | undefined>) {
   const serverSDK = useServerSDK()
   const data = useData()
 
+  createEffect(() => {
+    const value = directory()
+    if (!value) return
+    onCleanup(data.location.retain({ directory: value }))
+  })
   createEffect(() => {
     if (serverSDK.connection.status() !== "connected") return
     const value = directory()

--- a/packages/app/src/providers/catalog/providers.ts
+++ b/packages/app/src/providers/catalog/providers.ts
@@ -2,7 +2,7 @@ import { useData } from "@/runtime/server/current"
 import { useServerSDK } from "@/runtime/server/client"
 import { normalizeProviderList } from "@/runtime/server/global-sync/utils"
 import { Iterable, pipe } from "effect"
-import { createEffect, createMemo, type Accessor } from "solid-js"
+import { createEffect, createMemo, onCleanup, type Accessor } from "solid-js"
 import type { ProviderListResponse } from "@/runtime/server/types"
 import { useIntegrations } from "./integrations"
 import { popularProviders } from "./order"
@@ -19,6 +19,11 @@ export function useProviders(directory: Accessor<string | undefined>) {
     return dir ? { directory: dir } : undefined
   }
 
+  createEffect(() => {
+    const ref = location()
+    if (!ref) return
+    onCleanup(data.location.retain(ref))
+  })
   createEffect(() => {
     if (sdk.connection.status() !== "connected") return
     const ref = location()

--- a/packages/app/src/runtime/server/residency.ts
+++ b/packages/app/src/runtime/server/residency.ts
@@ -1,0 +1,27 @@
+import { createEffect, mapArray, onCleanup } from "solid-js"
+import type { Data } from "@opencode-ai/client/solid"
+import type { ServerConnection } from "@/runtime/server/registry"
+import type { Tab } from "@/shell/tabs/tabs"
+
+// Every open tab keeps its workspace catalogs resident, so switching between open tabs never
+// reloads them. Closing the last tab for a directory releases its catalogs unless a mounted
+// consumer such as the current route still holds them.
+export function createLocationResidency(input: {
+  key: ServerConnection.Key
+  tabs: () => readonly Tab[]
+  data: Pick<Data, "location"> & { session: Pick<Data["session"], "get"> }
+}) {
+  createEffect(
+    mapArray(
+      () => input.tabs().filter((tab) => tab.server === input.key),
+      (tab) => {
+        createEffect(() => {
+          const location =
+            tab.type === "draft" ? { directory: tab.directory } : input.data.session.get(tab.sessionId)?.location
+          if (!location) return
+          onCleanup(input.data.location.retain(location))
+        })
+      },
+    ),
+  )
+}

--- a/packages/app/src/runtime/server/runtime.tsx
+++ b/packages/app/src/runtime/server/runtime.tsx
@@ -13,6 +13,8 @@ import { createServerNotificationState } from "@/shell/notifications/notificatio
 import { Persist, persisted } from "@/runtime/persistence/storage"
 import { createDesktopData } from "./data"
 import { ModelState } from "./persistence"
+import { createLocationResidency } from "./residency"
+import { useTabs } from "@/shell/tabs/tabs"
 
 export const { use: useGlobal, provider: GlobalProvider } = createSimpleContext({
   name: "Global",
@@ -145,6 +147,8 @@ function createServerController(
   const sync = createServerSyncContext(sdk, data)
   createPermissionAutoApprover({ sdk, data })
   const notification = createServerNotificationState({ sdk, data, key: connKey })
+  const tabs = useTabs()
+  createLocationResidency({ key: connKey, tabs: () => tabs.store, data })
 
   function enrich(project: { worktree: string; expanded: boolean }) {
     const [childStore] = sync.child(project.worktree, { bootstrap: false })

--- a/packages/app/src/workspaces/location.tsx
+++ b/packages/app/src/workspaces/location.tsx
@@ -29,6 +29,10 @@ const context = createSimpleContext({
     const current = createMemo(() => data.location.info(ref()))
 
     createEffect(() => {
+      onCleanup(data.location.retain(ref()))
+    })
+
+    createEffect(() => {
       const location = ref()
       let stale = false
       onCleanup(() => {

--- a/packages/app/test-browser/location-residency.test.ts
+++ b/packages/app/test-browser/location-residency.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { OpenCode } from "@opencode-ai/client/promise"
-import { createData } from "@opencode-ai/client/solid"
-import type { SessionInfo } from "@opencode-ai/client/promise"
+import { createData, type CreateDataInput } from "@opencode-ai/client/solid"
+import type { OpenCodeEvent, SessionInfo } from "@opencode-ai/client/promise"
 import { createRoot } from "solid-js"
 import { createStore } from "solid-js/store"
 import type { ServerConnection } from "@/runtime/server/registry"
@@ -24,6 +24,7 @@ function session(id: string, directory: string): SessionInfo {
 
 function fixture() {
   const requests: string[] = []
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
   const api = OpenCode.make({
     baseUrl: "http://opencode.local",
     fetch: Object.assign(
@@ -31,9 +32,10 @@ function fixture() {
         const request = new Request(input, init)
         const url = new URL(request.url)
         const directory = url.searchParams.get("location[directory]") ?? "/default"
-        requests.push(`${url.pathname} ${directory}`)
+        const workspaceID = url.searchParams.get("location[workspace]") ?? undefined
+        requests.push(`${url.pathname} ${directory}${workspaceID ? ` (${workspaceID})` : ""}`)
         return Response.json({
-          location: { directory, project: { id: "project", directory, canonical: directory } },
+          location: { directory, workspaceID, project: { id: "project", directory, canonical: directory } },
           data: [{ id: `model-${directory}`, providerID: "opencode" }],
         })
       },
@@ -45,16 +47,90 @@ function fixture() {
     const data = createData({
       api: () => api,
       directory: "/default",
-      event: { on: () => () => {}, listen: () => () => {} },
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
     })
     createLocationResidency({ key: server, tabs: () => tabs, data })
     // Releases drop catalogs after the current task.
     const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
-    return { data, tabs, setTabs, requests, settle, dispose }
+    return {
+      data,
+      tabs,
+      setTabs,
+      requests,
+      settle,
+      dispose,
+      emit: (details: OpenCodeEvent) => listeners.forEach((listener) => listener({ name: details.type, details })),
+    }
   })
 }
 
 describe("location residency", () => {
+  test.each(["event", "remember"] as const)("moving a tab via %s releases the original identity only", async (mode) => {
+    const setup = fixture()
+    const a = { directory: "/repo/a", workspaceID: "workspace-a" }
+    const b = { directory: "/repo/b", workspaceID: "workspace-b" }
+    try {
+      setup.data.session.remember({ ...session("ses_move", a.directory), location: { ...a } })
+      setup.setTabs([{ type: "session", server, sessionId: "ses_move" }])
+      const original = setup.data.session.get("ses_move")!.location
+      await Promise.all(
+        [a, b].flatMap((ref) => [setup.data.location.model.sync(ref), setup.data.location.provider.sync(ref)]),
+      )
+      if (mode === "event") {
+        setup.emit({
+          id: "evt_move",
+          created: 1,
+          type: "session.moved",
+          durable: { aggregateID: "ses_move", seq: 1, version: 1 },
+          data: { sessionID: "ses_move", location: b, projectID: "project" },
+        })
+      } else {
+        setup.data.session.remember({ ...session("ses_move", b.directory), location: { ...b } })
+      }
+      await setup.settle()
+      const afterMove = {
+        model: setup.data.location.model.list(a) ?? null,
+        provider: setup.data.location.provider.list(a) ?? null,
+      }
+      setup.requests.length = 0
+      await Promise.all([setup.data.location.model.sync(b), setup.data.location.provider.sync(b)])
+      const bRequests = [...setup.requests]
+      setup.requests.length = 0
+      await Promise.all([setup.data.location.model.sync(a), setup.data.location.provider.sync(a)])
+      const evidence = {
+        mode,
+        sameProxy: original === setup.data.session.get("ses_move")!.location,
+        originalNow: { directory: original.directory, workspaceID: original.workspaceID },
+        afterMove,
+        bRequests,
+        aRequests: [...setup.requests],
+        aModel: setup.data.location.model.list(a) ?? null,
+        aProvider: setup.data.location.provider.list(a) ?? null,
+        bModel: setup.data.location.model.list(b) ?? null,
+        bProvider: setup.data.location.provider.list(b) ?? null,
+      }
+      if (process.env.OPENCODE_LOCATION_EVIDENCE) console.log("LOCATION_MOVE", JSON.stringify(evidence))
+      expect(evidence.afterMove).toEqual({ model: null, provider: null })
+      expect(evidence.bRequests).toEqual([])
+      expect(evidence.aRequests).toEqual(["/api/model /repo/a (workspace-a)", "/api/provider /repo/a (workspace-a)"])
+      expect(evidence.aModel?.map((model) => model.id)).toEqual(["model-/repo/a"])
+      expect(evidence.aProvider?.map((provider) => provider.id)).toEqual(["model-/repo/a"])
+      expect(evidence.bModel?.map((model) => model.id)).toEqual(["model-/repo/b"])
+      expect(evidence.bProvider?.map((provider) => provider.id)).toEqual(["model-/repo/b"])
+      setup.requests.length = 0
+      await Promise.all([setup.data.location.model.sync(a), setup.data.location.provider.sync(a)])
+      expect(setup.requests).toEqual([])
+    } finally {
+      setup.dispose()
+    }
+  })
+
   test("keeps catalogs for open tabs and releases them when the last tab closes", async () => {
     const setup = fixture()
     try {

--- a/packages/app/test-browser/location-residency.test.ts
+++ b/packages/app/test-browser/location-residency.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test"
+import { OpenCode } from "@opencode-ai/client/promise"
+import { createData } from "@opencode-ai/client/solid"
+import type { SessionInfo } from "@opencode-ai/client/promise"
+import { createRoot } from "solid-js"
+import { createStore } from "solid-js/store"
+import type { ServerConnection } from "@/runtime/server/registry"
+import type { Tab } from "@/shell/tabs/tabs"
+import { createLocationResidency } from "@/runtime/server/residency"
+
+const server = "local" as ServerConnection.Key
+const other = "http://remote:4096" as ServerConnection.Key
+
+function session(id: string, directory: string): SessionInfo {
+  return {
+    id,
+    projectID: "project",
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    time: { created: 0, updated: 0 },
+    location: { directory },
+  }
+}
+
+function fixture() {
+  const requests: string[] = []
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: Object.assign(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const request = new Request(input, init)
+        const url = new URL(request.url)
+        const directory = url.searchParams.get("location[directory]") ?? "/default"
+        requests.push(`${url.pathname} ${directory}`)
+        return Response.json({
+          location: { directory, project: { id: "project", directory, canonical: directory } },
+          data: [{ id: `model-${directory}`, providerID: "opencode" }],
+        })
+      },
+      { preconnect() {} },
+    ),
+  })
+  return createRoot((dispose) => {
+    const [tabs, setTabs] = createStore<Tab[]>([])
+    const data = createData({
+      api: () => api,
+      directory: "/default",
+      event: { on: () => () => {}, listen: () => () => {} },
+    })
+    createLocationResidency({ key: server, tabs: () => tabs, data })
+    // Releases drop catalogs after the current task.
+    const settle = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+    return { data, tabs, setTabs, requests, settle, dispose }
+  })
+}
+
+describe("location residency", () => {
+  test("keeps catalogs for open tabs and releases them when the last tab closes", async () => {
+    const setup = fixture()
+    try {
+      setup.data.session.remember(session("ses_a", "/repo/a"))
+      setup.data.session.remember(session("ses_b", "/repo/a"))
+      setup.setTabs([
+        { type: "session", server, sessionId: "ses_a" },
+        { type: "session", server, sessionId: "ses_b" },
+        { type: "draft", server, draftID: "draft", directory: "/repo/draft" },
+        { type: "session", server: other, sessionId: "ses_a" },
+      ])
+      await setup.data.location.model.sync({ directory: "/repo/a" })
+      await setup.data.location.model.sync({ directory: "/repo/draft" })
+      expect(setup.requests).toEqual(["/api/model /repo/a", "/api/model /repo/draft"])
+
+      setup.setTabs((tabs) => tabs.filter((tab) => tab.type !== "session" || tab.sessionId !== "ses_a"))
+      await setup.settle()
+      expect(setup.data.location.model.list({ directory: "/repo/a" })).toHaveLength(1)
+
+      setup.setTabs((tabs) => tabs.filter((tab) => tab.type !== "session" || tab.server !== server))
+      await setup.settle()
+      expect(setup.data.location.model.list({ directory: "/repo/a" })).toBeUndefined()
+      expect(setup.data.location.model.list({ directory: "/repo/draft" })).toHaveLength(1)
+
+      setup.setTabs([])
+      await setup.settle()
+      expect(setup.data.location.model.list({ directory: "/repo/draft" })).toBeUndefined()
+
+      await setup.data.location.model.sync({ directory: "/repo/a" })
+      expect(setup.requests).toHaveLength(3)
+      expect(setup.data.location.model.list({ directory: "/repo/a" })).toHaveLength(1)
+    } finally {
+      setup.dispose()
+    }
+  })
+
+  test("holds a session tab's directory once its session info arrives", async () => {
+    const setup = fixture()
+    try {
+      setup.setTabs([{ type: "session", server, sessionId: "ses_late" }])
+      await setup.data.location.model.sync({ directory: "/repo/late" })
+      setup.data.session.remember(session("ses_late", "/repo/late"))
+      setup.setTabs([])
+      await setup.settle()
+      expect(setup.data.location.model.list({ directory: "/repo/late" })).toBeUndefined()
+    } finally {
+      setup.dispose()
+    }
+  })
+
+  test("promoting a draft to a session tab keeps the directory resident", async () => {
+    const setup = fixture()
+    try {
+      setup.data.session.remember(session("ses_new", "/repo/a"))
+      setup.setTabs([{ type: "draft", server, draftID: "draft", directory: "/repo/a" }])
+      await setup.data.location.model.sync({ directory: "/repo/a" })
+      setup.requests.length = 0
+      setup.setTabs([{ type: "session", server, sessionId: "ses_new" }])
+      await setup.settle()
+      expect(setup.data.location.model.list({ directory: "/repo/a" })).toHaveLength(1)
+      await setup.data.location.model.sync({ directory: "/repo/a" })
+      expect(setup.requests).toEqual([])
+    } finally {
+      setup.dispose()
+    }
+  })
+})

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -171,17 +171,20 @@ function createSync() {
       const active = state.get(key)
       return active !== undefined && active !== true
     },
+    // Reports whether the key held loaded or in-flight state, so event handlers can refresh
+    // only data a consumer has actually loaded.
     invalidate(key?: string) {
       if (key) {
         const active = state.get(key)
         if (active === true) state.delete(key)
         if (active !== undefined && active !== true) active.invalidated = true
-        return
+        return active !== undefined
       }
       state.forEach((active, current) => {
         if (active === true) state.delete(current)
         if (active !== true) active.invalidated = true
       })
+      return true
     },
   }
 }
@@ -215,6 +218,7 @@ export function createData(config: CreateDataInput) {
   )
   const messageIndex = new Map<string, Map<string, number>>()
   const sync = createSync()
+  const holds = new Map<string, number>()
   let activeUpdates: Map<string, DataSessionStatus | undefined> | undefined
 
   function setSessionActive(sessionID: string, status: DataSessionStatus) {
@@ -1156,13 +1160,14 @@ export function createData(config: CreateDataInput) {
         return
     }
 
+    // Event-driven refreshes reload only catalogs a consumer has loaded or is loading. Released
+    // locations keep light metadata; their catalogs reload when a consumer next syncs them.
     if (event.type === "credential.updated" || event.type === "credential.switched") {
       Object.keys(store.location).forEach((key) => {
         const ref = JSON.parse(key) as [string, string | null]
         const location = { directory: ref[0], workspaceID: ref[1] ?? undefined }
         if (event.type === "credential.updated") {
-          result.location.integration.invalidate(location)
-          void result.location.integration.sync(location)
+          if (result.location.integration.invalidate(location)) void result.location.integration.sync(location)
           return
         }
         setStore("location", key, (data) => ({
@@ -1179,9 +1184,8 @@ export function createData(config: CreateDataInput) {
             }
           }),
         }))
-        result.location.model.invalidate(location)
-        result.location.provider.invalidate(location)
-        void Promise.all([result.location.model.sync(location), result.location.provider.sync(location)])
+        if (result.location.model.invalidate(location)) void result.location.model.sync(location)
+        if (result.location.provider.invalidate(location)) void result.location.provider.sync(location)
       })
       return
     }
@@ -1190,21 +1194,17 @@ export function createData(config: CreateDataInput) {
     const location = event.location
     switch (event.type) {
       case "catalog.updated":
-        result.location.model.invalidate(location)
-        result.location.provider.invalidate(location)
-        void Promise.all([result.location.model.sync(location), result.location.provider.sync(location)])
+        if (result.location.model.invalidate(location)) void result.location.model.sync(location)
+        if (result.location.provider.invalidate(location)) void result.location.provider.sync(location)
         break
       case "agent.updated":
-        result.location.agent.invalidate(location)
-        void result.location.agent.sync(location)
+        if (result.location.agent.invalidate(location)) void result.location.agent.sync(location)
         break
       case "command.updated":
-        result.location.command.invalidate(location)
-        void result.location.command.sync(location)
+        if (result.location.command.invalidate(location)) void result.location.command.sync(location)
         break
       case "skill.updated":
-        result.location.skill.invalidate(location)
-        void result.location.skill.sync(location)
+        if (result.location.skill.invalidate(location)) void result.location.skill.sync(location)
         break
       case "vcs.branch.updated":
         setStore("location", locationKey(location), (data) => ({
@@ -1245,14 +1245,9 @@ export function createData(config: CreateDataInput) {
         void result.location.reference.sync()
         break
       case "integration.updated":
-        result.location.integration.invalidate(location)
-        result.location.model.invalidate(location)
-        result.location.provider.invalidate(location)
-        void Promise.all([
-          result.location.integration.sync(location),
-          result.location.model.sync(location),
-          result.location.provider.sync(location),
-        ])
+        if (result.location.integration.invalidate(location)) void result.location.integration.sync(location)
+        if (result.location.model.invalidate(location)) void result.location.model.sync(location)
+        if (result.location.provider.invalidate(location)) void result.location.provider.sync(location)
         break
       case "config.updated":
       case "websearch.updated":
@@ -1261,12 +1256,10 @@ export function createData(config: CreateDataInput) {
       // Authenticating an MCP integration reconnects its server, which emits mcp.status.changed,
       // so the mcp list syncs here rather than off integration.updated.
       case "mcp.status.changed":
-        result.location.mcp.server.invalidate(location)
-        void result.location.mcp.server.sync(location)
+        if (result.location.mcp.server.invalidate(location)) void result.location.mcp.server.sync(location)
         break
       case "mcp.resources.changed":
-        result.location.mcp.resource.invalidate(location)
-        void result.location.mcp.resource.sync(location)
+        if (result.location.mcp.resource.invalidate(location)) void result.location.mcp.resource.sync(location)
         break
     }
   }
@@ -1840,6 +1833,50 @@ export function createData(config: CreateDataInput) {
         result.location.skill.invalidate(location)
         result.shell.invalidate(location)
         result.session.form.invalidate("global", location)
+      },
+      // Catalogs stay resident while a consumer holds the location. Releasing the last hold drops
+      // the loaded catalogs and their sync state so the next consumer reloads them. Light metadata
+      // (info, vcs, running shells) and the default location stay resident.
+      retain(ref: LocationRef) {
+        const key = locationKey(ref)
+        holds.set(key, (holds.get(key) ?? 0) + 1)
+        let released = false
+        return () => {
+          if (released) return
+          released = true
+          const next = (holds.get(key) ?? 1) - 1
+          if (next > 0) {
+            holds.set(key, next)
+            return
+          }
+          holds.delete(key)
+          // Route swaps and draft promotion release and re-acquire within one update, so the drop
+          // waits for the current task; a new hold by then keeps the catalogs.
+          queueMicrotask(() => {
+            if (holds.has(key) || key === locationKey(defaultLocation())) return
+            result.location.agent.invalidate(ref)
+            result.location.command.invalidate(ref)
+            result.location.integration.invalidate(ref)
+            result.location.mcp.server.invalidate(ref)
+            result.location.mcp.resource.invalidate(ref)
+            result.location.model.invalidate(ref)
+            result.location.provider.invalidate(ref)
+            result.location.reference.invalidate(ref)
+            result.location.skill.invalidate(ref)
+            if (!store.location[key]) return
+            setStore("location", key, {
+              agent: undefined,
+              command: undefined,
+              integration: undefined,
+              mcpServer: undefined,
+              mcpResource: undefined,
+              model: undefined,
+              provider: undefined,
+              reference: undefined,
+              skill: undefined,
+            })
+          })
+        }
       },
       vcs: { info: vcs.list, sync: vcs.sync, invalidate: vcs.invalidate },
       agent: locationResource("agent", (location) => api().agent.list({ location })),

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -138,14 +138,14 @@ function formRequestOptions(sessionID: string, ref?: LocationRef) {
 }
 
 function createSync() {
-  type Pending = { promise: Promise<void>; invalidated: boolean }
+  type Pending = { promise: Promise<void>; invalidated: boolean; current?: () => boolean }
   const state = new Map<string, true | Pending>()
-  const start = (key: string, load: () => Promise<void>, wait?: Promise<void>) => {
-    const entry: Pending = { promise: Promise.resolve(), invalidated: false }
+  const start = (key: string, load: () => Promise<void>, current?: () => boolean, wait?: Promise<void>) => {
+    const entry: Pending = { promise: Promise.resolve(), invalidated: false, current }
     state.set(key, entry)
     entry.promise = (wait ? wait.catch(() => undefined).then(load) : load())
       .then(() => {
-        if (state.get(key) === entry && !entry.invalidated) state.set(key, true)
+        if (state.get(key) === entry && !entry.invalidated && current?.() !== false) state.set(key, true)
       })
       .finally(() => {
         if (state.get(key) === entry) state.delete(key)
@@ -153,12 +153,12 @@ function createSync() {
     return entry.promise
   }
   return {
-    run(key: string, load: () => Promise<void>) {
+    run(key: string, load: () => Promise<void>, current?: () => boolean) {
       const active = state.get(key)
       if (active === true) return Promise.resolve()
-      if (!active) return start(key, load)
+      if (!active) return start(key, load, current)
       if (!active.invalidated) return active.promise
-      return start(key, load, active.promise)
+      return start(key, load, current, active.promise)
     },
     complete(key: string) {
       if (state.has(key)) return
@@ -178,7 +178,8 @@ function createSync() {
         const active = state.get(key)
         if (active === true) state.delete(key)
         if (active !== undefined && active !== true) active.invalidated = true
-        return active !== undefined
+        // An obsolete pending catalog must not admit a fresh event-driven load after release.
+        return active !== undefined && (active === true || active.current?.() !== false)
       }
       state.forEach((active, current) => {
         if (active === true) state.delete(current)
@@ -219,6 +220,7 @@ export function createData(config: CreateDataInput) {
   const messageIndex = new Map<string, Map<string, number>>()
   const sync = createSync()
   const holds = new Map<string, number>()
+  const locationGeneration = new Map<string, number>()
   let activeUpdates: Map<string, DataSessionStatus | undefined> | undefined
 
   function setSessionActive(sessionID: string, status: DataSessionStatus) {
@@ -1264,6 +1266,12 @@ export function createData(config: CreateDataInput) {
     }
   }
 
+  function locationCurrent(ref: LocationRef) {
+    const key = locationKey(ref)
+    const generation = locationGeneration.get(key)
+    return () => locationGeneration.get(key) === generation
+  }
+
   // A cached per-location catalog. `sync` loads once per invalidation, keyed by the
   // effective location, and publishes under the server's canonical location; `alias`
   // also publishes under the requested key when the two differ.
@@ -1278,12 +1286,20 @@ export function createData(config: CreateDataInput) {
       sync: (ref?: LocationRef) => {
         const location = ref ?? defaultLocation()
         const id = locationKey(location)
-        return sync.run(`location.${field}:${id}`, async () => {
-          const response = await load(locationQuery(location))
-          const key = locationKey(response.location)
-          publish(key, response.data)
-          if (options?.alias && key !== id) publish(id, response.data)
-        })
+        // Capture before sync.run can queue the callback behind an earlier read.
+        const current = field === "vcs" || field === "shell" ? undefined : locationCurrent(location)
+        return sync.run(
+          `location.${field}:${id}`,
+          async () => {
+            if (current?.() === false) return
+            const response = await load(locationQuery(location))
+            if (current?.() === false) return
+            const key = locationKey(response.location)
+            publish(key, response.data)
+            if (options?.alias && key !== id) publish(id, response.data)
+          },
+          current,
+        )
       },
       invalidate: (ref?: LocationRef) => sync.invalidate(`location.${field}:${locationKey(ref ?? defaultLocation())}`),
     }
@@ -1801,7 +1817,9 @@ export function createData(config: CreateDataInput) {
         })
       },
       async sync(ref?: LocationRef) {
+        const current = locationCurrent(ref ?? defaultLocation())
         await result.location.syncInfo(ref)
+        if (!current()) return
         const location = ref ?? defaultLocation()
         await Promise.all([
           result.location.vcs.sync(location),
@@ -1854,6 +1872,7 @@ export function createData(config: CreateDataInput) {
           // waits for the current task; a new hold by then keeps the catalogs.
           queueMicrotask(() => {
             if (holds.has(key) || key === locationKey(defaultLocation())) return
+            locationGeneration.set(key, (locationGeneration.get(key) ?? 0) + 1)
             result.location.agent.invalidate(ref)
             result.location.command.invalidate(ref)
             result.location.integration.invalidate(ref)

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -1855,7 +1855,9 @@ export function createData(config: CreateDataInput) {
       // Catalogs stay resident while a consumer holds the location. Releasing the last hold drops
       // the loaded catalogs and their sync state so the next consumer reloads them. Light metadata
       // (info, vcs, running shells) and the default location stay resident.
-      retain(ref: LocationRef) {
+      retain(location: LocationRef) {
+        // Session movement can mutate a caller's Solid store proxy in place.
+        const ref = { directory: location.directory, workspaceID: location.workspaceID }
         const key = locationKey(ref)
         holds.set(key, (holds.get(key) ?? 0) + 1)
         let released = false

--- a/packages/client/test/solid-location.test.ts
+++ b/packages/client/test/solid-location.test.ts
@@ -110,7 +110,7 @@ test.each([false, true])("release-window events do not revive pending catalogs (
     setup.emit({ id: "evt_credentials", created: 1, type: "credential.updated", data: {} })
     setup.emit({ id: "evt_switch", created: 1, type: "credential.switched", data: { integrationID: "integration", credentialID: null } })
     for (const type of ["catalog.updated", "agent.updated", "command.updated", "skill.updated", "integration.updated", "mcp.status.changed", "mcp.resources.changed"] as const) {
-      setup.emit({ id: `evt_${type}`, created: 1, type, location: released, data: {} })
+      setup.emit({ id: `evt_${type}`, created: 1, type, location: released, data: { server: "fixture" } })
     }
     gate.resolve()
     await Promise.all(initial)

--- a/packages/client/test/solid-location.test.ts
+++ b/packages/client/test/solid-location.test.ts
@@ -1,10 +1,162 @@
 import { expect, test } from "bun:test"
 import { createRoot } from "solid-js"
-import { createData, type CreateDataInput } from "../src/solid"
+import { createData, type CreateDataInput, type Data } from "../src/solid"
 import { OpenCode, type OpenCodeEvent } from "../src/promise"
 
 const held = { directory: "/held" }
 const released = { directory: "/released" }
+const categories = ["model", "provider", "agent", "command", "integration", "skill", "reference", "mcp.server", "mcp.resource"] as const
+
+test.each(categories)("last release rejects a late first %s response", async (category) => {
+  const requested = Promise.withResolvers<void>()
+  const gate = Promise.withResolvers<void>()
+  const setup = fixture(async () => {
+    requested.resolve()
+    await gate.promise
+  })
+  const resource = catalog(setup.data, category)
+  try {
+    const release = setup.data.location.retain(released)
+    const initial = resource.sync(released)
+    await requested.promise
+    release()
+    await Promise.resolve()
+    gate.resolve()
+    await initial
+    expect(resource.list(released)).toBeUndefined()
+    await resource.sync(released)
+    await resource.sync(released)
+    expect(setup.requests).toHaveLength(2)
+    expect(resource.list(released)).toHaveLength(1)
+  } finally {
+    gate.resolve()
+    setup.dispose()
+  }
+})
+
+test.each(categories)("a queued %s sync keeps its invocation generation across close/reopen/close", async (category) => {
+  const requested = Promise.withResolvers<void>()
+  const gate = Promise.withResolvers<void>()
+  const setup = fixture(async () => {
+    requested.resolve()
+    await gate.promise
+  })
+  const resource = catalog(setup.data, category)
+  try {
+    const release = setup.data.location.retain(released)
+    const initial = resource.sync(released)
+    await requested.promise
+    release()
+    await Promise.resolve()
+    const close = setup.data.location.retain(released)
+    const queued = resource.sync(released)
+    close()
+    await Promise.resolve()
+    gate.resolve()
+    await Promise.all([initial, queued])
+    expect(resource.list(released)).toBeUndefined()
+    expect(setup.requests).toHaveLength(1)
+    const reopen = setup.data.location.retain(released)
+    await resource.sync(released)
+    await resource.sync(released)
+    expect(setup.requests).toHaveLength(2)
+    expect(resource.list(released)).toHaveLength(1)
+    reopen()
+    await Promise.resolve()
+    expect(resource.list(released)).toBeUndefined()
+  } finally {
+    gate.resolve()
+    setup.dispose()
+  }
+})
+
+test("released aggregate sync does not start catalogs after delayed location info", async () => {
+  const requested = Promise.withResolvers<void>()
+  const gate = Promise.withResolvers<void>()
+  const setup = fixture(async (url) => {
+    if (url.pathname !== "/api/location") return
+    requested.resolve()
+    await gate.promise
+  })
+  try {
+    const release = setup.data.location.retain(released)
+    const initial = setup.data.location.sync(released)
+    await requested.promise
+    release()
+    await Promise.resolve()
+    gate.resolve()
+    await initial
+    for (const category of categories) expect(catalog(setup.data, category).list(released)).toBeUndefined()
+    expect(setup.requests).toEqual(["/api/location /released"])
+    await setup.data.location.sync(released)
+    for (const category of categories) expect(catalog(setup.data, category).list(released)).toHaveLength(1)
+  } finally {
+    gate.resolve()
+    setup.dispose()
+  }
+})
+
+test.each([false, true])("release-window events do not revive pending catalogs (reacquire: %s)", async (reacquire) => {
+  const gate = Promise.withResolvers<void>()
+  const setup = fixture((url) => url.pathname === "/api/location" ? Promise.resolve() : gate.promise)
+  try {
+    await setup.data.location.syncInfo(released)
+    const release = setup.data.location.retain(released)
+    const initial = categories.map((category) => catalog(setup.data, category).sync(released))
+    release()
+    await Promise.resolve()
+    // Merely retaining again does not make an old pending request current.
+    const close = reacquire ? setup.data.location.retain(released) : () => {}
+    setup.emit({ id: "evt_credentials", created: 1, type: "credential.updated", data: {} })
+    setup.emit({ id: "evt_switch", created: 1, type: "credential.switched", data: { integrationID: "integration", credentialID: null } })
+    for (const type of ["catalog.updated", "agent.updated", "command.updated", "skill.updated", "integration.updated", "mcp.status.changed", "mcp.resources.changed"] as const) {
+      setup.emit({ id: `evt_${type}`, created: 1, type, location: released, data: {} })
+    }
+    gate.resolve()
+    await Promise.all(initial)
+    await setup.settle()
+    expect(setup.requests).toHaveLength(categories.length + 1)
+    for (const category of categories) expect(catalog(setup.data, category).list(released)).toBeUndefined()
+    // An explicit load after release is supported even without a hold (including TUI callers).
+    await Promise.all(categories.map((category) => catalog(setup.data, category).sync(released)))
+    const reads = setup.requests.length
+    setup.emit({ id: "evt_current", created: 2, type: "catalog.updated", location: released, data: {} })
+    await setup.settle()
+    expect(setup.requests).toHaveLength(reads + 2)
+    for (const category of categories) expect(catalog(setup.data, category).list(released)).toHaveLength(1)
+    close()
+  } finally {
+    gate.resolve()
+    setup.dispose()
+  }
+})
+
+test("default-location late loads survive last release", async () => {
+  const gate = Promise.withResolvers<void>()
+  const setup = fixture((url) => url.pathname === "/api/location" ? Promise.resolve() : gate.promise)
+  try {
+    await setup.data.location.syncInfo()
+    const release = setup.data.location.retain(setup.data.location.default())
+    const initial = categories.map((category) => catalog(setup.data, category).sync())
+    release()
+    await Promise.resolve()
+    gate.resolve()
+    await Promise.all(initial)
+    for (const category of categories) expect(catalog(setup.data, category).list()).toHaveLength(1)
+    const reads = setup.requests.length
+    await Promise.all(categories.map((category) => catalog(setup.data, category).sync()))
+    expect(setup.requests).toHaveLength(reads)
+  } finally {
+    gate.resolve()
+    setup.dispose()
+  }
+})
+
+function catalog(data: Data, category: (typeof categories)[number]) {
+  if (category === "mcp.server") return data.location.mcp.server
+  if (category === "mcp.resource") return data.location.mcp.resource
+  return data.location[category]
+}
 
 test("releasing the last hold drops catalogs, keeps light metadata, and reloads on the next sync", async () => {
   const setup = fixture()

--- a/packages/client/test/solid-location.test.ts
+++ b/packages/client/test/solid-location.test.ts
@@ -1,0 +1,180 @@
+import { expect, test } from "bun:test"
+import { createRoot } from "solid-js"
+import { createData, type CreateDataInput } from "../src/solid"
+import { OpenCode, type OpenCodeEvent } from "../src/promise"
+
+const held = { directory: "/held" }
+const released = { directory: "/released" }
+
+test("releasing the last hold drops catalogs, keeps light metadata, and reloads on the next sync", async () => {
+  const setup = fixture()
+  try {
+    const release = setup.data.location.retain(released)
+    const again = setup.data.location.retain(released)
+    await Promise.all([setup.data.location.sync(released), setup.data.location.sync(held)])
+    setup.requests.length = 0
+
+    release()
+    await setup.settle()
+    expect(setup.data.location.model.list(released)).toHaveLength(1)
+    again()
+    again()
+    expect(setup.data.location.model.list(released)).toHaveLength(1)
+    await setup.settle()
+    expect(setup.data.location.model.list(released)).toBeUndefined()
+    expect(setup.data.location.provider.list(released)).toBeUndefined()
+    expect(setup.data.location.agent.list(released)).toBeUndefined()
+    expect(setup.data.location.command.list(released)).toBeUndefined()
+    expect(setup.data.location.skill.list(released)).toBeUndefined()
+    expect(setup.data.location.integration.list(released)).toBeUndefined()
+    expect(setup.data.location.mcp.server.list(released)).toBeUndefined()
+    expect(setup.data.location.mcp.resource.list(released)).toBeUndefined()
+    expect(setup.data.location.reference.list(released)).toBeUndefined()
+    expect(setup.data.location.info(released)?.directory).toBe("/released")
+    expect(setup.data.location.vcs.info(released)?.branch.current).toBe("main")
+    expect(setup.data.location.model.list(held)).toHaveLength(1)
+    expect(setup.requests).toEqual([])
+
+    await setup.data.location.model.sync(released)
+    expect(setup.requests).toEqual(["/api/model /released"])
+    expect(setup.data.location.model.list(released)).toHaveLength(1)
+  } finally {
+    setup.dispose()
+  }
+})
+
+test("a hold re-acquired within the same task keeps the catalogs", async () => {
+  const setup = fixture()
+  try {
+    const release = setup.data.location.retain(released)
+    await setup.data.location.sync(released)
+    setup.requests.length = 0
+    release()
+    const next = setup.data.location.retain(released)
+    await setup.settle()
+    expect(setup.data.location.model.list(released)).toHaveLength(1)
+    await setup.data.location.model.sync(released)
+    expect(setup.requests).toEqual([])
+    next()
+    await setup.settle()
+    expect(setup.data.location.model.list(released)).toBeUndefined()
+  } finally {
+    setup.dispose()
+  }
+})
+
+test("the default location stays resident after its holds release", async () => {
+  const setup = fixture()
+  try {
+    await setup.data.location.sync()
+    const release = setup.data.location.retain(setup.data.location.default())
+    release()
+    await setup.settle()
+    expect(setup.data.location.model.list()).toHaveLength(1)
+    expect(setup.data.location.model.list({ directory: "/project" })).toHaveLength(1)
+  } finally {
+    setup.dispose()
+  }
+})
+
+test("event-driven refreshes reload only catalogs that are loaded or loading", async () => {
+  const setup = fixture()
+  try {
+    const release = setup.data.location.retain(released)
+    await Promise.all([setup.data.location.sync(released), setup.data.location.sync(held)])
+    release()
+    await setup.settle()
+    setup.requests.length = 0
+
+    setup.emit({ id: "evt_credential", created: 1, type: "credential.updated", data: {} })
+    setup.emit({
+      id: "evt_switched",
+      created: 2,
+      type: "credential.switched",
+      data: { integrationID: "integration", credentialID: "credential" },
+    })
+    await setup.settle()
+    expect(setup.requests.toSorted()).toEqual(["/api/integration /held", "/api/model /held", "/api/provider /held"])
+    setup.requests.length = 0
+
+    for (const type of ["catalog.updated", "agent.updated", "command.updated", "skill.updated"] as const) {
+      setup.emit({ id: `evt_${type}_released`, created: 3, type, location: released, data: {} })
+      setup.emit({ id: `evt_${type}_unknown`, created: 3, type, location: { directory: "/never" }, data: {} })
+      setup.emit({ id: `evt_${type}_held`, created: 3, type, location: held, data: {} })
+    }
+    await setup.settle()
+    expect(setup.requests.toSorted()).toEqual([
+      "/api/agent /held",
+      "/api/command /held",
+      "/api/model /held",
+      "/api/provider /held",
+      "/api/skill /held",
+    ])
+    expect(setup.data.location.model.list(released)).toBeUndefined()
+  } finally {
+    setup.dispose()
+  }
+})
+
+test("an event during the first load still refreshes after that load settles", async () => {
+  const gate = Promise.withResolvers<void>()
+  const setup = fixture(async (url) => {
+    if (url.pathname === "/api/model" && url.searchParams.get("location[directory]") === "/held") await gate.promise
+  })
+  try {
+    const initial = setup.data.location.model.sync(held)
+    setup.emit({ id: "evt_catalog", created: 1, type: "catalog.updated", location: held, data: {} })
+    gate.resolve()
+    await initial
+    await setup.settle()
+    expect(setup.requests.filter((request) => request === "/api/model /held")).toHaveLength(2)
+  } finally {
+    gate.resolve()
+    setup.dispose()
+  }
+})
+
+function fixture(before?: (url: URL) => Promise<void>) {
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
+  const requests: string[] = []
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => {
+      const request = new Request(input, init)
+      const url = new URL(request.url)
+      const directory = url.searchParams.get("location[directory]") || "/project"
+      requests.push(`${url.pathname} ${directory}`)
+      await before?.(url)
+      const location = { directory, project: { id: "project", directory, canonical: directory } }
+      if (url.pathname === "/api/location") return Response.json(location)
+      if (url.pathname === "/api/vcs") return Response.json({ location, data: { branch: { current: "main" } } })
+      if (url.pathname === "/api/mcp/resource")
+        return Response.json({ location, data: { resources: [{ server: "mcp", uri: "file://x" }], templates: [] } })
+      if (url.pathname === "/api/shell") return Response.json({ location, data: [] })
+      if (url.pathname === "/api/form/request") return Response.json({ location, data: [] })
+      return Response.json({ location, data: [{ id: `${url.pathname}:${directory}`, providerID: "opencode" }] })
+    },
+  })
+  return createRoot((dispose) => {
+    const data = createData({
+      api: () => api,
+      directory: "",
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
+      connection: { status: () => "connected" },
+    })
+    return {
+      data,
+      requests,
+      dispose,
+      emit: (details: OpenCodeEvent) => listeners.forEach((listener) => listener({ name: details.type, details })),
+      // Event handlers issue their reads synchronously; a macrotask lets those reads settle.
+      settle: () => new Promise<void>((resolve) => setTimeout(resolve, 0)),
+    }
+  })
+}

--- a/packages/client/test/solid-location.test.ts
+++ b/packages/client/test/solid-location.test.ts
@@ -5,7 +5,17 @@ import { OpenCode, type OpenCodeEvent } from "../src/promise"
 
 const held = { directory: "/held" }
 const released = { directory: "/released" }
-const categories = ["model", "provider", "agent", "command", "integration", "skill", "reference", "mcp.server", "mcp.resource"] as const
+const categories = [
+  "model",
+  "provider",
+  "agent",
+  "command",
+  "integration",
+  "skill",
+  "reference",
+  "mcp.server",
+  "mcp.resource",
+] as const
 
 test.each(categories)("last release rejects a late first %s response", async (category) => {
   const requested = Promise.withResolvers<void>()
@@ -34,41 +44,44 @@ test.each(categories)("last release rejects a late first %s response", async (ca
   }
 })
 
-test.each(categories)("a queued %s sync keeps its invocation generation across close/reopen/close", async (category) => {
-  const requested = Promise.withResolvers<void>()
-  const gate = Promise.withResolvers<void>()
-  const setup = fixture(async () => {
-    requested.resolve()
-    await gate.promise
-  })
-  const resource = catalog(setup.data, category)
-  try {
-    const release = setup.data.location.retain(released)
-    const initial = resource.sync(released)
-    await requested.promise
-    release()
-    await Promise.resolve()
-    const close = setup.data.location.retain(released)
-    const queued = resource.sync(released)
-    close()
-    await Promise.resolve()
-    gate.resolve()
-    await Promise.all([initial, queued])
-    expect(resource.list(released)).toBeUndefined()
-    expect(setup.requests).toHaveLength(1)
-    const reopen = setup.data.location.retain(released)
-    await resource.sync(released)
-    await resource.sync(released)
-    expect(setup.requests).toHaveLength(2)
-    expect(resource.list(released)).toHaveLength(1)
-    reopen()
-    await Promise.resolve()
-    expect(resource.list(released)).toBeUndefined()
-  } finally {
-    gate.resolve()
-    setup.dispose()
-  }
-})
+test.each(categories)(
+  "a queued %s sync keeps its invocation generation across close/reopen/close",
+  async (category) => {
+    const requested = Promise.withResolvers<void>()
+    const gate = Promise.withResolvers<void>()
+    const setup = fixture(async () => {
+      requested.resolve()
+      await gate.promise
+    })
+    const resource = catalog(setup.data, category)
+    try {
+      const release = setup.data.location.retain(released)
+      const initial = resource.sync(released)
+      await requested.promise
+      release()
+      await Promise.resolve()
+      const close = setup.data.location.retain(released)
+      const queued = resource.sync(released)
+      close()
+      await Promise.resolve()
+      gate.resolve()
+      await Promise.all([initial, queued])
+      expect(resource.list(released)).toBeUndefined()
+      expect(setup.requests).toHaveLength(1)
+      const reopen = setup.data.location.retain(released)
+      await resource.sync(released)
+      await resource.sync(released)
+      expect(setup.requests).toHaveLength(2)
+      expect(resource.list(released)).toHaveLength(1)
+      reopen()
+      await Promise.resolve()
+      expect(resource.list(released)).toBeUndefined()
+    } finally {
+      gate.resolve()
+      setup.dispose()
+    }
+  },
+)
 
 test("released aggregate sync does not start catalogs after delayed location info", async () => {
   const requested = Promise.withResolvers<void>()
@@ -98,7 +111,7 @@ test("released aggregate sync does not start catalogs after delayed location inf
 
 test.each([false, true])("release-window events do not revive pending catalogs (reacquire: %s)", async (reacquire) => {
   const gate = Promise.withResolvers<void>()
-  const setup = fixture((url) => url.pathname === "/api/location" ? Promise.resolve() : gate.promise)
+  const setup = fixture((url) => (url.pathname === "/api/location" ? Promise.resolve() : gate.promise))
   try {
     await setup.data.location.syncInfo(released)
     const release = setup.data.location.retain(released)
@@ -108,8 +121,21 @@ test.each([false, true])("release-window events do not revive pending catalogs (
     // Merely retaining again does not make an old pending request current.
     const close = reacquire ? setup.data.location.retain(released) : () => {}
     setup.emit({ id: "evt_credentials", created: 1, type: "credential.updated", data: {} })
-    setup.emit({ id: "evt_switch", created: 1, type: "credential.switched", data: { integrationID: "integration", credentialID: null } })
-    for (const type of ["catalog.updated", "agent.updated", "command.updated", "skill.updated", "integration.updated", "mcp.status.changed", "mcp.resources.changed"] as const) {
+    setup.emit({
+      id: "evt_switch",
+      created: 1,
+      type: "credential.switched",
+      data: { integrationID: "integration", credentialID: null },
+    })
+    for (const type of [
+      "catalog.updated",
+      "agent.updated",
+      "command.updated",
+      "skill.updated",
+      "integration.updated",
+      "mcp.status.changed",
+      "mcp.resources.changed",
+    ] as const) {
       setup.emit({ id: `evt_${type}`, created: 1, type, location: released, data: { server: "fixture" } })
     }
     gate.resolve()
@@ -133,7 +159,7 @@ test.each([false, true])("release-window events do not revive pending catalogs (
 
 test("default-location late loads survive last release", async () => {
   const gate = Promise.withResolvers<void>()
-  const setup = fixture((url) => url.pathname === "/api/location" ? Promise.resolve() : gate.promise)
+  const setup = fixture((url) => (url.pathname === "/api/location" ? Promise.resolve() : gate.promise))
   try {
     await setup.data.location.syncInfo()
     const release = setup.data.location.retain(setup.data.location.default())
@@ -146,6 +172,33 @@ test("default-location late loads survive last release", async () => {
     const reads = setup.requests.length
     await Promise.all(categories.map((category) => catalog(setup.data, category).sync()))
     expect(setup.requests).toHaveLength(reads)
+  } finally {
+    gate.resolve()
+    setup.dispose()
+  }
+})
+
+test("a current explicit load queued after release can still be refreshed by events", async () => {
+  const gate = Promise.withResolvers<void>()
+  const setup = fixture((url) => (url.pathname === "/api/location" ? Promise.resolve() : gate.promise))
+  try {
+    await setup.data.location.syncInfo(released)
+    const release = setup.data.location.retain(released)
+    const initial = categories.map((category) => catalog(setup.data, category).sync(released))
+    release()
+    await Promise.resolve()
+    const close = setup.data.location.retain(released)
+    const current = categories.map((category) => catalog(setup.data, category).sync(released))
+    setup.emit({ id: "evt_reopened", created: 1, type: "catalog.updated", location: released, data: {} })
+    gate.resolve()
+    await Promise.all([...initial, ...current])
+    await setup.settle()
+    expect(setup.requests).toHaveLength(1 + categories.length * 2 + 2)
+    const reads = setup.requests.length
+    await Promise.all(categories.map((category) => catalog(setup.data, category).sync(released)))
+    expect(setup.requests).toHaveLength(reads)
+    for (const category of categories) expect(catalog(setup.data, category).list(released)).toHaveLength(1)
+    close()
   } finally {
     gate.resolve()
     setup.dispose()

--- a/packages/client/test/solid-location.test.ts
+++ b/packages/client/test/solid-location.test.ts
@@ -17,6 +17,63 @@ const categories = [
   "mcp.resource",
 ] as const
 
+test("a release keeps the identity of a live session location across session.moved", async () => {
+  const setup = fixture()
+  const a = { directory: "/move-a" }
+  const b = { directory: "/move-b" }
+  try {
+    setup.data.session.remember({
+      id: "ses_move",
+      projectID: "project",
+      location: { ...a },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: 0, updated: 0 },
+    })
+    const original = setup.data.session.get("ses_move")!.location
+    const release = setup.data.location.retain(original)
+    await Promise.all([a, b].flatMap((ref) => categories.map((category) => catalog(setup.data, category).sync(ref))))
+    setup.emit({
+      id: "evt_move",
+      created: 1,
+      type: "session.moved",
+      durable: { aggregateID: "ses_move", seq: 1, version: 1 },
+      data: { sessionID: "ses_move", location: b, projectID: "project" },
+    })
+    release()
+    await setup.settle()
+    for (const category of categories) expect(catalog(setup.data, category).list(a)).toBeUndefined()
+    setup.requests.length = 0
+    await Promise.all(categories.map((category) => catalog(setup.data, category).sync(b)))
+    const bRequests = [...setup.requests]
+    setup.requests.length = 0
+    await Promise.all(categories.map((category) => catalog(setup.data, category).sync(a)))
+    if (process.env.OPENCODE_LOCATION_EVIDENCE)
+      console.log(
+        "LOCATION_MOVE_CLIENT",
+        JSON.stringify({
+          sameProxy: original === setup.data.session.get("ses_move")!.location,
+          originalNow: original.directory,
+          bRequests,
+          aRequests: setup.requests,
+          a: categories.map((category) => [category, catalog(setup.data, category).list(a) ?? null]),
+          b: categories.map((category) => [category, catalog(setup.data, category).list(b) ?? null]),
+        }),
+      )
+    expect(bRequests).toEqual([])
+    expect(setup.requests).toHaveLength(categories.length)
+    for (const category of categories) {
+      expect(catalog(setup.data, category).list(a)).toHaveLength(1)
+      expect(catalog(setup.data, category).list(b)).toHaveLength(1)
+    }
+    setup.requests.length = 0
+    await Promise.all(categories.map((category) => catalog(setup.data, category).sync(a)))
+    expect(setup.requests).toEqual([])
+  } finally {
+    setup.dispose()
+  }
+})
+
 test.each(categories)("last release rejects a late first %s response", async (category) => {
   const requested = Promise.withResolvers<void>()
   const gate = Promise.withResolvers<void>()

--- a/packages/tui/test/cli/tui/dialog-integration.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-integration.test.tsx
@@ -67,8 +67,8 @@ test("switches the selected account with enter and keeps the reactive account ma
     const frame = fixture.app.captureCharFrame()
     expect(frame.indexOf("Personal")).toBeLessThan(frame.indexOf("Work"))
     expect(fixture.reads.integration).toBe(1)
-    expect(fixture.reads.model).toBeGreaterThan(0)
-    expect(fixture.reads.provider).toBeGreaterThan(0)
+    expect(fixture.reads.model).toBeGreaterThan(1)
+    expect(fixture.reads.provider).toBeGreaterThan(1)
   } finally {
     fixture.app.renderer.destroy()
   }
@@ -82,8 +82,8 @@ test("does not refetch when selecting the already-active account", async () => {
     fixture.app.mockInput.pressEnter()
 
     expect(fixture.requests).toEqual([])
-    expect(fixture.reads.model).toBe(0)
-    expect(fixture.reads.provider).toBe(0)
+    expect(fixture.reads.model).toBe(1)
+    expect(fixture.reads.provider).toBe(1)
   } finally {
     fixture.app.renderer.destroy()
   }
@@ -130,8 +130,8 @@ test("requires delete confirmation and preserves the account manager when anothe
 
     expect(fixture.requests).toEqual([{ method: "DELETE", path: "/api/credential/cred_work" }])
     expect(fixture.accounts).toEqual([{ type: "credential", id: "cred_personal", label: "Personal" }])
-    expect(fixture.reads.model).toBe(0)
-    expect(fixture.reads.provider).toBe(0)
+    expect(fixture.reads.model).toBe(1)
+    expect(fixture.reads.provider).toBe(1)
     expect(fixture.app.captureCharFrame()).toContain("Add account")
     expect(fixture.app.captureCharFrame()).toContain("Personal")
   } finally {
@@ -319,9 +319,13 @@ async function renderIntegration(activeLocation?: LocationRef) {
     const location = useLocation()
     onMount(() => {
       location.set(activeLocation)
-      void data.location.integration
-        .sync(activeLocation)
-        .then(() => dialog.replace(() => <DialogIntegration integrationID="openai" autoConnect />))
+      // The TUI syncs the current location's catalogs before the account manager can open;
+      // credential events refresh only catalogs that are loaded.
+      void Promise.all([
+        data.location.integration.sync(activeLocation),
+        data.location.model.sync(activeLocation),
+        data.location.provider.sync(activeLocation),
+      ]).then(() => dialog.replace(() => <DialogIntegration integrationID="openai" autoConnect />))
     })
     return null
   }


### PR DESCRIPTION
- Release loaded location catalogs when the last tab or mounted catalog reader releases its hold. Keep lightweight metadata, running shells, and the default location.
- Snapshot `directory` and `workspaceID` at retain time. A live Solid session-location proxy can change in place during movement; cleanup must invalidate the original location, not its destination.
- Capture the location generation at public read invocation, before a callback can queue behind an earlier read. Check it before requesting and before publishing, including the aggregate `location.sync()` continuation after `syncInfo()`.
- Pending sync entries carry the same predicate: credential/catalog events cannot revive obsolete work after release, and discarded reads cannot mark a cache entry complete. A genuine explicit load still works without a hold, including existing TUI callers. Same-task owner handoff keeps the current generation.
- No request-abort framework, session transcript eviction changes, or Core/server implementation changes.

```ts
const current = locationCurrent(location)
return sync.run(key, async () => {
  if (!current()) return
  const response = await load(locationQuery(location))
  if (!current()) return
  publish(response)
}, current)
```

**Movement Identity**
Actual `createData` + `createLocationResidency`, tested with both `session.moved` and remembered metadata reconciliation, confirms that the retained proxy changes from non-default A to non-default B. Before `d19561c6bc`, cleanup cleared A but invalidated B's cache markers, leaving A unable to reload.

| Model/provider reads after A moves to B | Reviewed `519ec6772b` | Corrected `d19561c6bc` |
| --- | --- | --- |
| Reuse B | 2 unnecessary requests | 0 requests; catalogs remain correct |
| Revisit A | 0 requests; both catalogs stay empty | 2 requests; both catalogs restored |

The real-client regression covers all nine released catalog categories. The production correction is one two-field identity snapshot; generation guards and direct unheld callers are unchanged.

**Current Controls**
Unchanged production catalog workload below, 30 workspaces, three forced-GC samples per case. Reviewed source `519ec6772b` uses its previously verified `repair-after-dist` bundle; corrected source `d19561c6bc` has a new build. Six production source-map entries and 770 asset hashes per bundle were verified/recorded separately. These controls preserve the earlier retention behavior, not establish a new performance gain.

| Control | Reviewed median MiB (samples) | Corrected median MiB (samples) |
| --- | --- | --- |
| Loaded, then closed | 9.73 (8.49, 9.73, 9.80) | 9.70 (8.52, 9.70, 9.70) |
| Closed before first response; sampled after bodies settle | 8.20 (8.25, 6.48, 8.20) | 8.04 (6.74, 8.04, 8.22) |

Every sample on both builds: zero late refresh requests, nine reopen reads, zero warm-switch reads, and nine reconnect reads. Heap is post-GC renderer-main-isolate memory minus initial Home, not total desktop RAM. No new latency claim.

**Earlier Benchmark**
- Production Chromium 147, 1440x900, Playwright route transport, service workers blocked. Each directory has 1,200 models (488,790 response bytes), eight agents with system prompts (24,620 B), 24 commands (3,313 B), 12 skills (40,625 B), and a four-exchange session.
- Restore one tab per directory, visit each, close all tabs to Home, emit `credential.switched`, reopen one workspace, then reconnect. The pending case gates all first catalog responses until tabs are closed and the event is handled, then releases them on Home and waits for body readers to finish.
- These historical generation-repair measurements used frozen before `afb3a14299` and after `7c8a32d2cb`, with six changed production sources verified against source maps and 770 asset hashes recorded per build. Their frontend source is equivalent to public revisions `cbbc0dd69c` and `304dfd04e8`/`519ec6772b`. They are not measurements of the later identity snapshot in `d19561c6bc`.

Three serial forced-GC samples per case. Heap is renderer-main-isolate retained memory minus the initial Home sample, in MiB. Loaded cases sample after close; pending cases sample after late bodies settle.

| Case | Directories | Before MiB, median (samples) | After MiB, median (samples) | Late refresh requests before / after |
| --- | ---: | --- | --- | --- |
| Loaded, then closed | 5 | 8.39 (8.62, 8.37, 8.39) | 8.39 (8.70, 8.39, 8.39) | 0 / 0 |
| Loaded, then closed | 15 | 8.97 (9.29, 8.97, 8.97) | 8.98 (8.97, 8.98, 9.05) | 0 / 0 |
| Loaded, then closed | 30 | 9.71 (8.46, 9.75, 9.71) | 9.78 (9.70, 9.78, 9.78) | 0 / 0 |
| Closed before first response | 5 | 9.74 (9.74, 9.74, 9.74) | 7.03 (7.03, 7.02, 7.33) | 10 / 0 |
| Closed before first response | 15 | 15.71 (15.71, 15.71, 15.79) | 7.63 (7.63, 7.55, 7.97) | 30 / 0 |
| Closed before first response | 30 | 24.48 (24.52, 24.32, 24.48) | 8.07 (8.04, 8.27, 8.07) | 60 / 0 |

- Loaded-then-closed retention is preserved. For context, the original upstream `499e22bf52` baseline retained 13.0 / 24.0 / 40.5 MiB after closing 5 / 15 / 30 directories. Those historical measurements used the older base and are not the controlled repair comparison above.
- Reopening fetches nine catalogs. The unrepaired pending case fetched seven because its late credential event had already refilled models/providers. Warm open-tab switches still make zero catalog requests; reconnect makes nine for the reopened workspace in both builds.

Separate natural-GC timing: five loaded directories, 20 samples per build, counterbalanced in 10-sample ABBA blocks. Playwright-observed reopen-to-model-ready:

| | Before | After |
| --- | ---: | ---: |
| Median / p95 | 227 / 261 ms | 193 / 319 ms |
| Range | 158-295 ms | 147-372 ms |

The distribution does not establish reduced reopen latency; on-demand catalog reads remain the trade-off.

**Scope**
- Old-generation first responses and queued refreshes are discarded, not cancelled. Already-started HTTP reads and JSON parsing still finish. Explicit new loads remain supported; this is not a global memory cap.
- Lightweight location entries and generation counters remain. Retained location-entry counts were not instrumented, and the residual heap was not attributed to individual caches.
- Browser renderer only, not total desktop RAM, server memory, worker/GPU memory, allocation peaks, or a reproduction of the reported approximately 1 GB spike. No cross-directory payload sharing was added.
