### PR TITLE
feat: honor OPENCODE_CLI_NAME in MCP OAuth prompts

### DIFF
--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -36,6 +36,7 @@ import { McpEvent } from "@opencode-ai/schema/mcp-event"
 import { McpBrowser } from "./browser"
 
 const DEFAULT_TIMEOUT = 30_000
+const cli = process.env.OPENCODE_CLI_NAME ?? "opencode"
 const CLIENT_OPTIONS = {
   capabilities: {
     // https://github.com/anomalyco/opencode/issues/11948
@@ -314,7 +315,7 @@ const layer = Layer.effect(
                 return events
                   .publish(TuiEvent.ToastShow, {
                     title: "MCP Authentication Required",
-                    message: `Server "${key}" requires authentication. Run: opencode mcp auth ${key}`,
+                    message: `Server "${key}" requires authentication. Run: ${cli} mcp auth ${key}`,
                     variant: "warning",
                     duration: 8000,
                   })

--- a/packages/tui/src/component/dialog-status.tsx
+++ b/packages/tui/src/component/dialog-status.tsx
@@ -7,6 +7,8 @@ import { For, Match, Switch, Show, createMemo } from "solid-js"
 
 export type DialogStatusProps = {}
 
+const cli = process.env.OPENCODE_CLI_NAME ?? "opencode"
+
 export function DialogStatus() {
   const sync = useSync()
   const { theme } = useTheme()
@@ -80,7 +82,7 @@ export function DialogStatus() {
                       <Match when={item.status === "failed" && item}>{(val) => val().error}</Match>
                       <Match when={item.status === "disabled"}>Disabled in configuration</Match>
                       <Match when={(item.status as string) === "needs_auth"}>
-                        Needs authentication (run: opencode mcp auth {key})
+                        Needs authentication (run: {cli} mcp auth {key})
                       </Match>
                       <Match when={(item.status as string) === "needs_client_registration" && item}>
                         {(val) => (val() as { error: string }).error}


### PR DESCRIPTION
### Issue for this PR

Closes #46790

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two runtime MCP-auth prompts hardcode `opencode` as the CLI name:

- `packages/opencode/src/mcp/index.ts` — the toast published when a server connect fails with an auth error: `Server "<key>" requires authentication. Run: opencode mcp auth <key>`
- `packages/tui/src/component/dialog-status.tsx` — the `/mcp` dialog line: `Needs authentication (run: opencode mcp auth <key>)`

Downstream distributions and wrappers invoke the same binary under a different name, so the printed command isn't on the user's `$PATH`. This reads `OPENCODE_CLI_NAME` (default `"opencode"`, so existing installs are unchanged) at module scope in each file and interpolates it into both prompts. Following CONTRIBUTING's "keep logic in one function" rule, I didn't add a shared helper for a single-use constant.

### How did you verify your code works?

- `bun typecheck` in `packages/opencode` and `packages/tui`: clean.
- Scoped tests: `test/mcp/` (61 pass) and `test/cli/help` (34 snapshots) green. Grepped both test trees for the modified literals — no test asserts either string.
- Manual e2e pending: default run shows `opencode mcp auth <name>`; `OPENCODE_CLI_NAME=foocode` shows `foocode mcp auth <name>` in both the toast and the `/mcp` dialog. Screenshots to follow.

### Screenshots / recordings

Screenshots pending (will attach against a Sentry MCP server: default vs `OPENCODE_CLI_NAME=foocode`).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
