### PR TITLE
feat(app): markdown preview toggle for file viewer and clickable file paths in chat

### DIFF
--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -1172,12 +1172,15 @@ export default function Page() {
       return
     }
     showAllFiles()
-    const tab = file.tab(path)
-    const normalized = file.pathFromTab(tab) ?? path
-    tabs().previewTab(tab)
-    void file.load(normalized)
-    view().reviewPanel.open()
-    queueMicrotask(() => tabs().setActive(tab))
+    const maybePromise = file.load(path)
+    const open = () => {
+      const tab = file.tab(path)
+      tabs().open(tab)
+      view().reviewPanel.open()
+      tabs().setActive(tab)
+    }
+    if (maybePromise instanceof Promise) void maybePromise.then(open)
+    else open()
   }
 
   const changesLabel = (option: ChangeMode) => {

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -35,6 +35,7 @@ import { Tabs } from "@opencode-ai/ui/tabs"
 import { ButtonV2 } from "@opencode-ai/ui/v2/button-v2"
 import { createAutoScroll } from "@opencode-ai/ui/hooks"
 import { previewSelectedLines } from "@opencode-ai/session-ui/pierre/selection-bridge"
+import { OpenFileProvider } from "@opencode-ai/session-ui/context/open-file"
 import { Button } from "@opencode-ai/ui/button"
 import { showToast } from "@/utils/toast"
 import { base64Encode, checksum } from "@opencode-ai/core/util/encode"
@@ -1161,6 +1162,24 @@ export default function Page() {
     loadFile: file.load,
   })
 
+  const openFileFromChat = (raw: string) => {
+    const path = raw.trim()
+    if (!path) return
+    const root = sdk().directory
+    const absolute = path.startsWith("/") || /^[a-zA-Z]:[\\/]/.test(path)
+    if (absolute && (!root || (path !== root && !path.startsWith(root.endsWith("/") ? root : root + "/")))) {
+      if (platform.revealPath) void platform.revealPath(path)
+      return
+    }
+    showAllFiles()
+    const tab = file.tab(path)
+    const normalized = file.pathFromTab(tab) ?? path
+    tabs().previewTab(tab)
+    void file.load(normalized)
+    view().reviewPanel.open()
+    queueMicrotask(() => tabs().setActive(tab))
+  }
+
   const changesLabel = (option: ChangeMode) => {
     if (option === "git") return language.t("ui.sessionReview.title.git")
     if (option === "branch") return language.t("ui.sessionReview.title.branch")
@@ -2247,145 +2266,147 @@ export default function Page() {
   )
 
   return (
-    <SessionRouteFrame>
-      <SessionHeader />
-      <div
-        ref={panelRow}
-        class="flex-1 min-h-0 flex flex-col md:flex-row"
-        classList={{
-          "gap-2 p-2": settings.general.newLayoutDesigns(),
-        }}
-      >
-        <Show when={!isDesktop() && !!params.id && !settings.general.newLayoutDesigns()}>{mobileTabs()}</Show>
-
+    <OpenFileProvider onOpenFile={openFileFromChat}>
+      <SessionRouteFrame>
+        <SessionHeader />
         <div
+          ref={panelRow}
+          class="flex-1 min-h-0 flex flex-col md:flex-row"
           classList={{
-            "@container relative shrink-0 flex flex-col min-h-0 h-full flex-1 md:flex-none transition-[width]": true,
-            "duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
-              !size.active() && !ui.reviewSnap && !desktopInlineTerminalOnlyOpen(),
-          }}
-          style={{
-            width: sessionPanelWidth(),
+            "gap-2 p-2": settings.general.newLayoutDesigns(),
           }}
         >
-          {settings.general.newLayoutDesigns() ? (
-            <Show when={sessionPanelKey()} keyed>
-              {(_) => (
-                <SessionPanelFrame newLayout raised={!!params.id}>
-                  <ErrorBoundary fallback={sessionErrorFallback}>{sessionPanelContent()}</ErrorBoundary>
-                </SessionPanelFrame>
-              )}
-            </Show>
-          ) : (
-            <SessionPanelFrame newLayout={false} raised={!!params.id}>
-              {sessionPanelContent()}
-            </SessionPanelFrame>
-          )}
+          <Show when={!isDesktop() && !!params.id && !settings.general.newLayoutDesigns()}>{mobileTabs()}</Show>
 
-          <Show when={desktopSessionResizeOpen()}>
-            <div onPointerDown={() => size.start()}>
-              <ResizeHandle
-                classList={{
-                  "-end-1": settings.general.newLayoutDesigns(),
-                }}
-                direction="horizontal"
-                size={sessionPanelResizedWidth()}
-                min={SESSION_PANEL_WIDTH_MIN}
-                max={sessionPanelMax()}
-                onResize={(width) => {
-                  size.touch()
-                  layout.session.resize(width)
-                }}
+          <div
+            classList={{
+              "@container relative shrink-0 flex flex-col min-h-0 h-full flex-1 md:flex-none transition-[width]": true,
+              "duration-[240ms] ease-[cubic-bezier(0.22,1,0.36,1)] will-change-[width] motion-reduce:transition-none":
+                !size.active() && !ui.reviewSnap && !desktopInlineTerminalOnlyOpen(),
+            }}
+            style={{
+              width: sessionPanelWidth(),
+            }}
+          >
+            {settings.general.newLayoutDesigns() ? (
+              <Show when={sessionPanelKey()} keyed>
+                {(_) => (
+                  <SessionPanelFrame newLayout raised={!!params.id}>
+                    <ErrorBoundary fallback={sessionErrorFallback}>{sessionPanelContent()}</ErrorBoundary>
+                  </SessionPanelFrame>
+                )}
+              </Show>
+            ) : (
+              <SessionPanelFrame newLayout={false} raised={!!params.id}>
+                {sessionPanelContent()}
+              </SessionPanelFrame>
+            )}
+
+            <Show when={desktopSessionResizeOpen()}>
+              <div onPointerDown={() => size.start()}>
+                <ResizeHandle
+                  classList={{
+                    "-end-1": settings.general.newLayoutDesigns(),
+                  }}
+                  direction="horizontal"
+                  size={sessionPanelResizedWidth()}
+                  min={SESSION_PANEL_WIDTH_MIN}
+                  max={sessionPanelMax()}
+                  onResize={(width) => {
+                    size.touch()
+                    layout.session.resize(width)
+                  }}
+                />
+              </div>
+            </Show>
+          </div>
+
+          <Show when={!newSessionDesign() && desktopSidePanelOpen()}>
+            <Suspense>
+              <SessionSidePanel
+                canReview={canReview}
+                diffs={reviewDiffs}
+                diffsReady={reviewReady}
+                empty={reviewEmptyText}
+                hasReview={hasReview}
+                reviewHasFocusableContent={hasReview}
+                reviewCount={reviewCount}
+                reviewPanel={reviewPanel}
+                activeDiff={activeReviewFile()}
+                focusReviewDiff={focusReviewDiff}
+                reviewSnap={ui.reviewSnap}
+                size={size}
               />
-            </div>
+            </Suspense>
+          </Show>
+          <Show when={newSessionDesign()}>
+            <Show when={isDesktop() ? desktopV2PanelLayout().visible : terminalOpen()}>
+              <div class="min-w-0 h-full flex flex-1 flex-col">
+                <Show when={isDesktop() && (desktopV2ReviewOpen() || desktopFileTreeOpen())}>
+                  <div class="min-h-0 flex-1">
+                    <Suspense>
+                      <SessionSidePanel
+                        canReview={canReview}
+                        diffs={reviewDiffs}
+                        diffsReady={reviewReady}
+                        empty={reviewEmptyText}
+                        hasReview={hasReview}
+                        reviewHasFocusableContent={() => hasReview() || reviewV2State.sidebarOpened()}
+                        reviewCount={reviewCount}
+                        reviewPanel={reviewPanelV2}
+                        reviewSidebarToggle={(disabled) => (
+                          <SessionReviewV2SidebarToggle
+                            opened={reviewV2State.sidebarOpened()}
+                            disabled={disabled}
+                            onToggle={reviewV2State.toggleSidebar}
+                          />
+                        )}
+                        fileBrowserState={reviewV2State}
+                        activeDiff={activeReviewFile()}
+                        focusReviewDiff={focusReviewDiff}
+                        reviewSnap={ui.reviewSnap}
+                        size={size}
+                        stacked={desktopV2PanelLayout().stacked}
+                      />
+                    </Suspense>
+                  </div>
+                </Show>
+                <Show when={desktopV2PanelLayout().stacked}>
+                  <div class="relative h-2 shrink-0" onPointerDown={() => size.start()}>
+                    <ResizeHandle
+                      class="!relative !inset-auto !h-full !w-full !transform-none"
+                      direction="vertical"
+                      size={layout.terminal.height()}
+                      min={100}
+                      max={typeof window === "undefined" ? 600 : window.innerHeight * 0.6}
+                      collapseThreshold={50}
+                      onResize={(height) => {
+                        size.touch()
+                        layout.terminal.resize(height)
+                      }}
+                      onCollapse={() => view().terminal.close()}
+                    />
+                  </div>
+                </Show>
+                <Show when={terminalOpen()}>
+                  <div
+                    classList={{
+                      "min-h-0 shrink-0": desktopV2PanelLayout().stacked,
+                      "min-h-0 flex-1": !desktopV2PanelLayout().stacked,
+                    }}
+                  >
+                    <TerminalPanelV2 stacked={desktopV2PanelLayout().stacked} />
+                  </div>
+                </Show>
+              </div>
+            </Show>
           </Show>
         </div>
 
-        <Show when={!newSessionDesign() && desktopSidePanelOpen()}>
-          <Suspense>
-            <SessionSidePanel
-              canReview={canReview}
-              diffs={reviewDiffs}
-              diffsReady={reviewReady}
-              empty={reviewEmptyText}
-              hasReview={hasReview}
-              reviewHasFocusableContent={hasReview}
-              reviewCount={reviewCount}
-              reviewPanel={reviewPanel}
-              activeDiff={activeReviewFile()}
-              focusReviewDiff={focusReviewDiff}
-              reviewSnap={ui.reviewSnap}
-              size={size}
-            />
-          </Suspense>
+        <Show when={!newSessionDesign()}>
+          <TerminalPanel />
         </Show>
-        <Show when={newSessionDesign()}>
-          <Show when={isDesktop() ? desktopV2PanelLayout().visible : terminalOpen()}>
-            <div class="min-w-0 h-full flex flex-1 flex-col">
-              <Show when={isDesktop() && (desktopV2ReviewOpen() || desktopFileTreeOpen())}>
-                <div class="min-h-0 flex-1">
-                  <Suspense>
-                    <SessionSidePanel
-                      canReview={canReview}
-                      diffs={reviewDiffs}
-                      diffsReady={reviewReady}
-                      empty={reviewEmptyText}
-                      hasReview={hasReview}
-                      reviewHasFocusableContent={() => hasReview() || reviewV2State.sidebarOpened()}
-                      reviewCount={reviewCount}
-                      reviewPanel={reviewPanelV2}
-                      reviewSidebarToggle={(disabled) => (
-                        <SessionReviewV2SidebarToggle
-                          opened={reviewV2State.sidebarOpened()}
-                          disabled={disabled}
-                          onToggle={reviewV2State.toggleSidebar}
-                        />
-                      )}
-                      fileBrowserState={reviewV2State}
-                      activeDiff={activeReviewFile()}
-                      focusReviewDiff={focusReviewDiff}
-                      reviewSnap={ui.reviewSnap}
-                      size={size}
-                      stacked={desktopV2PanelLayout().stacked}
-                    />
-                  </Suspense>
-                </div>
-              </Show>
-              <Show when={desktopV2PanelLayout().stacked}>
-                <div class="relative h-2 shrink-0" onPointerDown={() => size.start()}>
-                  <ResizeHandle
-                    class="!relative !inset-auto !h-full !w-full !transform-none"
-                    direction="vertical"
-                    size={layout.terminal.height()}
-                    min={100}
-                    max={typeof window === "undefined" ? 600 : window.innerHeight * 0.6}
-                    collapseThreshold={50}
-                    onResize={(height) => {
-                      size.touch()
-                      layout.terminal.resize(height)
-                    }}
-                    onCollapse={() => view().terminal.close()}
-                  />
-                </div>
-              </Show>
-              <Show when={terminalOpen()}>
-                <div
-                  classList={{
-                    "min-h-0 shrink-0": desktopV2PanelLayout().stacked,
-                    "min-h-0 flex-1": !desktopV2PanelLayout().stacked,
-                  }}
-                >
-                  <TerminalPanelV2 stacked={desktopV2PanelLayout().stacked} />
-                </div>
-              </Show>
-            </div>
-          </Show>
-        </Show>
-      </div>
-
-      <Show when={!newSessionDesign()}>
-        <TerminalPanel />
-      </Show>
-    </SessionRouteFrame>
+      </SessionRouteFrame>
+    </OpenFileProvider>
   )
 }

--- a/packages/app/src/pages/session/file-tabs.tsx
+++ b/packages/app/src/pages/session/file-tabs.tsx
@@ -10,8 +10,10 @@ import { createLineCommentControllerV2 } from "@opencode-ai/session-ui/v2/line-c
 import { sampledChecksum } from "@opencode-ai/core/util/encode"
 import { DropdownMenu } from "@opencode-ai/ui/dropdown-menu"
 import { IconButton } from "@opencode-ai/ui/icon-button"
+import { RadioGroup } from "@opencode-ai/ui/radio-group"
 import { LineCommentV2OverflowIcon } from "@opencode-ai/ui/v2/line-comment-v2"
 import { MenuV2 } from "@opencode-ai/ui/v2/menu-v2"
+import { Markdown } from "@opencode-ai/session-ui/markdown"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { ScrollView } from "@opencode-ai/ui/scroll-view"
 import { showToast } from "@/utils/toast"
@@ -26,6 +28,24 @@ import { createSessionTabs } from "@/pages/session/helpers"
 
 type SessionFileViewProps = {
   tab: string
+}
+
+type FileViewMode = "preview" | "source"
+
+const isMarkdownPath = (filePath: string | undefined) => !!filePath && /\.(md|markdown)$/.test(filePath)
+
+function FilePreviewToggle(props: { mode: FileViewMode; onSelect: (mode: FileViewMode) => void }) {
+  return (
+    <div class="absolute right-4 top-2 z-10">
+      <RadioGroup
+        options={["preview", "source"] as const}
+        current={props.mode}
+        size="small"
+        onSelect={(mode) => mode && props.onSelect(mode)}
+        label={(mode) => (mode === "preview" ? "Preview" : "Source")}
+      />
+    </div>
+  )
 }
 
 const selectionSide = (range: SelectedLineRange) => range.endSide ?? range.side ?? "additions"
@@ -252,6 +272,8 @@ function SessionFileViewV1(props: { tab: string }) {
   })
   const contents = createMemo(() => state()?.content?.content ?? "")
   const cacheKey = createMemo(() => sampledChecksum(contents()))
+  const [mode, setMode] = createSignal<FileViewMode>("preview")
+  const markdown = createMemo(() => isMarkdownPath(path()))
   const selectedLines = createMemo<SelectedLineRange | null>(() => {
     const p = path()
     if (!p) return null
@@ -493,9 +515,18 @@ function SessionFileViewV1(props: { tab: string }) {
 
   const content = () => (
     <div class="mt-3 relative h-full min-h-0">
+      <Show when={markdown() && state()?.loaded}>
+        <FilePreviewToggle mode={mode()} onSelect={setMode} />
+      </Show>
       <ScrollView class="h-full" viewportRef={scrollSync.setViewport} onScroll={scrollSync.handleScroll as any}>
         <Switch>
-          <Match when={state()?.loaded}>{renderFile(contents())}</Match>
+          <Match when={state()?.loaded}>
+            <Show when={markdown() && mode() === "preview"} fallback={renderFile(contents())}>
+              <div class="px-6 py-4 pb-40">
+                <Markdown text={contents()} cacheKey={cacheKey()} />
+              </div>
+            </Show>
+          </Match>
           <Match when={state()?.loading}>
             <div class="px-6 py-4 text-text-weak">{language.t("common.loading")}...</div>
           </Match>
@@ -537,6 +568,8 @@ function SessionFileViewV2(props: { tab: string }) {
   })
   const contents = createMemo(() => state()?.content?.content ?? "")
   const cacheKey = createMemo(() => sampledChecksum(contents()))
+  const [mode, setMode] = createSignal<FileViewMode>("preview")
+  const markdown = createMemo(() => isMarkdownPath(path()))
   const selectedLines = createMemo<SelectedLineRange | null>(() => {
     const p = path()
     if (!p) return null
@@ -784,9 +817,18 @@ function SessionFileViewV2(props: { tab: string }) {
 
   const content = () => (
     <div class="mt-3 relative h-full min-h-0">
+      <Show when={markdown() && state()?.loaded}>
+        <FilePreviewToggle mode={mode()} onSelect={setMode} />
+      </Show>
       <ScrollView class="h-full" viewportRef={scrollSync.setViewport} onScroll={scrollSync.handleScroll as any}>
         <Switch>
-          <Match when={state()?.loaded}>{renderFile(contents())}</Match>
+          <Match when={state()?.loaded}>
+            <Show when={markdown() && mode() === "preview"} fallback={renderFile(contents())}>
+              <div class="px-6 py-4 pb-40">
+                <Markdown text={contents()} cacheKey={cacheKey()} />
+              </div>
+            </Show>
+          </Match>
           <Match when={state()?.loading}>
             <div class="px-6 py-4 text-text-weak">{language.t("common.loading")}...</div>
           </Match>

--- a/packages/session-ui/src/components/markdown.css
+++ b/packages/session-ui/src/components/markdown.css
@@ -257,6 +257,7 @@
       var(--markdown-inline-code-path-color) var(--markdown-inline-code-bg-mix),
       transparent
     );
+    cursor: pointer;
   }
 
   a.external-link > code[data-inline-code-kind="url"] {

--- a/packages/session-ui/src/components/markdown.tsx
+++ b/packages/session-ui/src/components/markdown.tsx
@@ -17,6 +17,7 @@ import { Icon as IconV2 } from "@opencode-ai/ui/v2/icon"
 import { IconButtonV2 } from "@opencode-ai/ui/v2/icon-button-v2"
 import { TooltipV2 } from "@opencode-ai/ui/v2/tooltip-v2"
 import { canReusePendingBlock, completedProjection } from "./markdown-projection"
+import { useOpenFile } from "../context/open-file"
 import type { Block, Projection } from "./markdown-stream"
 import {
   disposeMarkdownProjection,
@@ -330,6 +331,28 @@ function setupCodeCopy(root: HTMLDivElement, getLabels: () => CopyLabels) {
   }
 }
 
+function setupPathLinks(root: HTMLDivElement, onOpenFile: (path: string) => void) {
+  const handleClick = (event: MouseEvent) => {
+    if (event.button !== 0) return
+    if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) return
+    const target = event.target
+    if (!(target instanceof Element)) return
+    const code = target.closest('code[data-inline-code-kind="path"]')
+    if (!(code instanceof HTMLElement)) return
+    const path = code.textContent?.trim()
+    if (!path) return
+    event.preventDefault()
+    event.stopPropagation()
+    onOpenFile(path)
+  }
+
+  root.addEventListener("click", handleClick)
+
+  return () => {
+    root.removeEventListener("click", handleClick)
+  }
+}
+
 function initialResult(text: string, key: string | undefined, projection: Projection, owner: string): RenderResult {
   if (!text) return { text, blocks: [] }
   const base = key ?? checksum(text)
@@ -490,7 +513,9 @@ export function Markdown(
     },
   )
 
+  const openFile = useOpenFile()
   let copyCleanup: (() => void) | undefined
+  let pathLinksCleanup: (() => void) | undefined
 
   createEffect(() => {
     const container = root()
@@ -530,10 +555,12 @@ export function Markdown(
         copy: i18n.t("ui.message.copy"),
         copied: i18n.t("ui.message.copied"),
       }))
+    if (openFile && !pathLinksCleanup) pathLinksCleanup = setupPathLinks(container, openFile)
   })
 
   onCleanup(() => {
     if (copyCleanup) copyCleanup()
+    if (pathLinksCleanup) pathLinksCleanup()
     disposeMarkdownProjection(owner)
     activeCodeKeys.forEach(disposeCode)
     completedCode.clear()

--- a/packages/session-ui/src/context/index.ts
+++ b/packages/session-ui/src/context/index.ts
@@ -1,1 +1,2 @@
 export * from "./data"
+export * from "./open-file"

--- a/packages/session-ui/src/context/open-file.tsx
+++ b/packages/session-ui/src/context/open-file.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext, type ParentProps } from "solid-js"
+
+export type OpenFileFn = (path: string) => void
+
+const ctx = createContext<OpenFileFn>()
+
+export function OpenFileProvider(props: ParentProps<{ onOpenFile?: OpenFileFn }>) {
+  return <ctx.Provider value={props.onOpenFile}>{props.children}</ctx.Provider>
+}
+
+export function useOpenFile() {
+  return useContext(ctx)
+}


### PR DESCRIPTION
### Issue for this PR

Refs #39611 — rendered preview for markdown documents opened in the app file viewer. Preview-only for now; editing stays out of scope. The TUI-side counterpart for #43598 is #46714.

### Type of change

- [x] New feature

### What does this PR do?

- `.md`/`.markdown` files opened in the file viewer render with the same markdown pipeline as chat messages (marked + shiki worker + DOMPurify) — no new dependencies, and file content is already in memory so nothing extra is fetched
- A small `Preview | Source` segmented control switches modes; source view keeps line selection and line comments working
- File paths that render as path-like inline code in chat now open the referenced file in the viewer panel when clicked (a new `OpenFileProvider` context in session-ui carries the callback; absolute paths outside the project fall back to `platform.revealPath`)

### How did you verify your code works?

- `bun typecheck` passes for `packages/app` and `packages/session-ui`; `bun run test:unit` in `packages/app` passes (the one failing `desktop-native` test fails on clean `dev` too)
- Manually in the desktop app: clicking a file path in chat opens the file in the viewer, and the preview/source toggle renders markdown including tables (screenshots below)

### Screenshots / recordings

Markdown preview after clicking a file path in chat (toggle top-right):

![markdown preview](https://raw.githubusercontent.com/xxxiaocat/opencode/pr-media/pr-1-md-preview.png)

Source view after switching:

![source view](https://raw.githubusercontent.com/xxxiaocat/opencode/pr-media/pr-2-md-source.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
