### PR TITLE
feat: make webfetch max response size configurable

### DIFF
--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -146,6 +146,15 @@ export const Info = Schema.Struct({
     description:
       "Thresholds for truncating tool output. When output exceeds either limit, the full text is written to the truncation directory and a preview is returned.",
   }),
+  webfetch: Schema.optional(
+    Schema.Struct({
+      max_response_size: Schema.optional(PositiveInt).annotate({
+        description: "Maximum webfetch response size in bytes. Defaults to 5242880 (5MB).",
+      }),
+    }),
+  ).annotate({
+    description: "Webfetch tool limits",
+  }),
   compaction: Schema.optional(
     Schema.Struct({
       auto: Schema.optional(Schema.Boolean).annotate({

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -1,4 +1,5 @@
-import { Effect, Schema } from "effect"
+import { Effect, Option, Schema } from "effect"
+import { Config } from "@/config/config"
 import { HttpClient, HttpClientRequest } from "effect/unstable/http"
 import { Parser } from "htmlparser2"
 import * as Tool from "./tool"
@@ -6,7 +7,12 @@ import TurndownService from "turndown"
 import DESCRIPTION from "./webfetch.txt"
 import { isImageAttachment } from "@/util/media"
 
-const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
+export const DEFAULT_MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
+
+export function resolveMaxResponseSize(config?: { webfetch?: { max_response_size?: number } }) {
+  return config?.webfetch?.max_response_size ?? DEFAULT_MAX_RESPONSE_SIZE
+}
+
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
 const MAX_TIMEOUT = 120 * 1000 // 2 minutes
 
@@ -46,6 +52,12 @@ export const WebFetchTool = Tool.define(
               timeout: params.timeout,
             },
           })
+
+          const configSvc = yield* Effect.serviceOption(Config.Service)
+          const cfg = Option.isNone(configSvc)
+            ? undefined
+            : yield* configSvc.value.get().pipe(Effect.catch(() => Effect.succeed(undefined)))
+          const maxResponseSize = resolveMaxResponseSize(cfg)
 
           const timeout = Math.min((params.timeout ?? DEFAULT_TIMEOUT / 1000) * 1000, MAX_TIMEOUT)
 
@@ -94,13 +106,13 @@ export const WebFetchTool = Tool.define(
 
           // Check content length
           const contentLength = response.headers["content-length"]
-          if (contentLength && parseInt(contentLength) > MAX_RESPONSE_SIZE) {
-            throw new Error("Response too large (exceeds 5MB limit)")
+          if (contentLength && parseInt(contentLength) > maxResponseSize) {
+            throw new Error("Response too large (exceeds configured size limit)")
           }
 
           const arrayBuffer = yield* response.arrayBuffer
-          if (arrayBuffer.byteLength > MAX_RESPONSE_SIZE) {
-            throw new Error("Response too large (exceeds 5MB limit)")
+          if (arrayBuffer.byteLength > maxResponseSize) {
+            throw new Error("Response too large (exceeds configured size limit)")
           }
 
           const contentType = response.headers["content-type"] || ""

--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -9,8 +9,19 @@ import { isImageAttachment } from "@/util/media"
 
 export const DEFAULT_MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
 
+function parsePositiveIntEnv(raw: string | undefined) {
+  if (raw == null || raw === "") return undefined
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isInteger(parsed) || parsed <= 0 || String(parsed) !== raw.trim()) return undefined
+  return parsed
+}
+
 export function resolveMaxResponseSize(config?: { webfetch?: { max_response_size?: number } }) {
-  return config?.webfetch?.max_response_size ?? DEFAULT_MAX_RESPONSE_SIZE
+  // Prefer config when set, then OPENCODE_WEBFETCH_MAX_SIZE, then default 5MB.
+  if (config?.webfetch?.max_response_size != null) {
+    return config.webfetch.max_response_size
+  }
+  return parsePositiveIntEnv(process.env["OPENCODE_WEBFETCH_MAX_SIZE"]) ?? DEFAULT_MAX_RESPONSE_SIZE
 }
 
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -119,12 +119,54 @@ describe("tool.webfetch", () => {
 })
 
 describe("resolveMaxResponseSize", () => {
+  const envKey = "OPENCODE_WEBFETCH_MAX_SIZE"
+
   test("defaults to 5MB", () => {
-    expect(resolveMaxResponseSize()).toBe(DEFAULT_MAX_RESPONSE_SIZE)
-    expect(resolveMaxResponseSize({})).toBe(DEFAULT_MAX_RESPONSE_SIZE)
+    const prev = process.env[envKey]
+    delete process.env[envKey]
+    try {
+      expect(resolveMaxResponseSize()).toBe(DEFAULT_MAX_RESPONSE_SIZE)
+      expect(resolveMaxResponseSize({})).toBe(DEFAULT_MAX_RESPONSE_SIZE)
+    } finally {
+      if (prev === undefined) delete process.env[envKey]
+      else process.env[envKey] = prev
+    }
   })
 
   test("uses configured max_response_size", () => {
-    expect(resolveMaxResponseSize({ webfetch: { max_response_size: 1024 } })).toBe(1024)
+    const prev = process.env[envKey]
+    process.env[envKey] = "4096"
+    try {
+      expect(resolveMaxResponseSize({ webfetch: { max_response_size: 1024 } })).toBe(1024)
+    } finally {
+      if (prev === undefined) delete process.env[envKey]
+      else process.env[envKey] = prev
+    }
+  })
+
+  test("falls back to OPENCODE_WEBFETCH_MAX_SIZE when config unset", () => {
+    const prev = process.env[envKey]
+    process.env[envKey] = "20971520"
+    try {
+      expect(resolveMaxResponseSize()).toBe(20971520)
+      expect(resolveMaxResponseSize({})).toBe(20971520)
+      expect(resolveMaxResponseSize({ webfetch: {} })).toBe(20971520)
+    } finally {
+      if (prev === undefined) delete process.env[envKey]
+      else process.env[envKey] = prev
+    }
+  })
+
+  test("ignores invalid OPENCODE_WEBFETCH_MAX_SIZE values", () => {
+    const prev = process.env[envKey]
+    try {
+      for (const invalid of ["", "0", "-1", "1.5", "abc", "1024abc"]) {
+        process.env[envKey] = invalid
+        expect(resolveMaxResponseSize()).toBe(DEFAULT_MAX_RESPONSE_SIZE)
+      }
+    } finally {
+      if (prev === undefined) delete process.env[envKey]
+      else process.env[envKey] = prev
+    }
   })
 })

--- a/packages/opencode/test/tool/webfetch.test.ts
+++ b/packages/opencode/test/tool/webfetch.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { httpClient } from "@opencode-ai/core/effect/app-node-platform"
 import { Effect, Layer } from "effect"
 import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { Agent } from "../../src/agent/agent"
 import { Truncate } from "@/tool/truncate"
-import { WebFetchTool } from "../../src/tool/webfetch"
+import { DEFAULT_MAX_RESPONSE_SIZE, resolveMaxResponseSize, WebFetchTool } from "../../src/tool/webfetch"
 import { SessionID, MessageID } from "../../src/session/schema"
 import { Tool } from "@/tool/tool"
 import { testEffect } from "../lib/effect"
@@ -116,4 +116,15 @@ describe("tool.webfetch", () => {
         }),
     ),
   )
+})
+
+describe("resolveMaxResponseSize", () => {
+  test("defaults to 5MB", () => {
+    expect(resolveMaxResponseSize()).toBe(DEFAULT_MAX_RESPONSE_SIZE)
+    expect(resolveMaxResponseSize({})).toBe(DEFAULT_MAX_RESPONSE_SIZE)
+  })
+
+  test("uses configured max_response_size", () => {
+    expect(resolveMaxResponseSize({ webfetch: { max_response_size: 1024 } })).toBe(1024)
+  })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #15459

### Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Webfetch currently hard-caps the response at 5MB. This adds webfetch.max_response_size (bytes) so operators can raise or lower that cap. Default stays 5MB. OPENCODE_WEBFETCH_MAX_SIZE is a fallback when the config key is omitted (positive integer only).

### How did you verify your code works?

Existing webfetch tests plus the env-fallback path for OPENCODE_WEBFETCH_MAX_SIZE. Default remains 5MB when neither config nor env is set.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
