### PR TITLE
fix: bound MCP connect so mcp list cannot hang

### DIFF
--- a/packages/opencode/src/cli/cmd/mcp.ts
+++ b/packages/opencode/src/cli/cmd/mcp.ts
@@ -70,7 +70,12 @@ function listState() {
     const cfg = yield* Config.Service
     const mcp = yield* MCP.Service
     const config = yield* cfg.get()
-    const statuses = yield* mcp.status()
+    const statuses = yield* mcp.status().pipe(
+      Effect.timeoutOrElse({
+        duration: "20 seconds",
+        orElse: () => Effect.succeed({} as Record<string, MCP.Status>),
+      }),
+    )
     const stored = yield* Effect.all(
       Object.fromEntries(configuredServers(config).map(([name]) => [name, mcp.hasStoredTokens(name)])),
       { concurrency: "unbounded" },

--- a/packages/opencode/src/mcp/index.ts
+++ b/packages/opencode/src/mcp/index.ts
@@ -516,7 +516,16 @@ const layer = Layer.effect(
                 return
               }
 
-              const result = yield* create(key, mcp)
+              const timeoutMs = mcp.timeout ?? DEFAULT_TIMEOUT
+              const result = yield* create(key, mcp).pipe(
+                Effect.timeoutOrElse({
+                  duration: timeoutMs,
+                  orElse: () =>
+                    Effect.succeed<CreateResult>({
+                      status: { status: "failed", error: "Failed to connect" },
+                    }),
+                }),
+              )
               s.status[key] = result.status
               if (result.mcpClient) {
                 s.clients[key] = result.mcpClient


### PR DESCRIPTION
### Issue for this PR

Closes #43484

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

mcp list can hang forever if an MCP server never finishes connecting. This times out each MCP create during status init and caps the wait on MCP.status() so a stuck plugin cannot block the command.

### How did you verify your code works?

MCP status/list path with a slow or stuck create should return instead of blocking. Unrelated MCP behavior is unchanged.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
