### PR TITLE
fix(ai): honor chunkTimeout on HTTP SSE streams

### DIFF
--- a/packages/ai/src/provider-package.ts
+++ b/packages/ai/src/provider-package.ts
@@ -4,6 +4,7 @@ export interface Settings extends Readonly<Record<string, unknown>> {
   readonly baseURL?: string
   readonly headers?: Readonly<Record<string, string>>
   readonly body?: Readonly<Record<string, unknown>>
+  readonly chunkTimeout?: number
 }
 
 export interface Definition<

--- a/packages/ai/src/providers/azure.ts
+++ b/packages/ai/src/providers/azure.ts
@@ -35,7 +35,6 @@ export type Settings = ProviderPackage.Settings &
     readonly useDeploymentBasedUrls?: boolean
     readonly providerOptions?: OpenAIProviderOptionsInput
   }
-
 const resourceBaseURL = (resourceName: string) => `https://${resourceName.trim()}.openai.azure.com/openai`
 
 const responsesRoute = OpenAIResponses.route.with({
@@ -147,11 +146,18 @@ export const provider = {
 }
 
 const config = (settings: Settings): Config => {
+  const http =
+    settings.body === undefined && settings.chunkTimeout === undefined
+      ? undefined
+      : {
+          body: settings.body === undefined ? undefined : { ...settings.body },
+          chunkTimeout: settings.chunkTimeout,
+        }
   const common = {
     apiKey: settings.apiKey,
     apiVersion: settings.apiVersion,
     headers: settings.headers === undefined ? undefined : { ...settings.headers },
-    http: settings.body === undefined ? undefined : { body: { ...settings.body } },
+    http,
     providerOptions: settings.providerOptions,
     queryParams: settings.queryParams === undefined ? undefined : { ...settings.queryParams },
     useDeploymentBasedUrls: settings.useDeploymentBasedUrls,

--- a/packages/ai/src/route/transport/http.ts
+++ b/packages/ai/src/route/transport/http.ts
@@ -1,11 +1,11 @@
-import { Effect } from "effect"
+import { Duration, Effect, Stream } from "effect"
 import { Headers, HttpClientRequest } from "effect/unstable/http"
 import { Auth } from "../auth.js"
 import { render as renderEndpoint } from "../endpoint.js"
 import { Framing } from "../framing.js"
 import type { HttpMiddleware, Transport, TransportPrepareInput } from "./index.js"
 import * as ProviderShared from "../../protocols/shared.js"
-import { mergeJsonRecords, type LLMRequest } from "../../schema/index.js"
+import { AIError, mergeJsonRecords, TransportError, type LLMRequest } from "../../schema/index.js"
 import { RequestExecutor } from "../executor.js"
 
 export type JsonRequestInput<Body> = TransportPrepareInput<Body>
@@ -87,11 +87,36 @@ export const httpJson = <Body, Frame>(input: HttpJsonInput<Body, Frame>): HttpJs
         middleware: prepareInput.middleware,
       }
     }),
-  execute: (prepared, _request, runtime) =>
+  execute: (prepared, request, runtime) =>
     Effect.gen(function* () {
       const response = yield* runtime.http.execute(prepared.request, prepared.middleware)
+      const chunkTimeout = request.http?.chunkTimeout
+      const bytes = RequestExecutor.responseStream(response)
+      const guarded =
+        chunkTimeout === undefined || chunkTimeout <= 0
+          ? bytes
+          : bytes.pipe(
+              // A stalled provider stream that sends nothing is otherwise bounded only by the
+              // OS socket; abort once no chunk arrives within the configured window.
+              Stream.timeoutOrElse({
+                duration: Duration.millis(chunkTimeout),
+                orElse: () =>
+                  Stream.fail(
+                    new AIError({
+                      reason: new TransportError({
+                        message: `No data received from ${response.request.url} within the ${chunkTimeout}ms chunkTimeout; the stream may be stalled`,
+                        transport: "http",
+                        operation: "read",
+                        code: "chunk-timeout",
+                        url: response.request.url,
+                        phase: "receive",
+                      }),
+                    }),
+                  ),
+              }),
+            )
       return {
-        frames: prepared.framing.frame(RequestExecutor.responseStream(response)),
+        frames: prepared.framing.frame(guarded),
         http: RequestExecutor.responseHttp(response),
         body: prepared.framing.body,
       }

--- a/packages/ai/src/schema/options.ts
+++ b/packages/ai/src/schema/options.ts
@@ -47,6 +47,9 @@ export class HttpOptions extends Schema.Class<HttpOptions>("AI.HttpOptions")({
   body: Schema.optional(JsonSchema),
   headers: Schema.optional(Schema.Record(Schema.String, Schema.String)),
   query: Schema.optional(Schema.Record(Schema.String, Schema.String)),
+  chunkTimeout: Schema.optional(Schema.Number).annotate({
+    description: "Abort the stream when no data chunk arrives within this many milliseconds.",
+  }),
 }) {}
 
 export namespace HttpOptions {
@@ -60,8 +63,9 @@ export const mergeHttpOptions = (...items: ReadonlyArray<HttpOptions | undefined
   const body = mergeJsonRecords(...items.map((item) => item?.body))
   const headers = mergeStringRecords(...items.map((item) => item?.headers))
   const query = mergeStringRecords(...items.map((item) => item?.query))
-  if (!body && !headers && !query) return undefined
-  return new HttpOptions({ body, headers, query })
+  const chunkTimeout = items.reduceRight((found, item) => found ?? item?.chunkTimeout, undefined as number | undefined)
+  if (!body && !headers && !query && chunkTimeout === undefined) return undefined
+  return new HttpOptions({ body, headers, query, chunkTimeout })
 }
 
 export class GenerationOptions extends Schema.Class<GenerationOptions>("LLM.GenerationOptions")({

--- a/packages/ai/test/chunk-timeout.test.ts
+++ b/packages/ai/test/chunk-timeout.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { AIError, LLM } from "../src/index.js"
+import { HttpOptions, mergeHttpOptions } from "../src/schema/options.js"
+import * as OpenAIChat from "../src/protocols/openai-chat.js"
+import { LLMClient } from "../src/route.js"
+import { dynamicResponse } from "./lib/http.js"
+import { it } from "./lib/effect.js"
+
+const headers = { "content-type": "text/event-stream" }
+
+// Sends one SSE frame, then holds the connection open without further data.
+// Only a configured chunkTimeout can terminate the read.
+const stalledResponse = dynamicResponse((input) =>
+  Effect.sync(() => {
+    const encoder = new TextEncoder()
+    let sent = false
+    const stream = new ReadableStream({
+      pull(controller) {
+        if (!sent) {
+          sent = true
+          controller.enqueue(encoder.encode('data: {"choices":[]}\n\n'))
+        }
+      },
+    })
+    return input.respond(stream, { headers })
+  }),
+)
+
+describe("chunkTimeout", () => {
+  it.live("aborts a stalled HTTP SSE stream with a typed transport error", () =>
+    Effect.gen(function* () {
+      const route = OpenAIChat.route.with({ http: { chunkTimeout: 100 } })
+      const request = LLM.request({ model: route.model({ id: "test" }), prompt: "Hello" })
+      const error = yield* LLMClient.generate(request).pipe(Effect.provide(stalledResponse), Effect.flip)
+
+      expect(error).toBeInstanceOf(AIError)
+      expect(error.reason).toMatchObject({
+        _tag: "Transport",
+        operation: "read",
+        phase: "receive",
+        code: "chunk-timeout",
+      })
+      expect(error.message).toContain("chunkTimeout")
+    }),
+  )
+
+  test("mergeHttpOptions keeps the rightmost configured chunkTimeout", () => {
+    const merged = mergeHttpOptions(new HttpOptions({ chunkTimeout: 1000 }), new HttpOptions({ chunkTimeout: 250 }))
+    expect(merged?.chunkTimeout).toBe(250)
+    expect(mergeHttpOptions(new HttpOptions({ chunkTimeout: 250 }))?.chunkTimeout).toBe(250)
+    expect(mergeHttpOptions(new HttpOptions({ body: { a: 1 } }))?.chunkTimeout).toBeUndefined()
+    expect(mergeHttpOptions(new HttpOptions({ chunkTimeout: 250 }), new HttpOptions())?.chunkTimeout).toBe(250)
+  })
+})

--- a/packages/core/src/session/model-request.ts
+++ b/packages/core/src/session/model-request.ts
@@ -229,6 +229,7 @@ const applyModelHooks = (hooks: PluginHooks.Interface, scope: HookScope, request
         body: request.http?.body,
         headers: Object.keys(event.headers).length === 0 ? undefined : event.headers,
         query: request.http?.query,
+        chunkTimeout: request.http?.chunkTimeout,
       }),
     })
   })

--- a/packages/www/src/docs/content/providers.mdx
+++ b/packages/www/src/docs/content/providers.mdx
@@ -33,7 +33,7 @@ The `providers` object is keyed by provider ID. Each provider accepts these fiel
 | `name`     | Display name.                                                   |
 | `env`      | Ordered environment variable names that provide a connection.   |
 | `package`  | Runtime provider package.                                       |
-| `settings` | JSON settings passed to the runtime package, such as `baseURL`. |
+| `settings` | JSON settings passed to the runtime package, such as `baseURL` and `chunkTimeout`. |
 | `headers`  | String-valued HTTP headers added to requests.                   |
 | `body`     | JSON fields merged into request bodies.                         |
 | `models`   | Models to add or override, keyed by catalog model ID.           |
@@ -113,7 +113,9 @@ models, and connection continue to apply:
 }
 ```
 
-`settings` is package-specific. A field only has an effect when the selected package supports it.
+`settings` is package-specific. A field only has an effect when the selected package supports it. Packages that
+support `chunkTimeout` abort a stream when no data chunk arrives within the given number of milliseconds, guarding
+against a stalled provider.
 
 ## Headers and body
 


### PR DESCRIPTION
### Issue for this PR

Fixes #46692

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`chunkTimeout` was accepted in provider settings but never read on the native path — `HttpOptions` had no field, the HTTP transport applied no stall guard, and the setting was silently dropped. A stalled provider stream was bounded only by the OS socket.

- Add `chunkTimeout` (ms) to `HttpOptions` and thread it through `mergeHttpOptions`
- Apply it as a per-chunk timeout on the response stream in the HTTP transport (`transport/http.ts`), failing with a typed `TransportError` (`chunk-timeout`) when no chunk arrives within the window
- Add `chunkTimeout` to `ProviderPackage.Settings` and wire it through the azure provider first; remaining providers share the same `config()` pattern and can adopt the same field
- Preserve `chunkTimeout` when `model.request` hooks rebuild `HttpOptions`

### How did you verify your code works?

- New `test/chunk-timeout.test.ts`: a stalled SSE stream (one frame then silence) aborts with `code: chunk-timeout` under a real clock; `mergeHttpOptions` keeps the rightmost configured value
- `bun typecheck` + `bun test` in `packages/ai` (954 passing) and `packages/core` (only pre-existing environment-dependent failures in git-worktree/pty tests, confirmed on a clean baseline)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR