### PR TITLE
fix(tui): place provider before cost in footer

### DIFF
--- a/packages/tui/src/mini/footer.width.ts
+++ b/packages/tui/src/mini/footer.width.ts
@@ -73,8 +73,8 @@ export function footerStatuslinePolicy(input: {
       "agent",
       "model",
       "context",
-      "cost",
       "provider",
+      "cost",
       "menu",
     ]
     const groups = order.flatMap((id) => selected.get(id) ?? [])

--- a/packages/tui/test/mini/footer.responsive.test.tsx
+++ b/packages/tui/test/mini/footer.responsive.test.tsx
@@ -124,7 +124,7 @@ test.each([false, true])(
         const model = width === 112 ? "GPT-5.6 Sol (50% Off) [max]" : mono ? "GPT-5.6... [max]" : "GPT-5.6\u2026 [max]"
         expect(row).toBe(
           (width === 112
-            ? ["Build", model, "14.1K (1%)", "$0.04", "Anomaly / OpenCode", "ctrl+p menu"]
+            ? ["Build", model, "14.1K (1%)", "Anomaly / OpenCode", "$0.04", "ctrl+p menu"]
             : width === 40
               ? ["Build", model, "1% ctx"]
               : ["Build", model]

--- a/packages/tui/test/mini/footer.width.test.ts
+++ b/packages/tui/test/mini/footer.width.test.ts
@@ -72,9 +72,15 @@ describe("run footer width", () => {
 
   test("allocation priority is separate from placement", () => {
     expect(footerStatuslinePolicy({ ...screenshot, width: 15 }).groups.map((group) => group.id)).toEqual(["model"])
+    expect(footerStatuslinePolicy({ ...screenshot, width: 60 }).groups.map((group) => group.id)).toEqual([
+      "agent",
+      "model",
+      "context",
+      "cost",
+    ])
     const full = footerStatuslinePolicy({ ...screenshot, width: 112 })
     expect(full.text).toBe(
-      "Build \u00b7 GPT-5.6 Sol (50% Off) [max] \u00b7 14.1K (1%) \u00b7 $0.04 \u00b7 Anomaly / OpenCode \u00b7 ctrl+p menu",
+      "Build \u00b7 GPT-5.6 Sol (50% Off) [max] \u00b7 14.1K (1%) \u00b7 Anomaly / OpenCode \u00b7 $0.04 \u00b7 ctrl+p menu",
     )
   })
 


### PR DESCRIPTION
Show provider information before cost when both fit in the mini footer. Keep cost's higher allocation priority so the new display order does not displace cost information on narrow terminals.
