### PR TITLE
fix(opencode): preserve native tool content results

### DIFF
--- a/packages/opencode/src/session/llm/native-request.ts
+++ b/packages/opencode/src/session/llm/native-request.ts
@@ -66,11 +66,32 @@ const mediaPart = (part: Record<string, unknown>) => {
 
 const toolResult = (part: Record<string, unknown>) => {
   const output = isRecord(part.output) ? part.output : { type: "json", value: part.output }
-  const type = output.type === "text" ? "text" : output.type === "error-text" ? "error" : "json"
+  const type =
+    output.type === "text" ? "text" : output.type === "error-text" ? "error" : output.type === "content" ? "content" : "json"
+  const result =
+    output.type === "content" && Array.isArray(output.value)
+      ? output.value.map((item) => {
+          if (!isRecord(item)) throw new Error("Native LLM request adapter only supports object tool content")
+          if (item.type === "text") return { type: "text" as const, text: typeof item.text === "string" ? item.text : "" }
+          if (item.type === "media") {
+            if (typeof item.data !== "string")
+              throw new Error("Native LLM request adapter only supports tool media content with string data")
+            const mime = typeof item.mediaType === "string" ? item.mediaType : "application/octet-stream"
+            return {
+              type: "file" as const,
+              uri: item.data.startsWith("data:") ? item.data : `data:${mime};base64,${item.data}`,
+              mime,
+            }
+          }
+          throw new Error(`Native LLM request adapter does not support ${String(item.type)} tool content`)
+        })
+      : "value" in output
+        ? output.value
+        : output
   return ToolResultPart.make({
     id: typeof part.toolCallId === "string" ? part.toolCallId : "",
     name: typeof part.toolName === "string" ? part.toolName : "",
-    result: "value" in output ? output.value : output,
+    result,
     resultType: type,
     providerExecuted: typeof part.providerExecuted === "boolean" ? part.providerExecuted : undefined,
     providerMetadata: partProviderMetadata(part),

--- a/packages/opencode/test/session/llm-native.test.ts
+++ b/packages/opencode/test/session/llm-native.test.ts
@@ -296,6 +296,51 @@ describe("session.llm-native.request", () => {
     ])
   })
 
+  test("preserves content tool results in native requests", () => {
+    const request = LLMNative.request({
+      model: baseModel,
+      messages: [
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "call-1",
+              toolName: "read",
+              output: {
+                type: "content",
+                value: [
+                  { type: "text", text: "preview" },
+                  { type: "media", mediaType: "image/png", data: "Zm9v" },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(request.messages).toMatchObject([
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            id: "call-1",
+            name: "read",
+            result: {
+              type: "content",
+              value: [
+                { type: "text", text: "preview" },
+                { type: "file", uri: "data:image/png;base64,Zm9v", mime: "image/png" },
+              ],
+            },
+          },
+        ],
+      },
+    ])
+  })
+
   test("maps stored provider metadata to native content metadata", () => {
     const reasoning = Object.assign(
       { type: "reasoning" as const, text: "thinking" },


### PR DESCRIPTION
### Issue for this PR

Closes #46811

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves `content` tool results in the native request path instead of downgrading them to JSON. Media parts are converted to native `file` content using data URIs so the payload matches the native runtime schema.

### How did you verify your code works?

- `bun test packages/opencode/test/session/llm-native.test.ts` (17/17)
- `bun test packages/opencode/test/session/message-v2.test.ts` (39/39)
- `bun typecheck`
- `git diff --check upstream/dev...HEAD`

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR