### PR TITLE
fix(opencode): let config opt out of Anthropic thinking blockBinding

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -705,6 +705,19 @@ function anthropicBindsThinking(apiId: string) {
 // The patched AI SDK adds the thinking-binding-controls beta whenever it is set.
 const ANTHROPIC_BLOCK_BINDING = { prefixMismatchBehavior: "drop_block" }
 
+// Not every Claude deployment accepts the field after all. Bedrock, Vertex and
+// Anthropic-compatible proxy endpoints have each been observed rejecting it with
+//   thinking.adaptive.block_binding: Extra inputs are not permitted
+// (#46729), and sending the thinking-binding-controls beta does not change that.
+// Honour an explicit `blockBinding` in config so those deployments can opt out with
+// `blockBinding: false` (or pin their own value) instead of being stuck on 1.18.25.
+function applyBlockBinding(config: { [x: string]: any }) {
+  if (!("blockBinding" in config)) return { ...config, blockBinding: ANTHROPIC_BLOCK_BINDING }
+  if (config.blockBinding) return config
+  const { blockBinding: _disabled, ...rest } = config
+  return rest
+}
+
 function anthropicBlockBinding(model: Provider.Model, options: { [x: string]: any }) {
   if (!anthropicBindsThinking(model.api.id)) return options
   switch (model.api.npm) {
@@ -712,12 +725,12 @@ function anthropicBlockBinding(model: Provider.Model, options: { [x: string]: an
     case "@ai-sdk/google-vertex/anthropic": {
       const thinking = options.thinking ?? { type: "adaptive" }
       if (thinking.type !== "adaptive" && thinking.type !== "enabled") return options
-      return { ...options, thinking: { ...thinking, blockBinding: ANTHROPIC_BLOCK_BINDING } }
+      return { ...options, thinking: applyBlockBinding(thinking) }
     }
     case "@ai-sdk/amazon-bedrock": {
       const reasoningConfig = options.reasoningConfig ?? { type: "adaptive" }
       if (reasoningConfig.type !== "adaptive" && reasoningConfig.type !== "enabled") return options
-      return { ...options, reasoningConfig: { ...reasoningConfig, blockBinding: ANTHROPIC_BLOCK_BINDING } }
+      return { ...options, reasoningConfig: applyBlockBinding(reasoningConfig) }
     }
   }
   return options

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -705,35 +705,29 @@ function anthropicBindsThinking(apiId: string) {
 // The patched AI SDK adds the thinking-binding-controls beta whenever it is set.
 const ANTHROPIC_BLOCK_BINDING = { prefixMismatchBehavior: "drop_block" }
 
-// Not every Claude deployment accepts the field after all. Bedrock, Vertex and
-// Anthropic-compatible proxy endpoints have each been observed rejecting it with
-//   thinking.adaptive.block_binding: Extra inputs are not permitted
-// (#46729), and sending the thinking-binding-controls beta does not change that.
-// Honour an explicit `blockBinding` in config so those deployments can opt out with
-// `blockBinding: false` (or pin their own value) instead of being stuck on 1.18.25.
-function applyBlockBinding(config: { [x: string]: any }) {
-  if (!("blockBinding" in config)) return { ...config, blockBinding: ANTHROPIC_BLOCK_BINDING }
-  if (config.blockBinding) return config
-  const { blockBinding: _disabled, ...rest } = config
-  return rest
-}
-
 function anthropicBlockBinding(model: Provider.Model, options: { [x: string]: any }) {
-  if (!anthropicBindsThinking(model.api.id)) return options
-  switch (model.api.npm) {
-    case "@ai-sdk/anthropic":
-    case "@ai-sdk/google-vertex/anthropic": {
-      const thinking = options.thinking ?? { type: "adaptive" }
-      if (thinking.type !== "adaptive" && thinking.type !== "enabled") return options
-      return { ...options, thinking: applyBlockBinding(thinking) }
-    }
-    case "@ai-sdk/amazon-bedrock": {
-      const reasoningConfig = options.reasoningConfig ?? { type: "adaptive" }
-      if (reasoningConfig.type !== "adaptive" && reasoningConfig.type !== "enabled") return options
-      return { ...options, reasoningConfig: applyBlockBinding(reasoningConfig) }
-    }
+  const key =
+    model.api.npm === "@ai-sdk/amazon-bedrock"
+      ? "reasoningConfig"
+      : ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)
+        ? "thinking"
+        : undefined
+  if (!key) return options
+
+  // `false` is an OpenCode-only opt-out, not a valid SDK value. Remove it even
+  // on models outside the default scope, and omit opt-out-only thinking objects.
+  if (options[key]?.blockBinding === false) {
+    const result = { ...options, [key]: { ...options[key] } }
+    delete result[key].blockBinding
+    if (Object.keys(result[key]).length === 0) delete result[key]
+    return result
   }
-  return options
+
+  if (!anthropicBindsThinking(model.api.id)) return options
+  const thinking = options[key] ?? { type: "adaptive" }
+  if (thinking.type !== "adaptive" && thinking.type !== "enabled") return options
+  if (thinking.blockBinding !== undefined) return options
+  return { ...options, [key]: { ...thinking, blockBinding: ANTHROPIC_BLOCK_BINDING } }
 }
 
 function googleThinkingLevelEfforts(apiId: string) {

--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -706,17 +706,10 @@ function anthropicBindsThinking(apiId: string) {
 const ANTHROPIC_BLOCK_BINDING = { prefixMismatchBehavior: "drop_block" }
 
 function anthropicBlockBinding(model: Provider.Model, options: { [x: string]: any }) {
-  const key =
-    model.api.npm === "@ai-sdk/amazon-bedrock"
-      ? "reasoningConfig"
-      : ["@ai-sdk/anthropic", "@ai-sdk/google-vertex/anthropic"].includes(model.api.npm)
-        ? "thinking"
-        : undefined
-  if (!key) return options
-
-  // `false` is an OpenCode-only opt-out, not a valid SDK value. Remove it even
-  // on models outside the default scope, and omit opt-out-only thinking objects.
-  if (options[key]?.blockBinding === false) {
+  const sdk = sdkKey(model.api.npm)
+  const key = sdk === "bedrock" ? "reasoningConfig" : sdk === "anthropic" ? "thinking" : undefined
+  // Consume the OpenCode-only opt-out even on models outside the default scope.
+  if (key && options[key]?.blockBinding === false) {
     const result = { ...options, [key]: { ...options[key] } }
     delete result[key].blockBinding
     if (Object.keys(result[key]).length === 0) delete result[key]
@@ -724,10 +717,22 @@ function anthropicBlockBinding(model: Provider.Model, options: { [x: string]: an
   }
 
   if (!anthropicBindsThinking(model.api.id)) return options
-  const thinking = options[key] ?? { type: "adaptive" }
-  if (thinking.type !== "adaptive" && thinking.type !== "enabled") return options
-  if (thinking.blockBinding !== undefined) return options
-  return { ...options, [key]: { ...thinking, blockBinding: ANTHROPIC_BLOCK_BINDING } }
+  switch (model.api.npm) {
+    case "@ai-sdk/anthropic":
+    case "@ai-sdk/google-vertex/anthropic": {
+      const thinking = options.thinking ?? { type: "adaptive" }
+      if (thinking.type !== "adaptive" && thinking.type !== "enabled") return options
+      if (thinking.blockBinding !== undefined) return options
+      return { ...options, thinking: { ...thinking, blockBinding: ANTHROPIC_BLOCK_BINDING } }
+    }
+    case "@ai-sdk/amazon-bedrock": {
+      const reasoningConfig = options.reasoningConfig ?? { type: "adaptive" }
+      if (reasoningConfig.type !== "adaptive" && reasoningConfig.type !== "enabled") return options
+      if (reasoningConfig.blockBinding !== undefined) return options
+      return { ...options, reasoningConfig: { ...reasoningConfig, blockBinding: ANTHROPIC_BLOCK_BINDING } }
+    }
+  }
+  return options
 }
 
 function googleThinkingLevelEfforts(apiId: string) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -939,14 +939,64 @@ describe("ProviderTransform.providerOptions", () => {
         })
 
         test.each([
-          ["claude-opus-5", "default"],
-          ["claude-opus-5", "high"],
-          ["claude-sonnet-5", "default"],
-          ["claude-sonnet-5", "high"],
-          ["claude-mythos-5-1", "default"],
-          ["claude-mythos-5-1", "high"],
-          ["claude-haiku-4-5", "title"],
-        ])("omits binding from the %s %s request body and betas", async (id, mode) => {
+          "claude-fable-5-1",
+          "claude-opus-6",
+          "claude-opus-5",
+          "claude-mythos-5-1",
+          "claude-haiku-4-5",
+          "kimi-k2-thinking",
+        ])("normalizes binding opt-out for %s without mutating options", (id) => {
+          const model = claude(sdk.npm, id)
+          const options = Object.freeze({
+            [sdk.option]: Object.freeze({ type: "adaptive", display: "summarized", blockBinding: false }),
+            metadata: { userId: "test-user" },
+          })
+          expect(ProviderTransform.providerOptions(model, options)).toEqual({
+            [sdk.key]: {
+              [sdk.option]: { type: "adaptive", display: "summarized" },
+              metadata: options.metadata,
+            },
+          })
+          expect(options[sdk.option]).toEqual({ type: "adaptive", display: "summarized", blockBinding: false })
+          expect(
+            ProviderTransform.providerOptions(model, {
+              [sdk.option]: { type: "enabled", budgetTokens: 4000, blockBinding: false },
+            }),
+          ).toEqual({ [sdk.key]: { [sdk.option]: { type: "enabled", budgetTokens: 4000 } } })
+          expect(
+            ProviderTransform.providerOptions(model, { [sdk.option]: { type: "disabled", blockBinding: false } }),
+          ).toEqual({ [sdk.key]: { [sdk.option]: { type: "disabled" } } })
+          expect(
+            ProviderTransform.providerOptions(model, {
+              [sdk.option]: { blockBinding: false },
+              metadata: options.metadata,
+            }),
+          ).toEqual({ [sdk.key]: { metadata: options.metadata } })
+        })
+
+        test.each(["error", "drop_block"])("preserves explicit %s binding behavior on eligible models", (behavior) => {
+          const options = { [sdk.option]: { type: "adaptive", blockBinding: { prefixMismatchBehavior: behavior } } }
+          expect(ProviderTransform.providerOptions(claude(sdk.npm, "claude-fable-5-1"), options)).toEqual({
+            [sdk.key]: options,
+          })
+        })
+
+        test.each([
+          ["claude-opus-5", "default", "auto"],
+          ["claude-opus-5", "high", "auto"],
+          ["claude-sonnet-5", "default", "auto"],
+          ["claude-sonnet-5", "high", "auto"],
+          ["claude-mythos-5-1", "default", "auto"],
+          ["claude-mythos-5-1", "high", "auto"],
+          ["claude-haiku-4-5", "title", "auto"],
+          ["claude-fable-5-1", "default", "off"],
+          ["claude-fable-5-1", "high", "off"],
+          ["claude-opus-5", "default", "off"],
+          ["claude-opus-5", "high", "off"],
+          ["claude-mythos-5-1", "default", "off"],
+          ["claude-mythos-5-1", "high", "off"],
+          ["claude-haiku-4-5", "title", "off"],
+        ])("omits binding from the %s %s request body and betas (%s)", async (id, mode, setting) => {
           const requests: Request[] = []
           const capture = Object.assign(
             async (...args: Parameters<typeof fetch>) => {
@@ -991,12 +1041,14 @@ describe("ProviderTransform.providerOptions", () => {
                 : id,
           )
           const variants = ProviderTransform.variants(model)
-          const options =
+          const base =
             mode === "title"
               ? ProviderTransform.smallOptions({ ...model, variants })
               : mode === "high"
                 ? variants.high
                 : {}
+          const options =
+            setting === "off" ? { ...base, [sdk.option]: { ...base[sdk.option], blockBinding: false } } : base
           await generateText({
             model: provider(model.api.id),
             prompt: "hi",
@@ -1050,24 +1102,26 @@ describe("ProviderTransform.providerOptions", () => {
 
     test("omits blockBinding when config opts out with false", () => {
       const model = claude("@ai-sdk/anthropic", "claude-opus-5")
-      expect(
-        ProviderTransform.providerOptions(model, { thinking: { type: "adaptive", blockBinding: false } }),
-      ).toEqual({
-        anthropic: { thinking: { type: "adaptive" } },
-      })
+      expect(ProviderTransform.providerOptions(model, { thinking: { type: "adaptive", blockBinding: false } })).toEqual(
+        {
+          anthropic: { thinking: { type: "adaptive" } },
+        },
+      )
     })
 
     test("opt-out also works for models that think by default", () => {
       const model = claude("@ai-sdk/anthropic", "claude-sonnet-5")
       expect(
-        ProviderTransform.providerOptions(model, { thinking: { type: "enabled", budgetTokens: 4000, blockBinding: false } }),
+        ProviderTransform.providerOptions(model, {
+          thinking: { type: "enabled", budgetTokens: 4000, blockBinding: false },
+        }),
       ).toEqual({
         anthropic: { thinking: { type: "enabled", budgetTokens: 4000 } },
       })
     })
 
     test("preserves an explicit blockBinding instead of overwriting it", () => {
-      const model = claude("@ai-sdk/anthropic", "claude-opus-5")
+      const model = claude("@ai-sdk/anthropic", "claude-fable-5-1")
       const custom = { prefixMismatchBehavior: "error" }
       expect(
         ProviderTransform.providerOptions(model, { thinking: { type: "adaptive", blockBinding: custom } }),

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -938,65 +938,30 @@ describe("ProviderTransform.providerOptions", () => {
           ).toEqual({ [sdk.key]: { [sdk.option]: { type: "enabled", budgetTokens: 4000 } } })
         })
 
-        test.each([
-          "claude-fable-5-1",
-          "claude-opus-6",
-          "claude-opus-5",
-          "claude-mythos-5-1",
-          "claude-haiku-4-5",
-          "kimi-k2-thinking",
-        ])("normalizes binding opt-out for %s without mutating options", (id) => {
+        test.each(["claude-fable-5-1", "claude-opus-5"])("honors explicit binding controls for %s", (id) => {
           const model = claude(sdk.npm, id)
           const options = Object.freeze({
-            [sdk.option]: Object.freeze({ type: "adaptive", display: "summarized", blockBinding: false }),
-            metadata: { userId: "test-user" },
+            [sdk.option]: Object.freeze({ type: "adaptive", blockBinding: false }),
           })
           expect(ProviderTransform.providerOptions(model, options)).toEqual({
-            [sdk.key]: {
-              [sdk.option]: { type: "adaptive", display: "summarized" },
-              metadata: options.metadata,
-            },
+            [sdk.key]: { [sdk.option]: { type: "adaptive" } },
           })
-          expect(options[sdk.option]).toEqual({ type: "adaptive", display: "summarized", blockBinding: false })
-          expect(
-            ProviderTransform.providerOptions(model, {
-              [sdk.option]: { type: "enabled", budgetTokens: 4000, blockBinding: false },
-            }),
-          ).toEqual({ [sdk.key]: { [sdk.option]: { type: "enabled", budgetTokens: 4000 } } })
-          expect(
-            ProviderTransform.providerOptions(model, { [sdk.option]: { type: "disabled", blockBinding: false } }),
-          ).toEqual({ [sdk.key]: { [sdk.option]: { type: "disabled" } } })
-          expect(
-            ProviderTransform.providerOptions(model, {
-              [sdk.option]: { blockBinding: false },
-              metadata: options.metadata,
-            }),
-          ).toEqual({ [sdk.key]: { metadata: options.metadata } })
-        })
-
-        test.each(["error", "drop_block"])("preserves explicit %s binding behavior on eligible models", (behavior) => {
-          const options = { [sdk.option]: { type: "adaptive", blockBinding: { prefixMismatchBehavior: behavior } } }
-          expect(ProviderTransform.providerOptions(claude(sdk.npm, "claude-fable-5-1"), options)).toEqual({
-            [sdk.key]: options,
+          expect(ProviderTransform.providerOptions(model, { [sdk.option]: { blockBinding: false } })).toEqual({
+            [sdk.key]: {},
           })
+          const custom = { [sdk.option]: { type: "adaptive", blockBinding: { prefixMismatchBehavior: "error" } } }
+          expect(ProviderTransform.providerOptions(model, custom)).toEqual({ [sdk.key]: custom })
         })
 
         test.each([
-          ["claude-opus-5", "default", "auto"],
-          ["claude-opus-5", "high", "auto"],
-          ["claude-sonnet-5", "default", "auto"],
-          ["claude-sonnet-5", "high", "auto"],
-          ["claude-mythos-5-1", "default", "auto"],
-          ["claude-mythos-5-1", "high", "auto"],
-          ["claude-haiku-4-5", "title", "auto"],
-          ["claude-fable-5-1", "default", "off"],
-          ["claude-fable-5-1", "high", "off"],
-          ["claude-opus-5", "default", "off"],
-          ["claude-opus-5", "high", "off"],
-          ["claude-mythos-5-1", "default", "off"],
-          ["claude-mythos-5-1", "high", "off"],
-          ["claude-haiku-4-5", "title", "off"],
-        ])("omits binding from the %s %s request body and betas (%s)", async (id, mode, setting) => {
+          ["claude-opus-5", "default"],
+          ["claude-opus-5", "high"],
+          ["claude-sonnet-5", "default"],
+          ["claude-sonnet-5", "high"],
+          ["claude-mythos-5-1", "default"],
+          ["claude-mythos-5-1", "high"],
+          ["claude-haiku-4-5", "title"],
+        ])("omits binding from the %s %s request body and betas", async (id, mode) => {
           const requests: Request[] = []
           const capture = Object.assign(
             async (...args: Parameters<typeof fetch>) => {
@@ -1041,14 +1006,12 @@ describe("ProviderTransform.providerOptions", () => {
                 : id,
           )
           const variants = ProviderTransform.variants(model)
-          const base =
+          const options =
             mode === "title"
               ? ProviderTransform.smallOptions({ ...model, variants })
               : mode === "high"
                 ? variants.high
                 : {}
-          const options =
-            setting === "off" ? { ...base, [sdk.option]: { ...base[sdk.option], blockBinding: false } } : base
           await generateText({
             model: provider(model.api.id),
             prompt: "hi",
@@ -1097,45 +1060,6 @@ describe("ProviderTransform.providerOptions", () => {
       })
       expect(ProviderTransform.providerOptions(model, {})).toEqual({
         bedrock: { reasoningConfig: { type: "adaptive", blockBinding: binding } },
-      })
-    })
-
-    test("omits blockBinding when config opts out with false", () => {
-      const model = claude("@ai-sdk/anthropic", "claude-opus-5")
-      expect(ProviderTransform.providerOptions(model, { thinking: { type: "adaptive", blockBinding: false } })).toEqual(
-        {
-          anthropic: { thinking: { type: "adaptive" } },
-        },
-      )
-    })
-
-    test("opt-out also works for models that think by default", () => {
-      const model = claude("@ai-sdk/anthropic", "claude-sonnet-5")
-      expect(
-        ProviderTransform.providerOptions(model, {
-          thinking: { type: "enabled", budgetTokens: 4000, blockBinding: false },
-        }),
-      ).toEqual({
-        anthropic: { thinking: { type: "enabled", budgetTokens: 4000 } },
-      })
-    })
-
-    test("preserves an explicit blockBinding instead of overwriting it", () => {
-      const model = claude("@ai-sdk/anthropic", "claude-fable-5-1")
-      const custom = { prefixMismatchBehavior: "error" }
-      expect(
-        ProviderTransform.providerOptions(model, { thinking: { type: "adaptive", blockBinding: custom } }),
-      ).toEqual({
-        anthropic: { thinking: { type: "adaptive", blockBinding: custom } },
-      })
-    })
-
-    test("bedrock reasoningConfig honours the opt-out", () => {
-      const model = claude("@ai-sdk/amazon-bedrock", "us.anthropic.claude-opus-5-v1:0")
-      expect(
-        ProviderTransform.providerOptions(model, { reasoningConfig: { type: "adaptive", blockBinding: false } }),
-      ).toEqual({
-        bedrock: { reasoningConfig: { type: "adaptive" } },
       })
     })
 

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1048,6 +1048,43 @@ describe("ProviderTransform.providerOptions", () => {
       })
     })
 
+    test("omits blockBinding when config opts out with false", () => {
+      const model = claude("@ai-sdk/anthropic", "claude-opus-5")
+      expect(
+        ProviderTransform.providerOptions(model, { thinking: { type: "adaptive", blockBinding: false } }),
+      ).toEqual({
+        anthropic: { thinking: { type: "adaptive" } },
+      })
+    })
+
+    test("opt-out also works for models that think by default", () => {
+      const model = claude("@ai-sdk/anthropic", "claude-sonnet-5")
+      expect(
+        ProviderTransform.providerOptions(model, { thinking: { type: "enabled", budgetTokens: 4000, blockBinding: false } }),
+      ).toEqual({
+        anthropic: { thinking: { type: "enabled", budgetTokens: 4000 } },
+      })
+    })
+
+    test("preserves an explicit blockBinding instead of overwriting it", () => {
+      const model = claude("@ai-sdk/anthropic", "claude-opus-5")
+      const custom = { prefixMismatchBehavior: "error" }
+      expect(
+        ProviderTransform.providerOptions(model, { thinking: { type: "adaptive", blockBinding: custom } }),
+      ).toEqual({
+        anthropic: { thinking: { type: "adaptive", blockBinding: custom } },
+      })
+    })
+
+    test("bedrock reasoningConfig honours the opt-out", () => {
+      const model = claude("@ai-sdk/amazon-bedrock", "us.anthropic.claude-opus-5-v1:0")
+      expect(
+        ProviderTransform.providerOptions(model, { reasoningConfig: { type: "adaptive", blockBinding: false } }),
+      ).toEqual({
+        bedrock: { reasoningConfig: { type: "adaptive" } },
+      })
+    })
+
     test("does not touch bedrock non-anthropic models", () => {
       const model = claude("@ai-sdk/amazon-bedrock", "amazon.nova-pro-v1:0")
       expect(ProviderTransform.providerOptions(model, { reasoningConfig: { type: "enabled" } })).toEqual({

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -135,6 +135,33 @@ You can also define custom variants that extend built-in ones. Variants let you 
 
 ---
 
+### Thinking block binding
+
+OpenCode enables Anthropic's [thinking block binding controls](https://platform.claude.com/docs/en/build-with-claude/thinking#preserved-thinking-controls) by default for Claude 5.1 and later, except Mythos 5.1. If an endpoint rejects `thinking.block_binding`, disable the control in the model's options:
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "anthropic": {
+      "models": {
+        "claude-fable-5-1": {
+          "options": {
+            "thinking": { "blockBinding": false },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
+Anthropic and Google Vertex Anthropic use `options.thinking.blockBinding`. Amazon Bedrock uses `options.reasoningConfig.blockBinding` instead. These settings also apply to custom providers using the corresponding SDK packages.
+
+This disables only the binding control, not thinking or the selected reasoning effort. OpenCode removes the `false` value before sending the request. On models that enforce binding, disabling the control can cause signature errors when earlier conversation content changes.
+
+---
+
 ## Variants
 
 Many models support multiple variants with different configurations. OpenCode ships with built-in default variants for popular providers.

--- a/packages/web/src/content/docs/models.mdx
+++ b/packages/web/src/content/docs/models.mdx
@@ -135,33 +135,6 @@ You can also define custom variants that extend built-in ones. Variants let you 
 
 ---
 
-### Thinking block binding
-
-OpenCode enables Anthropic's [thinking block binding controls](https://platform.claude.com/docs/en/build-with-claude/thinking#preserved-thinking-controls) by default for Claude 5.1 and later, except Mythos 5.1. If an endpoint rejects `thinking.block_binding`, disable the control in the model's options:
-
-```jsonc title="opencode.jsonc"
-{
-  "$schema": "https://opencode.ai/config.json",
-  "provider": {
-    "anthropic": {
-      "models": {
-        "claude-fable-5-1": {
-          "options": {
-            "thinking": { "blockBinding": false },
-          },
-        },
-      },
-    },
-  },
-}
-```
-
-Anthropic and Google Vertex Anthropic use `options.thinking.blockBinding`. Amazon Bedrock uses `options.reasoningConfig.blockBinding` instead. These settings also apply to custom providers using the corresponding SDK packages.
-
-This disables only the binding control, not thinking or the selected reasoning effort. OpenCode removes the `false` value before sending the request. On models that enforce binding, disabling the control can cause signature errors when earlier conversation content changes.
-
----
-
 ## Variants
 
 Many models support multiple variants with different configurations. OpenCode ships with built-in default variants for popular providers.


### PR DESCRIPTION
### Issue for this PR

Closes #46729

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

#46653 added `blockBinding` to every Claude request whose thinking type is `adaptive` or `enabled`. Its comment says "Models that do not run the check accept the field, so it is safe on every Claude", but that turns out not to be true — #46729 has reports of it being rejected on Bedrock, on Google Vertex, and on Anthropic-compatible endpoints:

```
thinking.adaptive.block_binding: Extra inputs are not permitted
```

I hit this on the third of those. To work out whether it was opencode or my endpoint, I sent requests with `curl` directly, no opencode involved. `thinking: {"type":"adaptive"}` is accepted on its own; adding `block_binding` to it gets rejected; adding the `thinking-binding-controls-2026-08-01` beta header does not change that. But `block_binding` under `thinking: {"type":"enabled", "budget_tokens": N}` **is** accepted. So the field is only refused under the `adaptive` variant, which lines up with the error naming the path `thinking.adaptive.block_binding`.

Since the injection is unconditional there's no way for an affected user to avoid it short of pinning 1.18.25. That's worse on managed installs — where a root-owned config wins the merge, overriding `options.thinking.type` doesn't take, and registering a corrected provider doesn't either because `enabled_providers` can't be extended from user config. So there's no escape hatch at all.

The change makes `anthropicBlockBinding` respect an explicit `blockBinding` in config instead of always overwriting it:

- `blockBinding: false` → omit the field
- `blockBinding: {...}` → use the caller's value
- absent → inject `ANTHROPIC_BLOCK_BINDING`, exactly as today

The default path is unchanged, so deployments where the field works keep getting it and the prefix-mismatch problem #46653 fixed stays fixed. I pulled the logic into a small `applyBlockBinding` helper so the `@ai-sdk/anthropic`, vertex, and bedrock `reasoningConfig` branches all behave the same way.

Affected users can then do:

```jsonc
"claude-opus-5": { "options": { "thinking": { "type": "adaptive", "blockBinding": false } } }
```

One thing I could not explain, in case it matters to you: `claude-opus-4-8` is configured identically (`{"thinking":{"type":"adaptive"}}`) and by my reading of `anthropicBlockBinding` should also get the field — but the same endpoint that rejects `claude-opus-5` accepts it. Either I've misread how `anthropicThinksByDefault`/`anthropicOmitsThinking` interact, or the API only validates this for Claude 5. I'd rather flag it than pretend I know.

If you'd prefer a different shape — a provider-level flag, a capability check, or retrying without the field on rejection — I'm happy to redo it.

### How did you verify your code works?

Added 4 tests to `packages/opencode/test/provider/transform.test.ts`: opt-out on `adaptive`, opt-out on a think-by-default model, preserving an explicit value rather than overwriting it, and the bedrock `reasoningConfig` path.

Checked red/green rather than just green — with the test changes in place but `transform.ts` reverted to `dev`, those 4 fail; with the fix they pass:

```
without the source change:  440 pass, 4 fail
with the source change:     444 pass, 0 fail
```

All 440 pre-existing tests in that file still pass. Run with `bun test test/provider/transform.test.ts` from `packages/opencode`.

I also confirmed the underlying behaviour end to end outside the test suite: switching the model to `thinking: {"type":"enabled", budgetTokens}` unblocked `claude-opus-5` and `claude-sonnet-5` (default, `max`, and `off` variants) against the endpoint that was failing, which is the same code path this flag now lets you control.

### Screenshots / recordings

N/A — not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
