### PR TITLE
fix(tui): keep terminal panes off by default on Windows

### DIFF
--- a/packages/tui/src/component/dialog-config.tsx
+++ b/packages/tui/src/component/dialog-config.tsx
@@ -55,7 +55,7 @@ export const settings: Setting[] = [
     title: "Terminal",
     category: "Session",
     path: ["session", "terminal"],
-    default: true,
+    default: process.platform !== "win32",
     values: [false, true],
     labels: ["off", "on"],
     keywords: ["pty", "shell", "terminal pane"],

--- a/packages/tui/src/config/index.tsx
+++ b/packages/tui/src/config/index.tsx
@@ -299,7 +299,8 @@ export function resolve(input: Info, options: { terminalSuspend: boolean }): Res
     session: {
       ...input.session,
       new_location: input.session?.new_location ?? "launch",
-      terminal: input.session?.terminal ?? true,
+      // Persistent terminal panes need the opencode-pty daemon, which does not ship Windows binaries.
+      terminal: input.session?.terminal ?? process.platform !== "win32",
       tps: input.session?.tps ?? true,
     },
     tabs: {


### PR DESCRIPTION
## Summary

Follow-up to #46797. The persistent terminal pane relies on the opencode-pty daemon, which intentionally ships no Windows binaries (its persistent transport uses Unix sockets), so the on-by-default behavior should not apply there.

- `resolve()` now defaults `session.terminal` to `process.platform !== "win32"`
- Settings dialog default for Sessions > Terminal matches, following the existing platform-dependent pattern used by `terminal.copy`

Users can still opt in explicitly with `session.terminal: true` on Windows (e.g. against a remote server).

## Testing

- `bun test test/config-v2.test.tsx` in `packages/tui` (19 pass)
- `bun typecheck` in `packages/tui`