### PR TITLE
fix(core): place model prompt before project instructions

### DIFF
--- a/packages/core/src/plugin/system-prompt.ts
+++ b/packages/core/src/plugin/system-prompt.ts
@@ -54,7 +54,7 @@ function make(
           const prompt = getPrompt(`${model?.modelID ?? event.model.id} ${model?.family ?? ""}`.toLowerCase())
           if (!prompt) return
           if (options.operation === "append") {
-            event.system.push(SystemPart.make(prompt))
+            event.system.splice(1, 0, SystemPart.make(prompt))
             return
           }
           event.system[0] = { ...system, text: prompt }

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1590,8 +1590,8 @@ describe("SessionRunnerLLM", () => {
 
     expect(s.requests.at(-1)?.system.map((part) => part.text)).toEqual([
       defaultSystem,
-      "Initial context",
       expect.stringContaining("# Delegation"),
+      "Initial context",
     ])
   })
 
@@ -1611,8 +1611,8 @@ describe("SessionRunnerLLM", () => {
 
     expect(s.requests.at(-1)?.system.map((part) => part.text)).toEqual([
       defaultSystem,
-      "Initial context",
       expect.stringContaining("# Delegation"),
+      "Initial context",
     ])
   })
 


### PR DESCRIPTION
Appended model-specific prompts (currently the GPT extension) now insert directly after the baseline system prompt instead of after project instructions, so the system parts are ordered `[baseline, model prompt, instructions]`.

Model guidance is static harness content and belongs with the baseline; AGENTS.md and other project instructions should follow it. This also keeps the stable prefix contiguous for prompt caching.

- `system-prompt.ts`: `splice(1, 0, ...)` instead of `push` for `operation: "append"`.
- `session-runner.test.ts`: expectation order updated.

No change to the recorded cassette: that test has no instruction parts, so the wire payload is identical.