### PR TITLE
refactor(client): share location resource reads

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -1279,10 +1279,7 @@ export function createData(config: CreateDataInput) {
     load: (location: ReturnType<typeof locationQuery>) => Promise<{ location: LocationRef; data: LocationData[Field] }>,
     options?: { alias?: boolean },
   ) {
-    const publish = (key: string, value: LocationData[Field]) => {
-      if (!store.location[key]) setStore("location", key, {})
-      setStore("location", key, field, value)
-    }
+    const publish = (key: string, value: LocationData[Field]) => setStore("location", key, { [field]: value })
     return {
       list: (ref?: LocationRef) => store.location[locationKey(ref ?? defaultLocation())]?.[field],
       sync: (ref?: LocationRef) => {

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -83,10 +83,8 @@ type LocationData = {
   agent?: AgentInfo[]
   command?: CommandInfo[]
   integration?: IntegrationInfo[]
-  mcp?: {
-    server?: McpServer[]
-    resource?: McpResource[]
-  }
+  mcpServer?: McpServer[]
+  mcpResource?: McpResource[]
   model?: ModelInfo[]
   provider?: ProviderInfo[]
   reference?: ReferenceInfo[]
@@ -125,8 +123,8 @@ export function locationKey(location: LocationRef) {
   return JSON.stringify([location.directory, location.workspaceID])
 }
 
-function locationQuery(ref?: LocationRef) {
-  return ref ? { directory: ref.directory, workspace: ref.workspaceID } : undefined
+function locationQuery(ref: LocationRef) {
+  return { directory: ref.directory, workspace: ref.workspaceID }
 }
 
 function formRequestOptions(sessionID: string, ref?: LocationRef) {
@@ -1273,6 +1271,44 @@ export function createData(config: CreateDataInput) {
     }
   }
 
+  // A cached per-location catalog. `sync` loads once per invalidation, keyed by the
+  // effective location, and publishes under the server's canonical location; `alias`
+  // also publishes under the requested key when the two differ.
+  function locationResource<Field extends keyof LocationData>(
+    field: Field,
+    load: (location: ReturnType<typeof locationQuery>) => Promise<{ location: LocationRef; data: LocationData[Field] }>,
+    options?: { alias?: boolean },
+  ) {
+    const publish = (key: string, value: LocationData[Field]) => {
+      if (!store.location[key]) setStore("location", key, {})
+      setStore("location", key, field, value)
+    }
+    return {
+      list: (ref?: LocationRef) => store.location[locationKey(ref ?? defaultLocation())]?.[field],
+      sync: (ref?: LocationRef) => {
+        const location = ref ?? defaultLocation()
+        const id = locationKey(location)
+        return sync.run(`location.${field}:${id}`, async () => {
+          const response = await load(locationQuery(location))
+          const key = locationKey(response.location)
+          publish(key, response.data)
+          if (options?.alias && key !== id) publish(id, response.data)
+        })
+      },
+      invalidate: (ref?: LocationRef) => sync.invalidate(`location.${field}:${locationKey(ref ?? defaultLocation())}`),
+    }
+  }
+
+  const vcs = locationResource("vcs", (location) => api().vcs.get({ location }))
+  const shells = locationResource("shell", async (location) => {
+    const response = await api().shell.list({ location })
+    const ref = { directory: response.location.directory, workspaceID: response.location.workspaceID }
+    return {
+      location: response.location,
+      data: Object.fromEntries(response.data.map((info) => [info.id, { ...info, location: ref }])),
+    }
+  })
+
   const result = {
     on: config.event.on,
     listen: config.event.listen,
@@ -1740,7 +1776,7 @@ export function createData(config: CreateDataInput) {
     },
     shell: {
       list(location?: LocationRef) {
-        return Object.values(store.location[locationKey(location ?? defaultLocation())]?.shell ?? {})
+        return Object.values(shells.list(location) ?? {})
       },
       listBySession(sessionID: string) {
         return Object.values(store.location)
@@ -1752,31 +1788,8 @@ export function createData(config: CreateDataInput) {
           .map((data) => data.shell?.[id])
           .find((shell) => shell !== undefined)
       },
-      sync(ref?: LocationRef) {
-        const id = locationKey(ref ?? defaultLocation())
-        return sync.run(`location.shell:${id}`, async () => {
-          const response = await api().shell.list({ location: locationQuery(ref ?? defaultLocation()) })
-          const key = locationKey(response.location)
-          setStore("location", key, {
-            ...store.location[key],
-            shell: Object.fromEntries(
-              response.data.map((info) => [
-                info.id,
-                {
-                  ...info,
-                  location: {
-                    directory: response.location.directory,
-                    workspaceID: response.location.workspaceID,
-                  },
-                },
-              ]),
-            ),
-          })
-        })
-      },
-      invalidate(ref?: LocationRef) {
-        sync.invalidate(`location.shell:${locationKey(ref ?? defaultLocation())}`)
-      },
+      sync: shells.sync,
+      invalidate: shells.invalidate,
     },
     location: {
       info(ref?: LocationRef) {
@@ -1831,162 +1844,20 @@ export function createData(config: CreateDataInput) {
         result.shell.invalidate(location)
         result.session.form.invalidate("global", location)
       },
-      vcs: {
-        info(location?: LocationRef) {
-          return store.location[locationKey(location ?? defaultLocation())]?.vcs
-        },
-        sync(ref?: LocationRef) {
-          const location = ref ?? defaultLocation()
-          return sync.run(`location.vcs:${locationKey(location)}`, async () => {
-            const response = await api().vcs.get({ location: locationQuery(location) })
-            const key = locationKey(response.location)
-            setStore("location", key, { ...store.location[key], vcs: response.data })
-          })
-        },
-        invalidate(ref?: LocationRef) {
-          sync.invalidate(`location.vcs:${locationKey(ref ?? defaultLocation())}`)
-        },
-      },
-      agent: {
-        list(location?: LocationRef) {
-          return store.location[locationKey(location ?? defaultLocation())]?.agent
-        },
-        sync(ref?: LocationRef) {
-          const id = locationKey(ref ?? defaultLocation())
-          return sync.run(`location.agent:${id}`, async () => {
-            const response = await api().agent.list({ location: locationQuery(ref ?? defaultLocation()) })
-            const key = locationKey(response.location)
-            setStore("location", key, { ...store.location[key], agent: response.data })
-          })
-        },
-        invalidate(ref?: LocationRef) {
-          sync.invalidate(`location.agent:${locationKey(ref ?? defaultLocation())}`)
-        },
-      },
-      command: {
-        list(location?: LocationRef) {
-          return store.location[locationKey(location ?? defaultLocation())]?.command
-        },
-        sync(ref?: LocationRef) {
-          const id = locationKey(ref ?? defaultLocation())
-          return sync.run(`location.command:${id}`, async () => {
-            const response = await api().command.list({ location: locationQuery(ref ?? defaultLocation()) })
-            const key = locationKey(response.location)
-            setStore("location", key, { ...store.location[key], command: response.data })
-          })
-        },
-        invalidate(ref?: LocationRef) {
-          sync.invalidate(`location.command:${locationKey(ref ?? defaultLocation())}`)
-        },
-      },
-      integration: {
-        list(location?: LocationRef) {
-          return store.location[locationKey(location ?? defaultLocation())]?.integration
-        },
-        sync(ref?: LocationRef) {
-          const id = locationKey(ref ?? defaultLocation())
-          return sync.run(`location.integration:${id}`, async () => {
-            const response = await api().integration.list({ location: locationQuery(ref ?? defaultLocation()) })
-            const key = locationKey(response.location)
-            setStore("location", key, { ...store.location[key], integration: response.data })
-          })
-        },
-        invalidate(ref?: LocationRef) {
-          sync.invalidate(`location.integration:${locationKey(ref ?? defaultLocation())}`)
-        },
-      },
+      vcs: { info: vcs.list, sync: vcs.sync, invalidate: vcs.invalidate },
+      agent: locationResource("agent", (location) => api().agent.list({ location })),
+      command: locationResource("command", (location) => api().command.list({ location })),
+      integration: locationResource("integration", (location) => api().integration.list({ location })),
       mcp: {
-        server: {
-          list(location?: LocationRef) {
-            return store.location[locationKey(location ?? defaultLocation())]?.mcp?.server
-          },
-          sync(ref?: LocationRef) {
-            const id = locationKey(ref ?? defaultLocation())
-            return sync.run(`location.mcp.server:${id}`, async () => {
-              const response = await api().mcp.list({ location: locationQuery(ref ?? defaultLocation()) })
-              const key = locationKey(response.location)
-              setStore("location", key, {
-                ...store.location[key],
-                mcp: { ...store.location[key]?.mcp, server: response.data },
-              })
-            })
-          },
-          invalidate(ref?: LocationRef) {
-            sync.invalidate(`location.mcp.server:${locationKey(ref ?? defaultLocation())}`)
-          },
-        },
-        resource: {
-          list(location?: LocationRef) {
-            return store.location[locationKey(location ?? defaultLocation())]?.mcp?.resource
-          },
-          sync(ref?: LocationRef) {
-            const id = locationKey(ref ?? defaultLocation())
-            return sync.run(`location.mcp.resource:${id}`, async () => {
-              const response = await api().mcp.resource.catalog({
-                location: locationQuery(ref ?? defaultLocation()),
-              })
-              const key = locationKey(response.location)
-              setStore("location", key, {
-                ...store.location[key],
-                mcp: { ...store.location[key]?.mcp, resource: response.data.resources },
-              })
-            })
-          },
-          invalidate(ref?: LocationRef) {
-            sync.invalidate(`location.mcp.resource:${locationKey(ref ?? defaultLocation())}`)
-          },
-        },
+        server: locationResource("mcpServer", (location) => api().mcp.list({ location })),
+        resource: locationResource("mcpResource", async (location) => {
+          const response = await api().mcp.resource.catalog({ location })
+          return { location: response.location, data: response.data.resources }
+        }),
       },
-      model: {
-        list(location?: LocationRef) {
-          return store.location[locationKey(location ?? defaultLocation())]?.model
-        },
-        sync(ref?: LocationRef) {
-          const id = locationKey(ref ?? defaultLocation())
-          return sync.run(`location.model:${id}`, async () => {
-            const response = await api().model.list({ location: locationQuery(ref ?? defaultLocation()) })
-            const key = locationKey(response.location)
-            setStore("location", key, { ...store.location[key], model: response.data })
-            if (key !== id) setStore("location", id, { ...store.location[id], model: response.data })
-          })
-        },
-        invalidate(ref?: LocationRef) {
-          sync.invalidate(`location.model:${locationKey(ref ?? defaultLocation())}`)
-        },
-      },
-      provider: {
-        list(location?: LocationRef) {
-          return store.location[locationKey(location ?? defaultLocation())]?.provider
-        },
-        sync(ref?: LocationRef) {
-          const id = locationKey(ref ?? defaultLocation())
-          return sync.run(`location.provider:${id}`, async () => {
-            const response = await api().provider.list({ location: locationQuery(ref ?? defaultLocation()) })
-            const key = locationKey(response.location)
-            setStore("location", key, { ...store.location[key], provider: response.data })
-            if (key !== id) setStore("location", id, { ...store.location[id], provider: response.data })
-          })
-        },
-        invalidate(ref?: LocationRef) {
-          sync.invalidate(`location.provider:${locationKey(ref ?? defaultLocation())}`)
-        },
-      },
-      reference: {
-        list(location?: LocationRef) {
-          return store.location[locationKey(location ?? defaultLocation())]?.reference
-        },
-        sync(ref?: LocationRef) {
-          const id = locationKey(ref ?? defaultLocation())
-          return sync.run(`location.reference:${id}`, async () => {
-            const response = await api().reference.list({ location: locationQuery(ref ?? defaultLocation()) })
-            const key = locationKey(response.location)
-            setStore("location", key, { ...store.location[key], reference: response.data })
-          })
-        },
-        invalidate(ref?: LocationRef) {
-          sync.invalidate(`location.reference:${locationKey(ref ?? defaultLocation())}`)
-        },
-      },
+      model: locationResource("model", (location) => api().model.list({ location }), { alias: true }),
+      provider: locationResource("provider", (location) => api().provider.list({ location }), { alias: true }),
+      reference: locationResource("reference", (location) => api().reference.list({ location })),
       websearch: {
         list(location?: LocationRef) {
           return store.location[locationKey(location ?? defaultLocation())]?.websearch
@@ -2001,22 +1872,7 @@ export function createData(config: CreateDataInput) {
           })
         },
       },
-      skill: {
-        list(location?: LocationRef) {
-          return store.location[locationKey(location ?? defaultLocation())]?.skill
-        },
-        sync(ref?: LocationRef) {
-          const id = locationKey(ref ?? defaultLocation())
-          return sync.run(`location.skill:${id}`, async () => {
-            const response = await api().skill.list({ location: locationQuery(ref ?? defaultLocation()) })
-            const key = locationKey(response.location)
-            setStore("location", key, { ...store.location[key], skill: response.data })
-          })
-        },
-        invalidate(ref?: LocationRef) {
-          sync.invalidate(`location.skill:${locationKey(ref ?? defaultLocation())}`)
-        },
-      },
+      skill: locationResource("skill", (location) => api().skill.list({ location })),
     },
   }
 


### PR DESCRIPTION
## Why

Ten per-location catalogs (agents, commands, integrations, MCP servers and resources, models, providers, references, skills, VCS) plus the shell list each hand-implement the same cached read: look up the store at the effective location, load once per invalidation under a `sync` key, publish under the server's canonical location, invalidate the key. That is 195 lines of near-identical plumbing in `data.ts`. Adding a catalog means copying a neighbour and renaming, and the two real differences (model/provider alias publication, VCS capturing its location up front) are easy to lose in the copy.

This is the first of a planned series of small PRs that simplify the client data service against `v2`. Each is judged on the same bar: behavior preserved, public interface unchanged, and a net reduction in production code counting every helper it introduces.

## What Changes

One private `locationResource(field, load, options?)` inside `createData` owns the repeated mechanism. Each catalog becomes a declaration of what it loads:

```ts
agent: locationResource("agent", (location) => api().agent.list({ location })),
model: locationResource("model", (location) => api().model.list({ location }), { alias: true }),
mcp: {
  server: locationResource("mcpServer", (location) => api().mcp.list({ location })),
  resource: locationResource("mcpResource", async (location) => {
    const response = await api().mcp.resource.catalog({ location })
    return { location: response.location, data: response.data.resources }
  }),
},
```

| Member | Behavior |
| --- | --- |
| `list(ref?)` | Reactive read of the field at the effective location (`ref ?? defaultLocation()`) |
| `sync(ref?)` | Runs the loader once per invalidation via the existing `createSync`, keyed by the effective location; publishes under the response's canonical location |
| `{ alias: true }` | Also publishes under the requested key when it differs from the canonical one (models and providers, as before) |
| `invalidate(ref?)` | Drops the same key |

VCS keeps its public `info` getter through a one-line facade; shells keep `list`, `listBySession`, and `get` and take `sync`/`invalidate` from the helper. `websearch.refresh` stays uncached and untouched, as do `syncInfo` and the `location.sync`/`location.invalidate` fan-out lists.

Three deliberate normalizations, all private:

- The request location is captured when `sync()` is called. VCS already did this; the other nine resolved `defaultLocation()` inside the queued loader, so the cache key and the request could disagree if the default changed while an invalidated load was still in flight.
- Publication sets a one-field partial (`setStore("location", key, { [field]: value })`), which Solid shallow-merges into the existing location record or creates it when missing. This is a code-shape change, not a reactivity change: measured in isolation, neither the old spread write nor the partial write re-runs readers of sibling catalogs, because Solid short-circuits unchanged fields.
- Private `LocationData.mcp.{server,resource}` flattens to `mcpServer`/`mcpResource`. The public `location.mcp.server` / `location.mcp.resource` shape is unchanged.

`locationQuery` also drops its optional branch; every caller already passed a defined ref.

## Scope

`packages/client/src/solid/data.ts` only: **2,037 → 1,890 lines (+55 / −202, net −147)**. No new files, dependencies, or public exports. Planned follow-ups, each as its own PR: a `refresh()` replacing the `invalidate` + `void sync` pairs in the event handlers, direct message-target mutation helpers for the streaming projections, and deriving `session.input` from `session.pending`.

## Verification

Commands run with Bun 1.4.0 from the indicated package directories:

```sh
# packages/client
bun run test
bun typecheck
bun run build

# packages/tui
bun run test test/cli/tui/data.test.tsx test/cli/tui/dialog-mcp.test.tsx test/cli/tui/composer-keymap.test.tsx
bun typecheck

# packages/app
bun run test
bun typecheck
```

- Client: 144 passed. Includes the credential-refresh test that syncs integrations, models, and providers across two locations and workspaces.
- TUI: 53 passed across the data, MCP dialog, and composer keymap suites, which exercise VCS info, MCP server/resource lists, agent/model/integration/reference syncs, and multi-location shell lists through the public getters.
- App: 708 unit passed, 1 skipped; 113 browser-runtime passed.
- Typechecks passed for client, TUI, and app; the pre-push hook completed all 33 workspace typecheck tasks. `oxlint` warnings on `data.ts` are unchanged from the base (4).
- No UI surface changes, so no recording. The tab-switch benchmark was not run: this touches location catalog reads, not session or timeline projections.
