### PR TITLE
feat(console): add Muse Spark 1.3 and Gemini 3.8 Flash

### DIFF
--- a/packages/console/app/src/component/limits-graph.tsx
+++ b/packages/console/app/src/component/limits-graph.tsx
@@ -54,7 +54,7 @@ export function LimitsGraph(props: { href: string }) {
     { id: "deepseek-v4-flash", name: "DeepSeek V4 Flash", req: 7600 },
     { id: "longcat-2.0", name: "LongCat-2.0", req: 11400 },
     { id: "mimo-v2.5", name: "MiMo-V2.5", req: 30100 },
-    { id: "muse-spark-1.2-contributor", name: "Muse Spark 1.2 Contributor", req: 45300, edge: true },
+    { id: "muse-spark-1.3-contributor", name: "Muse Spark 1.3 Contributor", req: 45300, edge: true },
   ].map((model, index) => ({ ...model, d: `${50 + index * 25}ms` }))
   const bonuses = graph.filter((model) => model.baseReq)
 
@@ -232,7 +232,7 @@ export function LimitsGraph(props: { href: string }) {
                     <span data-value>{"infinite" in m ? "\u221e" : m.req.toLocaleString()}</span>
                   )}
                   <span data-name>{m.name}</span>
-                  {m.id === "muse-spark-1.2-contributor" && (
+                  {m.id === "muse-spark-1.3-contributor" && (
                     <span data-regions>
                       (
                       <a href="https://ai.developer.meta.com/legal/geographic-use-policy">

--- a/packages/console/app/src/lib/request-country.ts
+++ b/packages/console/app/src/lib/request-country.ts
@@ -31,7 +31,12 @@ export function countryFromRequest(request: Request | undefined) {
 
 export function isModelCountryRestricted(model: string, country: string | undefined) {
   return (
-    ["muse-spark-1.2-contributor", "muse-spark-1.2-contributor-free"].includes(model) &&
+    [
+      "muse-spark-1.3-contributor",
+      "muse-spark-1.3-contributor-free",
+      "muse-spark-1.2-contributor",
+      "muse-spark-1.2-contributor-free",
+    ].includes(model) &&
     country !== undefined &&
     MUSE_SPARK_BLOCKED_COUNTRIES.has(country.toUpperCase())
   )

--- a/packages/console/app/src/routes/go/index.css
+++ b/packages/console/app/src/routes/go/index.css
@@ -1035,7 +1035,7 @@ body {
             gap: 3px 8px;
           }
 
-          &[data-model="muse-spark-1.2-contributor"] {
+          &[data-model="muse-spark-1.3-contributor"] {
             transform: translateY(11px);
 
             [data-regions] {

--- a/packages/console/app/src/routes/go/index.tsx
+++ b/packages/console/app/src/routes/go/index.tsx
@@ -43,6 +43,7 @@ const models = [
   { name: "Qwen3.6 Plus", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "MiniMax M3", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "MiniMax M2.7", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
+  { name: "Muse Spark 1.3 Contributor", training: "go.faq.a5.used", retention: "go.faq.a5.notZdr" },
   { name: "Muse Spark 1.2 Contributor", training: "go.faq.a5.used", retention: "go.faq.a5.notZdr" },
   { name: "DeepSeek V4 Pro", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
   { name: "DeepSeek V4 Flash", training: "go.faq.a5.notUsed", retention: "go.faq.a5.retention0" },
@@ -327,6 +328,13 @@ export default function Home() {
                     <p>
                       <strong>GPT 5.6 Luna:</strong> {i18n.t("go.faq.a5.gptRetention")}{" "}
                       <a href="https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring">
+                        {i18n.t("go.faq.a5.learnMore")}
+                      </a>
+                      .
+                    </p>
+                    <p>
+                      <strong>Muse Spark 1.3 Contributor:</strong> {i18n.t("go.faq.a5.museRetention")}{" "}
+                      <a href="https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier">
                         {i18n.t("go.faq.a5.learnMore")}
                       </a>
                       .

--- a/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
+++ b/packages/console/app/src/routes/workspace/[id]/go/lite-section.tsx
@@ -652,6 +652,7 @@ export function LiteSection(props: { lite: LiteSubscription | undefined }) {
             <li>LongCat-2.0</li>
             <li>MiniMax M3</li>
             <li>MiniMax M2.7</li>
+            <li>Muse Spark 1.3 Contributor</li>
             <li>Muse Spark 1.2 Contributor</li>
             <li>Qwen3.8 Max</li>
             <li>Qwen3.8 Flash</li>

--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -49,6 +49,7 @@ import { Workspace } from "@opencode-ai/console-core/workspace.js"
 import { countryFromRequest, isModelCountryRestricted } from "~/lib/request-country"
 import { isPeakPricing } from "./pricing"
 import { prepareRequestBody } from "./requestBody"
+import { requiresGoTrainingConsent } from "./trainingConsent"
 
 type ZenData = Awaited<ReturnType<typeof ZenData.list>>
 type PreparedBody = Awaited<ReturnType<typeof prepareRequestBody>>
@@ -125,7 +126,7 @@ export async function handler(
     if (
       authInfo &&
       opts.modelList === "lite" &&
-      modelInfo.id === "muse-spark-1.2-contributor" &&
+      requiresGoTrainingConsent(modelInfo.id) &&
       !authInfo.allowTraining
     )
       throw new DataPolicyError(

--- a/packages/console/app/src/routes/zen/util/trainingConsent.ts
+++ b/packages/console/app/src/routes/zen/util/trainingConsent.ts
@@ -1,0 +1,3 @@
+export function requiresGoTrainingConsent(model: string) {
+  return ["muse-spark-1.3-contributor", "muse-spark-1.2-contributor"].includes(model)
+}

--- a/packages/console/app/test/museSparkPolicy.test.ts
+++ b/packages/console/app/test/museSparkPolicy.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { isModelCountryRestricted } from "../src/lib/request-country"
+import { requiresGoTrainingConsent } from "../src/routes/zen/util/trainingConsent"
+
+describe("Muse Spark model policies", () => {
+  test.each([
+    "muse-spark-1.3-contributor",
+    "muse-spark-1.3-contributor-free",
+    "muse-spark-1.2-contributor",
+    "muse-spark-1.2-contributor-free",
+  ])("restricts %s in blocked countries", (model) => {
+    expect(isModelCountryRestricted(model, "CN")).toBe(true)
+    expect(isModelCountryRestricted(model, "US")).toBe(false)
+  })
+
+  test("does not apply the country restriction to similar model IDs", () => {
+    expect(isModelCountryRestricted("muse-spark-1.3-contributor-preview", "CN")).toBe(false)
+  })
+
+  test.each(["muse-spark-1.3-contributor", "muse-spark-1.2-contributor"])(
+    "requires Go training consent for %s",
+    (model) => {
+      expect(requiresGoTrainingConsent(model)).toBe(true)
+    },
+  )
+
+  test("does not require Go training consent for the free or similar model IDs", () => {
+    expect(requiresGoTrainingConsent("muse-spark-1.3-contributor-free")).toBe(false)
+    expect(requiresGoTrainingConsent("muse-spark-1.3-contributor-preview")).toBe(false)
+  })
+})

--- a/packages/web/src/content/docs/ar/go.mdx
+++ b/packages/web/src/content/docs/ar/go.mdx
@@ -63,6 +63,7 @@ OpenCode Go هو اشتراك منخفض التكلفة بقيمة **$10/شهر�
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([مناطق محدودة](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([مناطق محدودة](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -107,6 +108,7 @@ OpenCode Go هو اشتراك منخفض التكلفة بقيمة **$10/شهر�
 | MiMo-V2.5-Pro                | 3,250               | 8,150              | 16,300           |
 | MiniMax M3                   | 3,200               | 8,000              | 16,000           |
 | MiniMax M2.7                 | 3,400               | 8,500              | 17,000           |
+| Muse Spark 1.3 Contributor   | 45,300              | 113,300            | 226,600          |
 | Muse Spark 1.2 Contributor   | 45,300              | 113,300            | 226,600          |
 | Qwen3.8 Max                  | 160                 | 400                | 810              |
 | Qwen3.8 Flash                | 5,400               | 13,500             | 27,000           |
@@ -133,6 +135,7 @@ OpenCode Go هو اشتراك منخفض التكلفة بقيمة **$10/شهر�
 - DeepSeek V4 Flash Vision Exp — ‏410 input، و71,300 cached، و310 output tokens لكل طلب
 - MiniMax M3 — ‏510 input، و56,000 cached، و190 output tokens لكل طلب
 - MiniMax M2.7 — ‏300 input، و55,000 cached، و125 output tokens لكل طلب
+- Muse Spark 1.3 Contributor — ‏620 input، و71,400 cached، و300 output tokens لكل طلب
 - Muse Spark 1.2 Contributor — ‏620 input، و71,400 cached، و300 output tokens لكل طلب
 - Qwen3.8 Max — ‏420 input، و66,000 cached، و200 output tokens لكل طلب
 - Qwen3.8 Flash — ‏600 input، و58,000 cached، و200 output tokens لكل طلب
@@ -165,6 +168,7 @@ OpenCode Go هو اشتراك منخفض التكلفة بقيمة **$10/شهر�
 | MiniMax M3                              | $0.30   | $1.20   | $0.06           | -               | $60       |
 | MiniMax M2.7                            | $0.30   | $1.20   | $0.06           | $0.375          | $60       |
 | MiniMax M2.5                            | $0.30   | $1.20   | $0.06           | $0.375          | $60       |
+| Muse Spark 1.3 Contributor              | $0.10   | $0.20   | $0.002          | -               | $60       |
 | Muse Spark 1.2 Contributor              | $0.10   | $0.20   | $0.002          | -               | $60       |
 | Qwen3.8 Max                             | $2.00   | $6.00   | $0.25           | $2.50           | $15       |
 | Qwen3.8 Flash                           | $0.15   | $0.47   | $0.016          | $0.20           | $30       |
@@ -238,6 +242,7 @@ OpenCode Go هو اشتراك منخفض التكلفة بقيمة **$10/شهر�
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -284,6 +289,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | غير مستخدَمة  | 0 أيام             |
 | MiniMax M3                   | غير مستخدَمة  | 0 أيام             |
 | MiniMax M2.7                 | غير مستخدَمة  | 0 أيام             |
+| Muse Spark 1.3 Contributor   | نعم           | ليست ZDR           |
 | Muse Spark 1.2 Contributor   | نعم           | ليست ZDR           |
 | DeepSeek V4 Pro              | غير مستخدَمة  | 0 أيام             |
 | DeepSeek V4 Flash            | غير مستخدَمة  | 0 أيام             |
@@ -293,6 +299,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** تعطّل ZDR ميزات API مهمة تعتمد على البيانات المخزنة، بما في ذلك Responses API ذات الحالة، وFiles and Collections، وBatch API. [اعرف المزيد](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** تُنشأ سجلات مراقبة إساءة الاستخدام لكل استخدام لميزات API، ويُحتفظ بها لمدة تصل إلى 30 يومًا. [اعرف المزيد](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** أسعار توكنات مخفّضة للغاية مقابل منح الإذن باستخدام مطالباتك وإكمالات النموذج لتدريب نماذج Meta المستقبلية. يقتصر التوفر على المناطق التي تسمح بها [سياسة الاستخدام الجغرافي](https://ai.developer.meta.com/legal/geographic-use-policy) الخاصة بـ Meta. [اعرف المزيد](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** أسعار توكنات مخفّضة للغاية مقابل منح الإذن باستخدام مطالباتك وإكمالات النموذج لتدريب نماذج Meta المستقبلية. يقتصر التوفر على المناطق التي تسمح بها [سياسة الاستخدام الجغرافي](https://ai.developer.meta.com/legal/geographic-use-policy) الخاصة بـ Meta. [اعرف المزيد](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** تُجدَّد اتفاقية ZDR شهريًا. الاتفاقية الحالية سارية حتى 31 أغسطس 2026.
 

--- a/packages/web/src/content/docs/ar/zen.mdx
+++ b/packages/web/src/content/docs/ar/zen.mdx
@@ -86,6 +86,7 @@ OpenCode Zen هي بوابة AI تتيح لك الوصول إلى هذه الن�
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -117,6 +118,7 @@ OpenCode Zen هي بوابة AI تتيح لك الوصول إلى هذه الن�
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 يستخدم [معرّف النموذج](/docs/config/#models) في إعدادات OpenCode الصيغة `opencode/<model-id>`. على سبيل المثال، بالنسبة إلى GPT 5.5، ستستخدم `opencode/gpt-5.5` في إعداداتك.
@@ -144,6 +146,7 @@ https://opencode.ai/zen/v1/models
 | Ling 3.0 Flash Fin Free           | Free    | Free    | Free            | -               |
 | Nemotron 3 Ultra Free             | Free    | Free    | Free            | -               |
 | Nemotron 3.5 Lightning Free       | Free    | Free    | Free            | -               |
+| Muse Spark 1.3 Contributor Free   | Free    | Free    | Free            | -               |
 | Muse Spark 1.2 Contributor Free   | Free    | Free    | Free            | -               |
 | MiniMax M3                        | $0.30   | $1.20   | $0.06           | -               |
 | MiniMax M2.7                      | $0.30   | $1.20   | $0.06           | -               |
@@ -175,6 +178,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00   | $15.00  | $0.30           | $3.75           |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60           | $7.50           |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10           | $1.25           |
+| Gemini 3.8 Flash                  | $1.50   | $7.50   | $0.15           | -               |
 | Gemini 3.7 Flash                  | $1.50   | $7.50   | $0.15           | -               |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15           | -               |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15           | -               |
@@ -231,6 +235,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3 Ultra Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 - Nemotron 3.5 Lightning Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 - Big Pickle نموذج خفي ومتاح مجانا على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
+- Muse Spark 1.3 Contributor Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 - Muse Spark 1.2 Contributor Free متاح على OpenCode لفترة محدودة. يستخدم الفريق هذه الفترة لجمع الملاحظات وتحسين النموذج.
 
 <a href={email}>تواصل معنا</a> إذا كانت لديك أي أسئلة.
@@ -289,6 +294,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3.5 Lightning Free (نقاط نهاية NVIDIA المجانية): للاستخدام التجريبي فقط — لا ترسل بيانات شخصية أو سرية. يُسجَّل استخدامك لأغراض أمنية ولتحسين منتجات وخدمات NVIDIA. بيانات الجلسة المُسجَّلة لأغراض التحسين غير مرتبطة بهويتك أو بأي مُعرِّف دائم. لمزيد من المعلومات حول ممارسات معالجة البيانات لدينا، راجع [سياسة الخصوصية](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). بتفاعلك مع نقطة النهاية هذه، فإنك توافق على جمعنا لهذه المعلومات وتسجيلها واستخدامها وعلى [شروط خدمة النسخة التجريبية من واجهة NVIDIA API](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: يتم الاحتفاظ بالطلبات لمدة 30 يوما وفقا لـ [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: يتم الاحتفاظ بالطلبات لمدة 30 يوما وفقا لـ [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: أسعار توكنات مخفّضة للغاية مقابل منح الإذن باستخدام مطالباتك وإكمالاتك لتدريب نماذج Meta المستقبلية. [اعرف المزيد](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: أسعار توكنات مخفّضة للغاية مقابل منح الإذن باستخدام مطالباتك وإكمالاتك لتدريب نماذج Meta المستقبلية. [اعرف المزيد](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/bs/go.mdx
+++ b/packages/web/src/content/docs/bs/go.mdx
@@ -73,6 +73,7 @@ Trenutna lista modela uključuje:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([ograničene regije](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([ograničene regije](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -117,6 +118,7 @@ Tabela ispod pruža procijenjeni broj zahtjeva na osnovu tipičnih obrazaca kori
 | MiMo-V2.5-Pro                | 3,250              | 8,150             | 16,300            |
 | MiniMax M3                   | 3,200              | 8,000             | 16,000            |
 | MiniMax M2.7                 | 3,400              | 8,500             | 17,000            |
+| Muse Spark 1.3 Contributor   | 45,300             | 113,300           | 226,600           |
 | Muse Spark 1.2 Contributor   | 45,300             | 113,300           | 226,600           |
 | Qwen3.8 Max                  | 160                | 400               | 810               |
 | Qwen3.8 Flash                | 5,400              | 13,500            | 27,000            |
@@ -143,6 +145,7 @@ Procjene se zasnivaju na zapaženim obrascima zahtjeva:
 - DeepSeek V4 Flash Vision Exp — 410 ulaznih, 71,300 keširanih, 310 izlaznih tokena po zahtjevu
 - MiniMax M3 — 510 ulaznih, 56,000 keširanih, 190 izlaznih tokena po zahtjevu
 - MiniMax M2.7 — 300 ulaznih, 55,000 keširanih, 125 izlaznih tokena po zahtjevu
+- Muse Spark 1.3 Contributor — 620 ulaznih, 71,400 keširanih, 300 izlaznih tokena po zahtjevu
 - Muse Spark 1.2 Contributor — 620 ulaznih, 71,400 keširanih, 300 izlaznih tokena po zahtjevu
 - Qwen3.8 Max — 420 ulaznih, 66,000 keširanih, 200 izlaznih tokena po zahtjevu
 - Qwen3.8 Flash — 600 ulaznih, 58,000 keširanih, 200 izlaznih tokena po zahtjevu
@@ -175,6 +178,7 @@ Procjene se također zasnivaju na sljedećim cijenama po 1M tokena i mjesečnoj 
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60       |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60       |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60       |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60       |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60       |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15       |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30       |
@@ -250,6 +254,7 @@ Također možete pristupiti Go modelima putem sljedećih API endpointa.
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -298,6 +303,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Ne koristi se     | 0 dana               |
 | MiniMax M3                   | Ne koristi se     | 0 dana               |
 | MiniMax M2.7                 | Ne koristi se     | 0 dana               |
+| Muse Spark 1.3 Contributor   | Da                | Nije ZDR             |
 | Muse Spark 1.2 Contributor   | Da                | Nije ZDR             |
 | DeepSeek V4 Pro              | Ne koristi se     | 0 dana               |
 | DeepSeek V4 Flash            | Ne koristi se     | 0 dana               |
@@ -307,6 +313,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR onemogućava važne API funkcije koje zavise od pohranjenih podataka, uključujući Responses API s očuvanjem stanja, Files and Collections i Batch API. [Saznajte više](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Zapisi o nadzoru zloupotrebe generišu se za svako korištenje API funkcija i čuvaju do 30 dana. [Saznajte više](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Znatno snižene cijene tokena u zamjenu za dopuštenje da se vaši promptovi i odgovori modela koriste za treniranje budućih Meta modela. Dostupnost je ograničena na regije dopuštene [Pravilima geografskog korištenja](https://ai.developer.meta.com/legal/geographic-use-policy) kompanije Meta. [Saznajte više](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Znatno snižene cijene tokena u zamjenu za dopuštenje da se vaši promptovi i odgovori modela koriste za treniranje budućih Meta modela. Dostupnost je ograničena na regije dopuštene [Pravilima geografskog korištenja](https://ai.developer.meta.com/legal/geographic-use-policy) kompanije Meta. [Saznajte više](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** ZDR sporazum obnavlja se mjesečno. Trenutni sporazum važi do 31. augusta 2026.
 

--- a/packages/web/src/content/docs/bs/zen.mdx
+++ b/packages/web/src/content/docs/bs/zen.mdx
@@ -91,6 +91,7 @@ Našim modelima možete pristupiti i preko sljedećih API endpointa.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -122,6 +123,7 @@ Našim modelima možete pristupiti i preko sljedećih API endpointa.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 [model id](/docs/config/#models) u vašoj OpenCode konfiguraciji koristi format
@@ -151,6 +153,7 @@ Podržavamo pay-as-you-go model. Ispod su cijene **po 1M tokena**.
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -182,6 +185,7 @@ Podržavamo pay-as-you-go model. Ispod su cijene **po 1M tokena**.
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -238,6 +242,7 @@ Besplatni modeli:
 - Nemotron 3 Ultra Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 - Nemotron 3.5 Lightning Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 - Big Pickle je stealth model koji je besplatan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
+- Muse Spark 1.3 Contributor Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 - Muse Spark 1.2 Contributor Free je dostupan na OpenCode ograničeno vrijeme. Tim koristi ovo vrijeme da prikupi povratne informacije i poboljša model.
 
 <a href={email}>Kontaktirajte nas</a> ako imate bilo kakvih pitanja.
@@ -301,6 +306,7 @@ i ne koriste vaše podatke za treniranje modela, uz sljedeće izuzetke:
 - Nemotron 3.5 Lightning Free (besplatni NVIDIA endpointi): Samo za probnu upotrebu — nemojte slati lične ili povjerljive podatke. Vaše korištenje se bilježi radi sigurnosti i poboljšanja NVIDIA proizvoda i usluga. Zabilježeni podaci sesije koji se koriste u svrhu poboljšanja nisu povezani s vašim identitetom niti bilo kojim trajnim identifikatorom. Za više informacija o našim praksama obrade podataka pogledajte našu [Politiku privatnosti](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Interakcijom s ovim endpointom pristajete na naše prikupljanje, bilježenje i korištenje takvih informacija te na [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: Requests are retained for 30 days in accordance with [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Requests are retained for 30 days in accordance with [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: Znatno snižene cijene tokena u zamjenu za dozvolu da se vaši promptovi i odgovori koriste za treniranje budućih Meta modela. [Saznajte više](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Znatno snižene cijene tokena u zamjenu za dozvolu da se vaši promptovi i odgovori koriste za treniranje budućih Meta modela. [Saznajte više](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/da/go.mdx
+++ b/packages/web/src/content/docs/da/go.mdx
@@ -73,6 +73,7 @@ Den nuværende liste over modeller inkluderer:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([begrænsede regioner](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([begrænsede regioner](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -117,6 +118,7 @@ Tabellen nedenfor giver et estimeret antal anmodninger baseret på typiske Go-fo
 | MiMo-V2.5-Pro                | 3,250                   | 8,150               | 16,300                |
 | MiniMax M3                   | 3,200                   | 8,000               | 16,000                |
 | MiniMax M2.7                 | 3,400                   | 8,500               | 17,000                |
+| Muse Spark 1.3 Contributor   | 45,300                  | 113,300             | 226,600               |
 | Muse Spark 1.2 Contributor   | 45,300                  | 113,300             | 226,600               |
 | Qwen3.8 Max                  | 160                     | 400                 | 810                   |
 | Qwen3.8 Flash                | 5,400                   | 13,500              | 27,000                |
@@ -143,6 +145,7 @@ Estimaterne er baseret på observerede anmodningsmønstre:
 - DeepSeek V4 Flash Vision Exp — 410 input, 71.300 cachelagrede, 310 output-tokens pr. anmodning
 - MiniMax M3 — 510 input, 56.000 cachelagrede, 190 output-tokens pr. anmodning
 - MiniMax M2.7 — 300 input, 55.000 cachelagrede, 125 output-tokens pr. anmodning
+- Muse Spark 1.3 Contributor — 620 input, 71.400 cachelagrede, 300 output-tokens pr. anmodning
 - Muse Spark 1.2 Contributor — 620 input, 71.400 cachelagrede, 300 output-tokens pr. anmodning
 - Qwen3.8 Max — 420 input, 66.000 cachelagrede, 200 output-tokens pr. anmodning
 - Qwen3.8 Flash — 600 input, 58.000 cachelagrede, 200 output-tokens pr. anmodning
@@ -175,6 +178,7 @@ Estimaterne er også baseret på følgende priser pr. 1M tokens og det månedlig
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60     |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60     |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60     |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60     |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60     |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15     |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30     |
@@ -250,6 +254,7 @@ Du kan også få adgang til Go-modeller gennem følgende API-endpoints.
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -298,6 +303,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Ikke brugt   | 0 dage         |
 | MiniMax M3                   | Ikke brugt   | 0 dage         |
 | MiniMax M2.7                 | Ikke brugt   | 0 dage         |
+| Muse Spark 1.3 Contributor   | Ja           | Ikke ZDR       |
 | Muse Spark 1.2 Contributor   | Ja           | Ikke ZDR       |
 | DeepSeek V4 Pro              | Ikke brugt   | 0 dage         |
 | DeepSeek V4 Flash            | Ikke brugt   | 0 dage         |
@@ -307,6 +313,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR deaktiverer vigtige API-funktioner, der afhænger af lagrede data, herunder den tilstandsbevarende Responses API, Files and Collections og Batch API. [Læs mere](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Logfiler til overvågning af misbrug genereres ved al brug af API-funktioner og opbevares i op til 30 dage. [Læs mere](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Kraftigt nedsatte tokenpriser til gengæld for tilladelse til at bruge dine prompts og modelsvar til at træne fremtidige Meta-modeller. Tilgængeligheden er begrænset til regioner, der er tilladt i henhold til [politikken for geografisk brug](https://ai.developer.meta.com/legal/geographic-use-policy) fra Meta. [Læs mere](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Kraftigt nedsatte tokenpriser til gengæld for tilladelse til at bruge dine prompts og modelsvar til at træne fremtidige Meta-modeller. Tilgængeligheden er begrænset til regioner, der er tilladt i henhold til [politikken for geografisk brug](https://ai.developer.meta.com/legal/geographic-use-policy) fra Meta. [Læs mere](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** ZDR-aftalen fornyes månedligt. Den nuværende aftale er gyldig til og med 31. august 2026.
 

--- a/packages/web/src/content/docs/da/zen.mdx
+++ b/packages/web/src/content/docs/da/zen.mdx
@@ -91,6 +91,7 @@ Du kan også få adgang til vores modeller gennem følgende API-endpoints.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -122,6 +123,7 @@ Du kan også få adgang til vores modeller gennem følgende API-endpoints.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 [model id](/docs/config/#models) i din OpenCode-konfiguration
@@ -151,6 +153,7 @@ Vi understøtter en pay-as-you-go-model. Nedenfor er priserne **pr. 1M tokens**.
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -182,6 +185,7 @@ Vi understøtter en pay-as-you-go-model. Nedenfor er priserne **pr. 1M tokens**.
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -238,6 +242,7 @@ De gratis modeller:
 - Nemotron 3 Ultra Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 - Nemotron 3.5 Lightning Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 - Big Pickle er en stealth-model, som er gratis på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
+- Muse Spark 1.3 Contributor Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 - Muse Spark 1.2 Contributor Free er tilgængelig på OpenCode i en begrænset periode. Teamet bruger denne tid til at indsamle feedback og forbedre modellen.
 
 <a href={email}>Kontakt os</a>, hvis du har spørgsmål.
@@ -299,6 +304,7 @@ Alle vores modeller hostes i US. Vores udbydere følger en nul-opbevaringspoliti
 - Nemotron 3.5 Lightning Free (gratis NVIDIA-endpoints): Kun til prøvebrug — indsend ikke personlige eller fortrolige data. Din brug logges af sikkerhedshensyn og for at forbedre NVIDIAs produkter og tjenester. De loggede sessionsdata, der bruges til forbedringsformål, er ikke knyttet til din identitet eller nogen vedvarende identifikator. For mere information om vores databehandlingspraksis, se vores [privatlivspolitik](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Ved at interagere med dette endpoint giver du samtykke til vores indsamling, registrering og brug af sådanne oplysninger samt [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: Anmodninger opbevares i 30 dage i overensstemmelse med [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Anmodninger opbevares i 30 dage i overensstemmelse med [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: Kraftigt nedsatte tokenpriser til gengæld for tilladelse til at bruge dine prompts og svar til at træne fremtidige Meta-modeller. [Læs mere](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Kraftigt nedsatte tokenpriser til gengæld for tilladelse til at bruge dine prompts og svar til at træne fremtidige Meta-modeller. [Læs mere](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/de/go.mdx
+++ b/packages/web/src/content/docs/de/go.mdx
@@ -65,6 +65,7 @@ Die aktuelle Liste der Modelle umfasst:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([begrenzte Regionen](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([begrenzte Regionen](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -109,6 +110,7 @@ Die folgende Tabelle zeigt eine geschätzte Anzahl von Anfragen basierend auf ty
 | MiMo-V2.5-Pro                | 3,250                  | 8,150              | 16,300             |
 | MiniMax M3                   | 3,200                  | 8,000              | 16,000             |
 | MiniMax M2.7                 | 3,400                  | 8,500              | 17,000             |
+| Muse Spark 1.3 Contributor   | 45,300                 | 113,300            | 226,600            |
 | Muse Spark 1.2 Contributor   | 45,300                 | 113,300            | 226,600            |
 | Qwen3.8 Max                  | 160                    | 400                | 810                |
 | Qwen3.8 Flash                | 5,400                  | 13,500             | 27,000             |
@@ -135,6 +137,7 @@ Die Schätzungen basieren auf beobachteten Anfragemustern:
 - DeepSeek V4 Flash Vision Exp — 410 Input-, 71.300 Cached-, 310 Output-Tokens pro Anfrage
 - MiniMax M3 — 510 Input-, 56.000 Cached-, 190 Output-Tokens pro Anfrage
 - MiniMax M2.7 — 300 Input-, 55.000 Cached-, 125 Output-Tokens pro Anfrage
+- Muse Spark 1.3 Contributor — 620 Input-, 71.400 Cached-, 300 Output-Tokens pro Anfrage
 - Muse Spark 1.2 Contributor — 620 Input-, 71.400 Cached-, 300 Output-Tokens pro Anfrage
 - Qwen3.8 Max — 420 Input-, 66.000 Cached-, 200 Output-Tokens pro Anfrage
 - Qwen3.8 Flash — 600 Input-, 58.000 Cached-, 200 Output-Tokens pro Anfrage
@@ -167,6 +170,7 @@ Die Schätzungen basieren außerdem auf den folgenden Preisen pro 1M Tokens und 
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60     |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60     |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60     |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60     |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60     |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15     |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30     |
@@ -240,6 +244,7 @@ Du kannst auf die Go-Modelle auch über die folgenden API-Endpunkte zugreifen.
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -286,6 +291,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Nicht verwendet | 0 Tage            |
 | MiniMax M3                   | Nicht verwendet | 0 Tage            |
 | MiniMax M2.7                 | Nicht verwendet | 0 Tage            |
+| Muse Spark 1.3 Contributor   | Ja              | Kein ZDR          |
 | Muse Spark 1.2 Contributor   | Ja              | Kein ZDR          |
 | DeepSeek V4 Pro              | Nicht verwendet | 0 Tage            |
 | DeepSeek V4 Flash            | Nicht verwendet | 0 Tage            |
@@ -295,6 +301,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR deaktiviert wichtige API-Funktionen, die von gespeicherten Daten abhängen, einschließlich der zustandsbehafteten Responses API, Files and Collections und der Batch API. [Mehr erfahren](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Für die Nutzung aller API-Funktionen werden Protokolle zur Missbrauchsüberwachung erstellt und bis zu 30 Tage lang aufbewahrt. [Mehr erfahren](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Stark vergünstigte Tokenpreise im Gegenzug für die Erlaubnis, deine Prompts und Vervollständigungen zum Trainieren zukünftiger Meta-Modelle zu verwenden. Die Verfügbarkeit ist auf Regionen beschränkt, die gemäß der [Richtlinie zur geografischen Nutzung](https://ai.developer.meta.com/legal/geographic-use-policy) von Meta zulässig sind. [Mehr erfahren](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Stark vergünstigte Tokenpreise im Gegenzug für die Erlaubnis, deine Prompts und Vervollständigungen zum Trainieren zukünftiger Meta-Modelle zu verwenden. Die Verfügbarkeit ist auf Regionen beschränkt, die gemäß der [Richtlinie zur geografischen Nutzung](https://ai.developer.meta.com/legal/geographic-use-policy) von Meta zulässig sind. [Mehr erfahren](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** Die ZDR-Vereinbarung wird monatlich erneuert. Die aktuelle Vereinbarung gilt bis einschließlich 31. August 2026.
 

--- a/packages/web/src/content/docs/de/zen.mdx
+++ b/packages/web/src/content/docs/de/zen.mdx
@@ -82,6 +82,7 @@ Du kannst auch über die folgenden API-Endpunkte auf unsere Modelle zugreifen.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -113,6 +114,7 @@ Du kannst auch über die folgenden API-Endpunkte auf unsere Modelle zugreifen.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 Die [Model-ID](/docs/config/#models) in deiner OpenCode-Konfiguration verwendet das Format `opencode/<model-id>`. Für GPT 5.5 würdest du zum Beispiel `opencode/gpt-5.5` in deiner Konfiguration verwenden.
@@ -140,6 +142,7 @@ Wir unterstützen ein Pay-as-you-go-Modell. Unten findest du die Preise **pro 1M
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -171,6 +174,7 @@ Wir unterstützen ein Pay-as-you-go-Modell. Unten findest du die Preise **pro 1M
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -227,6 +231,7 @@ Die kostenlosen Modelle:
 - Nemotron 3 Ultra Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 - Nemotron 3.5 Lightning Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 - Big Pickle ist ein Stealth-Modell, das für begrenzte Zeit kostenlos auf OpenCode verfügbar ist. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
+- Muse Spark 1.3 Contributor Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 - Muse Spark 1.2 Contributor Free ist für begrenzte Zeit auf OpenCode verfügbar. Das Team nutzt diese Zeit, um Feedback zu sammeln und das Modell zu verbessern.
 
 <a href={email}>Kontaktiere uns</a>, wenn du Fragen hast.
@@ -285,6 +290,7 @@ Alle unsere Modelle werden in den USA gehostet. Unsere Provider folgen einer Zer
 - Nemotron 3.5 Lightning Free (kostenlose NVIDIA-Endpunkte): Nur für Testzwecke — übermitteln Sie keine personenbezogenen oder vertraulichen Daten. Ihre Nutzung wird zu Sicherheitszwecken und zur Verbesserung der Produkte und Dienste von NVIDIA protokolliert. Die zu Verbesserungszwecken protokollierten Sitzungsdaten sind nicht mit Ihrer Identität oder einem dauerhaften Identifikator verknüpft. Weitere Informationen zu unseren Datenverarbeitungspraktiken finden Sie in unserer [Datenschutzrichtlinie](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Durch die Interaktion mit diesem Endpunkt stimmen Sie unserer Erhebung, Aufzeichnung und Nutzung solcher Informationen sowie den [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf) zu.
 - OpenAI APIs: Anfragen werden in Übereinstimmung mit [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) 30 Tage lang gespeichert.
 - Anthropic APIs: Anfragen werden in Übereinstimmung mit [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) 30 Tage lang gespeichert.
+- Muse Spark 1.3 Contributor Free: Stark vergünstigte Token-Preise im Austausch für die Erlaubnis, deine Prompts und Completions zum Trainieren zukünftiger Meta-Modelle zu verwenden. [Mehr erfahren](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Stark vergünstigte Token-Preise im Austausch für die Erlaubnis, deine Prompts und Completions zum Trainieren zukünftiger Meta-Modelle zu verwenden. [Mehr erfahren](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/es/go.mdx
+++ b/packages/web/src/content/docs/es/go.mdx
@@ -73,6 +73,7 @@ La lista actual de modelos incluye:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([regiones limitadas](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([regiones limitadas](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -117,6 +118,7 @@ La siguiente tabla proporciona una cantidad estimada de peticiones basada en los
 | MiMo-V2.5-Pro                | 3,250                  | 8,150                 | 16,300             |
 | MiniMax M3                   | 3,200                  | 8,000                 | 16,000             |
 | MiniMax M2.7                 | 3,400                  | 8,500                 | 17,000             |
+| Muse Spark 1.3 Contributor   | 45,300                 | 113,300               | 226,600            |
 | Muse Spark 1.2 Contributor   | 45,300                 | 113,300               | 226,600            |
 | Qwen3.8 Max                  | 160                    | 400                   | 810                |
 | Qwen3.8 Flash                | 5,400                  | 13,500                | 27,000             |
@@ -143,6 +145,7 @@ Las estimaciones se basan en los patrones de peticiones observados:
 - DeepSeek V4 Flash Vision Exp — 410 tokens de entrada, 71,300 en caché, 310 tokens de salida por petición
 - MiniMax M3 — 510 tokens de entrada, 56,000 en caché, 190 tokens de salida por petición
 - MiniMax M2.7 — 300 tokens de entrada, 55,000 en caché, 125 tokens de salida por petición
+- Muse Spark 1.3 Contributor — 620 tokens de entrada, 71,400 en caché, 300 tokens de salida por petición
 - Muse Spark 1.2 Contributor — 620 tokens de entrada, 71,400 en caché, 300 tokens de salida por petición
 - Qwen3.8 Max — 420 tokens de entrada, 66,000 en caché, 200 tokens de salida por petición
 - Qwen3.8 Flash — 600 tokens de entrada, 58,000 en caché, 200 tokens de salida por petición
@@ -175,6 +178,7 @@ Las estimaciones también se basan en los siguientes precios por 1M tokens y en 
 | MiniMax M3                              | $0.30   | $1.20  | $0.06            | -                  | $60 |
 | MiniMax M2.7                            | $0.30   | $1.20  | $0.06            | $0.375             | $60 |
 | MiniMax M2.5                            | $0.30   | $1.20  | $0.06            | $0.375             | $60 |
+| Muse Spark 1.3 Contributor              | $0.10   | $0.20  | $0.002           | -                  | $60 |
 | Muse Spark 1.2 Contributor              | $0.10   | $0.20  | $0.002           | -                  | $60 |
 | Qwen3.8 Max                             | $2.00   | $6.00  | $0.25            | $2.50              | $15 |
 | Qwen3.8 Flash                           | $0.15   | $0.47  | $0.016           | $0.20              | $30 |
@@ -250,6 +254,7 @@ También puedes acceder a los modelos de Go a través de los siguientes endpoint
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -298,6 +303,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | No utilizado             | 0 días             |
 | MiniMax M3                   | No utilizado             | 0 días             |
 | MiniMax M2.7                 | No utilizado             | 0 días             |
+| Muse Spark 1.3 Contributor   | Sí                       | Sin ZDR            |
 | Muse Spark 1.2 Contributor   | Sí                       | Sin ZDR            |
 | DeepSeek V4 Pro              | No utilizado             | 0 días             |
 | DeepSeek V4 Flash            | No utilizado             | 0 días             |
@@ -307,6 +313,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR deshabilita funciones importantes de la API que dependen de datos almacenados, incluidas la Responses API con estado, Files and Collections y la Batch API. [Más información](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Se generan registros de supervisión de abusos para todo el uso de funciones de la API y se conservan durante un máximo de 30 días. [Más información](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Precios de tokens muy reducidos a cambio de permitir que tus prompts y las respuestas generadas se utilicen para entrenar futuros modelos de Meta. La disponibilidad está limitada a las regiones permitidas por la [Política de uso geográfico](https://ai.developer.meta.com/legal/geographic-use-policy) de Meta. [Más información](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Precios de tokens muy reducidos a cambio de permitir que tus prompts y las respuestas generadas se utilicen para entrenar futuros modelos de Meta. La disponibilidad está limitada a las regiones permitidas por la [Política de uso geográfico](https://ai.developer.meta.com/legal/geographic-use-policy) de Meta. [Más información](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** El acuerdo de ZDR se renueva mensualmente. El acuerdo actual es válido hasta el 31 de agosto de 2026.
 

--- a/packages/web/src/content/docs/es/zen.mdx
+++ b/packages/web/src/content/docs/es/zen.mdx
@@ -91,6 +91,7 @@ También puedes acceder a nuestros modelos a través de los siguientes endpoints
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -122,6 +123,7 @@ También puedes acceder a nuestros modelos a través de los siguientes endpoints
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 El [identificador del modelo](/docs/config/#models) en tu configuración de OpenCode
@@ -151,6 +153,7 @@ Admitimos un modelo de pago por uso. A continuación se muestran los precios **p
 | Ling 3.0 Flash Fin Free           | Free    | Free    | Free             | -                  |
 | Nemotron 3 Ultra Free             | Free    | Free    | Free             | -                  |
 | Nemotron 3.5 Lightning Free       | Free    | Free    | Free             | -                  |
+| Muse Spark 1.3 Contributor Free   | Free    | Free    | Free             | -                  |
 | Muse Spark 1.2 Contributor Free   | Free    | Free    | Free             | -                  |
 | MiniMax M3                        | $0.30   | $1.20   | $0.06            | -                  |
 | MiniMax M2.7                      | $0.30   | $1.20   | $0.06            | -                  |
@@ -182,6 +185,7 @@ Admitimos un modelo de pago por uso. A continuación se muestran los precios **p
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00   | $15.00  | $0.30            | $3.75              |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60            | $7.50              |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10            | $1.25              |
+| Gemini 3.8 Flash                  | $1.50   | $7.50   | $0.15            | -                  |
 | Gemini 3.7 Flash                  | $1.50   | $7.50   | $0.15            | -                  |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15            | -                  |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15            | -                  |
@@ -238,6 +242,7 @@ Los modelos gratuitos:
 - Nemotron 3 Ultra Free está disponible en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
 - Nemotron 3.5 Lightning Free está disponible en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
 - Big Pickle es un modelo stealth que es gratuito en OpenCode por tiempo limitado. El equipo está usando este tiempo para recopilar comentarios y mejorar el modelo.
+- Muse Spark 1.3 Contributor Free está disponible en OpenCode por tiempo limitado. El equipo está aprovechando este período para recopilar comentarios y mejorar el modelo.
 - Muse Spark 1.2 Contributor Free está disponible en OpenCode por tiempo limitado. El equipo está aprovechando este período para recopilar comentarios y mejorar el modelo.
 
 <a href={email}>Contáctanos</a> si tienes alguna pregunta.
@@ -299,6 +304,7 @@ Todos nuestros modelos están alojados en US. Nuestros proveedores siguen una po
 - Nemotron 3.5 Lightning Free (endpoints gratuitos de NVIDIA): Solo para uso de prueba — no envíes datos personales ni confidenciales. Tu uso se registra con fines de seguridad y para mejorar los productos y servicios de NVIDIA. Los datos de sesión registrados con fines de mejora no están vinculados a tu identidad ni a ningún identificador persistente. Para obtener más información sobre nuestras prácticas de procesamiento de datos, consulta nuestra [Política de privacidad](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Al interactuar con este endpoint, aceptas que recopilemos, registremos y usemos dicha información, así como los [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: Las solicitudes se conservan durante 30 días de acuerdo con [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Las solicitudes se conservan durante 30 días de acuerdo con [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: Tarifas de tokens con grandes descuentos a cambio de permiso para usar tus prompts y respuestas para entrenar futuros modelos de Meta. [Más información](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Tarifas de tokens con grandes descuentos a cambio de permiso para usar tus prompts y respuestas para entrenar futuros modelos de Meta. [Más información](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/fr/go.mdx
+++ b/packages/web/src/content/docs/fr/go.mdx
@@ -63,6 +63,7 @@ La liste actuelle des modèles comprend :
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([régions limitées](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([régions limitées](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -107,6 +108,7 @@ Le tableau ci-dessous fournit une estimation du nombre de requêtes basée sur d
 | MiMo-V2.5-Pro                | 3,250                 | 8,150                | 16,300            |
 | MiniMax M3                   | 3,200                 | 8,000                | 16,000            |
 | MiniMax M2.7                 | 3,400                 | 8,500                | 17,000            |
+| Muse Spark 1.3 Contributor   | 45,300                | 113,300              | 226,600           |
 | Muse Spark 1.2 Contributor   | 45,300                | 113,300              | 226,600           |
 | Qwen3.8 Max                  | 160                   | 400                  | 810               |
 | Qwen3.8 Flash                | 5,400                 | 13,500               | 27,000            |
@@ -133,6 +135,7 @@ Les estimations sont basées sur les schémas de requêtes observés :
 - DeepSeek V4 Flash Vision Exp — 410 tokens en entrée, 71,300 en cache, 310 tokens en sortie par requête
 - MiniMax M3 — 510 tokens en entrée, 56,000 en cache, 190 tokens en sortie par requête
 - MiniMax M2.7 — 300 tokens en entrée, 55,000 en cache, 125 tokens en sortie par requête
+- Muse Spark 1.3 Contributor — 620 tokens en entrée, 71,400 en cache, 300 tokens en sortie par requête
 - Muse Spark 1.2 Contributor — 620 tokens en entrée, 71,400 en cache, 300 tokens en sortie par requête
 - Qwen3.8 Max — 420 tokens en entrée, 66,000 en cache, 200 tokens en sortie par requête
 - Qwen3.8 Flash — 600 tokens en entrée, 58,000 en cache, 200 tokens en sortie par requête
@@ -165,6 +168,7 @@ Les estimations sont également basées sur les prix suivants par 1M tokens et s
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60         |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60         |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60         |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60         |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60         |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15         |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30         |
@@ -238,6 +242,7 @@ Vous pouvez également accéder aux modèles Go via les points de terminaison d'
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -284,6 +289,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Non utilisé              | 0 jour                   |
 | MiniMax M3                   | Non utilisé              | 0 jour                   |
 | MiniMax M2.7                 | Non utilisé              | 0 jour                   |
+| Muse Spark 1.3 Contributor   | Oui                      | Pas de ZDR               |
 | Muse Spark 1.2 Contributor   | Oui                      | Pas de ZDR               |
 | DeepSeek V4 Pro              | Non utilisé              | 0 jour                   |
 | DeepSeek V4 Flash            | Non utilisé              | 0 jour                   |
@@ -293,6 +299,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** Le ZDR désactive d’importantes fonctionnalités API qui dépendent des données stockées, notamment Responses API avec état, Files and Collections et Batch API. [En savoir plus](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Des journaux de surveillance des abus sont générés pour toute utilisation des fonctionnalités API et conservés pendant un maximum de 30 jours. [En savoir plus](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Des tarifs de tokens fortement réduits en échange de l’autorisation d’utiliser vos prompts et vos complétions pour entraîner de futurs modèles Meta. La disponibilité est limitée aux régions autorisées par la [Politique d’utilisation géographique](https://ai.developer.meta.com/legal/geographic-use-policy) de Meta. [En savoir plus](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Des tarifs de tokens fortement réduits en échange de l’autorisation d’utiliser vos prompts et vos complétions pour entraîner de futurs modèles Meta. La disponibilité est limitée aux régions autorisées par la [Politique d’utilisation géographique](https://ai.developer.meta.com/legal/geographic-use-policy) de Meta. [En savoir plus](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** L’accord ZDR est renouvelé chaque mois. L’accord actuel est valable jusqu’au 31 août 2026.
 

--- a/packages/web/src/content/docs/fr/zen.mdx
+++ b/packages/web/src/content/docs/fr/zen.mdx
@@ -82,6 +82,7 @@ Vous pouvez également accéder à nos modèles via les points de terminaison AP
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -113,6 +114,7 @@ Vous pouvez également accéder à nos modèles via les points de terminaison AP
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 Le [model id](/docs/config/#models) dans votre configuration OpenCode utilise le format `opencode/<model-id>`. Par exemple, pour GPT 5.5, vous utiliseriez `opencode/gpt-5.5` dans votre configuration.
@@ -140,6 +142,7 @@ Nous prenons en charge un modèle de paiement à l'utilisation. Vous trouverez c
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -171,6 +174,7 @@ Nous prenons en charge un modèle de paiement à l'utilisation. Vous trouverez c
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -227,6 +231,7 @@ Les modèles gratuits :
 - Nemotron 3 Ultra Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 - Nemotron 3.5 Lightning Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 - Big Pickle est un modèle stealth gratuit sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
+- Muse Spark 1.3 Contributor Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 - Muse Spark 1.2 Contributor Free est disponible sur OpenCode pour une durée limitée. L'équipe utilise cette période pour recueillir des retours et améliorer le modèle.
 
 <a href={email}>Contactez-nous</a> si vous avez des questions.
@@ -285,6 +290,7 @@ Tous nos modèles sont hébergés aux US. Nos fournisseurs suivent une politique
 - Nemotron 3.5 Lightning Free (endpoints NVIDIA gratuits) : Réservé à un usage d'essai — n'envoyez pas de données personnelles ou confidentielles. Votre utilisation est journalisée à des fins de sécurité et pour améliorer les produits et services de NVIDIA. Les données de session journalisées à des fins d'amélioration ne sont pas liées à votre identité ni à un quelconque identifiant persistant. Pour plus d'informations sur nos pratiques de traitement des données, consultez notre [Politique de confidentialité](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). En interagissant avec cet endpoint, vous consentez à notre collecte, à notre enregistrement et à notre utilisation de ces informations ainsi qu'aux [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs : Les requêtes sont conservées pendant 30 jours conformément à [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs : Les requêtes sont conservées pendant 30 jours conformément à [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free : Tarification des tokens fortement réduite en échange de l'autorisation d'utiliser vos prompts et complétions pour entraîner les futurs modèles Meta. [En savoir plus](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free : Tarification des tokens fortement réduite en échange de l'autorisation d'utiliser vos prompts et complétions pour entraîner les futurs modèles Meta. [En savoir plus](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/go.mdx
+++ b/packages/web/src/content/docs/go.mdx
@@ -73,6 +73,7 @@ The current list of models includes:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([limited regions](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([limited regions](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -129,6 +130,7 @@ The table below provides an estimated request count based on typical Go usage pa
 | MiMo-V2.5-Pro                | 3,250               | 8,150             | 16,300             |
 | MiniMax M3                   | 3,200               | 8,000             | 16,000             |
 | MiniMax M2.7                 | 3,400               | 8,500             | 17,000             |
+| Muse Spark 1.3 Contributor   | 45,300              | 113,300           | 226,600            |
 | Muse Spark 1.2 Contributor   | 45,300              | 113,300           | 226,600            |
 | Qwen3.8 Max                  | 160                 | 400               | 810                |
 | Qwen3.8 Flash                | 5,400               | 13,500            | 27,000             |
@@ -155,6 +157,7 @@ The estimates are based on observed request patterns:
 - DeepSeek V4 Flash Vision Exp — 410 input, 71,300 cached, 310 output tokens per request
 - MiniMax M3 — 510 input, 56,000 cached, 190 output tokens per request
 - MiniMax M2.7 — 300 input, 55,000 cached, 125 output tokens per request
+- Muse Spark 1.3 Contributor — 620 input, 71,400 cached, 300 output tokens per request
 - Muse Spark 1.2 Contributor — 620 input, 71,400 cached, 300 output tokens per request
 - MiMo-V2.5 — 830 input, 71,500 cached, 295 output tokens per request
 - MiMo-V2.5-Pro — 790 input, 86,000 cached, 305 output tokens per request
@@ -187,6 +190,7 @@ The estimates are also based on the following prices per 1M tokens and the month
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60   |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60   |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60   |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15   |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30   |
@@ -262,6 +266,7 @@ You can also access Go models through the following API endpoints.
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -310,6 +315,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Not used       | 0 days         |
 | MiniMax M3                   | Not used       | 0 days         |
 | MiniMax M2.7                 | Not used       | 0 days         |
+| Muse Spark 1.3 Contributor   | Yes            | Not ZDR        |
 | Muse Spark 1.2 Contributor   | Yes            | Not ZDR        |
 | DeepSeek V4 Pro              | Not used       | 0 days\*       |
 | DeepSeek V4 Flash            | Not used       | 0 days\*       |
@@ -319,6 +325,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR disables important API features that depend on stored data, including the stateful Responses API, Files and Collections, and the Batch API. [Learn more](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Abuse monitoring logs are generated for all API feature usage and retained for up to 30 days. [Learn more](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Heavily discounted token pricing in exchange for permission to use your prompts and completions to train future Meta models. Availability is limited to regions permitted by Meta's [Geographic Use Policy](https://ai.developer.meta.com/legal/geographic-use-policy). [Learn more](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Heavily discounted token pricing in exchange for permission to use your prompts and completions to train future Meta models. Availability is limited to regions permitted by Meta's [Geographic Use Policy](https://ai.developer.meta.com/legal/geographic-use-policy). [Learn more](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek:** ZDR agreement is renewed monthly. The current agreement is valid through August 31, 2026.
 

--- a/packages/web/src/content/docs/it/go.mdx
+++ b/packages/web/src/content/docs/it/go.mdx
@@ -71,6 +71,7 @@ L'elenco attuale dei modelli include:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([regioni limitate](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([regioni limitate](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -115,6 +116,7 @@ La tabella seguente fornisce una stima del conteggio delle richieste in base a p
 | MiMo-V2.5-Pro                | 3,250                | 8,150                 | 16,300            |
 | MiniMax M3                   | 3,200                | 8,000                 | 16,000            |
 | MiniMax M2.7                 | 3,400                | 8,500                 | 17,000            |
+| Muse Spark 1.3 Contributor   | 45,300               | 113,300               | 226,600           |
 | Muse Spark 1.2 Contributor   | 45,300               | 113,300               | 226,600           |
 | Qwen3.8 Max                  | 160                  | 400                   | 810               |
 | Qwen3.8 Flash                | 5,400                | 13,500                | 27,000            |
@@ -141,6 +143,7 @@ Le stime si basano sui pattern di richieste osservati:
 - DeepSeek V4 Flash Vision Exp — 410 di input, 71.300 in cache, 310 token di output per richiesta
 - MiniMax M3 — 510 di input, 56.000 in cache, 190 token di output per richiesta
 - MiniMax M2.7 — 300 di input, 55.000 in cache, 125 token di output per richiesta
+- Muse Spark 1.3 Contributor — 620 di input, 71.400 in cache, 300 token di output per richiesta
 - Muse Spark 1.2 Contributor — 620 di input, 71.400 in cache, 300 token di output per richiesta
 - Qwen3.8 Max — 420 di input, 66.000 in cache, 200 token di output per richiesta
 - Qwen3.8 Flash — 600 di input, 58.000 in cache, 200 token di output per richiesta
@@ -173,6 +176,7 @@ Le stime si basano anche sui seguenti prezzi per 1M token e sull'utilizzo mensil
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60      |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60      |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60      |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60      |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60      |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15      |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30      |
@@ -248,6 +252,7 @@ Puoi anche accedere ai modelli Go tramite i seguenti endpoint API.
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -296,6 +301,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Non utilizzato            | 0 giorni               |
 | MiniMax M3                   | Non utilizzato            | 0 giorni               |
 | MiniMax M2.7                 | Non utilizzato            | 0 giorni               |
+| Muse Spark 1.3 Contributor   | Sì                        | Non ZDR                |
 | Muse Spark 1.2 Contributor   | Sì                        | Non ZDR                |
 | DeepSeek V4 Pro              | Non utilizzato            | 0 giorni               |
 | DeepSeek V4 Flash            | Non utilizzato            | 0 giorni               |
@@ -305,6 +311,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR disabilita importanti funzionalità API che dipendono dai dati archiviati, tra cui la Responses API con stato, Files and Collections e Batch API. [Scopri di più](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** I log di monitoraggio degli abusi vengono generati per l'utilizzo di tutte le funzionalità API e conservati per un massimo di 30 giorni. [Scopri di più](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Prezzi dei token fortemente scontati in cambio dell'autorizzazione a utilizzare i tuoi prompt e completamenti per addestrare futuri modelli Meta. La disponibilità è limitata alle regioni consentite dalla [Politica sull'uso geografico](https://ai.developer.meta.com/legal/geographic-use-policy) di Meta. [Scopri di più](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Prezzi dei token fortemente scontati in cambio dell'autorizzazione a utilizzare i tuoi prompt e completamenti per addestrare futuri modelli Meta. La disponibilità è limitata alle regioni consentite dalla [Politica sull'uso geografico](https://ai.developer.meta.com/legal/geographic-use-policy) di Meta. [Scopri di più](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** L'accordo ZDR viene rinnovato mensilmente. L'accordo attuale è valido fino al 31 agosto 2026.
 

--- a/packages/web/src/content/docs/it/zen.mdx
+++ b/packages/web/src/content/docs/it/zen.mdx
@@ -91,6 +91,7 @@ Puoi anche accedere ai nostri modelli tramite i seguenti endpoint API.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -122,6 +123,7 @@ Puoi anche accedere ai nostri modelli tramite i seguenti endpoint API.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 Il [model id](/docs/config/#models) nella config di OpenCode
@@ -151,6 +153,7 @@ Supportiamo un modello pay-as-you-go. Qui sotto trovi i prezzi **per 1M token**.
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -182,6 +185,7 @@ Supportiamo un modello pay-as-you-go. Qui sotto trovi i prezzi **per 1M token**.
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -238,6 +242,7 @@ I modelli gratuiti:
 - Nemotron 3 Ultra Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 - Nemotron 3.5 Lightning Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 - Big Pickle è un modello stealth che è gratuito su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
+- Muse Spark 1.3 Contributor Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 - Muse Spark 1.2 Contributor Free è disponibile su OpenCode per un periodo limitato. Il team usa questo periodo per raccogliere feedback e migliorare il modello.
 
 <a href={email}>Contattaci</a> se hai domande.
@@ -299,6 +304,7 @@ Tutti i nostri modelli sono ospitati negli US. I nostri provider seguono una pol
 - Nemotron 3.5 Lightning Free (endpoint NVIDIA gratuiti): solo per uso di prova — non inviare dati personali o riservati. Il tuo utilizzo viene registrato per finalità di sicurezza e per migliorare i prodotti e i servizi di NVIDIA. I dati di sessione registrati a fini di miglioramento non sono collegati alla tua identità né ad alcun identificatore persistente. Per maggiori informazioni sulle nostre pratiche di trattamento dei dati, consulta la nostra [Informativa sulla privacy](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Interagendo con questo endpoint, acconsenti alla nostra raccolta, registrazione e utilizzo di tali informazioni e ai [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: le richieste vengono conservate per 30 giorni in conformità con [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: le richieste vengono conservate per 30 giorni in conformità con [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: prezzi dei token fortemente scontati in cambio dell'autorizzazione a utilizzare i tuoi prompt e completamenti per addestrare i futuri modelli Meta. [Scopri di più](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: prezzi dei token fortemente scontati in cambio dell'autorizzazione a utilizzare i tuoi prompt e completamenti per addestrare i futuri modelli Meta. [Scopri di più](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/ja/go.mdx
+++ b/packages/web/src/content/docs/ja/go.mdx
@@ -63,6 +63,7 @@ OpenCode Goをサブスクライブできるのは、1つのワークスペー�
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([一部の地域に限定](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([一部の地域に限定](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -107,6 +108,7 @@ OpenCode Goには以下の制限が含まれています：
 | MiMo-V2.5-Pro                | 3,250                     | 8,150            | 16,300           |
 | MiniMax M3                   | 3,200                     | 8,000            | 16,000           |
 | MiniMax M2.7                 | 3,400                     | 8,500            | 17,000           |
+| Muse Spark 1.3 Contributor   | 45,300                    | 113,300          | 226,600          |
 | Muse Spark 1.2 Contributor   | 45,300                    | 113,300          | 226,600          |
 | Qwen3.8 Max                  | 160                       | 400              | 810              |
 | Qwen3.8 Flash                | 5,400                     | 13,500           | 27,000           |
@@ -133,6 +135,7 @@ OpenCode Goには以下の制限が含まれています：
 - DeepSeek V4 Flash Vision Exp — リクエストあたり 入力 410トークン、キャッシュ 71,300トークン、出力 310トークン
 - MiniMax M3 — リクエストあたり 入力 510トークン、キャッシュ 56,000トークン、出力 190トークン
 - MiniMax M2.7 — リクエストあたり 入力 300トークン、キャッシュ 55,000トークン、出力 125トークン
+- Muse Spark 1.3 Contributor — リクエストあたり 入力 620トークン、キャッシュ 71,400トークン、出力 300トークン
 - Muse Spark 1.2 Contributor — リクエストあたり 入力 620トークン、キャッシュ 71,400トークン、出力 300トークン
 - Qwen3.8 Max — リクエストあたり 入力 420トークン、キャッシュ 66,000トークン、出力 200トークン
 - Qwen3.8 Flash — リクエストあたり 入力 600トークン、キャッシュ 58,000トークン、出力 200トークン
@@ -165,6 +168,7 @@ OpenCode Goには以下の制限が含まれています：
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60   |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60   |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60   |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15   |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30   |
@@ -238,6 +242,7 @@ Goでは月額$10を支払い、その6倍の利用枠を提供することを�
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -284,6 +289,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | 使用なし             | 0日         |
 | MiniMax M3                   | 使用なし             | 0日         |
 | MiniMax M2.7                 | 使用なし             | 0日         |
+| Muse Spark 1.3 Contributor   | はい                 | ZDRではない |
 | Muse Spark 1.2 Contributor   | はい                 | ZDRではない |
 | DeepSeek V4 Pro              | 使用なし             | 0日         |
 | DeepSeek V4 Flash            | 使用なし             | 0日         |
@@ -293,6 +299,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDRでは、保存データに依存する重要なAPI機能（ステートフルなResponses API、Files and Collections、Batch APIなど）が無効になります。[詳しく見る](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr)。
 - **GPT 5.6 Luna:** 不正使用監視ログはすべてのAPI機能の使用時に生成され、最大30日間保持されます。[詳しく見る](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring)。
+- **Muse Spark 1.3 Contributor:** 将来のMetaモデルのトレーニングにプロンプトと生成結果を使用する許可と引き換えに、トークン料金が大幅に割引されます。利用できるのは、Metaの[地域別利用ポリシー](https://ai.developer.meta.com/legal/geographic-use-policy)で許可されている地域に限られます。[詳しく見る](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - **Muse Spark 1.2 Contributor:** 将来のMetaモデルのトレーニングにプロンプトと生成結果を使用する許可と引き換えに、トークン料金が大幅に割引されます。利用できるのは、Metaの[地域別利用ポリシー](https://ai.developer.meta.com/legal/geographic-use-policy)で許可されている地域に限られます。[詳しく見る](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - **DeepSeek V4 Flash:** ZDR契約は毎月更新されます。現在の契約は2026年8月31日まで有効です。
 

--- a/packages/web/src/content/docs/ja/zen.mdx
+++ b/packages/web/src/content/docs/ja/zen.mdx
@@ -82,6 +82,7 @@ OpenCode Zen は、OpenCode のほかのプロバイダーと同じように動�
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -113,6 +114,7 @@ OpenCode Zen は、OpenCode のほかのプロバイダーと同じように動�
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 OpenCode 設定で使う [model id](/docs/config/#models) は `opencode/<model-id>` 形式です。たとえば、GPT 5.5 では設定に `opencode/gpt-5.5` を使用します。
@@ -140,6 +142,7 @@ https://opencode.ai/zen/v1/models
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -171,6 +174,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -227,6 +231,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3 Ultra Free は期間限定で OpenCode で利用できます。チームはこの期間中にフィードバックを集め、モデルを改善しています。
 - Nemotron 3.5 Lightning Free は期間限定で OpenCode で利用できます。チームはこの期間中にフィードバックを集め、モデルを改善しています。
 - Big Pickle はステルスモデルで、期間限定で OpenCode で無料提供されています。チームはこの期間中にフィードバックを集め、モデルを改善しています。
+- Muse Spark 1.3 Contributor Free は期間限定で OpenCode で利用できます。チームはこの期間を活用してフィードバックを収集し、モデルを改善しています。
 - Muse Spark 1.2 Contributor Free は期間限定で OpenCode で利用できます。チームはこの期間を活用してフィードバックを収集し、モデルを改善しています。
 
 ご不明な点があれば、<a href={email}>お問い合わせください</a>。
@@ -285,6 +290,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3.5 Lightning Free（NVIDIA の無料エンドポイント）: 試用専用です — 個人情報や機密データは送信しないでください。お客様の利用は、セキュリティ目的および NVIDIA の製品とサービスの改善のために記録されます。改善目的で記録されたセッションデータは、お客様の身元や永続的な識別子とは関連付けられません。当社のデータ処理慣行の詳細については、[プライバシーポリシー](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf)をご覧ください。このエンドポイントを利用することで、お客様はそのような情報の当社による収集、記録、利用、および [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf) に同意したものとみなされます。
 - OpenAI APIs: リクエストは [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) に従って 30 日間保持されます。
 - Anthropic APIs: リクエストは [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) に従って 30 日間保持されます。
+- Muse Spark 1.3 Contributor Free: 将来の Meta モデルのトレーニングにプロンプトと生成結果を使用する許可と引き換えに、トークン料金が大幅に割引されます。[詳しく見る](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - Muse Spark 1.2 Contributor Free: 将来の Meta モデルのトレーニングにプロンプトと生成結果を使用する許可と引き換えに、トークン料金が大幅に割引されます。[詳しく見る](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 
 ---

--- a/packages/web/src/content/docs/ko/go.mdx
+++ b/packages/web/src/content/docs/ko/go.mdx
@@ -63,6 +63,7 @@ workspace당 한 명의 멤버만 OpenCode Go를 구독할 수 있습니다.
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([일부 지역에서만 제공](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([일부 지역에서만 제공](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -107,6 +108,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | MiMo-V2.5-Pro                | 3,250             | 8,150          | 16,300         |
 | MiniMax M3                   | 3,200             | 8,000          | 16,000         |
 | MiniMax M2.7                 | 3,400             | 8,500          | 17,000         |
+| Muse Spark 1.3 Contributor   | 45,300            | 113,300        | 226,600        |
 | Muse Spark 1.2 Contributor   | 45,300            | 113,300        | 226,600        |
 | Qwen3.8 Max                  | 160               | 400            | 810            |
 | Qwen3.8 Flash                | 5,400             | 13,500         | 27,000         |
@@ -133,6 +135,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 - DeepSeek V4 Flash Vision Exp — 요청당 입력 410, 캐시 71,300, 출력 토큰 310
 - MiniMax M3 — 요청당 입력 510, 캐시 56,000, 출력 토큰 190
 - MiniMax M2.7 — 요청당 입력 300, 캐시 55,000, 출력 토큰 125
+- Muse Spark 1.3 Contributor — 요청당 입력 620, 캐시 71,400, 출력 토큰 300
 - Muse Spark 1.2 Contributor — 요청당 입력 620, 캐시 71,400, 출력 토큰 300
 - Qwen3.8 Max — 요청당 입력 420, 캐시 66,000, 출력 토큰 200
 - Qwen3.8 Flash — 요청당 입력 600, 캐시 58,000, 출력 토큰 200
@@ -165,6 +168,7 @@ OpenCode Go에는 다음과 같은 한도가 포함됩니다.
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60   |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60   |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60   |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15   |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30   |
@@ -238,6 +242,7 @@ Go에서는 월 $10를 지불하며, 저희는 그 6배의 사용량을 제공�
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -284,6 +289,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | 사용되지 않음 | 0일         |
 | MiniMax M3                   | 사용되지 않음 | 0일         |
 | MiniMax M2.7                 | 사용되지 않음 | 0일         |
+| Muse Spark 1.3 Contributor   | 예            | ZDR 아님    |
 | Muse Spark 1.2 Contributor   | 예            | ZDR 아님    |
 | DeepSeek V4 Pro              | 사용되지 않음 | 0일         |
 | DeepSeek V4 Flash            | 사용되지 않음 | 0일         |
@@ -293,6 +299,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR은 저장된 데이터에 의존하는 중요한 API 기능(상태 저장형 Responses API, Files and Collections, Batch API 포함)을 비활성화합니다. [자세히 알아보기](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** 모든 API 기능 사용에 대해 악용 모니터링 로그가 생성되며 최대 30일 동안 보존됩니다. [자세히 알아보기](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** 향후 Meta 모델 학습에 사용자의 프롬프트와 생성 결과를 사용할 수 있도록 허용하는 대신 토큰 가격이 대폭 할인됩니다. Meta의 [지역별 사용 정책](https://ai.developer.meta.com/legal/geographic-use-policy)에서 허용하는 지역에서만 이용할 수 있습니다. [자세히 알아보기](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** 향후 Meta 모델 학습에 사용자의 프롬프트와 생성 결과를 사용할 수 있도록 허용하는 대신 토큰 가격이 대폭 할인됩니다. Meta의 [지역별 사용 정책](https://ai.developer.meta.com/legal/geographic-use-policy)에서 허용하는 지역에서만 이용할 수 있습니다. [자세히 알아보기](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** ZDR 계약은 매월 갱신됩니다. 현재 계약은 2026년 8월 31일까지 유효합니다.
 

--- a/packages/web/src/content/docs/ko/zen.mdx
+++ b/packages/web/src/content/docs/ko/zen.mdx
@@ -82,6 +82,7 @@ OpenCode Zen은 OpenCode의 다른 provider와 똑같이 작동합니다.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -113,6 +114,7 @@ OpenCode Zen은 OpenCode의 다른 provider와 똑같이 작동합니다.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 OpenCode config에서 사용하는 [모델 ID](/docs/config/#models)는 `opencode/<model-id>` 형식입니다. 예를 들어 GPT 5.5를 사용하려면 config에서 `opencode/gpt-5.5`를 사용하면 됩니다.
@@ -140,6 +142,7 @@ https://opencode.ai/zen/v1/models
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -171,6 +174,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -227,6 +231,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3 Ultra Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
 - Nemotron 3.5 Lightning Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
 - Big Pickle은 한정된 기간 동안 OpenCode에서 무료로 제공되는 stealth model입니다. 팀은 이 기간에 피드백을 수집하고 모델을 개선합니다.
+- Muse Spark 1.3 Contributor Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간을 활용해 피드백을 수집하고 모델을 개선하고 있습니다.
 - Muse Spark 1.2 Contributor Free는 한정된 기간 동안 OpenCode에서 제공됩니다. 팀은 이 기간을 활용해 피드백을 수집하고 모델을 개선하고 있습니다.
 
 궁금한 점이 있으면 <a href={email}>Contact us</a>로 문의해 주세요.
@@ -285,6 +290,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3.5 Lightning Free(NVIDIA 무료 엔드포인트): 평가판 전용이며 — 개인 정보나 기밀 데이터는 제출하지 마세요. 사용 내역은 보안 목적과 NVIDIA 제품 및 서비스 개선을 위해 기록됩니다. 개선 목적으로 기록된 세션 데이터는 사용자의 신원이나 영구 식별자와 연결되지 않습니다. 당사의 데이터 처리 관행에 대한 자세한 내용은 [개인정보처리방침](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf)을 참조하세요. 이 엔드포인트와 상호 작용함으로써 사용자는 당사가 이러한 정보를 수집, 기록, 사용하는 것과 [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf)에 동의하게 됩니다.
 - OpenAI APIs: 요청은 [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data)에 따라 30일 동안 보관됩니다.
 - Anthropic APIs: 요청은 [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage)에 따라 30일 동안 보관됩니다.
+- Muse Spark 1.3 Contributor Free: 대폭 할인된 토큰 가격을 제공하는 대신, 사용자의 프롬프트와 생성 결과를 향후 Meta 모델 학습에 사용할 수 있도록 허용해야 합니다. [자세히 알아보기](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: 대폭 할인된 토큰 가격을 제공하는 대신, 사용자의 프롬프트와 생성 결과를 향후 Meta 모델 학습에 사용할 수 있도록 허용해야 합니다. [자세히 알아보기](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/nb/go.mdx
+++ b/packages/web/src/content/docs/nb/go.mdx
@@ -73,6 +73,7 @@ Den nåværende listen over modeller inkluderer:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([begrensede regioner](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([begrensede regioner](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -117,6 +118,7 @@ Tabellen nedenfor gir et estimert antall forespørsler basert på typiske bruksm
 | MiMo-V2.5-Pro                | 3,250                    | 8,150                | 16,300                 |
 | MiniMax M3                   | 3,200                    | 8,000                | 16,000                 |
 | MiniMax M2.7                 | 3,400                    | 8,500                | 17,000                 |
+| Muse Spark 1.3 Contributor   | 45,300                   | 113,300              | 226,600                |
 | Muse Spark 1.2 Contributor   | 45,300                   | 113,300              | 226,600                |
 | Qwen3.8 Max                  | 160                      | 400                  | 810                    |
 | Qwen3.8 Flash                | 5,400                    | 13,500               | 27,000                 |
@@ -143,6 +145,7 @@ Estimatene er basert på observerte forespørselsmønstre:
 - DeepSeek V4 Flash Vision Exp — 410 input, 71 300 bufret, 310 output-tokens per forespørsel
 - MiniMax M3 — 510 input, 56 000 bufret, 190 output-tokens per forespørsel
 - MiniMax M2.7 — 300 input, 55 000 bufret, 125 output-tokens per forespørsel
+- Muse Spark 1.3 Contributor — 620 input, 71 400 bufret, 300 output-tokens per forespørsel
 - Muse Spark 1.2 Contributor — 620 input, 71 400 bufret, 300 output-tokens per forespørsel
 - Qwen3.8 Max — 420 input, 66 000 bufret, 200 output-tokens per forespørsel
 - Qwen3.8 Flash — 600 input, 58 000 bufret, 200 output-tokens per forespørsel
@@ -175,6 +178,7 @@ Estimatene er også basert på følgende priser per 1M tokens og den månedlige 
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60  |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60  |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60  |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60  |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60  |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15  |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30  |
@@ -250,6 +254,7 @@ Du kan også få tilgang til Go-modeller gjennom følgende API-endepunkter.
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -298,6 +303,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Brukes ikke   | 0 dager         |
 | MiniMax M3                   | Brukes ikke   | 0 dager         |
 | MiniMax M2.7                 | Brukes ikke   | 0 dager         |
+| Muse Spark 1.3 Contributor   | Ja            | Ikke ZDR        |
 | Muse Spark 1.2 Contributor   | Ja            | Ikke ZDR        |
 | DeepSeek V4 Pro              | Brukes ikke   | 0 dager         |
 | DeepSeek V4 Flash            | Brukes ikke   | 0 dager         |
@@ -307,6 +313,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR deaktiverer viktige API-funksjoner som er avhengige av lagrede data, inkludert den tilstandsbaserte Responses API, Files and Collections og Batch API. [Les mer](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Logger for overvåking av misbruk genereres for all bruk av API-funksjoner og oppbevares i opptil 30 dager. [Les mer](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Kraftig rabatterte tokenpriser i bytte mot tillatelse til å bruke ledetekstene og fullføringene dine til å trene fremtidige Meta-modeller. Tilgjengeligheten er begrenset til regioner som er tillatt i henhold til [retningslinjene for geografisk bruk](https://ai.developer.meta.com/legal/geographic-use-policy) fra Meta. [Les mer](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Kraftig rabatterte tokenpriser i bytte mot tillatelse til å bruke ledetekstene og fullføringene dine til å trene fremtidige Meta-modeller. Tilgjengeligheten er begrenset til regioner som er tillatt i henhold til [retningslinjene for geografisk bruk](https://ai.developer.meta.com/legal/geographic-use-policy) fra Meta. [Les mer](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** ZDR-avtalen fornyes månedlig. Den gjeldende avtalen er gyldig til og med 31. august 2026.
 

--- a/packages/web/src/content/docs/nb/zen.mdx
+++ b/packages/web/src/content/docs/nb/zen.mdx
@@ -91,6 +91,7 @@ Du kan også få tilgang til modellene våre gjennom følgende API-endepunkter.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -122,6 +123,7 @@ Du kan også få tilgang til modellene våre gjennom følgende API-endepunkter.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 [modell-id](/docs/config/#models) i OpenCode-konfigurasjonen din
@@ -151,6 +153,7 @@ Vi støtter en pay-as-you-go-modell. Nedenfor er prisene **per 1M tokens**.
 | Ling 3.0 Flash Fin Free           | Free    | Free    | Free          | -               |
 | Nemotron 3 Ultra Free             | Free    | Free    | Free          | -               |
 | Nemotron 3.5 Lightning Free       | Free    | Free    | Free          | -               |
+| Muse Spark 1.3 Contributor Free   | Free    | Free    | Free          | -               |
 | Muse Spark 1.2 Contributor Free   | Free    | Free    | Free          | -               |
 | MiniMax M3                        | $0.30   | $1.20   | $0.06         | -               |
 | MiniMax M2.7                      | $0.30   | $1.20   | $0.06         | -               |
@@ -182,6 +185,7 @@ Vi støtter en pay-as-you-go-modell. Nedenfor er prisene **per 1M tokens**.
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00   | $15.00  | $0.30         | $3.75           |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60         | $7.50           |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10         | $1.25           |
+| Gemini 3.8 Flash                  | $1.50   | $7.50   | $0.15         | -               |
 | Gemini 3.7 Flash                  | $1.50   | $7.50   | $0.15         | -               |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15         | -               |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15         | -               |
@@ -238,6 +242,7 @@ Gratis-modellene:
 - Nemotron 3 Ultra Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 - Nemotron 3.5 Lightning Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 - Big Pickle er en stealth-modell som er gratis på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
+- Muse Spark 1.3 Contributor Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 - Muse Spark 1.2 Contributor Free er tilgjengelig på OpenCode i en begrenset periode. Teamet bruker denne tiden til å samle inn tilbakemeldinger og forbedre modellen.
 
 <a href={email}>Kontakt oss</a> hvis du har spørsmål.
@@ -299,6 +304,7 @@ Alle modellene våre hostes i US. Leverandørene våre følger en policy for zer
 - Nemotron 3.5 Lightning Free (gratis NVIDIA-endepunkter): Kun for prøvebruk — ikke send inn personopplysninger eller konfidensielle data. Bruken din logges av sikkerhetshensyn og for å forbedre NVIDIAs produkter og tjenester. Sesjonsdataene som logges for forbedringsformål, er ikke knyttet til identiteten din eller noen vedvarende identifikator. For mer informasjon om vår databehandlingspraksis, se vår [personvernerklæring](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Ved å samhandle med dette endepunktet samtykker du til at vi samler inn, registrerer og bruker slik informasjon, samt til [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: Forespørsler lagres i 30 dager i samsvar med [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Forespørsler lagres i 30 dager i samsvar med [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: Sterkt rabatterte tokenpriser mot tillatelse til å bruke ledetekstene og fullføringene dine til å trene fremtidige Meta-modeller. [Les mer](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Sterkt rabatterte tokenpriser mot tillatelse til å bruke ledetekstene og fullføringene dine til å trene fremtidige Meta-modeller. [Les mer](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/pl/go.mdx
+++ b/packages/web/src/content/docs/pl/go.mdx
@@ -67,6 +67,7 @@ Obecna lista modeli obejmuje:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([ograniczone regiony](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([ograniczone regiony](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -111,6 +112,7 @@ Poniższa tabela przedstawia szacunkową liczbę żądań na podstawie typowych 
 | MiMo-V2.5-Pro                | 3,250               | 8,150              | 16,300             |
 | MiniMax M3                   | 3,200               | 8,000              | 16,000             |
 | MiniMax M2.7                 | 3,400               | 8,500              | 17,000             |
+| Muse Spark 1.3 Contributor   | 45,300              | 113,300            | 226,600            |
 | Muse Spark 1.2 Contributor   | 45,300              | 113,300            | 226,600            |
 | Qwen3.8 Max                  | 160                 | 400                | 810                |
 | Qwen3.8 Flash                | 5,400               | 13,500             | 27,000             |
@@ -137,6 +139,7 @@ Szacunki te opierają się na zaobserwowanych wzorcach żądań:
 - DeepSeek V4 Flash Vision Exp — 410 tokenów wejściowych, 71 300 w pamięci podręcznej, 310 tokenów wyjściowych na żądanie
 - MiniMax M3 — 510 tokenów wejściowych, 56 000 w pamięci podręcznej, 190 tokenów wyjściowych na żądanie
 - MiniMax M2.7 — 300 tokenów wejściowych, 55 000 w pamięci podręcznej, 125 tokenów wyjściowych na żądanie
+- Muse Spark 1.3 Contributor — 620 tokenów wejściowych, 71 400 w pamięci podręcznej, 300 tokenów wyjściowych na żądanie
 - Muse Spark 1.2 Contributor — 620 tokenów wejściowych, 71 400 w pamięci podręcznej, 300 tokenów wyjściowych na żądanie
 - Qwen3.8 Max — 420 tokenów wejściowych, 66 000 w pamięci podręcznej, 200 tokenów wyjściowych na żądanie
 - Qwen3.8 Flash — 600 tokenów wejściowych, 58 000 w pamięci podręcznej, 200 tokenów wyjściowych na żądanie
@@ -169,6 +172,7 @@ Szacunki opierają się również na następujących cenach za 1M tokenów oraz 
 | MiniMax M3                              | $0.30   | $1.20   | $0.06          | -              | $60    |
 | MiniMax M2.7                            | $0.30   | $1.20   | $0.06          | $0.375         | $60    |
 | MiniMax M2.5                            | $0.30   | $1.20   | $0.06          | $0.375         | $60    |
+| Muse Spark 1.3 Contributor              | $0.10   | $0.20   | $0.002         | -              | $60    |
 | Muse Spark 1.2 Contributor              | $0.10   | $0.20   | $0.002         | -              | $60    |
 | Qwen3.8 Max                             | $2.00   | $6.00   | $0.25          | $2.50          | $15    |
 | Qwen3.8 Flash                           | $0.15   | $0.47   | $0.016         | $0.20          | $30    |
@@ -242,6 +246,7 @@ Możesz również uzyskać dostęp do modeli Go za pośrednictwem następującyc
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -290,6 +295,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Niewykorzystywane | 0 dni           |
 | MiniMax M3                   | Niewykorzystywane | 0 dni           |
 | MiniMax M2.7                 | Niewykorzystywane | 0 dni           |
+| Muse Spark 1.3 Contributor   | Tak               | Nie ZDR         |
 | Muse Spark 1.2 Contributor   | Tak               | Nie ZDR         |
 | DeepSeek V4 Pro              | Niewykorzystywane | 0 dni           |
 | DeepSeek V4 Flash            | Niewykorzystywane | 0 dni           |
@@ -299,6 +305,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR wyłącza ważne funkcje API zależne od przechowywanych danych, w tym stanowy Responses API, Files and Collections oraz Batch API. [Dowiedz się więcej](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Dzienniki monitorowania nadużyć są generowane dla każdego użycia funkcji API i przechowywane przez maksymalnie 30 dni. [Dowiedz się więcej](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Znacznie obniżone ceny tokenów w zamian za zgodę na wykorzystanie Twoich promptów i odpowiedzi do trenowania przyszłych modeli Meta. Dostępność jest ograniczona do regionów dozwolonych przez [Zasady korzystania w poszczególnych regionach geograficznych](https://ai.developer.meta.com/legal/geographic-use-policy) firmy Meta. [Dowiedz się więcej](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Znacznie obniżone ceny tokenów w zamian za zgodę na wykorzystanie Twoich promptów i odpowiedzi do trenowania przyszłych modeli Meta. Dostępność jest ograniczona do regionów dozwolonych przez [Zasady korzystania w poszczególnych regionach geograficznych](https://ai.developer.meta.com/legal/geographic-use-policy) firmy Meta. [Dowiedz się więcej](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** Umowa ZDR jest odnawiana co miesiąc. Obecna umowa obowiązuje do 31 sierpnia 2026 r.
 

--- a/packages/web/src/content/docs/pl/zen.mdx
+++ b/packages/web/src/content/docs/pl/zen.mdx
@@ -91,6 +91,7 @@ Możesz też uzyskać dostęp do naszych modeli przez poniższe endpointy API.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -122,6 +123,7 @@ Możesz też uzyskać dostęp do naszych modeli przez poniższe endpointy API.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 [ID modelu](/docs/config/#models) w Twojej konfiguracji OpenCode używa formatu
@@ -151,6 +153,7 @@ Obsługujemy model pay-as-you-go. Poniżej znajdują się ceny **za 1M tokenów*
 | Ling 3.0 Flash Fin Free           | Free    | Free    | Free           | -              |
 | Nemotron 3 Ultra Free             | Free    | Free    | Free           | -              |
 | Nemotron 3.5 Lightning Free       | Free    | Free    | Free           | -              |
+| Muse Spark 1.3 Contributor Free   | Free    | Free    | Free           | -              |
 | Muse Spark 1.2 Contributor Free   | Free    | Free    | Free           | -              |
 | MiniMax M3                        | $0.30   | $1.20   | $0.06          | -              |
 | MiniMax M2.7                      | $0.30   | $1.20   | $0.06          | -              |
@@ -182,6 +185,7 @@ Obsługujemy model pay-as-you-go. Poniżej znajdują się ceny **za 1M tokenów*
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00   | $15.00  | $0.30          | $3.75          |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60          | $7.50          |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10          | $1.25          |
+| Gemini 3.8 Flash                  | $1.50   | $7.50   | $0.15          | -              |
 | Gemini 3.7 Flash                  | $1.50   | $7.50   | $0.15          | -              |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15          | -              |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15          | -              |
@@ -238,6 +242,7 @@ Darmowe modele:
 - Nemotron 3 Ultra Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 - Nemotron 3.5 Lightning Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 - Big Pickle to stealth model, który jest darmowy w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
+- Muse Spark 1.3 Contributor Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 - Muse Spark 1.2 Contributor Free jest dostępny w OpenCode przez ograniczony czas. Zespół wykorzystuje ten czas do zbierania opinii i ulepszania modelu.
 
 <a href={email}>Skontaktuj się z nami</a>, jeśli masz pytania.
@@ -299,6 +304,7 @@ Wszystkie nasze modele są hostowane w US. Nasi dostawcy stosują politykę zero
 - Nemotron 3.5 Lightning Free (darmowe endpointy NVIDIA): Tylko do użytku próbnego — nie przesyłaj danych osobowych ani poufnych. Twoje korzystanie jest rejestrowane w celach bezpieczeństwa oraz w celu ulepszania produktów i usług NVIDIA. Rejestrowane dane sesji wykorzystywane do celów ulepszania nie są powiązane z Twoją tożsamością ani żadnym trwałym identyfikatorem. Aby uzyskać więcej informacji o naszych praktykach przetwarzania danych, zapoznaj się z naszą [Polityką prywatności](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Korzystając z tego endpointu, wyrażasz zgodę na gromadzenie, rejestrowanie i wykorzystywanie przez nas takich informacji oraz na [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: Żądania są przechowywane przez 30 dni zgodnie z [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Żądania są przechowywane przez 30 dni zgodnie z [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: Znacznie obniżone ceny tokenów w zamian za zgodę na wykorzystanie Twoich promptów i odpowiedzi do trenowania przyszłych modeli Meta. [Dowiedz się więcej](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Znacznie obniżone ceny tokenów w zamian za zgodę na wykorzystanie Twoich promptów i odpowiedzi do trenowania przyszłych modeli Meta. [Dowiedz się więcej](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/pt-br/go.mdx
+++ b/packages/web/src/content/docs/pt-br/go.mdx
@@ -73,6 +73,7 @@ A lista atual de modelos inclui:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([regiões limitadas](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([regiões limitadas](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -117,6 +118,7 @@ A tabela abaixo fornece uma contagem estimada de requisições com base nos padr
 | MiMo-V2.5-Pro                | 3,250                   | 8,150                  | 16,300              |
 | MiniMax M3                   | 3,200                   | 8,000                  | 16,000              |
 | MiniMax M2.7                 | 3,400                   | 8,500                  | 17,000              |
+| Muse Spark 1.3 Contributor   | 45,300                  | 113,300                | 226,600             |
 | Muse Spark 1.2 Contributor   | 45,300                  | 113,300                | 226,600             |
 | Qwen3.8 Max                  | 160                     | 400                    | 810                 |
 | Qwen3.8 Flash                | 5,400                   | 13,500                 | 27,000              |
@@ -143,6 +145,7 @@ As estimativas se baseiam nos padrões de requisições observados:
 - DeepSeek V4 Flash Vision Exp — 410 tokens de entrada, 71.300 em cache, 310 tokens de saída por requisição
 - MiniMax M3 — 510 tokens de entrada, 56.000 em cache, 190 tokens de saída por requisição
 - MiniMax M2.7 — 300 tokens de entrada, 55.000 em cache, 125 tokens de saída por requisição
+- Muse Spark 1.3 Contributor — 620 tokens de entrada, 71.400 em cache, 300 tokens de saída por requisição
 - Muse Spark 1.2 Contributor — 620 tokens de entrada, 71.400 em cache, 300 tokens de saída por requisição
 - Qwen3.8 Max — 420 tokens de entrada, 66.000 em cache, 200 tokens de saída por requisição
 - Qwen3.8 Flash — 600 tokens de entrada, 58.000 em cache, 200 tokens de saída por requisição
@@ -175,6 +178,7 @@ As estimativas também se baseiam nos seguintes preços por 1M tokens e no uso m
 | MiniMax M3                              | $0.30   | $1.20  | $0.06            | -                | $60 |
 | MiniMax M2.7                            | $0.30   | $1.20  | $0.06            | $0.375           | $60 |
 | MiniMax M2.5                            | $0.30   | $1.20  | $0.06            | $0.375           | $60 |
+| Muse Spark 1.3 Contributor              | $0.10   | $0.20  | $0.002           | -                | $60 |
 | Muse Spark 1.2 Contributor              | $0.10   | $0.20  | $0.002           | -                | $60 |
 | Qwen3.8 Max                             | $2.00   | $6.00  | $0.25            | $2.50            | $15 |
 | Qwen3.8 Flash                           | $0.15   | $0.47  | $0.016           | $0.20            | $30 |
@@ -250,6 +254,7 @@ Você também pode acessar os modelos do Go através dos seguintes endpoints de 
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -298,6 +303,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Não usado              | 0 dias            |
 | MiniMax M3                   | Não usado              | 0 dias            |
 | MiniMax M2.7                 | Não usado              | 0 dias            |
+| Muse Spark 1.3 Contributor   | Sim                    | Não é ZDR         |
 | Muse Spark 1.2 Contributor   | Sim                    | Não é ZDR         |
 | DeepSeek V4 Pro              | Não usado              | 0 dias            |
 | DeepSeek V4 Flash            | Não usado              | 0 dias            |
@@ -307,6 +313,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** O ZDR desativa recursos importantes da API que dependem de dados armazenados, incluindo a Responses API com estado, Files and Collections e a Batch API. [Saiba mais](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Logs de monitoramento de abuso são gerados para todo uso de recursos da API e retidos por até 30 dias. [Saiba mais](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Preços de tokens com grandes descontos em troca da permissão para usar seus prompts e respostas geradas para treinar futuros modelos da Meta. A disponibilidade é limitada às regiões permitidas pela [Política de Uso Geográfico](https://ai.developer.meta.com/legal/geographic-use-policy) da Meta. [Saiba mais](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Preços de tokens com grandes descontos em troca da permissão para usar seus prompts e respostas geradas para treinar futuros modelos da Meta. A disponibilidade é limitada às regiões permitidas pela [Política de Uso Geográfico](https://ai.developer.meta.com/legal/geographic-use-policy) da Meta. [Saiba mais](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** O acordo de ZDR é renovado mensalmente. O acordo atual é válido até 31 de agosto de 2026.
 

--- a/packages/web/src/content/docs/pt-br/zen.mdx
+++ b/packages/web/src/content/docs/pt-br/zen.mdx
@@ -82,6 +82,7 @@ Você também pode acessar nossos modelos pelos seguintes endpoints de API.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -113,6 +114,7 @@ Você também pode acessar nossos modelos pelos seguintes endpoints de API.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 O [model id](/docs/config/#models) na sua configuração do OpenCode usa o formato `opencode/<model-id>`. Por exemplo, para GPT 5.5, você usaria `opencode/gpt-5.5` na sua configuração.
@@ -140,6 +142,7 @@ Oferecemos um modelo pay-as-you-go. Abaixo estão os preços **por 1M tokens**.
 | Ling 3.0 Flash Fin Free           | Free    | Free    | Free             | -                |
 | Nemotron 3 Ultra Free             | Free    | Free    | Free             | -                |
 | Nemotron 3.5 Lightning Free       | Free    | Free    | Free             | -                |
+| Muse Spark 1.3 Contributor Free   | Free    | Free    | Free             | -                |
 | Muse Spark 1.2 Contributor Free   | Free    | Free    | Free             | -                |
 | MiniMax M3                        | $0.30   | $1.20   | $0.06            | -                |
 | MiniMax M2.7                      | $0.30   | $1.20   | $0.06            | -                |
@@ -171,6 +174,7 @@ Oferecemos um modelo pay-as-you-go. Abaixo estão os preços **por 1M tokens**.
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00   | $15.00  | $0.30            | $3.75            |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00   | $22.50  | $0.60            | $7.50            |
 | Claude Haiku 4.5                  | $1.00   | $5.00   | $0.10            | $1.25            |
+| Gemini 3.8 Flash                  | $1.50   | $7.50   | $0.15            | -                |
 | Gemini 3.7 Flash                  | $1.50   | $7.50   | $0.15            | -                |
 | Gemini 3.6 Flash                  | $1.50   | $7.50   | $0.15            | -                |
 | Gemini 3.5 Flash                  | $1.50   | $9.00   | $0.15            | -                |
@@ -227,6 +231,7 @@ Os modelos gratuitos:
 - Nemotron 3 Ultra Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 - Nemotron 3.5 Lightning Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 - Big Pickle é um modelo stealth que está gratuito no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
+- Muse Spark 1.3 Contributor Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 - Muse Spark 1.2 Contributor Free está disponível no OpenCode por tempo limitado. A equipe está usando esse período para coletar feedback e melhorar o modelo.
 
 <a href={email}>Entre em contato</a> se você tiver alguma dúvida.
@@ -285,6 +290,7 @@ Todos os nossos modelos são hospedados nos US. Nossos provedores seguem uma pol
 - Nemotron 3.5 Lightning Free (endpoints gratuitos da NVIDIA): Apenas para uso de avaliação — não envie dados pessoais ou confidenciais. Seu uso é registrado para fins de segurança e para melhorar os produtos e serviços da NVIDIA. Os dados de sessão registrados para fins de melhoria não estão vinculados à sua identidade nem a qualquer identificador persistente. Para mais informações sobre nossas práticas de processamento de dados, consulte nossa [Política de Privacidade](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Ao interagir com este endpoint, você consente com a nossa coleta, registro e uso dessas informações e com os [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: As solicitações são retidas por 30 dias de acordo com [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: As solicitações são retidas por 30 dias de acordo com [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: Preços de tokens com grandes descontos em troca da permissão para usar seus prompts e respostas para treinar futuros modelos da Meta. [Saiba mais](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Preços de tokens com grandes descontos em troca da permissão para usar seus prompts e respostas para treinar futuros modelos da Meta. [Saiba mais](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/ru/go.mdx
+++ b/packages/web/src/content/docs/ru/go.mdx
@@ -73,6 +73,7 @@ OpenCode Go работает так же, как и любой другой пр
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([доступно в отдельных регионах](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([доступно в отдельных регионах](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -117,6 +118,7 @@ OpenCode Go включает следующие лимиты:
 | MiMo-V2.5-Pro                | 3,250               | 8,150             | 16,300           |
 | MiniMax M3                   | 3,200               | 8,000             | 16,000           |
 | MiniMax M2.7                 | 3,400               | 8,500             | 17,000           |
+| Muse Spark 1.3 Contributor   | 45,300              | 113,300           | 226,600          |
 | Muse Spark 1.2 Contributor   | 45,300              | 113,300           | 226,600          |
 | Qwen3.8 Max                  | 160                 | 400               | 810              |
 | Qwen3.8 Flash                | 5,400               | 13,500            | 27,000           |
@@ -143,6 +145,7 @@ OpenCode Go включает следующие лимиты:
 - DeepSeek V4 Flash Vision Exp — 410 входных, 71,300 кешированных, 310 выходных токенов на запрос
 - MiniMax M3 — 510 входных, 56,000 кешированных, 190 выходных токенов на запрос
 - MiniMax M2.7 — 300 входных, 55,000 кешированных, 125 выходных токенов на запрос
+- Muse Spark 1.3 Contributor — 620 входных, 71,400 кешированных, 300 выходных токенов на запрос
 - Muse Spark 1.2 Contributor — 620 входных, 71,400 кешированных, 300 выходных токенов на запрос
 - Qwen3.8 Max — 420 входных, 66,000 кешированных, 200 выходных токенов на запрос
 - Qwen3.8 Flash — 600 входных, 58,000 кешированных, 200 выходных токенов на запрос
@@ -175,6 +178,7 @@ OpenCode Go включает следующие лимиты:
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60           |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60           |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60           |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60           |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60           |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15           |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30           |
@@ -250,6 +254,7 @@ OpenCode Go включает следующие лимиты:
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -298,6 +303,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Не используется  | 0 дней          |
 | MiniMax M3                   | Не используется  | 0 дней          |
 | MiniMax M2.7                 | Не используется  | 0 дней          |
+| Muse Spark 1.3 Contributor   | Да               | Не ZDR          |
 | Muse Spark 1.2 Contributor   | Да               | Не ZDR          |
 | DeepSeek V4 Pro              | Не используется  | 0 дней          |
 | DeepSeek V4 Flash            | Не используется  | 0 дней          |
@@ -307,6 +313,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR отключает важные функции API, зависящие от сохраненных данных, включая Responses API с сохранением состояния, Files and Collections и Batch API. [Подробнее](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Журналы мониторинга злоупотреблений создаются при любом использовании функций API и хранятся до 30 дней. [Подробнее](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** Значительно сниженная стоимость токенов в обмен на разрешение использовать ваши промпты и ответы для обучения будущих моделей Meta. Доступность ограничена регионами, разрешёнными [Политикой географического использования](https://ai.developer.meta.com/legal/geographic-use-policy) компании Meta. [Подробнее](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** Значительно сниженная стоимость токенов в обмен на разрешение использовать ваши промпты и ответы для обучения будущих моделей Meta. Доступность ограничена регионами, разрешёнными [Политикой географического использования](https://ai.developer.meta.com/legal/geographic-use-policy) компании Meta. [Подробнее](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** Соглашение ZDR продлевается ежемесячно. Текущее соглашение действует до 31 августа 2026 года.
 

--- a/packages/web/src/content/docs/ru/zen.mdx
+++ b/packages/web/src/content/docs/ru/zen.mdx
@@ -91,6 +91,7 @@ OpenCode Zen работает как любой другой провайдер 
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -122,6 +123,7 @@ OpenCode Zen работает как любой другой провайдер 
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 [идентификатор модели](/docs/config/#models) в вашей конфигурации OpenCode
@@ -151,6 +153,7 @@ https://opencode.ai/zen/v1/models
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -182,6 +185,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -238,6 +242,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3 Ultra Free доступна в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
 - Nemotron 3.5 Lightning Free доступна в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
 - Big Pickle — это скрытая модель, которая доступна бесплатно в OpenCode ограниченное время. Команда использует это время, чтобы собирать отзывы и улучшать модель.
+- Muse Spark 1.3 Contributor Free доступна в OpenCode в течение ограниченного времени. Команда использует этот период для сбора отзывов и улучшения модели.
 - Muse Spark 1.2 Contributor Free доступна в OpenCode в течение ограниченного времени. Команда использует этот период для сбора отзывов и улучшения модели.
 
 <a href={email}>Свяжитесь с нами</a>, если у вас есть вопросы.
@@ -299,6 +304,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3.5 Lightning Free (бесплатные эндпоинты NVIDIA): только для пробного использования — не отправляйте персональные или конфиденциальные данные. Использование логируется в целях безопасности и для улучшения продуктов и сервисов NVIDIA. Логируемые данные сессии, используемые в целях улучшения, не связаны с вашей личностью или каким-либо постоянным идентификатором. Подробнее о наших практиках обработки данных см. в нашей [Политике конфиденциальности](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). Взаимодействуя с этим эндпоинтом, вы соглашаетесь на сбор, запись и использование нами такой информации, а также с [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: запросы хранятся 30 дней в соответствии с [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: запросы хранятся 30 дней в соответствии с [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: значительно сниженная стоимость токенов в обмен на разрешение использовать ваши запросы и ответы для обучения будущих моделей Meta. [Подробнее](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: значительно сниженная стоимость токенов в обмен на разрешение использовать ваши запросы и ответы для обучения будущих моделей Meta. [Подробнее](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/th/go.mdx
+++ b/packages/web/src/content/docs/th/go.mdx
@@ -63,6 +63,7 @@ OpenCode Go ทำงานเหมือนกับผู้ให้บร�
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([เฉพาะบางภูมิภาค](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([เฉพาะบางภูมิภาค](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -107,6 +108,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | MiMo-V2.5-Pro                | 3,250                  | 8,150               | 16,300            |
 | MiniMax M3                   | 3,200                  | 8,000               | 16,000            |
 | MiniMax M2.7                 | 3,400                  | 8,500               | 17,000            |
+| Muse Spark 1.3 Contributor   | 45,300                 | 113,300             | 226,600           |
 | Muse Spark 1.2 Contributor   | 45,300                 | 113,300             | 226,600           |
 | Qwen3.8 Max                  | 160                    | 400                 | 810               |
 | Qwen3.8 Flash                | 5,400                  | 13,500              | 27,000            |
@@ -133,6 +135,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 - DeepSeek V4 Flash Vision Exp — 410 input, 71,300 cached, 310 output tokens ต่อ request
 - MiniMax M3 — 510 input, 56,000 cached, 190 output tokens ต่อ request
 - MiniMax M2.7 — 300 input, 55,000 cached, 125 output tokens ต่อ request
+- Muse Spark 1.3 Contributor — 620 input, 71,400 cached, 300 output tokens ต่อ request
 - Muse Spark 1.2 Contributor — 620 input, 71,400 cached, 300 output tokens ต่อ request
 - Qwen3.8 Max — 420 input, 66,000 cached, 200 output tokens ต่อ request
 - Qwen3.8 Flash — 600 input, 58,000 cached, 200 output tokens ต่อ request
@@ -165,6 +168,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60   |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60   |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60   |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60   |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15   |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30   |
@@ -238,6 +242,7 @@ OpenCode Go มีขีดจำกัดดังต่อไปนี้:
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -284,6 +289,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | ไม่นำไปใช้  | 0 วัน              |
 | MiniMax M3                   | ไม่นำไปใช้  | 0 วัน              |
 | MiniMax M2.7                 | ไม่นำไปใช้  | 0 วัน              |
+| Muse Spark 1.3 Contributor   | ใช่         | ไม่ใช่ ZDR         |
 | Muse Spark 1.2 Contributor   | ใช่         | ไม่ใช่ ZDR         |
 | DeepSeek V4 Pro              | ไม่นำไปใช้  | 0 วัน              |
 | DeepSeek V4 Flash            | ไม่นำไปใช้  | 0 วัน              |
@@ -293,6 +299,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR ปิดใช้งานฟีเจอร์ API สำคัญที่ต้องอาศัยข้อมูลที่จัดเก็บไว้ ซึ่งรวมถึง Responses API แบบมีสถานะ, Files and Collections และ Batch API [ดูข้อมูลเพิ่มเติม](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr)
 - **GPT 5.6 Luna:** ระบบจะสร้างบันทึกการตรวจสอบการใช้งานในทางที่ผิดสำหรับการใช้งานฟีเจอร์ API ทั้งหมด และเก็บรักษาไว้นานสูงสุด 30 วัน [ดูข้อมูลเพิ่มเติม](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring)
+- **Muse Spark 1.3 Contributor:** ราคาของ token ลดลงอย่างมาก โดยแลกกับการอนุญาตให้นำพรอมต์และผลลัพธ์ที่สร้างขึ้นของคุณไปใช้ฝึกโมเดล Meta ในอนาคต การให้บริการจำกัดเฉพาะภูมิภาคที่ได้รับอนุญาตตาม[นโยบายการใช้งานตามพื้นที่ทางภูมิศาสตร์](https://ai.developer.meta.com/legal/geographic-use-policy)ของ Meta [ดูข้อมูลเพิ่มเติม](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)
 - **Muse Spark 1.2 Contributor:** ราคาของ token ลดลงอย่างมาก โดยแลกกับการอนุญาตให้นำพรอมต์และผลลัพธ์ที่สร้างขึ้นของคุณไปใช้ฝึกโมเดล Meta ในอนาคต การให้บริการจำกัดเฉพาะภูมิภาคที่ได้รับอนุญาตตาม[นโยบายการใช้งานตามพื้นที่ทางภูมิศาสตร์](https://ai.developer.meta.com/legal/geographic-use-policy)ของ Meta [ดูข้อมูลเพิ่มเติม](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)
 - **DeepSeek V4 Flash:** ข้อตกลง ZDR จะต่ออายุทุกเดือน ข้อตกลงปัจจุบันมีผลใช้ถึงวันที่ 31 สิงหาคม 2026
 

--- a/packages/web/src/content/docs/th/zen.mdx
+++ b/packages/web/src/content/docs/th/zen.mdx
@@ -84,6 +84,7 @@ OpenCode Zen ทำงานเหมือน provider อื่น ๆ ใน 
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -115,6 +116,7 @@ OpenCode Zen ทำงานเหมือน provider อื่น ๆ ใน 
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 [model id](/docs/config/#models) ใน OpenCode config ของคุณใช้รูปแบบ `opencode/<model-id>` ตัวอย่างเช่น สำหรับ GPT 5.5 คุณจะใช้ `opencode/gpt-5.5` ใน config ของคุณ
@@ -142,6 +144,7 @@ https://opencode.ai/zen/v1/models
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -173,6 +176,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -229,6 +233,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3 Ultra Free เปิดให้ใช้บน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
 - Nemotron 3.5 Lightning Free เปิดให้ใช้บน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
 - Big Pickle เป็น stealth model ที่ใช้งานฟรีบน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อเก็บ feedback และปรับปรุงโมเดล
+- Muse Spark 1.3 Contributor Free เปิดให้ใช้งานบน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อรวบรวมความคิดเห็นและปรับปรุงโมเดล
 - Muse Spark 1.2 Contributor Free เปิดให้ใช้งานบน OpenCode ในช่วงเวลาจำกัด ทีมกำลังใช้ช่วงเวลานี้เพื่อรวบรวมความคิดเห็นและปรับปรุงโมเดล
 
 <a href={email}>ติดต่อเรา</a> หากคุณมีคำถาม
@@ -287,6 +292,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3.5 Lightning Free (endpoint ฟรีของ NVIDIA): ใช้สำหรับการทดลองเท่านั้น — โปรดอย่าส่งข้อมูลส่วนบุคคลหรือข้อมูลลับ การใช้งานของคุณจะถูกบันทึกเพื่อวัตถุประสงค์ด้านความปลอดภัยและเพื่อปรับปรุงผลิตภัณฑ์และบริการของ NVIDIA ข้อมูลเซสชันที่บันทึกไว้เพื่อวัตถุประสงค์ในการปรับปรุงจะไม่เชื่อมโยงกับตัวตนของคุณหรือตัวระบุถาวรใด ๆ สำหรับข้อมูลเพิ่มเติมเกี่ยวกับแนวปฏิบัติในการประมวลผลข้อมูลของเรา โปรดดู [นโยบายความเป็นส่วนตัว](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf) ของเรา การโต้ตอบกับ endpoint นี้ถือว่าคุณยินยอมให้เราเก็บรวบรวม บันทึก และใช้ข้อมูลดังกล่าว รวมถึง [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf)
 - OpenAI APIs: คำขอจะถูกเก็บไว้เป็นเวลา 30 วันตาม [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: คำขอจะถูกเก็บไว้เป็นเวลา 30 วันตาม [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: ราคาของ token ที่ลดลงอย่างมาก แลกกับการอนุญาตให้นำ prompts และ completions ของคุณไปใช้ฝึกโมเดลของ Meta ในอนาคต [ดูข้อมูลเพิ่มเติม](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: ราคาของ token ที่ลดลงอย่างมาก แลกกับการอนุญาตให้นำ prompts และ completions ของคุณไปใช้ฝึกโมเดลของ Meta ในอนาคต [ดูข้อมูลเพิ่มเติม](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/tr/go.mdx
+++ b/packages/web/src/content/docs/tr/go.mdx
@@ -63,6 +63,7 @@ Mevcut model listesi şunları içerir:
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([sınırlı bölgeler](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([sınırlı bölgeler](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -107,6 +108,7 @@ Aşağıdaki tablo, tipik Go kullanım modellerine dayalı tahmini bir istek say
 | MiMo-V2.5-Pro                | 3,250              | 8,150          | 16,300      |
 | MiniMax M3                   | 3,200              | 8,000          | 16,000      |
 | MiniMax M2.7                 | 3,400              | 8,500          | 17,000      |
+| Muse Spark 1.3 Contributor   | 45,300             | 113,300        | 226,600     |
 | Muse Spark 1.2 Contributor   | 45,300             | 113,300        | 226,600     |
 | Qwen3.8 Max                  | 160                | 400            | 810         |
 | Qwen3.8 Flash                | 5,400              | 13,500         | 27,000      |
@@ -133,6 +135,7 @@ Tahminler, gözlemlenen istek modellerine dayanır:
 - DeepSeek V4 Flash Vision Exp — İstek başına 410 girdi, 71.300 önbelleğe alınmış, 310 çıktı token'ı
 - MiniMax M3 — İstek başına 510 girdi, 56.000 önbelleğe alınmış, 190 çıktı token'ı
 - MiniMax M2.7 — İstek başına 300 girdi, 55.000 önbelleğe alınmış, 125 çıktı token'ı
+- Muse Spark 1.3 Contributor — İstek başına 620 girdi, 71.400 önbelleğe alınmış, 300 çıktı token'ı
 - Muse Spark 1.2 Contributor — İstek başına 620 girdi, 71.400 önbelleğe alınmış, 300 çıktı token'ı
 - Qwen3.8 Max — İstek başına 420 girdi, 66.000 önbelleğe alınmış, 200 çıktı token'ı
 - Qwen3.8 Flash — İstek başına 600 girdi, 58.000 önbelleğe alınmış, 200 çıktı token'ı
@@ -165,6 +168,7 @@ Tahminler ayrıca 1M token başına aşağıdaki fiyatlara ve her modelle birlik
 | MiniMax M3                              | $0.30  | $1.20  | $0.06       | -            | $60      |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06       | $0.375       | $60      |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06       | $0.375       | $60      |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60      |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002      | -            | $60      |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25       | $2.50        | $15      |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016      | $0.20        | $30      |
@@ -238,6 +242,7 @@ Go modellerine aşağıdaki API uç noktaları aracılığıyla da erişebilirsi
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -284,6 +289,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | Kullanılmaz   | 0 gün        |
 | MiniMax M3                   | Kullanılmaz   | 0 gün        |
 | MiniMax M2.7                 | Kullanılmaz   | 0 gün        |
+| Muse Spark 1.3 Contributor   | Evet          | ZDR değil    |
 | Muse Spark 1.2 Contributor   | Evet          | ZDR değil    |
 | DeepSeek V4 Pro              | Kullanılmaz   | 0 gün        |
 | DeepSeek V4 Flash            | Kullanılmaz   | 0 gün        |
@@ -293,6 +299,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR, durum bilgisi tutan Responses API, Files and Collections ve Batch API dahil olmak üzere saklanan verilere bağlı önemli API özelliklerini devre dışı bırakır. [Daha fazla bilgi](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr).
 - **GPT 5.6 Luna:** Tüm API özelliklerinin kullanımı için kötüye kullanım izleme günlükleri oluşturulur ve 30 güne kadar saklanır. [Daha fazla bilgi](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring).
+- **Muse Spark 1.3 Contributor:** İstemlerinizi ve tamamlamalarınızı gelecekteki Meta modellerini eğitmek için kullanma izni karşılığında büyük ölçüde indirimli token fiyatları. Kullanılabilirlik, Meta'nın [Coğrafi Kullanım Politikası](https://ai.developer.meta.com/legal/geographic-use-policy) kapsamında izin verilen bölgelerle sınırlıdır. [Daha fazla bilgi](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **Muse Spark 1.2 Contributor:** İstemlerinizi ve tamamlamalarınızı gelecekteki Meta modellerini eğitmek için kullanma izni karşılığında büyük ölçüde indirimli token fiyatları. Kullanılabilirlik, Meta'nın [Coğrafi Kullanım Politikası](https://ai.developer.meta.com/legal/geographic-use-policy) kapsamında izin verilen bölgelerle sınırlıdır. [Daha fazla bilgi](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - **DeepSeek V4 Flash:** ZDR anlaşması aylık olarak yenilenir. Mevcut anlaşma 31 Ağustos 2026 tarihine kadar geçerlidir.
 

--- a/packages/web/src/content/docs/tr/zen.mdx
+++ b/packages/web/src/content/docs/tr/zen.mdx
@@ -82,6 +82,7 @@ Modellerimize aşağıdaki API uç noktaları aracılığıyla da erişebilirsin
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -113,6 +114,7 @@ Modellerimize aşağıdaki API uç noktaları aracılığıyla da erişebilirsin
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 OpenCode yapılandırmanızdaki [model id](/docs/config/#models) `opencode/<model-id>` biçimini kullanır. Örneğin, GPT 5.5 için yapılandırmanızda `opencode/gpt-5.5` kullanırsınız.
@@ -140,6 +142,7 @@ Kullandıkça öde modelini destekliyoruz. Aşağıda **1M token başına** fiya
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -171,6 +174,7 @@ Kullandıkça öde modelini destekliyoruz. Aşağıda **1M token başına** fiya
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -227,6 +231,7 @@ Kredi kartı ücretleri maliyet üzerinden yansıtılır (%4.4 + işlem başına
 - Nemotron 3 Ultra Free, sınırlı bir süre için OpenCode'da ücretsizdir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 - Nemotron 3.5 Lightning Free, sınırlı bir süre için OpenCode'da ücretsizdir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 - Big Pickle, sınırlı bir süre için OpenCode'da ücretsiz olan gizli bir modeldir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
+- Muse Spark 1.3 Contributor Free, sınırlı bir süre için OpenCode'da kullanılabilir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 - Muse Spark 1.2 Contributor Free, sınırlı bir süre için OpenCode'da kullanılabilir. Ekip bu süreyi geri bildirim toplamak ve modeli iyileştirmek için kullanıyor.
 
 Sorularınız varsa <a href={email}>bizimle iletişime geçin</a>.
@@ -285,6 +290,7 @@ Tüm modellerimiz US'de barındırılıyor. Sağlayıcılarımız zero-retention
 - Nemotron 3.5 Lightning Free (ücretsiz NVIDIA uç noktaları): Yalnızca deneme amaçlıdır — kişisel veya gizli veri göndermeyin. Kullanımınız güvenlik amacıyla ve NVIDIA ürünlerini ve hizmetlerini geliştirmek için kaydedilir. Geliştirme amacıyla kaydedilen oturum verileri kimliğinizle veya herhangi bir kalıcı tanımlayıcıyla ilişkilendirilmez. Veri işleme uygulamalarımız hakkında daha fazla bilgi için [Gizlilik Politikamıza](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf) bakın. Bu uç noktayla etkileşime geçerek, bu tür bilgileri toplamamıza, kaydetmemize ve kullanmamıza ve [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf) koşullarına onay vermiş olursunuz.
 - OpenAI APIs: İstekler [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) uyarınca 30 gün boyunca saklanır.
 - Anthropic APIs: İstekler [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) uyarınca 30 gün boyunca saklanır.
+- Muse Spark 1.3 Contributor Free: Gelecekteki Meta modellerini eğitmek için istemlerinizi ve tamamlamalarınızı kullanma izni karşılığında büyük ölçüde indirimli token fiyatlandırması. [Daha fazla bilgi](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Gelecekteki Meta modellerini eğitmek için istemlerinizi ve tamamlamalarınızı kullanma izni karşılığında büyük ölçüde indirimli token fiyatlandırması. [Daha fazla bilgi](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/zen.mdx
+++ b/packages/web/src/content/docs/zen.mdx
@@ -91,6 +91,7 @@ You can also access our models through the following API endpoints.
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -122,6 +123,7 @@ You can also access our models through the following API endpoints.
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 The [model id](/docs/config/#models) in your OpenCode config
@@ -151,6 +153,7 @@ We support a pay-as-you-go model. Below are the prices **per 1M tokens**.
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free        | -            |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free        | -            |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free        | -            |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free        | -            |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free        | -            |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06       | -            |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06       | -            |
@@ -182,6 +185,7 @@ We support a pay-as-you-go model. Below are the prices **per 1M tokens**.
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30       | $3.75        |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60       | $7.50        |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10       | $1.25        |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15       | -            |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15       | -            |
@@ -238,6 +242,7 @@ The free models:
 - Nemotron 3 Ultra Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Nemotron 3.5 Lightning Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Big Pickle is a stealth model that's free on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
+- Muse Spark 1.3 Contributor Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 - Muse Spark 1.2 Contributor Free is available on OpenCode for a limited time. The team is using this time to collect feedback and improve the model.
 
 <a href={email}>Contact us</a> if you have any questions.
@@ -299,6 +304,7 @@ All our models are hosted in the US. Our providers follow a zero-retention polic
 - Nemotron 3.5 Lightning Free (NVIDIA free endpoints): Trial use only — do not submit personal or confidential data. Your use is logged for security purposes and to improve NVIDIA products and services. The logged session data for improvement purposes is not linked to your identity or any persistent identifier. For more information about our data processing practices, see our [Privacy Policy](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf). By interacting with this endpoint, you consent to our collection, recording, and use of such information and the [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf).
 - OpenAI APIs: Requests are retained for 30 days in accordance with [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data).
 - Anthropic APIs: Requests are retained for 30 days in accordance with [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage).
+- Muse Spark 1.3 Contributor Free: Heavily discounted token pricing in exchange for permission to use your prompts and completions to train future Meta models. [Learn more](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 - Muse Spark 1.2 Contributor Free: Heavily discounted token pricing in exchange for permission to use your prompts and completions to train future Meta models. [Learn more](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier).
 
 ---

--- a/packages/web/src/content/docs/zh-cn/go.mdx
+++ b/packages/web/src/content/docs/zh-cn/go.mdx
@@ -63,6 +63,7 @@ OpenCode Go 的工作方式与 OpenCode 中的其他提供商一样。
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([仅限部分地区](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([仅限部分地区](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -107,6 +108,7 @@ OpenCode Go 包含以下限制：
 | MiMo-V2.5-Pro                | 3,250           | 8,150      | 16,300     |
 | MiniMax M3                   | 3,200           | 8,000      | 16,000     |
 | MiniMax M2.7                 | 3,400           | 8,500      | 17,000     |
+| Muse Spark 1.3 Contributor   | 45,300          | 113,300    | 226,600    |
 | Muse Spark 1.2 Contributor   | 45,300          | 113,300    | 226,600    |
 | Qwen3.8 Max                  | 160             | 400        | 810        |
 | Qwen3.8 Flash                | 5,400           | 13,500     | 27,000     |
@@ -135,6 +137,7 @@ OpenCode Go 包含以下限制：
 - MiMo-V2.5-Pro — 每次请求 790 个输入 token，86,000 个缓存 token，305 个输出 token
 - MiniMax M3 — 每次请求 510 个输入 token，56,000 个缓存 token，190 个输出 token
 - MiniMax M2.7 — 每次请求 300 个输入 token，55,000 个缓存 token，125 个输出 token
+- Muse Spark 1.3 Contributor — 每次请求 620 个输入 token，71,400 个缓存 token，300 个输出 token
 - Muse Spark 1.2 Contributor — 每次请求 620 个输入 token，71,400 个缓存 token，300 个输出 token
 - Qwen3.8 Max — 每次请求 420 个输入 token，66,000 个缓存 token，200 个输出 token
 - Qwen3.8 Flash — 每次请求 600 个输入 token，58,000 个缓存 token，200 个输出 token
@@ -165,6 +168,7 @@ OpenCode Go 包含以下限制：
 | MiniMax M3                              | $0.30  | $1.20  | $0.06     | -        | $60      |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06     | $0.375   | $60      |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06     | $0.375   | $60      |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002    | -        | $60      |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002    | -        | $60      |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25     | $2.50    | $15      |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016    | $0.20    | $30      |
@@ -238,6 +242,7 @@ OpenCode Go 包含以下限制：
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -284,6 +289,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | 不使用   | 0 天     |
 | MiniMax M3                   | 不使用   | 0 天     |
 | MiniMax M2.7                 | 不使用   | 0 天     |
+| Muse Spark 1.3 Contributor   | 是       | 非 ZDR   |
 | Muse Spark 1.2 Contributor   | 是       | 非 ZDR   |
 | DeepSeek V4 Pro              | 不使用   | 0 天     |
 | DeepSeek V4 Flash            | 不使用   | 0 天     |
@@ -293,6 +299,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR 会禁用依赖所存储数据的重要 API 功能，包括有状态的 Responses API、Files and Collections 和 Batch API。[了解更多](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr)。
 - **GPT 5.6 Luna:** 所有 API 功能的使用都会生成滥用监控日志，并最多保留 30 天。[了解更多](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring)。
+- **Muse Spark 1.3 Contributor:** 以允许使用你的提示词和补全结果训练未来的 Meta 模型为交换，token 价格可获得大幅折扣。仅在 Meta 的[地理使用政策](https://ai.developer.meta.com/legal/geographic-use-policy)允许的地区提供。[了解更多](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - **Muse Spark 1.2 Contributor:** 以允许使用你的提示词和补全结果训练未来的 Meta 模型为交换，token 价格可获得大幅折扣。仅在 Meta 的[地理使用政策](https://ai.developer.meta.com/legal/geographic-use-policy)允许的地区提供。[了解更多](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - **DeepSeek V4 Flash:** ZDR 协议每月续签。当前协议有效期至 2026 年 8 月 31 日。
 

--- a/packages/web/src/content/docs/zh-cn/zen.mdx
+++ b/packages/web/src/content/docs/zh-cn/zen.mdx
@@ -82,6 +82,7 @@ OpenCode Zen 的工作方式与 OpenCode 中的任何其他提供商相同。
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -113,6 +114,7 @@ OpenCode Zen 的工作方式与 OpenCode 中的任何其他提供商相同。
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 在你的 OpenCode 配置中，[模型 ID](/docs/config/#models) 使用 `opencode/<model-id>` 格式。例如，对于 GPT 5.5，你需要在配置中使用 `opencode/gpt-5.5`。
@@ -140,6 +142,7 @@ https://opencode.ai/zen/v1/models
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free     | -        |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free     | -        |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free     | -        |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free     | -        |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free     | -        |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06    | -        |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06    | -        |
@@ -171,6 +174,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30    | $3.75    |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60    | $7.50    |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10    | $1.25    |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15    | -        |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15    | -        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15    | -        |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15    | -        |
@@ -227,6 +231,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3 Ultra Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 - Nemotron 3.5 Lightning Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 - Big Pickle 是一个隐身模型，目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
+- Muse Spark 1.3 Contributor Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 - Muse Spark 1.2 Contributor Free 目前在 OpenCode 上限时免费提供。团队正在利用这段时间收集反馈并改进模型。
 
 如果你有任何问题，请<a href={email}>联系我们</a>。
@@ -285,6 +290,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3.5 Lightning Free（NVIDIA 免费端点）：仅供试用 — 请勿提交个人或机密数据。出于安全目的以及为改进 NVIDIA 产品和服务，系统会记录你的使用情况。出于改进目的而记录的会话数据不会与你的身份或任何持久标识符相关联。有关我们数据处理实践的更多信息，请参阅我们的[隐私政策](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf)。与此端点进行交互，即表示你同意我们收集、记录和使用此类信息，并同意 [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf)。
 - OpenAI APIs：请求会根据 [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) 保留 30 天。
 - Anthropic APIs：请求会根据 [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) 保留 30 天。
+- Muse Spark 1.3 Contributor Free：以允许使用你的提示词和补全内容训练未来的 Meta 模型为条件，享受大幅折扣的 token 价格。[了解更多](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - Muse Spark 1.2 Contributor Free：以允许使用你的提示词和补全内容训练未来的 Meta 模型为条件，享受大幅折扣的 token 价格。[了解更多](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 
 ---

--- a/packages/web/src/content/docs/zh-tw/go.mdx
+++ b/packages/web/src/content/docs/zh-tw/go.mdx
@@ -63,6 +63,7 @@ OpenCode Go 的運作方式與 OpenCode 中的任何其他供應商相同。
 - **MiMo-V2.5-Pro**
 - **MiniMax M3**
 - **MiniMax M2.7**
+- **Muse Spark 1.3 Contributor** ([僅限部分地區](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Muse Spark 1.2 Contributor** ([僅限部分地區](https://ai.developer.meta.com/legal/geographic-use-policy))
 - **Qwen3.8 Max**
 - **Qwen3.8 Flash**
@@ -107,6 +108,7 @@ OpenCode Go 包含以下限制：
 | MiMo-V2.5-Pro                | 3,250           | 8,150      | 16,300     |
 | MiniMax M3                   | 3,200           | 8,000      | 16,000     |
 | MiniMax M2.7                 | 3,400           | 8,500      | 17,000     |
+| Muse Spark 1.3 Contributor   | 45,300          | 113,300    | 226,600    |
 | Muse Spark 1.2 Contributor   | 45,300          | 113,300    | 226,600    |
 | Qwen3.8 Max                  | 160             | 400        | 810        |
 | Qwen3.8 Flash                | 5,400           | 13,500     | 27,000     |
@@ -133,6 +135,7 @@ OpenCode Go 包含以下限制：
 - DeepSeek V4 Flash Vision Exp — 每次請求 410 個輸入 token、71,300 個快取 token、310 個輸出 token
 - MiniMax M3 — 每次請求 510 個輸入 token、56,000 個快取 token、190 個輸出 token
 - MiniMax M2.7 — 每次請求 300 個輸入 token、55,000 個快取 token、125 個輸出 token
+- Muse Spark 1.3 Contributor — 每次請求 620 個輸入 token、71,400 個快取 token、300 個輸出 token
 - Muse Spark 1.2 Contributor — 每次請求 620 個輸入 token、71,400 個快取 token、300 個輸出 token
 - Qwen3.8 Max — 每次請求 420 個輸入 token、66,000 個快取 token、200 個輸出 token
 - Qwen3.8 Flash — 每次請求 600 個輸入 token、58,000 個快取 token、200 個輸出 token
@@ -165,6 +168,7 @@ OpenCode Go 包含以下限制：
 | MiniMax M3                              | $0.30  | $1.20  | $0.06     | -        | $60    |
 | MiniMax M2.7                            | $0.30  | $1.20  | $0.06     | $0.375   | $60    |
 | MiniMax M2.5                            | $0.30  | $1.20  | $0.06     | $0.375   | $60    |
+| Muse Spark 1.3 Contributor              | $0.10  | $0.20  | $0.002    | -        | $60    |
 | Muse Spark 1.2 Contributor              | $0.10  | $0.20  | $0.002    | -        | $60    |
 | Qwen3.8 Max                             | $2.00  | $6.00  | $0.25     | $2.50    | $15    |
 | Qwen3.8 Flash                           | $0.15  | $0.47  | $0.016    | $0.20    | $30    |
@@ -238,6 +242,7 @@ OpenCode Go 包含以下限制：
 | MiniMax M3                   | minimax-m3                   | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.7                 | minimax-m2.7                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | MiniMax M2.5                 | minimax-m2.5                 | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
+| Muse Spark 1.3 Contributor   | muse-spark-1.3-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor   | muse-spark-1.2-contributor   | `https://opencode.ai/zen/go/v1/responses`        | `@ai-sdk/openai`            |
 | Qwen3.8 Max                  | qwen3.8-max                  | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
 | Qwen3.8 Flash                | qwen3.8-flash                | `https://opencode.ai/zen/go/v1/messages`         | `@ai-sdk/anthropic`         |
@@ -284,6 +289,7 @@ https://opencode.ai/zen/go/v1/models
 | Qwen3.6 Plus                 | 不使用   | 0 天     |
 | MiniMax M3                   | 不使用   | 0 天     |
 | MiniMax M2.7                 | 不使用   | 0 天     |
+| Muse Spark 1.3 Contributor   | 是       | 非 ZDR   |
 | Muse Spark 1.2 Contributor   | 是       | 非 ZDR   |
 | DeepSeek V4 Pro              | 不使用   | 0 天     |
 | DeepSeek V4 Flash            | 不使用   | 0 天     |
@@ -293,6 +299,7 @@ https://opencode.ai/zen/go/v1/models
 
 - **Grok 4.6:** ZDR 會停用依賴儲存資料的重要 API 功能，包括具狀態的 Responses API、Files and Collections 與 Batch API。[了解更多](https://docs.x.ai/developers/faq/security#what-is-zero-data-retention-zdr)。
 - **GPT 5.6 Luna:** 所有 API 功能的使用都會產生濫用監控日誌，並保留最多 30 天。[了解更多](https://developers.openai.com/api/docs/guides/your-data#data-retention-controls-for-abuse-monitoring)。
+- **Muse Spark 1.3 Contributor:** 以允許使用您的提示詞和生成結果來訓練未來的 Meta 模型為交換，token 價格可享大幅折扣。僅在 Meta 的[地理使用政策](https://ai.developer.meta.com/legal/geographic-use-policy)允許的地區提供。[了解更多](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - **Muse Spark 1.2 Contributor:** 以允許使用您的提示詞和生成結果來訓練未來的 Meta 模型為交換，token 價格可享大幅折扣。僅在 Meta 的[地理使用政策](https://ai.developer.meta.com/legal/geographic-use-policy)允許的地區提供。[了解更多](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - **DeepSeek V4 Flash:** ZDR 協議每月續簽。目前的協議有效至 2026 年 8 月 31 日。
 

--- a/packages/web/src/content/docs/zh-tw/zen.mdx
+++ b/packages/web/src/content/docs/zh-tw/zen.mdx
@@ -86,6 +86,7 @@ OpenCode Zen 的運作方式和 OpenCode 中的其他供應商一樣。
 | Claude Sonnet 4.6               | claude-sonnet-4-6               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Sonnet 4.5               | claude-sonnet-4-5               | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
 | Claude Haiku 4.5                | claude-haiku-4-5                | `https://opencode.ai/zen/v1/messages`                     | `@ai-sdk/anthropic`         |
+| Gemini 3.8 Flash                | gemini-3.8-flash                | `https://opencode.ai/zen/v1/models/gemini-3.8-flash`      | `@ai-sdk/google`            |
 | Gemini 3.7 Flash                | gemini-3.7-flash                | `https://opencode.ai/zen/v1/models/gemini-3.7-flash`      | `@ai-sdk/google`            |
 | Gemini 3.6 Flash                | gemini-3.6-flash                | `https://opencode.ai/zen/v1/models/gemini-3.6-flash`      | `@ai-sdk/google`            |
 | Gemini 3.5 Flash                | gemini-3.5-flash                | `https://opencode.ai/zen/v1/models/gemini-3.5-flash`      | `@ai-sdk/google`            |
@@ -117,6 +118,7 @@ OpenCode Zen 的運作方式和 OpenCode 中的其他供應商一樣。
 | Ling 3.0 Flash Fin Free         | ling-3.0-flash-fin-free         | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3 Ultra Free           | nemotron-3-ultra-free           | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
 | Nemotron 3.5 Lightning Free     | nemotron-3.5-lightning-free     | `https://opencode.ai/zen/v1/chat/completions`             | `@ai-sdk/openai-compatible` |
+| Muse Spark 1.3 Contributor Free | muse-spark-1.3-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 | Muse Spark 1.2 Contributor Free | muse-spark-1.2-contributor-free | `https://opencode.ai/zen/v1/responses`                    | `@ai-sdk/openai`            |
 
 OpenCode 設定中的 [模型 ID](/docs/config/#models) 會使用 `opencode/<model-id>`
@@ -145,6 +147,7 @@ https://opencode.ai/zen/v1/models
 | Ling 3.0 Flash Fin Free           | Free   | Free    | Free     | -        |
 | Nemotron 3 Ultra Free             | Free   | Free    | Free     | -        |
 | Nemotron 3.5 Lightning Free       | Free   | Free    | Free     | -        |
+| Muse Spark 1.3 Contributor Free   | Free   | Free    | Free     | -        |
 | Muse Spark 1.2 Contributor Free   | Free   | Free    | Free     | -        |
 | MiniMax M3                        | $0.30  | $1.20   | $0.06    | -        |
 | MiniMax M2.7                      | $0.30  | $1.20   | $0.06    | -        |
@@ -176,6 +179,7 @@ https://opencode.ai/zen/v1/models
 | Claude Sonnet 4.5 (≤ 200K tokens) | $3.00  | $15.00  | $0.30    | $3.75    |
 | Claude Sonnet 4.5 (> 200K tokens) | $6.00  | $22.50  | $0.60    | $7.50    |
 | Claude Haiku 4.5                  | $1.00  | $5.00   | $0.10    | $1.25    |
+| Gemini 3.8 Flash                  | $1.50  | $7.50   | $0.15    | -        |
 | Gemini 3.7 Flash                  | $1.50  | $7.50   | $0.15    | -        |
 | Gemini 3.6 Flash                  | $1.50  | $7.50   | $0.15    | -        |
 | Gemini 3.5 Flash                  | $1.50  | $9.00   | $0.15    | -        |
@@ -232,6 +236,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3 Ultra Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
 - Nemotron 3.5 Lightning Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
 - Big Pickle 是一個隱身模型，在 OpenCode 上限時免費提供。團隊正在利用這段時間收集回饋並改進模型。
+- Muse Spark 1.3 Contributor Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
 - Muse Spark 1.2 Contributor Free 在 OpenCode 上限時提供。團隊正在利用這段時間收集回饋並改進模型。
 
 如果你有任何問題，請<a href={email}>聯絡我們</a>。
@@ -291,6 +296,7 @@ https://opencode.ai/zen/v1/models
 - Nemotron 3.5 Lightning Free（NVIDIA 免費端點）：僅供試用 — 請勿提交個人或機密資料。基於安全目的以及為了改進 NVIDIA 產品與服務，系統會記錄你的使用情況。基於改進目的而記錄的工作階段資料不會與你的身分或任何持久識別碼相關聯。有關我們資料處理實務的更多資訊，請參閱我們的[隱私政策](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf)。與此端點進行互動，即表示你同意我們收集、記錄與使用此類資訊，並同意 [NVIDIA API Trial Terms of Service](https://assets.ngc.nvidia.com/products/api-catalog/legal/NVIDIA%20API%20Trial%20Terms%20of%20Service.pdf)。
 - OpenAI APIs: 請求會依據 [OpenAI's Data Policies](https://platform.openai.com/docs/guides/your-data) 保留 30 天。
 - Anthropic APIs: 請求會依據 [Anthropic's Data Policies](https://docs.anthropic.com/en/docs/claude-code/data-usage) 保留 30 天。
+- Muse Spark 1.3 Contributor Free: 以大幅折扣的 Token 價格，換取你同意讓提示詞與補全內容用於訓練未來的 Meta 模型。[了解更多](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 - Muse Spark 1.2 Contributor Free: 以大幅折扣的 Token 價格，換取你同意讓提示詞與補全內容用於訓練未來的 Meta 模型。[了解更多](https://dev.meta.ai/docs/pricing-rate-limits#contributor-tier)。
 
 ---


### PR DESCRIPTION
Add Muse Spark 1.3 Contributor to Go and the free tier, and Gemini 3.8 Flash to Zen. Update the related pages and localized documentation.