### PR TITLE
fix(tui): remove link from background subagent completion notice

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -2110,14 +2110,9 @@ function SessionNoticeMessageV2(props: { message: SessionMessageInfo }) {
   const metadata = () => (props.message.type === "synthetic" ? props.message.metadata : undefined)
   const source = () => stringValue(metadata()?.source)
   const target = createMemo<BackgroundToolTarget | undefined>(() => {
-    if (source() === "shell") {
-      const id = stringValue(metadata()?.shellID) ?? stringValue(metadata()?.jobID)
-      return id ? { source: "shell", id } : undefined
-    }
-    if (source() === "subagent") {
-      const id = stringValue(metadata()?.childID)
-      return id ? { source: "subagent", id } : undefined
-    }
+    if (source() !== "shell") return
+    const id = stringValue(metadata()?.shellID) ?? stringValue(metadata()?.jobID)
+    return id ? { source: "shell", id } : undefined
   })
   const completion = () => source() === "subagent" || source() === "shell"
   const state = () => stringValue(metadata()?.state)

--- a/packages/tui/src/routes/session/rows.ts
+++ b/packages/tui/src/routes/session/rows.ts
@@ -35,7 +35,7 @@ export type SessionRow =
   | { type: "assistant-footer"; messageID: string }
   | { type: "turn-usage"; messageIDs: string[]; previousCache?: CacheUsage }
 
-export type BackgroundToolTarget = { source: "shell" | "subagent"; id: string }
+export type BackgroundToolTarget = { source: "shell"; id: string }
 
 export function createSessionRows(sessionID: Accessor<string>, onSynced?: (sessionID: string) => void) {
   const data = useData()
@@ -419,23 +419,15 @@ export function backgroundToolRowIndex(
   const end = rows.findIndex((row) => row.type === "message" && row.messageID === beforeMessageID)
   return rows.slice(0, end === -1 ? rows.length : end).findLastIndex((row) => {
     if (row.type !== "part") return false
-    if (target.source === "shell" && row.ref.partID === target.id) return true
+    if (row.ref.partID === target.id) return true
     const message = byID.get(row.ref.messageID)
     if (message?.type !== "assistant") return false
     const part = resolvePart(message, row.ref.partID)
-    if (target.source === "shell")
-      return (
-        part?.type === "tool" &&
-        part.name.toLowerCase() === "shell" &&
-        part.state.status !== "streaming" &&
-        part.state.metadata?.shellID === target.id
-      )
     return (
       part?.type === "tool" &&
-      part.name.toLowerCase() === "subagent" &&
-      part.state.status === "completed" &&
-      part.state.metadata?.status === "running" &&
-      part.state.metadata.sessionID === target.id
+      part.name.toLowerCase() === "shell" &&
+      part.state.status !== "streaming" &&
+      part.state.metadata?.shellID === target.id
     )
   })
 }

--- a/packages/tui/test/cli/tui/session-rows.test.ts
+++ b/packages/tui/test/cli/tui/session-rows.test.ts
@@ -314,8 +314,6 @@ test("finds background tool launch rows for completion navigation", () => {
 
   expect(backgroundToolRowIndex(rows, messages, { source: "shell", id: "shell-1" }, "completion-2")).toBe(0)
   expect(backgroundToolRowIndex(rows, messages, { source: "shell", id: "sh_first" }, "completion-2")).toBe(0)
-  expect(backgroundToolRowIndex(rows, messages, { source: "subagent", id: "child-1" }, "completion-1")).toBe(1)
-  expect(backgroundToolRowIndex(rows, messages, { source: "subagent", id: "child-1" }, "completion-2")).toBe(3)
 })
 
 test("groups exploration parts across assistant messages until a delimiter", () => {


### PR DESCRIPTION
## Summary

The background subagent "finished" notice in the TUI rendered as a link: hovering highlighted it and clicking jumped to the originating subagent tool row. This removes that link behavior so the notice is plain, non-interactive text.

- `SessionNoticeMessageV2` now only builds a click target for shell completions; subagent notices get no hover state, anchor id, or click handler
- Narrowed `BackgroundToolTarget` to shell and removed the dead subagent branch from `backgroundToolRowIndex`
- Dropped the subagent completion-navigation assertions from the session-rows test

Shell completion notices keep their jump-to-tool-row behavior, and the subagent tool row itself still opens the child session when clicked.

## Testing

- `bun typecheck` in `packages/tui`
- `bun test test/cli/tui/session-rows.test.ts` in `packages/tui`