### PR TITLE
test(core): route test watcher updates to matching watches

### DIFF
--- a/packages/core/src/filesystem/watcher.ts
+++ b/packages/core/src/filesystem/watcher.ts
@@ -5,6 +5,7 @@ import { createWrapper } from "@parcel/watcher/wrapper"
 import type ParcelWatcher from "@parcel/watcher"
 import { FileSystem } from "@opencode-ai/schema/filesystem"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
+import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Cause, Context, Effect, Layer, PubSub, RcMap, Schema, Stream } from "effect"
 import { lazy } from "../util/lazy.js"
 import { watch } from "node:fs"
@@ -70,7 +71,7 @@ export type Options = typeof Options.Type
 export class Service extends Context.Service<Service, Interface>()("@opencode/Watcher") {}
 
 export interface TestInterface extends Interface {
-  /** Broadcasts one update to every subscriber. */
+  /** Delivers one update to every active watch whose target covers `update.path`. */
   readonly emit: (update: Update) => Effect.Effect<void>
   /** Returns every subscribe call observed so far, in order. */
   readonly subscriptions: () => Effect.Effect<readonly WatchInput[]>
@@ -150,12 +151,14 @@ export const layer = (options?: Options) =>
 
 /**
  * Watcher for tests: the real lifecycle over an in-memory Native that records
- * acquired watches and broadcasts emitted updates to every active watch.
+ * acquired watches and routes emitted updates the way the OS watches would: a
+ * file watch receives updates for its own path, a directory watch receives
+ * updates for paths inside it that no ignore entry covers.
  */
 export const testLayer = Layer.effectContext(
   Effect.gen(function* () {
     const subscriptions: WatchInput[] = []
-    const active = new Set<(update: Update) => void>()
+    const active = new Map<(update: Update) => void, (path: string) => boolean>()
     const native = Native.of({
       subscribe: (input) =>
         Effect.sync(() => {
@@ -166,7 +169,17 @@ export const testLayer = Layer.effectContext(
                 ? { path: input.target, type: "directory", ignore: input.ignore }
                 : { path: input.target, type: "directory" },
           )
-          active.add(input.publish)
+          // Ignore entries resolve against the target like the parcel wrapper's
+          // literal paths. Glob entries resolve to paths nothing lives under, so
+          // they are inert here rather than compiled the way parcel compiles them.
+          const ignored = input.ignore.map((entry) => path.resolve(input.target, entry))
+          active.set(
+            input.publish,
+            input.type === "file"
+              ? (target) => target === input.target
+              : (target) =>
+                  FSUtil.contains(input.target, target) && !ignored.some((entry) => FSUtil.contains(entry, target)),
+          )
           return {
             unsubscribe: () => {
               active.delete(input.publish)
@@ -178,7 +191,13 @@ export const testLayer = Layer.effectContext(
     const context = yield* Layer.build(layer().pipe(Layer.provide(Layer.succeed(Native, native))))
     const test = Test.of({
       subscribe: Context.get(context, Service).subscribe,
-      emit: (update) => Effect.sync(() => active.forEach((publish) => publish(update))),
+      emit: (update) =>
+        Effect.sync(() => {
+          const target = path.resolve(update.path)
+          active.forEach((matches, publish) => {
+            if (matches(target)) publish(update)
+          })
+        }),
       subscriptions: () => Effect.sync(() => [...subscriptions]),
     })
     return Context.empty().pipe(Context.add(Service, test), Context.add(Test, test))


### PR DESCRIPTION
## Why
`packages/core/test/instruction-discovery.test.ts` › `ConfigInstructionPlugin.Plugin > loads global and upward project files and rescans them on change` flakes at roughly 1–3% on `v2` (4/120 locally with `--rerun-each 40`, also seen on CI), failing at the delete step with `expect(removed).toContain(... no longer apply.)` receiving `""`. The cause is `Watcher.testLayer`: its `emit` broadcast every update to every active watch regardless of path, while the native layer only delivers an update to the watch whose target covers it. The test holds six file watches (one per candidate `AGENTS.md`), so one `emit` pushed six copies of the path into `ConfigInstructionPlugin`'s `PubSub.sliding(1)`. The consumer handled one and the sliding buffer kept a stale duplicate whose rescan raced the test's next `fs.rm(packageFile)`: `fs.up` saw the file, the read came back empty, the source resolved to `Instructions.unavailable`, and the resulting `Updated` event was mistaken by the next `emitAndWait` for its own, so `load()` rendered `""`.

## What Changes
- `Watcher.testLayer.emit(update)` now routes instead of broadcasting: a `file` watch receives the update only when `path.resolve(update.path)` equals its target; a `directory` watch receives it when `FSUtil.contains(target, path)` and no `ignore` entry (resolved against the target, as the parcel wrapper does for literal entries) contains the path. Glob ignore entries resolve to paths nothing lives under and are inert; the comment in the layer says so rather than pulling a glob matcher into `core` for a test layer.
- `active` is now a `Map` from each watch's `publish` to its match predicate, built once at subscribe time; `unsubscribe` bookkeeping and `subscriptions()` are unchanged.
- Audited every `Watcher.Test` / `watcher.emit` user (`test/instruction-discovery.test.ts`, `test/config/config.test.ts`, `test/config/skill.test.ts`). Every emitted path already matches a real watch (file targets or paths under a watched directory), so no test needed adjusting; they pass unchanged under routing.

## Verification
From `packages/core` with Bun 1.4.0:
- `bun typecheck` — clean
- `bun run test test/instruction-discovery.test.ts --rerun-each 120` — 1200 pass, 0 fail
- `bun run test test/config/config.test.ts test/config/skill.test.ts test/filesystem` — 92 pass, 0 fail
- `bun run test` — 3986 pass, 40 skip, 0 fail (4026 tests, 224 files)
- `bunx prettier --write packages/core/src/filesystem/watcher.ts` — unchanged
