### PR TITLE
fix(core): discover project config once under symlinked paths

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -188,7 +188,15 @@ export const layer = (options?: Options) =>
         const globalDirectory = AbsolutePath.make(global.config)
         const globalAgentsDirectory = AbsolutePath.make(path.join(global.home, ".agents"))
         const globalClaudeDirectory = AbsolutePath.make(path.join(global.home, ".claude"))
-        const locationIsGlobal = path.resolve(location.directory) === path.resolve(global.config)
+        // Global roots and the walk are compared by canonical path: the same
+        // directory reached under two spellings (a symlinked checkout, macOS
+        // /var vs /private/var, OPENCODE_CONFIG_DIR inside the project) must
+        // classify identically or it enters discovery twice.
+        const globalRoots = yield* Effect.forEach(
+          [globalDirectory, globalClaudeDirectory, globalAgentsDirectory],
+          (item) => fs.resolve(item),
+        )
+        const locationIsGlobal = (yield* fs.resolve(location.directory)) === globalRoots[0]
         const discovered =
           locationIsGlobal || options?.project === false
             ? []
@@ -197,22 +205,30 @@ export const layer = (options?: Options) =>
                   targets: [".opencode", ".claude", ".agents", ...names.toReversed()],
                   start: location.directory,
                 })
-                .pipe(Effect.orDie)
+                .pipe(
+                  Effect.flatMap((items) =>
+                    Effect.forEach(items, (item) =>
+                      fs.resolve(item).pipe(Effect.map((resolved) => ({ item, resolved }))),
+                    ),
+                  ),
+                  Effect.orDie,
+                )
 
         const globalEnabled = options?.global !== false
         // A walked path that resolves into a global root is global config
         // however the walk reached it (home above the project, or a location
         // beneath the global config dir), so global: false excludes it
-        // uniformly — classified once here, not per consumer below.
-        const globalRoots = [globalDirectory, globalClaudeDirectory, globalAgentsDirectory].map((item) =>
-          path.resolve(item),
-        )
-        const visible = globalEnabled
-          ? discovered
-          : discovered.filter((item) => {
-              const resolved = path.resolve(item)
-              return !globalRoots.some((root) => resolved === root || resolved.startsWith(root + path.sep))
-            })
+        // uniformly — classified once here, not per consumer below. With
+        // global enabled, the roots themselves and the global config files are
+        // already loaded below, so the walk must not add them a second time.
+        const globalFiles = yield* Effect.forEach(names, (name) => fs.resolve(path.join(globalDirectory, name)))
+        const visible = discovered
+          .filter(({ resolved }) =>
+            globalEnabled
+              ? !globalRoots.includes(resolved) && !globalFiles.includes(resolved)
+              : !globalRoots.some((root) => resolved === root || resolved.startsWith(root + path.sep)),
+          )
+          .map(({ item }) => item)
         // We load certain files from a few other folders in the ecosystem
         const claude = [
           ...new Set([

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -149,6 +149,37 @@ describe("Config", () => {
     ),
   )
 
+  it.live("discovers the global config directory once when the project walk reaches it", () =>
+    Effect.acquireDisposable(Effect.promise(() => tmpdir())).pipe(
+      Effect.flatMap((tmp) => {
+        // The global config dir is the project's own .opencode (as isolated
+        // hosts pin OPENCODE_CONFIG_DIR), and the location is the project under
+        // a symlinked spelling, so the walk reaches the same directory under a
+        // different string than the global root.
+        const real = path.join(tmp.path, "real")
+        const link = path.join(tmp.path, "link")
+        const global = AbsolutePath.make(path.join(real, ".opencode"))
+        const once = Effect.gen(function* () {
+          const config = yield* Config.Service
+          const watcher = yield* Watcher.Test
+          const entries = yield* config.entries()
+          expect(entries.flatMap((entry) => (entry.type === "directory" ? [entry.path] : []))).toEqual([global])
+          expect(entries.flatMap((entry) => (entry.type === "document" ? [entry.info.shell] : []))).toEqual(["global"])
+          expect((yield* watcher.subscriptions()).map((subscription) => subscription.path)).toEqual([global])
+        })
+        return Effect.promise(async () => {
+          await fs.mkdir(global, { recursive: true })
+          await fs.writeFile(path.join(global, "opencode.json"), JSON.stringify({ shell: "global" }))
+          await fs.symlink(real, link, process.platform === "win32" ? "junction" : undefined)
+        }).pipe(
+          Effect.andThen(once.pipe(Effect.provide(testLayer(link, global, real)))),
+          // Same spelling on both sides: still exactly once.
+          Effect.andThen(once.pipe(Effect.provide(testLayer(real, global, real)))),
+        )
+      }),
+    ),
+  )
+
   it.live("loads explicit file and content overrides in priority order", () =>
     Effect.acquireDisposable(Effect.promise(() => tmpdir())).pipe(
       Effect.flatMap((tmp) => {


### PR DESCRIPTION
## Why

Booting a Location whose project directory sits under a symlinked path (every macOS temp dir, `/var/folders/... → /private/var/folders/...`, or any symlinked checkout) could register the project's `.opencode` twice, once under each spelling. One Location boot span in the server log:

```
watcher started path=/var/.../files/.opencode
watcher started path=/private/var/.../files/.opencode
loading plugin id=/var/.../files/.opencode/plugins/alpha/index.ts
loading plugin id=/private/var/.../files/.opencode/plugins/alpha/index.ts
failed to reload plugins cause=Die(Error: Duplicate plugin ID: alpha)      ← before #46718
```

Since #46718 the duplicate no longer kills activation, but the plugin is reported as `failed: Duplicate plugin ID` in the inventory and two directory watchers stay alive. The same happens for plugins configured with a relative path (`plugins: ["../some/dir"]`), because the project document is loaded twice under two spellings and each resolves the relative target differently.

**Root cause.** The symlinked project alone does not reproduce this: `fs.up` walks from `Location.directory` as given and yields one spelling. The duplicate appears when that upward walk reaches the **global config directory** — which is what isolated hosts do by pinning `OPENCODE_CONFIG_DIR` to `<project>/.opencode` (OpenCode Drive), and what happens when someone runs OpenCode inside a symlinked `~/.config/opencode`. `Config.discover` compared the walk against `global.config` with `path.resolve` string equality (`locationIsGlobal`, `globalRoots`), so a directory reached under a different spelling than `global.config` was classified as a project `.opencode` while `loadDirectory(globalDirectory)` loaded the same directory again as global config. Even with identical spellings the walk produced a second `Directory` entry for the same path; the supervisor happened to mask that by keying operations on target string, which is exactly what breaks once the spellings differ.

## What Changes

- `packages/core/src/config.ts` `discover`: canonicalize the global roots (`global.config`, `~/.claude`, `~/.agents`), the Location directory, and each walked path once with `fs.resolve` (realpath with a not-found fallback). `locationIsGlobal` and the global-root classification now compare canonical paths.
- With `global` enabled, walked paths whose canonical form *is* a global root or the global directory's own `opencode.json[c]` are dropped from the project lists, because the global handling below already loads them. `global: false` keeps its existing behavior (everything at or beneath a global root is excluded), now robust to spelling differences.
- Nothing else changes: walked entries keep the spelling they were reached under, and `project: false`, `file`, and `content` handling is untouched. No `realpath` is added to consumers.
- `packages/core/src/config/plugin/source.ts` needs no second dedupe: `scan` derives auto-discovered operations from `Directory` entries and configured operations from `Document` entries, and both are now unique for a given directory, so relative plugin targets resolve against one document path.

## Verification

From `packages/core`:

- New test `Config > discovers the global config directory once when the project walk reaches it` (`test/config/config.test.ts`): a real project dir with `.opencode/opencode.json`, a symlink to it, `Location.directory` set to the symlinked spelling and the global config dir set to the real `.opencode`. Asserts exactly one `Directory` entry, one document, and one watcher subscription, then repeats with matching spellings. Fails on `v2` (an extra `link/.opencode` directory and watcher), passes with this change.
- `bun typecheck` — clean.
- `bun run test test/config test/plugin.test.ts test/plugin test/filesystem test/location.test.ts test/location-layer.test.ts` — 441 pass, 0 fail.
- Full `bun run test` — 3986 pass, 40 skip, 1 fail (`pty > retains exited sessions until removed`, a 5s timeout under full-suite load; passes in isolation and is unrelated to config).
