### PR TITLE
fix(cli): bridge question forms over ACP

### DIFF
--- a/packages/cli/src/acp/event.ts
+++ b/packages/cli/src/acp/event.ts
@@ -8,6 +8,7 @@ import type {
 import { partsToContentChunks, type ReplayPart } from "./content"
 import { ACPError } from "./error"
 import { replyPermission, syncEditedFiles } from "./permission"
+import { replyQuestion } from "./question"
 import {
   completedToolUpdate,
   errorToolUpdate,
@@ -18,7 +19,7 @@ import {
 } from "./tool"
 
 type Connection = Pick<AgentSideConnection, "sessionUpdate" | "requestPermission"> &
-  Partial<Pick<AgentSideConnection, "writeTextFile">>
+  Partial<Pick<AgentSideConnection, "extMethod" | "writeTextFile">>
 
 export type TurnControl = {
   cancelled: boolean
@@ -77,6 +78,7 @@ export async function streamTurn(input: {
   readonly start: TurnStart
   readonly writeTextFile: boolean
   readonly action?: boolean
+  readonly elicitation?: boolean
   readonly submit: (signal: AbortSignal) => Promise<unknown>
   readonly control: TurnControl
   readonly childSessionUpdate?: (update: ChildSessionUpdate) => Promise<void>
@@ -165,6 +167,16 @@ export async function streamTurn(input: {
         continue
       }
       if (event.type === "form.created" && (event.data.form.sessionID === input.sessionID || child)) {
+        if (event.data.form.metadata?.kind === "question") {
+          await replyQuestion({
+            client: input.client,
+            connection: input.connection.extMethod ? input.connection : undefined,
+            event,
+            clientSessionID: input.sessionID,
+            supported: input.elicitation === true,
+          })
+          continue
+        }
         await input.client.form
           .cancel({ sessionID: event.data.form.sessionID, formID: event.data.form.id })
           .catch(() => input.client.session.interrupt({ sessionID: event.data.form.sessionID }).catch(() => {}))

--- a/packages/cli/src/acp/question.ts
+++ b/packages/cli/src/acp/question.ts
@@ -1,0 +1,92 @@
+import type { AgentSideConnection } from "@agentclientprotocol/sdk"
+import type { EventSubscribeOutput, OpenCodeClient } from "@opencode-ai/client/promise"
+
+type FormEvent = Extract<EventSubscribeOutput, { type: "form.created" }>
+type QuestionField = Extract<FormEvent["data"]["form"]["fields"][number], { type: "string" | "multiselect" }>
+type Connection = Partial<Pick<AgentSideConnection, "extMethod">>
+
+type ElicitationResponse = {
+  readonly action?: {
+    readonly action?: "accept" | "decline" | "cancel"
+    readonly content?: Readonly<Record<string, unknown>> | null
+  }
+}
+
+export async function replyQuestion(input: {
+  readonly client: OpenCodeClient
+  readonly connection: Connection | undefined
+  readonly event: FormEvent
+  readonly clientSessionID: string
+  readonly supported: boolean
+}) {
+  const form = input.event.data.form
+  const cancel = () =>
+    input.client.form.cancel({
+      sessionID: form.sessionID,
+      formID: form.id,
+    })
+  if (!input.supported || !input.connection?.extMethod) return cancel()
+  const fields = form.fields.filter(
+    (field): field is QuestionField => field.type === "string" || field.type === "multiselect",
+  )
+  if (fields.length !== form.fields.length) return cancel()
+
+  const properties = Object.fromEntries(
+    fields.map((field) => {
+      const options = (field.options ?? []).map((option) => ({
+        const: option.value,
+        title: option.label,
+        description: option.description,
+      }))
+      return [
+        field.key,
+        field.type === "multiselect"
+          ? {
+              type: "array",
+              title: field.title,
+              description: field.description,
+              items: { anyOf: options },
+            }
+          : {
+              type: "string",
+              title: field.title,
+              description: field.description,
+              ...(options.length > 0 ? { oneOf: options } : {}),
+            },
+      ]
+    }),
+  )
+  const response = (await input.connection
+    .extMethod("session/elicitation", {
+      mode: "form",
+      sessionId: input.clientSessionID,
+      message: form.fields[0]?.description ?? form.title,
+      requestedSchema: {
+        type: "object",
+        properties,
+        required: Object.keys(properties),
+        title: form.title,
+      },
+    })
+    .catch(() => undefined)) as ElicitationResponse | undefined
+  if (response?.action?.action !== "accept") return cancel()
+
+  const content = response.action.content ?? {}
+  const answer = Object.fromEntries(
+    fields.flatMap((field): ReadonlyArray<readonly [string, string | ReadonlyArray<string>]> => {
+      const value = content[field.key]
+      if (field.type === "multiselect" && Array.isArray(value)) {
+        return [[field.key, value.flatMap((entry) => (typeof entry === "string" && entry.trim() ? [entry.trim()] : []))]]
+      }
+      if (field.type === "string" && typeof value === "string" && value.trim()) {
+        return [[field.key, value.trim()]]
+      }
+      return []
+    }),
+  )
+  return input.client.form.reply({
+    sessionID: form.sessionID,
+    formID: form.id,
+    answer,
+  })
+}

--- a/packages/cli/src/acp/service.ts
+++ b/packages/cli/src/acp/service.ts
@@ -57,7 +57,7 @@ import { ACPError } from "./error"
 export const AuthMethodID = "opencode-login"
 
 type Connection = Pick<AgentSideConnection, "sessionUpdate" | "requestPermission"> &
-  Partial<Pick<AgentSideConnection, "writeTextFile" | "extNotification" | "signal">>
+  Partial<Pick<AgentSideConnection, "writeTextFile" | "extMethod" | "extNotification" | "signal">>
 
 type Catalog = {
   readonly providers: ConfigOptionProvider[]
@@ -109,7 +109,7 @@ export function make(input: { readonly client: OpenCodeClient; readonly connecti
   const catalogs = new Map<string, Promise<Catalog>>()
   const registeredMcp = new Map<string, Set<string>>()
   const active = new Map<string, TurnControl>()
-  const capabilities = { writeTextFile: false, childSessionUpdates: false }
+  const capabilities = { writeTextFile: false, childSessionUpdates: false, elicitation: false }
 
   const catalog = (cwd: string) => {
     const cached = catalogs.get(cwd)
@@ -179,6 +179,7 @@ export function make(input: { readonly client: OpenCodeClient; readonly connecti
     initialize: async (params) => {
       capabilities.writeTextFile = params.clientCapabilities?.fs?.writeTextFile === true
       capabilities.childSessionUpdates = params.clientCapabilities?._meta?.[ChildSessionUpdatesCapability] === true
+      capabilities.elicitation = params.clientCapabilities?._meta?.["opencode/elicitation"] === true
       const authMethod: AuthMethod = {
         description: "Run `opencode auth login` in the terminal",
         name: "Login with opencode",
@@ -327,6 +328,7 @@ export function make(input: { readonly client: OpenCodeClient; readonly connecti
         start: prepared.start,
         writeTextFile: capabilities.writeTextFile,
         action: prepared.command !== undefined,
+        elicitation: capabilities.elicitation,
         control,
         connectionSignal: input.connection.signal,
         sessionSignal: state.abort.signal,

--- a/packages/cli/test/acp/event-behavior.test.ts
+++ b/packages/cli/test/acp/event-behavior.test.ts
@@ -6,7 +6,8 @@ import { replayMessages, streamTurn, type ChildSessionUpdate, type TurnControl }
 import { createSseFixture, durableEvent, ephemeralEvent, withTimeout } from "./sse-fixture"
 
 type SessionUpdateParams = Parameters<AgentSideConnection["sessionUpdate"]>[0]
-type Connection = Pick<AgentSideConnection, "sessionUpdate" | "requestPermission">
+type Connection = Pick<AgentSideConnection, "sessionUpdate" | "requestPermission"> &
+  Partial<Pick<AgentSideConnection, "extMethod">>
 type Fixture = ReturnType<typeof createSseFixture>
 
 describe("acp event behavior", () => {
@@ -678,6 +679,73 @@ describe("acp event behavior", () => {
     }
   })
 
+  test("passes question forms through ACP elicitation", async () => {
+    const elicitations: Array<{ method: string; params: Record<string, unknown> }> = []
+    const fixture = createSseFixture({
+      onPrompt({ id, send }) {
+        send(durableEvent("session.inbox.delivered", { sessionID: "ses_question", inboxID: id }))
+        send(
+          ephemeralEvent("form.created", {
+            form: {
+              id: "frm_question",
+              sessionID: "ses_question",
+              title: "Questions",
+              metadata: { kind: "question" },
+              fields: [
+                {
+                  key: "q0",
+                  title: "Choice",
+                  description: "Choose one",
+                  type: "string",
+                  options: [
+                    { value: "Alpha", label: "Alpha" },
+                    { value: "Beta", label: "Beta" },
+                  ],
+                },
+              ],
+            },
+          }),
+        )
+      },
+      onFormReply({ sessionID, formID, send }) {
+        send(ephemeralEvent("form.replied", { sessionID, id: formID, answer: { q0: "Alpha" } }))
+        send(durableEvent("session.execution.succeeded", { sessionID }))
+      },
+    })
+    const connection = {
+      ...recordingConnection([]),
+      extMethod: async (method: string, params: Record<string, unknown>) => {
+        elicitations.push({ method, params })
+        return { action: { action: "accept", content: { q0: "Alpha" } } }
+      },
+    } satisfies Connection
+
+    try {
+      const response = await turn({
+        fixture,
+        connection,
+        sessionID: "ses_question",
+        inboxID: "input_question",
+        elicitation: true,
+      })
+
+      expect(response.stopReason).toBe("end_turn")
+      expect(elicitations).toMatchObject([
+        {
+          method: "session/elicitation",
+          params: { requestedSchema: { properties: { q0: { type: "string", title: "Choice" } } } },
+        },
+      ])
+      expect(fixture.requests).toContainEqual({
+        method: "POST",
+        path: "/api/session/ses_question/form/frm_question/reply",
+        body: { answer: { q0: "Alpha" } },
+      })
+    } finally {
+      await fixture.stop()
+    }
+  })
+
   test("cancels unsupported session forms so execution can continue", async () => {
     const fixture = createSseFixture({
       onPrompt({ id, send }) {
@@ -732,6 +800,7 @@ function turn(input: {
   readonly connection: Connection
   readonly sessionID: string
   readonly inboxID: string
+  readonly elicitation?: boolean
   readonly childSessionUpdate?: (update: ChildSessionUpdate) => Promise<void>
 }) {
   return streamTurn({
@@ -741,6 +810,7 @@ function turn(input: {
     cwd: "/workspace",
     start: { type: "input", id: input.inboxID },
     writeTextFile: false,
+    elicitation: input.elicitation,
     control: { cancelled: false, admission: new AbortController() },
     childSessionUpdate: input.childSessionUpdate,
     submit: (signal) =>

--- a/packages/cli/test/acp/question.test.ts
+++ b/packages/cli/test/acp/question.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test"
+import type { AgentSideConnection } from "@agentclientprotocol/sdk"
+import { OpenCode } from "@opencode-ai/client/promise"
+import { replyQuestion } from "../../src/acp/question"
+import { ephemeralEvent } from "./sse-fixture"
+
+describe("ACP question elicitation", () => {
+  test("replies with accepted single, multiple, and custom answers", async () => {
+    const bodies: unknown[] = []
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        bodies.push(await request.json())
+        return new Response(null, { status: 204 })
+      },
+    })
+    const requests: Array<{ method: string; params: Record<string, unknown> }> = []
+    const connection = {
+      extMethod: async (method, params) => {
+        requests.push({ method, params })
+        return {
+          action: {
+            action: "accept",
+            content: { q0: "CustomTests", q1: ["Hydra", "Load"] },
+          },
+        }
+      },
+    } satisfies Partial<Pick<AgentSideConnection, "extMethod">>
+
+    try {
+      await replyQuestion({
+        client: OpenCode.make({ baseUrl: server.url.toString() }),
+        connection,
+        event: questionEvent("que_1"),
+        clientSessionID: "ses_parent",
+        supported: true,
+      })
+
+      expect(requests).toHaveLength(1)
+      expect(requests[0]).toMatchObject({
+        method: "session/elicitation",
+        params: {
+          mode: "form",
+          sessionId: "ses_parent",
+          requestedSchema: {
+            required: ["q0", "q1"],
+            properties: {
+              q0: { type: "string", title: "Package" },
+              q1: { type: "array", title: "Suites" },
+            },
+          },
+        },
+      })
+      expect(bodies).toEqual([{ answer: { q0: "CustomTests", q1: ["Hydra", "Load"] } }])
+    } finally {
+      await server.stop(true)
+    }
+  })
+
+  test("rejects when elicitation is declined or unsupported", async () => {
+    const paths: string[] = []
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        paths.push(new URL(request.url).pathname)
+        return new Response(null, { status: 204 })
+      },
+    })
+    const client = OpenCode.make({ baseUrl: server.url.toString() })
+    const connection = {
+      extMethod: async () => ({ action: { action: "decline" } }),
+    } satisfies Partial<Pick<AgentSideConnection, "extMethod">>
+
+    try {
+      await replyQuestion({
+        client,
+        connection,
+        event: questionEvent("que_declined"),
+        clientSessionID: "ses_parent",
+        supported: true,
+      })
+      await replyQuestion({
+        client,
+        connection,
+        event: questionEvent("que_unsupported"),
+        clientSessionID: "ses_parent",
+        supported: false,
+      })
+
+      expect(paths).toEqual([
+        "/api/session/ses_question/form/frm_declined/cancel",
+        "/api/session/ses_question/form/frm_unsupported/cancel",
+      ])
+    } finally {
+      await server.stop(true)
+    }
+  })
+})
+
+function questionEvent(id: string) {
+  return ephemeralEvent("form.created", {
+    form: {
+      id: id.replace("que_", "frm_"),
+      sessionID: "ses_question",
+      title: "Questions",
+      metadata: { kind: "question" },
+      fields: [
+        {
+          key: "q0",
+          type: "string",
+          title: "Package",
+          description: "Which package?",
+          options: [{ value: "DefaultTests", label: "DefaultTests", description: "Use the default package" }],
+        },
+        {
+          key: "q1",
+          type: "multiselect",
+          title: "Suites",
+          description: "Which suites?",
+          options: [
+            { value: "Hydra", label: "Hydra", description: "Run Hydra" },
+            { value: "Load", label: "Load", description: "Run load tests" },
+          ],
+        },
+      ],
+    },
+  })
+}

--- a/packages/cli/test/acp/sse-fixture.ts
+++ b/packages/cli/test/acp/sse-fixture.ts
@@ -33,6 +33,12 @@ type FixtureOptions = {
     readonly formID: string
     readonly send: (event: unknown) => void
   }) => void | Promise<void>
+  readonly onFormReply?: (input: {
+    readonly sessionID: string
+    readonly formID: string
+    readonly body: unknown
+    readonly send: (event: unknown) => void
+  }) => void | Promise<void>
 }
 
 const ids = { next: 0 }
@@ -145,6 +151,17 @@ export function createSseFixture(options: FixtureOptions = {}) {
         await options.onFormCancel?.({
           sessionID: decodeURIComponent(form[1]),
           formID: decodeURIComponent(form[2]),
+          send,
+        })
+        return new Response(null, { status: 204 })
+      }
+
+      const formReply = /^\/api\/session\/([^/]+)\/form\/([^/]+)\/reply$/.exec(url.pathname)
+      if (formReply?.[1] && formReply[2]) {
+        await options.onFormReply?.({
+          sessionID: decodeURIComponent(formReply[1]),
+          formID: decodeURIComponent(formReply[2]),
+          body,
           send,
         })
         return new Response(null, { status: 204 })


### PR DESCRIPTION
## Summary

- advertise the private OpenCode ACP elicitation capability during initialization
- translate question-backed `form.created` events into `session/elicitation` requests
- map accepted single-select, multiselect, and custom answers back through the V2 form reply API
- cancel question forms when elicitation is unsupported or declined

## Root cause

The V2 question tool emits `form.created`, but the ACP bridge treated all forms as unsupported and cancelled them. ACP clients therefore saw the question tool fail with `The user dismissed this question` and never received an elicitation request.

## Testing

- `bun test test/acp/question.test.ts test/acp/event-behavior.test.ts`
- `bun typecheck` in `packages/cli`
- repository pre-push `bun turbo typecheck --concurrency=3` (33 packages)
- manual ACP subprocess: observed `session/elicitation`, accepted `q0: "Alpha"`, question tool completed, prompt returned `end_turn`