### PR TITLE
fix(client): add extensions to effect imports

### DIFF
--- a/packages/client/script/build.ts
+++ b/packages/client/script/build.ts
@@ -95,7 +95,7 @@ await Effect.runPromise(
       ),
       write(
         emitEffectImported(effectContract, {
-          module: "../../contract",
+          module: "../../contract.js",
           api: "ClientApi",
           shapeModule: "../api/api.js",
         }),

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -3,7 +3,7 @@ import { Effect, Stream, Schema } from "effect"
 import { Sse } from "effect/unstable/encoding"
 import { HttpClientError } from "effect/unstable/http"
 import { HttpApiClient } from "effect/unstable/httpapi"
-import { ClientApi } from "../../contract"
+import { ClientApi } from "../../contract.js"
 import type {
   HealthGetOutput,
   ServerGetOutput,

--- a/packages/client/src/effect/index.ts
+++ b/packages/client/src/effect/index.ts
@@ -3,7 +3,7 @@
 import type { Effect } from "effect"
 import type { OpenCode } from "./client.js"
 
-export * from "./generated/index"
+export * from "./generated/index.js"
 export { OpenCode } from "./client.js"
 export type {
   AgentApi,


### PR DESCRIPTION
### Issue for this PR

Closes #46847

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The published Effect client contains extensionless relative imports that Node ESM cannot resolve. This adds `.js` extensions to the public entrypoint and generated contract import, and updates the generator input so regeneration preserves the fix.

### How did you verify your code works?

Ran the client test suite, client typecheck, generated output check, package build, and repository pre-push typechecks.

### Screenshots / recordings

N/A, no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR