### PR TITLE
fix(edit): reject an edit whose strings differ only in line ending style

### DIFF
--- a/packages/core/src/tool/edit.ts
+++ b/packages/core/src/tool/edit.ts
@@ -162,6 +162,11 @@ const layer = Layer.effectDiscard(
                 const ending = detectLineEnding(source.text)
                 const oldString = convertToLineEnding(input.oldString, ending)
                 const newString = convertToLineEnding(input.newString, ending)
+                if (oldString === newString) {
+                  return yield* new ToolFailure({
+                    message: "No changes to apply: oldString and newString are identical.",
+                  })
+                }
                 const replacements = countOccurrences(source.text, oldString)
                 if (replacements === 0) {
                   return yield* new ToolFailure({

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -381,6 +381,41 @@ describe("EditTool", () => {
     ),
   )
 
+  it.live("rejects an edit whose strings differ only in line ending style", () =>
+    Effect.acquireUseRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => {
+        reset()
+        const target = path.join(tmp.path, "crlf.txt")
+        return Effect.promise(() => fs.writeFile(target, "before\r\nrest\r\n")).pipe(
+          Effect.andThen(
+            withTool(tmp.path, (registry) =>
+              executeTool(
+                registry,
+                call({ path: "crlf.txt", oldString: "before\r\nrest", newString: "before\nrest" }),
+              ),
+            ),
+          ),
+          Effect.andThen((result) =>
+            Effect.promise(() => fs.readFile(target, "utf8")).pipe(
+              Effect.tap((content) =>
+                Effect.sync(() => {
+                  expect(result).toEqual({
+                    type: "error",
+                    value: "No changes to apply: oldString and newString are identical.",
+                  })
+                  expect(content).toBe("before\r\nrest\r\n")
+                  expect(writes).toHaveLength(0)
+                }),
+              ),
+            ),
+          ),
+        )
+      },
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ),
+  )
+
   it.live("rejects an in-place content change after matching but before conditional commit", () =>
     Effect.acquireUseRelease(
       Effect.promise(() => tmpdir()),


### PR DESCRIPTION
### Issue for this PR

Closes #45927

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/core/src/tool/edit.ts` rejects an edit where `oldString` equals `newString`. That check runs on the raw input at line 127. The tool converts both strings to the file's line ending at lines 163-164, 36 lines later.

Two strings that differ only in line ending style pass the raw check and become the same text after the conversion. `source.text.replace(oldString, newString)` is then the identity function. `countOccurrences` still returns 1, so the tool reports success and `diffLines` produces a patch with no content.

Measured on `dev` (69c172e), through the real tool, on a CRLF file holding `before\r\nrest\r\n`, with `oldString: "before\r\nrest"` and `newString: "before\nrest"`:

```
result: {"type":"text","value":"Edited file successfully: crlf.txt\nReplacements: 1\n```diff\n-before\n-rest\n+before\n+rest\n```"}
file unchanged: true
writes: 1
```

The model reads `Replacements: 1` and believes the edit landed. An LF file gives the same result with the arguments the other way round, because both strings convert to `\n`.

This PR runs the same check again after the conversion. The v1 tool already works this way: `packages/opencode/src/tool/edit.ts:683` holds the guard inside `replace()`, and its caller at `:129-132` converts both strings before it calls in. Fed the same input, v1 throws `No changes to apply: oldString and newString are identical.`

After the change the tool returns that error and writes nothing:

```
result: {"type":"error","value":"No changes to apply: oldString and newString are identical."}
file unchanged: true
writes: 0
```

The raw check at line 127 stays where it is. It fails before the permission prompt and before the file read, which is still the right place for the case it catches.

### How did you verify your code works?

New case in `packages/core/test/tool-edit.test.ts`, next to the existing `preserves BOM and CRLF line endings` case. It writes a CRLF file, calls the tool with strings that differ only in line ending style, and asserts the error, the unchanged file content, and zero writes.

```
bun test test/tool-edit.test.ts                  11 pass, 0 fail
bun test test/tool-edit.test.ts test/tool-write.test.ts \
         test/patch.test.ts test/file-mutation.test.ts    37 pass, 0 fail
bun run typecheck                                30 tasks successful
```

With the guard removed the new case fails and the other 10 pass, so it tests this fix and nothing else.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

