### PR TITLE
docs(ecosystem): add opencode-deja

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -40,6 +40,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer)                            | AI-powered automatic Zellij session naming based on OpenCode context                               |
 | [opencode-skillful](https://github.com/zenobi-us/opencode-skillful)                                | Allow OpenCode agents to lazy load prompts on demand with skill discovery and injection            |
 | [opencode-supermemory](https://github.com/supermemoryai/opencode-supermemory)                      | Persistent memory across sessions using Supermemory                                                |
+| [opencode-deja](https://github.com/vshulcz/deja-vu/tree/main/extensions/opencode)                  | Recall what you solved in Claude Code, Codex, Cursor and 18 more — a local index over their transcripts, no LLM |
 | [@plannotator/opencode](https://github.com/backnotprop/plannotator/tree/main/apps/opencode-plugin) | Interactive plan review with visual annotation and private/offline sharing                         |
 | [@openspoon/subtask2](https://github.com/spoons-and-mirrors/subtask2)                              | Extend opencode /commands into a powerful orchestration system with granular flow control          |
 | [opencode-scheduler](https://github.com/different-ai/opencode-scheduler)                           | Schedule recurring jobs using launchd (Mac) or systemd (Linux) with cron syntax                    |


### PR DESCRIPTION
### Issue for this PR

Closes #47008

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the Plugins table on the Ecosystem page: opencode-deja, a plugin that lets OpenCode search the session transcripts the other coding agents on the machine already write (Claude Code, Codex, Cursor and others) through a local index. No LLM, no network. I maintain it.

### How did you verify your code works?

Docs-only change; checked the table renders (same column widths as the neighbouring rows) and the link resolves.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR