### PR TITLE
fix(console): restore migrated inference proxy requests

### DIFF
--- a/packages/console/app/src/lib/inference-proxy.ts
+++ b/packages/console/app/src/lib/inference-proxy.ts
@@ -51,5 +51,5 @@ export async function proxyInference(request: Request, clientIP?: string): Promi
   const requestID = request.headers.get("x-opencode-request-id") ?? request.headers.get("x-opencode-request")
   if (requestID) forwarded.headers.set("x-opencode-request-id", requestID)
 
-  return fetch(forwarded, { redirect: "error" })
+  return fetch(forwarded, { redirect: "manual" })
 }


### PR DESCRIPTION
**Summary**
- Replace unsupported `redirect: "error"` with `redirect: "manual"` in the legacy inference proxy.
- Cloudflare Workers rejects the old mode before forwarding; middleware turns that exception into the generic routing 503.
- Return upstream responses directly, including redirects, without following them server-side.

**Validation**
- Pre-push typecheck: all 30 tasks passed.
- Targeted lint, formatting, and diff checks passed.
- No tests run; deployed dev verification pending.

Follow-up to #46830.