### PR TITLE
fix(provider): catch an empty image attachment on the file part shape

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -413,21 +413,18 @@ function unsupportedParts(msgs: ModelMessage[], model: Provider.Model): ModelMes
     const filtered = msg.content.map((part) => {
       if (part.type !== "file" && part.type !== "image") return part
 
-      // Check for empty base64 image data
-      if (part.type === "image") {
-        const imageStr = String(part.image)
-        if (imageStr.startsWith("data:")) {
-          const match = imageStr.match(/^data:([^;]+);base64,(.*)$/)
-          if (match && (!match[2] || match[2].length === 0)) {
-            return {
-              type: "text" as const,
-              text: "ERROR: Image file is empty or corrupted. Please provide a valid image.",
-            }
-          }
+      const mime = part.type === "image" ? String(part.image).split(";")[0].replace("data:", "") : part.mediaType
+
+      // Check for empty base64 image data. convertToModelMessages emits an attachment as a
+      // "file" part, so reading only part.image would never see a real one.
+      const data = part.type === "image" ? part.image : part.data
+      if (mime.startsWith("image/") && typeof data === "string" && /^data:[^;]+;base64,$/.test(data)) {
+        return {
+          type: "text" as const,
+          text: "ERROR: Image file is empty or corrupted. Please provide a valid image.",
         }
       }
 
-      const mime = part.type === "image" ? String(part.image).split(";")[0].replace("data:", "") : part.mediaType
       const filename = part.type === "file" ? part.filename : undefined
       const modality = mimeToModality(mime)
       if (!modality) return part

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test"
+import { convertToModelMessages } from "ai"
 import { Effect } from "effect"
 import { ProviderTransform } from "@/provider/transform"
 import { LLMRequestPrep } from "@/session/llm/request"
@@ -2515,6 +2516,55 @@ describe("ProviderTransform.message - empty image handling", () => {
       type: "text",
       text: "ERROR: Image file is empty or corrupted. Please provide a valid image.",
     })
+  })
+
+  test("should replace an empty image attachment that arrives as a file part", async () => {
+    const msgs = await convertToModelMessages([
+      {
+        id: "m1",
+        role: "user",
+        parts: [
+          { type: "text", text: "What is in this image?" },
+          { type: "file", url: "data:image/png;base64,", mediaType: "image/png", filename: "empty.png" },
+        ],
+      },
+    ] as any)
+
+    expect((msgs[0].content as any[])[1].type).toBe("file")
+
+    const result = ProviderTransform.message(msgs, mockModel, {})
+
+    expect(result[0].content).toHaveLength(2)
+    expect(result[0].content[0]).toEqual({ type: "text", text: "What is in this image?" })
+    expect(result[0].content[1]).toEqual({
+      type: "text",
+      text: "ERROR: Image file is empty or corrupted. Please provide a valid image.",
+    })
+  })
+
+  test("should keep a non-empty image attachment that arrives as a file part", async () => {
+    const validBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+    const msgs = await convertToModelMessages([
+      {
+        id: "m1",
+        role: "user",
+        parts: [
+          { type: "text", text: "What is in this image?" },
+          {
+            type: "file",
+            url: `data:image/png;base64,${validBase64}`,
+            mediaType: "image/png",
+            filename: "ok.png",
+          },
+        ],
+      },
+    ] as any)
+
+    const result = ProviderTransform.message(msgs, mockModel, {})
+
+    expect(result[0].content).toHaveLength(2)
+    expect((result[0].content as any[])[1].type).toBe("file")
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

Closes #46859

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`unsupportedParts` replaces an empty image with error text so the request does not reach the provider. The check read `part.image`, which only exists on an `image` part.

The prompt pipeline does not build that shape. `session/message-v2.ts:220` pushes an attachment as `{ type: "file", url, mediaType, filename }`, and `convertToModelMessages` keeps it a `file` part with the data URL in `part.data`. So the guard never ran on a real attachment, and the empty image went to the provider, which failed the request with its own error.

The two tests that cover the guard build the `image` shape by hand, so they passed while the production path was broken.

This reads the data from whichever shape the part carries. It also requires an `image/` media type, so an empty PDF no longer gets a message about an image. Moving the `mime` line above the check is what makes that media-type test available; nothing else about `mime` changed.

### How did you verify your code works?

`bun test test/provider/transform.test.ts` from `packages/opencode`: 557 pass, 0 fail. The whole `test/provider/` directory: 706 pass, 0 fail. `bun run typecheck`: 30/30 tasks pass.

I reverted the source change and kept the new tests. Exactly one test fails, and it is the one that drives the real path:

```
- "text": "ERROR: Image file is empty or corrupted. Please provide a valid image.",
- "type": "text",
+ "data": "data:image/png;base64,",
+ "filename": "empty.png",
+ "mediaType": "image/png",
+ "type": "file",

(fail) should replace an empty image attachment that arrives as a file part
 556 pass, 1 fail
```

I also measured the part shape directly against the pinned `ai@6.0.168`, which is the evidence in the issue: `convertToModelMessages` returns `type: "file"`, never `type: "image"`.

The second new test sends a valid 1x1 PNG through the same path and asserts the part is untouched, so a regex that matched too much would fail it.

`prettier --check` and `oxlint` are clean on both files (0 errors).

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

