### PR TITLE
fix(core): scope the migration lock to each database

### DIFF
--- a/packages/core/src/database/database.ts
+++ b/packages/core/src/database/database.ts
@@ -2,7 +2,7 @@ export * as Database from "./database.js"
 
 import { EffectDrizzleSqlite } from "./drizzle.js"
 import { sqliteLayer, supportsForeignKeyToggle, supportsTuningPragmas } from "#sqlite"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, Layer, Schema, Semaphore } from "effect"
 import type { SqlClient } from "effect/unstable/sql"
 import { Global } from "@opencode-ai/util/global"
 import { isAbsolute, join } from "path"
@@ -23,30 +23,52 @@ export type Options = typeof Options.Type
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/storage/Database") {}
 
-const databaseLayer = Layer.effect(
-  Service,
-  Effect.gen(function* () {
-    const db = yield* makeDatabase
+// The bootstrap lock is scoped to the database being built, never to this
+// module: on workerd every Durable Object in an isolate shares module state, and
+// releasing a shared semaphore resumes the waiting object's fiber inside the
+// releasing object's I/O context, where its first storage call is rejected as
+// cross-object I/O.
+const databaseLayer = (lock: Effect.Effect<Semaphore.Semaphore>) =>
+  Layer.effect(
+    Service,
+    Effect.gen(function* () {
+      const db = yield* makeDatabase
 
-    if (supportsTuningPragmas) {
-      yield* db.run("PRAGMA journal_mode = WAL")
-      yield* db.run("PRAGMA synchronous = NORMAL")
-      yield* db.run("PRAGMA busy_timeout = 5000")
-      yield* db.run("PRAGMA cache_size = -64000")
-      yield* db.run("PRAGMA wal_checkpoint(PASSIVE)")
-    }
-    // Durable Object SQLite always enforces foreign keys and rejects the pragma.
-    if (supportsForeignKeyToggle) yield* db.run("PRAGMA foreign_keys = ON")
-    yield* DatabaseMigration.apply(db)
+      if (supportsTuningPragmas) {
+        yield* db.run("PRAGMA journal_mode = WAL")
+        yield* db.run("PRAGMA synchronous = NORMAL")
+        yield* db.run("PRAGMA busy_timeout = 5000")
+        yield* db.run("PRAGMA cache_size = -64000")
+        yield* db.run("PRAGMA wal_checkpoint(PASSIVE)")
+      }
+      // Durable Object SQLite always enforces foreign keys and rejects the pragma.
+      if (supportsForeignKeyToggle) yield* db.run("PRAGMA foreign_keys = ON")
+      const semaphore = yield* lock
+      yield* semaphore.withPermit(DatabaseMigration.apply(db))
 
-    return { db }
-  }).pipe(Effect.orDie),
-)
+      return { db }
+    }).pipe(Effect.orDie),
+  )
+
+// Two instances over one file bootstrap the same schema, so file databases
+// share a lock per path. Each in-memory database is its own connection.
+const locks = new Map<string, Semaphore.Semaphore>()
+
+function lockFor(filename: string) {
+  const existing = locks.get(filename)
+  if (existing) return existing
+  const lock = Semaphore.makeUnsafe(1)
+  locks.set(filename, lock)
+  return lock
+}
 
 export function layer(options: Options = { path: ":memory:" }) {
   return Layer.unwrap(
     Effect.gen(function* () {
-      const provide = (filename: string) => layerFromClient.pipe(Layer.provide(sqliteLayer({ filename })))
+      const provide = (filename: string) =>
+        databaseLayer(filename === ":memory:" ? Semaphore.make(1) : Effect.succeed(lockFor(filename))).pipe(
+          Layer.provide(sqliteLayer({ filename })),
+        )
       const filename = options.path ?? ":memory:"
       if (filename === ":memory:" || isAbsolute(filename)) return provide(filename)
       const global = yield* Global.Service
@@ -58,8 +80,11 @@ export function layer(options: Options = { path: ":memory:" }) {
 // The database service over an injected SqlClient, for runtimes that receive
 // database storage instead of opening a filesystem path. Any client provided
 // here still goes through the pragma guards and migrations; Global is required
-// because migrations may read it (the v1 import).
-export const layerFromClient: Layer.Layer<Service, never, SqlClient.SqlClient | Global.Service> = databaseLayer
+// because migrations may read it (the v1 import). The lock is created per build
+// because every Durable Object builds this layer over its own storage.
+export const layerFromClient: Layer.Layer<Service, never, SqlClient.SqlClient | Global.Service> = databaseLayer(
+  Semaphore.make(1),
+)
 
 export function configured(options?: Options) {
   return makeGlobalNode({ service: Service, layer: layer(options), deps: [Global.node] })

--- a/packages/core/src/database/migration.ts
+++ b/packages/core/src/database/migration.ts
@@ -1,7 +1,7 @@
 export * as DatabaseMigration from "./migration.js"
 
 import { sql } from "drizzle-orm"
-import { Effect, Semaphore } from "effect"
+import { Effect } from "effect"
 import { supportsForeignKeyToggle } from "#sqlite"
 import type { EffectDrizzleSqlite } from "./drizzle.js"
 import { migrations } from "./migration.gen.js"
@@ -10,7 +10,6 @@ import { Global } from "@opencode-ai/util/global"
 
 type Database = EffectDrizzleSqlite.EffectSQLiteDatabase
 type Transaction = Parameters<Parameters<Database["transaction"]>[0]>[0]
-const lock = Semaphore.makeUnsafe(1)
 
 export type Migration = {
   id: string
@@ -18,38 +17,38 @@ export type Migration = {
   up: (tx: Transaction) => Effect.Effect<void, unknown, Global.Service>
 }
 
+// Not serialized here: the Database layer holds a lock scoped to the database
+// it is bootstrapping, since two instances over one file must not race.
 export function apply(db: Database) {
-  return lock.withPermit(
-    Effect.gen(function* () {
-      // OpenCode owns the unprefixed table namespace. Embedders sharing this
-      // database may own underscore-prefixed tables, which bootstrap ignores.
-      const tables = yield* db.all<{ name: string }>(
-        sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND substr(name, 1, 1) <> '_'`,
-      )
-      if (tables.some((table) => table.name === "session" || table.name === "session_v2"))
-        return yield* applyOnly(db, migrations)
-      if (tables.length > 0) return yield* Effect.die(new Error("Database is not empty and has no session table"))
-      const started = Date.now()
-      yield* Effect.logInfo("database schema bootstrap started", { migrations: migrations.length })
-      yield* db.transaction((tx) =>
-        Effect.gen(function* () {
-          yield* schema.up(tx)
-          yield* tx.run(
-            sql`CREATE TABLE ${sql.identifier("migration")} (id TEXT PRIMARY KEY, time_completed INTEGER NOT NULL)`,
-          )
-          yield* Effect.forEach(migrations, (migration) =>
-            tx.run(
-              sql`INSERT INTO ${sql.identifier("migration")} (id, time_completed) VALUES (${migration.id}, ${Date.now()})`,
-            ),
-          )
-        }),
-      )
-      yield* Effect.logInfo("database schema bootstrap completed", {
-        migrations: migrations.length,
-        durationMs: Date.now() - started,
-      })
-    }),
-  )
+  return Effect.gen(function* () {
+    // OpenCode owns the unprefixed table namespace. Embedders sharing this
+    // database may own underscore-prefixed tables, which bootstrap ignores.
+    const tables = yield* db.all<{ name: string }>(
+      sql`SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' AND substr(name, 1, 1) <> '_'`,
+    )
+    if (tables.some((table) => table.name === "session" || table.name === "session_v2"))
+      return yield* applyOnly(db, migrations)
+    if (tables.length > 0) return yield* Effect.die(new Error("Database is not empty and has no session table"))
+    const started = Date.now()
+    yield* Effect.logInfo("database schema bootstrap started", { migrations: migrations.length })
+    yield* db.transaction((tx) =>
+      Effect.gen(function* () {
+        yield* schema.up(tx)
+        yield* tx.run(
+          sql`CREATE TABLE ${sql.identifier("migration")} (id TEXT PRIMARY KEY, time_completed INTEGER NOT NULL)`,
+        )
+        yield* Effect.forEach(migrations, (migration) =>
+          tx.run(
+            sql`INSERT INTO ${sql.identifier("migration")} (id, time_completed) VALUES (${migration.id}, ${Date.now()})`,
+          ),
+        )
+      }),
+    )
+    yield* Effect.logInfo("database schema bootstrap completed", {
+      migrations: migrations.length,
+      durationMs: Date.now() - started,
+    })
+  })
 }
 
 export function applyOnly(db: Database, input: Migration[]) {

--- a/packages/core/test/database-migration.test.ts
+++ b/packages/core/test/database-migration.test.ts
@@ -4,14 +4,15 @@ import { fileURLToPath } from "url"
 import path from "path"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
 import { EffectDrizzleSqlite } from "@opencode-ai/core/database/drizzle"
-import { Effect, Layer } from "effect"
+import { Deferred, Effect, Fiber, Layer } from "effect"
+import { Reactivity } from "effect/unstable/reactivity"
+import { SqlClient, Statement } from "effect/unstable/sql"
 import { sql } from "drizzle-orm"
 import { DatabaseMigration } from "@opencode-ai/core/database/migration"
 import { migrations } from "@opencode-ai/core/database/migration.gen"
 import workspaceNameMigration from "@opencode-ai/core/database/migration/20260410174513_workspace-name"
 import { Database } from "@opencode-ai/core/database/database"
 import { tmpdir } from "./fixture/tmpdir"
-import type { SqlClient } from "effect/unstable/sql/SqlClient"
 import legacyCredentialsMigration from "@opencode-ai/core/database/migration/20260805200742_import_legacy_credentials"
 import worktreeMigration from "@opencode-ai/core/database/migration/20260812213948_worktree"
 import previousV2Migration from "@opencode-ai/core/database/migration/20260804233008_loose_psylocke"
@@ -22,7 +23,7 @@ import sessionViewedStateMigration from "@opencode-ai/core/database/migration/20
 import { Global } from "@opencode-ai/util/global"
 
 const run = <A, E>(
-  effect: Effect.Effect<A, E, SqlClient | Global.Service>,
+  effect: Effect.Effect<A, E, SqlClient.SqlClient | Global.Service>,
   global = Global.make({ data: path.join(process.cwd(), ".test-data") }),
 ) =>
   Effect.runPromise(
@@ -34,6 +35,31 @@ const run = <A, E>(
   )
 
 const makeDb = EffectDrizzleSqlite.makeWithDefaults()
+
+// A real in-memory SqlClient whose schema inspection signals `arrived` and then
+// waits on `gate`. Bootstrap inspects the schema as its first locked statement,
+// so a database built over this client parks while holding its migration lock.
+const parkedClient = (arrived: Deferred.Deferred<void>, gate: Deferred.Deferred<void>) =>
+  Layer.effect(
+    SqlClient.SqlClient,
+    Effect.gen(function* () {
+      const client = yield* SqlClient.SqlClient
+      const connection = yield* client.reserve
+      const park = <A, E>(query: string, effect: Effect.Effect<A, E>) =>
+        query.includes("sqlite_master")
+          ? Deferred.succeed(arrived, undefined).pipe(Effect.andThen(Deferred.await(gate)), Effect.andThen(effect))
+          : effect
+      return yield* SqlClient.make({
+        acquirer: Effect.succeed({
+          ...connection,
+          execute: (query, params, transform) => park(query, connection.execute(query, params, transform)),
+          executeRaw: (query, params) => park(query, connection.executeRaw(query, params)),
+        }),
+        compiler: Statement.makeCompilerSqlite(),
+        spanAttributes: [],
+      })
+    }),
+  ).pipe(Layer.provide(SqliteClient.layer({ filename: ":memory:", disableWAL: true })), Layer.provide(Reactivity.layer))
 
 describe("DatabaseMigration", () => {
   test("defaults missing workspace names while preserving legacy workspace data", async () => {
@@ -109,6 +135,31 @@ describe("DatabaseMigration", () => {
         ),
         { concurrency: "unbounded" },
       ).pipe(Effect.provideService(Global.Service, Global.make({ data: tmp.path }))),
+    )
+  })
+
+  test("bootstraps distinct databases without waiting on each other's lock", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const arrived = yield* Deferred.make<void>()
+        const gate = yield* Deferred.make<void>()
+        // Park the first database inside its bootstrap, after it holds its lock.
+        const parked = yield* Effect.forkScoped(
+          Layer.build(Database.layerFromClient.pipe(Layer.provide(parkedClient(arrived, gate)))),
+        )
+        yield* Deferred.await(arrived)
+
+        yield* Layer.build(
+          Database.layerFromClient.pipe(Layer.provide(SqliteClient.layer({ filename: ":memory:", disableWAL: true }))),
+        ).pipe(Effect.timeout("2 seconds"))
+
+        expect(parked.pollUnsafe()).toBeUndefined()
+        yield* Deferred.succeed(gate, undefined)
+        yield* Fiber.join(parked)
+      }).pipe(
+        Effect.provideService(Global.Service, Global.make({ data: path.join(process.cwd(), ".test-data") })),
+        Effect.scoped,
+      ),
     )
   })
 


### PR DESCRIPTION
## Why

`DatabaseMigration.apply` serialized schema bootstrap behind a `Semaphore` created at module scope. That is one lock per JS isolate, not per database. On Cloudflare workerd many Durable Objects share an isolate, so every embedded OpenCode instance (Console's `SlackSession`, opencode-slack's `SessionDO`) waited on the same semaphore. When object A releases the permit, the waiter's fiber resumes inside A's dispatcher task, so object B's very next statement runs on B's own storage while the current actor is still A, and workerd rejects it with `Cannot perform I/O on behalf of a different Durable Object (ActorCacheInterface)`. Reproduced downstream with 4 concurrent bootstraps: 3 fail; sequential bootstraps never contend. The shared lock also needlessly serialized bootstrap across unrelated databases everywhere.

## What Changes

The lock moves out of `DatabaseMigration.apply` and into the `Database` layer, which is the only production caller (`database.ts`) and the only place that knows which database it is building. `apply` itself is no longer locked.

**Before**

```
DO A  build ─ pragmas ─ lock.acquire ─ SELECT sqlite_master ─ … ─ lock.release ─┐
DO B  build ─ pragmas ─ lock.acquire ─────────── waits ────────────────────────┘─ resumes in A's task
                                                                                  └─ native.sql.exec on B's storage
                                                                                     ✗ Cannot perform I/O on behalf of a different Durable Object
```

**After**

```
DO A  build ─ pragmas ─ lockA.acquire ─ SELECT sqlite_master ─ … ─ lockA.release   (lockA created in this build)
DO B  build ─ pragmas ─ lockB.acquire ─ SELECT sqlite_master ─ … ─ lockB.release   (lockB created in this build)
                                                                                    ✓ no cross-object waiter
```

Scope chosen, based on what the callers showed:

- `apply` runs exactly once per `Database.Service` build, so the lock is created per build for `layerFromClient` (the workerd path: `Database.configuredClient(sqliteLayer({ storage }))`) and for `:memory:` databases, which are one database per connection.
- Per-instance alone was not enough for file databases. `Database.layer({ path })` can legitimately be built twice over the same file in one process (the existing `serializes concurrent embedded initialization for one database path` test), and without a shared lock both instances see an empty `sqlite_master`, both start bootstrap, and the second blocks on `busy_timeout` and then collides on the schema. File databases therefore share a lock keyed by the resolved filename. Different Durable Objects never take this path (the workerd adapter dies on filenames), so they can never share a lock.

No config option is added.

## Scope

Embedded workerd hosts (Console agent, opencode-slack) are the affected consumers. Node/Bun behavior is unchanged apart from unrelated databases no longer serializing against each other. No config or public API change; `DatabaseMigration.apply(db)` keeps its signature.

## Verification

```sh
cd packages/core
bun typecheck
bun test test/database-migration.test.ts test/v1-migration.test.ts test/session-store.test.ts
cd ../..
bunx oxlint packages/core/src/database/database.ts packages/core/src/database/migration.ts packages/core/test/database-migration.test.ts
bunx ast-grep scan -c script/ast-grep/sgconfig.yml packages/core/src/database/database.ts packages/core/src/database/migration.ts
bun run lint:effect-simplifications
bunx prettier --check packages/core/src/database/database.ts packages/core/src/database/migration.ts packages/core/test/database-migration.test.ts
```

- `bun typecheck`: clean.
- Tests: 44 pass, 0 fail across the three files.
- New test `bootstraps distinct databases without waiting on each other's lock`: builds one `Database.layerFromClient` over a real in-memory `SqlClient` whose `sqlite_master` query parks on a `Deferred` (so it holds its lock), then builds a second `layerFromClient` over another in-memory client and asserts it completes while the first is still parked. Verified it fails against the previous module-scoped lock (the second build times out) and passes with this change.
- Existing `serializes concurrent embedded initialization for one database path` still passes; removing the lock entirely was confirmed to make it fail, which is why file databases keep a shared per-path lock.
- oxlint: 0 errors, 4 warnings, all pre-existing on `v2`. `lint:effect-patterns` has 27 pre-existing errors on `v2`, none in the changed files. Prettier clean.

The workerd cross-object hand-off itself cannot be asserted in this suite: it needs multiple Durable Objects in one workerd isolate. That case is reproduced downstream in the Console repository (SDK `0.0.0-dev-18852`, Effect `4.0.0-rc.112`, workerd `1.20260828.1`).
