### PR TITLE
fix(format): look up a built-in formatter by its published name

### DIFF
--- a/packages/opencode/src/format/index.ts
+++ b/packages/opencode/src/format/index.ts
@@ -127,13 +127,14 @@ const layer = Layer.effect(
           }
         }
 
-        for (const item of Object.values(Formatter)) {
-          formatters[item.name] = item
-        }
+        // Keyed by Info.name, which is the name the docs publish and the config uses. It differs
+        // from the export identifier for clang-format, air and uv.
+        const builtIns = Object.fromEntries(Object.values(Formatter).map((item) => [item.name, item]))
+        Object.assign(formatters, builtIns)
 
         if (cfg.formatter !== true) {
           for (const [name, item] of Object.entries(cfg.formatter)) {
-            const builtIn = Formatter[name as keyof typeof Formatter]
+            const builtIn = builtIns[name]
 
             // Ruff and uv are both the same formatter, so disabling either should disable both.
             if (["ruff", "uv"].includes(name) && (cfg.formatter.ruff?.disabled || cfg.formatter.uv?.disabled)) {

--- a/packages/opencode/test/format/format.test.ts
+++ b/packages/opencode/test/format/format.test.ts
@@ -92,6 +92,59 @@ describe("Format", () => {
     { config: { formatter: { uv: { disabled: true } } } },
   )
 
+  it.instance(
+    "status() keeps the built-in definition when config uses the published formatter name",
+    () =>
+      Format.Service.use((fmt) =>
+        Effect.gen(function* () {
+          const statuses = yield* fmt.status()
+          expect(statuses.find((item) => item.name === "clang-format")?.extensions).toEqual(Formatter.clang.extensions)
+          expect(statuses.find((item) => item.name === "air")?.extensions).toEqual(Formatter.rlang.extensions)
+          expect(statuses.find((item) => item.name === "uv")?.extensions).toEqual(Formatter.uvformat.extensions)
+        }),
+      ),
+    { config: { formatter: { "clang-format": {}, air: {}, uv: {} } } },
+  )
+
+  it.instance(
+    "file() still runs a built-in whose published name differs from its export name",
+    () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const file = `${test.directory}/test.published`
+        yield* Effect.promise(() => Bun.write(file, "x"))
+
+        const original = { extensions: Formatter.clang.extensions, enabled: Formatter.clang.enabled }
+
+        yield* Effect.acquireUseRelease(
+          Effect.sync(() => {
+            Formatter.clang.extensions = [".published"]
+            Formatter.clang.enabled = async () => [
+              "node",
+              "-e",
+              "const fs = require('fs'); const file = process.argv[1]; fs.writeFileSync(file, fs.readFileSync(file, 'utf8') + 'C')",
+              "$FILE",
+            ]
+          }),
+          () =>
+            Format.Service.use((fmt) =>
+              Effect.gen(function* () {
+                yield* fmt.init()
+                yield* fmt.file(file)
+              }),
+            ),
+          () =>
+            Effect.sync(() => {
+              Formatter.clang.extensions = original.extensions
+              Formatter.clang.enabled = original.enabled
+            }),
+        )
+
+        expect(yield* Effect.promise(() => Bun.file(file).text())).toBe("xC")
+      }),
+    { config: { formatter: { "clang-format": {} } } },
+  )
+
   it.instance("service initializes without error", () => Format.Service.use(() => Effect.void))
 
   it.instance(


### PR DESCRIPTION
### Issue for this PR

Closes #46868

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/opencode/src/format/index.ts:134` looked up a built-in formatter with `Formatter[name as keyof typeof Formatter]`, where `name` is the config key. That reads the module's export identifier. Three built-ins publish a different name:

| config key, as `docs/formatters.mdx` publishes it | export identifier |
|---|---|
| `clang-format` | `clang` |
| `air` | `rlang` |
| `uv` | `uvformat` |

For those three the lookup returned `undefined`. The entry was then built from `builtIn ?? { extensions: [] }`, and `enabled` became `async () => info.command ?? false`. With no `command` in the config that check always returns `false`, and the built-in extensions were replaced by an empty list. So any override other than `disabled` turned the formatter off, with no error.

The published name is the correct key. `formatters` is already keyed by `item.name` one block above, `status()` reports `item.name`, and the docs table lists `clang-format`, `air` and `uv`. The docs also say you can configure a built-in with `environment` or `extensions`, which is the case that broke.

This keys the built-ins by `Info.name` and reads that map. The cast is what hid the defect, so it is gone with it.

One behaviour change beyond the fix. Writing the export identifier, for example `"clang": {}`, no longer resolves to the built-in. That spelling is not in the docs. Before this change it created a second entry alongside `clang-format`, so the formatter ran twice on the same file. It now behaves like any other unknown key: a custom formatter that needs its own `command`.

### How did you verify your code works?

Two cases added to `packages/opencode/test/format/format.test.ts`.

The first configures `clang-format`, `air` and `uv` with an empty override and asserts `status()` still reports each built-in's extensions.

The second is end to end. It points `Formatter.clang` at a scratch extension and a command that appends `C`. It restores the formatter afterwards, the way the existing parallel case does, then writes a file and calls `Format.file()`.

```
bun test test/format/format.test.ts               13 pass, 0 fail
bun test test/format test/tool test/config       287 pass, 3 skip, 0 fail
bun run typecheck                                 30 tasks successful
prettier --check                                  clean
oxlint                                            5 warnings, 0 errors, same as dev
```

With the source change reverted and both tests kept, exactly those two fail and the other 11 pass:

```
config: { formatter: { "clang-format": {} } }
file contents after Format.file()    expected "xC"    actual "x"
```

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
