### PR TITLE
fix(agent): rank legacy tools-derived permission below global permission config

### DIFF
--- a/packages/core/src/v1/config/agent.ts
+++ b/packages/core/src/v1/config/agent.ts
@@ -59,14 +59,11 @@ const KNOWN_KEYS = new Set([
   "tools",
 ])
 
-const normalize = (agent: Schema.Schema.Type<typeof AgentSchema>): Schema.Schema.Type<typeof AgentSchema> => {
-  const options: Record<string, unknown> = { ...agent.options }
-  for (const [key, value] of Object.entries(agent)) {
-    if (!KNOWN_KEYS.has(key)) options[key] = value
-  }
-
+// Derives permission rules from the deprecated per-agent `tools` map (write/edit/patch collapse to `edit`).
+// Exported so consumers can rank these legacy rules below explicit `permission` config.
+export const permissionFromTools = (tools: Record<string, boolean> | undefined): ConfigPermissionV1.Info => {
   const permission: ConfigPermissionV1.Info = {}
-  for (const [tool, enabled] of Object.entries(agent.tools ?? {})) {
+  for (const [tool, enabled] of Object.entries(tools ?? {})) {
     const action = enabled ? "allow" : "deny"
     if (tool === "write" || tool === "edit" || tool === "patch") {
       permission.edit = action
@@ -74,6 +71,16 @@ const normalize = (agent: Schema.Schema.Type<typeof AgentSchema>): Schema.Schema
     }
     permission[tool] = action
   }
+  return permission
+}
+
+const normalize = (agent: Schema.Schema.Type<typeof AgentSchema>): Schema.Schema.Type<typeof AgentSchema> => {
+  const options: Record<string, unknown> = { ...agent.options }
+  for (const [key, value] of Object.entries(agent)) {
+    if (!KNOWN_KEYS.has(key)) options[key] = value
+  }
+
+  const permission = permissionFromTools(agent.tools)
   globalThis.Object.assign(permission, agent.permission)
 
   const steps = agent.steps ?? agent.maxSteps

--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -1,5 +1,7 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { ConfigAgentV1 } from "@opencode-ai/core/v1/config/agent"
+import { ConfigPermissionV1 } from "@opencode-ai/core/v1/config/permission"
 import { Config } from "@/config/config"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
 import { Provider } from "@/provider/provider"
@@ -148,7 +150,6 @@ const layer = Layer.effect(
                 question: "allow",
                 plan_enter: "allow",
               }),
-              user,
             ),
             mode: "primary",
             native: true,
@@ -174,7 +175,6 @@ const layer = Layer.effect(
                   [path.relative(ctx.worktree, path.join(Global.Path.data, path.join("plans", "*.md")))]: "allow",
                 },
               }),
-              user,
             ),
             mode: "primary",
             native: true,
@@ -187,7 +187,6 @@ const layer = Layer.effect(
               Permission.fromConfig({
                 todowrite: "deny",
               }),
-              user,
             ),
             options: {},
             mode: "subagent",
@@ -208,7 +207,6 @@ const layer = Layer.effect(
                 read: "allow",
                 external_directory: readonlyExternalDirectory,
               }),
-              user,
             ),
             description: `Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. "src/components/**/*.tsx"), search code for keywords (eg. "API endpoints"), or answer questions about the codebase (eg. "how do API endpoints work?"). When calling this agent, specify the desired thoroughness level: "quick" for basic searches, "medium" for moderate exploration, or "very thorough" for comprehensive analysis across multiple locations and naming conventions.`,
             prompt: PROMPT_EXPLORE,
@@ -227,7 +225,6 @@ const layer = Layer.effect(
               Permission.fromConfig({
                 "*": "deny",
               }),
-              user,
             ),
             options: {},
           },
@@ -243,7 +240,6 @@ const layer = Layer.effect(
               Permission.fromConfig({
                 "*": "deny",
               }),
-              user,
             ),
             prompt: PROMPT_TITLE,
           },
@@ -258,12 +254,12 @@ const layer = Layer.effect(
               Permission.fromConfig({
                 "*": "deny",
               }),
-              user,
             ),
             prompt: PROMPT_SUMMARY,
           },
         }
 
+        const configuredAgents = new Set(Object.keys(cfg.agent ?? {}))
         for (const [key, value] of Object.entries(cfg.agent ?? {})) {
           if (value.disable) {
             delete agents[key]
@@ -274,7 +270,7 @@ const layer = Layer.effect(
             item = agents[key] = {
               name: key,
               mode: "all",
-              permission: Permission.merge(defaults, user),
+              permission: defaults,
               options: {},
               native: false,
             }
@@ -290,7 +286,25 @@ const layer = Layer.effect(
           item.name = value.name ?? item.name
           item.steps = value.steps ?? item.steps
           item.options = mergeDeep(item.options, value.options ?? {})
-          item.permission = Permission.merge(item.permission, Permission.fromConfig(value.permission ?? {}))
+
+          // Legacy `tools` maps are a deprecated shorthand for permission rules. Rank the
+          // tools-derived rules BELOW the user's global `permission` config so a tools-based
+          // "*" deny cannot defeat global allows, while explicit per-agent `permission`
+          // still ranks above everything else.
+          const legacy = Permission.fromConfig(ConfigAgentV1.permissionFromTools(value.tools))
+          const legacyKeys = new Set(legacy.map((rule) => rule.permission))
+          const explicit: ConfigPermissionV1.Info = {}
+          for (const [permissionKey, permissionValue] of Object.entries(value.permission ?? {})) {
+            if (legacyKeys.has(permissionKey)) continue
+            explicit[permissionKey] = permissionValue
+          }
+          item.permission = Permission.merge(item.permission, legacy, user, Permission.fromConfig(explicit))
+        }
+
+        // Native agents that were not overridden in config still receive the user's global permission
+        for (const key of Object.keys(agents)) {
+          if (configuredAgents.has(key)) continue
+          agents[key].permission = Permission.merge(agents[key].permission, user)
         }
 
         // Ensure Truncate.GLOB is allowed unless explicitly configured

--- a/packages/opencode/test/agent/agent.test.ts
+++ b/packages/opencode/test/agent/agent.test.ts
@@ -552,6 +552,90 @@ it.instance("global tmp directory children are allowed for external_directory", 
 )
 
 it.instance(
+  "legacy tools deny-all does not defeat global permission allows",
+  () =>
+    Effect.gen(function* () {
+      const agent = yield* load((svc) => svc.get("myagent"))
+      expect(agent).toBeDefined()
+      expect(Permission.evaluate("external_directory", "/tmp/some/path", agent!.permission).action).toBe("allow")
+      expect(evalPerm(agent, "bash")).toBe("deny")
+      expect(evalPerm(agent, "read")).toBe("allow")
+    }),
+  {
+    config: {
+      permission: {
+        external_directory: {
+          "/tmp/**": "allow",
+        },
+      },
+      agent: {
+        myagent: {
+          tools: {
+            "*": false,
+            read: true,
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "legacy tools deny-all does not defeat global permission allows on overridden native agents",
+  () =>
+    Effect.gen(function* () {
+      const build = yield* load((svc) => svc.get("build"))
+      expect(build).toBeDefined()
+      expect(Permission.evaluate("external_directory", "/tmp/some/path", build!.permission).action).toBe("allow")
+      expect(evalPerm(build, "bash")).toBe("deny")
+    }),
+  {
+    config: {
+      permission: {
+        external_directory: {
+          "/tmp/**": "allow",
+        },
+      },
+      agent: {
+        build: {
+          tools: {
+            "*": false,
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
+  "explicit agent permission still ranks above global permission",
+  () =>
+    Effect.gen(function* () {
+      const agent = yield* load((svc) => svc.get("myagent"))
+      expect(agent).toBeDefined()
+      expect(Permission.evaluate("external_directory", "/tmp/locked", agent!.permission).action).toBe("deny")
+    }),
+  {
+    config: {
+      permission: {
+        external_directory: {
+          "/tmp/**": "allow",
+        },
+      },
+      agent: {
+        myagent: {
+          permission: {
+            external_directory: {
+              "/tmp/locked": "deny",
+            },
+          },
+        },
+      },
+    },
+  },
+)
+
+it.instance(
   "Truncate.GLOB is allowed even when user denies external_directory per-agent",
   () =>
     Effect.gen(function* () {


### PR DESCRIPTION
### Issue for this PR

Fixes #46873

### Type of change

- [x] Bug fix

### What does this PR do?

Fixes the rule ordering described in #46873: permission rules derived from the deprecated per-agent `tools` map were merged into the agent ruleset after the user's global `permission` config, so a `"*": false` tools entry produced a deny-all that outranked user-defined allows (evaluate is last-match-wins).

Changes:

- `packages/core/src/v1/config/agent.ts` — extracted the tools-to-permission conversion into an exported `permissionFromTools()` helper. `normalize()` output is unchanged.
- `packages/opencode/src/agent/agent.ts` — for user-defined agents the layers are now merged as `defaults -> legacy tools-derived -> user global permission -> explicit agent permission`. Collisions between `tools` and an explicit agent `permission` entry still resolve in favor of the explicit entry, same as before. Native agents no longer get the global permission layer injected mid-stack; agents not present in the config get the user layer appended after the loop, so those are unaffected.

Rule order for user-defined agents, before -> after:

```
defaults -> user global -> tools-derived -> explicit agent permission
defaults -> tools-derived -> user global -> explicit agent permission
```

Context: this regression surfaced downstream as stablyai/orca#18209 (looked Orca-specific, but reproduces with plain opencode).

### How did you verify your code works?

- `bun test test/agent/agent.test.ts` — 3 new regression tests: a tools deny-all no longer defeats a global `external_directory` allow (both for a new agent and for an overridden native agent), and an explicit agent permission entry still beats a global allow. 46/46 pass.
- Smoke-ran the related suites (permission-task, acp/permission, plan-mode-subagent-bypass, plugin-agent-regression, core v1 config + permission) — all green, typecheck clean.
- The repro from the issue: `opencode debug agent testagent` now ranks the user allow after the tools deny-all, and external reads work again.

### Screenshots / recordings

N/A (no UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR