### PR TITLE
fix(core): wait for plugin activation before session entry points

### DIFF
--- a/packages/core/src/filesystem/location-watcher.ts
+++ b/packages/core/src/filesystem/location-watcher.ts
@@ -24,7 +24,6 @@ const layer = Layer.effect(
     const bus = yield* Bus.Service
     const fs = yield* FSUtil.Service
     const git = yield* Git.Service
-    const plugins = yield* Plugin.Service
     const policy = yield* LocationWatcherPolicy.Service
     const publish = (update: { type: "create" | "update" | "delete"; path: string }) =>
       bus.publish(FileSystem.Event.Changed, {
@@ -93,7 +92,7 @@ const layer = Layer.effect(
     )
     yield* policy.observe(reconcile)
     yield* Effect.gen(function* () {
-      yield* plugins.awaitActivation
+      yield* Plugin.awaitActivation
       yield* reconcile(policy.current())
     }).pipe(
       Effect.catchCauseIf(

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -2,7 +2,6 @@ export * as Plugin from "./plugin.js"
 export { Event, ID, Info, Source, State } from "@opencode-ai/schema/plugin"
 
 import { Plugin } from "@opencode-ai/schema/plugin"
-import type { Plugin as PluginDefinition } from "@opencode-ai/plugin/effect/plugin"
 import { Node } from "@opencode-ai/util/effect/app-node"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import type { PersistentPty } from "./persistent-pty.js"
@@ -10,27 +9,10 @@ import { Cause, Context, Effect, Exit, Latch, Layer, Logger, References, Scope, 
 import { Bus } from "./bus.js"
 import { KV } from "./kv.js"
 import { PluginHost } from "./plugin/host.js"
+import { type Failure, type Generation, Service } from "./plugin/service.js"
 import { State } from "./state.js"
 
-export interface Interface {
-  readonly activate: (plugins: readonly Generation[], failures?: readonly Failure[]) => Effect.Effect<void>
-  readonly list: () => Effect.Effect<Plugin.Info[]>
-  readonly close: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void>
-  /** Wait for announced updates and activation to settle; failures remain in the inventory. */
-  readonly awaitActivation: Effect.Effect<void>
-  /** Keep readiness pending while preparing an update. Run the returned Effect to release it. */
-  readonly hold: () => Effect.Effect<Effect.Effect<void>>
-}
-
-type Failure = Plugin.Info & { readonly state: Extract<Plugin.State, { readonly status: "failed" }> }
-
-export type Generation = PluginDefinition & {
-  readonly revision: string
-  readonly source?: Plugin.Source
-  readonly features?: Plugin.Features
-}
-
-export class Service extends Context.Service<Service, Interface>()("@opencode/Plugin") {}
+export { awaitActivation, type Failure, type Generation, type Interface, Service } from "./plugin/service.js"
 
 const layer = Layer.effect(
   Service,

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -12,7 +12,7 @@ import { PluginHost } from "./plugin/host.js"
 import { type Failure, type Generation, Service } from "./plugin/service.js"
 import { State } from "./state.js"
 
-export { awaitActivation, type Failure, type Generation, type Interface, Service } from "./plugin/service.js"
+export { awaitActivation, type Generation, type Interface, Service } from "./plugin/service.js"
 
 const layer = Layer.effect(
   Service,

--- a/packages/core/src/plugin/service.ts
+++ b/packages/core/src/plugin/service.ts
@@ -31,4 +31,4 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Pl
  * and the model catalog. A cold Location activates its plugins asynchronously, so without the wait an
  * early request observes an empty registry and admits or fails work the plugins would have shaped.
  */
-export const awaitActivation: Effect.Effect<void, never, Service> = Service.use((plugins) => plugins.awaitActivation)
+export const awaitActivation = Service.use((plugins) => plugins.awaitActivation)

--- a/packages/core/src/plugin/service.ts
+++ b/packages/core/src/plugin/service.ts
@@ -1,0 +1,34 @@
+export * as Plugin from "./service.js"
+
+// The service tag lives apart from the layer so Session entry points can wait on activation without
+// importing the plugin host, which itself depends on Session.
+import { Plugin } from "@opencode-ai/schema/plugin"
+import type { Plugin as PluginDefinition } from "@opencode-ai/plugin/effect/plugin"
+import { Context, type Effect, type Exit } from "effect"
+
+export interface Interface {
+  readonly activate: (plugins: readonly Generation[], failures?: readonly Failure[]) => Effect.Effect<void>
+  readonly list: () => Effect.Effect<Plugin.Info[]>
+  readonly close: (exit: Exit.Exit<unknown, unknown>) => Effect.Effect<void>
+  /** Wait for announced updates and activation to settle; failures remain in the inventory. */
+  readonly awaitActivation: Effect.Effect<void>
+  /** Keep readiness pending while preparing an update. Run the returned Effect to release it. */
+  readonly hold: () => Effect.Effect<Effect.Effect<void>>
+}
+
+export type Failure = Plugin.Info & { readonly state: Extract<Plugin.State, { readonly status: "failed" }> }
+
+export type Generation = PluginDefinition & {
+  readonly revision: string
+  readonly source?: Plugin.Source
+  readonly features?: Plugin.Features
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/Plugin") {}
+
+/**
+ * Session entry points wait here before reading plugin-provided state such as commands, skills, hooks,
+ * and the model catalog. A cold Location activates its plugins asynchronously, so without the wait an
+ * early request observes an empty registry and admits or fails work the plugins would have shaped.
+ */
+export const awaitActivation: Effect.Effect<void, never, Service> = Service.use((plugins) => plugins.awaitActivation)

--- a/packages/core/src/session/command.ts
+++ b/packages/core/src/session/command.ts
@@ -6,6 +6,7 @@ import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
 import { Effect } from "effect"
 import { Command } from "../command.js"
 import { Instance } from "../instance/service.js"
+import { Plugin } from "../plugin/service.js"
 
 export const execute = Effect.fn("SessionCommand.execute")(function* (input: {
   session: Session.Info
@@ -17,7 +18,7 @@ export const execute = Effect.fn("SessionCommand.execute")(function* (input: {
   delivery?: SessionInbox.Delivery
 }) {
   const instances = yield* Instance.Service
-  const commands = yield* Command.Service.pipe(instances.provide(input.session))
+  const commands = yield* Plugin.awaitActivation.pipe(Effect.andThen(Command.Service), instances.provide(input.session))
   yield* commands.execute({
     name: input.command,
     invocation: {

--- a/packages/core/src/session/generate.ts
+++ b/packages/core/src/session/generate.ts
@@ -4,6 +4,7 @@ import { LLMClient, Message, type AIError } from "@opencode-ai/ai"
 import { Effect } from "effect"
 import { Database } from "../database/database.js"
 import { Instance } from "../instance/service.js"
+import { Plugin } from "../plugin/service.js"
 import type { Instructions } from "../instructions/index.js"
 import { SessionContext } from "./context.js"
 import type { AgentNotFoundError } from "./error.js"
@@ -24,6 +25,7 @@ export const generate = Effect.fn("SessionGenerate.generate")(function* (input: 
   const llm = yield* LLMClient.Service
 
   return yield* Effect.gen(function* () {
+    yield* Plugin.awaitActivation
     const context = yield* SessionContext.Service
     const selection = yield* context.select(input.session.id)
     const model = yield* context.resolveModel(selection.session)

--- a/packages/core/src/session/prompt.ts
+++ b/packages/core/src/session/prompt.ts
@@ -12,6 +12,7 @@ import { fileURLToPath } from "url"
 import { Image } from "../image.js"
 import { Instance } from "../instance/service.js"
 import { Mime } from "../mime.js"
+import { Plugin } from "../plugin/service.js"
 import { PluginHooks } from "../plugin/hooks.js"
 import { Skill } from "../skill.js"
 import { AttachmentError, SkillNotFoundError } from "./error.js"
@@ -34,6 +35,7 @@ export const prepare = Effect.fn("SessionPrompt.prepare")(function* (request: {
   const instances = yield* Instance.Service
 
   return yield* Effect.gen(function* () {
+    yield* Plugin.awaitActivation
     const hooks = yield* PluginHooks.Service
     const event = yield* hooks.trigger("session", "prompt", {
       sessionID: request.session.id,

--- a/packages/core/src/session/shell.ts
+++ b/packages/core/src/session/shell.ts
@@ -3,12 +3,13 @@ export * as SessionShell from "./shell.js"
 import type { Session } from "@opencode-ai/schema/session"
 import { Effect } from "effect"
 import { Instance } from "../instance/service.js"
+import { Plugin } from "../plugin/service.js"
 import { Shell } from "../shell.js"
 import { ShellResult } from "../shell/result.js"
 
 export const start = Effect.fn("SessionShell.start")(function* (input: { session: Session.Info; command: string }) {
   const instances = yield* Instance.Service
-  const shell = yield* Shell.Service.pipe(instances.provide(input.session))
+  const shell = yield* Plugin.awaitActivation.pipe(Effect.andThen(Shell.Service), instances.provide(input.session))
   const info = yield* shell.create({
     command: input.command,
     cwd: input.session.location.directory,

--- a/packages/core/src/session/skill.ts
+++ b/packages/core/src/session/skill.ts
@@ -3,12 +3,13 @@ export * as SessionSkill from "./skill.js"
 import type { Session } from "@opencode-ai/schema/session"
 import { Effect } from "effect"
 import { Instance } from "../instance/service.js"
+import { Plugin } from "../plugin/service.js"
 import { Skill } from "../skill.js"
 import { SkillNotFoundError } from "./error.js"
 
 export const get = Effect.fn("SessionSkill.get")(function* (input: { session: Session.Info; skill: Skill.ID }) {
   const instances = yield* Instance.Service
-  const skills = yield* Skill.Service.pipe(instances.provide(input.session))
+  const skills = yield* Plugin.awaitActivation.pipe(Effect.andThen(Skill.Service), instances.provide(input.session))
   const skill = yield* skills.get(input.skill)
   if (!skill) return yield* new SkillNotFoundError({ skill: input.skill })
   return skill

--- a/packages/core/test/fixture/prompt-location.ts
+++ b/packages/core/test/fixture/prompt-location.ts
@@ -2,6 +2,7 @@ import { Bus } from "@opencode-ai/core/bus"
 import { Image } from "@opencode-ai/core/image"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
 import type { LocationServices } from "@opencode-ai/core/location-services"
+import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
 import { Skill } from "@opencode-ai/core/skill"
 import type { Location } from "@opencode-ai/schema/location"
@@ -18,8 +19,11 @@ export const promptLocationNode = makeGlobalNode({
       const bus = yield* Bus.Service
       return yield* LayerMap.make(
         (_ref: Location.Ref) =>
-          LayerNode.compile(LayerNode.group([PluginHooks.node, Image.node, Skill.node]), {
-            replacements: [Bus.node.replace(Layer.succeed(Bus.Service, bus))],
+          LayerNode.compile(LayerNode.group([PluginHooks.node, Image.node, Skill.node, Plugin.node]), {
+            replacements: [
+              Bus.node.replace(Layer.succeed(Bus.Service, bus)),
+              Plugin.node.replace(Layer.mock(Plugin.Service, { awaitActivation: Effect.void })),
+            ],
           }) as Layer.Layer<LocationServices>,
       )
     }),

--- a/packages/core/test/session-activation.test.ts
+++ b/packages/core/test/session-activation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, setDefaultTimeout } from "bun:test"
+import { Effect } from "effect"
+import path from "path"
+import { Bus } from "@opencode-ai/core/bus"
+import { Database } from "@opencode-ai/core/database/database"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
+import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Session } from "@opencode-ai/core/session"
+import { SessionExecution } from "@opencode-ai/core/session/execution"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Global } from "@opencode-ai/util/global"
+import { tempGlobalLayer } from "./fixture/global"
+import { tmpdirScoped } from "./fixture/tmpdir"
+import { testEffect } from "./lib/effect"
+
+// Real Location boot with plugin discovery, so the first request races the initial plugin activation.
+setDefaultTimeout(15_000)
+
+const it = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Database.node, Bus.node, SessionProjector.node, Session.node, LocationServiceMap.node]),
+    [
+      Global.node.replace(tempGlobalLayer),
+      Watcher.node.replace(Watcher.configured({ enabled: false })),
+      SessionExecution.node.replace(SessionExecution.noopLayer),
+    ],
+  ),
+)
+
+const project = Effect.gen(function* () {
+  const tmp = yield* tmpdirScoped()
+  yield* Effect.promise(() =>
+    Bun.write(
+      path.join(tmp.path, ".opencode/plugins/prompt.ts"),
+      `export default {
+        id: "prompt-readiness",
+        async setup(ctx) {
+          await ctx.session.hook("prompt", (event) => {
+            event.prompt.text = "Prepared by plugin"
+          })
+          await ctx.command.transform((editor) =>
+            editor.add({ name: "ready", description: "Registered by plugin", execute: async () => {} }),
+          )
+        },
+      }`,
+    ),
+  )
+  return tmp
+})
+
+describe("Session waits for plugin activation", () => {
+  it.live("runs prompt hooks from a cold Location before admitting a prompt", () =>
+    Effect.gen(function* () {
+      const tmp = yield* project
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ location: { directory: AbsolutePath.make(tmp.path) } })
+      const admitted = yield* sessions.prompt({ sessionID: session.id, text: "Original", resume: false })
+      expect(admitted.payload.text).toBe("Prepared by plugin")
+    }),
+  )
+
+  it.live("resolves plugin commands from a cold Location", () =>
+    Effect.gen(function* () {
+      const tmp = yield* project
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ location: { directory: AbsolutePath.make(tmp.path) } })
+      yield* sessions.command({ sessionID: session.id, command: "ready", text: "now" })
+    }),
+  )
+})

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -37,6 +37,7 @@ import {
 } from "@opencode-ai/core/session/sql"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { SkillInstructions } from "@opencode-ai/core/skill/instructions"
+import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginSupervisor } from "@opencode-ai/core/plugin/supervisor"
 import { Tool } from "@opencode-ai/core/tool"
 import { asc, eq } from "drizzle-orm"
@@ -227,7 +228,13 @@ const setup = Effect.gen(function* () {
     instructions: yield* instructionBuiltIns.load(sessionID),
     instances: Instance.Service.of({
       // Generation only exercises the Location's model context.
-      provide: () => Effect.provide(Layer.succeed(SessionContext.Service, context) as Layer.Layer<Instance.Services>),
+      provide: () =>
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(SessionContext.Service, context),
+            Layer.mock(Plugin.Service, { awaitActivation: Effect.void }),
+          ) as Layer.Layer<Instance.Services>,
+        ),
     }),
   }
 })

--- a/packages/core/test/session-owned.test.ts
+++ b/packages/core/test/session-owned.test.ts
@@ -239,7 +239,7 @@ describe("Session-owned handles", () => {
       const calls: string[] = []
       yield* fixture.hooks.register("session", "prompt", (event) =>
         Effect.sync(() => {
-          expect(fixture.activationWaits).toEqual([])
+          expect(fixture.activationWaits).toEqual([source])
           calls.push(event.prompt.text)
           event.prompt.text += " prepared"
         }),
@@ -264,7 +264,7 @@ describe("Session-owned handles", () => {
       )
       expect(calls).toEqual(["Original"])
       expect(fixture.locations).toEqual([source])
-      expect(fixture.activationWaits).toEqual([])
+      expect(fixture.activationWaits).toEqual([source])
       expect(fixture.wakes).toEqual([
         { sessionID, pending: [synthetic.id, first.id], enqueued: 2 },
         { sessionID, pending: [synthetic.id, first.id], enqueued: 2 },
@@ -350,7 +350,7 @@ describe("Session-owned handles", () => {
       expect(fixture.locations).toEqual([source])
       yield* prompt
       expect(fixture.locations).toEqual([source, destination])
-      expect(fixture.activationWaits).toEqual([])
+      expect(fixture.activationWaits).toEqual([source, destination])
       expect((yield* fixture.sessions.forSession(otherID).get()).location).toEqual(source)
     }),
   )
@@ -395,7 +395,7 @@ describe("Session-owned handles", () => {
       expect(
         events.filter((event) => event.type === SessionEvent.Skill.Activated.type).map((event) => event.location),
       ).toEqual([undefined, undefined, source])
-      expect(fixture.activationWaits).toEqual([])
+      expect(fixture.activationWaits).toEqual([source, destination, destination])
       expect(fixture.resumes).toEqual([])
       expect(fixture.wakes).toEqual([])
     }),
@@ -429,7 +429,7 @@ describe("Session-owned handles", () => {
       expect(yield* handle.get()).toEqual(before)
       expect(yield* handle.inbox()).toEqual([])
       expect(yield* fixture.store.context(sessionID)).toEqual([])
-      expect(fixture.activationWaits).toEqual([])
+      expect(fixture.activationWaits).toEqual([source])
       expect(fixture.resumes).toEqual([])
       expect(fixture.wakes).toEqual([])
     }),

--- a/packages/core/test/session-shell.test.ts
+++ b/packages/core/test/session-shell.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, setDefaultTimeout } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
 import { Cause, Context, Deferred, Effect, Exit, Fiber, Layer, Option, Schedule, Stream } from "effect"
@@ -16,6 +16,9 @@ import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { location } from "./fixture/location"
 import { tmpdirScoped } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
+
+// Every test boots a real Location, so shell start waits for cold plugin activation before spawning.
+setDefaultTimeout(15_000)
 
 class ExecutionControl extends Context.Service<
   ExecutionControl,

--- a/packages/core/test/session-skill.test.ts
+++ b/packages/core/test/session-skill.test.ts
@@ -11,6 +11,7 @@ import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
 import type { LocationServices } from "@opencode-ai/core/location-services"
 import { Project } from "@opencode-ai/core/project"
+import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
@@ -47,6 +48,7 @@ const locations = makeGlobalNode({
             get: (id) => Effect.succeed(id === info.id ? info : undefined),
             list: () => Effect.succeed([info]),
           }),
+          Layer.mock(Plugin.Service, { awaitActivation: Effect.void }),
         ) as unknown as Layer.Layer<LocationServices>,
     ),
   ),

--- a/packages/server/src/handlers/plugin.ts
+++ b/packages/server/src/handlers/plugin.ts
@@ -13,7 +13,7 @@ export const PluginHandler = HttpApiBuilder.group(Api, "server.plugin", (handler
         return yield* response(Plugin.Service.use((plugin) => plugin.list()))
       }),
     )
-    .handle("plugin.awaitActivation", () => Plugin.Service.use((plugin) => plugin.awaitActivation))
+    .handle("plugin.awaitActivation", () => Plugin.awaitActivation)
     .handle("plugin.check", (ctx) =>
       Effect.gen(function* () {
         const plugins = yield* Plugin.Service

--- a/packages/server/src/handlers/rpc.ts
+++ b/packages/server/src/handlers/rpc.ts
@@ -8,8 +8,7 @@ import { Api } from "../api"
 export const RpcHandler = HttpApiBuilder.group(Api, "server.rpc", (handlers) =>
   handlers.handle("rpc.call", ({ params, payload }) =>
     Effect.gen(function* () {
-      const plugins = yield* Plugin.Service
-      yield* plugins.awaitActivation
+      yield* Plugin.awaitActivation
       const rpc = yield* Rpc.Service
       const output = yield* rpc.call(params.rpcID, params.method, payload.input)
       return output === undefined ? {} : { output }


### PR DESCRIPTION
## Why

A cold Location activates its plugins asynchronously: the supervisor's initial generation runs behind a 100 ms `Stream.debounce`, and builtins such as `ConfigCommandPlugin`, `SkillPlugin`, and every provider plugin register only when it completes. Session entry points used to wait on that before reading plugin-provided state. #46639 removed the waits from `Session.command`, `SessionPrompt.prepare`, and `Session.shell` and flipped the `session-owned` assertions from `activationWaits == [source]` to `[]`, while its description says sessions wait on `Plugin`. Only `SessionRunner.drain` still does.

The consequence is deterministic on `v2` for the first request after boot:

```text
sessions.prompt({ text: "Original" })   → plugin prompt hooks never run; "Original" is durably admitted
sessions.command({ command: "ready" })  → Command.NotFoundError for a command a discovered plugin registers
```

The new `session-activation.test.ts` boots a real Location with a `.opencode/plugins/prompt.ts` and reproduces both. It fails on `v2` and passes with this change. This is also the root of the ACP catalog race that #46682 worked around from the client side.

## What Changes

- `SessionPrompt.prepare`, `SessionCommand.execute`, `SessionSkill.get`, `SessionShell.start`, and `SessionGenerate` wait on `Plugin.awaitActivation` inside the Location they enter, before resolving hooks, commands, skills, the shell, or the model catalog. Revert is unchanged: it only touches `Snapshot` → `Git`, which no plugin provides.
- `Plugin.awaitActivation` is a new accessor (`Service.use((plugins) => plugins.awaitActivation)`) so each site is one line instead of the old three-line `Effect.gen` block.
- The `Plugin.Service` tag, `Interface`, `Generation`, and `Failure` move to `plugin/service.ts`, mirroring `instance/service.ts`. Session code importing `plugin.ts` directly creates the cycle `plugin.ts → plugin/host.ts → session.ts → session/prompt.ts → plugin.ts`, which the standalone server hits at boot (`ReferenceError: Cannot access 'node' before initialization` in `plugin/host.ts`). `plugin.ts` re-exports the same names, so no other import changes.
- `session-shell.test.ts` gets a 15 s default timeout like the other real-Location suites: every test there boots a fresh Location, so shell start now includes cold activation before PowerShell spawns, and the Windows runner exceeded the 5 s default on the `exit 7` case.
- Tests: `session-owned` assertions restored to the pre-#46639 expectations (`[source]`, `[source, destination]`, …), with the skill and missing-session cases updated to match. The `prompt-location` fixture and the `session-skill`/`session-generate` mocks gain a `Plugin.Service` mock, since their hand-built Locations predate the wait.

Cost: one activation wait per cold Location on the first prompt/command/skill/shell/generate — about 250 ms locally for the builtins plus one file plugin (100 ms of it is the initial `Stream.debounce`), evidently longer on the Windows runner. Warm Locations pay nothing; the runner already waited before this change.

Not in scope, from the same audit: the catalog/VCS/shell server handlers also lost their bounded readiness wait in `5d73a5789f`, and the initial generation still pays the 100 ms debounce. Both are separate decisions.

## Verification

```sh
# packages/core
bun typecheck
bun run test test/session-activation.test.ts       # fails on v2 (2/2), passes here (2/2, --rerun-each 5)
bun run test                                        # 3,998 pass, 39 skip, 0 fail
# packages/server
bun run ../core/script/test.ts                      # 50 pass, 0 fail
# packages/cli
bun typecheck && bun run test test/acp              # 96 pass, 0 fail
# manual: OPENCODE_* isolated env, `opencode serve --stdio --port 0` boots and prints its endpoint
```
