### PR TITLE
feat(tui): show live tokens per second while a response streams

### DIFF
--- a/packages/tui/src/routes/session/index.tsx
+++ b/packages/tui/src/routes/session/index.tsx
@@ -1489,6 +1489,28 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
   const childShortcut = useCommandShortcut("session.child.first")
   const backgroundShortcut = useCommandShortcut("session.background")
 
+  const [tick, setTick] = createSignal(0)
+  createEffect(() => {
+    if (final()) return
+    const id = setInterval(() => setTick((t) => t + 1), 500)
+    onCleanup(() => clearInterval(id))
+  })
+  // ponytail: output tokens aren't known until step-finish, so streaming tok/s
+  // is estimated from accumulated output chars (~4 chars/token). Upstream
+  // upgrade path: core emitting periodic usage during the stream.
+  const liveTps = createMemo(() => {
+    if (final()) return undefined
+    tick()
+    let chars = 0
+    for (const part of props.parts) {
+      if (part.type === "text" || part.type === "reasoning") chars += part.text?.length ?? 0
+    }
+    if (chars <= 0) return undefined
+    const elapsedMs = Date.now() - props.message.time.created
+    if (elapsedMs < 1000) return undefined
+    return Math.round(chars / 4 / (elapsedMs / 1000))
+  })
+
   return (
     <>
       <For each={props.parts}>
@@ -1561,6 +1583,9 @@ function AssistantMessage(props: { message: AssistantMessage; parts: Part[]; las
               </span>{" "}
               <span style={{ fg: theme.text }}>{Locale.titlecase(props.message.mode)}</span>
               <span style={{ fg: theme.textMuted }}> · {model()}</span>
+              <Show when={liveTps()}>
+                <span style={{ fg: theme.textMuted }}> · ~{liveTps()} tok/s</span>
+              </Show>
               <Show when={duration()}>
                 <span style={{ fg: theme.textMuted }}> · {Locale.duration(duration())}</span>
               </Show>


### PR DESCRIPTION
## What

Shows a live, estimated tokens-per-second figure in the assistant message footer **while a response is streaming**:

`Build · Muse Spark 1.2 Free · ~42 tok/s`

When the message completes, the ticker disappears (the footer's final stats take over; an exact final tok/s figure is proposed separately in #46108).

## Why

#43857 (throughput visibility) covers completed responses; this covers the streaming window — the part of a response where "is this model slow or just warming up?" is most felt. Same motivator: with gateways and shared free pools, per-response speed varies wildly between turns, and nothing in the UI surfaces that until it's over.

## Design disclosure (the part reviewers should scrutinize)

Exact output tokens are only known at `step-finish` (`ctx.assistantMessage.tokens = usage.tokens` in the session processor) — the client receives no token counts mid-stream. So the ticker is an **estimate**:

- accumulates `text` + `reasoning` part characters for the streaming message
- estimates tokens as `chars / 4`
- divides by elapsed ms since `message.time.created`
- rendered with a `~` prefix to mark it approximate, refreshed every 500 ms, hidden for the first second and whenever the message is final or has no output yet

No protocol/schema changes — pure TUI diff. If maintainers prefer, the tilde could become a settings-gated display, or the estimate could move server-side later (periodic usage emission during the stream) as a follow-up.

## Verification

- `bun turbo run typecheck --filter=@opencode-ai/tui` — passes
- Manual: run `bun run dev` in `packages/tui`, send a prompt that produces a long response — `~N tok/s` appears while streaming and disappears at completion. Short responses may finish before the 1s warm-up elapses and show nothing (intended).
