### PR TITLE
fix(util): stage npm installs under the cache directory's real path

### DIFF
--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -319,6 +319,31 @@ describe("Npm.add", () => {
     expect(result.pinned).toContain("root: true")
     expect(result.current).toBeFalse()
   }, 30_000)
+
+  // Symlink creation needs elevated privileges on Windows.
+  test.skipIf(win)("records Git revisions when the cache directory is reached through a symlink", async () => {
+    await using tmp = await tmpdir()
+    const fixture = await createGitFixture(tmp.path)
+    await fs.mkdir(path.join(tmp.path, "cache"))
+    await fs.symlink(path.join(tmp.path, "cache"), path.join(tmp.path, "link"))
+    const mutable = `git+${pathToFileURL(fixture.repository).href}#fixture-branch`
+
+    const result = await Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      const added = yield* npm.add(mutable)
+      const current = yield* npm.check(mutable)
+      yield* Effect.promise(async () => {
+        await Bun.write(path.join(fixture.repository, "index.js"), 'export default { root: "second" }\n')
+        await Bun.$`git -C ${fixture.repository} add .`
+        await Bun.$`git -C ${fixture.repository} -c user.name=fixture -c user.email=fixture@example.com commit -qm second`
+      })
+      return { added, current, outdated: yield* npm.check(mutable) }
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(path.join(tmp.path, "link"))), Effect.runPromise)
+
+    expect(result.added.version).toBe(fixture.commit)
+    expect(result.current).toBeFalse()
+    expect(result.outdated).toBeTrue()
+  }, 30_000)
 })
 
 describe("Npm.resolve", () => {

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -286,7 +286,13 @@ const layer = Layer.effect(
 
       yield* mkdir(dir)
       const startedAt = yield* Clock.currentTimeMillis
-      const staging = path.join(dir, `.staging-${startedAt}-${randomUUID()}`)
+      // Arborist keys lockfile entries relative to the root's real path. When the cache
+      // directory is reached through a symlink (macOS `/var` → `/private/var`, a linked
+      // XDG cache), the keys become `../../…` paths that installedRevision never finds,
+      // so Git checks report "not installed" and updates go undetected. Stage under the
+      // resolved directory so the root path and real path agree.
+      const root = yield* fs.realPath(dir).pipe(Effect.mapError((cause) => new InstallFailedError({ dir, cause })))
+      const staging = path.join(root, `.staging-${startedAt}-${randomUUID()}`)
       const staged = yield* Effect.gen(function* () {
         const tree = yield* reify({ dir: staging, config: dir, add: [pkg], update })
         const installed = tree.edgesOut.values().next().value?.to


### PR DESCRIPTION
## Why

When the OpenCode cache directory is reached through a symlink, Git plugin update checks silently report "up to date" forever. On macOS every path under `/var/folders` is one (`/var` → `/private/var`), so any run with `HOME` or the cache under the system temp dir hits it, as does a linked `XDG_CACHE_HOME` or a symlinked home directory. A plain `~/.cache` is unaffected, which is why it has gone unnoticed.

Arborist keys `package-lock.json` entries relative to the root's *real* path. With the staging root at `/var/…/.staging-…`, the installed package lands under a key like `../../../../private/var/…/.staging-…/node_modules/<name>` instead of `node_modules/<name>`, and `installedRevision` never finds it.

```ts
Npm.install                                   // packages/util/src/npm.ts
├─ staging = path.join(dir, ".staging-…")     // dir = <cache>/npm/<key>, reached via symlink
├─ Arborist({ path: staging }).reify()        // lock key = relpath(realpath(root), node) = "../../…/private/var/…"
├─ installedRevision(staging, name)           // reads lock.packages["node_modules/<name>"] → undefined
│    └─ entry.version falls back to the manifest version ("1.0.0" instead of the commit)
└─ Npm.check(pkg)
     └─ InstallFailedError("Package is not installed")
          └─ PluginUpdate.check: Effect.option → outdated: false      // "All plugins are up to date"
```

## What Changes

`install` resolves the cache directory with `realPath` before creating the staging root, so the path Arborist is given and the real path agree and the lock keys come out as `node_modules/<name>`. Generations, cleanup, and the returned entry paths keep using the configured (possibly linked) directory as before.

| | Before | After |
| --- | --- | --- |
| Git package installed via a symlinked cache, `entry.version` | manifest version | commit SHA |
| `Npm.check` right after install | `InstallFailedError: Package is not installed` | `false` |
| `Npm.check` after the remote gains a commit | error, swallowed to `outdated: false` | `true` |
| Startup log | `failed to check plugin update … Package is not installed` | nothing |

## Scope

Only the staging root changes. The existing `npm.test.ts` fixtures already `realpath` their temp directories, which is why the suite never exercised this; the new test creates an explicit symlink to the cache directory and is skipped on Windows where symlink creation needs privileges.

## Verification

```sh
cd packages/core && bun test test/npm.test.ts
cd packages/util && bun typecheck
cd packages/core && bun typecheck
```

- New test `records Git revisions when the cache directory is reached through a symlink`: fails on `v2` with the production error (`error: Package is not installed: git+file:///private/var/…`), passes with the fix. Full `npm.test.ts`: 16 pass.
- End to end: the same `opencode-drive` scenario used for #46884, run with the default symlinked macOS `TMPDIR` against this branch. On `v2` the Plugins dialog showed `1.0.0` and the server logged `failed to check plugin update`; on this branch it shows the installed commit `088d9c2` and the log is clean.
