### PR TITLE
feat(tui): show per-model health and throughput in the model selector

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -24,7 +24,7 @@ import {
   Show,
   on,
 } from "solid-js"
-import { TuiPathsProvider, TuiStartupProvider, TuiTerminalEnvironmentProvider, useTuiStartup } from "./context/runtime"
+import { TuiPathsProvider, TuiStartupProvider, TuiTerminalEnvironmentProvider, useTuiPaths, useTuiStartup } from "./context/runtime"
 import { DialogProvider, useDialog } from "./ui/dialog"
 import { DialogProvider as DialogProviderList } from "./component/dialog-provider"
 import { ErrorComponent } from "./component/error-component"
@@ -32,6 +32,7 @@ import { PluginRouteMissing } from "./component/plugin-route-missing"
 import { ProjectProvider, useProject } from "./context/project"
 import { EditorContextProvider } from "./context/editor"
 import { useEvent } from "./context/event"
+import { initModelStats, recordModelEvent } from "./util/model-stats"
 import { SDKProvider, useSDK } from "./context/sdk"
 import { StartupLoading } from "./component/startup-loading"
 import { SyncProvider, useSync } from "./context/sync"
@@ -373,6 +374,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
   const kv = useKV()
   const keymap = useOpencodeKeymap()
   const event = useEvent()
+  initModelStats(useTuiPaths().state)
+  onCleanup(event.on("message.updated", recordModelEvent))
   const sdk = useSDK()
   const toast = useToast()
   const themeState = useTheme()

--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -8,6 +8,9 @@ import { DialogVariant } from "./dialog-variant"
 import * as fuzzysort from "fuzzysort"
 import { useConnected } from "./use-connected"
 import { useSync } from "../context/sync"
+import { useTheme } from "../context/theme"
+import { modelStats, summarizeModelStat } from "../util/model-stats"
+import type { JSX } from "solid-js"
 
 export function DialogModel(props: { providerID?: string }) {
   const local = useLocal()
@@ -17,6 +20,25 @@ export function DialogModel(props: { providerID?: string }) {
 
   const connected = useConnected()
   const providers = createDialogProviderOptions()
+  const { theme } = useTheme()
+
+  // Health/throughput footer from TUI-local observed history: a green dot with
+  // the average tok/s of recent responses, red if the model errored recently.
+  // Models with no local history render exactly as before.
+  function statFooter(providerID: string, modelID: string, existing?: string): JSX.Element | string | undefined {
+    const summary = summarizeModelStat(modelStats[`${providerID}/${modelID}`])
+    if (!summary) return existing
+    const dot = <span style={{ fg: summary.healthy ? theme.diffAdded : theme.error }}>●</span>
+    const speed = summary.avg ? ` ${summary.avg} tok/s` : " err"
+    const base = existing ? ` · ${existing}` : ""
+    return (
+      <span style={{ fg: theme.textMuted }}>
+        {dot}
+        {speed}
+        {base}
+      </span>
+    )
+  }
 
   const showExtra = createMemo(() => connected() && !props.providerID)
 
@@ -41,7 +63,11 @@ export function DialogModel(props: { providerID?: string }) {
             description: provider.name,
             category,
             disabled: provider.id === "opencode" && model.id.includes("-nano"),
-            footer: model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            footer: statFooter(
+              provider.id,
+              item.modelID,
+              model.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            ),
             onSelect: () => {
               onSelect(provider.id, model.id)
             },
@@ -79,7 +105,7 @@ export function DialogModel(props: { providerID?: string }) {
               : undefined,
             category: connected() ? provider.name : undefined,
             disabled: provider.id === "opencode" && model.includes("-nano"),
-            footer: info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined,
+            footer: statFooter(provider.id, model, info.cost?.input === 0 && provider.id === "opencode" ? "Free" : undefined),
             onSelect() {
               onSelect(provider.id, model)
             },
@@ -183,7 +209,7 @@ export function DialogModel(props: { providerID?: string }) {
   )
 }
 
-export function sortModelOptions<T extends { footer?: string; releaseDate: string | number; title: string }>(
+export function sortModelOptions<T extends { footer?: string | JSX.Element; releaseDate: string | number; title: string }>(
   options: T[],
   newestFirst: boolean,
 ) {

--- a/packages/tui/src/util/model-stats.ts
+++ b/packages/tui/src/util/model-stats.ts
@@ -1,0 +1,93 @@
+// TUI-local per-model reliability/throughput stats, recorded from
+// message.updated events and persisted to the TUI state directory.
+// ponytail: client-local observations only (this TUI's own traffic), exact
+// tok/s from completed messages, not a server-side aggregate — a shared
+// cross-device version would need a core endpoint (possible follow-up).
+
+import { createStore, reconcile, unwrap } from "solid-js/store"
+import { Flock } from "@opencode-ai/core/util/flock"
+import { readJson, writeJsonAtomic } from "./persistence"
+import path from "path"
+
+const MAX_SAMPLES = 10
+const ERROR_WINDOW_MS = 15 * 60 * 1000
+const LOCK = "tui-model-stats"
+
+export type ModelStat = {
+  samples: number[]
+  errors: number
+  lastErrorAt?: number
+}
+
+const [stats, setStats] = createStore<Record<string, ModelStat>>({})
+export { stats as modelStats }
+
+const seen = new Set<string>()
+let stateDir: string | undefined
+let writeTimer: ReturnType<typeof setTimeout> | undefined
+
+function file() {
+  return path.join(stateDir!, "model-stats.json")
+}
+
+function persist() {
+  if (!stateDir) return
+  clearTimeout(writeTimer)
+  writeTimer = setTimeout(() => {
+    void Flock.withLock(LOCK, () => writeJsonAtomic(file(), unwrap(stats)))
+  }, 300)
+}
+
+export function initModelStats(dir: string) {
+  if (stateDir) return
+  stateDir = dir
+  void Flock.withLock(LOCK, async () => {
+    const stored = await readJson<Record<string, ModelStat>>(file())
+    if (stored && typeof stored === "object") setStats(reconcile(stored))
+  })
+}
+
+export function summarizeModelStat(stat: ModelStat | undefined) {
+  if (!stat) return undefined
+  const avg = stat.samples.length
+    ? Math.round(stat.samples.reduce((a, b) => a + b, 0) / stat.samples.length)
+    : undefined
+  const healthy = !stat.lastErrorAt || Date.now() - stat.lastErrorAt > ERROR_WINDOW_MS
+  return { avg, healthy }
+}
+
+export function recordModelEvent(event: { type: string; properties?: any }) {
+  try {
+    if (!event || event.type !== "message.updated") return
+    const info = event.properties?.info
+    if (!info || info.role !== "assistant") return
+    const key = `${info.providerID}/${info.modelID}`
+    if (!info.providerID || !info.modelID) return
+
+    if (info.error) {
+      if (!seen.has(info.id)) {
+        seen.add(info.id)
+        const prev = stats[key] ?? { samples: [], errors: 0 }
+        setStats(key, { samples: prev.samples, errors: prev.errors + 1, lastErrorAt: Date.now() })
+        persist()
+      }
+      return
+    }
+
+    if (seen.has(info.id)) return
+    const time = info.time ?? {}
+    if (typeof time.completed !== "number" || typeof time.created !== "number") return
+    seen.add(info.id)
+
+    const output = info.tokens?.output ?? 0
+    const seconds = (time.completed - time.created) / 1000
+    if (output <= 0 || seconds <= 0 || info.finish === "error") return
+
+    const prev = stats[key] ?? { samples: [], errors: 0 }
+    const tps = Math.round((output / seconds) * 10) / 10
+    setStats(key, { ...prev, samples: [...prev.samples, tps].slice(-MAX_SAMPLES) })
+    persist()
+  } catch {
+    // stats must never break the event loop
+  }
+}


### PR DESCRIPTION
## What

The model selector now shows a health/throughput line for models **you have actually used on this machine**:

```
● 44 tok/s · Free      (green dot — working, recent average speed)
● 12 tok/s             (red dot — errored in the last 15 minutes)
```

Models with no local history render exactly as before — no clutter, no fake data.

## Why

#43857 and #46882 cover tok/s during and after generation. This closes the loop on the third part: choosing a model. Gateways and shared free pools mean the same model name can be fast one turn and dead the next (upstream 429s, capacity errors) — nothing in the selector reflects that today. With this, the selector answers "which of my models are actually usable right now, and how fast are they?" from observed reality.

## Design disclosure

- **Client-local, not server-side:** stats are recorded by the TUI from `message.updated` events it already receives (exact tok/s from `tokens.output / elapsed` on completion, error counts on `info.error`), kept for the last 10 responses per model, and persisted atomically (`Flock` + `writeJsonAtomic`) to `model-stats.json` in the TUI state directory. No protocol, schema, or SDK changes; no network calls; nothing leaves the machine.
- **Failure semantics:** a recent error (last 15 min) turns the dot red — the speed average stays visible so a slow-but-alive model is distinguishable from a dead one. The window is arbitrary; happy to make it configurable or expiry-only.
- **Known ceiling:** stats reflect this client's own traffic only. A shared/cross-device aggregate would need a core endpoint — happy to explore that as a follow-up if maintainers want it.

## Verification

- `bun turbo run typecheck --filter=@opencode-ai/tui` — passes
- Manual: `bun run dev` in `packages/tui` — send a few messages across models (including one against a rate-limited/errored model), open the model selector: used models show `● <avg> tok/s`, the errored one shows red. Untried models are unchanged.

## Screenshot

To follow in a comment (needs an interactive session; behavior described above is testable with any two models, one forced to error).
