### PR TITLE
fix(opencode): default chunk timeout to five minutes

### DIFF
--- a/packages/core/src/v1/config/provider.ts
+++ b/packages/core/src/v1/config/provider.ts
@@ -114,9 +114,14 @@ export const Info = Schema.Struct({
           description:
             "Timeout in milliseconds to wait for response headers. Provider integrations may set defaults. Set to false to disable timeout.",
         }),
-        chunkTimeout: Schema.optional(PositiveInt).annotate({
+        chunkTimeout: Schema.optional(
+          Schema.Union([PositiveInt, Schema.Literal(false)]).annotate({
+            description:
+              "Timeout in milliseconds between streamed SSE chunks for this provider (default: 300000). If no chunk arrives within this window, the request is aborted. Set to false to disable timeout.",
+          }),
+        ).annotate({
           description:
-            "Timeout in milliseconds between streamed SSE chunks for this provider. If no chunk arrives within this window, the request is aborted.",
+            "Timeout in milliseconds between streamed SSE chunks for this provider (default: 300000). If no chunk arrives within this window, the request is aborted. Set to false to disable timeout.",
         }),
       }),
       [Schema.Record(Schema.String, Schema.Any)],

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1671,6 +1671,8 @@ const layer = Layer.effect(
             continue
           }
 
+          provider.options.chunkTimeout ??= 300_000
+
           const configProvider = cfg.provider?.[providerID]
 
           for (const [modelID, model] of Object.entries(provider.models)) {

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -1671,8 +1671,6 @@ const layer = Layer.effect(
             continue
           }
 
-          provider.options.chunkTimeout ??= 300_000
-
           const configProvider = cfg.provider?.[providerID]
 
           for (const [modelID, model] of Object.entries(provider.models)) {
@@ -1794,7 +1792,7 @@ const layer = Layer.effect(
         if (existing) return existing
 
         const customFetch = options["fetch"]
-        const chunkTimeout = options["chunkTimeout"]
+        const chunkTimeout = options["chunkTimeout"] ?? 300_000
         const headerTimeout = options["headerTimeout"]
         delete options["chunkTimeout"]
         delete options["headerTimeout"]

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -13,6 +13,8 @@ import { Env } from "@/env"
 import { Plugin } from "@/plugin"
 import { Provider } from "@/provider/provider"
 import { ProviderError } from "@/provider/error"
+import { MessageV2 } from "@/session/message-v2"
+import { SessionRetry } from "@/session/retry"
 
 afterEach(async () => {
   await disposeAllInstances()
@@ -46,7 +48,18 @@ it.live("headerTimeout does not abort delayed SSE body after headers arrive", ()
   }),
 )
 
-it.live("chunkTimeout raises a response stream error when SSE body stalls", () =>
+it.instance(
+  "chunkTimeout defaults to five minutes for custom providers",
+  () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider.Service
+      const configured = yield* provider.getProvider(ProviderV2.ID.make("test"))
+      expect(configured.options.chunkTimeout).toBe(300_000)
+    }),
+  { config: providerConfig("http://localhost:1234") },
+)
+
+it.live("configured chunkTimeout raises a retryable response stream error when SSE body stalls", () =>
   Effect.gen(function* () {
     const server = yield* Effect.acquireRelease(
       Effect.promise(() => delayedBodyServer(250)),
@@ -74,6 +87,9 @@ it.live("chunkTimeout raises a response stream error when SSE body stalls", () =
             }
           })
           expect(error).toBeInstanceOf(ProviderError.ResponseStreamError)
+          expect(
+            SessionRetry.retryable(MessageV2.fromError(error, { providerID: model.providerID }), model.providerID),
+          ).toEqual({ message: "SSE read timed out" })
         }),
       { config: providerConfig(server.url, { chunkTimeout: 50 }) },
     )
@@ -154,7 +170,7 @@ it.live("OpenAI Codex headerTimeout default can be disabled by config", () =>
   }),
 )
 
-it.live("OpenAI API auth gets default headerTimeout", () =>
+it.live("OpenAI API auth gets default header and chunk timeouts", () =>
   Effect.gen(function* () {
     yield* withAuthContent(
       Effect.gen(function* () {
@@ -163,6 +179,7 @@ it.live("OpenAI API auth gets default headerTimeout", () =>
             const provider = yield* Provider.Service
             const openai = yield* provider.getProvider(ProviderV2.ID.openai)
             expect(openai.options.headerTimeout).toBe(300_000)
+            expect(openai.options.chunkTimeout).toBe(300_000)
           }),
         )
       }),

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -96,6 +96,32 @@ it.live("configured chunkTimeout raises a retryable response stream error when S
   }),
 )
 
+it.live("chunkTimeout can be disabled with false", () =>
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.promise(() => delayedBodyServer(250)),
+      (server) => Effect.sync(() => server.server.close()),
+    )
+
+    yield* provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const provider = yield* Provider.Service
+          const configured = yield* provider.getProvider(ProviderV2.ID.make("test"))
+          expect(configured.options.chunkTimeout).toBe(false)
+          const model = yield* provider.getModel(ProviderV2.ID.make("test"), ModelV2.ID.make("test-model"))
+          const result = streamText({
+            model: yield* provider.getLanguage(model),
+            messages: [{ role: "user", content: "hello" }],
+          })
+
+          expect(yield* Effect.promise(() => result.text)).toBe("late")
+        }),
+      { config: providerConfig(server.url, { chunkTimeout: false }) },
+    )
+  }),
+)
+
 it.live("headerTimeout aborts when response headers do not arrive", () =>
   Effect.gen(function* () {
     const server = yield* Effect.acquireRelease(
@@ -152,7 +178,7 @@ it.live("headerTimeout is opt-in for non-OpenAI providers", () =>
   }),
 )
 
-it.live("OpenAI Codex headerTimeout default can be disabled by config", () =>
+it.live("OpenAI Codex header and chunk timeout defaults can be disabled by config", () =>
   Effect.gen(function* () {
     yield* withAuthContent(
       Effect.gen(function* () {
@@ -162,8 +188,9 @@ it.live("OpenAI Codex headerTimeout default can be disabled by config", () =>
               const provider = yield* Provider.Service
               const openai = yield* provider.getProvider(ProviderV2.ID.openai)
               expect(openai.options.headerTimeout).toBe(false)
+              expect(openai.options.chunkTimeout).toBe(false)
             }),
-          { config: { provider: { openai: { options: { headerTimeout: false } } } } },
+          { config: { provider: { openai: { options: { headerTimeout: false, chunkTimeout: false } } } } },
         )
       }),
     )

--- a/packages/opencode/test/provider/header-timeout.test.ts
+++ b/packages/opencode/test/provider/header-timeout.test.ts
@@ -48,15 +48,39 @@ it.live("headerTimeout does not abort delayed SSE body after headers arrive", ()
   }),
 )
 
-it.instance(
-  "chunkTimeout defaults to five minutes for custom providers",
-  () =>
-    Effect.gen(function* () {
-      const provider = yield* Provider.Service
-      const configured = yield* provider.getProvider(ProviderV2.ID.make("test"))
-      expect(configured.options.chunkTimeout).toBe(300_000)
-    }),
-  { config: providerConfig("http://localhost:1234") },
+it.live("default chunkTimeout is applied at fetch without changing provider options", () =>
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.promise(() => delayedBodyServer(250)),
+      (server) => Effect.sync(() => server.server.close()),
+    )
+
+    yield* provideTmpdirInstance(
+      () =>
+        Effect.gen(function* () {
+          const provider = yield* Provider.Service
+          const configured = yield* provider.getProvider(ProviderV2.ID.make("test"))
+          const signals: (AbortSignal | null | undefined)[] = []
+          configured.options.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+            signals.push(init?.signal)
+            return fetch(input, init)
+          }
+          const model = yield* provider.getModel(ProviderV2.ID.make("test"), ModelV2.ID.make("test-model"))
+          const language = yield* provider.getLanguage(model)
+          yield* Effect.acquireRelease(
+            Effect.promise(() =>
+              language.doStream({ prompt: [{ role: "user", content: [{ type: "text", text: "hello" }] }] }),
+            ),
+            (result) => Effect.promise(() => result.stream.cancel()),
+          )
+
+          expect(signals).toHaveLength(1)
+          expect(signals[0]).toBeInstanceOf(AbortSignal)
+          expect(configured.options.chunkTimeout).toBeUndefined()
+        }),
+      { config: providerConfig(server.url) },
+    )
+  }),
 )
 
 it.live("configured chunkTimeout raises a retryable response stream error when SSE body stalls", () =>
@@ -197,7 +221,7 @@ it.live("OpenAI Codex header and chunk timeout defaults can be disabled by confi
   }),
 )
 
-it.live("OpenAI API auth gets default header and chunk timeouts", () =>
+it.live("OpenAI API auth gets default headerTimeout", () =>
   Effect.gen(function* () {
     yield* withAuthContent(
       Effect.gen(function* () {
@@ -206,7 +230,6 @@ it.live("OpenAI API auth gets default header and chunk timeouts", () =>
             const provider = yield* Provider.Service
             const openai = yield* provider.getProvider(ProviderV2.ID.openai)
             expect(openai.options.headerTimeout).toBe(300_000)
-            expect(openai.options.chunkTimeout).toBe(300_000)
           }),
         )
       }),

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -1754,8 +1754,11 @@ export type ProviderConfig = {
      * Timeout in milliseconds to wait for response headers. Provider integrations may set defaults. Set to false to disable timeout.
      */
     headerTimeout?: number | false
-    chunkTimeout?: number
-    [key: string]: unknown | string | boolean | number | false | number | false | number | undefined
+    /**
+     * Timeout in milliseconds between streamed SSE chunks for this provider (default: 300000). If no chunk arrives within this window, the request is aborted. Set to false to disable timeout.
+     */
+    chunkTimeout?: number | false
+    [key: string]: unknown | string | boolean | number | false | number | false | number | false | undefined
   }
   models?: {
     [key: string]: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -20783,8 +20783,17 @@
                 "description": "Timeout in milliseconds to wait for response headers. Provider integrations may set defaults. Set to false to disable timeout."
               },
               "chunkTimeout": {
-                "type": "integer",
-                "exclusiveMinimum": 0
+                "anyOf": [
+                  {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  {
+                    "type": "boolean",
+                    "enum": [false]
+                  }
+                ],
+                "description": "Timeout in milliseconds between streamed SSE chunks for this provider (default: 300000). If no chunk arrives within this window, the request is aborted. Set to false to disable timeout."
               }
             },
             "additionalProperties": {}

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -392,7 +392,7 @@ Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
 ```
 
 - `timeout` - Request timeout in milliseconds (default: 300000). Set to `false` to disable.
-- `chunkTimeout` - Timeout in milliseconds between streamed response chunks. If no chunk arrives in time, the request is aborted.
+- `chunkTimeout` - Timeout in milliseconds between streamed response chunks (default: 300000, or 5 minutes). If no chunk arrives in time, the request is aborted.
 - `setCacheKey` - Ensure a cache key is always set for designated provider.
 
 You can also configure [local models](/docs/models#local). [Learn more](/docs/models).

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -392,7 +392,7 @@ Provider options can include `timeout`, `chunkTimeout`, and `setCacheKey`:
 ```
 
 - `timeout` - Request timeout in milliseconds (default: 300000). Set to `false` to disable.
-- `chunkTimeout` - Timeout in milliseconds between streamed response chunks (default: 300000, or 5 minutes). If no chunk arrives in time, the request is aborted.
+- `chunkTimeout` - Timeout in milliseconds between streamed response chunks (default: 300000, or 5 minutes). If no chunk arrives in time, the request is aborted. Set to `false` to disable.
 - `setCacheKey` - Ensure a cache key is always set for designated provider.
 
 You can also configure [local models](/docs/models#local). [Learn more](/docs/models).


### PR DESCRIPTION
Sets the default timeout between streamed SSE response chunks to five minutes (300,000 ms). Stalled requests are aborted and retried using the existing retry policy. This limits inactivity between chunks, not the total response duration.

To disable it for a provider, set `chunkTimeout` to `false` in your project's `opencode.json` or global `~/.config/opencode/opencode.json`:

```json
{
  "provider": {
    "anthropic": {
      "options": {
        "chunkTimeout": false
      }
    }
  }
}
```

Replace `anthropic` with your provider. To change the timeout instead, use a positive number of milliseconds, such as `"chunkTimeout": 600000` for ten minutes. Omit the setting to use the five-minute default.
