### PR TITLE
fix(app): hydrate Home projects from the server project list

### DIFF
--- a/packages/app/e2e/regression/home-server-projects.spec.ts
+++ b/packages/app/e2e/regression/home-server-projects.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test, type Page } from "@playwright/test"
+import { fixture, pageMessages } from "../smoke/session-timeline.fixture"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible } from "../utils/waits"
+
+// Regression: Home used to render its project sidebar exclusively from a
+// browser-localStorage registry. Projects known to the server (created via the
+// TUI/CLI in another terminal) never appeared until manually re-added in that
+// browser, leaving Home empty on a fresh profile. Server-known projects must
+// hydrate automatically, while a project the user closed stays closed.
+
+const otherDirectory = "C:/OpenCode/OtherProject"
+const otherProject = {
+  id: "proj_other",
+  worktree: otherDirectory,
+  vcs: "git",
+  name: "other-project",
+  time: { created: 1700000000000, updated: 1700000000000 },
+  sandboxes: [],
+}
+const globalProject = {
+  id: "global",
+  worktree: "C:/",
+  time: { created: 1700000000000, updated: 1700000000000 },
+  sandboxes: [],
+}
+const otherSession = {
+  id: "ses_other_tui",
+  slug: "other-tui",
+  projectID: otherProject.id,
+  directory: otherDirectory,
+  title: "Session created from the TUI",
+  version: "dev",
+  time: { created: 1700000002000, updated: 1700000002000 },
+}
+
+const projectRows = (page: Page) => page.locator('[data-component="home-project-row"]')
+const sessionRows = (page: Page) => page.locator('[data-component="home-session-row"]')
+
+async function mockMultiProjectServer(page: Page) {
+  await mockOpenCodeServer(page, {
+    sessions: [...fixture.sessions, otherSession],
+    provider: fixture.provider,
+    directory: fixture.directory,
+    project: fixture.project,
+    projects: [globalProject, otherProject, fixture.project],
+    pageMessages,
+  })
+}
+
+test("home lists server-known projects and their sessions on a fresh profile", async ({ page }) => {
+  await mockMultiProjectServer(page)
+  await page.goto("/")
+
+  await expect(projectRows(page)).toHaveCount(2)
+  await expect(projectRows(page).filter({ hasText: "smoke-project" })).toHaveCount(1)
+  await expect(projectRows(page).filter({ hasText: "other-project" })).toHaveCount(1)
+
+  await expect(sessionRows(page).filter({ hasText: otherSession.title! })).toHaveCount(1)
+  await expect(sessionRows(page).filter({ hasText: fixture.expected.sourceTitle })).toHaveCount(1)
+})
+
+test("home keeps an explicitly closed server project closed", async ({ page }) => {
+  await mockMultiProjectServer(page)
+  await page.addInitScript(
+    ({ worktree, closed }) => {
+      localStorage.setItem(
+        "opencode.global.dat:server",
+        JSON.stringify({
+          projects: { local: [{ worktree, expanded: true }] },
+          lastProject: {},
+          recentlyClosed: { local: [closed] },
+        }),
+      )
+    },
+    { worktree: fixture.directory, closed: otherDirectory },
+  )
+  await page.goto("/")
+
+  const add = page.getByRole("button", { name: "Add project" }).first()
+  await expectAppVisible(add)
+
+  await expect(projectRows(page)).toHaveCount(1)
+  await expect(projectRows(page).filter({ hasText: "smoke-project" })).toHaveCount(1)
+  await expect(projectRows(page).filter({ hasText: "other-project" })).toHaveCount(0)
+  await expect(sessionRows(page).filter({ hasText: otherSession.title! })).toHaveCount(0)
+})

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -11,6 +11,7 @@ export interface MockServerConfig {
   onInstanceDispose?: () => void
   directory: string
   project: unknown
+  projects?: unknown[]
   sessions: ({ id: string } & Record<string, unknown>)[]
   pageMessages: (sessionId: string, limit: number, before?: string) => { items: unknown[]; cursor?: string }
   vcsDiff?: unknown[]
@@ -41,7 +42,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
       directory: config.directory,
       home: "C:/OpenCode",
     },
-    "/project": [config.project],
+    "/project": config.projects ?? [config.project],
     "/project/current": config.project,
     "/agent": [{ name: "build", mode: "primary" }],
     "/vcs": { branch: "main", default_branch: "main" },
@@ -149,7 +150,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
       config.onConnectKey?.({ integrationID: integrationConnect, body: route.request().postDataJSON() })
       return route.fulfill({ status: 204, headers: { "access-control-allow-origin": "*" } })
     }
-    if (path === "/api/project") return json(route, [config.project])
+    if (path === "/api/project") return json(route, config.projects ?? [config.project])
     if (path === "/api/project/current")
       return json(route, { id: (config.project as { id?: string }).id, directory: config.directory })
     if (path.startsWith("/api/project/") && route.request().method() === "PATCH") return json(route, config.project)

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -1,5 +1,5 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
-import { createEffect, createMemo, createRoot } from "solid-js"
+import { createEffect, createMemo, createRoot, untrack } from "solid-js"
 import { createStore } from "solid-js/store"
 import { createServerProjects, RECENTLY_CLOSED_DISPLAY_LIMIT, ServerConnection, useServer } from "./server"
 import { pathKey } from "@/utils/path-key"
@@ -109,6 +109,20 @@ function createServerCtx(
   })
   const sdk = createServerSdkContext(conn, scope)
   const sync = createServerSyncContext(sdk)
+
+  // The server knows every project that has sessions (TUI, CLI, or another browser).
+  // Adopt any server-known project missing from the persisted list so Home shows it
+  // without a manual add. The persisted list remains the UI source of truth for
+  // ordering and dismissal (recentlyClosed). The global project is skipped: its
+  // worktree is the filesystem root, not a project a user can open. untrack keeps
+  // this from re-running on every persisted-list change: worktree normalization
+  // removes entries this must not re-add until the server project list changes.
+  createEffect(() => {
+    const serverProjects = sync.data.project
+    untrack(() =>
+      projects.hydrate(serverProjects.flatMap((project) => (project.id === "global" ? [] : [project.worktree]))),
+    )
+  })
 
   function enrich(project: { worktree: string; expanded: boolean }) {
     const [childStore] = sync.child(project.worktree, { bootstrap: false })

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -197,6 +197,52 @@ describe("createServerProjects", () => {
       dispose()
     })
   })
+
+  test("hydrate appends missing server projects after persisted entries", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("/opened")
+      projects.hydrate(["/server-a", "/opened", "/server-b"])
+      expect(projects.list()).toEqual([
+        { worktree: "/opened", expanded: true },
+        { worktree: "/server-a", expanded: true },
+        { worktree: "/server-b", expanded: true },
+      ])
+      dispose()
+    })
+  })
+
+  test("hydrate keeps explicitly closed projects closed", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("/a")
+      projects.close("/a")
+      projects.hydrate(["/a", "/b"])
+      expect(projects.list()).toEqual([{ worktree: "/b", expanded: true }])
+      expect(projects.recentlyClosed()).toEqual(["/a"])
+      dispose()
+    })
+  })
+
+  test("hydrate ignores empty worktrees and dedupes by normalized path", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.hydrate(["", "/repo", "/repo/"])
+      expect(projects.list()).toEqual([{ worktree: "/repo", expanded: true }])
+      projects.hydrate(["/repo"])
+      expect(projects.list()).toEqual([{ worktree: "/repo", expanded: true }])
+      dispose()
+    })
+  })
 })
 
 describe("migrateCanonicalLocalServerState", () => {

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -120,6 +120,25 @@ export function createServerProjects<T extends ServerProjectState>(input: {
       )
       setStore("recentlyClosed", input.scope(), closed)
     },
+    // Adopt server-known projects (GET /project) that this browser never opened, so
+    // sessions created in the TUI/CLI still appear on Home. Appends instead of
+    // prepending: the persisted list keeps user ordering first. Entries the user
+    // closed stay closed — recentlyClosed is the explicit dismissal set.
+    hydrate(worktrees: string[]) {
+      const existing = new Set(current().map((project) => pathKey(project.worktree)))
+      const closed = new Set(currentClosed().map(pathKey))
+      const missing = worktrees.filter((worktree) => {
+        const key = pathKey(worktree)
+        if (!key || existing.has(key) || closed.has(key)) return false
+        existing.add(key)
+        return true
+      })
+      if (missing.length === 0) return
+      setStore("projects", input.scope(), [
+        ...current(),
+        ...missing.map((worktree) => ({ worktree, expanded: true })),
+      ])
+    },
     expand(directory: string) {
       const index = current().findIndex((project) => project.worktree === directory)
       if (index !== -1) setStore("projects", input.scope(), index, "expanded", true)


### PR DESCRIPTION
Fixes #45011
Related: #27837, #41412

## Problem

The Home project sidebar renders exclusively from a browser-localStorage registry. On a fresh browser profile the Home page is empty even though the server knows every project and session (`GET /project` and the session list return everything). Projects only appear after being manually re-added in that browser, so sessions created in the TUI/CLI never show up on Home.

## Fix

When the server project list arrives (it is already fetched at bootstrap), append any server-known project that is missing from the persisted list (`createServerProjects.hydrate` in `packages/app/src/context/server.tsx`, driven from `createServerCtx` in `packages/app/src/context/global.tsx`).

- The persisted list stays the UI source of truth for ordering; hydrated entries are appended after existing ones.
- A project the user closed stays closed (`recentlyClosed` acts as the dismissal set).
- The `global` project is skipped: its worktree is the filesystem root, not an openable project.
- `untrack` around the hydrate call keeps worktree normalization (which removes sandbox entries) from fighting re-hydration.

## Verification

- Unit tests for `hydrate` (append order, dismissal, dedupe by normalized path) in `packages/app/src/context/server.test.ts`.
- New e2e regression spec `home-server-projects.spec.ts`: fresh profile + multi-project mock server → both projects and their sessions listed; explicitly closed project stays hidden. The mock server util gained an optional `projects` list.
- `bun typecheck` and `bun run typecheck:e2e` pass in `packages/app`; full app unit suite and e2e regression suite pass (only pre-existing/flaky failures elsewhere).
- Manual check against a live `opencode web` server (v1.18.26, two projects, 89 sessions): fresh browser profile goes from `PROJECT ROWS: [], SESSION ROWS: 0` on current dev to both projects + 30 session rows with this patch.