### PR TITLE
fix(app): animate subagent card chevron

### DIFF
--- a/packages/session-ui/src/components/basic-tool.css
+++ b/packages/session-ui/src/components/basic-tool.css
@@ -252,13 +252,25 @@
     justify-content: center;
     flex-shrink: 0;
     color: var(--v2-text-text-faint);
-    margin-left: auto;
+    margin-inline-start: auto;
+    opacity: 0;
+    transform: translateX(-4px);
     transition:
       opacity 0.15s ease,
-      color 0.15s ease;
+      color 0.15s ease,
+      transform 0.15s ease;
 
-    @media (hover: hover) {
-      opacity: 0;
+    :dir(rtl) & {
+      transform: translateX(4px);
+    }
+
+    @media (hover: none) {
+      opacity: 1;
+      transform: none;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
     }
   }
 
@@ -285,6 +297,7 @@
 
     [data-component="task-tool-action"] {
       opacity: 1;
+      transform: none;
     }
   }
 }

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -1398,13 +1398,13 @@ ToolRegistry.register({
                 <span data-slot="basic-tool-tool-subtitle">{subtitle()}</span>
               </Show>
             </div>
+            <Show when={clickable()}>
+              <div data-component="task-tool-action">
+                <Icon name="chevron-right" size="small" />
+              </div>
+            </Show>
           </div>
         </div>
-        <Show when={clickable()}>
-          <div data-component="task-tool-action">
-            <Icon name="square-arrow-top-right" size="small" />
-          </div>
-        </Show>
       </div>
     )
 


### PR DESCRIPTION
## Summary
- replace the subagent card external-window icon with a right chevron
- reserve the chevron space inside the card to prevent layout shifts
- fade and slide the chevron by 4px on hover with RTL and reduced-motion handling

## Testing
- `bun typecheck` (`packages/app`)
- `bun test src --only-failures` (`packages/session-ui`): 177 passed
- production timeline benchmark before and after: 4 passed

## Note
- `packages/session-ui` typecheck is blocked by existing unresolved `vite-plugin-solid` imports in performance fixtures.