### PR TITLE
docs: note that plugin reload watches the entrypoint only

### DIFF
--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -59,6 +59,10 @@ export default Plugin.define({
 })
 ```
 
+OpenCode reloads a local plugin when its `index.*` entrypoint changes. Edits to sibling modules such as `rpc.ts` or
+`tui.ts` are not picked up until the entrypoint changes too or the server restarts, so touch `index.ts` after editing
+a sibling.
+
 ### Context
 
 The plugin context is essentially an [OpenCode server client](/build/client).


### PR DESCRIPTION
## Why

Directory plugins (`index.ts` + `rpc.ts` + `tui.ts`) are the documented default, but hot reload watches and cache-busts only the resolved `index.*` path (`packages/core/src/plugin/module.ts:44`, `config/plugin/source.ts:59`); Bun keeps sibling modules cached by resolved path, so a re-imported `index.ts?mtime=N` binds the old `rpc.ts`. Until that is fixed, authors should know the workaround.

## What Changes

One paragraph under Lifecycle in the plugin guide.

## Scope

Docs only. Making sibling edits reload is tracked as a spike.