### PR TITLE
fix(core): honor OPENCODE_DISABLE_MODELS_FETCH in core

### DIFF
--- a/packages/core/src/models-dev.ts
+++ b/packages/core/src/models-dev.ts
@@ -594,7 +594,11 @@ export const layer = (options?: Options) =>
       )
 
       const source = options?.url || defaultSource
-      const fetch = options?.fetch ?? true
+      // The CLI maps OPENCODE_DISABLE_MODELS_FETCH into options.fetch; the
+      // unconfigured default node (core tests, embedded hosts) reads it here so
+      // the env var disables the network fetch everywhere.
+      const disabled = process.env.OPENCODE_DISABLE_MODELS_FETCH
+      const fetch = options?.fetch ?? !(disabled === "1" || disabled?.toLowerCase() === "true")
       const userAgent = App.useragent(app)
       const key = cacheKey(source)
       const ttl = Duration.minutes(5)

--- a/packages/core/test/models.test.ts
+++ b/packages/core/test/models.test.ts
@@ -336,6 +336,25 @@ describe("ModelsDev Service", () => {
     }),
   )
 
+  // test/preload.ts sets OPENCODE_DISABLE_MODELS_FETCH=true for the whole run;
+  // the unconfigured default node must honor it so tests that boot the real
+  // Location graph never reach models.opencode.ai.
+  it.live("default node skips the background fetch when OPENCODE_DISABLE_MODELS_FETCH is set", () =>
+    Effect.gen(function* () {
+      expect(process.env.OPENCODE_DISABLE_MODELS_FETCH).toBe("true")
+      const cache = makeCache()
+      const state = yield* Ref.make(initialState)
+      const layer = Layer.fresh(
+        AppNodeBuilder.build(ModelsDev.node, [
+          LayerNodePlatform.httpClient.replace(Layer.succeed(HttpClient.HttpClient, makeMockClient(state))),
+          KV.node.replace(makeMockKV(cache)),
+        ]),
+      )
+      yield* Effect.sleep("50 millis").pipe(Effect.provide(layer))
+      expect((yield* Ref.get(state)).calls).toEqual([])
+    }),
+  )
+
   it.live("get() is single-flight under concurrent calls", () =>
     Effect.gen(function* () {
       const cache = makeCache()


### PR DESCRIPTION
## Why

`OPENCODE_DISABLE_MODELS_FETCH` was only read in `packages/cli/src/server-process.ts`, which maps it into the server's `models.fetch` option. `packages/server/src/routes.ts` then replaces `ModelsDev.node` with `ModelsDev.configured(options.models)`, so the CLI path was fine. Core itself never read the env var: the unconfigured default `ModelsDev.node = configured()` fell back to `fetch: true`.

`packages/core/test/preload.ts` sets `OPENCODE_DISABLE_MODELS_FETCH=true` expecting core to honor it, but every core test that boots the default node (anything building a real Location graph, e.g. `test/session-activation.test.ts`) forked a real `GET https://models.opencode.ai/api.json` on layer build.

## What Changes

- `packages/core/src/models-dev.ts`: resolve the `fetch` default from `OPENCODE_DISABLE_MODELS_FETCH` (same `"1"` / `"true"` semantics as the CLI's `truthy`) at the layer boundary where `source` is resolved. An explicit `options.fetch` still wins, so the server's mapped option behaves exactly as before. Fetch schedule, snapshot decode, and cache paths are untouched.
- `packages/core/test/models.test.ts`: new test builds the unconfigured `ModelsDev.node` with a counting mock `HttpClient`, settles briefly, and asserts zero requests. It fails on the unfixed tree with a request to `https://models.opencode.ai/api.json` observed.

## Verification

- `bun typecheck` in `packages/core` and `packages/cli`
- New test `--rerun-each 5`: 5 pass
- `bun run test test/models.test.ts`: 17 pass
- `bun run test test/plugin test/session-activation.test.ts`: 254 pass, 0 fail
- Full `bun run test` in `packages/core`: 3999 pass, 39 skip, 0 fail (225 files)