### PR TITLE
fix(core): report non-directory configured plugins as failed

### DIFF
--- a/packages/core/src/config/plugin/source.ts
+++ b/packages/core/src/config/plugin/source.ts
@@ -23,6 +23,12 @@ export type Operation =
       readonly type: "remove"
       readonly target: string
     }
+  // A configured entry rejected before loading; reported in the plugin inventory so it does not silently vanish.
+  | {
+      readonly type: "fail"
+      readonly target: string
+      readonly error: string
+    }
 
 export interface Interface {
   readonly operations: () => Effect.Effect<readonly Operation[], never, Scope.Scope>
@@ -143,21 +149,23 @@ const scan = Effect.fn("ConfigPluginSource.scan")(function* (
     )
   const resolved = yield* Effect.forEach(configured, (operation) =>
     Effect.gen(function* () {
-      if (operation.type === "remove" || !path.isAbsolute(operation.target)) return Option.some(operation)
+      if (operation.type === "remove" || !path.isAbsolute(operation.target)) return operation
+      const failed = (error: string): Operation => ({ type: "fail", target: operation.target, error })
+      // Configured local plugins must be directories so rpc.ts and tui.ts siblings resolve beside index.ts.
       if (yield* fs.isFile(operation.target)) {
         yield* Effect.logWarning("configured plugin path must be a directory", { target: operation.target })
-        return Option.none<Operation>()
+        return failed(`Configured plugin path must be a directory: ${operation.target}`)
       }
-      if (!(yield* fs.isDir(operation.target))) return Option.some<Operation>(operation)
+      if (!(yield* fs.isDir(operation.target))) return operation
       const entrypoint = yield* PluginSourceDirectory.entrypoint(fs, operation.target)
-      if (Option.isSome(entrypoint)) return Option.some<Operation>({ ...operation, target: entrypoint.value })
+      if (Option.isSome(entrypoint)) return { ...operation, target: entrypoint.value }
       yield* Effect.logWarning("configured plugin directory has no index entrypoint", { target: operation.target })
-      return Option.none<Operation>()
+      return failed(`Configured plugin directory has no index.ts or index.js entrypoint: ${operation.target}`)
     }),
-  ).pipe(Effect.map((operations) => operations.flatMap(Option.toArray)))
+  )
   // Explicit config is applied last so it can remove auto-discovered packages.
   return yield* Effect.forEach([...discovered, ...resolved], (operation) => {
-    if (operation.type === "remove" || !path.isAbsolute(operation.target)) return Effect.succeed(operation)
+    if (operation.type !== "add" || !path.isAbsolute(operation.target)) return Effect.succeed(operation)
     return fs.stat(operation.target).pipe(
       Effect.map((info) => ({
         ...operation,

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -40,6 +40,14 @@ const resolve = Effect.fn("PluginSupervisor.resolve")(function* (
         .forEach((plugin) => enabled.delete(plugin.id))
       continue
     }
+    if (operation.type === "fail") {
+      failures.set(operation.target, {
+        source: pluginSource(operation.target),
+        state: { status: "failed", error: operation.error },
+        features: { server: true },
+      })
+      continue
+    }
 
     const matched = plugins().filter((plugin) => matches(operation.target, plugin.id))
     const selectsPlugins =

--- a/packages/core/test/plugin/supervisor.test.ts
+++ b/packages/core/test/plugin/supervisor.test.ts
@@ -1,3 +1,5 @@
+import fs from "fs/promises"
+import path from "path"
 import { describe, expect } from "bun:test"
 import { Duration, Effect, Layer, LayerMap } from "effect"
 import { define } from "@opencode-ai/plugin/effect/plugin"
@@ -5,6 +7,7 @@ import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Global } from "@opencode-ai/util/global"
 import { Command } from "@opencode-ai/core/command"
+import { Config } from "@opencode-ai/core/config"
 import { Instance } from "@opencode-ai/core/instance"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
 import { Location } from "@opencode-ai/core/location"
@@ -27,12 +30,23 @@ const greeter = (command: string) =>
       ctx.command.transform((editor) => editor.add({ name: command, execute: () => Effect.void })).pipe(Effect.asVoid),
   })
 
+// A location named "file-plugin" configures a local plugin whose path is a file rather than a directory.
+const filePluginConfig: LayerNode.Replacements = [
+  Config.node.replace(
+    Config.configured({ project: false, global: false, content: JSON.stringify({ plugins: ["./plugins/foo.ts"] }) }),
+  ),
+]
+
 const instances = Layer.effect(
   LocationServiceMap.Service,
   Effect.gen(function* () {
     const map = yield* LayerMap.make(
       (ref: Location.Ref) =>
-        Instance.layer(ref, { discovery: false, plugins: [greeter("instance-greet")], replacements: bindings }),
+        Instance.layer(ref, {
+          discovery: false,
+          plugins: [greeter("instance-greet")],
+          replacements: [...bindings, ...(path.basename(ref.directory) === "file-plugin" ? filePluginConfig : [])],
+        }),
       { idleTimeToLive: Duration.infinity },
     )
     const bindings: LayerNode.Replacements = [
@@ -92,6 +106,40 @@ describe("PluginSupervisor", () => {
       expect(
         state.inventory.some((plugin) => plugin.id?.startsWith("opencode.") && plugin.state.status === "active"),
       ).toBe(true)
+    }),
+  )
+
+  it.live("reports a configured plugin file as a failure instead of dropping it", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const root = path.join(directory.path, "file-plugin")
+      const target = path.join(root, "plugins", "foo.ts")
+      yield* Effect.promise(async () => {
+        await fs.mkdir(path.dirname(target), { recursive: true })
+        await fs.writeFile(target, "export default { id: 'foo', setup: () => ({}) }\n")
+      })
+      const locations = yield* LocationServiceMap.Service
+      const state = yield* Effect.gen(function* () {
+        const plugins = yield* Plugin.Service
+        yield* plugins.awaitActivation
+        const commands = yield* Command.Service
+        return {
+          inventory: yield* plugins.list(),
+          instance: yield* commands.get("instance-greet"),
+        }
+      }).pipe(Effect.scoped, Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(root) }))))
+
+      // The directory-only rule stands; the rejected entry is reported rather than silently vanishing.
+      expect(state.inventory.filter((plugin) => plugin.source.type === "local")).toEqual([
+        {
+          source: { type: "local", path: target },
+          state: { status: "failed", error: `Configured plugin path must be a directory: ${target}` },
+          features: { server: true },
+        },
+      ])
+      // Other plugins still activate.
+      expect(state.instance).toBeDefined()
+      expect(state.inventory.some((plugin) => plugin.id === id && plugin.state.status === "active")).toBe(true)
     }),
   )
 })


### PR DESCRIPTION
## Why

A configured plugin entry (`opencode.json` → `plugins: ["./plugins/foo.ts"]`) whose path resolves to a file rather than a directory was dropped by `ConfigPluginSource.scan` with only an `Effect.logWarning` and `Option.none`. It never reached the plugin inventory, so `opencode plugin list` and the TUI plugin dialog showed nothing: the plugin silently vanished. The same silent drop applied to a configured directory with no `index.ts`/`index.js` entrypoint.

The directory-only rule for configured local plugins is **unchanged and deliberate** (from #46105): directory plugins carry `rpc.ts` / `tui.ts` siblings that are resolved relative to `index.ts`, so accepting bare files would break feature detection. This PR only makes the rejection visible.

## What Changes

- `ConfigPluginSource.Operation` gains a third variant, `{ type: "fail", target, error }`, for a configured entry rejected before loading.
- `scan` returns a `fail` operation instead of dropping the entry in both log-and-drop branches:
  - path is a file → `Configured plugin path must be a directory: <path>`
  - directory without `index.ts`/`index.js` → `Configured plugin directory has no index.ts or index.js entrypoint: <path>`
- `PluginSupervisor.resolve` routes `fail` operations into the existing `failures` map, i.e. the same channel used for `PluginModule.load` errors and duplicate plugin IDs (#46718). The entry appears in the inventory as `source: { type: "local", path }`, `state: { status: "failed", error }`.
- Nonexistent configured paths were not a drop branch: they already flow into `PluginModule.load` and surface through its `catchCause` failure path, so no change there.
- Auto-discovery (`PluginSourceDirectory.discover`) is untouched; flat `.opencode/plugins/foo.ts` files continue to load as before.
- No TUI change: `packages/tui/src/plugin/context.tsx` skips file entries only for the TUI-runtime plugin list (a file cannot have a `tui.ts` sibling). The plugin dialog already merges the server inventory under its "Server" category, so the failed entry now shows up there without a duplicate TUI-side report.

```ts
// before: dropped
plugins: ["./plugins/foo.ts"]  // foo.ts is a file
→ scan: logWarning + Option.none → inventory: []

// after: reported
→ scan: { type: "fail", target, error }
→ supervisor: failures.set(target, { source: { type: "local", path }, state: { status: "failed", error } })
→ inventory: [{ source: { type: "local", path: ".../plugins/foo.ts" },
                state: { status: "failed", error: "Configured plugin path must be a directory: .../plugins/foo.ts" },
                features: { server: true } }]
```

## Verification

- New test in `packages/core/test/plugin/supervisor.test.ts`: boots a Location whose config has `plugins: ["./plugins/foo.ts"]` where that path is a file, awaits activation, and asserts the inventory contains the failed local entry with the directory-rule message while the instance plugin and builtins still activate. Confirmed failing on the unfixed tree (inventory `[]`), passing after the fix; `--rerun-each 5` → 10 pass.
- `bun typecheck` in `packages/core`: clean.
- `bun run test test/plugin test/plugin.test.ts test/config`: 389 pass, 0 fail.
- Full `bun run test` in `packages/core`: 3999 pass, 39 skip, 0 fail (4038 tests, 225 files).