### PR TITLE
fix(core): keep plugin activation stable across failures and refreshes

### DIFF
--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -20,7 +20,9 @@ const layer = Layer.effect(
     const bus = yield* Bus.Service
     const kv = yield* KV.Service
     const scope = yield* Scope.make()
-    const active = new Map<Plugin.ID, { readonly plugin: Generation; readonly scope: Scope.Closeable }>()
+    // One slot per requested definition in activation order, including ones whose setup failed, so
+    // the prefix diff below stays index-aligned and a failed revision is not retried until it changes.
+    const active = new Map<Plugin.ID, Slot>()
     const lock = Semaphore.makeUnsafe(1)
     const ready = yield* Latch.make(true)
     const pending = new Set<object>()
@@ -91,7 +93,7 @@ const layer = Layer.effect(
                 if (entry) active.set(definition.id, { ...entry, plugin: definition })
               }
               if (prefix === definitions.length && active.size === definitions.length) {
-                const nextInventory = [...definitions.map(activeInfo), ...failures]
+                const nextInventory = [...Array.from(active.values()).map(slotInfo), ...failures]
                 if (JSON.stringify(inventory) === JSON.stringify(nextInventory)) return
                 inventory = nextInventory
                 yield* bus.publish(Plugin.Event.Updated, {})
@@ -104,33 +106,33 @@ const layer = Layer.effect(
                   const previous = new Map(Array.from(active.entries()).slice(prefix))
                   yield* Effect.forEach(
                     Array.from(previous.entries()).toReversed(),
-                    ([id, entry]) =>
+                    ([id, slot]) =>
                       Effect.gen(function* () {
                         active.delete(id)
-                        yield* Scope.close(entry.scope, Exit.void)
+                        if (slot.loaded) yield* Scope.close(slot.loaded.scope, Exit.void)
                       }),
                     { discard: true },
                   )
-                  const nextInventory = definitions.slice(0, prefix).map(activeInfo)
                   for (const definition of definitions.slice(prefix)) {
                     const loaded = yield* load(definition)
                     if (loaded.scope !== undefined) {
-                      active.set(definition.id, { plugin: definition, scope: loaded.scope })
-                      nextInventory.push(activeInfo(definition))
+                      active.set(definition.id, {
+                        plugin: definition,
+                        loaded: { plugin: definition, scope: loaded.scope },
+                      })
                       continue
                     }
-                    nextInventory.push({
-                      id: definition.id,
-                      source: definition.source ?? { type: "builtin" },
-                      state: { status: "failed", error: loaded.error },
-                      features: { server: true, ...definition.features },
-                    })
+                    active.set(definition.id, { plugin: definition, error: loaded.error })
 
-                    const fallback = previous.get(definition.id)
+                    const fallback = previous.get(definition.id)?.loaded
                     if (!fallback) continue
                     const restored = yield* load(fallback.plugin)
                     if (restored.scope !== undefined) {
-                      active.set(definition.id, { plugin: fallback.plugin, scope: restored.scope })
+                      active.set(definition.id, {
+                        plugin: definition,
+                        loaded: { plugin: fallback.plugin, scope: restored.scope },
+                        error: loaded.error,
+                      })
                       continue
                     }
                     yield* Effect.logError("failed to restore plugin; deactivating", {
@@ -138,7 +140,7 @@ const layer = Layer.effect(
                     })
                   }
 
-                  inventory = [...nextInventory, ...failures]
+                  inventory = [...Array.from(active.values()).map(slotInfo), ...failures]
                 }),
               )
               yield* bus.publish(Plugin.Event.Updated, {})
@@ -167,12 +169,20 @@ const layer = Layer.effect(
   }),
 )
 
-function activeInfo(plugin: Generation): Plugin.Info {
+// `plugin` is the definition the slot was last asked to run; `loaded` is the generation actually
+// running, which stays an older fallback while the requested revision keeps failing setup.
+type Slot = {
+  readonly plugin: Generation
+  readonly loaded?: { readonly plugin: Generation; readonly scope: Scope.Closeable }
+  readonly error?: string
+}
+
+function slotInfo(slot: Slot): Plugin.Info {
   return {
-    id: Plugin.ID.make(plugin.id),
-    source: plugin.source ?? { type: "builtin" },
-    state: { status: "active" },
-    features: { server: true, ...plugin.features },
+    id: Plugin.ID.make(slot.plugin.id),
+    source: slot.plugin.source ?? { type: "builtin" },
+    state: slot.error === undefined ? { status: "active" } : { status: "failed", error: slot.error },
+    features: { server: true, ...slot.plugin.features },
   }
 }
 

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -1,7 +1,7 @@
 export * as PluginSupervisor from "./supervisor.js"
 
 import { Event } from "@opencode-ai/schema/config"
-import { Cause, Effect, Layer, Stream } from "effect"
+import { Cause, Effect, Layer, PubSub, Stream } from "effect"
 import path from "path"
 import { ConfigPluginSource } from "../config/plugin/source.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
@@ -19,6 +19,7 @@ const resolve = Effect.fn("PluginSupervisor.resolve")(function* (
   post: readonly Plugin.Generation[],
   operations: readonly ConfigPluginSource.Operation[],
   install: boolean,
+  running: ReadonlyMap<string, Plugin.Generation>,
 ) {
   const matches = (selector: string, target: string) =>
     selector === "*" || (selector.endsWith(".*") ? target.startsWith(selector.slice(0, -1)) : selector === target)
@@ -71,6 +72,11 @@ const resolve = Effect.fn("PluginSupervisor.resolve")(function* (
         state: { status: "failed", error: plugin.error, ref: plugin.ref },
         features: { server: true },
       })
+      // The new revision never became a generation, so the one already running keeps its place.
+      const retained = packages.get(operation.target) ?? running.get(operation.target)
+      if (!retained) continue
+      packages.set(operation.target, retained)
+      enabled.add(retained.id)
       continue
     }
     failures.delete(operation.target)
@@ -91,6 +97,7 @@ const resolve = Effect.fn("PluginSupervisor.resolve")(function* (
     ordered.findIndex((other) => other.id === plugin.id) !== index
   return {
     plugins: ordered.filter((plugin, index) => !duplicate(plugin, index)),
+    packages: new Map([...packages].filter(([, plugin]) => enabled.has(plugin.id))),
     failures: [
       ...failures.values(),
       ...ordered.filter(duplicate).map((plugin) => ({
@@ -118,10 +125,13 @@ export const layer = Layer.effectDiscard(
     // Built-ins capture services from this layer; unload them before those services close.
     yield* Effect.addFinalizer(registry.close)
     let packages = new Set<string>()
+    // Last generation handed to the registry per target; a failed reload keeps it in place.
+    let running = new Map<string, Plugin.Generation>()
     let outdated = new Set<string>()
     const updating = new Set<string>()
     let generation = 0
     let observed = 0
+    const refresh = yield* PubSub.unbounded<void>()
 
     const activate = Effect.fn("PluginSupervisor.activate")(function* () {
       const current = ++generation
@@ -140,7 +150,7 @@ export const layer = Layer.effectDiscard(
       }))
       const operations = yield* sources.operations()
       // Activate everything available locally before waiting on missing package installs.
-      const immediate = yield* resolve(pre, post, operations, false)
+      const immediate = yield* resolve(pre, post, operations, false, running)
       const source = (source: Plugin.Source) =>
         source.type === "package"
           ? {
@@ -155,16 +165,17 @@ export const layer = Layer.effectDiscard(
           resolved.failures.map((failure) => ({ ...failure, source: source(failure.source) })),
         )
       yield* apply(immediate)
-      const resolved = immediate.pending.length ? yield* resolve(pre, post, operations, true) : immediate
+      const resolved = immediate.pending.length ? yield* resolve(pre, post, operations, true, running) : immediate
       if (resolved !== immediate) yield* apply(resolved)
-      const loaded = new Set(
+      running = resolved.packages
+      const targets = new Set(
         [...resolved.plugins, ...resolved.failures].flatMap((plugin) =>
           plugin.source?.type === "package" ? [plugin.source.target] : [],
         ),
       )
-      packages = loaded
+      packages = targets
       yield* Effect.forEach(
-        loaded,
+        targets,
         (target) => updates.check(target).pipe(Effect.map((available) => [target, available] as const)),
         { concurrency: "unbounded" },
       ).pipe(
@@ -179,7 +190,10 @@ export const layer = Layer.effectDiscard(
       )
     })
     const reloads = Stream.merge(
-      Stream.merge(sources.changes(), bus.subscribe([Event.Updated, SdkPlugins.Updated])),
+      Stream.merge(
+        Stream.merge(sources.changes(), Stream.fromPubSub(refresh)),
+        bus.subscribe([Event.Updated, SdkPlugins.Updated]),
+      ),
       updates.changes().pipe(
         Stream.filter((update) => packages.has(update.target)),
         Stream.tap((update) =>
@@ -215,14 +229,9 @@ export const layer = Layer.effectDiscard(
       ),
       Effect.forkScoped({ startImmediately: true }),
     )
+    // The periodic refresh joins the reload feed above so it never activates concurrently with a change.
     yield* Effect.sleep("24 hours").pipe(
-      Effect.andThen(
-        Effect.acquireUseRelease(
-          registry.hold(),
-          () => activate(),
-          (release) => release,
-        ),
-      ),
+      Effect.andThen(PubSub.publish(refresh, undefined)),
       Effect.forever,
       Effect.forkScoped,
     )

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -154,6 +154,48 @@ it.effect("reports a failed plugin without blocking a healthy plugin", () =>
   }),
 )
 
+it.effect("keeps the suffix after a failed plugin alive across identical activations", () =>
+  Effect.gen(function* () {
+    const plugins = yield* Plugin.Service
+    const setups = { good1: 0, broken: 0, good2: 0 }
+    const good = (id: "good1" | "good2"): Plugin.Generation => ({
+      id,
+      revision: "1",
+      effect: () => Effect.sync(() => void setups[id]++),
+    })
+    const broken = (revision: string): Plugin.Generation => ({
+      id: "broken",
+      revision,
+      effect: () =>
+        Effect.suspend(() => {
+          setups.broken++
+          return Effect.die(new Error("Setup failed"))
+        }),
+    })
+    const failed = () =>
+      plugins.list().pipe(Effect.map((inventory) => inventory.find((plugin) => plugin.id === "broken")?.state))
+
+    yield* plugins.activate([good("good1"), broken("1"), good("good2")])
+    expect(setups).toEqual({ good1: 1, broken: 1, good2: 1 })
+    expect(yield* failed()).toMatchObject({ status: "failed", error: expect.stringContaining("Setup failed") })
+
+    // Identical definitions: nothing restarts and the failed revision is not retried.
+    yield* plugins.activate([good("good1"), broken("1"), good("good2")])
+    expect(setups).toEqual({ good1: 1, broken: 1, good2: 1 })
+    expect(yield* failed()).toMatchObject({ status: "failed", error: expect.stringContaining("Setup failed") })
+    expect((yield* plugins.list()).map((plugin) => `${plugin.id}:${plugin.state.status}`)).toEqual([
+      "good1:active",
+      "broken:failed",
+      "good2:active",
+    ])
+
+    // A new revision of the failed plugin is retried once, restarting only the suffix behind it.
+    yield* plugins.activate([good("good1"), broken("2"), good("good2")])
+    expect(setups).toEqual({ good1: 1, broken: 2, good2: 2 })
+    expect(yield* failed()).toMatchObject({ status: "failed" })
+  }),
+)
+
 it.effect("reloading a plugin replaces its command implementation", () =>
   Effect.gen(function* () {
     const plugins = yield* Plugin.Service

--- a/packages/core/test/plugin/supervisor-reload.test.ts
+++ b/packages/core/test/plugin/supervisor-reload.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, setDefaultTimeout } from "bun:test"
+import fs from "fs/promises"
+import path from "path"
+import { Deferred, Duration, Effect, Layer, LayerMap, Schedule } from "effect"
+import { TestClock } from "effect/testing"
+import { Event } from "@opencode-ai/schema/config"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { Global } from "@opencode-ai/util/global"
+import { Npm } from "@opencode-ai/util/npm"
+import { Bus } from "@opencode-ai/core/bus"
+import { Command } from "@opencode-ai/core/command"
+import { Database } from "@opencode-ai/core/database/database"
+import { Watcher } from "@opencode-ai/core/filesystem/watcher"
+import { Instance } from "@opencode-ai/core/instance"
+import { LocationServiceMap } from "@opencode-ai/core/location-services"
+import { Location } from "@opencode-ai/core/location"
+import { Plugin } from "@opencode-ai/core/plugin"
+import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { tempGlobalLayer } from "../fixture/global"
+import { tmpdirScoped } from "../fixture/tmpdir"
+import { testEffect } from "../lib/effect"
+
+// Real Location boot with plugin-directory discovery, so local plugin files are loaded and reloaded.
+setDefaultTimeout(15_000)
+
+// Package resolution for the fake npm below: the entrypoint is a fixture file, and resolving the
+// main entry can be held open so overlapping activations become observable.
+const npm = {
+  entrypoint: "",
+  gate: undefined as Deferred.Deferred<void> | undefined,
+  inflight: 0,
+  peak: 0,
+}
+
+const npmLayer = Layer.succeed(
+  Npm.Service,
+  Npm.Service.of({
+    add: () => Effect.succeed({ directory: "", entrypoint: npm.entrypoint }),
+    resolve: (_, options) =>
+      Effect.gen(function* () {
+        if (!options?.subpaths?.includes("")) return { directory: "", entrypoint: undefined }
+        npm.inflight++
+        npm.peak = Math.max(npm.peak, npm.inflight)
+        if (npm.gate) yield* Deferred.await(npm.gate)
+        npm.inflight--
+        return { directory: "", entrypoint: npm.entrypoint }
+      }),
+    check: () => Effect.succeed(false),
+    update: () => Effect.succeed({ directory: "", entrypoint: npm.entrypoint }),
+    which: () => Effect.undefined,
+  }),
+)
+
+const instances = Layer.effect(
+  LocationServiceMap.Service,
+  Effect.gen(function* () {
+    const map = yield* LayerMap.make((ref: Location.Ref) => Instance.layer(ref, { replacements: bindings }), {
+      idleTimeToLive: Duration.infinity,
+    })
+    const bindings: LayerNode.Replacements = [
+      Global.node.replace(tempGlobalLayer),
+      Npm.node.replace(npmLayer),
+      Watcher.node.replace(Watcher.configured({ enabled: false })),
+      LocationServiceMap.node.replace(Layer.succeed(LocationServiceMap.Service, map)),
+      Instance.node.replace(
+        Layer.succeed(Instance.Service, {
+          provide: (session) => Effect.provide(map.get(session.location)),
+        }),
+      ),
+    ]
+    return map
+  }),
+)
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
+    Global.node.replace(tempGlobalLayer),
+    LocationServiceMap.node.replace(instances),
+  ]),
+)
+
+const greeter = (command: string) => `export default {
+  id: "greeter",
+  async setup(ctx) {
+    await ctx.command.transform((editor) => editor.add({ name: "${command}", execute: async () => {} }))
+  },
+}`
+
+// Real-time polling: reloads do filesystem work that the TestClock cannot advance.
+const settle = (predicate: () => boolean, attempts = 200): Effect.Effect<void, string> =>
+  Effect.suspend(() => {
+    if (predicate()) return Effect.void
+    if (attempts === 0) return Effect.fail("not settled")
+    return Effect.promise(() => Bun.sleep(10)).pipe(Effect.andThen(settle(predicate, attempts - 1)))
+  })
+
+const failed = (plugins: Plugin.Interface) =>
+  plugins.list().pipe(
+    Effect.flatMap((inventory) => {
+      const failure = inventory.find((plugin) => plugin.state.status === "failed" && plugin.source.type === "local")
+      return failure ? Effect.succeed(failure) : Effect.fail("activation pending")
+    }),
+    Effect.retry({ times: 200, schedule: Schedule.spaced("25 millis") }),
+  )
+
+describe("PluginSupervisor reload", () => {
+  it.live("keeps the running generation when an updated local plugin fails to import", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const file = path.join(directory.path, ".opencode/plugins/greeter.ts")
+      // Local plugin revisions key on mtime, so give each rewrite a distinct timestamp.
+      const write = (content: string, mtime: Date) =>
+        Effect.promise(async () => {
+          await Bun.write(file, content)
+          await fs.utimes(file, mtime, mtime)
+        })
+      yield* write(greeter("greet-v1"), new Date(Date.now() - 60_000))
+      const bus = yield* Bus.Service
+      const locations = yield* LocationServiceMap.Service
+      yield* Effect.gen(function* () {
+        const plugins = yield* Plugin.Service
+        const commands = yield* Command.Service
+        yield* plugins.awaitActivation
+        expect(yield* commands.get("greet-v1")).toBeDefined()
+
+        yield* write("export default {", new Date())
+        yield* bus.publish(Event.Updated, {})
+        const failure = yield* failed(plugins)
+
+        expect(failure).toMatchObject({ source: { type: "local", path: file }, state: { status: "failed" } })
+        // The broken revision never produced a generation, so the previous one keeps running.
+        expect(yield* commands.get("greet-v1")).toBeDefined()
+        expect(yield* plugins.list()).toContainEqual(
+          expect.objectContaining({
+            id: "greeter",
+            source: { type: "local", path: file },
+            state: { status: "active" },
+          }),
+        )
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(directory.path) }))),
+      )
+    }),
+  )
+
+  it.effect("serializes the periodic refresh behind an in-flight reload", () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      npm.entrypoint = path.join(directory.path, "fixture-plugin.ts")
+      npm.gate = undefined
+      npm.peak = 0
+      yield* Effect.promise(() => Bun.write(npm.entrypoint, greeter("greet-pkg")))
+      yield* Effect.promise(() =>
+        Bun.write(path.join(directory.path, ".opencode/opencode.json"), JSON.stringify({ plugins: ["fixture-pkg"] })),
+      )
+      const bus = yield* Bus.Service
+      const locations = yield* LocationServiceMap.Service
+      yield* Effect.gen(function* () {
+        const plugins = yield* Plugin.Service
+        const commands = yield* Command.Service
+        yield* TestClock.adjust("100 millis")
+        yield* plugins.awaitActivation
+        expect(yield* commands.get("greet-pkg")).toBeDefined()
+        expect(npm.peak).toBe(1)
+
+        // Hold the next resolve open, then let the 24 hour refresh fire while it is blocked.
+        const gate = yield* Deferred.make<void>()
+        npm.gate = gate
+        npm.inflight = 0
+        npm.peak = 0
+        yield* bus.publish(Event.Updated, {})
+        yield* TestClock.adjust("100 millis")
+        yield* settle(() => npm.inflight === 1)
+        yield* TestClock.adjust("24 hours")
+        // Without serialization the refresh resolves concurrently with the held reload and the peak reaches 2.
+        yield* settle(() => npm.peak > 1, 50).pipe(Effect.ignore)
+        const peak = npm.peak
+        yield* Deferred.succeed(gate, undefined)
+        npm.gate = undefined
+        yield* TestClock.adjust("100 millis")
+        yield* plugins.awaitActivation
+
+        expect(peak).toBe(1)
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(directory.path) }))),
+      )
+    }),
+  )
+})


### PR DESCRIPTION
## Why

**One failed plugin misaligns the activation prefix diff.** `Plugin.activate` in `packages/core/src/plugin.ts` compares incoming definitions against `Array.from(active.values())` by index, but `active` only held plugins whose setup succeeded. With `[a, b(fails), c, ...builtins]`, index 1 compared `b` against `c`, so `c` and every `opencode.config.*` builtin were torn down and re-run on every activation (config touch, `outdated`/`updating` flip, periodic refresh), and `b` was re-attempted each time. #46857 narrowed the reload to the suffix but did not fix the misalignment.

**A package update whose new module fails to import tears down the running old version.** In `PluginSupervisor.resolve` (`packages/core/src/plugin/supervisor.ts`), a `PluginModule.load` failure lands in `failures` and the target is absent from `definitions`, so the registry closes the previously running generation. Only `setup()` failures fell back; a syntax error in a reloaded local plugin, or a broken published package version, silently unloaded a working plugin.

**The 24 h refresh bypasses the serialized activation lane.** The reload stream (`merge -> buffer(sliding) -> debounce -> runForEach(activate)`) is the single serialized lane, but the `Effect.sleep("24 hours")` loop called `activate()` directly. Two `resolve()` passes could run concurrently, and a stale resolve could apply last.

## What Changes

- `plugin.ts`: `active` now holds one `Slot` per requested definition, including failed ones (`{ plugin, loaded?, error? }`). The prefix diff keys on the requested `plugin`, so index alignment holds and a failed revision is not retried until its revision changes. `loaded` tracks the generation actually running (the fallback after a setup failure), which keeps the existing restore path intact. Inventory is derived from the slots via `slotInfo`, replacing the separate `nextInventory` bookkeeping and `activeInfo`.
- `supervisor.ts`: `resolve` takes the map of last-handed-over generations per target (`running`). When load fails for a target that has one, that generation is re-emitted into `packages` so the registry sees an unchanged revision and keeps it running; the failure is still recorded in inventory. The supervisor stores `resolved.packages` after each activation.
- `supervisor.ts`: the periodic refresh publishes into a `refresh` PubSub merged into the reload feed instead of calling `activate()` directly, so it goes through the same hold, coalescing, and serialization as every other trigger.

## Verification

From `packages/core` (Bun 1.4.0):

- `bun typecheck`: clean.
- `bun run test test/plugin/supervisor-reload.test.ts test/plugin.test.ts --rerun-each 5`: 65 pass, 0 fail.
- `bun run test test/plugin test/plugin.test.ts test/session-activation.test.ts test/session-owned.test.ts`: 277 pass, 0 fail.
- `bun run test`: 4001 pass, 39 skip, 0 fail.

From `packages/cli`: `bun run test test/acp`: 96 pass. From `packages/server`: `bun run ../core/script/test.ts`: 50 pass, 3 skip.

New tests:

- `test/plugin.test.ts` "keeps the suffix after a failed plugin alive across identical activations": fails on v2 because the second identical activation re-runs `good2` and `broken` (`{ broken: 2, good2: 2 }` instead of `1`); passes here, and a revision bump on `broken` retries it exactly once.
- `test/plugin/supervisor-reload.test.ts` "keeps the running generation when an updated local plugin fails to import": fails on v2 because `commands.get("greet-v1")` is `undefined` after the plugin file is rewritten with a syntax error; passes here with the failure reported in `plugins.list()` alongside the still-active v1 entry.
- `test/plugin/supervisor-reload.test.ts` "serializes the periodic refresh behind an in-flight reload": runs under `TestClock` with a fake `Npm` whose `resolve` can be held open; fails on v2 because advancing 24 h while a reload is blocked in `resolve` produces a second concurrent `npm.resolve` (peak 2); passes here (peak 1).

Not changed: the 100 ms debounce, the hold/release latch protocol, `awaitActivation` semantics, public schemas. The brief also asked for a generation guard on the second `apply(resolved)`; with the refresh routed through the lane, `activate()` can no longer overlap itself, so that guard would be unreachable and was left out. The existing guard in the forked update check stays.
