### PR TITLE
fix(core): tell plan agent to discuss plans instead of writing files by default

### DIFF
--- a/packages/core/src/plugin/plan.ts
+++ b/packages/core/src/plugin/plan.ts
@@ -12,7 +12,7 @@ import { Permission } from "../permission.js"
 const plan = Agent.ID.make("plan")
 
 const enter = (directory: string) => `<system-reminder>
-You are in Plan mode. You may optionally create or update plan documents in:
+You are in Plan mode. Discuss the plan with the user directly in the conversation. Do not create or update plan files unless the user explicitly asks you to; when they do, write them only in:
 ${directory}
 
 Do not modify any other files or ask a subagent to do so.

--- a/packages/core/test/plugin/plan.test.ts
+++ b/packages/core/test/plugin/plan.test.ts
@@ -166,7 +166,7 @@ describe("plan plugin reminders", () => {
       const { persisted } = yield* run([agentSelected(plan, build), agentSelected(build, plan)])
       yield* settle(persisted, 2)
       expect(persisted[0]).toContain("You are in Plan mode")
-      expect(persisted[0]).toContain("optionally create or update plan documents")
+      expect(persisted[0]).toContain("Do not create or update plan files unless the user explicitly asks you to")
       expect(persisted[0]).toContain(planDirectory)
       expect(persisted[0]).toContain("Do not modify any other files")
       expect(persisted[1]).toContain("NO LONGER in Plan mode")


### PR DESCRIPTION
## Summary

The Plan agent's enter reminder said it "may optionally create or update plan documents", which nudged models toward writing plan files instead of talking through the plan. This adjusts the reminder so the agent discusses the plan in conversation by default and only writes plan files when the user explicitly asks, still restricted to the Plan directory.

- Reword the Plan mode enter reminder in `packages/core/src/plugin/plan.ts`
- Update the matching assertion in `packages/core/test/plugin/plan.test.ts`

## Testing

- `bun test test/plugin/plan.test.ts` from `packages/core`
- `bun typecheck` from `packages/core`