### PR TITLE
fix(core): drop undefined permission metadata values before publishing requests

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -190,7 +190,11 @@ const layer = Layer.effect(
         action: input.action,
         resources: input.resources,
         save: input.save,
-        metadata: input.metadata,
+        // Tools copy optional inputs straight into metadata; undefined values are not JSON and would
+        // fail the HttpApi response encoder when clients list pending requests.
+        metadata:
+          input.metadata &&
+          Object.fromEntries(Object.entries(input.metadata).filter(([, value]) => value !== undefined)),
         source: input.source,
         message,
       }

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect } from "bun:test"
-import { Cause, Deferred, Effect, Fiber, Layer } from "effect"
+import { Cause, Deferred, Effect, Fiber, Layer, Schema } from "effect"
 import { Agent } from "@opencode-ai/core/agent"
 import { Database } from "@opencode-ai/core/database/database"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -257,6 +257,33 @@ describe("Permission", () => {
       yield* Fiber.join(fiber)
       expect(yield* service.list()).toEqual([])
       expect(yield* service.get(request.id)).toBeUndefined()
+    }),
+  )
+
+  it.effect("drops undefined metadata values so pending requests encode as JSON", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      // Tools copy optional model inputs straight into metadata, so omitted inputs arrive as undefined values.
+      const { service, request } = yield* waitForRequest({
+        action: "glob",
+        resources: ["/project"],
+        metadata: { root: "/project", path: undefined, hidden: undefined, limit: undefined },
+      })
+      expect(request.metadata).toStrictEqual({ root: "/project" })
+      expect(yield* service.forSession(request.sessionID)).toEqual([request])
+      // HttpApi encodes JSON success bodies through Schema.toCodecJson, which rejects undefined values in Unknown.
+      const encode = Schema.encodeEffect(Schema.toCodecJson(Schema.Struct({ data: Schema.Array(Permission.Request) })))
+      expect(yield* encode({ data: yield* service.forSession(request.sessionID) })).toEqual({
+        data: [
+          {
+            id: request.id,
+            sessionID: request.sessionID,
+            action: "glob",
+            resources: ["/project"],
+            metadata: { root: "/project" },
+          },
+        ],
+      })
     }),
   )
 


### PR DESCRIPTION
## Why

`GET /api/session/:id/permission` returns 400 while a `glob` (or `grep`) permission is pending whose optional inputs the model omitted. The server logs `schema rejection kind=Body`. Any client hydrating pending permissions through `permission.list` (session open, reconnect, a second client) gets an error instead of the prompt; only the live `permission.asked` event gets through, so the pending request is invisible to anyone who was not already subscribed.

`glob.ts` and `grep.ts` copy optional inputs straight into permission metadata (`{ root, path: input.path, hidden: input.hidden, limit: input.limit }`), so omitted inputs become `undefined` values inside the `Schema.Record(String, Unknown)` metadata field. `HttpApiEndpoint` wraps JSON success schemas in `Schema.toCodecJson(...)`, and the JSON codec for `Schema.Unknown` rejects `undefined` (`Expected JSON value at ["data"][0]["metadata"]["path"]`). The bus event is not JSON-codec encoded, which is why it still arrives.

The probe that exposed this is documented in anomalyco/opencode-drive#78 (multi-tool-interleavings).

## What Changes

`Permission.Service` drops `undefined`-valued metadata keys once, where it builds the `Request` from `AssertInput`, so every tool is covered without touching each call site.

**Before**, with the model calling `glob {"pattern":"**/*.ts"}`:

| Request | Pending request metadata | `GET /api/session/:id/permission` |
| --- | --- | --- |
| `{pattern}` | `{ root, path: undefined, hidden: undefined, limit: undefined }` | 400 at `metadata.path` |
| `{pattern, path, limit}` | `{ root, path, hidden: undefined, limit }` | 400 at `metadata.hidden` |
| `{pattern, path, limit, hidden: false}` | all defined | 200 |

**After**:

| Request | Pending request metadata | `GET /api/session/:id/permission` |
| --- | --- | --- |
| `{pattern}` | `{ root }` | 200 |
| `{pattern, path, limit}` | `{ root, path, limit }` | 200 |
| `{pattern, path, limit, hidden: false}` | all defined | 200 |

Defined values, including `false`, `0`, `""`, and `null`, are kept. Only `undefined` is dropped, which matches what the wire could ever carry anyway.

## Scope

One boundary change in `packages/core/src/permission.ts` plus a regression test. `glob.ts` and `grep.ts` are unchanged; the public `Permission.Request` schema shape is unchanged, so no client regeneration is needed. A schema-level alternative (making the `Unknown` record tolerate `undefined` on encode) was not taken because the metadata field is shared with `permission.asked` events and the `session.permission.create` payload; normalizing at the service keeps one canonical request value for the bus, the HTTP list, and plugin hooks that read `existing.request`.

## Verification

```sh
export PATH=<bun 1.4.0>:$PATH
bun install
cd packages/core && bun test test/permission.test.ts -t "undefined metadata"   # before fix: 1 fail, "Expected JSON value at [\"data\"][0][\"metadata\"][\"path\"]"
cd packages/core && bun test test/permission.test.ts                            # after fix: 104 pass
cd packages/core && bun test test/tool                                          # 331 pass, 19 skip
cd packages/core && bun typecheck
cd packages/server && bun test test/session-instances.test.ts                  # real HttpApi route /api/session/:id/permission, 1 pass
```

The new test drives the real `Permission.Service` (`assert` with `metadata: { root, path: undefined, hidden: undefined, limit: undefined }`), reads it back through `forSession`, and encodes the result with `Schema.toCodecJson(Schema.Struct({ data: Schema.Array(Permission.Request) }))`, the same codec `HttpApiEndpoint` applies to the `session.permission.list` success body. It failed before the fix with the production error and passes after.
