### PR TITLE
fix(core): align supervisor reload fixture with Npm.Package

### DIFF
--- a/packages/core/test/plugin/supervisor-reload.test.ts
+++ b/packages/core/test/plugin/supervisor-reload.test.ts
@@ -25,10 +25,10 @@ import { testEffect } from "../lib/effect"
 // Real Location boot with plugin-directory discovery, so local plugin files are loaded and reloaded.
 setDefaultTimeout(15_000)
 
-// Package resolution for the fake npm below: the entrypoint is a fixture file, and resolving the
-// main entry can be held open so overlapping activations become observable.
+// Package resolution for the fake npm below: the package is a fixture directory the host resolves
+// by self-reference, and resolving it can be held open so overlapping activations become observable.
 const npm = {
-  entrypoint: "",
+  directory: "",
   gate: undefined as Deferred.Deferred<void> | undefined,
   inflight: 0,
   peak: 0,
@@ -37,18 +37,17 @@ const npm = {
 const npmLayer = Layer.succeed(
   Npm.Service,
   Npm.Service.of({
-    add: () => Effect.succeed({ directory: "", entrypoint: npm.entrypoint }),
-    resolve: (_, options) =>
+    add: (name) => Effect.succeed({ directory: npm.directory, name }),
+    resolve: (name) =>
       Effect.gen(function* () {
-        if (!options?.subpaths?.includes("")) return { directory: "", entrypoint: undefined }
         npm.inflight++
         npm.peak = Math.max(npm.peak, npm.inflight)
         if (npm.gate) yield* Deferred.await(npm.gate)
         npm.inflight--
-        return { directory: "", entrypoint: npm.entrypoint }
+        return { directory: npm.directory, name }
       }),
     check: () => Effect.succeed(false),
-    update: () => Effect.succeed({ directory: "", entrypoint: npm.entrypoint }),
+    update: (name) => Effect.succeed({ directory: npm.directory, name }),
     which: () => Effect.undefined,
   }),
 )
@@ -149,13 +148,20 @@ describe("PluginSupervisor reload", () => {
   it.effect("serializes the periodic refresh behind an in-flight reload", () =>
     Effect.gen(function* () {
       const directory = yield* tmpdirScoped()
-      npm.entrypoint = path.join(directory.path, "fixture-plugin.ts")
+      npm.directory = path.join(directory.path, "fixture-pkg")
       npm.gate = undefined
       npm.peak = 0
-      yield* Effect.promise(() => Bun.write(npm.entrypoint, greeter("greet-pkg")))
-      yield* Effect.promise(() =>
-        Bun.write(path.join(directory.path, ".opencode/opencode.json"), JSON.stringify({ plugins: ["fixture-pkg"] })),
-      )
+      yield* Effect.promise(async () => {
+        await Bun.write(path.join(npm.directory, "index.ts"), greeter("greet-pkg"))
+        await Bun.write(
+          path.join(npm.directory, "package.json"),
+          JSON.stringify({ name: "fixture-pkg", exports: "./index.ts" }),
+        )
+        await Bun.write(
+          path.join(directory.path, ".opencode/opencode.json"),
+          JSON.stringify({ plugins: ["fixture-pkg"] }),
+        )
+      })
       const bus = yield* Bus.Service
       const locations = yield* LocationServiceMap.Service
       yield* Effect.gen(function* () {


### PR DESCRIPTION
## Why

`v2` is red on typecheck from a merge race between two PRs that were each green on their own base. #46901 (21:04Z) changed `Npm.Package` to `{ directory, name, version?, revision? }` and dropped the `options` parameter from `resolve`, moving entrypoint resolution to `Host.resolve`. #46899 (22:56Z) then merged `packages/core/test/plugin/supervisor-reload.test.ts` with a fake `Npm` layer still returning `{ directory, entrypoint }` and gating on `options.subpaths`. Every workspace typecheck now fails on that file, which also blocks the pre-push hook for every worktree.

## What Changes

The fake `Npm` layer speaks the current interface, following the shape #46901 gave `provider-dynamic.test.ts`:

```diff
 const npm = {
-  entrypoint: "",
+  directory: "",
   gate: undefined as Deferred.Deferred<void> | undefined,
   inflight: 0,
   peak: 0,
 }

-    add: () => Effect.succeed({ directory: "", entrypoint: npm.entrypoint }),
-    resolve: (_, options) =>
-      Effect.gen(function* () {
-        if (!options?.subpaths?.includes("")) return { directory: "", entrypoint: undefined }
+    add: (name) => Effect.succeed({ directory: npm.directory, name }),
+    resolve: (name) =>
+      Effect.gen(function* () {
         npm.inflight++
         ...
-        return { directory: "", entrypoint: npm.entrypoint }
+        return { directory: npm.directory, name }
```

The serialization test writes a real package directory (`fixture-pkg/index.ts` plus a `package.json` with `name` and `exports`) instead of a bare `.ts` file, so `Host.resolve` finds the server entrypoint by package self-reference exactly as it does for installed plugins. The in-flight counter now counts every `resolve` call, since the current interface resolves a package once rather than once per subpath; the gate, peak assertion, and 24-hour refresh serialization check are unchanged.

## Scope

Test fixture only; no production code. The `peak === 1` assertion passing confirms the fake `resolve` path is exercised, not bypassed.

## Verification

From `packages/core` with Bun 1.4.0:

```sh
bun typecheck                                      # 0 errors (was 5)
bun run test test/plugin/supervisor-reload.test.ts # 2 passed
```

The pre-push hook completed all 33 workspace typecheck tasks.
