### PR TITLE
fix(core): activate the initial plugin generation without the reload debounce

### DIFF
--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -1,7 +1,7 @@
 export * as PluginSupervisor from "./supervisor.js"
 
 import { Event } from "@opencode-ai/schema/config"
-import { Cause, Effect, Layer, PubSub, Stream } from "effect"
+import { Cause, Effect, Layer, PubSub, Queue, Stream } from "effect"
 import path from "path"
 import { ConfigPluginSource } from "../config/plugin/source.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
@@ -189,16 +189,15 @@ export const layer = Layer.effectDiscard(
         Effect.forkScoped({ startImmediately: true }),
       )
     })
-    // Reload triggers are subscribed eagerly, each on its own fiber, before generation 0 starts
-    // activating: Stream.merge and Stream.debounce open upstream a fiber hop later and PubSub does not
-    // replay for late subscribers, so a change landing during the first activation would otherwise be
-    // lost. The sliding slot keeps observing while activation runs, retaining only the latest request.
-    const triggers = yield* PubSub.sliding<number>(1)
+    // Each reload source is subscribed on its own fiber before generation 0 starts activating; a merged
+    // stream would open them a fiber hop later and lose a change that lands during the first activation.
+    // The sliding slot keeps accepting triggers while activation runs, retaining only the latest request.
+    const triggers = yield* Queue.sliding<number>(1)
     // Make accepted work visible to awaitActivation before coalescing the burst.
     const notify = Effect.gen(function* () {
       observed++
       if (!release) release = yield* registry.hold()
-      yield* PubSub.publish(triggers, observed)
+      yield* Queue.offer(triggers, observed)
     })
     const watch = <A>(stream: Stream.Stream<A>) =>
       stream.pipe(
@@ -219,10 +218,9 @@ export const layer = Layer.effectDiscard(
         ),
       ),
     )
-    const reloads = yield* PubSub.subscribe(triggers)
     // One lane serializes every activation. Generation 0 has nothing to coalesce with, so it runs at
     // once; only the reload feed waits out the debounce that absorbs file-save bursts.
-    yield* Stream.concat(Stream.succeed(0), Stream.fromSubscription(reloads).pipe(Stream.debounce("100 millis"))).pipe(
+    yield* Stream.concat(Stream.succeed(0), Stream.fromQueue(triggers).pipe(Stream.debounce("100 millis"))).pipe(
       Stream.runForEach((target) =>
         Effect.gen(function* () {
           yield* activate().pipe(Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause })))

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -1,7 +1,7 @@
 export * as PluginSupervisor from "./supervisor.js"
 
 import { Event } from "@opencode-ai/schema/config"
-import { Cause, Effect, Layer, PubSub, Queue, Stream } from "effect"
+import { Cause, Effect, Layer, Queue, Stream } from "effect"
 import path from "path"
 import { ConfigPluginSource } from "../config/plugin/source.js"
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
@@ -131,7 +131,6 @@ export const layer = Layer.effectDiscard(
     const updating = new Set<string>()
     let generation = 0
     let observed = 0
-    const refresh = yield* PubSub.unbounded<void>()
 
     const activate = Effect.fn("PluginSupervisor.activate")(function* () {
       const current = ++generation
@@ -189,9 +188,8 @@ export const layer = Layer.effectDiscard(
         Effect.forkScoped({ startImmediately: true }),
       )
     })
-    // Each reload source is subscribed on its own fiber before generation 0 starts activating; a merged
-    // stream would open them a fiber hop later and lose a change that lands during the first activation.
-    // The sliding slot keeps accepting triggers while activation runs, retaining only the latest request.
+    // Start source consumers before activation, without an extra merge/debounce boundary delaying them.
+    // Each source owns its upstream subscriptions; the queue retains the latest observed request.
     const triggers = yield* Queue.sliding<number>(1)
     // Make accepted work visible to awaitActivation before coalescing the burst.
     const notify = Effect.gen(function* () {
@@ -205,7 +203,7 @@ export const layer = Layer.effectDiscard(
         Effect.forkScoped({ startImmediately: true }),
       )
     yield* watch(sources.changes())
-    yield* watch(Stream.fromPubSub(refresh))
+    yield* watch(Stream.fromEffectRepeat(Effect.sleep("24 hours")))
     yield* watch(bus.subscribe([Event.Updated, SdkPlugins.Updated]))
     yield* watch(
       updates.changes().pipe(
@@ -218,8 +216,7 @@ export const layer = Layer.effectDiscard(
         ),
       ),
     )
-    // One lane serializes every activation. Generation 0 has nothing to coalesce with, so it runs at
-    // once; only the reload feed waits out the debounce that absorbs file-save bursts.
+    // Run initial activation immediately; debounce only later requests. One consumer serializes both.
     yield* Stream.concat(Stream.succeed(0), Stream.fromQueue(triggers).pipe(Stream.debounce("100 millis"))).pipe(
       Stream.runForEach((target) =>
         Effect.gen(function* () {
@@ -231,12 +228,6 @@ export const layer = Layer.effectDiscard(
         }),
       ),
       Effect.forkScoped({ startImmediately: true }),
-    )
-    // The periodic refresh joins the reload feed above so it never activates concurrently with a change.
-    yield* Effect.sleep("24 hours").pipe(
-      Effect.andThen(PubSub.publish(refresh, undefined)),
-      Effect.forever,
-      Effect.forkScoped,
     )
   }),
 )

--- a/packages/core/src/plugin/supervisor.ts
+++ b/packages/core/src/plugin/supervisor.ts
@@ -189,11 +189,26 @@ export const layer = Layer.effectDiscard(
         Effect.forkScoped({ startImmediately: true }),
       )
     })
-    const reloads = Stream.merge(
-      Stream.merge(
-        Stream.merge(sources.changes(), Stream.fromPubSub(refresh)),
-        bus.subscribe([Event.Updated, SdkPlugins.Updated]),
-      ),
+    // Reload triggers are subscribed eagerly, each on its own fiber, before generation 0 starts
+    // activating: Stream.merge and Stream.debounce open upstream a fiber hop later and PubSub does not
+    // replay for late subscribers, so a change landing during the first activation would otherwise be
+    // lost. The sliding slot keeps observing while activation runs, retaining only the latest request.
+    const triggers = yield* PubSub.sliding<number>(1)
+    // Make accepted work visible to awaitActivation before coalescing the burst.
+    const notify = Effect.gen(function* () {
+      observed++
+      if (!release) release = yield* registry.hold()
+      yield* PubSub.publish(triggers, observed)
+    })
+    const watch = <A>(stream: Stream.Stream<A>) =>
+      stream.pipe(
+        Stream.runForEach(() => notify),
+        Effect.forkScoped({ startImmediately: true }),
+      )
+    yield* watch(sources.changes())
+    yield* watch(Stream.fromPubSub(refresh))
+    yield* watch(bus.subscribe([Event.Updated, SdkPlugins.Updated]))
+    yield* watch(
       updates.changes().pipe(
         Stream.filter((update) => packages.has(update.target)),
         Stream.tap((update) =>
@@ -202,22 +217,12 @@ export const layer = Layer.effectDiscard(
             update.updating ? updating.add(update.target) : updating.delete(update.target)
           }),
         ),
-        Stream.map(() => undefined),
-      ),
-    ).pipe(
-      // Make accepted work visible to awaitActivation before coalescing the burst.
-      Stream.mapEffect(() =>
-        Effect.gen(function* () {
-          observed++
-          if (!release) release = yield* registry.hold()
-          return observed
-        }),
       ),
     )
-    yield* Stream.concat(Stream.succeed(0), reloads).pipe(
-      // Keep observing updates while activation runs, retaining only the latest generation request.
-      Stream.buffer({ capacity: 1, strategy: "sliding" }),
-      Stream.debounce("100 millis"),
+    const reloads = yield* PubSub.subscribe(triggers)
+    // One lane serializes every activation. Generation 0 has nothing to coalesce with, so it runs at
+    // once; only the reload feed waits out the debounce that absorbs file-save bursts.
+    yield* Stream.concat(Stream.succeed(0), Stream.fromSubscription(reloads).pipe(Stream.debounce("100 millis"))).pipe(
       Stream.runForEach((target) =>
         Effect.gen(function* () {
           yield* activate().pipe(Effect.catchCause((cause) => Effect.logError("failed to reload plugins", { cause })))

--- a/packages/core/test/plugin/supervisor-reload.test.ts
+++ b/packages/core/test/plugin/supervisor-reload.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, setDefaultTimeout } from "bun:test"
 import fs from "fs/promises"
 import path from "path"
-import { Deferred, Duration, Effect, Layer, LayerMap, Schedule } from "effect"
+import { Deferred, Duration, Effect, Fiber, Layer, LayerMap, Schedule } from "effect"
 import { TestClock } from "effect/testing"
+import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Event } from "@opencode-ai/schema/config"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
@@ -20,6 +21,7 @@ import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { tempGlobalLayer } from "../fixture/global"
 import { tmpdirScoped } from "../fixture/tmpdir"
+import { advance } from "../lib/clock"
 import { testEffect } from "../lib/effect"
 
 // Real Location boot with plugin-directory discovery, so local plugin files are loaded and reloaded.
@@ -54,13 +56,14 @@ const npmLayer = Layer.succeed(
 const instances = Layer.effect(
   LocationServiceMap.Service,
   Effect.gen(function* () {
+    const watcher = yield* Watcher.Test
     const map = yield* LayerMap.make((ref: Location.Ref) => Instance.layer(ref, { replacements: bindings }), {
       idleTimeToLive: Duration.infinity,
     })
     const bindings: LayerNode.Replacements = [
       Global.node.replace(tempGlobalLayer),
       Npm.node.replace(npmLayer),
-      Watcher.node.replace(Watcher.configured({ enabled: false })),
+      Watcher.node.replace(Layer.succeed(Watcher.Service, watcher)),
       LocationServiceMap.node.replace(Layer.succeed(LocationServiceMap.Service, map)),
       Instance.node.replace(
         Layer.succeed(Instance.Service, {
@@ -70,13 +73,13 @@ const instances = Layer.effect(
     ]
     return map
   }),
-)
+).pipe(Layer.provide(Watcher.testLayer))
 
 const it = testEffect(
   AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
     Global.node.replace(tempGlobalLayer),
     LocationServiceMap.node.replace(instances),
-  ]),
+  ]).pipe(Layer.provideMerge(Watcher.testLayer)),
 )
 
 const greeter = (command: string) => `export default {
@@ -104,6 +107,61 @@ const failed = (plugins: Plugin.Interface) =>
   )
 
 describe("PluginSupervisor reload", () => {
+  ;(["discovered", "configured"] as const).forEach((mode) => {
+    it.effect(`retains a ${mode} plugin change during initial activation`, () =>
+      Effect.gen(function* () {
+        const directory = yield* tmpdirScoped()
+        const file = path.join(
+          directory.path,
+          mode === "discovered" ? ".opencode/plugins/greeter.ts" : "external/greeter/index.ts",
+        )
+        yield* Effect.promise(async () => {
+          await Bun.write(file, greeter("greet-v1"))
+          await fs.utimes(file, new Date(0), new Date(0))
+          if (mode === "configured") {
+            await Bun.write(
+              path.join(directory.path, ".opencode/opencode.json"),
+              JSON.stringify({ plugins: [path.dirname(file)] }),
+            )
+          }
+        })
+        const entered = yield* Deferred.make<void>()
+        const gate = yield* Deferred.make<void>()
+        const sdk = yield* SdkPlugins.Service
+        yield* sdk.register(
+          define({
+            id: "gated",
+            effect: () => Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(gate))),
+          }),
+        )
+        const watcher = yield* Watcher.Test
+        const locations = yield* LocationServiceMap.Service
+        yield* Effect.gen(function* () {
+          const plugins = yield* Plugin.Service
+          const commands = yield* Command.Service
+          yield* Deferred.await(entered)
+          // The real ConfigPluginSource merges config-root changes and configured-path watches.
+          // Emit while setup is blocked, without a bus event that could mask a lost source trigger.
+          yield* Effect.promise(async () => {
+            await Bun.write(file, greeter("greet-v2"))
+            await fs.utimes(file, new Date(), new Date())
+          })
+          yield* watcher.emit({ path: file, type: "update" })
+          const ready = yield* plugins.awaitActivation.pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Deferred.succeed(gate, undefined)
+          yield* advance(() => ready.pollUnsafe() !== undefined)
+          yield* Fiber.join(ready)
+
+          expect(yield* commands.get("greet-v1")).toBeUndefined()
+          expect(yield* commands.get("greet-v2")).toBeDefined()
+        }).pipe(
+          Effect.scoped,
+          Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(directory.path) }))),
+        )
+      }),
+    )
+  })
+
   it.live("keeps the running generation when an updated local plugin fails to import", () =>
     Effect.gen(function* () {
       const directory = yield* tmpdirScoped()

--- a/packages/core/test/plugin/supervisor-reload.test.ts
+++ b/packages/core/test/plugin/supervisor-reload.test.ts
@@ -20,6 +20,7 @@ import { Plugin } from "@opencode-ai/core/plugin"
 import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { tempGlobalLayer } from "../fixture/global"
+import { offlineModels } from "../fixture/models"
 import { tmpdirScoped } from "../fixture/tmpdir"
 import { advance } from "../lib/clock"
 import { testEffect } from "../lib/effect"
@@ -62,6 +63,7 @@ const instances = Layer.effect(
     })
     const bindings: LayerNode.Replacements = [
       Global.node.replace(tempGlobalLayer),
+      offlineModels,
       Npm.node.replace(npmLayer),
       Watcher.node.replace(Layer.succeed(Watcher.Service, watcher)),
       LocationServiceMap.node.replace(Layer.succeed(LocationServiceMap.Service, map)),
@@ -78,6 +80,7 @@ const instances = Layer.effect(
 const it = testEffect(
   AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
     Global.node.replace(tempGlobalLayer),
+    offlineModels,
     LocationServiceMap.node.replace(instances),
   ]).pipe(Layer.provideMerge(Watcher.testLayer)),
 )

--- a/packages/core/test/plugin/supervisor.test.ts
+++ b/packages/core/test/plugin/supervisor.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect } from "bun:test"
 import { Deferred, Duration, Effect, Layer, LayerMap, Stream } from "effect"
+import { TestClock } from "effect/testing"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
@@ -131,6 +132,32 @@ describe("PluginSupervisor", () => {
         Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(directory.path) }))),
       )
       expect(source.activations).toBe(1)
+    }),
+  )
+
+  it.effect("refreshes every 24 hours without adding an immediate reload", () =>
+    Effect.gen(function* () {
+      source.activations = 0
+      const directory = yield* tmpdirScoped()
+      const locations = yield* LocationServiceMap.Service
+      yield* Effect.gen(function* () {
+        const plugins = yield* Plugin.Service
+        yield* plugins.awaitActivation
+        yield* TestClock.adjust("23 hours")
+        expect(source.activations).toBe(1)
+
+        yield* TestClock.adjust("1 hour")
+        yield* advance(() => source.activations === 2)
+        yield* plugins.awaitActivation
+
+        yield* TestClock.adjust("24 hours")
+        yield* advance(() => source.activations === 3)
+        yield* plugins.awaitActivation
+        expect(source.activations).toBe(3)
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(directory.path) }))),
+      )
     }),
   )
 

--- a/packages/core/test/plugin/supervisor.test.ts
+++ b/packages/core/test/plugin/supervisor.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect } from "bun:test"
-import { Duration, Effect, Layer, LayerMap } from "effect"
+import { Deferred, Duration, Effect, Layer, LayerMap, Stream } from "effect"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 import { Global } from "@opencode-ai/util/global"
 import { Command } from "@opencode-ai/core/command"
+import { ConfigPluginSource } from "@opencode-ai/core/config/plugin/source"
 import { Instance } from "@opencode-ai/core/instance"
 import { LocationServiceMap } from "@opencode-ai/core/location-services"
 import { Location } from "@opencode-ai/core/location"
@@ -16,17 +17,32 @@ import { Bus } from "../../src/bus"
 import { tempGlobalLayer } from "../fixture/global"
 import { offlineModels } from "../fixture/models"
 import { tmpdirScoped } from "../fixture/tmpdir"
+import { advance } from "../lib/clock"
 import { testEffect } from "../lib/effect"
 
 const id = Plugin.ID.make("account-prompts")
 
 // Host and instance plugins share one ID; each registers a distinct command so the winner is observable.
-const greeter = (command: string) =>
+const greeter = (command: string, plugin: string = id) =>
   define({
-    id,
+    id: plugin,
     effect: (ctx) =>
       ctx.command.transform((editor) => editor.add({ name: command, execute: () => Effect.void })).pipe(Effect.asVoid),
   })
+
+// Every supervisor activation scans the config plugin operations once, so counting scans counts activations.
+const source = { activations: 0 }
+const sourceLayer = Layer.succeed(
+  ConfigPluginSource.Service,
+  ConfigPluginSource.Service.of({
+    operations: () =>
+      Effect.sync(() => {
+        source.activations++
+        return []
+      }),
+    changes: () => Stream.never,
+  }),
+)
 
 const instances = Layer.effect(
   LocationServiceMap.Service,
@@ -39,6 +55,7 @@ const instances = Layer.effect(
     const bindings: LayerNode.Replacements = [
       Global.node.replace(tempGlobalLayer),
       offlineModels,
+      ConfigPluginSource.node.replace(sourceLayer),
       LocationServiceMap.node.replace(Layer.succeed(LocationServiceMap.Service, map)),
       Instance.node.replace(
         Layer.succeed(Instance.Service, {
@@ -95,6 +112,93 @@ describe("PluginSupervisor", () => {
       expect(
         state.inventory.some((plugin) => plugin.id?.startsWith("opencode.") && plugin.state.status === "active"),
       ).toBe(true)
+    }),
+  )
+
+  it.effect("activates the initial generation without waiting for the reload debounce", () =>
+    Effect.gen(function* () {
+      source.activations = 0
+      const directory = yield* tmpdirScoped()
+      const locations = yield* LocationServiceMap.Service
+      yield* Effect.gen(function* () {
+        const plugins = yield* Plugin.Service
+        const commands = yield* Command.Service
+        // The TestClock never advances here, so any timer between boot and the first activation would hang this.
+        yield* plugins.awaitActivation
+        expect(yield* commands.get("instance-greet")).toBeDefined()
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(directory.path) }))),
+      )
+      expect(source.activations).toBe(1)
+    }),
+  )
+
+  it.effect("reloads for a trigger published while the initial generation is activating", () =>
+    Effect.gen(function* () {
+      source.activations = 0
+      const sdk = yield* SdkPlugins.Service
+      const entered = yield* Deferred.make<void>()
+      const gate = yield* Deferred.make<void>()
+      yield* sdk.register(
+        define({
+          id: "gated",
+          effect: () => Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(gate))),
+        }),
+      )
+      let late = false
+      const directory = yield* tmpdirScoped()
+      const locations = yield* LocationServiceMap.Service
+      yield* Effect.gen(function* () {
+        const plugins = yield* Plugin.Service
+        const commands = yield* Command.Service
+        yield* Deferred.await(entered)
+        // Generation 0 is mid-setup: the reload feed must already be subscribed for this update to count.
+        yield* sdk.register(
+          define({
+            id: "late",
+            effect: (ctx) =>
+              ctx.command
+                .transform((editor) => editor.add({ name: "late-greet", execute: () => Effect.void }))
+                .pipe(Effect.tap(() => Effect.sync(() => (late = true)))),
+          }),
+        )
+        yield* Deferred.succeed(gate, undefined)
+        yield* advance(() => late)
+        yield* plugins.awaitActivation
+        expect(yield* commands.get("late-greet")).toBeDefined()
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(directory.path) }))),
+      )
+      expect(source.activations).toBe(2)
+    }),
+  )
+
+  it.effect("coalesces a burst of reload triggers after the initial generation into one activation", () =>
+    Effect.gen(function* () {
+      source.activations = 0
+      const sdk = yield* SdkPlugins.Service
+      const directory = yield* tmpdirScoped()
+      const locations = yield* LocationServiceMap.Service
+      yield* Effect.gen(function* () {
+        const plugins = yield* Plugin.Service
+        const commands = yield* Command.Service
+        yield* plugins.awaitActivation
+        expect(source.activations).toBe(1)
+
+        yield* sdk.register(greeter("greet-a", "a"))
+        yield* sdk.register(greeter("greet-b", "b"))
+        yield* sdk.register(greeter("greet-c", "c"))
+        yield* advance(() => source.activations > 1)
+        yield* plugins.awaitActivation
+        expect(yield* commands.get("greet-a")).toBeDefined()
+        expect(yield* commands.get("greet-c")).toBeDefined()
+      }).pipe(
+        Effect.scoped,
+        Effect.provide(locations.get(Location.Ref.make({ directory: AbsolutePath.make(directory.path) }))),
+      )
+      expect(source.activations).toBe(2)
     }),
   )
 })

--- a/packages/server/test/session-instances.test.ts
+++ b/packages/server/test/session-instances.test.ts
@@ -195,7 +195,8 @@ it.live(
           expect(yield* Effect.promise<unknown>(() => response.json())).toEqual({ data: [] })
         }
       }
-      expect(boots).toEqual([])
+      // Reading permissions or forms builds the Session's Instance and starts its plugin activation at once; the
+      // ordering assertion after the prompts is what proves each Session boots exactly once.
 
       for (const config of configs) {
         const session = yield* sessions.get(config.id)


### PR DESCRIPTION
## Why

Cold Locations wait an unnecessary 100 ms before their first plugin activation because the initial generation passes through the reload debounce. Prompt admission waits for that activation; the debounce should absorb later file-save bursts, not delay startup.

## What Changes

| Situation | Behavior |
|---|---|
| Initial activation | Starts without waiting for a debounce timer |
| Burst of later changes | Coalesces through the existing 100 ms debounce |
| Change during activation | Retains the latest observed request for a subsequent activation |
| Periodic refresh | First fires after 24 hours, then joins the same serialized activation queue |

The activation stream is now:

```ts
Stream.concat(
  Stream.succeed(0),
  Stream.fromQueue(triggers).pipe(Stream.debounce("100 millis")),
)
```

The periodic source needs no separate PubSub relay:

```ts
yield* watch(Stream.fromEffectRepeat(Effect.sleep("24 hours")))
```

## Activation Ordering

Each source consumer starts independently before the initial activation, rather than placing the consumers behind another merge or debounce boundary. The consumers feed one `Queue.sliding(1)`; one `runForEach` serializes initial activation, subsequent reloads, and periodic refreshes. Accepted triggers hold `awaitActivation` pending until an activation catches up to the latest observed request.

`startImmediately` starts the consumer; each source still owns its upstream subscription behavior. Regression tests cover SDK registration and both branches of the real `ConfigPluginSource` change feed: discovered plugins under config roots and configured plugin directories outside them. They change a plugin while initial setup is blocked and verify that the new command becomes available afterward.

## Scope

Changes the supervisor's startup and trigger plumbing, preserving plugin resolution and activation behavior. The server instance-selection test drops a timing-dependent assertion that no plugins have activated yet after permission/form reads; its once-per-Session boot-order assertion remains.

Rebased onto the test-network guard from #46908, retaining its offline model fixtures and adding the same replacement to the reload-test graph.

## Verification

```sh
# packages/core
bun typecheck
bun run test test/plugin/supervisor.test.ts test/plugin/supervisor-reload.test.ts --rerun-each 5
bun run test

# packages/server
bun run ../core/script/test.ts

# packages/cli
bun run test test/acp
```

- Core typecheck: clean.
- Supervisor tests repeated five times: 45 pass, 0 fail.
- Full Core suite after rebase: 4017 pass, 39 skip, 0 fail.
- Server suite: 50 pass, 3 skip, 0 fail.
- ACP suite: 96 pass, 0 fail.
- Startup completes without advancing `TestClock`; SDK changes during initial setup are retained; later trigger bursts still coalesce.
- Both config-source startup tests fail when the source consumer is deliberately removed. The tests use real plugin files and `ConfigPluginSource`, with filesystem notifications supplied through `Watcher.testLayer` rather than OS timing.
- The cadence test checks no extra activation before 24 hours and refreshes at 24 and 48 hours. Replacing the periodic source with plain `Stream.tick`, which emits immediately, makes it fail.
- The existing periodic-refresh test still verifies that refresh cannot overlap an in-flight reload.

Earlier boot measurements on the initial implementation (Apple M2 Max, `none nofetch`, five processes with six Locations each) showed:

| Median | Before | After |
|---|---:|---:|
| Location-cold, 25 samples | 164 ms | 60 ms |
| Process-cold, 5 samples | 251 ms | 157 ms |

These measurements were not rerun for the subsequent queue/timer simplifications.
