### PR TITLE
refactor(client): derive session inputs from pending items

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -107,7 +107,6 @@ type Store = {
     messageCursor: Record<string, string | undefined>
     messageLoading: Record<string, boolean>
     pending: Record<string, SessionInboxInfo[]>
-    input: Record<string, string[]>
     permission: Record<string, PermissionRequest[]>
     // Pending forms keyed by owner: a session ID or the temporary "global" elicitation sentinel.
     form: Record<string, FormWithLocation[]>
@@ -198,7 +197,6 @@ export function createData(config: CreateDataInput) {
       messageCursor: {},
       messageLoading: {},
       pending: {},
-      input: {},
       permission: {},
       form: {},
     },
@@ -230,13 +228,6 @@ export function createData(config: CreateDataInput) {
         "pending",
         sessionID,
         (store.session.pending[sessionID] ?? []).filter((item) => item.id !== inboxID),
-      )
-    if (store.session.input[sessionID]?.includes(inboxID))
-      setStore(
-        "session",
-        "input",
-        sessionID,
-        (store.session.input[sessionID] ?? []).filter((id) => id !== inboxID),
       )
   }
 
@@ -335,8 +326,8 @@ export function createData(config: CreateDataInput) {
     return request
   }
 
-  // Upsert an admitted inbox item into pending, input, and (for user and
-  // synthetic items) the visible transcript. Used by the inbox.enqueued
+  // Upsert an admitted inbox item into pending and (for user and synthetic
+  // items) the visible transcript. Used by the inbox.enqueued
   // handler and by optimistic admission; the upsert is what reconciles
   // the durable echo with an optimistic placeholder — the durable payload and
   // times replace the client's guess.
@@ -351,8 +342,6 @@ export function createData(config: CreateDataInput) {
         at < 0 ? [...pending, item] : pending.map((entry, index) => (index === at ? item : entry)),
       )
       if (item.type === "compaction") return
-      const input = store.session.input[item.sessionID] ?? []
-      if (!input.includes(item.id)) setStore("session", "input", item.sessionID, [...input, item.id])
       materializeInboxMessage(item)
     })
   }
@@ -524,12 +513,8 @@ export function createData(config: CreateDataInput) {
         delete draft.messageCursor[sessionID]
         delete draft.messageLoading[sessionID]
         delete draft.pending[sessionID]
-        delete draft.input[sessionID]
         if (messages.length) draft.message[sessionID] = messages
-        if (pending.length) {
-          draft.pending[sessionID] = pending
-          draft.input[sessionID] = pending.filter((item) => item.type !== "compaction").map((item) => item.id)
-        }
+        if (pending.length) draft.pending[sessionID] = pending
       }),
     )
   }
@@ -553,7 +538,6 @@ export function createData(config: CreateDataInput) {
         delete draft.messageCursor[sessionID]
         delete draft.messageLoading[sessionID]
         delete draft.pending[sessionID]
-        delete draft.input[sessionID]
         delete draft.permission[sessionID]
         delete draft.form[sessionID]
         for (const [rootID, family] of Object.entries(draft.family)) {
@@ -714,7 +698,7 @@ export function createData(config: CreateDataInput) {
         return
       }
       case "session.inbox.delivered": {
-        const admitted = store.session.input[event.data.sessionID]?.includes(event.data.inboxID) ?? false
+        const admitted = result.session.input.has(event.data.sessionID, event.data.inboxID)
         removePending(event.data.sessionID, event.data.inboxID)
         message.update(event.data.sessionID, (draft, index) => {
           const position = index.get(event.data.inboxID)
@@ -1027,11 +1011,12 @@ export function createData(config: CreateDataInput) {
         if (store.session.info[event.data.sessionID]) {
           setStore("session", "info", event.data.sessionID, "revert", undefined)
         }
+        // The projector also deletes inbox items enqueued at or after the boundary without a cancel event.
         setStore(
           "session",
-          "input",
+          "pending",
           event.data.sessionID,
-          (store.session.input[event.data.sessionID] ?? []).filter((id) => id < event.data.to),
+          (store.session.pending[event.data.sessionID] ?? []).filter((item) => item.id < event.data.to),
         )
         message.update(event.data.sessionID, (draft, index) => {
           const position = draft.findIndex((item) => item.id >= event.data.to)
@@ -1308,12 +1293,17 @@ export function createData(config: CreateDataInput) {
       status(sessionID: string) {
         return store.session.active[sessionID] ?? "idle"
       },
+      // Inputs are the pending user and synthetic items; compactions are control items.
       input: {
         list(sessionID: string) {
-          return store.session.input[sessionID] ?? []
+          return (store.session.pending[sessionID] ?? []).flatMap((item) =>
+            item.type === "compaction" ? [] : [item.id],
+          )
         },
         has(sessionID: string, inboxID: string) {
-          return store.session.input[sessionID]?.includes(inboxID) ?? false
+          return (
+            store.session.pending[sessionID]?.some((item) => item.id === inboxID && item.type !== "compaction") ?? false
+          )
         },
       },
       pending: {
@@ -1337,12 +1327,6 @@ export function createData(config: CreateDataInput) {
             const merged = inflight.length === 0 ? pending : [...pending, ...inflight]
             batch(() => {
               setStore("session", "pending", sessionID, reconcile(merged))
-              setStore(
-                "session",
-                "input",
-                sessionID,
-                reconcile(merged.filter((item) => item.type !== "compaction").map((item) => item.id)),
-              )
               merged.forEach(materializeInboxMessage)
             })
           })

--- a/packages/tui/test/cli/tui/data.test.tsx
+++ b/packages/tui/test/cli/tui/data.test.tsx
@@ -1129,6 +1129,10 @@ test("removes committed revert messages from local state", async () => {
     expect(data.session.message.list(sessionID).map((message) => message.id)).toEqual(["msg_001"])
     expect(data.session.message.get(sessionID, "msg_002")).toBeUndefined()
     expect(data.session.message.get(sessionID, "msg_003")).toBeUndefined()
+    // The projector also drops inbox items enqueued at or after the boundary, without a cancel event.
+    expect(data.session.pending.list(sessionID).map((item) => item.id)).toEqual(["msg_001"])
+    expect(data.session.input.list(sessionID)).toEqual(["msg_001"])
+    expect(data.session.input.has(sessionID, "msg_002")).toBe(false)
   } finally {
     app.renderer.destroy()
   }


### PR DESCRIPTION
## Why

`store.session.input` is a second copy of information already held by `store.session.pending`: the IDs of the pending user and synthetic items, excluding compaction control items. Seven sites keep the two in step by hand (`admitLocal`, `removePending`, `evictSession`, `removeSession`, `pending.sync`, `revert.committed`, and the store shape itself). Two collections that must agree are a synchronization rule; one collection with a derived view is not.

The one place the copies were *allowed* to disagree turned out to be a bug. Third PR in the data-service simplification series after #46831 and #46924; same bar of behavior preserved and net production deletion, with one deliberate correction described below.

## What Changes

`input` becomes a view over `pending`:

```ts
input: {
  list: (sessionID) => pending(sessionID).flatMap((item) => (item.type === "compaction" ? [] : [item.id])),
  has:  (sessionID, inboxID) => pending(sessionID).some((item) => item.id === inboxID && item.type !== "compaction"),
}
```

and every site that wrote `input` alongside `pending` writes only `pending`. Public getters `session.input.list` and `session.input.has` keep their signatures and return the same values in every state the two collections previously agreed on.

### Revert Boundary

On `session.revert.committed { to }`, the server projector deletes both the messages **and the inbox items** at or after the boundary (`packages/core/src/session/projector.ts`, `DELETE session_inbox WHERE enqueued_seq >= boundary`), without emitting `inbox.cancelled` for them. The client mirrored that for `messages` and for `input`, but left `pending` untouched, so `pending.list` kept items the server had already removed until the next re-sync.

Concrete case: inputs `msg_5` (queued prompt) and `msg_6` (queued compaction) are pending; the user commits a revert to `msg_3`.

| Collection | Before this PR | After |
| --- | --- | --- |
| `messages` | truncated to `< msg_3` | same |
| `input.list` | `[]` | `[]` |
| `pending.list` | **`[msg_5, msg_6]`** (stale; server has neither) | `[]` |

The stale `pending` fed the TUI tab busy badge (`pending.list(id).length > 0`), the queued-compaction row, and the app's steer detection. `revert.committed` now filters `pending` with the same `id < to` comparison `input` already used, which is what makes the derivation exact rather than "exact except after a revert." The existing TUI revert test gains assertions for `pending.list`, `input.list`, and `input.has`; they fail on `v2` (two stale items) and pass here.

## Scope

`packages/client/src/solid/data.ts` **1,844 → 1,828 lines (+14 / −30, net −16)** plus 4 test lines. One private store field removed; no new files, dependencies, or public exports. `input.list` now returns a fresh array per read; its consumers (`tui/routes/session/rows.ts`, devtools) already read `pending.list` in the same computation, so no new reactive re-runs are introduced.

## Verification

Commands run with Bun 1.4.0 from the indicated package directories:

```sh
# packages/client
bun run test
bun typecheck
bun run build

# packages/tui
bun run test
bun typecheck

# packages/app
bun run test
bun typecheck
```

- Client: 144 passed.
- TUI: 1,175 passed, 4 skipped, including the extended revert test and the `input.list` / `input.has` assertions across enqueue, delivery, cancellation, eviction, and pending-sync scenarios in `test/cli/tui/data.test.tsx`.
- App: 708 unit passed, 1 skipped; 113 browser-runtime passed. The app composer adapters read `input.has` for admission checks.
- Typechecks passed for client, TUI, and app; the pre-push hook completed all 33 workspace typecheck tasks. `oxlint` warnings on `data.ts` unchanged from base (4).
- No UI surface change beyond the revert correction, which is covered by the test rather than a recording.
