### PR TITLE
fix(client): refresh references for the updated location

### DIFF
--- a/packages/app/src/runtime/server/sync.tsx
+++ b/packages/app/src/runtime/server/sync.tsx
@@ -230,8 +230,6 @@ export function createServerSyncContextInner(serverSDK: ServerSDK, data: Data) {
     children.mark(key)
     if (event.type === "config.updated" || event.type === "agent.updated") queue.push(key)
     if (event.type === "worktree.updated") void bootstrap.refetch()
-    if (event.type === "reference.updated" && children.active(key))
-      void data.location.reference.sync({ directory: key }).catch(() => undefined)
   })
 
   onCleanup(unsub)

--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -1180,8 +1180,8 @@ export function createData(config: CreateDataInput) {
         }))
         break
       case "reference.updated":
-        result.location.reference.invalidate()
-        void result.location.reference.sync()
+        result.location.reference.invalidate(location)
+        void result.location.reference.sync(location)
         break
       case "integration.updated":
         result.location.integration.invalidate(location)

--- a/packages/client/test/solid-data.test.ts
+++ b/packages/client/test/solid-data.test.ts
@@ -409,6 +409,66 @@ test("refreshes global credential events across every loaded location and worksp
   }
 })
 
+test("refreshes references for the location an update names", async () => {
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
+  const requests: URL[] = []
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      const url = new URL(request.url)
+      requests.push(url)
+      const directory = url.searchParams.get("location[directory]") ?? "/project"
+      return Response.json({
+        location: {
+          directory,
+          workspaceID: url.searchParams.get("location[workspace]") ?? undefined,
+          project: { id: "project", directory, canonical: directory },
+        },
+        data: [],
+      })
+    },
+  })
+  const setup = createRoot((dispose) => ({
+    data: createData({
+      api: () => api,
+      directory: "/project",
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
+      connection: { status: () => "connected" },
+    }),
+    dispose,
+  }))
+  const other = { directory: "/other", workspaceID: "workspace-other" }
+
+  try {
+    await Promise.all([setup.data.location.reference.sync(), setup.data.location.reference.sync(other)])
+    requests.length = 0
+
+    const updated: OpenCodeEvent = {
+      id: "evt_reference.updated",
+      created: 1,
+      type: "reference.updated",
+      location: other,
+      data: {},
+    }
+    listeners.forEach((listener) => listener({ name: updated.type, details: updated }))
+    await wait(() => requests.length === 1)
+    expect([
+      requests[0]!.pathname,
+      requests[0]!.searchParams.get("location[directory]"),
+      requests[0]!.searchParams.get("location[workspace]"),
+    ]).toEqual(["/api/reference", "/other", "workspace-other"])
+  } finally {
+    setup.dispose()
+  }
+})
+
 test("reports optimistic sessions as creating until the request settles", async () => {
   const release = Promise.withResolvers<void>()
   const api = OpenCode.make({


### PR DESCRIPTION
## Why

`reference.updated` is a location-scoped event, and the client data layer handles it inside the block that already has `event.location` in hand. Every sibling case there (`agent.updated`, `command.updated`, `skill.updated`, `mcp.*`, `integration.updated`) passes that location through. `reference.updated` alone did not:

```ts
case "reference.updated":
  result.location.reference.invalidate()   // default location only
  void result.location.reference.sync()
```

So references for any non-default directory never refreshed from the client's own handler. The app noticed and added a workaround in `runtime/server/sync.tsx` that calls `data.location.reference.sync({ directory })` for active child directories, but without an `invalidate` first, which `createSync` treats as "already fresh, do nothing" once that directory has loaded. Neither path refreshed a non-default directory's references.

Found while inventorying consumer `sync()` calls for the data-service simplification series (#46831, #46924, #46926).

## What Changes

The handler uses the event's location like its siblings, and the app workaround is deleted:

```diff
 case "reference.updated":
-  result.location.reference.invalidate()
-  void result.location.reference.sync()
+  result.location.reference.invalidate(location)
+  void result.location.reference.sync(location)
```

```diff
   if (event.type === "worktree.updated") void bootstrap.refetch()
-  if (event.type === "reference.updated" && children.active(key))
-    void data.location.reference.sync({ directory: key }).catch(() => undefined)
 })
```

| `reference.updated` for | Before | After |
| --- | --- | --- |
| the default location | refreshed | refreshed (unchanged) |
| another loaded directory | never refreshed by either layer | refreshed by the data layer |

The default-location behavior is unchanged because the event for that location carries that location. The TUI's existing `reference.updated` test injects the default location into the event and still passes.

## Scope

Two production lines changed in `packages/client/src/solid/data.ts`, two deleted in `packages/app/src/runtime/server/sync.tsx`, plus one client regression test that syncs references for a second location, emits `reference.updated` naming it, and asserts the refresh request targets `/other` with its workspace. The test fails on `v2` (it requests `/project`) and passes here. No public interface change. The app change is outside session/timeline code, so no production benchmark was taken.

## Verification

Commands run with Bun 1.4.0 from the indicated package directories:

```sh
# packages/client
bun run test
bun typecheck

# packages/tui
bun run test test/cli/tui/data.test.tsx

# packages/app
bun run test
bun typecheck
```

- Client: 145 passed, including the new regression test.
- TUI data suite: 46 passed, including the existing `reference.updated` refresh test.
- App: 709 unit passed, 1 skipped; 113 browser-runtime passed.
- Typechecks passed for client and app; the pre-push hook completed all 33 workspace typecheck tasks.
