### PR TITLE
test(core): keep supervisor reload tests offline

### DIFF
--- a/packages/core/test/plugin/supervisor-reload.test.ts
+++ b/packages/core/test/plugin/supervisor-reload.test.ts
@@ -19,6 +19,7 @@ import { Plugin } from "@opencode-ai/core/plugin"
 import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { tempGlobalLayer } from "../fixture/global"
+import { offlineModels } from "../fixture/models"
 import { tmpdirScoped } from "../fixture/tmpdir"
 import { testEffect } from "../lib/effect"
 
@@ -59,6 +60,7 @@ const instances = Layer.effect(
     })
     const bindings: LayerNode.Replacements = [
       Global.node.replace(tempGlobalLayer),
+      offlineModels,
       Npm.node.replace(npmLayer),
       Watcher.node.replace(Watcher.configured({ enabled: false })),
       LocationServiceMap.node.replace(Layer.succeed(LocationServiceMap.Service, map)),
@@ -75,6 +77,7 @@ const instances = Layer.effect(
 const it = testEffect(
   AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SdkPlugins.node, LocationServiceMap.node]), [
     Global.node.replace(tempGlobalLayer),
+    offlineModels,
     LocationServiceMap.node.replace(instances),
   ]),
 )


### PR DESCRIPTION
## Why

`v2` unit tests are red after two independent merges met:

- #46908 (`test(core): refuse network in the test harness`) made any network request from a core test a failure, and opted the real-Location fixtures out of the models.dev refresh with `offlineModels`.
- #46901 added `test/plugin/supervisor-reload.test.ts`, which builds the same `SdkPlugins` graph as `supervisor.test.ts` but was not in #46908's file set.

The reload tests therefore still let the default `ModelsDev` node fetch `https://models.opencode.ai/api.json`, and the guard fails both of them on `v2` HEAD (`1e4e9c5d85`):

```
(fail) PluginSupervisor reload > keeps the running generation when an updated local plugin fails to import
(fail) PluginSupervisor reload > serializes the periodic refresh behind an in-flight reload
error: test attempted network request: GET https://models.opencode.ai/api.json — provide an explicit HttpClient or disable the fetch
```

## What Changes

Add `offlineModels` to both layer-replacement lists in `supervisor-reload.test.ts`, at the same two positions #46908 used in the sibling `supervisor.test.ts`. Three lines, test-only; no production code.

## Verification

From `packages/core` with Bun 1.4.0, against `origin/v2` at `1e4e9c5d85`:

```sh
bun test test/plugin/supervisor-reload.test.ts
```

- Before: 0 pass, 2 fail, ~500 refused `models.opencode.ai` requests logged.
- After: 2 pass, 0 fail, no network attempts.

The pre-push hook completed all 33 workspace typecheck tasks.
