### PR TITLE
fix(core): normalize RPC handler failures

### DIFF
--- a/packages/core/src/rpc.ts
+++ b/packages/core/src/rpc.ts
@@ -121,7 +121,15 @@ const layer = Layer.effect(
         // The heterogeneous registry erases handlers after their selected schema validates input.
         const execution: Effect.Effect<unknown, unknown> = Reflect.apply(handler, undefined, [parsed, callContext])
         return execution
-      }).pipe(Effect.catch((error) => encodeError(method, error)))
+      }).pipe(
+        Effect.catch((error) => encodeError(method, error)),
+        // Normalize handler bugs here so direct callers can recover just like HTTP callers.
+        Effect.catchDefect((defect) =>
+          Effect.logError("rpc handler failed", { rpc: rpcID, method: name, defect }).pipe(
+            Effect.andThen(Effect.fail(failure("rpc.internal", "RPC call failed"))),
+          ),
+        ),
+      )
       return yield* encode(method.output, result).pipe(
         Effect.mapError((error) => failure("rpc.invalid_output", errorMessage(error, "Invalid RPC output"))),
       )

--- a/packages/core/test/rpc-handler-errors.test.ts
+++ b/packages/core/test/rpc-handler-errors.test.ts
@@ -1,0 +1,62 @@
+import { expect } from "bun:test"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Location } from "@opencode-ai/core/location"
+import { Rpc } from "@opencode-ai/core/rpc"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Effect, Layer, Logger, Schema } from "effect"
+import { location } from "./fixture/location"
+import { testEffect } from "./lib/effect"
+
+const it = testEffect(
+  AppNodeBuilder.build(Rpc.node, [
+    Location.node.replace(Layer.succeed(Location.Service, location({ directory: AbsolutePath.make("/rpc-project") }))),
+  ]),
+)
+const Broken = Rpc.define({
+  id: "broken",
+  methods: {
+    dies: { input: Schema.Undefined, output: Schema.String },
+    throws: { input: Schema.Undefined, output: Schema.String },
+    raw: { input: Schema.Undefined, output: Schema.String },
+    undeclared: { input: Schema.Undefined, output: Schema.String },
+    invalidError: {
+      input: Schema.Undefined,
+      output: Schema.String,
+      errors: { known: Schema.Struct({ count: Schema.Int }) },
+    },
+  },
+  events: {},
+})
+
+for (const method of ["dies", "throws", "raw", "undeclared", "invalidError"] as const) {
+  it.effect(`recovers from ${method} through the typed rpc.internal failure`, () =>
+    Effect.gen(function* () {
+      const rpc = yield* Rpc.Service
+      yield* rpc.register(Broken, {
+        dies: () => Effect.die(new Error("handler defect")),
+        throws: () => {
+          throw new Error("handler threw")
+        },
+        // Raw Promise rejections reach this boundary as failed Effects.
+        // @ts-expect-error intentionally exercise an undeclared failure
+        raw: () => Effect.fail(new Error("raw failure")),
+        // @ts-expect-error intentionally exercise an undeclared error name
+        undeclared: (_input, context) => Effect.fail(context.error("unknown", "Unknown")),
+        invalidError: (_input, context) => Effect.fail(context.error("known", "Invalid count", { count: 1.5 })),
+      })
+      const logged: unknown[] = []
+      const result = yield* rpc
+        .client(Broken)
+        [method]()
+        .pipe(
+          Effect.catchIf(
+            (error) => "type" in error && error.type === "rpc.internal",
+            (error) => Effect.succeed(error),
+          ),
+          Effect.provideService(Logger.CurrentLoggers, new Set([Logger.make((entry) => logged.push(entry.message))])),
+        )
+      expect(result).toEqual({ type: "rpc.internal", message: "RPC call failed" })
+      expect(logged).toHaveLength(1)
+    }),
+  )
+}

--- a/packages/server/src/handlers/rpc.ts
+++ b/packages/server/src/handlers/rpc.ts
@@ -14,7 +14,7 @@ export const RpcHandler = HttpApiBuilder.group(Api, "server.rpc", (handlers) =>
       return output === undefined ? {} : { output }
     }).pipe(
       Effect.mapError((error) =>
-        error.type === "rpc.invalid_output"
+        error.type === "rpc.invalid_output" || error.type === "rpc.internal"
           ? new RpcInternalError({ type: error.type, message: error.message })
           : new RpcError({
               type: error.type,
@@ -22,12 +22,10 @@ export const RpcHandler = HttpApiBuilder.group(Api, "server.rpc", (handlers) =>
               ...(error.data === undefined ? {} : { data: error.data }),
             }),
       ),
-      Effect.catchDefect((error) =>
-        Effect.fail(
-          new RpcInternalError({
-            type: "rpc.internal",
-            message: error instanceof Error ? error.message : "RPC call failed",
-          }),
+      // Defects outside handler execution are still logged, never echoed to the client.
+      Effect.catchDefect((defect) =>
+        Effect.logError("rpc call failed", { rpc: params.rpcID, method: params.method, defect }).pipe(
+          Effect.andThen(Effect.fail(new RpcInternalError({ type: "rpc.internal", message: "RPC call failed" }))),
         ),
       ),
     ),

--- a/packages/server/test/rpc-handler-errors.test.ts
+++ b/packages/server/test/rpc-handler-errors.test.ts
@@ -1,0 +1,74 @@
+import { expect } from "bun:test"
+import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
+import { define } from "@opencode-ai/plugin/effect/plugin"
+import { Rpc } from "@opencode-ai/schema/rpc"
+import { Context, Effect, Layer, Schema } from "effect"
+import { HttpEffect, HttpRouter, HttpServer } from "effect/unstable/http"
+import { tmpdirScoped } from "../../core/test/fixture/tmpdir"
+import { it } from "../../core/test/lib/effect"
+import { createEmbeddedRoutes } from "../src/routes"
+
+const Broken = Rpc.define({
+  id: "broken",
+  methods: {
+    handler: { input: Schema.String, output: Schema.String },
+    schema: {
+      input: Schema.String.check(
+        Schema.makeFilter(() => {
+          throw new Error("private schema detail")
+        }),
+      ),
+      output: Schema.String,
+    },
+  },
+  events: {},
+})
+
+for (const method of ["handler", "schema"] as const) {
+  it.live(`returns HTTP 500 without exposing the ${method} defect`, () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const context = yield* Layer.build(
+        createEmbeddedRoutes({
+          database: { path: ":memory:" },
+          models: { fetch: false },
+          config: { directory: directory.path, project: false, content: "{}" },
+          fs: { filewatcher: false },
+        }).pipe(Layer.provide(HttpServer.layerServices)),
+      )
+      const sdk = Context.get(context, SdkPlugins.Service)
+      yield* sdk.register(
+        define({
+          id: "broken-rpc",
+          effect: (ctx) =>
+            ctx.rpc
+              .register(Broken, {
+                handler: () => Effect.die(new Error("private handler detail")),
+                schema: Effect.succeed,
+              })
+              .pipe(Effect.asVoid, Effect.orDie),
+        }),
+      )
+      const handler = Context.get(context, HttpRouter.HttpRouter)
+        .asHttpEffect()
+        .pipe(HttpEffect.toWebHandlerWith(context))
+      const url = new URL(`/api/rpc/broken/${method}`, "http://opencode.local")
+      url.searchParams.set("location[directory]", directory.path)
+      const response = yield* Effect.promise(() =>
+        handler(
+          new Request(url, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ input: "hello" }),
+          }),
+        ),
+      )
+      expect(response.status).toBe(500)
+      expect(yield* Effect.promise(() => response.json())).toEqual({
+        _tag: "RpcInternalError",
+        type: "rpc.internal",
+        message: "RPC call failed",
+      })
+    }),
+  )
+}


### PR DESCRIPTION
## Why

An unexpected RPC handler failure bypasses ordinary Effect error recovery for in-process callers, while HTTP callers receive `rpc.internal`. The same call should have a recoverable failure at either entry point.

## What Changes

- **Before:** thrown exceptions, defects, undeclared failures, and invalid declared-error payloads escape direct calls as defects. HTTP defect responses can expose the exception message.
- **After:** handler defects are logged and become typed `{ type: "rpc.internal", message: "RPC call failed" }` failures. HTTP maps them to 500; its fallback also logs rather than echoes defects outside handler execution.

The existing declared-error encoder stays in place. Valid declared errors, successful results, input/output validation, and interruption retain their behavior.

### Same caller, different outcome

For example, inside a scoped `Effect.gen`, with `rpc` obtained from `Rpc.Service`:

```ts
const Weather = Rpc.define({
  id: "weather",
  methods: {
    forecast: { input: Schema.String, output: Schema.String },
  },
  events: {},
})

yield* rpc.register(Weather, {
  forecast: () => Effect.die(new Error("backend unavailable")),
})

// The caller is identical before and after this PR.
const result = yield* rpc.client(Weather).forecast("Boston").pipe(
  Effect.catchIf(
    (error) => "type" in error && error.type === "rpc.internal",
    () => Effect.succeed("Weather unavailable"),
  ),
)

// BEFORE: the defect escapes; catchIf never runs and no result is produced.
// AFTER:  result === "Weather unavailable"; the original defect is logged.
```

The failed handler does not become successful. It becomes an ordinary RPC failure that the caller can choose to recover from, instead of requiring a separate `Effect.catchDefect` at each call site.

### HTTP response for the same handler failure

```ts
// BEFORE: HTTP 500, with the handler's exception message exposed.
{
  "_tag": "RpcInternalError",
  "type": "rpc.internal",
  "message": "backend unavailable"
}

// AFTER: HTTP 500, with a generic message; details remain in server logs.
{
  "_tag": "RpcInternalError",
  "type": "rpc.internal",
  "message": "RPC call failed"
}
```

## Scope

Supersedes #46902 with a smaller implementation and **only seven regression cases**, not the restored RPC test suite. Production changes are confined to `core/src/rpc.ts` and `server/src/handlers/rpc.ts`.

All seven tests were run against unmodified `v2` at `c992716523` and failed for the intended reason:

| Cases | Before | After |
|---|---|---|
| Five direct-call cases: defect, throw, raw failure, undeclared error, invalid error payload | Defect bypasses recovery | Typed `rpc.internal`, logged once |
| HTTP handler defect | Raw handler message returned | Generic HTTP 500 |
| HTTP input-schema defect | Raw schema message returned | Generic HTTP 500 |

Unlike #46902, undeclared-error names also stay in logs rather than the public message.

## Verification

```sh
# packages/core
bun typecheck
bun run test test/rpc-handler-errors.test.ts --rerun-each 5
bun run test

# packages/server
bun typecheck
bun run ../core/script/test.ts test/rpc-handler-errors.test.ts --rerun-each 5
bun run ../core/script/test.ts
```

- Both package typechecks pass.
- Before the fix: 5 Core + 2 HTTP failures. After: 35/35 repeated regression tests pass.
- Full Core suite: 4022 pass, 39 skip, 0 fail.
- Full Server suite: 52 pass, 3 skip, 0 fail.
- A separate runtime probe confirmed that valid declared errors, successful values, invalid-input/output errors, and cancellation remain unchanged.
