### PR TITLE
fix(core): preserve provider identity in catalog updates

### DIFF
--- a/packages/core/src/catalog.ts
+++ b/packages/core/src/catalog.ts
@@ -100,6 +100,7 @@ const layer = Layer.effect(
                 editor.providers.set(providerID, current)
               }
               fn(current.provider)
+              current.provider.id = providerID
             },
             remove: (providerID) => {
               editor.providers.delete(providerID)

--- a/packages/core/test/catalog.test.ts
+++ b/packages/core/test/catalog.test.ts
@@ -93,6 +93,32 @@ describe("Catalog", () => {
     }),
   )
 
+  it.effect("preserves provider identity when updating new and existing providers", () =>
+    Effect.gen(function* () {
+      const catalog = yield* Catalog.Service
+      const providerID = Provider.ID.make("original")
+      const renamed = Provider.ID.make("renamed")
+      yield* catalog.transform((editor) => {
+        editor.provider.update(providerID, (provider) => {
+          provider.id = renamed
+          provider.name = "Created"
+        })
+        expect(editor.provider.get(providerID)?.provider.id).toBe(providerID)
+        editor.provider.update(providerID, (provider) => {
+          provider.id = renamed
+          provider.name = "Updated"
+        })
+      })
+
+      expect(yield* catalog.provider.get(providerID)).toMatchObject({ id: providerID, name: "Updated" })
+      expect(yield* catalog.provider.get(renamed)).toBeUndefined()
+      expect((yield* catalog.provider.all()).map((provider) => provider.id)).toEqual([providerID])
+
+      yield* catalog.reload()
+      expect(yield* catalog.provider.get(providerID)).toMatchObject({ id: providerID, name: "Updated" })
+    }),
+  )
+
   it.effect("derives availability from active credentials without changing provider state", () => {
     const integrationID = Integration.ID.make("test")
     const localCatalogLayer = Layer.fresh(


### PR DESCRIPTION
## Why

A provider update could change `provider.id` while leaving the catalog entry indexed under its original ID. Listing the provider then advertised an ID that could not retrieve that entry. Agent, model, skill, and integration updates already preserve their keyed identities.

## What Changes

Provider updates now restore the ID passed to `update` after the callback completes. Other field edits still apply.

| Operation | Before | After |
| --- | --- | --- |
| Update `original`, assigning ID `renamed` and name `Updated` | Stored under `original`, but reports ID `renamed` | Stored under `original` and reports ID `original`; name becomes `Updated` |
| Read using `renamed` | No entry | No entry: updating is not renaming |

The regression covers creation, an existing provider, editor reads, public lookup/listing, and replay after reload.

## Scope

One runtime assignment in `Catalog.provider.update`, matching the existing model-editor behavior. This does not redesign editor methods or make all returned catalog values immutable.

## Verification

```sh
# packages/core
bun run test test/catalog.test.ts --test-name-pattern 'preserves provider identity'
bun run test test/catalog.test.ts test/agent.test.ts test/state.test.ts test/state-replay.test.ts
bun typecheck

# repository root
bunx prettier --check packages/core/src/catalog.ts packages/core/test/catalog.test.ts
git diff --check
```

The focused regression failed before the fix (`original` expected, `renamed` received). After the fix, all 59 focused tests pass, including the regression; Core typechecking and formatting pass. The normal pre-push workspace typecheck also passed.
