### PR TITLE
fix(plugin): export Promise ToolEditor

### DIFF
--- a/packages/plugin/src/promise/tool.ts
+++ b/packages/plugin/src/promise/tool.ts
@@ -22,7 +22,7 @@ export type Info<
   ) => Promise<Tool.Result<Output>>
 }
 
-interface ToolEditor {
+export interface ToolEditor {
   list(): readonly (Info & { readonly id: string })[]
   get(id: string): (Info & { readonly id: string }) | undefined
   namespace(namespace: Tool.Namespace): void


### PR DESCRIPTION
## Why

Promise plugin authors cannot import `ToolEditor` to type reusable transform helpers: TypeScript reports that the module declares it locally but does not export it. The Effect API and the other public editor interfaces already export their editor types.

## What Changes

Export the existing Promise interface without changing its members:

```ts
import type { ToolEditor } from "@opencode-ai/plugin/promise/tool"

function removeLegacyTool(editor: ToolEditor) {
  editor.remove("legacy")
}
```

Before: this named type import fails with TS2459. After: a separate source-linked consumer can import it and use the editor's methods.

## Scope

One `export` keyword. No runtime changes, method renames, or changes to the Effect API.

## Verification

```sh
# packages/plugin
bun typecheck
TMPDIR="$(realpath "${TMPDIR:-/tmp}")" bun run test

# separate source-linked consumer package
bun typecheck

# repository root
bunx prettier --check packages/plugin/src/promise/tool.ts
git diff --check
```

The consumer check failed with TS2459 before the change and passed afterward. Package typechecking, all 9 plugin tests, formatting, and the normal pre-push workspace typecheck pass. `TMPDIR` is canonicalized so the existing host-resolution tests compare the same filesystem path spelling on macOS.
