### PR TITLE
feat(plugin): add skill editor lookup

### DIFF
--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -407,6 +407,7 @@ export const make = Effect.fn("PluginHost.make")(function* (
         skill.transform((editor) => {
           callback({
             list: () => mutable(editor.list()),
+            get: editor.get,
             add: (value) => editor.add(Schema.decodeUnknownSync(Skill.Info)(value)),
             update: editor.update,
             remove: editor.remove,

--- a/packages/core/src/skill.ts
+++ b/packages/core/src/skill.ts
@@ -74,6 +74,7 @@ export type Data = {
 
 export type Editor = {
   list: () => readonly Types.DeepMutable<Info>[]
+  get: (id: string) => Types.DeepMutable<Info> | undefined
   add: (skill: Info) => void
   update: (id: string, update: (skill: Types.DeepMutable<Info>) => void) => void
   remove: (id: string) => void
@@ -96,6 +97,7 @@ const layer = Layer.effect(
       initial: () => ({ skills: new Map() }),
       editor: (editor) => ({
         list: () => Array.from(editor.skills.values()),
+        get: (id) => editor.skills.get(ID.make(id)),
         add: (skill) => {
           editor.skills.set(skill.id, { ...skill } as Types.DeepMutable<Info>)
         },

--- a/packages/core/test/skill.test.ts
+++ b/packages/core/test/skill.test.ts
@@ -20,6 +20,25 @@ const info = (id: string, description: string) =>
   })
 
 describe("Skill", () => {
+  it.effect("reads the current editor entry by ID", () =>
+    Effect.gen(function* () {
+      const skill = yield* Skill.Service
+      yield* skill.transform((editor) => editor.add(info("review", "Initial")))
+      yield* skill.transform((editor) => {
+        expect(editor.get("review")).toBe(editor.list()[0])
+        expect(editor.get("missing")).toBeUndefined()
+        editor.update("review", (value) => {
+          value.description = "Updated"
+        })
+        expect(editor.get("review")?.description).toBe("Updated")
+        editor.remove("review")
+        expect(editor.get("review")).toBeUndefined()
+      })
+
+      expect(yield* skill.list()).toEqual([])
+    }),
+  )
+
   it.effect("registers values with last-write-wins precedence", () =>
     Effect.gen(function* () {
       const skill = yield* Skill.Service

--- a/packages/plugin/src/effect/skill.ts
+++ b/packages/plugin/src/effect/skill.ts
@@ -5,6 +5,7 @@ import type { Transform } from "./registration.js"
 
 export interface SkillEditor {
   list(): readonly Types.DeepMutable<Skill.Info>[]
+  get(id: string): Types.DeepMutable<Skill.Info> | undefined
   add(skill: Skill.Info): void
   update(id: string, update: (skill: Types.DeepMutable<Skill.Info>) => void): void
   remove(id: string): void

--- a/packages/plugin/src/promise/skill.ts
+++ b/packages/plugin/src/promise/skill.ts
@@ -5,6 +5,7 @@ import type { DeepMutable } from "./types.js"
 
 export interface SkillEditor {
   list(): readonly DeepMutable<Skill.Info>[]
+  get(id: string): DeepMutable<Skill.Info> | undefined
   add(skill: Skill.Info): void
   update(id: string, update: (skill: DeepMutable<Skill.Info>) => void): void
   remove(id: string): void

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -747,7 +747,8 @@ effect: (ctx) =>
   }),
 ```
 
-Transform and reload skills. Use the re-exported Effect schema constructors for branded values.
+Transform and reload skills. Use the re-exported Effect schema constructors for branded values. `get(id)` returns the
+current editor entry, or `undefined` when the skill is absent.
 
 ```ts
 effect: (ctx) =>
@@ -761,6 +762,7 @@ effect: (ctx) =>
         location: "/workspace/.opencode/skills/review.md",
         content: "Review the current changes for correctness and missing tests.",
       }))
+      const review = editor.get("review")
       editor.update("review", (item) => (item.autoinvoke = true))
       editor.remove("legacy")
     })
@@ -773,6 +775,7 @@ Schema: [`Skill.Info`](/api#schema-Skill.Info).
 ```ts
 interface SkillEditor {
   list(): readonly Types.DeepMutable<Skill.Info>[]
+  get(id: string): Types.DeepMutable<Skill.Info> | undefined
   add(skill: Skill.Info): void
   update(id: string, update: (skill: Types.DeepMutable<Skill.Info>) => void): void
   remove(id: string): void

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -717,7 +717,8 @@ Read the skills available at a location.
 const skills = await ctx.skill.list()
 ```
 
-Register a transform to inspect, add, update, or remove skills.
+Register a transform to inspect, add, update, or remove skills. `get(id)` returns the current editor entry, or `undefined`
+when the skill is absent.
 
 ```ts
 await ctx.skill.transform((editor) => {
@@ -729,6 +730,7 @@ await ctx.skill.transform((editor) => {
     location: "/workspace/.opencode/skills/review.md",
     content: "Review the current changes for correctness and missing tests.",
   })
+  const review = editor.get("review")
   editor.update("review", (skill) => {
     skill.autoinvoke = true
   })
@@ -755,6 +757,7 @@ interface SkillContext {
 
 interface SkillEditor {
   list(): readonly SkillInfo[]
+  get(id: string): SkillInfo | undefined
   add(skill: SkillInfo): void
   update(id: string, update: (skill: SkillInfo) => void): void
   remove(id: string): void


### PR DESCRIPTION
## Why

Skill transforms can update and remove entries by ID, but reading one requires scanning `editor.list()`. Agent, tool, and MCP editors already offer keyed lookup.

## What Changes

Add synchronous `SkillEditor.get(id)` to the Core editor and both plugin APIs, and pass it through the plugin host:

```ts
await ctx.skill.transform((editor) => {
  const review = editor.get("review")
  if (!review) return
  editor.update("review", (skill) => {
    skill.description = `${review.description ?? "Review"} with verification`
  })
})
```

`get` returns the same current draft entry as `list`, or `undefined` if the ID is absent. It sees preceding transforms and in-callback updates/removals, performs no I/O, and does not create entries.

The Promise and Effect guides include the method and its missing-entry behavior.

## Scope

Skill-editor lookup only. Existing registration, update, removal, and replay behavior stay unchanged. Reference-editor lookup is a separate follow-up; no method renames or changes to upsert semantics are included.

## Verification

```sh
# packages/core
bun run test test/skill.test.ts test/plugin/skill.test.ts test/config/skill.test.ts test/state.test.ts test/state-replay.test.ts
bun typecheck

# packages/plugin
bun typecheck
TMPDIR="$(realpath "${TMPDIR:-/tmp}")" bun run test

# packages/www
bun typecheck
bun run check:generated
bun run build

# repository root
git diff --check
```

The new regression failed before implementation because `editor.get` was absent. Afterward, all 47 focused Core tests and 9 plugin tests pass. Core, Plugin, and website typechecks pass; the website generated-data check and build pass. The normal pre-push workspace typecheck also passed.

Formatting passes for changed source and the Promise guide. The Effect guide passes with embedded-language formatting disabled; its existing standalone `yield*` example elsewhere already fails a whole-file Prettier check on the base revision and is left untouched.
