### PR TITLE
fix(core): recover idle moves through the selected instance

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,7 +1,7 @@
 export * as Session from "./session.js"
 export * from "./session/schema.js"
 
-import { Cause, Effect, Layer, Schema, Context, Stream } from "effect"
+import { Effect, Layer, Schema, Context, Stream } from "effect"
 import { LLMClient } from "@opencode-ai/ai"
 import { ListAnchor } from "@opencode-ai/schema/session"
 import { and, desc, eq } from "drizzle-orm"
@@ -16,7 +16,7 @@ import { Database } from "./database/database.js"
 import { SessionProjector } from "./session/projector.js"
 import { SessionMessageTable } from "./session/sql.js"
 import { SessionSchema } from "./session/schema.js"
-import { AbsolutePath, RelativePath } from "./schema.js"
+import { RelativePath } from "./schema.js"
 import { Agent } from "@opencode-ai/schema/agent"
 import { App } from "./app.js"
 import { Slug } from "./util/slug.js"
@@ -166,15 +166,7 @@ export interface Interface {
   readonly switchAgent: (input: { sessionID: SessionSchema.ID; agent: Agent.ID }) => Effect.Effect<void, NotFoundError>
   readonly switchModel: (input: { sessionID: SessionSchema.ID; model: Model.Ref }) => Effect.Effect<void, NotFoundError>
   readonly rename: (input: { sessionID: SessionSchema.ID; title: string }) => Effect.Effect<void, NotFoundError>
-  readonly move: (input: {
-    sessionID: SessionSchema.ID
-    directory: AbsolutePath
-    workspaceID?: Location.Ref["workspaceID"]
-    delivery?: SessionInbox.Delivery
-  }) => Effect.Effect<
-    void,
-    NotFoundError | DestinationNotFoundError | DestinationNotDirectoryError | DestinationUnavailableError
-  >
+  readonly move: SessionMove.Interface["move"]
   readonly prompt: (
     input: Parameters<Session.Handle["prompt"]>[0] & { sessionID: SessionSchema.ID },
   ) => ReturnType<Session.Handle["prompt"]>
@@ -236,11 +228,9 @@ const layer = Layer.effect(
     const store = yield* SessionStore.Service
     const instances = yield* Instance.Service
     const moves = yield* SessionMove.Service
-    const fs = yield* FSUtil.Service
     const jobs = yield* Job.Service
     const environments = yield* SessionEnvironment.Service
     const sessions = yield* Session.make()
-    const admission = yield* SessionInbox.Service
     const isDurableSessionEvent = Schema.is(SessionEvent.Durable)
 
     const result = Service.of({
@@ -407,55 +397,7 @@ const layer = Layer.effect(
       switchAgent: (input) => sessions.forSession(input.sessionID).switchAgent(input),
       switchModel: (input) => sessions.forSession(input.sessionID).switchModel(input),
       rename: (input) => sessions.forSession(input.sessionID).rename(input),
-      move: Effect.fn("Session.move")(function* (input) {
-        const session = yield* result.get(input.sessionID)
-        const payload = yield* moves.prepare({ ...input, session })
-        // Probe the same instance execution would use, without holding up inbox cancellation.
-        const unavailable =
-          !(yield* execution.isActive(input.sessionID)) &&
-          (!(yield* fs.isDir(session.location.directory)) ||
-            !(yield* SessionRunner.Service.pipe(
-              instances.provide(session),
-              Effect.as(true),
-              Effect.catchCause((cause) =>
-                Cause.hasInterrupts(cause) ? Effect.failCause(cause) : Effect.succeed(false),
-              ),
-            )))
-        const item = SessionInbox.Item.make({
-          type: "move",
-          payload,
-          delivery: input.delivery ?? "steer",
-        })
-        yield* SessionInbox.serialized(
-          input.sessionID,
-          Effect.gen(function* () {
-            const latest = yield* result.get(input.sessionID)
-            // Active runners must hand off at a step boundary to retain their continuation.
-            if (
-              unavailable &&
-              latest.location.directory === session.location.directory &&
-              latest.location.workspaceID === session.location.workspaceID &&
-              !(yield* execution.isActive(input.sessionID))
-            ) {
-              const cancellations = (yield* SessionInbox.moveIDs(db, input.sessionID)).map(
-                (item) => [SessionEvent.InboxCancelled, { sessionID: input.sessionID, inboxID: item.id }] as const,
-              )
-              const moved = [SessionEvent.Moved, { sessionID: input.sessionID, ...payload }] as const
-              const first = cancellations[0]
-              if (!first) return yield* bus.publish(...moved).pipe(Effect.asVoid)
-              return yield* bus.publishAll([first, ...cancellations.slice(1), moved])
-            }
-            yield* admission
-              .admit({
-                id: SessionMessage.ID.create(),
-                sessionID: input.sessionID,
-                item,
-              })
-              .pipe(Effect.orDie)
-          }),
-        )
-        yield* execution.wake(input.sessionID)
-      }),
+      move: moves.move,
       compact: (input) => sessions.forSession(input.sessionID).compact(input),
       wait: (sessionID) => sessions.forSession(sessionID).wait(),
       active: execution.active,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -42,7 +42,6 @@ import {
 } from "./session/error.js"
 import { Node } from "@opencode-ai/util/effect/app-node"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
-import { LocationServiceMap } from "./location-service-map.js"
 import { SessionEvent } from "./session/event.js"
 import { SessionInbox } from "./session/inbox.js"
 import { InstructionState } from "./session/instruction-state.js"
@@ -62,7 +61,6 @@ import { FSUtil } from "@opencode-ai/util/fs-util"
 import type { EventLog } from "@opencode-ai/schema/event-log"
 import { Job } from "./job.js"
 import type { Command } from "./command.js"
-import { Global } from "@opencode-ai/util/global"
 import { SessionEnvironment } from "./session/environment.js"
 import { InstructionEntry } from "./session/instruction-entry.js"
 
@@ -232,13 +230,12 @@ const layer = Layer.effect(
     const db = database.db
     const bus = yield* Bus.Service
     const projects = yield* Project.Service
-    const global = yield* Global.Service
     const execution = yield* SessionExecution.Service
     const llm = yield* LLMClient.Service
     const transport = yield* SessionModelTransport.Service
     const store = yield* SessionStore.Service
     const instances = yield* Instance.Service
-    const locations = yield* LocationServiceMap.Service
+    const moves = yield* SessionMove.Service
     const fs = yield* FSUtil.Service
     const jobs = yield* Job.Service
     const environments = yield* SessionEnvironment.Service
@@ -412,12 +409,7 @@ const layer = Layer.effect(
       rename: (input) => sessions.forSession(input.sessionID).rename(input),
       move: Effect.fn("Session.move")(function* (input) {
         const session = yield* result.get(input.sessionID)
-        const payload = yield* SessionMove.prepare({ ...input, session }).pipe(
-          Effect.provideService(FSUtil.Service, fs),
-          Effect.provideService(Global.Service, global),
-          Effect.provideService(Project.Service, projects),
-          Effect.provideService(LocationServiceMap.Service, locations),
-        )
+        const payload = yield* moves.prepare({ ...input, session })
         // Probe the same instance execution would use, without holding up inbox cancellation.
         const unavailable =
           !(yield* execution.isActive(input.sessionID)) &&
@@ -514,10 +506,9 @@ export const node: LayerNode.Provider<Service, never, typeof Node.tags.values.gl
     SessionStore.node,
     Instance.node,
     SessionInbox.node,
-    LocationServiceMap.node,
+    SessionMove.node,
     SessionProjector.node,
     FSUtil.node,
-    Global.node,
     App.node,
   ],
 })

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -1,7 +1,7 @@
 export * as Session from "./session.js"
 export * from "./session/schema.js"
 
-import { Effect, Layer, Schema, Context, Stream } from "effect"
+import { Cause, Effect, Layer, Schema, Context, Stream } from "effect"
 import { LLMClient } from "@opencode-ai/ai"
 import { ListAnchor } from "@opencode-ai/schema/session"
 import { and, desc, eq } from "drizzle-orm"
@@ -418,6 +418,17 @@ const layer = Layer.effect(
           Effect.provideService(Project.Service, projects),
           Effect.provideService(LocationServiceMap.Service, locations),
         )
+        // Probe the same instance execution would use, without holding up inbox cancellation.
+        const unavailable =
+          !(yield* execution.isActive(input.sessionID)) &&
+          (!(yield* fs.isDir(session.location.directory)) ||
+            !(yield* SessionRunner.Service.pipe(
+              instances.provide(session),
+              Effect.as(true),
+              Effect.catchCause((cause) =>
+                Cause.hasInterrupts(cause) ? Effect.failCause(cause) : Effect.succeed(false),
+              ),
+            )))
         const item = SessionInbox.Item.make({
           type: "move",
           payload,
@@ -427,9 +438,13 @@ const layer = Layer.effect(
           input.sessionID,
           Effect.gen(function* () {
             const latest = yield* result.get(input.sessionID)
-            const source = yield* fs.stat(latest.location.directory).pipe(Effect.orElseSucceed(() => undefined))
             // Active runners must hand off at a step boundary to retain their continuation.
-            if ((!source || source.type !== "Directory") && !(yield* execution.isActive(input.sessionID))) {
+            if (
+              unavailable &&
+              latest.location.directory === session.location.directory &&
+              latest.location.workspaceID === session.location.workspaceID &&
+              !(yield* execution.isActive(input.sessionID))
+            ) {
               const cancellations = (yield* SessionInbox.moveIDs(db, input.sessionID)).map(
                 (item) => [SessionEvent.InboxCancelled, { sessionID: input.sessionID, inboxID: item.id }] as const,
               )

--- a/packages/core/src/session/move.ts
+++ b/packages/core/src/session/move.ts
@@ -2,9 +2,10 @@ export * as SessionMove from "./move.js"
 
 import type { Session } from "@opencode-ai/schema/session"
 import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
+import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
-import { Cause, Effect, Schema } from "effect"
+import { Cause, Context, Effect, Layer, Schema } from "effect"
 import path from "path"
 import { Location } from "../location.js"
 import { LocationServiceMap } from "../location-service-map.js"
@@ -26,36 +27,60 @@ export class DestinationUnavailableError extends Schema.TaggedError<DestinationU
   { directory: AbsolutePath },
 ) {}
 
-export const prepare = Effect.fn("SessionMove.prepare")(function* (input: {
-  session: Session.Info
-  directory: AbsolutePath
-  workspaceID?: Location.Ref["workspaceID"]
-}) {
-  const fs = yield* FSUtil.Service
-  const global = yield* Global.Service
-  const projects = yield* Project.Service
-  const locations = yield* LocationServiceMap.Service
-  const value = input.directory.trim()
-  const expanded = value === "~" ? global.home : value.startsWith("~/") ? path.join(global.home, value.slice(2)) : value
-  const directory = AbsolutePath.make(path.resolve(input.session.location.directory, expanded))
-  const info = yield* fs.stat(directory).pipe(Effect.orElseSucceed(() => undefined))
-  if (!info) return yield* new DestinationNotFoundError({ directory })
-  if (info.type !== "Directory") return yield* new DestinationNotDirectoryError({ directory })
-  const project = yield* projects.resolve(directory)
-  const payload: SessionInbox.MovePayload = {
-    location: Location.Ref.make({ directory, workspaceID: input.workspaceID }),
-    projectID: project.id,
-    subpath: RelativePath.make(path.relative(project.directory, directory).replaceAll("\\", "/")),
-  }
-  yield* Location.Service.pipe(
-    Effect.provide(locations.get(payload.location)),
-    Effect.scoped,
-    Effect.catchCause((cause) => {
-      if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause)
-      return Effect.logWarning("session move destination unavailable", { directory, cause }).pipe(
-        Effect.andThen(Effect.fail(new DestinationUnavailableError({ directory }))),
-      )
-    }),
-  )
-  return payload
+export interface Interface {
+  readonly prepare: (input: {
+    session: Session.Info
+    directory: AbsolutePath
+    workspaceID?: Location.Ref["workspaceID"]
+  }) => Effect.Effect<
+    SessionInbox.MovePayload,
+    DestinationNotFoundError | DestinationNotDirectoryError | DestinationUnavailableError
+  >
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/SessionMove") {}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const fs = yield* FSUtil.Service
+    const global = yield* Global.Service
+    const projects = yield* Project.Service
+    const locations = yield* LocationServiceMap.Service
+
+    return Service.of({
+      prepare: Effect.fn("SessionMove.prepare")(function* (input) {
+        const value = input.directory.trim()
+        const expanded =
+          value === "~" ? global.home : value.startsWith("~/") ? path.join(global.home, value.slice(2)) : value
+        const directory = AbsolutePath.make(path.resolve(input.session.location.directory, expanded))
+        const info = yield* fs.stat(directory).pipe(Effect.orElseSucceed(() => undefined))
+        if (!info) return yield* new DestinationNotFoundError({ directory })
+        if (info.type !== "Directory") return yield* new DestinationNotDirectoryError({ directory })
+        const project = yield* projects.resolve(directory)
+        const payload: SessionInbox.MovePayload = {
+          location: Location.Ref.make({ directory, workspaceID: input.workspaceID }),
+          projectID: project.id,
+          subpath: RelativePath.make(path.relative(project.directory, directory).replaceAll("\\", "/")),
+        }
+        yield* Location.Service.pipe(
+          Effect.provide(locations.get(payload.location)),
+          Effect.scoped,
+          Effect.catchCause((cause) => {
+            if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause)
+            return Effect.logWarning("session move destination unavailable", { directory, cause }).pipe(
+              Effect.andThen(Effect.fail(new DestinationUnavailableError({ directory }))),
+            )
+          }),
+        )
+        return payload
+      }),
+    })
+  }),
+)
+
+export const node = makeGlobalNode({
+  service: Service,
+  layer,
+  deps: [FSUtil.node, Global.node, Project.node, LocationServiceMap.node],
 })

--- a/packages/core/src/session/move.ts
+++ b/packages/core/src/session/move.ts
@@ -1,16 +1,26 @@
 export * as SessionMove from "./move.js"
 
 import type { Session } from "@opencode-ai/schema/session"
-import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
 import { Cause, Context, Effect, Layer, Schema } from "effect"
 import path from "path"
+import { Bus } from "../bus.js"
+import { Database } from "../database/database.js"
+import { Instance } from "../instance/service.js"
 import { Location } from "../location.js"
 import { LocationServiceMap } from "../location-service-map.js"
 import { Project } from "../project.js"
 import { AbsolutePath, RelativePath } from "../schema.js"
+import { NotFoundError } from "./error.js"
+import { SessionEvent } from "./event.js"
+import { SessionExecution } from "./execution.js"
+import { SessionInbox } from "./inbox.js"
+import { SessionMessage } from "./message.js"
+import { SessionProjector } from "./projector.js"
+import { SessionRunner } from "./runner/index.js"
+import { SessionStore } from "./store.js"
 
 export class DestinationNotFoundError extends Schema.TaggedError<DestinationNotFoundError>()(
   "Session.DestinationNotFoundError",
@@ -28,13 +38,14 @@ export class DestinationUnavailableError extends Schema.TaggedError<DestinationU
 ) {}
 
 export interface Interface {
-  readonly prepare: (input: {
-    session: Session.Info
+  readonly move: (input: {
+    sessionID: Session.ID
     directory: AbsolutePath
     workspaceID?: Location.Ref["workspaceID"]
+    delivery?: SessionInbox.Delivery
   }) => Effect.Effect<
-    SessionInbox.MovePayload,
-    DestinationNotFoundError | DestinationNotDirectoryError | DestinationUnavailableError
+    void,
+    NotFoundError | DestinationNotFoundError | DestinationNotDirectoryError | DestinationUnavailableError
   >
 }
 
@@ -47,33 +58,98 @@ const layer = Layer.effect(
     const global = yield* Global.Service
     const projects = yield* Project.Service
     const locations = yield* LocationServiceMap.Service
+    const store = yield* SessionStore.Service
+    const execution = yield* SessionExecution.Service
+    const instances = yield* Instance.Service
+    const admission = yield* SessionInbox.Service
+    const database = yield* Database.Service
+    const bus = yield* Bus.Service
+
+    const get = Effect.fn("SessionMove.get")(function* (sessionID: Session.ID) {
+      const session = yield* store.get(sessionID)
+      if (!session) return yield* new NotFoundError({ sessionID })
+      return session
+    })
+
+    const resolveDestination = Effect.fn("SessionMove.resolveDestination")(function* (
+      session: Session.Info,
+      input: Parameters<Interface["move"]>[0],
+    ) {
+      const value = input.directory.trim()
+      const expanded =
+        value === "~" ? global.home : value.startsWith("~/") ? path.join(global.home, value.slice(2)) : value
+      const directory = AbsolutePath.make(path.resolve(session.location.directory, expanded))
+      const info = yield* fs.stat(directory).pipe(Effect.orElseSucceed(() => undefined))
+      if (!info) return yield* new DestinationNotFoundError({ directory })
+      if (info.type !== "Directory") return yield* new DestinationNotDirectoryError({ directory })
+      const project = yield* projects.resolve(directory)
+      const destination: SessionInbox.MovePayload = {
+        location: Location.Ref.make({ directory, workspaceID: input.workspaceID }),
+        projectID: project.id,
+        subpath: RelativePath.make(path.relative(project.directory, directory).replaceAll("\\", "/")),
+      }
+      yield* locations.contextEffect(destination.location).pipe(
+        Effect.scoped,
+        Effect.catchCause((cause) => {
+          if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause)
+          return Effect.logWarning("session move destination unavailable", { directory, cause }).pipe(
+            Effect.andThen(Effect.fail(new DestinationUnavailableError({ directory }))),
+          )
+        }),
+      )
+      return destination
+    })
+
+    const sourceUnavailable = Effect.fn("SessionMove.sourceUnavailable")(function* (session: Session.Info) {
+      if (yield* execution.isActive(session.id)) return false
+      if (!(yield* fs.isDir(session.location.directory))) return true
+      return yield* SessionRunner.Service.pipe(
+        instances.provide(session),
+        Effect.as(false),
+        Effect.catchCause((cause) => (Cause.hasInterrupts(cause) ? Effect.failCause(cause) : Effect.succeed(true))),
+      )
+    })
 
     return Service.of({
-      prepare: Effect.fn("SessionMove.prepare")(function* (input) {
-        const value = input.directory.trim()
-        const expanded =
-          value === "~" ? global.home : value.startsWith("~/") ? path.join(global.home, value.slice(2)) : value
-        const directory = AbsolutePath.make(path.resolve(input.session.location.directory, expanded))
-        const info = yield* fs.stat(directory).pipe(Effect.orElseSucceed(() => undefined))
-        if (!info) return yield* new DestinationNotFoundError({ directory })
-        if (info.type !== "Directory") return yield* new DestinationNotDirectoryError({ directory })
-        const project = yield* projects.resolve(directory)
-        const payload: SessionInbox.MovePayload = {
-          location: Location.Ref.make({ directory, workspaceID: input.workspaceID }),
-          projectID: project.id,
-          subpath: RelativePath.make(path.relative(project.directory, directory).replaceAll("\\", "/")),
-        }
-        yield* Location.Service.pipe(
-          Effect.provide(locations.get(payload.location)),
-          Effect.scoped,
-          Effect.catchCause((cause) => {
-            if (Cause.hasInterruptsOnly(cause)) return Effect.failCause(cause)
-            return Effect.logWarning("session move destination unavailable", { directory, cause }).pipe(
-              Effect.andThen(Effect.fail(new DestinationUnavailableError({ directory }))),
-            )
+      move: Effect.fn("SessionMove.move")(function* (input) {
+        const session = yield* get(input.sessionID)
+        const destination = yield* resolveDestination(session, input)
+        // Probe outside the inbox lock so cancellation remains available during initialization.
+        const unavailable = yield* sourceUnavailable(session)
+        const item = SessionInbox.Item.make({
+          type: "move",
+          payload: destination,
+          delivery: input.delivery ?? "steer",
+        })
+        yield* SessionInbox.serialized(
+          input.sessionID,
+          Effect.gen(function* () {
+            const latest = yield* get(input.sessionID)
+            // Only recover the placement we probed; active runners retain their step-boundary handoff.
+            if (
+              unavailable &&
+              latest.location.directory === session.location.directory &&
+              latest.location.workspaceID === session.location.workspaceID &&
+              !(yield* execution.isActive(input.sessionID))
+            ) {
+              const cancellations = (yield* SessionInbox.moveIDs(database.db, input.sessionID)).map(
+                (item) => [SessionEvent.InboxCancelled, { sessionID: input.sessionID, inboxID: item.id }] as const,
+              )
+              const moved = [SessionEvent.Moved, { sessionID: input.sessionID, ...destination }] as const
+              const first = cancellations[0]
+              if (!first) return yield* bus.publish(...moved).pipe(Effect.asVoid)
+              return yield* bus.publishAll([first, ...cancellations.slice(1), moved])
+            }
+            yield* admission
+              .admit({
+                id: SessionMessage.ID.create(),
+                sessionID: input.sessionID,
+                item,
+              })
+              .pipe(Effect.orDie)
           }),
         )
-        return payload
+        yield* execution.wake(input.sessionID)
       }),
     })
   }),
@@ -82,5 +158,17 @@ const layer = Layer.effect(
 export const node = makeGlobalNode({
   service: Service,
   layer,
-  deps: [FSUtil.node, Global.node, Project.node, LocationServiceMap.node],
+  deps: [
+    FSUtil.node,
+    Global.node,
+    Project.node,
+    LocationServiceMap.node,
+    SessionStore.node,
+    SessionExecution.node,
+    Instance.node,
+    SessionInbox.node,
+    Database.node,
+    Bus.node,
+    SessionProjector.node,
+  ],
 })

--- a/packages/core/test/session-move.test.ts
+++ b/packages/core/test/session-move.test.ts
@@ -17,6 +17,7 @@ import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
 import { SessionEvent } from "@opencode-ai/core/session/event"
 import { SessionExecution } from "@opencode-ai/core/session/execution"
+import { SessionMove } from "@opencode-ai/core/session/move"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionRunner } from "@opencode-ai/core/session/runner/index"
 import { SessionStore } from "@opencode-ai/core/session/store"
@@ -138,6 +139,52 @@ const sourceProbe = (options: { execution?: boolean } = {}) =>
   })
 
 describe("Session.move", () => {
+  itWithInstance.live("binds move preparation dependencies in the service implementation", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      const directory = AbsolutePath.make(tmp.path)
+      const context = yield* Layer.build(
+        AppNodeBuilder.build(LayerNode.group([Session.node, SessionMove.node]), [
+          Global.node.replace(tempGlobalLayer),
+          Project.node.replace(globalProjectNode),
+          SessionExecution.node.replace(SessionExecution.noopLayer),
+          offlineModels,
+        ]),
+      )
+      const sessions = Context.get(context, Session.Service)
+      const moves = Context.get(context, SessionMove.Service)
+      const session = yield* sessions.create({ location: Location.Ref.make({ directory }) })
+
+      // Call the bound service outside its construction context: no leaf services are provided here.
+      expect(yield* moves.prepare({ session, directory })).toMatchObject({
+        location: { directory },
+        projectID: Project.ID.global,
+      })
+    }),
+  )
+
+  itWithInstance.live("uses the provided move preparation service", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      const directory = AbsolutePath.make(tmp.path)
+      const rejection = new Session.DestinationUnavailableError({ directory })
+      const context = yield* Layer.build(
+        AppNodeBuilder.build(Session.node, [
+          Global.node.replace(tempGlobalLayer),
+          Project.node.replace(globalProjectNode),
+          SessionExecution.node.replace(SessionExecution.noopLayer),
+          SessionMove.node.replace(Layer.succeed(SessionMove.Service, { prepare: () => Effect.fail(rejection) })),
+          offlineModels,
+        ]),
+      )
+      const sessions = Context.get(context, Session.Service)
+      const created = yield* sessions.create({ location: Location.Ref.make({ directory }) })
+
+      expect(yield* sessions.move({ sessionID: created.id, directory }).pipe(Effect.flip)).toBe(rejection)
+      expect(yield* sessions.inbox(created.id)).toEqual([])
+    }),
+  )
+
   for (const broken of [false, true]) {
     itWithExecution.live(
       `moves an idle session from ${broken ? "broken" : "healthy"} source configuration`,

--- a/packages/core/test/session-move.test.ts
+++ b/packages/core/test/session-move.test.ts
@@ -139,31 +139,45 @@ const sourceProbe = (options: { execution?: boolean } = {}) =>
   })
 
 describe("Session.move", () => {
-  itWithInstance.live("binds move preparation dependencies in the service implementation", () =>
+  itWithInstance.live("moves through the bound service without depending on the Session facade", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped()
       const directory = AbsolutePath.make(tmp.path)
       const context = yield* Layer.build(
-        AppNodeBuilder.build(LayerNode.group([Session.node, SessionMove.node]), [
+        AppNodeBuilder.build(LayerNode.group([SessionMove.node, SessionStore.node, Bus.node, Project.node]), [
           Global.node.replace(tempGlobalLayer),
           Project.node.replace(globalProjectNode),
           SessionExecution.node.replace(SessionExecution.noopLayer),
           offlineModels,
         ]),
       )
-      const sessions = Context.get(context, Session.Service)
       const moves = Context.get(context, SessionMove.Service)
-      const session = yield* sessions.create({ location: Location.Ref.make({ directory }) })
+      const store = Context.get(context, SessionStore.Service)
+      const bus = Context.get(context, Bus.Service)
+      const projects = Context.get(context, Project.Service)
+      const sessionID = Session.ID.create()
 
-      // Call the bound service outside its construction context: no leaf services are provided here.
-      expect(yield* moves.prepare({ session, directory })).toMatchObject({
+      // Call outside the construction context: the service owns all of its dependencies.
+      expect(yield* moves.move({ sessionID, directory }).pipe(Effect.flip)).toEqual(
+        new Session.NotFoundError({ sessionID }),
+      )
+      yield* projects.resolve(directory)
+      yield* bus.publish(SessionEvent.Created, {
+        sessionID,
+        slug: "move-service",
+        version: "test",
+        projectID: Project.ID.global,
+        location: Location.Ref.make({ directory: AbsolutePath.make(path.join(tmp.path, "missing")) }),
+      })
+      yield* moves.move({ sessionID, directory })
+      expect(yield* store.get(sessionID)).toMatchObject({
         location: { directory },
         projectID: Project.ID.global,
       })
     }),
   )
 
-  itWithInstance.live("uses the provided move preparation service", () =>
+  itWithInstance.live("delegates to the provided move service", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped()
       const directory = AbsolutePath.make(tmp.path)
@@ -173,7 +187,7 @@ describe("Session.move", () => {
           Global.node.replace(tempGlobalLayer),
           Project.node.replace(globalProjectNode),
           SessionExecution.node.replace(SessionExecution.noopLayer),
-          SessionMove.node.replace(Layer.succeed(SessionMove.Service, { prepare: () => Effect.fail(rejection) })),
+          SessionMove.node.replace(Layer.succeed(SessionMove.Service, { move: () => Effect.fail(rejection) })),
           offlineModels,
         ]),
       )

--- a/packages/core/test/session-move.test.ts
+++ b/packages/core/test/session-move.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect } from "bun:test"
 import path from "path"
-import { mkdir, rm } from "fs/promises"
-import { Effect, Layer, LayerMap } from "effect"
+import { chmod, mkdir, readdir, rm } from "fs/promises"
+import { Cause, Context, Deferred, Duration, Effect, Exit, Fiber, Layer, LayerMap, Queue } from "effect"
 import { Worktree } from "@opencode-ai/schema/worktree"
+import { Workspace } from "@opencode-ai/schema/workspace"
 import { Bus } from "@opencode-ai/core/bus"
+import { Config } from "@opencode-ai/core/config"
 import { Database } from "@opencode-ai/core/database/database"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Instance } from "@opencode-ai/core/instance"
 import { Location } from "@opencode-ai/core/location"
 import { LocationServiceMap } from "@opencode-ai/core/location-service-map"
 import type { LocationServices } from "@opencode-ai/core/location-services"
@@ -18,6 +21,9 @@ import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionRunner } from "@opencode-ai/core/session/runner/index"
 import { SessionStore } from "@opencode-ai/core/session/store"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
+import { Global } from "@opencode-ai/util/global"
+import { tempGlobalLayer } from "./fixture/global"
 import { offlineModels } from "./fixture/models"
 import { tmpdirScoped } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
@@ -74,8 +80,312 @@ const itWithUnavailableDestination = testEffect(
     ],
   ),
 )
+const itWithExecution = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Session.node, SessionExecution.node]), [
+    Global.node.replace(tempGlobalLayer),
+    offlineModels,
+  ]),
+)
+// Windows does not enforce POSIX mode bits, and root can traverse mode-000 directories.
+const itWithPermissions =
+  process.platform === "win32" || process.getuid?.() === 0 ? itWithExecution.live.skip : itWithExecution.live
+const itWithInstance = testEffect(Layer.empty)
+const sourceProbe = (options: { execution?: boolean } = {}) =>
+  Effect.gen(function* () {
+    const tmp = yield* tmpdirScoped()
+    const source = AbsolutePath.make(path.join(tmp.path, "source"))
+    const destination = AbsolutePath.make(tmp.path)
+    yield* Effect.promise(() => mkdir(source))
+    const probes = yield* Queue.unbounded<Deferred.Deferred<void>>()
+    const context = yield* Layer.build(
+      AppNodeBuilder.build(LayerNode.group([Session.node, Bus.node, SessionExecution.node]), [
+        Global.node.replace(tempGlobalLayer),
+        ...(options.execution ? [] : [SessionExecution.node.replace(SessionExecution.noopLayer)]),
+        offlineModels,
+        Instance.node.replace(
+          makeGlobalNode({
+            service: Instance.Service,
+            deps: [LocationServiceMap.node],
+            layer: Layer.effect(
+              Instance.Service,
+              Effect.gen(function* () {
+                const locations = yield* LocationServiceMap.Service
+                return Instance.Service.of({
+                  provide: (session) => (effect) =>
+                    Effect.gen(function* () {
+                      if (session.location.directory === source) {
+                        const release = yield* Deferred.make<void>()
+                        yield* Queue.offer(probes, release)
+                        yield* Deferred.await(release)
+                      }
+                      return yield* effect.pipe(Effect.provide(locations.get(session.location)))
+                    }),
+                })
+              }),
+            ),
+          }),
+        ),
+      ]),
+    )
+    return {
+      source,
+      destination,
+      probes,
+      session: Context.get(context, Session.Service),
+      bus: Context.get(context, Bus.Service),
+      execution: Context.get(context, SessionExecution.Service),
+    }
+  })
 
 describe("Session.move", () => {
+  for (const broken of [false, true]) {
+    itWithExecution.live(
+      `moves an idle session from ${broken ? "broken" : "healthy"} source configuration`,
+      () =>
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          const source = AbsolutePath.make(path.join(tmp.path, "source"))
+          const destination = AbsolutePath.make(path.join(tmp.path, "destination"))
+          yield* Effect.promise(() => Promise.all([mkdir(source), mkdir(destination)]))
+          if (broken)
+            yield* Effect.promise(() =>
+              Bun.write(path.join(source, "opencode.json"), JSON.stringify({ instructions: ["{file:./missing.txt}"] })),
+            )
+          const session = yield* Session.Service
+          const execution = yield* SessionExecution.Service
+          const created = yield* session.create({ location: Location.Ref.make({ directory: source }) })
+
+          yield* session.move({ sessionID: created.id, directory: destination })
+          yield* execution.awaitIdle(created.id)
+
+          expect((yield* session.get(created.id)).location.directory).toBe(destination)
+          expect(yield* session.inbox(created.id)).toEqual([])
+        }),
+      { timeout: 15_000 },
+    )
+  }
+
+  itWithPermissions(
+    "recovers an idle session from an unreadable source directory",
+    () =>
+      Effect.gen(function* () {
+        const tmp = yield* tmpdirScoped()
+        const source = AbsolutePath.make(path.join(tmp.path, "source"))
+        const destination = AbsolutePath.make(path.join(tmp.path, "destination"))
+        yield* Effect.promise(() => Promise.all([mkdir(source), mkdir(destination)]))
+        const session = yield* Session.Service
+        const execution = yield* SessionExecution.Service
+        const created = yield* session.create({ location: Location.Ref.make({ directory: source }) })
+        yield* Effect.addFinalizer(() => Effect.promise(() => chmod(source, 0o755)))
+        yield* Effect.promise(() => chmod(source, 0o000))
+        expect(
+          yield* Effect.promise(() =>
+            readdir(source).then(
+              () => false,
+              () => true,
+            ),
+          ),
+        ).toBe(true)
+
+        yield* session.move({ sessionID: created.id, directory: destination })
+        yield* execution.awaitIdle(created.id)
+
+        expect((yield* session.get(created.id)).location.directory).toBe(destination)
+        expect(yield* session.inbox(created.id)).toEqual([])
+      }),
+    { timeout: 15_000 },
+  )
+
+  for (const broken of [false, true]) {
+    itWithInstance.live(
+      `uses the ${broken ? "broken" : "healthy discovery-disabled"} selected instance rather than the default Location`,
+      () =>
+        Effect.gen(function* () {
+          const tmp = yield* tmpdirScoped()
+          const source = Location.Ref.make({ directory: AbsolutePath.make(path.join(tmp.path, "source")) })
+          const destination = AbsolutePath.make(path.join(tmp.path, "destination"))
+          yield* Effect.promise(() => Promise.all([mkdir(source.directory), mkdir(destination)]))
+          const config = JSON.stringify({ instructions: ["{file:./missing.txt}"] })
+          if (!broken) yield* Effect.promise(() => Bun.write(path.join(source.directory, "opencode.json"), config))
+          const selectedID = Session.ID.create()
+          const replacements: LayerNode.Replacements = [
+            Global.node.replace(tempGlobalLayer),
+            SessionExecution.node.replace(SessionExecution.noopLayer),
+            offlineModels,
+            Instance.node.replace(
+              makeGlobalNode({
+                service: Instance.Service,
+                deps: [LocationServiceMap.node],
+                layer: Layer.effect(
+                  Instance.Service,
+                  Effect.gen(function* () {
+                    const locations = yield* LocationServiceMap.Service
+                    const privateInstances = yield* LayerMap.make(
+                      () =>
+                        Instance.layer(source, {
+                          discovery: false,
+                          replacements: [
+                            ...bindings,
+                            ...(broken
+                              ? [
+                                  Config.node.replace(
+                                    Config.configured({ project: false, global: false, content: config }),
+                                  ),
+                                ]
+                              : []),
+                          ],
+                        }),
+                      { idleTimeToLive: Duration.infinity },
+                    )
+                    const selector = Instance.Service.of({
+                      provide: (session) =>
+                        Effect.provide(
+                          session.id === selectedID && session.location.directory === source.directory
+                            ? privateInstances.get(session.id)
+                            : locations.get(session.location),
+                        ),
+                    })
+                    const bindings: LayerNode.Replacements = [
+                      ...replacements,
+                      Instance.node.replace(Layer.succeed(Instance.Service, selector)),
+                      LocationServiceMap.node.replace(Layer.succeed(LocationServiceMap.Service, locations)),
+                    ]
+                    return selector
+                  }),
+                ),
+              }),
+            ),
+          ]
+          const context = yield* Layer.build(AppNodeBuilder.build(Session.node, replacements))
+          const session = Context.get(context, Session.Service)
+          const created = yield* session.create({ id: selectedID, location: source })
+          const pending = yield* session.synthetic({
+            sessionID: created.id,
+            text: "Keep pending",
+            delivery: "queue",
+            resume: false,
+          })
+
+          yield* session.move({ sessionID: created.id, directory: destination, delivery: "queue" })
+
+          expect((yield* session.get(created.id)).location.directory).toBe(broken ? destination : source.directory)
+          const inbox = yield* session.inbox(created.id)
+          expect(inbox[0]).toEqual(pending)
+          if (broken) expect(inbox).toEqual([pending])
+          if (!broken) expect(inbox.slice(1)).toMatchObject([{ type: "move", delivery: "queue" }])
+        }),
+      { timeout: 15_000 },
+    )
+  }
+
+  for (const interrupt of ["source", "caller"] as const) {
+    itWithInstance.live(`does not recover or enqueue a move when the ${interrupt} interrupts the probe`, () =>
+      Effect.gen(function* () {
+        const fixture = yield* sourceProbe()
+        const created = yield* fixture.session.create({ location: Location.Ref.make({ directory: fixture.source }) })
+        const pending = yield* fixture.session.synthetic({ sessionID: created.id, text: "Keep pending", resume: false })
+        const moving = yield* fixture.session
+          .move({ sessionID: created.id, directory: fixture.destination })
+          .pipe(Effect.forkScoped)
+        const release = yield* Queue.take(fixture.probes)
+
+        if (interrupt === "source") yield* Deferred.interrupt(release)
+        if (interrupt === "caller") yield* Fiber.interrupt(moving)
+        const exit = yield* Fiber.await(moving)
+
+        expect(Exit.isFailure(exit) && Cause.hasInterruptsOnly(exit.cause)).toBe(true)
+        expect((yield* fixture.session.get(created.id)).location.directory).toBe(fixture.source)
+        expect(yield* fixture.session.inbox(created.id)).toEqual([pending])
+      }).pipe(Effect.timeout("5 seconds")),
+    )
+  }
+
+  itWithInstance.live("does not recover if execution starts during the source probe", () =>
+    Effect.gen(function* () {
+      const fixture = yield* sourceProbe({ execution: true })
+      const created = yield* fixture.session.create({ location: Location.Ref.make({ directory: fixture.source }) })
+      const moving = yield* fixture.session
+        .move({ sessionID: created.id, directory: fixture.destination })
+        .pipe(Effect.forkScoped)
+      const release = yield* Queue.take(fixture.probes)
+
+      yield* fixture.execution.wake(created.id)
+      // The real coordinator now owns execution; its separate instance acquisition stays suspended.
+      yield* Queue.take(fixture.probes)
+      expect(yield* fixture.execution.isActive(created.id)).toBe(true)
+      yield* Deferred.die(release, new Error("source unavailable"))
+      yield* Fiber.join(moving)
+
+      expect((yield* fixture.session.get(created.id)).location.directory).toBe(fixture.source)
+      expect(yield* fixture.session.inbox(created.id)).toMatchObject([{ type: "move", delivery: "steer" }])
+      expect(yield* fixture.execution.isActive(created.id)).toBe(true)
+      yield* fixture.execution.interrupt(created.id)
+      yield* fixture.execution.awaitIdle(created.id)
+    }).pipe(Effect.timeout("5 seconds")),
+  )
+
+  itWithInstance.live(
+    "recovers a missing source without initializing its instance and retains destination workspace identity",
+    () =>
+      Effect.gen(function* () {
+        const fixture = yield* sourceProbe()
+        const created = yield* fixture.session.create({
+          location: Location.Ref.make({ directory: fixture.source, workspaceID: Workspace.ID.create() }),
+        })
+        yield* Effect.promise(() => rm(fixture.source, { recursive: true }))
+        const workspaceID = Workspace.ID.create()
+
+        yield* fixture.session.move({ sessionID: created.id, directory: fixture.destination, workspaceID })
+
+        expect((yield* fixture.session.get(created.id)).location).toEqual(
+          Location.Ref.make({ directory: fixture.destination, workspaceID }),
+        )
+        expect(yield* fixture.session.inbox(created.id)).toEqual([])
+        expect(yield* Queue.size(fixture.probes)).toBe(0)
+      }).pipe(Effect.timeout("5 seconds")),
+  )
+
+  for (const changed of ["directory", "workspace"] as const) {
+    itWithInstance.live(`allows inbox cancellation during a source probe and rejects stale ${changed} recovery`, () =>
+      Effect.gen(function* () {
+        const fixture = yield* sourceProbe()
+        const created = yield* fixture.session.create({ location: Location.Ref.make({ directory: fixture.source }) })
+        const pending = yield* fixture.session.synthetic({
+          sessionID: created.id,
+          text: "Cancel pending",
+          resume: false,
+        })
+        const moving = yield* fixture.session
+          .move({ sessionID: created.id, directory: fixture.destination })
+          .pipe(Effect.exit, Effect.forkScoped)
+        const release = yield* Queue.take(fixture.probes)
+
+        yield* fixture.session.cancelInbox({ sessionID: created.id, inboxID: pending.id }).pipe(
+          Effect.timeout("2 seconds"),
+          Effect.onError(() => Deferred.interrupt(release)),
+        )
+        expect(yield* fixture.session.inbox(created.id)).toEqual([])
+        expect(moving.pollUnsafe()).toBeUndefined()
+        const location = Location.Ref.make({
+          directory: changed === "directory" ? fixture.destination : fixture.source,
+          workspaceID: changed === "workspace" ? Workspace.ID.create() : undefined,
+        })
+        yield* fixture.bus.publish(SessionEvent.Moved, {
+          sessionID: created.id,
+          location,
+          projectID: created.projectID,
+        })
+        yield* Deferred.die(release, new Error("source unavailable"))
+        expect(Exit.isSuccess(yield* Fiber.join(moving))).toBe(true)
+
+        expect((yield* fixture.session.get(created.id)).location).toEqual(location)
+        expect(yield* fixture.session.inbox(created.id)).toMatchObject([
+          { type: "move", payload: { location: { directory: fixture.destination } } },
+        ])
+      }).pipe(Effect.timeout("5 seconds")),
+    )
+  }
+
   itWithUnavailableDestination.effect("rejects an unavailable destination before admitting the move", () =>
     tmpdirScoped().pipe(
       Effect.flatMap((tmp) =>
@@ -111,15 +421,23 @@ describe("Session.move", () => {
           yield* session.move({ sessionID: created.id, directory: destination })
           expect((yield* session.get(created.id)).location.directory).toBe(AbsolutePath.make(source))
           expect(yield* session.inbox(created.id)).toHaveLength(1)
+          const pending = yield* session.synthetic({
+            sessionID: created.id,
+            text: "Keep queued",
+            delivery: "queue",
+            resume: false,
+          })
+          yield* session.move({ sessionID: created.id, directory: destination, delivery: "queue" })
+          expect(yield* session.inbox(created.id)).toHaveLength(3)
 
           yield* Effect.promise(() => rm(source, { recursive: true }))
           yield* session.move({ sessionID: created.id, directory: destination })
 
           expect((yield* session.get(created.id)).location.directory).toBe(destination)
-          expect(yield* session.inbox(created.id)).toEqual([])
+          expect(yield* session.inbox(created.id)).toEqual([pending])
 
           yield* session.move({ sessionID: created.id, directory: destination })
-          expect(yield* session.inbox(created.id)).toHaveLength(1)
+          expect(yield* session.inbox(created.id)).toHaveLength(2)
 
           yield* Effect.promise(() => mkdir(path.join(tmp.path, "other")))
           const steered = yield* session.create({


### PR DESCRIPTION
## Why

An idle session cannot escape an existing source directory whose instance fails to initialize. For example, a missing `{file:./missing.txt}` config reference or unreadable directory prevents the source runner from starting, leaving accepted moves stranded in the inbox.

## What Changes

Extend the existing missing-source recovery path to failed source-instance initialization:

| Source state | Result |
| --- | --- |
| Active execution | Keep the runner's normal step-boundary handoff. |
| Idle, selected instance initializes | Admit the move normally, preserving inbox ordering. |
| Idle, source missing or selected instance cannot initialize | Apply the validated destination directly, cancel superseded move controls, and retain other queued inputs. |
| Source probe interrupted | Preserve interruption; do not recover or admit the move. |

### Selected instance and admission ordering

Probe `SessionRunner.Service` through `instances.provide(session)`, the same selection boundary used by execution—not the default Location map. A healthy private instance with `discovery: false` must remain usable even when ambient configuration is broken; a broken private instance must not be mistaken for a healthy default Location. This corrects the selection problem in the closed #46445 approach.

Initialization runs outside the inbox lock so cancellation remains available. Inside the lock, recovery requires the same directory/workspace placement and a fresh idle-execution check. Missing sources still skip initialization entirely.

### Move service ownership

`SessionMove.Service` owns the complete operation: loading current session state, resolving and validating the destination, checking source availability, recovering or admitting the move under the inbox lock, and waking execution. Its implementation binds its dependencies using the existing `Context.Service` / global node pattern. The public `Session` service delegates with `move: moves.move`.

Destination resolution is private. The value is named `destination`; it becomes an inbox payload or the fields of `session.moved` only at the publication site. Destination validation acquires the cached context directly instead of requesting `Location.Service` merely to trigger graph construction. Error translation, interruption handling, source checks, and admission ordering remain unchanged.

The move service depends on `SessionStore` and the session projector, not `Session.Service`. A standalone test constructs and exercises it without the Session facade, including a missing-session error and a projected recovery move; another test verifies that the facade delegates to a substituted move service.

## Scope

Core-only idle-move recovery and move-service ownership. The HTTP API is unchanged. Failed Location-cache eviction and active runner continuation remain separate concerns.

## Verification

Latest service-ownership follow-up: `c08dfb71f7`.

```sh
# packages/core
bun run test test/session-move.test.ts
bun run test
bun typecheck
bunx prettier --write src/session.ts src/session/move.ts test/session-move.test.ts

# packages/server
bun run test test/session-instances.test.ts

# worktree root
bunx oxlint packages/core/src/session.ts packages/core/src/session/move.ts packages/core/test/session-move.test.ts
git diff --check
git push origin recover-idle-moves
```

- **Current move suite:** 17 passed, zero failures, including standalone service ownership and facade substitution coverage.
- **Current full Core suite:** 4,031 passed, 39 skipped, zero failures across 227 files.
- **Server integration:** selected-instance test passed, with 52 assertions.
- Core typecheck, formatting, and whitespace checks passed. Scoped lint reports no errors and four warnings on pre-existing code.
- The normal pre-push hook passed all 33 repository typecheck tasks; no hooks were bypassed. New-head GitHub CI must complete after this update.

Earlier recovery verification on `c23cb367ad`:

- Real Session/SessionExecution fixtures failed before the fix for broken source configuration and mode-000 permissions on non-root macOS; the healthy control passed. The broken selected-instance regression also failed before the fix.
- 274 focused tests passed; all 15 then-current move tests passed across three repeated runs. Independent review additionally passed 261 related Core tests and two scratch cases using the real SDK instance selector.
- Temporarily replacing the probe with default-Location selection made both selected-instance regressions fail; restoring the selected-instance probe passed both.

Permission coverage is skipped on Windows and root, where POSIX mode bits cannot establish this fixture. This is real-core integration coverage, not packaged TUI/provider verification; no live server or session was changed.
