### PR TITLE
feat(plugin): add reference editor lookup

### DIFF
--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -397,6 +397,7 @@ export const make = Effect.fn("PluginHost.make")(function* (
             add: (name, source) => editor.add(name, Schema.decodeUnknownSync(Reference.Source)(source)),
             remove: editor.remove,
             list: editor.list,
+            get: editor.get,
           })
         }),
     },

--- a/packages/core/src/reference.ts
+++ b/packages/core/src/reference.ts
@@ -32,6 +32,7 @@ type Editor = {
   add(name: string, source: Source): void
   remove(name: string): void
   list(): readonly [string, Source][]
+  get(name: string): Source | undefined
 }
 
 export interface Interface extends State.Transformable<Editor> {
@@ -98,6 +99,7 @@ const layer = Layer.effect(
         add: (name, source) => editor.sources.set(name, source),
         remove: (name) => editor.sources.delete(name),
         list: () => Array.from(editor.sources),
+        get: (name) => editor.sources.get(name),
       }),
       notify: () =>
         Effect.gen(function* () {

--- a/packages/core/test/reference.test.ts
+++ b/packages/core/test/reference.test.ts
@@ -19,6 +19,26 @@ const referenceLayer = AppNodeBuilder.build(LayerNode.group([Reference.node, Bus
 ])
 
 describe("Reference", () => {
+  it.effect("reads the current editor source by name", () =>
+    Effect.gen(function* () {
+      const references = yield* Reference.Service
+      const source = Reference.LocalSource.make({ type: "local", path: AbsolutePath.make("/docs") })
+      yield* references.transform((editor) => editor.add("docs", source))
+      yield* references.transform((editor) => {
+        expect(editor.get("docs")).toBe(editor.list()[0]?.[1])
+        expect(editor.get("docs")).toEqual(source)
+        expect(editor.get("missing")).toBeUndefined()
+        const replacement = Reference.GitSource.make({ type: "git", repository: "owner/repo" })
+        editor.add("docs", replacement)
+        expect(editor.get("docs")).toBe(replacement)
+        editor.remove("docs")
+        expect(editor.get("docs")).toBeUndefined()
+      })
+
+      expect(yield* references.list()).toEqual([])
+    }).pipe(Effect.provide(referenceLayer)),
+  )
+
   it.effect("reads batched references before cache work and update events", () => {
     const operations: RepositoryCache.EnsureInput[] = []
     const started = Deferred.makeUnsafe<void>()

--- a/packages/plugin/src/effect/reference.ts
+++ b/packages/plugin/src/effect/reference.ts
@@ -7,6 +7,7 @@ export interface ReferenceEditor {
   add(name: string, source: ReferenceLocalSource | ReferenceGitSource): void
   remove(name: string): void
   list(): readonly (readonly [string, ReferenceLocalSource | ReferenceGitSource])[]
+  get(name: string): ReferenceLocalSource | ReferenceGitSource | undefined
 }
 
 export interface ReferenceDomain extends ReferenceApi<unknown> {

--- a/packages/plugin/src/promise/reference.ts
+++ b/packages/plugin/src/promise/reference.ts
@@ -6,6 +6,7 @@ export interface ReferenceEditor {
   add(name: string, source: ReferenceLocalSource | ReferenceGitSource): void
   remove(name: string): void
   list(): readonly (readonly [string, ReferenceLocalSource | ReferenceGitSource])[]
+  get(name: string): ReferenceLocalSource | ReferenceGitSource | undefined
 }
 
 export interface ReferenceDomain extends ReferenceApi {

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -644,7 +644,8 @@ effect: (ctx) =>
   }),
 ```
 
-Add or remove local and Git references, then reload after external state changes.
+Add or remove local and Git references, then reload after external state changes. `get(name)` returns the current configured
+source, or `undefined` when the name is absent.
 
 ```ts
 effect: (ctx) =>
@@ -653,6 +654,7 @@ effect: (ctx) =>
     yield* reference.transform((editor) => {
       editor.add("handbook", { type: "local", path: "/workspace/docs/handbook" })
       editor.add("standards", { type: "git", repository: "https://github.com/acme/standards", branch: "main" })
+      const handbook = editor.get("handbook")
       editor.remove("legacy")
     })
     yield* reference.reload()
@@ -667,6 +669,7 @@ interface ReferenceEditor {
   add(name: string, source: ReferenceLocalSource | ReferenceGitSource): void
   remove(name: string): void
   list(): readonly (readonly [string, ReferenceLocalSource | ReferenceGitSource])[]
+  get(name: string): ReferenceLocalSource | ReferenceGitSource | undefined
 }
 
 interface ReferenceDomain extends ReferenceApi<unknown> {

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -596,13 +596,15 @@ Read the references available at a location.
 const references = await ctx.reference.list()
 ```
 
-Register a transform to inspect, add, or remove local and Git references.
+Register a transform to inspect, add, or remove local and Git references. `get(name)` returns the current configured source,
+or `undefined` when the name is absent.
 
 ```ts
 await ctx.reference.transform((editor) => {
   const references = editor.list()
   editor.add("handbook", { type: "local", path: "/workspace/docs/handbook" })
   editor.add("standards", { type: "git", repository: "https://github.com/acme/standards", branch: "main" })
+  const handbook = editor.get("handbook")
   editor.remove("legacy")
 })
 ```
@@ -627,6 +629,7 @@ interface ReferenceContext {
 
 interface ReferenceEditor {
   list(): readonly (readonly [string, ReferenceLocalSource | ReferenceGitSource])[]
+  get(name: string): ReferenceLocalSource | ReferenceGitSource | undefined
   add(name: string, source: ReferenceLocalSource | ReferenceGitSource): void
   remove(name: string): void
 }


### PR DESCRIPTION
## Why

Reference transforms address additions and removals by name, but reading one source requires searching the tuples returned by `editor.list()`. Other keyed editors already offer direct lookup.

## What Changes

Add synchronous `ReferenceEditor.get(name)` to Core and both plugin APIs, wired through the plugin host:

```ts
await ctx.reference.transform((editor) => {
  const handbook = editor.get("handbook")
  if (!handbook) return
  editor.add("handbook", { ...handbook, description: "Project handbook" })
})
```

The result is the current configured local or Git source, not a materialized `Reference.Info`. It is the same source value returned by the matching `list()` tuple, or `undefined` when absent. Lookup observes preceding transforms and replacements/removals within the current callback; it performs no materialization and creates no entry.

The Promise and Effect guides document the method and absence behavior.

## Scope

Reference-editor lookup only. This is independent of the matching skill-editor addition in #46952. Existing add/remove semantics, source materialization, and replay behavior are unchanged.

## Verification

```sh
# packages/core
bun run test test/reference.test.ts test/state.test.ts test/state-replay.test.ts
bun run test test/reference-instructions.test.ts
bun typecheck

# packages/plugin
bun typecheck
TMPDIR="$(realpath "${TMPDIR:-/tmp}")" bun run test

# packages/www
bun typecheck
bun run check:generated
bun run build

# repository root
git diff --check
```

The new regression failed before implementation because `editor.get` was absent. Afterward, all 40 focused Core tests and 9 plugin tests pass, along with Core, Plugin, and website typechecking, the generated-documentation check, and the website build. The normal pre-push workspace typecheck also passed.

Formatting passes for changed source and the Promise guide. The Effect guide passes with embedded-language formatting disabled; the pre-existing standalone `yield*` formatting issue elsewhere in that guide is left untouched.
