### PR TITLE
fix(core): reject GitHub Copilot login without chat entitlement

### DIFF
--- a/packages/core/src/plugin/provider/github-copilot.ts
+++ b/packages/core/src/plugin/provider/github-copilot.ts
@@ -30,6 +30,8 @@ const Token = Schema.Struct({
   interval: Schema.optional(Schema.Number),
 })
 const User = Schema.Struct({
+  chat_enabled: Schema.optional(Schema.Boolean),
+  can_signup_for_limited: Schema.optional(Schema.Boolean),
   endpoints: Schema.optional(
     Schema.Struct({
       api: Schema.optional(Schema.String),
@@ -107,23 +109,30 @@ const oauth = (app: App.Info) =>
                     },
                   },
                 ).pipe(
-                  Effect.map((user) => Option.getOrUndefined(decodeUser(user))?.endpoints?.api?.replace(/\/+$/, "")),
+                  Effect.map((user) => Option.getOrUndefined(decodeUser(user))),
+                  // Only an explicit entitlement answer blocks login; a failed
+                  // or malformed lookup must not turn a GitHub hiccup into a denial.
                   Effect.orElseSucceed(() => undefined),
-                  Effect.map((apiEndpoint) =>
-                    Credential.OAuth.make({
-                      type: "oauth",
-                      methodID,
-                      refresh: access,
-                      access,
-                      expires: 0,
-                      ...((enterprise || apiEndpoint) && {
-                        metadata: {
-                          ...(enterprise ? { enterpriseUrl: domain } : {}),
-                          ...(apiEndpoint ? { apiEndpoint } : {}),
-                        },
+                  Effect.flatMap((user) => {
+                    const denied = user && copilotEntitlementError(user)
+                    if (denied) return Effect.fail(new Error(denied))
+                    const apiEndpoint = user?.endpoints?.api?.replace(/\/+$/, "")
+                    return Effect.succeed(
+                      Credential.OAuth.make({
+                        type: "oauth",
+                        methodID,
+                        refresh: access,
+                        access,
+                        expires: 0,
+                        ...((enterprise || apiEndpoint) && {
+                          metadata: {
+                            ...(enterprise ? { enterpriseUrl: domain } : {}),
+                            ...(apiEndpoint ? { apiEndpoint } : {}),
+                          },
+                        }),
                       }),
-                    }),
-                  ),
+                    )
+                  }),
                 )
               }
               if (token.error === "authorization_pending")
@@ -296,6 +305,15 @@ function oauthURLs(domain: string) {
 
 function baseURL(enterprise?: string) {
   return enterprise ? `https://copilot-api.${normalizeDomain(enterprise)}` : "https://api.githubcopilot.com"
+}
+
+// GitHub reports Copilot access on /copilot_internal/user; OAuth itself succeeds
+// for any GitHub account, so this is the only signal that the account can chat.
+export function copilotEntitlementError(user: { chat_enabled?: boolean; can_signup_for_limited?: boolean }) {
+  if (user.chat_enabled !== false) return
+  if (user.can_signup_for_limited)
+    return "This GitHub account is not signed up for GitHub Copilot. Sign up for Copilot Free at https://github.com/features/copilot/plans and connect again."
+  return "This GitHub account does not have GitHub Copilot access. It needs an active Copilot subscription or a seat assigned by an organization."
 }
 
 export function copilotBaseURL(metadata?: Readonly<Record<string, unknown>>) {

--- a/packages/core/test/plugin/provider-github-copilot.test.ts
+++ b/packages/core/test/plugin/provider-github-copilot.test.ts
@@ -10,7 +10,12 @@ import { ModelResolver } from "@opencode-ai/core/model-resolver"
 import { Plugin } from "@opencode-ai/core/plugin"
 import { PluginHost } from "@opencode-ai/core/plugin/host"
 import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
-import { copilotBaseURL, copilotFetch, GithubCopilotPlugin } from "@opencode-ai/core/plugin/provider/github-copilot"
+import {
+  copilotBaseURL,
+  copilotEntitlementError,
+  copilotFetch,
+  GithubCopilotPlugin,
+} from "@opencode-ai/core/plugin/provider/github-copilot"
 import { Provider } from "@opencode-ai/core/provider"
 import { Integration } from "@opencode-ai/core/integration"
 import { fakeSelectorSdk } from "../fixture/selector"
@@ -38,6 +43,20 @@ describe("GithubCopilotPlugin", () => {
         apiEndpoint: "https://api.business.githubcopilot.com",
       }),
     ).toBe("https://api.business.githubcopilot.com")
+  })
+
+  test("rejects accounts without Copilot chat access", () => {
+    expect(copilotEntitlementError({ chat_enabled: false, can_signup_for_limited: true })).toContain("Copilot Free")
+    expect(copilotEntitlementError({ chat_enabled: false, can_signup_for_limited: false })).toContain(
+      "subscription or a seat",
+    )
+    expect(copilotEntitlementError({ chat_enabled: false })).toContain("subscription or a seat")
+  })
+
+  test("only blocks on an explicit entitlement denial", () => {
+    expect(copilotEntitlementError({ chat_enabled: true })).toBeUndefined()
+    expect(copilotEntitlementError({ chat_enabled: true, can_signup_for_limited: true })).toBeUndefined()
+    expect(copilotEntitlementError({})).toBeUndefined()
   })
 
   it.effect("registers GitHub Copilot device OAuth", () =>


### PR DESCRIPTION
Fixes #46891

## Problem

GitHub device OAuth succeeds for any GitHub account, including ones with no Copilot subscription or organization seat. The plugin persisted the credential regardless, so Integrations showed GitHub Copilot as connected while `/models` returned an empty list and there was no explanation.

## Change

The plugin already calls `GET /copilot_internal/user` after the device flow, but only read `endpoints.api`. This is the same endpoint VS Code uses as its Copilot entitlement gate (`chat_enabled` in `defaultAccount.ts` / `chatEntitlementService.ts`).

- Decode `chat_enabled` and `can_signup_for_limited` from that response.
- If the account reports `chat_enabled: false`, fail the OAuth attempt instead of persisting the credential. The failure message is surfaced through the existing attempt error path:
  - eligible for Copilot Free (`can_signup_for_limited: true`): tells the user to sign up and reconnect.
  - otherwise: tells the user the account needs an active subscription or an org-assigned seat.
- A failed or malformed lookup (network error, 5xx, 401/404) keeps the previous tolerant behavior and still persists the credential, so a GitHub API hiccup cannot block login. Only an explicit denial blocks.

Existing connections made before this change are not affected; disconnecting and reconnecting hits the new check.

## Testing

- Added unit tests for `copilotEntitlementError` covering both denial messages and the tolerant path.
- `bun test test/plugin/provider-github-copilot.test.ts` and `bun typecheck` pass in `packages/core`.