### PR TITLE
fix(core): drop undefined metadata values from permission requests

### DIFF
--- a/packages/core/src/permission.ts
+++ b/packages/core/src/permission.ts
@@ -183,6 +183,12 @@ const layer = Layer.effect(
       return { effect: event.effect, message: event.message, rules: all }
     })
 
+    // Metadata is JSON-encoded; drop undefined values tools pass for absent optional inputs.
+    function metadata(value: AssertInput["metadata"]): Request["metadata"] {
+      if (!value) return value
+      return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined))
+    }
+
     function request(input: AssertInput, message?: string): Request {
       return {
         id: input.id ?? ID.create(),
@@ -190,7 +196,7 @@ const layer = Layer.effect(
         action: input.action,
         resources: input.resources,
         save: input.save,
-        metadata: input.metadata,
+        metadata: metadata(input.metadata),
         source: input.source,
         message,
       }

--- a/packages/core/test/permission.test.ts
+++ b/packages/core/test/permission.test.ts
@@ -260,6 +260,17 @@ describe("Permission", () => {
     }),
   )
 
+  it.effect("omits undefined metadata values from pending requests", () =>
+    Effect.gen(function* () {
+      yield* setup()
+      const service = yield* Permission.Service
+      yield* service.ask(assertion({ metadata: { root: ".", path: undefined, limit: undefined } }))
+      const request = yield* service.get(Permission.ID.create("per_test"))
+      expect(request?.metadata).toEqual({ root: "." })
+      expect(Object.keys(request?.metadata ?? {})).toEqual(["root"])
+    }),
+  )
+
   it.effect("defects when an asked permission is declined", () =>
     Effect.gen(function* () {
       yield* setup()


### PR DESCRIPTION
### Issue for this PR

Closes #37650

Supersedes #37679, which was closed by the automated cleanup and which GitHub will not reopen.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pending `glob` and `grep` permissions store absent optional inputs as `undefined` inside permission metadata (for example `metadata: { path: input.path, limit: input.limit }`). The metadata record is `Schema.Record(Schema.String, Schema.Unknown)` and the wire codec serializes `Unknown` as a JSON value, so `session.permission.list` fails to encode its response with `Expected JSON value, got undefined`.

Since #37679 the set of affected fields has grown: `glob` now also passes `hidden` (#46724) and `grep` passes `literal` and `caseSensitive`. A glob call that omits `hidden` trips the same 400 at `metadata.hidden`.

This strips `undefined` values in `request()` in `packages/core/src/permission.ts`, the one place every pending request is constructed for both `assert` and `ask`. That covers every field above without touching either tool, and protects the event publish path as well as the list and get endpoints. I re-audited the `permission.assert` and `permission.ask` call sites on current `v2`: `glob` and `grep` are still the only ones passing raw optional inputs through. The one nested value, `files` in the patch tool, is a typed `FileDiff.Info` built from the diff rather than from tool input, so a shallow strip is still sufficient. A deep JSON round trip was rejected because it would silently normalize values that should fail loudly.

### How did you verify your code works?

One regression test: ask for a permission whose metadata contains `undefined` values, then assert the pending request omits those keys. On current `v2` it fails without the fix and passes with it. The permission suite in `packages/core` (104 tests) and the `packages/core` typecheck pass. I also previously reproduced the reported error against the JSON value codec with the old metadata shape and confirmed the stripped shape encodes cleanly.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

https://claude.ai/code/session_01VfnVqHyavHygRQS2KBChYb
