### PR TITLE
fix(core): attribute deferred skill plugin failures

### DIFF
--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -1634,7 +1634,7 @@ export function make(options: ClientOptions) {
             path: `/api/skill`,
             query: { location: input?.["location"] },
             successStatus: 200,
-            declaredStatuses: [400, 401],
+            declaredStatuses: [400, 401, 500],
             empty: false,
           },
           requestOptions,

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -2488,6 +2488,15 @@ export type PermissionNotFoundError = {
 export const isPermissionNotFoundError = (value: unknown): value is PermissionNotFoundError =>
   typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "PermissionNotFoundError"
 
+export type PluginCallbackError = {
+  readonly _tag: "PluginCallbackError"
+  readonly pluginID: string
+  readonly operation: "skill.transform"
+  readonly message: string
+}
+export const isPluginCallbackError = (value: unknown): value is PluginCallbackError =>
+  typeof value === "object" && value !== null && "_tag" in value && value["_tag"] === "PluginCallbackError"
+
 export type RpcError = {
   readonly _tag: "RpcError"
   readonly type: string

--- a/packages/client/test/effect.test.ts
+++ b/packages/client/test/effect.test.ts
@@ -15,6 +15,23 @@ import {
 
 const synced = { type: "log.synced" as const, aggregateID: "ses_test", seq: Event.Seq.make(1) }
 
+test("skill.list decodes a declared plugin callback failure", async () => {
+  const failure = {
+    _tag: "PluginCallbackError",
+    pluginID: "broken-skills",
+    operation: "skill.transform",
+    message: 'Plugin "broken-skills" failed during skill.transform. Check server logs for details.',
+  }
+  const httpClient = HttpClient.make((request) =>
+    Effect.succeed(HttpClientResponse.fromWeb(request, Response.json(failure, { status: 500 }))),
+  )
+  const error = await Effect.gen(function* () {
+    const client = yield* OpenCode.make({ baseUrl: "http://localhost:3000" })
+    return yield* client.skill.list().pipe(Effect.flip)
+  }).pipe(Effect.provideService(HttpClient.HttpClient, httpClient), Effect.runPromise)
+  expect(error).toMatchObject(failure)
+})
+
 test("health.get decodes the readiness response", async () => {
   const httpClient = HttpClient.make((request) =>
     Effect.succeed(HttpClientResponse.fromWeb(request, Response.json({ healthy: true, version: "old", pid: 123 }))),

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -1,5 +1,20 @@
 import { expect, test } from "bun:test"
-import { isSessionNotFoundError, isUnauthorizedError, OpenCode } from "../src/promise/index"
+import { isPluginCallbackError, isSessionNotFoundError, isUnauthorizedError, OpenCode } from "../src/promise/index"
+
+test("skill.list preserves a declared plugin callback failure", async () => {
+  const failure = {
+    _tag: "PluginCallbackError",
+    pluginID: "broken-skills",
+    operation: "skill.transform",
+    message: 'Plugin "broken-skills" failed during skill.transform. Check server logs for details.',
+  }
+  const client = OpenCode.make({
+    baseUrl: "http://localhost:3000",
+    fetch: async () => Response.json(failure, { status: 500 }),
+  })
+  await expect(client.skill.list()).rejects.toEqual(failure)
+  expect(isPluginCallbackError(failure)).toBe(true)
+})
 
 test("exposes every standard HTTP API group", () => {
   const client = OpenCode.make({ baseUrl: "http://localhost:3000" })

--- a/packages/core/src/plugin.ts
+++ b/packages/core/src/plugin.ts
@@ -43,9 +43,7 @@ const layer = Layer.effect(
     const load = Effect.fnUntraced(function* (plugin: Generation) {
       const child = yield* Scope.fork(scope)
       const inherit = yield* State.inherit()
-      const loaded = yield* Effect.suspend(() =>
-        plugin.effect({ ...host, storage: PluginHost.storage(kv, plugin.id) }),
-      ).pipe(
+      const loaded = yield* Effect.suspend(() => plugin.effect(PluginHost.forPlugin(host, kv, plugin.id))).pipe(
         inherit,
         Effect.updateContext((context: Context.Context<never>) =>
           Context.make(Scope.Scope, child).pipe(

--- a/packages/core/src/plugin/callback.ts
+++ b/packages/core/src/plugin/callback.ts
@@ -1,0 +1,14 @@
+export * as PluginCallback from "./callback.js"
+
+import { Data } from "effect"
+
+/** Local failure detail. Transport boundaries must explicitly select public fields. */
+export class Error extends Data.TaggedError("PluginCallbackError")<{
+  readonly pluginID: string
+  readonly operation: "skill.transform"
+  readonly cause: unknown
+}> {
+  override get message() {
+    return `Plugin "${this.pluginID}" failed during ${this.operation}.`
+  }
+}

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -33,6 +33,7 @@ import { WebSearch } from "../websearch.js"
 import { Generate } from "../generate.js"
 import { Permission } from "../permission.js"
 import { PluginHooks } from "./hooks.js"
+import { PluginCallback } from "./callback.js"
 import type { Interface } from "../plugin.js"
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
 
@@ -517,6 +518,25 @@ export const requirements = LayerNode.group([
   PersistentPty.node,
   LocationServiceMap.node,
 ])
+
+export function forPlugin(host: Plugin.Context, kv: KV.Interface, pluginID: string): Plugin.Context {
+  return {
+    ...host,
+    storage: storage(kv, pluginID),
+    skill: {
+      ...host.skill,
+      transform: (callback) =>
+        host.skill.transform((editor) => {
+          try {
+            callback(editor)
+          } catch (cause) {
+            // Replay happens after setup, potentially in a different consumer's Effect context.
+            throw new PluginCallback.Error({ pluginID, operation: "skill.transform", cause })
+          }
+        }),
+    },
+  }
+}
 
 export function storage(kv: KV.Interface, pluginID: string): Plugin.Context["storage"] {
   const namespace = `plugin:${pluginID

--- a/packages/core/test/plugin/skill-failures.test.ts
+++ b/packages/core/test/plugin/skill-failures.test.ts
@@ -1,0 +1,95 @@
+import { expect } from "bun:test"
+import { Cause, Effect, Exit } from "effect"
+import { Plugin } from "@opencode-ai/core/plugin"
+import { Skill } from "@opencode-ai/core/skill"
+import { AbsolutePath } from "@opencode-ai/schema/schema"
+import { testEffect } from "../lib/effect"
+import { PluginTestLayer } from "./fixture"
+
+const it = testEffect(PluginTestLayer)
+const skill = {
+  id: Skill.ID.make("review"),
+  name: Skill.Name.make("Review"),
+  description: "Review changes",
+  location: AbsolutePath.make("/fixture/review.md"),
+  content: "Review changes",
+}
+
+for (const cause of [new TypeError("synthetic-private-detail"), "synthetic-private-detail"]) {
+  it.effect(`attributes a deferred skill transform throwing ${typeof cause}`, () =>
+    Effect.gen(function* () {
+      const plugins = yield* Plugin.Service
+      const skills = yield* Skill.Service
+      let setup = false
+      const activation = yield* plugins
+        .activate([
+          {
+            id: "healthy",
+            revision: "1",
+            effect: (ctx) => ctx.skill.transform((editor) => editor.add(skill)).pipe(Effect.asVoid),
+          },
+          {
+            id: "broken-skills",
+            revision: "1",
+            effect: (ctx) =>
+              Effect.gen(function* () {
+                yield* ctx.skill.transform((editor) => {
+                  editor.remove(skill.id)
+                  throw cause
+                })
+                setup = true
+              }),
+          },
+        ])
+        .pipe(Effect.exit)
+
+      expect(setup).toBe(true)
+      // Neither a partial fold nor the old value is returned after failure. Every read retries.
+      for (const exit of [
+        activation,
+        yield* skills.list().pipe(Effect.asVoid, Effect.exit),
+        yield* skills.get(skill.id).pipe(Effect.asVoid, Effect.exit),
+      ]) {
+        if (Exit.isSuccess(exit)) throw new Error("Expected a failed skill fold")
+        expect(Cause.hasFails(exit.cause)).toBe(false)
+        expect(Cause.squash(exit.cause)).toMatchObject({
+          _tag: "PluginCallbackError",
+          pluginID: "broken-skills",
+          operation: "skill.transform",
+          message: 'Plugin "broken-skills" failed during skill.transform.',
+          cause,
+        })
+      }
+
+      // Only an explicit registration change removes the failure; nothing is silently disabled.
+      yield* plugins.activate([
+        {
+          id: "healthy",
+          revision: "1",
+          effect: (ctx) => ctx.skill.transform((editor) => editor.add(skill)).pipe(Effect.asVoid),
+        },
+      ])
+      expect(yield* skills.list()).toEqual([skill])
+    }),
+  )
+}
+
+it.effect("keeps setup failures distinct from deferred callback failures", () =>
+  Effect.gen(function* () {
+    const plugins = yield* Plugin.Service
+    const skills = yield* Skill.Service
+    yield* plugins.activate([
+      { id: "setup-failure", revision: "1", effect: () => Effect.die(new Error("fixture setup failed")) },
+      {
+        id: "healthy",
+        revision: "1",
+        effect: (ctx) => ctx.skill.transform((editor) => editor.add(skill)).pipe(Effect.asVoid),
+      },
+    ])
+    expect((yield* plugins.list()).find((plugin) => plugin.id === "setup-failure")?.state).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("fixture setup failed"),
+    })
+    expect(yield* skills.list()).toEqual([skill])
+  }),
+)

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -9259,6 +9259,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "PluginCallbackError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginCallbackErrorEncoded"
+                }
+              }
+            }
           }
         },
         "description": "Retrieve currently registered skills.",
@@ -16983,6 +16993,27 @@
             "additionalProperties": false
           }
         ]
+      },
+      "PluginCallbackErrorEncoded": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["PluginCallbackError"]
+          },
+          "pluginID": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string",
+            "enum": ["skill.transform"]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "pluginID", "operation", "message"],
+        "additionalProperties": false
       },
       "Project": {
         "type": "object",

--- a/packages/protocol/src/errors.ts
+++ b/packages/protocol/src/errors.ts
@@ -1,5 +1,16 @@
 import { Schema } from "effect"
 import { Skill } from "@opencode-ai/schema/skill"
+import { Plugin } from "@opencode-ai/schema/plugin"
+
+export class PluginCallbackError extends Schema.TaggedError<PluginCallbackError>()(
+  "PluginCallbackError",
+  {
+    pluginID: Plugin.ID,
+    operation: Schema.Literal("skill.transform"),
+    message: Schema.String,
+  },
+  { httpApiStatus: 500 },
+) {}
 
 export class InvalidRequestError extends Schema.TaggedError<InvalidRequestError>()(
   "InvalidRequestError",

--- a/packages/protocol/src/groups/skill.ts
+++ b/packages/protocol/src/groups/skill.ts
@@ -3,12 +3,14 @@ import { Location } from "@opencode-ai/schema/location"
 import { Schema } from "effect"
 import { HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
 import { LocationQuery, locationQueryOpenApi } from "./location.js"
+import { PluginCallbackError } from "../errors.js"
 
 export const SkillGroup = HttpApiGroup.make("server.skill")
   .add(
     HttpApiEndpoint.get("skill.list", "/api/skill", {
       query: LocationQuery,
       success: Location.response(Schema.Array(Skill.Info)),
+      error: PluginCallbackError,
     })
       .annotateMerge(locationQueryOpenApi)
       .annotateMerge(

--- a/packages/server/src/handlers/skill.ts
+++ b/packages/server/src/handlers/skill.ts
@@ -1,8 +1,29 @@
 import { Skill } from "@opencode-ai/core/skill"
+import { PluginCallback } from "@opencode-ai/core/plugin/callback"
+import { PluginCallbackError } from "@opencode-ai/protocol/errors"
+import { Plugin } from "@opencode-ai/schema/plugin"
+import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
 import { response } from "../location"
 
 export const SkillHandler = HttpApiBuilder.group(Api, "server.skill", (handlers) =>
-  handlers.handle("skill.list", () => response(Skill.Service.use((skill) => skill.list()))),
+  handlers.handle("skill.list", () =>
+    response(Skill.Service.use((skill) => skill.list())).pipe(
+      Effect.catchDefect((error) => {
+        if (!(error instanceof PluginCallback.Error)) return Effect.die(error)
+        return Effect.logError("Plugin callback failed", error).pipe(
+          Effect.andThen(
+            Effect.fail(
+              new PluginCallbackError({
+                pluginID: Plugin.ID.make(error.pluginID),
+                operation: error.operation,
+                message: `${error.message} Check server logs for details.`,
+              }),
+            ),
+          ),
+        )
+      }),
+    ),
+  ),
 )

--- a/packages/server/test/skill-failures.test.ts
+++ b/packages/server/test/skill-failures.test.ts
@@ -1,0 +1,129 @@
+import { expect } from "bun:test"
+import path from "node:path"
+import { SdkPlugins } from "@opencode-ai/core/plugin/sdk"
+import { Skill } from "@opencode-ai/core/skill"
+import { Plugin } from "@opencode-ai/plugin/effect"
+import { Context, Effect, Layer, Logger } from "effect"
+import { HttpEffect, HttpRouter, HttpServer } from "effect/unstable/http"
+import { tmpdirScoped } from "../../core/test/fixture/tmpdir"
+import { it } from "../../core/test/lib/effect"
+import { createRoutes } from "../src/routes"
+
+it.live("skill.list reports the failing plugin without exposing its exception", () =>
+  Effect.gen(function* () {
+    const tmp = yield* tmpdirScoped("opencode-skill-failures-")
+    const messages: unknown[] = []
+    const logger = Logger.make((options) => messages.push(options.message))
+    const context = yield* Layer.build(
+      createRoutes({
+        password: "secret",
+        database: { path: ":memory:" },
+        models: { fetch: false },
+        fs: { filewatcher: false },
+        config: { directory: path.join(tmp.path, "config"), project: false },
+      }).pipe(
+        Layer.provide(HttpServer.layerServices),
+        Layer.provideMerge(Logger.layer([logger], { mergeWithExisting: false })),
+      ),
+    )
+    const sdk = Context.get(context, SdkPlugins.Service)
+    const cause = new TypeError("synthetic-private-detail")
+    yield* sdk.register(
+      Plugin.define({
+        id: "broken-skills",
+        effect: (ctx) =>
+          ctx.skill
+            .transform(() => {
+              throw cause
+            })
+            .pipe(Effect.asVoid),
+      }),
+    )
+    const handler = Context.get(context, HttpRouter.HttpRouter)
+      .asHttpEffect()
+      .pipe(HttpEffect.toWebHandlerWith(context))
+    const request = (method: string, route: string) =>
+      Effect.promise(() =>
+        handler(
+          new Request(`http://opencode.local${route}?location[directory]=${encodeURIComponent(tmp.path)}`, {
+            method,
+            headers: { authorization: `Basic ${btoa("opencode:secret")}` },
+          }),
+        ),
+      )
+    expect((yield* request("POST", "/api/plugin/await-activation")).status).toBe(204)
+    // The directory is valid. A skill failure is not a location-not-found error.
+    expect((yield* request("GET", "/api/location")).status).toBe(200)
+    for (const attempt of [1, 2]) {
+      const response = yield* request("GET", "/api/skill")
+      expect(response.status).toBe(500)
+      const body = yield* Effect.promise(() => response.text())
+      expect(body).toContain('"PluginCallbackError"')
+      expect(JSON.parse(body)).toEqual({
+        _tag: "PluginCallbackError",
+        pluginID: "broken-skills",
+        operation: "skill.transform",
+        message: 'Plugin "broken-skills" failed during skill.transform. Check server logs for details.',
+      })
+      expect(body).not.toContain("synthetic-private-detail")
+      expect(body).not.toContain("TypeError")
+      expect(body).not.toContain(tmp.path)
+      expect(
+        messages.filter((message) => Array.isArray(message) && message[0] === "Plugin callback failed"),
+      ).toHaveLength(attempt)
+    }
+    expect(messages).toContainEqual([
+      "Plugin callback failed",
+      expect.objectContaining({ pluginID: "broken-skills", operation: "skill.transform", cause }),
+    ])
+  }).pipe(Effect.timeout("10 seconds")),
+)
+
+for (const scenario of [
+  { name: "unrelated defects", effect: Effect.die(new Error("unrelated-private-detail")), status: 500 },
+  // Effect's HTTP boundary maps server interruption to 503 (a client abort is 499).
+  { name: "interruption", effect: Effect.interrupt, status: 503 },
+]) {
+  it.live(`skill.list does not label ${scenario.name} as plugin callback failures`, () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped("opencode-skill-control-")
+      const context = yield* Layer.build(
+        createRoutes(
+          {
+            password: "secret",
+            database: { path: ":memory:" },
+            models: { fetch: false },
+            fs: { filewatcher: false },
+            config: { directory: tmp.path, project: false },
+          },
+          () => [],
+          [
+            Skill.node.replace(
+              Layer.succeed(
+                Skill.Service,
+                Skill.Service.of({
+                  list: () => scenario.effect,
+                  get: () => Effect.undefined,
+                  reload: () => Effect.void,
+                  transform: () => Effect.succeed({ dispose: Effect.void }),
+                }),
+              ),
+            ),
+          ],
+        ).pipe(Layer.provide(HttpServer.layerServices)),
+      )
+      const handler = Context.get(context, HttpRouter.HttpRouter)
+        .asHttpEffect()
+        .pipe(HttpEffect.toWebHandlerWith(context))
+      const response = yield* Effect.promise(() =>
+        handler(
+          new Request(`http://opencode.local/api/skill?location[directory]=${encodeURIComponent(tmp.path)}`, {
+            headers: { authorization: `Basic ${btoa("opencode:secret")}` },
+          }),
+        ),
+      )
+      expect(response.status).toBe(scenario.status)
+      expect(yield* Effect.promise(() => response.text())).toBe("")
+    }).pipe(Effect.timeout("10 seconds")),
+  )
+}

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -9259,6 +9259,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "PluginCallbackError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginCallbackErrorEncoded"
+                }
+              }
+            }
           }
         },
         "description": "Retrieve currently registered skills.",
@@ -16983,6 +16993,27 @@
             "additionalProperties": false
           }
         ]
+      },
+      "PluginCallbackErrorEncoded": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["PluginCallbackError"]
+          },
+          "pluginID": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string",
+            "enum": ["skill.transform"]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "pluginID", "operation", "message"],
+        "additionalProperties": false
       },
       "Project": {
         "type": "object",

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -9259,6 +9259,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "PluginCallbackError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PluginCallbackErrorEncoded"
+                }
+              }
+            }
           }
         },
         "description": "Retrieve currently registered skills.",
@@ -16983,6 +16993,27 @@
             "additionalProperties": false
           }
         ]
+      },
+      "PluginCallbackErrorEncoded": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["PluginCallbackError"]
+          },
+          "pluginID": {
+            "type": "string"
+          },
+          "operation": {
+            "type": "string",
+            "enum": ["skill.transform"]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "pluginID", "operation", "message"],
+        "additionalProperties": false
       },
       "Project": {
         "type": "object",


### PR DESCRIPTION
## Why

A plugin can finish setup successfully and then throw when its skill transform is replayed. Listing skills returns an empty HTTP 500, so clients report `UnexpectedStatus` without identifying the plugin or failed operation.

## What Changes

**Before:** a deferred callback throws an unattributed defect; `GET /api/skill` has no declared failure payload.

**After:** the callback retains its registering plugin ID and operation. The endpoint logs the original exception and returns a declared HTTP 500:

```json
{
  "_tag": "PluginCallbackError",
  "pluginID": "broken-skills",
  "operation": "skill.transform",
  "message": "Plugin \"broken-skills\" failed during skill.transform. Check server logs for details."
}
```

Both generated Promise and Effect clients preserve that error. The payload contains no exception text, stack, source path, or plugin configuration. Plugin IDs are the existing public inventory identifiers.

The Core callback still fails as a defect. HTTP translates only this recognized boundary failure into its declared error. Unrelated defects remain defects; server interruption retains the HTTP runtime's empty 503 response. Reads continue to fail until the broken registration is explicitly changed—no transform is skipped, disabled, or partially published.

## Scope

One reporting slice: deferred skill transforms and `skill.list`. This does not change plugin inventory health, setup-error reporting, other callback domains, or TUI presentation. In particular it does not infer that a directory is absent or recommend moving it. Pre-model presentation and safe isolation are separate work; this does not overlap the RPC handler changes in #46946 or the location/catalog UI changes in #46961.

## Verification

```sh
# packages/core
bun typecheck
bun run test test/plugin/skill-failures.test.ts --rerun-each 5
bun run test

# packages/server: isolated HOME/XDG/TMPDIR via the Core wrapper
bun run ../core/script/test.ts test/skill-failures.test.ts test/plugin-activation.test.ts --rerun-each 5
bun run ../core/script/test.ts
bun typecheck

# packages/client
bun run generate
bun run test
bun typecheck

# packages/protocol
bun run generate
bun typecheck
bun run check:generated

# packages/www
bun script/generate-openapi.ts
bun run check:generated
bun typecheck
bun run build

# worktree, normal pre-push hook enabled
git diff --check
git push -u origin skill-failures
```

- Red before implementation: two Core attribution cases failed on the raw thrown values. Before adding the HTTP mapping/contract, the real endpoint returned an empty 500 and both client tests failed on `UnexpectedStatus`/`ClientError`.
- Green: Core **4,024 passed, 39 skipped**; Server **53 passed, 3 skipped**; Client **147 passed**. Focused repeats: **15 Core + 30 Server/activation cases passed**.
- The real registry tests cover Error and non-Error throws, successful setup followed by deferred failure, repeat reads, explicit registration removal, and a healthy plugin. Server tests verify that location metadata still succeeds, the original cause reaches the logger, and only the intended public fields reach HTTP.
- Unrelated-defect and interruption controls pass. An initial test expected client-abort status 499 for a server interruption; inspecting the pinned Effect runtime confirmed its existing 503 behavior, and the corrected control passes repeatedly.
- Typechecks, generated OpenAPI checks, website build/link validation, and all **33** normal pre-push typecheck tasks passed. The simplify pass found no additional behavior-preserving cleanup worth adding.
- CI is green: Linux/Windows unit jobs, Linux/Windows end-to-end jobs, and typechecks passed. The first Windows unit attempt passed Server tests but exited 3 when Bun 1.4.0 segfaulted in the TUI suite (`panic(main thread): Segmentation fault`), with no assertion failure reported. The unchanged rerun passed, including compiled service lifecycle and Node build checks.
