### PR TITLE
fix(tui): show execution failures in the viewed session

### DIFF
--- a/packages/tui/src/feature-plugins/system/notifications.ts
+++ b/packages/tui/src/feature-plugins/system/notifications.ts
@@ -60,12 +60,16 @@ export default Plugin.define({
       context.data.on("session.execution.interrupted", (event) => ended(event.data.sessionID)),
       context.data.on("session.execution.failed", (event) => {
         const sessionID = event.data.sessionID
+        if (terminal.has(sessionID)) return
         if (errored.has(sessionID)) {
           ended(sessionID)
           return
         }
         errored.add(sessionID)
         notify(context, sessionID, event.data.error.message, "error")
+        const route = context.ui.router.current()
+        if (route.type === "session" && route.sessionID === sessionID)
+          context.ui.toast.show({ title: "Session failed", message: event.data.error.message, variant: "error" })
         ended(sessionID)
       }),
     ]

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -1368,6 +1368,58 @@ test.each(["manual", "select"] as const)(
   },
 )
 
+test.each([100, 44])(
+  "execution failure keeps the empty session composer and draft usable at width %s",
+  async (width) => {
+    await using state = await tmpdir()
+    const session = {
+      id: "ses_failure",
+      projectID: "proj_test",
+      location: { directory },
+      title: "Failure fixture",
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: 1, updated: 1 },
+    }
+    await using setup = await createAppFixture({
+      width,
+      state: state.path,
+      args: { sessionID: session.id },
+      config: { animations: false, tabs: { enabled: false } },
+      fetch: (url) => {
+        if (url.pathname === "/api/session") return json({ data: [session], cursor: {} })
+        if (url.pathname === `/api/session/${session.id}`) return json({ data: session })
+        if (url.pathname === `/api/session/${session.id}/message`) return json({ data: [], cursor: {} })
+        if ([`/api/session/${session.id}/inbox`, `/api/session/${session.id}/permission`].includes(url.pathname))
+          return json({ data: [] })
+        return undefined
+      },
+    })
+    await setup.ready
+    await setup.waitForFrame((frame) => frame.includes("commands"))
+    setup.mockInput.pressKey("u", { ctrl: true })
+    await setup.mockInput.typeText("Keep this draft")
+    await setup.waitForFrame((frame) => frame.includes("Keep this draft"))
+    setup.events.emit({
+      id: "evt_execution_failed",
+      created: 2,
+      type: "session.execution.failed",
+      durable: { aggregateID: session.id, seq: 1, version: 1 },
+      data: {
+        sessionID: session.id,
+        error: { type: "unknown", message: 'Plugin "broken-skills" failed during skill.transform.' },
+      },
+    })
+    await setup.waitForFrame((frame) => frame.includes("Session failed"))
+    expect(setup.captureCharFrame()).toContain("broken-skills")
+    expect(setup.captureCharFrame()).toContain("skill.transform")
+    expect(setup.captureCharFrame()).toContain("Keep this draft")
+    expect(setup.captureCharFrame()).not.toContain("Select directory")
+    await setup.mockInput.typeText(" intact")
+    await setup.waitForFrame((frame) => frame.includes("Keep this draft intact"))
+  },
+)
+
 async function createAppFixture(
   input: {
     width?: number

--- a/packages/tui/test/cli/cmd/tui/notifications.test.ts
+++ b/packages/tui/test/cli/cmd/tui/notifications.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test"
 import Notifications from "../../../../src/feature-plugins/system/notifications"
 import type { OpenCodeEvent, PermissionAsked } from "@opencode-ai/client"
-import type { AttentionNotifyOptions, Context } from "@opencode-ai/plugin/tui/context"
+import type { AttentionNotifyOptions, Context, Route, ToastOptions } from "@opencode-ai/plugin/tui/context"
 
 type Session = { id: string; title: string; parentID?: string }
 
-async function setup() {
+async function setup(route: Route = { type: "session", sessionID: "session" }) {
   const notifications: AttentionNotifyOptions[] = []
+  const toasts: ToastOptions[] = []
   const handlers = new Map<OpenCodeEvent["type"], ((event: OpenCodeEvent) => void)[]>()
   const session = (id: string, title: string, parentID?: string): Session => ({
     id,
@@ -21,6 +22,10 @@ async function setup() {
   }
 
   await Notifications.setup({
+    ui: {
+      router: { current: () => route },
+      toast: { show: (toast: ToastOptions) => toasts.push(toast) },
+    },
     attention: {
       async notify(input: AttentionNotifyOptions) {
         notifications.push(input)
@@ -52,6 +57,7 @@ async function setup() {
 
   return {
     notifications,
+    toasts,
     emit(event: OpenCodeEvent) {
       for (const handler of handlers.get(event.type) ?? []) handler(event)
     },
@@ -140,6 +146,27 @@ const permissionNotification: AttentionNotifyOptions = {
 }
 
 describe("internal notifications TUI plugin", () => {
+  test("shows execution failures in the viewed session without needing an assistant message", async () => {
+    const harness = await setup()
+    harness.emit(executionStarted("started"))
+    harness.emit(executionFailed("failed"))
+    harness.emit(executionFailed("duplicate"))
+    expect(harness.toasts).toEqual([{ title: "Session failed", message: "boom", variant: "error" }])
+    harness.emit(executionStarted("retry"))
+    harness.emit(executionFailed("failed-again"))
+    expect(harness.toasts).toHaveLength(2)
+  })
+
+  test.each<Route>([{ type: "home" }, { type: "session", sessionID: "other" }])(
+    "keeps other sessions' failures out of the current composer (%j)",
+    async (route) => {
+      const harness = await setup(route)
+      harness.emit(executionFailed("failed"))
+      expect(harness.toasts).toEqual([])
+      expect(harness.notifications).toHaveLength(1)
+    },
+  )
+
   test("notifies for form and permission requests with blurred notifications and always-on sounds", async () => {
     const harness = await setup()
 


### PR DESCRIPTION
## Why

A session can fail before the first model request and before an assistant message exists. The TUI receives `session.execution.failed`, but only plays a sound or sends a desktop notification when blurred. A user looking at the focused terminal gets no error explanation.

## What Changes

The currently viewed session now shows the execution event's error message in a nonblocking **Session failed** toast. This works without an assistant message and leaves the composer and draft in place.

| Event | In-app behavior |
| --- | --- |
| Viewed session fails | Show its failure message |
| Different session fails, or home is open | Keep existing attention behavior, no unrelated toast |
| Duplicate terminal failure | Do not repeat the notification |
| A new execution starts and fails | Show the new failure |

This uses the existing terminal-event tracking and toast component, with four production lines added. It neither fabricates an assistant message nor infers that the working directory is missing.

## Demo

https://github.com/user-attachments/assets/6e729609-46b9-4c9c-beb3-b745d0efdce7

Before `efefd90443`; after `e790e81dfc`. One identical OpenCode Drive script runs the production TUI at 100×30, with an intentionally unavailable fictional model (`fixture/unavailable`) and an isolated project/server. The real execution fails before any model call; both runs assert zero LLM requests and zero assistant messages. The prompt is submitted through the real API while the visible composer contains a separate draft.

The matched, unscaled four-second clips start at the failure checkpoint. Both continue typing ` intact`; only the changed TUI shows the error. No live service, user configuration, real provider, or real model is involved. Drive 2.0.1 source `f6a3f55`; no acceleration.

## Scope

This is live presentation for the viewed session, including pre-model failures. All viewed execution failures get the toast, even when another error is already visible in the transcript. The default toast lifetime is unchanged; this does not reconstruct past errors after reopening a session.

Independent of #46967, which adds plugin/operation attribution for deferred skill failures. No dependency on or changes to #46961's location/catalog recovery UI, and no move recommendation or automatic retry.

## Verification

```sh
# packages/tui
bun run test test/cli/cmd/tui/notifications.test.ts test/app-lifecycle.test.tsx -t 'execution failure'
bun run test test/cli/cmd/tui/notifications.test.ts test/app-lifecycle.test.tsx
bun run test test/cli/cmd/tui/notifications.test.ts test/app-lifecycle.test.tsx -t 'execution failure|other sessions' --rerun-each 5
bun run test
bun typecheck

# worktree, same untracked local script against each revision
OPENCODE_UNDER_TEST=/path/to/base DEMO_LABEL=BEFORE bun /path/to/opencode-drive/packages/drive/src/cli/index.ts run .drive-output/execution-toast.ts
OPENCODE_UNDER_TEST=/path/to/change DEMO_LABEL=AFTER bun /path/to/opencode-drive/packages/drive/src/cli/index.ts run .drive-output/execution-toast.ts
bun .drive-output/export-toast.ts

# normal pre-push hook enabled
git diff --check
git push -u origin execution-toast
```

- Red on base: the notification regression and both 100/44-column real-component tests fail because no toast appears. Green: **33 focused tests passed**, plus **25 repeated cases passed**.
- The real-component tests receive an attributed synthetic plugin failure through SSE, verify its plugin/operation text, and continue editing the existing draft at both widths.
- Package typecheck and all 33 normal pre-push typecheck tasks passed. The simplify pass found no additional cleanup worth folding into this slice.
- Full TUI suite: **1,180 passed, 4 skipped**, zero failures, two snapshots. GitHub CI is green, including Linux and Windows unit jobs and typechecking.
