### PR TITLE
fix(sdk): bind embedded transport at request time

### DIFF
--- a/packages/sdk/src/effect/opencode.ts
+++ b/packages/sdk/src/effect/opencode.ts
@@ -4,7 +4,7 @@ import { OpenCode, type OpenCodeClient } from "@opencode-ai/client/effect"
 import type { Workspace } from "@opencode-ai/core/workspace"
 import { Context, Effect, Layer } from "effect"
 import type { Config, Scope } from "effect"
-import { FetchHttpClient } from "effect/unstable/http"
+import { FetchHttpClient, HttpClient } from "effect/unstable/http"
 import { EmbeddedHost } from "../internal/host"
 import type { SdkInstances } from "../internal/instances"
 
@@ -35,9 +35,12 @@ export const create: <R = never>(
   R = never,
 >(options: CreateOptions<R> = {}, embed: EmbedOptions = {}) {
   const host = yield* Effect.acquireRelease(EmbeddedHost.create(options, embed), (host) => Effect.promise(host.close))
+  const httpClient = yield* HttpClient.HttpClient.pipe(Effect.provide(FetchHttpClient.layer))
   const client = yield* OpenCode.make({ baseUrl: "http://opencode.local" }).pipe(
-    Effect.provide(
-      FetchHttpClient.layer.pipe(Layer.provide(Layer.succeed(FetchHttpClient.Fetch, host.fetch)), Layer.fresh),
+    Effect.provideService(
+      HttpClient.HttpClient,
+      // FetchHttpClient reads Fetch at request time; callers must not replace this host's in-process transport.
+      HttpClient.transformResponse(httpClient, Effect.provideService(FetchHttpClient.Fetch, host.fetch)),
     ),
   )
 

--- a/packages/sdk/test/transport.test.ts
+++ b/packages/sdk/test/transport.test.ts
@@ -1,0 +1,65 @@
+import { expect } from "bun:test"
+import { Context, Effect, Exit, Layer, Scope, Stream } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
+import { tmpdirScoped } from "../../core/test/fixture/tmpdir"
+import { testEffect } from "../../core/test/lib/effect"
+import { AbsolutePath, Location, OpenCode, Session } from "../src/effect"
+
+const it = testEffect(Layer.empty)
+
+for (const entrypoint of ["create", "layer"] as const) {
+  it.live(`${entrypoint} keeps requests and streams on its own transport despite an ambient Fetch`, () =>
+    Effect.gen(function* () {
+      const directory = yield* tmpdirScoped()
+      const calls: string[] = []
+      const ambient = Object.assign(
+        (input: RequestInfo | URL) => {
+          calls.push(input instanceof Request ? input.url : String(input))
+          return Promise.reject(new Error("The caller's Fetch must not receive embedded SDK requests"))
+        },
+        { preconnect: () => undefined },
+      )
+      const parent = yield* Effect.scope
+      const scope = yield* Scope.fork(parent)
+      const options: OpenCode.CreateOptions = {
+        app: { version: "transport-test" },
+        config: { directory: directory.path, project: false, content: "{}" },
+        events: { persist: true },
+        models: { fetch: false },
+        fs: { filewatcher: false },
+      }
+      const client = yield* (
+        entrypoint === "create"
+          ? OpenCode.create(options).pipe(Scope.provide(scope))
+          : Layer.buildWithScope(OpenCode.layer(options), scope).pipe(Effect.map(Context.get(OpenCode.Service)))
+      ).pipe(Effect.provideService(FetchHttpClient.Fetch, ambient))
+
+      yield* Effect.gen(function* () {
+        expect(yield* client.health.get()).toMatchObject({ healthy: true, version: "transport-test" })
+        const session = yield* client.sessions.create({
+          location: Location.Ref.make({ directory: AbsolutePath.make(directory.path) }),
+        })
+        expect((yield* client.sessions.get({ sessionID: session.id })).id).toBe(session.id)
+        const events = yield* client.sessions.log({ sessionID: session.id }).pipe(Stream.runCollect)
+        expect(events.some((event) => event.type === "session.created")).toBe(true)
+        expect(yield* client.events.subscribe().pipe(Stream.take(1), Stream.runCollect)).toMatchObject([
+          { type: "server.connected" },
+        ])
+        expect(yield* client.sessions.get({ sessionID: Session.ID.create() }).pipe(Effect.flip)).toMatchObject({
+          _tag: "SessionNotFoundError",
+        })
+        // Binding the SDK's transport must not change the caller's surrounding context.
+        expect(yield* FetchHttpClient.Fetch).toBe(ambient)
+      }).pipe(Effect.provideService(FetchHttpClient.Fetch, ambient))
+      expect(calls).toEqual([])
+
+      yield* Scope.close(scope, Exit.void)
+      expect(
+        Exit.isFailure(
+          yield* client.health.get().pipe(Effect.provideService(FetchHttpClient.Fetch, ambient), Effect.exit),
+        ),
+      ).toBe(true)
+      expect(calls).toEqual([])
+    }),
+  )
+}


### PR DESCRIPTION
## Why

An Effect application that supplies `FetchHttpClient.Fetch` can accidentally redirect embedded SDK requests away from their in-process host. Even `client.health.get()` uses the caller's Fetch instead of the embedded router. The Core test harness's network guard exposed this in all three Effect instance tests.

Providing Fetch while constructing `FetchHttpClient.layer` is not sufficient: Effect resolves that reference when each request executes, and the caller's context can override the captured value.

## What Changes

Bind the owning host's Fetch around the HTTP response effect for every SDK request using `HttpClient.transformResponse` and `Effect.provideService`.

- **Before:** a caller-side Fetch override receives requests for `http://opencode.local`, causing failures or sending them to the wrong transport.
- **After:** SDK requests always use their embedded host, while the caller's surrounding Fetch remains unchanged.
- The same binding covers ordinary requests and stream establishment, including calls made through `OpenCode.layer`.
- Typed API errors and host shutdown still use the existing client and transport paths. The network guard is unchanged.

## Scope

This changes the shared Effect SDK constructor, also used by the Effect Workerd entrypoint. It does not change generated clients, public APIs, provider HTTP configuration, or Promise SDK behavior. The Slack consumer upgrade remains a follow-up after a published SDK contains the fix.

## Verification

Using Bun 1.4.0:

```sh
cd packages/sdk
bun run test test/transport.test.ts
bun run test test/transport.test.ts test/instances.test.ts test/instances-effect.test.ts test/instances-lifecycle.test.ts
bun typecheck
bun run test
cd ../..
bunx prettier --check packages/sdk/src/effect/opencode.ts packages/sdk/test/transport.test.ts
bunx oxlint packages/sdk/src/effect/opencode.ts packages/sdk/test/transport.test.ts
git diff --check
```

- New regression tests: **2 failed before the fix, 2 passed after**. They exercise both `create` and `layer` with a conflicting Fetch at construction and call time, real router requests, durable event reads, live event subscription, typed not-found errors, and calls after host closure. No global Fetch mutation or network listener is used.
- Focused transport/instance suite: **11 passed**, including all three previously failing Effect instance tests.
- SDK typecheck, formatting, lint, and whitespace checks passed.
- The unmodified pre-push workspace typecheck passed: **33 successful tasks**, 24 cached. No hooks were skipped.
- Broader SDK suite: **29 passed, 2 failed**. The remaining known failures are the existing plugin-backed web-search test (`websearch_provider_not_found`) and Promise event cancellation expectation (iterator completion instead of a transport error); neither test was changed here.
- No native Workerd or Slack deployment test was performed.
