### PR TITLE
fix(core): guide Mermaid diagram syntax

### DIFF
--- a/packages/core/src/instructions/builtins.ts
+++ b/packages/core/src/instructions/builtins.ts
@@ -53,6 +53,30 @@ const layer = Layer.effect(
                 changed: (_previous, date) => `Today's date is now: ${date}`,
               },
             }),
+            Instructions.make({
+              key: Instructions.Key.make("core/mermaid-guidance"),
+              codec: Schema.toCodecJson(Schema.String),
+              read: Effect.succeed(
+                [
+                  "# Mermaid diagrams",
+                  "- Use fenced code blocks labelled `mermaid`.",
+                  "- Put each diagram statement on its own line; do not use semicolons as statement separators.",
+                  "- In sequence-diagram message text, encode a literal semicolon as `#59;`, or reword with a comma.",
+                  "- Close each structural block such as `opt`, `alt`, or `loop` with `end`.",
+                  "",
+                  "Example:",
+                  "```mermaid",
+                  "sequenceDiagram",
+                  "    Agent->>Plugin: Check permissions#59; create pending request",
+                  "    Plugin-->>Agent: Structured result",
+                  "```",
+                ].join("\n"),
+              ),
+              render: {
+                initial: (guidance) => guidance,
+                changed: (_previous, guidance) => guidance,
+              },
+            }),
           ]),
         ),
     })

--- a/packages/core/test/instructions/builtins.test.ts
+++ b/packages/core/test/instructions/builtins.test.ts
@@ -36,7 +36,7 @@ const it = testEffect(
 )
 
 describe("InstructionBuiltIns", () => {
-  it.effect("loads location-scoped environment and host-local date instructions", () =>
+  it.effect("loads environment, date, and shared Mermaid instructions", () =>
     Effect.gen(function* () {
       yield* TestClock.setTime(timestamp)
       const context = yield* InstructionBuiltIns.Service
@@ -55,6 +55,19 @@ describe("InstructionBuiltIns", () => {
           "</env>",
           "",
           `Today's date: ${localDate(timestamp)}`,
+          "",
+          "# Mermaid diagrams",
+          "- Use fenced code blocks labelled `mermaid`.",
+          "- Put each diagram statement on its own line; do not use semicolons as statement separators.",
+          "- In sequence-diagram message text, encode a literal semicolon as `#59;`, or reword with a comma.",
+          "- Close each structural block such as `opt`, `alt`, or `loop` with `end`.",
+          "",
+          "Example:",
+          "```mermaid",
+          "sequenceDiagram",
+          "    Agent->>Plugin: Check permissions#59; create pending request",
+          "    Plugin-->>Agent: Structured result",
+          "```",
         ].join("\n"),
       )
     }),


### PR DESCRIPTION
- Add shared Mermaid guidance that remains available when model-specific plugins replace the base system prompt.
- Recommend one statement per line, `#59;` for literal semicolons in sequence messages, and matching `end` statements. Leave rendering and source text unchanged.

```mermaid
sequenceDiagram
    Agent->>Plugin: Check permissions#59; create pending request
    Plugin-->>Agent: Structured result
```
