### PR TITLE
docs: add OrcaReplay to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay)                              | Record an OpenCode run, replay it offline, fork it onto a model  |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #

No issue. The ecosystem page says "Want to add your OpenCode related project to this list? Submit a PR."

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one row to the Projects table in `packages/web/src/content/docs/ecosystem.mdx`.

The project is OrcaReplay. It records an OpenCode session and lets you replay it later with the network off, or re-run it from a chosen step on a different model.

Why it needed work specific to OpenCode: most agents read a base-URL env var, so a proxy can be put in front of them by setting one variable. OpenCode keeps its provider origin in `opencode.json` instead, so there is nothing to redirect. The adapter handles it by intercepting the TLS OpenCode opens itself, using a throwaway CA that only the launched process trusts and that is deleted when the run ends. Your `opencode.json` is not modified.

I only touched the English file. Tell me if the translated copies should be updated in the same PR and I will add them.

### How did you verify your code works?

Docs only, no code. To be straight about what I did and did not do: I did **not** run the site build locally, so I am relying on CI for that.

What I did check:

- The diff is one added row inside the existing Projects table. No other lines touched, pipes and column order match the rows around it.
- The link resolves: https://github.com/Continuum-AI-Corp/OrcaReplay
- The description in the row matches what the tool actually does. `orca record opencode` records a session, `orca replay last` replays it with the network off, `orca replay last --from N --model X` re-runs from a step on another model. The OpenCode adapter has tests in that repo.

If the web build is expected to be run before submitting, say so and I will clone and run it.

### Screenshots / recordings

Not a UI change, docs table only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
