### PR TITLE
fix(session-ui): preserve configured groups on tool failure

### DIFF
--- a/packages/app/e2e/regression/session-timeline-reducer-projection.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-reducer-projection.spec.ts
@@ -138,7 +138,7 @@ test("combines follow-up patches into one three-file stack inside Used", async (
   await expect(group.locator('[data-slot="apply-patch-filename"]')).toHaveText(["a.ts", "b.ts", "c.ts"])
 })
 
-test("keeps failed search calls and their error cards outside the collapsed stack", async ({ page }) => {
+test("keeps failed search calls and their error cards inside the collapsed stack", async ({ page }) => {
   const parts = [
     toolPart(
       "prt_error_glob",
@@ -161,9 +161,14 @@ test("keeps failed search calls and their error cards outside the collapsed stac
   ]
   await setupTimeline(page, { messages: [userMessage(), assistantMessage(parts)] })
 
-  await expect(page.locator('[data-component="collapsed-tool-group"]')).toHaveCount(0)
-  await expect(page.locator('[data-kind="tool-error-card"]')).toHaveCount(2)
-  const glob = page.locator('[data-timeline-part-id="prt_error_glob"]')
+  const group = page.locator('[data-component="collapsed-tool-group"]')
+  const summary = group.getByRole("button", { name: "Used 1 Glob, 1 Grep", exact: true })
+  await expect(summary).toHaveAttribute("aria-expanded", "false")
+  await summary.click()
+  await expect(group.locator('[data-kind="tool-error-card"]')).toHaveCount(2)
+  const glob = group.locator('[data-timeline-part-id="prt_error_glob"]')
+  await expect(glob.getByRole("button")).toHaveAttribute("aria-expanded", "false")
+  await glob.getByRole("button").click()
   await expect(glob).toContainText("Invalid tool input")
   await expect(glob.locator('[data-component="tool-error-card-icon"]')).toBeVisible()
   await expect(glob.locator('[data-component="tool-error-card-icon"] use')).toHaveAttribute(
@@ -177,7 +182,8 @@ test("keeps failed search calls and their error cards outside the collapsed stac
         .evaluate((element) => getComputedStyle(element, "::before").display),
     )
     .toBe("none")
-  await expect(page.locator('[data-timeline-part-id="prt_error_grep"]')).toContainText(
+  await group.locator('[data-timeline-part-id="prt_error_grep"]').getByRole("button").click()
+  await expect(group.locator('[data-timeline-part-id="prt_error_grep"]')).toContainText(
     "Search timed out after 30 seconds",
   )
 })

--- a/packages/app/e2e/regression/session-timeline-tool-projection.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-tool-projection.spec.ts
@@ -8,13 +8,11 @@ import {
   userMessage,
 } from "../performance/timeline-stability/fixture"
 
-test("transitions shell and question through running error outcomes", async ({ page }) => {
+test("keeps shell and question failures in their Used group", async ({ page }) => {
   const shellID = "prt_transition_error_shell"
   const questionID = "prt_transition_error_question"
   const timeline = await setupTimeline(page, {
-    settings: {
-      timelineDetail: { ...timelinePresets[2].value, shell: { placement: "separate", details: "expanded" } },
-    },
+    settings: { timelineDetail: timelinePresets[2].value },
     messages: [
       userMessage(),
       assistantMessage(
@@ -26,13 +24,24 @@ test("transitions shell and question through running error outcomes", async ({ p
       ),
     ],
   })
+  const group = page.locator('[data-component="collapsed-tool-group"]')
+  const used = group.locator(':scope > [data-component="collapsible"] > [data-slot="collapsible-trigger"]')
+  await used.click()
   await expect(page.locator(`[data-timeline-part-id="${questionID}"]`)).toHaveCount(0)
   await timeline.send(partUpdated(toolPart(shellID, "shell", "running", { command: "exit 1" })))
   await expect(page.locator(`[data-timeline-part-id="${shellID}"]`)).toContainText("exit 1")
   await timeline.send(partUpdated(toolPart(questionID, "question", "running", questionInput())))
   await expect(page.locator(`[data-timeline-part-id="${questionID}"]`)).toHaveCount(0)
   await timeline.send(
-    partUpdated(toolPart(shellID, "shell", "error", { command: "exit 1" }, { error: "Command exited 1" })),
+    partUpdated(
+      toolPart(
+        shellID,
+        "shell",
+        "completed",
+        { command: "exit 1" },
+        { output: "Command exited 1", metadata: { exit: 1 } },
+      ),
+    ),
   )
   await timeline.send(
     partUpdated(
@@ -40,17 +49,21 @@ test("transitions shell and question through running error outcomes", async ({ p
     ),
   )
 
-  await expect(page.locator(`[data-timeline-part-id="${shellID}"] [data-kind="tool-error-card"]`)).toBeVisible()
-  await expect(page.locator(`[data-timeline-part-id="${questionID}"]`)).toContainText(/dismissed/i)
+  await expect(group).toHaveAttribute("data-timeline-part-ids", `${shellID},${questionID}`)
+  await expect(used).toHaveAttribute("aria-expanded", "true")
+  const shell = group.locator(`[data-timeline-part-id="${shellID}"]`)
+  await expect(shell.locator('[data-slot="collapsible-trigger"]')).toHaveAttribute("aria-expanded", "false")
+  await shell.locator('[data-slot="collapsible-trigger"]').click()
+  await expect(shell).toContainText("Command exited 1")
+  const question = group.locator(`[data-timeline-part-id="${questionID}"]`)
+  await expect(question).toContainText(/dismissed/i)
 })
 
-test("preserves surviving grouped patch state when its first patch fails", async ({ page }) => {
+test("keeps a failed patch in Used without losing the surviving file choice", async ({ page }) => {
   const failed = "prt_grouped_patch_failed"
   const surviving = "prt_grouped_patch_surviving"
   const timeline = await setupTimeline(page, {
-    settings: {
-      timelineDetail: { ...timelinePresets[2].value, edit: { placement: "separate", details: "collapsed" } },
-    },
+    settings: { timelineDetail: timelinePresets[2].value },
     messages: [
       userMessage(),
       assistantMessage(
@@ -81,7 +94,9 @@ test("preserves surviving grouped patch state when its first patch fails", async
     ],
   })
 
-  const group = page.locator(`[data-timeline-part-ids="${failed},${surviving}"]`)
+  const group = page.locator('[data-component="collapsed-tool-group"]')
+  const used = group.locator(':scope > [data-component="collapsible"] > [data-slot="collapsible-trigger"]')
+  await used.click()
   const file = group.locator('[data-scope="apply-patch"] button')
   await expect(file).toBeVisible()
   await expect(file).toHaveAttribute("aria-expanded", "false")
@@ -104,18 +119,14 @@ test("preserves surviving grouped patch state when its first patch fails", async
   const survivingRow = page.locator("[data-timeline-key]", {
     has: page.locator(`[data-timeline-part-id="${surviving}"]`),
   })
-  await expect(failedRow).toHaveAttribute("data-timeline-key", /^assistant-part:part:/)
-  await expect(survivingRow).toHaveAttribute("data-timeline-key", /^assistant-part:file:/)
+  await expect(group).toHaveAttribute("data-timeline-part-ids", `${failed},${surviving}`)
+  await expect(used).toHaveAttribute("aria-expanded", "true")
+  await expect(failedRow).toHaveAttribute("data-timeline-key", /^assistant-part:context:/)
+  await expect(survivingRow).toHaveAttribute("data-timeline-key", /^assistant-part:context:/)
+  await group.locator(`[data-timeline-part-id="${failed}"] [data-slot="collapsible-trigger"]`).click()
   await expect(failedRow.getByText("Patch failed visibly")).toBeVisible()
   await expect(survivingRow).toHaveAttribute("data-group-identity", "preserved")
   await expect(survivingRow.locator('[data-scope="apply-patch"] button')).toHaveAttribute("aria-expanded", "true")
-  await expect
-    .poll(async () => {
-      const previous = await failedRow.boundingBox()
-      const next = await survivingRow.boundingBox()
-      return previous && next ? next.y - (previous.y + previous.height) : Number.NEGATIVE_INFINITY
-    })
-    .toBeGreaterThanOrEqual(-0.5)
 })
 
 test("groups instruction files loaded by the same read", async ({ page }) => {

--- a/packages/session-ui/src/timeline/projection.ts
+++ b/packages/session-ui/src/timeline/projection.ts
@@ -271,9 +271,7 @@ export namespace Timeline {
             detail,
             new Set(
               messages
-                .filter(
-                  (message) => timelineNoticeRequired(message) || (message.type === "shell" && shellFailed(message)),
-                )
+                .filter((message) => message.type === "compaction" && timelineNoticeRequired(message))
                 .map((message) => message.id),
             ),
           )
@@ -321,7 +319,8 @@ export namespace Timeline {
       const refs = messages.flatMap((message, messageIndex) =>
         contentEntries(message)
           .filter(
-            (entry) => isRenderable(entry.content, showReasoning, detail) && !(thinking && entry.content === lastContent),
+            (entry) =>
+              isRenderable(entry.content, showReasoning, detail) && !(thinking && entry.content === lastContent),
           )
           .map((entry) => ({ messageID: message.id, messageIndex, partID: entry.id, content: entry.content })),
       )
@@ -662,9 +661,10 @@ function toolGroupType(
   detail?: TimelineDetail,
 ) {
   if (detail) {
-    if (currentToolFailed(content) || content.name === "question") return undefined
+    if (content.name === "question" && !currentToolFailed(content)) return undefined
     const category = timelineCategory(content)!
     if (detail[category].placement === "grouped") return "context"
+    if (currentToolFailed(content)) return undefined
     if (content.name === "patch") return "patch"
     if (content.name === "edit") return "edit"
     return undefined

--- a/packages/session-ui/src/timeline/session-timeline-row.tsx
+++ b/packages/session-ui/src/timeline/session-timeline-row.tsx
@@ -71,6 +71,8 @@ export function createSessionTimelineRowRenderer(input: {
     input.projection.rows().forEach((row) => {
       if (row._tag !== "AssistantPart" || row.group.type !== "context") return
       row.group.refs.forEach((ref) => {
+        const content = Timeline.resolveContent(input.projection.messageByID().get(ref.messageID), ref.partID)
+        if (content?.type !== "tool" || content.name !== "patch" || content.state.status === "error") return
         const part = `${ref.messageID}:${ref.partID}`
         const key = patchGroupKeys.get(part)
         if (key && !owners.has(key)) owners.set(key, part)
@@ -273,8 +275,14 @@ export function createSessionTimelineRowRenderer(input: {
 
   function contentDefaultOpen(item: SessionMessageAssistant["content"][number]) {
     if (input.timelineDetail) {
-      if (item.type === "tool" && currentToolFailed(item)) return true
       const category = timelineCategory(item)
+      if (
+        category &&
+        input.timelineDetail()[category].placement === "hidden" &&
+        item.type === "tool" &&
+        currentToolFailed(item)
+      )
+        return true
       if (category === "shell" || category === "edit" || category === "thinking")
         return input.timelineDetail()[category].details === "expanded"
     }
@@ -488,8 +496,8 @@ export function createSessionTimelineRowRenderer(input: {
       const value = message()
       return (
         input.timelineDetail().shell.details === "expanded" ||
-        value?.status === "timeout" ||
-        (value?.status === "exited" && value.exit !== undefined && value.exit !== 0)
+        (input.timelineDetail().shell.placement === "hidden" &&
+          (value?.status === "timeout" || (value?.status === "exited" && value.exit !== undefined && value.exit !== 0)))
       )
     })
     return (


### PR DESCRIPTION
- Keep failed tools and shell results in `Used …` when their category is Grouped.
- Respect the selected Collapsed/Expanded setting and retain surviving patch-file choices after a failure.
- Leave hidden-mode visibility and session-level error behavior unchanged.

| Before | After |
| --- | --- |
| ![Failures forced outside Used](https://github.com/user-attachments/assets/fa1677e6-011f-4921-87a4-30f0ab737eba) | ![Failures retained inside Used](https://github.com/user-attachments/assets/82741ac1-1537-45f7-be05-ba780412497c) |
