### PR TITLE
fix(opencode): skip ignored files during project icon discovery

### DIFF
--- a/packages/opencode/src/project/project.ts
+++ b/packages/opencode/src/project/project.ts
@@ -1,4 +1,5 @@
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import path from "path"
 import { and, eq, sql } from "drizzle-orm"
 import { Database } from "@opencode-ai/core/database/database"
 import { ProjectDirectoryTable, ProjectTable } from "@opencode-ai/core/project/sql"
@@ -15,6 +16,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { AppProcess } from "@opencode-ai/core/process"
 import { ProjectV2 } from "@opencode-ai/core/project"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { serviceUse } from "@opencode-ai/core/effect/service-use"
@@ -31,6 +33,10 @@ export const Event = {
 }
 
 type Row = typeof ProjectTable.$inferSelect
+
+// The project icon is the shallowest favicon in the worktree, so only enough
+// candidates to pick a winner are needed.
+const ICON_CANDIDATE_LIMIT = 100
 
 export function fromRow(row: Row): Info {
   const icon =
@@ -107,6 +113,7 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const fs = yield* FSUtil.Service
+    const ripgrep = yield* Ripgrep.Service
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const projectV2 = yield* ProjectV2.Service
     const projectDirectories = yield* ProjectDirectories.Service
@@ -314,19 +321,24 @@ const layer = Layer.effect(
       if (input.icon?.override) return
       if (input.icon?.url) return
 
-      const matches = yield* fs
-        .glob("**/favicon.{ico,png,svg,jpg,jpeg,webp}", {
+      // Ripgrep honours .gitignore, so build artifacts and vendored trees are
+      // pruned at the directory level. A plain recursive glob walks every entry
+      // in the worktree instead, which costs tens of seconds on large projects
+      // and can pick a dependency's favicon over the project's own.
+      const matches = yield* ripgrep
+        .glob({
           cwd: input.worktree,
-          absolute: true,
-          include: "file",
+          pattern: "**/favicon.{ico,png,svg,jpg,jpeg,webp}",
+          limit: ICON_CANDIDATE_LIMIT,
         })
         .pipe(Effect.orDie)
-      const shortest = matches.sort((a, b) => a.length - b.length)[0]
+      const shortest = matches.map((entry) => entry.path.toString()).sort((a, b) => a.length - b.length)[0]
       if (!shortest) return
 
-      const buffer = yield* fs.readFile(shortest).pipe(Effect.orDie)
+      const file = path.resolve(input.worktree, shortest)
+      const buffer = yield* fs.readFile(file).pipe(Effect.orDie)
       const base64 = Buffer.from(buffer).toString("base64")
-      const mime = FSUtil.mimeType(shortest)
+      const mime = FSUtil.mimeType(file)
       const url = `data:${mime};base64,${base64}`
       yield* update({ projectID: input.id, icon: { url } }).pipe(
         Effect.catchTag("Project.NotFoundError", () => Effect.void),
@@ -470,6 +482,7 @@ export const node = LayerNode.make({
   layer: layer,
   deps: [
     FSUtil.node,
+    Ripgrep.node,
     AppProcess.node,
     CrossSpawnSpawner.node,
     ProjectV2.node,

--- a/packages/opencode/test/project/project.test.ts
+++ b/packages/opencode/test/project/project.test.ts
@@ -95,7 +95,9 @@ const iconDiscoveryIt = testEffect(
   AppNodeBuilder.build(projectTestNode, [[RuntimeFlags.node, RuntimeFlags.layer({ experimentalIconDiscovery: true })]]),
 )
 
-function waitForProjectIcon(id: ProjectV2.ID, attempts = 50): Effect.Effect<Project.Info, never, Project.Service> {
+// Discovery shells out to ripgrep, so the readiness budget has to cover a
+// subprocess spawn plus one-time binary resolution, not just an in-process walk.
+function waitForProjectIcon(id: ProjectV2.ID, attempts = 300): Effect.Effect<Project.Info, never, Project.Service> {
   return Effect.gen(function* () {
     const project = yield* Project.Service
     const info = yield* project.get(id)
@@ -447,6 +449,26 @@ describe("Project.discover", () => {
       const updated = yield* project.get(result.project.id)
       expect(updated).toBeDefined()
       expect(updated!.icon).toBeUndefined()
+    }),
+  )
+
+  it.live("should not discover favicon in a gitignored directory", () =>
+    Effect.gen(function* () {
+      const project = yield* Project.Service
+      const tmp = yield* tmpdirScoped({ git: true })
+      const result = yield* project.fromDirectory(tmp)
+
+      const pngData = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+      yield* Effect.promise(() => Bun.write(path.join(tmp, ".gitignore"), "dep/\n"))
+      // Shorter path than the tracked icon, so it would win the shortest-path
+      // tie-break if the scan did not honour .gitignore.
+      yield* Effect.promise(() => Bun.write(path.join(tmp, "dep", "favicon.png"), pngData))
+      yield* Effect.promise(() => Bun.write(path.join(tmp, "assets", "favicon.svg"), "<svg/>"))
+
+      yield* project.discover(result.project)
+
+      const updated = yield* project.get(result.project.id)
+      expect(updated!.icon?.url).toStartWith("data:image/svg+xml")
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #29953

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Project.discover` globs `**/favicon.{ico,png,svg,jpg,jpeg,webp}` over the whole worktree via `Glob.scan`, and `toGlobOptions` in `packages/core/src/util/glob.ts` never passes an `ignore` option. So the walk descends into `node_modules` and every gitignored build directory.

Desktop forces `OPENCODE_EXPERIMENTAL_ICON_DISCOVERY` on for its sidecar and the CLI leaves it off, which is why only desktop users hit it. `InstanceBootstrap` awaits discovery before the rest of instance init, so every restored project stalls behind it and the window comes up unusable.

This switches the scan to `Ripgrep.glob`, which already honours `.gitignore` and prunes at the directory level, and caps candidates at 100. No new dependency, no hardcoded ignore list, no extra `git` call.

#35995 attempted this with a fixed path allowlist and was withdrawn by its author because an allowlist misses framework and monorepo layouts. This keeps the recursive pattern, so every layout still resolves — only ignored directories are skipped.

There is a correctness side too: because the old walk included `node_modules`, a dependency's favicon could win the shortest-path tie-break and become the project icon. On this repo the old scan finds 15 candidates (3 inside `node_modules`), the new one finds 4, all belonging to the project.

### How did you verify your code works?

Added `should not discover favicon in a gitignored directory`. It puts a favicon in a gitignored directory at a **shorter** path than a tracked one, so it wins the shortest-path tie-break unless the scan honours `.gitignore`. I checked it fails on `dev` and passes with this change.

`waitForProjectIcon` needed a larger readiness budget — the old 50 x 10 ms was tuned to an in-process walk and does not cover a subprocess spawn plus one-time ripgrep binary resolution. Test-only timing change; discovery itself stays forked and non-blocking.

- `bun typecheck` clean
- `bun test test/project` — 89 pass, 1 skip, 0 fail

Timings, restoring 6 projects (one 850k-file worktree, one 421k-file, 4 small), packaged sidecar under `ELECTRON_RUN_AS_NODE=1`, same build pipeline with only this patch differing:

```
before   21,991 ms / 24,430 ms
after       135 ms /    132 ms
```

Confirmed with a locally packaged build, measured from the server log between `bootstrapping <dir>` and the following `all LSPs are disabled`:

```
before (cold, after reboot)   24,554 ms
before (warm)                 15,745 ms
after                            135 ms
```

Per project after the fix: 850k-file worktree 4 ms, 421k-file worktree 28 ms. Ripgrep runs the same pattern on the 850k-file worktree in 30 ms.

One thing worth flagging for anyone else profiling this: the cost is very runtime-dependent. The same 6 projects take ~2 s under Bun but 17-25 s in the Electron utility process, so benchmarking with `bun run ./src/index.ts serve` understates it by roughly 10x.

### Screenshots / recordings

N/A, non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

Note on scope: this does not touch the `.gitignore` gap in the file watcher, which #20977 also involves. On macOS FSEvents that path is inert (I measured no contribution from `OPENCODE_EXPERIMENTAL_FILEWATCHER`), and I have no Linux machine to produce before/after numbers there, so I left it out rather than ship an unmeasured change.
