### PR TITLE
feat: queue follow-ups by default, steer with Ctrl+Enter

### DIFF
--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -91,6 +91,9 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
   const platform = usePlatform()
   const prompt = props.state ?? usePrompt()
   let editor: HTMLDivElement | undefined
+  // Tracks a per-message steer override: Ctrl+Enter forces a steer while the
+  // session is busy. Consumed once by getDelivery during submit.
+  let steerOverride = false
 
   const interaction = createPromptInputV2State()
   const mode = () => interaction[0].mode
@@ -215,6 +218,13 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
     newSessionWorktree: () => props.newSessionWorktree,
     onNewSessionWorktreeReset: props.onNewSessionWorktreeReset,
     shouldQueue: props.shouldQueue,
+    getDelivery: () => {
+      if (steerOverride) {
+        steerOverride = false
+        return "steer"
+      }
+      return props.getDelivery?.() ?? "queue"
+    },
     onQueue: props.onQueue,
     onAbort: props.onAbort,
     onSubmit: props.onSubmit,
@@ -405,6 +415,9 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
         working,
         onSubmit: () => void submission.handleSubmit(new Event("submit")),
         onStop: () => void submission.abort(),
+      },
+      onKeyDown: (event) => {
+        steerOverride = event.key === "Enter" && event.ctrlKey
       },
     },
   })

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -284,12 +284,20 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
     return text.trim().length === 0 && imageAttachments().length === 0 && commentCount() === 0
   })
   const stopping = createMemo(() => working() && blank())
+  const queueHint = () => working() && !stopping() && props.getDelivery?.() === "queue"
   const tip = () => {
     if (stopping()) {
       return (
         <div class="flex items-center gap-2">
           <span>{language.t("prompt.action.stop")}</span>
           <span class="text-icon-base text-12-medium text-[10px]!">{language.t("common.key.esc")}</span>
+        </div>
+      )
+    }
+    if (queueHint()) {
+      return (
+        <div class="flex items-center gap-2">
+          <span>{language.t("prompt.hint.queueSteer")}</span>
         </div>
       )
     }
@@ -1223,6 +1231,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
       newSessionWorktree: () => props.newSessionWorktree,
       onNewSessionWorktreeReset: props.onNewSessionWorktreeReset,
       shouldQueue: props.shouldQueue,
+      getDelivery: props.getDelivery,
       onQueue: props.onQueue,
       onAbort: props.onAbort,
       onSubmit: props.onSubmit,
@@ -1584,7 +1593,13 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                   icon={stopping() ? "stop" : store.mode === "shell" ? "arrow-undo-down" : "arrow-up"}
                   variant="primary"
                   class="size-8"
-                  aria-label={stopping() ? language.t("prompt.action.stop") : language.t("prompt.action.send")}
+                  aria-label={
+                    stopping()
+                      ? language.t("prompt.action.stop")
+                      : queueHint()
+                        ? language.t("prompt.action.queue")
+                        : language.t("prompt.action.send")
+                  }
                 />
               </Tooltip>
             </div>

--- a/packages/app/src/components/prompt-input/contracts.ts
+++ b/packages/app/src/components/prompt-input/contracts.ts
@@ -1,7 +1,7 @@
 import type { useLocal } from "@/context/local"
 import type { Prompt, usePrompt } from "@/context/prompt"
 import type { PromptInputHistory } from "./history-store"
-import type { FollowupDraft } from "./submit"
+import type { FollowupDelivery, FollowupDraft } from "./submit"
 
 export type PromptInputState = ReturnType<typeof usePrompt>
 
@@ -51,6 +51,7 @@ export interface PromptInputProps {
   edit?: { id: string; prompt: Prompt; context: FollowupDraft["context"] }
   onEditLoaded?: () => void
   shouldQueue?: () => boolean
+  getDelivery?: () => FollowupDelivery
   onQueue?: (draft: FollowupDraft) => void
   onAbort?: () => void
   onSubmit?: () => void

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -135,6 +135,7 @@ beforeAll(async () => {
   mock.module("@opencode-ai/ui/toast", () => ({
     Toast: { Region: () => null },
     showToast: () => 0,
+    toaster: { dismiss: () => undefined },
   }))
 
   mock.module("@opencode-ai/core/util/encode", () => ({
@@ -594,5 +595,88 @@ describe("prompt submit worktree selection", () => {
     expect(storedSessions["/repo/worktree-a"]).toHaveLength(1)
     expect(storedSessions["/repo/worktree-a"]?.[0]).toMatchObject({ id: "session-1", title: "New session 1" })
     expect(optimisticSeeded).toEqual([true])
+  })
+})
+
+describe("prompt submit follow-up delivery", () => {
+  const followupInput = (overrides: {
+    shouldQueue?: () => boolean
+    getDelivery?: () => "queue" | "steer"
+    onQueue?: (draft: { delivery?: string }) => void
+  }) =>
+    createPromptSubmit({
+      prompt,
+      info: () => ({ id: "session-1" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      shouldQueue: overrides.shouldQueue,
+      getDelivery: overrides.getDelivery,
+      onQueue: overrides.onQueue,
+    })
+
+  test("queues follow-ups locally when delivery is queue", async () => {
+    params = { id: "session-1" }
+    const queued: Array<{ delivery?: string }> = []
+    const submit = followupInput({
+      shouldQueue: () => true,
+      getDelivery: () => "queue",
+      onQueue: (draft) => {
+        queued.push(draft)
+      },
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    expect(queued).toHaveLength(1)
+    expect(queued[0]).toMatchObject({ sessionID: "session-1", delivery: "queue" })
+    expect(sentPrompts).toHaveLength(0)
+  })
+
+  test("sends follow-ups directly with steer delivery", async () => {
+    params = { id: "session-1" }
+    const queued: unknown[] = []
+    const submit = followupInput({
+      shouldQueue: () => true,
+      getDelivery: () => "steer",
+      onQueue: (draft) => {
+        queued.push(draft)
+      },
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await Bun.sleep(0)
+
+    expect(queued).toHaveLength(0)
+    expect(sentPrompts).toEqual(["/repo/main"])
+    expect(promptInputs[0]).toMatchObject({ sessionID: "session-1", delivery: "steer" })
+  })
+
+  test("forces steer delivery on Ctrl+Enter", async () => {
+    params = { id: "session-1" }
+    const queued: unknown[] = []
+    const submit = followupInput({
+      shouldQueue: () => true,
+      getDelivery: () => "queue",
+      onQueue: (draft) => {
+        queued.push(draft)
+      },
+    })
+
+    await submit.handleSubmit(new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true }))
+    await Bun.sleep(0)
+
+    expect(queued).toHaveLength(0)
+    expect(sentPrompts).toEqual(["/repo/main"])
+    expect(promptInputs[0]).toMatchObject({ sessionID: "session-1", delivery: "steer" })
   })
 })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -31,6 +31,8 @@ type PendingPrompt = {
 
 const pending = new Map<string, PendingPrompt>()
 
+export type FollowupDelivery = "queue" | "steer"
+
 export type FollowupDraft = {
   sessionID: string
   sessionDirectory: string
@@ -39,6 +41,7 @@ export type FollowupDraft = {
   agent: string
   model: { providerID: string; modelID: string }
   variant?: string
+  delivery?: FollowupDelivery
 }
 
 type FollowupSendInput = {
@@ -46,6 +49,7 @@ type FollowupSendInput = {
   serverSync: ServerSync
   sync: DirectorySync
   draft: FollowupDraft
+  delivery?: FollowupDelivery
   messageID?: string
   optimisticBusy?: boolean
   before?: () => Promise<boolean> | boolean
@@ -171,6 +175,7 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
       agent: input.draft.agent,
       model: input.draft.model,
       variant: input.draft.variant,
+      delivery: input.delivery ?? input.draft.delivery ?? "queue",
       legacyParts: requestParts,
       text: requestParts.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n"),
       files: requestParts.flatMap((part) => {
@@ -225,6 +230,7 @@ type PromptSubmitInput = {
   newSessionWorktree?: Accessor<string | undefined>
   onNewSessionWorktreeReset?: () => void
   shouldQueue?: Accessor<boolean>
+  getDelivery?: () => FollowupDelivery
   onQueue?: (draft: FollowupDraft) => void
   onAbort?: () => void
   onSubmit?: () => void
@@ -317,6 +323,11 @@ export function createPromptSubmit(input: PromptSubmitInput) {
 
   const handleSubmit = async (event: Event) => {
     event.preventDefault()
+
+    // Codex-like delivery: Enter follows the follow-up setting (queue by default),
+    // Ctrl+Enter always steers the running session.
+    const keySteer = event instanceof KeyboardEvent && event.key === "Enter" && event.ctrlKey
+    const delivery = keySteer ? "steer" : (input.getDelivery?.() ?? "queue")
 
     const target = prompt.capture()
     const submission = createPromptSubmissionState({
@@ -454,6 +465,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       agent,
       model,
       variant,
+      delivery,
     }
 
     const clearInput = () => {
@@ -479,7 +491,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       return true
     }
 
-    if (!isNewSession && mode === "normal" && input.shouldQueue?.()) {
+    if (!isNewSession && mode === "normal" && delivery === "queue" && input.shouldQueue?.()) {
       input.onQueue?.(draft)
       clearContext(submission.target())
       clearInput()

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -216,6 +216,11 @@ export const SettingsGeneral: Component = () => {
     })),
   )
 
+  const followupOptions = createMemo((): { value: "queue" | "steer"; label: string }[] => [
+    { value: "queue", label: language.t("settings.general.row.followup.option.queue") },
+    { value: "steer", label: language.t("settings.general.row.followup.option.steer") },
+  ])
+
   const noneSound = { id: "none", label: "sound.option.none" } as const
   const soundOptions = [noneSound, ...SOUND_OPTIONS]
   const mono = () => monoInput(settings.appearance.font())
@@ -344,6 +349,23 @@ export const SettingsGeneral: Component = () => {
             size="small"
             triggerVariant="settings"
             triggerStyle={{ "min-width": "180px" }}
+          />
+        </SettingsRow>
+
+        <SettingsRow
+          title={language.t("settings.general.row.followup.title")}
+          description={language.t("settings.general.row.followup.description")}
+        >
+          <Select
+            data-action="settings-followup"
+            options={followupOptions()}
+            current={followupOptions().find((option) => option.value === settings.general.followup())}
+            value={(option) => option.value}
+            label={(option) => option.label}
+            onSelect={(option) => option && settings.general.setFollowup(option.value)}
+            variant="secondary"
+            size="small"
+            triggerVariant="settings"
           />
         </SettingsRow>
 

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -28,6 +28,7 @@ import {
 import "./settings-v2.css"
 
 const schemeOptions: ("system" | "light" | "dark")[] = ["system", "light", "dark"]
+const followupOptions: ("queue" | "steer")[] = ["queue", "steer"]
 const fontSettings = {
   ui: {
     action: "settings-ui-font",
@@ -243,6 +244,31 @@ const SoundSetting: Component<{
   )
 }
 
+const FollowupSetting = () => {
+  const language = useLanguage()
+  const settings = useSettings()
+  return (
+    <SettingsRowV2
+      title={language.t("settings.general.row.followup.title")}
+      description={language.t("settings.general.row.followup.description")}
+    >
+      <SelectV2
+        appearance="inline"
+        data-action="settings-followup"
+        options={followupOptions}
+        placement="bottom-end"
+        gutter={6}
+        current={followupOptions.find((option) => option === settings.general.followup())}
+        label={(option) => {
+          if (option === "queue") return language.t("settings.general.row.followup.option.queue")
+          return language.t("settings.general.row.followup.option.steer")
+        }}
+        onSelect={(option) => option && settings.general.setFollowup(option)}
+      />
+    </SettingsRowV2>
+  )
+}
+
 const LanguageSetting = () => {
   const language = useLanguage()
   const options = createMemo(() =>
@@ -332,6 +358,8 @@ export const SettingsGeneralV2: Component<{
         <PermissionScopeSetting controller={permissionScope} />
 
         <ShellSetting controller={shell} />
+
+        <FollowupSetting />
 
         <SettingsRowV2
           title={language.t("settings.general.row.reasoningSummaries.title")}

--- a/packages/app/src/context/settings.tsx
+++ b/packages/app/src/context/settings.tsx
@@ -184,7 +184,7 @@ const defaultSettings: Settings = {
   general: {
     autoSave: true,
     releaseNotes: true,
-    followup: "steer",
+    followup: "queue",
     showFileTree: false,
     showNavigation: false,
     showSearch: false,
@@ -350,11 +350,6 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
       root.style.setProperty("--font-family-sans", sansFontFamily(store.appearance?.sans))
     })
 
-    createEffect(() => {
-      if (store.general?.followup !== "queue") return
-      setStore("general", "followup", "steer")
-    })
-
     return {
       ready,
       get current() {
@@ -369,12 +364,9 @@ export const { use: useSettings, provider: SettingsProvider } = createSimpleCont
         setReleaseNotes(value: boolean) {
           setStore("general", "releaseNotes", value)
         },
-        followup: withFallback(
-          () => (store.general?.followup === "queue" ? "steer" : store.general?.followup),
-          defaultSettings.general.followup,
-        ),
+        followup: withFallback(() => store.general?.followup, defaultSettings.general.followup),
         setFollowup(value: "queue" | "steer") {
-          setStore("general", "followup", value === "queue" ? "steer" : value)
+          setStore("general", "followup", value)
         },
         showFileTree,
         setShowFileTree(value: boolean) {

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -307,6 +307,8 @@ export const dict = {
   "prompt.attachment.remove": "Remove attachment",
   "prompt.action.send": "Send",
   "prompt.action.stop": "Stop",
+  "prompt.action.queue": "Queue",
+  "prompt.hint.queueSteer": "Enter to queue · Ctrl+Enter to steer",
 
   "prompt.toast.pasteUnsupported.title": "Unsupported attachment",
   "prompt.toast.pasteUnsupported.description": "Only images, PDFs, or text files can be attached here.",

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -63,7 +63,7 @@ import { PromptInputV2Composer, usePromptInputV2Controller } from "@/components/
 import { useSettingsCommand } from "@/components/settings-dialog"
 import { setCursorPosition } from "@/components/prompt-input/editor-dom"
 import { promptLength } from "@/components/prompt-input/history"
-import { type FollowupDraft, sendFollowupDraft } from "@/components/prompt-input/submit"
+import { type FollowupDelivery, type FollowupDraft, sendFollowupDraft } from "@/components/prompt-input/submit"
 import {
   createPromptInputController,
   createSessionComposerController,
@@ -1751,11 +1751,17 @@ export default function Page() {
     return followupMutation.variables?.id
   })
 
+  // Queueing is available while the session is busy and the composer is usable.
+  // The final queue-vs-steer routing uses the delivery (Enter follows the
+  // follow-up setting, Ctrl+Enter forces a steer), resolved in the submit path.
   const queueEnabled = createMemo(() => {
     const id = params.id
     if (!id) return false
-    return settings.general.followup() === "queue" && busy(id) && !composer.blocked() && !isChildSession()
+    if (!busy(id) || composer.blocked() || isChildSession()) return false
+    return true
   })
+
+  const getDelivery = (): FollowupDelivery => settings.general.followup()
 
   const followupText = (item: FollowupDraft) => {
     const text = item.prompt
@@ -1777,7 +1783,7 @@ export default function Page() {
   const queueFollowup = (draft: FollowupDraft) => {
     setFollowup("items", draft.sessionID, (items) => [
       ...(items ?? []),
-      { id: Identifier.ascending("message"), ...draft },
+      { id: Identifier.ascending("message"), ...draft, delivery: draft.delivery ?? "queue" },
     ])
     setFollowup("failed", draft.sessionID, undefined)
     setFollowup("paused", draft.sessionID, undefined)
@@ -2197,6 +2203,7 @@ export default function Page() {
                       edit={editingFollowup()}
                       onEditLoaded={clearFollowupEdit}
                       shouldQueue={queueEnabled}
+                      getDelivery={getDelivery}
                       onQueue={queueFollowup}
                       onAbort={() => {
                         const id = params.id
@@ -2227,6 +2234,7 @@ export default function Page() {
                       },
                       onEditLoaded: clearFollowupEdit,
                       shouldQueue: queueEnabled,
+                      getDelivery,
                       onQueue: queueFollowup,
                       onAbort: () => {
                         const id = params.id

--- a/packages/opencode/src/cli/cmd/run/footer.prompt.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.prompt.tsx
@@ -109,6 +109,7 @@ function clonePrompt(prompt: RunPrompt): RunPrompt {
     parts: structuredClone(prompt.parts),
     ...(prompt.mode ? { mode: prompt.mode } : {}),
     ...(prompt.command ? { command: prompt.command } : {}),
+    ...(prompt.steer ? { steer: prompt.steer } : {}),
   }
 }
 
@@ -1158,9 +1159,24 @@ export function createPromptState(input: PromptInput): PromptState {
     if (input.state().phase === "idle" && event.name.toLowerCase() === "escape") {
       input.onInputClear()
     }
+    if (
+      event.name.toLowerCase() === "return" &&
+      event.ctrl &&
+      !event.meta &&
+      !event.shift &&
+      !event.super &&
+      input.state().phase === "running"
+    ) {
+      const text = area && !area.isDestroyed ? area.plainText : draft.text
+      if (text.trim().length > 0) {
+        event.preventDefault()
+        syncDraft()
+        submitPrompt(clonePrompt(draft), { steer: true })
+      }
+    }
   }
 
-  const submitPrompt = (next: RunPrompt) => {
+  const submitPrompt = (next: RunPrompt, opts?: { steer?: boolean }) => {
     if (!area || area.isDestroyed) {
       draft = clonePrompt(next)
     }
@@ -1199,6 +1215,11 @@ export function createPromptState(input: PromptInput): PromptState {
       : parsed?.type === "command"
         ? { ...next, command: parsed.command }
         : next
+    if (opts?.steer) {
+      submit.steer = true
+    } else {
+      delete submit.steer
+    }
     const shellMode = next.mode === "shell"
 
     resetDraft()

--- a/packages/opencode/src/cli/cmd/run/footer.view.tsx
+++ b/packages/opencode/src/cli/cmd/run/footer.view.tsx
@@ -407,7 +407,7 @@ export function RunFooterView(props: RunFooterViewProps) {
     }
 
     if (busy()) {
-      return armed() ? "again to interrupt" : "interrupt"
+      return armed() ? "again to interrupt" : "interrupt · Enter queue · Ctrl+Enter steer"
     }
 
     if (stateStatus().length > 0) {

--- a/packages/opencode/src/cli/cmd/run/runtime.queue.ts
+++ b/packages/opencode/src/cli/cmd/run/runtime.queue.ts
@@ -4,6 +4,11 @@
 // here. The queue drains one turn at a time; ordinary prompts waiting behind
 // an active ordinary turn are exposed for edit/removal until they begin.
 //
+// Codex-like delivery: Enter queues behind the active turn, Ctrl+Enter steers
+// by preempting it. A steered prompt never enters the `queued` UI mirror;
+// it jumps to the front of the internal queue, aborts the active turn, and
+// drains immediately. When idle, steer behaves like a normal submit.
+//
 // The queue also handles /exit, /quit, and /new commands, empty-prompt rejection,
 // and tracks per-turn wall-clock duration for the footer status line.
 //
@@ -276,14 +281,17 @@ export async function runPromptQueue(input: QueueInput): Promise<void> {
     }
 
     const active = state.active
-    if (
-      active &&
-      active.mode !== "shell" &&
-      !active.command &&
-      prompt.mode !== "shell" &&
-      !prompt.command &&
-      !isNewCommand(prompt.text)
-    ) {
+    const ordinaryActive = active && active.mode !== "shell" && !active.command
+    const ordinaryPrompt =
+      prompt.mode !== "shell" && !prompt.command && !isNewCommand(prompt.text)
+    if (ordinaryActive && ordinaryPrompt) {
+      if (prompt.steer) {
+        state.queue.unshift(prompt)
+        syncQueue()
+        state.ctrl?.abort()
+        drain()
+        return
+      }
       const queued: FooterQueuedPrompt = {
         messageID: MessageID.ascending(),
         partID: PartID.ascending(),

--- a/packages/opencode/src/cli/cmd/run/types.ts
+++ b/packages/opencode/src/cli/cmd/run/types.ts
@@ -40,6 +40,9 @@ export type RunPrompt = {
     name: string
     arguments: string
   }
+  // Codex-like delivery: Enter queues behind the active turn, Ctrl+Enter
+  // steers by preempting it. Local-only; never sent to the backend.
+  steer?: boolean
 }
 
 export type FooterQueuedPrompt = {

--- a/packages/tui/src/component/prompt/index.tsx
+++ b/packages/tui/src/component/prompt/index.tsx
@@ -358,6 +358,24 @@ export function Prompt(props: PromptProps) {
         },
       },
       {
+        title: "Steer prompt",
+        name: "prompt.steer",
+        category: "Prompt",
+        hidden: true,
+        run: async (ctx?: CommandContext<Renderable, KeyEvent>) => {
+          if (!input.focused) return false
+          if (auto()?.visible) return false
+          if (status().type === "idle") return false
+          if (!store.prompt.input.trim() && input.plainText.trim() === "") return false
+          ctx?.event.preventDefault()
+          ctx?.event.stopPropagation()
+          const handled = await submit(true)
+          if (!handled) return false
+
+          dialog.clear()
+        },
+      },
+      {
         title: "Remove editor context",
         name: "prompt.editor_context.clear",
         category: "Prompt",
@@ -808,6 +826,15 @@ export function Prompt(props: PromptProps) {
   useBindings(() => {
     return {
       target: inputTarget,
+      enabled: inputTarget() !== undefined && !props.disabled && status().type !== "idle" && !auto()?.visible,
+      priority: 1,
+      bindings: tuiConfig.keybinds.get("prompt.steer"),
+    }
+  })
+
+  useBindings(() => {
+    return {
+      target: inputTarget,
       enabled: inputTarget() !== undefined && !props.disabled && store.prompt.input !== "",
       bindings: tuiConfig.keybinds.get("prompt.clear"),
     }
@@ -928,7 +955,7 @@ export function Prompt(props: PromptProps) {
   })
 
   let submitting = false
-  async function submit() {
+  async function submit(steer = false) {
     // Prevent overlapping invocations (e.g. a double-pressed Enter, or the
     // input's native onSubmit racing another dispatch). Without this guard,
     // a second call slips past the empty-input check before the first call
@@ -938,13 +965,13 @@ export function Prompt(props: PromptProps) {
     if (submitting) return false
     submitting = true
     try {
-      return await submitInner()
+      return await submitInner(steer)
     } finally {
       submitting = false
     }
   }
 
-  async function submitInner() {
+  async function submitInner(steer = false) {
     workspace.clearNotice()
 
     // IME: double-defer may fire before onContentChange flushes the last
@@ -1021,6 +1048,13 @@ export function Prompt(props: PromptProps) {
       }
 
       sessionID = res.data.id
+    }
+
+    // Codex-like steer: interrupt the active turn so the new prompt sends
+    // immediately instead of queueing behind it. V1 has no delivery param,
+    // so steer is an abort-then-prompt. Idle steer behaves like a normal submit.
+    if (steer && sessionID && status().type !== "idle") {
+      await sdk.client.session.abort({ sessionID }).catch(() => {})
     }
 
     const inputText = expandTrackedPastedText(

--- a/packages/tui/src/config/keybind.ts
+++ b/packages/tui/src/config/keybind.ts
@@ -151,6 +151,7 @@ export const Definitions = {
   display_thinking: keybind("none", "Toggle thinking blocks visibility"),
 
   prompt_submit: keybind("none", "Submit prompt"),
+  prompt_steer: keybind("ctrl+return", "Steer prompt (interrupt and send immediately)"),
   prompt_editor_context_clear: keybind("none", "Clear editor context"),
   prompt_skills: keybind("none", "Open skill selector"),
   prompt_stash: keybind("none", "Stash prompt"),
@@ -355,6 +356,7 @@ export const CommandMap = {
   tool_details: "session.toggle.actions",
   display_thinking: "session.toggle.thinking",
   prompt_submit: "prompt.submit",
+  prompt_steer: "prompt.steer",
   prompt_editor_context_clear: "prompt.editor_context.clear",
   prompt_skills: "prompt.skills",
   prompt_stash: "prompt.stash",


### PR DESCRIPTION
### Issue for this PR

Closes #44108

### Type of change

- [x] New feature

### What does this PR do?

Busy-session follow-ups were always steered (the queue setting was force-migrated to steer). Now Enter follows the follow-up setting (queue by default, runs as next turn when idle) and Ctrl+Enter forces a steer into the running turn. Restores the Queue/Steer setting row, passes delivery to the V2 prompt API, and adds the same Enter/Ctrl+Enter split to the mini-TUI queue and legacy TUI prompt.

### How did you verify your code works?

- bun typecheck in packages/app, packages/opencode, packages/tui: pass
- bun test prompt-input/submit.test.ts (with --conditions=solid --preload ./happydom.ts): 11/11 pass, incl. 3 new delivery tests
- bun test runtime.queue.test.ts: 16/16 pass

### Screenshots / recordings

UI-only hint text change (Enter queue / Ctrl+Enter steer); no layout change, skipping recording. Happy to add one on request.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR