### PR TITLE
fix: collapse system prompt array into a single chat message

### DIFF
--- a/packages/opencode/src/session/llm.ts
+++ b/packages/opencode/src/session/llm.ts
@@ -385,6 +385,7 @@ const live: Layer.Layer<
 )
 
 export const hasToolCalls = LLMRequestPrep.hasToolCalls
+export const systemMessages = LLMRequestPrep.systemMessages
 
 export const node = LayerNode.make({
   service: Service,

--- a/packages/opencode/src/session/llm/request.ts
+++ b/packages/opencode/src/session/llm/request.ts
@@ -98,18 +98,7 @@ export const prepare = Effect.fn("LLMRequestPrep.prepare")(function* (input: Pre
   }
   if (isOpenaiOauth) options.instructions = system.join("\n")
 
-  const messages =
-    isOpenaiOauth || input.isWorkflow
-      ? input.messages
-      : [
-          ...system.map(
-            (x): ModelMessage => ({
-              role: "system",
-              content: x,
-            }),
-          ),
-          ...input.messages,
-        ]
+  const messages = isOpenaiOauth || input.isWorkflow ? input.messages : [...systemMessages(system), ...input.messages]
 
   const params = yield* input.plugin.trigger(
     "chat.params",
@@ -211,6 +200,24 @@ function resolveTools(input: Pick<PrepareInput, "tools" | "agent" | "permission"
     Permission.merge(input.agent.permission, input.permission ?? []),
   )
   return Record.filter(input.tools, (_, k) => input.user.tools?.[k] !== false && !disabled.has(k))
+}
+
+// Joins every entry of `system` into a single leading system message instead
+// of emitting one chat message per array entry. `system` accumulates content
+// from multiple sources — the base agent/provider prompt, session-level
+// system text, and whatever plugins add via the `experimental.chat.system.
+// transform` hook (which is allowed to `push` onto the array, see
+// packages/plugin/src/index.ts) — and providers vary on whether they accept
+// more than one leading system-role message. Some don't: a chat template that
+// requires exactly one leading system message (observed against a
+// self-hosted Qwen3/vLLM backend) rejects the request outright the moment a
+// second system-role message appears, even though it's still ahead of the
+// user turn. Joining here means plugin authors don't each have to
+// defensively merge into a single array entry themselves to stay compatible
+// with strict backends.
+export function systemMessages(system: string[]): ModelMessage[] {
+  const content = system.filter((x) => x).join("\n")
+  return content ? [{ role: "system", content }] : []
 }
 
 export function hasToolCalls(messages: ModelMessage[]): boolean {

--- a/packages/opencode/test/session/llm.test.ts
+++ b/packages/opencode/test/session/llm.test.ts
@@ -173,6 +173,43 @@ describe("session.llm.hasToolCalls", () => {
   })
 })
 
+describe("session.llm.systemMessages", () => {
+  test("returns no message for an empty system array", () => {
+    expect(LLM.systemMessages([])).toEqual([])
+  })
+
+  test("returns no message when every entry is empty", () => {
+    expect(LLM.systemMessages(["", ""])).toEqual([])
+  })
+
+  test("wraps a single entry in one system message", () => {
+    expect(LLM.systemMessages(["You are a helpful assistant."])).toEqual([
+      { role: "system", content: "You are a helpful assistant." },
+    ])
+  })
+
+  test("joins multiple entries into exactly one system message", () => {
+    // Regression test: request.ts used to emit one chat message per array
+    // entry, so a plugin pushing onto `output.system` via the
+    // experimental.chat.system.transform hook produced a second leading
+    // system-role message. Some providers reject a second system message
+    // outright even though it's still ahead of the user turn (observed
+    // against a self-hosted Qwen3/vLLM backend, which errors with "System
+    // message must be at the beginning"). Every entry must collapse into a
+    // single message so plugin authors don't each have to defend against
+    // this themselves.
+    const messages = LLM.systemMessages(["base prompt", "plugin-added content"])
+    expect(messages).toHaveLength(1)
+    expect(messages).toEqual([{ role: "system", content: "base prompt\nplugin-added content" }])
+  })
+
+  test("skips empty entries when joining", () => {
+    expect(LLM.systemMessages(["base prompt", "", "plugin-added content"])).toEqual([
+      { role: "system", content: "base prompt\nplugin-added content" },
+    ])
+  })
+})
+
 describe("session.llm.ai-sdk adapter", () => {
   type AISDKAdapterEvent = Parameters<typeof LLMAISDK.toLLMEvents>[1]
 


### PR DESCRIPTION
## Summary

fixes #47003. opencode was sending multiple system-role chat messages whenever a plugin used `experimental.chat.system.transform` to push onto the system prompt array, and some backends reject that outright.

## Root cause

`prepare()` in `packages/opencode/src/session/llm/request.ts` built the messages array with `system.map(x => ({role: "system", content: x}))`, one chat message per entry in the `system` string array. that array starts as a single joined string (base agent/provider prompt + session system text), but any plugin registered under `experimental.chat.system.transform` can `push` extra strings onto it, that's the documented way for plugins to extend the system prompt. so the moment a plugin pushed onto `output.system`, opencode sent 2+ separate system messages instead of 1.

some backends reject a second system-role message outright, even when it's still ahead of the user turn. concretely, a self-hosted Qwen3 model served via vLLM behind a LiteLLM gateway rejects these requests with `"System message must be at the beginning"`. worth being clear this isn't a bug in `@ai-sdk/openai-compatible`, it just serializes whatever `messages[]` it's handed, the multi-message behavior originates in opencode's own request-preparation code.

## Fix

extracted a pure exported helper `systemMessages(system: string[]): ModelMessage[]` in `request.ts`. joins every non-empty entry of `system` with `\n` into exactly one system-role message (or zero messages if everything is empty), and `prepare()` now calls it instead of the old per-entry `.map()`. re-exported it from `llm.ts` as `LLM.systemMessages`, next to the existing `LLM.hasToolCalls`, same pattern as that one.

two small, intentional behavior deltas worth flagging for review, both are improvements not regressions:
- if `system` ends up entirely empty/whitespace after joining, zero system messages are sent now instead of one message with empty content
- an empty string entry pushed by a plugin gets skipped when joining, instead of becoming its own separate empty `{role:"system", content:""}` message

## Testing

- added 5 unit tests in `packages/opencode/test/session/llm.test.ts`, new `describe("session.llm.systemMessages", ...)` block right after the existing `describe("session.llm.hasToolCalls", ...)` block, same style: empty array, array of empty strings, single entry, multiple entries joined into one message (the regression test, with a comment explaining why), entries mixed with empty strings
- `bun run typecheck` clean
- `bun test test/session/llm.test.ts test/plugin/trigger.test.ts`, 37/37 pass, no regressions
- prettier and oxlint clean on the changed files (repo-wide oxlint has a bunch of pre-existing warnings and 1 pre-existing error in an unrelated file, not touched here)
- manually verified end-to-end against the real self-hosted Qwen3/vLLM backend that surfaced this, request succeeds cleanly after the fix, where before it 400'd on every single request

## Scope / follow-up

found the identical bug pattern in a second, unrelated call site, `Agent.generate` in `packages/opencode/src/agent/agent.ts` (used when generating a new sub-agent's config from a description) does the same one-message-per-entry construction. deliberately NOT touched in this PR, different feature I didn't reproduce or test end-to-end, keeping this minimal and reviewable. flagging it as a known follow-up for maintainers or a later PR.

Ref: https://github.com/anomalyco/opencode/issues/47003

https://claude.ai/code/session_01XKkeDmhtJ7HwUzfsSMJW4p
