### PR TITLE
feat: custom instructions and environment-aware shell context

### DIFF
--- a/packages/app/src/components/settings-custom-instructions.tsx
+++ b/packages/app/src/components/settings-custom-instructions.tsx
@@ -1,0 +1,99 @@
+import { createEffect, onCleanup, type Component } from "solid-js"
+import { createStore } from "solid-js/store"
+import { debounce } from "@solid-primitives/scheduled"
+import type { Config } from "@opencode-ai/sdk/v2/client"
+import { TextField } from "@opencode-ai/ui/text-field"
+import { TextareaV2 } from "@opencode-ai/ui/v2/textarea-v2"
+import { useLanguage } from "@/context/language"
+import { useServerSync } from "@/context/server-sync"
+import { SettingsList } from "./settings-list"
+import { SettingsListV2 } from "./settings-v2/parts/list"
+
+// The parallel config PR adds `customInstructions?: string` to the global
+// config schema. Until the regenerated SDK types include it, read and write
+// the field through this narrow extension instead of `any`.
+type GlobalConfigWithCustomInstructions = Config & { customInstructions?: string }
+
+const SAVE_DELAY = 500
+
+function createCustomInstructionsModel() {
+  const serverSync = useServerSync()
+  const saved = () => {
+    const config = serverSync().data.config as GlobalConfigWithCustomInstructions
+    return config.customInstructions ?? ""
+  }
+  const [store, setStore] = createStore({ draft: "", dirty: false })
+  createEffect(() => {
+    if (store.dirty) return
+    setStore("draft", saved())
+  })
+  const persist = debounce((next: string) => {
+    void serverSync().updateConfig({ customInstructions: next } as unknown as Config)
+  }, SAVE_DELAY)
+  onCleanup(() => persist.clear())
+  return {
+    draft: () => store.draft,
+    update: (next: string) => {
+      setStore({ draft: next, dirty: true })
+      persist(next)
+    },
+  }
+}
+
+export const SettingsCustomInstructions: Component = () => {
+  const language = useLanguage()
+  const model = createCustomInstructionsModel()
+  return (
+    <div class="flex flex-col gap-1">
+      <h3 class="text-14-medium text-text-strong pb-2">{language.t("settings.customInstructions.title")}</h3>
+      <SettingsList>
+        <div class="flex flex-col gap-2 py-3">
+          <span class="text-12-regular text-text-weak">{language.t("settings.customInstructions.description")}</span>
+          <TextField
+            data-action="settings-custom-instructions"
+            label={language.t("settings.customInstructions.title")}
+            hideLabel
+            multiline
+            value={model.draft()}
+            onChange={(value) => model.update(value)}
+            placeholder={language.t("settings.customInstructions.placeholder")}
+            spellcheck={false}
+            autocorrect="off"
+            autocomplete="off"
+            autocapitalize="off"
+          />
+          <span class="text-12-regular text-text-weak">{language.t("settings.customInstructions.hint")}</span>
+        </div>
+      </SettingsList>
+    </div>
+  )
+}
+
+export const SettingsCustomInstructionsV2: Component = () => {
+  const language = useLanguage()
+  const model = createCustomInstructionsModel()
+  return (
+    <div class="settings-v2-section">
+      <h3 class="settings-v2-section-title">{language.t("settings.customInstructions.title")}</h3>
+      <SettingsListV2>
+        <div data-component="settings-v2-row">
+          <div class="flex w-full flex-col gap-3">
+            <div data-slot="settings-v2-row-description">
+              {language.t("settings.customInstructions.description")}
+            </div>
+            <TextareaV2
+              data-action="settings-custom-instructions"
+              rows={5}
+              value={model.draft()}
+              placeholder={language.t("settings.customInstructions.placeholder")}
+              aria-label={language.t("settings.customInstructions.title")}
+              spellcheck={false}
+              onInput={(event) => model.update(event.currentTarget.value)}
+            />
+            <div data-slot="settings-v2-row-description">{language.t("settings.customInstructions.hint")}</div>
+          </div>
+        </div>
+      </SettingsListV2>
+    </div>
+  )
+}

--- a/packages/app/src/components/settings-general.tsx
+++ b/packages/app/src/components/settings-general.tsx
@@ -30,6 +30,7 @@ import {
 import { decode64 } from "@/utils/base64"
 import { playSoundById, SOUND_OPTIONS } from "@/utils/sound"
 import { ExternalLink } from "./external-link"
+import { SettingsCustomInstructions } from "./settings-custom-instructions"
 import { SettingsList } from "./settings-list"
 
 let demoSoundState = {
@@ -757,6 +758,9 @@ export const SettingsGeneral: Component = () => {
         </Show>
 
         <GeneralSection />
+
+        {/* Custom instructions sits in its own section so general-row changes merge cleanly. */}
+        <SettingsCustomInstructions />
 
         <AppearanceSection />
 

--- a/packages/app/src/components/settings-v2/general.tsx
+++ b/packages/app/src/components/settings-v2/general.tsx
@@ -12,6 +12,7 @@ import { useSettings } from "@/context/settings"
 import { ExternalLink } from "../external-link"
 import { SettingsListV2 } from "./parts/list"
 import { SettingsRowV2 } from "./parts/row"
+import { SettingsCustomInstructionsV2 } from "../settings-custom-instructions"
 import { LayoutRetirementNotice, LayoutTransitionToggle } from "./interface-transition"
 import {
   createAppearanceSettingsController,
@@ -551,6 +552,9 @@ export const SettingsGeneralV2: Component<{
         </Show>
 
         <GeneralSection />
+
+        {/* Custom instructions sits in its own section so general-row changes merge cleanly. */}
+        <SettingsCustomInstructionsV2 />
 
         <AppearanceSection controller={appearance} />
 

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -1147,4 +1147,12 @@ export const dict = {
   "workspace.reset.archived.one": "1 session will be archived.",
   "workspace.reset.archived.many": "{{count}} sessions will be archived.",
   "workspace.reset.note": "This will reset the workspace to match the default branch.",
+
+  "settings.customInstructions.title": "Custom instructions",
+  "settings.customInstructions.description":
+    "Tell OpenCode how to behave in every new chat: your role, the tools on this machine, and how you like to work.",
+  "settings.customInstructions.placeholder":
+    "e.g. You are a senior TypeScript engineer. Prefer Bun APIs, explain tradeoffs briefly, and run typecheck before finishing.",
+  "settings.customInstructions.hint":
+    "Saved to your global config and applied to each new chat. Project config can extend it.",
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -96,6 +96,9 @@ export class Info extends Schema.Class<Info>("Config.Info")({
   instructions: Schema.String.pipe(Schema.Array, Schema.optional).annotate({
     description: "Additional paths or URLs supplying ambient instructions",
   }),
+  customInstructions: Schema.String.pipe(Schema.optional).annotate({
+    description: "Free-form custom instructions included in the system prompt",
+  }),
   references: ConfigReference.Info.pipe(Schema.optional).annotate({
     description: "Named local directories or Git repositories available as external context",
   }),

--- a/packages/core/src/instruction-context.ts
+++ b/packages/core/src/instruction-context.ts
@@ -1,12 +1,13 @@
 export * as InstructionContext from "./instruction-context"
 
-import { Array, Effect, Layer, Schema } from "effect"
+import { Array, Effect, Layer, Option, Schema } from "effect"
 import { isAbsolute, join, relative, sep } from "path"
 import { FSUtil } from "./fs-util"
 import { Flag } from "./flag/flag"
 import { Global } from "./global"
 import { Location } from "./location"
 import { AbsolutePath } from "./schema"
+import { Config } from "./config"
 import { SystemContext } from "./system-context/index"
 import { SystemContextRegistry } from "./system-context/registry"
 import { makeLocationNode } from "./effect/app-node"
@@ -18,6 +19,7 @@ class File extends Schema.Class<File>("InstructionContext.File")({
 
 const Files = Schema.Array(File)
 const key = SystemContext.Key.make("core/instructions")
+const customKey = SystemContext.Key.make("core/custom-instructions")
 
 const layer = Layer.effectDiscard(
   Effect.gen(function* () {
@@ -25,6 +27,27 @@ const layer = Layer.effectDiscard(
     const global = yield* Global.Service
     const location = yield* Location.Service
     const registry = yield* SystemContextRegistry.Service
+
+    const customSource = (value: string) =>
+      SystemContext.make({
+        key: customKey,
+        codec: Schema.toCodecJson(Schema.String),
+        load: Effect.succeed(value),
+        baseline: renderCustom,
+        update: (_previous, current) => renderCustom(current),
+        removed: () => "Previously loaded custom instructions no longer apply.",
+      })
+
+    const observeCustom = Effect.fn("InstructionContext.observeCustom")(function* () {
+      const config = yield* Effect.serviceOption(Config.Service)
+      if (Option.isNone(config)) return undefined
+      const entries = yield* config.value.entries().pipe(Effect.catch(() => Effect.succeed([] as Config.Entry[])))
+      const parts = entries
+        .flatMap((entry) => (entry.type === "document" ? [entry.info.customInstructions?.trim()] : []))
+        .filter((part): part is string => Boolean(part))
+      if (parts.length === 0) return undefined
+      return parts.join("\n\n")
+    })
 
     const source = (value: ReadonlyArray<File> | SystemContext.Unavailable) =>
       SystemContext.make({
@@ -87,6 +110,15 @@ const layer = Layer.effectDiscard(
         Effect.catchDefect(() => Effect.succeed(source(SystemContext.unavailable))),
       ),
     })
+
+    yield* registry.register({
+      key: customKey,
+      load: observeCustom().pipe(
+        Effect.map((text) => (text === undefined ? SystemContext.empty : customSource(text))),
+        Effect.catch(() => Effect.succeed(SystemContext.empty)),
+        Effect.catchDefect(() => Effect.succeed(SystemContext.empty)),
+      ),
+    })
   }),
 )
 
@@ -95,6 +127,10 @@ export const node = makeLocationNode({
   layer,
   deps: [FSUtil.node, Global.node, Location.node, SystemContextRegistry.node],
 })
+
+function renderCustom(text: string) {
+  return [`<custom_instructions>`, text, `</custom_instructions>`].join("\n")
+}
 
 function render(files: ReadonlyArray<File>) {
   return files.map((file) => `Instructions from: ${file.path}\n${file.content}`).join("\n\n")

--- a/packages/core/src/system-context/builtins.ts
+++ b/packages/core/src/system-context/builtins.ts
@@ -1,31 +1,45 @@
 export * as SystemContextBuiltIns from "./builtins"
 
 import { makeLocationNode } from "../effect/app-node"
-import { DateTime, Effect, Layer, Schema } from "effect"
+import { DateTime, Effect, Layer, Option, Schema } from "effect"
 import { Location } from "../location"
 import { SystemContext } from "./index"
 import { InstructionContext } from "../instruction-context"
 import { SystemContextRegistry } from "./registry"
 import { FSUtil } from "../fs-util"
 import { Global } from "../global"
+import { Config } from "../config"
+import { Shell } from "../shell"
 
 const builtIns = Layer.effectDiscard(
   Effect.gen(function* () {
     const location = yield* Location.Service
     const registry = yield* SystemContextRegistry.Service
-    const environment = [
-      "<env>",
-      `  Working directory: ${location.directory}`,
-      `  Workspace root folder: ${location.project.directory}`,
-      `  Is directory a git repo: ${location.vcs?.type === "git" ? "yes" : "no"}`,
-      `  Platform: ${process.platform}`,
-      "</env>",
-    ].join("\n")
+    const loadEnvironment = Effect.fn("SystemContextBuiltIns.environment")(function* () {
+      const config = yield* Effect.serviceOption(Config.Service)
+      const configured = Option.isNone(config)
+        ? undefined
+        : Config.latest(
+            yield* config.value.entries().pipe(Effect.catch(() => Effect.succeed([] as Config.Entry[]))),
+            "shell",
+          )
+      const resolved = Shell.preferred(configured)
+      return [
+        "<env>",
+        `  Working directory: ${location.directory}`,
+        `  Workspace root folder: ${location.project.directory}`,
+        `  Is directory a git repo: ${location.vcs?.type === "git" ? "yes" : "no"}`,
+        `  Platform: ${process.platform}`,
+        `  OS: ${osLabel()}`,
+        `  Shell: ${Shell.name(resolved)} (${resolved})`,
+        "</env>",
+      ].join("\n")
+    })
     const context = SystemContext.combine([
       SystemContext.make({
         key: SystemContext.Key.make("core/environment"),
         codec: Schema.toCodecJson(Schema.String),
-        load: Effect.succeed(environment),
+        load: loadEnvironment(),
         baseline: (environment) =>
           ["Here is some useful information about the environment you are running in:", environment].join("\n"),
         update: (_previous, environment) => ["The environment you are running in is now:", environment].join("\n"),
@@ -48,3 +62,17 @@ export const node = makeLocationNode({
   layer: builtIns,
   deps: [Location.node, SystemContextRegistry.node, InstructionContext.node, FSUtil.node, Global.node],
 })
+
+const OS_NAMES: Record<string, string> = {
+  win32: "Windows",
+  darwin: "macOS",
+  linux: "Linux",
+  freebsd: "FreeBSD",
+  openbsd: "OpenBSD",
+  sunos: "SunOS",
+  aix: "AIX",
+}
+
+function osLabel(platform = process.platform, arch = process.arch) {
+  return `${OS_NAMES[platform] ?? platform} (${arch})`
+}

--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -106,7 +106,7 @@ const layer = Layer.effectDiscard(
     yield* tools
       .register({
         [name]: Tool.make({
-          description: `Execute one shell command string with the host user's filesystem, process, and network authority. The active Location is the default working directory. Relative workdir values resolve from that Location. External workdir values require external_directory approval; best-effort command-argument path warnings are advisory only. Timeout values are milliseconds (default: ${DEFAULT_TIMEOUT_MS}; maximum: ${MAX_TIMEOUT_MS}). Uses the configured shell when set; otherwise uses /bin/sh on POSIX and COMSPEC or cmd.exe on Windows.`,
+          description: `Execute one shell command string with the host user's filesystem, process, and network authority. The active Location is the default working directory. Relative workdir values resolve from that Location. External workdir values require external_directory approval; best-effort command-argument path warnings are advisory only. Timeout values are milliseconds (default: ${DEFAULT_TIMEOUT_MS}; maximum: ${MAX_TIMEOUT_MS}). Uses the configured shell when set; otherwise uses /bin/sh on POSIX and COMSPEC or cmd.exe on Windows. The effective shell and OS are listed in the <env> system context; adapt command syntax to that shell.`,
           input: Input,
           output: Output,
           structured: StructuredOutput,

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -124,6 +124,9 @@ export const Info = Schema.Struct({
   instructions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "Additional instruction files or patterns to include",
   }),
+  customInstructions: Schema.optional(Schema.String).annotate({
+    description: "Free-form custom instructions included in the system prompt",
+  }),
   layout: Schema.optional(ConfigLayoutV1.Layout).annotate({ description: "@deprecated Always uses stretch layout." }),
   permission: Schema.optional(ConfigPermissionV1.Info),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),

--- a/packages/core/src/v1/config/migrate.ts
+++ b/packages/core/src/v1/config/migrate.ts
@@ -62,6 +62,7 @@ export function migrate(info: typeof ConfigV1.Info.Type) {
     skills: info.skills && [...(info.skills.paths ?? []), ...(info.skills.urls ?? [])],
     commands: info.command,
     instructions: info.instructions,
+    customInstructions: info.customInstructions,
     references: info.references ?? info.reference,
     plugins: info.plugin?.map((plugin) =>
       typeof plugin === "string" ? plugin : { package: plugin[0], options: plugin[1] },

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -143,6 +143,12 @@ describe("Config", () => {
     }),
   )
 
+  it.effect("migrates v1 custom instructions into v2 configuration", () =>
+    Effect.sync(() => {
+      expect(ConfigMigrateV1.migrate({ customInstructions: "Use tabs." }).customInstructions).toBe("Use tabs.")
+    }),
+  )
+
   it.live("returns an empty configuration when directory files do not exist", () =>
     Effect.acquireRelease(
       Effect.promise(() => tmpdir()),

--- a/packages/core/test/instruction-context.test.ts
+++ b/packages/core/test/instruction-context.test.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises"
 import path from "path"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Config } from "@opencode-ai/core/config"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
 import { InstructionContext } from "@opencode-ai/core/instruction-context"
@@ -319,5 +320,129 @@ describe("InstructionContext", () => {
 
       expect(scanned).toBe(false)
     }),
+  )
+
+  it.live("loads custom instructions from config entries in global-first order", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const directory = path.join(tmp.path, "project")
+          yield* Effect.promise(() => fs.mkdir(directory, { recursive: true }))
+          const config = Config.Service.of({
+            entries: () =>
+              Effect.succeed([
+                new Config.Document({
+                  type: "document",
+                  info: new Config.Info({ customInstructions: "global rules" }),
+                }),
+                new Config.Document({
+                  type: "document",
+                  info: new Config.Info({ customInstructions: "project rules" }),
+                }),
+              ]),
+          })
+          const load = SystemContextRegistry.Service.pipe(
+            Effect.flatMap((service) => service.load()),
+            Effect.provide(
+              instructionLayer({
+                config: path.join(tmp.path, "global"),
+                locationServiceLayer: Layer.succeed(
+                  Location.Service,
+                  Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
+                ),
+              }),
+            ),
+            Effect.provideService(Config.Service, config),
+          )
+          const initialized = yield* SystemContext.initialize(yield* load)
+          expect(initialized.baseline).toBe("<custom_instructions>\nglobal rules\n\nproject rules\n</custom_instructions>")
+        }),
+      ),
+    ),
+  )
+
+  it.live("places custom instructions before AGENTS.md content", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const project = path.join(tmp.path, "project")
+          const agentsFile = path.join(project, "AGENTS.md")
+          yield* Effect.promise(() => fs.mkdir(project, { recursive: true }))
+          yield* Effect.promise(() => fs.writeFile(agentsFile, "project file"))
+          const config = Config.Service.of({
+            entries: () =>
+              Effect.succeed([
+                new Config.Document({
+                  type: "document",
+                  info: new Config.Info({ customInstructions: "custom rules" }),
+                }),
+              ]),
+          })
+          const load = SystemContextRegistry.Service.pipe(
+            Effect.flatMap((service) => service.load()),
+            Effect.provide(
+              instructionLayer({
+                config: path.join(tmp.path, "global"),
+                locationServiceLayer: Layer.succeed(
+                  Location.Service,
+                  Location.Service.of(
+                    location(
+                      { directory: AbsolutePath.make(project) },
+                      { projectDirectory: AbsolutePath.make(project) },
+                    ),
+                  ),
+                ),
+              }),
+            ),
+            Effect.provideService(Config.Service, config),
+          )
+          const baseline = (yield* SystemContext.initialize(yield* load)).baseline
+          expect(baseline).toContain("<custom_instructions>\ncustom rules\n</custom_instructions>")
+          expect(baseline).toContain(`Instructions from: ${agentsFile}\nproject file`)
+          expect(baseline.indexOf("<custom_instructions>")).toBeLessThan(baseline.indexOf("Instructions from:"))
+        }),
+      ),
+    ),
+  )
+
+  it.live("omits the custom block when custom instructions are blank", () =>
+    Effect.acquireRelease(
+      Effect.promise(() => tmpdir()),
+      (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+    ).pipe(
+      Effect.flatMap((tmp) =>
+        Effect.gen(function* () {
+          const directory = path.join(tmp.path, "project")
+          yield* Effect.promise(() => fs.mkdir(directory, { recursive: true }))
+          const config = Config.Service.of({
+            entries: () =>
+              Effect.succeed([
+                new Config.Document({ type: "document", info: new Config.Info({ customInstructions: "   " }) }),
+              ]),
+          })
+          const load = SystemContextRegistry.Service.pipe(
+            Effect.flatMap((service) => service.load()),
+            Effect.provide(
+              instructionLayer({
+                config: path.join(tmp.path, "global"),
+                locationServiceLayer: Layer.succeed(
+                  Location.Service,
+                  Location.Service.of(location({ directory: AbsolutePath.make(directory) })),
+                ),
+              }),
+            ),
+            Effect.provideService(Config.Service, config),
+          )
+          const initialized = yield* SystemContext.initialize(yield* load)
+          expect(initialized.baseline).not.toContain("<custom_instructions>")
+        }),
+      ),
+    ),
   )
 })

--- a/packages/core/test/system-context/builtins.test.ts
+++ b/packages/core/test/system-context/builtins.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from "bun:test"
+import { describe, expect, spyOn } from "bun:test"
 import { Effect, Layer } from "effect"
 import * as TestClock from "effect/testing/TestClock"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
@@ -7,6 +7,8 @@ import { Location } from "@opencode-ai/core/location"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { Global } from "@opencode-ai/core/global"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Config } from "@opencode-ai/core/config"
+import { Shell } from "@opencode-ai/core/shell"
 import { SystemContext } from "@opencode-ai/core/system-context"
 import { SystemContextBuiltIns } from "@opencode-ai/core/system-context/builtins"
 import { SystemContextRegistry } from "@opencode-ai/core/system-context/registry"
@@ -28,6 +30,13 @@ const locationLayer = Layer.succeed(
   ),
 )
 const builtInsNode = LayerNode.group([SystemContextBuiltIns.node, SystemContextRegistry.node])
+const osName = (platform: string) =>
+  platform === "win32" ? "Windows" : platform === "darwin" ? "macOS" : platform === "linux" ? "Linux" : platform
+const expectedOS = `  OS: ${osName(process.platform)} (${process.arch})`
+const expectedShell = () => {
+  const resolved = Shell.preferred()
+  return `  Shell: ${Shell.name(resolved)} (${resolved})`
+}
 const it = testEffect(
   AppNodeBuilder.build(builtInsNode, [
     [Location.node, locationLayer],
@@ -53,6 +62,11 @@ const itWithInstructions = testEffect(
     [Global.node, Global.layerWith({ config: "/global" })],
   ]),
 )
+const configWithShell = (shell: string) =>
+  Config.Service.of({
+    entries: () =>
+      Effect.succeed([new Config.Document({ type: "document", info: new Config.Info({ shell }) })]),
+  })
 
 describe("SystemContextBuiltIns", () => {
   it.effect("loads location-scoped environment and host-local date context", () =>
@@ -69,6 +83,8 @@ describe("SystemContextBuiltIns", () => {
           `  Workspace root folder: ${projectDirectory}`,
           "  Is directory a git repo: yes",
           `  Platform: ${process.platform}`,
+          expectedOS,
+          expectedShell(),
           "</env>",
           "",
           `Today's date: ${localDate(timestamp)}`,
@@ -117,6 +133,8 @@ describe("SystemContextBuiltIns", () => {
           `  Workspace root folder: ${projectDirectory}`,
           "  Is directory a git repo: yes",
           `  Platform: ${process.platform}`,
+          expectedOS,
+          expectedShell(),
           "</env>",
           "",
           `Today's date: ${localDate(timestamp)}`,
@@ -124,6 +142,53 @@ describe("SystemContextBuiltIns", () => {
           `Instructions from: ${instructionFile}\nBe precise.`,
         ].join("\n"),
       )
+    }),
+  )
+
+  it.effect("uses the configured shell in the env block", () =>
+    Effect.gen(function* () {
+      const preferred = spyOn(Shell, "preferred").mockReturnValue("/mock/custom-shell")
+      try {
+        yield* TestClock.setTime(timestamp)
+        const baseline = yield* Effect.gen(function* () {
+          const context = yield* SystemContextRegistry.Service
+          const loaded = yield* context.load()
+          return (yield* SystemContext.initialize(loaded)).baseline
+        }).pipe(Effect.provideService(Config.Service, configWithShell("configured-shell")))
+        expect(preferred).toHaveBeenCalledWith("configured-shell")
+        expect(baseline).toContain("  Shell: custom-shell (/mock/custom-shell)")
+        expect(baseline).toMatch(/  OS: .+ \(.+\)/)
+      } finally {
+        preferred.mockRestore()
+        Shell.preferred.reset()
+        Shell.acceptable.reset()
+      }
+    }),
+  )
+
+  it.effect("labels the OS per platform", () =>
+    Effect.gen(function* () {
+      const preferred = spyOn(Shell, "preferred").mockReturnValue("/mock/sh")
+      const originalPlatform = process.platform
+      const cases = [
+        ["win32", "Windows"],
+        ["darwin", "macOS"],
+        ["linux", "Linux"],
+      ] as const
+      try {
+        yield* TestClock.setTime(timestamp)
+        for (const [platform, name] of cases) {
+          Object.defineProperty(process, "platform", { value: platform })
+          const context = yield* SystemContextRegistry.Service
+          const baseline = (yield* SystemContext.initialize(yield* context.load())).baseline
+          expect(baseline).toContain(`  OS: ${name} (${process.arch})`)
+        }
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform })
+        preferred.mockRestore()
+        Shell.preferred.reset()
+        Shell.acceptable.reset()
+      }
     }),
   )
 })

--- a/packages/opencode/src/config/config.ts
+++ b/packages/opencode/src/config/config.ts
@@ -48,7 +48,16 @@ function mergeConfigConcatArrays(target: Info, source: Info): Info {
   if (target.instructions && source.instructions) {
     merged.instructions = Array.from(new Set([...target.instructions, ...source.instructions]))
   }
+  const customInstructions = mergeCustomInstructions(target.customInstructions, source.customInstructions)
+  if (customInstructions !== undefined) merged.customInstructions = customInstructions
+  if (customInstructions === undefined) delete merged.customInstructions
   return merged
+}
+
+function mergeCustomInstructions(target?: string, source?: string) {
+  const parts = [target, source].map((part) => part?.trim()).filter((part): part is string => Boolean(part))
+  if (parts.length === 0) return undefined
+  return parts.join("\n\n")
 }
 
 function normalizeLoadedConfig(data: unknown) {

--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -33,6 +33,7 @@ function extract(messages: SessionV1.WithParts[]) {
 
 export interface Interface {
   readonly clear: (messageID: MessageID) => Effect.Effect<void>
+  readonly custom: () => Effect.Effect<string | undefined>
   readonly systemPaths: () => Effect.Effect<Set<string>, FSUtil.Error>
   readonly system: () => Effect.Effect<string[], FSUtil.Error>
   readonly find: (dir: string) => Effect.Effect<string | undefined, FSUtil.Error>
@@ -105,6 +106,13 @@ const layer: Layer.Layer<
     const clear = Effect.fn("Instruction.clear")(function* (messageID: MessageID) {
       const s = yield* InstanceState.get(state)
       s.claims.delete(messageID)
+    })
+
+    const custom = Effect.fn("Instruction.custom")(function* () {
+      const config = yield* cfg.get()
+      const text = config.customInstructions?.trim()
+      if (!text) return undefined
+      return [`<custom_instructions>`, text, `</custom_instructions>`].join("\n")
     })
 
     const systemPaths = Effect.fn("Instruction.systemPaths")(function* () {
@@ -220,7 +228,7 @@ const layer: Layer.Layer<
       return results
     })
 
-    return Service.of({ clear, systemPaths, system, find, resolve })
+    return Service.of({ clear, custom, systemPaths, system, find, resolve })
   }),
 )
 

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1254,15 +1254,17 @@ const layer = Layer.effect(
 
             yield* plugin.trigger("experimental.chat.messages.transform", {}, { messages: msgs })
 
-            const [skills, env, instructions, mcpInstructions, modelMsgs] = yield* Effect.all([
+            const [skills, env, customInstructions, instructions, mcpInstructions, modelMsgs] = yield* Effect.all([
               sys.skills(agent),
               sys.environment(model),
+              instruction.custom(),
               instruction.system().pipe(Effect.orDie),
               sys.mcp(agent, session.permission),
               MessageV2.toModelMessagesEffect(msgs, model),
             ])
             const system = [
               ...env,
+              ...(customInstructions ? [customInstructions] : []),
               ...instructions,
               ...(mcpInstructions ? [mcpInstructions] : []),
               ...(skills ? [skills] : []),

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -1274,6 +1274,29 @@ it.effect("deduplicates duplicate instructions from global and local configs", (
   ),
 )
 
+it.effect("merges customInstructions text from global and local configs", () =>
+  withConfigTree(
+    {
+      global: { customInstructions: "global rules" },
+      local: { customInstructions: "local rules" },
+    },
+    Effect.gen(function* () {
+      expect((yield* Config.use.get()).customInstructions).toBe("global rules\n\nlocal rules")
+    }),
+  ),
+)
+
+it.effect("keeps single-sided customInstructions without extra separators", () =>
+  withConfigTree(
+    {
+      global: { customInstructions: "  global only  " },
+    },
+    Effect.gen(function* () {
+      expect((yield* Config.use.get()).customInstructions).toBe("global only")
+    }),
+  ),
+)
+
 it.effect("deduplicates duplicate plugins from global and local configs", () =>
   withConfigTree(
     {

--- a/packages/opencode/test/config/v2-compat.test.ts
+++ b/packages/opencode/test/config/v2-compat.test.ts
@@ -248,6 +248,11 @@ describe("ConfigV2Compat.lower", () => {
     expect(config.agent?.reviewer?.permission).toEqual({ edit: "deny" })
   })
 
+  test("preserves customInstructions through V2 lowering", () => {
+    const config = lower({ customInstructions: "Use tabs." })
+    expect(config.customInstructions).toBe("Use tabs.")
+  })
+
   test("does not sanitize malformed V1 fields before schema validation", () => {
     expect(() => lower({ model: 42 })).toThrow()
     expect(() => lower({ snapshot: "enabled" })).toThrow()

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -248,6 +248,54 @@ describe("Instruction.system", () => {
   )
 })
 
+describe("Instruction.custom", () => {
+  const customLayer = (customInstructions?: string) =>
+    AppNodeBuilder.build(Instruction.node, [
+      [
+        Config.node,
+        Layer.succeed(
+          Config.Service,
+          TestConfig.make({
+            get: () => Effect.succeed(customInstructions === undefined ? {} : { customInstructions }),
+          }),
+        ),
+      ],
+      [Global.node, Global.layerWith({ home: "/tmp", config: "/tmp" })],
+      [RuntimeFlags.node, RuntimeFlags.layer({})],
+    ])
+  const runCustom = (customInstructions?: string) =>
+    Effect.gen(function* () {
+      const svc = yield* Instruction.Service
+      return yield* svc.custom()
+    }).pipe(Effect.provide(customLayer(customInstructions)))
+
+  it.live("returns a formatted block when customInstructions is set", () =>
+    Effect.gen(function* () {
+      const result = yield* runCustom("Use tabs for indentation.")
+      expect(result).toBe("<custom_instructions>\nUse tabs for indentation.\n</custom_instructions>")
+    }),
+  )
+
+  it.live("returns undefined when customInstructions is missing", () =>
+    Effect.gen(function* () {
+      expect(yield* runCustom(undefined)).toBeUndefined()
+    }),
+  )
+
+  it.live("returns undefined when customInstructions is blank", () =>
+    Effect.gen(function* () {
+      expect(yield* runCustom("   \n  ")).toBeUndefined()
+    }),
+  )
+
+  it.live("trims surrounding whitespace", () =>
+    Effect.gen(function* () {
+      const result = yield* runCustom("  padded rules  ")
+      expect(result).toBe("<custom_instructions>\npadded rules\n</custom_instructions>")
+    }),
+  )
+})
+
 describe("Instruction.systemPaths global config", () => {
   it.live("uses Global.Service config AGENTS.md", () =>
     Effect.gen(function* () {

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -828,6 +828,21 @@ about rules here](/docs/rules).
 
 ---
 
+### Custom instructions
+
+You can store Codex-style personalized instructions in the `customInstructions` option. Describe your role, the tools available on your machine, and how you like to work:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "customInstructions": "You are a senior TypeScript engineer. Prefer Bun APIs, explain tradeoffs briefly, and run typecheck before finishing."
+}
+```
+
+Global and project configs are merged: keep personal defaults in your global config and extend them per project. `customInstructions` applies to every new chat. [Learn more about rules here](/docs/rules).
+
+---
+
 ### Disabled providers
 
 You can disable providers that are loaded automatically through the `disabled_providers` option. This is useful when you want to prevent certain providers from being loaded even if their credentials are available.

--- a/packages/web/src/content/docs/rules.mdx
+++ b/packages/web/src/content/docs/rules.mdx
@@ -102,6 +102,8 @@ When opencode starts, it looks for rule files in this order:
 
 The first matching file wins in each category. For example, if you have both `AGENTS.md` and `CLAUDE.md`, only `AGENTS.md` is used. Similarly, `~/.config/opencode/AGENTS.md` takes precedence over `~/.claude/CLAUDE.md`.
 
+Config `customInstructions` are applied after environment-provided config and before `AGENTS.md` files, so repo instructions can refine your global defaults.
+
 ---
 
 ## Custom Instructions


### PR DESCRIPTION
### Issue for this PR

Closes #47011

### Type of change

- [x] New feature

### What does this PR do?

Adds free-text `customInstructions` (Codex-style: role, machine tools, way of working) to opencode.json[c], merged global+project and injected into every new session after the env block, before AGENTS.md — plus a settings editor. Also extends the V2 `<env>` block with human-readable OS and the resolved effective shell, so generated commands match the runtime (no more Linux-isms on Windows). No protocol/server changes.

### How did you verify your code works?

- bun typecheck in packages/core, packages/opencode, packages/app: pass
- core: builtins + instruction-context + config + tool-bash — 42 pass
- opencode: instruction + v2-compat + config — 159 pass, 1 pre-existing todo
- app: server-compat + settings-v2 controllers — pass

### Screenshots / recordings

New settings card (textarea) in both settings UIs; no layout change to existing rows. Happy to add a screenshot on request.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
