### PR TITLE
feat: native infinite agent mode with limits

### DIFF
--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -21,6 +21,7 @@ import { useLanguage } from "@/context/language"
 import { useLayout } from "@/context/layout"
 import { usePermission } from "@/context/permission"
 import { type ImageAttachmentPart, usePrompt } from "@/context/prompt"
+import { useLocal } from "@/context/local"
 import { usePlatform } from "@/context/platform"
 import { useSDK } from "@/context/sdk"
 import { useSync } from "@/context/sync"
@@ -89,6 +90,7 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
   const permission = usePermission()
   const language = useLanguage()
   const platform = usePlatform()
+  const local = useLocal()
   const prompt = props.state ?? usePrompt()
   let editor: HTMLDivElement | undefined
 
@@ -399,6 +401,14 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
         current: () => props.controls.model.selection.variant.current() ?? "default",
         onSelect: (value) => props.controls.model.selection.variant.set(value === "default" ? undefined : value),
         keybind: () => command.keybindParts("model.variant.cycle"),
+      },
+      mode: {
+        options: () => [
+          { id: "complete", label: language.t("session.mode.complete") },
+          { id: "infinite", label: language.t("session.mode.infinite") },
+        ],
+        current: () => local.mode.current(),
+        onSelect: (value) => local.mode.set(value === "infinite" ? "infinite" : "complete"),
       },
       submit: {
         stopping,

--- a/packages/app/src/components/prompt-input/submit.test.ts
+++ b/packages/app/src/components/prompt-input/submit.test.ts
@@ -11,6 +11,7 @@ const sessionCreateInputs: Array<{
   agent?: string
   model?: { id: string; providerID: string; variant?: string }
   location?: { directory: string }
+  infinite?: boolean
 }> = []
 const enabledAutoAccept: Array<{ server: string; sessionID: string; directory: string }> = []
 const optimistic: Array<{
@@ -38,6 +39,7 @@ let params: { id?: string } = {}
 let search: { draftId?: string } = {}
 let selected = "/repo/worktree-a"
 let variant: string | undefined
+let sessionMode: string | undefined
 let permissionServer = "server-a"
 let createSessionGate: Promise<void> | undefined
 
@@ -135,6 +137,7 @@ beforeAll(async () => {
   mock.module("@opencode-ai/ui/toast", () => ({
     Toast: { Region: () => null },
     showToast: () => 0,
+    toaster: { dismiss: () => {} },
   }))
 
   mock.module("@opencode-ai/core/util/encode", () => ({
@@ -149,6 +152,10 @@ beforeAll(async () => {
       },
       agent: {
         current: () => ({ name: "agent" }),
+      },
+      mode: {
+        current: () => (sessionMode === "infinite" ? "infinite" : "complete"),
+        selected: () => (sessionMode === "infinite" ? "infinite" : undefined),
       },
       session: {
         promote(directory: string, sessionID: string) {
@@ -298,6 +305,7 @@ beforeEach(() => {
   syncedDirectories.length = 0
   selected = "/repo/worktree-a"
   variant = undefined
+  sessionMode = undefined
   permissionServer = "server-a"
   createSessionGate = undefined
   serverSessionSyncs = 0
@@ -339,11 +347,13 @@ describe("prompt submit worktree selection", () => {
         agent: "agent",
         model: { id: "model", providerID: "provider", variant: undefined },
         location: { directory: "/repo/worktree-a" },
+        infinite: false,
       },
       {
         agent: "agent",
         model: { id: "model", providerID: "provider", variant: undefined },
         location: { directory: "/repo/worktree-b" },
+        infinite: false,
       },
     ])
     expect(sentShell).toEqual([
@@ -594,5 +604,87 @@ describe("prompt submit worktree selection", () => {
     expect(storedSessions["/repo/worktree-a"]).toHaveLength(1)
     expect(storedSessions["/repo/worktree-a"]?.[0]).toMatchObject({ id: "session-1", title: "New session 1" })
     expect(optimisticSeeded).toEqual([true])
+  })
+
+  test("sends infinite false for complete mode followups", async () => {
+    params = { id: "session-1" }
+    sessionMode = "complete"
+
+    const submit = createPromptSubmit({
+      prompt,
+      info: () => ({ id: "session-1" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await submit.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await Bun.sleep(0)
+
+    expect(promptInputs[0]).toMatchObject({ sessionID: "session-1", infinite: false })
+  })
+
+  test("sends infinite true for infinite mode followups and creates", async () => {
+    params = { id: "session-1" }
+    sessionMode = "infinite"
+
+    const followup = createPromptSubmit({
+      prompt,
+      info: () => ({ id: "session-1" }),
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await followup.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+    await Bun.sleep(0)
+
+    expect(promptInputs[0]).toMatchObject({ sessionID: "session-1", infinite: true })
+
+    params = {}
+    const created = createPromptSubmit({
+      prompt,
+      info: () => undefined,
+      imageAttachments: () => [],
+      commentCount: () => 0,
+      autoAccept: () => false,
+      mode: () => "normal",
+      working: () => false,
+      editor: () => undefined,
+      queueScroll: () => undefined,
+      promptLength: (value) => value.reduce((sum, part) => sum + ("content" in part ? part.content.length : 0), 0),
+      addToHistory: () => undefined,
+      resetHistoryNavigation: () => undefined,
+      setMode: () => undefined,
+      setPopover: () => undefined,
+      newSessionWorktree: () => selected,
+      onNewSessionWorktreeReset: () => undefined,
+      onSubmit: () => undefined,
+    })
+
+    await created.handleSubmit({ preventDefault: () => undefined } as unknown as Event)
+
+    const lastCreate = sessionCreateInputs[sessionCreateInputs.length - 1]
+    expect(lastCreate).toMatchObject({ infinite: true })
   })
 })

--- a/packages/app/src/components/prompt-input/submit.ts
+++ b/packages/app/src/components/prompt-input/submit.ts
@@ -39,6 +39,7 @@ export type FollowupDraft = {
   agent: string
   model: { providerID: string; modelID: string }
   variant?: string
+  infinite?: boolean
 }
 
 type FollowupSendInput = {
@@ -171,6 +172,7 @@ export async function sendFollowupDraft(input: FollowupSendInput) {
       agent: input.draft.agent,
       model: input.draft.model,
       variant: input.draft.variant,
+      infinite: input.draft.infinite,
       legacyParts: requestParts,
       text: requestParts.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n"),
       files: requestParts.flatMap((part) => {
@@ -339,6 +341,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
     const currentModel = modelSelection.current()
     const currentAgent = local.agent.current()
     const variant = modelSelection.variant.current()
+    const infinite = local.mode.current() === "infinite"
     if (!currentModel || !currentAgent) {
       showToast({
         title: language.t("prompt.toast.modelAgentRequired.title"),
@@ -405,6 +408,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
           agent: currentAgent.name,
           model: { id: currentModel.id, providerID: currentModel.provider.id, variant },
           location: { directory: sessionDirectory },
+          infinite,
         })
         .then(normalizeSessionInfo)
         .catch((err) => {
@@ -424,6 +428,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
             agent: currentAgent.name,
             model: { providerID: currentModel.provider.id, modelID: currentModel.id },
             variant: variant ?? null,
+            mode: infinite ? "infinite" : null,
           })
           layout.handoff.setTabs(base64Encode(sessionDirectory), session.id)
           const draftID = search.draftId
@@ -454,6 +459,7 @@ export function createPromptSubmit(input: PromptSubmitInput) {
       agent,
       model,
       variant,
+      infinite,
     }
 
     const clearInput = () => {

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -10,6 +10,7 @@ import { resolveDefaultModel } from "@/hooks/provider-catalog"
 import { Persist, persisted } from "@/utils/persist"
 import { hasCustomAgent, resolveAgent } from "./local-agent"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "./model-variant"
+import { cycleSessionMode, resolveSessionMode, type SessionMode } from "./session-mode"
 import { useSDK } from "./sdk"
 import { useSync } from "./sync"
 import { useServerSDK } from "./server-sdk"
@@ -17,10 +18,13 @@ import { ScopedKey, type ServerScope } from "@/utils/server-scope"
 
 export type ModelKey = { providerID: string; modelID: string; variant?: string }
 
+export type { SessionMode }
+
 type State = {
   agent?: string
   model?: ModelKey
   variant?: string | null
+  mode?: SessionMode | null
 }
 
 type Saved = {
@@ -87,10 +91,11 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       draft?: State
       promoting?: State
       last?: {
-        type: "agent" | "model" | "variant"
+        type: "agent" | "model" | "variant" | "mode"
         agent?: string
         model?: ModelKey | null
         variant?: string | null
+        mode?: SessionMode | null
       }
     }>({
       current: list()[0]?.name,
@@ -199,12 +204,14 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             agent: item.name,
             model: item.model,
             variant: item.variant ?? null,
+            mode: selectedMode(),
           })
           const prev = scope()
           const next = {
             agent: item.name,
             model: item.model ?? prev?.model,
             variant: item.variant ?? prev?.variant,
+            mode: prev?.mode,
           } satisfies State
           const session = id()
           if (session) {
@@ -252,12 +259,15 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
 
     const selected = () => scope()?.variant
 
+    const selectedMode = () => scope()?.mode
+
     const snapshot = () => {
       const model = current()
       return {
         agent: agent.current()?.name,
         model: model ? { providerID: model.provider.id, modelID: model.id } : undefined,
         variant: selected(),
+        mode: selectedMode(),
       } satisfies State
     }
 
@@ -306,6 +316,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               agent: agent.current()?.name,
               model: item ?? null,
               variant: selected(),
+              mode: selectedMode(),
             })
             write({ model: item })
             if (!item) return
@@ -350,6 +361,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
                 agent: agent.current()?.name,
                 model: model ? { providerID: model.provider.id, modelID: model.id } : null,
                 variant: value ?? null,
+                mode: selectedMode(),
               })
               write({ variant: value ?? null })
               if (model) {
@@ -372,10 +384,36 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
       },
     }
 
+    const mode = {
+      selected: selectedMode,
+      current(): SessionMode {
+        return resolveSessionMode(selectedMode())
+      },
+      set(value: SessionMode | undefined) {
+        startTransition(() =>
+          batch(() => {
+            const item = current()
+            setStore("last", {
+              type: "mode",
+              agent: agent.current()?.name,
+              model: item ? { providerID: item.provider.id, modelID: item.id } : null,
+              variant: selected(),
+              mode: value ?? null,
+            })
+            write({ mode: value ?? null })
+          }),
+        )
+      },
+      cycle() {
+        mode.set(cycleSessionMode(mode.current()))
+      },
+    }
+
     const result = {
       slug: createMemo(() => base64Encode(sdk().directory)),
       model,
       agent,
+      mode,
       session: {
         ready: savedReady,
         reset() {

--- a/packages/app/src/context/session-mode.test.ts
+++ b/packages/app/src/context/session-mode.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { cycleSessionMode, resolveSessionMode, sessionModeInfinite } from "./session-mode"
+
+describe("session mode", () => {
+  test("defaults to complete", () => {
+    expect(resolveSessionMode(undefined)).toBe("complete")
+    expect(resolveSessionMode(null)).toBe("complete")
+    expect(resolveSessionMode("complete")).toBe("complete")
+  })
+
+  test("resolves infinite only for the infinite value", () => {
+    expect(resolveSessionMode("infinite")).toBe("infinite")
+    expect(resolveSessionMode("other")).toBe("complete")
+  })
+
+  test("cycles between complete and infinite", () => {
+    expect(cycleSessionMode("complete")).toBe("infinite")
+    expect(cycleSessionMode("infinite")).toBe("complete")
+  })
+
+  test("reports infinite flag", () => {
+    expect(sessionModeInfinite("infinite")).toBe(true)
+    expect(sessionModeInfinite("complete")).toBe(false)
+    expect(sessionModeInfinite(undefined)).toBe(false)
+  })
+})

--- a/packages/app/src/context/session-mode.ts
+++ b/packages/app/src/context/session-mode.ts
@@ -1,0 +1,15 @@
+export type SessionMode = "complete" | "infinite"
+
+export function resolveSessionMode(value: string | null | undefined): SessionMode {
+  if (value === "infinite") return "infinite"
+  return "complete"
+}
+
+export function cycleSessionMode(current: SessionMode): SessionMode {
+  if (current === "infinite") return "complete"
+  return "infinite"
+}
+
+export function sessionModeInfinite(value: string | null | undefined): boolean {
+  return resolveSessionMode(value) === "infinite"
+}

--- a/packages/app/src/i18n/en.ts
+++ b/packages/app/src/i18n/en.ts
@@ -77,6 +77,8 @@ export const dict = {
   "command.agent.cycle.reverse.description": "Switch to the previous agent",
   "command.model.variant.cycle": "Cycle thinking effort",
   "command.model.variant.cycle.description": "Switch to the next effort level",
+  "session.mode.complete": "Complete",
+  "session.mode.infinite": "Infinite",
   "command.prompt.mode.shell": "Shell",
   "command.prompt.mode.normal": "Prompt",
   "command.permissions.autoaccept.enable": "Auto-accept permissions",

--- a/packages/app/src/utils/server-compat.ts
+++ b/packages/app/src/utils/server-compat.ts
@@ -20,8 +20,12 @@ type LegacyClient = OpencodeClient
 type LegacyFor = (directory?: string) => LegacyClient
 type CompatibleSessionApi = Omit<
   SessionApi,
-  "prompt" | "command" | "shell" | "compact" | "rename" | "archive" | "remove"
+  "create" | "prompt" | "command" | "shell" | "compact" | "rename" | "archive" | "remove"
 > & {
+  create: (
+    input?: Parameters<SessionApi["create"]>[0] & { infinite?: boolean },
+    requestOptions?: Parameters<SessionApi["create"]>[1],
+  ) => ReturnType<SessionApi["create"]>
   prompt: (input: SessionPromptInput & LegacyPrompt) => Promise<SessionPromptOutput>
   command: (input: SessionCommandInput) => Promise<SessionCommandOutput>
   shell: (input: SessionShellInput & LegacyPrompt) => Promise<SessionShellOutput>
@@ -43,6 +47,7 @@ type LegacyPrompt = {
   agent?: string
   model?: { providerID: string; modelID: string }
   variant?: string
+  infinite?: boolean
   legacyParts?: (TextPartInput | FilePartInput | AgentPartInput)[]
 }
 type LegacyLocation = { directory?: string }

--- a/packages/client/src/generated-effect/client.ts
+++ b/packages/client/src/generated-effect/client.ts
@@ -63,10 +63,17 @@ type Endpoint3_1Input = {
   readonly agent?: Endpoint3_1Request["payload"]["agent"]
   readonly model?: Endpoint3_1Request["payload"]["model"]
   readonly location?: Endpoint3_1Request["payload"]["location"]
+  readonly infinite?: Endpoint3_1Request["payload"]["infinite"]
 }
 const Endpoint3_1 = (raw: RawClient["server.session"]) => (input?: Endpoint3_1Input) =>
   raw["session.create"]({
-    payload: { id: input?.["id"], agent: input?.["agent"], model: input?.["model"], location: input?.["location"] },
+    payload: {
+      id: input?.["id"],
+      agent: input?.["agent"],
+      model: input?.["model"],
+      location: input?.["location"],
+      infinite: input?.["infinite"],
+    },
   }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),
@@ -113,11 +120,18 @@ type Endpoint3_6Input = {
   readonly prompt: Endpoint3_6Request["payload"]["prompt"]
   readonly delivery?: Endpoint3_6Request["payload"]["delivery"]
   readonly resume?: Endpoint3_6Request["payload"]["resume"]
+  readonly infinite?: Endpoint3_6Request["payload"]["infinite"]
 }
 const Endpoint3_6 = (raw: RawClient["server.session"]) => (input: Endpoint3_6Input) =>
   raw["session.prompt"]({
     params: { sessionID: input["sessionID"] },
-    payload: { id: input["id"], prompt: input["prompt"], delivery: input["delivery"], resume: input["resume"] },
+    payload: {
+      id: input["id"],
+      prompt: input["prompt"],
+      delivery: input["delivery"],
+      resume: input["resume"],
+      infinite: input["infinite"],
+    },
   }).pipe(
     Effect.mapError(mapClientError),
     Effect.map((value) => value.data),

--- a/packages/client/src/generated/client.ts
+++ b/packages/client/src/generated/client.ts
@@ -314,6 +314,7 @@ export function make(options: ClientOptions) {
               agent: input?.["agent"],
               model: input?.["model"],
               location: input?.["location"],
+              infinite: input?.["infinite"],
             },
             successStatus: 200,
             declaredStatuses: [401, 400],
@@ -372,7 +373,13 @@ export function make(options: ClientOptions) {
           {
             method: "POST",
             path: `/api/session/${encodeURIComponent(input.sessionID)}/prompt`,
-            body: { id: input["id"], prompt: input["prompt"], delivery: input["delivery"], resume: input["resume"] },
+            body: {
+              id: input["id"],
+              prompt: input["prompt"],
+              delivery: input["delivery"],
+              resume: input["resume"],
+              infinite: input["infinite"],
+            },
             successStatus: 200,
             declaredStatuses: [409, 404, 400, 401],
             empty: false,

--- a/packages/client/src/generated/types.ts
+++ b/packages/client/src/generated/types.ts
@@ -272,25 +272,36 @@ export type SessionsCreateInput = {
     readonly agent?: string | null
     readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
     readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+    readonly infinite?: boolean | null
   }["id"]
   readonly agent?: {
     readonly id?: string | null
     readonly agent?: string | null
     readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
     readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+    readonly infinite?: boolean | null
   }["agent"]
   readonly model?: {
     readonly id?: string | null
     readonly agent?: string | null
     readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
     readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+    readonly infinite?: boolean | null
   }["model"]
   readonly location?: {
     readonly id?: string | null
     readonly agent?: string | null
     readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
     readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+    readonly infinite?: boolean | null
   }["location"]
+  readonly infinite?: {
+    readonly id?: string | null
+    readonly agent?: string | null
+    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly location?: { readonly directory: string; readonly workspaceID?: string } | null
+    readonly infinite?: boolean | null
+  }["infinite"]
 }
 
 export type SessionsCreateOutput = {
@@ -400,6 +411,7 @@ export type SessionsPromptInput = {
     }
     readonly delivery?: "steer" | "queue" | null
     readonly resume?: boolean | null
+    readonly infinite?: boolean | null
   }["id"]
   readonly prompt: {
     readonly id?: string | null
@@ -418,6 +430,7 @@ export type SessionsPromptInput = {
     }
     readonly delivery?: "steer" | "queue" | null
     readonly resume?: boolean | null
+    readonly infinite?: boolean | null
   }["prompt"]
   readonly delivery?: {
     readonly id?: string | null
@@ -436,6 +449,7 @@ export type SessionsPromptInput = {
     }
     readonly delivery?: "steer" | "queue" | null
     readonly resume?: boolean | null
+    readonly infinite?: boolean | null
   }["delivery"]
   readonly resume?: {
     readonly id?: string | null
@@ -454,7 +468,27 @@ export type SessionsPromptInput = {
     }
     readonly delivery?: "steer" | "queue" | null
     readonly resume?: boolean | null
+    readonly infinite?: boolean | null
   }["resume"]
+  readonly infinite?: {
+    readonly id?: string | null
+    readonly prompt: {
+      readonly text: string
+      readonly files?: ReadonlyArray<{
+        readonly uri: string
+        readonly name?: string
+        readonly description?: string
+        readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+      }>
+      readonly agents?: ReadonlyArray<{
+        readonly name: string
+        readonly source?: { readonly start: number; readonly end: number; readonly text: string }
+      }>
+    }
+    readonly delivery?: "steer" | "queue" | null
+    readonly resume?: boolean | null
+    readonly infinite?: boolean | null
+  }["infinite"]
 }
 
 export type SessionsPromptOutput = {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -13,6 +13,7 @@ import { AbsolutePath } from "./schema"
 import { ConfigAgent } from "./config/agent"
 import { ConfigAttachments } from "./config/attachments"
 import { ConfigCompaction } from "./config/compaction"
+import { ConfigInfinite } from "./config/infinite"
 import { ConfigCommand } from "./config/command"
 import { ConfigExperimental } from "./config/experimental"
 import { ConfigFormatter } from "./config/formatter"
@@ -86,6 +87,9 @@ export class Info extends Schema.Class<Info>("Config.Info")({
   }),
   compaction: ConfigCompaction.Info.pipe(Schema.optional).annotate({
     description: "Conversation compaction behavior",
+  }),
+  infinite: ConfigInfinite.Info.pipe(Schema.optional).annotate({
+    description: "Infinite agent mode auto-continue limits",
   }),
   skills: Schema.String.pipe(Schema.Array, Schema.optional).annotate({
     description: "Additional paths or URLs to discover skills from",

--- a/packages/core/src/config/infinite.ts
+++ b/packages/core/src/config/infinite.ts
@@ -1,0 +1,38 @@
+export * as ConfigInfinite from "./infinite"
+
+import { Schema } from "effect"
+import { PositiveInt } from "../schema"
+
+export class Info extends Schema.Class<Info>("ConfigV2.Infinite")({
+  maxIterations: PositiveInt.pipe(Schema.optional),
+  maxHours: PositiveInt.pipe(Schema.optional),
+  sentinel: Schema.String.pipe(Schema.optional),
+  todoDetection: Schema.Boolean.pipe(Schema.optional),
+}) {}
+
+export const Defaults = {
+  maxIterations: 100,
+  maxHours: 8,
+  sentinel: "[TASK_COMPLETE]",
+  todoDetection: true,
+} as const
+
+export type Resolved = {
+  readonly maxIterations: number
+  readonly maxHours: number
+  readonly sentinel: string
+  readonly todoDetection: boolean
+}
+
+export const resolve = (infos: ReadonlyArray<Info>): Resolved => {
+  const merged = infos.reduce<Resolved>(
+    (result, current) => ({
+      maxIterations: current.maxIterations ?? result.maxIterations,
+      maxHours: current.maxHours ?? result.maxHours,
+      sentinel: current.sentinel ?? result.sentinel,
+      todoDetection: current.todoDetection ?? result.todoDetection,
+    }),
+    { ...Defaults },
+  )
+  return merged
+}

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -32,6 +32,8 @@ import { LocationServiceMap } from "./location-service-map"
 import { MessageDecodeError } from "./session/error"
 import { SessionEvent } from "./session/event"
 import { SessionInput } from "./session/input"
+import { SessionInfinite } from "./session/infinite"
+import { ConfigInfinite } from "./config/infinite"
 import { Snapshot } from "./snapshot"
 import { SessionRevert } from "./session/revert"
 import { Revert } from "@opencode-ai/schema/revert"
@@ -81,6 +83,7 @@ type CreateInput = {
   agent?: AgentV2.ID
   model?: ModelV2.Ref
   location: Location.Ref
+  infinite?: boolean
 }
 
 type CompactInput = {
@@ -150,6 +153,7 @@ export interface Interface {
     prompt: PromptInput.Prompt
     delivery?: SessionInput.Delivery
     resume?: boolean
+    infinite?: boolean
   }) => Effect.Effect<SessionInput.Admitted, NotFoundError | PromptConflictError>
   readonly shell: (input: {
     id?: EventV2.ID
@@ -207,6 +211,8 @@ const layer = Layer.effect(
     const result = Service.of({
       create: Effect.fn("V2Session.create")(function* (input) {
         const sessionID = input.id ?? SessionSchema.ID.create()
+        if (input.infinite === true) SessionInfinite.enable(sessionID)
+        if (input.infinite === false) SessionInfinite.disable(sessionID)
         const recorded = yield* store.get(sessionID)
         if (recorded) return recorded
         const project = yield* projects.resolve(input.location.directory)
@@ -361,7 +367,13 @@ const layer = Layer.effect(
         Effect.uninterruptible(
           Effect.gen(function* () {
             yield* result.get(input.sessionID)
-            const prompt = resolvePrompt(input.prompt)
+            if (input.infinite === true) SessionInfinite.enable(input.sessionID)
+            if (input.infinite === false) SessionInfinite.disable(input.sessionID)
+            const resolvedText =
+              input.infinite === true
+                ? SessionInfinite.withSentinelInstruction(input.prompt.text, ConfigInfinite.Defaults.sentinel)
+                : input.prompt.text
+            const prompt = resolvePrompt({ ...input.prompt, text: resolvedText })
             const messageID = input.id ?? SessionMessage.ID.create()
             const delivery = input.delivery ?? "steer"
             const expected = { sessionID: input.sessionID, messageID, prompt, delivery }

--- a/packages/core/src/session/infinite.ts
+++ b/packages/core/src/session/infinite.ts
@@ -1,0 +1,47 @@
+export * as SessionInfinite from "./infinite"
+
+import { SessionSchema } from "./schema"
+
+export const withSentinelInstruction = (text: string, sentinel: string): string => {
+  if (text.includes(sentinel)) return text
+  return `${text}\n\nWhen the task is fully complete, emit ${sentinel} on its own line.`
+}
+
+export const continuationPrompt = (sentinel: string): string =>
+  `Continue working toward the objective. Do not stop until everything is done. When fully complete, emit ${sentinel} on its own line.`
+
+export const containsSentinel = (text: string, sentinel: string): boolean => text.includes(sentinel)
+
+export const isTerminated = (todos: ReadonlyArray<{ readonly status: string }>): boolean => {
+  if (todos.length === 0) return true
+  return todos.every((todo) => todo.status === "completed" || todo.status === "cancelled")
+}
+
+const enabled = new Set<string>()
+const progress = new Map<string, { readonly iterations: number; readonly startedAt: number }>()
+
+export const enable = (sessionID: SessionSchema.ID): void => {
+  enabled.add(sessionID)
+  if (!progress.has(sessionID)) progress.set(sessionID, { iterations: 0, startedAt: Date.now() })
+}
+
+export const disable = (sessionID: SessionSchema.ID): void => {
+  enabled.delete(sessionID)
+  progress.delete(sessionID)
+}
+
+export const isEnabled = (sessionID: SessionSchema.ID): boolean => enabled.has(sessionID)
+
+export const getProgress = (
+  sessionID: SessionSchema.ID,
+): { readonly iterations: number; readonly startedAt: number } | undefined => progress.get(sessionID)
+
+export const recordIteration = (sessionID: SessionSchema.ID): void => {
+  const current = progress.get(sessionID) ?? { iterations: 0, startedAt: Date.now() }
+  progress.set(sessionID, { iterations: current.iterations + 1, startedAt: current.startedAt })
+}
+
+export const clear = (): void => {
+  enabled.clear()
+  progress.clear()
+}

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -11,6 +11,7 @@ import {
 import { Cause, DateTime, Effect, FiberSet, Layer, Option, Semaphore, Stream } from "effect"
 import { AgentV2 } from "../../agent"
 import { Config } from "../../config"
+import { ConfigInfinite } from "../../config/infinite"
 import { Database } from "../../database/database"
 import { EventV2 } from "../../event"
 import { Location } from "../../location"
@@ -28,9 +29,13 @@ import { SessionContextEpoch } from "../context-epoch"
 import { SessionCompaction } from "../compaction"
 import { SessionEvent } from "../event"
 import { SessionHistory } from "../history"
+import { SessionInfinite } from "../infinite"
 import { SessionInput } from "../input"
+import { SessionMessage } from "../message"
+import { Prompt } from "../prompt"
 import { SessionSchema } from "../schema"
 import { SessionStore } from "../store"
+import { SessionTodo } from "../todo"
 import { type RunError, Service } from "./index"
 import { SessionRunnerModel } from "./model"
 import { createLLMEventPublisher } from "./publish-llm-event"
@@ -105,6 +110,9 @@ const layer = Layer.effect(
     const referenceGuidance = yield* ReferenceGuidance.Service
     const config = yield* Config.Service
     const snapshots = yield* Snapshot.Service
+    const todos = yield* SessionTodo.Service
+    const permissions = yield* PermissionV2.Service
+    const questions = yield* QuestionV2.Service
     const db = (yield* Database.Service).db
     const compaction = SessionCompaction.make({ events, llm, config: yield* config.entries() })
     const getSession = Effect.fn("SessionRunner.getSession")(function* (sessionID: SessionSchema.ID) {
@@ -349,7 +357,11 @@ const layer = Layer.effect(
           if (stream._tag === "Failure") return yield* Effect.failCause(stream.cause)
           if (settled._tag === "Failure" && Cause.hasInterrupts(settled.cause))
             return yield* Effect.failCause(settled.cause)
-          return { needsContinuation: !publisher.hasProviderError() && needsContinuation, step: currentStep }
+          return {
+            needsContinuation: !publisher.hasProviderError() && needsContinuation,
+            step: currentStep,
+            hadProviderError: publisher.hasProviderError(),
+          }
         }),
       )
     }, Effect.scoped)
@@ -357,7 +369,10 @@ const layer = Layer.effect(
       sessionID: SessionSchema.ID,
       promotion: SessionInput.Delivery | undefined,
       step: number,
-    ) => Effect.Effect<{ readonly needsContinuation: boolean; readonly step: number }, RunError>
+    ) => Effect.Effect<
+      { readonly needsContinuation: boolean; readonly step: number; readonly hadProviderError: boolean },
+      RunError
+    >
 
     const runAfterOverflowCompaction: RunTurn = Effect.fnUntraced(function* (sessionID, promotion, step) {
       return yield* runTurnAttempt(sessionID, promotion, step).pipe(
@@ -387,6 +402,50 @@ const layer = Layer.effect(
       )
     })
 
+    const lastAssistantText = Effect.fn("SessionRunner.lastAssistantText")(function* (
+      sessionID: SessionSchema.ID,
+    ) {
+      const context = yield* store.context(sessionID)
+      const assistant = context.toReversed().find((message) => message.type === "assistant")
+      if (!assistant || assistant.type !== "assistant") return ""
+      return assistant.content.flatMap((part) => (part.type === "text" ? [part.text] : [])).join("\n")
+    })
+
+    const maybeInfiniteContinue = Effect.fn("SessionRunner.maybeInfiniteContinue")(function* (
+      sessionID: SessionSchema.ID,
+      hadProviderError: boolean,
+    ) {
+      if (hadProviderError) return false
+      if (!SessionInfinite.isEnabled(sessionID)) return false
+      const entries = yield* config.entries()
+      const settings = ConfigInfinite.resolve(
+        entries
+          .filter((entry): entry is Config.Document => entry.type === "document")
+          .flatMap((entry) => (entry.info.infinite ? [entry.info.infinite] : [])),
+      )
+      const pendingPermissions = yield* permissions.forSession(sessionID)
+      if (pendingPermissions.length > 0) return false
+      const pendingQuestions = (yield* questions.list()).filter((request) => request.sessionID === sessionID)
+      if (pendingQuestions.length > 0) return false
+      const progress = SessionInfinite.getProgress(sessionID) ?? { iterations: 0, startedAt: Date.now() }
+      if (progress.iterations >= settings.maxIterations) return false
+      if (Date.now() - progress.startedAt >= settings.maxHours * 3_600_000) return false
+      const text = yield* lastAssistantText(sessionID)
+      if (SessionInfinite.containsSentinel(text, settings.sentinel)) return false
+      if (settings.todoDetection) {
+        const current = yield* todos.get(sessionID)
+        if (SessionInfinite.isTerminated(current)) return false
+      }
+      yield* SessionInput.admit(db, events, {
+        id: SessionMessage.ID.create(),
+        sessionID,
+        prompt: Prompt.make({ text: SessionInfinite.continuationPrompt(settings.sentinel) }),
+        delivery: "steer",
+      })
+      SessionInfinite.recordIteration(sessionID)
+      return true
+    })
+
     const run = Effect.fn("SessionRunner.run")(function* (input: {
       readonly sessionID: SessionSchema.ID
       readonly force: boolean
@@ -400,12 +459,23 @@ const layer = Layer.effect(
       while (shouldRun) {
         let needsContinuation = true
         let step = 1
+        let hadProviderError = false
         while (needsContinuation) {
           const result = yield* runTurn(input.sessionID, promotion, step)
           needsContinuation = result.needsContinuation
+          hadProviderError = result.hadProviderError
           step = result.step + 1
           promotion = "steer"
           if (!needsContinuation) needsContinuation = yield* SessionInput.hasPending(db, input.sessionID, "steer")
+          if (!needsContinuation) {
+            const continued = yield* maybeInfiniteContinue(input.sessionID, hadProviderError)
+            if (continued) {
+              needsContinuation = true
+              hadProviderError = false
+              step = 1
+              promotion = "steer"
+            }
+          }
         }
         shouldRun = yield* SessionInput.hasPending(db, input.sessionID, "queue")
         promotion = shouldRun ? "queue" : undefined
@@ -428,6 +498,9 @@ export const node = makeLocationNode({
     ToolRegistry.node,
     SessionRunnerModel.node,
     SessionStore.node,
+    SessionTodo.node,
+    PermissionV2.node,
+    QuestionV2.node,
     Location.node,
     SystemContextRegistry.node,
     SkillGuidance.node,

--- a/packages/core/test/config/infinite.test.ts
+++ b/packages/core/test/config/infinite.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer, Schema } from "effect"
+import { Config } from "@opencode-ai/core/config"
+import { ConfigInfinite } from "@opencode-ai/core/config/infinite"
+import { testEffect } from "../lib/effect"
+
+const it = testEffect(Layer.empty)
+const decode = Schema.decodeUnknownSync(Config.Info)
+
+describe("ConfigInfinite", () => {
+  it.effect("resolves defaults when no infinite config is present", () =>
+    Effect.sync(() => {
+      const resolved = ConfigInfinite.resolve([])
+      expect(resolved).toEqual({
+        maxIterations: 100,
+        maxHours: 8,
+        sentinel: "[TASK_COMPLETE]",
+        todoDetection: true,
+      })
+    }),
+  )
+
+  it.effect("merges partial configs with later documents winning", () =>
+    Effect.sync(() => {
+      const resolved = ConfigInfinite.resolve([
+        new ConfigInfinite.Info({ maxIterations: 5 }),
+        new ConfigInfinite.Info({ sentinel: "DONE", maxHours: 2 }),
+        new ConfigInfinite.Info({ todoDetection: false }),
+      ])
+      expect(resolved).toEqual({
+        maxIterations: 5,
+        maxHours: 2,
+        sentinel: "DONE",
+        todoDetection: false,
+      })
+    }),
+  )
+
+  it.effect("decodes infinite config from raw JSON and registers as optional", () =>
+    Effect.sync(() => {
+      const empty = decode({})
+      expect(empty.infinite).toBeUndefined()
+      const configured = decode({ infinite: { maxIterations: 10, sentinel: "[DONE]" } })
+      expect(configured.infinite).toBeInstanceOf(ConfigInfinite.Info)
+      expect(configured.infinite?.maxIterations).toBe(10)
+      expect(configured.infinite?.sentinel).toBe("[DONE]")
+      expect(configured.infinite?.maxHours).toBeUndefined()
+      expect(ConfigInfinite.resolve(configured.infinite ? [configured.infinite] : []).maxHours).toBe(8)
+      const latest = Config.latest(
+        [
+          new Config.Document({ type: "document", info: decode({ infinite: { maxIterations: 3 } }) }),
+          new Config.Document({ type: "document", info: decode({ infinite: { maxIterations: 7 } }) }),
+        ],
+        "infinite",
+      )
+      expect(latest?.maxIterations).toBe(7)
+    }),
+  )
+})

--- a/packages/core/test/session-infinite.test.ts
+++ b/packages/core/test/session-infinite.test.ts
@@ -1,0 +1,383 @@
+import { describe, expect } from "bun:test"
+import {
+  LLMClient,
+  LLMEvent,
+  Model,
+  type LLMClientShape,
+  type LLMRequest,
+} from "@opencode-ai/llm"
+import * as OpenAIChat from "@opencode-ai/llm/protocols/openai-chat"
+import { Database } from "@opencode-ai/core/database/database"
+import { makeLocationNode } from "@opencode-ai/core/effect/app-node"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNodePlatform } from "@opencode-ai/core/effect/app-node-platform"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { EventV2 } from "@opencode-ai/core/event"
+import { PermissionV2 } from "@opencode-ai/core/permission"
+import { PermissionSaved } from "@opencode-ai/core/permission/saved"
+import { Project } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { QuestionV2 } from "@opencode-ai/core/question"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { SessionV2 } from "@opencode-ai/core/session"
+import { SessionInfinite } from "@opencode-ai/core/session/infinite"
+import { Snapshot } from "@opencode-ai/core/snapshot"
+import { SessionEvent } from "@opencode-ai/core/session/event"
+import { Prompt } from "@opencode-ai/core/session/prompt"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { SessionExecution } from "@opencode-ai/core/session/execution"
+import { SessionRunCoordinator } from "@opencode-ai/core/session/run-coordinator"
+import { SessionRunner } from "@opencode-ai/core/session/runner"
+import * as SessionRunnerLLM from "@opencode-ai/core/session/runner/llm"
+import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
+import { SessionTodo } from "@opencode-ai/core/session/todo"
+import { ToolRegistry } from "@opencode-ai/core/tool/registry"
+import { ApplicationTools } from "@opencode-ai/core/tool/application-tools"
+import { AgentV2 } from "@opencode-ai/core/agent"
+import { Config } from "@opencode-ai/core/config"
+import { ConfigCompaction } from "@opencode-ai/core/config/compaction"
+import { ConfigInfinite } from "@opencode-ai/core/config/infinite"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionStore } from "@opencode-ai/core/session/store"
+import { SystemContext } from "@opencode-ai/core/system-context"
+import { SystemContextRegistry } from "@opencode-ai/core/system-context/registry"
+import { SkillGuidance } from "@opencode-ai/core/skill/guidance"
+import { ReferenceGuidance } from "@opencode-ai/core/reference/guidance"
+import { Location } from "@opencode-ai/core/location"
+import { Effect, Layer, Schema, Stream } from "effect"
+import { testEffect } from "./lib/effect"
+
+const requests: LLMRequest[] = []
+let responses: LLMEvent[][] | undefined
+let response: LLMEvent[] = []
+const client = Layer.succeed(
+  LLMClient.Service,
+  LLMClient.Service.of({
+    prepare: () => Effect.die("unused"),
+    stream: ((request: LLMRequest) => {
+      requests.push(request)
+      return Stream.fromIterable(responses === undefined ? response : (responses.shift() ?? []))
+    }) as unknown as LLMClientShape["stream"],
+    generate: () => Effect.die("unused"),
+  }),
+)
+const model = Model.make({ id: "fake-model", provider: "fake", route: OpenAIChat.route })
+const models = SessionRunnerModel.layerWith(() => Effect.succeed(model))
+const systemContext = Layer.effectDiscard(
+  SystemContextRegistry.Service.pipe(
+    Effect.flatMap((registry) =>
+      registry.register({
+        key: SystemContext.Key.make("test/context"),
+        load: Effect.succeed(SystemContext.empty),
+      }),
+    ),
+  ),
+).pipe(Layer.provideMerge(AppNodeBuilder.build(SystemContextRegistry.node)))
+const skillGuidance = Layer.mock(SkillGuidance.Service, { load: () => Effect.succeed(SystemContext.empty) })
+const referenceGuidance = Layer.mock(ReferenceGuidance.Service, { load: () => Effect.succeed(SystemContext.empty) })
+let infiniteOverride: ConfigInfinite.Info | undefined
+const config = Layer.succeed(
+  Config.Service,
+  Config.Service.of({
+    entries: () =>
+      Effect.succeed([
+        new Config.Document({
+          type: "document",
+          info: new Config.Info({
+            compaction: new ConfigCompaction.Info({
+              buffer: 3_000,
+              keep: new ConfigCompaction.Keep({ tokens: 1_000 }),
+            }),
+            ...(infiniteOverride ? { infinite: infiniteOverride } : {}),
+          }),
+        }),
+      ]),
+  }),
+)
+const runnerLayer = AppNodeBuilder.build(SessionRunnerLLM.node, [
+  [Snapshot.node, Snapshot.noopLayer],
+  [LayerNodePlatform.llmClient, client],
+  [SessionRunnerModel.node, models],
+  [SystemContextRegistry.node, systemContext],
+  [Location.node, Location.boundNode({ directory: AbsolutePath.make("/project") })],
+  [SkillGuidance.node, skillGuidance],
+  [ReferenceGuidance.node, referenceGuidance],
+  [Config.node, config],
+])
+const execution = Layer.effect(
+  SessionExecution.Service,
+  Effect.gen(function* () {
+    const sessionRunner = yield* SessionRunner.Service
+    const coordinator = yield* SessionRunCoordinator.make<SessionV2.ID, SessionRunner.RunError>({
+      drain: (sessionID, force) => sessionRunner.run({ sessionID, force }),
+    })
+    return SessionExecution.Service.of({
+      active: coordinator.active,
+      resume: coordinator.run,
+      wake: coordinator.wake,
+      interrupt: coordinator.interrupt,
+    })
+  }),
+).pipe(Layer.provide(runnerLayer))
+const it = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([
+      Database.node,
+      EventV2.node,
+      QuestionV2.node,
+      PermissionSaved.node,
+      SessionProjector.node,
+      SessionStore.node,
+      SessionTodo.node,
+      ApplicationTools.node,
+      AgentV2.node,
+      ToolRegistry.node,
+      ToolRegistry.toolsNode,
+      PermissionV2.node,
+      SessionRunnerModel.node,
+      SystemContextRegistry.node,
+      SkillGuidance.node,
+      ReferenceGuidance.node,
+      Config.node,
+      Snapshot.node,
+      SessionRunnerLLM.node,
+      SessionExecution.node,
+      SessionV2.node,
+    ]),
+    [
+      [LayerNodePlatform.llmClient, client],
+      [SessionRunnerModel.node, models],
+      [SystemContextRegistry.node, systemContext],
+      [Location.node, Location.boundNode({ directory: AbsolutePath.make("/project") })],
+      [SkillGuidance.node, skillGuidance],
+      [ReferenceGuidance.node, referenceGuidance],
+      [Snapshot.node, Snapshot.noopLayer],
+      [SessionExecution.node, execution],
+      [Config.node, config],
+    ],
+  ),
+)
+const sessionID = SessionV2.ID.make("ses_infinite_test")
+
+const insertSession = (id: SessionV2.ID) =>
+  Effect.gen(function* () {
+    const { db } = yield* Database.Service
+    yield* db
+      .insert(SessionTable)
+      .values({
+        id,
+        project_id: Project.ID.global,
+        slug: id,
+        directory: "/project",
+        title: "test",
+        version: "test",
+      })
+      .onConflictDoNothing()
+      .run()
+      .pipe(Effect.orDie)
+  })
+
+const setup = Effect.gen(function* () {
+  const { db } = yield* Database.Service
+  response = []
+  responses = undefined
+  requests.length = 0
+  infiniteOverride = undefined
+  SessionInfinite.clear()
+  yield* db
+    .insert(ProjectTable)
+    .values({ id: Project.ID.global, worktree: AbsolutePath.make("/project"), sandboxes: [] })
+    .onConflictDoNothing()
+    .run()
+    .pipe(Effect.orDie)
+  yield* insertSession(sessionID)
+})
+
+const textTurn = (id: string, text: string): LLMEvent[] => [
+  LLMEvent.stepStart({ index: 0 }),
+  LLMEvent.textStart({ id }),
+  LLMEvent.textDelta({ id, text }),
+  LLMEvent.textEnd({ id }),
+  LLMEvent.stepFinish({ index: 0, reason: "stop" }),
+  LLMEvent.finish({ reason: "stop" }),
+]
+
+describe("SessionInfinite", () => {
+  it.effect("appends sentinel instruction when the first prompt enables infinite", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const admitted = yield* session.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "Build the feature" }),
+        resume: false,
+        infinite: true,
+      })
+      expect(admitted.prompt.text).toContain("[TASK_COMPLETE]")
+      expect(admitted.prompt.text).toContain("Build the feature")
+      expect(SessionInfinite.isEnabled(sessionID)).toBe(true)
+    }),
+  )
+
+  it.effect("stops when the assistant emits the sentinel", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const todos = yield* SessionTodo.Service
+      yield* todos.update({
+        sessionID,
+        todos: [{ content: "work", status: "pending", priority: "high" }],
+      })
+      yield* session.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "Do work" }),
+        resume: false,
+        infinite: true,
+      })
+      requests.length = 0
+      response = textTurn("a1", "All done [TASK_COMPLETE]")
+      yield* session.resume(sessionID)
+      expect(requests).toHaveLength(1)
+    }),
+  )
+
+  it.effect("stops when all todos are done even without the sentinel", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const todos = yield* SessionTodo.Service
+      yield* todos.update({
+        sessionID,
+        todos: [{ content: "work", status: "completed", priority: "high" }],
+      })
+      yield* session.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "Do work" }),
+        resume: false,
+        infinite: true,
+      })
+      requests.length = 0
+      response = textTurn("a1", "Partial progress without sentinel")
+      yield* session.resume(sessionID)
+      expect(requests).toHaveLength(1)
+    }),
+  )
+
+  it.effect("continues when the sentinel is missing and todos remain open", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const todos = yield* SessionTodo.Service
+      yield* todos.update({
+        sessionID,
+        todos: [{ content: "work", status: "in_progress", priority: "high" }],
+      })
+      yield* session.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "Do work" }),
+        resume: false,
+        infinite: true,
+      })
+      requests.length = 0
+      responses = [textTurn("a1", "Still working"), textTurn("a2", "Finished [TASK_COMPLETE]")]
+      yield* session.resume(sessionID)
+      expect(requests).toHaveLength(2)
+      const context = yield* session.context(sessionID)
+      const users = context.filter((message) => message.type === "user")
+      expect(users.length).toBeGreaterThanOrEqual(2)
+      expect(SessionInfinite.getProgress(sessionID)?.iterations).toBe(1)
+    }),
+  )
+
+  it.effect("respects maxIterations", () =>
+    Effect.gen(function* () {
+      yield* setup
+      infiniteOverride = new ConfigInfinite.Info({ maxIterations: 1 })
+      const session = yield* SessionV2.Service
+      const todos = yield* SessionTodo.Service
+      yield* todos.update({
+        sessionID,
+        todos: [{ content: "work", status: "pending", priority: "high" }],
+      })
+      yield* session.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "Do work" }),
+        resume: false,
+        infinite: true,
+      })
+      requests.length = 0
+      responses = [
+        textTurn("a1", "Working 1"),
+        textTurn("a2", "Working 2"),
+        textTurn("a3", "Working 3"),
+      ]
+      yield* session.resume(sessionID)
+      expect(requests).toHaveLength(2)
+      expect(SessionInfinite.getProgress(sessionID)?.iterations).toBe(1)
+    }),
+  )
+
+  it.effect("does not continue while a permission request is pending", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const todos = yield* SessionTodo.Service
+      const permissions = yield* PermissionV2.Service
+      const agents = yield* AgentV2.Service
+      yield* agents.transform((editor) =>
+        editor.update(AgentV2.ID.make("build"), (agent) => {
+          agent.mode = "primary"
+          agent.permissions.push({ action: "*", resource: "*", effect: "allow" })
+          agent.permissions.push({ action: "read", resource: "secret.env", effect: "ask" })
+        }),
+      )
+      yield* todos.update({
+        sessionID,
+        todos: [{ content: "work", status: "pending", priority: "high" }],
+      })
+      yield* session.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "Do work" }),
+        resume: false,
+        infinite: true,
+      })
+      const askResult = yield* permissions.ask({
+        sessionID,
+        action: "read",
+        resources: ["secret.env"],
+      })
+      expect(askResult.effect).toBe("ask")
+      requests.length = 0
+      response = textTurn("a1", "Working without sentinel")
+      yield* session.resume(sessionID)
+      expect(requests).toHaveLength(1)
+    }),
+  )
+
+  it.effect("does not continue after a provider error", () =>
+    Effect.gen(function* () {
+      yield* setup
+      const session = yield* SessionV2.Service
+      const todos = yield* SessionTodo.Service
+      yield* todos.update({
+        sessionID,
+        todos: [{ content: "work", status: "pending", priority: "high" }],
+      })
+      yield* session.prompt({
+        sessionID,
+        prompt: Prompt.make({ text: "Do work" }),
+        resume: false,
+        infinite: true,
+      })
+      requests.length = 0
+      responses = [[LLMEvent.providerError({ message: "boom" })]]
+      const exit = yield* session.resume(sessionID).pipe(Effect.exit)
+      expect(requests).toHaveLength(1)
+      expect(yield* session.context(sessionID)).toMatchObject([
+        { type: "user" },
+        { type: "assistant", finish: "error" },
+      ])
+      void exit
+    }),
+  )
+})

--- a/packages/protocol/src/groups/session.ts
+++ b/packages/protocol/src/groups/session.ts
@@ -132,6 +132,7 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           agent: Agent.ID.pipe(Schema.optional),
           model: Model.Ref.pipe(Schema.optional),
           location: Location.Ref.pipe(Schema.optional),
+          infinite: Schema.Boolean.pipe(Schema.optional),
         }),
         success: Schema.Struct({ data: Session.Info }),
       }).annotateMerge(
@@ -209,6 +210,7 @@ export const makeSessionGroup = <I extends HttpApiMiddleware.AnyId, S>(sessionLo
           prompt: PromptInput.Prompt,
           delivery: SessionInput.Delivery.pipe(Schema.optional),
           resume: Schema.Boolean.pipe(Schema.optional),
+          infinite: Schema.Boolean.pipe(Schema.optional),
         }),
         success: Schema.Struct({ data: SessionInput.Admitted }),
         error: [ConflictError, SessionNotFoundError],

--- a/packages/server/src/handlers/session.ts
+++ b/packages/server/src/handlers/session.ts
@@ -73,6 +73,7 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
               agent: ctx.payload.agent,
               model: ctx.payload.model,
               location: ctx.payload.location ?? { directory: AbsolutePath.make(process.cwd()) },
+              infinite: ctx.payload.infinite,
             }),
           }
         }),
@@ -147,6 +148,7 @@ export const SessionHandler = HttpApiBuilder.group(Api, "server.session", (handl
                 prompt: ctx.payload.prompt,
                 delivery: ctx.payload.delivery,
                 resume: ctx.payload.resume,
+                infinite: ctx.payload.infinite,
               })
               .pipe(
                 Effect.catchTag("Session.NotFoundError", (error) =>

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -253,6 +253,14 @@ export function PromptInputV2(props: PromptInputV2Props) {
                 </Show>
               )}
             </Show>
+            <Show when={view.mode} keyed>
+              {(control) => (
+                <PromptInputV2ConfiguredSelect
+                  title={i18n.t("ui.promptInput.chooseMode")}
+                  control={control}
+                />
+              )}
+            </Show>
           </div>
           <PromptInputV2SubmitButton
             mode={state.mode}

--- a/packages/session-ui/src/v2/components/prompt-input/interaction.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/interaction.ts
@@ -34,6 +34,7 @@ export type PromptInputV2ViewConfig = {
   agent?: PromptInputV2SelectControl
   model?: PromptInputV2SelectControl
   variant?: PromptInputV2SelectControl
+  mode?: PromptInputV2SelectControl
   submit: {
     stopping: Accessor<boolean>
     working?: Accessor<boolean>

--- a/packages/ui/src/i18n/en.ts
+++ b/packages/ui/src/i18n/en.ts
@@ -136,6 +136,7 @@ export const dict: Record<string, string> = {
   "ui.promptInput.chooseAgent": "Choose agent",
   "ui.promptInput.chooseModel": "Choose model",
   "ui.promptInput.chooseVariant": "Choose model variant",
+  "ui.promptInput.chooseMode": "Choose mode",
   "ui.promptInput.send": "Send",
   "ui.promptInput.stop": "Stop",
 

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -763,6 +763,31 @@ You can control context compaction behavior through the `compaction` option.
 
 ---
 
+### Infinite
+
+You can control infinite agent mode auto-continue limits through the `infinite` option.
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "infinite": {
+    "maxIterations": 100,
+    "maxHours": 8,
+    "sentinel": "[TASK_COMPLETE]",
+    "todoDetection": true
+  }
+}
+```
+
+- `maxIterations` - Maximum auto-continue iterations before stopping (default: `100`).
+- `maxHours` - Maximum wall-clock hours before stopping (default: `8`).
+- `sentinel` - Completion marker the agent emits when the task is fully complete (default: `"[TASK_COMPLETE]"`).
+- `todoDetection` - Stop when all todos are completed or cancelled (default: `true`).
+
+Use the Mode toggle in the composer footer to switch between `Complete` and `Infinite` per session. The existing Stop button interrupts the loop at any time.
+
+---
+
 ### Watcher
 
 You can configure file watcher ignore patterns through the `watcher` option.


### PR DESCRIPTION
### Issue for this PR

Closes #47019

### Type of change

- [x] New feature

### What does this PR do?

Native infinite agent mode (inspired by the external opencode-infinite-agent supervisor, reimplemented inside the runner): per-session `Mode: Complete | Infinite` toggle in the composer next to agent/model/effort, `infinite?: boolean` on session create/prompt (SDK regenerated, no hand edits), and an `infinite` config section (maxIterations 100, maxHours 8, sentinel `[TASK_COMPLETE]`, todoDetection). When active, an idle-but-unfinished drain auto-continues with an internal steer until sentinel/todos-done or limits. Never continues with pending permission/question, provider errors, or after interrupt (existing stop button halts it).

### How did you verify your code works?

- bun typecheck: core, protocol, server, client, opencode, session-ui, app — pass
- core: infinite + session-infinite + config + builtins + instruction-context + tool-bash — pass
- opencode session-runner suite (87 tests): pass, no regression
- app: submit (incl. 2 new infinite tests) + session-mode — 14 pass

### Screenshots / recordings

Composer-only addition (Mode select next to effort); happy to add a screenshot on request.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
