### PR TITLE
fix(core): don't fail sibling tools on tool-output encode errors

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -317,6 +317,14 @@ const layer = Layer.effect(
           }
           if (settled._tag === "Failure" && !Cause.hasInterrupts(settled.cause)) {
             const failure = Cause.squash(settled.cause)
+            // An "encode" failure only means this one tool's own output could not be
+            // serialized; it says nothing about sibling tool calls' storage, so give
+            // them a chance to finish and self-report before sweeping whatever is
+            // still unsettled below (which converges to just the one that actually
+            // failed). A "write" failure is more likely a shared storage problem, so
+            // it keeps the immediate sweep.
+            if (failure instanceof ToolOutputStore.StorageError && failure.operation === "encode")
+              yield* restore(FiberSet.awaitEmpty(toolFibers)).pipe(Effect.exit)
             const message = failure instanceof Error ? failure.message : String(failure)
             yield* withPublication(publisher.failUnsettledTools(`Tool execution failed: ${message}`))
           }


### PR DESCRIPTION
### Issue for this PR

Closes #47024 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

I was reading through `session/runner/llm.ts` to understand how tool execution works in the V2 runner, and got stuck on the `raceFirst(FiberSet.join, FiberSet.awaitEmpty)` logic in `awaitToolFibers`. What confused me: if the model dispatches several tool calls at once and just one of them fails, the runner ends up marking *all* the other still-running ones as failed too — even ones that would've finished fine on their own. That felt wrong, so I dug into what could actually make `join` fail, and it turns out the only thing typed to reach it is `ToolOutputStore.Error` — a `StorageError` tagged with either `operation: "encode"` or `"write"`.

That's basically the whole fix: an `encode` failure only means *that one tool's* output couldn't be serialized, it has nothing to do with anyone else's storage — so there's no good reason to fail the whole batch because of it. I added a short extra wait (`FiberSet.awaitEmpty`) before sweeping unsettled tools in that specific case, so the other calls get a real chance to finish and report their own actual result instead of getting overwritten with a false "failed". A `write` failure is more likely a shared disk/storage problem, so that path still fails fast like before — didn't touch it.

### How did you verify your code works?

- `bun run typecheck` in packages/core passes; `bun turbo typecheck` across all 30 packages also passes (ran automatically via the pre-push hook).
- `bun test` in packages/core: 1096 tests pass, no regressions.
- Didn't add a new test for this specific race (concurrent tool calls + one encode failure) — flagging that so a maintainer can weigh in on whether one's expected.

### Screenshots / recordings

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

