### PR TITLE
docs: add opencode-local-tool-guard to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-local-tool-guard](https://github.com/kortega90/opencode-local-tool-guard)                | Progress-aware bash watchdog and safe grep/glob scope guard for local tool stalls on Linux and Windows |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #47035

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds opencode-local-tool-guard to the Ecosystem plugin list.

It is an external OpenCode plugin providing a progress-aware bash watchdog and safe grep/glob scope protection for local tool stalls on Linux and Windows.

### How did you verify your code works?

This is a documentation-only change. I verified that the repository link works, the project is not already listed, and the diff only changes the Ecosystem plugin table.

### Screenshots / recordings

Not applicable — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR