### PR TITLE
feat: custom instructions and environment-aware shell context

### DIFF
--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -1276,6 +1276,14 @@ export const dict = {
   "workspace.reset.archived.one": "1 session will be archived.",
   "workspace.reset.archived.many": "{{count}} sessions will be archived.",
   "workspace.reset.note": "This will reset the worktree to match the default branch.",
+
+  "settings.customInstructions.title": "Custom instructions",
+  "settings.customInstructions.description":
+    "Tell OpenCode how to behave in every new chat: your role, the tools on this machine, and how you like to work.",
+  "settings.customInstructions.placeholder":
+    "e.g. You are a senior TypeScript engineer. Prefer Bun APIs, explain tradeoffs briefly, and run typecheck before finishing.",
+  "settings.customInstructions.hint":
+    "Saved to your global config and applied to each new chat. Project config can extend it.",
 }
 
 export default dict

--- a/packages/app/src/runtime/server/types.ts
+++ b/packages/app/src/runtime/server/types.ts
@@ -157,6 +157,7 @@ export type Config = {
   agent?: Record<string, unknown>
   command?: Record<string, unknown>
   instructions?: string[]
+  customInstructions?: string
   disabled_providers?: string[]
   enabled_providers?: string[]
   permission?: string | Record<string, unknown>

--- a/packages/app/src/settings/general/controllers.ts
+++ b/packages/app/src/settings/general/controllers.ts
@@ -1,4 +1,5 @@
-import { createMemo, createResource, onMount, type Accessor } from "solid-js"
+import { createEffect, createMemo, createResource, onCleanup, onMount, type Accessor } from "solid-js"
+import { createStore } from "solid-js/store"
 import type { ColorScheme } from "@opencode-ai/ui/theme/context"
 import { useTheme } from "@opencode-ai/ui/theme/context"
 import {
@@ -40,6 +41,33 @@ export function createShellSettingsController(server: Accessor<ServerConnection.
       if (value === current()) return
       // TODO: Dax is considering the V2 shell discovery and config update APIs.
       // void serverSync.updateConfig({ shell: value })
+    },
+  }
+}
+
+export function createCustomInstructionsSettingsController(server: Accessor<ServerConnection.Any | undefined>) {
+  const serverCtx = useServerCtx(server)
+  const saved = createMemo(() => {
+    const value = serverCtx()?.sync.data.config.customInstructions
+    return typeof value === "string" ? value : ""
+  })
+  const [store, setStore] = createStore({ draft: "", dirty: false })
+  createEffect(() => {
+    if (store.dirty) return
+    setStore("draft", saved())
+  })
+  let timer: ReturnType<typeof setTimeout> | undefined
+  onCleanup(() => {
+    if (timer !== undefined) clearTimeout(timer)
+  })
+  return {
+    draft: () => store.draft,
+    update: (next: string) => {
+      setStore({ draft: next, dirty: true })
+      if (timer !== undefined) clearTimeout(timer)
+      timer = setTimeout(() => {
+        void serverCtx()?.sync.updateConfig({ customInstructions: next }).catch(() => undefined)
+      }, 500)
     },
   }
 }
@@ -148,5 +176,6 @@ export function createSoundSettingsController() {
 }
 
 export type ShellSettingsController = ReturnType<typeof createShellSettingsController>
+export type CustomInstructionsSettingsController = ReturnType<typeof createCustomInstructionsSettingsController>
 export type AppearanceSettingsController = ReturnType<typeof createAppearanceSettingsController>
 export type SoundSettingsController = ReturnType<typeof createSoundSettingsController>

--- a/packages/app/src/settings/general/custom-instructions.tsx
+++ b/packages/app/src/settings/general/custom-instructions.tsx
@@ -1,0 +1,36 @@
+import type { Component } from "solid-js"
+import { Textarea } from "@opencode-ai/ui/textarea"
+import { useLanguage } from "@/runtime/i18n/language"
+import { SettingsList } from "@/settings/list"
+import { SettingsRow } from "@/settings/row"
+import type { CustomInstructionsSettingsController } from "./controllers"
+
+export const CustomInstructionsSetting: Component<{ controller: CustomInstructionsSettingsController }> = (props) => {
+  const language = useLanguage()
+  return (
+    <div class="settings-section">
+      <h3 class="settings-section-title">{language.t("settings.customInstructions.title")}</h3>
+      <SettingsList>
+        <SettingsRow
+          title={language.t("settings.customInstructions.title")}
+          description={language.t("settings.customInstructions.description")}
+        >
+          <div class="w-full">
+            <Textarea
+              data-action="settings-custom-instructions"
+              rows={5}
+              value={props.controller.draft()}
+              placeholder={language.t("settings.customInstructions.placeholder")}
+              aria-label={language.t("settings.customInstructions.title")}
+              spellcheck={false}
+              onInput={(event) => props.controller.update(event.currentTarget.value)}
+            />
+            <span class="text-11-regular text-v2-text-text-muted">
+              {language.t("settings.customInstructions.hint")}
+            </span>
+          </div>
+        </SettingsRow>
+      </SettingsList>
+    </div>
+  )
+}

--- a/packages/app/src/settings/general/general.tsx
+++ b/packages/app/src/settings/general/general.tsx
@@ -20,11 +20,13 @@ import { SettingsList } from "@/settings/list"
 import { SettingsRow } from "@/settings/row"
 import {
   createAppearanceSettingsController,
+  createCustomInstructionsSettingsController,
   createShellOptions,
   createShellSettingsController,
   type AppearanceSettingsController,
   type ShellSettingsController,
 } from "./controllers"
+import { CustomInstructionsSetting } from "./custom-instructions"
 import "@/settings/settings.css"
 import { ServerConnection } from "@/runtime/server/registry"
 
@@ -304,6 +306,7 @@ export const SettingsGeneral: Component<{
   const mobile = createMediaQuery("(max-width: 767px)")
   const updater = useUpdaterAction()
   const shell = createShellSettingsController(() => props.server)
+  const customInstructions = createCustomInstructionsSettingsController(() => props.server)
   const desktop = createMemo(() => platform.platform === "desktop")
 
   const [pinchZoom, { mutate: setPinchZoom }] = createResource(
@@ -530,6 +533,9 @@ export const SettingsGeneral: Component<{
       </div>
       <div class="settings-tab-body">
         <GeneralSection />
+
+        {/* Custom instructions sits in its own section so general-row changes merge cleanly. */}
+        <CustomInstructionsSetting controller={customInstructions} />
 
         <section class="settings-section" aria-label={language.t("settings.timeline.title")}>
           <h3 class="settings-section-title">{language.t("settings.timeline.title")}</h3>

--- a/packages/core/src/config/normalize.ts
+++ b/packages/core/src/config/normalize.ts
@@ -205,6 +205,7 @@ export function normalize(input: unknown): Result {
     tool_output: Info.fields.tool_output,
     websearch: Info.fields.websearch,
     warming: Info.fields.warming,
+    customInstructions: Info.fields.customInstructions,
   }
   Object.entries(nativeAtomic).forEach(([key, schema]) => {
     if (!own(input, key)) return

--- a/packages/core/src/instructions/builtins.ts
+++ b/packages/core/src/instructions/builtins.ts
@@ -5,6 +5,8 @@ import { Context, DateTime, Effect, Layer, Schema } from "effect"
 import type { Session } from "@opencode-ai/schema/session"
 import { Global } from "@opencode-ai/util/global"
 import { Location } from "../location.js"
+import { Config } from "../config.js"
+import { ShellSelect } from "../shell/select.js"
 import { Instructions } from "./index.js"
 
 export interface Interface {
@@ -13,11 +15,15 @@ export interface Interface {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/InstructionBuiltIns") {}
 
+const customKey = Instructions.Key.make("core/custom-instructions")
+
 const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const global = yield* Global.Service
     const location = yield* Location.Service
+    const config = yield* Config.Service
+    const shellSelect = yield* ShellSelect.Service
     return Service.of({
       load: (sessionID) =>
         Effect.succeed(
@@ -25,18 +31,21 @@ const layer = Layer.effect(
             Instructions.make({
               key: Instructions.Key.make("core/environment"),
               codec: Schema.toCodecJson(Schema.String),
-              read: Effect.sync(() =>
-                [
+              read: Effect.gen(function* () {
+                const resolved = yield* shellSelect.resolve({ priority: "config" })
+                return [
                   "<env>",
                   `  Current conversation session ID: ${sessionID}`,
                   `  Working directory: ${location.directory}`,
                   `  Workspace root folder: ${location.project.directory}`,
                   `  Is directory a git repo: ${location.vcs?.type === "git" ? "yes" : "no"}`,
                   `  Platform: ${process.platform}`,
+                  `  OS: ${osLabel()}`,
+                  `  Shell: ${ShellSelect.name(resolved)} (${resolved})`,
                   `  Prefer ${global.tmp} over generic system temporary directories such as /tmp; it is pre-created and approved for external access.`,
                   "</env>",
-                ].join("\n"),
-              ),
+                ].join("\n")
+              }),
               render: {
                 initial: (environment) =>
                   ["Here is some useful information about the environment you are running in:", environment].join("\n"),
@@ -53,10 +62,50 @@ const layer = Layer.effect(
                 changed: (_previous, date) => `Today's date is now: ${date}`,
               },
             }),
+            Instructions.make({
+              key: customKey,
+              codec: Schema.toCodecJson(Schema.String),
+              read: Effect.gen(function* () {
+                const entries = yield* config.entries().pipe(Effect.orElseSucceed(() => []))
+                const parts = entries.flatMap((entry) => {
+                  const text = entry.type === "document" ? entry.info.customInstructions?.trim() : undefined
+                  return text ? [text] : []
+                })
+                if (parts.length === 0) return Instructions.removed
+                return parts.join("\n\n")
+              }),
+              render: {
+                initial: renderCustom,
+                changed: (_previous, current) => renderCustom(current),
+                removed: () => "Previously loaded custom instructions no longer apply.",
+              },
+            }),
           ]),
         ),
     })
   }),
 )
 
-export const node = makeLocationNode({ service: Service, layer, deps: [Global.node, Location.node] })
+export const node = makeLocationNode({
+  service: Service,
+  layer,
+  deps: [Global.node, Location.node, Config.node, ShellSelect.node],
+})
+
+const OS_NAMES: Record<string, string> = {
+  win32: "Windows",
+  darwin: "macOS",
+  linux: "Linux",
+  freebsd: "FreeBSD",
+  openbsd: "OpenBSD",
+  sunos: "SunOS",
+  aix: "AIX",
+}
+
+function osLabel(platform = process.platform, arch = process.arch) {
+  return `${OS_NAMES[platform] ?? platform} (${arch})`
+}
+
+function renderCustom(text: string) {
+  return [`<custom_instructions>`, text, `</custom_instructions>`].join("\n")
+}

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -123,6 +123,9 @@ export const Info = Schema.Struct({
   instructions: Schema.optional(Schema.mutable(Schema.Array(Schema.String))).annotate({
     description: "Additional instruction files or patterns to include",
   }),
+  customInstructions: Schema.optional(Schema.String).annotate({
+    description: "Free-form custom instructions included in the system prompt",
+  }),
   layout: Schema.optional(ConfigLayoutV1.Layout).annotate({ description: "@deprecated Always uses stretch layout." }),
   permission: Schema.optional(ConfigPermissionV1.Info),
   tools: Schema.optional(Schema.Record(Schema.String, Schema.Boolean)),

--- a/packages/core/src/v1/config/migrate.ts
+++ b/packages/core/src/v1/config/migrate.ts
@@ -57,6 +57,7 @@ export function migrate(info: typeof ConfigV1.Info.Type) {
         skills: info.skills && [...(info.skills.paths ?? []), ...(info.skills.urls ?? [])],
         commands: commands(info.command),
         instructions: info.instructions,
+        customInstructions: info.customInstructions,
         references: info.references ?? info.reference,
         experimental: experimental(info),
         plugins: info.plugin?.map((plugin) =>

--- a/packages/core/test/config/config.test.ts
+++ b/packages/core/test/config/config.test.ts
@@ -624,6 +624,10 @@ describe("Config", () => {
     expect(ConfigMigrateV1.migrate({}).update).toBeUndefined()
   })
 
+  test("migrates v1 custom instructions into v2 configuration", () => {
+    expect(ConfigMigrateV1.migrate({ customInstructions: "Use tabs." }).customInstructions).toBe("Use tabs.")
+  })
+
   test("migrates v1 provider lists to policies", () => {
     expect(
       ConfigMigrateV1.migrate({

--- a/packages/core/test/instructions/builtins.test.ts
+++ b/packages/core/test/instructions/builtins.test.ts
@@ -7,6 +7,8 @@ import { Location } from "@opencode-ai/core/location"
 import { FSUtil } from "@opencode-ai/util/fs-util"
 import { Global } from "@opencode-ai/util/global"
 import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Config } from "@opencode-ai/core/config"
+import { Document, Info } from "@opencode-ai/schema/config"
 import { InstructionBuiltIns } from "@opencode-ai/core/instructions/builtins"
 import { SessionSchema } from "@opencode-ai/core/session/schema"
 import { location } from "../fixture/location"
@@ -28,12 +30,16 @@ const locationLayer = Layer.succeed(
     ),
   ),
 )
-const it = testEffect(
+const osName = (platform: string) =>
+  platform === "win32" ? "Windows" : platform === "darwin" ? "macOS" : platform === "linux" ? "Linux" : platform
+const expectedOS = `  OS: ${osName(process.platform)} (${process.arch})`
+const baseLayer = (entries: Parameters<typeof Config.testLayer>[0] = []) =>
   AppNodeBuilder.build(InstructionBuiltIns.node, [
     Location.node.replace(locationLayer),
     Global.node.replace(Global.layerWith({ config: temporary, tmp: temporary })),
-  ]),
-)
+    Config.node.replace(Config.testLayer(entries)),
+  ])
+const it = testEffect(baseLayer())
 
 describe("InstructionBuiltIns", () => {
   it.effect("loads location-scoped environment and host-local date instructions", () =>
@@ -42,7 +48,7 @@ describe("InstructionBuiltIns", () => {
       const context = yield* InstructionBuiltIns.Service
       const initialized = yield* readInitial(yield* context.load(sessionID))
 
-      expect(initialized.text).toBe(
+      expect(initialized.text).toContain(
         [
           "Here is some useful information about the environment you are running in:",
           "<env>",
@@ -51,6 +57,12 @@ describe("InstructionBuiltIns", () => {
           `  Workspace root folder: ${projectDirectory}`,
           "  Is directory a git repo: yes",
           `  Platform: ${process.platform}`,
+          expectedOS,
+        ].join("\n"),
+      )
+      expect(initialized.text).toMatch(/  Shell: .+ \(.+\)/)
+      expect(initialized.text).toContain(
+        [
           `  Prefer ${temporary} over generic system temporary directories such as /tmp; it is pre-created and approved for external access.`,
           "</env>",
           "",
@@ -81,6 +93,53 @@ describe("InstructionBuiltIns", () => {
 
       yield* TestClock.setTime(timestamp + 60 * 60 * 1000)
       expect((yield* readUpdate(yield* context.load(sessionID), initialized)).changed).toBe(false)
+    }),
+  )
+})
+
+describe("InstructionBuiltIns custom instructions", () => {
+  const customIt = (entries: Parameters<typeof Config.testLayer>[0]) => testEffect(baseLayer(entries))
+
+  customIt([
+    new Document({ type: "document", info: new Info({ customInstructions: "global rules" }) }),
+    new Document({ type: "document", info: new Info({ customInstructions: "project rules" }) }),
+  ]).effect("merges custom instructions from global-first entries", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(timestamp)
+      const context = yield* InstructionBuiltIns.Service
+      const initialized = yield* readInitial(yield* context.load(sessionID))
+      expect(initialized.text).toContain("<custom_instructions>\nglobal rules\n\nproject rules\n</custom_instructions>")
+    }),
+  )
+
+  customIt([
+    new Document({ type: "document", info: new Info({ customInstructions: "  custom rules  " }) }),
+  ]).effect("trims surrounding whitespace", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(timestamp)
+      const context = yield* InstructionBuiltIns.Service
+      const initialized = yield* readInitial(yield* context.load(sessionID))
+      expect(initialized.text).toContain("<custom_instructions>\ncustom rules\n</custom_instructions>")
+    }),
+  )
+
+  customIt([
+    new Document({ type: "document", info: new Info({ customInstructions: "   " }) }),
+  ]).effect("omits the custom block when custom instructions are blank", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(timestamp)
+      const context = yield* InstructionBuiltIns.Service
+      const initialized = yield* readInitial(yield* context.load(sessionID))
+      expect(initialized.text).not.toContain("<custom_instructions>")
+    }),
+  )
+
+  customIt([]).effect("omits the custom block when no custom instructions are configured", () =>
+    Effect.gen(function* () {
+      yield* TestClock.setTime(timestamp)
+      const context = yield* InstructionBuiltIns.Service
+      const initialized = yield* readInitial(yield* context.load(sessionID))
+      expect(initialized.text).not.toContain("<custom_instructions>")
     }),
   )
 })

--- a/packages/schema/src/config.ts
+++ b/packages/schema/src/config.ts
@@ -89,6 +89,9 @@ export class Info extends Schema.Class<Info>("Config.Info")({
   instructions: Schema.String.pipe(Schema.Array, optional).annotate({
     description: "Additional paths or URLs supplying ambient instructions",
   }),
+  customInstructions: Schema.String.pipe(optional).annotate({
+    description: "Free-form custom instructions included in the system prompt",
+  }),
   references: ConfigReference.Info.pipe(optional).annotate({
     description: "Named local directories or Git repositories available as external context",
   }),

--- a/packages/www/src/docs/content/config.mdx
+++ b/packages/www/src/docs/content/config.mdx
@@ -396,6 +396,18 @@ but does not load these entries yet; use `AGENTS.md` for active instructions.
 
 See the [instructions guide](/instructions) for project instructions and `AGENTS.md`.
 
+### Custom instructions
+
+Store Codex-style personalized instructions in `customInstructions`. Describe your role, the tools on this machine, and how you like to work:
+
+```jsonc
+{
+  "customInstructions": "You are a senior TypeScript engineer. Prefer Bun APIs, explain tradeoffs briefly, and run typecheck before finishing.",
+}
+```
+
+Global and project configs are merged: keep personal defaults in your global config and extend them per project. `customInstructions` applies to every new chat.
+
 ### References
 
 Make local directories or Git repositories available as named supporting

--- a/packages/www/src/docs/content/instructions.mdx
+++ b/packages/www/src/docs/content/instructions.mdx
@@ -91,9 +91,10 @@ The selected agent or provider system prompt is sent first. OpenCode then sends
 the session's initial instructions, composed in this order:
 
 1. Built-in environment and date context.
-2. Ambient `AGENTS.md` discovery.
-3. Available skill, reference, and MCP guidance.
-4. Session-specific instruction entries supplied through the API.
+2. Config `customInstructions`, applied after environment context and before `AGENTS.md` files, so repo instructions can refine your global defaults.
+3. Ambient `AGENTS.md` discovery.
+4. Available skill, reference, and MCP guidance.
+5. Session-specific instruction entries supplied through the API.
 
 These sources are combined; ordering is not an override mechanism. Nested
 `AGENTS.md` files discovered by reads are chronological session entries rather


### PR DESCRIPTION
### Issue for this PR

Closes #47011

### Type of change

- [x] New feature

### What does this PR do?

Native port of #47012 to the `v2` branch (which restructured config, instructions, settings and docs, so a direct cherry-pick was impossible):
- Free-text `customInstructions` in config schema (v1 + migrate + normalize), merged global-first and injected as `<custom_instructions>` after env/date and before AGENTS.md discovery.
- V2 `<env>` block gains human-readable `OS` and resolved effective `Shell` (respects config/shell plugin + discovery); execution untouched.
- Settings editor (own section + controller, en-only i18n) and docs (`config.mdx`, `instructions.mdx` ordering).

Note: `sync.updateConfig` is currently stubbed upstream (`TODO: Restore config updates`), so the editor wiring typechecks but persistence lands once that TODO is restored.

### How did you verify your code works?

- `bun run typecheck` in schema, core, app, www: pass
- core: instructions builtins (7), config migrate: pass
- app: settings general controllers: pass
- session-generate + session-runner suites: 187 pass

### Screenshots / recordings

New settings section only; happy to add a screenshot on request.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
