### PR TITLE
feat(provider): add Red Hat OpenShift AI (MaaS) provider with live model discovery

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -19,6 +19,7 @@ import { PoeAuthPlugin } from "opencode-poe-auth"
 import { CloudflareAIGatewayAuthPlugin, CloudflareWorkersAuthPlugin } from "./cloudflare"
 import { AzureAuthPlugin } from "./azure"
 import { DigitalOceanAuthPlugin } from "./digitalocean"
+import { RhoaiMaasAuthPlugin } from "./rhoai-maas"
 import { XaiAuthPlugin } from "./xai"
 import { CerebrasPlugin } from "./cerebras"
 import { SnowflakeCortexAuthPlugin } from "./snowflake-cortex"
@@ -79,6 +80,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
     CloudflareAIGatewayAuthPlugin,
     AzureAuthPlugin,
     DigitalOceanAuthPlugin,
+    RhoaiMaasAuthPlugin,
     SnowflakeCortexAuthPlugin,
     XaiAuthPlugin,
     CerebrasPlugin,

--- a/packages/opencode/src/plugin/rhoai-maas.ts
+++ b/packages/opencode/src/plugin/rhoai-maas.ts
@@ -1,0 +1,129 @@
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+import type { Hooks } from "@opencode-ai/plugin"
+import type { Model } from "@opencode-ai/sdk/v2"
+
+// Red Hat OpenShift AI — Models-as-a-Service (MaaS).
+//
+// MaaS exposes a per-cluster, OpenAI-compatible `/v1` gateway (Kuadrant/Envoy in
+// front of vLLM/KServe) secured with subscription-scoped API keys. Every RHOAI
+// customer runs their own cluster, so the gateway base URL is not a constant we
+// can bake into models.dev — it is captured per-login and stored in the auth
+// metadata (`metadata.baseURL`). The models.dev catalog entry only needs to
+// exist so this plugin's `provider.models` hook is allowed to run; the actual
+// model list is discovered live from `<baseURL>/models`.
+
+export const PROVIDER_ID = "rhoai-maas"
+
+const DEFAULT_CONTEXT = 32768
+const DEFAULT_OUTPUT = 8192
+const DISCOVERY_TIMEOUT_MS = 10_000
+
+interface OpenAIModellist {
+  data?: Array<{ id?: unknown; name?: unknown }>
+}
+
+/** Normalize a user-entered gateway URL to an OpenAI-compatible base ending in `/v1`. */
+export function normalizeBaseURL(raw: string | undefined): string | undefined {
+  if (!raw) return undefined
+  let value = raw.trim()
+  if (!value) return undefined
+  if (!/^https?:\/\//i.test(value)) value = `https://${value}`
+  value = value.replace(/\/+$/, "")
+  if (!/\/v1$/i.test(value)) value = `${value}/v1`
+  return value
+}
+
+function maasModel(id: string, name: string, baseURL: string): Model {
+  return {
+    id,
+    providerID: PROVIDER_ID,
+    name,
+    family: "rhoai-maas",
+    api: { id, url: baseURL, npm: "@ai-sdk/openai-compatible" },
+    status: "active",
+    headers: {},
+    options: {},
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: DEFAULT_CONTEXT, output: DEFAULT_OUTPUT },
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    release_date: "",
+    variants: {},
+  }
+}
+
+async function discoverModels(
+  baseURL: string,
+  key: string,
+  request: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+): Promise<Record<string, Model>> {
+  const res = await request(`${baseURL}/models`, {
+    headers: {
+      Authorization: `Bearer ${key}`,
+      Accept: "application/json",
+      "User-Agent": `opencode/${InstallationVersion}`,
+    },
+    signal: AbortSignal.timeout(DISCOVERY_TIMEOUT_MS),
+  })
+  if (!res.ok) throw new Error(`MaaS model discovery failed (HTTP ${res.status})`)
+  const body = (await res.json()) as OpenAIModellist
+  const models: Record<string, Model> = {}
+  for (const entry of body.data ?? []) {
+    if (typeof entry?.id !== "string" || !entry.id) continue
+    const name = typeof entry.name === "string" && entry.name ? entry.name : entry.id
+    models[entry.id] = maasModel(entry.id, name, baseURL)
+  }
+  return models
+}
+
+export function createRhoaiMaasHooks(
+  request: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response> = fetch,
+): Hooks {
+  return {
+    provider: {
+      id: PROVIDER_ID,
+      async models(provider, ctx) {
+        if (ctx.auth?.type !== "api") return provider.models
+        const baseURL = normalizeBaseURL(ctx.auth.metadata?.baseURL)
+        if (!baseURL) return provider.models
+        return discoverModels(baseURL, ctx.auth.key, request).catch(() => provider.models)
+      },
+    },
+    auth: {
+      provider: PROVIDER_ID,
+      async loader(getAuth) {
+        const auth = await getAuth()
+        if (auth.type !== "api") return {}
+        const baseURL = normalizeBaseURL(auth.metadata?.baseURL)
+        if (!baseURL) return {}
+        return { baseURL, apiKey: auth.key }
+      },
+      methods: [
+        {
+          type: "api",
+          label: "API key",
+          prompts: [
+            {
+              type: "text",
+              key: "baseURL",
+              message: "Enter your MaaS gateway URL",
+              placeholder: "e.g. https://maas.apps.<cluster>/v1",
+              validate: (value) => (normalizeBaseURL(value) ? undefined : "A gateway URL is required"),
+            },
+          ],
+        },
+      ],
+    },
+  }
+}
+
+export async function RhoaiMaasAuthPlugin(): Promise<Hooks> {
+  return createRhoaiMaasHooks()
+}

--- a/packages/opencode/test/plugin/rhoai-maas.test.ts
+++ b/packages/opencode/test/plugin/rhoai-maas.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test"
+import type { Auth, Provider } from "@opencode-ai/sdk/v2"
+import { createRhoaiMaasHooks, normalizeBaseURL, PROVIDER_ID } from "../../src/plugin/rhoai-maas"
+
+const provider: Provider = {
+  id: PROVIDER_ID,
+  name: "Red Hat OpenShift AI",
+  source: "custom",
+  env: [],
+  options: {},
+  models: {},
+}
+
+const apiAuth = (metadata?: Record<string, string>): Auth => ({ type: "api", key: "test-key", metadata })
+
+function modelsHook(hooks: ReturnType<typeof createRhoaiMaasHooks>) {
+  const fn = hooks.provider?.models
+  if (!fn) throw new Error("MaaS provider model hook is missing")
+  return fn
+}
+
+function loader(hooks: ReturnType<typeof createRhoaiMaasHooks>) {
+  const fn = hooks.auth?.loader
+  if (!fn) throw new Error("MaaS auth loader is missing")
+  return fn
+}
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "Content-Type": "application/json" } })
+}
+
+describe("plugin.rhoai-maas", () => {
+  test("normalizeBaseURL adds scheme, trims trailing slash, and ensures /v1", () => {
+    expect(normalizeBaseURL("https://maas.example.com/v1")).toBe("https://maas.example.com/v1")
+    expect(normalizeBaseURL("https://maas.example.com/v1/")).toBe("https://maas.example.com/v1")
+    expect(normalizeBaseURL("maas.example.com")).toBe("https://maas.example.com/v1")
+    expect(normalizeBaseURL("  https://maas.example.com  ")).toBe("https://maas.example.com/v1")
+    expect(normalizeBaseURL("")).toBeUndefined()
+    expect(normalizeBaseURL(undefined)).toBeUndefined()
+  })
+
+  test("exposes a single API-key method with a gateway URL prompt", () => {
+    const hooks = createRhoaiMaasHooks()
+    expect(hooks.auth?.provider).toBe(PROVIDER_ID)
+    expect(hooks.provider?.id).toBe(PROVIDER_ID)
+    expect(hooks.auth?.methods.map((m) => [m.type, m.label])).toEqual([["api", "API key"]])
+    const method = hooks.auth?.methods[0]
+    expect(method?.prompts?.map((p) => p.key)).toEqual(["baseURL"])
+    const validate = method?.prompts?.[0].type === "text" ? method.prompts[0].validate : undefined
+    expect(validate?.("")).toBe("A gateway URL is required")
+    expect(validate?.("https://maas.example.com")).toBeUndefined()
+  })
+
+  test("discovers models live from <baseURL>/models", async () => {
+    const requests: string[] = []
+    const hooks = createRhoaiMaasHooks(async (input, init) => {
+      requests.push(String(input))
+      expect(new Headers(init?.headers).get("authorization")).toBe("Bearer test-key")
+      return jsonResponse({
+        object: "list",
+        data: [
+          { id: "publishers/red-hat/models/qwen2-5-instruct", name: "Qwen 2.5 Instruct" },
+          { id: "publishers/red-hat/models/granite-3-8b" },
+        ],
+      })
+    })
+
+    const result = await modelsHook(hooks)(provider, {
+      auth: apiAuth({ baseURL: "https://maas.example.com/v1/" }),
+    })
+
+    expect(requests).toEqual(["https://maas.example.com/v1/models"])
+    expect(Object.keys(result)).toEqual([
+      "publishers/red-hat/models/qwen2-5-instruct",
+      "publishers/red-hat/models/granite-3-8b",
+    ])
+    const model = result["publishers/red-hat/models/qwen2-5-instruct"]
+    expect(model.name).toBe("Qwen 2.5 Instruct")
+    expect(model.api).toEqual({
+      id: "publishers/red-hat/models/qwen2-5-instruct",
+      url: "https://maas.example.com/v1",
+      npm: "@ai-sdk/openai-compatible",
+    })
+    expect(model.capabilities.toolcall).toBe(true)
+    // Falls back to the model id when the gateway omits a display name.
+    expect(result["publishers/red-hat/models/granite-3-8b"].name).toBe("publishers/red-hat/models/granite-3-8b")
+  })
+
+  test("keeps catalog models when discovery fails or is unauthenticated", async () => {
+    const failing = createRhoaiMaasHooks(async () => jsonResponse({ error: "nope" }, 500))
+    const catalog = { ...provider, models: { foo: {} as never } }
+    expect(await modelsHook(failing)(catalog, { auth: apiAuth({ baseURL: "https://maas.example.com/v1" }) })).toBe(
+      catalog.models,
+    )
+    // No auth at all -> untouched catalog.
+    expect(await modelsHook(failing)(catalog, {})).toBe(catalog.models)
+    // Missing baseURL -> untouched catalog.
+    expect(await modelsHook(failing)(catalog, { auth: apiAuth() })).toBe(catalog.models)
+  })
+
+  test("loader supplies the per-cluster baseURL and key to the SDK", async () => {
+    const hooks = createRhoaiMaasHooks()
+    expect(await loader(hooks)(async () => apiAuth({ baseURL: "https://maas.example.com" }), provider)).toEqual({
+      baseURL: "https://maas.example.com/v1",
+      apiKey: "test-key",
+    })
+    // Without a stored baseURL the loader defers to catalog options.
+    expect(await loader(hooks)(async () => apiAuth(), provider)).toEqual({})
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #

### Type of change

- [x] New feature

### What does this PR do?

Adds a bundled **Red Hat OpenShift AI** auth provider for Models-as-a-Service (MaaS) gateways.

MaaS exposes an OpenAI-compatible `/v1` endpoint that is **per cluster**, so there is no single fixed base URL. Instead of hardcoding one, the provider captures the gateway URL during `opencode auth login` (stored in `auth.metadata.baseURL`) alongside the API key. The `provider.models` hook then queries `<baseURL>/models` at load time and maps the response into the model list, so a user sees whatever their own cluster serves without editing config. If discovery fails (network/401/no base URL) it falls back to the catalog models.

Files: the provider plugin (`plugin/rhoai-maas.ts`), its registration in `plugin/index.ts`, and unit tests.

### How did you verify your code works?

`bun test packages/opencode/test/plugin/rhoai-maas.test.ts` — 5 passing tests covering URL normalization, the API-key auth method + base-URL prompt, live model discovery, discovery-failure fallback to catalog models, and the auth loader supplying the per-cluster base URL.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_Note: this provider needs a matching `models.dev` catalog entry to appear in the provider list — submitted separately._
