### PR TITLE
fix: fail closed for unknown run agents

### DIFF
--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -25,6 +25,7 @@ import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
 import { INTERACTIVE_INPUT_ERROR, resolveInteractiveStdin } from "./run/runtime.stdin"
+import { formatUnknownRunAgentError, resolveRequestedRunAgent } from "./run/agent-flag"
 
 type ModelInput = Parameters<OpencodeClient["session"]["prompt"]>[0]["model"]
 
@@ -165,11 +166,11 @@ export const RunCommand = effectCmd({
       .option("model", {
         type: "string",
         alias: ["m"],
-        describe: "model to use in the format of provider/model",
+        describe: "model to use in the format of provider/model (pins the session model and skips plugin fallback chains)",
       })
       .option("agent", {
         type: "string",
-        describe: "agent to use",
+        describe: "agent to use (exact or case-insensitive registered name; unknown names exit instead of falling back)",
       })
       .option("format", {
         type: "string",
@@ -596,26 +597,15 @@ export const RunCommand = effectCmd({
         if (!args.agent) return undefined
         const name = args.agent
 
-        const entry = await Effect.runPromise(
-          agentSvc.get(name).pipe(Effect.provideService(InstanceRef, localInstance)),
+        const listed = await Effect.runPromise(
+          agentSvc.list().pipe(Effect.provideService(InstanceRef, localInstance)),
         )
-        if (!entry) {
-          UI.println(
-            UI.Style.TEXT_WARNING_BOLD + "!",
-            UI.Style.TEXT_NORMAL,
-            `agent "${name}" not found. Falling back to default agent`,
-          )
-          return undefined
+        const resolved = resolveRequestedRunAgent(name, listed)
+        if (!resolved.ok) {
+          UI.error(formatUnknownRunAgentError(name, resolved))
+          process.exit(1)
         }
-        if (entry.mode === "subagent") {
-          UI.println(
-            UI.Style.TEXT_WARNING_BOLD + "!",
-            UI.Style.TEXT_NORMAL,
-            `agent "${name}" is a subagent, not a primary agent. Falling back to default agent`,
-          )
-          return undefined
-        }
-        return name
+        return resolved.name
       }
 
       async function attachAgent(sdk: OpencodeClient) {
@@ -636,26 +626,12 @@ export const RunCommand = effectCmd({
           return undefined
         }
 
-        const agent = modes.find((a) => a.name === name)
-        if (!agent) {
-          UI.println(
-            UI.Style.TEXT_WARNING_BOLD + "!",
-            UI.Style.TEXT_NORMAL,
-            `agent "${name}" not found. Falling back to default agent`,
-          )
-          return undefined
+        const resolved = resolveRequestedRunAgent(name, modes)
+        if (!resolved.ok) {
+          UI.error(formatUnknownRunAgentError(name, resolved))
+          process.exit(1)
         }
-
-        if (agent.mode === "subagent") {
-          UI.println(
-            UI.Style.TEXT_WARNING_BOLD + "!",
-            UI.Style.TEXT_NORMAL,
-            `agent "${name}" is a subagent, not a primary agent. Falling back to default agent`,
-          )
-          return undefined
-        }
-
-        return name
+        return resolved.name
       }
 
       async function pickAgent(sdk: OpencodeClient) {

--- a/packages/opencode/src/cli/cmd/run/agent-flag.ts
+++ b/packages/opencode/src/cli/cmd/run/agent-flag.ts
@@ -1,0 +1,48 @@
+export type RunAgentListEntry = {
+  readonly name: string
+  readonly mode?: string
+}
+
+export type ResolveRequestedRunAgentResult =
+  | { readonly ok: true; readonly name: string }
+  | { readonly ok: false; readonly reason: "not_found" | "subagent"; readonly names: string[] }
+
+export function matchRunAgent(
+  requested: string,
+  agents: readonly RunAgentListEntry[],
+): RunAgentListEntry | undefined {
+  const exact = agents.find((agent) => agent.name === requested)
+  if (exact) return exact
+  const lower = requested.toLowerCase()
+  return agents.find((agent) => agent.name.toLowerCase() === lower)
+}
+
+export function primaryRunAgentNames(agents: readonly RunAgentListEntry[]): string[] {
+  return agents.filter((agent) => agent.mode !== "subagent").map((agent) => agent.name)
+}
+
+export function resolveRequestedRunAgent(
+  requested: string,
+  agents: readonly RunAgentListEntry[],
+): ResolveRequestedRunAgentResult {
+  const names = primaryRunAgentNames(agents)
+  const matched = matchRunAgent(requested, agents)
+  if (!matched) {
+    return { ok: false, reason: "not_found", names }
+  }
+  if (matched.mode === "subagent") {
+    return { ok: false, reason: "subagent", names }
+  }
+  return { ok: true, name: matched.name }
+}
+
+export function formatUnknownRunAgentError(
+  requested: string,
+  result: Extract<ResolveRequestedRunAgentResult, { ok: false }>,
+): string {
+  const list = result.names.length > 0 ? result.names.join(", ") : "(none)"
+  if (result.reason === "subagent") {
+    return `agent "${requested}" is a subagent, not a primary agent. Registered primary agents: ${list}`
+  }
+  return `agent "${requested}" not found. Registered primary agents: ${list}`
+}

--- a/packages/opencode/test/cli/run/agent-flag.test.ts
+++ b/packages/opencode/test/cli/run/agent-flag.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test"
+import {
+  formatUnknownRunAgentError,
+  resolveRequestedRunAgent,
+} from "../../../src/cli/cmd/run/agent-flag"
+
+describe("resolveRequestedRunAgent", () => {
+  const agents = [
+    { name: "Sisyphus - ultraworker", mode: "primary" },
+    { name: "sisyphus", mode: "primary" },
+    { name: "explore", mode: "subagent" },
+  ]
+
+  test("matches exact registered names", () => {
+    const result = resolveRequestedRunAgent("sisyphus", agents)
+    expect(result).toEqual({ ok: true, name: "sisyphus" })
+  })
+
+  test("matches registered names case-insensitively", () => {
+    const result = resolveRequestedRunAgent("sisyphus - ULTRAWORKER", agents)
+    expect(result).toEqual({ ok: true, name: "Sisyphus - ultraworker" })
+  })
+
+  test("fails closed on unknown names", () => {
+    const result = resolveRequestedRunAgent("not-an-agent", agents)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe("not_found")
+    expect(formatUnknownRunAgentError("not-an-agent", result)).toContain("Registered primary agents")
+    expect(formatUnknownRunAgentError("not-an-agent", result)).not.toContain("Falling back")
+  })
+
+  test("rejects subagents", () => {
+    const result = resolveRequestedRunAgent("explore", agents)
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.reason).toBe("subagent")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #47038
Fixes #47040

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

`opencode run --agent` now resolves the requested agent against registered agents using exact and then case-insensitive matching. If the name is unknown or resolves to a subagent, the command exits with an error listing registered primary agents instead of silently falling back to `default_agent`.

The `--model` / `-m` help text also documents that selecting a model pins the session model and bypasses plugin fallback chains.

### How did you verify your code works?

Ran `bun test test/cli/run/agent-flag.test.ts` from `packages/opencode`; all four tests passed, including unknown, case-insensitive, primary, and subagent cases.

### Screenshots / recordings

Not applicable; this changes CLI behavior and help text.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._