### PR TITLE
fix: preserve HTTP status on generic provider errors

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -603,6 +603,24 @@ function isAfter(info: Info, other?: Info) {
   return info.id > other.id
 }
 
+
+function readHttpStatus(error: unknown): number | undefined {
+  if (!error || typeof error !== "object") return undefined
+  const record = error as Record<string, unknown>
+  const candidates = [record.statusCode, record.status]
+  const cause = record.cause
+  if (cause && typeof cause === "object") {
+    const nested = cause as Record<string, unknown>
+    candidates.push(nested.statusCode, nested.status)
+  }
+  for (const value of candidates) {
+    if (typeof value === "number" && value >= 100 && value <= 599) return value
+  }
+  const message = typeof record.message === "string" ? record.message : errorMessage(error)
+  const match = message.match(/\b(401|403|408|429|500|502|503|504)\b/)
+  return match ? Number(match[1]) : undefined
+}
+
 export function fromError(
   e: unknown,
   ctx: { providerID: ProviderV2.ID; aborted?: boolean },
@@ -702,8 +720,20 @@ export function fromError(
         },
         { cause: e },
       ).toObject()
-    case e instanceof Error:
+    case e instanceof Error: {
+      const statusCode = readHttpStatus(e)
+      if (statusCode !== undefined) {
+        return new APIError(
+          {
+            message: errorMessage(e),
+            statusCode,
+            isRetryable: statusCode >= 500 || statusCode === 408 || statusCode === 429,
+          },
+          { cause: e },
+        ).toObject()
+      }
       return new NamedError.Unknown({ message: errorMessage(e) }, { cause: e }).toObject()
+    }
     default:
       try {
         const parsed = ProviderError.parseStreamError(e)

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1526,6 +1526,15 @@ describe("session.message-v2.fromError", () => {
     })
   })
 
+  test("preserves HTTP status on generic Error wraps so plugins can fallback", () => {
+    const error = Object.assign(new Error("Unexpected server error"), { statusCode: 401 })
+    const result = MessageV2.fromError(error, { providerID })
+    expect(SessionV1.APIError.isInstance(result)).toBe(true)
+    if (!SessionV1.APIError.isInstance(result)) return
+    expect(result.data.statusCode).toBe(401)
+    expect(result.data.message).toContain("Unexpected server error")
+  })
+
   test("classifies ZlibError from fetch as retryable APIError", () => {
     const zlibError = new Error(
       'ZlibError fetching "https://opencode.cloudflare.dev/anthropic/messages". For more information, pass `verbose: true` in the second argument to fetch()',


### PR DESCRIPTION
### Issue for this PR

Fixes #47039

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Preserves `status` and `statusCode` from generic provider errors and their causes when `MessageV2.fromError` converts them. Plugins can then distinguish authentication, rate-limit, and server failures instead of receiving an untyped `UnknownError`. Errors without an HTTP status still use `UnknownError`.

### How did you verify your code works?

Ran `bun test test/session/message-v2.test.ts` from `packages/opencode`, including the new generic-error HTTP-status case.

### Screenshots / recordings

Not applicable; no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR