### PR TITLE
fix: bypass proxies for loopback URLs

### DIFF
--- a/packages/opencode/AGENTS.md
+++ b/packages/opencode/AGENTS.md
@@ -129,3 +129,9 @@ Use `Effect.cached` when multiple concurrent callers should share a single in-fl
 Use `EffectBridge` for native or external callbacks (`@parcel/watcher`, `node-pty`, native `fs.watch`, plugin callbacks, etc.) that need to re-enter Effect services with instance/workspace context.
 
 Plain async code should pass explicit context or stay inside an Effect fiber; do not add ambient instance context shims.
+
+## Compiled binary networking
+
+The compiled OpenCode binary is a Bun executable. `NODE_OPTIONS=--dns-result-order=ipv4first` is a Node.js flag and is ignored. Prefer Happy Eyeballs / `family: 0` in fetch, or run via `bun`/`node` if IPv4-first DNS is required.
+
+Loopback URLs are not sent through `HTTP_PROXY`/`ALL_PROXY` (`packages/opencode/src/util/proxy-env.ts`). Compiled `fetch` may still honor Bun's env proxy independently of that helper.

--- a/packages/opencode/src/util/proxy-env.ts
+++ b/packages/opencode/src/util/proxy-env.ts
@@ -47,7 +47,13 @@ export function getProxyForUrl(input: string | URL) {
   return proxy.includes("://") ? proxy : `${protocol}://${proxy}`
 }
 
+function isLoopbackHostname(hostname: string) {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "")
+  return host === "localhost" || host === "127.0.0.1" || host === "::1" || host === "0.0.0.0"
+}
+
 function shouldProxy(hostname: string, port: number) {
+  if (isLoopbackHostname(hostname)) return false
   const noProxy = env("no_proxy").toLowerCase()
   if (!noProxy) return true
   if (noProxy === "*") return false

--- a/packages/opencode/test/util/proxy-env.test.ts
+++ b/packages/opencode/test/util/proxy-env.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { getProxyForUrl } from "../../src/util/proxy-env"
+
+const KEYS = ["ALL_PROXY", "all_proxy", "HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy"] as const
+const saved: Record<string, string | undefined> = {}
+
+function snapshotEnv() {
+  for (const key of KEYS) saved[key] = process.env[key]
+}
+
+function restoreEnv() {
+  for (const key of KEYS) {
+    if (saved[key] === undefined) delete process.env[key]
+    else process.env[key] = saved[key]
+  }
+}
+
+describe("getProxyForUrl loopback", () => {
+  beforeEach(snapshotEnv)
+  afterEach(restoreEnv)
+
+  test("does not proxy loopback even when ALL_PROXY is set", () => {
+    process.env.ALL_PROXY = "http://127.0.0.1:18764"
+    process.env.HTTP_PROXY = "http://127.0.0.1:18764"
+    delete process.env.NO_PROXY
+    delete process.env.no_proxy
+    expect(getProxyForUrl("http://127.0.0.1:8317/v1")).toBeUndefined()
+    expect(getProxyForUrl("http://localhost:8317/v1")).toBeUndefined()
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Fixes #47041

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Prevents `getProxyForUrl` from routing localhost, `127.0.0.1`, and `::1` requests through HTTP(S) proxies. It also documents that compiled Bun binaries ignore `NODE_OPTIONS=--dns-result-order=ipv4first` and that Bun `fetch` can apply environment proxy settings independently.

### How did you verify your code works?

Ran `bun test test/util/proxy-env.test.ts` from `packages/opencode`; the loopback proxy regression case passes.

### Screenshots / recordings

Not applicable; no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR