### PR TITLE
fix(console): proxy migrated model discovery to v1 endpoint

### DIFF
--- a/packages/console/app/src/lib/inference-proxy.ts
+++ b/packages/console/app/src/lib/inference-proxy.ts
@@ -4,7 +4,7 @@ import { KeyTable } from "@opencode-ai/console-core/schema/key.sql.js"
 import { WorkspaceTable } from "@opencode-ai/console-core/schema/workspace.sql.js"
 
 const paths: Record<string, string | undefined> = {
-  "GET /zen/v1/models": "/openai/v1/models",
+  "GET /zen/v1/models": "/v1/models",
   "POST /zen/v1/chat/completions": "/openai/v1/chat/completions",
   "POST /zen/v1/responses": "/openai/v1/responses",
   "POST /zen/v1/messages": "/anthropic/v1/messages",


### PR DESCRIPTION
## Summary
- Change the migrated `GET /zen/v1/models` proxy target from `/inference/openai/v1/models` to `/inference/v1/models`.
- One-line path change only; credentials, query strings, streaming, and existing routing behavior remain unchanged.
- Anonymous/unmigrated requests still use the legacy endpoint. Go paths remain untouched.

## Dependency and rollout
- Deploy the destination endpoint before this proxy change in each environment.
- Destination is already deployed and checked in dev; production deployment remains pending.
- This proxy change has not been deployed.

## Validation
- Legacy Console app typecheck and targeted formatting/diff checks passed.
- Pre-push workspace typecheck passed: 30 tasks.
- No local tests run; no end-to-end legacy proxy verification claimed.