### PR TITLE
docs(ecosystem): add opencode-autoguard plugin

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-autoguard](https://github.com/APLaS-Plus/opencode-autoguard)                             | Automatic permission review with local rules, LLM judge, circuit breaker, and audit logs           |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — new ecosystem listing, no linked issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds opencode-autoguard to the ecosystem plugins table. It is a permission-review plugin for OpenCode: local deny/fast-pass rules first, then an OpenAI-compatible LLM judge, plus circuit breaker, webfetch prompt-injection review, and audit logs. Both the repo and the npm package are live and the links check out.

### How did you verify your code works?

Docs-only, single-row change. Verified the markdown table renders correctly and both links resolve (GitHub repo and npm package page).

### Screenshots / recordings

N/A — docs-only change, no UI affected.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR