### PR TITLE
refactor(app): remove redundant project setter wrappers

### DIFF
--- a/packages/app/src/runtime/server/global-sync/bootstrap.test.ts
+++ b/packages/app/src/runtime/server/global-sync/bootstrap.test.ts
@@ -1,11 +1,59 @@
 import { describe, expect, test } from "bun:test"
 import { QueryClient } from "@tanstack/solid-query"
-import { loadPathQuery, loadProjectsQuery } from "./bootstrap"
+import { OpenCode } from "@opencode-ai/client/promise"
+import { createStore } from "solid-js/store"
+import { bootstrapGlobal, loadPathQuery, loadProjectsQuery } from "./bootstrap"
 import { ServerScope } from "@/runtime/server/scope"
 import type { ServerApi } from "@/runtime/server/api"
+import type { ServerSync } from "@/runtime/server/sync"
 
 type ProjectApi = ServerApi["project"]
 type WorktreeApi = ServerApi["worktree"]
+
+test("bootstraps projects through the native store setter and preserves subsequent updates", async () => {
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: Object.assign(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = new URL(new Request(input, init).url)
+        if (url.pathname === "/api/location")
+          return Response.json({
+            directory: "/repo",
+            project: { id: "project", directory: "/repo", canonical: "/repo" },
+          })
+        if (url.pathname === "/api/project")
+          return Response.json([{ id: "project", canonical: "/repo", time: { created: 1, updated: 1 }, sandboxes: [] }])
+        if (url.pathname === "/api/worktree") return Response.json([{ directory: "/repo" }])
+        throw new Error(`Unexpected request: ${url.pathname}`)
+      },
+      { preconnect() {} },
+    ),
+  })
+  const [store, setStore] = createStore<ServerSync["data"]>({
+    path: { state: "", config: "", worktree: "", directory: "", home: "" },
+    project: [],
+    provider_auth: {},
+    config: {},
+    reload: undefined,
+  })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  try {
+    await bootstrapGlobal({ serverAPI: api, scope: ServerScope.local, setGlobalStore: setStore, queryClient })
+    expect(store.project).toMatchObject([{ id: "project", worktree: "/repo" }])
+
+    setStore("project", (projects) => projects.map((project) => ({ ...project, name: "Renamed" })))
+    expect(store.project[0]?.name).toBe("Renamed")
+    setStore("project", [])
+    expect(store.project).toEqual([])
+
+    await bootstrapGlobal({ serverAPI: api, scope: ServerScope.local, setGlobalStore: setStore, queryClient })
+    expect(store.project).toMatchObject([{ id: "project", worktree: "/repo" }])
+    expect(store.config).toEqual({})
+  } finally {
+    queryClient.clear()
+  }
+})
 
 describe("query keys", () => {
   test("partitions identical directories by server scope", () => {

--- a/packages/app/src/runtime/server/global-sync/bootstrap.test.ts
+++ b/packages/app/src/runtime/server/global-sync/bootstrap.test.ts
@@ -40,7 +40,7 @@ test("bootstraps projects through the native store setter and preserves subseque
 
   try {
     await bootstrapGlobal({ serverAPI: api, scope: ServerScope.local, setGlobalStore: setStore, queryClient })
-    expect(store.project).toMatchObject([{ id: "project", worktree: "/repo" }])
+    expect(store.project.map((project) => [project.id, project.worktree])).toEqual([["project", "/repo"]])
 
     setStore("project", (projects) => projects.map((project) => ({ ...project, name: "Renamed" })))
     expect(store.project[0]?.name).toBe("Renamed")
@@ -48,7 +48,7 @@ test("bootstraps projects through the native store setter and preserves subseque
     expect(store.project).toEqual([])
 
     await bootstrapGlobal({ serverAPI: api, scope: ServerScope.local, setGlobalStore: setStore, queryClient })
-    expect(store.project).toMatchObject([{ id: "project", worktree: "/repo" }])
+    expect(store.project.map((project) => [project.id, project.worktree])).toEqual([["project", "/repo"]])
     expect(store.config).toEqual({})
   } finally {
     queryClient.clear()

--- a/packages/app/src/runtime/server/sync.tsx
+++ b/packages/app/src/runtime/server/sync.tsx
@@ -79,39 +79,19 @@ export function createServerSyncContextInner(serverSDK: ServerSDK, data: Data) {
   })
 
   const queryClient = useQueryClient()
-  const setProjects = (next: Project[] | ((draft: Project[]) => Project[])) => {
-    setGlobalStore("project", next)
-  }
-
-  const setBootStore = ((...input: unknown[]) => {
-    if (input[0] === "project" && Array.isArray(input[1])) {
-      setProjects(input[1] as Project[])
-      return input[1]
-    }
-    return (setGlobalStore as (...args: unknown[]) => unknown)(...input)
-  }) as typeof setGlobalStore
-
   const bootstrap = useQuery(() => ({
     queryKey: [serverSDK.scope, "bootstrap"],
     queryFn: async () => {
       await bootstrapGlobal({
         serverAPI: serverSDK.api,
         scope: serverSDK.scope,
-        setGlobalStore: setBootStore,
+        setGlobalStore,
         queryClient,
       })
       return Date.now()
     },
     enabled: connected(),
   }))
-
-  const set = ((...input: unknown[]) => {
-    if (input[0] === "project" && (Array.isArray(input[1]) || typeof input[1] === "function")) {
-      setProjects(input[1] as Project[] | ((draft: Project[]) => Project[]))
-      return input[1]
-    }
-    return (setGlobalStore as (...args: unknown[]) => unknown)(...input)
-  }) as typeof setGlobalStore
 
   const paused = () => untrack(() => globalStore.reload) !== undefined
 
@@ -216,7 +196,7 @@ export function createServerSyncContextInner(serverSDK: ServerSDK, data: Data) {
   }
 
   function applyProjectUpdate(update: Parameters<typeof updateProjectInfo>[1]) {
-    setProjects((projects) =>
+    setGlobalStore("project", (projects) =>
       projects.map((project) => (project.id === update.id ? updateProjectInfo(project, update) : project)),
     )
   }
@@ -275,7 +255,7 @@ export function createServerSyncContextInner(serverSDK: ServerSDK, data: Data) {
 
   return {
     data: globalStore,
-    set,
+    set: setGlobalStore,
     child: children.child,
     disableMcp: children.disableMcp,
     // bootstrap,


### PR DESCRIPTION
## Why

Project writes pass through three wrappers (`setProjects`, `setBootStore`, and `set`) that ultimately call the native Solid store setter without transforming the data. The wrappers add array/function checks and type assertions to operations the setter already supports.

## What Changes

Pass `setGlobalStore` directly to bootstrap, use it directly for project updates, and retain the returned setter as `set: setGlobalStore`.

```ts
// Before
bootstrapGlobal → setBootStore → setProjects → setGlobalStore
project.update  → setProjects → setGlobalStore
sync.set        → set → setProjects or setGlobalStore

// After
bootstrapGlobal → setGlobalStore
project.update  → setGlobalStore
sync.set        → setGlobalStore
```

Project-array replacement and functional updates retain their store behavior. The declared `SetStoreFunction` contract returns void; the removed wrappers' incidental return values have no production consumers. No loading, refresh, or reconnect rules change.

## Scope

`packages/app/src/runtime/server/sync.tsx`: **+3 / −23, net −20 production lines**. No new production helper or dependency. The existing bootstrap test file gains coverage for a real client with a fixture transport, native-setter bootstrap, functional updates, empty-array replacement, and another bootstrap; test code is **+49 / −1, net +48 lines**.

This is separate from the pending-inbox reconnect fix and the client location-spread cleanup. It changes no visible UI or session/timeline code.

## Verification

With Bun 1.4.0, from `packages/app`:

```sh
bun run test
bun run test:browser ./src/runtime/server/global-sync/bootstrap.test.ts
bun typecheck
bunx prettier --write src/runtime/server/sync.tsx src/runtime/server/global-sync/bootstrap.test.ts
git diff --check
```

- 718 unit tests passed, 1 skipped; 113 browser-runtime tests passed.
- The additional browser-condition run includes the five bootstrap tests: 118 passed. Project-array assertions compare explicit field projections so they also work with browser Solid proxies.
- App typecheck passed; the normal pre-push hook completed all 33 workspace typecheck tasks.
- No live app/server restart, end-to-end recording, or performance benchmark was needed for this setter-only cleanup.
