### PR TITLE
refactor(client): remove redundant location spreads

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -574,7 +574,7 @@ export function createData(config: CreateDataInput) {
           .location.get({ location: locationQuery(defaultLocation()) })
           .then((location) => {
             const key = locationKey(location)
-            setStore("location", key, { ...store.location[key], info: location })
+            setStore("location", key, { info: location })
           })
           .catch((error) => console.error("Failed to preload location", error))
         void result.location.vcs.sync().catch((error) => console.error("Failed to preload VCS info", error))
@@ -1105,7 +1105,6 @@ export function createData(config: CreateDataInput) {
           return
         }
         setStore("location", key, (data) => ({
-          ...data,
           integration: data?.integration?.map((integration) => {
             if (integration.id !== event.data.integrationID) return integration
             const active = integration.connections.find(
@@ -1147,7 +1146,6 @@ export function createData(config: CreateDataInput) {
         break
       case "vcs.branch.updated":
         setStore("location", locationKey(location), (data) => ({
-          ...data,
           vcs: {
             branch: {
               ...data?.vcs?.branch,
@@ -1165,7 +1163,6 @@ export function createData(config: CreateDataInput) {
         break
       case "shell.created":
         setStore("location", locationKey(location), (data) => ({
-          ...data,
           shell: {
             ...data?.shell,
             [event.data.info.id]: { ...event.data.info, location },
@@ -1175,7 +1172,6 @@ export function createData(config: CreateDataInput) {
       case "shell.exited":
       case "shell.deleted":
         setStore("location", locationKey(location), (data) => ({
-          ...data,
           shell: Object.fromEntries(Object.entries(data?.shell ?? {}).filter(([id]) => id !== event.data.id)),
         }))
         break
@@ -1801,10 +1797,7 @@ export function createData(config: CreateDataInput) {
           const input = { location: locationQuery(ref ?? defaultLocation()) }
           const providers = await api().websearch.providers(input)
           const key = locationKey(providers.location)
-          setStore("location", key, {
-            ...store.location[key],
-            websearch: providers.data,
-          })
+          setStore("location", key, { websearch: providers.data })
         },
       },
       skill: locationResource("skill", (location) => api().skill.list({ location })),

--- a/packages/client/test/solid-data.test.ts
+++ b/packages/client/test/solid-data.test.ts
@@ -355,8 +355,10 @@ test("refreshes global credential events across every loaded location and worksp
         setup.data.location.integration.sync(location),
         setup.data.location.model.sync(location),
         setup.data.location.provider.sync(location),
+        setup.data.location.reference.sync(location),
       ]),
     )
+    const references = locations.map((location) => setup.data.location.reference.list(location))
     requests.length = 0
 
     const updated: OpenCodeEvent = {
@@ -401,6 +403,9 @@ test("refreshes global credential events across every loaded location and worksp
           ["/api/model", "/other", "workspace-other"],
           ["/api/provider", "/other", "workspace-other"],
         ]),
+      )
+      locations.forEach((location, index) =>
+        expect(setup.data.location.reference.list(location)).toBe(references[index]),
       )
       requests.length = 0
     }
@@ -464,6 +469,99 @@ test("refreshes references for the location an update names", async () => {
       requests[0]!.searchParams.get("location[directory]"),
       requests[0]!.searchParams.get("location[workspace]"),
     ]).toEqual(["/api/reference", "/other", "workspace-other"])
+  } finally {
+    setup.dispose()
+  }
+})
+
+test("preserves sibling catalogs through location preload, branch, shell, and websearch updates", async () => {
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
+  const location = { directory: "/project", project: { id: "project", directory: "/project", canonical: "/project" } }
+  const requests: string[] = []
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => {
+      const pathname = new URL((input instanceof Request ? input : new Request(input, init)).url).pathname
+      requests.push(pathname)
+      if (pathname === "/api/session/active") return Response.json({})
+      if (pathname === "/api/project") return Response.json([])
+      if (pathname === "/api/location") return Response.json(location)
+      if (pathname === "/api/vcs")
+        return Response.json({ location, data: { branch: { current: "main", default: "main" } } })
+      if (pathname === "/api/reference")
+        return Response.json({
+          location,
+          data: [{ name: "docs", path: "/docs", source: { type: "local", path: "/docs" } }],
+        })
+      if (pathname === "/api/websearch/provider")
+        return Response.json({ location, data: [{ id: "search", name: "Search" }] })
+      throw new Error(`Unexpected request: ${pathname}`)
+    },
+  })
+  const setup = createRoot((dispose) => ({
+    data: createData({
+      api: () => api,
+      directory: location.directory,
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
+    }),
+    dispose,
+  }))
+  const emit = (details: OpenCodeEvent) => listeners.forEach((listener) => listener({ name: details.type, details }))
+  const shell = {
+    id: "sh_first",
+    status: "running" as const,
+    command: "echo hello",
+    cwd: location.directory,
+    shell: "/bin/sh",
+    file: "/shell-output",
+    metadata: {},
+    time: { started: 1 },
+  }
+
+  try {
+    // A live event may arrive before any location reads have populated this key.
+    emit({ type: "shell.created", location, data: { info: shell } })
+    expect(setup.data.shell.get(shell.id)).toMatchObject(shell)
+    const first = setup.data.shell.get(shell.id)
+    await Promise.all([setup.data.location.reference.sync(), setup.data.location.vcs.sync()])
+    const references = setup.data.location.reference.list()
+    expect(references?.map((reference) => [reference.name, reference.path])).toEqual([["docs", "/docs"]])
+    expect(setup.data.shell.get(shell.id)).toBe(first)
+
+    emit({ type: "vcs.branch.updated", location, data: { branch: "feature" } })
+    expect(setup.data.location.vcs.info()?.branch).toEqual({ current: "feature", default: "main" })
+    expect(setup.data.location.reference.list()).toBe(references)
+    emit({ type: "shell.created", location, data: { info: { ...shell, id: "sh_second" } } })
+    expect(setup.data.shell.list().map((shell) => shell.id)).toEqual(["sh_first", "sh_second"])
+    expect(setup.data.location.reference.list()).toBe(references)
+    emit({ type: "shell.deleted", location, data: { id: "sh_second" } })
+    expect(setup.data.shell.list().map((shell) => shell.id)).toEqual(["sh_first"])
+    expect(setup.data.shell.get(shell.id)).toBe(first)
+    expect(setup.data.location.reference.list()).toBe(references)
+
+    await setup.data.location.websearch.refresh()
+    expect(setup.data.location.websearch.list()).toEqual([{ id: "search", name: "Search" }])
+    expect(setup.data.location.reference.list()).toBe(references)
+    emit({ type: "server.connected", data: {} })
+    await wait(() => setup.data.location.info() !== undefined)
+    expect(setup.data.location.info()).toMatchObject(location)
+    expect(setup.data.location.reference.list()).toBe(references)
+    expect(setup.data.shell.get(shell.id)).toBe(first)
+    expect(setup.data.location.vcs.info()?.branch).toEqual({ current: "feature", default: "main" })
+    expect(requests.toSorted()).toEqual([
+      "/api/location",
+      "/api/project",
+      "/api/reference",
+      "/api/session/active",
+      "/api/vcs",
+      "/api/websearch/provider",
+    ])
   } finally {
     setup.dispose()
   }


### PR DESCRIPTION
## Why

Six location updates copy the entire cached location record before passing it to Solid's store setter. That setter already shallow-merges the provided record, so these copies repeat work and obscure which field the update owns.

## What Changes

Publish only the changed location field, matching the existing `locationResource` helper:

```ts
// Before
setStore("location", key, { ...store.location[key], websearch: providers.data })

// After
setStore("location", key, { websearch: providers.data })
```

Apply this to connection preload, credential switching, branch updates, shell creation/removal, and websearch refresh. Preserve the nested shell-map and branch spreads: unlike the outer location spreads, those carry fields the replacement value still needs.

## Scope

`packages/client/src/solid/data.ts`: **+2 / −9, net −7 production lines**. No helper, state, dependency, public interface, or request-scheduling change.

The existing client test file gains 98 lines covering cold shell-event initialization, sibling catalog and shell identity, retained branch metadata, request counts, and sibling preservation during credential events across locations/workspaces. These checks pass against both the original implementation and the deletion, including the focused browser-Solid run.

## Verification

With Bun 1.4.0, from the indicated package directories:

```sh
# packages/client
bun run test
bun run test --conditions=browser test/solid-data.test.ts -t 'preserves sibling catalogs|refreshes global credential'
bun typecheck
bun run build
bunx prettier --check src/solid/data.ts test/solid-data.test.ts

# packages/tui
bun run test test/cli/tui/data.test.tsx

# packages/app
bun run test
```

- Client: 147 passed; the two focused browser-condition checks also passed before and after the production change. Typecheck and package build passed.
- TUI data suite: 46 passed.
- App: 717 unit passed, 1 skipped; 113 browser-runtime passed.
- The normal pre-push hook completed all 33 workspace typecheck tasks.
- An exploratory whole-file `--conditions=browser` run before the production change exposed two existing assertions in the assistant-content replacement and user-shell metadata tests. The normal configured client suite passes; those unrelated browser-condition assertions are not changed here.
- No performance improvement is claimed beyond removing redundant object construction and setter inputs. There is no visible UI change or new fetch policy.
