### PR TITLE
fix(core): reject an edit whose strings differ only in line ending style

### DIFF
--- a/packages/core/src/tool/plugin/edit.ts
+++ b/packages/core/src/tool/plugin/edit.ts
@@ -168,6 +168,12 @@ export const Plugin = {
               const ending = source.includes(crlf) ? crlf : "\n"
               const oldString = input.oldString.replaceAll(crlf, "\n").replaceAll("\n", ending)
               const newString = input.newString.replaceAll(crlf, "\n").replaceAll("\n", ending)
+              // The conversion can turn two different inputs into the same text, which the raw check cannot see.
+              if (oldString === newString) {
+                return yield* new ToolFailure({
+                  message: "No changes to apply: oldString and newString are identical.",
+                })
+              }
               const exact = findOccurrences(source, oldString)
               // These one-to-one mappings preserve offsets into the original source.
               const unicode =

--- a/packages/core/test/tool-edit.test.ts
+++ b/packages/core/test/tool-edit.test.ts
@@ -430,6 +430,36 @@ describe("EditTool", () => {
     }),
   )
 
+  it.live("rejects an edit whose strings differ only in line ending style", () =>
+    withTempDir((tmp) => {
+      const edit = makeEditFixture()
+      const target = path.join(tmp.path, "crlf.txt")
+      return Effect.promise(() => fs.writeFile(target, "before\r\nrest\r\n")).pipe(
+        Effect.andThen(
+          withTool(tmp.path, edit, (registry) =>
+            Effect.gen(function* () {
+              expect(
+                yield* executeTool(
+                  registry,
+                  call({ path: "crlf.txt", oldString: "before\r\nrest", newString: "before\nrest" }),
+                ),
+              ).toEqual({
+                status: "error",
+                error: {
+                  type: "tool.execution",
+                  message: "No changes to apply: oldString and newString are identical.",
+                },
+              })
+              expect(yield* Effect.promise(() => fs.readFile(target, "utf8"))).toBe("before\r\nrest\r\n")
+              expect(edit.assertions).toEqual([])
+              expect(edit.writes).toEqual([])
+            }),
+          ),
+        ),
+      )
+    }),
+  )
+
   it.live("returns specific missing file and directory errors", () =>
     withTempDir((tmp) => {
       const edit = makeEditFixture()


### PR DESCRIPTION
### Issue for this PR

Closes #45927

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`packages/core/src/tool/plugin/edit.ts` rejects an edit where `oldString` equals `newString`. That check runs on the raw input at line 135. The tool converts both strings to the file's line ending at lines 169-170.

Two strings that differ only in line ending style pass the raw check. After the conversion they hold the same text, so the replacement does nothing. `findOccurrences` still returns one match.

The tool then asks for edit approval, writes the file back unchanged, and reports one replacement.

Measured on `v2` at f94eefaa5, through the registered tool. The file is CRLF and holds `before\r\nrest\r\n`. The call passes `oldString: "before\r\nrest"` and `newString: "before\nrest"`.

```
status: completed
content: [{"type":"text","text":"Edited crlf.txt (1 replacement)"}]
output: {"files":[{"file":"crlf.txt","patch":"Index: crlf.txt\n===...\n--- crlf.txt\n+++ crlf.txt\n","additions":0,"deletions":0,"status":"modified"}],"replacements":1}
file unchanged: true
writes: 1
permission asserts: 1
```

The model reads one replacement and believes the edit landed. An LF file gives the same result, because the conversion rewrites a CRLF `oldString` to `\n` as well.

This PR runs the same check again after the conversion. The raw check stays where it is. It fails before the file read and before any permission prompt, which is the right place for the case it catches.

After the change the tool returns an error and writes nothing.

```
status: error
error: {"type":"tool.execution","message":"No changes to apply: oldString and newString are identical."}
file unchanged: true
writes: 0
permission asserts: 0
```

#46849 fixes the same defect on `dev`, where the tool lives at `packages/core/src/tool/edit.ts`. The two diffs touch different files, so neither one covers the other branch.

### How did you verify your code works?

The new test is `rejects an edit whose strings differ only in line ending style` in `packages/core/test/tool-edit.test.ts`. It drives the registered tool through `executeTool` against a real CRLF file. It checks the error, the file content, the permission calls and the writes.

The test fails on `v2` before the change. The failure reports `status: "completed"` with `replacements: 1` and an empty patch.

`bun test test/tool-edit.test.ts` from `packages/core`: 17 pass, 0 fail.

`bun run test` from `packages/core`: 4040 pass, 39 skip, 3 fail. The failures are `PluginSupervisor reload` twice and `Watcher lifecycle` once. All three fail the same way on `origin/v2` with this branch reverted.

`bun typecheck` from `packages/core` is clean. `bun run lint:effect-simplifications`, `oxlint` and `prettier --check` are clean on both files.

I also moved the new guard below `permission.assert` as a mutation check. The test failed, which shows the guard runs before the approval prompt.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

