### PR TITLE
test(app): align timeline assertions with activity controls

### DIFF
--- a/packages/app/e2e/regression/session-timeline-notices.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-notices.spec.ts
@@ -78,7 +78,7 @@ test("renders current protocol notices in CLI order", async ({ page }) => {
 
   const notices = page.locator('[data-slot="session-timeline-notice"]')
   await expect(notices).toHaveCount(4)
-  await expect(notices.nth(0)).toContainText("Agent · explore")
+  await expect(notices.nth(0)).toHaveText(/^Agent changed\s*Explore$/)
   await expect(notices.nth(1)).toContainText("explore finished · Search code")
   await expect(notices.nth(2)).toContainText("Continuing after restart")
   await expect(notices.nth(3)).toContainText("Skill · Review")
@@ -182,20 +182,15 @@ test("moves blocking work to the background with Ctrl+B", async ({ page }) => {
   await expect(card).not.toContainText("(background)")
   await expect(page.getByText("Called `subagent`", { exact: false })).toHaveCount(0)
   await expect(page.locator('[data-component="background-tool-control"]')).toHaveCount(0)
-  const hint = page.locator('[data-component="session-background-hint"]')
-  const hintPrefix = hint.locator('[data-slot="session-background-hint-prefix"]')
+  const hint = page.getByRole("button", { name: /move running work to the background/i })
   await expect(hint).toBeVisible()
   await expect(page.locator('[data-timeline-row="Thinking"]')).toHaveCount(0)
   await expect
     .poll(async () => {
-      const [cardBox, hintBox, prefixBox] = await Promise.all([
-        card.boundingBox(),
-        hint.boundingBox(),
-        hintPrefix.boundingBox(),
-      ])
-      if (!cardBox || !hintBox || !prefixBox) return undefined
+      const [cardBox, hintBox] = await Promise.all([card.boundingBox(), hint.boundingBox()])
+      if (!cardBox || !hintBox) return undefined
       return {
-        aligned: Math.abs(cardBox.x - prefixBox.x) < 2,
+        aligned: Math.abs(cardBox.x - hintBox.x) < 2,
         ordered: cardBox.y < hintBox.y,
       }
     })
@@ -220,10 +215,10 @@ test("navigates from a running subagent card and hides background controls in th
     sessionStatus: { [sessionID]: { type: "busy" }, [childID]: { type: "busy" } },
   })
 
-  await expect(page.getByText(/move running work to the background/i)).toBeVisible()
+  await expect(page.getByRole("button", { name: /move running work to the background/i })).toBeVisible()
   await page.locator('[data-component="task-tool-card"]').click()
   await expect(page).toHaveURL(new RegExp(`/session/${childID}$`))
-  await expect(page.getByText(/move running work to the background/i)).toHaveCount(0)
+  await expect(page.getByRole("button", { name: /move running work to the background/i })).toHaveCount(0)
 })
 
 for (const name of ["shell", "subagent"] as const) {
@@ -267,7 +262,7 @@ for (const name of ["shell", "subagent"] as const) {
     const group = page.locator('[data-timeline-part-ids="call_read,call_running"]')
     await expect(group).toBeVisible()
     await expect(group.locator('[data-slot="collapsible-trigger"]')).toHaveAttribute("aria-expanded", "false")
-    await expect(page.locator('[data-component="session-background-hint"]')).toBeVisible()
+    await expect(page.getByRole("button", { name: /move running work to the background/i })).toBeVisible()
     const request = page.waitForRequest(
       (request) =>
         request.method() === "POST" && new URL(request.url()).pathname === `/api/session/${sessionID}/background`,
@@ -286,9 +281,9 @@ test("shows a badge for active background work", async ({ page }) => {
   })
 
   await page.getByRole("button", { name: "Session details" }).click()
-  const summary = page.getByRole("button", { name: "1 item running in background" })
+  const summary = page.getByRole("button", { name: "1 background task running", exact: true })
   await expect(summary).toContainText("1")
-  await expect(summary).toContainText("Running work in background")
+  await expect(summary).toContainText("1 background task running")
   await summary.click()
   await expect(
     page.locator('[data-component="session-background-list"]').getByText("Agent", { exact: true }),
@@ -387,7 +382,7 @@ test("separates blocking and already-backgrounded work into two rows", async ({ 
     },
   })
   const backgroundCard = page.locator('[data-timeline-part-id="call_backgrounded"]')
-  await expect(page.getByText(/move running work to the background/i)).toBeVisible()
+  await expect(page.getByRole("button", { name: /move running work to the background/i })).toBeVisible()
   const used = page
     .locator('[data-timeline-part-ids="call_backgrounded,call_shell_backgrounded,call_blocking"]')
     .locator(':scope > [data-component="collapsible"] > [data-slot="collapsible-trigger"]')
@@ -396,7 +391,7 @@ test("separates blocking and already-backgrounded work into two rows", async ({ 
   await used.click()
   await expect(used).toHaveAttribute("aria-expanded", "true")
   await page.getByRole("button", { name: "Session details" }).click()
-  const summary = page.getByRole("button", { name: "2 items running in background" })
+  const summary = page.getByRole("button", { name: "2 background tasks running", exact: true })
   await expect(summary).toContainText("2")
   await summary.click()
   const list = page.locator('[data-component="session-background-list"]')

--- a/packages/app/e2e/regression/session-timeline-reducer-projection.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-reducer-projection.spec.ts
@@ -173,7 +173,7 @@ test("keeps failed search calls and their error cards inside the collapsed stack
   await expect(glob.locator('[data-component="tool-error-card-icon"]')).toBeVisible()
   await expect(glob.locator('[data-component="tool-error-card-icon"] use')).toHaveAttribute(
     "href",
-    "#opencode-v2-icon-circle-exclamation",
+    "#opencode-v2-icon-outline-hexagonal-warning",
   )
   await expect
     .poll(() =>

--- a/packages/app/e2e/regression/session-timeline-working.spec.ts
+++ b/packages/app/e2e/regression/session-timeline-working.spec.ts
@@ -134,7 +134,7 @@ for (const name of ["read", "shell", "subagent"] as const) {
     await expect(trigger).toHaveAttribute("aria-expanded", "false")
     await expect(working).toBeInViewport()
     if (name !== "read") {
-      const hint = page.locator('[data-component="session-background-hint"]')
+      const hint = page.getByRole("button", { name: /move running work to the background/i })
       await expect(hint).toBeInViewport()
       await expect(page.locator('[data-component="session-background-hint-row"]')).toHaveCSS("height", "24px")
       await page.screenshot({ path: testInfo.outputPath(`working-grouped-${name}.png`) })


### PR DESCRIPTION
## Why

The activity-control changes in #47033 updated the production timeline without updating its e2e expectations. The suite still searches for the former background-hint markup and text, old background-task labels, the old agent-change wording, and the previous warning icon.

On unmodified `v2` at `f94eefaa50`, the production-build notices spec reproduces 7 failures / 2 passes. The failed-page snapshot shows the background action present as a button named "Press Ctrl+B to move running work to the background", with visible text "Move running work to background". This is also blocking #47085 and #47086, whose independent production diffs do not change these controls.

## What Changes

- Locate the background action by button role and accessible name instead of its removed text/overridden `data-component` attribute.
- Check alignment against the button itself instead of the deleted text-prefix element; retain the vertical-order and compact-height assertions.
- Expect the current "Agent changed" / "Explore" notice and singular/plural background-task labels.
- Expect the warning icon now rendered by `ToolErrorCard`.

The tests still check Ctrl+B's background request, child-session navigation, grouping/disclosure, background task counts and membership, working-state visibility, and error contents. No tests are skipped and no timeouts or retry counts are increased.

## Scope

Three existing e2e files only: timeline notices, working state, and reducer projection. No production code, fixtures, styling, or feature behavior changes.

## Verification

From `packages/app` with Bun 1.4.0 and an isolated production-build preview:

```sh
# Before: unmodified v2 at f94eefaa50
PLAYWRIGHT_PORT=4893 PLAYWRIGHT_BUILD=1 bunx playwright test e2e/regression/session-timeline-notices.spec.ts --workers=1 --retries=0 --reporter=line

# After: the three affected specs
PLAYWRIGHT_PORT=4893 PLAYWRIGHT_BUILD=1 bunx playwright test e2e/regression/session-timeline-notices.spec.ts e2e/regression/session-timeline-working.spec.ts e2e/regression/session-timeline-reducer-projection.spec.ts --workers=1 --retries=0 --reporter=line

# Full local suite, no retries
PLAYWRIGHT_PORT=4893 PLAYWRIGHT_BUILD=1 bunx playwright test --workers=5 --retries=0 --reporter=line

# Check the unrelated local failures separately, without parallel workers
PLAYWRIGHT_PORT=4893 PLAYWRIGHT_BUILD=1 bunx playwright test e2e/regression/composer-large-paste.spec.ts e2e/regression/mcp-workspace-toggle.spec.ts e2e/regression/new-session-workspace-pending.spec.ts e2e/regression/session-rename.spec.ts --workers=1 --retries=0 --reporter=line
```

- Before: 7 failed, 2 passed in the notices spec, matching the CI failures without either deletion PR applied.
- After: all 28 tests across the three specs passed with retries disabled.
- Full local macOS run: 222 passed / 12 failed. All repaired timeline tests passed. Remaining failures are in untouched `composer-large-paste`, `mcp-workspace-toggle`, `new-session-workspace-pending`, and `session-rename` tests (caret/keyboard/dialog assertions); they are not changed or skipped in this PR. Neither deletion PR is applied in this worktree.
- Running those four untouched files separately with one worker reproduces the same 12 failures / 22 passes. None of this PR's changed test files runs in that check, ruling out interference from them or parallel workers.
- The normal pre-push hook completed all 33 workspace typecheck tasks. Linux/Windows CI is still required before merging.
