### PR TITLE
fix(opencode): persist legacy plan reminders

### DIFF
--- a/packages/opencode/src/session/reminders.ts
+++ b/packages/opencode/src/session/reminders.ts
@@ -23,28 +23,54 @@ export const apply = Effect.fn("SessionReminders.apply")(function* (input: {
   const userMessage = input.messages.findLast((msg) => msg.info.role === "user")
   if (!userMessage) return input.messages
 
+  const persistReminder = Effect.fn("SessionReminders.persistReminder")(function* (text: string) {
+    const exists = userMessage.parts.some(
+      (part) => part.type === "text" && part.synthetic === true && part.text === text,
+    )
+    if (exists) return
+    const part = yield* sessions.updatePart({
+      id: PartID.ascending(),
+      messageID: userMessage.info.id,
+      sessionID: userMessage.info.sessionID,
+      type: "text",
+      text,
+      synthetic: true,
+    })
+    userMessage.parts.push(part)
+  })
+
   if (!flags.experimentalPlanMode) {
-    if (input.agent.name === "plan") {
-      userMessage.parts.push({
-        id: PartID.ascending(),
-        messageID: userMessage.info.id,
-        sessionID: userMessage.info.sessionID,
-        type: "text",
-        text: PROMPT_PLAN,
-        synthetic: true,
-      })
-    }
+    const assistantMessage = input.messages.findLast((msg) => msg.info.role === "assistant")
     const wasPlan = input.messages.some((msg) => msg.info.role === "assistant" && msg.info.agent === "plan")
-    if (wasPlan && input.agent.name === "build") {
-      userMessage.parts.push({
-        id: PartID.ascending(),
-        messageID: userMessage.info.id,
-        sessionID: userMessage.info.sessionID,
-        type: "text",
-        text: BUILD_SWITCH,
-        synthetic: true,
-      })
-    }
+    const reminder =
+      input.agent.name === "plan" ? PROMPT_PLAN : wasPlan && input.agent.name === "build" ? BUILD_SWITCH : undefined
+    const switching =
+      (input.agent.name === "plan" && assistantMessage?.info.agent !== "plan") ||
+      (input.agent.name === "build" && assistantMessage?.info.agent === "plan")
+    const reminders = input.messages.flatMap((message) =>
+      message.parts.flatMap((part) =>
+        part.type === "text" && part.synthetic === true && (part.text === PROMPT_PLAN || part.text === BUILD_SWITCH)
+          ? [{ message, part }]
+          : [],
+      ),
+    )
+    const keep = switching ? undefined : reminders.findLast((item) => item.part.text === reminder)
+    const stale = reminders.filter((item) => item !== keep)
+    yield* Effect.forEach(
+      stale,
+      (item) =>
+        sessions.removePart({
+          sessionID: item.message.info.sessionID,
+          messageID: item.message.info.id,
+          partID: item.part.id,
+        }),
+      { discard: true },
+    )
+    stale.forEach((item) => {
+      item.message.parts = item.message.parts.filter((part) => part.id !== item.part.id)
+    })
+    if (!reminder || keep) return input.messages
+    yield* persistReminder(reminder)
     return input.messages
   }
 

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -368,13 +368,13 @@ const succeedVoid = (deferred: Deferred.Deferred<void>) => {
   Effect.runSync(Deferred.succeed(deferred, void 0).pipe(Effect.ignore))
 }
 
-const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string) {
+const user = Effect.fn("test.user")(function* (sessionID: SessionID, text: string, agent = "build") {
   const session = yield* Session.Service
   const msg = yield* session.updateMessage({
     id: MessageID.ascending(),
     role: "user",
     sessionID,
-    agent: "build",
+    agent,
     model: ref,
     time: { created: Date.now() },
   })
@@ -443,6 +443,46 @@ const boot = Effect.fn("test.boot")(function* (input?: { title?: string }) {
 })
 
 // Loop semantics
+
+it.instance("keeps exactly one current legacy mode reminder across plan and build transitions", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+    const turns = ["plan", "plan", "build", "build", "plan"]
+
+    for (const [index, agent] of turns.entries()) {
+      yield* user(chat.id, `turn ${index}`, agent)
+      yield* llm.text(`answer ${index}`)
+      yield* prompt.loop({ sessionID: chat.id })
+    }
+
+    const inputs = yield* llm.inputs
+    const messages = inputs.map(
+      (input) =>
+        (input as { messages: Array<{ role: string; content: string | Array<{ type: string; text?: string }> }> })
+          .messages,
+    )
+    const text = (content: string | Array<{ type: string; text?: string }>) =>
+      typeof content === "string"
+        ? content
+        : content.flatMap((part) => (part.type === "text" && part.text ? [part.text] : [])).join("\n")
+    const count = (items: (typeof messages)[number], value: string) =>
+      items.reduce((total, message) => total + text(message.content).split(value).length - 1, 0)
+    const plan = "# Plan Mode - System Reminder"
+    const build = "Your operational mode has changed from plan to build."
+
+    expect(messages).toHaveLength(5)
+    expect(messages.map((items) => [count(items, plan), count(items, build)])).toEqual([
+      [1, 0],
+      [1, 0],
+      [0, 1],
+      [0, 1],
+      [1, 0],
+    ])
+  }),
+)
 
 noLLMServer.instance(
   "loop exits immediately when last assistant has stop finish",


### PR DESCRIPTION
### Issue for this PR

Fixes #23595

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Legacy Plan/Build reminders were appended only to the in-memory latest user message. On the next turn that historical message lost the reminder, changing the prompt prefix and forcing local backends such as llama.cpp to reprocess the remaining context.

This persists the active synthetic mode reminder while enforcing a single-reminder invariant:

- repeated turns in the same mode keep the existing reminder anchored to the same user message;
- Plan/Build transitions remove stale or duplicate mode reminders and persist only the newly active one;
- sessions affected by duplicate reminders are repaired on their next request.

This keeps provider history stable within a mode without leaving contradictory Plan and Build instructions in context.

### How did you verify your code works?

- Added a five-turn Plan → Plan → Build → Build → Plan regression test.
- Confirmed the test fails against the previous patch with cumulative reminder counts `[1,0] → [2,0] → [2,1] → [2,2] → [3,2]`.
- Confirmed the corrected implementation yields exactly one current reminder: `[1,0] → [1,0] → [0,1] → [0,1] → [1,0]`.
- `bun test test/session/prompt.test.ts`: 59 passed, 1 skipped, 0 failed.
- `bun run typecheck` from `packages/opencode` passed.

### Screenshots / recordings

N/A — non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
