### PR TITLE
feat(tui): announce server plugin failures

### DIFF
--- a/packages/tui/src/feature-plugins/home/footer.tsx
+++ b/packages/tui/src/feature-plugins/home/footer.tsx
@@ -52,7 +52,11 @@ function Plugins(props: { context: Plugin.Context }) {
   const dimensions = useTerminalDimensions()
   const visibility = createMemo(() => homeFooterVisibility(dimensions().width))
   const plugins = usePlugin()
-  const failed = createMemo(() => plugins.list().filter((item) => item.status === "failed").length)
+  const failed = createMemo(
+    () =>
+      plugins.list().filter((item) => item.status === "failed").length +
+      plugins.server().filter((item) => item.state.status === "failed").length,
+  )
 
   return (
     <Show when={failed()}>

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -79,7 +79,9 @@ export function PluginsDialog(props: {
       ...serverEntries.sort((a, b) => label(a, props.context).localeCompare(label(b, props.context))),
     ]
   })
-  const visibleEntries = createMemo(() => entries().filter((entry) => showInternal() || !entry.internal))
+  const visibleEntries = createMemo(() =>
+    entries().filter((entry) => showInternal() || !entry.internal || status(entry) === "failed"),
+  )
   createEffect(() => {
     if (visibleEntries().some((entry) => entry.key === focused())) return
     const first = visibleEntries().find((entry) => entry.runtime === "tui") ?? visibleEntries()[0]
@@ -286,9 +288,7 @@ function source(plugin: PluginInfo, context: Plugin.Context) {
 function isLocal(entry: Entry) {
   if (entry.runtime === "server") return entry.plugin.source.type === "local"
   const target = entry.target
-  return (
-    target.startsWith("file://") || target.startsWith("./") || target.startsWith("../") || path.isAbsolute(target)
-  )
+  return target.startsWith("file://") || target.startsWith("./") || target.startsWith("../") || path.isAbsolute(target)
 }
 
 function status(entry: Entry) {

--- a/packages/tui/src/plugin/context.tsx
+++ b/packages/tui/src/plugin/context.tsx
@@ -53,6 +53,7 @@ type RegisteredPlugin = {
 type Value = {
   readonly ready: () => boolean
   readonly list: () => ReadonlyArray<State>
+  readonly server: () => readonly PluginInfo[]
   readonly registered: () => ReadonlyArray<RegisteredPlugin>
   readonly route: (id: string, name: string) => Page["render"] | undefined
   readonly slots: {
@@ -90,13 +91,15 @@ export function PluginProvider(props: ParentProps<{ packages: PackageSource; dir
   const lifecycle = useTuiLifecycle()
   const client = useClient()
   const data = useData()
-  const [serverPlugins, setServerPlugins] = createSignal<
-    ReadonlyArray<
-      PluginInfo & { readonly state: { readonly status: "active" } } & {
-        readonly source: { readonly type: "package" } | { readonly type: "local" }
-      }
-    >
-  >([])
+  const [serverPlugins, setServerPlugins] = createSignal<readonly PluginInfo[]>([])
+  const serverTuiPlugins = createMemo(() =>
+    serverPlugins().filter(
+      (plugin): plugin is PluginInfo & { readonly source: { readonly type: "package" } | { readonly type: "local" } } =>
+        plugin.state.status === "active" &&
+        plugin.features.tui === true &&
+        (plugin.source.type === "package" || plugin.source.type === "local"),
+    ),
+  )
   const directory = config.path ? path.dirname(config.path) : process.cwd()
   const [store, setStore] = createStore({
     ready: false,
@@ -257,7 +260,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageSource; dir
         install: true,
         optional: true,
       })),
-      ...serverPlugins().map((plugin) => ({
+      ...serverTuiPlugins().map((plugin) => ({
         entry: plugin.source.type === "package" ? plugin.source.target : path.dirname(plugin.source.path),
         install: false,
         optional: true,
@@ -473,7 +476,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageSource; dir
   const resolved = createMemo(() => resolveSlots({ paths: new Set(Object.keys(mounted)), claims: claims() }))
   createEffect(
     on(
-      () => JSON.stringify([serverPlugins(), config.data.plugins ?? []]),
+      () => JSON.stringify([serverTuiPlugins(), config.data.plugins ?? []]),
       () => {
         npmFailures.clear()
         void enqueue(reconcile).then(
@@ -486,20 +489,26 @@ export function PluginProvider(props: ParentProps<{ packages: PackageSource; dir
   const syncServerPlugins = () =>
     client.api.plugin
       .list({ location: data.location.default() })
-      .then((response) =>
-        setServerPlugins(
-          response.data.filter(
-            (
-              plugin,
-            ): plugin is PluginInfo & { readonly state: { readonly status: "active" } } & {
-              readonly source: { readonly type: "package" } | { readonly type: "local" }
-            } =>
-              plugin.state.status === "active" &&
-              plugin.features.tui === true &&
-              (plugin.source.type === "package" || plugin.source.type === "local"),
-          ),
-        ),
-      )
+      .then((response) => {
+        const failed = response.data.filter(
+          (plugin) =>
+            plugin.state.status === "failed" &&
+            !serverPlugins().some(
+              (previous) =>
+                serverPluginName(previous) === serverPluginName(plugin) && isDeepEqual(previous.state, plugin.state),
+            ),
+        )
+        setServerPlugins(response.data)
+        const first = failed[0]
+        if (!first) return
+        host.toast.show({
+          variant: "error",
+          title: failed.length === 1 ? `Plugin failed: ${serverPluginName(first)}` : `${failed.length} plugins failed`,
+          message:
+            (failed.length > 1 ? `${failed.map(serverPluginName).join(", ")}\n` : "") + "Run /plugins to view details.",
+          action: { label: "Open plugins", run: () => host.keymap.dispatch("plugins.list") },
+        })
+      })
       .catch(() => undefined)
   createEffect(
     on(
@@ -538,6 +547,7 @@ export function PluginProvider(props: ParentProps<{ packages: PackageSource; dir
       value={{
         ready: () => store.ready,
         list: () => store.states,
+        server: serverPlugins,
         registered: () =>
           Object.entries(store.registrations).map(([id, plugin]) => ({
             id,
@@ -555,6 +565,17 @@ export function PluginProvider(props: ParentProps<{ packages: PackageSource; dir
     >
       {props.children}
     </PluginContext.Provider>
+  )
+}
+
+function serverPluginName(plugin: PluginInfo) {
+  return (
+    plugin.id ??
+    (plugin.source.type === "package"
+      ? plugin.source.target
+      : plugin.source.type === "local"
+        ? plugin.source.path
+        : plugin.source.type)
   )
 }
 

--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -9,6 +9,7 @@ import { createEventStream, createFetch, directory, json, type FetchHandler } fr
 import { tmpdir } from "./fixture/fixture"
 import type { TuiInput } from "../src/app"
 import type { Config } from "../src/config"
+import type { PluginInfo } from "@opencode-ai/client"
 
 test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deletions at width %s", async (width) => {
   await using state = await tmpdir()
@@ -1419,6 +1420,116 @@ test.each([100, 44])(
     await setup.waitForFrame((frame) => frame.includes("Keep this draft intact"))
   },
 )
+
+test.each([
+  [100, true],
+  [44, true],
+  [100, false],
+  [44, false],
+] as const)("server plugin failures are visible at width %s (already failed: %s)", async (width, initial) => {
+  await using state = await tmpdir()
+  const failure: PluginInfo["state"] = {
+    status: "failed",
+    error: "Plugin disabled after command.transform failed. Check server logs for details.",
+    ref: "err_fixture",
+  }
+  let inventory: PluginInfo[] = [
+    {
+      id: "broken",
+      source: { type: "builtin" },
+      features: { server: true },
+      state: initial ? failure : { status: "active" },
+    },
+    { id: "healthy", source: { type: "builtin" }, features: { server: true }, state: { status: "active" } },
+  ]
+  let requests = 0
+  await using setup = await createAppFixture({
+    width,
+    state: state.path,
+    fetch: (url) => {
+      if (url.pathname !== "/api/plugin") return undefined
+      requests++
+      return json({
+        location: { directory, project: { id: "proj_test", directory, canonical: directory } },
+        data: inventory,
+      })
+    },
+  })
+  await setup.ready
+  await setup.waitForFrame((frame) => frame.includes("commands"))
+  if (!initial) {
+    expect(setup.captureCharFrame()).not.toContain("Plugin failed")
+    inventory = inventory.map((plugin) => (plugin.id === "broken" ? { ...plugin, state: failure } : plugin))
+    setup.events.emit({ id: "evt_failure", created: 1, type: "plugin.updated", data: {} })
+  }
+  await setup.waitForFrame((frame) => frame.includes("Plugin failed:") && frame.includes("broken"))
+  expect(setup.captureCharFrame()).toContain("/plugins")
+  expect(setup.captureCharFrame()).toContain("1 plugin failed")
+
+  const lines = setup.captureCharFrame().split("\n")
+  const row = lines.findIndex((line) => line.includes("Open plugins"))
+  expect(row).toBeGreaterThanOrEqual(0)
+  const line = lines[row]
+  if (!line) throw new Error("Open plugins action is missing")
+  await setup.mockMouse.click(line.indexOf("Open plugins"), row)
+  await setup.waitForFrame((frame) => frame.includes("ctrl+a") && frame.includes("broken"))
+  expect(setup.captureCharFrame()).toContain("broken")
+  expect(setup.captureCharFrame()).not.toContain("healthy")
+  setup.mockInput.pressEnter()
+  await setup.waitForFrame((frame) => frame.includes("Server plugin error") && frame.includes("transform failed"))
+  expect(setup.captureCharFrame()).toContain("Plugin disabled")
+  expect(setup.captureCharFrame()).toContain("transform failed")
+  expect(setup.captureCharFrame()).toContain("err_fixture")
+  setup.mockInput.pressEscape()
+  await setup.waitForFrame((frame) => frame.includes("ctrl+a"))
+  setup.mockInput.pressEscape()
+  await setup.waitForFrame((frame) => !frame.includes("ctrl+a"))
+  expect(setup.captureCharFrame()).toContain("1 plugin failed")
+
+  const seen = requests
+  setup.events.emit({ id: "evt_repeat", created: 2, type: "plugin.updated", data: {} })
+  setup.events.emit({ id: "evt_reconnect", type: "server.connected", data: {} })
+  await setup.waitFor(() => requests >= seen + 2)
+  await setup.flush()
+  expect(setup.captureCharFrame()).not.toContain("Plugin failed:")
+
+  inventory = inventory.map((plugin) => ({ ...plugin, state: { status: "active" } }))
+  setup.events.emit({ id: "evt_recovered", created: 3, type: "plugin.updated", data: {} })
+  await setup.waitForFrame((frame) => !frame.includes("1 plugin failed"))
+  inventory = inventory.map((plugin) => (plugin.id === "broken" ? { ...plugin, state: failure } : plugin))
+  setup.events.emit({ id: "evt_failed_again", created: 4, type: "plugin.updated", data: {} })
+  await setup.waitForFrame((frame) => frame.includes("Plugin failed:") && frame.includes("broken"))
+})
+
+test("server plugin failures share one notice and use source names before an ID is known", async () => {
+  await using state = await tmpdir()
+  await using setup = await createAppFixture({
+    state: state.path,
+    fetch: (url) =>
+      url.pathname === "/api/plugin"
+        ? json({
+            location: { directory, project: { id: "proj_test", directory, canonical: directory } },
+            data: [
+              {
+                source: { type: "package", target: "missing-package" },
+                features: {},
+                state: { status: "failed", error: "Package missing" },
+              },
+              {
+                source: { type: "local", path: "/fixture/broken.ts" },
+                features: {},
+                state: { status: "failed", error: "Invalid plugin" },
+              },
+            ],
+          })
+        : undefined,
+  })
+  await setup.ready
+  await setup.waitForFrame((frame) => frame.includes("2 plugins failed"))
+  expect(setup.captureCharFrame()).toContain("missing-package")
+  expect(setup.captureCharFrame()).toContain("/fixture/broken.ts")
+  expect(setup.captureCharFrame()).toContain("Open plugins")
+})
 
 async function createAppFixture(
   input: {


### PR DESCRIPTION
## Why

A server plugin can now be disabled after a transform throws, but the TUI says nothing when its commands or other features disappear. The home screen only counts TUI-plugin failures, and `/plugins` hides failed built-ins unless the user knows to show internal plugins.

## What Changes

| Situation | Behavior |
| --- | --- |
| A server plugin is already failed at startup, or fails while connected | Show `Plugin failed: fancy`, with an **Open plugins** action and a `/plugins` hint. |
| Several server plugins fail in one inventory refresh | Show one notice naming the failed plugins. |
| The same failure is returned by another refresh or reconnect | Stay quiet. A changed failure, or a failure after recovery, can notify again. |
| A failure notice expires | Keep the failed-plugin count visible on the home screen. |
| A built-in server plugin fails | Show it in `/plugins` without requiring **show internal**. Healthy built-ins remain hidden. |

The TUI retains the full server inventory for failure visibility while continuing to load TUI entrypoints only from active server plugins. The existing error-details view supplies the failure reason and diagnostic reference.

## Demo

https://github.com/user-attachments/assets/a12165e7-9bbd-4c41-b205-62c405be45a0

Matched OpenCode Drive 2.0.1 runs: **before** `ac874a6e90`, **after** `f838682945`. Both use the same 80×28 fixture, configuration, and interactions. A local fixture plugin's RPC deliberately makes its command transform throw; the actual server disables it in both runs. The provider is simulated and no model call is made. Equal-length marked clips are shown side by side, with startup and idle time trimmed and no playback acceleration.

## Scope

TUI failure visibility only. This builds on #47083 and reuses the existing inventory, event, toast, and error-details surfaces. Explicit retry controls and desktop/web presentation remain follow-ups; no server or public API changes.

## Verification

```sh
# packages/tui
bun run test
bun run test test/app-lifecycle.test.tsx --test-name-pattern 'server plugin failures' --rerun-each 5
bun typecheck

# Repository root
git diff --check
```

- Full TUI suite: **1,193 passed, 4 skipped, 0 failed**, across 130 files.
- New failure-visibility cases: **25 passed, 0 failed** over five repetitions, covering startup/runtime failures, 44/100-column layouts, clicking through to details, failed built-in visibility, reconnect deduplication, recovery, and grouped notices.
- TUI typecheck and the push hook's 33-package typecheck passed. Prettier and `git diff --check` passed. Scoped Oxlint found no errors and eight warnings in unchanged code.
- Both real-server Drive runs passed; notice, home, and detail comparison frames were inspected before upload.
