### PR TITLE
feat(opencode): allow general nested task via depth

### DIFF
--- a/packages/opencode/src/agent/agent.ts
+++ b/packages/opencode/src/agent/agent.ts
@@ -186,6 +186,7 @@ const layer = Layer.effect(
               defaults,
               Permission.fromConfig({
                 todowrite: "deny",
+                task: "allow",
               }),
               user,
             ),


### PR DESCRIPTION
### Issue for this PR

No issue filed.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Nested subagents need two things today: subagent_depth >= 2 and a task: allow override on the agent. The built-in general agent denies todowrite but says nothing about task, so deriveSubagentSessionPermission adds an implicit task deny and hides the tool from the child. That means setting subagent_depth: 2 alone is not enough for general -> general, which is surprising next to the docs.

This adds task: allow to the default permission of general (one line in packages/opencode/src/agent/agent.ts). The depth check in task.ts is untouched, so the default (depth=1) still blocks nesting; you only get one nested level when you explicitly opt in with subagent_depth: 2. I left explore alone since it is read-only by design, and I did not change the default depth.

### How did you verify your code works?

I tried bun test test/tool/task.test.ts in packages/opencode but the suite does not boot in this env (missing @opentui/solid/preload), unrelated to this diff. I verified the one-line diff by reading deriveSubagentSessionPermission + visibleTools paths and confirmed the existing depth tests (prevents subagents from launching subagents by default, allows nested subagents up to the configured depth) cover the gate I left in place.

### Screenshots / recordings

Not a UI change.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
