### PR TITLE
chore(core): bump GitHub Copilot API version to 2026-08-01

### DIFF
--- a/packages/core/src/github-copilot/models.ts
+++ b/packages/core/src/github-copilot/models.ts
@@ -18,7 +18,9 @@ const RemoteModel = Schema.Struct({
         Schema.Struct({
           batch_size: Schema.Number,
           default: Schema.Struct({
-            cache_price: Schema.Number,
+            // API version 2026-08-01 renamed cache_price to cache_read_price.
+            cache_price: Schema.optional(Schema.Number),
+            cache_read_price: Schema.optional(Schema.Number),
             input_price: Schema.Number,
             output_price: Schema.Number,
           }),
@@ -166,7 +168,9 @@ function build(id: Model.ID, remote: UsableModel, baseURL: string, previous?: Mo
         input: Money.USDPerMillionTokens.make((prices?.default.input_price ?? 0) * usdPerMillion),
         output: Money.USDPerMillionTokens.make((prices?.default.output_price ?? 0) * usdPerMillion),
         cache: {
-          read: Money.USDPerMillionTokens.make((prices?.default.cache_price ?? 0) * usdPerMillion),
+          read: Money.USDPerMillionTokens.make(
+            (prices?.default.cache_read_price ?? prices?.default.cache_price ?? 0) * usdPerMillion,
+          ),
           write: Money.USDPerMillionTokens.zero,
         },
       },

--- a/packages/core/src/plugin/provider/github-copilot.ts
+++ b/packages/core/src/plugin/provider/github-copilot.ts
@@ -13,7 +13,7 @@ import { Provider } from "../../provider.js"
 import type { PluginInternal } from "../internal.js"
 
 const clientID = "Ov23li8tweQw6odWQebz"
-const apiVersion = "2026-06-01"
+const apiVersion = "2026-08-01"
 const userApiVersion = "2025-04-01"
 const pollingSafetyMargin = 3000
 const methodID = Integration.MethodID.make("device")

--- a/packages/core/test/github-copilot/models.test.ts
+++ b/packages/core/test/github-copilot/models.test.ts
@@ -118,3 +118,40 @@ test("defensively syncs advertised Copilot models", async () => {
     await server.stop(true)
   }
 })
+
+test("prices cache reads from either token price spelling", async () => {
+  // API version 2026-08-01 renamed cache_price to cache_read_price; older payloads still use cache_price.
+  const item = (id: string, prices: Record<string, number>) => ({
+    model_picker_enabled: true,
+    id,
+    name: id,
+    version: `${id}-2026-08-01`,
+    supported_endpoints: ["/chat/completions"],
+    billing: { token_prices: { batch_size: 1_000_000, default: { input_price: 250, output_price: 1500, ...prices } } },
+    capabilities: {
+      family: "gpt",
+      limits: { max_output_tokens: 1000, max_prompt_tokens: 8000 },
+      supports: { tool_calls: true },
+    },
+  })
+  const server = Bun.serve({
+    port: 0,
+    fetch: () =>
+      Response.json({
+        data: [
+          item("renamed", { cache_read_price: 25, cache_write_price: 0 }),
+          item("legacy", { cache_price: 25 }),
+          item("unpriced", {}),
+        ],
+      }),
+  })
+
+  try {
+    const models = await CopilotModels.get(server.url.origin, {}, [])
+    expect(models.get(Model.ID.make("renamed"))?.cost[0]).toMatchObject({ input: 2.5, output: 15, cache: { read: 0.25 } })
+    expect(models.get(Model.ID.make("legacy"))?.cost[0]).toMatchObject({ input: 2.5, output: 15, cache: { read: 0.25 } })
+    expect(models.get(Model.ID.make("unpriced"))?.cost[0]).toMatchObject({ cache: { read: 0 } })
+  } finally {
+    await server.stop(true)
+  }
+})

--- a/packages/core/test/plugin/provider-github-copilot.test.ts
+++ b/packages/core/test/plugin/provider-github-copilot.test.ts
@@ -122,7 +122,7 @@ describe("GithubCopilotPlugin", () => {
       expect(requests[0]?.has("x-api-key")).toBe(false)
       expect(requests[0]?.get("x-initiator")).toBe("user")
       expect(requests[0]?.get("copilot-vision-request")).toBe("true")
-      expect(requests[0]?.get("x-github-api-version")).toBe("2026-06-01")
+      expect(requests[0]?.get("x-github-api-version")).toBe("2026-08-01")
       expect(requests[0]?.get("user-agent")).toBe("opencode/beta/1.2.3/test")
     }),
   )
@@ -145,7 +145,7 @@ describe("GithubCopilotPlugin", () => {
       expect(event.request.headers.has("x-api-key")).toBe(false)
       expect(event.request.headers.get("x-initiator")).toBe("user")
       expect(event.request.headers.get("anthropic-beta")).toBe("interleaved-thinking-2025-05-14")
-      expect(event.request.headers.get("x-github-api-version")).toBe("2026-06-01")
+      expect(event.request.headers.get("x-github-api-version")).toBe("2026-08-01")
     }),
   )
 


### PR DESCRIPTION
## Change

Bumps the `X-GitHub-Api-Version` sent to the Copilot API (CAPI) from `2026-06-01` to `2026-08-01`, matching the version VS Code's `@vscode/copilot-api` client uses. Newer CAPI endpoints such as `POST /auto` reject the older version (`404 invalid apiVersion`), so this is groundwork for supporting them.

The only shape difference observed in `GET /models` between the two versions is that `billing.token_prices.default.cache_price` is renamed to `cache_read_price` (and `billing.auto_discount` appears). The remote model schema now accepts either spelling so decoding does not fail, preferring `cache_read_price` when present.

The GitHub API version used for `copilot_internal/user` is unchanged.

## Verification

- Ran `CopilotModels.get` against a real account with both versions: 37 models decoded on each, identical pricing (`gpt-5.4`: input 2.5, output 15, cache read 0.25 USD/M).
- Added a unit test covering `cache_read_price`, legacy `cache_price`, and unpriced payloads.
- Updated header assertions in the plugin tests.
- `bun test` and `bun typecheck` pass in `packages/core`.