### PR TITLE
fix(app): refresh pending inputs when sessions reconnect

### DIFF
--- a/packages/app/e2e/regression/session-queue.spec.ts
+++ b/packages/app/e2e/regression/session-queue.spec.ts
@@ -3,6 +3,7 @@ import type { OpenCodeEvent, SessionMessageInfo } from "@opencode-ai/client/prom
 import { base64Encode } from "@opencode-ai/util/encode"
 import { mockOpenCodeServer } from "../utils/mock-server"
 import { expectAppVisible } from "../utils/waits"
+import { installSseTransport } from "../utils/sse-transport"
 
 const directory = "C:/OpenCode/SessionQueueRegression"
 const projectID = "proj_session_queue_regression"
@@ -166,6 +167,65 @@ test("follow-up preference controls Enter while Mod+Enter uses the alternate del
   await expect.poll(() => mock.prompts.map((prompt) => prompt.delivery)).toEqual(["queue", "steer"])
   await expect(view.input).toHaveText("")
 })
+
+for (const outcome of ["delivered", "cancelled"] as const) {
+  test(`refreshes a queued prompt ${outcome} while disconnected without reloading the page`, async ({
+    page,
+  }, testInfo) => {
+    const transport = await installSseTransport(page, { server, retry: 50 })
+    const mock = createQueueMock(["Follow-up consumed while disconnected"])
+    const reads: string[] = []
+    const inboxPath = `/api/session/${sessionID}/inbox`
+    const messagePath = `/api/session/${sessionID}/message`
+    page.on("request", (request) => {
+      const path = new URL(request.url()).pathname
+      if (request.method() === "GET" && (path === inboxPath || path === messagePath)) reads.push(path)
+    })
+    const view = await openSession(page, mock)
+    const connection = await transport.waitForConnection()
+    await expect(view.rows).toHaveCount(1)
+    expect(reads.filter((path) => path === inboxPath)).toHaveLength(1)
+    const queued = mock.rows[0]
+    const transcript = page.locator(`[data-timeline-row="UserMessage"][data-message-id="${queued.id}"]`)
+    await expect(transcript).toHaveCount(0)
+
+    // Hold refreshed snapshots until the server-side change has been made, without
+    // depending on how quickly the browser establishes its replacement stream.
+    const changed = Promise.withResolvers<void>()
+    await page.route(
+      (url) => url.pathname === inboxPath || url.pathname === messagePath,
+      async (route) => {
+        await changed.promise
+        await route.fallback()
+      },
+    )
+    const refreshed = page.waitForResponse(
+      (response) => new URL(response.url()).pathname === messagePath && response.status() === 200,
+    )
+    await transport.disconnect()
+    mock.rows.splice(0)
+    if (outcome === "delivered") {
+      mock.messages.push({
+        id: queued.id,
+        type: "user",
+        text: queued.payload.text,
+        time: { created: queued.timeCreated + 1 },
+      })
+    }
+    // Deliberately emit no inbox-delivered/cancelled event: it was missed offline.
+    changed.resolve()
+    await transport.waitForConnection({ after: connection.id })
+    await refreshed
+
+    await expect(view.rows).toHaveCount(0)
+    await expect(transcript).toHaveCount(outcome === "delivered" ? 1 : 0)
+    if (outcome === "delivered") await expect(transcript).toContainText(queued.payload.text)
+    expect(reads.filter((path) => path === inboxPath)).toHaveLength(2)
+    expect(reads.filter((path) => path === messagePath)).toHaveLength(2)
+    await expect(page).toHaveURL(`/server/${base64Encode(server)}/session/${sessionID}`)
+    await page.screenshot({ path: testInfo.outputPath(`reconnected-${outcome}.png`) })
+  })
+}
 
 test("dragging reorders queued prompts", async ({ page }) => {
   const mock = createQueueMock(["first queued prompt", "second queued prompt", "third queued prompt"])

--- a/packages/app/src/session/session-resolution.test.ts
+++ b/packages/app/src/session/session-resolution.test.ts
@@ -5,7 +5,7 @@ import { createSessionResolution } from "./session-resolution"
 describe("session resolution", () => {
   test("waits for a route session ID", () => {
     createRoot((dispose) => {
-      const syncs = { session: 0, message: 0 }
+      const syncs = { session: 0, message: 0, pending: 0 }
       const sessions = {
         get: () => undefined,
         sync: () => {
@@ -18,6 +18,13 @@ describe("session resolution", () => {
             return Promise.resolve()
           },
         },
+        pending: {
+          list: () => [],
+          sync: () => {
+            syncs.pending++
+            return Promise.resolve()
+          },
+        },
       }
       const session = createSessionResolution(
         () => undefined,
@@ -25,7 +32,7 @@ describe("session resolution", () => {
       )
 
       expect(session()).toBeUndefined()
-      expect(syncs).toEqual({ session: 0, message: 0 })
+      expect(syncs).toEqual({ session: 0, message: 0, pending: 0 })
       dispose()
     })
   })

--- a/packages/app/src/session/session-resolution.ts
+++ b/packages/app/src/session/session-resolution.ts
@@ -7,6 +7,10 @@ type SessionStore<T> = {
   message: {
     sync: (id: string) => Promise<unknown>
   }
+  pending: {
+    list: (id: string) => readonly unknown[]
+    sync: (id: string) => Promise<unknown>
+  }
 }
 
 type Resolution<T> = { id: string; store: SessionStore<T> } & (
@@ -52,8 +56,11 @@ export function createSessionResolution<T>(
       onCleanup(() => {
         stale = true
       })
-      // The timeline owns message errors; metadata resolution stays independent.
-      void store.message.sync(id).catch(() => undefined)
+      // Message reconciliation retains pending placeholders. Refresh their membership
+      // first when present, but keep empty-cache reads parallel and metadata independent.
+      const messages = store.pending.list(id).length ? undefined : store.message.sync(id)
+      const pending = store.pending.sync(id).catch(() => undefined)
+      void (messages ?? pending.then(() => store.message.sync(id))).catch(() => undefined)
       if (cached() && !options?.children && !options?.connected) {
         setStatus({ id, store, state: "settled" })
         return

--- a/packages/app/test-browser/session-resolution.test.ts
+++ b/packages/app/test-browser/session-resolution.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
+import { createData } from "@opencode-ai/client/solid"
+import { OpenCode, type SessionInboxInfo, type SessionInfo, type SessionMessageInfo } from "@opencode-ai/client/promise"
 import { createSessionResolution } from "@/session/session-resolution"
 
 type Session = { id: string; directory: string }
@@ -17,9 +19,11 @@ function createFixture(initial: Record<string, Session> = {}) {
   const deferred = new Map<string, PromiseWithResolvers<unknown>>()
   const resolves: string[] = []
   const messages = { syncs: [] as string[], ...Promise.withResolvers<unknown>() }
+  const pending = { syncs: [] as string[], items: [] as string[], ...Promise.withResolvers<unknown>() }
   return {
     resolves,
     messages,
+    pending,
     sessions: {
       get: (id: string) => cache()[id],
       sync: (id: string) => {
@@ -32,6 +36,13 @@ function createFixture(initial: Record<string, Session> = {}) {
         sync: (id: string) => {
           messages.syncs.push(id)
           return messages.promise
+        },
+      },
+      pending: {
+        list: () => pending.items,
+        sync: (id: string) => {
+          pending.syncs.push(id)
+          return pending.promise
         },
       },
     },
@@ -73,6 +84,7 @@ test("refreshes the current session on reconnect while keeping cached content vi
 
     expect(current()).toEqual(sessionOf("ses_a"))
     expect(fixture.resolves).toEqual([])
+    expect(fixture.pending.syncs).toEqual([])
     await flush()
     setConnection("connected", true)
     expect(fixture.resolves).toEqual(["ses_a"])
@@ -86,6 +98,7 @@ test("refreshes the current session on reconnect while keeping cached content vi
     expect(fixture.resolves).toEqual(["ses_a", "ses_a"])
     expect(current()).toEqual(sessionOf("ses_a"))
     expect(fixture.messages.syncs).toEqual(["ses_a", "ses_a"])
+    expect(fixture.pending.syncs).toEqual(["ses_a", "ses_a"])
     fixture.settle("ses_a", "/worktrees/moved")
     await flush()
     expect(current()?.directory).toBe("/worktrees/moved")
@@ -93,7 +106,7 @@ test("refreshes the current session on reconnect while keeping cached content vi
   })
 })
 
-test("starts metadata and messages in parallel once the route has a session ID", async () => {
+test("starts metadata, messages, and an empty pending cache in parallel once the route has a session ID", async () => {
   await createRoot(async (dispose) => {
     const fixture = createFixture()
     const [id, setId] = createSignal<string>()
@@ -103,10 +116,12 @@ test("starts metadata and messages in parallel once the route has a session ID",
     await flush()
     expect(fixture.resolves).toEqual([])
     expect(fixture.messages.syncs).toEqual([])
+    expect(fixture.pending.syncs).toEqual([])
 
     setId("ses_a")
     expect(fixture.resolves).toEqual(["ses_a"])
     expect(fixture.messages.syncs).toEqual(["ses_a"])
+    expect(fixture.pending.syncs).toEqual(["ses_a"])
 
     fixture.messages.resolve(undefined)
     await flush()
@@ -120,7 +135,7 @@ test("starts metadata and messages in parallel once the route has a session ID",
   })
 })
 
-test("message failure does not fail metadata resolution", async () => {
+test.each(["messages", "pending"] as const)("%s failure does not fail metadata resolution", async (read) => {
   await createRoot(async (dispose) => {
     const fixture = createFixture()
     const current = createSessionResolution(
@@ -129,7 +144,7 @@ test("message failure does not fail metadata resolution", async () => {
     )
 
     await flush()
-    fixture.messages.reject(new Error("message sync failed"))
+    fixture[read].reject(new Error(`${read} sync failed`))
     await flush()
     expect(current()).toBeUndefined()
 
@@ -140,6 +155,122 @@ test("message failure does not fail metadata resolution", async () => {
     dispose()
   })
 })
+
+test.each(["resolve", "reject"] as const)(
+  "refreshes cached pending membership before messages when its read does %s",
+  async (outcome) => {
+    await createRoot(async (dispose) => {
+      const fixture = createFixture()
+      fixture.pending.items.push("msg_queued")
+      const current = createSessionResolution(
+        () => "ses_a",
+        () => fixture.sessions,
+      )
+
+      expect(fixture.pending.syncs).toEqual(["ses_a"])
+      expect(fixture.messages.syncs).toEqual([])
+      fixture.settle("ses_a")
+      await flush()
+      expect(current()?.id).toBe("ses_a")
+      expect(fixture.messages.syncs).toEqual([])
+
+      if (outcome === "resolve") fixture.pending.resolve(undefined)
+      if (outcome === "reject") fixture.pending.reject(new Error("pending sync failed"))
+      await flush()
+      expect(fixture.messages.syncs).toEqual(["ses_a"])
+      expect(current()?.id).toBe("ses_a")
+      dispose()
+    })
+  },
+)
+
+test.each(["delivered", "cancelled"] as const)(
+  "refreshes a prompt %s while disconnected without changing sessions",
+  async (outcome) => {
+    const session: SessionInfo = {
+      id: "ses_reconnect",
+      projectID: "project",
+      location: { directory: "/project" },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      time: { created: 1, updated: 1 },
+    }
+    const queued: SessionInboxInfo = {
+      id: "msg_queued",
+      sessionID: session.id,
+      type: "user",
+      delivery: "queue",
+      payload: { text: "Queued follow-up" },
+      timeCreated: 2,
+    }
+    const server = { inbox: [queued], messages: [] as SessionMessageInfo[] }
+    const requests: string[] = []
+    const api = OpenCode.make({
+      baseUrl: "http://opencode.local",
+      fetch: Object.assign(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          const path = new URL(new Request(input, init).url).pathname
+          requests.push(path)
+          if (path === `/api/session/${session.id}`) return Response.json({ data: session })
+          if (path === `/api/session/${session.id}/inbox`) return Response.json({ data: server.inbox })
+          if (path === `/api/session/${session.id}/message`) return Response.json({ data: server.messages, cursor: {} })
+          throw new Error(`Unexpected request: ${path}`)
+        },
+        { preconnect() {} },
+      ),
+    })
+    const root = createRoot((dispose) => {
+      const [connection, setConnection] = createStore({ connected: true })
+      const data = createData({
+        api: () => api,
+        directory: "/project",
+        event: { on: () => () => {}, listen: () => () => {} },
+        connection: { status: () => (connection.connected ? "connected" : "disconnected") },
+      })
+      const current = createSessionResolution(
+        () => session.id,
+        () => data.session,
+        { connected: () => connection.connected },
+      )
+      return { dispose, data, current, setConnection }
+    })
+
+    try {
+      // The timeline also hydrates pending on mount; the cache joins this read.
+      await Promise.all([
+        root.data.session.sync(session.id),
+        root.data.session.message.sync(session.id),
+        root.data.session.pending.sync(session.id),
+      ])
+      expect(root.current()?.id).toBe(session.id)
+      expect(root.data.session.pending.list(session.id).map((item) => item.id)).toEqual([queued.id])
+      expect(requests.filter((path) => path.endsWith("/inbox"))).toHaveLength(1)
+
+      root.setConnection("connected", false)
+      await flush()
+      server.inbox = []
+      server.messages =
+        outcome === "delivered" ? [{ id: queued.id, type: "user", text: "Queued follow-up", time: { created: 3 } }] : []
+      root.setConnection("connected", true)
+      await root.data.session.sync(session.id)
+      await flush()
+
+      // Check that the reconnect path started the inbox request before joining it below.
+      expect(requests.filter((path) => path.endsWith("/inbox"))).toHaveLength(2)
+      await root.data.session.pending.sync(session.id)
+      await root.data.session.message.sync(session.id)
+      expect(root.current()?.id).toBe(session.id)
+      expect(root.data.session.pending.list(session.id)).toHaveLength(0)
+      expect(root.data.session.input.list(session.id)).toEqual([])
+      expect(root.data.session.message.list(session.id).map((message) => message.id)).toEqual(
+        outcome === "delivered" ? [queued.id] : [],
+      )
+      expect(requests.filter((path) => path.endsWith("/message"))).toHaveLength(2)
+    } finally {
+      root.dispose()
+    }
+  },
+)
 
 // Session tabs on the same server share one route instance, so navigating to
 // another session changes the id in place; resolution must follow it instead


### PR DESCRIPTION
## Why

The selected app session refreshes metadata and messages after reconnecting, but its normal pending-inbox hydration is driven by a session-ID-keyed timeline resource that does not rerun for connection changes. Staying on the same session through a disconnection therefore leaves prompts in the queue after the server has delivered or cancelled them.

The missing read also has an ordering constraint: message reconciliation preserves local placeholders for pending inputs. Refreshing both snapshots in parallel can clear a cancelled prompt from the queue while retaining it as a phantom transcript message.

## What Changes

Include the pending read in the existing connection-aware session-resolution path.

| Cached pending state | Read behavior |
| --- | --- |
| Empty | Start messages and pending in parallel |
| Nonempty | Refresh pending membership before refreshing messages |
| Pending read fails | Still attempt the message refresh; metadata resolution remains independent |

The existing cache joins the timeline's mount-time reads. No observer system, cache policy, or generated client API changes are introduced.

Only the existing session-ID, store, and connection dependencies trigger the effect. Queue updates do not introduce a new refresh subscription. With cached pending rows, the message refresh deliberately waits for the inbox read to settle; cached content stays visible and session metadata does not wait for either read.

## Demo

Matched production-build screenshots after reconnecting to a session whose queued prompt was cancelled while disconnected. The HTTP responses and SSE disconnect are fixture-controlled; no live server was interrupted.

| Before (`7819e7f503`) | After (`97ba9242a5`) |
| --- | --- |
| The cancelled prompt remains queued. | The queue clears and no phantom user message appears. |
| ![Before reconnect fix](https://github.com/user-attachments/assets/b177d0f1-8cee-4dd1-9a75-9c5521b4c111) | ![After reconnect fix](https://github.com/user-attachments/assets/5baf0046-a89f-4400-873c-ab895fdf2b8f) |

## Scope

The selected app session's reconnect path and its regression coverage. This does not claim to resolve the separate, still-unexplained lost-submission report.

One production file: **+9 / −2, net +7 lines**. Test code: **net +198 lines** across the unit/browser fixtures and existing queue e2e file. The tests cover both delivery and cancellation offline, pending-read failure, parallel cold loads, ordered refresh with cached pending rows, and absence of duplicate inbox/message requests.

## Verification

With Bun 1.4.0, from `packages/app`:

```sh
bun run test
bun typecheck

PLAYWRIGHT_PORT=4894 PLAYWRIGHT_BUILD=1 bunx playwright test e2e/regression/session-queue.spec.ts e2e/regression/inactive-tab-prefetch.spec.ts --workers=1 --retries=0 --reporter=line

# Run serially before the production edit and again with the final implementation:
PLAYWRIGHT_PORT=4894 OPENCODE_PERFORMANCE_RUN_ID=pending-reconnect-base bun run bench:tabs --repeat-each=5
PLAYWRIGHT_PORT=4894 OPENCODE_PERFORMANCE_RUN_ID=pending-reconnect-final bun run bench:tabs --repeat-each=5
```

- 718 unit tests passed, 1 skipped; 118 browser-runtime tests passed; app typecheck passed.
- The normal pre-push hook completed all 33 workspace typecheck tasks.
- Both new browser-runtime regressions fail on the original implementation because reconnect never requests pending items. The cancellation assertion also rejects a naive parallel-refresh fix that leaves a phantom transcript row.
- Both new production e2e regressions fail against the unchanged original production file: after reconnect, one obsolete queue row remains. With this fix, all 8 queue/prefetch e2e tests pass without retries.

### Production tab-switch benchmark

Five serial samples per scenario, 25/25 passing before and after. Message requests during each switch remained one for cold switches and zero for warm switches.

| Scenario | First correct, before → after (median ms) | Stable, before → after (median ms) |
| --- | ---: | ---: |
| Cold, review closed | 121.0 → 128.9 | 137.6 → 137.8 |
| Cold, review open | 142.5 → 139.4 | 149.5 → 154.9 |
| Warm, review closed | 31.2 → 29.9 | 40.2 → 39.3 |
| Warm, review open | 50.1 → 48.1 | 71.0 → 63.8 |
| Warm, review resized | 51.0 → 51.2 | 65.0 → 65.1 |

This is a small diagnostic sample, not a claim of identical latency on every machine. The benchmark uses empty inboxes; reconnecting with cached pending items intentionally waits for the inbox snapshot before refreshing messages to avoid the cancellation inconsistency.
