### PR TITLE
fix(core): expand portable shell scanner compatibility

### DIFF
--- a/packages/core/src/shell/scan.ts
+++ b/packages/core/src/shell/scan.ts
@@ -166,13 +166,24 @@ function scanBash(input: string, depth: number, budget: { remaining: number }): 
         segment = index + 1
         continue
       }
+      if (structure?.kind === "for" && structure.phase === "header" && char === "(" && input[index + 1] !== "(") {
+        const values = bashExpansion(input, index, depth, "array")
+        if (!values) return { kind: "opaque", reason: "compound-command" }
+        finishCommand()
+        const failure = addSubstitutions(values)
+        if (failure) return failure
+        commands.push(...nestedCommands.splice(0))
+        // Zsh permits a sublist or brace group directly after the value list, without do/done.
+        structure.phase = "do"
+        if (!/^(?:[ \t\n;]|#[^\n]*(?:\n|$))*do(?=[ \t\n;]|$)/.test(input.slice(values.end + 1))) structures.pop()
+        index = values.end
+        segment = index + 1
+        continue
+      }
       if (!words.length && !hasRedirect && !compoundEnd) {
-        const definition =
-          /^(?:function[ \t]+[A-Za-z_][A-Za-z0-9_]*(?:[ \t]*\([ \t]*\))?|[A-Za-z_][A-Za-z0-9_]*[ \t]*\([ \t]*\))[ \t\n]*(?=[{(])/.exec(
-            input.slice(index),
-          )
+        const definition = bashFunctionHead(input, index)
         if (definition && !header()) {
-          index += definition[0].length - 1
+          index += definition.length - 1
           segment = index + 1
           continue
         }
@@ -536,6 +547,14 @@ function scanBash(input: string, depth: number, budget: { remaining: number }): 
 
 type BashExpansion = { source: string; end: number; substitutions?: string[] }
 
+function bashFunctionHead(input: string, start: number) {
+  // Share recognition with delimiter scanning so case patterns in function bodies do not close the outer group.
+  // Names need not be variable identifiers. Zsh permits anonymous functions, including in an if condition.
+  return /^(?!if[ \t]*\()(?:function[ \t]+[A-Za-z_][A-Za-z0-9_.:-]*(?:[ \t]*\([ \t]*\))?|(?:[A-Za-z_][A-Za-z0-9_.:-]*[ \t]*)?\([ \t]*\))(?:[ \t\n]|#[^\n]*(?:\n|$))*(?=[{(]|\[\[(?=[ \t\n])|(?:if|while|until|for|select|case)[ \t\n])/.exec(
+    input.slice(start),
+  )?.[0]
+}
+
 function bashDelimited(input: string, start: number, depth: number): BashExpansion | undefined {
   if (depth >= MAX_SUBSTITUTION_DEPTH) return
   const close = input[start] === "{" ? "}" : ")"
@@ -566,6 +585,11 @@ function bashDelimited(input: string, start: number, depth: number): BashExpansi
       continue
     }
     const boundary = index === start + 1 || /[ \t\n;|&(){}]/.test(input[index - 1])
+    const definition = commandStart && boundary ? bashFunctionHead(input, index) : undefined
+    if (definition) {
+      index += definition.length - 1
+      continue
+    }
     if (char === "#" && boundary) {
       const newline = input.indexOf("\n", index)
       if (newline < 0) return
@@ -725,7 +749,10 @@ function bashExpansion(
       index = nested.end
       continue
     }
-    if (kind === "array" && "<>=".includes(char) && input[index + 1] === "(") {
+    if (
+      ((kind === "array" && "<>=".includes(char)) || (kind === "test" && "<>".includes(char))) &&
+      input[index + 1] === "("
+    ) {
       const nested = bashDelimited(input, index + 1, depth + 1)
       if (!nested) return
       substitutions.push(nested.source)

--- a/packages/core/src/shell/scan.ts
+++ b/packages/core/src/shell/scan.ts
@@ -149,6 +149,7 @@ function scanBash(input: string, depth: number, budget: { remaining: number }): 
     const char = input[index]
     if (!wordStarted) wordStart = index
     if (!quote && !wordStarted) {
+      if (char === " " || char === "\t") continue
       const structure = structures.at(-1)
       const token = /^[A-Za-z_][A-Za-z0-9_]*(?=[ \t\n;()<>]|$)/.exec(input.slice(index))?.[0]
       if (structure?.kind === "case" && structure.phase === "header" && token === "in") {
@@ -175,7 +176,7 @@ function scanBash(input: string, depth: number, budget: { remaining: number }): 
         commands.push(...nestedCommands.splice(0))
         // Zsh permits a sublist or brace group directly after the value list, without do/done.
         structure.phase = "do"
-        if (!/^(?:[ \t\n;]|#[^\n]*(?:\n|$))*do(?=[ \t\n;]|$)/.test(input.slice(values.end + 1))) structures.pop()
+        if (!/^(?:[ \t\n;]|\\\n|#[^\n]*(?:\n|$))*do(?=[ \t\n;]|$)/.test(input.slice(values.end + 1))) structures.pop()
         index = values.end
         segment = index + 1
         continue
@@ -550,7 +551,7 @@ type BashExpansion = { source: string; end: number; substitutions?: string[] }
 function bashFunctionHead(input: string, start: number) {
   // Share recognition with delimiter scanning so case patterns in function bodies do not close the outer group.
   // Names need not be variable identifiers. Zsh permits anonymous functions, including in an if condition.
-  return /^(?!if[ \t]*\()(?:function[ \t]+[A-Za-z_][A-Za-z0-9_.:-]*(?:[ \t]*\([ \t]*\))?|(?:[A-Za-z_][A-Za-z0-9_.:-]*[ \t]*)?\([ \t]*\))(?:[ \t\n]|#[^\n]*(?:\n|$))*(?=[{(]|\[\[(?=[ \t\n])|(?:if|while|until|for|select|case)[ \t\n])/.exec(
+  return /^(?!if(?:[ \t]|\\\n)*\()(?:function[ \t]+(?:\\\n[ \t]*)*[A-Za-z_][A-Za-z0-9_.:-]*(?:(?:[ \t]|\\\n)*\([ \t]*\))?|(?:[A-Za-z_][A-Za-z0-9_.:-]*(?:[ \t]|\\\n)*)?\([ \t]*\))(?:[ \t\n]|\\\n|#[^\n]*(?:\n|$))*(?=[{(]|\[\[(?=[ \t\n])|(?:if|while|until|for|select|case)[ \t\n])/.exec(
     input.slice(start),
   )?.[0]
 }
@@ -563,6 +564,7 @@ function bashDelimited(input: string, start: number, depth: number): BashExpansi
   let commandStart = true
   for (let index = start + 1; index < input.length; index++) {
     const char = input[index]
+    if (char === " " || char === "\t") continue
     if (char === "\\") {
       if (input[index + 1] !== "\n") commandStart = false
       index++

--- a/packages/core/test/shell-scan/compound-parity.test.ts
+++ b/packages/core/test/shell-scan/compound-parity.test.ts
@@ -68,6 +68,7 @@ const loops = values.flatMap((value) =>
           `for value (${value}); do scan_probe "$value"; done`,
           `for value (${value})\ndo scan_probe "$value"; done`,
           `for value (${value}) # ignored\ndo scan_probe "$value"; done`,
+          `for value (${value}) \\\ndo scan_probe "$value"; done`,
         ]
       : []),
   ].map((source) => ({ source, equivalent: `for value in ${value}; do scan_probe "$value"; done` })),

--- a/packages/core/test/shell-scan/compound-parity.test.ts
+++ b/packages/core/test/shell-scan/compound-parity.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { ShellParse } from "../../src/shell/parse.js"
+import { ShellScan } from "../../src/shell/scan.js"
+
+const contexts = [
+  (source: string) => source,
+  (source: string) => `( ${source} )`,
+  (source: string) => `{ ${source}; }`,
+  (source: string) => `if true; then ${source}; fi`,
+  (source: string) => `outer() { ${source}; }; outer`,
+]
+
+const bodies = [
+  "for value in one two; do scan_probe; done",
+  "while true; do scan_probe; break; done",
+  "until false; do scan_probe; break; done",
+  "case value in value) scan_probe;; *) scan_other;; esac",
+]
+
+describe("compound function acceptance", () => {
+  for (const shell of ["bash", "zsh"]) {
+    for (const head of ["probe()", "function probe", "function probe()", "probe-name()"])
+      for (const body of bodies)
+        for (const context of contexts) {
+          const name = head.includes("probe-name") ? "probe-name" : "probe"
+          const source = context(`${head} ${body}; ${name}`)
+          test(`${shell}: ${source}`, async () => {
+            // Braces preserve the function's behavior, but avoid Tree-sitter's recovery artifacts.
+            const legacy = await Effect.runPromise(
+              ShellParse.scan(context(`${head} { ${body}; }; ${name}`), shell, "/workspace"),
+            )
+            expect(await Effect.runPromise(ShellParse.scanPortable(source, shell, "/workspace"))).toEqual(legacy)
+          })
+        }
+  }
+
+  test.each(bodies)("keeps compound function bodies inside command substitutions: %s", (body) => {
+    const source = `printf '%s' "$( probe() ${body}; probe )"`
+    const result = ShellScan.scan(source)
+    expect(result.kind).toBe("scanned")
+    if (result.kind !== "scanned") throw new Error(result.reason)
+    expect(result.commands[0]?.resource).toBe(source)
+    expect(result.commands.map((command) => command.words[0])).toContain("scan_probe")
+    expect(result.commands.at(-1)?.words).toEqual(["probe"])
+  })
+})
+
+const values = [
+  "one two",
+  "'two words' one",
+  "'cd' '/outside'",
+  "'do' 'done'",
+  "'(literal)' '$(scan_ignored)'",
+  "one\\\ntwo",
+  "$(printf one)",
+  '"$(printf one)"',
+  "<(printf one)",
+  "",
+]
+const loops = values.flatMap((value) =>
+  [
+    `for value (${value}) scan_probe "$value"`,
+    `for value (${value}) { scan_probe "$value"; }`,
+    ...(value
+      ? [
+          `for value (${value}) do scan_probe "$value"; done`,
+          `for value (${value}); do scan_probe "$value"; done`,
+          `for value (${value})\ndo scan_probe "$value"; done`,
+          `for value (${value}) # ignored\ndo scan_probe "$value"; done`,
+        ]
+      : []),
+  ].map((source) => ({ source, equivalent: `for value in ${value}; do scan_probe "$value"; done` })),
+)
+
+describe("Zsh parenthesized loop acceptance", () => {
+  for (const fixture of loops)
+    for (const context of contexts) {
+      const source = context(fixture.source)
+      test(source, async () => {
+        const legacy = await Effect.runPromise(ShellParse.scan(context(fixture.equivalent), "zsh", "/workspace"))
+        expect(await Effect.runPromise(ShellParse.scanPortable(source, "zsh", "/workspace"))).toEqual(legacy)
+      })
+    }
+
+  test.each([
+    "for x (one two) for y (a b) scan_probe",
+    "for x (one two) scan_probe && scan_other",
+    "for x (one two) scan_probe | scan_other",
+    "printf '%s' \"$(for x (one two) scan_probe)\"",
+    "for x (one two) { for y (a b); do scan_probe; done; }",
+    "for x (one two) [[ $(scan_probe) == ok ]]",
+    "for x (one two) (( 1 + $(scan_probe) ))",
+  ])("retains commands in nested shorthand loops: %s", (source) => {
+    const result = ShellScan.scan(source)
+    expect(result.kind).toBe("scanned")
+    if (result.kind !== "scanned") throw new Error(result.reason)
+    expect(result.commands.map((command) => command.words[0])).toContain("scan_probe")
+    if (source.includes("scan_other"))
+      expect(result.commands.map((command) => command.words[0])).toContain("scan_other")
+  })
+})
+
+describe("real-shell compound syntax", () => {
+  for (const shell of ["bash", "zsh"]) {
+    const executable = Bun.which(shell)
+    test
+      .skipIf(!executable)
+      .each([
+        ...bodies.map((body) => `probe() ${body}; probe`),
+        ...bodies.map((body) => `printf '%s' "$(probe() ${body}; probe)"`),
+        ...(shell === "zsh" ? loops.map((fixture) => fixture.source) : []),
+      ])(`${shell}: %s`, (source) => {
+      if (!executable) throw new Error(`${shell} is unavailable`)
+      const execution = Bun.spawnSync(
+        [
+          executable,
+          ...(shell === "bash" ? ["--noprofile", "--norc"] : ["-f"]),
+          "-c",
+          `scan_probe() { printf 'executed\\n' >&2; }; ${source}; wait`,
+        ],
+        { env: { PATH: "/usr/bin:/bin", LC_ALL: "C" }, timeout: 2_000 },
+      )
+      expect(execution.exitCode).toBe(0)
+      expect(execution.stderr.toString()).toEqual(
+        source.includes("value ()") ? "" : expect.stringContaining("executed\n"),
+      )
+      expect(ShellScan.scan(source).kind).toBe("scanned")
+    })
+  }
+})

--- a/packages/core/test/shell-scan/parity-regressions.test.ts
+++ b/packages/core/test/shell-scan/parity-regressions.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import { ShellParse } from "../../src/shell/parse.js"
+import { ShellScan } from "../../src/shell/scan.js"
+
+const conditions = ["[[ -n <(scan_probe) ]]", "[[ -n >(scan_probe) ]]"]
+const contexts = [
+  (source: string) => source,
+  (source: string) => `( ${source} )`,
+  (source: string) => `{ ${source}; }`,
+  (source: string) => `if ${source}; then printf visible; fi`,
+  (source: string) => `check() { ${source}; }; check`,
+  (source: string) => `printf '%s' "$( ${source}; printf visible)"`,
+]
+
+const functions = ["probe", "probe-name", "probe.name", "probe:name"].flatMap((name) =>
+  [`${name}()`, `function ${name}`, `function ${name}()`].flatMap((head) =>
+    [
+      "{ scan_probe; }",
+      "(scan_probe)",
+      "if true; then scan_probe; fi",
+      "[[ $(scan_probe) == ok ]]",
+      "(( 1 + $(scan_probe) ))",
+    ].map((body) => `${head} ${body}; ${name}`),
+  ),
+)
+
+describe("legacy-accepted shell syntax regressions", () => {
+  test.each(["() { scan_probe; }", "probe() { scan_probe; }; probe"])(
+    "preserves deeply indented function definitions: %s",
+    async (source) => {
+      const command = `( ${" ".repeat(32_000)}${source} )`
+      const legacy = await Effect.runPromise(ShellParse.scan(command, "zsh", "/workspace"))
+      expect(await Effect.runPromise(ShellParse.scanPortable(command, "zsh", "/workspace"))).toEqual(legacy)
+    },
+  )
+
+  test.each(conditions.flatMap((source) => contexts.map((context) => context(source))))(
+    "retains conditional process substitutions and permission resources: %s",
+    async (source) => {
+      const legacy = await Effect.runPromise(ShellParse.scan(source, "bash", "/workspace"))
+      expect(legacy.commands.some((command) => command.resource === "scan_probe")).toBe(true)
+      expect(await Effect.runPromise(ShellParse.scanPortable(source, "bash", "/workspace"))).toEqual(legacy)
+    },
+  )
+
+  for (const shell of ["bash", "zsh"]) {
+    test.each(
+      ["probe()", "function probe", "function probe()"].flatMap((head) =>
+        [" # ignored ) }\n", "\n# ignored ) }\n\n", " # first\n# second\n"].flatMap((gap) =>
+          contexts.map((context) => context(`${head}${gap}{ scan_probe; }; probe`)),
+        ),
+      ),
+    )(`${shell} preserves comments between a function head and its body: %s`, async (source) => {
+      const legacy = await Effect.runPromise(ShellParse.scan(source, shell, "/workspace"))
+      expect(legacy.commands.some((command) => command.resource === "scan_probe")).toBe(true)
+      expect(await Effect.runPromise(ShellParse.scanPortable(source, shell, "/workspace"))).toEqual(legacy)
+    })
+
+    test.each(functions)(
+      `${shell} preserves function resources, saved prefixes, and directories: %s`,
+      async (source) => {
+        const legacy = await Effect.runPromise(ShellParse.scan(source, shell, "/workspace"))
+        expect(legacy.commands.some((command) => command.resource === "scan_probe")).toBe(true)
+        expect(await Effect.runPromise(ShellParse.scanPortable(source, shell, "/workspace"))).toEqual(legacy)
+      },
+    )
+
+    const executable = Bun.which(shell)
+    test
+      .skipIf(!executable)
+      .each([
+        "probe-name() { scan_probe; }; probe-name",
+        "function probe.name { scan_probe; }; probe.name",
+        "probe:name() if true; then scan_probe; fi; probe:name",
+        "probe()# ignored ) }\n{ scan_probe; }; probe",
+        ...(shell === "bash" ? conditions : ["() { scan_probe; }"]),
+      ])(`${shell} really executes the extracted command: %s`, (source) => {
+      if (!executable) throw new Error(`${shell} is unavailable`)
+      const execution = Bun.spawnSync(
+        [
+          executable,
+          ...(shell === "bash" ? ["--noprofile", "--norc"] : ["-f"]),
+          "-c",
+          `scan_probe() { printf 'executed\\n' >&2; }; ${source}; wait`,
+        ],
+        { env: { PATH: "/usr/bin:/bin", LC_ALL: "C" } },
+      )
+      expect(execution.exitCode).toBe(0)
+      expect(execution.stderr.toString()).toBe("executed\n")
+      const result = ShellScan.scan(source)
+      expect(result.kind).toBe("scanned")
+      if (result.kind !== "scanned") throw new Error(result.reason)
+      expect(result.commands.map((command) => command.words[0])).toContain("scan_probe")
+    })
+  }
+
+  test.each([
+    "() { scan_probe; }",
+    "( () { scan_probe; } )",
+    "{ () { scan_probe; }; }",
+    "while() { scan_probe; break; }",
+    "until() { scan_probe; break; }",
+  ])("preserves Zsh anonymous functions and parenthesized loop permissions: %s", async (source) => {
+    const legacy = await Effect.runPromise(ShellParse.scan(source, "zsh", "/workspace"))
+    expect(legacy.commands.some((command) => command.resource === "scan_probe")).toBe(true)
+    expect(await Effect.runPromise(ShellParse.scanPortable(source, "zsh", "/workspace"))).toEqual(legacy)
+  })
+
+  // Tree-sitter recovers these valid Zsh forms with synthetic commands or truncated outer resources.
+  // Pin both results rather than treating recovery artifacts as executable shell syntax.
+  test.each([
+    {
+      source: "if () { scan_probe; }; then printf visible; fi",
+      legacy: ["scan_probe", "then printf visible", "fi"],
+      portable: ["scan_probe", "printf visible"],
+    },
+    {
+      source: "check() { () { scan_probe; }; }; check",
+      legacy: ["scan_probe", "}", "check"],
+      portable: ["scan_probe", "check"],
+    },
+    {
+      source: "printf '%s' \"$( () { scan_probe; }; printf visible)\"",
+      legacy: ["printf '%s'", "scan_probe", "printf visible"],
+      portable: ["printf '%s' \"$( () { scan_probe; }; printf visible)\"", "scan_probe", "printf visible"],
+    },
+  ])("accepts anonymous-function compositions despite legacy recovery artifacts: $source", async (fixture) => {
+    const legacy = await Effect.runPromise(ShellParse.scan(fixture.source, "zsh", "/workspace"))
+    const portable = await Effect.runPromise(ShellParse.scanPortable(fixture.source, "zsh", "/workspace"))
+    expect(legacy.commands.map((command) => command.resource)).toEqual([...fixture.legacy])
+    expect(portable.commands.map((command) => command.resource)).toEqual([...fixture.portable])
+  })
+
+  test.each([
+    "[[ -n '<(scan_ignored)' ]]",
+    '[[ -n "<(scan_ignored)" ]]',
+    "[[ -n '>(scan_ignored)' ]]",
+    '[[ -n ">(scan_ignored)" ]]',
+    "[[ -n $'<(scan_ignored)' ]]",
+  ])("does not turn quoted process-substitution text into commands: %s", (source) => {
+    expect(ShellScan.scan(source)).toEqual({ kind: "scanned", commands: [] })
+  })
+})

--- a/packages/core/test/shell-scan/parity-regressions.test.ts
+++ b/packages/core/test/shell-scan/parity-regressions.test.ts
@@ -46,6 +46,18 @@ describe("legacy-accepted shell syntax regressions", () => {
 
   for (const shell of ["bash", "zsh"]) {
     test.each(
+      ["probe()", "probe \\\n()", "function \\\nprobe()", "function probe \\\n()"].flatMap((head) =>
+        [" \\\n", " \\\n # ignored ) }\n", "# ignored \\\n"].flatMap((gap) =>
+          contexts.map((context) => context(`${head}${gap}{ scan_probe; }; probe`)),
+        ),
+      ),
+    )(`${shell} preserves line continuations at function boundaries: %s`, async (source) => {
+      const legacy = await Effect.runPromise(ShellParse.scan(source, shell, "/workspace"))
+      expect(legacy.commands.some((command) => command.resource === "scan_probe")).toBe(true)
+      expect(await Effect.runPromise(ShellParse.scanPortable(source, shell, "/workspace"))).toEqual(legacy)
+    })
+
+    test.each(
       ["probe()", "function probe", "function probe()"].flatMap((head) =>
         [" # ignored ) }\n", "\n# ignored ) }\n\n", " # first\n# second\n"].flatMap((gap) =>
           contexts.map((context) => context(`${head}${gap}{ scan_probe; }; probe`)),
@@ -74,6 +86,8 @@ describe("legacy-accepted shell syntax regressions", () => {
         "function probe.name { scan_probe; }; probe.name",
         "probe:name() if true; then scan_probe; fi; probe:name",
         "probe()# ignored ) }\n{ scan_probe; }; probe",
+        "probe \\\n() \\\n{ scan_probe; }; probe",
+        "function \\\nprobe() # ignored \\\n{ scan_probe; }; probe",
         ...(shell === "bash" ? conditions : ["() { scan_probe; }"]),
       ])(`${shell} really executes the extracted command: %s`, (source) => {
       if (!executable) throw new Error(`${shell} is unavailable`)

--- a/packages/core/test/shell-scan/powershell-runtime.test.ts
+++ b/packages/core/test/shell-scan/powershell-runtime.test.ts
@@ -3,7 +3,30 @@ import { ShellScan } from "../../src/shell/scan.js"
 
 const pwsh = process.env.SHELL_SCAN_PWSH ?? Bun.which("pwsh")
 
+// These ordinary forms must stay accepted, not disappear behind the oracle's opaque-result filter.
+const supported = [
+  "Invoke-ProbeA; Invoke-ProbeB",
+  "$result = Invoke-ProbeA; Invoke-ProbeB",
+  "if (Invoke-ProbeA) { Invoke-ProbeB } else { Invoke-ProbeC }",
+  "foreach ($item in (Invoke-ProbeA)) { Invoke-ProbeB }",
+  "function Get-Probe { param($x); Invoke-ProbeB }; Invoke-ProbeA",
+  "$x = @{ first = Invoke-ProbeA; second = @(Invoke-ProbeB; Invoke-ProbeC) }",
+  'Invoke-ProbeA "$(Invoke-ProbeB "$(Invoke-ProbeC)")"',
+  "Invoke-ProbeA | ForEach-Object { Invoke-ProbeB }",
+  "Invoke-ProbeA @'\nliteral ; }\n'@; Invoke-ProbeB",
+  'Invoke-ProbeA @"\n$(Invoke-ProbeB)\n"@; Invoke-ProbeC',
+  "Invoke-ProbeA `\n  argument; Invoke-ProbeB",
+  "Invoke-ProbeA 2>&1; Invoke-ProbeB",
+  "& 'Invoke-ProbeA' argument; Invoke-ProbeB",
+  "Invoke-ProbeA --% literal; ignored\nInvoke-ProbeB",
+]
+
+test.each(supported)("accepts supported PowerShell syntax without an opaque escape hatch: %s", (source) => {
+  expect(ShellScan.scanPowerShell(source).kind).toBe("scanned")
+})
+
 const fixtures = [
+  ...supported,
   ...[
     "$result = Invoke-ProbeA; Invoke-ProbeB",
     "$result = (Invoke-ProbeA); Invoke-ProbeB",
@@ -343,6 +366,10 @@ test.skipIf(!pwsh)(
     let executed = 0
     for (const result of results) {
       const scan = ShellScan.scanPowerShell(result.source)
+      if (supported.includes(result.source)) {
+        expect(result.errors, result.source).toEqual([])
+        expect(scan.kind, result.source).toBe("scanned")
+      }
       if (scan.kind === "opaque" || result.errors.length > 0) continue
       scanned++
       executed += result.executed.length

--- a/packages/core/test/tool-shell.test.ts
+++ b/packages/core/test/tool-shell.test.ts
@@ -526,6 +526,150 @@ describe("ShellTool scanner permissions", () => {
   }
 })
 
+describe("ShellTool conditional process substitution", () => {
+  const test = isWindows || !Bun.which("bash") ? permissionIt.live.skip : permissionIt.live
+  for (const portable of [false, true]) {
+    test(`${portable ? "native" : "legacy"}: a nested deny prevents the substitution from running`, () =>
+      withScanner(
+        portable,
+        (registry, directory) =>
+          Effect.gen(function* () {
+            const agents = yield* Agent.Service
+            yield* agents.transform((editor) =>
+              editor.update(toolIdentity.agent, (agent) => {
+                agent.permissions = [
+                  { action: "shell", resource: "*", effect: "allow" },
+                  { action: "shell", resource: "printf *", effect: "deny" },
+                ]
+              }),
+            )
+            const marker = path.join(directory.active, "marker")
+            const result = yield* runPermissionCommand(
+              registry,
+              '[[ -n <(printf reached > marker) ]]; wait "$!"',
+              marker,
+              [],
+            )
+            expect(result.exit).toMatchObject({
+              _tag: "Success",
+              value: { status: "error", error: { message: expect.stringContaining("Permission denied: shell") } },
+            })
+            expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
+          }),
+        "bash",
+      ))
+
+    for (const reply of ["reject", "once", "always"] as const) {
+      test(`${portable ? "native" : "legacy"}: conditional substitutions respect ${reply}`, () =>
+        withScanner(
+          portable,
+          (registry, directory) =>
+            Effect.gen(function* () {
+              const saved = yield* PermissionSaved.Service
+              const location = yield* Location.Service
+              yield* saved.add({ projectID: location.project.id, action: "shell", resources: ["wait *"] })
+              const marker = path.join(directory.active, "marker")
+              const command = '[[ -n <(printf reached > marker) ]]; wait "$!"'
+              const result = yield* runPermissionCommand(registry, command, marker, [reply])
+              expect(result.requests).toMatchObject([
+                { action: "shell", resources: ["printf reached > marker", 'wait "$!"'], save: ["printf *", "wait *"] },
+              ])
+              if (reply === "reject") {
+                expect(Exit.isFailure(result.exit)).toBe(true)
+                expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(false)
+                return
+              }
+              expect(result.exit).toMatchObject({
+                _tag: "Success",
+                value: { status: "completed", metadata: { exit: 0 } },
+              })
+              expect(yield* Effect.promise(() => Bun.file(marker).text())).toBe("reached")
+              yield* Effect.promise(() => fs.unlink(marker))
+              const repeat = yield* runPermissionCommand(
+                registry,
+                command,
+                marker,
+                reply === "always" ? [] : ["reject"],
+              )
+              expect(repeat.requests).toHaveLength(reply === "always" ? 0 : 1)
+              expect(yield* Effect.promise(() => Bun.file(marker).exists())).toBe(reply === "always")
+            }),
+          "bash",
+        ))
+    }
+  }
+})
+
+describe("ShellTool compound syntax approval compatibility", () => {
+  for (const fixture of [
+    {
+      shell: "zsh",
+      command: 'for value (a b) printf %s "$value"',
+      equivalent: 'for value in a b; do printf %s "$value"; done',
+      output: "ab",
+      saved: ["printf *"],
+    },
+    {
+      shell: "zsh",
+      command: 'for value (a b) { printf %s "$value"; }',
+      equivalent: 'for value in a b; do printf %s "$value"; done',
+      output: "ab",
+      saved: ["printf *"],
+    },
+    {
+      shell: "zsh",
+      command: 'for value ($(printf a)) do printf %s "$value"; done',
+      equivalent: 'for value in $(printf a); do printf %s "$value"; done',
+      output: "a",
+      saved: ["printf *"],
+    },
+    {
+      shell: "bash",
+      command: 'probe() for value in a b; do printf %s "$value"; done; probe',
+      equivalent: 'probe() { for value in a b; do printf %s "$value"; done; }; probe',
+      output: "ab",
+      saved: ["printf *", "probe *"],
+    },
+    {
+      shell: "bash",
+      command: 'printf %s "$(probe() case value in value) printf hello;; esac; probe)"',
+      equivalent: 'printf %s "$(probe() { case value in value) printf hello;; esac; }; probe)"',
+      output: "hello",
+      saved: ["printf *", "probe *"],
+    },
+  ]) {
+    const test = isWindows || !Bun.which(fixture.shell) ? permissionIt.live.skip : permissionIt.live
+    for (const portable of [false, true]) {
+      test(`${fixture.shell} ${portable ? "native" : "legacy equivalent"}: ${fixture.command}`, () =>
+        withScanner(
+          portable,
+          (registry, directory) =>
+            Effect.gen(function* () {
+              const saved = yield* PermissionSaved.Service
+              const location = yield* Location.Service
+              yield* saved.add({ projectID: location.project.id, action: "shell", resources: fixture.saved })
+              const result = yield* runPermissionCommand(
+                registry,
+                portable ? fixture.command : fixture.equivalent,
+                path.join(directory.active, "marker"),
+                [],
+              )
+              expect(result.requests).toEqual([])
+              expect(result.exit).toMatchObject({
+                _tag: "Success",
+                value: {
+                  status: "completed",
+                  metadata: { exit: 0 },
+                  content: [{ type: "text", text: fixture.output }, { type: "text" }],
+                },
+              })
+            }),
+          fixture.shell,
+        ))
+    }
+  }
+})
+
 describe("ShellTool ordinary shell syntax", () => {
   for (const shell of ["bash", "zsh"]) {
     const test = isWindows || !Bun.which(shell) ? permissionIt.live.skip : permissionIt.live


### PR DESCRIPTION
## Why

The experimental portable shell scanner rejects valid Bash/Zsh syntax that the Tree-sitter path accepts. It also misses process substitutions inside `[[ … ]]`, allowing those nested commands to execute without the shell permission check that Tree-sitter would request.

This expands compatibility toward replacing Tree-sitter without solving parser gaps through new blanket rejections.

## What Changes

| Input | Portable behavior after this change |
| --- | --- |
| `[[ -n <(printf hello) ]]` | Extracts `printf hello`, matching the existing permission resource and saved prefix. |
| `probe-name() { printf hello; }; probe-name` | Accepts function names containing hyphens, dots, or colons. |
| `probe() case value in value) printf hello;; esac; probe` | Accepts compound function bodies, including when nested inside command substitutions. |
| A function header followed by comments or escaped newlines | Finds the body without inventing a command or rejecting the input. |
| `for value (a b) printf '%s' "$value"` | Accepts Zsh parenthesized value lists, including short, brace, and `do/done` bodies. |

- Add exact comparisons of resources, saved prefixes, and directories against Tree-sitter.
- Where Tree-sitter produces recovery artifacts for valid shorthand, compare with equivalent long-form syntax or explicitly pin the differing outputs rather than claiming same-input parity.
- Exercise real Bash/Zsh execution and shell-tool permissions, including deny, reject, once, always, repeat execution, and existing saved approvals.
- Require ordinary PowerShell fixtures to remain accepted; the runtime oracle cannot silently filter these fixtures out as opaque.
- Skip unquoted horizontal whitespace before structural parsing, preserving quote, heredoc, and command boundaries.

## Scope

The portable scanner remains opt-in and Tree-sitter remains the default. This does not remove WASM dependencies, change executable Zsh glob-qualifier permission semantics, or claim complete grammar parity.

No benchmark scripts, package commands, or performance notes are included.

## Verification

From `packages/core`:

```sh
bun run test test/shell-scan test/shell-parse test/permission.test.ts test/tool-shell.test.ts
bun typecheck
```

- Focused scanner, parser, permission, and shell-tool suites: **2,647 passed, 23 skipped, 0 failed**.
- Real Bash/Zsh probes passed. The PowerShell runtime oracle was skipped locally because `pwsh` is unavailable; its unconditional acceptance fixtures passed.
- Core typechecking, formatting, and diff whitespace checks passed.
- The pre-push workspace typecheck passed: 33 successful tasks, 27 served from cache.
