### PR TITLE
fix(app): refine build indicators in tab navigation

### DIFF
--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -812,6 +812,10 @@ export const dict = {
 
   "titlebar.update": "Update",
   "titlebar.tabs": "Tabs",
+  "titlebar.channel.local": "Local",
+  "titlebar.channel.dev": "Dev",
+  "titlebar.channel.beta": "Beta",
+  "titlebar.toggleDebugTools": "Toggle debug tools",
   "titlebar.updateVersion": "Update {{version}}",
 
   "common.closeTab": "Close tab",

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -1,6 +1,6 @@
 import { createEffect, createMemo, createResource, Match, Show, Switch, untrack } from "solid-js"
 import { createStore, unwrap } from "solid-js/store"
-import { Portal } from "solid-js/web"
+import { Dynamic, Portal } from "solid-js/web"
 import { useLocation, useNavigate } from "@solidjs/router"
 import { IconButton } from "@opencode-ai/ui/icon-button"
 import { Icon } from "@opencode-ai/ui/icon"
@@ -31,12 +31,15 @@ import { SessionTabAvatar } from "@/shell/layout/session-tab-avatar"
 import { SessionProgressIndicatorV2 } from "@opencode-ai/session-ui/v2/session-progress-indicator-v2"
 import { projectForSession } from "@/shell/layout/helpers"
 import { useSettingsDialog } from "@/settings/command"
+import devIcon from "../../../../desktop/icons/dev/64x64.png"
+import betaIcon from "../../../../desktop/icons/beta/64x64.png"
 
 const titlebarHeight = 36
 const windowsTitlebarHeight = 44 // Includes the content inset; matches the native Windows overlay.
 const minTitlebarZoom = 0.25
 const windowsControlsBaseWidth = 138 // 3 native Windows caption buttons at 46px each.
-const macTrafficLightsBaseWidth = 84
+// Native controls: 14px left inset, two 20px button pitches, and a 14px button.
+const macTrafficLightsBaseWidth = 68
 const macTrafficLightsTopClearance = 28
 
 export type TitlebarUpdate = {
@@ -425,16 +428,15 @@ export function Titlebar(props: {
 
             return (
               <div
-                class="h-full flex-1 overflow-hidden flex flex-row items-center gap-1.5 px-2 md:pr-3"
+                class="h-full flex-1 overflow-hidden flex flex-row items-center gap-1.5 px-2 md:pe-3"
                 classList={{
                   "pt-[max(0px,calc(8px-env(safe-area-inset-top,0px)))]": !bottom() && !windows(),
                   "pb-[max(0px,calc(8px-env(safe-area-inset-bottom,0px)))]": bottom(),
-                  "md:pl-2": macTrafficLights(),
-                  "md:pl-4": !macTrafficLights(),
+                  "pl-4": macTrafficLights(),
                 }}
               >
-                <Show when={!mobile() && (!props.verticalTabs || windows())}>
-                  <ChannelIndicator debugTools={props.debugTools} />
+                <Show when={!mobile() && !props.verticalTabs}>
+                  <ChannelIndicator horizontal debugTools={props.debugTools} />
                 </Show>
                 <Show when={windows() || linux()}>
                   <WindowsAppMenu command={command} platform={platform} />
@@ -625,23 +627,12 @@ export function Titlebar(props: {
                           >
                             <Show when={macVerticalTabs()}>
                               <div
-                                class="relative mb-2 w-full shrink-0"
+                                class="mb-4 min-h-7 w-full shrink-0"
                                 style={{ height: `${macTrafficLightsTopClearance / zoom()}px` }}
                                 data-tauri-drag-region
-                              >
-                                <div
-                                  class="absolute -top-0.5 bottom-0.5 flex items-center"
-                                  style={{
-                                    // Native traffic lights stay on the physical left; subtract the sidebar padding.
-                                    left: macTrafficLights()
-                                      ? `calc(${macTrafficLightsBaseWidth / zoom()}px - 0.625rem)`
-                                      : "0px",
-                                  }}
-                                >
-                                  <ChannelIndicator debugTools={props.debugTools} />
-                                </div>
-                              </div>
+                              />
                             </Show>
+                            <ChannelIndicator sidebar debugTools={props.debugTools} />
                             {homeButton(true)}
                             <button
                               type="button"
@@ -675,9 +666,6 @@ export function Titlebar(props: {
                               class="mt-auto flex h-9 w-full shrink-0 items-center gap-1.5"
                             >
                               <TitlebarRightMount />
-                              <Show when={!macVerticalTabs() && !windows()}>
-                                <ChannelIndicator debugTools={props.debugTools} />
-                              </Show>
                             </div>
                           </Portal>
                         )}
@@ -753,45 +741,47 @@ function TitlebarUpdateIconButton(props: { state: TitlebarUpdatePillState }) {
   )
 }
 
-function ChannelIndicator(props: { debugTools?: { visible: boolean; toggle: () => void } }) {
+function ChannelIndicator(props: {
+  horizontal?: boolean
+  sidebar?: boolean
+  debugTools?: { visible: boolean; toggle: () => void }
+}) {
+  const language = useLanguage()
   const platform = usePlatform()
-  const windows = () => platform.platform === "desktop" && platform.os === "windows"
-  const classes = () => ({
-    "px-2 rounded-sm": windows(),
-    "inline-flex h-4 shrink-0 items-center leading-4 px-1.5 rounded-full": !windows(),
-  })
-  const style = () => ({
-    "font-size": windows() ? undefined : platform.platform === "desktop" && platform.os === "macos" ? "9px" : "10px",
-  })
   const channel = import.meta.env.VITE_OPENCODE_CHANNEL
-  if (channel === "dev" && props.debugTools) {
-    return (
-      <button
-        type="button"
-        class="bg-icon-interactive-base text-[#FFF] font-medium uppercase font-mono cursor-pointer [app-region:no-drag]"
-        classList={classes()}
-        style={style()}
-        onClick={props.debugTools.toggle}
-        aria-label="Toggle debug tools"
-        aria-pressed={props.debugTools.visible}
-      >
-        DEV
-      </button>
-    )
-  }
+  if (!channel || channel === "prod") return null
 
-  const label = channel && ["local", "beta", "dev"].includes(channel) ? channel.toUpperCase() : undefined
+  const label = () => language.t(`titlebar.channel.${channel}`)
+  const debug = () => (channel === "dev" ? props.debugTools : undefined)
   return (
-    <Show when={label}>
-      {(value) => (
-        <div
-          class="bg-icon-interactive-base text-[#FFF] font-medium uppercase font-mono"
-          classList={classes()}
-          style={style()}
-        >
-          {value()}
-        </div>
-      )}
-    </Show>
+    <Tooltip
+      placement={props.sidebar ? "right" : "bottom"}
+      value={label()}
+      class={`shrink-0 [app-region:no-drag] ${props.sidebar ? "mb-4 ms-0.5 self-start" : ""} ${props.horizontal ? "me-1.5" : ""} ${props.horizontal && platform.platform === "web" ? "ps-2.5" : ""}`}
+    >
+      <Dynamic
+        component={debug() ? "button" : "div"}
+        type={debug() ? "button" : undefined}
+        data-slot="channel-indicator"
+        class="flex h-7 shrink-0 items-center rounded-[6px] [app-region:no-drag]"
+        classList={{
+          "w-6": props.sidebar,
+          "w-5": !props.sidebar,
+          "cursor-pointer hover:bg-v2-background-bg-layer-02 focus-visible:outline-none focus-visible:bg-v2-background-bg-layer-02":
+            !!debug(),
+        }}
+        onClick={() => debug()?.toggle()}
+        aria-label={debug() ? language.t("titlebar.toggleDebugTools") : undefined}
+        aria-pressed={debug()?.visible}
+      >
+        <img
+          src={channel === "beta" ? betaIcon : devIcon}
+          alt={debug() ? "" : label()}
+          class="shrink-0 rounded-[4px] shadow-[var(--v2-elevation-raised)]"
+          classList={{ "size-6": props.sidebar, "size-5": !props.sidebar }}
+          draggable={false}
+        />
+      </Dynamic>
+    </Tooltip>
   )
 }


### PR DESCRIPTION
## Summary
- Replace Local/Dev/Beta text badges with the existing blue development and white beta app icons.
- In vertical tabs, show a 24px icon above Home, centered with the navigation/session icons, with a 16px row gap and a right-side build tooltip.
- In horizontal tabs, show a 20px icon before Home, with a 12px gap, additional web-only leading padding, and a bottom build tooltip.
- Use the shared raised elevation shadow, retain macOS traffic-light clearance, and preserve the dev debug-tools toggle.
- Localize build labels and the debug-tools accessible label.

## Validation
- App `bun typecheck` passed.
- All 25 existing titlebar tests passed.
- Beta production build passed.
- Pre-push workspace typechecks passed (33 tasks).
- Prettier and `git diff --check` passed.
- Browser checks covered Local/Beta assets, sizing, spacing, tooltips, and LTR/RTL icon alignment. Native desktop window chrome was not interactively verified.