### PR TITLE
refactor(core): remove unobservable websocket states

### DIFF
--- a/packages/core/src/session/model-transport.ts
+++ b/packages/core/src/session/model-transport.ts
@@ -28,11 +28,9 @@ const events = Metric.counter("opencode_session_websocket_events_total", {
 const metric = (event: string, attributes: Record<string, string> = {}) =>
   Metric.update(events.pipe(Metric.withAttributes({ event, ...attributes })), 1)
 
-type Delivery = "queued" | "connecting" | "ready" | "send-attempted" | "provider-observed" | "terminal"
-
 interface Active {
   readonly queue: Queue.Queue<string, AIError>
-  readonly lifecycle: { delivery: Delivery }
+  delivery: "send-attempted" | "provider-observed" | "terminal"
 }
 
 interface Channel {
@@ -130,14 +128,9 @@ export const makeLayer = (connector: WebSocketConnector) =>
                 code: "close",
                 phase: "close",
                 delivery:
-                  channel.active.lifecycle.delivery === "queued" ||
-                  channel.active.lifecycle.delivery === "connecting" ||
-                  channel.active.lifecycle.delivery === "ready"
-                    ? "not-sent"
-                    : channel.active.lifecycle.delivery === "provider-observed" ||
-                        channel.active.lifecycle.delivery === "terminal"
-                      ? "accepted"
-                      : "ambiguous",
+                  channel.active.delivery === "provider-observed" || channel.active.delivery === "terminal"
+                    ? "accepted"
+                    : "ambiguous",
               }),
             ),
           )
@@ -198,7 +191,7 @@ export const makeLayer = (connector: WebSocketConnector) =>
                       code: "idle-data",
                       phase: "receive",
                     })
-                  active.lifecycle.delivery = "provider-observed"
+                  active.delivery = "provider-observed"
                   if (typeof message !== "string")
                     return yield* transportError("Unsupported binary WebSocket frame", {
                       url: exchange.connect.url,
@@ -226,8 +219,8 @@ export const makeLayer = (connector: WebSocketConnector) =>
                         phase:
                           error.reason._tag === "Transport" && error.reason.phase === "close" ? "close" : "receive",
                         delivery:
-                          channel.active?.lifecycle.delivery === "provider-observed" ||
-                          channel.active?.lifecycle.delivery === "terminal" ||
+                          channel.active?.delivery === "provider-observed" ||
+                          channel.active?.delivery === "terminal" ||
                           (error.reason._tag === "Transport" && error.reason.code === "queue-overflow")
                             ? "accepted"
                             : error.reason._tag === "Transport" && error.reason.code === "1009"
@@ -256,7 +249,6 @@ export const makeLayer = (connector: WebSocketConnector) =>
       const start = Effect.fn("SessionModelTransport.start")(function* (
         owner: State,
         exchange: WebSocketChannelExchange,
-        lifecycle: { delivery: Delivery },
       ) {
         if (owner.closed)
           return yield* transportError("Session WebSocket owner is closed", {
@@ -288,7 +280,6 @@ export const makeLayer = (connector: WebSocketConnector) =>
           yield* closeChannel(owner, current)
         }
 
-        lifecycle.delivery = owner.channel ? "ready" : "connecting"
         if (owner.channel)
           yield* Effect.logDebug("session websocket reused", {
             sessionTransport: "websocket",
@@ -314,7 +305,6 @@ export const makeLayer = (connector: WebSocketConnector) =>
               ),
             )
         if (!channel) return fallback(exchange)
-        lifecycle.delivery = "ready"
 
         if (channel.pending) {
           channel.pending = undefined
@@ -326,9 +316,11 @@ export const makeLayer = (connector: WebSocketConnector) =>
           Effect.onInterrupt(() => closeChannel(owner, channel)),
         )
         if (create.mode === "full") channel.checkpoint = undefined
-        const active: Active = { queue: yield* Queue.bounded<string, AIError>(INBOUND_CAPACITY), lifecycle }
+        const active: Active = {
+          queue: yield* Queue.bounded<string, AIError>(INBOUND_CAPACITY),
+          delivery: "send-attempted",
+        }
         channel.active = active
-        lifecycle.delivery = "send-attempted"
         const sent = yield* channel.connection.sendText(create.message).pipe(
           Effect.withSpan("SessionModelTransport.send"),
           Effect.onInterrupt(() => closeChannel(owner, channel)),
@@ -366,7 +358,7 @@ export const makeLayer = (connector: WebSocketConnector) =>
                   operation: "read",
                   code: "idle-timeout",
                   phase: "receive",
-                  delivery: lifecycle.delivery === "provider-observed" ? "accepted" : "ambiguous",
+                  delivery: active.delivery === "provider-observed" ? "accepted" : "ambiguous",
                 }),
               ),
           }),
@@ -375,7 +367,7 @@ export const makeLayer = (connector: WebSocketConnector) =>
             Effect.sync(() => {
               if (!observationTerminal(observation)) return
               terminal = observation
-              lifecycle.delivery = "terminal"
+              active.delivery = "terminal"
               const staged = observation.type === "completed" ? observation.checkpoint : undefined
               if (staged) channel.pending = { token, checkpoint: staged }
               if (observation.type !== "completed" || !staged) channel.checkpoint = undefined
@@ -411,7 +403,7 @@ export const makeLayer = (connector: WebSocketConnector) =>
                     operation: "read",
                     code: "incomplete",
                     phase: "receive",
-                    delivery: lifecycle.delivery === "provider-observed" ? "accepted" : "ambiguous",
+                    delivery: active.delivery === "provider-observed" ? "accepted" : "ambiguous",
                   })
               yield* poison(owner, channel, error)
             }),
@@ -448,7 +440,6 @@ export const makeLayer = (connector: WebSocketConnector) =>
       const bind = (sessionID: SessionSchema.ID): WebSocketChannelExecutor => ({
         execute: (exchange) => {
           const owner = state(sessionID)
-          const lifecycle = { delivery: "queued" as Delivery }
           let execution: WebSocketChannelExecution | undefined
           return Effect.succeed({
             get http() {
@@ -456,7 +447,7 @@ export const makeLayer = (connector: WebSocketConnector) =>
             },
             frames: Stream.unwrap(
               Effect.acquireRelease(owner.lock.take(1), () => owner.lock.release(1), { interruptible: true }).pipe(
-                Effect.andThen(start(owner, exchange, lifecycle)),
+                Effect.andThen(start(owner, exchange)),
                 Effect.tap((started) =>
                   Effect.sync(() => {
                     execution = started

--- a/packages/core/test/session-model-transport.test.ts
+++ b/packages/core/test/session-model-transport.test.ts
@@ -445,14 +445,17 @@ describe("SessionModelTransport", () => {
     )
   })
 
-  test("closes an active exchange without waiting for its Session permit", async () => {
+  test.each([false, true])("classifies active and queued close (observed: %s)", async (observed) => {
     const started = Deferred.makeUnsafe<void>()
     const messages = queue<string | Uint8Array, AIError>()
     let closed = 0
     const connector: WebSocketConnector = {
       open: () =>
         Effect.succeed({
-          sendText: () => Deferred.succeed(started, undefined),
+          sendText: () =>
+            observed
+              ? Queue.offer(messages, "frame").pipe(Effect.asVoid)
+              : Deferred.succeed(started, undefined).pipe(Effect.asVoid),
           messages: Stream.fromQueue(messages),
           close: Effect.sync(() => closed++).pipe(Effect.andThen(Queue.shutdown(messages)), Effect.asVoid),
         }),
@@ -462,17 +465,30 @@ describe("SessionModelTransport", () => {
       connector,
       Effect.gen(function* () {
         const transport = yield* SessionModelTransport.Service
-        const running = yield* collect(transport.bind(session), exchange("active")).pipe(
+        const executor = transport.bind(session)
+        const item = exchange("active")
+        const running = yield* collect(executor, {
+          ...item,
+          driver: {
+            ...item.driver,
+            observe: (_create, frame) => Deferred.succeed(started, undefined).pipe(Effect.as({ type: "frame", frame })),
+          },
+        }).pipe(Effect.result, Effect.forkChild({ startImmediately: true }))
+        yield* Deferred.await(started)
+        const queued = yield* collect(executor, exchange("queued")).pipe(
+          Effect.result,
           Effect.forkChild({ startImmediately: true }),
         )
-        yield* Deferred.await(started)
 
         yield* transport.close(session)
-        const result = yield* Effect.result(Fiber.join(running))
 
-        expect(result).toMatchObject({
+        expect(yield* Fiber.join(running)).toMatchObject({
           _tag: "Failure",
-          failure: { reason: { _tag: "Transport", code: "close", delivery: "ambiguous" } },
+          failure: { reason: { _tag: "Transport", code: "close", delivery: observed ? "accepted" : "ambiguous" } },
+        })
+        expect(yield* Fiber.join(queued)).toMatchObject({
+          _tag: "Failure",
+          failure: { reason: { _tag: "Transport", code: "owner-closed", phase: "queue", delivery: "not-sent" } },
         })
         expect(closed).toBe(1)
       }),
@@ -540,6 +556,43 @@ describe("SessionModelTransport", () => {
         }).pipe(Effect.forkChild({ startImmediately: true }))
         yield* Deferred.await(opened)
         yield* Fiber.interrupt(fiber)
+        expect(closed).toBe(1)
+      }),
+    )
+  })
+
+  test("closes a connection returned after its owner closes during setup", async () => {
+    const connecting = Deferred.makeUnsafe<void>()
+    const release = Deferred.makeUnsafe<void>()
+    let closed = 0
+    const connector: WebSocketConnector = {
+      open: () =>
+        Deferred.succeed(connecting, undefined).pipe(
+          Effect.andThen(Deferred.await(release)),
+          Effect.as({
+            sendText: () => Effect.die("Unexpected send after owner close"),
+            messages: Stream.never,
+            close: Effect.sync(() => closed++).pipe(Effect.asVoid),
+          }),
+        ),
+    }
+
+    await run(
+      connector,
+      Effect.gen(function* () {
+        const transport = yield* SessionModelTransport.Service
+        const running = yield* collect(
+          transport.bind(session),
+          exchange("first", { fallback: () => Stream.die("Unexpected fallback after owner close") }),
+        ).pipe(Effect.result, Effect.forkChild({ startImmediately: true }))
+        yield* Deferred.await(connecting)
+        yield* transport.close(session)
+        yield* Deferred.succeed(release, undefined)
+
+        expect(yield* Fiber.join(running)).toMatchObject({
+          _tag: "Failure",
+          failure: { reason: { _tag: "Transport", code: "owner-closed", phase: "connect", delivery: "not-sent" } },
+        })
         expect(closed).toBe(1)
       }),
     )


### PR DESCRIPTION
## Why

The Session WebSocket transport carries `queued`, `connecting`, and `ready` delivery states that no reader can observe. They require a separate mutable lifecycle object and a close-classification branch, despite becoming reachable through `channel.active` only immediately before the state changes to `send-attempted`, with no intervening suspension or callback.

## What Changes

- Store delivery directly on the active exchange, initialized to `send-attempted`.
- Remove the three unobservable variants, their assignments, the lifecycle argument, and the unreachable pre-send branch in active-exchange close handling.
- Retain `provider-observed` and `terminal`, along with explicit pre-send failures and ambiguous-send protection.

Connection setup and request execution do not change. The retained close classifications are:

| Situation | Delivery classification |
| --- | --- |
| Owner closes while connecting, or an execution is still queued | `not-sent` |
| Active exchange has no provider response yet | `ambiguous` |
| Active exchange has received provider data | `accepted` |

The existing close test now covers both active classifications alongside a queued execution. A new deferred-gate test closes the owner during connection setup and verifies that the returned connection is closed without sending or falling back.

## Scope

Only `SessionModelTransport` and its existing test file. No changes to public transport APIs, HTTP fallback policy, same-Session serialization, or checkpoint commitment.

## Verification

```sh
# packages/core
RECORD=false bun --no-env-file run test test/session-model-transport.test.ts
RECORD=false bun --no-env-file run test test/session-model-transport.test.ts test/session-step.test.ts test/session-runner-tool-events.test.ts test/session-runner.test.ts
bun typecheck

# Repository root
bunx prettier --check packages/core/src/session/model-transport.ts packages/core/test/session-model-transport.test.ts
bunx oxlint packages/core/src/session/model-transport.ts packages/core/test/session-model-transport.test.ts --format=json
git diff --check

# Also run by the normal pre-push hook
bun typecheck
```

- All 25 original transport tests passed before changes. The strengthened suite passed all 27 tests against the original implementation before the state removal.
- After the change, 239 tests passed across the four focused Core suites. Core typechecking and formatting passed.
- Scoped lint reported zero errors and two existing error-object spread warnings.
- The pre-push workspace typecheck passed all 33 tasks, with 27 cache hits.
- Transport tests use in-memory connectors and deferred synchronization. No live provider calls or real WebSocket end-to-end run.
