### PR TITLE
fix(opencode): log worker crashes instead of swallowing them

### DIFF
--- a/packages/opencode/src/cli/tui/worker.ts
+++ b/packages/opencode/src/cli/tui/worker.ts
@@ -10,12 +10,26 @@ import { Heap } from "@/cli/heap"
 import { AppRuntime } from "@/effect/app-runtime"
 import { Effect } from "effect"
 import { disposeAllInstancesAndEmitGlobalDisposed } from "@/server/global-lifecycle"
+import { Global } from "@opencode-ai/core/global"
+import { appendFileSync } from "fs"
+import path from "path"
 
 Heap.start()
 
-const onUnhandledRejection = (_error: unknown) => {}
+// The file logger batches writes, so a crash can exit the process before the batch is flushed.
+// Write to the same file synchronously instead, otherwise the failure leaves no trace at all.
+const logCrash = (message: string, error: unknown) => {
+  try {
+    appendFileSync(
+      path.join(Global.Path.log, "opencode.log"),
+      `timestamp=${new Date().toISOString()} level=ERROR message=${message} error=${JSON.stringify(String(error))}\n`,
+    )
+  } catch {}
+}
 
-const onUncaughtException = (_error: Error) => {}
+const onUnhandledRejection = (error: unknown) => logCrash("worker.unhandledRejection", error)
+
+const onUncaughtException = (error: Error) => logCrash("worker.uncaughtException", error)
 
 process.on("unhandledRejection", onUnhandledRejection)
 process.on("uncaughtException", onUncaughtException)


### PR DESCRIPTION
### Issue for this PR

Closes #47113

### Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`onUncaughtException` and `onUnhandledRejection` in the TUI worker were empty functions. Registering a handler suppresses Node's default behaviour — print the stack, exit non-zero — so a crash in the worker produced nothing anywhere: no stderr output, no log line, no useful exit code.

The handlers now write the error to the log file. They write it synchronously on purpose: `fileLogger` uses `Logger.toFile` with a batch window (there's a comment in `packages/core/src/observability/logging.ts` warning against setting it to 0), so an async write can be lost when the process exits right after the crash — which is exactly the case being handled here. The line uses the same `key=value` shape the file formatter produces, so it doesn't stand out in the log.

The handlers stay installed, so this doesn't change the exit behaviour: the difference is that the failure leaves a record.

### How did you verify your code works?

Added `setTimeout(() => { throw new Error("VERIFY_WORKER_CRASH") }, 4000)` next to the `process.on` calls and ran `bun dev .`.

Before, on `dev`: the TUI stayed up, and `VERIFY_WORKER_CRASH` appeared nowhere — not on stdout, not anywhere under the data directory.

After, with this change, the log file contains:

```
timestamp=2026-09-03T18:01:22.082Z level=ERROR message=worker.uncaughtException error="Error: VERIFY_WORKER_CRASH"
```

`bun run --cwd packages/opencode typecheck` passes.

I didn't add an automated test: exercising it means crashing a real worker process, and there's no existing harness for that in this package. Happy to add one if you'd like it covered.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
