### PR TITLE
refactor(core): reuse job scope as generation identity

### DIFF
--- a/packages/core/src/job.ts
+++ b/packages/core/src/job.ts
@@ -55,7 +55,6 @@ type Active = {
   done: Deferred.Deferred<Info>
   backgrounded: Deferred.Deferred<Info>
   scope: Scope.Closeable
-  token: object
   blockingSessions: Map<SessionSchema.ID, number>
   isBackgrounded: boolean
   recovery?: Recovery
@@ -77,7 +76,7 @@ type BackgroundResult = {
   backgrounded?: Deferred.Deferred<Info>
 }
 
-type StartResult = { info: Info } | { info: Info; scope: Scope.Closeable; token: object }
+type StartResult = { info: Info } | { info: Info; scope: Scope.Closeable }
 
 type BlockWait = {
   done: Deferred.Deferred<Info>
@@ -184,14 +183,14 @@ export const make = Effect.gen(function* () {
     })
   })
 
-  const settle = Effect.fnUntraced(function* (id: string, token: object, exit: Exit.Exit<string, unknown>) {
+  const settle = Effect.fnUntraced(function* (id: string, scope: Scope.Closeable, exit: Exit.Exit<string, unknown>) {
     const completed_at = yield* Clock.currentTimeMillis
     const result = yield* SynchronizedRef.modifyEffect(
       state.jobs,
       Effect.fnUntraced(function* (jobs): Effect.fn.Return<readonly [FinishResult, Map<string, Active>]> {
         const job = jobs.get(id)
         if (!job) return [{}, jobs]
-        if (job.token !== token) return [{}, jobs]
+        if (job.scope !== scope) return [{}, jobs]
         if (job.info.status !== "running") return [{ info: snapshot(job) }, jobs]
         const status: Exclude<Status, "running"> = Exit.isSuccess(exit)
           ? "completed"
@@ -241,7 +240,6 @@ export const make = Effect.gen(function* () {
               return [{ info: snapshot(existing) }, jobs]
             }
             const scope = yield* Scope.fork(state.scope, "parallel")
-            const token = {}
             const job = {
               info: {
                 id,
@@ -255,18 +253,17 @@ export const make = Effect.gen(function* () {
               done,
               backgrounded,
               scope,
-              token,
               blockingSessions: new Map<SessionSchema.ID, number>(),
               isBackgrounded: false,
               recovery: input.recovery,
             }
-            return [{ info: snapshot(job), scope, token }, new Map(jobs).set(id, job)]
+            return [{ info: snapshot(job), scope }, new Map(jobs).set(id, job)]
           }),
         )
         if ("scope" in result)
           yield* restore(input.run).pipe(
             Effect.exit,
-            Effect.flatMap((exit) => settle(id, result.token, exit)),
+            Effect.flatMap((exit) => settle(id, result.scope, exit)),
             Effect.asVoid,
             Effect.forkIn(result.scope, { startImmediately: true }),
           )

--- a/packages/core/test/job.test.ts
+++ b/packages/core/test/job.test.ts
@@ -64,6 +64,71 @@ describe("Job", () => {
     }),
   )
 
+  it.live("reuses running work when started again with the same ID", () =>
+    Effect.gen(function* () {
+      const jobs = yield* Job.Service
+      const output = yield* Deferred.make<string>()
+      const job = yield* jobs.start({ id: "job_reused", type: "test", run: Deferred.await(output) })
+
+      expect(
+        yield* jobs.start({ id: job.id, type: "duplicate", run: Effect.die("Duplicate work must not run") }),
+      ).toEqual(job)
+
+      yield* Deferred.succeed(output, "original output")
+      expect((yield* jobs.wait({ id: job.id })).info).toMatchObject({
+        type: "test",
+        status: "completed",
+        output: "original output",
+      })
+    }),
+  )
+
+  it.live("ignores an obsolete callback after a cancellation waiter starts a same-ID replacement", () =>
+    Effect.gen(function* () {
+      const jobs = yield* Job.Service
+      const callback = yield* Deferred.make<() => void>()
+      const output = yield* Deferred.make<string>()
+      const finalized = yield* Deferred.make<void>()
+      const job = yield* jobs.start({
+        id: "job_replaced",
+        type: "test",
+        run: Effect.callback<string>((resume) => {
+          Deferred.doneUnsafe(
+            callback,
+            Effect.succeed(() => resume(Effect.succeed("obsolete output"))),
+          )
+        }),
+      })
+      const complete = yield* Deferred.await(callback)
+      // Cancellation wakes waiters before closing the old scope, allowing the old callback to race replacement.
+      const replacement = yield* jobs.wait({ id: job.id }).pipe(
+        Effect.tap((result) => Effect.sync(() => expect(result.info?.status).toBe("cancelled"))),
+        Effect.andThen(
+          jobs.start({
+            id: job.id,
+            type: "replacement",
+            run: Deferred.await(output).pipe(Effect.ensuring(Deferred.succeed(finalized, undefined))),
+          }),
+        ),
+        Effect.andThen(Effect.sync(complete)),
+        Effect.forkChild({ startImmediately: true }),
+      )
+
+      yield* jobs.cancel(job.id)
+      yield* Fiber.join(replacement)
+      expect(yield* jobs.get(job.id)).toMatchObject({ type: "replacement", status: "running" })
+      expect(yield* Deferred.isDone(finalized)).toBe(false)
+
+      yield* Deferred.succeed(output, "replacement output")
+      expect((yield* jobs.wait({ id: job.id })).info).toMatchObject({
+        type: "replacement",
+        status: "completed",
+        output: "replacement output",
+      })
+      expect(yield* Deferred.isDone(finalized)).toBe(true)
+    }),
+  )
+
   it.live("returns finished from a blocking wait when completion wins", () =>
     Effect.gen(function* () {
       const jobs = yield* Job.Service


### PR DESCRIPTION
## Why

Each Job generation allocates a separate token to keep obsolete completions from affecting a same-ID replacement. Its existing cleanup scope is already a fresh object for that generation, so the token duplicates an identity that Job already owns and passes through its execution path.

This is a behavior-preserving simplification, not removal of the stale-completion protection.

## What Changes

Use the scope itself as the generation identity in `settle`:

```ts
// Before: a separate token travels beside the scope.
if (job.token !== token) return [{}, jobs]

// After: the existing scope identifies the same generation.
if (job.scope !== scope) return [{}, jobs]
```

Remove the token allocation and fields from the active Job and start result. Every accepted new generation still calls `Scope.fork`; starting an already-running ID still returns the existing Job without launching new work.

The retained behavior is covered by two additional tests:

- Starting a running ID again reuses the original work and output.
- Cancellation wakes an existing waiter, which starts a same-ID replacement before the old callback resumes. The obsolete result cannot complete or finalize the replacement; the replacement later completes with its own output.

Both tests passed against the original token implementation. As a negative control, removing only the identity guard in memory made the second test fail: the replacement incorrectly completed with `"obsolete output"`.

## Scope

Only `packages/core/src/job.ts` and its existing test file. Cancellation order, scope lifetime, background recovery, and public Job APIs are unchanged. The separate coordinator-yield proposal is not included.

## Verification

```sh
# packages/core
RECORD=false bun --no-env-file run test test/job.test.ts
RECORD=false bun --no-env-file run test test/job.test.ts test/session-run-coordinator.test.ts test/session-execution.test.ts test/session-runner.test.ts test/tool-subagent.test.ts test/config/command-subagent.test.ts test/session-shell.test.ts test/tool-shell.test.ts
bun typecheck

# Repository root
bunx prettier --check packages/core/src/job.ts packages/core/test/job.test.ts
bunx oxlint packages/core/src/job.ts packages/core/test/job.test.ts --format=json
git diff --check

# Normal pre-push hook
bun turbo typecheck --concurrency=3
```

- Original Job suite: 12 passed; expanded suite against the original implementation: 14 passed.
- Changed implementation: 370 passed, 19 skipped, 0 failed across eight focused suites.
- Core typecheck and formatting passed; scoped lint reported zero errors and five existing warnings in unchanged tests.
- Pre-push workspace typecheck: 33 successful tasks, 27 cached.
- Verified fresh scope allocation in pinned Effect rc.112 and the current local Effect source. No live provider or deployed-server verification.
