### PR TITLE
fix(app): allow new session shortcut from settings

### DIFF
--- a/packages/app/e2e/regression/settings-loading.spec.ts
+++ b/packages/app/e2e/regression/settings-loading.spec.ts
@@ -27,6 +27,12 @@ test.beforeEach(async ({ page }) => {
     })),
     pageMessages: () => ({ items: [] }),
   })
+  await page.addInitScript((directory) => {
+    localStorage.setItem(
+      "opencode.global.dat:server",
+      JSON.stringify({ projects: { local: [{ worktree: directory, expanded: true }] } }),
+    )
+  }, directory)
   await page.goto("/")
   await page.getByRole("button", { name: "Settings", exact: true }).click()
   await expect(page.getByTestId("settings-screen").getByRole("tab", { name: "Preferences" })).toBeVisible()
@@ -48,6 +54,34 @@ test("settings has its own route and returns through app history", async ({ page
   await expect(page).toHaveURL("/")
   await expect(settings).toBeHidden()
   await expect(home).toHaveAttribute("aria-pressed", "true")
+})
+
+test("new session shortcut leaves settings and opens a new session screen", async ({ page }) => {
+  const settings = page.getByTestId("settings-screen")
+  await expect(settings).toBeFocused()
+  await page.keyboard.press("Control+t")
+
+  await expect(page).toHaveURL(/\/new-session\?draftId=.+$/)
+  await expect(settings).toBeHidden()
+  await expect(page.locator('[data-component="composer-editor"]')).toBeEditable()
+  await expect(page.locator('[data-titlebar-tab][data-active="true"]')).toHaveCount(1)
+})
+
+test("recording a new session shortcut stays in settings until recording finishes", async ({ page }) => {
+  const settings = page.getByTestId("settings-screen")
+  await settings.getByRole("tab", { name: "Shortcuts", exact: true }).click()
+  const binding = settings.locator('[data-keybind-id="tab.new"]')
+  await binding.click()
+  await expect(binding).toHaveText("Press keys")
+  await page.keyboard.press("Control+t")
+
+  await expect(binding).toHaveText("Ctrl+T")
+  await expect(page).toHaveURL("/settings")
+  await expect(page.locator("[data-titlebar-tab]")).toHaveCount(0)
+  await page.keyboard.press("Control+t")
+  await expect(page).toHaveURL(/\/new-session\?draftId=.+$/)
+  await expect(settings).toBeHidden()
+  await expect(page.locator('[data-component="composer-editor"]')).toBeEditable()
 })
 
 test("workspaces opens without waiting for inventory or sessions", async ({ page }) => {

--- a/packages/app/src/settings/shell.tsx
+++ b/packages/app/src/settings/shell.tsx
@@ -1,4 +1,4 @@
-import { Component, createEffect, createMemo, For, Show, onCleanup, onMount, startTransition } from "solid-js"
+import { Component, createEffect, createMemo, For, Show, onMount, startTransition } from "solid-js"
 import { Tabs } from "@opencode-ai/ui/tabs"
 import { Icon } from "@opencode-ai/ui/icon"
 import { Menu } from "@opencode-ai/ui/menu"
@@ -21,7 +21,6 @@ import { useLayout } from "@/shell/state/layout"
 import { useTabs } from "@/shell/tabs/tabs"
 import { useGlobal, useServerCtx } from "@/runtime/server/runtime"
 import { ServerConnection, useServers } from "@/runtime/server/registry"
-import { useCommand } from "@/shell/commands/command"
 import { useSettingsSurface } from "./surface"
 import "@/settings/settings.css"
 
@@ -48,7 +47,6 @@ export const SettingsScreen: Component = () => {
   const language = useLanguage()
   const platform = usePlatform()
   const dialog = useDialog()
-  const command = useCommand()
   const surface = useSettingsSurface()
   const layout = useLayout()
   const servers = useServers()
@@ -57,10 +55,8 @@ export const SettingsScreen: Component = () => {
   let root: HTMLDivElement | undefined
 
   onMount(() => {
-    command.keybinds(false)
     root?.focus({ preventScroll: true })
   })
-  onCleanup(() => command.keybinds(true))
 
   const server = createMemo(() => {
     const route = surface.route()


### PR DESCRIPTION
## Summary
- Remove Settings' blanket suspension of app keyboard shortcuts so Cmd/Ctrl+T leaves Settings and opens the new-session screen through the existing new-tab action.
- Preserve shortcut suppression while recording a keybinding and while dialogs are active.
- Add regression coverage for opening a new session from Settings and recording the shortcut without navigating away.

## Validation
- Settings regression suite: 6 passed
- Shortcut settings controller tests: 3 passed
- App typecheck passed
- Pre-push workspace typechecks passed

## Manual test
Run `bun run dev:desktop`, open a project, open Settings, then press Cmd/Ctrl+T. The app should navigate to a new-session screen.