### PR TITLE
refactor(core): call web search service directly

### DIFF
--- a/packages/core/src/tool/plugin/websearch.ts
+++ b/packages/core/src/tool/plugin/websearch.ts
@@ -50,21 +50,20 @@ export const Plugin = {
                 agent: context.agent,
                 source: { type: "tool", messageID: context.messageID, id: context.id },
               })
-              const search = (): Effect.Effect<Effect.Success<ReturnType<typeof ctx.websearch.query>>, unknown> =>
+              const search = (): Effect.Effect<WebSearch.Response, unknown> =>
                 websearch.default().pipe(
                   Effect.flatMap((provider) => {
-                    if (!provider) return ctx.websearch.query(input)
+                    if (!provider) return websearch.query(input)
                     return context
                       .progress({ provider: provider.id })
-                      .pipe(Effect.andThen(ctx.websearch.query({ ...input, providerID: provider.id })))
+                      .pipe(Effect.andThen(websearch.query({ ...input, providerID: provider.id })))
                   }),
-                  Effect.catch((error) => {
-                    if (!Schema.is(WebSearch.ProviderRequiredError)(error)) return Effect.fail(error)
+                  Effect.catchTag("WebSearch.ProviderRequired", () => {
                     return providerSelectionLock
                       .withPermit(
                         Effect.gen(function* () {
                           if (yield* websearch.default()) return
-                          const providers = (yield* ctx.websearch.providers()).data
+                          const providers = yield* websearch.providers()
                           const defaultProvider = providers[0]
                           if (!defaultProvider) return yield* new WebSearch.ProviderRequiredError()
                           const response = yield* forms.ask({
@@ -141,15 +140,15 @@ export const Plugin = {
                           if (!providerID) return Effect.suspend(search)
                           return context
                             .progress({ provider: providerID })
-                            .pipe(Effect.andThen(ctx.websearch.query({ ...input, providerID })))
+                            .pipe(Effect.andThen(websearch.query({ ...input, providerID })))
                         }),
                       )
                   }),
                 )
               const result = yield* search()
               const output = {
-                provider: result.data.providerID,
-                results: result.data.results,
+                provider: result.providerID,
+                results: result.results,
               }
               const content = output.results.length
                 ? output.results

--- a/packages/core/test/tool-websearch.test.ts
+++ b/packages/core/test/tool-websearch.test.ts
@@ -17,17 +17,11 @@ import { testEffect } from "./lib/effect"
 import { imagePassthrough } from "./lib/image"
 import { permissionLayer } from "./lib/permission"
 import { toolIdentity, executeTool, registerToolPlugin, toolDefinitions } from "./lib/tool"
-import { webSearchHost } from "./plugin/host"
 import { TestWebSearch } from "./lib/websearch"
 
 const webSearchToolNode = makeLocationNode({
   name: "test/websearch-tool-plugin",
-  layer: Layer.effectDiscard(
-    Effect.gen(function* () {
-      const websearch = yield* WebSearch.Service
-      yield* registerToolPlugin(WebSearchTool.Plugin, { websearch: webSearchHost(websearch) })
-    }),
-  ),
+  layer: Layer.effectDiscard(registerToolPlugin(WebSearchTool.Plugin)),
   deps: [Tool.node, Permission.node, WebSearch.node, Form.node],
 })
 
@@ -393,6 +387,7 @@ describe("WebSearchTool registration", () => {
           }),
         { discard: true },
       )
+      expect(fixture.formRequests).toEqual([])
     }),
   )
 })


### PR DESCRIPTION
## Why

The built-in web-search tool already captures `WebSearch.Service`, but sends queries and provider listing through the public plugin adapter. That adapter wraps results in unused Location metadata and widens the query's error type to `unknown`, requiring a schema check to rediscover `WebSearch.ProviderRequired`.

## What Changes

Call the captured Core service directly for all three query paths and provider listing:

```ts
// Before
const result = yield* ctx.websearch.query(input)
const output = { provider: result.data.providerID, results: result.data.results }

// After
const result = yield* websearch.query(input)
const output = { provider: result.providerID, results: result.results }
```

Use `Effect.catchTag("WebSearch.ProviderRequired", ...)` on the typed Core query path instead of schema-checking an unknown error. Keep the existing recursive helper's broader error channel and final HTTP-error presentation.

The tool tests no longer install a plugin web-search adapter. Their default host rejects those calls, so the suite now checks that the built-in uses its captured service. The HTTP-error test also asserts that provider failures do not reopen provider consent.

## Scope

Only the built-in tool and its test file. The external plugin API and host adapter remain unchanged, as do permissions, consent synchronization, timeout, provider-option validation, result formatting, and stored provider selection. This does not include the separate duplicate-option-check proposal or any database migration.

## Verification

```sh
# packages/core
RECORD=false bun --no-env-file run test test/tool-websearch.test.ts test/websearch.test.ts test/form.test.ts test/plugin/websearch.test.ts
bun typecheck

# Repository root
bunx prettier --check packages/core/src/tool/plugin/websearch.ts packages/core/test/tool-websearch.test.ts
bunx oxlint packages/core/src/tool/plugin/websearch.ts packages/core/test/tool-websearch.test.ts --format=json
git diff --check

# Normal pre-push hook
bun turbo typecheck --concurrency=3
```

- Baseline and changed implementations: 36 tests passed across four files; the changed suite made 123 assertions.
- Removing the test adapter before the implementation change failed the permission-ordering test with `unused websearch.query`; it passes after the direct-service change.
- Core typecheck and formatting passed. Scoped lint reported zero errors and seven warnings in the existing consent control flow.
- Workspace pre-push typecheck passed all 33 tasks, with 27 cached.
- Tests use local provider fixtures and mocked form/HTTP boundaries; no live provider or deployed-server verification.
