### PR TITLE
fix(skill): graceful skill discovery + depth-1 glob patterns; preserve deps on npm reify

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
     "packages/app": {
       "name": "@opencode-ai/app",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@corvu/drawer": "catalog:",
         "@dnd-kit/abstract": "0.5.0",
@@ -96,7 +96,7 @@
     },
     "packages/cli": {
       "name": "@opencode-ai/cli",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "bin": {
         "lildax": "./bin/lildax.cjs",
       },
@@ -144,7 +144,7 @@
     },
     "packages/codemode": {
       "name": "@opencode-ai/codemode",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "acorn": "8.15.0",
         "effect": "catalog:",
@@ -158,7 +158,7 @@
     },
     "packages/console/app": {
       "name": "@opencode-ai/console-app",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@ibm/plex": "6.4.1",
@@ -195,7 +195,7 @@
     },
     "packages/console/core": {
       "name": "@opencode-ai/console-core",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@aws-sdk/client-sts": "3.782.0",
         "@jsx-email/render": "1.1.1",
@@ -222,7 +222,7 @@
     },
     "packages/console/function": {
       "name": "@opencode-ai/console-function",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@ai-sdk/anthropic": "3.0.82",
         "@ai-sdk/openai": "3.0.48",
@@ -245,7 +245,7 @@
     },
     "packages/console/mail": {
       "name": "@opencode-ai/console-mail",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@jsx-email/all": "2.2.3",
         "@jsx-email/cli": "1.4.3",
@@ -269,7 +269,7 @@
     },
     "packages/console/support": {
       "name": "@opencode-ai/console-support",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@cloudflare/vite-plugin": "1.15.2",
         "@opencode-ai/console-core": "workspace:*",
@@ -289,7 +289,7 @@
     },
     "packages/core": {
       "name": "@opencode-ai/core",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -383,7 +383,7 @@
     },
     "packages/desktop": {
       "name": "@opencode-ai/desktop",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@zip.js/zip.js": "2.7.62",
         "drizzle-orm": "catalog:",
@@ -437,7 +437,7 @@
     },
     "packages/effect-drizzle-sqlite": {
       "name": "@opencode-ai/effect-drizzle-sqlite",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
@@ -451,7 +451,7 @@
     },
     "packages/effect-sqlite-node": {
       "name": "@opencode-ai/effect-sqlite-node",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "effect": "catalog:",
       },
@@ -463,7 +463,7 @@
     },
     "packages/enterprise": {
       "name": "@opencode-ai/enterprise",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@hono/standard-validator": "catalog:",
         "@opencode-ai/core": "workspace:*",
@@ -495,7 +495,7 @@
     },
     "packages/function": {
       "name": "@opencode-ai/function",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@octokit/auth-app": "8.0.1",
         "@octokit/rest": "catalog:",
@@ -511,7 +511,7 @@
     },
     "packages/http-recorder": {
       "name": "@opencode-ai/http-recorder",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@effect/platform-node": "4.0.0-beta.83",
         "@effect/platform-node-shared": "4.0.0-beta.83",
@@ -542,7 +542,7 @@
     },
     "packages/llm": {
       "name": "@opencode-ai/llm",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
@@ -561,7 +561,7 @@
     },
     "packages/opencode": {
       "name": "opencode",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "bin": {
         "opencode": "./bin/opencode",
       },
@@ -692,7 +692,7 @@
     },
     "packages/plugin": {
       "name": "@opencode-ai/plugin",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",
         "@opencode-ai/sdk": "workspace:*",
@@ -768,7 +768,7 @@
     },
     "packages/sdk/js": {
       "name": "@opencode-ai/sdk",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "cross-spawn": "catalog:",
       },
@@ -783,7 +783,7 @@
     },
     "packages/server": {
       "name": "@opencode-ai/server",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/protocol": "workspace:*",
@@ -798,7 +798,7 @@
     },
     "packages/session-ui": {
       "name": "@opencode-ai/session-ui",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@opencode-ai/client": "file:../app/vendor/opencode-ai-client-1.17.13-v2.tgz",
@@ -838,7 +838,7 @@
     },
     "packages/slack": {
       "name": "@opencode-ai/slack",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@opencode-ai/sdk": "workspace:*",
         "@slack/bolt": "^3.17.1",
@@ -851,7 +851,7 @@
     },
     "packages/stats/app": {
       "name": "@opencode-ai/stats-app",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@ibm/plex": "6.4.1",
         "@kobalte/core": "catalog:",
@@ -878,7 +878,7 @@
     },
     "packages/stats/core": {
       "name": "@opencode-ai/stats-core",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@aws-sdk/client-athena": "3.933.0",
         "@planetscale/database": "1.19.0",
@@ -897,7 +897,7 @@
     },
     "packages/stats/server": {
       "name": "@opencode-ai/stats-server",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.933.0",
         "@effect/platform-node": "catalog:",
@@ -939,7 +939,7 @@
     },
     "packages/tui": {
       "name": "@opencode-ai/tui",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@opencode-ai/core": "workspace:*",
         "@opencode-ai/plugin": "workspace:*",
@@ -966,7 +966,7 @@
     },
     "packages/ui": {
       "name": "@opencode-ai/ui",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@kobalte/core": "catalog:",
         "@pierre/diffs": "catalog:",
@@ -1017,7 +1017,7 @@
     },
     "packages/web": {
       "name": "@opencode-ai/web",
-      "version": "1.18.26",
+      "version": "1.18.27",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.3",
         "@astrojs/markdown-remark": "6.3.1",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/app",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/cli",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "type": "module",
   "license": "MIT",
   "bin": {

--- a/packages/codemode/package.json
+++ b/packages/codemode/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/codemode",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "description": "Effect-native confined code execution over schema-described tools",
   "private": true,
   "type": "module",

--- a/packages/console/app/package.json
+++ b/packages/console/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-app",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/console/core/package.json
+++ b/packages/console/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/console-core",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/console/function/package.json
+++ b/packages/console/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-function",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/console/mail/package.json
+++ b/packages/console/mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-mail",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "dependencies": {
     "@jsx-email/all": "2.2.3",
     "@jsx-email/cli": "1.4.3",

--- a/packages/console/support/package.json
+++ b/packages/console/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/console-support",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "name": "@opencode-ai/core",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -77,6 +77,42 @@ const layer = Layer.effect(
     const fs = yield* FileSystem.FileSystem
     const flock = yield* EffectFlock.Service
     const directory = (pkg: string) => path.join(global.cache, "packages", sanitize(pkg))
+    const nameOf = (spec: string) => {
+      try {
+        return npa(spec).name ?? spec
+      } catch {
+        return spec
+      }
+    }
+    const omitSet = (conf: Record<string, unknown>): Set<string> => {
+      const omit = conf.omit
+      if (Array.isArray(omit)) return new Set(omit)
+      return typeof omit === "string" ? new Set([omit]) : new Set<string>()
+    }
+    // Arborist rewrites package.json from the add list, so reifies must
+    // preserve every dependency already declared in the project's package.json.
+    const collectDeps = (pkg: any, add: string[], omit: Set<string>): string[] => {
+      const sections = [
+        ["dependencies", false],
+        ["devDependencies", omit.has("dev")],
+        ["peerDependencies", omit.has("peer")],
+        ["optionalDependencies", omit.has("optional")],
+      ] as const
+      const specs = sections.flatMap(([section, excluded]) =>
+        excluded
+          ? []
+          : Object.entries(pkg?.[section] || {}).map(([name, version]) => [name, version].filter(Boolean).join("@")),
+      )
+      const byName = new Map<string, string>()
+      for (const spec of specs) byName.set(nameOf(spec), spec)
+      for (const spec of add) byName.set(nameOf(spec), spec)
+      return [...byName.values()]
+    }
+    const readExistingDeps = (dir: string, add: string[], omit: Set<string>): Effect.Effect<string[]> =>
+      Effect.gen(function* () {
+        const pkg = yield* afs.readJson(path.join(dir, "package.json")).pipe(Effect.orElseSucceed(() => ({})))
+        return collectDeps(pkg, add, omit)
+      })
     const reify = (input: { dir: string; add?: string[] }) =>
       Effect.gen(function* () {
         yield* flock.acquire(`npm-install:${input.dir}`)
@@ -126,7 +162,9 @@ const layer = Layer.effect(
         return resolveEntryPoint(name, path.join(dir, "node_modules", name))
       }
 
-      const tree = yield* reify({ dir, add: [pkg] })
+      const omit = yield* NpmConfig.load(dir).pipe(Effect.map(omitSet))
+      const existing = yield* readExistingDeps(dir, [pkg], omit)
+      const tree = yield* reify({ dir, add: existing })
       const first = tree.edgesOut.values().next().value?.to
       if (!first) {
         const result = resolveEntryPoint(name, path.join(dir, "node_modules", name))
@@ -144,11 +182,13 @@ const layer = Layer.effect(
       if (!canWrite) return
 
       const add = input?.add.map((pkg) => [pkg.name, pkg.version].filter(Boolean).join("@")) ?? []
+      const omit = yield* NpmConfig.load(dir).pipe(Effect.map(omitSet))
       if (
         yield* Effect.gen(function* () {
           const nodeModulesExists = yield* afs.existsSafe(path.join(dir, "node_modules"))
           if (!nodeModulesExists) {
-            yield* reify({ add, dir })
+            const existing = yield* readExistingDeps(dir, add, omit)
+            yield* reify({ add: existing, dir })
             return true
           }
           return false
@@ -180,7 +220,7 @@ const layer = Layer.effect(
 
         for (const name of declared) {
           if (!locked.has(name)) {
-            yield* reify({ dir, add })
+            yield* reify({ dir, add: collectDeps(pkgAny, add, omit) })
             return
           }
         }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opencode-ai/desktop",
   "private": true,
-  "version": "1.18.26",
+  "version": "1.18.27",
   "type": "module",
   "license": "MIT",
   "homepage": "https://opencode.ai",

--- a/packages/effect-drizzle-sqlite/package.json
+++ b/packages/effect-drizzle-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "name": "@opencode-ai/effect-drizzle-sqlite",
   "type": "module",
   "license": "MIT",

--- a/packages/effect-sqlite-node/package.json
+++ b/packages/effect-sqlite-node/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "name": "@opencode-ai/effect-sqlite-node",
   "type": "module",
   "license": "MIT",

--- a/packages/enterprise/package.json
+++ b/packages/enterprise/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/enterprise",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/function/package.json
+++ b/packages/function/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/function",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "$schema": "https://json.schemastore.org/package.json",
   "private": true,
   "type": "module",

--- a/packages/http-recorder/package.json
+++ b/packages/http-recorder/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "name": "@opencode-ai/http-recorder",
   "description": "Record and replay Effect HTTP client traffic with deterministic cassettes",
   "type": "module",

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "name": "@opencode-ai/llm",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "name": "opencode",
   "type": "module",
   "license": "MIT",

--- a/packages/opencode/src/skill/index.ts
+++ b/packages/opencode/src/skill/index.ts
@@ -20,9 +20,9 @@ import { escapeHtml } from "@/util/html"
 
 const CLAUDE_EXTERNAL_DIR = ".claude"
 const AGENTS_EXTERNAL_DIR = ".agents"
-const EXTERNAL_SKILL_PATTERN = "skills/**/SKILL.md"
-const OPENCODE_SKILL_PATTERN = "{skill,skills}/**/SKILL.md"
-const SKILL_PATTERN = "**/SKILL.md"
+const EXTERNAL_SKILL_PATTERN = ["skills/*/SKILL.md", "skills/**/SKILL.md"]
+const OPENCODE_SKILL_PATTERN = ["{skill,skills}/*/SKILL.md", "{skill,skills}/**/SKILL.md"]
+const SKILL_PATTERN = ["*/SKILL.md", "**/SKILL.md"]
 
 // Built-in skill that ships with opencode. The model's intuition for what an
 // opencode.json should look like is often wrong, and opencode hard-fails on
@@ -142,31 +142,35 @@ const add = Effect.fnUntraced(function* (state: State, match: string, events: Ev
 const scan = Effect.fnUntraced(function* (
   state: ScanState,
   root: string,
-  pattern: string,
+  patterns: string | string[],
   opts?: { dot?: boolean; scope?: string },
 ) {
-  const matches = yield* Effect.tryPromise({
-    try: () =>
-      Glob.scan(pattern, {
-        cwd: root,
-        absolute: true,
-        include: "file",
-        symlink: true,
-        dot: opts?.dot,
-      }),
-    catch: (error) => error,
-  }).pipe(
-    Effect.catch((error) => {
-      if (!opts?.scope) return Effect.die(error)
-      return Effect.logError(`failed to scan ${opts.scope} skills`, { dir: root, error: error }).pipe(
-        Effect.as([] as string[]),
-      )
-    }),
-  )
+  // Scan each pattern separately: a single array glob call is unreliable in
+  // the Desktop build, and a failure in one pattern must not drop the others.
+  const list = Array.isArray(patterns) ? patterns : [patterns]
+  for (const pattern of list) {
+    const matches = yield* Effect.tryPromise({
+      try: () =>
+        Glob.scan(pattern, {
+          cwd: root,
+          absolute: true,
+          include: "file",
+          symlink: true,
+          dot: opts?.dot,
+        }),
+      catch: (error) => error,
+    }).pipe(
+      Effect.catch((error) =>
+        Effect.logWarning("failed to scan skills", { dir: root, pattern: pattern, error: error }).pipe(
+          Effect.as([] as string[]),
+        ),
+      ),
+    )
 
-  for (const match of matches) {
-    state.matches.add(match)
-    state.dirs.add(path.dirname(match))
+    for (const match of matches) {
+      state.matches.add(match)
+      state.dirs.add(path.dirname(match))
+    }
   }
 })
 
@@ -209,7 +213,7 @@ const discoverSkills = Effect.fnUntraced(function* (
 
   const cfg = yield* config.get()
   for (const item of cfg.skills?.paths ?? []) {
-    const expanded = item.startsWith("~/") ? path.join(global.home, item.slice(2)) : item
+    const expanded = item === "~" || item.startsWith("~/") ? path.join(global.home, item.slice(2)) : item
     const dir = path.isAbsolute(expanded) ? expanded : path.join(directory, expanded)
     if (!(yield* fsys.isDir(dir))) {
       yield* Effect.logWarning("skill path not found", { path: dir })

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/plugin",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/sdk/js/package.json
+++ b/packages/sdk/js/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/sdk",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/server",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/session-ui/package.json
+++ b/packages/session-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/session-ui",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/slack",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/packages/stats/app/package.json
+++ b/packages/stats/app/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-app",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/core/package.json
+++ b/packages/stats/core/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-core",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/stats/server/package.json
+++ b/packages/stats/server/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/stats-server",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@opencode-ai/tui",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "private": true,
   "type": "module",
   "license": "MIT",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencode-ai/ui",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -2,7 +2,7 @@
   "name": "@opencode-ai/web",
   "type": "module",
   "license": "MIT",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "scripts": {
     "dev": "astro dev",
     "dev:remote": "VITE_API_URL=https://api.opencode.ai astro dev",

--- a/sdks/vscode/package.json
+++ b/sdks/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "opencode",
   "displayName": "opencode",
   "description": "opencode for VS Code",
-  "version": "1.18.26",
+  "version": "1.18.27",
   "publisher": "sst-dev",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue for this PR

Closes #47054
Closes #47131

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two bug fixes found while running OpenCode Desktop 1.18.27 on Linux:

1. **Skill discovery silently drops skills** (`packages/opencode/src/skill/index.ts`):
   - `scan()` called `Effect.die(error)` on glob failures in config-dir scans (no `scope`), killing the whole discovery pass — external skills survived, config skills (`~/.config/opencode/skills`, `.opencode/skills`) were lost.
   - The `skills/**/SKILL.md` pattern was unreliable for depth-1 skills (`skills/<name>/SKILL.md`) in the Desktop build.
   - Fix: `scan()` logs a warning and continues on any glob error; patterns now explicitly cover depth 1 and depth 2+ (`skills/*/SKILL.md` + `skills/**/SKILL.md`, etc.); `scan()` accepts `string | string[]` and scans each pattern separately.

2. **`Npm.install` reify drops user dependencies** (`packages/core/src/npm.ts`):
   - `reify()` runs `arborist.reify({ add, save: true })` with `add` containing only `@opencode-ai/plugin` — arborist rewrites `.opencode/package.json` from the add list, silently removing user deps like `opencode-rag-plugin` (breaking RAG tool registration on Desktop start).
   - Fix: existing dependencies from all four package.json sections (respecting npm `omit`) are merged into the add list before `reify`, deduped by package name.

### How did you verify your code works?

- `bun test test/skill/` (packages/opencode): 24/24 pass
- `bun test test/npm.test.ts` (packages/core): 4/4 pass; repro test (user dep preserved across `Npm.install`) passes
- `tsgo --noEmit` typecheck clean for both packages
- Built Desktop now logs `init count=17` consistently (all skills load); RAG plugin survives app restarts

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR