### PR TITLE
fix(tui): preserve selection under a stationary pointer

### DIFF
--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -87,7 +87,6 @@ export function Autocomplete(props: {
     index: 0,
     selected: 0,
     visible: false as AutocompleteRef["visible"],
-    input: "keyboard" as "keyboard" | "mouse",
   })
 
   const [positionTick, setPositionTick] = createSignal(0)
@@ -149,14 +148,6 @@ export function Autocomplete(props: {
   createEffect(() => {
     const next = filter()
     setSearch(next ? next : "")
-  })
-
-  // When the filter changes due to how TUI works, the mousemove might still be triggered
-  // via a synthetic event as the layout moves underneath the cursor. This is a workaround to make sure the input mode remains keyboard so
-  // that the mouseover event doesn't trigger when filtering.
-  createEffect(() => {
-    filter()
-    setStore("input", "keyboard")
   })
 
   function insertPart(
@@ -724,7 +715,6 @@ export function Autocomplete(props: {
         title: "Previous autocomplete item",
         group: "Autocomplete",
         run() {
-          setStore("input", "keyboard")
           move(-1)
         },
       },
@@ -733,7 +723,6 @@ export function Autocomplete(props: {
         title: "Next autocomplete item",
         group: "Autocomplete",
         run() {
-          setStore("input", "keyboard")
           move(1)
         },
       },
@@ -942,17 +931,8 @@ export function Autocomplete(props: {
                       : undefined
                 }
                 flexDirection="row"
-                onMouseMove={() => {
-                  setStore("input", "mouse")
-                }}
-                onMouseOver={() => {
-                  if (store.input !== "mouse") return
-                  moveTo(index)
-                }}
-                onMouseDown={() => {
-                  setStore("input", "mouse")
-                  moveTo(index)
-                }}
+                onMouseMove={() => moveTo(index)}
+                onMouseDown={() => moveTo(index)}
                 onMouseUp={() => select()}
               >
                 <text

--- a/packages/tui/src/mini/footer.form.tsx
+++ b/packages/tui/src/mini/footer.form.tsx
@@ -438,7 +438,7 @@ export function RunFormBody(props: {
                           flexDirection="row"
                           gap={1}
                           alignItems="flex-start"
-                          onMouseOver={() => setState((previous) => formSetSelected(previous, index()))}
+                          onMouseMove={() => setState((previous) => formSetSelected(previous, index()))}
                           backgroundColor={active() ? props.theme.formfieldFocusedBg : "transparent"}
                           onMouseUp={() => choose(index())}
                         >

--- a/packages/tui/src/mini/footer.permission.tsx
+++ b/packages/tui/src/mini/footer.permission.tsx
@@ -54,7 +54,7 @@ function buttons(
             paddingLeft={1}
             paddingRight={1}
             backgroundColor={option === selected ? theme.actionFocusedBg : transparent}
-            onMouseOver={() => {
+            onMouseMove={() => {
               if (!disabled) onHover(option)
             }}
             onMouseUp={() => {

--- a/packages/tui/src/routes/session/composer/shell-tab.tsx
+++ b/packages/tui/src/routes/session/composer/shell-tab.tsx
@@ -125,7 +125,7 @@ export function ShellTab(props: { sessionID: string }) {
                   backgroundColor={
                     active() ? theme.background.action.primary.focused : theme.background.action.primary.default
                   }
-                  onMouseOver={() => setStore("selected", index())}
+                  onMouseMove={() => setStore("selected", index())}
                   onMouseUp={() => {
                     setStore("selected", index())
                     open()

--- a/packages/tui/src/routes/session/composer/subagents-tab.tsx
+++ b/packages/tui/src/routes/session/composer/subagents-tab.tsx
@@ -215,7 +215,7 @@ export function SubagentsTab(props: { sessionID: string }) {
                         ? theme.background.action.primary.selected
                         : theme.background.action.primary.default
                   }
-                  onMouseOver={() => setStore("selected", index())}
+                  onMouseMove={() => setStore("selected", index())}
                   onMouseUp={() => {
                     setStore("selected", index())
                     navigate({ type: "session", sessionID: entry.sessionID })

--- a/packages/tui/src/routes/session/composer/terminals-tab.tsx
+++ b/packages/tui/src/routes/session/composer/terminals-tab.tsx
@@ -84,7 +84,7 @@ export function TerminalsTab(props: { sessionID: string; visibleTerminalID?: str
                       ? theme.background.action.primary.selected
                       : theme.background.action.primary.default
                 }
-                onMouseOver={() => setSelected(index())}
+                onMouseMove={() => setSelected(index())}
                 onMouseUp={() => {
                   setSelected(index())
                   select()

--- a/packages/tui/src/routes/session/form.tsx
+++ b/packages/tui/src/routes/session/form.tsx
@@ -907,7 +907,7 @@ export function FormPrompt(props: { form: FormWithLocation }) {
                     }
                     return (
                       <box
-                        onMouseOver={() => setStore("selected", i())}
+                        onMouseMove={() => setStore("selected", i())}
                         onMouseDown={() => setStore("selected", i())}
                         onMouseUp={() => {
                           if (renderer.getSelection()?.getSelectedText()) return
@@ -961,7 +961,7 @@ export function FormPrompt(props: { form: FormWithLocation }) {
                 </For>
                 <Show when={custom()}>
                   <box
-                    onMouseOver={() => setStore("selected", rows().length)}
+                    onMouseMove={() => setStore("selected", rows().length)}
                     onMouseDown={() => setStore("selected", rows().length)}
                     onMouseUp={() => {
                       if (renderer.getSelection()?.getSelectedText()) return

--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -591,7 +591,7 @@ export function SessionQuestion<const T extends Record<string, string>>(props: {
                     ? theme.background.action.primary.focused
                     : theme.background.action.primary.default
                 }
-                onMouseOver={() => setStore("selected", option)}
+                onMouseMove={() => setStore("selected", option)}
                 onMouseUp={() => {
                   setStore("selected", option)
                   props.onSelect(option)

--- a/packages/tui/src/ui/dialog-select.tsx
+++ b/packages/tui/src/ui/dialog-select.tsx
@@ -112,7 +112,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
   const [store, setStore] = createStore({
     selected: 0,
     filter: "",
-    input: "keyboard" as "keyboard" | "mouse",
   })
   const [focusedAction, setFocusedAction] = createSignal<number>()
   const actionFocused = createMemo(() => focusedAction() !== undefined)
@@ -201,12 +200,8 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
     return result
   })
 
-  // When the filter changes due to how TUI works, the mousemove might still be triggered
-  // via a synthetic event as the layout moves underneath the cursor. This is a workaround to make sure the input mode remains keyboard
-  // that the mouseover event doesn't trigger when filtering.
   createEffect(() => {
     filtered()
-    setStore("input", "keyboard")
     setFocusedAction(undefined)
   })
 
@@ -384,7 +379,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   function submit() {
     if (props.locked) return
-    setStore("input", "keyboard")
     const index = focusedAction()
     if (index !== undefined) {
       trigger(actionItems()[index])
@@ -418,7 +412,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           title: "Previous item",
           group: "Dialog",
           run() {
-            setStore("input", "keyboard")
             move(-1)
           },
         },
@@ -427,7 +420,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           title: "Next item",
           group: "Dialog",
           run() {
-            setStore("input", "keyboard")
             move(1)
           },
         },
@@ -436,7 +428,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           title: "Page up",
           group: "Dialog",
           run() {
-            setStore("input", "keyboard")
             move(-10)
           },
         },
@@ -445,7 +436,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           title: "Page down",
           group: "Dialog",
           run() {
-            setStore("input", "keyboard")
             move(10)
           },
         },
@@ -455,7 +445,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           group: "Dialog",
           run() {
             if (props.locked) return
-            setStore("input", "keyboard")
             moveTo(0)
           },
         },
@@ -465,7 +454,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
           group: "Dialog",
           run() {
             if (props.locked) return
-            setStore("input", "keyboard")
             moveTo(flat().length - 1)
           },
         },
@@ -538,7 +526,6 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
 
   function trigger(item: Action | undefined) {
     if (props.locked || !item || isActionDisabled(item)) return
-    setStore("input", "keyboard")
     if (item.selection === "none") {
       item.onTrigger()
       return
@@ -709,20 +696,15 @@ export function DialogSelect<T>(props: DialogSelectProps<T>) {
                           position="relative"
                           onMouseMove={() => {
                             if (props.locked) return
-                            setStore("input", "mouse")
                             setFocusedAction(undefined)
+                            const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
+                            if (index === -1 || index === store.selected) return
+                            moveTo(index)
                           }}
                           onMouseUp={() => {
                             if (props.locked) return
                             option.onSelect?.(dialog)
                             props.onSelect?.(option)
-                          }}
-                          onMouseOver={() => {
-                            if (props.locked) return
-                            if (store.input !== "mouse") return
-                            const index = flat().findIndex((x) => isDeepEqual(x.value, option.value))
-                            if (index === -1) return
-                            moveTo(index)
                           }}
                           onMouseDown={() => {
                             if (props.locked) return


### PR DESCRIPTION
## Why

Opening a panel beneath a stationary pointer can change the keyboard selection. This can redirect Enter, interrupt, kill, or permission actions to a different option.

OpenTUI refreshes hover when layout changes underneath the pointer. Several controls treated those `onMouseOver` events as selection intent.

## What Changes

- Select on `onMouseMove` in all three composer tabs, form choices and permission buttons (including mini mode), shared selection dialogs, and prompt autocomplete.
- Remove the picker's and autocomplete's keyboard/mouse-mode workarounds. Moving within a row now takes selection back from the keyboard immediately.
- Keep `onMouseOver` for visual hover effects, including tab-title scrolling, button colors, resize handles, and the mouse-only tab context menu. Click behavior is unchanged.

## Demo

Composer demonstration: matched recordings using the local OpenCode Drive mouse visualization (`e0fb4c7` plus local spring-motion updates). **Before `97303c39dd`** is on the left; **after `b6cb56dfca`** is on the right. The visible pointer stays on row 2 while the keyboard opens the panel, then moves to row 3.

https://github.com/user-attachments/assets/dc8942a4-f0b8-475d-a445-7d3a89abe084

Both temporary capture builds include identical mouse-input/recording support from `52974a6057`; that support is not part of this PR. Both runs use the same isolated fixture and interactions, with simulated model responses, running shell fixtures, and seeded terminal entries. The pointer overlay follows recorded `ui.mouse` events and stays visible during the stationary pause. Clips are cropped to the composer and lightly retimed to synchronize the comparison.

## Scope

V2 TUI selection handlers only; no OpenTUI renderer changes. No added tests or test harness: existing test files are unchanged.

## Verification

```sh
cd packages/tui
bun run test
bun typecheck
```

- Existing TUI suite and type checking pass.
- The Drive scenario was rerun after the audit: keyboard-open and subsequent mouse movement behave correctly in all three composer tabs.
