### PR TITLE
fix(tui): anchor diff file menus to the screen

### DIFF
--- a/packages/tui/src/feature-plugins/system/diff-viewer-file-menu.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer-file-menu.tsx
@@ -1,0 +1,87 @@
+/** @jsxImportSource @opentui/solid */
+import type { Plugin } from "@opencode-ai/plugin/tui"
+import { BoxRenderable, MouseButton } from "@opentui/core"
+import { Portal, useTerminalDimensions } from "@opentui/solid"
+import { createSignal, onCleanup } from "solid-js"
+
+export function DiffFileMenu(props: {
+  context: Plugin.Context
+  state: { fileIndex: number; x: number; y: number }
+  reviewed: boolean
+  onToggle: () => void
+  onClose: () => void
+}) {
+  const dimensions = useTerminalDimensions()
+  const theme = props.context.theme.contextual.overlay
+  const [hovered, setHovered] = createSignal(false)
+  const label = () => (props.reviewed ? "Mark incomplete" : "Mark complete")
+  const width = () => Math.min(19, dimensions().width)
+  const run = () => {
+    props.onClose()
+    props.onToggle()
+  }
+  onCleanup(props.context.keymap.mode.push("menu"))
+  props.context.keymap.layer(() => ({
+    mode: "menu",
+    commands: [
+      { bind: "escape,ctrl+c", title: "Close file menu", group: "Diff", run: props.onClose },
+      { bind: "return", title: label(), group: "Diff", run },
+    ],
+  }))
+
+  return (
+    <Portal
+      ref={(container) => {
+        if (!(container instanceof BoxRenderable)) return
+        // Portal's wrapper must also escape root flow, not follow the full-height app.
+        container.position = "absolute"
+        container.left = 0
+        container.top = 0
+        container.zIndex = 2600
+      }}
+    >
+      <box
+        id="diff-file-menu-overlay"
+        position="absolute"
+        left={0}
+        top={0}
+        width={dimensions().width}
+        height={dimensions().height}
+        zIndex={2600}
+        onMouseDown={(event) => {
+          props.onClose()
+          event.preventDefault()
+          event.stopPropagation()
+        }}
+      >
+        <box
+          id="diff-file-menu"
+          position="absolute"
+          left={Math.max(0, Math.min(props.state.x, dimensions().width - width()))}
+          top={Math.max(0, Math.min(props.state.y + 1, dimensions().height - 1))}
+          width={width()}
+          height={1}
+          paddingLeft={1}
+          paddingRight={1}
+          backgroundColor={hovered() ? theme.background.action.primary.hovered : theme.background.default}
+          onMouseOver={() => setHovered(true)}
+          onMouseOut={() => setHovered(false)}
+          onMouseDown={(event) => {
+            if (event.button === MouseButton.RIGHT) props.onClose()
+            event.preventDefault()
+            event.stopPropagation()
+          }}
+          onMouseUp={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            if (event.button === MouseButton.LEFT) run()
+          }}
+        >
+          <text fg={theme.text.default} selectable={false} wrapMode="none" truncate>
+            {label()}
+          </text>
+        </box>
+      </box>
+    </Portal>
+  )
+}

--- a/packages/tui/src/feature-plugins/system/diff-viewer.tsx
+++ b/packages/tui/src/feature-plugins/system/diff-viewer.tsx
@@ -14,6 +14,7 @@ import { filetype } from "../../util/filetype"
 import { useRenderer, useTerminalDimensions } from "@opentui/solid"
 import { createEffect, createMemo, createResource, createSignal, For, Match, onCleanup, Show, Switch } from "solid-js"
 import { DiffViewerFileTree } from "./diff-viewer-file-tree"
+import { DiffFileMenu } from "./diff-viewer-file-menu"
 import { DiffViewerImage, isDiffImageFile } from "./diff-viewer-image"
 import { DialogSelect } from "../../ui/dialog-select"
 import { EmptyBorder } from "../../ui/border"
@@ -1072,76 +1073,6 @@ export function DiffViewerContent(props: {
           />
         )}
       </Show>
-    </box>
-  )
-}
-
-function DiffFileMenu(props: {
-  context: Plugin.Context
-  state: FileMenuState
-  reviewed: boolean
-  onToggle: () => void
-  onClose: () => void
-}) {
-  const dimensions = useTerminalDimensions()
-  const theme = props.context.theme.contextual.overlay
-  const [hovered, setHovered] = createSignal(false)
-  const label = () => (props.reviewed ? "Mark incomplete" : "Mark complete")
-  const run = () => {
-    props.onClose()
-    props.onToggle()
-  }
-  onCleanup(props.context.keymap.mode.push("menu"))
-  props.context.keymap.layer(() => ({
-    mode: "menu",
-    commands: [
-      { bind: "escape,ctrl+c", title: "Close file menu", group: "Diff", run: props.onClose },
-      { bind: "return", title: label(), group: "Diff", run },
-    ],
-  }))
-
-  return (
-    <box
-      id="diff-file-menu-overlay"
-      position="absolute"
-      left={0}
-      top={0}
-      width={dimensions().width}
-      height={dimensions().height}
-      zIndex={2600}
-      onMouseDown={(event) => {
-        props.onClose()
-        event.preventDefault()
-        event.stopPropagation()
-      }}
-    >
-      <box
-        id="diff-file-menu"
-        position="absolute"
-        left={Math.max(0, Math.min(props.state.x, dimensions().width - 19))}
-        top={Math.max(0, Math.min(props.state.y + 1, dimensions().height - 1))}
-        width={19}
-        height={1}
-        paddingLeft={1}
-        paddingRight={1}
-        backgroundColor={hovered() ? theme.background.action.primary.hovered : theme.background.default}
-        onMouseOver={() => setHovered(true)}
-        onMouseOut={() => setHovered(false)}
-        onMouseDown={(event) => {
-          if (event.button === MouseButton.RIGHT) props.onClose()
-          event.preventDefault()
-          event.stopPropagation()
-        }}
-        onMouseUp={(event) => {
-          event.preventDefault()
-          event.stopPropagation()
-          if (event.button === MouseButton.LEFT) run()
-        }}
-      >
-        <text fg={theme.text.default} selectable={false}>
-          {label()}
-        </text>
-      </box>
     </box>
   )
 }


### PR DESCRIPTION
## Stack
Part **1 of 4 remaining PRs**, replacing the monolithic #47132. Current base is `v2`.

#47144 is merged into `v2`. #47149 is superseded: its identical production-app fixture already exists on `v2` at `packages/tui/test/fixture/app.ts`.

1. #47147 — Screen-relative diff menus
2. #47148 — Reactive theme contexts
3. #47150 — Generic plugin panel slots and host
4. #47152 — Diff plugin consumer and regressions

**Landing:** merge bottom-up. After a predecessor is squash-merged, rebase and retarget the next PR onto `v2` before merging it. Do not merge a child into an unlanded feature branch.

## Summary
- extract the diff file menu into a focused component
- render through a root portal so offset/clipped panes cannot misplace the menu
- preserve scope-owned keyboard handling, dismissal, focus, and theme behavior

No diff side-panel UI is introduced in this PR.

## Validation
- `bun typecheck` in `packages/tui`
- The newly added file-menu test file was removed at the reviewer’s request.
- Production code is unchanged by that removal; `git diff --check` passed.

## Restack validation (2026-09-04, before test-file removal)
- Rebased the remaining stack onto `90cd910f52` (`v2`, including merged #47144).
- Combined stack: 1,258 TUI tests passed, 4 skipped, 0 failures.
- TUI, CLI, and plugin package typechecks passed.
- Preserved the upstream updater provider; reused the existing app fixture instead of adding a duplicate.
