### PR TITLE
refactor(tui): support reactive theme contexts

### DIFF
--- a/packages/tui/src/context/theme.tsx
+++ b/packages/tui/src/context/theme.tsx
@@ -23,7 +23,7 @@ import {
 } from "../theme"
 import { generateSystem, terminalMode } from "../theme/system"
 import { discoverThemes } from "../theme/discovery"
-import { createComponentTheme, type ComponentTheme } from "../theme/component"
+import { createComponentTheme, createComponentThemeView, type ComponentTheme } from "../theme/component"
 import { createEffect, createMemo, onCleanup, onMount, type Accessor, type ParentProps } from "solid-js"
 import { createStore, produce } from "solid-js/store"
 import { createSimpleContext } from "./helper"
@@ -379,12 +379,15 @@ export function useTheme(context?: ContextName) {
 }
 export const ThemeProvider = themeContext.provider
 
-export function ThemeContextProvider(props: ParentProps<{ context: ContextName }>) {
+/** Switches context without remounting children; undefined inherits the enclosing view. */
+export function ThemeContextProvider(props: ParentProps<{ context: ContextName | undefined }>) {
   const value = themeContext.use()
+  const current = createComponentThemeView(() => {
+    const name = props.context
+    return name ? value.themes.currentTokens().contextual[name] : value.current
+  }, value.themes.mode)
   return (
-    <themeContext.context.Provider
-      value={{ current: value.themes.current.contextual[props.context], themes: value.themes, ready: value.ready }}
-    >
+    <themeContext.context.Provider value={{ current, themes: value.themes, ready: value.ready }}>
       {props.children}
     </themeContext.context.Provider>
   )

--- a/packages/tui/src/theme/component.ts
+++ b/packages/tui/src/theme/component.ts
@@ -3,7 +3,16 @@ import type { Accessor } from "solid-js"
 import type { Mode, ResolvedTheme, ResolvedThemeTokens } from "@opencode-ai/theme/tui"
 
 export function createComponentTheme(current: Accessor<ResolvedTheme>, mode: Accessor<Mode>) {
-  const create = (view: Accessor<ResolvedThemeTokens>) => ({
+  return Object.assign(createComponentThemeView(current, mode), {
+    contextual: {
+      elevated: createComponentThemeView(() => current().contextual.elevated, mode),
+      overlay: createComponentThemeView(() => current().contextual.overlay, mode),
+    },
+  })
+}
+
+export function createComponentThemeView(view: Accessor<ResolvedThemeTokens>, mode: Accessor<Mode>) {
+  return {
     get hue() {
       return view().hue
     },
@@ -35,14 +44,7 @@ export function createComponentTheme(current: Accessor<ResolvedTheme>, mode: Acc
     increase: (color: RGBA, amount = 1) => view().increase(color, amount),
     decrease: (color: RGBA, amount = 1) => view().decrease(color, amount),
     raise: (color: RGBA) => (mode() === "light" ? view().increase(color) : view().decrease(color)),
-  })
-
-  return Object.assign(create(current), {
-    contextual: {
-      elevated: create(() => current().contextual.elevated),
-      overlay: create(() => current().contextual.overlay),
-    },
-  })
+  }
 }
 
 export type ComponentTheme = ReturnType<typeof createComponentTheme>

--- a/packages/tui/test/cli/tui/theme-mode.test.tsx
+++ b/packages/tui/test/cli/tui/theme-mode.test.tsx
@@ -2,6 +2,7 @@
 import { testRender } from "@opentui/solid"
 import { expect, test } from "bun:test"
 import { RGBA } from "@opentui/core"
+import { createSignal } from "solid-js"
 import { DEFAULT_THEME, selectTheme } from "@opencode-ai/theme/tui"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 import { DEFAULT_THEMES } from "../../../src/theme"
@@ -166,10 +167,58 @@ test("contextual hooks resolve overrides and fall back to a standalone theme's b
     if (!theme) throw new Error("Contextual theme is not mounted")
     if (!explicit) throw new Error("Explicit contextual theme is not mounted")
     expect(theme.text.default.equals(RGBA.fromHex("#abcdef"))).toBeTrue()
-    expect(theme).toBe(explicit)
+    expect(theme.text.default).toBe(explicit.text.default)
     expect(theme.text.default).toBe(themes.current.contextual.elevated.text.default)
     expect(themes.current.contextual.overlay.background.default).toBe(themes.current.background.default)
   } finally {
     app.renderer.destroy()
   }
 })
+
+test.each(["dark", "light"] as const)(
+  "reactive %s theme contexts change without remounting their contents",
+  async (mode) => {
+    const [context, setContext] = createSignal<"elevated" | undefined>("elevated")
+    const [parent, setParent] = createSignal<"overlay" | undefined>()
+    let theme: ReturnType<typeof useTheme> | undefined
+    let themes: ReturnType<typeof useThemes> | undefined
+    let mounts = 0
+    function Probe() {
+      mounts++
+      theme = useTheme()
+      themes = useThemes()
+      return <text fg={theme.text.default}>probe</text>
+    }
+    const app = await testRender(() => (
+      <ConfigProvider config={createTuiResolvedConfig({ theme: { name: "opencode", mode } })}>
+        <ThemeProvider mode={mode} source={{ discover: async () => ({}) }}>
+          <ThemeContextProvider context={parent()}>
+            <ThemeContextProvider context={context()}>
+              <Probe />
+            </ThemeContextProvider>
+          </ThemeContextProvider>
+        </ThemeProvider>
+      </ConfigProvider>
+    ))
+    app.renderer.start()
+    try {
+      await wait(() => themes?.ready === true)
+      if (!theme || !themes) throw new Error("Theme provider is not mounted")
+      const view = theme
+      expect(view.background.default).toBe(themes.current.contextual.elevated.background.default)
+      setContext(undefined)
+      await app.flush()
+      expect(view.background.default).toBe(themes.current.background.default)
+      setParent("overlay")
+      await app.flush()
+      expect(view.background.default).toBe(themes.current.contextual.overlay.background.default)
+      setContext("elevated")
+      await app.flush()
+      expect(view.text.default).toBe(themes.current.contextual.elevated.text.default)
+      expect(theme).toBe(view)
+      expect(mounts).toBe(1)
+    } finally {
+      app.renderer.destroy()
+    }
+  },
+)

--- a/packages/tui/test/theme/v2/component.test.ts
+++ b/packages/tui/test/theme/v2/component.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "bun:test"
 import { createSignal } from "solid-js"
 import { RGBA } from "@opentui/core"
 import { DEFAULT_THEME, resolveTheme, selectTheme, type ContextName } from "@opencode-ai/theme/tui"
-import { createComponentTheme } from "../../../src/theme/component"
+import { createComponentTheme, createComponentThemeView } from "../../../src/theme/component"
 
 test("provides reactive properties, states, contexts, and color operations", () => {
   const [resolved, setResolved] = createSignal(resolveTheme(selectTheme(DEFAULT_THEME, "light")))
@@ -66,4 +66,20 @@ test("provides reactive properties, states, contexts, and color operations", () 
   expect(current().text.default).toBe(resolved().contextual.elevated.text.default)
   expect(current().decrease(current().background.surface.offset, 1)).toBe(resolved().hue.neutral[600])
   expect(current().raise(current().background.surface.offset)).toBe(resolved().hue.neutral[600])
+})
+
+test("a stable component theme view follows presentation context changes", () => {
+  const [resolved, setResolved] = createSignal(resolveTheme(selectTheme(DEFAULT_THEME, "dark")))
+  const [context, setContext] = createSignal<ContextName>()
+  const theme = createComponentThemeView(
+    () => (context() ? resolved().contextual[context()!] : resolved()),
+    () => "dark",
+  )
+  expect(theme.background.default).toBe(resolved().background.default)
+  setContext("elevated")
+  expect(theme.background.default).toBe(resolved().contextual.elevated.background.default)
+  setContext(undefined)
+  expect(theme.background.default).toBe(resolved().background.default)
+  setResolved(resolveTheme(selectTheme(DEFAULT_THEME, "light")))
+  expect(theme.text.default).toBe(resolved().text.default)
 })


### PR DESCRIPTION
## Stack
Part **1 of 3 remaining PRs**, replacing the monolithic #47132. Current base is `v2`.

#47144 and #47147 are merged into `v2`. #47149 is superseded by the identical production-app fixture already on `v2` at `packages/tui/test/fixture/app.ts`.

1. #47148 — Reactive theme contexts
2. #47150 — Generic plugin panel slots and host
3. #47152 — Diff plugin consumer and regressions

**Landing:** merge bottom-up. After a predecessor is squash-merged, rebase and retarget the next PR onto `v2` before merging it. Do not merge a child into an unlanded feature branch.

## Summary
- allow the ordinary reactive `context` prop to switch inherited theme context without remounting children; no callback prop required
- keep one stable theme view per provider; static contexts retain their colors but no longer share object identity with explicit contextual hooks
- cover base/elevated transitions and reactive parent-context inheritance in both light and dark modes

No theme tokens or diff UI behavior change here.

## Validation
- `bun typecheck` in `packages/tui`
- theme-context suites: 9 tests passed
- `git diff --check`

## Restack validation (2026-09-04)
- Rebased the remaining stack onto `90cd910f52` (`v2`, including merged #47144).
- Combined stack: 1,258 TUI tests passed, 4 skipped, 0 failures.
- TUI, CLI, and plugin package typechecks passed.
- Preserved the upstream updater provider; reused the existing app fixture instead of adding a duplicate.

## Restack after #47147 merged
- Rebased onto `8ff1ef1a62` (`v2`). All remaining patches are unchanged, and the complete resulting tree is identical to the previous stack tip.
- No conflicts or code changes; `git diff --check` passed. Tests were not rerun for this history-only restack.

## Direct context prop update
- Callers now use `context={condition ? "elevated" : undefined}`. The panel-host consumer is updated in #47150.
- Focused theme tests: 9 passed. Full updated stack: 1,249 TUI tests passed, 4 skipped, 0 failures.
- TUI typecheck and `git diff --check` passed.
