### PR TITLE
test(tui): share the production app fixture

### DIFF
--- a/packages/tui/test/app-lifecycle.test.tsx
+++ b/packages/tui/test/app-lifecycle.test.tsx
@@ -5,10 +5,9 @@ import { Effect, FileSystem } from "effect"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
 import { Global } from "@opencode-ai/util/global"
 import path from "node:path"
-import { createEventStream, createFetch, directory, json, type FetchHandler } from "./fixture/tui-client"
+import { createEventStream, createFetch, directory, json } from "./fixture/tui-client"
+import { createAppFixture } from "./fixture/tui-app"
 import { tmpdir } from "./fixture/fixture"
-import type { TuiInput } from "../src/app"
-import type { Config } from "../src/config"
 import type { PluginInfo } from "@opencode-ai/client"
 
 test.each([100, 44])("Ctrl-O is immediate, dismissible, and prunes cached deletions at width %s", async (width) => {
@@ -1530,54 +1529,3 @@ test("server plugin failures share one notice and use source names before an ID 
   expect(setup.captureCharFrame()).toContain("/fixture/broken.ts")
   expect(setup.captureCharFrame()).toContain("Open plugins")
 })
-
-async function createAppFixture(
-  input: {
-    width?: number
-    height?: number
-    state?: string
-    config?: Config.Info
-    args?: TuiInput["args"]
-    fetch?: FetchHandler
-  } = {},
-) {
-  const { run } = await import("../src/app")
-  const setup = await createTestRenderer({
-    width: input.width ?? 100,
-    height: input.height ?? 30,
-    useThread: false,
-    kittyKeyboard: true,
-  })
-  setup.renderer.start()
-  const ready = Promise.withResolvers<void>()
-  const events = createEventStream()
-  const calls = createFetch(input.fetch, events)
-  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
-  const task = Effect.runPromise(
-    run({
-      app: { name: "test", version: "test", channel: "test" },
-      server: { endpoint: { url: server.url.toString() } },
-      config: { get: async () => input.config ?? { animations: false }, update: async () => ({}) },
-      packages: { prepare: async () => ({ directory: "" }) },
-      terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
-      args: input.args ?? {},
-      log: () => {},
-    }).pipe(
-      Effect.provide(input.state ? Global.layerWith({ state: input.state }) : AppNodeBuilder.build(Global.node)),
-      Effect.provide(FileSystem.layerNoop({})),
-    ),
-  )
-  return {
-    ...setup,
-    events,
-    ready: ready.promise,
-    async [Symbol.asyncDispose]() {
-      try {
-        if (!setup.renderer.isDestroyed) setup.renderer.destroy()
-        await task
-      } finally {
-        await server.stop()
-      }
-    },
-  }
-}

--- a/packages/tui/test/fixture/tui-app.ts
+++ b/packages/tui/test/fixture/tui-app.ts
@@ -1,0 +1,58 @@
+import { createTestRenderer } from "@opentui/core/testing"
+import { Effect, FileSystem } from "effect"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { Global } from "@opencode-ai/util/global"
+import type { TuiInput } from "../../src/app"
+import type { Config } from "../../src/config"
+import { createEventStream, createFetch, type FetchHandler } from "./tui-client"
+
+export async function createAppFixture(
+  input: {
+    width?: number
+    height?: number
+    state?: string
+    config?: Config.Info
+    args?: TuiInput["args"]
+    fetch?: FetchHandler
+  } = {},
+) {
+  const { run } = await import("../../src/app")
+  const setup = await createTestRenderer({
+    width: input.width ?? 100,
+    height: input.height ?? 30,
+    useThread: false,
+    kittyKeyboard: true,
+  })
+  setup.renderer.start()
+  const ready = Promise.withResolvers<void>()
+  const events = createEventStream()
+  const calls = createFetch(input.fetch, events)
+  const server = Bun.serve({ port: 0, fetch: (request) => calls.fetch(request) })
+  const task = Effect.runPromise(
+    run({
+      app: { name: "test", version: "test", channel: "test" },
+      server: { endpoint: { url: server.url.toString() } },
+      config: { get: async () => input.config ?? { animations: false }, update: async () => ({}) },
+      packages: { prepare: async () => ({ directory: "" }) },
+      terminalHandoff: async () => ({ renderer: setup.renderer, mode: "dark", complete: ready.resolve }),
+      args: input.args ?? {},
+      log: () => {},
+    }).pipe(
+      Effect.provide(input.state ? Global.layerWith({ state: input.state }) : AppNodeBuilder.build(Global.node)),
+      Effect.provide(FileSystem.layerNoop({})),
+    ),
+  )
+  return {
+    ...setup,
+    events,
+    ready: ready.promise,
+    async [Symbol.asyncDispose]() {
+      try {
+        if (!setup.renderer.isDestroyed) setup.renderer.destroy()
+        await task
+      } finally {
+        await server.stop()
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Stack
Part **4 of 6**, replacing the monolithic #47132. Depends on #47148; current base is `reactive-theme-context`.

1. #47144 — Shared interactivity context and input scopes
2. #47147 — Screen-relative diff menus
3. #47148 — Reactive theme contexts
4. #47149 — Shared production-app test fixture
5. #47150 — Generic plugin panel slots and host
6. #47152 — Diff plugin consumer and regressions

**Landing:** merge bottom-up. Each PR currently targets its predecessor so the review diff contains only that piece. After a predecessor is squash-merged, rebase and retarget the next PR onto `v2` before merging it. Do not merge a child into an unlanded feature branch.

## Summary
- extract the existing production-app test harness into `test/fixture/tui-app.ts`
- reuse it from the lifecycle suite without changing test behavior
- prepare real-host panel regression coverage without duplicating App/SessionFrame logic

Test-only change; no production behavior changes.

## Validation
- `bun typecheck` in `packages/tui`
- all 29 app-lifecycle tests passed
- `git diff --check`