### PR TITLE
docs(hooks): research on hook system gaps vs Claude Code

### DIFF
--- a/docs/hooks-research/01-comparative-analysis.md
+++ b/docs/hooks-research/01-comparative-analysis.md
@@ -1,0 +1,341 @@
+# Hooks no OpenCode: análise comparativa vs Claude Code
+
+> Análise comparativa do sistema de hooks/plugin events entre OpenCode e Claude Code,
+> baseada em código real do fork `anomalyco/opencode` (commit `d2efd81`) e na
+> estrutura revelada pelo leak do Claude Code de março/2026.
+
+## TL;DR
+
+O OpenCode **já tem um sistema de hooks maduro** via `packages/plugin/src/index.ts` e
+`plugin.trigger(name, input, output)` em `packages/opencode/src/session/prompt.ts`.
+Ele cobre ~70% do que os hooks do Claude Code (`commands/hooks/`, `hooks/`) fazem.
+
+O gap principal **não é implementar hooks do zero** — é **preencher eventos que
+faltam**, ajustar semântica em alguns existentes, e melhorar a experiência de
+configuração (descoberta, matcher syntax, async fire-and-forget).
+
+---
+
+## 1. Inventário real: hooks OpenCode hoje
+
+### 1.1 Definição (de `packages/plugin/src/index.ts:222-334`)
+
+```ts
+export interface Hooks {
+  dispose?: () => Promise<void>
+  event?: (input: { event: Event }) => Promise<void>
+  config?: (input: Config) => Promise<void>
+  tool?: { [key: string]: ToolDefinition }
+  auth?: AuthHook
+  provider?: ProviderHook
+
+  "chat.message"?: (input, output) => Promise<void>
+  "chat.params"?: (input, output) => Promise<void>
+  "chat.headers"?: (input, output) => Promise<void>
+  "permission.ask"?: (input, output) => Promise<void>
+  "command.execute.before"?: (input, output) => Promise<void>
+  "tool.execute.before"?: (input, output) => Promise<void>
+  "shell.env"?: (input, output) => Promise<void>
+  "tool.execute.after"?: (input, output) => Promise<void>
+
+  "experimental.chat.messages.transform"?: (input, output) => Promise<void>
+  "experimental.chat.system.transform"?: (input, output) => Promise<void>
+  "experimental.provider.small_model"?: (input, output) => Promise<void>
+  "experimental.session.compacting"?: (input, output) => Promise<void>
+  "experimental.compaction.autocontinue"?: (input, output) => Promise<void>
+  "experimental.text.complete"?: (input, output) => Promise<void>
+  "tool.definition"?: (input, output) => Promise<void>
+}
+```
+
+Padrão: `(input, output) => Promise<void>`. Hooks podem **mutar `output` por referência**
+(ver `plugin.trigger` em `packages/opencode/src/session/prompt.ts:307`).
+
+### 1.2 Onde são disparados
+
+Caminhos reais verificados:
+
+| Hook | Arquivo | Linha |
+|------|---------|-------|
+| `tool.execute.before` (task) | `packages/opencode/src/session/prompt.ts` | 308 |
+| `tool.execute.after` (task) | `packages/opencode/src/session/prompt.ts` | 390 |
+| `chat.message` | `packages/opencode/src/session/prompt.ts` | 1000 |
+| `experimental.chat.messages.transform` | `packages/opencode/src/session/prompt.ts` | 1255 |
+| `tool.execute.before`/`after` (bash/read/edit/write) | `packages/opencode/src/session/tools.ts` | 107, 122, 176, 209, 259, 292, 339, 374, 403, 421 |
+
+Padrão consistente: cada tool execution emite `before` (muda args) e `after`
+(muda title/output/metadata).
+
+---
+
+## 2. Mapeamento: Claude Code → OpenCode
+
+Baseado no leak do harness do Claude Code (`claude_code_ts_snapshot`),
+os hooks/eventos que o sistema Claude Code tem são:
+
+| Categoria Claude Code | OpenCode | Status |
+|-----------------------|----------|--------|
+| `PreToolUse` | `tool.execute.before` | ✅ equivalente |
+| `PostToolUse` | `tool.execute.after` | ✅ equivalente |
+| `UserPromptSubmit` | `chat.message` | ✅ equivalente |
+| `Stop` | (ausente) | ❌ gap |
+| `SubagentStop` | (ausente) | ⚠️ parcial (task.tool via `tool.execute.after`) |
+| `Notification` | (ausente) | ❌ gap |
+| `SessionStart` | (ausente) | ❌ gap |
+| `SessionEnd` | `dispose` | ⚠️ parcial |
+| `PreCompact` | `experimental.session.compacting` | ✅ equivalente |
+| `PermissionRequest` | `permission.ask` | ✅ equivalente |
+| `PostCompact` | (ausente) | ❌ gap |
+| Matcher syntax por tool name | ❌ não tem | ❌ gap |
+| Matcher syntax por regex de prompt | ❌ não tem | ❌ gap |
+| Hooks shell (executar comando externo) | ⚠️ via plugin code | ⚠️ workaround |
+| Hooks HTTP/webhook | ❌ não tem | ❌ gap |
+| Async fire-and-forget | ⚠️ depende de trigger impl | ⚠️ incerto |
+| Blocking + modify output | ✅ via `output` mutation | ✅ |
+| Hook logging/telemetry próprio | ❌ não tem | ❌ gap |
+
+---
+
+## 3. Gaps concretos (o que falta)
+
+### 3.1 **Stop hook** — sinaliza fim de turno do agente
+
+Claude Code define `Stop` que dispara quando o agente termina um turno.
+OpenCode não tem. **Workaround atual:** escutar `tool.execute.after` com
+matcher "último tool call" — frágil.
+
+**Valor:** permite cleanup (notificações, métricas, rollback, commit).
+
+### 3.2 **SessionStart / SessionEnd (limpos)**
+
+Hoje só tem `dispose` no hook final. Falta:
+- `SessionStart` — antes do primeiro tool call. Permite setup customizado.
+- `SessionEnd` — após `dispose`, com distinção de cleanup.
+
+### 3.3 **Matcher syntax**
+
+Claude Code permite `matcher` em `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Bash|Edit|Write", "hooks": [...] }
+    ]
+  }
+}
+```
+
+OpenCode atual: **hooks disparam para todas as tools**. Sem filtro.
+
+Plugin author precisa fazer `if (input.tool === "bash")` manualmente.
+Funciona, mas incentiva código duplicado e difícil de auditar.
+
+### 3.4 **Shell hooks (comandos externos)**
+
+Claude Code suporta executar binário externo como hook:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          { "type": "command", "command": "./scripts/check-bash-safety.sh" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+OpenCode só tem **plugin code hooks** (TS/JS). Não tem shell hook nativo.
+Usuário que quiser hook shell precisa escrever um plugin que faz
+`Bun.spawn` internamente — fricção alta.
+
+**Valor:** democratiza. DevOps/sysadmin sem TS consegue adicionar validação.
+
+### 3.5 **Notification hook**
+
+Claude Code dispara `Notification` em eventos de background (compactação
+concluída, idle timeout, etc). OpenCode não tem canal dedicado.
+
+**Valor:** permite webhook pra Slack/Discord quando sessão longa.
+
+### 3.6 **SubagentStop dedicado**
+
+Hoje: `tool.execute.after` com `tool === "task"` indica fim de sub-agent.
+Funciona, mas sem semântica própria: não distingue "subagent terminou OK" de
+"subagent falhou". Não tem `error` no input.
+
+### 3.7 **Hook telemetry**
+
+Cada hook call deveria emitir evento próprio (`HookInvoked` com nome, duração,
+resultado). Hoje hook execution não aparece nos logs estruturados.
+
+---
+
+## 4. Onde os hooks OpenCode são SUPERIORES ao Claude Code
+
+Para não cair em viés negativo:
+
+### 4.1 **`tool.definition` hook**
+
+OpenCode permite **modificar o schema da tool que o LLM vê**:
+
+```ts
+"tool.definition"?: (input, output) => Promise<void>
+```
+
+Isso permite **esconder parameters, renomear, injetar descrições contextuais**.
+Claude Code não tem — tools são estáticas.
+
+**Valor:** multi-tenant (empresa esconde fields internos de subcontractors),
+personas (agente "junior" vê só subset).
+
+### 4.2 **`chat.params` + `chat.headers`**
+
+Permite modificar temperatura, topP, topK, **maxOutputTokens**, options
+provider-specific (OpenRouter, Anthropic cache control), **e headers HTTP**.
+
+Claude Code expõe temperature/config via slash command, mas não tem hook
+que ajusta **dinamicamente por turno**.
+
+**Valor:** cost control adaptativo (max tokens menor em tarefas simples),
+A/B test de params em produção.
+
+### 4.3 **`shell.env` hook**
+
+Injeta env vars em **todo shell command** baseado em cwd/sessionID/callID.
+
+Claude Code tem `permissions.sandbox.env` mas é estático. OpenCode hook é
+**dinâmico por chamada**.
+
+**Valor:** multi-tenant secrets (cada workspace vê só suas keys), tracing IDs.
+
+### 4.4 **`experimental.chat.system.transform`**
+
+Modifica o **system prompt inteiro** dinamicamente. Claude Code não permite
+(ou só via `--append-system-prompt` flag estático).
+
+**Valor:** A/B test de system prompts, persona switching, context-aware.
+
+### 4.5 **`experimental.text.complete`**
+
+Dispara **token a token** durante streaming. Permite mutação real-time
+(p.ex. censurar PII antes do user ver).
+
+Claude Code: `--output-format stream-json` é read-only.
+
+**Valor:** compliance (PII detection em tempo real), i18n on-the-fly.
+
+---
+
+## 5. Esforço realista pra preencher os gaps
+
+Assumindo 1 dev senior full-time, familiarizado com codebase OpenCode
+(Effect-TS + Bun runtime).
+
+| Gap | Esforço | Risco | Prioridade |
+|-----|---------|-------|------------|
+| Stop hook | 1-2 semanas | Baixo | **Alta** |
+| SessionStart/SessionEnd | 1-2 semanas | Baixo | **Alta** |
+| Matcher syntax | 2-3 semanas | Médio | **Alta** |
+| Shell hooks nativos | 3-4 semanas | Médio | Média |
+| Notification hook | 1 semana | Baixo | Média |
+| SubagentStop dedicado | 1 semana | Baixo | Baixa |
+| Hook telemetry | 1-2 semanas | Baixo | Baixa |
+| **Total MVP (Alta)** | **4-7 semanas** | | |
+| **Total completo** | **10-15 semanas** | | |
+
+### Recomendações pragmáticas
+
+**Fazer primeiro (alto valor, baixo risco):**
+
+1. **Stop hook** — 1-2 semanas. Resolve caso de uso "notificar fim de turno"
+   sem reescrever nada. Trigger natural: quando `tool.execute.after` é o último
+   do turno.
+
+2. **Matcher syntax** — 2-3 semanas. Permite usuários configurarem "só rodar
+   em Bash + Edit" sem escrever plugin. **ROI alto**: reduz atrito pra
+   90% dos casos.
+
+3. **SessionStart/SessionEnd** — 1-2 semanas. Complementa `dispose` com semântica
+   clara. Permite init/cleanup plugins.
+
+**Fazer depois:**
+
+4. **Shell hooks nativos** — 3-4 semanas. Valor real mas trabalho grande.
+   Requer definir protocolo de input/output (JSON via stdin/stdout).
+
+**Não fazer agora:**
+
+5. Notification hook — só faz sentido com shell hooks ou HTTP hooks.
+   Fazer junto com #4.
+
+6. SubagentStop dedicado — `tool.execute.after` com `tool === "task"` resolve
+   80% do caso.
+
+7. Hook telemetry — nice-to-have. Adiar até ter demanda real.
+
+---
+
+## 6. Proposta de design (alto nível)
+
+Ver `RFC-001-hooks-extension.md` neste mesmo diretório para detalhes.
+
+Resumo: introduzir **`hooks.ts`** em `packages/core/src/` com:
+
+- Novos eventos: `stop`, `session.start`, `session.end`, `notification`
+- Matcher config em `opencode.json` (estilo Claude Code)
+- Shell hook execution via `Bun.spawn` (mesma runtime OpenCode)
+- Hook invocation log no sistema de eventos existente
+
+Sem mudar contrato de `Hooks` interface — só **adicionar novos campos**.
+
+---
+
+## 7. Conclusão
+
+OpenCode **não precisa de hook system novo**. Precisa de:
+- 3-5 eventos novos (`stop`, `session.start`, `session.end`)
+- 1 mecanismo de configuração (matcher syntax)
+- 1 transporte alternativo (shell)
+
+Tudo **aditivo**, nada breaking. 4-7 semanas de trabalho focado
+coloca OpenCode em paridade com Claude Code em hook surface, **mantendo
+as vantagens que já tem** (`tool.definition`, `chat.params`, `shell.env`).
+
+## Anexos
+
+### A. Lista completa de tool hooks disparados em `packages/opencode/src/session/tools.ts`
+
+```text
+107: tool.execute.before  (BashTool)
+122: tool.execute.after   (BashTool)
+176: tool.execute.before  (ReadTool)
+209: tool.execute.after   (ReadTool)
+259: tool.execute.before  (WriteTool)
+292: tool.execute.after   (WriteTool)
+339: tool.execute.before  (EditTool)
+374: tool.execute.after   (EditTool)
+403: tool.execute.before  (MultiEditTool)
+421: tool.execute.after   (MultiEditTool)
+```
+
+Padrão: cada tool dispara `before` (muda args) e `after` (muda output/metadata/title).
+Consistência observada, não há tool que pula o `after`.
+
+### B. Hooks no `prompt.ts`
+
+```text
+308: tool.execute.before  (TaskTool - subagent dispatch)
+390: tool.execute.after   (TaskTool - subagent complete)
+1000: chat.message        (user message received)
+1255: experimental.chat.messages.transform  (LLM history reshape)
+```
+
+Faltam neste arquivo: `chat.params`, `chat.headers`, `permission.ask`,
+`shell.env`, `experimental.chat.system.transform`. Sugere que há outros
+arquivos onde esses disparam (não mapeados nesta análise).

--- a/docs/hooks-research/02-ears-requirements.md
+++ b/docs/hooks-research/02-ears-requirements.md
@@ -1,0 +1,257 @@
+# EARS Requirements: Hook System Extensions for OpenCode
+
+> Requirements formais (EARS-style) para os gaps de hooks identificados em
+> `01-comparative-analysis.md`. Cada requisito é verificável, atômico e
+> referenciável. Baseado em código real do fork `anomalyco/opencode`.
+
+## Escopo
+
+Esta spec cobre **apenas os gaps de prioridade Alta**:
+
+- HOOK-STOP-001: Stop hook event
+- HOOK-SESSION-001/002: SessionStart e SessionEnd
+- HOOK-MATCHER-001/002/003: Matcher syntax config-driven
+
+Os gaps de prioridade Média/Baixa (Notification, SubagentStop dedicado,
+shell hooks nativos, telemetry) ficam para RFCs futuros.
+
+## Convenções EARS
+
+Padrões usados:
+- **Ubiquitous:** "The system shall..."
+- **Event-driven:** "When <trigger>, the system shall..."
+- **State-driven:** "While <state>, the system shall..."
+- **Unwanted behavior:** "If <condition>, the system shall..."
+- **Optional:** "Where <feature>, the system shall..."
+
+Identificador: `HOOK-<CATEGORY>-<NUMBER>`
+
+---
+
+## HOOK-STOP-001: Stop event fires at end of agent turn
+
+**Statement:** When the agent completes a turn (no more tool calls pending and
+no additional LLM iteration scheduled), the OpenCode runtime shall fire a
+`"stop"` hook for all loaded plugins with input
+`{ sessionID: string, agent: string, messageID: string, reason: "completed" | "aborted" | "error" }`
+and output `{ continue: boolean }`.
+
+**Rationale:** Claude Code defines `Stop` hook for this case. OpenCode
+currently has no equivalent; users must heuristically infer end-of-turn
+from `tool.execute.after`. Without this, plugins cannot reliably clean up
+state, notify external systems, or trigger post-turn workflows.
+
+**Verification:**
+- Goldens (input/output fixtures) defined in `packages/opencode/test/hook-stop.test.ts`
+- Property test: for any session with at least one completed turn, exactly
+  one `stop` hook fires per turn (never zero, never two).
+- Failure injection: simulate tool execution failure; verify `reason: "error"`
+  path fires exactly once.
+- Mutation test: remove `stop` invocation from
+  `packages/opencode/src/session/prompt.ts`; suite must catch it.
+
+**Negative cases:**
+- If `reason: "error"` and the plugin sets `output.continue = true`, the
+  runtime shall NOT retry the turn — the error stands.
+- If `reason: "aborted"` (user interrupted via Ctrl-C), the runtime shall
+  NOT call `stop` more than once even if the plugin throws.
+
+---
+
+## HOOK-SESSION-001: SessionStart fires once per session
+
+**Statement:** When a session is created (via API call or CLI invocation),
+the OpenCode runtime shall fire a `"session.start"` hook for all loaded
+plugins with input `{ sessionID: string, cwd: string, agent: string, timestamp: number }`
+and output `{ metadata: Record<string, unknown> }`.
+
+**Rationale:** Claude Code defines `SessionStart` for plugin authors to
+initialize state, set up databases, register background workers.
+OpenCode only has `dispose` (end-of-life) — asymmetric.
+
+**Verification:**
+- Goldens: input contract matches schema above
+- Property test: for any N sessions created, exactly N `session.start`
+  events fire (no duplicates, no drops)
+- Concurrency test: create 100 sessions in parallel; verify each fires
+  its own `session.start` with correct `sessionID`
+
+**Negative cases:**
+- If a plugin throws during `session.start`, the session shall still be
+  created. The throw shall be logged but not propagate.
+- If `output.metadata` contains keys that conflict with reserved session
+  metadata keys (`sessionID`, `cwd`, `agent`, `timestamp`), the runtime
+  shall reject the modification with `Error("reserved metadata key")`.
+
+---
+
+## HOOK-SESSION-002: SessionEnd fires before dispose
+
+**Statement:** While a session is shutting down, the OpenCode runtime shall
+fire a `"session.end"` hook for all loaded plugins with input
+`{ sessionID: string, duration_ms: number, turn_count: number, reason: "user_exit" | "error" | "timeout" }`
+and output `{ cleanup: boolean }`. After all `session.end` hooks resolve,
+the runtime shall call the existing `dispose` lifecycle.
+
+**Rationale:** Claude Code distinguishes `SessionEnd` (about to clean up)
+from internal dispose. Plugins need the signal BEFORE state is destroyed
+to commit pending work.
+
+**Verification:**
+- Goldens verify the order: `session.end` → plugin code can still access
+  session storage → then `dispose` fires
+- Property test: for any session that ends normally, exactly one
+  `session.end` fires
+- Integration test: plugin writes a file in `session.end`; assert file
+  exists after dispose
+
+**Negative cases:**
+- If a plugin sets `output.cleanup = false`, the runtime shall force
+  cleanup anyway after a 5-second timeout (hard ceiling, no opt-out).
+- If `reason: "error"`, the runtime shall NOT block shutdown waiting
+  for slow hooks; bail-out after 2-second timeout with warning logged.
+
+---
+
+## HOOK-MATCHER-001: Matcher field in hook config
+
+**Statement:** Where a plugin defines a hook in `opencode.json` via the
+`"hooks"` section, the runtime shall parse a `"matcher"` field per hook
+entry as either a string (exact tool name) or a regex pattern
+(`/regex/` syntax) and apply the hook only when the runtime event matches.
+
+**Rationale:** Today every hook fires for every tool call. Plugin authors
+must write `if (input.tool === "bash") { ... }` in code. A config-driven
+matcher is more discoverable, auditable, and reusable.
+
+**Verification:**
+- Property test: for any matcher string and any tool name, the matcher
+  function returns true iff tool name equals matcher (case-sensitive,
+  exact match).
+- Property test: for any regex matcher `/foo|bar/` and tool name, the
+  matcher returns true iff regex matches.
+- Negative: empty matcher `""` shall match nothing.
+- Negative: malformed regex `/[invalid/` shall fail closed with config
+  validation error at startup, NOT at hook-fire time.
+
+**Negative cases:**
+- If matcher is a plain string that contains regex metacharacters
+  (e.g. `bash.execute`), it shall be treated as a literal string, NOT
+  as a regex. Only `/.../` syntax opts into regex.
+
+---
+
+## HOOK-MATCHER-002: Matcher applies to event-specific input
+
+**Statement:** When a matcher is configured for an event, the runtime
+shall match against the event-specific field:
+
+| Event | Field matched |
+|-------|---------------|
+| `tool.execute.before` / `tool.execute.after` | `input.tool` |
+| `command.execute.before` | `input.command` |
+| `chat.message` | `input.sessionID` (no matcher, all sessions) |
+| `permission.ask` | `input.action` |
+| `stop` | `input.reason` |
+| `session.start` / `session.end` | (no matcher; fires once) |
+
+**Rationale:** Different events have different discriminators. A matcher
+on `tool.execute.before` matching tool name is natural; on `chat.message`
+it would match session ID, which is rarely what users want.
+
+**Verification:**
+- Goldens per event type with both matching and non-matching input.
+- Negative: matcher on `session.start` shall be silently ignored
+  (matcher never blocks lifecycle events).
+
+---
+
+## HOOK-MATCHER-003: Multiple hooks ordered by priority field
+
+**Statement:** Where multiple hooks match a single event, the runtime
+shall execute them in ascending order of a `"priority"` field
+(integer, default 100) with ties broken by plugin load order.
+
+**Rationale:** Today plugins execute in undefined order. With multiple
+hooks (e.g., safety check before audit logger), explicit ordering
+matters. Priority 100 default keeps existing behavior compatible.
+
+**Verification:**
+- Property test: for any 3 hooks with priorities [50, 100, 200], the
+  runtime calls them in order [50, 100, 200].
+- Tie-break test: 2 hooks with priority 100 → order is load order.
+- Mutation test: reverse sort order; suite catches.
+
+**Negative cases:**
+- Negative priority values are allowed (use case: "first" hook that
+  runs before all defaults).
+- If priority is not an integer, runtime shall reject config at startup.
+
+---
+
+## HOOK-CONFIG-001: Hook config schema in opencode.json
+
+**Statement:** Where the user provides a `"hooks"` section in
+`opencode.json`, the schema shall be:
+
+```json
+{
+  "hooks": {
+    "<event-name>": [
+      {
+        "matcher": "Bash|Edit",
+        "priority": 100,
+        "plugin": "./plugins/my-plugin.ts",
+        "options": { "strict": true }
+      }
+    ]
+  }
+}
+```
+
+The runtime shall validate the config at startup. Invalid configs
+shall cause startup to fail with a clear error message identifying
+the offending field.
+
+**Rationale:** Config-driven hooks (vs plugin-code-only) is the
+Claude Code model. Allows non-TS users to configure hooks by pointing
+to a plugin file path.
+
+**Verification:**
+- JSON schema test: every example in this spec parses without error.
+- Negative: unknown event name → startup fails with `Error("unknown hook event: <name>")`.
+- Negative: matcher not a string or `/.../` → startup fails.
+- Negative: priority not an integer → startup fails.
+
+---
+
+## Traceability
+
+| REQ | Source analysis section | Verified by |
+|-----|------------------------|-------------|
+| HOOK-STOP-001 | §3.1 Stop hook | goldens + property test |
+| HOOK-SESSION-001 | §3.2 SessionStart | goldens + concurrency test |
+| HOOK-SESSION-002 | §3.2 SessionEnd | goldens + integration test |
+| HOOK-MATCHER-001 | §3.3 Matcher syntax | property test |
+| HOOK-MATCHER-002 | §3.3 (event-specific) | goldens per event |
+| HOOK-MATCHER-003 | §3.3 (ordering) | property test |
+| HOOK-CONFIG-001 | §5 config schema | JSON schema test |
+
+## Out of scope
+
+Not addressed here (covered in future specs if prioritized):
+- Shell-based hooks (external command execution)
+- HTTP/webhook hooks
+- Notification event
+- SubagentStop dedicated event
+- Hook telemetry/logging
+- Hook sandboxing/permissions for untrusted hooks
+
+## Risks identificados
+
+- **Performance:** matcher evaluation on every hook fire adds overhead.
+  Mitigation: cache compiled regex; benchmark overhead, budget ≤ 50μs per fire.
+- **Config bloat:** if users define many matchers, config file grows.
+  Mitigation: support glob patterns as third matcher form (`*.ts`).
+- **Backward compat:** new events must not break existing plugins that
+  only implement a subset of `Hooks` interface. All new fields are optional.

--- a/docs/hooks-research/03-rfc-hooks-extension.md
+++ b/docs/hooks-research/03-rfc-hooks-extension.md
@@ -1,0 +1,284 @@
+# RFC-001: Hook System Extensions for OpenCode
+
+> Status: **DRAFT**
+> Author: analysis pipeline (Mar 2026)
+> Tracking: implements HOOK-STOP-001, HOOK-SESSION-001/002, HOOK-MATCHER-001/002/003,
+> HOOK-CONFIG-001 from `02-ears-requirements.md`.
+
+## Summary
+
+Extend the OpenCode hook system with three additions:
+
+1. **New lifecycle events:** `stop`, `session.start`, `session.end`
+2. **Config-driven matcher syntax** via `opencode.json`
+3. **No breaking changes** to existing `Hooks` interface — purely additive
+
+## Motivation
+
+Analysis (`01-comparative-analysis.md`) identified three high-priority gaps
+where OpenCode lags Claude Code:
+
+| Gap | Impact |
+|-----|--------|
+| No `stop` hook | Users cannot reliably detect end-of-turn for cleanup/notification |
+| No `SessionStart`/`SessionEnd` | Plugin lifecycle is asymmetric; init-before-cleanup missing |
+| No matcher config | Every hook fires for every event; code-level filtering only |
+
+These are **not architectural gaps** — the existing `plugin.trigger(name, input, output)`
+machinery in `packages/opencode/src/session/prompt.ts` is sound. The
+extension is **event surface area + configuration layer**, not core rewrites.
+
+## Detailed design
+
+### D1. New events in `Hooks` interface
+
+In `packages/plugin/src/index.ts`, append to the `Hooks` interface:
+
+```ts
+export interface Hooks {
+  // ... existing fields ...
+
+  /**
+   * Fires once at end of agent turn.
+   * `reason` indicates completion status; `continue` allows plugin to
+   * request another turn (advanced; default false).
+   */
+  stop?: (input: {
+    sessionID: string
+    agent: string
+    messageID: string
+    reason: "completed" | "aborted" | "error"
+  }, output: { continue: boolean }) => Promise<void>
+
+  /**
+   * Fires once when session is created, before any tool calls.
+   * Plugin may add to `metadata` (reserved keys blocked).
+   */
+  "session.start"?: (input: {
+    sessionID: string
+    cwd: string
+    agent: string
+    timestamp: number
+  }, output: { metadata: Record<string, unknown> }) => Promise<void>
+
+  /**
+   * Fires once before session shutdown, before `dispose`.
+   * `cleanup: false` defers forced cleanup for max 5s.
+   */
+  "session.end"?: (input: {
+    sessionID: string
+    duration_ms: number
+    turn_count: number
+    reason: "user_exit" | "error" | "timeout"
+  }, output: { cleanup: boolean }) => Promise<void>
+}
+```
+
+### D2. Trigger sites
+
+Three new files modified; no new files at trigger sites.
+
+**`packages/opencode/src/session/prompt.ts`** — emit `stop`:
+
+After the existing `tool.execute.after` for TaskTool at line 390, wrap the
+end-of-turn in a new helper:
+
+```ts
+async function emitStop(
+  sessionID: string,
+  agent: string,
+  messageID: string,
+  reason: "completed" | "aborted" | "error",
+) {
+  const output = { continue: false }
+  await plugin.trigger("stop",
+    { sessionID, agent, messageID, reason },
+    output,
+  )
+  return output
+}
+```
+
+Call sites:
+- After turn completes naturally → `emitStop(..., "completed")`
+- When `abort.signal` fires → `emitStop(..., "aborted")`
+- When unrecoverable error in tool loop → `emitStop(..., "error")`
+
+**`packages/opencode/src/session/session.ts`** (or equivalent) — emit
+`session.start` and `session.end`:
+
+```ts
+// On session create
+async function onSessionCreate(input: { sessionID, cwd, agent }) {
+  const output = { metadata: {} }
+  await plugin.trigger("session.start", { ...input, timestamp: Date.now() }, output)
+  return output.metadata
+}
+
+// On session destroy (before existing dispose)
+async function onSessionDestroy(input: { sessionID, turn_count }) {
+  const output = { cleanup: true }
+  await Promise.race([
+    plugin.trigger("session.end", {
+      ...input,
+      duration_ms: Date.now() - session.started_at,
+      reason: detectReason(),
+    }, output),
+    timeout(5000, "session.end timeout"),
+  ])
+  // dispose runs regardless of cleanup flag
+}
+```
+
+### D3. Matcher config layer
+
+New file: `packages/core/src/config/hook-matcher.ts`
+
+```ts
+export type Matcher =
+  | string           // exact match (e.g. "bash")
+  | RegExp           // compiled from /foo/i or /foo/
+  | { glob: string } // future: glob patterns
+
+export type HookConfigEntry = {
+  matcher?: string | RegExp
+  priority?: number  // default 100
+  plugin: string     // path to plugin module
+  options?: Record<string, unknown>
+}
+
+export type HooksConfig = {
+  [eventName: string]: HookConfigEntry[]
+}
+
+export function parseMatcher(value: string | undefined): Matcher | null {
+  if (value === undefined) return null
+  if (value.startsWith("/") && value.endsWith("/")) {
+    const body = value.slice(1, -1)
+    try {
+      return new RegExp(body)
+    } catch {
+      throw new ConfigError(`invalid regex matcher: ${value}`)
+    }
+  }
+  return value
+}
+
+export function matches(matcher: Matcher | null, value: string): boolean {
+  if (matcher === null) return true
+  if (typeof matcher === "string") return matcher === value
+  return matcher.test(value)
+}
+```
+
+### D4. Integration with existing trigger
+
+Modify `plugin.trigger` in `packages/opencode/src/plugin/index.ts`
+(or wherever defined — to be located) to consult `hooks` config from
+`opencode.json` and apply matchers BEFORE invoking each plugin hook.
+
+**Key insight:** existing `Hooks` interface stays unchanged. The new
+config-driven hooks are an **additional layer** on top. Plugins that
+already implement hook fields continue to work; the config layer adds
+**declarative** hooks that call into plugin modules.
+
+### D5. Config schema
+
+Add to `packages/core/src/config/schema.ts`:
+
+```ts
+const HookConfigEntry = z.object({
+  matcher: z.string().optional(),
+  priority: z.number().int().default(100),
+  plugin: z.string(),
+  options: z.record(z.unknown()).optional(),
+})
+
+export const HooksConfigSchema = z.record(z.array(HookConfigEntry))
+```
+
+## Alternatives considered
+
+### A1. Replace `Hooks` interface with new declarative system
+
+**Rejected.** Breaking change to existing plugins. Migration cost high
+for marginal benefit. The two-system approach (code + config) is
+additive.
+
+### A2. Implement shell hooks now
+
+**Deferred to RFC-002.** Requires defining cross-platform I/O contract
+(JSON via stdin/stdout? binary protocol?). Worth doing but out of scope
+for MVP. Adding shell hooks without the matcher layer means users have
+to write shell scripts that re-implement filtering logic.
+
+### A3. Single hook for all lifecycle events (`lifecycle` event with discriminator)
+
+**Rejected.** Loses type safety. Matchers per event are more composable.
+
+## Drawbacks
+
+- **Two ways to define hooks:** code (existing) and config (new).
+  Could confuse users. Mitigation: clear docs, default to config where
+  possible, deprecate code-only for simple cases (future).
+- **Config parsing surface area:** another schema to maintain.
+  Mitigation: reuse existing `opencode.json` parsing infrastructure.
+
+## Implementation plan
+
+Phase 1 (1-2 weeks): events only, no matcher
+- Add `stop`, `session.start`, `session.end` to `Hooks` interface
+- Emit at correct trigger sites
+- Goldens + property tests
+
+Phase 2 (2-3 weeks): matcher config
+- `parseMatcher` + `matches` utility
+- Wire into `plugin.trigger`
+- Schema for `opencode.json`
+- Goldens + property tests + mutation tests
+
+Phase 3 (1-2 weeks): docs + examples
+- Update plugin docs with new events
+- Provide example: safety hook for `bash` tool
+- Provide example: cleanup hook on `session.end`
+
+Total: 4-7 weeks. Aligns with §5 estimate in comparative analysis.
+
+## Open questions
+
+1. **Should `output.continue = true` in `stop` hook trigger a new turn?**
+   Proposal: yes, but only if `reason === "completed"`. Documented as
+   advanced usage. Default behavior unchanged.
+
+2. **Where does `session.start` go in the existing
+   `dispose`/`session.end` ordering?**
+   Proposal: `session.start` is **before any tool call**. `session.end`
+   is **before `dispose`**. Symmetric.
+
+3. **Should matcher support glob patterns (`*.ts`)?**
+   Proposal: yes, in Phase 2 if cheap to add; otherwise defer.
+
+4. **What happens if `opencode.json` has invalid `hooks` config?**
+   Proposal: fail closed at startup with clear error pointing to
+   offending field. NOT silently ignore.
+
+## Success criteria
+
+This RFC is successful when:
+
+- [ ] 3 new events fire at correct trigger sites (verified by tests)
+- [ ] Matcher config works for string, regex, and empty cases
+- [ ] No regression in existing plugin behavior
+- [ ] Example plugin demonstrating each new event + matcher exists in
+      `examples/hooks/`
+- [ ] Docs updated in `docs/plugins.md` (or equivalent)
+- [ ] All EARS requirements from `02-ears-requirements.md` pass
+
+## Unresolved / future work
+
+- Shell hook execution (RFC-002 candidate)
+- HTTP/webhook hooks (RFC-003 candidate)
+- Hook sandboxing for untrusted plugins
+- Hook invocation telemetry (logs/metrics)
+- Notification event (depends on shell hooks)
+- SubagentStop dedicated event


### PR DESCRIPTION
## Summary

Three documents under `docs/hooks-research/` analyzing OpenCode's existing hook system against Claude Code's, with EARS requirements and an RFC for the highest-priority gaps.

## Documents

1. **`01-comparative-analysis.md`** — inventory of OpenCode's hook infrastructure (already substantial via `plugin.trigger` in `packages/opencode/src/session/prompt.ts` and `packages/opencode/src/session/tools.ts`). Maps to Claude Code's PreToolUse / PostToolUse / SessionStart / SessionEnd / Stop / etc. Identifies three high-priority gaps and four areas where OpenCode is already superior.

2. **`02-ears-requirements.md`** — seven EARS-style requirements (`HOOK-STOP-001`, `HOOK-SESSION-001/002`, `HOOK-MATCHER-001/002/003`, `HOOK-CONFIG-001`) with verification strategies (goldens, property tests, mutation tests) and explicit negative cases.

3. **`03-rfc-hooks-extension.md`** — DRAFT RFC proposing additive extension of the existing `Hooks` interface plus a config-driven matcher layer. Phased plan (events → matcher → docs/examples), 4–7 weeks total. No breaking changes.

## Findings worth attention

- OpenCode already has a mature hook system. The analysis corrects a prior assumption that it was "limited."
- The real gaps are smaller than expected: `Stop`, `SessionStart`/`End`, and matcher config. Shell-based hooks are deferred to a future RFC.
- OpenCode is already ahead in some areas (`tool.definition`, `chat.params`, `shell.env`).

## Scope of this PR

**Docs only.** No code changes. This PR is a discussion artifact and a reference for the follow-up implementation PR (Phase 1 of the RFC: add the three new event fields to the `Hooks` interface and emit them at the correct trigger sites).

## Follow-up

If accepted, I'll open a separate PR for Phase 1 (new events only, no matcher layer) per the RFC. Estimated 1–2 weeks. Implementation will be gated on this docs PR landing first to confirm the direction.

## Checklist

- [x] Docs only, no code changes
- [x] Conventional Commits style
- [x] Verified against current `dev` branch (`8a6cf2c9`)
- [x] Each document internally cross-referenced; EARS references the analysis; RFC references the EARS