### PR TITLE
fix(core): retry transient compaction failures

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -417,112 +417,105 @@ export const layer = Layer.effect(
         },
       })
       const retry = yield* SessionRunnerRetry.policy(context.session.id)
-      // Keep transient retries separate from the one template correction.
-      let corrected = false
-      while (true) {
-        chunks.length = 0
-        providerState = undefined
-        failure = undefined
-        const retried = yield* llm
-          .stream(
-            !corrected
-              ? prepared.request
-              : LLMRequest.update(prepared.request, {
-                  messages: [
-                    ...prepared.request.messages,
-                    Message.user(
-                      "The previous response did not fill in the required summary template. Do not call tools. Return the summary as text using the exact section headings from the template.",
-                    ),
-                  ],
-                }),
-            prepared.options,
-          )
-          .pipe(
-            Stream.runForEach((event) => {
-              if (LLMEvent.is.providerError(event))
+      // Both requests share the retry allowance; rejected output never enters the reminder request.
+      for (const request of [
+        prepared.request,
+        LLMRequest.update(prepared.request, {
+          messages: [
+            ...prepared.request.messages,
+            Message.user(
+              "The previous response did not fill in the required summary template. Do not call tools. Return the summary as text using the exact section headings from the template.",
+            ),
+          ],
+        }),
+      ]) {
+        yield* Stream.suspend(() => {
+          chunks.length = 0
+          providerState = undefined
+          failure = undefined
+          return llm.stream(request, prepared.options)
+        }).pipe(
+          Stream.runForEach((event) => {
+            if (LLMEvent.is.providerError(event))
+              failure = {
+                type: event.classification === "context-overflow" ? "provider.invalid-request" : "provider.error",
+                message: event.message,
+              }
+            if (LLMEvent.is.textDelta(event)) {
+              chunks.push(event.text)
+              return bus.publish(SessionEvent.Compaction.Delta, {
+                sessionID: context.session.id,
+                text: event.text,
+              })
+            }
+            if (LLMEvent.is.stepFinish(event)) {
+              providerState =
+                event.providerMetadata?.[context.model.model.route.providerMetadataKey ?? context.model.model.provider]
+              const step = SessionUsage.record(event.usage, context.model.cost)
+              usage = usage ? SessionUsage.add(usage, step) : step
+            }
+            if (LLMEvent.is.finish(event)) {
+              if (event.reason.normalized === "length")
+                failure = { type: "compaction.failed", message: "Compaction summary reached the output token limit" }
+              if (event.reason.normalized === "content-filter")
                 failure = {
-                  type: event.classification === "context-overflow" ? "provider.invalid-request" : "provider.error",
-                  message: event.message,
+                  type: "provider.content-filter",
+                  message: "Compaction summary was blocked by the provider",
                 }
-              if (LLMEvent.is.textDelta(event)) {
-                chunks.push(event.text)
-                return bus.publish(SessionEvent.Compaction.Delta, {
-                  sessionID: context.session.id,
-                  text: event.text,
-                })
-              }
-              if (LLMEvent.is.stepFinish(event)) {
-                providerState =
-                  event.providerMetadata?.[
-                    context.model.model.route.providerMetadataKey ?? context.model.model.provider
-                  ]
-                const step = SessionUsage.record(event.usage, context.model.cost)
-                usage = usage ? SessionUsage.add(usage, step) : step
-              }
-              if (LLMEvent.is.finish(event)) {
-                if (event.reason.normalized === "length")
-                  failure = { type: "compaction.failed", message: "Compaction summary reached the output token limit" }
-                if (event.reason.normalized === "content-filter")
-                  failure = {
-                    type: "provider.content-filter",
-                    message: "Compaction summary was blocked by the provider",
-                  }
-                if (event.reason.normalized === "unknown")
-                  return Effect.fail(
-                    new AIError({
-                      reason: new InvalidProviderOutputError({
-                        message: "The provider response ended with an unknown finish reason.",
-                        classification: "incomplete-stream",
-                      }),
+              if (event.reason.normalized === "unknown")
+                return Effect.fail(
+                  new AIError({
+                    reason: new InvalidProviderOutputError({
+                      message: "The provider response ended with an unknown finish reason.",
+                      classification: "incomplete-stream",
                     }),
-                  )
-                if (event.reason.normalized === "error")
-                  return Effect.fail(
-                    new AIError({ reason: new UnknownProviderError({ message: "Compaction generation failed" }) }),
-                  )
-              }
-              return Effect.void
+                  }),
+                )
+              if (event.reason.normalized === "error")
+                return Effect.fail(
+                  new AIError({ reason: new UnknownProviderError({ message: "Compaction generation failed" }) }),
+                )
+            }
+            return Effect.void
+          }),
+          Effect.retry({
+            while: (cause) =>
+              Effect.gen(function* () {
+                if (isContextOverflowFailure(cause)) return false
+                const decision = yield* retry({
+                  cause,
+                  error: toSessionError(cause),
+                  agent: Agent.ID.make("compaction"),
+                  model: context.model.ref,
+                  hook: prepared.retry,
+                  retry: SessionRunnerRetry.isRetryable(cause),
+                })
+                if (!decision.retry) return false
+                yield* Effect.sleep(decision.delay)
+                return true
+              }),
+          }),
+          Effect.catchTag("AI.Error", (error) =>
+            Effect.sync(() => {
+              failure = toSessionError(error)
             }),
-            Effect.matchEffect({
-              onSuccess: () => Effect.succeed(false),
-              onFailure: (cause) =>
-                Effect.gen(function* () {
-                  failure = toSessionError(cause)
-                  if (isContextOverflowFailure(cause)) return false
-                  const decision = yield* retry({
-                    cause,
-                    error: failure,
-                    agent: Agent.ID.make("compaction"),
-                    model: context.model.ref,
-                    hook: prepared.retry,
-                    retry:
-                      SessionRunnerRetry.isRetryable(cause) ||
-                      (cause.reason._tag === "Transport" && cause.reason.operation === "read"),
-                  })
-                  if (!decision.retry) return false
-                  yield* Effect.sleep(decision.delay)
-                  return true
-                }),
-            }),
-            Effect.onInterrupt(() =>
-              recordUsage.pipe(
-                Effect.andThen(
-                  input.reason === "auto"
-                    ? failed({
-                        sessionID: context.session.id,
-                        reason: input.reason,
-                        error: { type: "compaction.interrupted", message: "Compaction was interrupted" },
-                        inputID: input.inputID,
-                      }).pipe(Effect.asVoid)
-                    : Effect.void,
-                ),
+          ),
+          Effect.onInterrupt(() =>
+            recordUsage.pipe(
+              Effect.andThen(
+                input.reason === "auto"
+                  ? failed({
+                      sessionID: context.session.id,
+                      reason: input.reason,
+                      error: { type: "compaction.interrupted", message: "Compaction was interrupted" },
+                      inputID: input.inputID,
+                    }).pipe(Effect.asVoid)
+                  : Effect.void,
               ),
             ),
-          )
-        if (retried) continue
-        if (failure || hasSummarySection(chunks.join("")) || corrected) break
-        // Ignored output never enters the correction request or needs fabricated tool results.
-        corrected = true
+          ),
+        )
+        if (failure || hasSummarySection(chunks.join(""))) break
       }
       yield* recordUsage
       const summary = chunks.join("")

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -1,6 +1,16 @@
 export * as SessionCompaction from "./compaction.js"
 
-import { LLMClient, LLMEvent, LLMRequest, Message, type ContentPart } from "@opencode-ai/ai"
+import {
+  AIError,
+  InvalidProviderOutputError,
+  UnknownProviderError,
+  isContextOverflowFailure,
+  LLMClient,
+  LLMEvent,
+  LLMRequest,
+  Message,
+  type ContentPart,
+} from "@opencode-ai/ai"
 import { Agent } from "@opencode-ai/schema/agent"
 import { SessionError } from "@opencode-ai/schema/session-error"
 import { Context, Effect, Layer, Stream } from "effect"
@@ -12,6 +22,7 @@ import type { SessionContext } from "./context.js"
 import type { SessionMessage } from "./message.js"
 import { SessionModelRequest } from "./model-request.js"
 import type { SessionRunnerModel } from "./runner/model.js"
+import { SessionRunnerRetry } from "./runner/retry.js"
 import { SessionSchema } from "./schema.js"
 import { toSessionError } from "./to-session-error.js"
 import { Token } from "../util/token.js"
@@ -405,13 +416,16 @@ export const layer = Layer.effect(
           ],
         },
       })
-      // Ignored tool calls never enter the follow-up history or need fabricated results.
-      for (let attempt = 0; attempt < 2; attempt++) {
+      const retry = yield* SessionRunnerRetry.policy(context.session.id)
+      // Keep transient retries separate from the one template correction.
+      let corrected = false
+      while (true) {
         chunks.length = 0
         providerState = undefined
-        yield* llm
+        failure = undefined
+        const retried = yield* llm
           .stream(
-            attempt === 0
+            !corrected
               ? prepared.request
               : LLMRequest.update(prepared.request, {
                   messages: [
@@ -445,13 +459,51 @@ export const layer = Layer.effect(
                 const step = SessionUsage.record(event.usage, context.model.cost)
                 usage = usage ? SessionUsage.add(usage, step) : step
               }
+              if (LLMEvent.is.finish(event)) {
+                if (event.reason.normalized === "length")
+                  failure = { type: "compaction.failed", message: "Compaction summary reached the output token limit" }
+                if (event.reason.normalized === "content-filter")
+                  failure = {
+                    type: "provider.content-filter",
+                    message: "Compaction summary was blocked by the provider",
+                  }
+                if (event.reason.normalized === "unknown")
+                  return Effect.fail(
+                    new AIError({
+                      reason: new InvalidProviderOutputError({
+                        message: "The provider response ended with an unknown finish reason.",
+                        classification: "incomplete-stream",
+                      }),
+                    }),
+                  )
+                if (event.reason.normalized === "error")
+                  return Effect.fail(
+                    new AIError({ reason: new UnknownProviderError({ message: "Compaction generation failed" }) }),
+                  )
+              }
               return Effect.void
             }),
-            Effect.catchTag("AI.Error", (error) =>
-              Effect.sync(() => {
-                failure = toSessionError(error)
-              }),
-            ),
+            Effect.matchEffect({
+              onSuccess: () => Effect.succeed(false),
+              onFailure: (cause) =>
+                Effect.gen(function* () {
+                  failure = toSessionError(cause)
+                  if (isContextOverflowFailure(cause)) return false
+                  const decision = yield* retry({
+                    cause,
+                    error: failure,
+                    agent: Agent.ID.make("compaction"),
+                    model: context.model.ref,
+                    hook: prepared.retry,
+                    retry:
+                      SessionRunnerRetry.isRetryable(cause) ||
+                      (cause.reason._tag === "Transport" && cause.reason.operation === "read"),
+                  })
+                  if (!decision.retry) return false
+                  yield* Effect.sleep(decision.delay)
+                  return true
+                }),
+            }),
             Effect.onInterrupt(() =>
               recordUsage.pipe(
                 Effect.andThen(
@@ -467,7 +519,10 @@ export const layer = Layer.effect(
               ),
             ),
           )
-        if (failure || hasSummarySection(chunks.join(""))) break
+        if (retried) continue
+        if (failure || hasSummarySection(chunks.join("")) || corrected) break
+        // Ignored output never enters the correction request or needs fabricated tool results.
+        corrected = true
       }
       yield* recordUsage
       const summary = chunks.join("")

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -78,11 +78,11 @@ const schedule = Schedule.max([Schedule.exponential("2 seconds"), Schedule.recur
   }),
 )
 
-export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
+export const policy = (sessionID: SessionSchema.ID) =>
   Effect.gen(function* () {
     const step = yield* Schedule.toStep(schedule)
     let attempt = 1
-    const decide = (input: Input) =>
+    return (input: Input) =>
       Effect.gen(function* () {
         const now = yield* Clock.currentTimeMillis
         const next = yield* step(now, input).pipe(Pull.catchDone(() => Effect.succeed(undefined)))
@@ -104,6 +104,11 @@ export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
           Number.isFinite(event.decision.delay) && event.decision.delay >= 0 ? Math.ceil(event.decision.delay) : delay
         return { retry: true as const, attempt, delay: normalized }
       })
+  })
+
+export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
+  Effect.gen(function* () {
+    const decide = yield* policy(sessionID)
     const wait = (input: {
       readonly decision: Decision
       readonly assistantMessageID: SessionMessage.ID

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import {
   AIError,
+  HttpContext,
   LLMEvent,
   LLMRequest,
   Message,
@@ -2337,26 +2338,46 @@ describe("SessionRunnerLLM", () => {
     })
   }
 
-  scenario("allows the retry hook to stop compaction retries", function* (s) {
-    yield* s.llm.push(TestLLM.text("Earlier answer", "history"))
-    yield* s.runPrompt("Earlier question")
-    s.requests.length = 0
-    const hooks = yield* PluginHooks.Service
-    yield* hooks.register("session", "retry", (event) =>
-      Effect.sync(() => {
-        event.decision = { retry: false }
-      }),
-    )
-    yield* s.llm.push(Stream.fail(incompleteStream()))
-    const compaction = yield* s.session.compact({ sessionID })
-    yield* s.resume
+  for (const header of [false, true]) {
+    scenario(`stops compaction retries through the ${header ? "provider header" : "retry hook"}`, function* (s) {
+      yield* s.llm.push(TestLLM.text("Earlier answer", "history"))
+      yield* s.runPrompt("Earlier question")
+      s.requests.length = 0
+      const hooks = yield* PluginHooks.Service
+      yield* hooks.register("session", "retry", (event) =>
+        Effect.sync(() => {
+          expect(event.decision.retry).toBe(!header)
+          event.decision = { retry: false }
+        }),
+      )
+      yield* s.llm.push(
+        Stream.fail(
+          header
+            ? new AIError({
+                reason: new TransportError({
+                  message: "Connection closed",
+                  transport: "http",
+                  operation: "read",
+                  http: new HttpContext({
+                    url: "https://example.com",
+                    status: 200,
+                    headers: { "x-should-retry": "false" },
+                  }),
+                }),
+              })
+            : incompleteStream(),
+        ),
+      )
+      const compaction = yield* s.session.compact({ sessionID })
+      yield* s.resume
 
-    expect(s.requests).toHaveLength(1)
-    expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
-      status: "failed",
-      error: { type: "provider.invalid-output" },
+      expect(s.requests).toHaveLength(1)
+      expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
+        status: "failed",
+        error: { type: header ? "provider.transport" : "provider.invalid-output" },
+      })
     })
-  })
+  }
 
   for (const response of ["length", "content-filter", "invalid request", "context overflow"] as const) {
     scenario(`rejects compaction ${response} without retrying or committing its draft`, function* (s) {

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2260,47 +2260,179 @@ describe("SessionRunnerLLM", () => {
     }
   }
 
-  scenario("preserves typed provider failures from manual compaction", function* (s) {
+  scenario("restarts compaction drafts after transient failures and unsuccessful finishes", function* (s) {
     yield* s.llm.push(TestLLM.text("Earlier answer", "text-manual-failure-history"))
     yield* s.runPrompt("Earlier question")
-
-    yield* s.llm.push(Stream.fail(providerUnavailable()))
+    s.requests.length = 0
+    const hooks = yield* PluginHooks.Service
+    const retries: PluginHooks.Domains["session"]["retry"][] = []
+    yield* hooks.register("session", "retry", (event) =>
+      Effect.sync(() => {
+        retries.push({ ...event })
+        event.decision = { retry: true, delay: 0 }
+      }),
+    )
+    const draft = TestLLM.complete(
+      {
+        reason: { normalized: "unknown" },
+        usage: { nonCachedInputTokens: 10 },
+        providerMetadata: { openai: { responseId: "discarded-draft" } },
+      },
+      LLMEvent.textDelta({ id: "draft", text: "## Objective\n- Partial draft" }),
+    )
+    yield* s.llm.push(
+      TestLLM.failAfter(streamDisconnected(), ...draft.slice(0, -1)),
+      draft,
+      TestLLM.complete(
+        { reason: { normalized: "error" } },
+        LLMEvent.textDelta({ id: "failed", text: "## Objective\n- Failed draft" }),
+      ),
+      Stream.fail(rateLimited(60_000)),
+      TestLLM.textWithUsage("## Objective\n- Accepted summary", "accepted", 30),
+    )
     const compaction = yield* s.session.compact({ sessionID })
     yield* s.resume
 
+    expect(s.requests).toHaveLength(5)
+    for (const request of s.requests) expect(request).toEqual(s.requests[0])
+    expect(retries.map((event) => event.attempt)).toEqual([2, 3, 4, 5])
+    expect(retries.every((event) => event.sessionID === sessionID && event.agent === "compaction")).toBe(true)
+    expect(retries[3].decision).toEqual({ retry: true, delay: 60_000 })
     expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
-      type: "compaction",
-      status: "failed",
-      error: { type: "provider.transport", message: "Provider unavailable" },
+      status: "completed",
+      summary: "## Objective\n- Accepted summary",
     })
+    expect(JSON.stringify(yield* s.messages)).not.toContain("discarded-draft")
+    expect((yield* s.session.get(sessionID))?.tokens.input).toBe(50)
   })
 
-  scenario("records cancelled manual compaction without surfacing an internal failure", function* (s) {
-    yield* s.llm.push(TestLLM.text("Earlier answer", "text-manual-interrupt-history"))
+  for (const correction of [false, true]) {
+    scenario(`bounds compaction network retries with${correction ? "" : "out"} a template correction`, function* (s) {
+      yield* s.llm.push(TestLLM.text("Earlier answer", "history"))
+      yield* s.runPrompt("Earlier question")
+      s.requests.length = 0
+      const hooks = yield* PluginHooks.Service
+      const attempts: number[] = []
+      yield* hooks.register("session", "retry", (event) =>
+        Effect.sync(() => {
+          attempts.push(event.attempt)
+          expect(event.decision).toMatchObject({ retry: true })
+          event.decision = { retry: true, delay: 0 }
+        }),
+      )
+      if (correction) yield* s.llm.push(Stream.fail(providerUnavailable()), TestLLM.text("Not a summary", "invalid"))
+      yield* s.llm.always(Stream.fail(providerUnavailable()))
+      const compaction = yield* s.session.compact({ sessionID })
+      yield* s.resume
+
+      expect(attempts).toEqual([2, 3, 4, 5])
+      expect(s.requests).toHaveLength(correction ? 6 : 5)
+      expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
+        status: "failed",
+        error: { type: "provider.transport", message: "Provider unavailable" },
+      })
+      expect((yield* s.context).some((message) => message.type === "user" && message.text === "Earlier question")).toBe(
+        true,
+      )
+    })
+  }
+
+  scenario("allows the retry hook to stop compaction retries", function* (s) {
+    yield* s.llm.push(TestLLM.text("Earlier answer", "history"))
     yield* s.runPrompt("Earlier question")
-
-    const streamed = yield* Deferred.make<void>()
-    const partial = fragmentFixture("text", "text-manual-interrupt-summary", ["Partial summary"])
-    yield* s.llm.push(
-      Stream.concat(
-        Stream.fromIterable(partial.partialEvents),
-        Stream.fromEffect(Deferred.succeed(streamed, undefined)).pipe(Stream.flatMap(() => Stream.never)),
-      ),
+    s.requests.length = 0
+    const hooks = yield* PluginHooks.Service
+    yield* hooks.register("session", "retry", (event) =>
+      Effect.sync(() => {
+        event.decision = { retry: false }
+      }),
     )
+    yield* s.llm.push(Stream.fail(incompleteStream()))
     const compaction = yield* s.session.compact({ sessionID })
-    const run = yield* s.resume.pipe(Effect.forkChild)
-    yield* Deferred.await(streamed)
-    yield* s.session.interrupt(sessionID)
+    yield* s.resume
 
-    yield* Fiber.await(run)
-    expect(yield* SessionInbox.find(s.db, compaction.id)).toBeUndefined()
+    expect(s.requests).toHaveLength(1)
     expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
-      type: "compaction",
       status: "failed",
-      reason: "manual",
-      error: { type: "aborted", message: "Compaction cancelled" },
+      error: { type: "provider.invalid-output" },
     })
   })
+
+  for (const response of ["length", "content-filter", "invalid request", "context overflow"] as const) {
+    scenario(`rejects compaction ${response} without retrying or committing its draft`, function* (s) {
+      yield* s.llm.push(TestLLM.text("Earlier answer", "history"))
+      yield* s.runPrompt("Earlier question")
+      s.requests.length = 0
+      yield* s.llm.push(
+        response === "invalid request"
+          ? Stream.fail(invalidRequest())
+          : response === "context overflow"
+            ? Stream.fail(
+                new AIError({
+                  reason: new InvalidRequestError({ message: "Too long", classification: "context-overflow" }),
+                }),
+              )
+            : TestLLM.complete(
+                { reason: { normalized: response } },
+                LLMEvent.textDelta({ id: "truncated", text: "## Objective\n- Incomplete summary" }),
+              ),
+      )
+      const compaction = yield* s.session.compact({ sessionID })
+      yield* s.resume
+
+      expect(s.requests).toHaveLength(1)
+      expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({ status: "failed" })
+      yield* s.llm.push(TestLLM.text("Continued", "continued"))
+      yield* s.runPrompt("Continue")
+      expect(userTexts(s.requests[1])).toContain("Earlier question")
+      expect(JSON.stringify(s.requests[1])).not.toContain("Incomplete summary")
+    })
+  }
+
+  for (const phase of ["stream", "backoff"]) {
+    scenario(
+      `records cancelled manual compaction during ${phase} without surfacing an internal failure`,
+      function* (s) {
+        yield* s.llm.push(TestLLM.text("Earlier answer", "text-manual-interrupt-history"))
+        yield* s.runPrompt("Earlier question")
+        s.requests.length = 0
+
+        const streamed = yield* Deferred.make<void>()
+        if (phase === "backoff") {
+          const hooks = yield* PluginHooks.Service
+          yield* hooks.register("session", "retry", () => Deferred.succeed(streamed, undefined))
+        }
+        const partial = fragmentFixture("text", "text-manual-interrupt-summary", ["Partial summary"])
+        yield* s.llm.push(
+          phase === "backoff"
+            ? TestLLM.failAfter(rateLimited(60_000), ...partial.partialEvents)
+            : Stream.concat(
+                Stream.fromIterable(partial.partialEvents),
+                Stream.fromEffect(Deferred.succeed(streamed, undefined)).pipe(Stream.flatMap(() => Stream.never)),
+              ),
+        )
+        const execution = yield* SessionExecution.Service
+        const compaction = yield* s.session.compact({ sessionID })
+        yield* Deferred.await(streamed)
+        if (phase === "backoff") yield* TestClock.adjust("59999 millis")
+        yield* s.session.interrupt(sessionID)
+
+        yield* execution.awaitIdle(sessionID)
+        expect(s.requests).toHaveLength(1)
+        expect(yield* SessionInbox.find(s.db, compaction.id)).toBeUndefined()
+        expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
+          type: "compaction",
+          status: "failed",
+          reason: "manual",
+          error: { type: "aborted", message: "Compaction cancelled" },
+        })
+        yield* s.llm.push(TestLLM.text("Continued", "continued"))
+        yield* s.runPrompt("Continue")
+        expect(userTexts(s.requests[1])).toContain("Earlier question")
+        expect(JSON.stringify(s.requests[1])).not.toContain("Partial summary")
+      },
+    )
+  }
 
   scenario("settles an admitted manual compaction when pre-start resolution throws", function* (s) {
     yield* s.llm.push(TestLLM.text("Earlier answer", "text-manual-resolution-history"))

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2307,36 +2307,34 @@ describe("SessionRunnerLLM", () => {
     expect((yield* s.session.get(sessionID))?.tokens.input).toBe(50)
   })
 
-  for (const correction of [false, true]) {
-    scenario(`bounds compaction network retries with${correction ? "" : "out"} a template correction`, function* (s) {
-      yield* s.llm.push(TestLLM.text("Earlier answer", "history"))
-      yield* s.runPrompt("Earlier question")
-      s.requests.length = 0
-      const hooks = yield* PluginHooks.Service
-      const attempts: number[] = []
-      yield* hooks.register("session", "retry", (event) =>
-        Effect.sync(() => {
-          attempts.push(event.attempt)
-          expect(event.decision).toMatchObject({ retry: true })
-          event.decision = { retry: true, delay: 0 }
-        }),
-      )
-      if (correction) yield* s.llm.push(Stream.fail(providerUnavailable()), TestLLM.text("Not a summary", "invalid"))
-      yield* s.llm.always(Stream.fail(providerUnavailable()))
-      const compaction = yield* s.session.compact({ sessionID })
-      yield* s.resume
+  scenario("bounds compaction network retries across a template correction", function* (s) {
+    yield* s.llm.push(TestLLM.text("Earlier answer", "history"))
+    yield* s.runPrompt("Earlier question")
+    s.requests.length = 0
+    const hooks = yield* PluginHooks.Service
+    const attempts: number[] = []
+    yield* hooks.register("session", "retry", (event) =>
+      Effect.sync(() => {
+        attempts.push(event.attempt)
+        expect(event.decision).toMatchObject({ retry: true })
+        event.decision = { retry: true, delay: 0 }
+      }),
+    )
+    yield* s.llm.push(Stream.fail(providerUnavailable()), TestLLM.text("Not a summary", "invalid"))
+    yield* s.llm.always(Stream.fail(providerUnavailable()))
+    const compaction = yield* s.session.compact({ sessionID })
+    yield* s.resume
 
-      expect(attempts).toEqual([2, 3, 4, 5])
-      expect(s.requests).toHaveLength(correction ? 6 : 5)
-      expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
-        status: "failed",
-        error: { type: "provider.transport", message: "Provider unavailable" },
-      })
-      expect((yield* s.context).some((message) => message.type === "user" && message.text === "Earlier question")).toBe(
-        true,
-      )
+    expect(attempts).toEqual([2, 3, 4, 5])
+    expect(s.requests).toHaveLength(6)
+    expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
+      status: "failed",
+      error: { type: "provider.transport", message: "Provider unavailable" },
     })
-  }
+    expect((yield* s.context).some((message) => message.type === "user" && message.text === "Earlier question")).toBe(
+      true,
+    )
+  })
 
   for (const header of [false, true]) {
     scenario(`stops compaction retries through the ${header ? "provider header" : "retry hook"}`, function* (s) {
@@ -2379,24 +2377,22 @@ describe("SessionRunnerLLM", () => {
     })
   }
 
-  for (const response of ["length", "content-filter", "invalid request", "context overflow"] as const) {
+  for (const response of ["length", "content-filter", "context overflow"] as const) {
     scenario(`rejects compaction ${response} without retrying or committing its draft`, function* (s) {
       yield* s.llm.push(TestLLM.text("Earlier answer", "history"))
       yield* s.runPrompt("Earlier question")
       s.requests.length = 0
       yield* s.llm.push(
-        response === "invalid request"
-          ? Stream.fail(invalidRequest())
-          : response === "context overflow"
-            ? Stream.fail(
-                new AIError({
-                  reason: new InvalidRequestError({ message: "Too long", classification: "context-overflow" }),
-                }),
-              )
-            : TestLLM.complete(
-                { reason: { normalized: response } },
-                LLMEvent.textDelta({ id: "truncated", text: "## Objective\n- Incomplete summary" }),
-              ),
+        response === "context overflow"
+          ? Stream.fail(
+              new AIError({
+                reason: new InvalidRequestError({ message: "Too long", classification: "context-overflow" }),
+              }),
+            )
+          : TestLLM.complete(
+              { reason: { normalized: response } },
+              LLMEvent.textDelta({ id: "truncated", text: "## Objective\n- Incomplete summary" }),
+            ),
       )
       const compaction = yield* s.session.compact({ sessionID })
       yield* s.resume
@@ -2410,50 +2406,32 @@ describe("SessionRunnerLLM", () => {
     })
   }
 
-  for (const phase of ["stream", "backoff"]) {
-    scenario(
-      `records cancelled manual compaction during ${phase} without surfacing an internal failure`,
-      function* (s) {
-        yield* s.llm.push(TestLLM.text("Earlier answer", "text-manual-interrupt-history"))
-        yield* s.runPrompt("Earlier question")
-        s.requests.length = 0
+  scenario("records cancelled manual compaction without surfacing an internal failure", function* (s) {
+    yield* s.llm.push(TestLLM.text("Earlier answer", "text-manual-interrupt-history"))
+    yield* s.runPrompt("Earlier question")
 
-        const streamed = yield* Deferred.make<void>()
-        if (phase === "backoff") {
-          const hooks = yield* PluginHooks.Service
-          yield* hooks.register("session", "retry", () => Deferred.succeed(streamed, undefined))
-        }
-        const partial = fragmentFixture("text", "text-manual-interrupt-summary", ["Partial summary"])
-        yield* s.llm.push(
-          phase === "backoff"
-            ? TestLLM.failAfter(rateLimited(60_000), ...partial.partialEvents)
-            : Stream.concat(
-                Stream.fromIterable(partial.partialEvents),
-                Stream.fromEffect(Deferred.succeed(streamed, undefined)).pipe(Stream.flatMap(() => Stream.never)),
-              ),
-        )
-        const execution = yield* SessionExecution.Service
-        const compaction = yield* s.session.compact({ sessionID })
-        yield* Deferred.await(streamed)
-        if (phase === "backoff") yield* TestClock.adjust("59999 millis")
-        yield* s.session.interrupt(sessionID)
-
-        yield* execution.awaitIdle(sessionID)
-        expect(s.requests).toHaveLength(1)
-        expect(yield* SessionInbox.find(s.db, compaction.id)).toBeUndefined()
-        expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
-          type: "compaction",
-          status: "failed",
-          reason: "manual",
-          error: { type: "aborted", message: "Compaction cancelled" },
-        })
-        yield* s.llm.push(TestLLM.text("Continued", "continued"))
-        yield* s.runPrompt("Continue")
-        expect(userTexts(s.requests[1])).toContain("Earlier question")
-        expect(JSON.stringify(s.requests[1])).not.toContain("Partial summary")
-      },
+    const streamed = yield* Deferred.make<void>()
+    const partial = fragmentFixture("text", "text-manual-interrupt-summary", ["Partial summary"])
+    yield* s.llm.push(
+      Stream.concat(
+        Stream.fromIterable(partial.partialEvents),
+        Stream.fromEffect(Deferred.succeed(streamed, undefined)).pipe(Stream.flatMap(() => Stream.never)),
+      ),
     )
-  }
+    const compaction = yield* s.session.compact({ sessionID })
+    const run = yield* s.resume.pipe(Effect.forkChild)
+    yield* Deferred.await(streamed)
+    yield* s.session.interrupt(sessionID)
+
+    yield* Fiber.await(run)
+    expect(yield* SessionInbox.find(s.db, compaction.id)).toBeUndefined()
+    expect((yield* s.messages).find((message) => message.id === compaction.id)).toMatchObject({
+      type: "compaction",
+      status: "failed",
+      reason: "manual",
+      error: { type: "aborted", message: "Compaction cancelled" },
+    })
+  })
 
   scenario("settles an admitted manual compaction when pre-start resolution throws", function* (s) {
     yield* s.llm.push(TestLLM.text("Earlier answer", "text-manual-resolution-history"))

--- a/packages/www/src/docs/content/compaction.mdx
+++ b/packages/www/src/docs/content/compaction.mdx
@@ -88,6 +88,14 @@ summary must contain at least one heading from the requested template, such as
 to fill in the template correctly. A second invalid response fails compaction.
 Provider-hosted tools remain subject to the selected provider's behavior.
 
+Compaction uses the normal session retry defaults and `session.retry` hook:
+
+- Transient provider failures and interrupted streams restart the summary from
+  scratch, with up to four retries, exponential backoff, jitter, and `Retry-After`.
+- The template correction does not consume or reset that retry allowance.
+- Output-token-limit stops fail compaction instead of saving a truncated summary.
+- Cancellation stops generation or backoff immediately, leaving prior context intact.
+
 The summary records the objective, requirements, decisions, completed and active
 work, blockers, next moves, relevant files, and additional context.
 

--- a/packages/www/src/docs/content/compaction.mdx
+++ b/packages/www/src/docs/content/compaction.mdx
@@ -88,14 +88,6 @@ summary must contain at least one heading from the requested template, such as
 to fill in the template correctly. A second invalid response fails compaction.
 Provider-hosted tools remain subject to the selected provider's behavior.
 
-Compaction uses the normal session retry defaults and `session.retry` hook:
-
-- Transient provider failures and interrupted streams restart the summary from
-  scratch, with up to four retries, exponential backoff, jitter, and `Retry-After`.
-- The template correction does not consume or reset that retry allowance.
-- Output-token-limit stops fail compaction instead of saving a truncated summary.
-- Cancellation stops generation or backoff immediately, leaving prior context intact.
-
 The summary records the objective, requirements, decisions, completed and active
 work, blockers, next moves, relevant files, and additional context.
 


### PR DESCRIPTION
### Issue for this PR

None.

### Type of change

- [x] Bug fix

### What does this PR do?

- Retry transient compaction failures from scratch using the existing session retry policy and hook.
- Reject truncated summaries.
- User cancellation stops compaction without retrying or replacing prior context.

### How did you verify your code works?

257 focused Core tests and Core typecheck passed.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR