### PR TITLE
fix: Add functioning deep links for the desktop app

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -33,6 +33,7 @@ import {
   type JSX,
   lazy,
   onCleanup,
+  onMount,
   type ParentProps,
   Show,
 } from "solid-js"
@@ -46,7 +47,7 @@ import { ServerSyncProvider, useServerSync } from "@/context/server-sync"
 import { GlobalProvider, useGlobal } from "@/context/global"
 import { HighlightsProvider } from "@/context/highlights"
 import { LanguageProvider, type Locale, useLanguage } from "@/context/language"
-import { LayoutProvider } from "@/context/layout"
+import { LayoutProvider, useLayout } from "@/context/layout"
 import { ModelsProvider } from "@/context/models"
 import { NotificationProvider } from "@/context/notification"
 import { PermissionProvider } from "@/context/permission"
@@ -68,6 +69,11 @@ import { createSessionLineage } from "@/pages/session/session-lineage"
 import { SessionPage, SessionRouteErrorBoundary, TargetSessionRouteContent } from "@/pages/session"
 import { NewHome } from "@/pages/home"
 import { LegacyHome } from "@/pages/home/legacy-home"
+import {
+  deepLinkEvent,
+  drainPendingDeepLinks,
+  handleDeepLinks,
+} from "@/pages/layout/deep-links"
 
 const NewSession = lazy(() => import("@/pages/new-session"))
 
@@ -360,6 +366,55 @@ function ServerScopedProviders(props: ServerScopedShellProps) {
   )
 }
 
+function DesktopDeepLinks() {
+  const settings = useSettings()
+  const server = useServer()
+  const layout = useLayout()
+  const tabs = useTabs()
+  const navigate = useNavigate()
+  const pending: string[] = []
+
+  const receive = (urls: string[]) => {
+    if (!settings.general.newLayoutDesigns()) return
+    pending.push(...urls)
+    flush()
+  }
+
+  const flush = () => {
+    if (!settings.general.newLayoutDesigns()) return
+    if (!tabs.ready()) return
+    const urls = pending.splice(0)
+    if (urls.length === 0) return
+
+    handleDeepLinks(urls, {
+      canHandle: server.isLocal,
+      openProject: (directory) => {
+        layout.projects.open(directory)
+        server.projects.touch(directory)
+        layout.home.setSelection({ server: server.key, directory })
+        navigate("/")
+      },
+      openNewSession: (link) => {
+        layout.projects.open(link.directory)
+        server.projects.touch(link.directory)
+        void tabs.newDraft({ server: server.key, directory: link.directory }, link.prompt)
+      },
+    })
+  }
+
+  createEffect(flush)
+
+  onMount(() => {
+    receive(drainPendingDeepLinks(window))
+    makeEventListener(window, deepLinkEvent, (event: Event) => {
+      const detail = (event as CustomEvent<{ urls: string[] }>).detail
+      receive(detail?.urls ?? [])
+    })
+  })
+
+  return null
+}
+
 function LegacyServerScopedShell(props: ServerScopedShellProps) {
   return (
     <ServerScopedProviders directory={props.directory} serverScoped={props.serverScoped}>
@@ -372,6 +427,7 @@ function NewAppLayout(props: ParentProps<{ serverScoped?: JSX.Element }>) {
   return (
     <SelectedServerProviders>
       <ServerScopedProviders serverScoped={props.serverScoped}>
+        <DesktopDeepLinks />
         <NewLayout>{props.children}</NewLayout>
       </ServerScopedProviders>
     </SelectedServerProviders>

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -68,10 +68,9 @@ import {
   sortedRootSessions,
 } from "./layout/helpers"
 import {
-  collectNewSessionDeepLinks,
-  collectOpenProjectDeepLinks,
   deepLinkEvent,
   drainPendingDeepLinks,
+  handleDeepLinks,
 } from "./layout/deep-links"
 import { createInlineEditorController } from "./layout/inline-editor"
 import {
@@ -1249,24 +1248,22 @@ export default function LegacyLayout(props: ParentProps) {
     if (navigate) return navigateToProject(directory)
   }
 
-  const handleDeepLinks = (urls: string[]) => {
-    if (!server.isLocal()) return
-
-    for (const directory of collectOpenProjectDeepLinks(urls)) {
-      void openProject(directory)
-    }
-
-    for (const link of collectNewSessionDeepLinks(urls)) {
-      void openProject(link.directory, false)
-      const slug = base64Encode(link.directory)
-      if (link.prompt) {
-        setSessionHandoff(SessionStateKey.from(server.scope(), SessionRouteKey.fromLegacy(slug)), {
-          prompt: link.prompt,
-        })
-      }
-      const href = link.prompt ? `/${slug}/session?prompt=${encodeURIComponent(link.prompt)}` : `/${slug}/session`
-      navigateWithSidebarReset(href)
-    }
+  const handleLegacyDeepLinks = (urls: string[]) => {
+    handleDeepLinks(urls, {
+      canHandle: () => server.isLocal() && !settings.general.newLayoutDesigns(),
+      openProject: (directory) => void openProject(directory),
+      openNewSession: (link) => {
+        void openProject(link.directory, false)
+        const slug = base64Encode(link.directory)
+        if (link.prompt) {
+          setSessionHandoff(SessionStateKey.from(server.scope(), SessionRouteKey.fromLegacy(slug)), {
+            prompt: link.prompt,
+          })
+        }
+        const href = link.prompt ? `/${slug}/session?prompt=${encodeURIComponent(link.prompt)}` : `/${slug}/session`
+        navigateWithSidebarReset(href)
+      },
+    })
   }
 
   onMount(() => {
@@ -1274,10 +1271,10 @@ export default function LegacyLayout(props: ParentProps) {
       const detail = (event as CustomEvent<{ urls: string[] }>).detail
       const urls = detail?.urls ?? []
       if (urls.length === 0) return
-      handleDeepLinks(urls)
+      handleLegacyDeepLinks(urls)
     }
 
-    handleDeepLinks(drainPendingDeepLinks(window))
+    handleLegacyDeepLinks(drainPendingDeepLinks(window))
     makeEventListener(window, deepLinkEvent, handler as EventListener)
   })
 

--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -36,6 +36,25 @@ export const collectOpenProjectDeepLinks = (urls: string[]) =>
 export const collectNewSessionDeepLinks = (urls: string[]) =>
   urls.map(parseNewSessionDeepLink).filter((link): link is { directory: string; prompt?: string } => !!link)
 
+export function handleDeepLinks(
+  urls: string[],
+  handlers: {
+    canHandle: () => boolean
+    openProject: (directory: string) => void
+    openNewSession: (link: { directory: string; prompt?: string }) => void
+  },
+) {
+  if (!handlers.canHandle()) return
+
+  for (const directory of collectOpenProjectDeepLinks(urls)) {
+    handlers.openProject(directory)
+  }
+
+  for (const link of collectNewSessionDeepLinks(urls)) {
+    handlers.openNewSession(link)
+  }
+}
+
 type OpenCodeWindow = Window & {
   __OPENCODE__?: {
     deepLinks?: string[]

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -3,6 +3,7 @@ import {
   collectNewSessionDeepLinks,
   collectOpenProjectDeepLinks,
   drainPendingDeepLinks,
+  handleDeepLinks,
   parseDeepLink,
   parseNewSessionDeepLink,
 } from "./deep-links"
@@ -109,6 +110,41 @@ describe("layout deep links", () => {
 
     expect(drainPendingDeepLinks(target)).toEqual(["opencode://open-project?directory=/a"])
     expect(drainPendingDeepLinks(target)).toEqual([])
+  })
+
+  test("dispatches project and new-session deep links", () => {
+    const projects: string[] = []
+    const sessions: Array<{ directory: string; prompt?: string }> = []
+
+    handleDeepLinks(
+      [
+        "opencode://open-project?directory=/a",
+        "opencode://new-session?directory=/b&prompt=ship%20it",
+        "opencode://other?directory=/c",
+      ],
+      {
+        canHandle: () => true,
+        openProject: (directory) => projects.push(directory),
+        openNewSession: (link) => sessions.push(link),
+      },
+    )
+
+    expect(projects).toEqual(["/a"])
+    expect(sessions).toEqual([{ directory: "/b", prompt: "ship it" }])
+  })
+
+  test("does not dispatch deep links when handler is disabled", () => {
+    const projects: string[] = []
+    const sessions: Array<{ directory: string; prompt?: string }> = []
+
+    handleDeepLinks(["opencode://open-project?directory=/a", "opencode://new-session?directory=/b"], {
+      canHandle: () => false,
+      openProject: (directory) => projects.push(directory),
+      openNewSession: (link) => sessions.push(link),
+    })
+
+    expect(projects).toEqual([])
+    expect(sessions).toEqual([])
   })
 })
 


### PR DESCRIPTION
### Issue for this PR

Closes #44160 

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The current desktop deep linking functionality is failing because only the legacy app was listening for desktop deep link events. The old deep link handling on desktop was in `packages/app/src/pages/layout.tsx` which is the legacy layout.

The Dev build is using the NewLayout as well which made it easy to test. When the event was firing, it would focus the desktop app Electron window but otherwise be a no-op.

I fixed this by moving event handlers for deep links into the shared app shell area (shared between legacy and new desktop app setups). 

### How did you verify your code works?

I locally tested it + added tests. See below for validation videos.

### Screenshots / recordings

|Before|After|
|------|-----|
|<video src="https://github.com/user-attachments/assets/2f6cb702-f11e-4a57-b5c9-4789e727bc77">|<video src="https://github.com/user-attachments/assets/9d10bcc1-527b-46cb-a97c-293860da457c">|

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
