### PR TITLE
fix(util): skip unused audits during package installs

### DIFF
--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -69,12 +69,16 @@ async function createRegistryFixture(directory: string) {
     await Bun.$`tar -czf package.tgz package`.cwd(root)
     tarballs.set(version, await Bun.file(path.join(root, "package.tgz")).bytes())
   }
-  const state = { latest: "1.0.0" }
+  const state = { latest: "1.0.0", audits: 0 }
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
     fetch(request) {
       const url = new URL(request.url)
+      if (url.pathname.startsWith("/-/npm/v1/security/")) {
+        state.audits++
+        return Response.json({})
+      }
       if (decodeURIComponent(url.pathname) === "/@fixture/registry-plugin")
         return Response.json({
           name: "@fixture/registry-plugin",
@@ -97,7 +101,7 @@ async function createRegistryFixture(directory: string) {
       await fs.mkdir(root, { recursive: true })
       await Bun.write(
         path.join(root, ".npmrc"),
-        `@fixture:registry=${server.url}\ncache=${path.join(directory, "npm-cache")}\nfetch-retries=0\naudit=false\n`,
+        `registry=${server.url}\n@fixture:registry=${server.url}\ncache=${path.join(directory, "npm-cache")}\nfetch-retries=0\naudit=true\n`,
       )
       return root
     },
@@ -359,6 +363,25 @@ describe("Npm.resolve", () => {
 })
 
 describe("Npm.check and Npm.update", () => {
+  test("installs and updates without requesting registry audits", async () => {
+    await using tmp = await tmpdir()
+    await using registry = await createRegistryFixture(tmp.path)
+    const cache = path.join(tmp.path, "cache")
+    const spec = "@fixture/registry-plugin@latest"
+    await registry.configure(cache, spec)
+
+    await Effect.gen(function* () {
+      const npm = yield* Npm.Service
+      expect((yield* npm.add(spec)).version).toBe("1.0.0")
+      expect(registry.state.audits).toBe(0)
+
+      registry.state.latest = "1.1.0"
+      expect((yield* npm.update(spec)).version).toBe("1.1.0")
+      expect(registry.state.audits).toBe(0)
+      expect((yield* npm.resolve(spec)).version).toBe("1.1.0")
+    }).pipe(Effect.scoped, Effect.provide(npmLayer(cache)), Effect.runPromise)
+  })
+
   test("checks a mutable registry target without mutation and explicitly updates it", async () => {
     await using tmp = await tmpdir()
     await using registry = await createRegistryFixture(tmp.path)

--- a/packages/util/src/npm.ts
+++ b/packages/util/src/npm.ts
@@ -210,8 +210,12 @@ const layer = Layer.effect(
       Effect.gen(function* () {
         const { Arborist } = yield* Effect.promise(() => import("@npmcli/arborist"))
         const add = input.add ?? []
-        const npmOptions = yield* NpmConfig.load(input.config ?? input.dir)
-        const options = input.update ? { ...npmOptions, preferOnline: true, noGitRevCache: true } : npmOptions
+        const options = {
+          ...(yield* NpmConfig.load(input.config ?? input.dir)),
+          ...(input.update ? { preferOnline: true, noGitRevCache: true } : {}),
+          // Audit reports are unused here, but Arborist waits for them before completing an install.
+          audit: false,
+        }
         const arborist = new Arborist({
           ...options,
           path: input.dir,


### PR DESCRIPTION
## Why

A plugin update can remain stuck on “updating” after its package files have already downloaded. Arborist waits for its automatic npm vulnerability audit before returning from `reify()`, but OpenCode never reads or displays that audit report. A stalled audit therefore prevents the staged package from becoming the active generation.

In a Bun 1.4.0 reproduction, an audit request timed out after 10 seconds while the equivalent Node request completed in about one second. The live install used a five-minute request timeout.

## What Changes

Set `audit: false` in the options shared by Arborist construction and `reify()` for OpenCode-managed installs and updates.

| Operation | Before | After |
| --- | --- | --- |
| Install or update a managed package | Wait for an unused vulnerability report, potentially after all files are written | Finish without requesting the report |
| npm config contains `audit=true` | Run the audit | Skip the audit for this internal operation only |
| User runs npm directly | Follow the user's npm settings | Unchanged |

The regression test uses the real installer and a local registry with `audit=true`. It checks that both installation and updating complete, the new version becomes resolvable, and no audit endpoint is called. Previously the fixture disabled auditing, hiding this behavior.

## Security Scope

This intentionally removes automatic vulnerability-report requests from the shared managed-package installer, including plugins, provider packages, and formatter packages. It does **not** remove an existing vulnerability enforcement check: OpenCode neither inspected these reports nor rejected installs based on their findings.

Package-integrity verification and the existing `ignoreScripts: true` restriction are unchanged. No global or project npm configuration files are modified. If OpenCode adds a user-facing vulnerability-audit feature later, it should explicitly consume and expose the findings rather than make installation wait for a discarded report.

## Scope

This is an installer-only change; there are no TUI changes. Investigating the underlying Bun/npm HTTP interaction is separate. This PR has not been deployed to the running service.

## Verification

```sh
cd packages/core
bun run test test/npm.test.ts test/npm-config.test.ts
bun run test test/plugin/supervisor.test.ts test/plugin/supervisor-reload.test.ts
bun typecheck
cd ../util
bun typecheck
```

- Regression test failed before the fix: expected zero audit requests, received one. It passes afterward.
- 30 focused tests pass; both package typechecks pass.
- The normal pre-push hook also passed the workspace typecheck: 33 successful tasks.
- A real Git plugin installed in an isolated temporary cache in **11.6 seconds**; an explicit update completed in **8.35 seconds**, with the result verified through `Npm.resolve`. The temporary cache was removed; the live plugin cache and server were not modified.
- `git diff --check` passes. Prettier reports pre-existing formatting differences outside the changed lines; those were left untouched.
