### PR TITLE
fix(core): settle abandoned compactions before resuming sessions

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -1,6 +1,7 @@
 export * as SessionRunnerLLM from "./llm.js"
 
 import { Message } from "@opencode-ai/ai"
+import { and, desc, eq, sql } from "drizzle-orm"
 import { Cause, Effect, Exit, FiberMap, Layer } from "effect"
 import { Database } from "../../database/database.js"
 import { Bus } from "../../bus.js"
@@ -15,6 +16,7 @@ import { SessionModelTransport } from "../model-transport.js"
 import { SessionMessage } from "../message.js"
 import { SessionSchema } from "../schema.js"
 import { SessionStore } from "../store.js"
+import { SessionMessageTable } from "../sql.js"
 import { SessionTitle } from "../title.js"
 import { DrainResult, Service, type Interface } from "./index.js"
 import { Snapshot } from "../../snapshot.js"
@@ -59,6 +61,7 @@ const layer = Layer.effect(
         if (promotable === "steer" && pending.delivery === "queue" && !control) return DrainResult.Complete()
       }
       yield* plugins.awaitActivation
+      yield* settleStaleCompactions(sessionID)
       yield* settleStaleToolCalls(sessionID)
 
       const advanceToStep = Effect.fn("SessionRunner.advanceToStep")(() =>
@@ -273,6 +276,36 @@ const layer = Layer.effect(
           }),
         })
         if (completed !== undefined) return completed
+      }
+    })
+
+    const settleStaleCompactions = Effect.fn("SessionRunner.settleStaleCompactions")(function* (
+      sessionID: SessionSchema.ID,
+    ) {
+      // A process death skips compaction finalizers. Include orphans behind a
+      // completed checkpoint, and settle newest first to match event projection.
+      const rows = yield* db
+        .select()
+        .from(SessionMessageTable)
+        .where(
+          and(
+            eq(SessionMessageTable.session_id, sessionID),
+            eq(SessionMessageTable.type, "compaction"),
+            sql`json_extract(${SessionMessageTable.data}, '$.status') = 'running'`,
+          ),
+        )
+        .orderBy(desc(SessionMessageTable.seq))
+        .all()
+        .pipe(Effect.orDie)
+      for (const row of rows) {
+        const message = yield* SessionHistory.decodeMessageRow(row)
+        if (message.type !== "compaction") continue
+        yield* bus.publish(SessionEvent.Compaction.Failed, {
+          sessionID,
+          reason: message.reason,
+          inputID: message.id,
+          error: { type: "compaction.interrupted", message: "Compaction was interrupted" },
+        })
       }
     })
 

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -3472,6 +3472,83 @@ describe("SessionRunnerLLM", () => {
     expect(userTexts(s.requests[1])).toEqual(["Start working", "Recover with this"])
   })
 
+  scenario("settles abandoned compactions before continuing after a process crash", function* (s) {
+    yield* s.runPrompt("History before the crash")
+    const first = SessionMessage.ID.create()
+    const completed = SessionMessage.ID.create()
+    const last = SessionMessage.ID.create()
+    yield* s.bus.publish(SessionEvent.Compaction.Started, {
+      sessionID,
+      reason: "manual",
+      inputID: first,
+      recent: "",
+    })
+    yield* s.bus.publish(SessionEvent.Compaction.Started, {
+      sessionID,
+      reason: "manual",
+      inputID: completed,
+      recent: "",
+    })
+    yield* s.bus.publish(SessionEvent.Compaction.Ended, {
+      sessionID,
+      reason: "manual",
+      text: "## Objective\n- Earlier completed checkpoint",
+      recent: "",
+    })
+    yield* s.bus.publish(SessionEvent.Compaction.Started, {
+      sessionID,
+      reason: "auto",
+      inputID: last,
+      recent: "",
+    })
+
+    // These starts have no terminal events, as after SIGKILL. The older orphan
+    // is outside model-visible history; recovery must settle it as well.
+    expect(
+      (yield* s.messages).filter((message) => message.type === "compaction" && message.status === "running"),
+    ).toHaveLength(2)
+    yield* s.llm.push(TestLLM.text("Recovered response", "recovered"))
+    const run = yield* s.resumePaused
+    expect((yield* s.messages).filter((message) => message.type === "compaction").toReversed()).toMatchObject([
+      { id: first, status: "failed", reason: "manual", error: { type: "compaction.interrupted" } },
+      { id: completed, status: "completed", summary: "## Objective\n- Earlier completed checkpoint" },
+      { id: last, status: "failed", reason: "auto", error: { type: "compaction.interrupted" } },
+    ])
+    yield* run.finish
+
+    yield* s.llm.push(TestLLM.text("## Objective\n- New checkpoint", "new-summary"))
+    const next = yield* s.session.compact({ sessionID })
+    yield* s.session.wait(sessionID)
+    expect((yield* s.messages).find((message) => message.id === next.id)).toMatchObject({
+      status: "completed",
+      summary: "## Objective\n- New checkpoint",
+    })
+    expect(
+      (yield* s.messages).filter((message) => message.type === "compaction" && message.status === "running"),
+    ).toHaveLength(0)
+  })
+
+  scenario("settles an abandoned compaction before delivering another manual compaction", function* (s) {
+    yield* s.runPrompt("History before the crash")
+    const previous = SessionMessage.ID.create()
+    yield* s.bus.publish(SessionEvent.Compaction.Started, {
+      sessionID,
+      reason: "manual",
+      inputID: previous,
+      recent: "",
+    })
+    yield* s.llm.push(TestLLM.text("## Objective\n- New checkpoint", "new-summary"))
+    const gate = yield* s.llm.gate
+    const next = yield* s.session.compact({ sessionID })
+    yield* gate.started
+    expect((yield* s.messages).filter((message) => message.type === "compaction").toReversed()).toMatchObject([
+      { id: previous, status: "failed", error: { type: "compaction.interrupted" } },
+      { id: next.id, status: "running" },
+    ])
+    yield* gate.release
+    yield* s.session.wait(sessionID)
+  })
+
   scenario("durably fails local tools left running by a prior process before continuing", function* (s) {
     yield* s.admit("Recover interrupted tool")
     yield* SessionInbox.promote(s.db, s.bus, sessionID, "steer")


### PR DESCRIPTION
## Why

An abrupt server death during compaction skips its interruption finalizer. Restart recovery resumes the Session, but the abandoned compaction remains durably `running`. Requesting `/compact` again produces two spinning Compaction rows, and completing the new summary still leaves the old spinner behind.

This is persisted Session state, not duplicate TUI rendering. Graceful shutdown already settles compaction correctly; an isolated Drive crash fixture reproduces the missing-cleanup path.

## What Changes

Settle abandoned compactions before the runner starts new work, alongside its existing stale-tool recovery.

| Situation | Before | After |
| --- | --- | --- |
| Resume after a crash during compaction | Abandoned row stays `running` | Row becomes `failed` with `compaction.interrupted` |
| Request another compaction | Both rows appear active | Only the new compaction is active |
| Earlier orphan behind a completed checkpoint | Hidden from model-visible history but still spinning in the transcript | Recovered without changing the completed checkpoint |

Recovery reads running compactions across the Session's persisted transcript, not just model-visible history. It settles newest first because the existing compaction event projection targets the newest running record. Each record retains its original manual/auto reason.

## Demo

https://github.com/user-attachments/assets/a210219e-e5bf-43b4-b45d-b03c52cd9c6f

Left: base `c76e602ba4`. Right: fix `28ba731b11`. Both run the same deterministic Drive 2.0.1 fixture against the production TUI at 72×36, with a simulated LLM and an isolated file-backed database. The fixture kills the server without allowing shutdown finalizers, restarts it, and requests a second compaction. The video aligns the running and completed checkpoints, trims startup, and briefly holds the final frames; playback is not accelerated.

## Scope

Core recovery and two runner regression tests. No TUI workaround, public protocol change, or database migration. Existing abandoned rows are settled when their Session next enters a drain. Drive's lack of an explicit abrupt-kill control is tracked separately in anomalyco/opencode-drive#82.

## Verification

```sh
cd packages/core
bun run test test/session-runner.test.ts --test-name-pattern 'abandoned compaction'
bun run test test/session-runner.test.ts test/session-compaction.test.ts test/session-compact.test.ts test/session-execution.test.ts test/session-projector.test.ts
bun typecheck

cd ../client
bun run test test/solid-compaction.test.ts
```

- Both new regressions failed before the fix and pass after it.
- 248 core tests and 22 client tests pass. Core typecheck passes; the normal pre-push hook also passed all 33 package typechecks.
- Drive crash fixture passes at 72 and 100 columns; graceful restart passes too. The base recording fails the assertion with two running compactions, as expected.
- Existing Drive `quiescence-restart` and `compact-admission` (`coalesce`) gauntlets pass.
- Formatting and `git diff --check` pass. Focused lint reports no errors and three existing warnings in unrelated portions of the runner test file.
