### PR TITLE
fix(opencode): resolve LSP for nested TypeScript sub-projects

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -170,8 +170,17 @@ export async function create(input: {
     }
     updatePushDiagnostics(filePath, params.diagnostics)
   })
-  connection.onRequest("window/workDoneProgress/create", (params) => {
-    return null
+
+  const inFlightProgress = new Set<unknown>()
+  connection.onNotification("$/progress", (params: { token?: unknown; kind?: string }) => {
+    if (params?.kind === "begin") {
+      inFlightProgress.add(params.token)
+    } else if (params?.kind === "end") {
+      inFlightProgress.delete(params.token)
+    }
+  })
+  connection.onRequest("window/workDoneProgress/create", (params: { token: unknown }) => {
+    return params.token
   })
   connection.onRequest("workspace/configuration", async (params) => {
     const items = (params as { items?: { section?: string }[] }).items ?? []
@@ -461,6 +470,22 @@ export async function create(input: {
     })
   }
 
+  function awaitProgress(timeoutMs: number): Promise<void> {
+    if (timeoutMs <= 0) return Promise.resolve()
+    if (inFlightProgress.size === 0) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      const start = Date.now()
+      const tick = () => {
+        if (inFlightProgress.size === 0 || Date.now() - start >= timeoutMs) {
+          resolve()
+          return
+        }
+        setTimeout(tick, 50)
+      }
+      tick()
+    })
+  }
+
   function waitForFreshPush(request: { path: string; version: number; after: number; timeout: number }) {
     if (request.timeout <= 0) return Promise.resolve(false)
     return new Promise<boolean>((resolve) => {
@@ -617,6 +642,9 @@ export async function create(input: {
           },
         })
         files[request.path] = { version: 0, text }
+        if (input.serverID === "typescript") {
+          await awaitProgress(5_000)
+        }
         return 0
       },
     },

--- a/packages/opencode/src/lsp/server.ts
+++ b/packages/opencode/src/lsp/server.ts
@@ -115,12 +115,14 @@ export const Deno: Info = {
 export const Typescript: Info = {
   id: "typescript",
   root: NearestRoot(
-    ["package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"],
+    ["tsconfig.json", "package-lock.json", "bun.lockb", "bun.lock", "pnpm-lock.yaml", "yarn.lock"],
     ["deno.json", "deno.jsonc"],
   ),
   extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".mts", ".cts"],
   async spawn(root, ctx) {
-    const tsserver = Module.resolve("typescript/lib/tsserver.js", ctx.directory)
+    const tsserver =
+      Module.resolve("typescript/lib/tsserver.js", root) ??
+      Module.resolve("typescript/lib/tsserver.js", ctx.directory)
     if (!tsserver) return
     const bin = await Npm.which("typescript-language-server")
     if (!bin) return

--- a/packages/opencode/test/lsp/typescript-root.test.ts
+++ b/packages/opencode/test/lsp/typescript-root.test.ts
@@ -1,0 +1,153 @@
+import { describe, test, expect, afterAll } from "bun:test"
+import path from "path"
+import fs from "fs/promises"
+import os from "os"
+import * as LSPServer from "@/lsp/server"
+import type { InstanceContext } from "@/project/instance-context"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const tmpBase = path.join(os.tmpdir(), "opencode-typescript-root-test")
+
+function makeCtx(directory: string): InstanceContext {
+  return { directory, worktree: "/", project: {} as any }
+}
+
+async function mkdirp(p: string) {
+  await fs.mkdir(p, { recursive: true })
+}
+
+async function touch(p: string) {
+  await mkdirp(path.dirname(p))
+  await fs.writeFile(p, "", "utf-8")
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+afterAll(async () => {
+  await fs.rm(tmpBase, { recursive: true, force: true }).catch(() => {})
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Typescript.root", () => {
+  test("nested tsconfig in workspace with no parent lockfile returns sub-project directory", async () => {
+    const workspace = path.join(tmpBase, "nested-tsconfig")
+    await mkdirp(workspace)
+    const projectDir = path.join(workspace, "frontend")
+    await touch(path.join(projectDir, "tsconfig.json"))
+    const srcDir = path.join(projectDir, "src", "lib", "services")
+    await mkdirp(srcDir)
+    await touch(path.join(srcDir, "query.service.ts"))
+
+    const file = path.join(srcDir, "query.service.ts")
+    const result = await LSPServer.Typescript.root(file, makeCtx(workspace))
+    expect(result).toBe(projectDir)
+  })
+
+  test("sibling sub-projects each resolve to their own tsconfig.json directory", async () => {
+    const workspace = path.join(tmpBase, "sibling-tsconfigs")
+    await mkdirp(workspace)
+    for (const name of ["frontend", "backend", "website", "sdk-ts"]) {
+      await touch(path.join(workspace, name, "tsconfig.json"))
+      const srcDir = path.join(workspace, name, "src")
+      await mkdirp(srcDir)
+      await touch(path.join(srcDir, "index.ts"))
+    }
+
+    const expected = new Map(
+      await Promise.all(
+        ["frontend", "backend", "website", "sdk-ts"].map(async (name) => [
+          name,
+          await LSPServer.Typescript.root(
+            path.join(workspace, name, "src", "index.ts"),
+            makeCtx(workspace),
+          ),
+        ] as const),
+      ),
+    )
+
+    expect(expected.get("frontend")).toBe(path.join(workspace, "frontend"))
+    expect(expected.get("backend")).toBe(path.join(workspace, "backend"))
+    expect(expected.get("website")).toBe(path.join(workspace, "website"))
+    expect(expected.get("sdk-ts")).toBe(path.join(workspace, "sdk-ts"))
+    expect(new Set(expected.values()).size).toBe(4)
+  })
+
+  test("tsconfig co-located with lockfile: tsconfig wins (nearest first)", async () => {
+    const workspace = path.join(tmpBase, "tsconfig-with-lockfile")
+    await mkdirp(workspace)
+    await touch(path.join(workspace, "package-lock.json"))
+    const projectDir = path.join(workspace, "app")
+    await touch(path.join(projectDir, "tsconfig.json"))
+    await touch(path.join(projectDir, "package-lock.json"))
+    const srcDir = path.join(projectDir, "src")
+    await mkdirp(srcDir)
+    await touch(path.join(srcDir, "main.ts"))
+
+    const file = path.join(srcDir, "main.ts")
+    const result = await LSPServer.Typescript.root(file, makeCtx(workspace))
+    expect(result).toBe(projectDir)
+  })
+
+  test("lockfile only, no tsconfig.json: falls back to lockfile directory (backward compat)", async () => {
+    const workspace = path.join(tmpBase, "lockfile-only")
+    await mkdirp(workspace)
+    await touch(path.join(workspace, "package-lock.json"))
+    const srcDir = path.join(workspace, "src")
+    await mkdirp(srcDir)
+    await touch(path.join(srcDir, "index.ts"))
+
+    const file = path.join(srcDir, "index.ts")
+    const result = await LSPServer.Typescript.root(file, makeCtx(workspace))
+    expect(result).toBe(workspace)
+  })
+
+  test("no markers at all: falls back to ctx.directory (backward compat)", async () => {
+    const workspace = path.join(tmpBase, "no-markers")
+    await mkdirp(workspace)
+    const srcDir = path.join(workspace, "src")
+    await mkdirp(srcDir)
+    await touch(path.join(srcDir, "index.ts"))
+
+    const file = path.join(srcDir, "index.ts")
+    const result = await LSPServer.Typescript.root(file, makeCtx(workspace))
+    expect(result).toBe(workspace)
+  })
+
+  test("deno.json in path: root is undefined (exclusion preserved)", async () => {
+    const workspace = path.join(tmpBase, "deno-excluded")
+    await mkdirp(workspace)
+    const projectDir = path.join(workspace, "deno-app")
+    await touch(path.join(projectDir, "deno.json"))
+    await touch(path.join(projectDir, "tsconfig.json"))
+    const srcDir = path.join(projectDir, "src")
+    await mkdirp(srcDir)
+    await touch(path.join(srcDir, "main.ts"))
+
+    const file = path.join(srcDir, "main.ts")
+    const result = await LSPServer.Typescript.root(file, makeCtx(workspace))
+    expect(result).toBeUndefined()
+  })
+
+  test("tsconfig wins over a more distant lockfile at the workspace root", async () => {
+    const workspace = path.join(tmpBase, "distant-lockfile")
+    await mkdirp(workspace)
+    await touch(path.join(workspace, "yarn.lock"))
+    const projectDir = path.join(workspace, "packages", "core")
+    await touch(path.join(projectDir, "tsconfig.json"))
+    const srcDir = path.join(projectDir, "src")
+    await mkdirp(srcDir)
+    await touch(path.join(srcDir, "index.ts"))
+
+    const file = path.join(srcDir, "index.ts")
+    const result = await LSPServer.Typescript.root(file, makeCtx(workspace))
+    expect(result).toBe(projectDir)
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #47174

Related to #40413, #35396, #18694 — the same change set addresses all three (the `Typescript.root` walk covers #18694, the `tsserver.js` resolution covers #35396, and the `$/progress` wait covers #40413). Maintainers can decide which to close as superseded when this lands.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The `lsp` tool returns empty results for `.ts` files in nested TypeScript sub-projects (each with its own `tsconfig.json` under the working directory), and for some sub-projects it returns `"No LSP server available for this file type."` outright.

Three defects in the LSP runtime compound to produce both symptoms.

`Typescript.root` in `packages/opencode/src/lsp/server.ts` walks up looking only for lockfiles, never for `tsconfig.json`. In a layout like the one in the issue (no lockfile at the workspace root), every `.ts` file resolves to `ctx.directory` and all sub-projects share one tsserver client that never learns about the sub-project's `tsconfig.json`.

`Typescript.spawn` resolves `typescript/lib/tsserver.js` from `ctx.directory` via `createRequire(path.join(dir, "package.json"))`. When the opencode working directory has no `package.json`, the call returns `undefined` and the key is marked broken, which is what produces the "No LSP server available" error.

`packages/opencode/src/lsp/client.ts` has a `window/workDoneProgress/create` handler that returns `null` (silently dropping the progress token) and no `$/progress` listener. typescript-language-server relays tsserver's `projectLoadingStart` / `projectLoadingFinish` as standard `$/progress` notifications, so the first request races tsserver's project load and gets `[]`.

Changes:

- `packages/opencode/src/lsp/server.ts`: include `"tsconfig.json"` in `Typescript.root`'s include patterns (nearest wins, fully backward compatible) and resolve `tsserver.js` from the sub-project root first with a fallback to `ctx.directory`.
- `packages/opencode/src/lsp/client.ts`: return the token from `window/workDoneProgress/create`, listen for `$/progress`, expose an `awaitProgress(timeoutMs)` helper, and call it (5 s budget) after the cold `didOpen` path for the `typescript` server.

### How did you verify your code works?

- `bun typecheck` in `packages/opencode` is clean.
- `bun test test/lsp/typescript-root.test.ts` — 7 new tests covering nested tsconfig, sibling sub-projects resolving to distinct roots, tsconfig-over-lockfile priority, lockfile-only fallback, no-markers fallback, deno exclusion, and distant-lockfile.
- `bun test test/lsp/ test/tool/ test/config/` — 636 pass, 3 skip, 0 fail. Existing `jdtls-root.test.ts`, `lsp/client.test.ts`, `lsp.test.ts` (tool), and `config/lsp.test.ts` are all unaffected.

End-to-end repro against the layout in #47174 (one scratch workspace with `frontend/`, `backend/`, `website/`, `sdk-ts/` each containing a `tsconfig.json`):

- `documentSymbol`, `hover`, `goToDefinition` on `frontend/src/lib/services/query.service.ts` returns non-empty results.
- Same operations on `sdk-ts/src/client.ts` no longer throw `"No LSP server available for this file type."`.
- `bun run packages/opencode/src/cli/cmd/debug/lsp.ts status` reports two connected `typescript` clients rooted at each sub-project (different cache keys per `tsconfig.json`).

### Screenshots / recordings

Not applicable — non-UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR