### PR TITLE
refactor(ai): drop converse tool deltas without an open block

### DIFF
--- a/packages/ai/src/protocols/bedrock-converse.ts
+++ b/packages/ai/src/protocols/bedrock-converse.ts
@@ -415,10 +415,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
 
 // System prompts share the cache-point convention: emit the text block, then
 // optionally a positional `cachePoint` marker.
-const lowerSystem = (
-  breakpoints: BedrockCache.Breakpoints,
-  system: ReadonlyArray<LLMRequest["system"][number]>,
-) => {
+const lowerSystem = (breakpoints: BedrockCache.Breakpoints, system: ReadonlyArray<LLMRequest["system"][number]>) => {
   const content = system
     .filter((part) => part.text.length > 0)
     .flatMap((part) => textWithCache(breakpoints, part.text, part.cache))
@@ -508,7 +505,6 @@ const mapUsage = (usage: BedrockUsageSchema | undefined, providerMetadataKey: st
 interface ParserState {
   readonly providerMetadataKey: string
   readonly tools: ToolStream.State<number>
-  readonly finishedTools: ReadonlySet<number>
   // Bedrock splits the finish into `messageStop` (carries `stopReason`) and
   // `metadata` (carries usage). Hold both in state so `onHalt` can emit exactly
   // one finish after both chunks have had a chance to arrive.
@@ -620,16 +616,14 @@ const step = (state: ParserState, event: BedrockEvent) =>
     }
 
     if (event.contentBlockDelta?.delta?.toolUse) {
-      const index = event.contentBlockDelta.contentBlockIndex
-      if (state.finishedTools.has(index)) return [state, []] as const
-      const result = ToolStream.appendExisting(
-        ADAPTER,
+      // A delta for a block that is not open, whether it already stopped or never
+      // started, has nothing to attach to and is dropped.
+      const result = ToolStream.append(
         state.tools,
-        index,
+        event.contentBlockDelta.contentBlockIndex,
         event.contentBlockDelta.delta.toolUse.input,
-        "Bedrock Converse tool delta is missing its tool call",
       )
-      if (ToolStream.isError(result)) return yield* result
+      if (!result) return [state, []] as const
       const events: LLMEvent[] = []
       const lifecycle = result.events.length ? Lifecycle.stepStart(state.lifecycle, events) : state.lifecycle
       events.push(...result.events)
@@ -668,7 +662,6 @@ const step = (state: ParserState, event: BedrockEvent) =>
             state.hasToolCalls,
           lifecycle,
           tools: result.tools,
-          finishedTools: resultEvents.length > 0 ? new Set([...state.finishedTools, index]) : state.finishedTools,
           reasoningSignatures: Object.fromEntries(
             Object.entries(state.reasoningSignatures).filter(([key]) => key !== String(index)),
           ),
@@ -765,7 +758,6 @@ export const protocol = Protocol.make({
     initial: (request) => ({
       providerMetadataKey: request.model.route.providerMetadataKey ?? String(request.model.provider),
       tools: ToolStream.empty<number>(),
-      finishedTools: new Set<number>(),
       finishReason: undefined,
       usage: undefined,
       hasToolCalls: false,

--- a/packages/ai/src/protocols/utils/tool-stream.ts
+++ b/packages/ai/src/protocols/utils/tool-stream.ts
@@ -160,6 +160,17 @@ export const appendOrStart = <K extends StreamKey>(
 }
 
 /**
+ * Append argument text to a started tool. Returns `undefined` when no tool is
+ * open under `key`, for protocols that ignore deltas without a matching block.
+ */
+export const append = <K extends StreamKey>(tools: State<K>, key: K, text: string): AppendOutcome<K> | undefined => {
+  const current = tools[key]
+  if (!current) return undefined
+  if (text.length === 0) return { tools, tool: current, events: [] }
+  return appendTool(tools, key, { ...current, input: `${current.input}${text}` }, text)
+}
+
+/**
  * Append argument text to a tool that must already have been started. This keeps
  * protocols honest when their stream grammar promises a start event before any
  * argument delta.
@@ -170,12 +181,7 @@ export const appendExisting = <K extends StreamKey>(
   key: K,
   text: string,
   missingToolMessage: string,
-): AppendOutcome<K> | AIError => {
-  const current = tools[key]
-  if (!current) return eventError(route, missingToolMessage)
-  if (text.length === 0) return { tools, tool: current, events: [] }
-  return appendTool(tools, key, { ...current, input: `${current.input}${text}` }, text)
-}
+): AppendOutcome<K> | AIError => append(tools, key, text) ?? eventError(route, missingToolMessage)
 
 /**
  * Finalize one pending tool call: parse the accumulated raw JSON, remove it

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -713,9 +713,10 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
-  it.effect("ignores late tool deltas after contentBlockStop", () =>
+  it.effect("ignores tool deltas without an open tool block", () =>
     Effect.gen(function* () {
       const body = eventStreamBody(
+        ["contentBlockDelta", { contentBlockIndex: 5, delta: { toolUse: { input: "{}" } } }],
         [
           "contentBlockStart",
           {
@@ -742,27 +743,6 @@ describe("Bedrock Converse route", () => {
           input: { query: "weather" },
         },
       ])
-    }),
-  )
-
-  it.effect("rejects tool deltas without contentBlockStart", () =>
-    Effect.gen(function* () {
-      const error = yield* LLMClient.generate(baseRequest).pipe(
-        Effect.provide(
-          fixedBytes(
-            eventStreamBody(
-              ["contentBlockDelta", { contentBlockIndex: 0, delta: { toolUse: { input: "{}" } } }],
-              ["messageStop", { stopReason: "tool_use" }],
-            ),
-          ),
-        ),
-        Effect.flip,
-      )
-
-      expect(error).toMatchObject({
-        reason: { _tag: "InvalidProviderOutput" },
-        message: "Bedrock Converse tool delta is missing its tool call",
-      })
     }),
   )
 


### PR DESCRIPTION
## Why

The Bedrock Converse parser handled a `toolUse` delta whose block was not open in two different ways depending on history: if the index had already received `contentBlockStop` it was silently ignored via a `finishedTools` set (#45847), and if the index had never received `contentBlockStart` it failed the stream with `InvalidProviderOutput`. The set existed only to tell those two cases apart.

Converse guarantees `contentBlockStart` before any delta and treats `contentBlockStop` as terminal for an index, so neither input comes from a compliant stream, and #45847 did not cite a provider or captured stream that produced one. Distinguishing them buys nothing: in both cases there is no open block to attach the delta to.

This collapses the two branches into one. A tool delta with no matching open block is dropped, regardless of why the block is not open. `state.tools` is the only record of in-flight tool blocks, matching how `completedMessages`, `completedTools` (#46965), and reasoning `open` flags (#47100) were removed from the Responses parser.

## What changes

- `ToolStream.append` returns `undefined` when no tool is open under the key; `appendExisting` now delegates to it and keeps its error for protocols that want one. Anthropic Messages and Open Responses still use `appendExisting` and are unchanged.
- Bedrock Converse uses `append` and treats `undefined` as a no-op. `finishedTools` and the "tool delta is missing its tool call" error are removed.
- Tests: the two tests for late and orphan deltas become one, "ignores tool deltas without an open tool block", covering a delta before any start and a delta after stop in the same stream.

## Verification

```sh
cd packages/ai
bun typecheck
bun run test   # 976 pass, 28 skip, 0 fail
```