### PR TITLE
feat(opencode): add run_in_background to shell tool with auto notification

### DIFF
--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Scope, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -21,6 +21,11 @@ import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { ShellPrompt, type Parameters } from "./shell/prompt"
 import { BashArity } from "@/permission/arity"
+import { BackgroundJob } from "@/background/job"
+import { Session } from "@/session/session"
+import { Database } from "@opencode-ai/core/database/database"
+import { MessageV2 } from "../session/message-v2"
+import type { TaskPromptOps } from "./task"
 
 export { Parameters } from "./shell/prompt"
 
@@ -260,6 +265,30 @@ const parse = Effect.fn("ShellTool.parse")(function* (command: string, ps: boole
   return tree
 })
 
+const BACKGROUND_GUIDANCE = [
+  "The command is running in the background. You will be notified automatically when it finishes.",
+  "DO NOT sleep, poll for progress, check on it, or run the same command again.",
+  "Continue with non-overlapping work, or briefly tell the user what you started and end your response.",
+].join("\n")
+
+function renderJobOutput(input: { jobID: string; command: string; state: "running" | "completed" | "error"; text: string }) {
+  const tag = input.state === "error" ? "shell_job_error" : "shell_job_result"
+  const summary =
+    input.state === "completed"
+      ? `Background command completed: ${input.command}`
+      : input.state === "error"
+        ? `Background command failed: ${input.command}`
+        : `Background command started: ${input.command}`
+  return [
+    `<shell_job id="${input.jobID}" state="${input.state}">`,
+    `<summary>${summary}</summary>`,
+    `<${tag}>`,
+    input.text,
+    `</${tag}>`,
+    "</shell_job>",
+  ].join("\n")
+}
+
 const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan, input: { command: string }) {
   if (scan.dirs.size > 0) {
     const directories = Array.from(scan.dirs)
@@ -344,6 +373,10 @@ export const ShellTool = Tool.define(
     const trunc = yield* Truncate.Service
     const plugin = yield* Plugin.Service
     const flags = yield* RuntimeFlags.Service
+    const background = yield* BackgroundJob.Service
+    const sessions = yield* Session.Service
+    const database = yield* Database.Service
+    const scope = yield* Scope.Scope
     const defaultTimeoutMs = flags.bashDefaultTimeoutMs ?? 2 * 60 * 1000
 
     const cygpath = Effect.fn("ShellTool.cygpath")(function* (shell: string, text: string) {
@@ -431,7 +464,8 @@ export const ShellTool = Tool.define(
         command: string
         cwd: string
         env: NodeJS.ProcessEnv
-        timeout: number
+        timeout: number | undefined
+        background: boolean
       },
       ctx: Tool.Context,
     ) {
@@ -446,6 +480,9 @@ export const ShellTool = Tool.define(
       let cut = false
       let expired = false
       let aborted = false
+      // Background jobs outlive the tool call, so live part updates would land
+      // on an already-completed tool part (a no-op at best).
+      const report = (metadata: { output: string }) => (input.background ? Effect.void : ctx.metadata({ metadata }))
 
       const closeSink = Effect.fnUntraced(function* () {
         const stream = sink
@@ -472,11 +509,7 @@ export const ShellTool = Tool.define(
         ).pipe(Effect.catch(() => Effect.void))
       })
 
-      yield* ctx.metadata({
-        metadata: {
-          output: "",
-        },
-      })
+      yield* report({ output: "" })
 
       const code: number | null = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -511,22 +544,12 @@ export const ShellTool = Tool.define(
                         full = ""
                       }),
                     ),
-                    Effect.andThen(
-                      ctx.metadata({
-                        metadata: {
-                          output: last,
-                        },
-                      }),
-                    ),
+                    Effect.andThen(report({ output: last })),
                   )
                 }
               }
 
-              return ctx.metadata({
-                metadata: {
-                  output: last,
-                },
-              })
+              return report({ output: last })
             }),
           )
 
@@ -537,12 +560,21 @@ export const ShellTool = Tool.define(
             return Effect.sync(() => ctx.abort.removeEventListener("abort", handler))
           })
 
-          const timeout = Effect.sleep(`${input.timeout + 100} millis`)
+          const sleep = Effect.sleep(`${(input.timeout ?? 0) + 100} millis`)
 
+          // Background jobs only race the exit code (plus an explicit timeout if
+          // the model asked for one); the tool-call abort signal belongs to a
+          // turn that has already ended by the time the command finishes.
           const exit = yield* Effect.raceAll([
             handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),
-            abort.pipe(Effect.map(() => ({ kind: "abort" as const, code: null }))),
-            timeout.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
+            ...(input.background
+              ? input.timeout === undefined
+                ? []
+                : [sleep.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null })))]
+              : [
+                  abort.pipe(Effect.map(() => ({ kind: "abort" as const, code: null }))),
+                  sleep.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
+                ]),
           ])
 
           if (exit.kind === "abort") {
@@ -600,7 +632,9 @@ export const ShellTool = Tool.define(
         const shell = Shell.acceptable(cfg.shell)
         const name = Shell.name(shell)
         const limits = yield* trunc.limits()
-        const prompt = ShellPrompt.render(name, process.platform, limits, defaultTimeoutMs)
+        const prompt = ShellPrompt.render(name, process.platform, limits, defaultTimeoutMs, {
+          background: flags.experimentalBackgroundSubagents,
+        })
         yield* Effect.logInfo("shell tool using shell", { shell })
 
         return {
@@ -615,7 +649,6 @@ export const ShellTool = Tool.define(
               if (params.timeout !== undefined && params.timeout < 0) {
                 throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
               }
-              const timeout = params.timeout ?? defaultTimeoutMs
               const ps = Shell.ps(shell)
               yield* Effect.scoped(
                 Effect.gen(function* () {
@@ -627,14 +660,103 @@ export const ShellTool = Tool.define(
                   yield* ask(ctx, scan, params)
                 }),
               )
+              const env = yield* shellEnv(ctx, cwd)
+
+              if (params.run_in_background === true) {
+                if (!flags.experimentalBackgroundSubagents) {
+                  throw new Error(
+                    "Background shell requires OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true. Re-run the command in the foreground instead.",
+                  )
+                }
+                const ops = ctx.extra?.promptOps as TaskPromptOps | undefined
+                if (!ops) throw new Error("Background shell requires promptOps in ctx.extra")
+                const msg = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }).pipe(
+                  Effect.provideService(Database.Service, database),
+                  Effect.orDie,
+                )
+                const variant = msg.info.role === "assistant" ? msg.info.variant : undefined
+                const parent = yield* sessions.get(ctx.sessionID).pipe(Effect.orDie)
+
+                const inject = Effect.fn("ShellTool.injectBackgroundResult")(function* (
+                  jobID: string,
+                  state: "completed" | "error",
+                  text: string,
+                ) {
+                  yield* ops
+                    .prompt({
+                      sessionID: ctx.sessionID,
+                      agent: parent.agent ?? ctx.agent,
+                      variant,
+                      parts: [
+                        {
+                          type: "text",
+                          synthetic: true,
+                          text: renderJobOutput({ jobID, command: params.command, state, text }),
+                        },
+                      ],
+                    })
+                    .pipe(
+                      Effect.catch((error) =>
+                        Effect.logError("shell background inject prompt failed", { jobID, error: String(error) }),
+                      ),
+                      Effect.forkIn(scope, { startImmediately: true }),
+                    )
+                })
+
+                const notify = Effect.fn("ShellTool.notifyBackgroundResult")(function* (jobID: string) {
+                  yield* background.wait({ id: jobID }).pipe(
+                    Effect.flatMap((result) => {
+                      if (result.info?.status === "completed") return inject(jobID, "completed", result.info.output ?? "")
+                      if (result.info?.status === "error") return inject(jobID, "error", result.info.error ?? "")
+                      return Effect.void
+                    }),
+                    Effect.forkIn(scope, { startImmediately: true }),
+                  )
+                })
+
+                const started = yield* background.start({
+                  type: ShellID.ToolID,
+                  title: params.command,
+                  metadata: { command: params.command, cwd, background: true },
+                  run: run(
+                    {
+                      shell,
+                      command: params.command,
+                      cwd,
+                      env,
+                      timeout: params.timeout,
+                      background: true,
+                    },
+                    ctx,
+                  ).pipe(Effect.map((result) => result.output)),
+                })
+                yield* notify(started.id)
+                return {
+                  title: params.command,
+                  metadata: {
+                    output: "(running in background)",
+                    exit: null,
+                    truncated: false,
+                    background: true,
+                    jobId: started.id,
+                  },
+                  output: renderJobOutput({
+                    jobID: started.id,
+                    command: params.command,
+                    state: "running",
+                    text: BACKGROUND_GUIDANCE,
+                  }),
+                }
+              }
 
               return yield* run(
                 {
                   shell,
                   command: params.command,
                   cwd,
-                  env: yield* shellEnv(ctx, cwd),
-                  timeout,
+                  env,
+                  timeout: params.timeout ?? defaultTimeoutMs,
+                  background: false,
                 },
                 ctx,
               )

--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -19,6 +19,10 @@ export function parameterSchema() {
     workdir: Schema.optional(Schema.String).annotate({
       description: `The working directory to run the command in. Defaults to the current directory. Use this instead of 'cd' commands.`,
     }),
+    run_in_background: Schema.optional(Schema.Boolean).annotate({
+      description:
+        "Set to true to run the command in the background and return immediately. The output is delivered automatically when the command exits; do not poll, sleep, or re-run the command while it runs. Intended for long-running commands like dev servers, watch processes, builds, or long test suites.",
+    }),
   })
 }
 
@@ -270,7 +274,22 @@ function profile(name: string, platform: NodeJS.Platform, limits: Limits, defaul
   }
 }
 
-export function render(name: string, platform: NodeJS.Platform, limits: Limits, defaultTimeoutMs: number) {
+function backgroundSection(enabled: boolean) {
+  if (!enabled) return ""
+  return `# Running commands in the background
+- Set \`run_in_background: true\` for long-running commands (dev servers, watch modes, builds, long test suites) so you do not block on them.
+- The tool returns immediately with a \`jobId\` in its metadata; when the command exits, its output is delivered to you automatically as a new message.
+- While a background command runs, NEVER sleep, poll, check on it, or re-run it to see progress. Continue other work or briefly tell the user what you started and end your turn.
+- Do not use it when the next step depends on the command's result; run those commands in the foreground.`
+}
+
+export function render(
+  name: string,
+  platform: NodeJS.Platform,
+  limits: Limits,
+  defaultTimeoutMs: number,
+  options?: { background?: boolean },
+) {
   const selected = profile(name, platform, limits, defaultTimeoutMs)
   return {
     description: renderPrompt(DESCRIPTION, {
@@ -280,6 +299,7 @@ export function render(name: string, platform: NodeJS.Platform, limits: Limits, 
       tmp: Global.Path.tmp,
       workdirSection: selected.workdirSection,
       commandSection: selected.commandSection,
+      backgroundSection: backgroundSection(options?.background === true),
       gitCommands: selected.gitCommands,
       toolName: ShellID.ToolID,
       gitCommandRestriction: selected.gitCommandRestriction,

--- a/packages/opencode/src/tool/shell/shell.txt
+++ b/packages/opencode/src/tool/shell/shell.txt
@@ -10,6 +10,8 @@ IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO N
 
 ${commandSection}
 
+${backgroundSection}
+
 # Git and GitHub
 - Only commit, amend, push, or create PRs when explicitly requested.
 - Before committing, inspect `git status`, `git diff`, and `git log --oneline -10`; stage only intended files and never commit secrets.

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1,7 +1,7 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Deferred, Effect, Exit, Layer } from "effect"
 import type * as Scope from "effect/Scope"
 import os from "os"
 import path from "path"
@@ -21,6 +21,18 @@ import { testEffect } from "../lib/effect"
 import { Tool } from "@/tool/tool"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { InstanceStore } from "@/project/instance-store"
+import { BackgroundJob } from "@/background/job"
+import { Database } from "@opencode-ai/core/database/database"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Session } from "@/session/session"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { SessionRunState } from "@/session/run-state"
+import { SessionStatus } from "@/session/status"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import type { SessionPrompt } from "../../src/session/prompt"
+import type { TaskPromptOps } from "../../src/tool/task"
 
 const shellLayer = Layer.mergeAll(
   LayerNode.compile(
@@ -32,6 +44,13 @@ const shellLayer = Layer.mergeAll(
       Config.node,
       Agent.node,
       RuntimeFlags.node,
+      BackgroundJob.node,
+      Database.node,
+      EventV2Bridge.node,
+      Session.node,
+      SessionProjector.node,
+      SessionRunState.node,
+      SessionStatus.node,
     ]),
   ),
   testInstanceStoreLayer,
@@ -1197,3 +1216,160 @@ describe("tool.shell truncation", () => {
     ),
   )
 })
+
+const backgroundLayer = Layer.mergeAll(
+  LayerNode.compile(
+    LayerNode.group([
+      CrossSpawnSpawner.node,
+      FSUtil.node,
+      Plugin.node,
+      Truncate.node,
+      Config.node,
+      Agent.node,
+      RuntimeFlags.node,
+      BackgroundJob.node,
+      Database.node,
+      EventV2Bridge.node,
+      Session.node,
+      SessionProjector.node,
+      SessionRunState.node,
+      SessionStatus.node,
+    ]),
+    [[RuntimeFlags.node, RuntimeFlags.layer({ experimentalBackgroundSubagents: true })]],
+  ),
+  testInstanceStoreLayer,
+)
+const backgroundIt = testEffect(backgroundLayer)
+
+const backgroundRef = {
+  providerID: ProviderV2.ID.make("test"),
+  modelID: ModelV2.ID.make("test-model"),
+}
+
+const seedChat = Effect.fn("ShellBackgroundTest.seed")(function* () {
+  const session = yield* Session.Service
+  const chat = yield* session.create({ title: "shell background" })
+  const user = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID: chat.id,
+    agent: "build",
+    model: backgroundRef,
+    time: { created: Date.now() },
+  })
+  const assistant: SessionV1.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: user.id,
+    sessionID: chat.id,
+    mode: "build",
+    agent: "build",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: backgroundRef.modelID,
+    providerID: backgroundRef.providerID,
+    variant: "xhigh",
+    time: { created: Date.now() },
+  }
+  yield* session.updateMessage(assistant)
+  return { chat, assistant }
+})
+
+describe("tool.shell background", () => {
+  backgroundIt.live("returns immediately and injects the result on completion", () =>
+    Effect.gen(function* () {
+      const captured = yield* Deferred.make<SessionPrompt.PromptInput>()
+      const ops: TaskPromptOps = {
+        cancel: () => Effect.void,
+        resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+        prompt: (input) => {
+          const id = MessageID.ascending()
+          return Deferred.succeed(captured, input).pipe(
+            Effect.as({
+              info: {
+                id,
+                role: "assistant" as const,
+                parentID: input.messageID ?? id,
+                sessionID: input.sessionID,
+                mode: input.agent ?? "build",
+                agent: input.agent ?? "build",
+                cost: 0,
+                path: { cwd: "/tmp", root: "/tmp" },
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                modelID: backgroundRef.modelID,
+                providerID: backgroundRef.providerID,
+                time: { created: Date.now() },
+                finish: "stop" as const,
+              },
+              parts: [],
+            }),
+          )
+        },
+      }
+
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const jobs = yield* BackgroundJob.Service
+          const { chat, assistant } = yield* seedChat()
+          const result = yield* Effect.gen(function* () {
+            const bash = yield* initShell()
+            return yield* bash.execute(
+              { command: "echo bg-marker-ok", run_in_background: true },
+              {
+                sessionID: chat.id,
+                messageID: assistant.id,
+                agent: "build",
+                abort: new AbortController().signal,
+                extra: { promptOps: ops },
+                messages: [],
+                metadata: () => Effect.void,
+                ask: () => Effect.void,
+              },
+            )
+          })
+
+          const meta = result.metadata as { background?: boolean; jobId?: string }
+          expect(meta.background).toBe(true)
+          expect(result.metadata.truncated).toBe(false)
+          expect(result.output).toContain(`state="running"`)
+          const jobID = meta.jobId
+          if (!jobID) throw new Error("expected jobId in metadata")
+
+          const waited = yield* jobs.wait({ id: jobID })
+          expect(waited.info?.status).toBe("completed")
+          expect(waited.info?.output).toContain("bg-marker-ok")
+
+          const injected = yield* Deferred.await(captured)
+          expect(injected.sessionID).toBe(chat.id)
+          expect(injected.variant).toBe("xhigh")
+          expect(injected.agent).toBe("build")
+          const part = injected.parts[0]
+          expect(part?.type).toBe("text")
+          if (part?.type !== "text") throw new Error("expected text part")
+          expect(part.text).toContain(`state="completed"`)
+          expect(part.text).toContain("bg-marker-ok")
+        }),
+      )
+    }),
+  )
+})
+
+it.live("rejects background execution when the experiment is disabled", () =>
+  Effect.gen(function* () {
+    const tmp = yield* tmpdirScoped()
+    const exit = yield* runIn(
+      tmp,
+      Effect.gen(function* () {
+        const bash = yield* initShell()
+        return yield* bash.execute(
+          { command: "echo nope", run_in_background: true },
+          ctx,
+        )
+      }),
+    ).pipe(Effect.exit)
+    expect(Exit.isFailure(exit)).toBe(true)
+  }),
+)


### PR DESCRIPTION
### Issue for this PR

Closes # (no existing issue, happy to file one if useful)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The shell tool is synchronous, so long-running commands (dev servers, watch modes, long test suites) block the turn until they exit or time out.

This adds a `run_in_background` parameter. When set, the command runs via the existing `BackgroundJob` registry (same one the task tool uses for background subagents), the tool returns immediately with a `jobId`, and when the command exits its output is injected into the session as a synthetic message so the model gets re-invoked automatically. No polling needed.

Background jobs skip the live metadata streaming and the tool-call abort race, since the tool call is already done by the time the command exits. An explicit `timeout` is still honored. Gated behind the same `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS` flag the task tool uses. Job state stays process-local, consistent with the existing registry.

### How did you verify your code works?

- New integration test in `test/tool/shell.test.ts` covering the immediate return, the completed job output, the synthetic prompt delivery, and the flag-disabled rejection.
- Ran the TUI against a real model: `sleep 20 && echo ...` returned instantly, I could keep chatting while it ran, and the completion notice came back on its own ~20s later.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
