### PR TITLE
fix(app): align Windows app icon in title bar

### DIFF
--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -444,7 +444,7 @@ export function Titlebar(props: {
                   "pl-4": macTrafficLights(),
                 }}
               >
-                <Show when={!mobile() && !props.verticalTabs}>
+                <Show when={!mobile() && (!props.verticalTabs || windows())}>
                   <ChannelIndicator horizontal debugTools={props.debugTools} />
                 </Show>
                 <Show when={windows() || linux()}>
@@ -641,7 +641,9 @@ export function Titlebar(props: {
                                 data-tauri-drag-region
                               />
                             </Show>
-                            <ChannelIndicator sidebar debugTools={props.debugTools} />
+                            <Show when={!windows()}>
+                              <ChannelIndicator sidebar debugTools={props.debugTools} />
+                            </Show>
                             {homeButton(true)}
                             <button
                               type="button"

--- a/packages/app/src/shell/titlebar/titlebar.tsx
+++ b/packages/app/src/shell/titlebar/titlebar.tsx
@@ -442,6 +442,8 @@ export function Titlebar(props: {
                   "pt-[max(0px,calc(8px-env(safe-area-inset-top,0px)))]": !bottom() && !windows(),
                   "pb-[max(0px,calc(8px-env(safe-area-inset-bottom,0px)))]": bottom(),
                   "pl-4": macTrafficLights(),
+                  // Center the 20px app icon over the sidebar's 16px icon column.
+                  "ps-3.5": windows(),
                 }}
               >
                 <Show when={!mobile() && (!props.verticalTabs || windows())}>


### PR DESCRIPTION
- Move the Windows app icon beside the menu button, with both vertically centered.
- Align the app icon with the vertical tab icons and keep the same left position in horizontal mode.
- Reclaim 44 px for vertical tabs. Leave macOS and other platforms unchanged.

### Vertical tabs

| Before | After |
| --- | --- |
| ![Windows vertical tabs before](https://github.com/user-attachments/assets/4880b6e7-635e-4c60-b20b-68048e171779) | ![Windows vertical tabs after](https://github.com/user-attachments/assets/048baae2-ff40-46e8-8ba1-4ef61e27260f) |

### Horizontal tabs

| Before | After |
| --- | --- |
| ![Windows horizontal tabs before](https://github.com/user-attachments/assets/ef2183e7-8c53-44a7-ae27-27e7d8d15c95) | ![Windows horizontal tabs after](https://github.com/user-attachments/assets/0e5f6823-369e-4c8d-832b-d18b2af7cd65) |