### PR TITLE
feat: add durable heartbeat monitoring

### DIFF
--- a/packages/app/src/pages/session/timeline/message-timeline.tsx
+++ b/packages/app/src/pages/session/timeline/message-timeline.tsx
@@ -17,6 +17,7 @@ import { useNavigate } from "@solidjs/router"
 import { useMutation } from "@tanstack/solid-query"
 import { createVirtualizer, defaultRangeExtractor, elementScroll, type VirtualItem } from "@tanstack/solid-virtual"
 import { Accordion } from "@opencode-ai/ui/accordion"
+import { Collapsible } from "@opencode-ai/ui/collapsible"
 import { Button } from "@opencode-ai/ui/button"
 import { Card } from "@opencode-ai/ui/card"
 import {
@@ -24,7 +25,9 @@ import {
   Message,
   MessageDivider,
   Part as MessagePart,
+  groupParts,
   partDefaultOpen,
+  renderable,
   type UserActions,
 } from "@opencode-ai/session-ui/message-part"
 import { DiffChanges } from "@opencode-ai/ui/diff-changes"
@@ -1043,7 +1046,7 @@ export function MessageTimeline(props: {
   function TimelineRowFrame(input: { row: Accessor<FramedTimelineRow>; children: JSX.Element }) {
     const anchor = () => {
       const row = input.row()
-      return row._tag === "CommentStrip" || (row._tag === "UserMessage" && row.anchor)
+      return row._tag === "CommentStrip" || row._tag === "Heartbeat" || (row._tag === "UserMessage" && row.anchor)
     }
     const previousAssistantPart = () => {
       const row = input.row()
@@ -1113,6 +1116,144 @@ export function MessageTimeline(props: {
                   </Index>
                 </div>
               </div>
+            </div>
+          </TimelineRowFrame>
+        )
+      }
+      case "Heartbeat": {
+        const heartbeatRow = row as Accessor<TimelineRowByTag<"Heartbeat">>
+        const assistantParts = createMemo(() =>
+          (assistantMessagesByParent().get(heartbeatRow().userMessageID) ?? emptyAssistantMessages).flatMap((message) =>
+            getMsgParts(message.id)
+              .filter((part) => renderable(part, settings.general.showReasoningSummaries()))
+              .map((part) => ({ messageID: message.id, part })),
+          ),
+        )
+        const groups = createMemo(() => groupParts(assistantParts()))
+        const summary = createMemo(() => {
+          const parts = assistantParts()
+          for (let index = parts.length - 1; index >= 0; index -= 1) {
+            const part = parts[index]?.part
+            if (part?.type === "text" && part.text.trim()) return part.text.trim()
+          }
+        })
+        const heartbeatTool = createMemo(() => {
+          const parts = assistantParts()
+          for (let index = parts.length - 1; index >= 0; index -= 1) {
+            const part = parts[index]?.part
+            if (part?.type === "tool" && part.tool === "heartbeat") return part
+          }
+        })
+        const durableStatus = createMemo(() => {
+          const state = heartbeatTool()?.state
+          if (!state || !("metadata" in state)) return
+          const metadata = state.metadata
+          if (!metadata || typeof metadata !== "object") return
+          const value = (metadata as Record<string, unknown>).durableStatus
+          return typeof value === "string" ? value : undefined
+        })
+        const heartbeatStatus = createMemo(() => {
+          if (workingTurn(heartbeatRow().userMessageID)) return "checking" as const
+          if (heartbeatRow().error || heartbeatTool()?.state.status === "error") return "failed" as const
+          if (durableStatus() === "scheduled" || durableStatus() === "firing") return "scheduled" as const
+          if (durableStatus() === "cancelled") return "cancelled" as const
+          return "completed" as const
+        })
+        const statusLabel = createMemo(() => {
+          switch (heartbeatStatus()) {
+            case "checking":
+              return "Checking"
+            case "scheduled":
+              return "Scheduled"
+            case "failed":
+              return "Failed"
+            case "cancelled":
+              return "Cancelled"
+            case "completed":
+              return "Completed"
+          }
+        })
+        const statusColor = createMemo(() => {
+          switch (heartbeatStatus()) {
+            case "checking":
+              return "var(--icon-info-base)"
+            case "scheduled":
+              return "var(--icon-success-base)"
+            case "failed":
+              return "var(--icon-critical-base)"
+            case "cancelled":
+            case "completed":
+              return "var(--icon-weak-base)"
+          }
+        })
+        const openKey = () => `heartbeat:${heartbeatRow().userMessageID}`
+        const opened = () => toolOpen[openKey()] === true
+        const handleOpenChange = (value: boolean) => {
+          setToolOpen(openKey(), value)
+          queueMicrotask(() => onSizeChange?.())
+        }
+
+        return (
+          <TimelineRowFrame row={heartbeatRow}>
+            <div data-slot="session-turn-message-container" class="w-full px-4 md:px-5">
+              <Collapsible
+                variant="ghost"
+                open={opened()}
+                onOpenChange={handleOpenChange}
+                class="rounded-[8px] border border-border-weak-base bg-background-base px-3"
+              >
+                <Collapsible.Trigger class="!h-auto !cursor-pointer !flex-col !items-stretch py-2.5 text-left">
+                  <div class="flex min-w-0 items-center gap-2">
+                    <Icon name="task" size="small" class="shrink-0 text-icon-info-base" />
+                    <span class="text-12-medium text-text-strong">Heartbeat</span>
+                    <span class="min-w-0 truncate text-12-regular text-text-base">{heartbeatRow().task}</span>
+                    <span class="shrink-0 rounded-md bg-surface-base px-1.5 py-0.5 text-11-medium text-text-weak">
+                      {heartbeatRow().check}
+                    </span>
+                    <span class="ml-auto flex shrink-0 items-center gap-1.5 text-11-regular text-text-weak">
+                      <span
+                        class="size-1.5 rounded-full"
+                        style={{ "background-color": statusColor() }}
+                        aria-hidden="true"
+                      />
+                      {statusLabel()}
+                    </span>
+                    <Collapsible.Arrow />
+                  </div>
+                  <Show when={summary()}>
+                    {(text) => <div class="truncate pl-6 text-12-regular text-text-weak">{text()}</div>}
+                  </Show>
+                </Collapsible.Trigger>
+                <Collapsible.Content>
+                  <div class="border-t border-border-weak-base pb-3 pt-3">
+                    <div data-slot="session-turn-assistant-content">
+                      <Index each={groups()}>
+                        {(group, index) =>
+                          renderAssistantPartGroup(
+                            () =>
+                              new TimelineRow.AssistantPart({
+                                userMessageID: heartbeatRow().userMessageID,
+                                group: group(),
+                                previousAssistantPart: index > 0,
+                              }),
+                            onSizeChange,
+                          )
+                        }
+                      </Index>
+                      <Show when={workingTurn(heartbeatRow().userMessageID) && groups().length === 0}>
+                        <TimelineThinkingRow showReasoningSummaries={false} />
+                      </Show>
+                      <Show when={heartbeatRow().error}>
+                        {(error) => (
+                          <Card variant="error" class="error-card">
+                            {error()}
+                          </Card>
+                        )}
+                      </Show>
+                    </div>
+                  </div>
+                </Collapsible.Content>
+              </Collapsible>
             </div>
           </TimelineRowFrame>
         )

--- a/packages/app/src/pages/session/timeline/rows-current.test.ts
+++ b/packages/app/src/pages/session/timeline/rows-current.test.ts
@@ -92,6 +92,44 @@ describe("current session timeline rows", () => {
     ])
   })
 
+  test("folds a synthetic heartbeat turn into one trackable row", () => {
+    const source = [
+      { id: "msg_heartbeat", type: "user", text: "heartbeat", time: { created: 1 } },
+      {
+        id: "msg_check",
+        type: "assistant",
+        agent: "build",
+        model: { id: "model", providerID: "provider" },
+        content: [{ type: "text", text: "112/140 done, 0 crashes. Waiting." }],
+        time: { created: 2, completed: 3 },
+      },
+    ] satisfies SessionMessageInfo[]
+    const normalized = normalizeSessionMessages("ses_1", source)
+    const messages = new Map(normalized.messages.map((message) => [message.id, message]))
+    const heartbeatParts = normalized.parts.get("msg_heartbeat") ?? []
+    const text = heartbeatParts[0]
+    if (!text || text.type !== "text") throw new Error("expected heartbeat text")
+    text.synthetic = true
+    text.text = '<heartbeat task="r4matrix" check="17/40">\nNo-thinking monitoring turn.\n</heartbeat>'
+
+    const result = Timeline.constructSessionMessageRows(
+      source,
+      (messageID) => messages.get(messageID),
+      (messageID) => normalized.parts.get(messageID) ?? [],
+      true,
+      "idle",
+      true,
+      normalized.messages.filter((message) => message.role === "user"),
+    )
+
+    expect(result.rows.map(TimelineRow.key)).toEqual(["heartbeat:msg_heartbeat"])
+    expect(result.rows[0]).toMatchObject({
+      _tag: "Heartbeat",
+      task: "r4matrix",
+      check: "17/40",
+    })
+  })
+
   test("keeps a projected parent missing from the source page before newer turns", () => {
     const source = [
       { id: "msg_user_1", type: "user", text: "first question", time: { created: 1 } },

--- a/packages/app/src/pages/session/timeline/rows.ts
+++ b/packages/app/src/pages/session/timeline/rows.ts
@@ -17,6 +17,12 @@ export type TimelineRowMap = {
     userMessageID: string
     anchor: boolean
   }
+  Heartbeat: {
+    userMessageID: string
+    task: string
+    check: string
+    error?: string
+  }
   TurnDivider: {
     userMessageID: string
     label: "compaction" | "interrupted"
@@ -33,6 +39,23 @@ export type TimelineRowMap = {
 }
 
 export namespace Timeline {
+  export function heartbeatInfo(parts: Part[]) {
+    const part = parts.find(
+      (item) => item.type === "text" && item.synthetic && item.text.trimStart().startsWith("<heartbeat "),
+    )
+    if (!part || part.type !== "text") return
+    const match = part.text.trimStart().match(/^<heartbeat\s+task=("(?:[^"\\]|\\.)*")\s+check=("(?:[^"\\]|\\.)*")>/)
+    if (!match?.[1] || !match[2]) return
+    try {
+      const task = JSON.parse(match[1])
+      const check = JSON.parse(match[2])
+      if (typeof task !== "string" || typeof check !== "string") return
+      return { task, check }
+    } catch {
+      return
+    }
+  }
+
   export function constructSessionMessageRows(
     messages: SessionMessageInfo[],
     getMessage: (messageID: string) => UserMessage | AssistantMessage | undefined,
@@ -113,6 +136,7 @@ export namespace Timeline {
 
     const previousUserMessage = index > 0
     const userParts = getMessageParts(userMessage.id)
+    const heartbeat = heartbeatInfo(userParts)
     const comments = userParts.flatMap((p) => MessageComment.fromPart(p) ?? [])
     const compaction = userParts.some((p) => p.type === "compaction")
     const interruptedMessageIndex = assistantMessages.findIndex((m) => m.error?.name === "MessageAbortedError")
@@ -144,6 +168,26 @@ export namespace Timeline {
           ]
         : groupParts(assistantPartRefs).map((group) => ({ type: "part" as const, group }))
     if (previousUserMessage) rows.push(new TimelineRow.TurnGap({ userMessageID: userMessage.id }))
+
+    if (heartbeat) {
+      rows.push(
+        new TimelineRow.Heartbeat({
+          userMessageID: userMessage.id,
+          task: heartbeat.task,
+          check: heartbeat.check,
+          error: error
+            ? unwrapErrorMessage(
+                typeof error.data?.message === "string"
+                  ? error.data.message
+                  : error.data?.message === undefined || error.data.message === null
+                    ? ""
+                    : String(error.data.message),
+              )
+            : undefined,
+        }),
+      )
+      return rows
+    }
 
     if (comments.length > 0 && !inlineComments)
       rows.push(

--- a/packages/app/src/pages/session/timeline/timeline-row.ts
+++ b/packages/app/src/pages/session/timeline/timeline-row.ts
@@ -15,6 +15,12 @@ export namespace TimelineRow {
     userMessageID: string
     anchor: boolean
   }> {}
+  export class Heartbeat extends Data.TaggedClass("Heartbeat")<{
+    userMessageID: string
+    task: string
+    check: string
+    error?: string
+  }> {}
   export class TurnDivider extends Data.TaggedClass("TurnDivider")<{
     userMessageID: string
     label: "compaction" | "interrupted"
@@ -44,6 +50,7 @@ export namespace TimelineRow {
     | TurnGap
     | CommentStrip
     | UserMessage
+    | Heartbeat
     | TurnDivider
     | AssistantPart
     | Thinking
@@ -59,6 +66,8 @@ export namespace TimelineRow {
         return `comment-strip:${row.userMessageID}`
       case "UserMessage":
         return `user-message:${row.userMessageID}`
+      case "Heartbeat":
+        return `heartbeat:${row.userMessageID}`
       case "TurnDivider":
         return `turn-divider:${row.userMessageID}:${row.label}`
       case "AssistantPart":

--- a/packages/core/schema.json
+++ b/packages/core/schema.json
@@ -1,8 +1,10 @@
 {
   "version": "7",
   "dialect": "sqlite",
-  "id": "f14a9b18-8207-487e-a3d3-227e629ba9ad",
-  "prevIds": ["169a0f0f-d58f-479f-b024-fa1c7b9a09db"],
+  "id": "1f752d92-9118-4b5d-9d84-dc850eb4fe41",
+  "prevIds": [
+    "f14a9b18-8207-487e-a3d3-227e629ba9ad"
+  ],
   "ddl": [
     {
       "name": "workspace",
@@ -34,6 +36,10 @@
     },
     {
       "name": "event",
+      "entityType": "tables"
+    },
+    {
+      "name": "heartbeat",
       "entityType": "tables"
     },
     {
@@ -539,6 +545,206 @@
       "name": "data",
       "entityType": "columns",
       "table": "event"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "task",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "directory",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "agent",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "revision",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_number",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "max_checks",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "delay_seconds",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "initial_delay_seconds",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "interval_seconds",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "backoff",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "max_interval_seconds",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "next_delay_seconds",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "scheduled_at",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "fires_at",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "error",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_created",
+      "entityType": "columns",
+      "table": "heartbeat"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "time_updated",
+      "entityType": "columns",
+      "table": "heartbeat"
     },
     {
       "type": "text",
@@ -1481,9 +1687,13 @@
       "table": "session_share"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1492,9 +1702,13 @@
       "table": "workspace"
     },
     {
-      "columns": ["active_account_id"],
+      "columns": [
+        "active_account_id"
+      ],
       "tableTo": "account",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "SET NULL",
       "nameExplicit": false,
@@ -1503,9 +1717,13 @@
       "table": "account_state"
     },
     {
-      "columns": ["aggregate_id"],
+      "columns": [
+        "aggregate_id"
+      ],
       "tableTo": "event_sequence",
-      "columnsTo": ["aggregate_id"],
+      "columnsTo": [
+        "aggregate_id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1514,9 +1732,28 @@
       "table": "event"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "session_id"
+      ],
+      "tableTo": "session",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_heartbeat_session_id_session_id_fk",
+      "entityType": "fks",
+      "table": "heartbeat"
+    },
+    {
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1525,9 +1762,13 @@
       "table": "permission"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1536,9 +1777,13 @@
       "table": "project_directory"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1547,9 +1792,13 @@
       "table": "message"
     },
     {
-      "columns": ["message_id"],
+      "columns": [
+        "message_id"
+      ],
       "tableTo": "message",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1558,9 +1807,13 @@
       "table": "part"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1569,9 +1822,13 @@
       "table": "session_context_epoch"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1580,9 +1837,13 @@
       "table": "session_input"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1591,9 +1852,13 @@
       "table": "session_message"
     },
     {
-      "columns": ["project_id"],
+      "columns": [
+        "project_id"
+      ],
       "tableTo": "project",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1602,9 +1867,13 @@
       "table": "session"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1613,9 +1882,13 @@
       "table": "todo"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "tableTo": "session",
-      "columnsTo": ["id"],
+      "columnsTo": [
+        "id"
+      ],
       "onUpdate": "NO ACTION",
       "onDelete": "CASCADE",
       "nameExplicit": false,
@@ -1624,133 +1897,183 @@
       "table": "session_share"
     },
     {
-      "columns": ["email", "url"],
+      "columns": [
+        "email",
+        "url"
+      ],
       "nameExplicit": false,
       "name": "control_account_pk",
       "entityType": "pks",
       "table": "control_account"
     },
     {
-      "columns": ["project_id", "directory"],
+      "columns": [
+        "project_id",
+        "directory"
+      ],
       "nameExplicit": false,
       "name": "project_directory_pk",
       "entityType": "pks",
       "table": "project_directory"
     },
     {
-      "columns": ["session_id", "position"],
+      "columns": [
+        "session_id",
+        "position"
+      ],
       "nameExplicit": false,
       "name": "todo_pk",
       "entityType": "pks",
       "table": "todo"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "workspace_pk",
       "table": "workspace",
       "entityType": "pks"
     },
     {
-      "columns": ["name"],
+      "columns": [
+        "name"
+      ],
       "nameExplicit": false,
       "name": "data_migration_pk",
       "table": "data_migration",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "account_state_pk",
       "table": "account_state",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "account_pk",
       "table": "account",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "credential_pk",
       "table": "credential",
       "entityType": "pks"
     },
     {
-      "columns": ["aggregate_id"],
+      "columns": [
+        "aggregate_id"
+      ],
       "nameExplicit": false,
       "name": "event_sequence_pk",
       "table": "event_sequence",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "event_pk",
       "table": "event",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "job_id"
+      ],
+      "nameExplicit": false,
+      "name": "heartbeat_pk",
+      "table": "heartbeat",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "permission_pk",
       "table": "permission",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "project_pk",
       "table": "project",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "message_pk",
       "table": "message",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "part_pk",
       "table": "part",
       "entityType": "pks"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "nameExplicit": false,
       "name": "session_context_epoch_pk",
       "table": "session_context_epoch",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_input_pk",
       "table": "session_input",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_message_pk",
       "table": "session_message",
       "entityType": "pks"
     },
     {
-      "columns": ["id"],
+      "columns": [
+        "id"
+      ],
       "nameExplicit": false,
       "name": "session_pk",
       "table": "session",
       "entityType": "pks"
     },
     {
-      "columns": ["session_id"],
+      "columns": [
+        "session_id"
+      ],
       "nameExplicit": false,
       "name": "session_share_pk",
       "table": "session_share",
@@ -1795,6 +2118,42 @@
       "name": "event_aggregate_type_seq_idx",
       "entityType": "indexes",
       "table": "event"
+    },
+    {
+      "columns": [
+        {
+          "value": "session_id",
+          "isExpression": false
+        },
+        {
+          "value": "task",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "heartbeat_session_task_idx",
+      "entityType": "indexes",
+      "table": "heartbeat"
+    },
+    {
+      "columns": [
+        {
+          "value": "status",
+          "isExpression": false
+        },
+        {
+          "value": "fires_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "heartbeat_status_fires_idx",
+      "entityType": "indexes",
+      "table": "heartbeat"
     },
     {
       "columns": [

--- a/packages/core/src/database/migration.gen.ts
+++ b/packages/core/src/database/migration.gen.ts
@@ -40,5 +40,6 @@ export const migrations = (
     import("./migration/20260622142730_simplify_session_context_epoch"),
     import("./migration/20260622170816_reset_v2_session_state"),
     import("./migration/20260622202450_simplify_session_input"),
+    import("./migration/20260903225524_durable_heartbeat"),
   ])
 ).map((module) => module.default) satisfies DatabaseMigration.Migration[]

--- a/packages/core/src/database/migration/20260903225524_durable_heartbeat.ts
+++ b/packages/core/src/database/migration/20260903225524_durable_heartbeat.ts
@@ -1,0 +1,37 @@
+import { Effect } from "effect"
+import type { DatabaseMigration } from "../migration"
+
+export default {
+  id: "20260903225524_durable_heartbeat",
+  up(tx) {
+    return Effect.gen(function* () {
+      yield* tx.run(`
+        CREATE TABLE \`heartbeat\` (
+          \`job_id\` text PRIMARY KEY,
+          \`session_id\` text NOT NULL,
+          \`task\` text NOT NULL,
+          \`directory\` text NOT NULL,
+          \`agent\` text NOT NULL,
+          \`status\` text NOT NULL,
+          \`revision\` integer NOT NULL,
+          \`check_number\` integer NOT NULL,
+          \`max_checks\` integer NOT NULL,
+          \`delay_seconds\` integer NOT NULL,
+          \`initial_delay_seconds\` integer NOT NULL,
+          \`interval_seconds\` integer NOT NULL,
+          \`backoff\` text NOT NULL,
+          \`max_interval_seconds\` integer NOT NULL,
+          \`next_delay_seconds\` integer NOT NULL,
+          \`scheduled_at\` integer NOT NULL,
+          \`fires_at\` integer NOT NULL,
+          \`error\` text,
+          \`time_created\` integer NOT NULL,
+          \`time_updated\` integer NOT NULL,
+          CONSTRAINT \`fk_heartbeat_session_id_session_id_fk\` FOREIGN KEY (\`session_id\`) REFERENCES \`session\`(\`id\`) ON DELETE CASCADE
+        );
+      `)
+      yield* tx.run(`CREATE UNIQUE INDEX \`heartbeat_session_task_idx\` ON \`heartbeat\` (\`session_id\`,\`task\`);`)
+      yield* tx.run(`CREATE INDEX \`heartbeat_status_fires_idx\` ON \`heartbeat\` (\`status\`,\`fires_at\`);`)
+    })
+  },
+} satisfies DatabaseMigration.Migration

--- a/packages/core/src/database/schema.gen.ts
+++ b/packages/core/src/database/schema.gen.ts
@@ -87,6 +87,31 @@ export default {
         );
       `)
       yield* tx.run(`
+        CREATE TABLE \`heartbeat\` (
+          \`job_id\` text PRIMARY KEY,
+          \`session_id\` text NOT NULL,
+          \`task\` text NOT NULL,
+          \`directory\` text NOT NULL,
+          \`agent\` text NOT NULL,
+          \`status\` text NOT NULL,
+          \`revision\` integer NOT NULL,
+          \`check_number\` integer NOT NULL,
+          \`max_checks\` integer NOT NULL,
+          \`delay_seconds\` integer NOT NULL,
+          \`initial_delay_seconds\` integer NOT NULL,
+          \`interval_seconds\` integer NOT NULL,
+          \`backoff\` text NOT NULL,
+          \`max_interval_seconds\` integer NOT NULL,
+          \`next_delay_seconds\` integer NOT NULL,
+          \`scheduled_at\` integer NOT NULL,
+          \`fires_at\` integer NOT NULL,
+          \`error\` text,
+          \`time_created\` integer NOT NULL,
+          \`time_updated\` integer NOT NULL,
+          CONSTRAINT \`fk_heartbeat_session_id_session_id_fk\` FOREIGN KEY (\`session_id\`) REFERENCES \`session\`(\`id\`) ON DELETE CASCADE
+        );
+      `)
+      yield* tx.run(`
         CREATE TABLE \`permission\` (
           \`id\` text PRIMARY KEY,
           \`project_id\` text NOT NULL,
@@ -238,6 +263,8 @@ export default {
       `)
       yield* tx.run(`CREATE UNIQUE INDEX \`event_aggregate_seq_idx\` ON \`event\` (\`aggregate_id\`,\`seq\`);`)
       yield* tx.run(`CREATE INDEX \`event_aggregate_type_seq_idx\` ON \`event\` (\`aggregate_id\`,\`type\`,\`seq\`);`)
+      yield* tx.run(`CREATE UNIQUE INDEX \`heartbeat_session_task_idx\` ON \`heartbeat\` (\`session_id\`,\`task\`);`)
+      yield* tx.run(`CREATE INDEX \`heartbeat_status_fires_idx\` ON \`heartbeat\` (\`status\`,\`fires_at\`);`)
       yield* tx.run(
         `CREATE UNIQUE INDEX \`permission_project_action_resource_idx\` ON \`permission\` (\`project_id\`,\`action\`,\`resource\`);`,
       )

--- a/packages/core/src/heartbeat/sql.ts
+++ b/packages/core/src/heartbeat/sql.ts
@@ -1,0 +1,36 @@
+import { index, integer, sqliteTable, text, uniqueIndex } from "drizzle-orm/sqlite-core"
+import { Timestamps } from "../database/schema.sql"
+import { SessionTable } from "../session/sql"
+
+export type HeartbeatStatus = "scheduled" | "firing" | "fired" | "cancelled" | "error"
+
+export const HeartbeatTable = sqliteTable(
+  "heartbeat",
+  {
+    job_id: text().primaryKey(),
+    session_id: text()
+      .notNull()
+      .references(() => SessionTable.id, { onDelete: "cascade" }),
+    task: text().notNull(),
+    directory: text().notNull(),
+    agent: text().notNull(),
+    status: text().$type<HeartbeatStatus>().notNull(),
+    revision: integer().notNull(),
+    check_number: integer().notNull(),
+    max_checks: integer().notNull(),
+    delay_seconds: integer().notNull(),
+    initial_delay_seconds: integer().notNull(),
+    interval_seconds: integer().notNull(),
+    backoff: text().$type<"fixed" | "linear" | "exponential">().notNull(),
+    max_interval_seconds: integer().notNull(),
+    next_delay_seconds: integer().notNull(),
+    scheduled_at: integer().notNull(),
+    fires_at: integer().notNull(),
+    error: text(),
+    ...Timestamps,
+  },
+  (table) => [
+    uniqueIndex("heartbeat_session_task_idx").on(table.session_id, table.task),
+    index("heartbeat_status_fires_idx").on(table.status, table.fires_at),
+  ],
+)

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -182,6 +182,30 @@ export const Info = Schema.Struct({
       mcp_timeout: Schema.optional(PositiveInt).annotate({
         description: "Timeout in milliseconds for model context protocol (MCP) requests",
       }),
+      heartbeat: Schema.optional(
+        Schema.Struct({
+          enabled: Schema.optional(Schema.Boolean).annotate({ description: "Enable heartbeat scheduling" }),
+          initial_delay_seconds: Schema.optional(
+            PositiveInt.check(Schema.isBetween({ minimum: 1, maximum: 3600 })),
+          ).annotate({ description: "Seconds of silence before the first heartbeat (default: 5)" }),
+          interval_seconds: Schema.optional(
+            PositiveInt.check(Schema.isBetween({ minimum: 1, maximum: 3600 })),
+          ).annotate({ description: "Base interval for follow-up heartbeats (default: 10)" }),
+          backoff: Schema.optional(Schema.Literals(["fixed", "linear", "exponential"])).annotate({
+            description: "Backoff applied to follow-up heartbeat intervals (default: exponential)",
+          }),
+          max_interval_seconds: Schema.optional(
+            PositiveInt.check(Schema.isBetween({ minimum: 1, maximum: 3600 })),
+          ).annotate({ description: "Maximum automatically selected heartbeat interval (default: 60)" }),
+          max_checks: Schema.optional(
+            PositiveInt.check(Schema.isBetween({ minimum: 1, maximum: 1000 })),
+          ).annotate({
+            description: "Maximum heartbeat checks in one same-session task chain (default: 60)",
+          }),
+        }),
+      ).annotate({
+        description: "Same-session no-thinking heartbeat defaults for monitoring long-running external work",
+      }),
       policies: Schema.optional(Schema.mutable(Schema.Array(ConfigExperimental.Policy))).annotate({
         description: "Policy statements applied to supported resources, such as provider access",
       }),

--- a/packages/opencode/src/heartbeat/recovery.ts
+++ b/packages/opencode/src/heartbeat/recovery.ts
@@ -1,0 +1,89 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { SessionID } from "@/session/schema"
+import { SessionPrompt } from "@/session/prompt"
+import { BackgroundJob } from "@/background/job"
+import { InstanceStore } from "@/project/instance-store"
+import { HeartbeatStore } from "./store"
+import { HeartbeatScheduler } from "./scheduler"
+import { Cause, Context, Effect, Layer, Scope } from "effect"
+
+export interface Interface {
+  readonly recovered: number
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/HeartbeatRecovery") {}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const background = yield* BackgroundJob.Service
+    const store = yield* HeartbeatStore.Service
+    const prompts = yield* SessionPrompt.Service
+    const instances = yield* InstanceStore.Service
+    const scope = yield* Scope.Scope
+    const pending = yield* store.recoverable()
+
+    const results = yield* Effect.forEach(
+      pending,
+      (saved) =>
+        Effect.gen(function* () {
+          const heartbeat = saved.status === "firing" ? yield* store.requeue(saved.jobID, saved.revision) : saved
+          if (!heartbeat) return false
+          yield* instances.provide(
+            { directory: heartbeat.directory },
+            HeartbeatScheduler.arm({
+              background,
+              store,
+              scope,
+              heartbeat,
+              deliver: (current) =>
+                prompts
+                  .prompt({
+                    sessionID: SessionID.make(current.sessionID),
+                    agent: current.agent,
+                    parts: [
+                      {
+                        type: "text",
+                        synthetic: true,
+                        text: HeartbeatScheduler.promptText(current),
+                      },
+                    ],
+                  })
+                  .pipe(Effect.asVoid),
+            }),
+          )
+          yield* Effect.logInfo("recovered durable heartbeat", {
+            jobID: heartbeat.jobID,
+            sessionID: heartbeat.sessionID,
+            task: heartbeat.task,
+            checkNumber: heartbeat.checkNumber,
+            firesAt: heartbeat.firesAt,
+          })
+          return true
+        }).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logError("failed to recover durable heartbeat", {
+              jobID: saved.jobID,
+              sessionID: saved.sessionID,
+              task: saved.task,
+              cause: Cause.pretty(cause),
+            }).pipe(Effect.as(false)),
+          ),
+        ),
+      { concurrency: "unbounded" },
+    )
+    const recovered = results.filter(Boolean).length
+    if (pending.length > 0) {
+      yield* Effect.logInfo("durable heartbeat recovery complete", { recovered, pending: pending.length })
+    }
+    return Service.of({ recovered })
+  }),
+)
+
+export const node = LayerNode.make({
+  service: Service,
+  layer,
+  deps: [HeartbeatStore.node, BackgroundJob.node, SessionPrompt.node, InstanceStore.node],
+})
+
+export * as HeartbeatRecovery from "./recovery"

--- a/packages/opencode/src/heartbeat/scheduler.ts
+++ b/packages/opencode/src/heartbeat/scheduler.ts
@@ -1,0 +1,88 @@
+import { BackgroundJob } from "@/background/job"
+import { HeartbeatStore } from "./store"
+import { Cause, Clock, Effect, Scope } from "effect"
+
+export function arm(input: {
+  background: BackgroundJob.Interface
+  store: HeartbeatStore.Interface
+  scope: Scope.Scope
+  heartbeat: HeartbeatStore.Info
+  deliver: (heartbeat: HeartbeatStore.Info) => Effect.Effect<unknown, unknown>
+}) {
+  const heartbeat = input.heartbeat
+  return Effect.gen(function* () {
+    yield* input.background.cancel(heartbeat.jobID)
+    return yield* input.background.start({
+      id: heartbeat.jobID,
+      type: "heartbeat",
+      title: heartbeat.task,
+      metadata: backgroundMetadata(heartbeat),
+      run: Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis
+        const remaining = Math.max(0, heartbeat.firesAt - now)
+        if (remaining > 0) yield* Effect.sleep(`${remaining} millis`)
+        const claimed = yield* input.store.claim(heartbeat.jobID, heartbeat.revision)
+        if (!claimed)
+          return `Skipped stale heartbeat ${heartbeat.checkNumber}/${heartbeat.maxChecks} for ${heartbeat.task}`
+
+        yield* input.deliver(claimed).pipe(
+          Effect.tap(() => input.store.complete(claimed.jobID, claimed.revision)),
+          Effect.catchCause((cause) =>
+            input.store.fail(claimed.jobID, claimed.revision, Cause.pretty(cause)).pipe(
+              Effect.andThen(
+                Effect.logError("heartbeat delivery failed", {
+                  jobID: claimed.jobID,
+                  sessionID: claimed.sessionID,
+                  task: claimed.task,
+                  cause,
+                }),
+              ),
+            ),
+          ),
+          Effect.forkIn(input.scope, { startImmediately: true }),
+        )
+
+        return `Heartbeat ${claimed.checkNumber}/${claimed.maxChecks} fired for ${claimed.task}`
+      }),
+    })
+  })
+}
+
+export function promptText(heartbeat: HeartbeatStore.Info) {
+  return [
+    `<heartbeat task=${JSON.stringify(heartbeat.task)} check=${JSON.stringify(
+      `${heartbeat.checkNumber}/${heartbeat.maxChecks}`,
+    )}>`,
+    "No-thinking monitoring turn. Inspect only the current state of this same task with the cheapest direct status command.",
+    "Do not repeat completed work, re-read unrelated context, or use sleep/blocking polling.",
+    "Report only material progress; an unchanged state is expected and is not a blocker.",
+    `If it is still running, call heartbeat again with action="schedule" and task=${JSON.stringify(heartbeat.task)}.`,
+    `Omit delay_seconds to use the next configured interval (${heartbeat.nextDelaySeconds}s), or set it to choose the exact next delay.`,
+    "If the task finished, continue the original request and verify its result.",
+    "If it failed or needs user input, diagnose it or report the blocker and do not reschedule blindly.",
+    `This check was scheduled at ${new Date(heartbeat.scheduledAt).toISOString()} and fired at approximately ${new Date(
+      heartbeat.firesAt,
+    ).toISOString()}.`,
+    "</heartbeat>",
+  ].join("\n")
+}
+
+export function backgroundMetadata(heartbeat: HeartbeatStore.Info) {
+  return {
+    sessionId: heartbeat.sessionID,
+    task: heartbeat.task,
+    revision: heartbeat.revision,
+    checkNumber: heartbeat.checkNumber,
+    maxChecks: heartbeat.maxChecks,
+    delaySeconds: heartbeat.delaySeconds,
+    initialDelaySeconds: heartbeat.initialDelaySeconds,
+    intervalSeconds: heartbeat.intervalSeconds,
+    backoff: heartbeat.backoff,
+    maxIntervalSeconds: heartbeat.maxIntervalSeconds,
+    nextDelaySeconds: heartbeat.nextDelaySeconds,
+    scheduledAt: heartbeat.scheduledAt,
+    firesAt: heartbeat.firesAt,
+  }
+}
+
+export * as HeartbeatScheduler from "./scheduler"

--- a/packages/opencode/src/heartbeat/store.ts
+++ b/packages/opencode/src/heartbeat/store.ts
@@ -1,0 +1,264 @@
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Database } from "@opencode-ai/core/database/database"
+import { HeartbeatTable, type HeartbeatStatus } from "@opencode-ai/core/heartbeat/sql"
+import { and, eq, inArray } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+
+type Row = typeof HeartbeatTable.$inferSelect
+
+export type Info = {
+  jobID: string
+  sessionID: string
+  task: string
+  directory: string
+  agent: string
+  status: HeartbeatStatus
+  revision: number
+  checkNumber: number
+  maxChecks: number
+  delaySeconds: number
+  initialDelaySeconds: number
+  intervalSeconds: number
+  backoff: "fixed" | "linear" | "exponential"
+  maxIntervalSeconds: number
+  nextDelaySeconds: number
+  scheduledAt: number
+  firesAt: number
+  error?: string
+  timeCreated: number
+  timeUpdated: number
+}
+
+export type ScheduleInput = Omit<Info, "status" | "revision" | "error" | "timeCreated" | "timeUpdated">
+
+export interface Interface {
+  readonly get: (jobID: string) => Effect.Effect<Info | undefined>
+  readonly recoverable: () => Effect.Effect<Info[]>
+  readonly schedule: (input: ScheduleInput) => Effect.Effect<Info>
+  readonly claim: (jobID: string, revision: number) => Effect.Effect<Info | undefined>
+  readonly complete: (jobID: string, revision: number) => Effect.Effect<Info | undefined>
+  readonly fail: (jobID: string, revision: number, error: string) => Effect.Effect<Info | undefined>
+  readonly cancel: (jobID: string) => Effect.Effect<Info | undefined>
+  readonly requeue: (jobID: string, revision: number) => Effect.Effect<Info | undefined>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/HeartbeatStore") {}
+
+const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const { db } = yield* Database.Service
+
+    const get: Interface["get"] = Effect.fn("HeartbeatStore.get")(function* (jobID) {
+      const row = yield* db
+        .select()
+        .from(HeartbeatTable)
+        .where(eq(HeartbeatTable.job_id, jobID))
+        .get()
+        .pipe(Effect.orDie)
+      return row ? fromRow(row) : undefined
+    })
+
+    const recoverable: Interface["recoverable"] = Effect.fn("HeartbeatStore.recoverable")(function* () {
+      const rows = yield* db
+        .select()
+        .from(HeartbeatTable)
+        .where(inArray(HeartbeatTable.status, ["scheduled", "firing"]))
+        .all()
+        .pipe(Effect.orDie)
+      return rows.map(fromRow)
+    })
+
+    const schedule: Interface["schedule"] = Effect.fn("HeartbeatStore.schedule")(function* (input) {
+      return yield* db
+        .transaction((tx) =>
+          Effect.gen(function* () {
+            const previous = yield* tx.select().from(HeartbeatTable).where(eq(HeartbeatTable.job_id, input.jobID)).get()
+            const now = input.scheduledAt
+            const value: typeof HeartbeatTable.$inferInsert = {
+              job_id: input.jobID,
+              session_id: input.sessionID,
+              task: input.task,
+              directory: input.directory,
+              agent: input.agent,
+              status: "scheduled",
+              revision: (previous?.revision ?? 0) + 1,
+              check_number: input.checkNumber,
+              max_checks: input.maxChecks,
+              delay_seconds: input.delaySeconds,
+              initial_delay_seconds: input.initialDelaySeconds,
+              interval_seconds: input.intervalSeconds,
+              backoff: input.backoff,
+              max_interval_seconds: input.maxIntervalSeconds,
+              next_delay_seconds: input.nextDelaySeconds,
+              scheduled_at: input.scheduledAt,
+              fires_at: input.firesAt,
+              error: null,
+              time_created: previous?.time_created ?? now,
+              time_updated: now,
+            }
+            yield* tx
+              .insert(HeartbeatTable)
+              .values(value)
+              .onConflictDoUpdate({
+                target: HeartbeatTable.job_id,
+                set: {
+                  session_id: value.session_id,
+                  task: value.task,
+                  directory: value.directory,
+                  agent: value.agent,
+                  status: value.status,
+                  revision: value.revision,
+                  check_number: value.check_number,
+                  max_checks: value.max_checks,
+                  delay_seconds: value.delay_seconds,
+                  initial_delay_seconds: value.initial_delay_seconds,
+                  interval_seconds: value.interval_seconds,
+                  backoff: value.backoff,
+                  max_interval_seconds: value.max_interval_seconds,
+                  next_delay_seconds: value.next_delay_seconds,
+                  scheduled_at: value.scheduled_at,
+                  fires_at: value.fires_at,
+                  error: null,
+                  time_updated: now,
+                },
+              })
+              .run()
+            return fromRow(value as Row)
+          }),
+        )
+        .pipe(Effect.orDie)
+    })
+
+    const claim: Interface["claim"] = Effect.fn("HeartbeatStore.claim")(function* (jobID, revision) {
+      const row = yield* db
+        .update(HeartbeatTable)
+        .set({ status: "firing", error: null, time_updated: Date.now() })
+        .where(
+          and(
+            eq(HeartbeatTable.job_id, jobID),
+            eq(HeartbeatTable.revision, revision),
+            eq(HeartbeatTable.status, "scheduled"),
+          ),
+        )
+        .returning()
+        .get()
+        .pipe(Effect.orDie)
+      return row ? fromRow(row) : undefined
+    })
+
+    const complete: Interface["complete"] = Effect.fn("HeartbeatStore.complete")(function* (jobID, revision) {
+      const row = yield* db
+        .update(HeartbeatTable)
+        .set({ status: "fired", time_updated: Date.now() })
+        .where(
+          and(
+            eq(HeartbeatTable.job_id, jobID),
+            eq(HeartbeatTable.revision, revision),
+            eq(HeartbeatTable.status, "firing"),
+          ),
+        )
+        .returning()
+        .get()
+        .pipe(Effect.orDie)
+      return row ? fromRow(row) : undefined
+    })
+
+    const fail: Interface["fail"] = Effect.fn("HeartbeatStore.fail")(function* (jobID, revision, error) {
+      const row = yield* db
+        .update(HeartbeatTable)
+        .set({ status: "error", error, time_updated: Date.now() })
+        .where(
+          and(
+            eq(HeartbeatTable.job_id, jobID),
+            eq(HeartbeatTable.revision, revision),
+            eq(HeartbeatTable.status, "firing"),
+          ),
+        )
+        .returning()
+        .get()
+        .pipe(Effect.orDie)
+      return row ? fromRow(row) : undefined
+    })
+
+    const cancel: Interface["cancel"] = Effect.fn("HeartbeatStore.cancel")(function* (jobID) {
+      return yield* db
+        .transaction((tx) =>
+          Effect.gen(function* () {
+            const previous = yield* tx.select().from(HeartbeatTable).where(eq(HeartbeatTable.job_id, jobID)).get()
+            if (!previous) return
+            if (previous.status === "cancelled") return fromRow(previous)
+            const row = yield* tx
+              .update(HeartbeatTable)
+              .set({
+                status: "cancelled",
+                revision: previous.revision + 1,
+                error: null,
+                time_updated: Date.now(),
+              })
+              .where(and(eq(HeartbeatTable.job_id, jobID), eq(HeartbeatTable.revision, previous.revision)))
+              .returning()
+              .get()
+            return row ? fromRow(row) : undefined
+          }),
+        )
+        .pipe(Effect.orDie)
+    })
+
+    const requeue: Interface["requeue"] = Effect.fn("HeartbeatStore.requeue")(function* (jobID, revision) {
+      const now = Date.now()
+      const row = yield* db
+        .update(HeartbeatTable)
+        .set({
+          status: "scheduled",
+          revision: revision + 1,
+          scheduled_at: now,
+          fires_at: now,
+          error: null,
+          time_updated: now,
+        })
+        .where(
+          and(
+            eq(HeartbeatTable.job_id, jobID),
+            eq(HeartbeatTable.revision, revision),
+            eq(HeartbeatTable.status, "firing"),
+          ),
+        )
+        .returning()
+        .get()
+        .pipe(Effect.orDie)
+      return row ? fromRow(row) : undefined
+    })
+
+    return Service.of({ get, recoverable, schedule, claim, complete, fail, cancel, requeue })
+  }),
+)
+
+export const node = LayerNode.make({ service: Service, layer, deps: [Database.node] })
+
+function fromRow(row: Row): Info {
+  return {
+    jobID: row.job_id,
+    sessionID: row.session_id,
+    task: row.task,
+    directory: row.directory,
+    agent: row.agent,
+    status: row.status,
+    revision: row.revision,
+    checkNumber: row.check_number,
+    maxChecks: row.max_checks,
+    delaySeconds: row.delay_seconds,
+    initialDelaySeconds: row.initial_delay_seconds,
+    intervalSeconds: row.interval_seconds,
+    backoff: row.backoff,
+    maxIntervalSeconds: row.max_interval_seconds,
+    nextDelaySeconds: row.next_delay_seconds,
+    scheduledAt: row.scheduled_at,
+    firesAt: row.fires_at,
+    error: row.error ?? undefined,
+    timeCreated: row.time_created,
+    timeUpdated: row.time_updated,
+  }
+}
+
+export * as HeartbeatStore from "./store"

--- a/packages/opencode/src/server/routes/instance/httpapi/server.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/server.ts
@@ -8,6 +8,7 @@ import { Account } from "@/account/account"
 import { Agent } from "@/agent/agent"
 import { Auth } from "@/auth"
 import { BackgroundJob } from "@/background/job"
+import { HeartbeatRecovery } from "@/heartbeat/recovery"
 import { Command } from "@/command"
 import { Config } from "@/config/config"
 import { Workspace } from "@/control-plane/workspace"
@@ -236,6 +237,7 @@ const app = LayerNode.group([
   SessionProjector.node,
   SessionStatus.node,
   BackgroundJob.node,
+  HeartbeatRecovery.node,
   RuntimeFlags.node,
   EventV2Bridge.node,
   SessionRunState.node,

--- a/packages/opencode/src/session/run-state.ts
+++ b/packages/opencode/src/session/run-state.ts
@@ -117,6 +117,10 @@ const cancelBackgroundJobs = Effect.fn("SessionRunState.cancelBackgroundJobs")(f
   const cancelled = new Set<string>()
   const matches = (job: BackgroundJob.Info) => {
     if (job.status !== "running") return false
+    // Heartbeats are durable session monitors, not child work owned by the
+    // active response. A new prompt or response cancellation must not silently
+    // disarm them; only the heartbeat cancel action (or session deletion) does.
+    if (job.type === "heartbeat") return false
     if (cancelled.has(job.id)) return false
     if (pending.has(job.id)) return true
     if (typeof job.metadata?.sessionId === "string" && pending.has(job.metadata.sessionId)) return true

--- a/packages/opencode/src/tool/heartbeat.ts
+++ b/packages/opencode/src/tool/heartbeat.ts
@@ -1,0 +1,275 @@
+import { BackgroundJob } from "@/background/job"
+import { Config } from "@/config/config"
+import { InstanceState } from "@/effect/instance-state"
+import { HeartbeatScheduler } from "@/heartbeat/scheduler"
+import { HeartbeatStore } from "@/heartbeat/store"
+import { PositiveInt } from "@opencode-ai/core/schema"
+import { Clock, Effect, Schema, Scope } from "effect"
+import type { TaskPromptOps } from "./task"
+import { Tool } from "./tool"
+import DESCRIPTION from "./heartbeat.txt"
+
+const MAX_DELAY_SECONDS = 60 * 60
+const MAX_CHECKS = 1000
+const DEFAULT_INITIAL_DELAY_SECONDS = 5
+const DEFAULT_INTERVAL_SECONDS = 10
+const DEFAULT_MAX_INTERVAL_SECONDS = 60
+const DEFAULT_MAX_CHECKS = 60
+
+const Backoff = Schema.Literals(["fixed", "linear", "exponential"])
+
+export const Parameters = Schema.Struct({
+  action: Schema.optional(Schema.Literals(["schedule", "status", "cancel"])).annotate({
+    description: "Operation to perform (default: schedule)",
+  }),
+  task: Schema.String.annotate({
+    description: "Stable short name for the ongoing task. Reuse it for status, rescheduling, and cancellation.",
+  }),
+  delay_seconds: Schema.optional(
+    PositiveInt.check(Schema.isBetween({ minimum: 1, maximum: MAX_DELAY_SECONDS })),
+  ).annotate({
+    description: "Exact delay before this next check. Omit to use the configured initial/next interval.",
+  }),
+  interval_seconds: Schema.optional(
+    PositiveInt.check(Schema.isBetween({ minimum: 1, maximum: MAX_DELAY_SECONDS })),
+  ).annotate({
+    description: "Base interval retained for later checks in this same task chain.",
+  }),
+  backoff: Schema.optional(Backoff).annotate({
+    description: "Interval policy retained for later checks: fixed, linear, or exponential.",
+  }),
+  max_interval_seconds: Schema.optional(
+    PositiveInt.check(Schema.isBetween({ minimum: 1, maximum: MAX_DELAY_SECONDS })),
+  ).annotate({
+    description: "Upper bound for automatically calculated intervals.",
+  }),
+  max_checks: Schema.optional(PositiveInt.check(Schema.isBetween({ minimum: 1, maximum: MAX_CHECKS }))).annotate({
+    description: "Safety limit for checks in this task chain.",
+  }),
+})
+
+export const HeartbeatTool = Tool.define(
+  "heartbeat",
+  Effect.gen(function* () {
+    const background = yield* BackgroundJob.Service
+    const config = yield* Config.Service
+    const store = yield* HeartbeatStore.Service
+    const scope = yield* Scope.Scope
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Schema.Schema.Type<typeof Parameters>, ctx: Tool.Context) =>
+        Effect.gen(function* () {
+          const jobID = `heartbeat:${ctx.sessionID}:${params.task}`
+          const action = params.action ?? "schedule"
+          const existing = yield* store.get(jobID)
+
+          if (action === "status") {
+            const now = yield* Clock.currentTimeMillis
+            if (!existing) {
+              return {
+                title: `Heartbeat status: ${params.task}`,
+                metadata: heartbeatMetadata({ jobID, task: params.task }),
+                output: `No heartbeat history found for ${JSON.stringify(params.task)} in this session.`,
+              }
+            }
+            const remainingSeconds =
+              existing.status === "scheduled" && existing.firesAt > now ? Math.ceil((existing.firesAt - now) / 1000) : 0
+            return {
+              title: `Heartbeat status: ${params.task}`,
+              metadata: heartbeatMetadata({ heartbeat: existing, remainingSeconds }),
+              output: [
+                `Heartbeat ${JSON.stringify(params.task)} is ${publicStatus(existing.status)}.`,
+                `Durable state: ${existing.status}; revision: ${existing.revision}.`,
+                `Check: ${existing.checkNumber}/${existing.maxChecks}.`,
+                existing.firesAt > 0
+                  ? `Scheduled fire time: ${new Date(existing.firesAt).toISOString()} (${remainingSeconds} seconds remaining).`
+                  : "No future fire time is recorded.",
+                `Next default interval: ${existing.nextDelaySeconds} seconds.`,
+              ].join("\n"),
+            }
+          }
+
+          if (action === "cancel") {
+            yield* background.cancel(jobID)
+            const cancelled = yield* store.cancel(jobID)
+            return {
+              title: `Heartbeat cancelled: ${params.task}`,
+              metadata: cancelled
+                ? heartbeatMetadata({ heartbeat: cancelled, remainingSeconds: 0 })
+                : heartbeatMetadata({ jobID, task: params.task }),
+              output: cancelled
+                ? `Heartbeat ${JSON.stringify(params.task)} is cancelled; no new check was scheduled.`
+                : `No heartbeat history found for ${JSON.stringify(params.task)} in this session.`,
+            }
+          }
+
+          const ops = ctx.extra?.promptOps as TaskPromptOps | undefined
+          if (!ops) return yield* Effect.fail(new Error("Heartbeat requires session prompt operations"))
+          const settings = (yield* config.get()).experimental?.heartbeat
+          if (settings?.enabled === false) return yield* Effect.fail(new Error("Heartbeat scheduling is disabled"))
+
+          const initialDelaySeconds =
+            existing?.initialDelaySeconds ?? settings?.initial_delay_seconds ?? DEFAULT_INITIAL_DELAY_SECONDS
+          const intervalSeconds =
+            params.interval_seconds ??
+            existing?.intervalSeconds ??
+            settings?.interval_seconds ??
+            DEFAULT_INTERVAL_SECONDS
+          const backoff = params.backoff ?? existing?.backoff ?? settings?.backoff ?? "exponential"
+          const maxIntervalSeconds =
+            params.max_interval_seconds ??
+            existing?.maxIntervalSeconds ??
+            settings?.max_interval_seconds ??
+            DEFAULT_MAX_INTERVAL_SECONDS
+          const maxChecks = params.max_checks ?? existing?.maxChecks ?? settings?.max_checks ?? DEFAULT_MAX_CHECKS
+          const checkNumber =
+            existing?.status === "scheduled"
+              ? existing.checkNumber
+              : existing?.status === "firing" || existing?.status === "fired"
+                ? existing.checkNumber + 1
+                : 1
+          if (checkNumber > maxChecks) {
+            return yield* Effect.fail(
+              new Error(`Heartbeat ${JSON.stringify(params.task)} reached its ${maxChecks}-check safety limit`),
+            )
+          }
+
+          const delaySeconds =
+            params.delay_seconds ??
+            delayForCheck({
+              checkNumber,
+              initialDelaySeconds,
+              intervalSeconds,
+              backoff,
+              maxIntervalSeconds,
+            })
+          const nextDelaySeconds = delayForCheck({
+            checkNumber: checkNumber + 1,
+            initialDelaySeconds,
+            intervalSeconds,
+            backoff,
+            maxIntervalSeconds,
+          })
+          const scheduledAt = yield* Clock.currentTimeMillis
+          const directory = yield* InstanceState.directory
+          const heartbeat = yield* store.schedule({
+            jobID,
+            sessionID: ctx.sessionID,
+            task: params.task,
+            directory,
+            agent: ctx.agent,
+            checkNumber,
+            maxChecks,
+            delaySeconds,
+            initialDelaySeconds,
+            intervalSeconds,
+            backoff,
+            maxIntervalSeconds,
+            nextDelaySeconds,
+            scheduledAt,
+            firesAt: scheduledAt + delaySeconds * 1000,
+          })
+
+          yield* HeartbeatScheduler.arm({
+            background,
+            store,
+            scope,
+            heartbeat,
+            deliver: (current) =>
+              ops
+                .prompt({
+                  sessionID: ctx.sessionID,
+                  agent: current.agent,
+                  parts: [
+                    {
+                      type: "text",
+                      synthetic: true,
+                      text: HeartbeatScheduler.promptText(current),
+                    },
+                  ],
+                })
+                .pipe(Effect.asVoid),
+          })
+
+          return {
+            title: `Heartbeat ${heartbeat.checkNumber}/${heartbeat.maxChecks}: ${heartbeat.task}`,
+            metadata: heartbeatMetadata({ heartbeat, remainingSeconds: delaySeconds }),
+            output: [
+              `Scheduled durable no-thinking heartbeat ${heartbeat.checkNumber}/${heartbeat.maxChecks} for ${JSON.stringify(
+                heartbeat.task,
+              )}.`,
+              `Fires at ${new Date(heartbeat.firesAt).toISOString()} (in ${delaySeconds} seconds).`,
+              `If still running, the next default interval is ${nextDelaySeconds} seconds (${backoff} backoff, maximum ${maxIntervalSeconds} seconds).`,
+              "This schedule survives OpenCode restarts.",
+              "Call action=status to inspect it, action=cancel to stop it, or action=schedule with the same task to replace it.",
+            ].join("\n"),
+          }
+        }).pipe(Effect.orDie),
+    }
+  }),
+)
+
+function publicStatus(status: HeartbeatStore.Info["status"]) {
+  if (status === "scheduled" || status === "firing") return "running"
+  if (status === "fired") return "completed"
+  return status
+}
+
+function heartbeatMetadata(
+  input: { heartbeat: HeartbeatStore.Info; remainingSeconds: number } | { jobID: string; task: string },
+) {
+  if ("heartbeat" in input) {
+    const heartbeat = input.heartbeat
+    return {
+      jobId: heartbeat.jobID,
+      task: heartbeat.task,
+      status: publicStatus(heartbeat.status),
+      durableStatus: heartbeat.status,
+      revision: heartbeat.revision,
+      checkNumber: heartbeat.checkNumber,
+      maxChecks: heartbeat.maxChecks,
+      delaySeconds: heartbeat.delaySeconds,
+      initialDelaySeconds: heartbeat.initialDelaySeconds,
+      intervalSeconds: heartbeat.intervalSeconds,
+      backoff: heartbeat.backoff,
+      maxIntervalSeconds: heartbeat.maxIntervalSeconds,
+      nextDelaySeconds: heartbeat.nextDelaySeconds,
+      scheduledAt: heartbeat.scheduledAt,
+      firesAt: heartbeat.firesAt,
+      remainingSeconds: input.remainingSeconds,
+    }
+  }
+  return {
+    jobId: input.jobID,
+    task: input.task,
+    status: "missing",
+    durableStatus: "missing",
+    revision: 0,
+    checkNumber: 0,
+    maxChecks: 0,
+    delaySeconds: 0,
+    initialDelaySeconds: 0,
+    intervalSeconds: 0,
+    backoff: "exponential" as const,
+    maxIntervalSeconds: 0,
+    nextDelaySeconds: 0,
+    scheduledAt: 0,
+    firesAt: 0,
+    remainingSeconds: 0,
+  }
+}
+
+function delayForCheck(input: {
+  checkNumber: number
+  initialDelaySeconds: number
+  intervalSeconds: number
+  backoff: "fixed" | "linear" | "exponential"
+  maxIntervalSeconds: number
+}) {
+  if (input.checkNumber <= 1) return Math.min(input.initialDelaySeconds, MAX_DELAY_SECONDS)
+  const step = input.checkNumber - 2
+  const multiplier = input.backoff === "fixed" ? 1 : input.backoff === "linear" ? step + 1 : 2 ** Math.min(step, 52)
+  return Math.min(input.intervalSeconds * multiplier, input.maxIntervalSeconds, MAX_DELAY_SECONDS)
+}

--- a/packages/opencode/src/tool/heartbeat.txt
+++ b/packages/opencode/src/tool/heartbeat.txt
@@ -1,0 +1,27 @@
+Manage lightweight, no-thinking follow-ups in this same session for ongoing external work.
+
+Use this after starting work that outlives the current tool call, such as a nohup build, benchmark, fuzz run, deployment, or remote job that has no automatic completion notification. Do not sleep or hold a shell call open just to poll it.
+
+Actions:
+- schedule: create or replace the next check for this task;
+- status: inspect its current schedule, check number, and next fire time;
+- cancel: stop its pending check.
+
+For schedule, delay_seconds is optional. The first check uses the configured initial silence delay. Later checks use the configured interval and backoff. Set delay_seconds when the next check needs an exact custom delay. You may also override interval_seconds, backoff, max_interval_seconds, and max_checks for this task chain.
+
+Each scheduled heartbeat fires once. When it fires:
+- check the task using the cheapest direct status command;
+- report only material progress;
+- if it is still running, call heartbeat again with the same task and set delay_seconds to the desired next interval;
+- if it completed, continue and verify the original task;
+- if it failed, diagnose or report the failure.
+
+Calling schedule again with the same task before it fires replaces the pending schedule without incrementing the check number. Do not use heartbeat for Task-tool background agents because those already notify this session automatically.
+
+Schedules, check counts, timing, and interval policy are durable. If OpenCode restarts, a pending check resumes at its original fire time; an overdue check runs immediately without resetting the chain.
+
+Default schedule when config does not override it:
+- first check after 5 seconds;
+- follow-ups start at 10 seconds;
+- exponential backoff capped at 60 seconds;
+- at most 60 checks.

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -4,6 +4,7 @@ import { Ripgrep } from "@opencode-ai/core/ripgrep"
 import { PlanExitTool } from "./plan"
 import { Session } from "@/session/session"
 import { QuestionTool } from "./question"
+import { HeartbeatTool } from "./heartbeat"
 import { ShellTool } from "./shell"
 import { EditTool } from "./edit"
 import { GlobTool } from "./glob"
@@ -48,6 +49,7 @@ import { Agent } from "../agent/agent"
 import { Skill } from "../skill"
 import { Permission } from "@/permission"
 import { BackgroundJob } from "@/background/job"
+import { HeartbeatStore } from "@/heartbeat/store"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
 import { ModelV2 } from "@opencode-ai/core/model"
@@ -108,6 +110,7 @@ const layer = Layer.effect(
     const webfetch = yield* WebFetchTool
     const websearch = yield* WebSearchTool
     const shell = yield* ShellTool
+    const heartbeat = yield* HeartbeatTool
     const globtool = yield* GlobTool
     const writetool = yield* WriteTool
     const edit = yield* EditTool
@@ -209,6 +212,7 @@ const layer = Layer.effect(
         const tool = yield* Effect.all({
           invalid: Tool.init(invalid),
           shell: Tool.init(shell),
+          heartbeat: Tool.init(heartbeat),
           read: Tool.init(read),
           glob: Tool.init(globtool),
           grep: Tool.init(greptool),
@@ -232,6 +236,7 @@ const layer = Layer.effect(
             tool.invalid,
             ...(questionEnabled ? [tool.question] : []),
             tool.shell,
+            tool.heartbeat,
             tool.read,
             tool.glob,
             tool.grep,
@@ -436,6 +441,7 @@ export const node = LayerNode.make({
     Skill.node,
     Session.node,
     BackgroundJob.node,
+    HeartbeatStore.node,
     Provider.node,
     LSP.node,
     Instruction.node,

--- a/packages/opencode/src/tool/shell/shell.txt
+++ b/packages/opencode/src/tool/shell/shell.txt
@@ -10,6 +10,10 @@ IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO N
 
 ${commandSection}
 
+# Long-running external work
+
+When a command starts work that will continue after this shell call (for example via nohup or a remote job), call Heartbeat with action=schedule after the command returns. Pick a short stable task name. Omit delay_seconds for the configured first-silence/interval/backoff policy, or set it for an exact next check. Each heartbeat is a no-thinking follow-up; if work is still running, schedule the same task again. Use action=status to inspect a schedule and action=cancel when it is no longer needed. Do not use sleep or a blocking polling loop to wait for external work.
+
 # Git and GitHub
 - Only commit, amend, push, or create PRs when explicitly requested.
 - Before committing, inspect `git status`, `git diff`, and `git log --oneline -10`; stage only intended files and never commit secrets.

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -136,6 +136,68 @@ exports[`tool parameters JSON Schema (wire shape) invalid 1`] = `
 }
 `;
 
+exports[`tool parameters JSON Schema (wire shape) heartbeat 1`] = `
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "action": {
+      "description": "Operation to perform (default: schedule)",
+      "enum": [
+        "schedule",
+        "status",
+        "cancel",
+      ],
+      "type": "string",
+    },
+    "backoff": {
+      "description": "Interval policy retained for later checks: fixed, linear, or exponential.",
+      "enum": [
+        "fixed",
+        "linear",
+        "exponential",
+      ],
+      "type": "string",
+    },
+    "delay_seconds": {
+      "description": "Exact delay before this next check. Omit to use the configured initial/next interval.",
+      "exclusiveMinimum": 0,
+      "maximum": 3600,
+      "minimum": 1,
+      "type": "integer",
+    },
+    "interval_seconds": {
+      "description": "Base interval retained for later checks in this same task chain.",
+      "exclusiveMinimum": 0,
+      "maximum": 3600,
+      "minimum": 1,
+      "type": "integer",
+    },
+    "max_checks": {
+      "description": "Safety limit for checks in this task chain.",
+      "exclusiveMinimum": 0,
+      "maximum": 1000,
+      "minimum": 1,
+      "type": "integer",
+    },
+    "max_interval_seconds": {
+      "description": "Upper bound for automatically calculated intervals.",
+      "exclusiveMinimum": 0,
+      "maximum": 3600,
+      "minimum": 1,
+      "type": "integer",
+    },
+    "task": {
+      "description": "Stable short name for the ongoing task. Reuse it for status, rescheduling, and cancellation.",
+      "type": "string",
+    },
+  },
+  "required": [
+    "task",
+  ],
+  "type": "object",
+}
+`;
+
 exports[`tool parameters JSON Schema (wire shape) lsp 1`] = `
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/packages/opencode/test/tool/heartbeat.test.ts
+++ b/packages/opencode/test/tool/heartbeat.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProjectV2 } from "@opencode-ai/core/project"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { Deferred, Effect, Layer, Ref, Scope } from "effect"
+import { Agent } from "@/agent/agent"
+import { BackgroundJob } from "@/background/job"
+import { Config } from "@/config/config"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Database } from "@opencode-ai/core/database/database"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { HeartbeatScheduler } from "@/heartbeat/scheduler"
+import { HeartbeatStore } from "@/heartbeat/store"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { MessageID, SessionID } from "@/session/schema"
+import type { SessionPrompt } from "@/session/prompt"
+import { HeartbeatTool } from "@/tool/heartbeat"
+import type { TaskPromptOps } from "@/tool/task"
+import { Truncate } from "@/tool/truncate"
+import { disposeAllInstances } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const layer = LayerNode.compile(
+  LayerNode.group([
+    Agent.node,
+    BackgroundJob.node,
+    Database.node,
+    HeartbeatStore.node,
+    Config.node,
+    CrossSpawnSpawner.node,
+    Truncate.node,
+    RuntimeFlags.node,
+    Ripgrep.node,
+  ]),
+  [[RuntimeFlags.node, RuntimeFlags.layer()]],
+)
+const it = testEffect(layer)
+
+afterEach(async () => {
+  await disposeAllInstances()
+})
+
+function reply(sessionID: SessionID): SessionV1.WithParts {
+  const id = MessageID.ascending()
+  return {
+    info: {
+      id,
+      role: "assistant",
+      parentID: MessageID.ascending(),
+      sessionID,
+      mode: "build",
+      agent: "build",
+      cost: 0,
+      path: { cwd: "/tmp", root: "/tmp" },
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      modelID: ModelV2.ID.make("test-model"),
+      providerID: ProviderV2.ID.make("test"),
+      time: { created: Date.now() },
+      finish: "stop",
+    },
+    parts: [],
+  }
+}
+
+const seedSession = Effect.fn("HeartbeatTest.seedSession")(function* (sessionID: SessionID) {
+  const { db } = yield* Database.Service
+  const projectID = ProjectV2.ID.global
+  yield* db
+    .insert(ProjectTable)
+    .values({ id: projectID, worktree: AbsolutePath.make("/"), sandboxes: [] })
+    .onConflictDoNothing()
+    .run()
+    .pipe(Effect.orDie)
+  yield* db
+    .insert(SessionTable)
+    .values({
+      id: sessionID,
+      project_id: projectID,
+      slug: "heartbeat-session",
+      directory: "/tmp",
+      title: "heartbeat session",
+      version: "test",
+    })
+    .onConflictDoNothing()
+    .run()
+    .pipe(Effect.orDie)
+})
+
+describe("tool.heartbeat", () => {
+  it.instance("fires once and replaces a pending heartbeat for the same task", () =>
+    Effect.gen(function* () {
+      const fired = yield* Deferred.make<SessionPrompt.PromptInput>()
+      const count = yield* Ref.make(0)
+      const promptOps: TaskPromptOps = {
+        cancel: () => Effect.void,
+        resolvePromptParts: (text) => Effect.succeed([{ type: "text", text }]),
+        prompt: (input) =>
+          Effect.all([Ref.update(count, (value) => value + 1), Deferred.succeed(fired, input)], { discard: true }).pipe(
+            Effect.as(reply(input.sessionID)),
+          ),
+      }
+      const sessionID = SessionID.make("ses_heartbeat")
+      yield* seedSession(sessionID)
+      const jobs = yield* BackgroundJob.Service
+      const store = yield* HeartbeatStore.Service
+      const tool = yield* HeartbeatTool
+      const heartbeat = yield* tool.init()
+      const context = {
+        sessionID,
+        messageID: MessageID.make("msg_heartbeat"),
+        callID: "call_heartbeat",
+        agent: "build",
+        abort: new AbortController().signal,
+        messages: [],
+        extra: { promptOps },
+        metadata: () => Effect.void,
+        ask: () => Effect.void,
+      }
+
+      const first = yield* heartbeat.execute(
+        {
+          task: "fuzz matrix",
+          delay_seconds: 2,
+          interval_seconds: 10,
+          backoff: "exponential",
+          max_interval_seconds: 60,
+          max_checks: 3,
+        },
+        context,
+      )
+      const second = yield* heartbeat.execute({ task: "fuzz matrix", delay_seconds: 1 }, context)
+      expect(first.metadata.jobId).toBe(second.metadata.jobId)
+      expect(second.metadata).toMatchObject({ checkNumber: 1, nextDelaySeconds: 10 })
+
+      const running = yield* heartbeat.execute({ action: "status", task: "fuzz matrix" }, context)
+      expect(running.metadata).toMatchObject({ status: "running", checkNumber: 1 })
+      expect(yield* store.get(String(second.metadata.jobId))).toMatchObject({
+        status: "scheduled",
+        revision: 2,
+        checkNumber: 1,
+      })
+
+      const input = yield* Deferred.await(fired).pipe(Effect.timeout("3 seconds"))
+      expect(input.sessionID).toBe(sessionID)
+      expect(input.agent).toBe("build")
+      expect(input.parts[0]).toMatchObject({
+        type: "text",
+        synthetic: true,
+      })
+      if (input.parts[0]?.type !== "text") throw new Error("expected heartbeat text")
+      expect(input.parts[0].text).toContain('<heartbeat task="fuzz matrix" check="1/3">')
+      expect(input.parts[0].text).toContain("No-thinking monitoring turn")
+
+      const settled = yield* jobs.wait({ id: String(second.metadata.jobId), timeout: 2000 })
+      expect(settled.info?.status).toBe("completed")
+      yield* Effect.sleep("20 millis")
+
+      const completed = yield* heartbeat.execute({ action: "status", task: "fuzz matrix" }, context)
+      expect(completed.metadata).toMatchObject({ status: "completed", checkNumber: 1 })
+
+      const followup = yield* heartbeat.execute({ action: "schedule", task: "fuzz matrix" }, context)
+      expect(followup.metadata).toMatchObject({
+        checkNumber: 2,
+        delaySeconds: 10,
+        nextDelaySeconds: 20,
+        backoff: "exponential",
+      })
+      const cancelled = yield* heartbeat.execute({ action: "cancel", task: "fuzz matrix" }, context)
+      expect(cancelled.metadata.status).toBe("cancelled")
+
+      yield* Effect.sleep("1200 millis")
+      expect(yield* Ref.get(count)).toBe(1)
+    }),
+  )
+
+  it.instance("re-arms a persisted pending heartbeat without incrementing its check", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionID.make("ses_heartbeat_restart")
+      yield* seedSession(sessionID)
+      const delivered = yield* Deferred.make<HeartbeatStore.Info>()
+      const promptOps: TaskPromptOps = {
+        cancel: () => Effect.void,
+        resolvePromptParts: (text) => Effect.succeed([{ type: "text", text }]),
+        prompt: (input) => Effect.succeed(reply(input.sessionID)),
+      }
+      const jobs = yield* BackgroundJob.Service
+      const store = yield* HeartbeatStore.Service
+      const scope = yield* Scope.Scope
+      const tool = yield* HeartbeatTool
+      const heartbeat = yield* tool.init()
+      const context = {
+        sessionID,
+        messageID: MessageID.make("msg_heartbeat_restart"),
+        callID: "call_heartbeat_restart",
+        agent: "build",
+        abort: new AbortController().signal,
+        messages: [],
+        extra: { promptOps },
+        metadata: () => Effect.void,
+        ask: () => Effect.void,
+      }
+
+      const scheduled = yield* heartbeat.execute({ task: "restart recovery", delay_seconds: 1, max_checks: 5 }, context)
+      const jobID = String(scheduled.metadata.jobId)
+      const saved = yield* store.get(jobID)
+      if (!saved) throw new Error("expected durable heartbeat row")
+      yield* jobs.cancel(jobID)
+
+      expect(yield* store.get(jobID)).toMatchObject({ status: "scheduled", checkNumber: 1 })
+      yield* HeartbeatScheduler.arm({
+        background: jobs,
+        store,
+        scope,
+        heartbeat: saved,
+        deliver: (current) => Deferred.succeed(delivered, current),
+      })
+
+      const fired = yield* Deferred.await(delivered).pipe(Effect.timeout("3 seconds"))
+      expect(fired).toMatchObject({ revision: saved.revision, checkNumber: 1 })
+      yield* Effect.sleep("20 millis")
+      expect(yield* store.get(jobID)).toMatchObject({ status: "fired", checkNumber: 1 })
+    }),
+  )
+
+  it.instance("retains the persisted timing policy when scheduling the next check", () =>
+    Effect.gen(function* () {
+      const sessionID = SessionID.make("ses_heartbeat_policy")
+      yield* seedSession(sessionID)
+      const store = yield* HeartbeatStore.Service
+      const tool = yield* HeartbeatTool
+      const heartbeat = yield* tool.init()
+      const jobID = `heartbeat:${sessionID}:persisted policy`
+      const now = Date.now()
+      const saved = yield* store.schedule({
+        jobID,
+        sessionID,
+        task: "persisted policy",
+        directory: "/tmp",
+        agent: "build",
+        checkNumber: 1,
+        maxChecks: 8,
+        delaySeconds: 37,
+        initialDelaySeconds: 37,
+        intervalSeconds: 41,
+        backoff: "linear",
+        maxIntervalSeconds: 97,
+        nextDelaySeconds: 41,
+        scheduledAt: now,
+        firesAt: now + 37_000,
+      })
+      const claimed = yield* store.claim(jobID, saved.revision)
+      if (!claimed) throw new Error("expected heartbeat claim")
+      yield* store.complete(jobID, claimed.revision)
+
+      const promptOps: TaskPromptOps = {
+        cancel: () => Effect.void,
+        resolvePromptParts: (text) => Effect.succeed([{ type: "text", text }]),
+        prompt: (input) => Effect.succeed(reply(input.sessionID)),
+      }
+      const context = {
+        sessionID,
+        messageID: MessageID.make("msg_heartbeat_policy"),
+        callID: "call_heartbeat_policy",
+        agent: "build",
+        abort: new AbortController().signal,
+        messages: [],
+        extra: { promptOps },
+        metadata: () => Effect.void,
+        ask: () => Effect.void,
+      }
+
+      const next = yield* heartbeat.execute({ task: "persisted policy", delay_seconds: 60 }, context)
+      expect(next.metadata).toMatchObject({
+        initialDelaySeconds: 37,
+        intervalSeconds: 41,
+        backoff: "linear",
+        maxIntervalSeconds: 97,
+        checkNumber: 2,
+      })
+      expect(yield* store.get(jobID)).toMatchObject({
+        initialDelaySeconds: 37,
+        intervalSeconds: 41,
+        backoff: "linear",
+        maxIntervalSeconds: 97,
+        checkNumber: 2,
+      })
+      yield* heartbeat.execute({ action: "cancel", task: "persisted policy" }, context)
+    }),
+  )
+})

--- a/packages/opencode/test/tool/parameters.test.ts
+++ b/packages/opencode/test/tool/parameters.test.ts
@@ -14,6 +14,7 @@ import { Parameters as Edit } from "../../src/tool/edit"
 import { Parameters as Glob } from "../../src/tool/glob"
 import { Parameters as Grep } from "../../src/tool/grep"
 import { Parameters as Invalid } from "../../src/tool/invalid"
+import { Parameters as Heartbeat } from "../../src/tool/heartbeat"
 import { Parameters as Lsp } from "../../src/tool/lsp"
 import { Parameters as Plan } from "../../src/tool/plan"
 import { Parameters as Question } from "../../src/tool/question"
@@ -42,6 +43,7 @@ describe("tool parameters", () => {
     test("glob", () => expect(toJsonSchema(Glob)).toMatchSnapshot())
     test("grep", () => expect(toJsonSchema(Grep)).toMatchSnapshot())
     test("invalid", () => expect(toJsonSchema(Invalid)).toMatchSnapshot())
+    test("heartbeat", () => expect(toJsonSchema(Heartbeat)).toMatchSnapshot())
     test("lsp", () => expect(toJsonSchema(Lsp)).toMatchSnapshot())
     test("plan", () => expect(toJsonSchema(Plan)).toMatchSnapshot())
     test("question", () => expect(toJsonSchema(Question)).toMatchSnapshot())

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -109,6 +109,15 @@ describe("tool.registry", () => {
     }),
   )
 
+  it.instance("exposes heartbeat scheduling", () =>
+    Effect.gen(function* () {
+      const registry = yield* ToolRegistry.Service
+      const ids = yield* registry.ids()
+
+      expect(ids).toContain("heartbeat")
+    }),
+  )
+
   it.instance("does not expose execute unless code mode is enabled", () =>
     Effect.gen(function* () {
       const registry = yield* ToolRegistry.Service

--- a/packages/opencode/test/tool/task.test.ts
+++ b/packages/opencode/test/tool/task.test.ts
@@ -1098,4 +1098,25 @@ describe("tool.task", () => {
       expect((yield* jobs.get(grandchild.id))?.status).toBe("cancelled")
     }),
   )
+
+  it.instance("cancelling a parent run preserves durable heartbeat monitors", () =>
+    Effect.gen(function* () {
+      const jobs = yield* BackgroundJob.Service
+      const runState = yield* SessionRunState.Service
+      const { chat } = yield* seed()
+      const jobID = `heartbeat:${chat.id}:monitor`
+
+      yield* jobs.start({
+        id: jobID,
+        type: "heartbeat",
+        metadata: { sessionId: chat.id, task: "monitor" },
+        run: Effect.never,
+      })
+
+      yield* runState.cancel(chat.id)
+
+      expect((yield* jobs.get(jobID))?.status).toBe("running")
+      yield* jobs.cancel(jobID)
+    }),
+  )
 })


### PR DESCRIPTION
Persist heartbeat schedules and policy across restarts, recover pending checks on startup, and present heartbeat turns as collapsible timeline cards in the web app.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds durable heartbeat monitoring for long-running external commands.

Heartbeat checks can be scheduled, inspected, or cancelled. Their timing, check count, and backoff policy are stored in SQLite, so pending checks survive an OpenCode restart. A revision check prevents stale timers from firing twice.

Heartbeat is enabled by default and can be disabled with `experimental.heartbeat.enabled: false`. Disabling it hides the tool and its shell guidance, and automatically cancels pending heartbeat jobs.

The web timeline groups each heartbeat turn into a collapsible card showing its task, check count, state, and latest progress.

### How did you verify your code works?

- Ran 103 backend tests successfully.
- Ran 15 web timeline tests successfully.
- Ran backend and web type checks.
- Built and smoke-tested the OpenCode binary.
- Restarted OpenCode with a scheduled heartbeat and verified its timing and count were preserved.
- Verified collapsed and expanded heartbeat cards in the web UI.

### Screenshots / recordings

<!-- Attach the heartbeat timeline screenshot here. -->

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR