### PR TITLE
feat(app): keep model selection per agent

### DIFF
--- a/packages/app/src/context/agent-model-selection.test.ts
+++ b/packages/app/src/context/agent-model-selection.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { modelForAgent, setModelForAgent, type AgentModelState } from "./agent-model-selection"
+
+const build = { providerID: "openai", modelID: "gpt-5" }
+const plan = { providerID: "anthropic", modelID: "claude-sonnet" }
+
+describe("agent model selection", () => {
+  test("keeps model selections independent per agent", () => {
+    let state: AgentModelState = {}
+    state = setModelForAgent(state, "build", build)
+    state = setModelForAgent(state, "plan", plan)
+
+    expect(modelForAgent(state, "build")).toEqual(build)
+    expect(modelForAgent(state, "plan")).toEqual(plan)
+  })
+
+  test("falls back to the legacy session model when no agent selection exists", () => {
+    expect(modelForAgent({ model: build }, "plan")).toEqual(build)
+  })
+
+  test("does not use the legacy model once per-agent selections exist", () => {
+    expect(modelForAgent({ model: build, models: { plan } }, "build")).toBeUndefined()
+  })
+
+  test("allows an agent selection to be cleared without changing another agent", () => {
+    const state = setModelForAgent({ models: { plan } }, "build", undefined)
+
+    expect(modelForAgent(state, "build")).toBeUndefined()
+    expect(modelForAgent(state, "plan")).toEqual(plan)
+  })
+})

--- a/packages/app/src/context/agent-model-selection.ts
+++ b/packages/app/src/context/agent-model-selection.ts
@@ -1,0 +1,30 @@
+export type AgentModelKey = {
+  providerID: string
+  modelID: string
+  variant?: string
+}
+
+export type AgentModelState = {
+  model?: AgentModelKey
+  models?: Record<string, AgentModelKey | null>
+}
+
+export function modelForAgent(state: AgentModelState | undefined, agent: string | undefined) {
+  if (agent && state?.models) return state.models[agent] ?? undefined
+  return state?.model
+}
+
+export function setModelForAgent(
+  state: AgentModelState | undefined,
+  agent: string | undefined,
+  model: AgentModelKey | undefined,
+) {
+  if (!agent) return { ...(state ?? {}), model }
+  return {
+    ...(state ?? {}),
+    models: {
+      ...(state?.models ?? {}),
+      [agent]: model ?? null,
+    },
+  }
+}

--- a/packages/app/src/context/local.tsx
+++ b/packages/app/src/context/local.tsx
@@ -14,12 +14,15 @@ import { useSDK } from "./sdk"
 import { useSync } from "./sync"
 import { useServerSDK } from "./server-sdk"
 import { ScopedKey, type ServerScope } from "@/utils/server-scope"
+import { modelForAgent, setModelForAgent } from "./agent-model-selection"
+import type { AgentModelKey } from "./agent-model-selection"
 
-export type ModelKey = { providerID: string; modelID: string; variant?: string }
+export type ModelKey = AgentModelKey
 
 type State = {
   agent?: string
   model?: ModelKey
+  models?: Record<string, ModelKey | null>
   variant?: string | null
 }
 
@@ -53,6 +56,9 @@ const clone = (value: State | undefined) => {
   return {
     ...value,
     model: value.model ? { ...value.model } : undefined,
+    models: value.models
+      ? Object.fromEntries(Object.entries(value.models).map(([agent, model]) => [agent, model ? { ...model } : null]))
+      : undefined,
   } satisfies State
 }
 
@@ -193,6 +199,8 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
         }
 
         batch(() => {
+          const previousAgent = agent.current()?.name
+          const previous = scope()
           setStore("current", item.name)
           setStore("last", {
             type: "agent",
@@ -200,11 +208,13 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
             model: item.model,
             variant: item.variant ?? null,
           })
-          const prev = scope()
           const next = {
             agent: item.name,
-            model: item.model ?? prev?.model,
-            variant: item.variant ?? prev?.variant,
+            model: previous?.models || previousAgent ? undefined : previous?.model,
+            models:
+              previous?.models ??
+              (previous?.model && previousAgent ? { [previousAgent]: previous.model } : undefined),
+            variant: previous?.variant,
           } satisfies State
           const session = id()
           if (session) {
@@ -231,8 +241,9 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
     }
 
     const current = () => {
+      const currentAgent = agent.current()?.name
       const item = firstModel(
-        () => scope()?.model,
+        () => modelForAgent(scope(), currentAgent),
         () => agent.current()?.model,
         fallback,
       )
@@ -307,7 +318,7 @@ export const { use: useLocal, provider: LocalProvider } = createSimpleContext({
               model: item ?? null,
               variant: selected(),
             })
-            write({ model: item })
+            write(setModelForAgent(scope(), agent.current()?.name, item))
             if (!item) return
             models.setVisibility(item, true)
             if (!options?.recent) return

--- a/packages/app/src/pages/session/composer/prompt-model-selection.ts
+++ b/packages/app/src/pages/session/composer/prompt-model-selection.ts
@@ -1,5 +1,6 @@
 import { batch, createMemo, startTransition } from "solid-js"
 import { useModels } from "@/context/models"
+import { useLocal } from "@/context/local"
 import type { ModelKey, ModelSelection } from "@/context/local"
 import { cycleModelVariant, getConfiguredAgentVariant, resolveModelVariant } from "@/context/model-variant"
 import { usePrompt } from "@/context/prompt"
@@ -12,6 +13,7 @@ export function createPromptModelSelection(input: { agent: () => { model?: Model
   const sdk = useSDK()
   const sync = useSync()
   const models = useModels()
+  const local = useLocal()
   const prompt = usePrompt()
   const providers = useProviders(() => sdk().directory)
   const connected = createMemo(() => new Set(providers.connected().map((item) => item.id)))
@@ -37,7 +39,9 @@ export function createPromptModelSelection(input: { agent: () => { model?: Model
   }
 
   const current = () => {
-    const key = [prompt.model.current(), input.agent()?.model, configured(), recent(), fallback()].find(
+    const selected = local.model.current()
+    const localKey = selected ? { providerID: selected.provider.id, modelID: selected.id } : undefined
+    const key = [localKey, prompt.model.current(), input.agent()?.model, configured(), recent(), fallback()].find(
       (item): item is ModelKey => !!item && valid(item),
     )
     if (!key) return
@@ -67,6 +71,7 @@ export function createPromptModelSelection(input: { agent: () => { model?: Model
     set(item: ModelKey | undefined, options?: { recent?: boolean }) {
       startTransition(() =>
         batch(() => {
+          local.model.set(item)
           prompt.model.set(item ? { ...item, variant: prompt.model.current()?.variant } : undefined)
           if (!item) return
           models.setVisibility(item, true)


### PR DESCRIPTION
## Summary
- keep model selections independent for each primary agent
- make model picker updates apply only to the active agent
- preserve legacy single-model session selections as a fallback
- cover new-session drafts and add regression tests

## Tests
- `bun test --conditions=solid --preload ./happydom.ts ./src/context/agent-model-selection.test.ts ./src/pages/session/session-model-helpers.test.ts ./src/context/prompt-state.test.ts`
- `bun run typecheck` (from `packages/app`)

Closes the gap where changing the model in Plan changes the model used by Build.