### PR TITLE
fix(simulation): remove artificial click pacing

### DIFF
--- a/packages/simulation/script/bench-click.ts
+++ b/packages/simulation/script/bench-click.ts
@@ -1,0 +1,42 @@
+import { BoxRenderable, TextRenderable } from "@opentui/core"
+import { Effect } from "effect"
+import { SimulationActions } from "../src/frontend/actions"
+import { SimulationRenderer } from "../src/frontend/renderer"
+
+// One warmup, seven measured batches. Real mouse dispatch and rendering included.
+await Effect.runPromise(
+  Effect.scoped(
+    Effect.gen(function* () {
+      const renderer = yield* SimulationRenderer.create({})
+      const label = new TextRenderable(renderer, { content: "Clicks: 0" })
+      let clicks = 0
+      const button = new BoxRenderable(renderer, {
+        width: 20,
+        height: 1,
+        onMouseUp: () => {
+          label.content = `Clicks: ${++clicks}`
+        },
+      })
+      button.add(label)
+      renderer.root.add(button)
+      const harness = SimulationActions.createHarness(renderer)
+      yield* Effect.promise(() => harness.renderOnce())
+      const samples: number[] = []
+      for (let batch = 0; batch < 8; batch++) {
+        const start = performance.now()
+        for (let index = 0; index < 20; index++) {
+          yield* SimulationActions.execute(harness, { type: "ui.click", target: button.num, x: 1, y: 0 })
+          if (!harness.screen().includes(`Clicks: ${clicks}`)) throw new Error("click returned before painting")
+          if (harness.mockMouse.getPressedButtons().length) throw new Error("click left a button held")
+        }
+        if (clicks !== (batch + 1) * 20) throw new Error("lost a native click")
+        if (batch > 0) samples.push((performance.now() - start) / 20)
+      }
+      const median = samples.toSorted((a, b) => a - b)[3]
+      if (median === undefined) throw new Error("missing benchmark samples")
+      const mad = samples.map((value) => Math.abs(value - median)).sort((a, b) => a - b)[3]
+      console.log(JSON.stringify({ metric: "simulation_click_ms", median, mad, samples, clicks }))
+      console.log(`METRIC simulation_click_ms=${median.toFixed(3)}`)
+    }),
+  ),
+)

--- a/packages/simulation/src/frontend/actions.ts
+++ b/packages/simulation/src/frontend/actions.ts
@@ -233,7 +233,10 @@ export const execute = Effect.fn("SimulationActions.execute")(function* (harness
       )
         return yield* Effect.fail(new Error("click position must be within the target element"))
       SimulationRenderer.recordPointer(harness.renderer, "click", target.screenX + action.x, target.screenY + action.y)
-      yield* Effect.tryPromise(() => harness.mockMouse.click(target.screenX + action.x, target.screenY + action.y))
+      // Opt out of test-helper pacing; retain its down/up ordering and the render below.
+      yield* Effect.tryPromise(() =>
+        harness.mockMouse.click(target.screenX + action.x, target.screenY + action.y, undefined, { delayMs: 0 }),
+      )
       break
     }
     case "ui.resize":

--- a/packages/simulation/test/actions.test.ts
+++ b/packages/simulation/test/actions.test.ts
@@ -103,6 +103,64 @@ test("clicks a target at relative coordinates through descendant text", async ()
   )
 })
 
+test("unpaced clicks preserve native event order, button release and rendered state", async () => {
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const renderer = yield* SimulationRenderer.create({})
+        const events: string[] = []
+        const label = new TextRenderable(renderer, { content: "Not clicked" })
+        let clicks = 0
+        const button = new BoxRenderable(renderer, {
+          id: "click-order",
+          width: 20,
+          height: 1,
+          onMouseDown: () => {
+            events.push("down")
+            queueMicrotask(() => events.push("down microtask"))
+          },
+          onMouseUp: () => {
+            events.push("up")
+            label.content = `Clicks: ${++clicks}`
+          },
+        })
+        button.add(label)
+        renderer.root.add(button)
+        const harness = createHarness(renderer)
+        yield* Effect.promise(() => harness.renderOnce())
+
+        for (let index = 0; index < 5; index++) {
+          const result = yield* execute(harness, { type: "ui.click", target: button.num, x: 1, y: 0 })
+          expect(clicks).toBe(index + 1)
+          expect(events.splice(0)).toEqual(["down", "down microtask", "up"])
+          expect(harness.mockMouse.getPressedButtons()).toEqual([])
+          expect(harness.screen()).toContain(`Clicks: ${index + 1}`)
+          expect(result).toEqual(state(harness))
+        }
+      }),
+    ),
+  )
+})
+
+test("unpaced clicks retain native double-click text selection", async () => {
+  await Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const renderer = yield* SimulationRenderer.create({})
+        const text = new TextRenderable(renderer, { content: "alpha beta", selectable: true })
+        renderer.root.add(text)
+        const harness = createHarness(renderer)
+        yield* Effect.promise(() => harness.renderOnce())
+
+        yield* execute(harness, { type: "ui.click", target: text.num, x: 1, y: 0 })
+        yield* execute(harness, { type: "ui.click", target: text.num, x: 1, y: 0 })
+        expect(renderer.getSelection()?.getSelectedText()).toBe("alpha")
+        expect(harness.mockMouse.getPressedButtons()).toEqual([])
+      }),
+    ),
+  )
+})
+
 test("mouse input drives native hover, drag, buttons and scrolling at absolute coordinates", async () => {
   await Effect.runPromise(
     Effect.scoped(


### PR DESCRIPTION
## Why

Every simulated `ui.click` inherits OpenTUI's test-helper pacing: 10ms after mouse-down, another 10ms between events, and 10ms after mouse-up. That's roughly three seconds of artificial waiting per hundred clicks, before ordinary RPC and rendering costs.

## What Changes

Pass `{ delayMs: 0 }` at OpenCode's existing `mockMouse.click` call site. Keep the helper's event-loop boundary between down/up, native input dispatch, pointer recording, stale/semantic target checks, and the awaited render before returning state.

| Measurement | Before | After |
| --- | ---: | ---: |
| Simulation harness, including rendering | 33.54ms/click | 1.26ms/click |
| Production TUI through Drive | 34.8ms/click | 4.2ms/click |

The harness benchmark uses one warmup and seven 20-click batches, verifying every native click, rendered result, and button release. Median absolute deviation: 0.39ms before / 0.02ms after. The production TUI measurement is a separate 20-click smoke test, not the seven-batch benchmark.

## Demo

https://github.com/user-attachments/assets/917692af-391e-47fe-8625-e03954c0fcdd

Same Drive fixture against immutable V2 base `a1cb005799` on the left and `69e9cc80a4` on the right. Twenty clicks open/close the real TUI's Theme devtools panel; every resulting state is checked. The button's padding is targeted to avoid native double-click text selection. Both runs use 100×30 cells, the same dark theme, no LLM calls, and no playback acceleration. Equal two-second viewing holds precede/follow the interaction and are excluded from the click measurements. The footer reports measured RPC durations.

## Scope

Simulation click pacing only. No protocol, CLI, real-user mouse handling, rendering-readiness, or OpenTUI default changes. Native double-click text selection remains supported and is covered by a regression test.

## Verification

```sh
cd packages/simulation
bun run script/bench-click.ts
bun run test
bun typecheck
```

- 48 tests pass. Added native down → microtask → up ordering, repeated clicks, button release, rendered-state visibility, and double-click text selection coverage.
- Existing stale/semantic target, hover/drag/button/scroll, and recording tests pass.
- Standard pre-push hook passes all 33 package typechecks.
- Real production TUI comparison verifies all 20 transitions in each run.
