### PR TITLE
fix(core): scope compaction Completed section to finished work

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -51,7 +51,7 @@ const SUMMARY_TEMPLATE = `You MUST use this format for your response (you may om
 
 ## Work State
 ### Completed
-- [finished work, verified facts, or changes made; otherwise "(none)"]
+- [finished work or changes made; otherwise "(none)"]
 
 ### Active
 - [current work, partial changes, or investigation state; otherwise "(none)"]


### PR DESCRIPTION
## Summary

Removes "verified facts" from the Completed placeholder in the compaction summary template.

```diff
 ### Completed
-- [finished work, verified facts, or changes made; otherwise "(none)"]
+- [finished work or changes made; otherwise "(none)"]
```

"Verified facts" turned Completed into a findings ledger (CI run IDs, test counts, version comparisons) rather than a list of finished work. Since the update prompt moves items into Completed but nothing scopes what stays there, that section grew across compactions. Findings that still matter belong in Decisions, Blocked, or Additional Context.

First of a series of small, independent compaction prompt adjustments.

## Verification

- No tests or docs reference the previous placeholder text.