### PR TITLE
fix(client): back off reconnects when the stream never connects

### DIFF
--- a/packages/client/src/solid/connection.ts
+++ b/packages/client/src/solid/connection.ts
@@ -19,6 +19,11 @@ export type ClientConnectionOptions = {
   readonly flushInterval?: number
   readonly pageLifecycle?: boolean
   /**
+   * Base delay between reconnect attempts. Streams that never connected
+   * successfully scale this up per attempt (see `reconnectBackoffDelay`).
+   */
+  readonly reconnectDelayMs?: number
+  /**
    * Abort and reconnect a stream that receives no bytes for this long. The server writes a keepalive
    * comment every 15 seconds, so a quiet but healthy stream never trips this.
    */
@@ -31,7 +36,17 @@ export type ClientConnectionOptions = {
 
 const connectTimeout = 2_000
 const reconnectDelay = 1_000
+const maxReconnectBackoff = 30_000
 const connectionHistoryLimit = 50
+
+/**
+ * Delay before the next reconnect attempt. Streams that never connected
+ * successfully (bad credentials, server still booting) scale the delay up so a
+ * failing endpoint is not hammered every second; streams that connected and
+ * later dropped reset the attempt counter and keep the base delay.
+ */
+export const reconnectBackoffDelay = (attempt: number, baseDelay: number) =>
+  Math.min(baseDelay * Math.max(attempt, 1), maxReconnectBackoff)
 export const defaultIdleTimeout = 45_000
 // Longer than one server keepalive interval: a stream that is silent this long when the page
 // returns to the foreground is probably half-open after the device slept.
@@ -178,7 +193,7 @@ export function createClientConnection(initialApi: OpenCodeClient, options: Clie
         forced = false
         continue
       }
-      await wait(reconnectDelay, controller.signal)
+      await wait(reconnectBackoffDelay(attempt, options.reconnectDelayMs ?? reconnectDelay), controller.signal)
     }
   }
 

--- a/packages/client/test/solid-connection.test.ts
+++ b/packages/client/test/solid-connection.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "bun:test"
+import { describe, expect, test } from "bun:test"
 import { createRoot } from "solid-js"
-import { createClientConnection } from "../src/solid"
+import { createClientConnection, reconnectBackoffDelay } from "../src/solid/connection.js"
 import { OpenCode, type OpenCodeEvent } from "../src/promise"
 
 const connected = { id: "evt_connected", created: 1, type: "server.connected", data: {} }
@@ -147,6 +147,45 @@ test("a stream the server closes reconnects and reports the disconnect", async (
     await until(() => ctx.connection.status() === "reconnecting")
     expect(ctx.connection.error()).toBe("Event stream disconnected")
     await until(() => fake.streams.length === 2)
+  } finally {
+    ctx.dispose()
+  }
+})
+
+describe("reconnectBackoffDelay", () => {
+  test("scales with the attempt count and caps at the maximum", () => {
+    expect(reconnectBackoffDelay(1, 1_000)).toBe(1_000)
+    expect(reconnectBackoffDelay(2, 1_000)).toBe(2_000)
+    expect(reconnectBackoffDelay(5, 1_000)).toBe(5_000)
+    expect(reconnectBackoffDelay(100, 1_000)).toBe(30_000)
+    expect(reconnectBackoffDelay(0, 1_000)).toBe(1_000)
+  })
+})
+
+test("backs off instead of retrying every second while the stream is unauthorized", async () => {
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async () =>
+      new Response(null, { status: 401, headers: { "www-authenticate": 'Basic realm="Secure Area"' } }),
+  })
+  const ctx = createRoot((dispose) => ({
+    dispose,
+    connection: createClientConnection(api, { reconnectDelayMs: 20, onEvent: () => {} }),
+  }))
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    const history = ctx.connection.internal.history().filter((item) => item.data.status === "disconnected")
+
+    expect(history.length).toBeGreaterThanOrEqual(3)
+    const attempts = history.map((item) => item.data.attempt)
+    expect([...attempts].sort((a, b) => a - b)).toEqual(attempts)
+    expect(attempts.at(-1)).toBeGreaterThan(2)
+
+    const gaps: number[] = []
+    for (let index = 1; index < history.length; index++) {
+      gaps.push(history[index].created - history[index - 1].created)
+    }
+    expect(gaps.at(-1)).toBeGreaterThan(gaps[0] ?? 0)
   } finally {
     ctx.dispose()
   }


### PR DESCRIPTION
### Issue for this PR

Fixes #47062

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The event-stream client retried on a fixed one-second delay regardless of why the stream died, so an unauthenticated browser session re-triggered the Basic auth prompt every second while the shell sat there unauthenticated. Streams that never connected successfully now scale the retry delay with the attempt count up to 30 seconds, which gives the browser prompt time to be answered; streams that connected and later dropped reset the attempt counter and keep the existing one-second retry.

The failure reason is intentionally not inspected — a declared 401 with an empty body surfaces client-side as an indistinguishable `ClientError("UnsupportedContentType")`, and the never-connected case is the one that needs the guard regardless of cause.

### How did you verify your code works?

- New `test/solid-connection.test.ts`: a 401-empty-response API under a real clock — reconnect attempts stay monotonically increasing across 400ms and the inter-attempt gaps grow (no backoff would produce ~20 attempts, backoff produces ~7)
- `reconnectBackoffDelay` unit cases for scaling, the 30s cap, and the attempt-0 floor
- `bun typecheck` + full `packages/client` suite (152 passing)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR