### PR TITLE
fix(app): show server-known projects in project lists

### DIFF
--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -1,7 +1,13 @@
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { createEffect, createMemo, createRoot } from "solid-js"
 import { createStore } from "solid-js/store"
-import { createServerProjects, RECENTLY_CLOSED_DISPLAY_LIMIT, ServerConnection, useServer } from "./server"
+import {
+  createServerProjects,
+  knownProjectWorktrees,
+  RECENTLY_CLOSED_DISPLAY_LIMIT,
+  ServerConnection,
+  useServer,
+} from "./server"
 import { pathKey } from "@/utils/path-key"
 import { useServerHealth } from "@/utils/server-health"
 import { createServerSdkContext } from "./server-sdk"
@@ -127,7 +133,13 @@ function createServerCtx(
     return base
   }
 
-  const projectsList = createMemo(() => projects.list().map(enrich))
+  const projectsList = createMemo(() => {
+    const opened = projects.list()
+    const known = knownProjectWorktrees({ opened, known: sync.data.project }).map(
+      (worktree) => enrich({ worktree, expanded: false }),
+    )
+    return [...opened.map(enrich), ...known]
+  })
   const recentlyClosedList = createMemo(() => {
     const known = new Set(sync.data.project.map((project) => pathKey(project.worktree)))
     return projects
@@ -147,6 +159,9 @@ function createServerCtx(
     isLocal,
     projects: {
       ...projects,
+      // Pre-union list of user-opened projects, for callers whose checks must ignore
+      // the appended server-known entries (e.g. "add project" persistence).
+      opened: projects.list,
       list: projectsList,
       recentlyClosed: recentlyClosedList,
     },

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -5,7 +5,12 @@ import { createSimpleContext } from "@opencode-ai/ui/context"
 import { makeEventListener } from "@solid-primitives/event-listener"
 import { useServerSync } from "./server-sync"
 import { useServerSDK } from "./server-sdk"
-import { RECENTLY_CLOSED_DISPLAY_LIMIT, ServerConnection, useServer } from "./server"
+import {
+  knownProjectWorktrees,
+  RECENTLY_CLOSED_DISPLAY_LIMIT,
+  ServerConnection,
+  useServer,
+} from "./server"
 import { usePlatform } from "./platform"
 import { Project } from "@opencode-ai/sdk/v2"
 import { normalizeProjectInfo } from "./global-sync/utils"
@@ -513,7 +518,13 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       })
     })
 
-    const enriched = createMemo(() => server.projects.list().map(enrich))
+    const enriched = createMemo(() => {
+      const opened = server.projects.list()
+      const known = knownProjectWorktrees({ opened, known: serverSync().data.project }).map(
+        (worktree) => enrich({ worktree, expanded: false }),
+      )
+      return [...opened.map(enrich), ...known]
+    })
     const list = createMemo(() => {
       const projects = enriched()
       return projects.map((project) => {

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -3,6 +3,7 @@ import { createRoot, createSignal } from "solid-js"
 import { createStore } from "solid-js/store"
 import {
   createServerProjects,
+  knownProjectWorktrees,
   migrateCanonicalLocalServerState,
   nextServerAfterRemoval,
   resolveServerList,
@@ -241,5 +242,63 @@ describe("migrateCanonicalLocalServerState", () => {
       },
       lastProject: { local: "/local" },
     })
+  })
+})
+
+describe("knownProjectWorktrees", () => {
+  const opened = (worktree: string) => ({ worktree, expanded: true })
+  const known = (worktree: string, updated = 0) => ({ worktree, id: "p1", time: { created: 0, updated } })
+
+  test("appends server-known projects that were never opened, newest first", () => {
+    const result = knownProjectWorktrees({
+      opened: [opened("D:\\work\\alpha")],
+      known: [
+        known("D:\\work\\alpha", 100),
+        known("D:\\work\\old", 10),
+        known("D:\\work\\new", 50),
+      ],
+    })
+
+    expect(result).toEqual(["D:\\work\\new", "D:\\work\\old"])
+  })
+
+  test("dedupes against opened projects across path separators", () => {
+    const result = knownProjectWorktrees({
+      opened: [opened("D:\\work\\alpha"), opened("E:/work/beta")],
+      known: [known("D:/work/alpha", 100), known("E:\\work\\beta", 90), known("D:\\work\\gamma", 5)],
+    })
+
+    expect(result).toEqual(["D:\\work\\gamma"])
+  })
+
+  test("caps the appended known projects at the configured limit", () => {
+    const result = knownProjectWorktrees({
+      opened: [],
+      known: Array.from({ length: 15 }, (_, i) => known(`D:\\work\\p${i}`, i)),
+      limit: 3,
+    })
+
+    expect(result).toHaveLength(3)
+    expect(result).toEqual(["D:\\work\\p14", "D:\\work\\p13", "D:\\work\\p12"])
+  })
+
+  test("filters out the global project and empty worktrees", () => {
+    const result = knownProjectWorktrees({
+      opened: [],
+      known: [
+        { worktree: "/", id: "global", time: { created: 0, updated: 99 } },
+        { worktree: "", id: "p-blank", time: { created: 0, updated: 98 } },
+        { worktree: "D:\\work\\real", id: "p-real", time: { created: 0, updated: 1 } },
+      ],
+    })
+
+    expect(result).toEqual(["D:\\work\\real"])
+  })
+
+  test("returns empty for empty or fully-overlapping inputs", () => {
+    expect(knownProjectWorktrees({ opened: [], known: [] })).toEqual([])
+    expect(
+      knownProjectWorktrees({ opened: [opened("D:\\work\\alpha")], known: [known("D:\\work\\alpha", 5)] }),
+    ).toEqual([])
   })
 })

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -76,6 +76,27 @@ export function migrateCanonicalLocalServerState(value: unknown, canonicalLocalS
   return next
 }
 
+// Projects known to the server but never opened through the UI (agent-created or
+// CLI-registered) stay discoverable when appended after the opened ones, newest first.
+// The persisted store keeps only user-opened entries; the union is render-only.
+const KNOWN_PROJECTS_LIMIT = 10
+
+export function knownProjectWorktrees(input: {
+  opened: Array<{ worktree: string }>
+  known: Array<{ worktree: string; id?: string; time?: { updated?: number } }>
+  limit?: number
+}) {
+  const openedKeys = new Set(input.opened.map((project) => pathKey(project.worktree)))
+  return input.known
+    .filter(
+      (project) =>
+        !!project.worktree && project.id !== "global" && !openedKeys.has(pathKey(project.worktree)),
+    )
+    .sort((a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0))
+    .slice(0, input.limit ?? KNOWN_PROJECTS_LIMIT)
+    .map((project) => project.worktree)
+}
+
 export function createServerProjects<T extends ServerProjectState>(input: {
   scope: Accessor<ServerScope>
   store: Store<T>

--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -91,7 +91,9 @@ export function createHomeController() {
         if (!directory) return
         const ctx = global.ensureServerCtx(conn)
         directories.forEach((item) => {
-          if (ctx.projects.list().some((project) => project.worktree === item)) return
+          // Compare against user-opened projects only: server-known entries appended
+          // to projects.list() must not stop an explicit add from persisting.
+          if (ctx.projects.opened.some((project) => project.worktree === item)) return
           const location = { directory: item }
           void ctx.sdk.api.file
             .list({ path: ".", location })

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -541,7 +541,10 @@ export default function LegacyLayout(props: ParentProps) {
     await layout.ready.promise
     if (!untrack(() => state.autoselect)) return
 
-    const list = layout.projects.list()
+    // Autoselect restores what the user last opened, so it reads the persisted
+    // project store directly — layout.projects.list() also appends server-known
+    // projects that were never opened, which must not trigger auto-opening.
+    const list = server.projects.list()
     const last = server.projects.last()
 
     if (list.length === 0) {


### PR DESCRIPTION
### Issue for this PR

Closes #43072

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The project list in the home panel and the session sidebar is fed exclusively by a locally persisted store (`Persist.global("server")`, i.e. `opencode.global.dat`), and the only thing that ever writes to it is `createServerProjects.open()` when a project is opened through the UI. The server-side project list (`/project`, fetched once at startup by `loadProjectsQuery` in `packages/app/src/context/global-sync/bootstrap.ts`) goes into `globalStore.project` and is never merged into either list. So a project the agent creates during a chat — or any directory the CLI has registered — never shows up in the app, even after a restart; the only workaround is adding the folder manually through the project picker.

This makes it look like the agent failed to create the project (that is exactly how the issue reporter experienced it), and it makes every CLI-known project invisible in the desktop/web app.

The fix appends server-known projects that were never opened after the user-opened ones, newest first, capped at 10 so a long CLI history can't flood the list:

- `knownProjectWorktrees()` in `packages/app/src/context/server.tsx` — pure helper: filters out `global` and empty worktrees, dedupes against opened projects via `pathKey` (so `D:\x` and `D:/x` match), sorts by `time.updated` descending, caps at 10.
- `projectsList` in `packages/app/src/context/global.tsx` (home panel) and `enriched` in `packages/app/src/context/layout.tsx` (sidebar / page logic) now union the appended entries through the existing `enrich()`, so icons and metadata resolve the same way as for opened projects. The union is render-only — the persisted store still contains only user-opened projects.

Two existing behaviors are intentionally kept on the raw store so the appended entries can't change their semantics:

- autoselect (`packages/app/src/pages/layout.tsx`) reads `server.projects.list()` instead of the unioned list, otherwise a fresh install with server-known projects would auto-open one of them instead of restoring the last opened project.
- "add project" in the home controller compares against a new `ctx.projects.opened` (pre-union list), so explicitly adding a directory that is already server-known still persists it to the store.

This follows the same direction as #41018, which made opening a project from home register it; this covers the projects nobody has opened yet.

### How did you verify your code works?

- `bun run test:unit` in `packages/app`: 729 pass / 0 fail, including 5 new tests for `knownProjectWorktrees` (union order, cross-separator dedupe, cap, `global`/empty filtering, empty inputs).
- Manually on Windows 11 with `opencode serve` (1.18.21, 13 projects registered in the local DB) plus `bun dev` in `packages/app` and a fresh browser profile:
  - before: the project panel is empty ("Add project" only) while `GET /project` returns 13 projects;
  - after: the panel lists 10 server-known projects (cap working: 12 candidates), each with icon and metadata resolved via `enrich()`.
- `tsgo -b` typecheck cannot run on my Windows checkout for pre-existing reasons: `packages/app/src/custom-elements.d.ts` is a symlink in the repo, and the Windows checkout materialized it as a 33-byte text file, so a clean `dev` checkout already fails with TS1128 before any of my changes. CI will run the typecheck on Linux. I did not run the browser e2e suite locally.

### Screenshots / recordings

Before (13 server-known projects, panel empty):

![before](https://github.com/weiconghe/opencode/releases/download/pr-assets-43072/oc_repro_before.png)

After (same server, fresh profile, panel lists the capped known projects):

![after](https://github.com/weiconghe/opencode/releases/download/pr-assets-43072/oc_repro_after.png)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
