### PR TITLE
fix(app): move project icon setting to experimental

### DIFF
--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -1045,8 +1045,8 @@ export const dict = {
   "settings.general.row.showTerminal.description": "Show the terminal button in the desktop title bar",
   "settings.general.row.showStatus.title": "Server status",
   "settings.general.row.showStatus.description": "Show the server status button in the title bar",
-  "settings.general.row.showProjectIcon.title": "Project icon",
-  "settings.general.row.showProjectIcon.description": "Show the project icon in the session header",
+  "settings.general.row.showProjectIcon.title": "Show project icon",
+  "settings.general.row.showProjectIcon.description": "Show project icon in session header",
   "settings.general.row.mobileTitlebarBottom.title": "Bottom navigation",
   "settings.general.row.mobileTitlebarBottom.description": "Place the title bar at the bottom of the screen on mobile",
   "settings.general.row.mobileDiffWrap.description":

--- a/packages/app/src/settings/experimental/experimental.tsx
+++ b/packages/app/src/settings/experimental/experimental.tsx
@@ -1,4 +1,4 @@
-import { Component } from "solid-js"
+import { Component, Show } from "solid-js"
 import { Select } from "@opencode-ai/ui/select"
 import { Switch } from "@opencode-ai/ui/switch"
 import { useLanguage } from "@/runtime/i18n/language"
@@ -61,6 +61,22 @@ export const SettingsExperimental: Component = () => {
                 </Switch>
               </div>
             </SettingsRow>
+            <Show when={import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"}>
+              <SettingsRow
+                title={language.t("settings.general.row.showProjectIcon.title")}
+                description={language.t("settings.general.row.showProjectIcon.description")}
+              >
+                <div data-action="settings-show-project-icon">
+                  <Switch
+                    checked={settings.general.showProjectIcon()}
+                    onChange={settings.general.setShowProjectIcon}
+                    hideLabel
+                  >
+                    {language.t("settings.general.row.showProjectIcon.title")}
+                  </Switch>
+                </div>
+              </SettingsRow>
+            </Show>
           </SettingsList>
         </div>
       </div>

--- a/packages/app/src/settings/general/general.tsx
+++ b/packages/app/src/settings/general/general.tsx
@@ -348,20 +348,6 @@ export const SettingsGeneral: Component<{
           </div>
         </SettingsRow>
 
-        <Show when={import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"}>
-          <SettingsRow
-            title={language.t("settings.general.row.showProjectIcon.title")}
-            description={language.t("settings.general.row.showProjectIcon.description")}
-          >
-            <div data-action="settings-show-project-icon">
-              <Switch
-                checked={settings.general.showProjectIcon()}
-                onChange={(checked) => settings.general.setShowProjectIcon(checked)}
-              />
-            </div>
-          </SettingsRow>
-        </Show>
-
         <Show when={mobile() && import.meta.env.VITE_OPENCODE_CHANNEL !== "prod"}>
           <SettingsRow
             title={language.t("settings.general.row.mobileTitlebarBottom.title")}


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves the project icon toggle from Preferences to Experimental, next to Show project names. Keeps the saved preference and non-production visibility unchanged.

Updates the copy to:
- Title: Show project icon
- Description: Show project icon in session header

### How did you verify your code works?

- `bun typecheck` passed in `packages/app`.
- `git diff --check` passed.
- Electron visual verification not performed.

### Screenshots / recordings

Not captured.

### Checklist

- [ ] I have tested my changes locally
- [x] I have not included unrelated changes in this PR