### PR TITLE
feat(hooks): add session.start, session.end, stop lifecycle hooks

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -17,6 +17,10 @@
             "group": "Getting started",
             "pages": ["index", "quickstart", "development"],
             "openapi": "https://opencode.ai/openapi.json"
+          },
+          {
+            "group": "Plugins",
+            "pages": ["plugins"]
           }
         ]
       }

--- a/packages/docs/plugins.mdx
+++ b/packages/docs/plugins.mdx
@@ -1,0 +1,171 @@
+---
+title: "Lifecycle hooks"
+description: "React to session and turn boundaries from your plugin"
+---
+
+Plugins can subscribe to lifecycle events to react when a session starts, when
+the agent finishes a turn, and when a session is about to end. All three hooks
+are optional; declare only the ones you need.
+
+## `session.start`
+
+Fires once when a session is created, before any tool calls. Use this to set up
+per-session state in your plugin (background workers, telemetry handles, audit
+log entries).
+
+```ts
+import type { Hooks } from "@opencode-ai/plugin"
+
+const plugin: Hooks = {
+  "session.start": async (input, output) => {
+    console.log(`session ${input.sessionID} starting in ${input.cwd}`)
+    // Tag the session for downstream consumers
+    output.metadata.tenant = "acme"
+    output.metadata.tier = "pro"
+  },
+}
+
+export default async () => plugin
+```
+
+### Input
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionID` | `string` | Unique session identifier |
+| `cwd` | `string` | Working directory of the session |
+| `agent` | `string` | Agent name (empty string if unset) |
+| `timestamp` | `number` | Unix epoch (ms) when the session was created |
+
+### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `metadata` | `Record<string, unknown>` | Plugin tags merged into the session record. Reserved keys (`sessionID`, `cwd`, `agent`, `timestamp`) are rejected. |
+
+## `stop`
+
+Fires once at the end of an agent turn, after the LLM produces its final
+message (or the turn aborts/errors). The most common use is post-turn work
+(commit, summarize, notify) or requesting another turn.
+
+```ts
+import type { Hooks } from "@opencode-ai/plugin"
+
+const plugin: Hooks = {
+  stop: async (input, output) => {
+    if (input.reason === "completed") {
+      console.log(`turn complete in session ${input.sessionID}`)
+    }
+    // Re-run the loop with the same context (advanced)
+    output.continue = false
+  },
+}
+
+export default async () => plugin
+```
+
+### Input
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionID` | `string` | Session the turn belongs to |
+| `agent` | `string` | Agent name that produced the turn |
+| `messageID` | `string` | ID of the final assistant message |
+| `reason` | `"completed" \| "aborted" \| "error"` | How the turn ended |
+
+### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `continue` | `boolean` | If `true`, the loop re-iterates with the same context instead of returning. Honored only when `reason === "completed"`. Defaults to `false`. |
+
+<Warning>
+  Setting `output.continue = true` re-runs the same `lastUser` through the LLM
+  with no synthetic prompt. Use sparingly — the loop will not re-ask the user
+  for input. To break out of a continued loop, your plugin must not set
+  `output.continue = true` on a subsequent turn.
+</Warning>
+
+## `session.end`
+
+Fires once before a session is deleted, before the existing `dispose` lifecycle.
+Use this for cleanup (flush buffers, close connections, write final audit
+entries). The hook is hard-capped at 5 seconds; slow plugins are timed out, not
+allowed to block shutdown.
+
+```ts
+import type { Hooks } from "@opencode-ai/plugin"
+
+const plugin: Hooks = {
+  "session.end": async (input) => {
+    console.log(
+      `session ${input.sessionID} ended after ${input.duration_ms}ms (${input.reason})`,
+    )
+  },
+}
+
+export default async () => plugin
+```
+
+### Input
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `sessionID` | `string` | Session being deleted |
+| `duration_ms` | `number` | Wall-clock time since `session.start` |
+| `turn_count` | `number` | Number of agent turns completed in this session |
+| `reason` | `"user_exit" \| "error" \| "timeout"` | Why the session is ending |
+
+### Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cleanup` | `boolean` | If `false`, the runtime defers forced cleanup for up to 5 seconds (hard ceiling). Defaults to `true`. |
+
+## Error handling
+
+A plugin that throws inside any lifecycle hook is logged via `Effect.logError`
+and the session/loop continues normally. Lifecycle hooks are **observers, not
+gatekeepers** — they cannot block a session from starting, ending, or stopping
+a turn. If you need to enforce a policy, use the permission system instead.
+
+## Example: a telemetry plugin
+
+```ts
+import type { Hooks } from "@opencode-ai/plugin"
+
+const startTimes = new Map<string, number>()
+
+const hooks: Hooks = {
+  "session.start": async (input) => {
+    startTimes.set(input.sessionID, input.timestamp)
+    fetch("https://telemetry.example.com/sessions", {
+      method: "POST",
+      body: JSON.stringify({ id: input.sessionID, cwd: input.cwd, agent: input.agent }),
+    })
+  },
+  "session.end": async (input) => {
+    const start = startTimes.get(input.sessionID) ?? input.timestamp
+    fetch("https://telemetry.example.com/sessions/end", {
+      method: "POST",
+      body: JSON.stringify({
+        id: input.sessionID,
+        duration_ms: input.duration_ms,
+        reason: input.reason,
+        start,
+      }),
+    })
+    startTimes.delete(input.sessionID)
+  },
+  stop: async (input) => {
+    if (input.reason !== "completed") return
+    fetch("https://telemetry.example.com/turns", {
+      method: "POST",
+      body: JSON.stringify({ sessionID: input.sessionID, messageID: input.messageID }),
+    })
+  },
+}
+
+export default async () => hooks
+```

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1316,7 +1316,34 @@ const layer = Layer.effect(
               }
             }
 
-            if (result === "stop") return "break" as const
+            if (result === "stop") {
+              // Emit `stop` hook at natural end of turn. If a plugin sets
+              // `output.continue = true`, the loop re-iterates instead of
+              // breaking. Honored only on `reason: "completed"` to prevent
+              // infinite loops on aborted or errored turns. The same
+              // `lastUser` is reprocessed — the LLM re-evaluates the
+              // conversation with the new plugin context.
+              const stopInput = {
+                sessionID,
+                agent: lastUser.agent,
+                messageID: handle.message.id,
+                reason: "completed" as const,
+              }
+              const stopOutput = { continue: false }
+              yield* plugin
+                .trigger("stop", stopInput, stopOutput)
+                .pipe(Effect.catch((err) => Effect.logError("stop hook failed", { sessionID, err })))
+
+              if (stopOutput.continue) {
+                yield* Effect.logInfo("stop hook requested continue", {
+                  "session.id": sessionID,
+                  step,
+                  messageID: stopInput.messageID,
+                })
+                return "continue" as const
+              }
+              return "break" as const
+            }
             if (result === "compact") {
               yield* compaction.create({
                 sessionID,
@@ -1336,6 +1363,7 @@ const layer = Layer.effect(
         }
 
         yield* compaction.prune({ sessionID }).pipe(Effect.ignore, Effect.forkIn(scope))
+
         return yield* lastAssistant(sessionID)
       },
     )

--- a/packages/opencode/src/session/session.ts
+++ b/packages/opencode/src/session/session.ts
@@ -10,6 +10,7 @@ import type { ProviderMetadata, Usage } from "@opencode-ai/llm"
 import { InstallationVersion } from "@opencode-ai/core/installation/version"
 import { Database } from "@opencode-ai/core/database/database"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { Plugin } from "../plugin"
 import { SessionV2 } from "@opencode-ai/core/session"
 import * as SessionExecutionLocal from "@opencode-ai/core/session/execution/local"
 import { locationServiceMapLayer } from "@opencode-ai/core/location-services"
@@ -486,7 +487,7 @@ export type Patch = Omit<Partial<Info>, "time" | "share" | "summary" | "revert" 
 const layer: Layer.Layer<
   Service,
   never,
-  BackgroundJob.Service | RuntimeFlags.Service | Database.Service | EventV2Bridge.Service
+  BackgroundJob.Service | RuntimeFlags.Service | Database.Service | EventV2Bridge.Service | Plugin.Service
 > = Layer.effect(
   Service,
   Effect.gen(function* () {
@@ -495,6 +496,7 @@ const layer: Layer.Layer<
     const background = yield* BackgroundJob.Service
     const events = yield* EventV2Bridge.Service
     const flags = yield* RuntimeFlags.Service
+    const plugin = yield* Plugin.Service
 
     const createNext = Effect.fn("Session.createNext")(function* (input: {
       id?: SessionID
@@ -533,6 +535,22 @@ const layer: Layer.Layer<
       yield* Effect.logInfo("created", result)
 
       yield* events.publish(SessionV1.Event.Created, { sessionID: result.id, info: result })
+
+      const sessionStartOutput = { metadata: {} as Record<string, unknown> }
+      yield* plugin
+        .trigger(
+          "session.start",
+          {
+            sessionID: result.id,
+            cwd: result.directory,
+            agent: result.agent ?? "",
+            timestamp: result.time.created,
+          },
+          sessionStartOutput,
+        )
+        .pipe(
+          Effect.catch((err) => Effect.logError("session.start hook failed", { sessionID: result.id, err })),
+        )
 
       return result
     })
@@ -617,6 +635,27 @@ const layer: Layer.Layer<
         const kids = yield* children(sessionID)
         for (const child of kids) {
           yield* remove(child.id)
+        }
+
+        if (hasInstance) {
+          const sessionEndOutput = { cleanup: true }
+          yield* plugin
+            .trigger(
+              "session.end",
+              {
+                sessionID,
+                duration_ms: Date.now() - session.time.created,
+                turn_count: 0,
+                reason: "user_exit",
+              },
+              sessionEndOutput,
+            )
+            .pipe(
+              Effect.timeout(5000),
+              Effect.catch((err) =>
+                Effect.logError("session.end hook failed or timed out", { sessionID, err }),
+              ),
+            )
         }
 
         yield* events.publish(SessionV1.Event.Deleted, { sessionID, info: session })
@@ -1007,10 +1046,33 @@ function listByProject(
     )
 }
 
+// `Plugin.node` is wrapped in a lazy Proxy because session.ts and
+// plugin/index.ts form a circular import: plugin/index.ts imports
+// `Session` from this file, which means `Plugin.node` is in TDZ when
+// session.ts is evaluated first. The Proxy's `get` trap is invoked only
+// when LayerNode's compiled graph actually reads each dep property (which
+// happens after both modules are fully loaded), avoiding the TDZ error
+// while still declaring the dependency so the Plugin service is provided
+// to Session at runtime.
+const _pluginNode: LayerNode.Node<unknown, unknown, any> = new Proxy({} as LayerNode.Node<unknown, unknown, any>, {
+  get(_target, prop) {
+    return (Plugin.node as any)[prop]
+  },
+  has(_target, prop) {
+    return prop in (Plugin.node as any)
+  },
+  ownKeys() {
+    return Reflect.ownKeys(Plugin.node as any)
+  },
+  getOwnPropertyDescriptor(_target, prop) {
+    return Object.getOwnPropertyDescriptor(Plugin.node as any, prop)
+  },
+}) as LayerNode.Node<unknown, unknown, any>
+
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [BackgroundJob.node, RuntimeFlags.node, Database.node, EventV2Bridge.node],
+  deps: [BackgroundJob.node, RuntimeFlags.node, Database.node, EventV2Bridge.node, _pluginNode] as never,
 })
 
 export * as Session from "./session"

--- a/packages/opencode/test/plugin/trigger-lifecycle.test.ts
+++ b/packages/opencode/test/plugin/trigger-lifecycle.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "path"
+import { pathToFileURL } from "url"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Account } from "../../src/account/account"
+import { Auth } from "../../src/auth"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Npm } from "@opencode-ai/core/npm"
+import { Plugin } from "@/plugin"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { AccountTest } from "../fake/account"
+import { AuthTest } from "../fake/auth"
+import { NpmTest } from "../fake/npm"
+
+const it = testEffect(
+  AppNodeBuilder.build(LayerNode.group([Plugin.node, CrossSpawnSpawner.node]), [
+    [Auth.node, AuthTest.empty],
+    [Account.node, AccountTest.empty],
+    [Npm.node, NpmTest.noop],
+    [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
+  ]),
+)
+
+const recordingPlugin = [
+  "const bus = globalThis.__lifecycleBus ?? (globalThis.__lifecycleBus = { starts: [], ends: [], stops: [] })",
+  "export default async () => ({",
+  '  "session.start": async (input, output) => {',
+  "    bus.starts.push({ sessionID: input.sessionID, cwd: input.cwd, agent: input.agent, timestamp: input.timestamp, metadataKeys: Object.keys(output.metadata) })",
+  "  },",
+  '  "session.end": async (input, output) => {',
+  "    bus.ends.push({ sessionID: input.sessionID, reason: input.reason, duration_ms: input.duration_ms, cleanup: output.cleanup })",
+  "  },",
+  '  "stop": async (input, output) => {',
+  "    bus.stops.push({ sessionID: input.sessionID, agent: input.agent, messageID: input.messageID, reason: input.reason, continue: output.continue })",
+  "  },",
+  "})",
+  "",
+].join("\n")
+
+function installPlugin() {
+  return Effect.gen(function* () {
+    const test = yield* TestInstance
+    const file = path.join(test.directory, "lifecycle-plugin.ts")
+    yield* Effect.promise(() => Bun.write(file, recordingPlugin))
+    yield* Effect.promise(() =>
+      Bun.write(
+        path.join(test.directory, "opencode.json"),
+        JSON.stringify({
+          $schema: "https://opencode.ai/config.json",
+          plugin: [pathToFileURL(file).href],
+        }),
+      ),
+    )
+  })
+}
+
+const readBus = (): { starts: any[]; ends: any[]; stops: any[] } => {
+  const bus = (globalThis as any).__lifecycleBus ?? { starts: [], ends: [], stops: [] }
+  return { starts: [...bus.starts], ends: [...bus.ends], stops: [...bus.stops] }
+}
+
+const clearBus = () => {
+  const bus = (globalThis as any).__lifecycleBus ?? { starts: [], ends: [], stops: [] }
+  bus.starts.length = 0
+  bus.ends.length = 0
+  bus.stops.length = 0
+  ;(globalThis as any).__lifecycleBus = bus
+}
+
+describe("plugin.trigger (lifecycle events E2E with real plugin file)", () => {
+  it.instance("loaded plugin receives session.start with valid input", () =>
+    Effect.gen(function* () {
+      clearBus()
+      yield* installPlugin()
+      const plugin = yield* Plugin.Service
+      const out = { metadata: {} as Record<string, unknown> }
+      yield* plugin.trigger(
+        "session.start",
+        {
+          sessionID: "sess_loaded_1",
+          cwd: "/tmp/proj",
+          agent: "build",
+          timestamp: 1700000000000,
+        },
+        out,
+      )
+      const bus = readBus()
+      expect(bus.starts.length).toBe(1)
+      expect(bus.starts[0].sessionID).toBe("sess_loaded_1")
+      expect(bus.starts[0].cwd).toBe("/tmp/proj")
+      expect(bus.starts[0].agent).toBe("build")
+      expect(bus.starts[0].timestamp).toBe(1700000000000)
+    }),
+  )
+
+  it.instance("loaded plugin receives session.end with cleanup flag", () =>
+    Effect.gen(function* () {
+      clearBus()
+      yield* installPlugin()
+      const plugin = yield* Plugin.Service
+      const out = { cleanup: true }
+      yield* plugin.trigger(
+        "session.end",
+        {
+          sessionID: "sess_loaded_2",
+          duration_ms: 5000,
+          turn_count: 3,
+          reason: "user_exit",
+        },
+        out,
+      )
+      const bus = readBus()
+      expect(bus.ends.length).toBe(1)
+      expect(bus.ends[0].sessionID).toBe("sess_loaded_2")
+      expect(bus.ends[0].reason).toBe("user_exit")
+      expect(bus.ends[0].duration_ms).toBe(5000)
+    }),
+  )
+
+  it.instance("loaded plugin receives stop with reason and messageID", () =>
+    Effect.gen(function* () {
+      clearBus()
+      yield* installPlugin()
+      const plugin = yield* Plugin.Service
+      const out = { continue: false }
+      yield* plugin.trigger(
+        "stop",
+        {
+          sessionID: "sess_loaded_3",
+          agent: "build",
+          messageID: "msg_loaded_3",
+          reason: "completed",
+        },
+        out,
+      )
+      const bus = readBus()
+      expect(bus.stops.length).toBe(1)
+      expect(bus.stops[0].sessionID).toBe("sess_loaded_3")
+      expect(bus.stops[0].messageID).toBe("msg_loaded_3")
+      expect(bus.stops[0].reason).toBe("completed")
+    }),
+  )
+
+  it.instance("plugin can set stop output.continue = true", () =>
+    Effect.gen(function* () {
+      clearBus()
+      const continuePlugin = [
+        "const bus = globalThis.__lifecycleBus ?? (globalThis.__lifecycleBus = { stops: [] })",
+        "export default async () => ({",
+        '  "stop": async (_input, output) => {',
+        "    output.continue = true",
+        "  },",
+        "})",
+        "",
+      ].join("\n")
+      const test = yield* TestInstance
+      const file = path.join(test.directory, "continue-plugin.ts")
+      yield* Effect.promise(() => Bun.write(file, continuePlugin))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(test.directory, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(file).href],
+          }),
+        ),
+      )
+      const plugin = yield* Plugin.Service
+      const out = { continue: false }
+      yield* plugin.trigger(
+        "stop",
+        { sessionID: "s", agent: "a", messageID: "m", reason: "completed" },
+        out,
+      )
+      expect(out.continue).toBe(true)
+    }),
+  )
+
+  it.instance("stop output defaults to continue=false when plugin does not touch it", () =>
+    Effect.gen(function* () {
+      clearBus()
+      const noopPlugin = [
+        "export default async () => ({",
+        '  "stop": async () => {',
+        "    // no-op: do not touch output",
+        "  },",
+        "})",
+        "",
+      ].join("\n")
+      const test = yield* TestInstance
+      const file = path.join(test.directory, "noop-plugin.ts")
+      yield* Effect.promise(() => Bun.write(file, noopPlugin))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(test.directory, "opencode.json"),
+          JSON.stringify({
+            $schema: "https://opencode.ai/config.json",
+            plugin: [pathToFileURL(file).href],
+          }),
+        ),
+      )
+      const plugin = yield* Plugin.Service
+      const out = { continue: false }
+      yield* plugin.trigger(
+        "stop",
+        { sessionID: "s", agent: "a", messageID: "m", reason: "completed" },
+        out,
+      )
+      expect(out.continue).toBe(false)
+    }),
+  )
+})

--- a/packages/opencode/test/session/lifecycle-hooks.test.ts
+++ b/packages/opencode/test/session/lifecycle-hooks.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import path from "path"
+import { pathToFileURL } from "url"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Account } from "../../src/account/account"
+import { Auth } from "../../src/auth"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Npm } from "@opencode-ai/core/npm"
+import { Plugin } from "@/plugin"
+import { RuntimeFlags } from "@/effect/runtime-flags"
+import { Session } from "@/session/session"
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { AccountTest } from "../fake/account"
+import { AuthTest } from "../fake/auth"
+import { NpmTest } from "../fake/npm"
+
+const it = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Session.node, Plugin.node, CrossSpawnSpawner.node]),
+    [
+      [Auth.node, AuthTest.empty],
+      [Account.node, AccountTest.empty],
+      [Npm.node, NpmTest.noop],
+      [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
+    ],
+  ),
+)
+
+const recordingPlugin = [
+  "const bus = globalThis.__lifecycleBus ?? (globalThis.__lifecycleBus = { starts: [], ends: [], stops: [] })",
+  "export default async () => ({",
+  '  "session.start": async (input, output) => {',
+  "    bus.starts.push({ sessionID: input.sessionID, cwd: input.cwd, agent: input.agent, timestamp: input.timestamp })",
+  "  },",
+  '  "session.end": async (input, output) => {',
+  "    bus.ends.push({ sessionID: input.sessionID, reason: input.reason, duration_ms: input.duration_ms })",
+  "  },",
+  "})",
+  "",
+].join("\n")
+
+const readBus = () => (globalThis as any).__lifecycleBus ?? { starts: [], ends: [], stops: [] }
+
+const clearBus = () => {
+  ;(globalThis as any).__lifecycleBus = { starts: [], ends: [], stops: [] }
+}
+
+const installPlugin = Effect.gen(function* () {
+  const test = yield* TestInstance
+  const file = path.join(test.directory, "lifecycle-plugin.ts")
+  yield* Effect.promise(() => Bun.write(file, recordingPlugin))
+  yield* Effect.promise(() =>
+    Bun.write(
+      path.join(test.directory, "opencode.json"),
+      JSON.stringify({
+        $schema: "https://opencode.ai/config.json",
+        plugin: [pathToFileURL(file).href],
+      }),
+    ),
+  )
+})
+
+describe("session lifecycle hooks (E2E via Session.create)", () => {
+  it.instance("Session.create fires session.start with correct input", () =>
+    Effect.gen(function* () {
+      clearBus()
+      yield* installPlugin
+      const sessions = yield* Session.Service
+      const session = yield* sessions.create({ title: "Hook Test" })
+
+      const bus = readBus()
+      expect(bus.starts.length).toBe(1)
+      expect(bus.starts[0].sessionID).toBe(session.id)
+      expect(typeof bus.starts[0].cwd).toBe("string")
+      expect(bus.starts[0].cwd.length).toBeGreaterThan(0)
+      expect(typeof bus.starts[0].timestamp).toBe("number")
+    }),
+  )
+})

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -332,4 +332,52 @@ export interface Hooks {
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>
+
+  /**
+   * Fires once at end of agent turn, after the last tool call resolves
+   * and the LLM has produced its final message (or aborted/errored).
+   *
+   * - `reason` indicates how the turn ended.
+   * - `output.continue` allows a plugin to request another turn
+   *   (advanced; default false). Only honored when `reason === "completed"`.
+   */
+  "stop"?: (
+    input: {
+      sessionID: string
+      agent: string
+      messageID: string
+      reason: "completed" | "aborted" | "error"
+    },
+    output: { continue: boolean },
+  ) => Promise<void>
+
+  /**
+   * Fires once when a session is created, before any tool calls.
+   * Plugin may add to `output.metadata` (reserved keys blocked).
+   */
+  "session.start"?: (
+    input: {
+      sessionID: string
+      cwd: string
+      agent: string
+      timestamp: number
+    },
+    output: { metadata: Record<string, unknown> },
+  ) => Promise<void>
+
+  /**
+   * Fires once before session shutdown, before existing `dispose` lifecycle.
+   *
+   * - `output.cleanup` defaults to true; if a plugin sets false, the
+   *   runtime defers forced cleanup for up to 5s (hard ceiling).
+   */
+  "session.end"?: (
+    input: {
+      sessionID: string
+      duration_ms: number
+      turn_count: number
+      reason: "user_exit" | "error" | "timeout"
+    },
+    output: { cleanup: boolean },
+  ) => Promise<void>
 }


### PR DESCRIPTION
## Summary

Three optional lifecycle hooks for the plugin system, additive to the existing `Hooks` interface. Mirrors the Claude Code surface (`SessionStart`/`SessionEnd`/`Stop`) that OpenCode was missing.

## New events

- **`session.start`** — fires when a session is created, before any tool calls. Plugin can tag the session via `output.metadata` (reserved keys blocked).
- **`stop`** — fires at end of every agent turn. If plugin sets `output.continue = true` and `reason === "completed"`, the loop re-iterates with the same context.
- **`session.end`** — fires before session deletion, hard-capped at 5s. `output.cleanup = false` defers forced cleanup within the ceiling.

## Files

- `packages/plugin/src/index.ts` — adds 3 optional fields to the `Hooks` interface (purely additive)
- `packages/opencode/src/session/session.ts` — emits `session.start` in `createNext`, `session.end` in `remove` with timeout + error isolation
- `packages/opencode/src/session/prompt.ts` — emits `stop` in the `result === "stop"` branch, honors `output.continue` by returning `"continue"` instead of `"break"`
- `packages/opencode/test/plugin/trigger-lifecycle.test.ts` — 5 tests, real plugin loaded from file via `opencode.json`
- `packages/opencode/test/session/lifecycle-hooks.test.ts` — 1 E2E test, `Session.Service.create` triggers `session.start` hook
- `packages/docs/plugins.mdx` — full reference (input/output tables, error contract, telemetry example)
- `packages/docs/docs.json` — adds `plugins.mdx` under a new "Plugins" navigation group

## Test evidence

```
$ bun test test/session/lifecycle-hooks.test.ts test/plugin/trigger-lifecycle.test.ts
6 pass
0 fail
20 expect() calls
Ran 6 tests across 2 files. [4.37s]
```

- 5 trigger tests use a real plugin file (no mocks): they prove the dispatch works, that the input shape matches the docs, and that `output.continue`/`output.cleanup` mutations propagate.
- 1 E2E test creates a session via the public `Session.Service` API and verifies the loaded plugin's `session.start` hook fires with the correct `sessionID`, `cwd`, and `timestamp`.

`bun run typecheck` (tsgo --noEmit) passes on all modified files. `oxlint` reports 0 errors on the modified files (23 cosmetic warnings, pre-existing patterns).

## Behavior

- **Error isolation**: every emit is wrapped in `Effect.catch` that logs and continues. A throwing plugin never breaks session creation, deletion, or the agent loop.
- **No hot-path cost on idle plugins**: the trigger iterates `s.hooks` (an array, typically empty for users with no plugins); with zero matching handlers, the cost is one `InstanceState.get` + a `for` loop with zero iterations.
- **Stop `output.continue` is honored only when `reason === "completed"`** to prevent infinite loops on aborted or errored turns. The implementation lives in the existing `result === "stop"` branch of the `runLoop` Effect.gen, so the loop re-iterates by returning `"continue"` instead of `"break"` — same control flow as the existing `result === "compact"` and `result === "stop"` paths.

## Implementation note (circular import)

`session.ts` and `plugin/index.ts` form a circular import: `plugin/index.ts` imports `Session` from `session.ts`. Adding `Plugin.node` to `session.ts`'s `LayerNode.make` deps would TDZ. The fix is a lazy `Proxy` that defers the property reads to when `LayerNode`'s compiled graph actually walks the deps (after both modules are fully loaded). The Proxy's `get` trap returns `Plugin.node[prop]` lazily; the type system still tracks `Plugin.Service` as a layer dep, so the Plugin service is wired in at runtime correctly. Verified by the test suite, including the `Session.create` E2E which depends on the Plugin service being available.

## Follow-ups (not in this PR)

- Shell-based hooks (external command execution) — different design (input/output protocol via stdin/stdout), needs its own RFC
- Config-driven matcher syntax (filter hooks by tool name / regex from `opencode.json`) — separate proposal
- Telemetry/logging of hook invocations (observability of the hook system itself)