### PR TITLE
refactor(plugin): rename session request kind "session" to "primary"

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -217,7 +217,7 @@ const layer = Layer.effect(
           messages: loaded.messages,
         })
         const prepared = yield* context.prepare({
-          kind: "session",
+          kind: "primary",
           scope: { session: loaded.session, agentID: loaded.agent.id, model: loaded.model, tools: loaded.tools },
           transcript: {
             system: transcript.system,

--- a/packages/core/test/plugin/provider-azure.test.ts
+++ b/packages/core/test/plugin/provider-azure.test.ts
@@ -281,7 +281,7 @@ describe("AzurePlugin", () => {
             sessionID: Session.ID.make("ses_azure"),
             agent: Agent.ID.make("build"),
             model,
-            kind: "session",
+            kind: "primary",
             request: new Request("https://test-resource.openai.azure.com/openai/v1/responses", {
               headers: { "api-key": "stored-token", "x-keep": "yes" },
             }),
@@ -296,7 +296,7 @@ describe("AzurePlugin", () => {
             sessionID: Session.ID.make("ses_foundry"),
             agent: Agent.ID.make("build"),
             model,
-            kind: "session",
+            kind: "primary",
             request: new Request("https://test-resource.services.ai.azure.com/anthropic/v1/messages", {
               headers: { "x-api-key": "stored-token" },
             }),

--- a/packages/core/test/plugin/provider-github-copilot.test.ts
+++ b/packages/core/test/plugin/provider-github-copilot.test.ts
@@ -156,7 +156,7 @@ describe("GithubCopilotPlugin", () => {
         sessionID: Session.ID.make("ses_test"),
         agent: Agent.ID.make("build"),
         model: Model.Ref.make({ providerID: Provider.ID.githubCopilot, id: Model.ID.make("claude-sonnet-4.5") }),
-        kind: "session",
+        kind: "primary",
         request: new Request("https://api.githubcopilot.com/v1/messages", {
           method: "POST",
           headers: { "Content-Type": "application/json", "x-api-key": "token" },
@@ -174,7 +174,7 @@ describe("GithubCopilotPlugin", () => {
   it.effect("classifies main-loop steps as agent interactions", () =>
     Effect.gen(function* () {
       yield* addPlugin()
-      const event = yield* modelRequest((yield* sessions()).parent, "session")
+      const event = yield* modelRequest((yield* sessions()).parent, "primary")
       expect(event.headers).toEqual({ "X-Interaction-Type": "conversation-agent" })
     }),
   )
@@ -182,7 +182,7 @@ describe("GithubCopilotPlugin", () => {
   it.effect("classifies child-session steps as subagent interactions", () =>
     Effect.gen(function* () {
       yield* addPlugin()
-      const event = yield* modelRequest((yield* sessions()).child, "session")
+      const event = yield* modelRequest((yield* sessions()).child, "primary")
       expect(event.headers).toEqual({ "X-Interaction-Type": "conversation-subagent", "x-initiator": "agent" })
     }),
   )
@@ -206,7 +206,7 @@ describe("GithubCopilotPlugin", () => {
   it.effect("does not classify by agent name", () =>
     Effect.gen(function* () {
       yield* addPlugin()
-      const event = yield* modelRequest((yield* sessions()).parent, "session", "compaction")
+      const event = yield* modelRequest((yield* sessions()).parent, "primary", "compaction")
       expect(event.headers).toEqual({ "X-Interaction-Type": "conversation-agent" })
     }),
   )
@@ -219,7 +219,7 @@ describe("GithubCopilotPlugin", () => {
         sessionID: (yield* sessions()).parent,
         agent: Agent.ID.make("build"),
         model: Model.Ref.make({ providerID: Provider.ID.make("openai"), id: Model.ID.make("gpt-5.4") }),
-        kind: "session",
+        kind: "primary",
         headers: {},
       })
       expect(event.headers).toEqual({})

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -48,7 +48,7 @@ const request = Effect.fn(function* (providerID: Provider.ID, baseURL: string) {
     sessionID: Session.ID.make("ses_test"),
     agent: Agent.ID.make("build"),
     model: Model.Ref.make({ providerID, id: Model.ID.make("gpt-5.5") }),
-    kind: "session",
+    kind: "primary",
     baseURL,
     headers: {},
   })
@@ -227,7 +227,7 @@ describe("OpenAIPlugin", () => {
       const program = Effect.gen(function* () {
         const requests = yield* SessionModelRequest.Service
         return yield* requests.prepare({
-          kind: "session",
+          kind: "primary",
           scope: {
             session: Session.Info.make({
               id: sessionID,

--- a/packages/core/test/session-model-request-hooks.test.ts
+++ b/packages/core/test/session-model-request-hooks.test.ts
@@ -18,7 +18,7 @@ import { PluginTestLayer } from "./plugin/fixture"
 
 const it = testEffect(PluginTestLayer)
 
-const KINDS: ReadonlyArray<SessionRequestKind> = ["session", "compaction", "title", "generate"]
+const KINDS: ReadonlyArray<SessionRequestKind> = ["primary", "compaction", "title", "generate"]
 
 const session = Session.Info.make({
   id: Session.ID.make("ses_hook_kind"),

--- a/packages/plugin/src/effect/session.ts
+++ b/packages/plugin/src/effect/session.ts
@@ -34,7 +34,7 @@ export interface SessionContext {
  * Why a Session request is being made. Auxiliary requests share the Session's
  * hook identity but need to be told apart from the agent loop.
  */
-export type SessionRequestKind = "session" | "compaction" | "title" | "generate"
+export type SessionRequestKind = "primary" | "compaction" | "title" | "generate"
 
 export interface SessionModelRequest {
   readonly sessionID: Session.ID

--- a/packages/plugin/src/promise/session.ts
+++ b/packages/plugin/src/promise/session.ts
@@ -34,7 +34,7 @@ export interface SessionContext {
  * Why a Session request is being made. Auxiliary requests share the Session's
  * hook identity but need to be told apart from the agent loop.
  */
-export type SessionRequestKind = "session" | "compaction" | "title" | "generate"
+export type SessionRequestKind = "primary" | "compaction" | "title" | "generate"
 
 export interface SessionModelRequest {
   readonly sessionID: Session.ID

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -1120,7 +1120,7 @@ effect: (ctx) =>
 ```
 
 Modify native provider requests or responses. Their bodies are one-shot streams; clone or replace a body before reading
-it. Both hooks run for every request a session issues; `event.kind` is `"session"`, `"compaction"`, `"title"`, or
+it. Both hooks run for every request a session issues; `event.kind` is `"primary"`, `"compaction"`, `"title"`, or
 `"generate"` depending on which flow issued it.
 
 ```ts

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -1157,7 +1157,7 @@ await ctx.session.hook(
 Modify native provider requests or responses. Their bodies are one-shot streams; clone or replace a body before reading
 it.
 
-Both hooks run for every request a session issues. `event.kind` says which flow issued it: `"session"` for the agent
+Both hooks run for every request a session issues. `event.kind` says which flow issued it: `"primary"` for the agent
 loop, `"compaction"` for checkpoint summaries, `"title"` for title generation, and `"generate"` for transient
 `ctx.session.generate` calls. Use it instead of the agent ID to tell auxiliary requests apart.
 


### PR DESCRIPTION
## Summary

Follow-up to #47214. Renames the agent-loop value of `SessionRequestKind` from `"session"` to `"primary"`:

```ts
export type SessionRequestKind = "primary" | "compaction" | "title" | "generate"
```

`"session"` named the container, not the request. `"primary"` marks the loop call as the one the auxiliary kinds serve, matching the main/auxiliary split used elsewhere (Hermes `call_role: primary`, Codex `request_kind: turn` vs. auxiliaries).

Mechanical rename across plugin types, the runner call site, tests, and docs. No behavior change.