### PR TITLE
fix(provider): retain Zen discovery transport metadata

### DIFF
--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -31,6 +31,7 @@ import { ModelV2 } from "@opencode-ai/core/model"
 import { ModelStatus } from "./model-status"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderError } from "./error"
+import { ZenModels } from "./zen-models"
 
 const OPENAI_HEADER_TIMEOUT_DEFAULT = 300_000
 
@@ -184,14 +185,19 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       }),
     opencode: Effect.fnUntraced(function* (input: Info) {
       const env = yield* dep.env()
+      const auth = yield* dep.auth(input.id)
+      const configApiKey = (yield* dep.config()).provider?.["opencode"]?.options?.apiKey
       const hasKey = iife(() => {
         if (input.env.some((item) => env[item])) return true
         return false
       })
-      const ok =
-        hasKey ||
-        Boolean(yield* dep.auth(input.id)) ||
-        Boolean((yield* dep.config()).provider?.["opencode"]?.options?.apiKey)
+      const ok = hasKey || Boolean(auth) || Boolean(configApiKey)
+      const apiKey = iife(() => {
+        const fromEnv = input.env.map((item) => env[item]).find(Boolean)
+        if (fromEnv) return fromEnv
+        if (auth?.type === "api") return auth.key
+        if (typeof configApiKey === "string") return configApiKey
+      })
 
       if (!ok) {
         for (const [key, value] of Object.entries(input.models)) {
@@ -203,6 +209,18 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
       return {
         autoload: Object.keys(input.models).length > 0,
         options: ok ? {} : { apiKey: "public" },
+        async getModel(sdk: any, modelID: string, _options?: Record<string, any>, model?: Model) {
+          if (model?.api.npm === "@ai-sdk/openai" && sdk.responses) return sdk.responses(modelID)
+          return sdk.languageModel(modelID)
+        },
+        async discoverModels() {
+          if (!ok || !apiKey) return {}
+          const baseURL = iife(() => {
+            if (typeof input.options?.baseURL === "string" && input.options.baseURL) return input.options.baseURL
+            return Object.values(input.models)[0]?.api.url || "https://opencode.ai/zen/v1"
+          })
+          return ZenModels.get(baseURL, apiKey, input.models).catch(() => ({}))
+        },
       }
     }),
     openai: () =>
@@ -1493,6 +1511,8 @@ const layer = Layer.effect(
               model.provider?.npm ??
               provider.npm ??
               existingModel?.api.npm ??
+              modelsDev[providerID]?.models[apiID]?.provider?.npm ??
+              (providerID === ProviderV2.ID.opencode ? ZenModels.inferNpm(modelID, parsed.models) : undefined) ??
               // Config-defined gateway models bypass fromModelsDevModel, so resolve the
               // native passthrough npm here before falling back to the catalog default.
               cloudflareGatewayNpm(providerID, apiID) ??
@@ -1650,17 +1670,14 @@ const layer = Layer.effect(
           mergeProvider(providerID, partial)
         }
 
-        const gitlab = ProviderV2.ID.make("gitlab")
-        if (discoveryLoaders[gitlab] && providers[gitlab] && isProviderAllowed(gitlab)) {
+        for (const [id, discover] of Object.entries(discoveryLoaders)) {
+          const providerID = ProviderV2.ID.make(id)
+          if (!providers[providerID] || !isProviderAllowed(providerID)) continue
           yield* Effect.promise(async () => {
-            try {
-              const discovered = await discoveryLoaders[gitlab]()
-              for (const [modelID, model] of Object.entries(discovered)) {
-                if (!providers[gitlab].models[modelID]) {
-                  providers[gitlab].models[modelID] = model
-                }
-              }
-            } catch (e) {}
+            const discovered = await discover().catch(() => ({}))
+            for (const [modelID, model] of Object.entries(discovered)) {
+              providers[providerID].models[modelID] = model
+            }
           })
         }
 

--- a/packages/opencode/src/provider/zen-models.ts
+++ b/packages/opencode/src/provider/zen-models.ts
@@ -1,0 +1,135 @@
+import { Option, Schema } from "effect"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import type { Model } from "./provider"
+
+const item = Schema.Struct({
+  id: Schema.String,
+  npm: Schema.optional(Schema.String),
+  package: Schema.optional(Schema.String),
+  provider: Schema.optional(
+    Schema.Struct({
+      npm: Schema.optional(Schema.String),
+    }),
+  ),
+})
+
+const response = Schema.Struct({
+  data: Schema.Array(Schema.Unknown),
+})
+
+const decodeResponse = Schema.decodeUnknownSync(response)
+const decodeItem = Schema.decodeUnknownOption(item)
+
+type NpmModel = { api?: { npm?: string } }
+
+export function siblingModel<T extends NpmModel>(modelID: string, existing: Record<string, T>) {
+  const stem = modelID.replace(/[-_.]?\d.*$/, "")
+  if (stem.length < 4) return
+  const matches = Object.entries(existing)
+    .filter(([id]) => id !== modelID)
+    .filter(([id]) => id === stem || id.startsWith(`${stem}-`) || id.startsWith(`${stem}.`) || id.startsWith(`${stem}_`))
+    .sort(([left], [right]) => right.length - left.length)
+  if (!matches[0]) return
+  return matches[0][1]
+}
+
+export function inferNpm(modelID: string, existing: Record<string, NpmModel>, fallback?: string) {
+  const sibling = siblingModel(modelID, existing)?.api?.npm
+  if (sibling) return sibling
+  if (/^(gpt-|o[1-9]|chatgpt-|muse-spark)/i.test(modelID)) return "@ai-sdk/openai"
+  if (/^claude/i.test(modelID)) return "@ai-sdk/anthropic"
+  if (/^gemini/i.test(modelID)) return "@ai-sdk/google"
+  return fallback
+}
+
+function remoteNpm(value: Schema.Schema.Type<typeof item>) {
+  return value.npm ?? value.package ?? value.provider?.npm
+}
+
+function build(id: string, existing: Record<string, Model>, baseURL: string, npm: string): Model {
+  const sibling = siblingModel(id, existing)
+  if (sibling) {
+    return {
+      ...sibling,
+      id: ModelV2.ID.make(id),
+      name: id,
+      api: {
+        id,
+        url: sibling.api.url || baseURL,
+        npm,
+      },
+    }
+  }
+  return {
+    id: ModelV2.ID.make(id),
+    providerID: ProviderV2.ID.opencode,
+    name: id,
+    family: "",
+    api: {
+      id,
+      url: baseURL,
+      npm,
+    },
+    status: "active",
+    headers: {},
+    options: {},
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 128000, output: 4096 },
+    capabilities: {
+      temperature: true,
+      reasoning: false,
+      attachment: false,
+      toolcall: true,
+      input: { text: true, audio: false, image: false, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    release_date: "",
+    variants: {},
+  }
+}
+
+export function merge(existing: Record<string, Model>, ids: Schema.Schema.Type<typeof item>[], baseURL: string) {
+  const next = { ...existing }
+  for (const entry of ids) {
+    const current = next[entry.id]
+    const npm =
+      remoteNpm(entry) ?? inferNpm(entry.id, existing, current?.api.npm) ?? "@ai-sdk/openai-compatible"
+    if (!current) {
+      next[entry.id] = build(entry.id, next, baseURL, npm)
+      continue
+    }
+    if (current.api.npm === npm) continue
+    if (current.api.npm !== "@ai-sdk/openai-compatible") continue
+    next[entry.id] = {
+      ...current,
+      api: {
+        ...current.api,
+        npm,
+        url: current.api.url || baseURL,
+      },
+    }
+  }
+  return next
+}
+
+export async function get(baseURL: string, apiKey: string, existing: Record<string, Model>) {
+  const data = await fetch(`${baseURL.replace(/\/+$/, "")}/models`, {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+    signal: AbortSignal.timeout(3_000),
+  }).then(async (res) => {
+    if (!res.ok) throw new Error(`Failed to fetch Zen models: ${res.status}`)
+    return decodeResponse(await res.json())
+  })
+
+  const ids = data.data.flatMap((raw) => {
+    const parsed = Option.getOrUndefined(decodeItem(raw))
+    return parsed ? [parsed] : []
+  })
+  return merge(existing, ids, baseURL)
+}
+
+export * as ZenModels from "./zen-models"

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -2085,6 +2085,78 @@ it.effect("opencode loader keeps paid models when config apiKey is present", () 
   }).pipe(provideMultiInstance),
 )
 
+it.instance(
+  "empty opencode model config retains zen transport metadata",
+  Effect.gen(function* () {
+    const providers = yield* list
+    const model = providers[ProviderV2.ID.opencode].models["muse-spark-9.9-contributor-free"]
+    expect(model).toBeDefined()
+    expect(model.api.npm).toBe("@ai-sdk/openai")
+    expect(model.api.id).toBe("muse-spark-9.9-contributor-free")
+  }),
+  {
+    config: {
+      provider: {
+        opencode: {
+          models: {
+            "muse-spark-9.9-contributor-free": {},
+          },
+        },
+      },
+    },
+  },
+)
+
+it.effect("authenticated zen discovery exposes endpoint models without a models map", () =>
+  Effect.gen(function* () {
+    const server = yield* Effect.acquireRelease(
+      Effect.sync(() =>
+        Bun.serve({
+          port: 0,
+          fetch(request) {
+            if (!new URL(request.url).pathname.endsWith("/models")) return new Response("not found", { status: 404 })
+            return Response.json({
+              object: "list",
+              data: [{ id: "muse-spark-9.9-contributor-free", object: "model" }],
+            })
+          },
+        }),
+      ),
+      (server) => Effect.sync(() => void server.stop()),
+    )
+
+    const dir = yield* tmpdirScoped({
+      config: {
+        provider: {
+          opencode: {
+            options: {
+              apiKey: "zen-key",
+              baseURL: `${server.url}zen/v1`,
+            },
+          },
+        },
+      },
+    })
+
+    const result = yield* Effect.gen(function* () {
+      const provider = yield* Provider.Service
+      const providers = yield* provider.list()
+      const model = providers[ProviderV2.ID.opencode].models["muse-spark-9.9-contributor-free"]
+      expect(model).toBeDefined()
+      expect(model.api.npm).toBe("@ai-sdk/openai")
+      const language = yield* provider.getLanguage(model)
+      return language.constructor.name
+    }).pipe(
+      provideInstanceEffect(dir),
+      Effect.provide(instanceStoreLayer),
+      Effect.provide(AppNodeBuilder.build(CrossSpawnSpawner.node)),
+    )
+
+    expect(result).not.toContain("Compatible")
+    expect(result).toMatch(/Responses|OpenAI/)
+  }).pipe(provideMultiInstance),
+)
+
 it.effect("opencode loader keeps paid models when auth exists", () =>
   Effect.gen(function* () {
     const noneDir = yield* tmpdirScoped()

--- a/packages/opencode/test/provider/zen-models.test.ts
+++ b/packages/opencode/test/provider/zen-models.test.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "bun:test"
+import type { Model } from "@/provider/provider"
+import { ZenModels } from "@/provider/zen-models"
+
+const BASE_URL = "https://opencode.ai/zen/v1"
+
+function model(id: string, npm: string): Model {
+  return {
+    id,
+    providerID: "opencode",
+    name: id,
+    family: id.startsWith("muse-spark") ? "muse-free" : "",
+    api: {
+      id,
+      url: BASE_URL,
+      npm,
+    },
+    status: "active",
+    headers: {},
+    options: {},
+    cost: { input: 0, output: 0, cache: { read: 0, write: 0 } },
+    limit: { context: 128000, output: 4096 },
+    capabilities: {
+      temperature: true,
+      reasoning: true,
+      attachment: true,
+      toolcall: true,
+      input: { text: true, audio: false, image: true, video: false, pdf: false },
+      output: { text: true, audio: false, image: false, video: false, pdf: false },
+      interleaved: false,
+    },
+    release_date: "2026-08-05",
+    variants: {},
+  }
+}
+
+test("inferNpm keeps sibling catalog package for endpoint-only zen ids", () => {
+  const existing = {
+    "muse-spark-1.2-contributor-free": model("muse-spark-1.2-contributor-free", "@ai-sdk/openai"),
+  }
+  expect(ZenModels.inferNpm("muse-spark-1.3-contributor-free", existing)).toBe("@ai-sdk/openai")
+})
+
+test("inferNpm uses Responses package for muse-spark without a sibling", () => {
+  expect(ZenModels.inferNpm("muse-spark-1.3-contributor-free", {})).toBe("@ai-sdk/openai")
+})
+
+test("merge does not collapse endpoint ids into empty openai-compatible entries", () => {
+  const existing = {
+    "muse-spark-1.2-contributor-free": model("muse-spark-1.2-contributor-free", "@ai-sdk/openai"),
+  }
+  const merged = ZenModels.merge(existing, [{ id: "muse-spark-1.3-contributor-free" }], BASE_URL)
+  const discovered = merged["muse-spark-1.3-contributor-free"]
+
+  expect(discovered).toBeDefined()
+  expect(discovered.api).toEqual({
+    id: "muse-spark-1.3-contributor-free",
+    url: BASE_URL,
+    npm: "@ai-sdk/openai",
+  })
+  expect(discovered.family).toBe("muse-free")
+  expect(discovered.capabilities.toolcall).toBe(true)
+  expect(merged["muse-spark-1.2-contributor-free"].api.npm).toBe("@ai-sdk/openai")
+})
+
+test("merge repairs collapsed empty-config entries that dropped transport metadata", () => {
+  const collapsed = model("muse-spark-1.3-contributor-free", "@ai-sdk/openai-compatible")
+  const merged = ZenModels.merge(
+    {
+      "muse-spark-1.2-contributor-free": model("muse-spark-1.2-contributor-free", "@ai-sdk/openai"),
+      "muse-spark-1.3-contributor-free": collapsed,
+    },
+    [{ id: "muse-spark-1.3-contributor-free" }],
+    BASE_URL,
+  )
+
+  expect(merged["muse-spark-1.3-contributor-free"].api.npm).toBe("@ai-sdk/openai")
+})
+
+test("merge keeps catalog package when the endpoint also sends npm", () => {
+  const existing = {
+    "gpt-5": model("gpt-5", "@ai-sdk/openai"),
+  }
+  const merged = ZenModels.merge(existing, [{ id: "gpt-5", npm: "@ai-sdk/openai" }], BASE_URL)
+  expect(merged["gpt-5"].api.npm).toBe("@ai-sdk/openai")
+})
+
+test("get discovers zen models and retains per-model package metadata", async () => {
+  const requests: Array<{ authorization: string | null; path: string }> = []
+  using server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      requests.push({
+        authorization: request.headers.get("authorization"),
+        path: new URL(request.url).pathname,
+      })
+      return Response.json({
+        object: "list",
+        data: [
+          { id: "muse-spark-1.2-contributor-free", object: "model" },
+          { id: "muse-spark-1.3-contributor-free", object: "model" },
+        ],
+      })
+    },
+  })
+
+  const models = await ZenModels.get(`${server.url}zen/v1`, "zen-key", {
+    "muse-spark-1.2-contributor-free": model("muse-spark-1.2-contributor-free", "@ai-sdk/openai"),
+  })
+
+  expect(requests).toEqual([
+    {
+      authorization: "Bearer zen-key",
+      path: "/zen/v1/models",
+    },
+  ])
+  expect(models["muse-spark-1.3-contributor-free"].api.npm).toBe("@ai-sdk/openai")
+  expect(models["muse-spark-1.2-contributor-free"].api.npm).toBe("@ai-sdk/openai")
+})
+
+test("get rejects when the zen models endpoint is unavailable", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch() {
+      return new Response(null, { status: 503 })
+    },
+  })
+
+  const existing = {
+    "muse-spark-1.2-contributor-free": model("muse-spark-1.2-contributor-free", "@ai-sdk/openai"),
+  }
+  expect(await ZenModels.get(`${server.url}zen/v1`, "zen-key", existing).catch(() => ({}))).toEqual({})
+})

--- a/packages/opencode/test/provider/zen-models.test.ts
+++ b/packages/opencode/test/provider/zen-models.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "bun:test"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
 import type { Model } from "@/provider/provider"
 import { ZenModels } from "@/provider/zen-models"
 
@@ -6,8 +8,8 @@ const BASE_URL = "https://opencode.ai/zen/v1"
 
 function model(id: string, npm: string): Model {
   return {
-    id,
-    providerID: "opencode",
+    id: ModelV2.ID.make(id),
+    providerID: ProviderV2.ID.opencode,
     name: id,
     family: id.startsWith("muse-spark") ? "muse-free" : "",
     api: {


### PR DESCRIPTION
### Issue for this PR

Closes #47120

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Zen authenticated model discovery was merging endpoint-only IDs into empty provider.opencode.models entries. That dropped per-model SDK/transport metadata, so Responses models like muse-spark fell back to the openai-compatible chat path and failed as opaque UnknownError.

This keeps discovery metadata so a model returned by authenticated Zen /v1/models stays on the right transport without a hand-written models map.

### How did you verify your code works?

In packages/opencode:

- bun typecheck
- bun test test/provider/zen-models.test.ts test/provider/provider.test.ts (111 pass)

### Screenshots / recordings

N/A - provider/catalog path, no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
