### PR TITLE
feat(opencode): add run_in_background to shell tool with auto notification

### DIFF
--- a/packages/opencode/src/tool/bash-jobs.ts
+++ b/packages/opencode/src/tool/bash-jobs.ts
@@ -1,0 +1,82 @@
+import { Effect, Schema } from "effect"
+import { BackgroundJob } from "@/background/job"
+import { ShellID } from "./shell/id"
+import * as Tool from "./tool"
+
+const DESCRIPTION = `List, inspect, and cancel shell commands that were started with run_in_background=true.
+
+Actions:
+- list: show all background shell jobs with their id, status, command, and log file path. Use this when you need to recall what is running or find a job id.
+- kill: terminate a background command. Requires job_id. Use this to stop a command that is no longer needed, stuck, or occupying a port. The command and its whole process group are killed. Do not kill jobs that are about to finish on their own.
+
+Live output is available by Reading or Grepping the job's log file path at any time; completion output is delivered automatically without polling.`
+
+type Parameters = Schema.Schema.Type<typeof Parameters>
+
+export const Parameters = Schema.Struct({
+  action: Schema.Literals(["list", "kill"]).annotate({
+    description: "list shows background shell jobs; kill terminates one",
+  }),
+  job_id: Schema.optional(Schema.String).annotate({
+    description: "The job id to act on. Required for kill; obtain it from list or from the original run_in_background result.",
+  }),
+})
+
+type JobsMetadata = {
+  action: string
+  count?: number
+  jobId?: string
+  status?: string
+}
+
+function renderList(jobs: BackgroundJob.Info[]) {
+  if (jobs.length === 0) return "No background shell jobs."
+  const lines = jobs.map((job) => {
+    const log = typeof job.metadata?.logPath === "string" ? job.metadata.logPath : undefined
+    return `- ${job.id} [${job.status}] ${job.title}${log ? ` (log: ${log})` : ""}`
+  })
+  return lines.join("\n")
+}
+
+export const BashJobsTool = Tool.define(
+  "bash_jobs",
+  Effect.gen(function* () {
+    const background = yield* BackgroundJob.Service
+
+    return {
+      description: DESCRIPTION,
+      parameters: Parameters,
+      execute: (params: Parameters, _ctx: Tool.Context): Effect.Effect<Tool.ExecuteResult<JobsMetadata>> =>
+        Effect.gen(function* () {
+          if (params.action === "kill") {
+            if (!params.job_id) throw new Error("job_id is required when action is 'kill'")
+            const info = yield* background.cancel(params.job_id)
+            if (!info) {
+              return {
+                title: `kill ${params.job_id}`,
+                metadata: { action: "kill", jobId: params.job_id, status: undefined },
+                output: `No background job found with id ${params.job_id}. Use action "list" to see jobs from this session.`,
+              }
+            }
+            return {
+              title: `kill ${info.title ?? params.job_id}`,
+              metadata: { action: "kill", jobId: params.job_id, status: info.status },
+              output:
+                info.status === "cancelled"
+                  ? `Cancelled background job ${params.job_id}: ${info.title ?? ""}`
+                  : `Background job ${params.job_id} already finished with status ${info.status}.`,
+            }
+          }
+
+          const jobs = (yield* background.list()).filter((job) => job.type === ShellID.ToolID)
+          return {
+            title: "list background jobs",
+            metadata: { action: "list", count: jobs.length },
+            output: renderList(jobs),
+          }
+        }),
+    }
+  }),
+)
+
+export * as BashJobs from "./bash-jobs"

--- a/packages/opencode/src/tool/bash-jobs.ts
+++ b/packages/opencode/src/tool/bash-jobs.ts
@@ -3,13 +3,13 @@ import { BackgroundJob } from "@/background/job"
 import { ShellID } from "./shell/id"
 import * as Tool from "./tool"
 
-const DESCRIPTION = `List, inspect, and cancel shell commands that were started with run_in_background=true.
+const DESCRIPTION = `List, inspect, and cancel background jobs: shell commands started with run_in_background=true, and subagents started with background=true.
 
 Actions:
-- list: show all background shell jobs with their id, status, command, and log file path. Use this when you need to recall what is running or find a job id.
-- kill: terminate a background command. Requires job_id. Use this to stop a command that is no longer needed, stuck, or occupying a port. The command and its whole process group are killed. Do not kill jobs that are about to finish on their own.
+- list: show all background jobs with their id, type, status, title, and log file path (shell commands) or child session id (subagents). Use this when you need to recall what is running or find a job id.
+- kill: terminate a background job. Requires job_id. Use this to stop a command or subagent that is no longer needed or stuck. Shell commands are killed with their whole process group; subagents are cancelled and their session stops. Do not kill jobs that are about to finish on their own.
 
-Live output is available by Reading or Grepping the job's log file path at any time; completion output is delivered automatically without polling.`
+Live output of background shell commands is available by Reading or Grepping the job's log file path at any time; completion output of both kinds is delivered automatically without polling.`
 
 type Parameters = Schema.Schema.Type<typeof Parameters>
 
@@ -30,10 +30,12 @@ type JobsMetadata = {
 }
 
 function renderList(jobs: BackgroundJob.Info[]) {
-  if (jobs.length === 0) return "No background shell jobs."
+  if (jobs.length === 0) return "No background jobs."
   const lines = jobs.map((job) => {
     const log = typeof job.metadata?.logPath === "string" ? job.metadata.logPath : undefined
-    return `- ${job.id} [${job.status}] ${job.title}${log ? ` (log: ${log})` : ""}`
+    const session = typeof job.metadata?.sessionId === "string" ? job.metadata.sessionId : undefined
+    const detail = log ? ` (log: ${log})` : session ? ` (session: ${session})` : ""
+    return `- ${job.id} [${job.type}] [${job.status}] ${job.title}${detail}`
   })
   return lines.join("\n")
 }
@@ -68,7 +70,7 @@ export const BashJobsTool = Tool.define(
             }
           }
 
-          const jobs = (yield* background.list()).filter((job) => job.type === ShellID.ToolID)
+          const jobs = (yield* background.list()).filter((job) => job.type === ShellID.ToolID || job.type === "task")
           return {
             title: "list background jobs",
             metadata: { action: "list", count: jobs.length },

--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -5,6 +5,7 @@ import { PlanExitTool } from "./plan"
 import { Session } from "@/session/session"
 import { QuestionTool } from "./question"
 import { ShellTool } from "./shell"
+import { BashJobsTool } from "./bash-jobs"
 import { EditTool } from "./edit"
 import { GlobTool } from "./glob"
 import { GrepTool } from "./grep"
@@ -108,6 +109,7 @@ const layer = Layer.effect(
     const webfetch = yield* WebFetchTool
     const websearch = yield* WebSearchTool
     const shell = yield* ShellTool
+    const bashjobs = yield* BashJobsTool
     const globtool = yield* GlobTool
     const writetool = yield* WriteTool
     const edit = yield* EditTool
@@ -209,6 +211,7 @@ const layer = Layer.effect(
         const tool = yield* Effect.all({
           invalid: Tool.init(invalid),
           shell: Tool.init(shell),
+          bashjobs: Tool.init(bashjobs),
           read: Tool.init(read),
           glob: Tool.init(globtool),
           grep: Tool.init(greptool),
@@ -232,6 +235,7 @@ const layer = Layer.effect(
             tool.invalid,
             ...(questionEnabled ? [tool.question] : []),
             tool.shell,
+            tool.bashjobs,
             tool.read,
             tool.glob,
             tool.grep,

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -268,10 +268,16 @@ const parse = Effect.fn("ShellTool.parse")(function* (command: string, ps: boole
 const BACKGROUND_GUIDANCE = [
   "The command is running in the background. You will be notified automatically when it finishes.",
   "DO NOT sleep, poll for progress, check on it, or run the same command again.",
-  "Continue with non-overlapping work, or briefly tell the user what you started and end your response.",
+  "If you truly need a peek, Read or Grep the log file in <log>; otherwise continue with non-overlapping work or end your response.",
 ].join("\n")
 
-function renderJobOutput(input: { jobID: string; command: string; state: "running" | "completed" | "error"; text: string }) {
+function renderJobOutput(input: {
+  jobID: string
+  command: string
+  state: "running" | "completed" | "error"
+  text: string
+  logPath?: string
+}) {
   const tag = input.state === "error" ? "shell_job_error" : "shell_job_result"
   const summary =
     input.state === "completed"
@@ -282,6 +288,7 @@ function renderJobOutput(input: { jobID: string; command: string; state: "runnin
   return [
     `<shell_job id="${input.jobID}" state="${input.state}">`,
     `<summary>${summary}</summary>`,
+    ...(input.logPath ? [`<log>${input.logPath}</log>`] : []),
     `<${tag}>`,
     input.text,
     `</${tag}>`,
@@ -466,6 +473,7 @@ export const ShellTool = Tool.define(
         env: NodeJS.ProcessEnv
         timeout: number | undefined
         background: boolean
+        logPath?: string
       },
       ctx: Tool.Context,
     ) {
@@ -514,6 +522,10 @@ export const ShellTool = Tool.define(
       const code: number | null = yield* Effect.scoped(
         Effect.gen(function* () {
           yield* Effect.addFinalizer(closeSink)
+          if (input.logPath) {
+            file = input.logPath
+            sink = createWriteStream(input.logPath, { flags: "a" })
+          }
           const handle = yield* spawner.spawn(cmd(input.shell, input.command, input.cwd, input.env))
 
           yield* Effect.forkScoped(
@@ -621,6 +633,7 @@ export const ShellTool = Tool.define(
           exit: code,
           truncated: cut,
           ...(cut && file ? { outputPath: file } : {}),
+          ...(input.background && file ? { logPath: file } : {}),
         },
         output,
       }
@@ -691,7 +704,7 @@ export const ShellTool = Tool.define(
                         {
                           type: "text",
                           synthetic: true,
-                          text: renderJobOutput({ jobID, command: params.command, state, text }),
+                          text: renderJobOutput({ jobID, command: params.command, state, text, logPath }),
                         },
                       ],
                     })
@@ -714,10 +727,11 @@ export const ShellTool = Tool.define(
                   )
                 })
 
+                const logPath = yield* trunc.write("")
                 const started = yield* background.start({
                   type: ShellID.ToolID,
                   title: params.command,
-                  metadata: { command: params.command, cwd, background: true },
+                  metadata: { command: params.command, cwd, background: true, logPath },
                   run: run(
                     {
                       shell,
@@ -726,6 +740,7 @@ export const ShellTool = Tool.define(
                       env,
                       timeout: params.timeout,
                       background: true,
+                      logPath,
                     },
                     ctx,
                   ).pipe(Effect.map((result) => result.output)),
@@ -739,12 +754,14 @@ export const ShellTool = Tool.define(
                     truncated: false,
                     background: true,
                     jobId: started.id,
+                    logPath,
                   },
                   output: renderJobOutput({
                     jobID: started.id,
                     command: params.command,
                     state: "running",
                     text: BACKGROUND_GUIDANCE,
+                    logPath,
                   }),
                 }
               }

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Effect, Scope, Stream } from "effect"
 import os from "os"
 import { createWriteStream } from "node:fs"
 import * as Tool from "./tool"
@@ -21,6 +21,11 @@ import { ChildProcess } from "effect/unstable/process"
 import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
 import { ShellPrompt, type Parameters } from "./shell/prompt"
 import { BashArity } from "@/permission/arity"
+import { BackgroundJob } from "@/background/job"
+import { Session } from "@/session/session"
+import { Database } from "@opencode-ai/core/database/database"
+import { MessageV2 } from "../session/message-v2"
+import type { TaskPromptOps } from "./task"
 
 export { Parameters } from "./shell/prompt"
 
@@ -260,6 +265,30 @@ const parse = Effect.fn("ShellTool.parse")(function* (command: string, ps: boole
   return tree
 })
 
+const BACKGROUND_GUIDANCE = [
+  "The command is running in the background. You will be notified automatically when it finishes.",
+  "DO NOT sleep, poll for progress, check on it, or run the same command again.",
+  "Continue with non-overlapping work, or briefly tell the user what you started and end your response.",
+].join("\n")
+
+function renderJobOutput(input: { jobID: string; command: string; state: "running" | "completed" | "error"; text: string }) {
+  const tag = input.state === "error" ? "shell_job_error" : "shell_job_result"
+  const summary =
+    input.state === "completed"
+      ? `Background command completed: ${input.command}`
+      : input.state === "error"
+        ? `Background command failed: ${input.command}`
+        : `Background command started: ${input.command}`
+  return [
+    `<shell_job id="${input.jobID}" state="${input.state}">`,
+    `<summary>${summary}</summary>`,
+    `<${tag}>`,
+    input.text,
+    `</${tag}>`,
+    "</shell_job>",
+  ].join("\n")
+}
+
 const ask = Effect.fn("ShellTool.ask")(function* (ctx: Tool.Context, scan: Scan, input: { command: string }) {
   if (scan.dirs.size > 0) {
     const directories = Array.from(scan.dirs)
@@ -344,6 +373,10 @@ export const ShellTool = Tool.define(
     const trunc = yield* Truncate.Service
     const plugin = yield* Plugin.Service
     const flags = yield* RuntimeFlags.Service
+    const background = yield* BackgroundJob.Service
+    const sessions = yield* Session.Service
+    const database = yield* Database.Service
+    const scope = yield* Scope.Scope
     const defaultTimeoutMs = flags.bashDefaultTimeoutMs ?? 2 * 60 * 1000
 
     const cygpath = Effect.fn("ShellTool.cygpath")(function* (shell: string, text: string) {
@@ -431,7 +464,8 @@ export const ShellTool = Tool.define(
         command: string
         cwd: string
         env: NodeJS.ProcessEnv
-        timeout: number
+        timeout: number | undefined
+        background: boolean
       },
       ctx: Tool.Context,
     ) {
@@ -446,6 +480,9 @@ export const ShellTool = Tool.define(
       let cut = false
       let expired = false
       let aborted = false
+      // Background jobs outlive the tool call, so live part updates would land
+      // on an already-completed tool part (a no-op at best).
+      const report = (metadata: { output: string }) => (input.background ? Effect.void : ctx.metadata({ metadata }))
 
       const closeSink = Effect.fnUntraced(function* () {
         const stream = sink
@@ -472,11 +509,7 @@ export const ShellTool = Tool.define(
         ).pipe(Effect.catch(() => Effect.void))
       })
 
-      yield* ctx.metadata({
-        metadata: {
-          output: "",
-        },
-      })
+      yield* report({ output: "" })
 
       const code: number | null = yield* Effect.scoped(
         Effect.gen(function* () {
@@ -511,22 +544,12 @@ export const ShellTool = Tool.define(
                         full = ""
                       }),
                     ),
-                    Effect.andThen(
-                      ctx.metadata({
-                        metadata: {
-                          output: last,
-                        },
-                      }),
-                    ),
+                    Effect.andThen(report({ output: last })),
                   )
                 }
               }
 
-              return ctx.metadata({
-                metadata: {
-                  output: last,
-                },
-              })
+              return report({ output: last })
             }),
           )
 
@@ -537,12 +560,21 @@ export const ShellTool = Tool.define(
             return Effect.sync(() => ctx.abort.removeEventListener("abort", handler))
           })
 
-          const timeout = Effect.sleep(`${input.timeout + 100} millis`)
+          const sleep = Effect.sleep(`${(input.timeout ?? 0) + 100} millis`)
 
+          // Background jobs only race the exit code (plus an explicit timeout if
+          // the model asked for one); the tool-call abort signal belongs to a
+          // turn that has already ended by the time the command finishes.
           const exit = yield* Effect.raceAll([
             handle.exitCode.pipe(Effect.map((code) => ({ kind: "exit" as const, code }))),
-            abort.pipe(Effect.map(() => ({ kind: "abort" as const, code: null }))),
-            timeout.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
+            ...(input.background
+              ? input.timeout === undefined
+                ? []
+                : [sleep.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null })))]
+              : [
+                  abort.pipe(Effect.map(() => ({ kind: "abort" as const, code: null }))),
+                  sleep.pipe(Effect.map(() => ({ kind: "timeout" as const, code: null }))),
+                ]),
           ])
 
           if (exit.kind === "abort") {
@@ -600,7 +632,9 @@ export const ShellTool = Tool.define(
         const shell = Shell.acceptable(cfg.shell)
         const name = Shell.name(shell)
         const limits = yield* trunc.limits()
-        const prompt = ShellPrompt.render(name, process.platform, limits, defaultTimeoutMs)
+        const prompt = ShellPrompt.render(name, process.platform, limits, defaultTimeoutMs, {
+          background: flags.experimentalBackgroundSubagents,
+        })
         yield* Effect.logInfo("shell tool using shell", { shell })
 
         return {
@@ -615,7 +649,6 @@ export const ShellTool = Tool.define(
               if (params.timeout !== undefined && params.timeout < 0) {
                 throw new Error(`Invalid timeout value: ${params.timeout}. Timeout must be a positive number.`)
               }
-              const timeout = params.timeout ?? defaultTimeoutMs
               const ps = Shell.ps(shell)
               yield* Effect.scoped(
                 Effect.gen(function* () {
@@ -627,14 +660,103 @@ export const ShellTool = Tool.define(
                   yield* ask(ctx, scan, params)
                 }),
               )
+              const env = yield* shellEnv(ctx, cwd)
+
+              if (params.run_in_background === true) {
+                if (!flags.experimentalBackgroundSubagents) {
+                  throw new Error(
+                    "Background shell requires OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS=true. Re-run the command in the foreground instead.",
+                  )
+                }
+                const ops = ctx.extra?.promptOps as TaskPromptOps | undefined
+                if (!ops) throw new Error("Background shell requires promptOps in ctx.extra")
+                const msg = yield* MessageV2.get({ sessionID: ctx.sessionID, messageID: ctx.messageID }).pipe(
+                  Effect.provideService(Database.Service, database),
+                  Effect.orDie,
+                )
+                const variant = msg.info.role === "assistant" ? msg.info.variant : undefined
+                const parent = yield* sessions.get(ctx.sessionID).pipe(Effect.orDie)
+
+                const inject = Effect.fn("ShellTool.injectBackgroundResult")(function* (
+                  jobID: string,
+                  state: "completed" | "error",
+                  text: string,
+                ) {
+                  yield* ops
+                    .prompt({
+                      sessionID: ctx.sessionID,
+                      agent: parent.agent ?? ctx.agent,
+                      variant,
+                      parts: [
+                        {
+                          type: "text",
+                          synthetic: true,
+                          text: renderJobOutput({ jobID, command: params.command, state, text }),
+                        },
+                      ],
+                    })
+                    .pipe(
+                      Effect.catch((error) =>
+                        Effect.logError("shell background inject prompt failed", { jobID, error: String(error) }),
+                      ),
+                      Effect.forkIn(scope, { startImmediately: true }),
+                    )
+                })
+
+                const notify = Effect.fn("ShellTool.notifyBackgroundResult")(function* (jobID: string) {
+                  yield* background.wait({ id: jobID }).pipe(
+                    Effect.flatMap((result) => {
+                      if (result.info?.status === "completed") return inject(jobID, "completed", result.info.output ?? "")
+                      if (result.info?.status === "error") return inject(jobID, "error", result.info.error ?? "")
+                      return Effect.void
+                    }),
+                    Effect.forkIn(scope, { startImmediately: true }),
+                  )
+                })
+
+                const started = yield* background.start({
+                  type: ShellID.ToolID,
+                  title: params.command,
+                  metadata: { command: params.command, cwd, background: true },
+                  run: run(
+                    {
+                      shell,
+                      command: params.command,
+                      cwd,
+                      env,
+                      timeout: params.timeout,
+                      background: true,
+                    },
+                    ctx,
+                  ).pipe(Effect.map((result) => result.output)),
+                })
+                yield* notify(started.id)
+                return {
+                  title: params.command,
+                  metadata: {
+                    output: "(running in background)",
+                    exit: null,
+                    truncated: false,
+                    background: true,
+                    jobId: started.id,
+                  },
+                  output: renderJobOutput({
+                    jobID: started.id,
+                    command: params.command,
+                    state: "running",
+                    text: BACKGROUND_GUIDANCE,
+                  }),
+                }
+              }
 
               return yield* run(
                 {
                   shell,
                   command: params.command,
                   cwd,
-                  env: yield* shellEnv(ctx, cwd),
-                  timeout,
+                  env,
+                  timeout: params.timeout ?? defaultTimeoutMs,
+                  background: false,
                 },
                 ctx,
               )

--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -19,6 +19,10 @@ export function parameterSchema() {
     workdir: Schema.optional(Schema.String).annotate({
       description: `The working directory to run the command in. Defaults to the current directory. Use this instead of 'cd' commands.`,
     }),
+    run_in_background: Schema.optional(Schema.Boolean).annotate({
+      description:
+        "Set to true to run the command in the background and return immediately. The output is delivered automatically when the command exits; do not poll, sleep, or re-run the command while it runs. Intended for long-running commands like dev servers, watch processes, builds, or long test suites.",
+    }),
   })
 }
 
@@ -270,7 +274,22 @@ function profile(name: string, platform: NodeJS.Platform, limits: Limits, defaul
   }
 }
 
-export function render(name: string, platform: NodeJS.Platform, limits: Limits, defaultTimeoutMs: number) {
+function backgroundSection(enabled: boolean) {
+  if (!enabled) return ""
+  return `# Running commands in the background
+- Set \`run_in_background: true\` for long-running commands (dev servers, watch modes, builds, long test suites) so you do not block on them.
+- The tool returns immediately with a \`jobId\` in its metadata; when the command exits, its output is delivered to you automatically as a new message.
+- While a background command runs, NEVER sleep, poll, check on it, or re-run it to see progress. Continue other work or briefly tell the user what you started and end your turn.
+- Do not use it when the next step depends on the command's result; run those commands in the foreground.`
+}
+
+export function render(
+  name: string,
+  platform: NodeJS.Platform,
+  limits: Limits,
+  defaultTimeoutMs: number,
+  options?: { background?: boolean },
+) {
   const selected = profile(name, platform, limits, defaultTimeoutMs)
   return {
     description: renderPrompt(DESCRIPTION, {
@@ -280,6 +299,7 @@ export function render(name: string, platform: NodeJS.Platform, limits: Limits, 
       tmp: Global.Path.tmp,
       workdirSection: selected.workdirSection,
       commandSection: selected.commandSection,
+      backgroundSection: backgroundSection(options?.background === true),
       gitCommands: selected.gitCommands,
       toolName: ShellID.ToolID,
       gitCommandRestriction: selected.gitCommandRestriction,

--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -21,7 +21,7 @@ export function parameterSchema() {
     }),
     run_in_background: Schema.optional(Schema.Boolean).annotate({
       description:
-        "Set to true to run the command in the background and return immediately. The output is delivered automatically when the command exits; do not poll, sleep, or re-run the command while it runs. Intended for long-running commands like dev servers, watch processes, builds, or long test suites.",
+        "Set to true to run the command in the background and return immediately. The output is delivered automatically when the command exits; do not poll, sleep, or re-run the command while it runs. All output is also written to a log file (logPath in the result metadata) that you can Read or Grep at any time. Use the bash_jobs tool to list or kill background commands. Intended for long-running commands like dev servers, watch processes, builds, or long test suites.",
     }),
   })
 }
@@ -278,7 +278,9 @@ function backgroundSection(enabled: boolean) {
   if (!enabled) return ""
   return `# Running commands in the background
 - Set \`run_in_background: true\` for long-running commands (dev servers, watch modes, builds, long test suites) so you do not block on them.
-- The tool returns immediately with a \`jobId\` in its metadata; when the command exits, its output is delivered to you automatically as a new message.
+- The tool returns immediately with a \`jobId\` and a \`logPath\`; when the command exits, its output is delivered to you automatically as a new message.
+- All output is teed to the log file, so Read/Grep \`logPath\` if you ever need to inspect progress.
+- Use the \`bash_jobs\` tool to list background commands or kill one that is no longer needed.
 - While a background command runs, NEVER sleep, poll, check on it, or re-run it to see progress. Continue other work or briefly tell the user what you started and end your turn.
 - Do not use it when the next step depends on the command's result; run those commands in the foreground.`
 }

--- a/packages/opencode/src/tool/shell/shell.txt
+++ b/packages/opencode/src/tool/shell/shell.txt
@@ -10,6 +10,8 @@ IMPORTANT: This tool is for terminal operations like git, npm, docker, etc. DO N
 
 ${commandSection}
 
+${backgroundSection}
+
 # Git and GitHub
 - Only commit, amend, push, or create PRs when explicitly requested.
 - Before committing, inspect `git status`, `git diff`, and `git log --oneline -10`; stage only intended files and never commit secrets.

--- a/packages/opencode/test/tool/bash-jobs.test.ts
+++ b/packages/opencode/test/tool/bash-jobs.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect } from "bun:test"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Effect, Layer } from "effect"
+import { Agent } from "../../src/agent/agent"
+import { BackgroundJob } from "@/background/job"
+import { Truncate } from "@/tool/truncate"
+import { BashJobsTool } from "../../src/tool/bash-jobs"
+import { testInstanceStoreLayer, tmpdirScoped, provideInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+
+const jobsLayer = Layer.mergeAll(
+  LayerNode.compile(LayerNode.group([BackgroundJob.node, CrossSpawnSpawner.node, Truncate.node, Agent.node])),
+  testInstanceStoreLayer,
+)
+const it = testEffect(jobsLayer)
+
+const initJobsTool = Effect.fn("BashJobsTest.init")(function* () {
+  const info = yield* BashJobsTool
+  return yield* info.init()
+})
+
+describe("tool.bash_jobs", () => {
+  it.live("lists background shell jobs with status and log path", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* provideInstance(tmp)(
+        Effect.gen(function* () {
+          const jobs = yield* BackgroundJob.Service
+          const started = yield* jobs.start({
+            type: "bash",
+            title: "sleep 30",
+            metadata: { command: "sleep 30", logPath: "/tmp/fake-log.txt" },
+            run: Effect.gen(function* () {
+              yield* Effect.sleep("30 seconds")
+              return "done"
+            }),
+          })
+          const def = yield* initJobsTool()
+
+          const result = yield* def.execute(
+            { action: "list" },
+            {
+              sessionID: started.id as never,
+              messageID: started.id as never,
+              agent: "build",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+
+          expect(result.metadata.action).toBe("list")
+          expect(result.metadata.count).toBeGreaterThan(0)
+          expect(result.output).toContain(started.id)
+          expect(result.output).toContain("[running]")
+          expect(result.output).toContain("sleep 30")
+          expect(result.output).toContain("/tmp/fake-log.txt")
+
+          yield* jobs.cancel(started.id)
+        }),
+      )
+    }),
+  )
+
+  it.live("kills a running background job", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* provideInstance(tmp)(
+        Effect.gen(function* () {
+          const jobs = yield* BackgroundJob.Service
+          const started = yield* jobs.start({
+            type: "bash",
+            title: "sleep 30",
+            metadata: { command: "sleep 30" },
+            run: Effect.gen(function* () {
+              yield* Effect.sleep("30 seconds")
+              return "done"
+            }),
+          })
+          const def = yield* initJobsTool()
+
+          const result = yield* def.execute(
+            { action: "kill", job_id: started.id },
+            {
+              sessionID: started.id as never,
+              messageID: started.id as never,
+              agent: "build",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+
+          expect(result.metadata.status).toBe("cancelled")
+          expect(result.output).toContain("Cancelled")
+
+          const waited = yield* jobs.wait({ id: started.id })
+          expect(waited.info?.status).toBe("cancelled")
+        }),
+      )
+    }),
+  )
+
+  it.live("reports unknown job ids", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* provideInstance(tmp)(
+        Effect.gen(function* () {
+          const def = yield* initJobsTool()
+          const result = yield* def.execute(
+            { action: "kill", job_id: "job_missing" },
+            {
+              sessionID: "job_missing" as never,
+              messageID: "job_missing" as never,
+              agent: "build",
+              abort: new AbortController().signal,
+              messages: [],
+              metadata: () => Effect.void,
+              ask: () => Effect.void,
+            },
+          )
+          expect(result.output).toContain("No background job found")
+        }),
+      )
+    }),
+  )
+})

--- a/packages/opencode/test/tool/bash-jobs.test.ts
+++ b/packages/opencode/test/tool/bash-jobs.test.ts
@@ -36,6 +36,15 @@ describe("tool.bash_jobs", () => {
               return "done"
             }),
           })
+          const subagent = yield* jobs.start({
+            type: "task",
+            title: "inspect bug",
+            metadata: { sessionId: "ses_child", background: true },
+            run: Effect.gen(function* () {
+              yield* Effect.sleep("30 seconds")
+              return "done"
+            }),
+          })
           const def = yield* initJobsTool()
 
           const result = yield* def.execute(
@@ -52,13 +61,17 @@ describe("tool.bash_jobs", () => {
           )
 
           expect(result.metadata.action).toBe("list")
-          expect(result.metadata.count).toBeGreaterThan(0)
+          expect(result.metadata.count).toBe(2)
           expect(result.output).toContain(started.id)
-          expect(result.output).toContain("[running]")
+          expect(result.output).toContain("[bash] [running]")
           expect(result.output).toContain("sleep 30")
           expect(result.output).toContain("/tmp/fake-log.txt")
+          expect(result.output).toContain("[task] [running]")
+          expect(result.output).toContain("inspect bug")
+          expect(result.output).toContain("(session: ses_child)")
 
           yield* jobs.cancel(started.id)
+          yield* jobs.cancel(subagent.id)
         }),
       )
     }),

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1335,12 +1335,18 @@ describe("tool.shell background", () => {
           expect(meta.background).toBe(true)
           expect(result.metadata.truncated).toBe(false)
           expect(result.output).toContain(`state="running"`)
+          expect(result.output).toContain(`<log>`)
           const jobID = meta.jobId
           if (!jobID) throw new Error("expected jobId in metadata")
+          const logPath = (result.metadata as { logPath?: string }).logPath
+          expect(logPath).toBeTruthy()
 
           const waited = yield* jobs.wait({ id: jobID })
           expect(waited.info?.status).toBe("completed")
           expect(waited.info?.output).toContain("bg-marker-ok")
+
+          const log = yield* (yield* FSUtil.Service).readFileString(logPath!)
+          expect(log).toContain("bg-marker-ok")
 
           const injected = yield* Deferred.await(captured)
           expect(injected.sessionID).toBe(chat.id)

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -1,7 +1,7 @@
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { describe, expect } from "bun:test"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Deferred, Effect, Exit, Layer } from "effect"
 import type * as Scope from "effect/Scope"
 import os from "os"
 import path from "path"
@@ -21,6 +21,18 @@ import { testEffect } from "../lib/effect"
 import { Tool } from "@/tool/tool"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { InstanceStore } from "@/project/instance-store"
+import { BackgroundJob } from "@/background/job"
+import { Database } from "@opencode-ai/core/database/database"
+import { EventV2Bridge } from "@/event-v2-bridge"
+import { Session } from "@/session/session"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { SessionRunState } from "@/session/run-state"
+import { SessionStatus } from "@/session/status"
+import { SessionV1 } from "@opencode-ai/core/v1/session"
+import { ModelV2 } from "@opencode-ai/core/model"
+import { ProviderV2 } from "@opencode-ai/core/provider"
+import type { SessionPrompt } from "../../src/session/prompt"
+import type { TaskPromptOps } from "../../src/tool/task"
 
 const shellLayer = Layer.mergeAll(
   LayerNode.compile(
@@ -32,6 +44,13 @@ const shellLayer = Layer.mergeAll(
       Config.node,
       Agent.node,
       RuntimeFlags.node,
+      BackgroundJob.node,
+      Database.node,
+      EventV2Bridge.node,
+      Session.node,
+      SessionProjector.node,
+      SessionRunState.node,
+      SessionStatus.node,
     ]),
   ),
   testInstanceStoreLayer,
@@ -1197,3 +1216,160 @@ describe("tool.shell truncation", () => {
     ),
   )
 })
+
+const backgroundLayer = Layer.mergeAll(
+  LayerNode.compile(
+    LayerNode.group([
+      CrossSpawnSpawner.node,
+      FSUtil.node,
+      Plugin.node,
+      Truncate.node,
+      Config.node,
+      Agent.node,
+      RuntimeFlags.node,
+      BackgroundJob.node,
+      Database.node,
+      EventV2Bridge.node,
+      Session.node,
+      SessionProjector.node,
+      SessionRunState.node,
+      SessionStatus.node,
+    ]),
+    [[RuntimeFlags.node, RuntimeFlags.layer({ experimentalBackgroundSubagents: true })]],
+  ),
+  testInstanceStoreLayer,
+)
+const backgroundIt = testEffect(backgroundLayer)
+
+const backgroundRef = {
+  providerID: ProviderV2.ID.make("test"),
+  modelID: ModelV2.ID.make("test-model"),
+}
+
+const seedChat = Effect.fn("ShellBackgroundTest.seed")(function* () {
+  const session = yield* Session.Service
+  const chat = yield* session.create({ title: "shell background" })
+  const user = yield* session.updateMessage({
+    id: MessageID.ascending(),
+    role: "user",
+    sessionID: chat.id,
+    agent: "build",
+    model: backgroundRef,
+    time: { created: Date.now() },
+  })
+  const assistant: SessionV1.Assistant = {
+    id: MessageID.ascending(),
+    role: "assistant",
+    parentID: user.id,
+    sessionID: chat.id,
+    mode: "build",
+    agent: "build",
+    cost: 0,
+    path: { cwd: "/tmp", root: "/tmp" },
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    modelID: backgroundRef.modelID,
+    providerID: backgroundRef.providerID,
+    variant: "xhigh",
+    time: { created: Date.now() },
+  }
+  yield* session.updateMessage(assistant)
+  return { chat, assistant }
+})
+
+describe("tool.shell background", () => {
+  backgroundIt.live("returns immediately and injects the result on completion", () =>
+    Effect.gen(function* () {
+      const captured = yield* Deferred.make<SessionPrompt.PromptInput>()
+      const ops: TaskPromptOps = {
+        cancel: () => Effect.void,
+        resolvePromptParts: (template) => Effect.succeed([{ type: "text" as const, text: template }]),
+        prompt: (input) => {
+          const id = MessageID.ascending()
+          return Deferred.succeed(captured, input).pipe(
+            Effect.as({
+              info: {
+                id,
+                role: "assistant" as const,
+                parentID: input.messageID ?? id,
+                sessionID: input.sessionID,
+                mode: input.agent ?? "build",
+                agent: input.agent ?? "build",
+                cost: 0,
+                path: { cwd: "/tmp", root: "/tmp" },
+                tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+                modelID: backgroundRef.modelID,
+                providerID: backgroundRef.providerID,
+                time: { created: Date.now() },
+                finish: "stop" as const,
+              },
+              parts: [],
+            }),
+          )
+        },
+      }
+
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const jobs = yield* BackgroundJob.Service
+          const { chat, assistant } = yield* seedChat()
+          const result = yield* Effect.gen(function* () {
+            const bash = yield* initShell()
+            return yield* bash.execute(
+              { command: "echo bg-marker-ok", run_in_background: true },
+              {
+                sessionID: chat.id,
+                messageID: assistant.id,
+                agent: "build",
+                abort: new AbortController().signal,
+                extra: { promptOps: ops },
+                messages: [],
+                metadata: () => Effect.void,
+                ask: () => Effect.void,
+              },
+            )
+          })
+
+          const meta = result.metadata as { background?: boolean; jobId?: string }
+          expect(meta.background).toBe(true)
+          expect(result.metadata.truncated).toBe(false)
+          expect(result.output).toContain(`state="running"`)
+          const jobID = meta.jobId
+          if (!jobID) throw new Error("expected jobId in metadata")
+
+          const waited = yield* jobs.wait({ id: jobID })
+          expect(waited.info?.status).toBe("completed")
+          expect(waited.info?.output).toContain("bg-marker-ok")
+
+          const injected = yield* Deferred.await(captured)
+          expect(injected.sessionID).toBe(chat.id)
+          expect(injected.variant).toBe("xhigh")
+          expect(injected.agent).toBe("build")
+          const part = injected.parts[0]
+          expect(part?.type).toBe("text")
+          if (part?.type !== "text") throw new Error("expected text part")
+          expect(part.text).toContain(`state="completed"`)
+          expect(part.text).toContain("bg-marker-ok")
+        }),
+      )
+    }),
+  )
+})
+
+it.live("rejects background execution when the experiment is disabled", () =>
+  Effect.gen(function* () {
+    const tmp = yield* tmpdirScoped()
+    const exit = yield* runIn(
+      tmp,
+      Effect.gen(function* () {
+        const bash = yield* initShell()
+        return yield* bash.execute(
+          { command: "echo nope", run_in_background: true },
+          ctx,
+        )
+      }),
+    ).pipe(Effect.exit)
+    expect(Exit.isFailure(exit)).toBe(true)
+  }),
+)


### PR DESCRIPTION
### Issue for this PR

Closes # (no existing issue, happy to file one if useful)

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The shell tool is synchronous, so long-running commands (dev servers, watch modes, long test suites) block the turn until they exit or time out.

This adds a `run_in_background` parameter. When set, the command runs via the existing `BackgroundJob` registry (same one the task tool uses for background subagents), the tool returns immediately with a `jobId`, and when the command exits its output is injected into the session as a synthetic message so the model gets re-invoked automatically. No polling needed.

Background jobs skip the live metadata streaming and the tool-call abort race, since the tool call is already done by the time the command exits. An explicit `timeout` is still honored. Gated behind the same `OPENCODE_EXPERIMENTAL_BACKGROUND_SUBAGENTS` flag the task tool uses. Job state stays process-local, consistent with the existing registry.

### How did you verify your code works?

- New integration test in `test/tool/shell.test.ts` covering the immediate return, the completed job output, the synthetic prompt delivery, and the flag-disabled rejection.
- Ran the TUI against a real model: `sleep 20 && echo ...` returned instantly, I could keep chatting while it ran, and the completion notice came back on its own ~20s later.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
