### PR TITLE
fix: use unicode ellipsis in truncated interface text

### DIFF
--- a/packages/codemode/src/tool-runtime.ts
+++ b/packages/codemode/src/tool-runtime.ts
@@ -453,7 +453,7 @@ const searchDescription = describeDefinition(`${reservedNamespace}.search`, make
 const catalogLine = (tool: ToolDescription) => {
   // Keep the tool description concise; the full schema documentation remains in the signature.
   const line = tool.description.split("\n", 1)[0]!.trim()
-  const description = line.length > 120 ? line.slice(0, 119) + "..." : line
+  const description = line.length > 120 ? line.slice(0, 119) + "…" : line
   return description === "" ? `  - ${tool.signature}` : `  - ${tool.signature} // ${description}`
 }
 

--- a/packages/core/src/filesystem/search.ts
+++ b/packages/core/src/filesystem/search.ts
@@ -179,7 +179,7 @@ export const fffLayer = Layer.effect(
               }),
               line: match.lineNumber,
               offset: match.byteOffset,
-              text: match.lineContent.length > 2_000 ? match.lineContent.slice(0, 2_000) + "..." : match.lineContent,
+              text: match.lineContent.length > 2_000 ? match.lineContent.slice(0, 2_000) + "…" : match.lineContent,
               submatches: match.matchRanges.map(([start, end]) => ({
                 text: bytes.subarray(start, end).toString("utf8"),
                 start,

--- a/packages/core/src/ripgrep.ts
+++ b/packages/core/src/ripgrep.ts
@@ -266,7 +266,7 @@ const layer = Layer.effect(
                 offset: match.absolute_offset,
                 text:
                   match.lines.text.length > 2_000
-                    ? match.lines.text.slice(0, 2_000).replace(/[\uD800-\uDBFF]$/, "") + "..."
+                    ? match.lines.text.slice(0, 2_000).replace(/[\uD800-\uDBFF]$/, "") + "…"
                     : match.lines.text,
                 submatches: match.submatches.map((submatch) => ({
                   text: submatch.match.text,

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -246,7 +246,7 @@ const layer = Layer.effect(
         .map((line) => line.trim())
         .find((line) => line.length > 0)
       if (!cleaned) return
-      const t = cleaned.length > 100 ? cleaned.substring(0, 97) + "..." : cleaned
+      const t = cleaned.length > 100 ? cleaned.substring(0, 97) + "…" : cleaned
       yield* sessions
         .setTitle({ sessionID: input.session.id, title: t })
         .pipe(Effect.catchCause((cause) => Effect.logError("failed to generate title", { error: Cause.squash(cause) })))

--- a/packages/session-ui/src/components/session-retry.tsx
+++ b/packages/session-ui/src/components/session-retry.tsx
@@ -31,7 +31,7 @@ export function SessionRetry(props: { status: SessionStatus; show?: boolean }) {
     if (current.message.includes("exceeded your current quota") && current.message.includes("gemini")) {
       return i18n.t("ui.sessionTurn.retry.geminiHot")
     }
-    if (current.message.length > 80) return current.message.slice(0, 80) + "..."
+    if (current.message.length > 80) return current.message.slice(0, 80) + "…"
     return current.message
   })
   const truncated = createMemo(() => {


### PR DESCRIPTION
Fixes #47234

## What

Follow-up to #45126: converts the remaining ASCII `...` truncation suffixes in human-facing interface text to the unicode ellipsis (\u2026), so titles and previews render consistently:

- `packages/opencode/src/session/prompt.ts` — auto-generated session title truncation (the source of the title the TUI displays)
- `packages/session-ui/src/components/session-retry.tsx` — retry message preview
- `packages/core/src/filesystem/search.ts` — search result line preview
- `packages/core/src/ripgrep.ts` — ripgrep match preview
- `packages/codemode/src/tool-runtime.ts` — tool catalog description truncation

`packages/opencode/src/patch/index.ts:423` (machine-readable patch format: ellipsis to `...`) is intentionally left untouched.

## Tests

- `bun typecheck` in packages/opencode, packages/core, packages/session-ui, packages/codemode — all exit 0
- No behavior change beyond the rendered character; string-literal edits only

## Notes

Verified on Windows 11 native host. No tests assert the ASCII `...` truncation (checked), so no test updates needed.