### PR TITLE
fix(app): match new session prompt sizing to chat

### DIFF
--- a/packages/app/src/new-session/layout.ts
+++ b/packages/app/src/new-session/layout.ts
@@ -1,2 +1,2 @@
-/** Inline new-session content width — keep in sync with session composer `placement === "inline"`. */
-export const NEW_SESSION_CONTENT_WIDTH = "w-full max-w-[720px] px-0"
+/** Keep the prompt width and side padding in sync with SessionComposerRegion. */
+export const NEW_SESSION_CONTENT_WIDTH = "w-full px-3 md:max-w-[1000px] md:mx-auto"

--- a/packages/app/src/new-session/view.tsx
+++ b/packages/app/src/new-session/view.tsx
@@ -54,9 +54,9 @@ export function NewSessionView(props: {
         data-component="new-session"
         class="relative flex-1 min-h-0 overflow-hidden rounded-[10px] bg-v2-background-bg-base shadow-[var(--v2-elevation-raised)]"
       >
-        <div class="absolute inset-x-0 top-[25.375%] flex justify-center px-6">
+        <div class="absolute inset-x-0 top-[25.375%] flex justify-center">
           <div class={NEW_SESSION_CONTENT_WIDTH}>
-            <Wordmark class="h-auto w-full text-v2-background-bg-inverse" />
+            <Wordmark class="mx-auto h-auto w-full max-w-[720px] text-v2-background-bg-inverse" />
             <div class="mt-8 flex flex-col gap-8">
               <Composer model={props.composer} />
               <Show when={props.project.empty()}>


### PR DESCRIPTION
## Summary
- Match the new-session prompt to the chat composer’s 12px side padding and responsive 1000px container width.
- Remove the extra outer padding while preserving the wordmark’s 720px maximum width.

## Validation
- `bun typecheck` in `packages/app` passed.
- `git diff --check origin/v2...HEAD` passed.
- Before/after screenshots were not captured: the available local preview had no connected server and could not open a new-session draft. Visual verification remains outstanding.