### PR TITLE
feat(core): add keenable web search

### DIFF
--- a/packages/core/src/plugin/websearch/index.ts
+++ b/packages/core/src/plugin/websearch/index.ts
@@ -1,11 +1,13 @@
 import { WebSearchExa } from "./exa.js"
 import { WebSearchFirecrawl } from "./firecrawl.js"
+import { WebSearchKeenable } from "./keenable.js"
 import { WebSearchParallel } from "./parallel.js"
 import { WebSearchTavily } from "./tavily.js"
 
 export const WebSearchPlugins = [
   WebSearchExa.Plugin,
   WebSearchFirecrawl.Plugin,
+  WebSearchKeenable.Plugin,
   WebSearchParallel.Plugin,
   WebSearchTavily.Plugin,
 ] as const

--- a/packages/core/src/plugin/websearch/keenable.ts
+++ b/packages/core/src/plugin/websearch/keenable.ts
@@ -1,0 +1,89 @@
+export * as WebSearchKeenable from "./keenable.js"
+
+import { define } from "@opencode/plugin/effect/plugin"
+import { Duration, Effect, Schema, Scope } from "effect"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { App } from "../../app.js"
+
+export const endpoint = "https://api.keenable.ai/v1/search/public"
+export const keyedEndpoint = "https://api.keenable.ai/v1/search"
+
+const SearchRequest = Schema.Struct({
+  query: Schema.String,
+  max_results: Schema.Number,
+  snippet_max_length: Schema.Number,
+})
+
+const SearchResponse = Schema.Struct({
+  results: Schema.Array(
+    Schema.Struct({
+      url: Schema.String,
+      title: Schema.NullOr(Schema.String).pipe(Schema.optional),
+      snippet: Schema.NullOr(Schema.String).pipe(Schema.optional),
+      description: Schema.NullOr(Schema.String).pipe(Schema.optional),
+      published_at: Schema.NullOr(Schema.String).pipe(Schema.optional),
+    }),
+  ),
+})
+
+export const Plugin = define<HttpClient.HttpClient | Scope.Scope>({
+  id: "opencode.websearch.keenable",
+  effect: Effect.fn("WebSearchKeenable.Plugin")(function* (ctx) {
+    const http = yield* HttpClient.HttpClient
+    yield* ctx.integration.transform((editor) => {
+      editor.update("keenable", (integration) => (integration.name = "Keenable"))
+      editor.method.update({
+        integrationID: "keenable",
+        method: { type: "key" },
+      })
+      editor.method.update({
+        integrationID: "keenable",
+        method: { type: "env", names: ["KEENABLE_API_KEY"] },
+      })
+    })
+    yield* ctx.websearch.transform((editor) => {
+      editor.add({
+        id: "keenable",
+        name: "Keenable",
+        execute: (input) =>
+          Effect.gen(function* () {
+            const connection = yield* ctx.integration.connection.active("keenable")
+            const credential = connection ? yield* ctx.integration.connection.resolve(connection) : undefined
+            const keyed = credential?.type === "key"
+            const request = yield* HttpClientRequest.post(keyed ? keyedEndpoint : endpoint).pipe(
+              HttpClientRequest.acceptJson,
+              HttpClientRequest.setHeaders({
+                "User-Agent": App.useragent(ctx.app),
+                "X-Keenable-Title": "opencode",
+                ...(keyed ? { Authorization: `Bearer ${credential.key}` } : {}),
+              }),
+              HttpClientRequest.schemaBodyJson(SearchRequest)({
+                query: input.query,
+                max_results: 8,
+                snippet_max_length: 1000,
+              }),
+            )
+            const response = yield* HttpClient.filterStatusOk(http)
+              .execute(request)
+              .pipe(
+                Effect.flatMap(HttpClientResponse.schemaBodyJson(SearchResponse)),
+                Effect.timeoutOrElse({
+                  duration: Duration.seconds(25),
+                  orElse: () => Effect.fail(new Error("Keenable web search request timed out")),
+                }),
+              )
+            return response.results.map((item) => {
+              const content = item.snippet || item.description
+              const published = item.published_at ? Date.parse(item.published_at) : undefined
+              return {
+                url: item.url,
+                ...(item.title ? { title: item.title } : {}),
+                ...(content ? { content } : {}),
+                time: published !== undefined && Number.isFinite(published) ? { published } : {},
+              }
+            })
+          }),
+      })
+    })
+  }),
+})

--- a/packages/core/src/plugin/websearch/keenable.ts
+++ b/packages/core/src/plugin/websearch/keenable.ts
@@ -63,10 +63,11 @@ export const Plugin = define<HttpClient.HttpClient | Scope.Scope>({
                 snippet_max_length: 1000,
               }),
             )
-            const response = yield* HttpClient.filterStatusOk(http)
+            const response = yield* HttpClient.withScope(HttpClient.filterStatusOk(http))
               .execute(request)
               .pipe(
                 Effect.flatMap(HttpClientResponse.schemaBodyJson(SearchResponse)),
+                Effect.scoped,
                 Effect.timeoutOrElse({
                   duration: Duration.seconds(25),
                   orElse: () => Effect.fail(new Error("Keenable web search request timed out")),

--- a/packages/core/test/plugin/websearch.test.ts
+++ b/packages/core/test/plugin/websearch.test.ts
@@ -31,24 +31,26 @@ beforeEach(() => {
 const it = webSearchIntegrationTest
 
 describe("built-in web search providers", () => {
-  ;[WebSearchExa.Plugin, WebSearchParallel.Plugin, WebSearchFirecrawl.Plugin, WebSearchTavily.Plugin].forEach(
-    (plugin) => {
-      it.effect(`releases rate-limited HTTP requests for ${plugin.id} before caching their errors`, () =>
-        Effect.gen(function* () {
-          resetWebSearchFixture("Rate limited", 429)
-          const integrations = yield* Integration.Service
-          const websearch = yield* WebSearch.Service
-          yield* plugin.effect(
-            host({ integration: integrationHost(integrations), websearch: webSearchHost(websearch) }),
-          )
-          yield* websearch.select("random")
-          expect(yield* websearch.query({ query: "limited" }).pipe(Effect.flip)).toBeInstanceOf(WebSearch.RequestError)
-          expect(signals).toHaveLength(1)
-          expect(signals[0]?.aborted).toBe(true)
-        }),
-      )
-    },
-  )
+  ;[
+    WebSearchExa.Plugin,
+    WebSearchParallel.Plugin,
+    WebSearchFirecrawl.Plugin,
+    WebSearchTavily.Plugin,
+    WebSearchKeenable.Plugin,
+  ].forEach((plugin) => {
+    it.effect(`releases rate-limited HTTP requests for ${plugin.id} before caching their errors`, () =>
+      Effect.gen(function* () {
+        resetWebSearchFixture("Rate limited", 429)
+        const integrations = yield* Integration.Service
+        const websearch = yield* WebSearch.Service
+        yield* plugin.effect(host({ integration: integrationHost(integrations), websearch: webSearchHost(websearch) }))
+        yield* websearch.select("random")
+        expect(yield* websearch.query({ query: "limited" }).pipe(Effect.flip)).toBeInstanceOf(WebSearch.RequestError)
+        expect(signals).toHaveLength(1)
+        expect(signals[0]?.aborted).toBe(true)
+      }),
+    )
+  })
 
   it.effect("registers a provider without an integration", () =>
     Effect.gen(function* () {

--- a/packages/core/test/plugin/websearch.test.ts
+++ b/packages/core/test/plugin/websearch.test.ts
@@ -4,6 +4,7 @@ import { Integration } from "@opencode/core/integration"
 import { WebSearch } from "@opencode/core/websearch"
 import { WebSearchExa } from "@opencode/core/plugin/websearch/exa"
 import { WebSearchFirecrawl } from "@opencode/core/plugin/websearch/firecrawl"
+import { WebSearchKeenable } from "@opencode/core/plugin/websearch/keenable"
 import { WebSearchParallel } from "@opencode/core/plugin/websearch/parallel"
 import { WebSearchTavily } from "@opencode/core/plugin/websearch/tavily"
 import { host, integrationHost, webSearchHost } from "./host"
@@ -208,6 +209,87 @@ describe("built-in web search providers", () => {
         },
       })
       expect(JSON.stringify(output)).not.toContain("parallel-secret")
+    }),
+  )
+
+  it.effect("registers Keenable with keyless and keyed Search API access", () =>
+    Effect.gen(function* () {
+      resetWebSearchFixture(
+        JSON.stringify({
+          query: "effect typescript",
+          mode: "pro",
+          results: [
+            {
+              title: "Effect",
+              url: "https://effect.website",
+              description: "",
+              snippet: "Effect documentation",
+              published_at: "2026-07-25T00:00:00Z",
+              acquired_at: "2026-08-01T00:00:00Z",
+            },
+            {
+              title: "",
+              url: "https://effect.website/docs",
+              description: "Effect docs index",
+              snippet: "",
+              acquired_at: "2026-08-01T00:00:00Z",
+            },
+          ],
+        }),
+      )
+      const integrations = yield* Integration.Service
+      const websearch = yield* WebSearch.Service
+      yield* WebSearchKeenable.Plugin.effect(
+        host({ integration: integrationHost(integrations), websearch: webSearchHost(websearch) }),
+      )
+
+      expect(yield* integrations.get(Integration.ID.make("keenable"))).toMatchObject({
+        id: "keenable",
+        name: "Keenable",
+        methods: [{ type: "key" }, { type: "env", names: ["KEENABLE_API_KEY"] }],
+      })
+      const query = {
+        query: "effect typescript",
+        providerID: WebSearch.ID.make("keenable"),
+      }
+      expect(yield* websearch.query(query)).toEqual(
+        new WebSearch.Response({
+          providerID: WebSearch.ID.make("keenable"),
+          results: [
+            {
+              url: "https://effect.website",
+              title: "Effect",
+              content: "Effect documentation",
+              time: { published: Date.parse("2026-07-25T00:00:00Z") },
+            },
+            {
+              url: "https://effect.website/docs",
+              content: "Effect docs index",
+              time: {},
+            },
+          ],
+        }),
+      )
+      expect(requests[0]).toMatchObject({
+        url: WebSearchKeenable.endpoint,
+        headers: { "x-keenable-title": "opencode" },
+        body: {
+          query: "effect typescript",
+          max_results: 8,
+          snippet_max_length: 1000,
+        },
+      })
+      expect(requests[0]?.headers.authorization).toBeUndefined()
+
+      yield* integrations.connection.key({
+        integrationID: Integration.ID.make("keenable"),
+        key: "keenable-secret",
+      })
+      yield* websearch.query(query)
+      expect(requests[1]).toMatchObject({
+        url: WebSearchKeenable.keyedEndpoint,
+        headers: { authorization: "Bearer keenable-secret", "x-keenable-title": "opencode" },
+      })
     }),
   )
 

--- a/packages/session-ui/src/tools/tool-renderer.tsx
+++ b/packages/session-ui/src/tools/tool-renderer.tsx
@@ -266,7 +266,9 @@ function webSearchProviderLabel(provider: unknown, i18n: ReturnType<typeof useI1
           ? "Firecrawl"
           : provider === "tavily"
             ? "Tavily"
-            : undefined
+            : provider === "keenable"
+              ? "Keenable"
+              : undefined
   if (name) return i18n.t("ui.tool.websearch.provider", { provider: name })
   return i18n.t("ui.tool.websearch")
 }


### PR DESCRIPTION
### Issue for this PR

Closes # _(none)_

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Keenable as a built-in web search provider next to Exa, Firecrawl, Parallel and Tavily, in the same shape as `tavily.ts`.

- `packages/core/src/plugin/websearch/keenable.ts`: registers the `keenable` integration (key + `KEENABLE_API_KEY` env methods) and the `keenable` provider. With no connection it calls the keyless `POST https://api.keenable.ai/v1/search/public`; with a key it calls `/v1/search` with a bearer token. `X-Keenable-Title: opencode` identifies the client, as `X-Client-Name` does for Tavily.
- Results map `snippet` (falling back to `description`) to `content`, `published_at` to `time.published`. `snippet_max_length: 1000` keeps each result to roughly a paragraph, 8 results per query like the other providers.
- Registered in `WebSearchPlugins` and labelled in `session-ui`; the TUI label is already dynamic.

Keenable is a keyless-first search API (the key only lifts rate limits), so this works out of the box the same way Tavily does here.

### How did you verify your code works?

- New test in `packages/core/test/plugin/websearch.test.ts` covering keyless headers/body, the keyed endpoint switch with the bearer header, and the `snippet`/`description` mapping. `bun run test test/plugin/websearch.test.ts` in `packages/core`: 6 pass.
- `bun typecheck` in `packages/core` and `packages/session-ui`; full workspace `bun typecheck`.
- Live keyless request through the provider (real `FetchHttpClient`, same host wiring as the tests): 8 results, all with content.

### Screenshots / recordings

Not a UI change beyond the provider name label.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
