### PR TITLE
fix(opencode): expose Copilot Auto so Free and Student plans work

### DIFF
--- a/packages/opencode/src/plugin/github-copilot/auto.ts
+++ b/packages/opencode/src/plugin/github-copilot/auto.ts
@@ -1,0 +1,180 @@
+import type { LanguageModelV3, LanguageModelV3CallOptions } from "@ai-sdk/provider"
+import { InstallationVersion } from "@opencode-ai/core/installation/version"
+
+const API_VERSION = "2026-06-01"
+const SESSION_EXPIRY_MARGIN_SECONDS = 30
+
+type CopilotEndpoint = "chat" | "responses" | "messages"
+
+type CopilotSdk = {
+  chat?: (modelID: string) => LanguageModelV3
+  responses?: (modelID: string) => LanguageModelV3
+  languageModel?: (modelID: string) => LanguageModelV3
+}
+
+type Input = {
+  sdk: CopilotSdk
+  baseURL: string
+  fetch?: typeof fetch
+  sessionID?: string
+  endpoints?: Record<string, CopilotEndpoint>
+}
+
+type Session = {
+  availableModels: string[]
+  selectedModel: string
+  sessionToken: string
+  expiresAt: number
+}
+
+const sessions = new Map<string, Session>()
+
+export function create(input: Input) {
+  return new CopilotAutoLanguageModel(input)
+}
+
+/**
+ * Copilot exposes "Auto" as a routing service rather than a model: a session is
+ * opened to learn which models the plan may route to, then each turn asks the
+ * router which of those to use. Free/Student plans expose no directly selectable
+ * models at all, so this is the only way to reach inference on those plans.
+ */
+class CopilotAutoLanguageModel implements LanguageModelV3 {
+  readonly specificationVersion = "v3"
+  readonly modelId = "auto"
+  readonly provider = "github-copilot.auto"
+
+  constructor(private readonly input: Input) {}
+
+  get supportedUrls() {
+    return {}
+  }
+
+  async doGenerate(options: LanguageModelV3CallOptions) {
+    const routed = await this.route(options)
+    return routed.model.doGenerate(this.withSessionToken(options, routed.sessionToken))
+  }
+
+  async doStream(options: LanguageModelV3CallOptions) {
+    const routed = await this.route(options)
+    return routed.model.doStream(this.withSessionToken(options, routed.sessionToken))
+  }
+
+  private withSessionToken(options: LanguageModelV3CallOptions, sessionToken: string): LanguageModelV3CallOptions {
+    return {
+      ...options,
+      headers: {
+        ...options.headers,
+        "copilot-session-token": sessionToken,
+      },
+    }
+  }
+
+  private async route(options: LanguageModelV3CallOptions) {
+    const session = await this.session(options.abortSignal)
+    const modelID = await this.intent(session, options).catch(() => undefined)
+    return {
+      sessionToken: session.sessionToken,
+      // The router is advisory: the session already names a usable model, so a
+      // routing failure downgrades to that instead of failing the request.
+      model: this.model(modelID ?? session.selectedModel),
+    }
+  }
+
+  private async intent(session: Session, options: LanguageModelV3CallOptions) {
+    const prompt = promptText(options.prompt)
+    const response = await this.fetch(`${this.input.baseURL}/models/session/intent`, {
+      method: "POST",
+      headers: {
+        ...this.headers(),
+        "copilot-session-token": session.sessionToken,
+      },
+      body: JSON.stringify({
+        prompt,
+        available_models: session.availableModels,
+        session_id: `opencode-session://${this.input.sessionID ?? "auto"}`,
+        reference_count: 0,
+        prompt_char_count: prompt.length,
+        turn_number: options.prompt.filter((message) => message.role === "user").length,
+        routing_method: "hydra",
+        copilot_plan: "individual",
+      }),
+      signal: options.abortSignal ?? AbortSignal.timeout(5_000),
+    })
+    if (!response.ok) throw new Error(`Failed to route Copilot auto model: ${response.status}`)
+    const intent = (await response.json()) as { chosen_model?: string }
+    // Never route to a model the session did not offer.
+    if (intent.chosen_model && session.availableModels.includes(intent.chosen_model)) return intent.chosen_model
+    return undefined
+  }
+
+  private async session(signal?: AbortSignal) {
+    const key = `${this.input.sessionID ?? "auto"}:${this.input.baseURL}`
+    const cached = sessions.get(key)
+    if (cached && cached.expiresAt > Math.floor(Date.now() / 1000) + SESSION_EXPIRY_MARGIN_SECONDS) return cached
+
+    const response = await this.fetch(`${this.input.baseURL}/models/session`, {
+      method: "POST",
+      headers: this.headers(),
+      body: JSON.stringify({ auto_mode: { model_hints: ["auto"] } }),
+      signal: signal ?? AbortSignal.timeout(5_000),
+    })
+    if (!response.ok) throw new Error(`Failed to create Copilot auto session: ${response.status}`)
+    const data = (await response.json()) as {
+      available_models?: string[]
+      selected_model?: string
+      session_token: string
+      expires_at: number
+    }
+    if (!data.selected_model) throw new Error("Copilot auto session did not return a model to route to")
+    const next: Session = {
+      availableModels: data.available_models ?? [data.selected_model],
+      selectedModel: data.selected_model,
+      sessionToken: data.session_token,
+      expiresAt: data.expires_at,
+    }
+    sessions.set(key, next)
+    return next
+  }
+
+  private model(modelID: string) {
+    const endpoint = this.input.endpoints?.[modelID]
+    if (endpoint === "responses" && this.input.sdk.responses) return this.input.sdk.responses(modelID)
+    if (endpoint === "chat" && this.input.sdk.chat) return this.input.sdk.chat(modelID)
+
+    const match = /^gpt-(\d+)/.exec(modelID)
+    if (match && Number(match[1]) >= 5 && !modelID.startsWith("gpt-5-mini")) {
+      return (
+        this.input.sdk.responses?.(modelID) ?? this.input.sdk.languageModel?.(modelID) ?? this.input.sdk.chat!(modelID)
+      )
+    }
+    return (
+      this.input.sdk.chat?.(modelID) ?? this.input.sdk.languageModel?.(modelID) ?? this.input.sdk.responses!(modelID)
+    )
+  }
+
+  private headers() {
+    return {
+      "Content-Type": "text/plain;charset=UTF-8",
+      "User-Agent": `opencode/${InstallationVersion}`,
+      "X-GitHub-Api-Version": API_VERSION,
+    }
+  }
+
+  private fetch(input: string, init: RequestInit) {
+    return (this.input.fetch ?? fetch)(input, init)
+  }
+}
+
+function promptText(prompt: LanguageModelV3CallOptions["prompt"]) {
+  const message = prompt.findLast((message) => message.role === "user")
+  if (!message) return ""
+  if (typeof message.content === "string") return message.content
+  if (!Array.isArray(message.content)) return ""
+  return message.content
+    .map((part) => (part.type === "text" ? part.text : ""))
+    .filter(Boolean)
+    .join("\n")
+}
+
+export * as CopilotAuto from "./auto"

--- a/packages/opencode/src/plugin/github-copilot/models.ts
+++ b/packages/opencode/src/plugin/github-copilot/models.ts
@@ -79,6 +79,68 @@ type CopilotModel = Omit<Model, "api"> & {
 const decodeModels = Schema.decodeUnknownSync(schema)
 const decodeItem = Schema.decodeUnknownOption(item)
 
+const AUTO_CONTEXT_FALLBACK = 128_000
+const AUTO_OUTPUT_FALLBACK = 16_384
+
+/**
+ * Ask Copilot which models Auto may route to. This is the only authoritative
+ * source: `/models` lists everything the account can see, including utility
+ * models Auto never selects.
+ */
+async function routable(baseURL: string, headers: HeadersInit): Promise<string[] | undefined> {
+  return fetch(`${baseURL}/models/session`, {
+    method: "POST",
+    headers: { ...headers, "Content-Type": "text/plain;charset=UTF-8" },
+    body: JSON.stringify({ auto_mode: { model_hints: ["auto"] } }),
+    signal: AbortSignal.timeout(5_000),
+  })
+    .then(async (res) => {
+      if (!res.ok) return undefined
+      const data = (await res.json()) as { available_models?: unknown }
+      if (!Array.isArray(data.available_models)) return undefined
+      const models = data.available_models.filter((id): id is string => typeof id === "string")
+      return models.length > 0 ? models : undefined
+    })
+    .catch(() => undefined)
+}
+
+/**
+ * Copilot routes "Auto" only within the models a plan is entitled to, and never
+ * lists it in `/models`. Size it from the routable models so compaction triggers
+ * at the right point; without that list fall back to conservative defaults rather
+ * than the smallest model on the account, since Copilot also lists tiny utility
+ * models (search, compaction, legacy gpt-3.5) that Auto never routes to.
+ */
+function autoModel(remote: Map<string, SelectableItem>, available?: readonly string[]): SelectableItem {
+  const limits = (available ?? []).flatMap((id) => {
+    const entry = remote.get(id)
+    return entry ? [entry.capabilities.limits] : []
+  })
+  const min = (pick: (limit: (typeof limits)[number]) => number | undefined, fallback: number) => {
+    const values = limits.map(pick).filter((value): value is number => typeof value === "number" && value > 0)
+    return values.length > 0 ? Math.min(...values) : fallback
+  }
+  const prompt = min((limit) => limit.max_prompt_tokens, AUTO_CONTEXT_FALLBACK)
+  return {
+    model_picker_enabled: true,
+    id: "auto",
+    name: "Auto",
+    version: "auto",
+    capabilities: {
+      family: "auto",
+      limits: {
+        max_context_window_tokens: min((limit) => limit.max_context_window_tokens ?? limit.max_prompt_tokens, prompt),
+        max_output_tokens: min((limit) => limit.max_output_tokens, AUTO_OUTPUT_FALLBACK),
+        max_prompt_tokens: prompt,
+      },
+      supports: {
+        streaming: true,
+        tool_calls: true,
+      },
+    },
+  }
+}
+
 function build(key: string, remote: SelectableItem, url: string, prev?: Model): Model {
   const reasoning =
     !!remote.capabilities.supports.adaptive_thinking ||
@@ -252,9 +314,26 @@ export async function get(
     result[id] = build(id, m, baseURL)
   }
 
+  // "Auto" is a routing service, not a listed model, so synthesize it. Free and
+  // Student plans report `model_picker_enabled: false` on every model, which
+  // would otherwise leave the picker empty and drop the provider entirely.
+  const auto = autoModel(remote, await routable(baseURL, headers))
+  result.auto = build("auto", auto, baseURL)
+  result.auto.options = {
+    ...result.auto.options,
+    // Routed models keep their own transport; remember which to use for each.
+    endpoints: Object.fromEntries(
+      Object.values(result).flatMap((model) => {
+        if (model.id === "auto") return []
+        if (!("endpoint" in model.api) || !model.api.endpoint) return []
+        return [[model.api.id, model.api.endpoint]]
+      }),
+    ),
+  }
+
   return {
     models: result,
-    pickerEnabled: new Set([...remote].filter(([, item]) => item.model_picker_enabled).map(([id]) => id)),
+    pickerEnabled: new Set(["auto", ...[...remote].filter(([, item]) => item.model_picker_enabled).map(([id]) => id)]),
   }
 }
 

--- a/packages/opencode/src/provider/provider.ts
+++ b/packages/opencode/src/provider/provider.ts
@@ -231,7 +231,23 @@ function custom(dep: CustomDep): Record<string, CustomLoader> {
     "github-copilot": () =>
       Effect.succeed({
         autoload: false,
-        async getModel(sdk: any, modelID: string, _options?: Record<string, any>, model?: Model) {
+        async getModel(sdk: any, modelID: string, options?: Record<string, any>, model?: Model) {
+          // "Auto" is Copilot's server-side router rather than a real model, so it
+          // resolves to a wrapper that picks a routable model per request.
+          if (modelID === "auto") {
+            const { CopilotAuto } = await import("@/plugin/github-copilot/auto")
+            return CopilotAuto.create({
+              sdk,
+              baseURL:
+                model?.api.url ??
+                (typeof options?.baseURL === "string" ? options.baseURL : "https://api.githubcopilot.com"),
+              fetch: typeof options?.fetch === "function" ? options.fetch : undefined,
+              endpoints:
+                options?.endpoints && typeof options.endpoints === "object"
+                  ? (options.endpoints as Record<string, "chat" | "responses" | "messages">)
+                  : undefined,
+            })
+          }
           if (sdk.responses === undefined && sdk.chat === undefined) return sdk.languageModel(modelID)
           if (model && "endpoint" in model.api) {
             if (model.api.endpoint === "responses" && sdk.responses) return sdk.responses(modelID)

--- a/packages/opencode/test/plugin/github-copilot-models.test.ts
+++ b/packages/opencode/test/plugin/github-copilot-models.test.ts
@@ -490,3 +490,175 @@ test("remaps fallback oauth model urls to the enterprise host", async () => {
   expect(models.claude.api.url).toBe("https://copilot-api.ghe.example.com")
   expect(models.claude.api.npm).toBe("@ai-sdk/github-copilot")
 })
+
+// Regression for #34644: Free/Student plans report `model_picker_enabled: false`
+// on every model, which left the picker empty and dropped the provider entirely.
+test("keeps Copilot selectable when the plan disables every model picker flag", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: false,
+              id: "gpt-5-mini",
+              name: "GPT-5 mini",
+              version: "gpt-5-mini",
+              policy: { state: "enabled" },
+              capabilities: {
+                family: "gpt-5-mini",
+                limits: {
+                  max_context_window_tokens: 128000,
+                  max_output_tokens: 16384,
+                  max_prompt_tokens: 128000,
+                },
+                supports: { streaming: true, tool_calls: true },
+              },
+            },
+            {
+              model_picker_enabled: false,
+              id: "claude-opus-5",
+              name: "Claude Opus 5",
+              version: "claude-opus-5",
+              policy: { state: "disabled" },
+              capabilities: {
+                family: "claude-opus-5",
+                limits: {
+                  max_context_window_tokens: 400000,
+                  max_output_tokens: 128000,
+                  max_prompt_tokens: 272000,
+                },
+                supports: { streaming: true, tool_calls: true },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const result = await CopilotModels.get("https://api.githubcopilot.com")
+
+  expect(result.pickerEnabled.has("auto")).toBe(true)
+  expect(result.models.auto.api.id).toBe("auto")
+  expect(result.models.auto.capabilities.toolcall).toBe(true)
+  // Plan-locked models stay unselectable, and Auto is the only way to reach them.
+  expect(result.pickerEnabled.has("gpt-5-mini")).toBe(false)
+  expect(result.models["claude-opus-5"]).toBeUndefined()
+})
+
+test("advertises the most conservative limits of the routable models for auto", async () => {
+  globalThis.fetch = mock((url: string) => {
+    // Auto routes only within the session's available_models. "utility" is listed
+    // on the account but never routed to, so it must not shrink auto's context.
+    if (String(url).endsWith("/models/session")) {
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            available_models: ["big", "small"],
+            selected_model: "big",
+            session_token: "token",
+            expires_at: Math.floor(Date.now() / 1000) + 3600,
+          }),
+          { status: 200 },
+        ),
+      )
+    }
+    return Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: true,
+              id: "utility",
+              name: "Legacy utility",
+              version: "utility",
+              capabilities: {
+                family: "utility",
+                limits: {
+                  max_context_window_tokens: 16384,
+                  max_output_tokens: 4096,
+                  max_prompt_tokens: 16384,
+                },
+                supports: { streaming: true, tool_calls: true },
+              },
+            },
+            {
+              model_picker_enabled: true,
+              id: "big",
+              name: "Big",
+              version: "big",
+              capabilities: {
+                family: "big",
+                limits: {
+                  max_context_window_tokens: 400000,
+                  max_output_tokens: 128000,
+                  max_prompt_tokens: 272000,
+                },
+                supports: { streaming: true, tool_calls: true },
+              },
+            },
+            {
+              model_picker_enabled: true,
+              id: "small",
+              name: "Small",
+              version: "small",
+              capabilities: {
+                family: "small",
+                limits: {
+                  max_context_window_tokens: 64000,
+                  max_output_tokens: 8192,
+                  max_prompt_tokens: 64000,
+                },
+                supports: { streaming: true, tool_calls: true },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    )
+  }) as unknown as typeof fetch
+
+  const result = await CopilotModels.get("https://api.githubcopilot.com")
+
+  // Overstating context here would break compaction once Auto routes to "small";
+  // understating it to "utility" would compact almost immediately.
+  expect(result.models.auto.limit.context).toBe(64000)
+  expect(result.models.auto.limit.output).toBe(8192)
+})
+
+test("auto uses the resolved base url so enterprise deployments keep working", async () => {
+  globalThis.fetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          data: [
+            {
+              model_picker_enabled: false,
+              id: "gpt-5-mini",
+              name: "GPT-5 mini",
+              version: "gpt-5-mini",
+              policy: { state: "enabled" },
+              capabilities: {
+                family: "gpt-5-mini",
+                limits: {
+                  max_context_window_tokens: 128000,
+                  max_output_tokens: 16384,
+                  max_prompt_tokens: 128000,
+                },
+                supports: { streaming: true, tool_calls: true },
+              },
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    ),
+  ) as unknown as typeof fetch
+
+  const result = await CopilotModels.get("https://copilot-api.ghe.example.com")
+
+  expect(result.models.auto.api.url).toBe("https://copilot-api.ghe.example.com")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #34644

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Free and Student Copilot plans return every model with model_picker_enabled: false, so opencode filters all of them out and drops the provider entirely. That's the actual cause behind "Provider not found: github-copilot" even with a valid login.

Auto isn't in /models because it isn't a model, it's routing done server-side. POST /models/session returns the models a plan can actually route to plus a session token, and /models/session/intent picks one per turn using that session. Both work fine on a Student account. This PR adds a synthetic auto entry that stays selectable no matter what the picker flags say, backed by a small LanguageModelV3 wrapper that opens the session, asks for a routing decision, and calls through to whatever model got chosen.

My first attempt sized auto's context off the smallest limits across every model on the account, and that was wrong: /models also lists utility models like gpt-3.5-turbo-0613 and copilot-search that Auto never routes to, so it capped the context at 16k and the session compacted after one message. Deriving the limits from the session's available_models instead gets 144k on my account.

It also uses the already-resolved base URL instead of a hardcoded host, so enterprise deployments keep working, and falls back to the session's default model if the intent call fails rather than erroring out.

Credit to @OpeOginni on #34682 for finding the session/intent endpoints first, that's the part that took real digging. That PR has drifted out of sync with dev and has the enterprise-host and context-sizing issues above, so I rebuilt it against current dev with those fixed and tests added.

Worth saying upfront: these are undocumented endpoints. If that's why this kept stalling, I'd rather hear it than have the PR just sit.

One thing this doesn't do: you can't tell which model Auto actually picked for a given reply. That'd need a field on the assistant message plus an SDK regen and TUI/web changes, which felt like too much to bundle into a bug fix. Happy to follow up on it if wanted.

### How did you verify your code works?

Tested against my own Copilot Student account since the bug only reproduces on a restricted plan.

Before:
```
$ opencode models github-copilot
Error: Provider not found: github-copilot
```

After:
```
$ bun dev models --refresh | grep copilot
github-copilot/auto
```

Logged the routing decision for one turn to confirm it's an actual routing call and not just a fallback:
```
available: gpt-5-mini,gpt-5.4-mini,claude-haiku-4.5,mai-code-1.1-flash,gpt-5.3-codex
selected:  gpt-5-mini
intent chose: mai-code-1.1-flash
```

Context/output limits went from 16384/4096 (compacting immediately) to 144000/32000 (no premature compaction) once I switched to session-derived sizing.

`bun test test/plugin/ test/provider/`: 905 pass, 0 fail, three of those are new. oxlint clean on the changed files.

### Screenshots / recordings

Student plan, every model locked except Auto:
<img width="2048" height="988" alt="plan-details" src="https://github.com/user-attachments/assets/eaba5b66-0ba7-4137-af09-10b81e540b12" />
<img width="1426" height="1016" alt="no-desired-model-selection-allowed" src="https://github.com/user-attachments/assets/fa820f54-d028-41d0-8e72-8fbd44da7695" />

Provider missing entirely before the fix, despite a valid credential:
<img width="2230" height="1040" alt="CMDPrompt" src="https://github.com/user-attachments/assets/9a24b7a0-c554-4d73-beac-a0bc4adb3213" />

Auto selectable and answering after, context at 7% instead of compacting:
<img width="2880" height="1800" alt="Fix-Working" src="https://github.com/user-attachments/assets/465d63db-9ca2-44fe-b06a-a03f5d44f08e" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
