### PR TITLE
fix(workflows): skip close-issues and close-prs jobs on forks

### DIFF
--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   close:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/close-prs.yml
+++ b/.github/workflows/close-prs.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   close:
+    if: github.repository == 'anomalyco/opencode'
     runs-on: ubuntu-latest
     timeout-minutes: 240
     permissions:


### PR DESCRIPTION
### Issue for this PR

Closes #35666

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `if: github.repository == 'anomalyco/opencode'` to the `close-issues` and `close-prs` jobs. Both are scheduled workflows whose scripts operate on `anomalyco/opencode` (`close-issues.ts` hardcodes the repository). On forks, the run's `GITHUB_TOKEN` is scoped to the fork, so listing upstream issues/PRs succeeds (public read) but every write call fails with 403 — e.g. `error: Failed to comment #35504: 403 Forbidden`, still reproducible today on a fork synced to current `dev`.

The guard skips these maintenance jobs on forks while leaving upstream behavior unchanged, matching the pattern already used in `stats.yml`, `publish.yml` and `deploy.yml`.

This is the same two-line guard as #39727, which was closed by the automated PR cleanup after a month without review (not by maintainer decision). Resubmitting fresh, as the cleanup notice invites.

### How did you verify your code works?

Diff review; the guard expression is byte-identical to the one already shipped in `stats.yml`. The `close-issues.yml` half of this change is also running on my fork (niStee/opencode), where the job now evaluates to skipped instead of failing.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._