### PR TITLE
fix(app): adjust sidebar and settings spacing

### DIFF
--- a/packages/app/src/settings/settings.css
+++ b/packages/app/src/settings/settings.css
@@ -647,7 +647,8 @@
 
 .settings-tab-search {
   position: relative;
-  width: 100%;
+  width: calc(100% - 2px);
+  margin-inline: 1px;
 }
 
 .settings-tab-search [data-component="text-input-v2"] {

--- a/packages/app/src/settings/workspaces/projects.tsx
+++ b/packages/app/src/settings/workspaces/projects.tsx
@@ -42,7 +42,7 @@ export const SettingsProjects: Component = () => {
     const name = () => displayName(props.project)
     return (
       <div
-        class="group flex items-center justify-between gap-5 px-4 py-2.5 rounded-lg bg-v2-background-bg-base shadow-[var(--v2-elevation-raised)] transition-all hover:bg-v2-background-bg-layer-01"
+        class="group mx-px flex items-center justify-between gap-5 px-4 py-2.5 rounded-lg bg-v2-background-bg-base shadow-[var(--v2-elevation-raised)] transition-all hover:bg-v2-background-bg-layer-01"
         onClick={() => openProjectSettings(props.project, props.server)}
       >
         <div class="flex items-center gap-2.5 min-w-0 flex-1">

--- a/packages/app/src/shell/shell.tsx
+++ b/packages/app/src/shell/shell.tsx
@@ -64,7 +64,7 @@ export default function Layout(props: ParentProps) {
             <aside
               ref={(element) => setState("tabsMount", element)}
               data-slot="vertical-tabs-sidebar"
-              class="relative flex h-full min-h-0 shrink-0 flex-col bg-v2-background-bg-deep px-2.5 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]"
+              class="relative flex h-full min-h-0 shrink-0 flex-col bg-v2-background-bg-deep pe-0.5 ps-2.5 pb-[var(--shell-bottom-inset,8px)] pt-[var(--shell-top-inset,8px)]"
               style={{
                 width: `${state.tabsWidth}px`,
                 "padding-bottom": "max(10px, env(safe-area-inset-bottom, 0px))",


### PR DESCRIPTION
### Issue for this PR
Fixes #219 

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
- Updated spacing in vertical tabs sidebar
- Fixed clipping on search bars / project cards in settings

### How did you verify your code works?
- Ran the app locally and verified the updated UI manually

### Screenshots / recordings
Before
<img width="390" height="256" alt="image" src="https://github.com/user-attachments/assets/84d9f44b-24bc-4087-b530-914ceef73ea2" />

After
<img width="396" height="268" alt="image" src="https://github.com/user-attachments/assets/357a9bc3-3518-483e-95c6-b054a50c278b" />

#### Settings clipping — before / after

[View the search-field and project-card screenshots](https://slack.com/archives/C0BFS9520BG/p1788515169542209) (Slack team access required).

The captures show the previously clipped left/right borders and the restored borders after the 1px inline inset. Captured from the real app at 1100×760, light theme, device scale 1, 100% zoom, English, reduced motion; identical mocked backend with one seeded demo project. Search focus/filter/clear and project-card hover/open/Escape dismissal passed on both refs.

- Before (fetched `v2`): `ed877cfebcebd24aa0ba8e4af74720ccb38025fe`
- After (PR head): `11d8466e0224393aed64d88cee6d1e50acc8561b`

Native GitHub attachment upload was unavailable in the capture environment, so the PNG is uploaded to Slack rather than embedded here.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

_If you do not follow this template your PR will be automatically rejected._
