### PR TITLE
feat(console): route migrated BYOK through provider connections

### DIFF
--- a/packages/console/app/src/lib/inference-proxy.ts
+++ b/packages/console/app/src/lib/inference-proxy.ts
@@ -1,16 +1,24 @@
 import { Resource } from "@opencode-ai/console-resource"
-import { Database, eq } from "@opencode-ai/console-core/drizzle/index.js"
+import { and, Database, eq, isNull, sql } from "@opencode-ai/console-core/drizzle/index.js"
 import { KeyTable } from "@opencode-ai/console-core/schema/key.sql.js"
+import { ProviderTable } from "@opencode-ai/console-core/schema/provider.sql.js"
 import { WorkspaceTable } from "@opencode-ai/console-core/schema/workspace.sql.js"
 
 const paths: Record<string, string | undefined> = {
-  "GET /zen/v1/models": "/v1/models",
   "POST /zen/v1/chat/completions": "/openai/v1/chat/completions",
   "POST /zen/v1/responses": "/openai/v1/responses",
   "POST /zen/v1/messages": "/anthropic/v1/messages",
 }
 
-export async function proxyInference(request: Request, clientIP?: string): Promise<Response | undefined> {
+export async function proxyInference(
+  request: Request,
+  generation: {
+    provider?: "openai" | "anthropic" | "google"
+    /** The provider's native model ID, not the public Zen alias. */
+    model?: string
+    body: (model?: string) => ReadableStream<Uint8Array>
+  },
+): Promise<Response | undefined> {
   const url = new URL(request.url)
   const path =
     paths[`${request.method} ${url.pathname}`] ??
@@ -30,23 +38,52 @@ export async function proxyInference(request: Request, clientIP?: string): Promi
   // Routing only; the destination owns authentication and revocation after cutover.
   const workspace = await Database.use((tx) =>
     tx
-      .select({ migratedAt: WorkspaceTable.migrated_at })
+      .select({
+        id: WorkspaceTable.id,
+        migratedAt: WorkspaceTable.migrated_at,
+        provider: ProviderTable.provider,
+      })
       .from(KeyTable)
       .innerJoin(WorkspaceTable, eq(WorkspaceTable.id, KeyTable.workspaceID))
+      .leftJoin(
+        ProviderTable,
+        generation.provider
+          ? and(
+              eq(ProviderTable.workspaceID, KeyTable.workspaceID),
+              eq(ProviderTable.provider, generation.provider),
+              isNull(ProviderTable.timeDeleted),
+              sql`length(${ProviderTable.credentials}) > 0`,
+            )
+          : sql`false`,
+      )
       .where(eq(KeyTable.key, key))
       .limit(1)
       .then((rows) => rows[0]),
   )
   if (!workspace?.migratedAt) return undefined
+  const model = workspace.provider ? generation.model : undefined
+  if (workspace.provider && !model) throw new Error("Legacy BYOK model mapping is unavailable")
 
   const destination = new URL(Resource.ConsoleMigration.inferenceUrl)
-  destination.pathname = `${destination.pathname.replace(/\/$/, "")}${path}`
+  // Imported connections must use this same workspace/provider-derived ID.
+  const target = model
+    ? `/custom/conn_${workspace.id.slice(4)}_${workspace.provider}${
+        path.startsWith("/google/")
+          ? `/models/${encodeURIComponent(model)}${url.pathname.slice(url.pathname.lastIndexOf(":"))}`
+          : url.pathname.slice("/zen/v1".length)
+      }`
+    : path
+  destination.pathname = `${destination.pathname.replace(/\/$/, "")}${target}`
   destination.search = url.search
   destination.hash = ""
 
-  const forwarded = new Request(destination, request)
+  // Model extraction has already read part of the body; forward its replay stream.
+  const forwarded = new Request(
+    destination,
+    new Request(request, { method: request.method, body: generation.body(model) }),
+  )
   forwarded.headers.set("authorization", `Bearer ${key}`)
-  const ip = request.headers.get("cf-connecting-ip") ?? clientIP
+  const ip = request.headers.get("cf-connecting-ip")
   if (ip) forwarded.headers.set("x-real-ip", ip)
   const requestID = request.headers.get("x-opencode-request-id") ?? request.headers.get("x-opencode-request")
   if (requestID) forwarded.headers.set("x-opencode-request-id", requestID)

--- a/packages/console/app/src/middleware.ts
+++ b/packages/console/app/src/middleware.ts
@@ -2,7 +2,6 @@ import { createMiddleware } from "@solidjs/start/middleware"
 import { LOCALE_HEADER, cookie, fromPathname, strip } from "~/lib/language"
 import { normalizeReferralCode, referralCookie } from "~/lib/referral-invite"
 import { sanitizeServerActionRequest } from "~/lib/server-action"
-import { proxyInference } from "~/lib/inference-proxy"
 
 export default createMiddleware({
   async onRequest(event) {
@@ -20,12 +19,5 @@ export default createMiddleware({
 
     const referralCode = normalizeReferralCode(url.searchParams.get("ref"))
     if (referralCode) event.response.headers.append("set-cookie", referralCookie(referralCode))
-
-    return proxyInference(event.request, event.clientAddress).catch(() =>
-      Response.json(
-        { error: { type: "api_error", message: "Inference routing is unavailable. Please retry later." } },
-        { status: 503, headers: { "Cache-Control": "no-store" } },
-      ),
-    )
   },
 })

--- a/packages/console/app/src/routes/zen/util/handler.ts
+++ b/packages/console/app/src/routes/zen/util/handler.ts
@@ -50,6 +50,7 @@ import { countryFromRequest, isModelCountryRestricted } from "~/lib/request-coun
 import { isPeakPricing } from "./pricing"
 import { prepareRequestBody } from "./requestBody"
 import { requiresGoTrainingConsent } from "./trainingConsent"
+import { proxyInference } from "~/lib/inference-proxy"
 
 type ZenData = Awaited<ReturnType<typeof ZenData.list>>
 type PreparedBody = Awaited<ReturnType<typeof prepareRequestBody>>
@@ -100,6 +101,26 @@ export async function handler(
     const ip = rawIp.includes(":") ? rawIp.split(":").slice(0, 4).join(":") : rawIp
     const rawZenApiKey = opts.parseApiKey(input.request.headers)
     const zenApiKey = rawZenApiKey === "public" ? undefined : rawZenApiKey
+    const zenData = ZenData.list(opts.modelList)
+    if (opts.modelList === "full" && model) {
+      // Read routing metadata without running legacy model, auth, or balance checks.
+      const configured = zenData.models[model]
+      const entry = Array.isArray(configured)
+        ? configured.find((entry) => entry.formatFilter === opts.format)
+        : configured
+      const response = await proxyInference(input.request, {
+        provider: entry?.byokProvider,
+        model: entry?.providers.find((provider) => provider.id === entry.byokProvider)?.model,
+        body: (providerModel) => requestBody?.stream(providerModel ?? model, false) ?? body,
+      }).catch(() => {
+        void (requestBody ? requestBody.cancel() : body.cancel()).catch(() => {})
+        return Response.json(
+          { error: { type: "api_error", message: "Inference routing is unavailable. Please retry later." } },
+          { status: 503, headers: { "Cache-Control": "no-store" } },
+        )
+      })
+      if (response) return response
+    }
     const sessionId = input.request.headers.get("x-opencode-session") ?? ""
     const requestId = input.request.headers.get("x-opencode-request") ?? ""
     const ocClient = input.request.headers.get("x-opencode-client") ?? ""
@@ -112,7 +133,6 @@ export async function handler(
       user_agent: userAgent,
       "model.tier": opts.modelList === "full" ? "zen" : "go",
     })
-    const zenData = ZenData.list(opts.modelList)
     const modelInfo = validateModel(zenData, model)
     const country = countryFromRequest(input.request)
     if (isModelCountryRestricted(modelInfo.id, country)) throw new RegionError(t("zen.api.error.countryNotAllowed"))

--- a/packages/console/app/src/routes/zen/v1/models.ts
+++ b/packages/console/app/src/routes/zen/v1/models.ts
@@ -5,14 +5,25 @@ import { KeyTable } from "@opencode-ai/console-core/schema/key.sql.js"
 import { WorkspaceTable } from "@opencode-ai/console-core/schema/workspace.sql.js"
 import { ModelTable } from "@opencode-ai/console-core/schema/model.sql.js"
 import { buildOptionsResponse, buildModelsResponse } from "~/routes/zen/util/modelsHandler"
+import { Resource } from "@opencode-ai/console-resource"
 
 export async function OPTIONS(_input: APIEvent) {
   return buildOptionsResponse()
 }
 
 export async function GET(input: APIEvent) {
+  const apiKey = input.request.headers.get("authorization")?.split(" ")[1]
+  if (apiKey && apiKey !== "public") {
+    const response = await proxyModels(input, apiKey).catch(() =>
+      Response.json(
+        { error: { type: "api_error", message: "Inference routing is unavailable. Please retry later." } },
+        { status: 503, headers: { "Cache-Control": "no-store" } },
+      ),
+    )
+    if (response) return response
+  }
+
   const disabledModels = await (() => {
-    const apiKey = input.request.headers.get("authorization")?.split(" ")[1]
     if (!apiKey) return [] as string[]
 
     return Database.use((tx) =>
@@ -33,4 +44,27 @@ export async function GET(input: APIEvent) {
     .filter((id) => !disabledModels.includes(id))
 
   return buildModelsResponse(models)
+}
+
+async function proxyModels(input: APIEvent, apiKey: string) {
+  // No legacy revocation or model-policy checks before destination authentication.
+  const workspace = await Database.use((tx) =>
+    tx
+      .select({ migratedAt: WorkspaceTable.migrated_at })
+      .from(KeyTable)
+      .innerJoin(WorkspaceTable, eq(WorkspaceTable.id, KeyTable.workspaceID))
+      .where(eq(KeyTable.key, apiKey))
+      .limit(1)
+      .then((rows) => rows[0]),
+  )
+  if (!workspace?.migratedAt) return undefined
+
+  const destination = new URL(Resource.ConsoleMigration.inferenceUrl)
+  destination.pathname = `${destination.pathname.replace(/\/$/, "")}/v1/models`
+  destination.search = new URL(input.request.url).search
+  destination.hash = ""
+  const headers = new Headers({ authorization: `Bearer ${apiKey}` })
+  const ip = input.request.headers.get("cf-connecting-ip")
+  if (ip) headers.set("x-real-ip", ip)
+  return fetch(destination, { headers, signal: input.request.signal, redirect: "manual" })
 }


### PR DESCRIPTION
## Summary
- Move generation proxying out of global middleware and into the shared inference handler after model extraction, before legacy model/authentication/rate-limit/billing checks.
- Use a routing-only key/workspace/provider lookup to send BYOK to `/inference/custom/conn_<workspace suffix>_<provider>/...`; other migrated requests retain managed destinations.
- Forward the unchanged Zen credential, use native model IDs for BYOK, and reuse existing body streaming. Do not forward provider credentials or fall back to paid managed inference after BYOK errors.
- Keep Go excluded. Give `GET /zen/v1/models` its own route-level proxy to `/inference/v1/models`, forwarding only Authorization and client IP headers.
- Preserve query strings, streaming, manual redirects, and sanitized routing failures. No request-body helper, APIEvent type, or special missing-model response changes remain.

## Validation
- Console app typecheck passed; pre-push workspace typecheck passed all 30 tasks.
- Formatting and diff checks passed; targeted lint reported no errors, with existing handler warnings only.
- No local tests run; no deployment or live request verification.

## Rollout limits
- Requires corresponding imported connections in new Console; do not enable BYOK cutover before they exist.
- Destination model mapping, policies, budgets, and OpenAI Chat/Responses compatibility still require end-to-end verification.
- Missing-model requests retain existing legacy validation rather than introducing a new error response.

## Companion PR
Provider import: https://github.com/anomalyco/opencode-console/pull/2014