### PR TITLE
chore: upgrade Bun to 1.4.1 and re-enable bytecode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
 
       - uses: ./.github/actions/setup-bun
         with:
-          bun-version: 1.4.0
+          bun-version: 1.4.1
 
       - name: Setup git committer
         id: committer
@@ -113,7 +113,7 @@ jobs:
         id: build
         run: ./packages/cli/script/build.ts ${{ (github.ref_name == 'beta' && '--sourcemaps') || '' }}
         env:
-          BUN_COMPILE_RELEASE: bun-v1.4.0
+          BUN_COMPILE_RELEASE: bun-v1.4.1
           OPENCODE_VERSION: ${{ needs.version.outputs.version }}
           OPENCODE_RELEASE: ${{ needs.version.outputs.release }}
           GH_REPO: ${{ needs.version.outputs.repo }}

--- a/bun.lock
+++ b/bun.lock
@@ -1065,6 +1065,7 @@
     "@opentui/solid": "catalog:",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
+    "bun-types": "1.4.1",
     "effect": "catalog:",
     "solid-js": "catalog:",
   },
@@ -1102,7 +1103,7 @@
     "@tanstack/solid-virtual": "3.13.37",
     "@tsconfig/bun": "1.0.9",
     "@tsconfig/node22": "22.0.2",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.4.0",
     "@types/cross-spawn": "6.0.6",
     "@types/luxon": "3.7.1",
     "@types/node": "24.12.2",
@@ -3032,7 +3033,7 @@
 
     "@types/braces": ["@types/braces@3.0.5", "", {}, "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/cacache": ["@types/cacache@20.0.1", "", { "dependencies": { "@types/node": "*", "minipass": "*" } }, "sha512-QlKW3AFoFr/hvPHwFHMIVUH/ZCYeetBNou3PCmxu5LaNDvrtBlPJtIA6uhmU9JRt9oxj7IYoqoLcpxtzpPiTcw=="],
 
@@ -3484,7 +3485,7 @@
 
     "bun-pty": ["bun-pty@0.4.8", "", {}, "sha512-rO70Mrbr13+jxHHHu2YBkk2pNqrJE5cJn29WE++PUr+GFA0hq/VgtQPZANJ8dJo6d7XImvBk37Innt8GM7O28w=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -6340,10 +6341,6 @@
 
     "@solidjs/start/vite": ["vite@7.1.10", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA=="],
 
-    "@standard-community/standard-json/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
-
-    "@standard-community/standard-openapi/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
-
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" }, "bundled": true }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
@@ -6921,8 +6918,6 @@
     "@brendonovich/vite-plugin-opencode/@opencode-ai/client/@opencode-ai/protocol": ["@opencode-ai/protocol@0.0.0-beta-18050", "", { "dependencies": { "@opencode-ai/schema": "0.0.0-beta-18050", "effect": "4.0.0-rc.111" } }, "sha512-HDQMnvGp8IU0MdBRbEuydX1WQm09BZ4HJm9iSMQwzweJuQ2HNscgzHJPIH6P02BsbbtfJ8J7sZGPItrz1tWSgw=="],
 
     "@brendonovich/vite-plugin-opencode/@opencode-ai/client/@opencode-ai/schema": ["@opencode-ai/schema@0.0.0-beta-18050", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "effect": "4.0.0-rc.111" } }, "sha512-/D6VXaWlytTXR3IOiMLIKuPcfp7FQNUzRPm9z3K7UBFd1Bw4q/WZksaf5RVcBGz+0YRxYMc1V4D7MFlceSgtyg=="],
-
-    "@brendonovich/vite-plugin-opencode/@opencode-ai/client/effect": ["effect@4.0.0-rc.111", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "msgpackr": "^2.0.5" } }, "sha512-ASd5L58EIR0CUNueZNKKjSsyOCd+2alxOAIaTcHaqkJkPsaYSsw5Cg/cfANk5K4Jr2YsX756xvX11shzqsreWA=="],
 
     "@bruits/satteri-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "packageManager": "bun@1.4.0",
+  "packageManager": "bun@1.4.1",
   "scripts": {
     "dev": "bun run --cwd packages/cli --conditions=browser src/index.ts",
     "dev:live": "sh -c 'OPENCODE_TUI_CHANNEL=dev OPENCODE_PASSWORD=\"$(opencode2 service get password)\" exec bun run dev \"$@\" --server \"$(opencode2 service status)\"' --",
@@ -43,7 +43,7 @@
       "@effect/platform-node-shared": "4.0.0-rc.112",
       "@effect/sql-sqlite-bun": "4.0.0-rc.112",
       "@npmcli/arborist": "9.4.0",
-      "@types/bun": "1.3.13",
+      "@types/bun": "1.4.0",
       "@types/cross-spawn": "6.0.6",
       "@octokit/rest": "22.0.0",
       "@hono/standard-validator": "0.2.0",
@@ -159,6 +159,7 @@
     "@effect/platform-node-shared": "catalog:",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",
+    "bun-types": "1.4.1",
     "effect": "catalog:",
     "solid-js": "catalog:"
   },

--- a/packages/cli/script/build.ts
+++ b/packages/cli/script/build.ts
@@ -128,9 +128,7 @@ export default { path: file, version: ${JSON.stringify(opencodePty.version)}, sh
     external: ["node-gyp"],
     format: "esm",
     minify: true,
-    // Bun 1.4.0 cross-compiled bytecode can crash on Windows (oven-sh/bun#40270).
-    // Re-enable after both the builder and embedded runtime move to Bun 1.4.1.
-    bytecode: false,
+    bytecode: true,
     sourcemap: Script.channel === "dev" || Script.channel === "local" ? "inline" : "none",
     splitting: true,
     compile: {

--- a/packages/containers/bun-node/Dockerfile
+++ b/packages/containers/bun-node/Dockerfile
@@ -4,7 +4,7 @@ FROM ${REGISTRY}/build/base:24.04
 SHELL ["/bin/bash", "-lc"]
 
 ARG NODE_VERSION=24.4.0
-ARG BUN_VERSION=1.3.14
+ARG BUN_VERSION=1.4.1
 
 ENV BUN_INSTALL=/opt/bun
 ENV PATH=/opt/bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/packages/core/script/build.ts
+++ b/packages/core/script/build.ts
@@ -41,37 +41,3 @@ const result = await Bun.build({
   },
 })
 if (!result.success) throw new AggregateError(result.logs, "Failed to build Core")
-
-// Bun's Node target eagerly creates its shared require helper, so every split
-// entry evaluates import.meta.url even when it never requires a module. Keep
-// the helper lazy until Bun stops hoisting it into workerd-reachable chunks.
-// https://github.com/oven-sh/bun/issues/12615
-const eagerRequire = "var __require = /* @__PURE__ */ createRequire(import.meta.url);"
-const lazyRequire = `var __require = (specifier) => createRequire(import.meta.url ?? "file:///worker.js")(specifier);
-__require.resolve = (specifier, options) => createRequire(import.meta.url ?? "file:///worker.js").resolve(specifier, options);`
-const rewritten = await Promise.all(
-  result.outputs.map(async (output) => {
-    if (!output.path.endsWith(".js")) return false
-    const source = await output.text()
-
-    const generatedUses = source
-      .replace(/import\s*\{[^}]*\b__require\b[^}]*\}\s*from\s*["'][^"']+["'];/g, "")
-      .replace(/export\s*\{[^}]*\b__require\b[^}]*\};/g, "")
-      .replace(eagerRequire, "")
-    if (/\bnew\s+__require\s*\(/.test(generatedUses))
-      throw new Error(`Unsupported generated require constructor in ${output.path}`)
-    const unsupported = generatedUses.replace(/\b__require\.resolve\s*\(/g, "").replace(/\b__require\s*\(/g, "")
-    if (/\b__require\b/.test(unsupported)) throw new Error(`Unsupported generated require usage in ${output.path}`)
-
-    if (!source.includes(eagerRequire)) return false
-    if (source.indexOf(eagerRequire) !== source.lastIndexOf(eagerRequire))
-      throw new Error(`Multiple eager require helpers in ${output.path}`)
-    const rewrittenSource = source.replace(eagerRequire, lazyRequire)
-    if (rewrittenSource.includes(eagerRequire))
-      throw new Error(`Failed to rewrite eager require helper in ${output.path}`)
-    await Bun.write(output.path, rewrittenSource)
-    return true
-  }),
-)
-if (rewritten.filter(Boolean).length !== 1)
-  throw new Error("Expected exactly one eager require helper; Bun may have fixed #12615 and made this shim removable")

--- a/packages/core/src/util/process-lock-ffi.bun.ts
+++ b/packages/core/src/util/process-lock-ffi.bun.ts
@@ -44,7 +44,7 @@ export function lockLinux(fd: number): LockResult {
   }
 }
 
-function errorCode(pointer: Pointer | null) {
+function errorCode(pointer: Pointer | bigint | null) {
   if (pointer === null) throw new Error("Failed to read process lock error code")
   return read.i32(pointer, 0)
 }

--- a/packages/sdk/script/verify-package.ts
+++ b/packages/sdk/script/verify-package.ts
@@ -216,9 +216,6 @@ for (const module of modules) {
 
   const transpiler = new Bun.Transpiler({ loader: "js" })
   const bundled = await Bun.file(join(consumer, "dist/worker.js")).text()
-  if (/createRequire\s*\(\s*import\.meta\.url\s*\)/.test(bundled)) {
-    throw new Error("Packed workerd bundle contains Bun's eager Node require initializer")
-  }
   const bunGlobals = Array.from(new Set(bundled.match(/\bBun\.[A-Za-z_$][\w$]*/g) ?? []))
   if (bunGlobals.length > 0) throw new Error(`Packed workerd bundle references Bun globals: ${bunGlobals.join(", ")}`)
   const leaked = [
@@ -230,6 +227,8 @@ for (const module of modules) {
   ].filter((specifier) => specifier === "bun" || specifier.startsWith("bun:"))
   if (leaked.length > 0) throw new Error(`Packed workerd bundle statically imports Bun builtins: ${leaked.join(", ")}`)
 
+  // Boot in workerd to catch eager Node initializers; lazy createRequire calls
+  // in native-only code are valid and must not fail a bundle-wide text check.
   await $`node boot.mjs`.cwd(consumer)
   console.log("packed SDK consumer OK")
 } finally {

--- a/packages/stats/server/Dockerfile
+++ b/packages/stats/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.14-alpine AS base
+FROM oven/bun:1.4.1-alpine AS base
 
 WORKDIR /app
 


### PR DESCRIPTION
- Upgrade the repository, release builder, embedded CLI runtime, and container pins to Bun 1.4.1.
- Re-enable CLI bytecode compilation now that Bun supports [portable cross-compiled bytecode](https://github.com/oven-sh/bun/pull/40270).
- Upgrade `@types/bun` to the published 1.4.0 wrapper and override `bun-types` to 1.4.1 for the fixed process-event declarations. Accept the updated FFI pointer return type.
- Remove Core's obsolete generated-require rewrite. Use actual workerd startup, rather than a bundle-wide text match, to reject eager Node initialization.
