### PR TITLE
fix(session): drop phantom invalid tool calls when replaying messages

### DIFF
--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -288,6 +288,9 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
             type: "step-start",
           })
         if (part.type === "tool") {
+          // Phantom tool calls were never executed; replaying them between signed
+          // thinking blocks wedges Anthropic turns. Drop them.
+          if (part.tool === "invalid") continue
           toolNames.add(part.tool)
           if (part.state.status === "completed") {
             const outputText = part.state.time.compacted

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1361,6 +1361,62 @@ describe("session.message-v2.toModelMessage", () => {
     const texts = (result[0].content as any[]).filter((p) => p.type === "text")
     expect(texts.map((t) => t.text)).toStrictEqual(["", "hello"])
   })
+
+  test("drops phantom invalid tool calls, keeps the real one", async () => {
+    const userID = "m-user-invalid"
+    const assistantID = "m-assistant-invalid"
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [{ ...basePart(userID, "u1-invalid"), type: "text", text: "hi" }] as SessionV1.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "r1-invalid"),
+            type: "reasoning",
+            text: "thinking",
+            metadata: { anthropic: { signature: "sig" } },
+          },
+          {
+            ...basePart(assistantID, "i1-invalid"),
+            type: "tool",
+            callID: "call-invalid",
+            tool: "invalid",
+            state: {
+              status: "completed",
+              input: { tool: "nope", error: "unavailable" },
+              output: "",
+              title: "",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+          {
+            ...basePart(assistantID, "b1-invalid"),
+            type: "tool",
+            callID: "call-bash",
+            tool: "bash",
+            state: {
+              status: "completed",
+              input: { command: "echo hi" },
+              output: "hi",
+              title: "bash",
+              metadata: {},
+              time: { start: 0, end: 1 },
+            },
+          },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+    const assistant = result.find((m) => m.role === "assistant")!
+    const toolNames = (assistant.content as any[]).filter((c) => c.type === "tool-call").map((c) => c.toolName)
+    expect(toolNames).not.toContain("invalid")
+    expect(toolNames).toContain("bash")
+  })
 })
 
 describe("session.message-v2.fromError", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #47274

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a model calls a tool that does not exist, we store it as an `invalid` tool part. `toModelMessagesEffect` was replaying those parts as regular tool_use/tool_result blocks. When the turn also has extended-thinking blocks, the invalid parts sit between the signed `thinking` blocks, and Anthropic then rejects the turn on replay with "thinking blocks in the latest assistant message cannot be modified". Because that turn stays the latest assistant message, the session is wedged for good.

The phantom call was never executed and adds nothing to context, so this skips `invalid` tool parts when building model messages. The thinking blocks are left exactly as they were, so replay passes.

### How did you verify your code works?

Added a test that replays an assistant turn with a signed reasoning block, an `invalid` tool part, and a real `bash` call, and asserts the invalid call is dropped while `bash` survives. It fails on `dev` and passes with this change. `bun test test/session/message-v2.test.ts` is green (40 pass) and `bun typecheck` is clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
