### PR TITLE
fix(session-ui): count paste line breaks without split allocation

### DIFF
--- a/packages/session-ui/src/v2/components/prompt-input/attachments.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/attachments.ts
@@ -274,5 +274,12 @@ function cursorPosition(editor: HTMLElement) {
 
 function largePaste(text: string) {
   if (text.length >= 8000) return true
-  return text.split("\n").length - 1 >= 120
+  let breaks = 0
+  for (let index = 0; index < text.length; index++) {
+    if (text[index] === "\n") {
+      breaks += 1
+      if (breaks >= 120) return true
+    }
+  }
+  return false
 }


### PR DESCRIPTION
### Issue for this PR
Closes #

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pasting large content (e.g. an XML file) into the prompt input hangs the GUI. One contributor is `largePaste` in `packages/session-ui/src/v2/components/prompt-input/attachments.ts`: to decide whether a paste counts as "large", it ran `text.split("\n")` on the entire pasted text just to count the breaks.

The fix counts line breaks in a single pass with an early exit instead of splitting. The thresholds are untouched (length >= 8000 checked first, then break count >= 120), so `split(...).length - 1 >= 120` and the new counter agree on every input by construction — same behavior, no big allocation.

### How did you verify your code works?

I have tested my changes locally.

### Screenshots / recordings

N/A — no visual change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
