### PR TITLE
feat(desktop): simplify move to background action

### DIFF
--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -676,7 +676,7 @@ export const dict = {
   "session.error.incompatible.description":
     "{{server}} is running OpenCode {{version}}, which isn't compatible with this app. Upgrade the server to OpenCode V2 to continue.",
   "session.background.moveTasks": "Move {{tasks}} to background",
-  "session.background.moveRunning": "Move running work to background",
+  "session.background.moveRunning": "Move to background",
   "session.background.inBackground": "Running {{tasks}} in background",
   "session.background.moveInline": "Press {{keybind}} to move running work to the background",
   "session.background.running": "Running work in background",

--- a/packages/app/src/session/timeline/message-timeline.tsx
+++ b/packages/app/src/session/timeline/message-timeline.tsx
@@ -58,7 +58,6 @@ export function BackgroundMoveHint(props: { keybind?: string[]; onMove?: () => v
       type="button"
       variant="ghost-faint"
       size="small"
-      icon="outline-arrow-to-corner-top-right"
       class="max-w-full"
       aria-label={language.t("session.background.moveInline", { keybind: keybind() })}
       onClick={() => props.onMove?.()}


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Simplifies the running-work action by removing its leading icon and changing the visible label to “Move to background”. The existing shortcut and accessible label remain unchanged.

### How did you verify your code works?

- `bun typecheck` from `packages/app`
- Production session-entry benchmark passed before and after the change
- Verified the production component in Storybook

### Screenshots / recordings

| Before | After |
| --- | --- |
| ![Move to background action before](https://github.com/user-attachments/assets/82d60fcf-7507-4c1e-9e1e-07e8f6506cde) | ![Move to background action after](https://github.com/user-attachments/assets/3e074e24-fce8-477c-afde-4631000af773) |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
