### PR TITLE
fix(ui): drive ResizeHandle with pointer capture

### DIFF
--- a/packages/ui/src/components/resize-handle.tsx
+++ b/packages/ui/src/components/resize-handle.tsx
@@ -28,8 +28,17 @@ export function ResizeHandle(props: ResizeHandleProps) {
     "classList",
   ])
 
-  const handleMouseDown = (e: MouseEvent) => {
+  // Use pointer capture instead of mousedown + document listeners.
+  // Without capture the drag silently does nothing in Electron: the handle is
+  // correctly positioned and is the topmost element at that point
+  // (document.elementFromPoint returns it), and dispatching synthetic
+  // mousedown/mousemove/mouseup resizes the panel — but real pointer input
+  // never drives it, because the events after the press are not guaranteed to
+  // reach this element. setPointerCapture guarantees they do.
+  const handlePointerDown = (e: PointerEvent & { currentTarget: HTMLDivElement }) => {
     if (e.detail > 1) return
+    const target = e.currentTarget
+    target.setPointerCapture(e.pointerId)
     e.preventDefault()
     const edge = local.edge ?? (local.direction === "vertical" ? "start" : "end")
     const start = local.direction === "horizontal" ? e.clientX : e.clientY
@@ -72,8 +81,10 @@ export function ResizeHandle(props: ResizeHandleProps) {
     const onMouseUp = () => {
       document.body.style.userSelect = ""
       document.body.style.overflow = ""
-      document.removeEventListener("mousemove", onMouseMove)
-      document.removeEventListener("mouseup", onMouseUp)
+      target.releasePointerCapture?.(e.pointerId)
+      target.removeEventListener("pointermove", onMouseMove)
+      target.removeEventListener("pointerup", onMouseUp)
+      target.removeEventListener("pointercancel", onMouseUp)
 
       if (collapsed) {
         onCollapse?.()
@@ -82,8 +93,9 @@ export function ResizeHandle(props: ResizeHandleProps) {
       onCollapseChange?.(false)
     }
 
-    document.addEventListener("mousemove", onMouseMove)
-    document.addEventListener("mouseup", onMouseUp)
+    target.addEventListener("pointermove", onMouseMove)
+    target.addEventListener("pointerup", onMouseUp)
+    target.addEventListener("pointercancel", onMouseUp)
   }
 
   return (
@@ -96,7 +108,7 @@ export function ResizeHandle(props: ResizeHandleProps) {
         ...local.classList,
         [local.class ?? ""]: !!local.class,
       }}
-      onMouseDown={handleMouseDown}
+      onPointerDown={handlePointerDown}
     />
   )
 }


### PR DESCRIPTION
## Problem

Dragging a `ResizeHandle` silently does nothing in the desktop app — the chat/review
divider cannot be moved with the mouse.

The handle itself is fine: it renders at the correct position, and
`document.elementFromPoint()` at that point returns the handle, so nothing overlaps
it and it is not inside a `[data-tauri-drag-region]`. Dispatching synthetic
`mousedown` → `mousemove` → `mouseup` on it **does** resize the panel, and the new
width persists. Only real pointer input fails to start a drag.

## Cause

`handleMouseDown` listened for `mousedown` and then attached `mousemove` / `mouseup`
to `document`. Events after the press are not guaranteed to reach the handle, so the
drag never starts.

## Fix

Drive the handle with pointer events and `setPointerCapture`, which guarantees every
subsequent move/up event is delivered to the element regardless of what is underneath.
The delta math, clamping and collapse behaviour are unchanged; only the event
plumbing moved from `mousedown` + document listeners to `pointerdown` + capture.

`pointercancel` is handled alongside `pointerup` so an interrupted gesture cleans up
the same way.

## Notes

- Verified on macOS (Electron desktop build): before the change a real drag does
  nothing; after it, the divider moves normally.
- Unrelated but worth mentioning separately: the handle's hit area is 8px wide, which
  is thin for a mouse target. Not changed here to keep this a pure bug fix.
