### PR TITLE
fix(ai): preserve websocket replay baselines

### DIFF
--- a/packages/ai/src/protocols/open-responses-continuation.ts
+++ b/packages/ai/src/protocols/open-responses-continuation.ts
@@ -57,7 +57,12 @@ const comparable = (value: unknown) => {
   if (value.type === "message" && value.role === "assistant")
     return {
       role: "assistant",
-      content: value.content,
+      // Annotations and logprobs describe the response, not the text replayed in model input.
+      content: Array.isArray(value.content)
+        ? value.content.map((part) =>
+            ProviderShared.isRecord(part) && part.type === "output_text" ? { type: part.type, text: part.text } : part,
+          )
+        : value.content,
       ...(value.phase === undefined ? {} : { phase: value.phase }),
     }
   if (value.type === "function_call")
@@ -121,7 +126,7 @@ const rejected = (
 
 export const driver = (input: DriverInput): WebSocketChannelDriver => {
   const { previous_response_id: _previousResponseID, ...request } = input.request
-  let output: unknown[] = []
+  let output: OpenResponses.StreamItem[] = []
   return {
     create: (checkpoint) =>
       Effect.sync(() => {
@@ -159,7 +164,14 @@ export const driver = (input: DriverInput): WebSocketChannelDriver => {
               version: VERSION,
               responseID,
               request,
-              output: event.response?.output ? [...event.response.output] : output.slice(),
+              // Completion can re-encrypt reasoning. Callers replay the item already emitted by output_item.done.
+              output: event.response?.output
+                ? event.response.output.map((item) =>
+                    item.type === "reasoning" && item.id !== undefined
+                      ? (output.find((done) => done.type === item.type && done.id === item.id) ?? item)
+                      : item,
+                  )
+                : output.slice(),
             } satisfies CheckpointValue,
           },
         }

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -657,7 +657,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("continues a promoted steer after the completed assistant output", () =>
+  it.effect("continues a promoted steer after assistant output with response-only text metadata", () =>
     Effect.gen(function* () {
       const firstInput = [{ role: "user", content: [{ type: "input_text", text: "First" }] }]
       const first = continuationDriver({ type: "response.create", model: "gpt-5.2", store: false, input: firstInput })
@@ -671,7 +671,7 @@ describe("OpenAI Responses route", () => {
             id: "msg_1",
             status: "completed",
             role: "assistant",
-            content: [{ type: "output_text", text: "Hello" }],
+            content: [{ type: "output_text", text: "Hello", annotations: [], logprobs: [] }],
           },
         }),
       )
@@ -699,42 +699,37 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("continues store-false reasoning while retaining the output item ID", () =>
+  it.effect("continues streamed reasoning when completion re-encrypts the same item", () =>
     Effect.gen(function* () {
       const firstInput = [{ role: "user", content: [{ type: "input_text", text: "Think" }] }]
       const request = { type: "response.create", model: "gpt-5.2", store: false, input: firstInput }
+      const reasoning = {
+        type: "reasoning",
+        id: "rs_1",
+        summary: [{ type: "summary_text", text: "Thought" }],
+        encrypted_content: "encrypted",
+      }
       const first = continuationDriver(request)
       const create = yield* first.create(undefined)
       yield* first.observe(
         create,
         ProviderShared.encodeJson({
           type: "response.output_item.done",
-          item: {
-            type: "reasoning",
-            id: "rs_1",
-            summary: [{ type: "summary_text", text: "Thought" }],
-            encrypted_content: "encrypted",
-          },
+          item: reasoning,
         }),
       )
       const saved = checkpoint(
         yield* first.observe(
           create,
-          ProviderShared.encodeJson({ type: "response.completed", response: { id: "resp_1" } }),
+          ProviderShared.encodeJson({
+            type: "response.completed",
+            response: { id: "resp_1", output: [{ ...reasoning, encrypted_content: "terminal-encrypted" }] },
+          }),
         ),
       )
       const next = continuationDriver({
         ...request,
-        input: [
-          ...firstInput,
-          {
-            type: "reasoning",
-            id: "rs_1",
-            summary: [{ type: "summary_text", text: "Thought" }],
-            encrypted_content: "encrypted",
-          },
-          { role: "user", content: [{ type: "input_text", text: "Continue" }] },
-        ],
+        input: [...firstInput, reasoning, { role: "user", content: [{ type: "input_text", text: "Continue" }] }],
       })
 
       const continued = yield* next.create(saved)
@@ -744,6 +739,11 @@ describe("OpenAI Responses route", () => {
         previous_response_id: "resp_1",
         input: [{ role: "user", content: [{ type: "input_text", text: "Continue" }] }],
       })
+      const edited = yield* continuationDriver({
+        ...request,
+        input: [...firstInput, { ...reasoning, encrypted_content: "edited" }, { role: "user", content: "Continue" }],
+      }).create(saved)
+      expect(edited.mode).toBe("full")
     }),
   )
 

--- a/packages/core/test/session-model-transport-live.test.ts
+++ b/packages/core/test/session-model-transport-live.test.ts
@@ -74,23 +74,34 @@ describe("SessionModelTransport local WebSocket server", () => {
           const index = requests.length
           const id = `msg_${index}`
           const text = index === 1 ? "Hello" : "Brief"
+          const reasoning = { type: "reasoning", id: `rs_${index}`, summary: [], encrypted_content: "stream-encrypted" }
+          const item = {
+            type: "message",
+            id,
+            status: "completed",
+            role: "assistant",
+            content: [{ type: "output_text", text, annotations: [], logprobs: [] }],
+          }
           socket.send(JSON.stringify({ type: "response.created", response: { id: `resp_${index}` } }))
+          socket.send(JSON.stringify({ type: "response.output_item.done", item: reasoning }))
           socket.send(JSON.stringify({ type: "response.output_item.added", item: { type: "message", id } }))
           socket.send(JSON.stringify({ type: "response.output_text.delta", item_id: id, delta: text }))
           socket.send(JSON.stringify({ type: "response.output_text.done", item_id: id, text }))
           socket.send(
             JSON.stringify({
               type: "response.output_item.done",
-              item: {
-                type: "message",
-                id,
-                status: "completed",
-                role: "assistant",
-                content: [{ type: "output_text", text }],
+              item,
+            }),
+          )
+          socket.send(
+            JSON.stringify({
+              type: "response.completed",
+              response: {
+                id: `resp_${index}`,
+                output: [{ ...reasoning, encrypted_content: "terminal-encrypted" }, item],
               },
             }),
           )
-          socket.send(JSON.stringify({ type: "response.completed", response: { id: `resp_${index}` } }))
         },
       },
       (server) =>
@@ -119,7 +130,7 @@ describe("SessionModelTransport local WebSocket server", () => {
               llm.generate(
                 LLM.request({
                   model,
-                  messages: [Message.user("First"), Message.assistant("Hello"), Message.user("Be brief")],
+                  messages: [Message.user("First"), first.message, Message.user("Be brief")],
                 }),
                 { webSocket: executor },
               ),


### PR DESCRIPTION
## Summary
- Fix Responses WebSocket follow-ups unnecessarily replaying full history. Live OpenAI responses re-encrypt the same reasoning item between `output_item.done` and `response.completed`, while replay uses the already-emitted item.
- Keep the streamed reasoning representation in the continuation baseline, and compare assistant text without response-only annotations/logprobs. Genuinely changed encrypted content still forces a full request.
- Update existing protocol and local-socket tests with the observed wire shapes. No retry, transport ownership, or public API changes.

## Validation
- Two focused regressions reproduced `full` instead of `incremental` before the fix and pass afterward.
- AI: typecheck, build, and **988 passing tests** (28 skipped).
- Core: typecheck and **34 passing transport tests**.
- Live `gpt-5.4-mini`, Bun 1.4.1: three requests used `full → incremental → incremental`; both follow-ups sent one input item with `previous_response_id`, returned correct answers, and used no HTTP fallback.

Separate prerequisite for #47082, based on latest `v2` (`acb462a173`).
