### PR TITLE
docs: add LLM Tech to the providers list

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -1968,6 +1968,48 @@ OpenCode Zen is a list of tested and verified models provided by the OpenCode te
 
 ---
 
+### LLM Tech
+
+1. Head over to the [LLM Tech docs](https://llmtech.eu/docs/), grab an API key, and copy it.
+
+2. Run the `/connect` command and search for LLM Tech.
+
+   ```txt
+   /connect
+   ```
+
+3. Enter the API key for the provider.
+
+   ```txt
+   ┌ API key
+   │
+   │
+   └ enter
+   ```
+
+4. Run the `/models` command to select the model you want.
+
+   ```txt
+   /models
+   ```
+
+   Inference runs on dedicated GPUs inside the EU with zero data retention, and the endpoint is OpenAI compatible. You can also add models through your opencode config.
+
+   ```json title="opencode.json" {6}
+   {
+     "$schema": "https://opencode.ai/config.json",
+     "provider": {
+       "llmtech": {
+         "models": {
+           "unsloth/Qwen3.8-27B-NVFP4": {}
+         }
+       }
+     }
+   }
+   ```
+
+---
+
 ### Poolside
 
 [Poolside](https://poolside.ai) provides access to its models through an OpenAI-compatible API.


### PR DESCRIPTION
### Issue for this PR

No issue. CONTRIBUTING lists "Documentation improvements" as a change type that gets merged, and `providers.mdx` itself says "If you'd like to add a provider to the list, feel free to open a PR."

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds a `### LLM Tech` section to `packages/web/src/content/docs/providers.mdx`, placed alphabetically after LLM Gateway.

No code changes. LLM Tech is already selectable through `/connect` today, because the provider entry exists in models.dev and opencode builds its provider list from that snapshot. So the provider works but is undocumented, and a user has no way to know it is there. This PR documents what already ships.

The section follows the same four steps as the neighbouring providers: get a key, `/connect`, paste the key, `/models`. The config snippet uses the same `provider` / `models` shape as the LLM Gateway and OpenRouter sections above it.

Context on the provider itself: OpenAI-compatible endpoint, open-weight models served from dedicated GPUs in the EU with no prompt retention. Currently Qwen3.8-27B in NVFP4 at 262,144 context with tool calling and prompt caching.

### How did you verify your code works?

- Checked that `llmtech` is present in the models.dev API (`https://models.dev/api.json`) with `api: https://api.llmtech.eu/v1`, so `/connect` already resolves it.
- Confirmed the endpoint answers: `curl https://api.llmtech.eu/v1/models` returns the model with `context_length: 262144`.
- Diffed against `upstream/dev`: 42 added lines, one file, nothing else touched.
- Matched the section structure and the JSON snippet against the existing LLM Gateway section immediately above.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
