### PR TITLE
feat(plugin): add experimental.session.stopping hook

### DIFF
--- a/packages/core/src/plugin/skill/customize-opencode.md
+++ b/packages/core/src/plugin/skill/customize-opencode.md
@@ -354,7 +354,7 @@ Hook surface (mutate `output` in place; return `void`):
 - `permission.ask`
 - `experimental.chat.messages.transform`, `experimental.chat.system.transform`,
   `experimental.session.compacting`, `experimental.compaction.autocontinue`,
-  `experimental.text.complete`
+  `experimental.text.complete`, `experimental.session.stopping`
 
 Special object-shaped (not callbacks): `tool: { my_tool: { ... } }`,
 `auth: { ... }`, `provider: { ... }`.

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -1125,6 +1125,39 @@ const layer = Layer.effect(
                 callID: orphan.callID,
               })
             }
+            // Give plugins a chance to keep the turn alive (for example to run a
+            // check and hand its findings back to the model). Errored turns and
+            // runs that reached the agent's step limit always stop, so a plugin
+            // cannot extend a run past that limit.
+            const agent = yield* agents.get(lastUser.agent)
+            const stopping: { continue: boolean; message?: string } = { continue: false }
+            if (!lastAssistant.error && step < (agent?.steps ?? Infinity))
+              yield* plugin.trigger(
+                "experimental.session.stopping",
+                { sessionID, messageID: lastAssistant.id },
+                stopping,
+              )
+            if (stopping.continue && stopping.message) {
+              const continueMsg = yield* sessions.updateMessage({
+                id: MessageID.ascending(),
+                role: "user",
+                sessionID,
+                time: { created: Date.now() },
+                agent: lastUser.agent,
+                model: lastUser.model,
+              })
+              yield* sessions.updatePart({
+                id: PartID.ascending(),
+                messageID: continueMsg.id,
+                sessionID,
+                type: "text",
+                synthetic: true,
+                text: stopping.message,
+                time: { start: Date.now(), end: Date.now() },
+              })
+              yield* Effect.logInfo("loop continued by plugin", { "session.id": sessionID, step })
+              continue
+            }
             yield* Effect.logInfo("exiting loop", { "session.id": sessionID })
             break
           }

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -8,7 +8,7 @@ import { EventV2Bridge } from "@/event-v2-bridge"
 import { expect } from "bun:test"
 import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer } from "effect"
 import path from "path"
-import { fileURLToPath } from "url"
+import { fileURLToPath, pathToFileURL } from "url"
 import { NamedError } from "@opencode-ai/core/util/error"
 import { Agent as AgentSvc } from "../../src/agent/agent"
 import { BackgroundJob } from "@/background/job"
@@ -2467,4 +2467,114 @@ noLLMServer.instance(
       }
     }),
   30_000,
+)
+
+// Plugin that keeps the loop alive once through experimental.session.stopping.
+// `withMessage: false` proves that `continue` alone is not enough to re-enter.
+const stoppingPlugin = Effect.fn("test.stoppingPlugin")(function* (input: { withMessage: boolean }) {
+  const { directory: dir } = yield* TestInstance
+  const file = path.join(dir, "stopping.ts")
+  yield* writeText(
+    file,
+    [
+      "let fired = 0",
+      "export default async () => ({",
+      '  "experimental.session.stopping": async (_input, output) => {',
+      "    fired += 1",
+      "    if (fired > 1) return",
+      "    output.continue = true",
+      input.withMessage ? '    output.message = "check failed, keep going"' : "",
+      "  },",
+      "})",
+      "",
+    ].join("\n"),
+  )
+  return pathToFileURL(file).href
+})
+
+it.instance(
+  "loop runs another step when a plugin continues from session.stopping",
+  () =>
+    Effect.gen(function* () {
+      const plugin = yield* stoppingPlugin({ withMessage: true })
+      const { llm } = yield* useServerConfig((url) => ({ ...providerCfg(url), plugin: [plugin] }))
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+
+      yield* llm.push(reply().text("first").stop(), reply().text("second").stop())
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      const result = yield* prompt.loop({ sessionID: chat.id })
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+      const users = messages.filter((m) => m.info.role === "user")
+      const assistants = messages.filter((m) => m.info.role === "assistant")
+      const hits = yield* llm.hits
+
+      expect(hits).toHaveLength(2)
+      expect(JSON.stringify(hits[1].body)).toContain("check failed, keep going")
+      expect(users).toHaveLength(2)
+      expect(users[1].parts).toEqual([
+        expect.objectContaining({ type: "text", text: "check failed, keep going", synthetic: true }),
+      ])
+      expect(assistants).toHaveLength(2)
+      expect(assistants[1].info.role === "assistant" && assistants[1].info.parentID).toBe(users[1].info.id)
+      expect(result.parts).toEqual(expect.arrayContaining([expect.objectContaining({ type: "text", text: "second" })]))
+    }),
+  30_000,
+)
+
+it.instance(
+  "loop stops when session.stopping continues without a message",
+  () =>
+    Effect.gen(function* () {
+      const plugin = yield* stoppingPlugin({ withMessage: false })
+      const { llm } = yield* useServerConfig((url) => ({ ...providerCfg(url), plugin: [plugin] }))
+      const prompt = yield* SessionPrompt.Service
+      const sessions = yield* Session.Service
+      const chat = yield* sessions.create({ title: "Pinned" })
+
+      yield* llm.push(reply().text("first").stop())
+      yield* prompt.prompt({
+        sessionID: chat.id,
+        agent: "build",
+        noReply: true,
+        parts: [{ type: "text", text: "hello" }],
+      })
+      yield* prompt.loop({ sessionID: chat.id })
+      const messages = yield* sessions.messages({ sessionID: chat.id })
+
+      expect(yield* llm.hits).toHaveLength(1)
+      expect(messages.filter((m) => m.info.role === "user")).toHaveLength(1)
+      expect(messages.filter((m) => m.info.role === "assistant")).toHaveLength(1)
+    }),
+  30_000,
+)
+
+it.instance("loop stops after one step without a session.stopping plugin", () =>
+  Effect.gen(function* () {
+    const { llm } = yield* useServerConfig(providerCfg)
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const chat = yield* sessions.create({ title: "Pinned" })
+
+    yield* llm.push(reply().text("first").stop())
+    yield* prompt.prompt({
+      sessionID: chat.id,
+      agent: "build",
+      noReply: true,
+      parts: [{ type: "text", text: "hello" }],
+    })
+    const result = yield* prompt.loop({ sessionID: chat.id })
+    const messages = yield* sessions.messages({ sessionID: chat.id })
+
+    expect(yield* llm.hits).toHaveLength(1)
+    expect(messages.filter((m) => m.info.role === "user")).toHaveLength(1)
+    expect(messages.filter((m) => m.info.role === "assistant")).toHaveLength(1)
+    expect(result.parts).toEqual(expect.arrayContaining([expect.objectContaining({ type: "text", text: "first" })]))
+  }),
 )

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -329,6 +329,20 @@ export interface Hooks {
     output: { text: string },
   ) => Promise<void>
   /**
+   * Called when the agent loop is about to end because the assistant's last
+   * message finished without tool calls. Set `continue` to `true` and provide
+   * a `message` to append it as a synthetic user message and run another
+   * step instead of ending the turn.
+   *
+   * Not called for turns that ended with an error or once the agent's `steps`
+   * limit is reached. A plugin that always continues keeps the loop running
+   * until that limit, so plugins must keep their own stopping condition.
+   */
+  "experimental.session.stopping"?: (
+    input: { sessionID: string; messageID: string },
+    output: { continue: boolean; message?: string },
+  ) => Promise<void>
+  /**
    * Modify tool definitions (description and parameters) sent to LLM
    */
   "tool.definition"?: (input: { toolID: string }, output: { description: string; parameters: any }) => Promise<void>

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -387,3 +387,30 @@ Format as a structured prompt that a new agent can use to resume work.
 ```
 
 When `output.prompt` is set, it completely replaces the default compaction prompt. The `output.context` array is ignored in this case.
+
+---
+
+### Keep the agent working
+
+Run a check when the agent is about to end its turn and hand the result back to it:
+
+```ts title=".opencode/plugins/stopping.ts"
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const StoppingPlugin: Plugin = async (ctx) => {
+  const checked = new Set<string>()
+  return {
+    "experimental.session.stopping": async (input, output) => {
+      // Only run the check once per session so the loop cannot run forever
+      if (checked.has(input.sessionID)) return
+      checked.add(input.sessionID)
+      const result = await ctx.$`npm run typecheck`.nothrow().quiet()
+      if (result.exitCode === 0) return
+      output.continue = true
+      output.message = `Type check failed, fix these errors:\n${result.stderr.toString()}`
+    },
+  }
+}
+```
+
+The `experimental.session.stopping` hook fires when the assistant's last message finished without tool calls and the loop is about to end. Setting `output.continue` to `true` together with `output.message` appends the message as a synthetic user message and runs another step. The hook is not called for turns that ended with an error or once the agent's `steps` limit is reached. A plugin that always continues keeps the loop running until that limit, so keep your own stopping condition.


### PR DESCRIPTION
### Issue for this PR

Closes #16626

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Plugins have no hook that runs before a turn ends. `session.idle` fires after the loop has already broken, so a plugin that wants to run a check (tests, type check, lint) and send the findings back to the model can only re-prompt afterwards: the report shows up as a visible user message in a new turn, and with `opencode run` it races process teardown.

This adds `experimental.session.stopping` to the plugin `Hooks` interface. It is triggered in `runLoop` right before the loop breaks because the last assistant message finished without tool calls. Input is `{ sessionID, messageID }`, output is `{ continue: boolean; message?: string }`. If a plugin sets `continue: true` and a `message`, the message is stored as a user message with one `synthetic` text part (same shape the compaction auto-continue uses) and the loop runs another step. With no plugin, or when the plugin leaves the output alone, nothing changes.

Two guards: the hook is not called for turns that ended with an error, and not once `step` has reached the agent's `steps` limit, so a plugin cannot extend a run past that limit. Beyond that, a plugin that always continues will loop until the limit; plugins keep their own stopping condition, as #16626 proposed.

Naming: the issue asks for `session.stopping`. I used the `experimental.` prefix because the other hooks that touch the loop and the message list carry it (`experimental.text.complete`, `experimental.session.compacting`, `experimental.compaction.autocontinue`). Dropping the prefix is a one-line change if you prefer the bare name.

Related: #16598 implemented the same idea and was closed by the age cleanup; #9272 (`session.before.idle`) is a similar hook without the continuation message; #47216 (`stop` hook) triggered at the `result === "stop"` branch, which only runs for blocked or errored turns, not for a normal finish. This PR triggers at the actual exit check and stays limited to the one hook.

Files: `packages/opencode/src/session/prompt.ts` (trigger + continuation), `packages/plugin/src/index.ts` (interface), `packages/opencode/test/session/prompt.test.ts` (tests), `packages/web/src/content/docs/plugins.mdx` and `packages/core/src/plugin/skill/customize-opencode.md` (docs).

### How did you verify your code works?

Three tests in `packages/opencode/test/session/prompt.test.ts`, using the existing fake LLM server and a real plugin file loaded through `opencode.json` (no mocks):

- a plugin that continues once with a message: the fake model is hit twice, the second request carries the injected text, the session holds two user messages (the second with a single `synthetic` text part) and two assistant messages, the second one parented to the injected message
- a plugin that sets `continue` without a message: one model hit, one user and one assistant message
- no plugin: one model hit, one user and one assistant message

Commands, run from `packages/opencode` and `packages/plugin`:

```
bun typecheck                # tsgo --noEmit, exit 0 in both packages
bun run test test/session/prompt.test.ts test/plugin/trigger.test.ts
# 63 pass, 1 skip (platform), 0 fail
bunx prettier --check <changed files>   # clean
bunx oxlint <changed files>             # 0 errors, no warnings in the new lines
```

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

**Related, found after opening:** #44712 (open since 2026-08-24) adds the same hook with a re-entry cap, a sticky veto across listeners and an exit-matrix test suite. This PR is the minimal form of the same idea (one trigger at the natural exit, one synthetic user message, three tests). If maintainers prefer #44712, this one can be closed; the two are not meant to compete.