### PR TITLE
fix: echo working directory in shell tool output

### DIFF
--- a/packages/core/src/tool/bash.ts
+++ b/packages/core/src/tool/bash.ts
@@ -41,6 +41,7 @@ const StructuredOutput = Schema.Struct({
 const Output = Schema.Struct({
   ...StructuredOutput.fields,
   output: Schema.String,
+  cwd: Schema.String,
   warnings: Schema.Array(Schema.String).pipe(Schema.optional),
 })
 
@@ -52,8 +53,10 @@ const modelOutput = (output: Output) => {
   const warnings = output.warnings?.length
     ? `\n\nWarnings:\n${output.warnings.map((warning) => `- ${warning}`).join("\n")}`
     : ""
-  if (output.timeout) return `${warnings.trimStart()}${warnings ? "\n\n" : ""}Command timed out before completion.`
-  return `${warnings.trimStart()}${warnings ? "\n\n" : ""}Command exited with code ${output.exit}.`
+  const prefix = `${warnings.trimStart()}${warnings ? "\n\n" : ""}`
+  const cwd = `\nWorking directory: ${output.cwd}`
+  if (output.timeout) return `${prefix}Command timed out before completion.${cwd}`
+  return `${prefix}Command exited with code ${output.exit}.${cwd}`
 }
 
 const isTimeout = (error: AppProcess.AppProcessError) =>
@@ -177,6 +180,7 @@ const layer = Layer.effectDiscard(
               if (!result) {
                 return {
                   output: `Command exceeded timeout of ${timeout} ms. Retry with a larger timeout if the command is expected to take longer.`,
+                  cwd: target.canonical,
                   truncated: false,
                   timeout: true,
                   ...(warnings.length ? { warnings } : {}),
@@ -190,6 +194,7 @@ const layer = Layer.effectDiscard(
               return {
                 exit: result.exitCode,
                 output: notice ? `${output}\n\n${notice}` : output,
+                cwd: target.canonical,
                 truncated: result.outputTruncated === true,
                 ...(warnings.length ? { warnings } : {}),
               }

--- a/packages/core/test/tool-bash.test.ts
+++ b/packages/core/test/tool-bash.test.ts
@@ -148,12 +148,13 @@ describe("BashTool", () => {
             expect(definitions[0]?.outputSchema).not.toHaveProperty("properties.command")
             expect(definitions[0]?.outputSchema).not.toHaveProperty("properties.cwd")
             expect(yield* toolDefinitions(registry, [{ action: "bash", resource: "*", effect: "deny" }])).toEqual([])
+            const status = `Command exited with code 0.\nWorking directory: ${realpathSync(tmp.path)}`
             expect(yield* settleTool(registry, call({ command: "pwd" }))).toEqual({
               result: {
                 type: "content",
                 value: [
                   { type: "text", text: "hello\n" },
-                  { type: "text", text: "Command exited with code 0." },
+                  { type: "text", text: status },
                 ],
               },
               output: {
@@ -163,7 +164,7 @@ describe("BashTool", () => {
                 },
                 content: [
                   { type: "text", text: "hello\n" },
-                  { type: "text", text: "Command exited with code 0." },
+                  { type: "text", text: status },
                 ],
               },
             })
@@ -244,7 +245,10 @@ describe("BashTool", () => {
                   type: "content",
                   value: [
                     { type: "text", text: "core-bash" },
-                    { type: "text", text: "Command exited with code 0." },
+                    {
+                      type: "text",
+                      text: `Command exited with code 0.\nWorking directory: ${realpathSync(tmp.path)}`,
+                    },
                   ],
                 })
                 expect(settled.output?.structured).toMatchObject({

--- a/packages/opencode/src/tool/shell.ts
+++ b/packages/opencode/src/tool/shell.ts
@@ -582,6 +582,7 @@ export const ShellTool = Tool.define(
       if (meta.length > 0) {
         output += "\n\n<shell_metadata>\n" + meta.join("\n") + "\n</shell_metadata>"
       }
+      output += `\n\nWorking directory: ${input.cwd}`
       return {
         title: input.command,
         metadata: {

--- a/packages/opencode/test/tool/shell.test.ts
+++ b/packages/opencode/test/tool/shell.test.ts
@@ -194,6 +194,19 @@ describe("tool.shell", () => {
     ),
   )
 
+  it.live("reports the working directory in output", () =>
+    Effect.gen(function* () {
+      const tmp = yield* tmpdirScoped()
+      yield* runIn(
+        tmp,
+        Effect.gen(function* () {
+          const result = yield* run({ command: "true" })
+          expect(result.output).toContain(`Working directory: ${tmp}`)
+        }),
+      )
+    }),
+  )
+
   it.live("falls back from terminal-only configured shell", () =>
     Effect.gen(function* () {
       const tmp = yield* tmpdirScoped({ config: { shell: "fish" } })


### PR DESCRIPTION
### Issue for this PR

Closes #47308

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Each shell call runs in a fresh process with cwd reset to the instance directory, so `cd` does not persist across calls. The result never tells the model its working directory, so it infers location from `ls`/`pwd` output and can misread that as the directory changing between calls, looping on `pwd`/`ls` (seen with GLM 5.3 Flash and DeepSeek v4; same repetition family as #43800 and #45442).

This appends `Working directory: <cwd>` to the model-visible output of the active shell tool (`packages/opencode/src/tool/shell.ts`), giving the model a stable anchor. The same line is added to the V2 core bash tool (`packages/core/src/tool/bash.ts`) so the two implementations stay consistent as the V2 migration lands.

Related: #43003 describes the broader version of this (cwd + env + exit code not persisting/surfaced); this PR only addresses the working-directory half.

### How did you verify your code works?

- `bun test test/tool/shell.test.ts` in `packages/opencode` — 24 pass, including a new test asserting the line.
- `bun test test/tool-bash.test.ts` in `packages/core` — 11 pass.
- `bun typecheck` passes in both packages.
- To confirm interactively: `bun dev <dir>`, run any bash command, and the result ends with a `Working directory:` line.

### Screenshots / recordings

N/A (not a UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR