### PR TITLE
docs: add temporal context plugin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [opencode-temporal-context](https://github.com/samiralibabic/opencode-temporal-context)            | Add sparse calendar chronology and date-aware compaction guidance to long-running sessions         |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #47309

### Type of change

- [x] Documentation

### What does this PR do?

Adds `opencode-temporal-context` to the ecosystem Plugins table. The entry links to the public plugin repository and describes its sparse calendar-date context and date-aware compaction guidance.

### How did you verify your code works?

Ran:

`bunx prettier@3.6.2 --check packages/web/src/content/docs/ecosystem.mdx`

The plugin repository also passes TypeScript validation, 13 focused tests, and packed-plugin verification against OpenCode 1.18.27.

### Screenshots / recordings

Not applicable; this is a documentation-table-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR