### PR TITLE
fix(ai): tolerate out-of-band responses notifications

### DIFF
--- a/packages/ai/src/protocols/open-responses-channel.ts
+++ b/packages/ai/src/protocols/open-responses-channel.ts
@@ -113,8 +113,8 @@ const driver = (options: Options, body: string): WebSocketChannelDriver => {
           responseID = created
           return { type: "frame", frame }
         }
-        // Keepalives carry no response state and may arrive before response.created.
-        if (event.type === "keepalive") return { type: "frame", frame }
+        // Keepalives and provider notifications carry no response state and may precede response.created.
+        if (!event.type.startsWith("response.")) return { type: "frame", frame }
         if (!responseID)
           return yield* ProviderShared.eventError(
             options.id,

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -526,7 +526,7 @@ describe("OpenAI Responses route", () => {
     }),
   )
 
-  it.effect("tolerates keepalive frames before response.created", () =>
+  it.effect("tolerates keepalive and provider notifications before response.created", () =>
     Effect.gen(function* () {
       const webSocket = WebSocketTransport.makeDirect({
         open: () =>
@@ -534,6 +534,7 @@ describe("OpenAI Responses route", () => {
             sendText: () => Effect.void,
             messages: Stream.fromArray([
               ProviderShared.encodeJson({ type: "keepalive", sequence_number: 0 }),
+              ProviderShared.encodeJson({ type: "codex.rate_limits" }),
               ProviderShared.encodeJson({ type: "response.created", response: { id: "resp_alive" } }),
               ProviderShared.encodeJson({
                 type: "response.completed",


### PR DESCRIPTION
## Summary
- Accept out-of-band provider notifications before `response.created`, just as keepalive frames are already accepted. The existing parser ignores unknown notification types.
- Fixes live ChatGPT Responses WebSocket generation failing with `OpenAI Responses emitted codex.rate_limits before response.created`.
- Keep explicit error handling, response ordering/ID checks, and terminal/retry behavior unchanged. No subscription-specific runtime logic or Core changes.

## Validation
- Updated the existing keepalive regression with the observed notification: reproduced the exact failure before the fix, passed afterward.
- AI typecheck/build and tests: **1,003 passed, 28 skipped**.
- Existing Core transport tests: **40 passed**.
- Live Core SDK with ChatGPT OAuth, `gpt-5.4-mini`, and WebSockets enabled: received two `codex.rate_limits` notices, both requests completed correctly (`OK`, then the remembered marker), and the second request used incremental continuation. Used an isolated database/config and an existing access token without refreshing or switching live credentials.

This is a standalone prerequisite for the unpublished Core provider-compaction stack. It is for user review and manual merge; no auto-merge is enabled. Idle-socket notification handling is unchanged and was not observed as a failure in this probe.
