### PR TITLE
fix: use Node.js 22 in Nix dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         default = pkgs.mkShell {
           packages = with pkgs; [
             bun
-            nodejs_20
+            nodejs_22
             pkg-config
             openssl
             git


### PR DESCRIPTION
### Issue for this PR

Closes #47319

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates the Nix dev shell from Node.js 20 to Node.js 22.

The native postinstall invokes `node-gyp@13`, which no longer supports Node 20. Using Node.js 22 allows the same install to complete successfully.

### How did you verify your code works?

Ran with a clean Bun cache and confirmed that `bun install` fails with Node.js 20 and succeeds with Node.js 22.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR