### PR TITLE
feat(core): schedule provider compaction automatically

### DIFF
--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -192,7 +192,7 @@ export type ModelReasoningField = "reasoning" | "reasoning_content" | "reasoning
 
 export type ModelMaxTokensField = "max_completion_tokens" | "max_tokens"
 
-export type ProviderCompaction = { mode: "local" | "provider" }
+export type ProviderCompaction = { mode: "local" } | { mode: "provider"; threshold?: number }
 
 export type ModelCapabilities = {
   tools: boolean

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -688,27 +688,26 @@ export const layer = Layer.effect(
       // Run the completed checkpoint before considering another automatic compaction.
       const last = input.messages.at(-1)
       if (last?.type === "compaction" && last.status === "completed") return false
-      const native = input.messages.findLastIndex(
-        (message) => message.type === "compaction" && message.status === "completed" && message.providerContext,
-      )
       // Native usage describes the compaction operation, not the replacement's size. Wait for
       // a primary response to anchor the new window, including after restart or new admission.
-      if (native >= 0 && !input.messages.some((message, index) => index > native && hasInputUsage(message)))
+      if (
+        input.messages.findLastIndex(hasInputUsage) < input.messages.findLastIndex(SessionProviderContext.isCheckpoint)
+      )
         return false
       const limit = input.resolved.limit
       const context = limit.context
-      const policy = input.resolved.compaction
-      // Preserve local behavior. Provider policies can use a known input limit or an
-      // explicit threshold when the catalog has no context limit; no universal default.
-      if (context <= 0 && policy?.mode !== "provider") return false
+      if (context <= 0) return false
       const output = Math.min(limit.output, OUTPUT_TOKEN_MAX)
       const promptCeiling = Math.min(
         limit.input === undefined ? Number.POSITIVE_INFINITY : limit.input - config.buffer,
-        context <= 0 ? Number.POSITIVE_INFINITY : context - Math.max(output, config.buffer),
+        context - Math.max(output, config.buffer),
       )
+      const policy = input.resolved.compaction
       const threshold =
-        policy?.mode === "provider" ? Math.min(policy.threshold ?? Infinity, promptCeiling) : promptCeiling
-      return Number.isFinite(threshold) && estimateTokens(input) >= threshold
+        policy?.mode === "provider" && policy.threshold !== undefined
+          ? Math.min(policy.threshold, promptCeiling)
+          : promptCeiling
+      return estimateTokens(input) >= threshold
     }
     const compactManual = Effect.fn("SessionCompaction.compactManual")(function* (input: ManualInput) {
       if (findTailStart(input.messages, state.get().tokens) === undefined)

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -144,14 +144,14 @@ export interface Interface extends State.Transformable<Editor> {
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionCompaction") {}
 
+const hasInputUsage = (message: SessionMessage.Info) =>
+  message.type === "assistant" &&
+  !message.error &&
+  message.tokens !== undefined &&
+  message.tokens.input + message.tokens.cache.read + message.tokens.cache.write > 0
+
 export const estimateTokens = (input: RequiredInput) => {
-  const index = input.messages.findLastIndex(
-    (message) =>
-      message.type === "assistant" &&
-      !message.error &&
-      message.tokens !== undefined &&
-      message.tokens.input + message.tokens.cache.read + message.tokens.cache.write > 0,
-  )
+  const index = input.messages.findLastIndex(hasInputUsage)
   const last = input.messages[index]
   // Keep the anchor's local tool results: they are not covered by its provider usage.
   const added = SessionModelRequest.unsupportedParts(
@@ -693,18 +693,7 @@ export const layer = Layer.effect(
       )
       // Native usage describes the compaction operation, not the replacement's size. Wait for
       // a primary response to anchor the new window, including after restart or new admission.
-      if (
-        native >= 0 &&
-        !input.messages
-          .slice(native + 1)
-          .some(
-            (message) =>
-              message.type === "assistant" &&
-              !message.error &&
-              message.tokens &&
-              message.tokens.input + message.tokens.cache.read + message.tokens.cache.write > 0,
-          )
-      )
+      if (native >= 0 && !input.messages.some((message, index) => index > native && hasInputUsage(message)))
         return false
       const limit = input.resolved.limit
       const context = limit.context

--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -96,6 +96,8 @@ export type Editor = {
 export type AutoInput = {
   readonly context: SessionContext.Loaded
   readonly prepare: SessionModelRequest.Interface["prepare"]
+  /** Known overflow must recover from durable history, not submit the overflowing native window again. */
+  readonly overflow?: boolean
 }
 
 type RequiredInput = {
@@ -127,7 +129,10 @@ type ExecuteInput = AutoInput & {
 }
 
 export type Outcome =
-  | Pick<SessionMessage.CompactionCompleted, "status">
+  | (Pick<SessionMessage.CompactionCompleted, "status"> & {
+      /** Consumes the logical step's one overflow rebuild even when the native attempt overflowed first. */
+      readonly recoveredOverflow?: boolean
+    })
   | Pick<SessionMessage.CompactionFailed, "status" | "error">
 
 export interface Interface extends State.Transformable<Editor> {
@@ -442,6 +447,10 @@ export const layer = Layer.effect(
     }
     /** The durable transcript since the last local summary, re-expanding every native window. */
     const original = (sessionID: SessionSchema.ID) => SessionHistory.load(db, sessionID, "local").pipe(Effect.orDie)
+    const recoverLocally = (input: ExecuteInput) =>
+      original(input.context.session.id).pipe(
+        Effect.flatMap((messages) => execute({ ...input, context: { ...input.context, messages } })),
+      )
     const executeProvider = Effect.fn("SessionCompaction.executeProvider")(function* (input: ExecuteInput) {
       const context = input.context
       const reject = (message: string) =>
@@ -469,7 +478,7 @@ export const layer = Layer.effect(
       yield* started(input, "")
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          // One physical attempt, with no local-summary fallback or provider-error retry.
+          // One native physical attempt; only a known automatic overflow permits local recovery.
           const result = yield* restore(
             Effect.gen(function* () {
               if (LLMClient.canCompact(request, { mechanism: "trigger" })) {
@@ -503,13 +512,21 @@ export const layer = Layer.effect(
         }),
       ).pipe(
         Effect.onInterrupt(() => interrupted(input)),
-        Effect.catchTag("AI.Error", (cause) =>
-          failed({
-            sessionID: context.session.id,
-            reason: input.reason,
-            inputID: input.inputID,
-            error: toSessionError(cause),
-          }),
+        Effect.catchTag(
+          "AI.Error",
+          (cause): Effect.Effect<Outcome> =>
+            input.reason === "auto" && isContextOverflowFailure(cause)
+              ? recoverLocally({ ...input, started: true }).pipe(
+                  Effect.map((result) =>
+                    result.status === "completed" ? { ...result, recoveredOverflow: true } : result,
+                  ),
+                )
+              : failed({
+                  sessionID: context.session.id,
+                  reason: input.reason,
+                  inputID: input.inputID,
+                  error: toSessionError(cause),
+                }),
         ),
       )
     })
@@ -659,22 +676,50 @@ export const layer = Layer.effect(
       })
       return { status: "completed" as const }
     })
-    const compact = (input: AutoInput) => execute({ ...input, reason: "auto" })
+    const compact = Effect.fn("SessionCompaction.compact")(function* (input: AutoInput): Effect.fn.Return<Outcome> {
+      const request = { ...input, reason: "auto" as const }
+      if (input.overflow) return yield* recoverLocally(request)
+      if (input.context.model.compaction?.mode !== "provider") return yield* execute(request)
+      return yield* executeProvider(request)
+    })
     const required = (input: RequiredInput) => {
       const config = state.get()
       if (!config.auto) return false
       // Run the completed checkpoint before considering another automatic compaction.
       const last = input.messages.at(-1)
       if (last?.type === "compaction" && last.status === "completed") return false
+      const native = input.messages.findLastIndex(
+        (message) => message.type === "compaction" && message.status === "completed" && message.providerContext,
+      )
+      // Native usage describes the compaction operation, not the replacement's size. Wait for
+      // a primary response to anchor the new window, including after restart or new admission.
+      if (
+        native >= 0 &&
+        !input.messages
+          .slice(native + 1)
+          .some(
+            (message) =>
+              message.type === "assistant" &&
+              !message.error &&
+              message.tokens &&
+              message.tokens.input + message.tokens.cache.read + message.tokens.cache.write > 0,
+          )
+      )
+        return false
       const limit = input.resolved.limit
       const context = limit.context
-      if (context <= 0) return false
+      const policy = input.resolved.compaction
+      // Preserve local behavior. Provider policies can use a known input limit or an
+      // explicit threshold when the catalog has no context limit; no universal default.
+      if (context <= 0 && policy?.mode !== "provider") return false
       const output = Math.min(limit.output, OUTPUT_TOKEN_MAX)
       const promptCeiling = Math.min(
         limit.input === undefined ? Number.POSITIVE_INFINITY : limit.input - config.buffer,
-        context - Math.max(output, config.buffer),
+        context <= 0 ? Number.POSITIVE_INFINITY : context - Math.max(output, config.buffer),
       )
-      return estimateTokens(input) >= promptCeiling
+      const threshold =
+        policy?.mode === "provider" ? Math.min(policy.threshold ?? Infinity, promptCeiling) : promptCeiling
+      return Number.isFinite(threshold) && estimateTokens(input) >= threshold
     }
     const compactManual = Effect.fn("SessionCompaction.compactManual")(function* (input: ManualInput) {
       if (findTailStart(input.messages, state.get().tokens) === undefined)

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -203,7 +203,6 @@ const layer = Layer.effect(
       let initial: SessionContext.Loaded | undefined = first
       let recoverOverflow = true
       let recoverContinuation = true
-      let compacted = false
       while (true) {
         // Reuse boundary preparation once; retries refresh context without delivering more input.
         const loaded = initial ?? (yield* prepareContext(sessionID).pipe(Effect.flatMap(context.load)))
@@ -212,10 +211,9 @@ const layer = Layer.effect(
           context: loaded,
           prepare: context.prepare,
         }
-        if (!compacted && compaction.required({ messages: loaded.messages, resolved: loaded.model, context: loaded })) {
+        if (compaction.required({ messages: loaded.messages, resolved: loaded.model, context: loaded })) {
           const result = yield* compaction.compact(compactionInput)
           if (result.status !== "completed") return yield* new StepFailedError({ error: result.error })
-          compacted = true
           if (result.recoveredOverflow) recoverOverflow = false
           assistantMessageID = SessionMessage.ID.create()
           continue
@@ -284,7 +282,6 @@ const layer = Layer.effect(
           }),
           Compacted: Effect.fnUntraced(function* () {
             recoverOverflow = false
-            compacted = true
             assistantMessageID = SessionMessage.ID.create()
           }),
           RecoverFull: Effect.fnUntraced(function* () {

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -203,6 +203,7 @@ const layer = Layer.effect(
       let initial: SessionContext.Loaded | undefined = first
       let recoverOverflow = true
       let recoverContinuation = true
+      let compacted = false
       while (true) {
         // Reuse boundary preparation once; retries refresh context without delivering more input.
         const loaded = initial ?? (yield* prepareContext(sessionID).pipe(Effect.flatMap(context.load)))
@@ -211,9 +212,11 @@ const layer = Layer.effect(
           context: loaded,
           prepare: context.prepare,
         }
-        if (compaction.required({ messages: loaded.messages, resolved: loaded.model, context: loaded })) {
-          const compacted = yield* compaction.compact(compactionInput)
-          if (compacted.status !== "completed") return yield* new StepFailedError({ error: compacted.error })
+        if (!compacted && compaction.required({ messages: loaded.messages, resolved: loaded.model, context: loaded })) {
+          const result = yield* compaction.compact(compactionInput)
+          if (result.status !== "completed") return yield* new StepFailedError({ error: result.error })
+          compacted = true
+          if (result.recoveredOverflow) recoverOverflow = false
           assistantMessageID = SessionMessage.ID.create()
           continue
         }
@@ -256,7 +259,9 @@ const layer = Layer.effect(
           recoverContinuation,
           recoverOverflow: Effect.suspend(() =>
             recoverOverflow && compaction.enabled()
-              ? compaction.compact(compactionInput).pipe(Effect.map((result) => result.status === "completed"))
+              ? compaction
+                  .compact({ ...compactionInput, overflow: true })
+                  .pipe(Effect.map((result) => result.status === "completed"))
               : Effect.succeed(false),
           ),
         })
@@ -279,6 +284,7 @@ const layer = Layer.effect(
           }),
           Compacted: Effect.fnUntraced(function* () {
             recoverOverflow = false
+            compacted = true
             assistantMessageID = SessionMessage.ID.create()
           }),
           RecoverFull: Effect.fnUntraced(function* () {

--- a/packages/core/test/config/provider.test.ts
+++ b/packages/core/test/config/provider.test.ts
@@ -42,9 +42,11 @@ describe("ConfigProviderPlugin.Plugin", () => {
             providers: {
               custom: {
                 package: "@opencode-ai/ai/providers/openai/responses",
-                compaction: { mode: "provider" },
+                compaction: { mode: "provider", threshold: 120_000 },
                 models: {
                   native: {},
+                  reset: { compaction: { mode: "provider" } },
+                  threshold: { compaction: { mode: "provider", threshold: 90_000 } },
                   local: { compaction: { mode: "local" }, package: "@opencode-ai/ai/providers/openai/chat" },
                   unsupported: { package: "@opencode-ai/ai/providers/openai/chat" },
                 },
@@ -58,7 +60,14 @@ describe("ConfigProviderPlugin.Plugin", () => {
       const local = required(yield* catalog.model.get(Provider.ID.make("custom"), Model.ID.make("local")))
       const unsupported = required(yield* catalog.model.get(Provider.ID.make("custom"), Model.ID.make("unsupported")))
       const defaultModel = required(yield* catalog.model.get(Provider.ID.make("default"), Model.ID.make("chat")))
-      expect(native.compaction).toEqual({ mode: "provider" })
+      expect(native.compaction).toEqual({ mode: "provider", threshold: 120_000 })
+      expect((yield* catalog.model.get(Provider.ID.make("custom"), Model.ID.make("reset")))?.compaction).toEqual({
+        mode: "provider",
+      })
+      expect((yield* catalog.model.get(Provider.ID.make("custom"), Model.ID.make("threshold")))?.compaction).toEqual({
+        mode: "provider",
+        threshold: 90_000,
+      })
       expect(local.compaction).toEqual({ mode: "local" })
       expect(defaultModel.compaction).toBeUndefined()
       yield* ModelResolver.fromCatalogModel(native)

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -197,6 +197,22 @@ it.effect("auto compaction estimates current content against the buffered prompt
     const inputLimited = { context: 400_000, input: 272_000, output: 128_000 }
     expect(compaction.required(input(251_999, inputLimited))).toBe(false)
     expect(compaction.required(input(252_000, inputLimited))).toBe(true)
+    const native = (
+      tokens: number,
+      limit: { context: number; input?: number; output: number } = inputLimited,
+      threshold?: number,
+    ) => {
+      const selected = input(tokens, limit)
+      return { ...selected, resolved: { ...selected.resolved, compaction: { mode: "provider" as const, threshold } } }
+    }
+    expect(compaction.required(native(251_999))).toBe(false)
+    expect(compaction.required(native(252_000))).toBe(true)
+    expect(compaction.required(native(99_999, inputLimited, 100_000))).toBe(false)
+    expect(compaction.required(native(100_000, inputLimited, 100_000))).toBe(true)
+    expect(compaction.required(native(252_000, inputLimited, 500_000))).toBe(true)
+    expect(compaction.required(native(1_000_000, { context: 0, input: undefined, output: 0 }))).toBe(false)
+    expect(compaction.required(native(100_000, { context: 0, input: undefined, output: 0 }, 100_000))).toBe(true)
+    expect(compaction.required(native(80_000, { context: 0, input: 100_000, output: 0 }))).toBe(true)
 
     const contextLimited = { context: 100_000, output: 10_000 }
     expect(compaction.required(input(79_999, contextLimited))).toBe(false)

--- a/packages/core/test/session-compaction.test.ts
+++ b/packages/core/test/session-compaction.test.ts
@@ -210,9 +210,7 @@ it.effect("auto compaction estimates current content against the buffered prompt
     expect(compaction.required(native(99_999, inputLimited, 100_000))).toBe(false)
     expect(compaction.required(native(100_000, inputLimited, 100_000))).toBe(true)
     expect(compaction.required(native(252_000, inputLimited, 500_000))).toBe(true)
-    expect(compaction.required(native(1_000_000, { context: 0, input: undefined, output: 0 }))).toBe(false)
-    expect(compaction.required(native(100_000, { context: 0, input: undefined, output: 0 }, 100_000))).toBe(true)
-    expect(compaction.required(native(80_000, { context: 0, input: 100_000, output: 0 }))).toBe(true)
+    expect(compaction.required(native(1_000_000, { context: 0, input: undefined, output: 0 }, 100_000))).toBe(false)
 
     const contextLimited = { context: 100_000, output: 10_000 }
     expect(compaction.required(input(79_999, contextLimited))).toBe(false)

--- a/packages/core/test/session-native-compaction.test.ts
+++ b/packages/core/test/session-native-compaction.test.ts
@@ -54,7 +54,7 @@ const setup = Effect.fnUntraced(function* (endpoint = false) {
   const hooks = yield* PluginHooks.Service
   const blocked = Deferred.makeUnsafe<void>()
   const hanging = Promise.withResolvers<Response>()
-  const state = { failure: false, hang: false, calls: 0 }
+  const state = { failure: false, hang: false, overflow: false, localFailure: false, calls: 0 }
   const bodies: Record<string, unknown>[] = []
   const headers: Headers[] = []
   const server = yield* Effect.acquireRelease(
@@ -79,6 +79,18 @@ const setup = Effect.fnUntraced(function* (endpoint = false) {
               { error: { message: "fixture rate limit", type: "rate_limit_error" } },
               { status: 429 },
             )
+          const trigger = JSON.stringify(bodies.at(-1)).includes("compaction_trigger")
+          if (state.overflow && (trigger || state.localFailure))
+            return Response.json(
+              {
+                error: {
+                  message: "Your input exceeds the context window",
+                  code: "context_length_exceeded",
+                  type: "invalid_request_error",
+                },
+              },
+              { status: 400 },
+            )
           const checkpoint = {
             type: "compaction",
             id: `cmp_${state.calls}`,
@@ -94,9 +106,27 @@ const setup = Effect.fnUntraced(function* (endpoint = false) {
               ],
               usage: { input_tokens: 20, output_tokens: 4, total_tokens: 24 },
             })
-          const output = JSON.stringify(bodies.at(-1)).includes("compaction_trigger") ? [checkpoint] : []
+          const output = trigger ? [checkpoint] : []
+          const summary = state.overflow
+            ? [
+                {
+                  type: "response.output_item.added",
+                  output_index: 0,
+                  item: { type: "message", id: "summary", role: "assistant", content: [] },
+                },
+                {
+                  type: "response.output_text.delta",
+                  item_id: "summary",
+                  output_index: 0,
+                  content_index: 0,
+                  delta: "## Objective\n- Recovered locally",
+                },
+              ]
+                .map((event) => `data: ${JSON.stringify(event)}\n\n`)
+                .join("")
+            : ""
           return new Response(
-            `data: ${JSON.stringify({
+            `${summary}data: ${JSON.stringify({
               type: "response.completed",
               response: {
                 id: `resp_${state.calls}`,
@@ -210,6 +240,9 @@ const setup = Effect.fnUntraced(function* (endpoint = false) {
   })
   return {
     compact,
+    automatic: Effect.gen(function* () {
+      return yield* compaction.compact({ context: yield* load, prepare: requests.prepare })
+    }),
     checkpoint,
     prompt,
     load,
@@ -292,6 +325,45 @@ it.live("endpoint-only compaction keeps the provider replacement unchanged", () 
     expect(fixture.state.calls).toBe(1)
     expect(fixture.headers[0]?.get("x-http-hook")).toBe("compaction")
     expect(fixture.bodies[0]).not.toHaveProperty("context_management")
+  }),
+)
+
+it.live("only known automatic native overflow falls back locally and failed recovery retains the checkpoint", () =>
+  Effect.gen(function* () {
+    const fixture = yield* setup()
+    yield* fixture.prompt("Original durable request")
+    expect(yield* fixture.compact).toEqual({ status: "completed" })
+    const installed = yield* fixture.checkpoint
+    yield* fixture.prompt("Recent request")
+    fixture.state.failure = true
+    expect(yield* fixture.automatic).toMatchObject({ status: "failed", error: { type: "provider.rate-limit" } })
+    expect(fixture.state.calls).toBe(2)
+    expect(yield* fixture.checkpoint).toEqual(installed)
+    fixture.state.failure = false
+    fixture.state.hang = true
+    const pending = yield* fixture.automatic.pipe(Effect.forkScoped)
+    yield* Deferred.await(fixture.blocked)
+    yield* Fiber.interrupt(pending)
+    expect((yield* fixture.load).messages.at(-1)).toMatchObject({
+      type: "compaction",
+      status: "failed",
+      error: { type: "compaction.interrupted" },
+    })
+    expect(yield* fixture.checkpoint).toEqual(installed)
+    fixture.state.hang = false
+    fixture.state.overflow = true
+    fixture.state.localFailure = true
+    expect(yield* fixture.automatic).toMatchObject({ status: "failed" })
+    expect(fixture.state.calls).toBe(5)
+    expect(yield* fixture.checkpoint).toEqual(installed)
+    expect(JSON.stringify(fixture.bodies[4])).toContain("Original durable request")
+    expect(JSON.stringify(fixture.bodies[4])).not.toContain("encrypted_1")
+    fixture.state.localFailure = false
+    expect(yield* fixture.automatic).toEqual({ status: "completed", recoveredOverflow: true })
+    expect(fixture.state.calls).toBe(7)
+    expect((yield* fixture.load).messages).toContainEqual(
+      expect.objectContaining({ type: "compaction", summary: "## Objective\n- Recovered locally" }),
+    )
   }),
 )
 

--- a/packages/core/test/session-native-compaction.test.ts
+++ b/packages/core/test/session-native-compaction.test.ts
@@ -314,15 +314,16 @@ it.live(
   15000,
 )
 
-it.live("endpoint-only compaction keeps the provider replacement unchanged", () =>
+it.live("manual and automatic endpoint compaction keep the provider replacement unchanged", () =>
   Effect.gen(function* () {
     const fixture = yield* setup(true)
     yield* fixture.prompt("Original user")
     expect(yield* fixture.compact).toEqual({ status: "completed" })
+    expect(yield* fixture.automatic).toEqual({ status: "completed" })
     const replacement = SessionProviderContext.decode(yield* fixture.checkpoint)
     expect(replacement[0]?.content).toEqual([Message.text("endpoint retained")])
     expect(JSON.stringify(replacement)).not.toContain("Original user")
-    expect(fixture.state.calls).toBe(1)
+    expect(fixture.state.calls).toBe(2)
     expect(fixture.headers[0]?.get("x-http-hook")).toBe("compaction")
     expect(fixture.bodies[0]).not.toHaveProperty("context_management")
   }),

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   AIError,
   CompactionPart,
+  CompactionCheckpointResponse,
   HttpContext,
   LLMEvent,
   LLMRequest,
@@ -194,7 +195,7 @@ test("does not apply an ineligible tier without base pricing", () => {
   ).toBe(Money.USD.zero)
 })
 
-const makeRunnerState = () => {
+const makeRunnerState = (compaction?: SessionRunnerModel.Resolved["compaction"]) => {
   let toolBarrier: ToolBarrier | undefined
   const releaseTools = (barrier: ToolBarrier) =>
     Effect.sync(() => {
@@ -202,6 +203,7 @@ const makeRunnerState = () => {
     }).pipe(Effect.andThen(Deferred.succeed(barrier.release, undefined)), Effect.asVoid)
   return {
     currentModel: model,
+    compaction,
     modelResolveHook: Effect.void,
     systemBaseline: "Initial context",
     systemRemoved: false,
@@ -321,6 +323,7 @@ const layer = Layer.unwrap(
               cost: [],
               limit: modelLimits.get(String(selected.id)) ?? defaultModelLimit,
               variant: session.model?.variant,
+              compaction: state.compaction,
             })
           }),
         ),
@@ -2764,6 +2767,88 @@ describe("SessionRunnerLLM", () => {
       summary: "## Objective\n- Preserve the updated task",
       recent: `[User]: ${"Newest exact request ".repeat(180)}`,
     })
+  })
+
+  scenario("automatically persists native windows, retains earlier users, and waits for fresh usage", function* (s) {
+    s.currentModel = LanguageModel.make({ id: "native", provider: "openai", route: OpenAIResponses.route })
+    s.compaction = { mode: "provider", threshold: 10_000 }
+    const agents = yield* Agent.Service
+    yield* agents.transform((editor) =>
+      editor.update(Agent.defaultID, (agent) => {
+        agent.steps = 2
+      }),
+    )
+    yield* s.llm.push(TestLLM.textWithUsage("Earlier answer", "before-native", 10_000))
+    yield* s.runPrompt("First real request")
+    const checkpoint = (encrypted: string) =>
+      CompactionCheckpointResponse.make({
+        responseID: `resp_${encrypted}`,
+        checkpoint: { type: "compaction", provider: s.currentModel.provider, encrypted },
+      })
+    yield* s.llm.push(
+      checkpoint("first"),
+      TestLLM.tool("echo-native", "echo", { text: "continue" }),
+      TestLLM.text("No usage yet", "no-usage"),
+    )
+    yield* s.runPrompt("Second real request")
+    expect(s.requests).toHaveLength(4)
+    expect(s.requests[2].toolChoice).not.toEqual({ type: "none" })
+    expect(s.executions).toEqual(["continue"])
+    expect(JSON.stringify(s.requests[2].messages)).toContain("first")
+    const installed = (yield* s.messages).filter((message) => message.type === "compaction")
+    expect(installed).toMatchObject([{ status: "completed", reason: "auto", providerContext: { version: 1 } }])
+    // New input without a post-checkpoint usage anchor must not retrigger compaction.
+    yield* s.llm.push(TestLLM.textWithUsage("Measured", "measured", 10_000))
+    yield* s.runPrompt("Third real request")
+    expect(s.requests).toHaveLength(5)
+    yield* s.llm.push(checkpoint("second"), TestLLM.textWithUsage("Continued", "continued", 10_000))
+    yield* s.runPrompt("Fourth real request")
+    expect(s.requests).toHaveLength(7)
+    expect(userTexts(s.requests[6])).toEqual([
+      "First real request",
+      "Second real request",
+      "Third real request",
+      "Fourth real request",
+    ])
+    expect(JSON.stringify(s.requests[6].messages)).not.toContain('"encrypted":"first"')
+    const compaction = yield* SessionCompaction.Service
+    yield* compaction.transform((editor) => editor.configure({ auto: false }))
+    yield* replaySessionProjection(sessionID)
+    yield* s.llm.push(TestLLM.text("Disabled auto still replays", "disabled"))
+    yield* s.runPrompt("Fifth real request")
+    expect(s.requests).toHaveLength(8)
+    expect(JSON.stringify(s.requests[7].messages)).toContain('"encrypted":"second"')
+  })
+
+  scenario("recovers an overflowing native window locally from original durable history", function* (s) {
+    s.currentModel = LanguageModel.make({ id: "native", provider: "openai", route: OpenAIResponses.route })
+    s.compaction = { mode: "provider", threshold: 10_000 }
+    yield* s.llm.push(TestLLM.textWithUsage("Earlier answer", "before-native", 10_000))
+    yield* s.runPrompt("Original durable request")
+    yield* s.llm.push(
+      CompactionCheckpointResponse.make({
+        responseID: "resp_native",
+        checkpoint: { type: "compaction", provider: s.currentModel.provider, encrypted: "native-window" },
+      }),
+      TestLLM.text("After native", "after-native"),
+    )
+    yield* s.runPrompt("Before native checkpoint")
+    s.requests.length = 0
+    yield* s.llm.push(
+      [LLMEvent.providerError({ message: "prompt too long", classification: "context-overflow" })],
+      TestLLM.text("## Objective\n- Recovered original history", "local-recovery"),
+      TestLLM.text("Recovered", "recovered"),
+    )
+    yield* s.runPrompt("Overflow request")
+    expect(s.requests).toHaveLength(3)
+    expect(JSON.stringify(s.requests[0].messages)).toContain("native-window")
+    expect(JSON.stringify(s.requests[1].messages)).not.toContain("native-window")
+    expect(userTexts(s.requests[1])).toContain("Original durable request")
+    expect(userTexts(s.requests[1]).at(-1)).toBe(SessionCompaction.buildPrompt(false))
+    expect(yield* s.context).toMatchObject([
+      { type: "compaction", summary: "## Objective\n- Recovered original history" },
+      { type: "assistant" },
+    ])
   })
 
   scenario("does not compact immediately when the advertised output limit fills the context", function* (s) {

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -17375,15 +17375,34 @@
         "additionalProperties": false
       },
       "Provider.Compaction": {
-        "type": "object",
-        "properties": {
-          "mode": {
-            "type": "string",
-            "enum": ["local", "provider"]
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["local"]
+              }
+            },
+            "required": ["mode"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["provider"]
+              },
+              "threshold": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["mode"],
+            "additionalProperties": false
           }
-        },
-        "required": ["mode"],
-        "additionalProperties": false
+        ]
       },
       "Provider.Info": {
         "type": "object",

--- a/packages/schema/src/provider.ts
+++ b/packages/schema/src/provider.ts
@@ -2,7 +2,7 @@ export * as Provider from "./provider.js"
 
 import { Effect, Schema } from "effect"
 import { Integration } from "./integration.js"
-import { optional, statics } from "./schema.js"
+import { optional, PositiveInt, statics } from "./schema.js"
 
 export const ID = Schema.String.pipe(
   Schema.brand("Provider.ID"),
@@ -28,10 +28,11 @@ export type Package = typeof Package.Type
 export const Activation = Schema.Literals(["auto", "enabled", "disabled"])
 export type Activation = typeof Activation.Type
 
-export interface Compaction extends Schema.Schema.Type<typeof Compaction> {}
-export const Compaction = Schema.Struct({
-  mode: Schema.Literals(["local", "provider"]),
-}).annotate({ identifier: "Provider.Compaction" })
+export type Compaction = typeof Compaction.Type
+export const Compaction = Schema.Union([
+  Schema.Struct({ mode: Schema.Literal("local") }),
+  Schema.Struct({ mode: Schema.Literal("provider"), threshold: PositiveInt.pipe(optional) }),
+]).annotate({ identifier: "Provider.Compaction" })
 
 export const Overlays = {
   settings: Schema.Record(Schema.String, Schema.Any).pipe(optional),

--- a/packages/schema/test/model.test.ts
+++ b/packages/schema/test/model.test.ts
@@ -63,6 +63,15 @@ describe("Model.Info", () => {
       mode: "provider",
     })
     expect(Schema.decodeUnknownSync(Provider.Compaction)({ mode: "local" })).toEqual({ mode: "local" })
+    expect(Schema.encodeSync(Provider.Compaction)({ mode: "provider", threshold: undefined })).toEqual({
+      mode: "provider",
+    })
+    expect(Schema.decodeUnknownSync(Provider.Compaction)({ mode: "provider", threshold: 120_000 })).toEqual({
+      mode: "provider",
+      threshold: 120_000,
+    })
+    for (const threshold of [0, -1, 1.5])
+      expect(() => Schema.decodeUnknownSync(Provider.Compaction)({ mode: "provider", threshold })).toThrow()
     expect(() => Schema.decodeUnknownSync(Provider.Compaction)({ mode: "automatic" })).toThrow()
   })
 

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -17375,15 +17375,34 @@
         "additionalProperties": false
       },
       "Provider.Compaction": {
-        "type": "object",
-        "properties": {
-          "mode": {
-            "type": "string",
-            "enum": ["local", "provider"]
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["local"]
+              }
+            },
+            "required": ["mode"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["provider"]
+              },
+              "threshold": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["mode"],
+            "additionalProperties": false
           }
-        },
-        "required": ["mode"],
-        "additionalProperties": false
+        ]
       },
       "Provider.Info": {
         "type": "object",

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -17375,15 +17375,34 @@
         "additionalProperties": false
       },
       "Provider.Compaction": {
-        "type": "object",
-        "properties": {
-          "mode": {
-            "type": "string",
-            "enum": ["local", "provider"]
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["local"]
+              }
+            },
+            "required": ["mode"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "mode": {
+                "type": "string",
+                "enum": ["provider"]
+              },
+              "threshold": {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            },
+            "required": ["mode"],
+            "additionalProperties": false
           }
-        },
-        "required": ["mode"],
-        "additionalProperties": false
+        ]
       },
       "Provider.Info": {
         "type": "object",

--- a/packages/www/src/docs/content/compaction.mdx
+++ b/packages/www/src/docs/content/compaction.mdx
@@ -18,18 +18,19 @@ the size of the final system prompt, messages, and advertised tools. It starts
 compaction when:
 
 ```text
-estimated tokens > context limit - max(requested output tokens, buffer)
+estimated tokens >= min(input limit - buffer, context limit - max(output reserve, buffer))
 ```
 
-The estimate is approximate: V2 JSON-serializes the request and assumes four
-characters per token. When compaction succeeds, V2 rebuilds the request from
-the new checkpoint and retries the step without promoting the input again.
+The estimate uses the latest model response's input usage plus output and newer
+content. Without usage, it estimates text, media, instructions, and tools locally.
+The output reserve is capped at 32,000 tokens; an absent input limit does not
+constrain the ceiling. Successful compaction rebuilds the request without promoting
+input again or spending another agent step.
 
 V2 also recognizes provider errors classified as context overflow. If an
 overflow occurs before the provider produces assistant output or other retry
 evidence, V2 can compact and retry that step once. This recovery is attempted
-even when `auto` is `false`; `auto` controls only the preflight size check. A
-second overflow after recovery is returned as an error.
+only when `auto` is enabled. A second overflow after recovery is returned as an error.
 
 ## Manual compaction
 
@@ -75,19 +76,20 @@ Add `compaction` to any [OpenCode configuration file](/config):
 preserves more recent detail but leaves less room for future work. Larger
 `buffer` triggers preflight compaction earlier.
 
-## Provider compaction (manual)
+## Provider compaction
 
 By default, compaction generates a local text summary. To use the selected
-provider's native compaction operation for manual requests, set a provider policy.
-An individual model's policy overrides it:
+provider's native compaction operation for automatic and manual requests, set a
+provider policy. An individual model's policy replaces the entire provider policy:
 
 ```jsonc title="opencode.jsonc"
 {
   "$schema": "https://opencode.ai/config.json",
   "providers": {
     "openai": {
-      "compaction": { "mode": "provider" },
+      "compaction": { "mode": "provider", "threshold": 120000 },
       "models": {
+        "gpt-5.4-mini": { "compaction": { "mode": "provider" } },
         "gpt-4.1": { "compaction": { "mode": "local" } },
       },
     },
@@ -95,11 +97,25 @@ An individual model's policy overrides it:
 }
 ```
 
-- Automatic and overflow compaction still use local summaries. This policy only
-  changes manual compaction; it does not enable in-band provider context management.
+- `threshold` is an optional positive integer in provider mode. Omit it to use the
+  selected model's usable input ceiling above. A configured threshold is clamped
+  to that ceiling. In this example, `gpt-5.4-mini` uses its own ceiling, not 120,000.
+- With unknown context limits, a known input limit still supplies a ceiling. With
+  neither limit, automatic provider compaction requires an explicit threshold;
+  there is no universal token default. Manual compaction remains available.
+- Scheduling uses the normal safe session step boundaries, not in-band provider
+  context management. `compaction.auto: false` disables all new automatic work.
+- After installing a native checkpoint, automatic checks wait for a fresh model
+  usage anchor. Encrypted checkpoint bytes are not a meaningful token count.
 - OpenAI Responses uses a streamed compaction trigger when the route supports it.
   Endpoint-only routes use their standalone compaction endpoint. Deployment/model
-  support can vary; provider errors are returned without a retry or local fallback.
+  support can vary; native operations make one attempt without generic retries.
+- A known automatic context overflow uses local recovery over the durable original
+  history, re-expanding native checkpoints. This applies both to ordinary model
+  calls and native compaction rejection. If local recovery fails, the prior
+  checkpoint remains intact and the error surfaces. Authentication, rate limits,
+  cancellation, and other failures do not trigger local fallback. Manual native
+  compaction also surfaces errors without fallback.
 - Unsupported routes are rejected during model resolution. Configure custom
   endpoints through provider/model `settings.baseURL`, not a `model.request` hook;
   native compaction rejects endpoint rewrites by that hook.
@@ -156,7 +172,8 @@ read. See [Instructions](/instructions) for source ordering and update behavior.
 
 ## Current limitations
 
-- Compaction requires a resolvable model with a positive catalog context limit.
+- Compaction requires a resolvable model. Default local automatic scheduling needs
+  a positive catalog context limit; manual and overflow recovery do not.
   There is no separate compaction-model setting or fallback model.
 - Summary generation can fail if the summary prompt itself cannot fit beside
   its output allowance, the model returns no summary, or the provider fails.

--- a/packages/www/src/docs/content/compaction.mdx
+++ b/packages/www/src/docs/content/compaction.mdx
@@ -100,9 +100,6 @@ provider policy. An individual model's policy replaces the entire provider polic
 - `threshold` is an optional positive integer in provider mode. Omit it to use the
   selected model's usable input ceiling above. A configured threshold is clamped
   to that ceiling. In this example, `gpt-5.4-mini` uses its own ceiling, not 120,000.
-- With unknown context limits, a known input limit still supplies a ceiling. With
-  neither limit, automatic provider compaction requires an explicit threshold;
-  there is no universal token default. Manual compaction remains available.
 - Scheduling uses the normal safe session step boundaries, not in-band provider
   context management. `compaction.auto: false` disables all new automatic work.
 - After installing a native checkpoint, automatic checks wait for a fresh model
@@ -123,6 +120,8 @@ provider policy. An individual model's policy replaces the entire provider polic
   `compaction.tokens` budget, including users retained across earlier native
   compactions. Synthetic guidance is not retained as user input. Endpoint results
   are stored as the provider returned them. Neither path fabricates a text summary.
+  Keep `threshold` comfortably above `tokens` plus the system prompt and tools, or
+  every step will compact again as soon as the next response reports usage.
 - Successful native checkpoints advance the instruction epoch and are replayed
   only with a matching provider, model, protocol, and endpoint. Switching to an
   incompatible route reuses an earlier compatible checkpoint or retained transcript.
@@ -172,8 +171,8 @@ read. See [Instructions](/instructions) for source ordering and update behavior.
 
 ## Current limitations
 
-- Compaction requires a resolvable model. Default local automatic scheduling needs
-  a positive catalog context limit; manual and overflow recovery do not.
+- Compaction requires a resolvable model. Automatic scheduling needs a positive
+  catalog context limit; manual and overflow recovery do not.
   There is no separate compaction-model setting or fallback model.
 - Summary generation can fail if the summary prompt itself cannot fit beside
   its output allowance, the model returns no summary, or the provider fails.

--- a/packages/www/src/docs/content/config.mdx
+++ b/packages/www/src/docs/content/config.mdx
@@ -354,7 +354,27 @@ Control automatic context compaction and how much recent context it preserves.
 }
 ```
 
-See the [compaction guide](/compaction) for automatic context management.
+Local summaries remain the default. Opt into native provider compaction for both
+automatic and manual requests with a provider or model policy:
+
+```jsonc
+{
+  "providers": {
+    "openai": {
+      "compaction": { "mode": "provider", "threshold": 120000 },
+      "models": {
+        "gpt-4.1": { "compaction": { "mode": "local" } },
+      },
+    },
+  },
+}
+```
+
+A model policy replaces the whole provider policy. The optional positive integer
+`threshold` defaults to the selected model's usable input budget and cannot exceed
+its safe ceiling. Top-level `compaction.auto: false` disables new automatic
+compaction without discarding installed checkpoints. See the
+[compaction guide](/compaction) for budgeting and overflow recovery.
 
 ### Session warming
 

--- a/packages/www/src/docs/content/config.mdx
+++ b/packages/www/src/docs/content/config.mdx
@@ -372,9 +372,11 @@ automatic and manual requests with a provider or model policy:
 
 A model policy replaces the whole provider policy. The optional positive integer
 `threshold` defaults to the selected model's usable input budget and cannot exceed
-its safe ceiling. Top-level `compaction.auto: false` disables new automatic
-compaction without discarding installed checkpoints. See the
-[compaction guide](/compaction) for budgeting and overflow recovery.
+its safe ceiling. Provider checkpoints keep recent user messages within the same
+`compaction.tokens` budget that local summaries use for their retained tail.
+Top-level `compaction.auto: false` disables new automatic compaction without
+discarding installed checkpoints. See the [compaction guide](/compaction) for
+budgeting and overflow recovery.
 
 ### Session warming
 


### PR DESCRIPTION
## Summary
- Enable automatic provider compaction at the existing safe Session boundaries when provider mode is selected. Add optional positive `threshold`, clamped to the model's usable input ceiling; omitted thresholds use that ceiling. Like local scheduling, automatic provider scheduling needs a positive catalog context limit.
- Keep `compaction.auto: false` authoritative for new automatic work while preserving installed native context. Wait for fresh primary usage after a native checkpoint before scheduling again.
- Recover classified automatic context overflow through existing local compaction over the original durable history (`SessionHistory.load(..., "local")`). Do not fall back for authentication, rate limits, cancellation, arbitrary failures, or manual native errors.
- Update configuration documentation and generated contracts.

Third layer of the Core provider-compaction stack.

## Validation
- Core suite via `bun run test`: 5,235 passed, 35 skipped; Core/Schema/Protocol/Server/Client/SDK/TUI/Session UI/UI typechecks passed.
- Live end-to-end runs through an isolated V2 server (`providers.openai.compaction: { mode: "provider", threshold: 10000 }`, `gpt-5.4-mini`) with both an API-key connection and a ChatGPT credential: automatic compaction fired at the step boundary with `reason: "auto"` and an installed `providerContext`, the runner waited for a fresh usage anchor before compacting again, manual `/compact` worked on top of the installed window, and a fact from before the checkpoints was recalled afterwards. Server logs contained no warnings or errors.
- Default HTTP/SSE transport was exercised throughout; the opt-in WebSocket channel is unchanged by this layer.
