### PR TITLE
docs(web): list Universal Agent Plugins in ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [Universal Agent Plugins](https://github.com/777genius/universal-agent-plugins)          | Install, update, and remove portable skills and MCP configs for OpenCode and other agents |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #47327. Replaces #23418, which was automatically closed for missing template sections.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds one entry for Universal Agent Plugins under Ecosystem > Projects, using the current repository URL. I maintain the project. It manages portable skills and MCP configurations for OpenCode and other agents; it is not an OpenCode JavaScript plugin.

### How did you verify your code works?

Checked locally that the diff adds exactly one two-column row and preserves the rest of the page. Verified the repository link and rendered the table through GitHub's Markdown API. No application code changed; the full docs build was not run.

### Screenshots / recordings

Not applicable: one documentation table entry, no application UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
