### PR TITLE
fix(app): let long model, agent and variant names truncate in the composer footer

### DIFF
--- a/packages/app/e2e/regression/prompt-controls-narrow.spec.ts
+++ b/packages/app/e2e/regression/prompt-controls-narrow.spec.ts
@@ -1,0 +1,87 @@
+import { expect, test } from "@playwright/test"
+import { base64Encode } from "@opencode-ai/core/util/encode"
+import { mockOpenCodeServer } from "../utils/mock-server"
+import { expectAppVisible } from "../utils/waits"
+
+// Regression for #43295: on a narrow viewport the V2 composer's agent / model / variant controls used to run under
+// the send button. The controls must stay inside the composer and clear of the button; long labels ellipsize.
+const directory = "C:/OpenCode/PromptControlsNarrowRegression"
+const projectID = "proj_prompt_controls_narrow_regression"
+const sessionID = "ses_prompt_controls_narrow_regression"
+
+test("keeps the V2 prompt controls clear of the send button on a narrow viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 800 })
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: projectID,
+      worktree: directory,
+      vcs: "git",
+      name: "prompt-controls-narrow-regression",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [],
+    },
+    provider: {
+      all: [
+        {
+          id: "opencode",
+          name: "OpenCode",
+          models: {
+            "long-name-model": {
+              id: "long-name-model",
+              name: "A Deliberately Long Model Display Name For Narrow Layouts",
+              limit: { context: 200_000 },
+              variants: { high: {} },
+            },
+          },
+        },
+      ],
+      connected: ["opencode"],
+      default: { providerID: "opencode", modelID: "long-name-model" },
+    },
+    sessions: [
+      {
+        id: sessionID,
+        slug: "prompt-controls-narrow-regression",
+        projectID,
+        directory,
+        title: "Prompt controls narrow regression",
+        version: "dev",
+        time: { created: 1700000000000, updated: 1700000000000 },
+      },
+    ],
+    pageMessages: () => ({ items: [] }),
+  })
+  await page.addInitScript(() => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+  })
+
+  await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
+  const composer = page.locator('[data-component="prompt-input-v2"]')
+  await expectAppVisible(composer)
+
+  const controls = composer.locator('[data-slot="prompt-controls"]')
+  const submit = composer.locator('[data-action="prompt-submit"]')
+  const model = composer.locator('[data-action="prompt-model"]')
+  const variant = composer.getByRole("button", { name: "Choose model variant" })
+  await expect(submit).toBeVisible()
+  await expect(model).toBeVisible()
+  await expect(variant).toBeVisible()
+
+  const [controlsBox, submitBox, modelBox, variantBox] = await Promise.all([
+    controls.boundingBox(),
+    submit.boundingBox(),
+    model.boundingBox(),
+    variant.boundingBox(),
+  ])
+  expect(controlsBox).not.toBeNull()
+  expect(submitBox).not.toBeNull()
+  expect(modelBox).not.toBeNull()
+  expect(variantBox).not.toBeNull()
+
+  // the whole controls row ends where the send button starts, and nothing pokes past the viewport
+  expect(controlsBox!.x + controlsBox!.width).toBeLessThanOrEqual(submitBox!.x + 1)
+  expect(variantBox!.x + variantBox!.width).toBeLessThanOrEqual(submitBox!.x + 1)
+  expect(modelBox!.x + modelBox!.width).toBeLessThanOrEqual(submitBox!.x + 1)
+  expect(submitBox!.x + submitBox!.width).toBeLessThanOrEqual(320)
+})

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -491,7 +491,7 @@ function PromptInputV2ModelControl(props: {
           />
         )}
       </Show>
-      <span class="truncate leading-4">{props.modelName}</span>
+      <span class="min-w-0 truncate leading-4">{props.modelName}</span>
       <span class="-ml-0.5 -mr-1 flex shrink-0">
         <Icon name="chevron-down" />
       </span>
@@ -502,6 +502,7 @@ function PromptInputV2ModelControl(props: {
       <TooltipV2
         placement="top"
         gutter={4}
+        class="min-w-0"
         value={
           <>
             {props.title}

--- a/packages/app/src/components/prompt-input.tsx
+++ b/packages/app/src/components/prompt-input.tsx
@@ -1707,7 +1707,7 @@ export const PromptInput: Component<PromptInputProps> = (props) => {
                                   style={{ "will-change": "opacity", transform: "translateZ(0)" }}
                                 />
                               </Show>
-                              <span class="truncate">
+                              <span class="min-w-0 truncate">
                                 {props.controls.model.selection.current()?.name ??
                                   language.t("dialog.model.select.title")}
                               </span>

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -561,6 +561,7 @@ export function PromptInputV2Select(props: {
   return (
     <TooltipV2
       placement="top"
+      class="min-w-0"
       value={
         <>
           {props.title}
@@ -573,11 +574,11 @@ export function PromptInputV2Select(props: {
           as={ButtonV2}
           variant="ghost-muted"
           size="normal"
-          class={`max-w-[220px] justify-start ![font-weight:440] ${props.class ?? ""}`}
+          class={`min-w-0 max-w-[220px] justify-start ![font-weight:440] ${props.class ?? ""}`}
           aria-label={props.title}
         >
           {props.currentIcon}
-          <span class="truncate capitalize leading-5">
+          <span class="min-w-0 truncate capitalize leading-5">
             {props.options.find((option) => option.id === props.current)?.label ?? props.current}
           </span>
           <span class="-ms-0.5 -me-1 flex shrink-0">

--- a/packages/session-ui/src/v2/components/prompt-input/index.tsx
+++ b/packages/session-ui/src/v2/components/prompt-input/index.tsx
@@ -197,6 +197,7 @@ export function PromptInputV2(props: PromptInputV2Props) {
 
         <div class="flex h-11 items-center px-2">
           <div
+            data-slot="prompt-controls"
             class="flex min-w-0 flex-1 items-center gap-1"
             aria-hidden={state.mode === "shell"}
             inert={state.mode === "shell" ? true : undefined}


### PR DESCRIPTION
### Issue for this PR
Closes #43295

### Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?
On a phone the V2 composer footer (agent / model / variant) runs under the send button when the model has a longer display name: the row is a flex row, and none of the controls can get narrower than their text, so the last one is pushed under the button.

Every control already renders its label in a `truncate` span, but that span sits inside an inline-flex button, which sits inside the TooltipV2 trigger div (`display: flex`). Flex items default to `min-width: auto`, so at each of those three levels the box refuses to shrink below its content and `truncate` never gets to act.

The change is `min-w-0` at those levels: the label spans, the shared agent/variant trigger button (it had `max-w-[220px]` without a `min-w`), and the tooltip trigger wrapper around the model control and the configured selects. With that the labels ellipsize instead of overflowing, and nothing changes on wide viewports. 3 files, +6/-4.

### How did you verify your code works?
- Built `dev` (1.18.28) with the patch, ran it on an Android phone (~412 px): the variant control no longer sits under the send button; the model name ellipsizes first.
- Headless Chromium at 360 px, measuring `getBoundingClientRect` of the footer controls before/after: before, the variant control spanned x 303–385 (past the viewport, under the send button at x 291); after, Build 73–120, model 124–230, variant 234–291, send button 291–319.
- Qwen and GLM sessions work as before (the change is CSS classes only).

### Screenshots / recordings
Phone, before / after:

<img src="https://raw.githubusercontent.com/Capicua25x/opencode/pr-assets/composer-overflow/phone-before.jpg" width="300"> <img src="https://raw.githubusercontent.com/Capicua25x/opencode/pr-assets/composer-overflow/phone-after.jpg" width="300">

Headless Chromium at 360 px, before / after:

<img src="https://raw.githubusercontent.com/Capicua25x/opencode/pr-assets/composer-overflow/headless-360-before.png" width="300"> <img src="https://raw.githubusercontent.com/Capicua25x/opencode/pr-assets/composer-overflow/headless-360-after.png" width="300">

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
