### PR TITLE
fix(core): hide tools whose rules deny every resource

### DIFF
--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -276,10 +276,10 @@ const layer = Layer.effect(
 // A tool is hidden from the model only when no resource could get past `deny`. Each rule's resource
 // pattern matches itself as a literal, so the patterns for this action are a complete set of probes:
 // a later broader rule overrides a probe exactly when it also covers every resource the probe covers.
+// The extra "*" probe stands for resources no narrow rule covers, which fall back to the default `ask`.
 const whollyDisabled = (action: string, rules: Permission.Ruleset) => {
   const probes = rules.filter((rule) => Wildcard.match(action, rule.action)).map((rule) => rule.resource)
-  if (probes.length === 0) return false
-  return probes.every((resource) => Permission.evaluate(action, resource, rules).effect === "deny")
+  return [...probes, "*"].every((resource) => Permission.evaluate(action, resource, rules).effect === "deny")
 }
 
 const formatSchemaIssue = SchemaIssue.makeFormatterDefault()

--- a/packages/core/src/tool.ts
+++ b/packages/core/src/tool.ts
@@ -273,9 +273,13 @@ const layer = Layer.effect(
   }),
 )
 
+// A tool is hidden from the model only when no resource could get past `deny`. Each rule's resource
+// pattern matches itself as a literal, so the patterns for this action are a complete set of probes:
+// a later broader rule overrides a probe exactly when it also covers every resource the probe covers.
 const whollyDisabled = (action: string, rules: Permission.Ruleset) => {
-  const rule = rules.findLast((rule) => Wildcard.match(action, rule.action))
-  return rule?.resource === "*" && rule.effect === "deny"
+  const probes = rules.filter((rule) => Wildcard.match(action, rule.action)).map((rule) => rule.resource)
+  if (probes.length === 0) return false
+  return probes.every((resource) => Permission.evaluate(action, resource, rules).effect === "deny")
 }
 
 const formatSchemaIssue = SchemaIssue.makeFormatterDefault()

--- a/packages/core/test/tool-registry.test.ts
+++ b/packages/core/test/tool-registry.test.ts
@@ -720,6 +720,16 @@ describe("Tool", () => {
           { action: "bash", resource: "git *", effect: "deny" },
         ]),
       ).toEqual([])
+      // without a catch-all, uncovered resources fall back to ask
+      expect(yield* names([{ action: "bash", resource: "rm*", effect: "deny" }])).toEqual(["bash", "execute"])
+      // a narrow ask superseded by the same narrow deny admits nothing
+      expect(
+        yield* names([
+          { action: "*", resource: "*", effect: "deny" },
+          { action: "bash", resource: "rm*", effect: "ask" },
+          { action: "bash", resource: "rm*", effect: "deny" },
+        ]),
+      ).toEqual([])
       // a trailing narrow ask or allow still admits some calls
       expect(
         yield* names([

--- a/packages/core/test/tool-registry.test.ts
+++ b/packages/core/test/tool-registry.test.ts
@@ -706,6 +706,45 @@ describe("Tool", () => {
     }),
   )
 
+  it.effect("hides tools whose narrower trailing rules cannot get past deny", () =>
+    Effect.gen(function* () {
+      const service = yield* Tool.Service
+      yield* transform(service, { bash: make() }, { codemode: false })
+      const names = (permissions: Permission.Ruleset) =>
+        toolDefinitions(service, permissions).pipe(Effect.map((definitions) => definitions.map((tool) => tool.name)))
+
+      // trailing narrow deny rules leave every call denied
+      expect(
+        yield* names([
+          { action: "*", resource: "*", effect: "deny" },
+          { action: "bash", resource: "git *", effect: "deny" },
+        ]),
+      ).toEqual([])
+      // a trailing narrow ask or allow still admits some calls
+      expect(
+        yield* names([
+          { action: "*", resource: "*", effect: "deny" },
+          { action: "bash", resource: "rm*", effect: "ask" },
+        ]),
+      ).toEqual(["bash"])
+      // a narrow allow that a later broader deny supersedes admits nothing
+      expect(
+        yield* names([
+          { action: "bash", resource: "git *", effect: "allow" },
+          { action: "bash", resource: "*", effect: "deny" },
+        ]),
+      ).toEqual(["execute"])
+      // a later narrower deny does not swallow the broader allow before it
+      expect(
+        yield* names([
+          { action: "bash", resource: "*", effect: "deny" },
+          { action: "bash", resource: "git *", effect: "allow" },
+          { action: "bash", resource: "git push*", effect: "deny" },
+        ]),
+      ).toEqual(["bash", "execute"])
+    }),
+  )
+
   it.effect("keeps permission options isolated between registrations", () =>
     Effect.gen(function* () {
       const service = yield* Tool.Service


### PR DESCRIPTION
## Problem

\`Tool.snapshot\` decides whether a tool is advertised to the model with \`whollyDisabled\`, which only peeked at the last rule matching the tool's **action** and hid the tool iff that rule was \`{ resource: "*", effect: "deny" }\`. Call-time \`Permission.evaluate\` matches on action **and** resource. The two disagree whenever a narrower rule for the action trails a catch-all deny:

\`\`\`
[*, *, deny], [shell, "git *", deny]   -> advertised, but every call is denied
[*, *, deny], [shell, "rm*", ask]      -> advertised, but every non-rm call is denied
\`\`\`

Observed in practice with the built-in \`explore\` subagent: a user's global \`permission.bash = { "rm*": "ask" }\` is appended after explore's \`{*, *, deny}\`, so \`shell\` shows up in explore's tool list and the model burns calls on \`Permission denied: shell\` before falling back to grep/glob.

## Fix

Define "wholly disabled" via \`Permission.evaluate\` so the filter cannot drift from call-time semantics: a tool is hidden iff no resource can get past \`deny\`. Each rule's resource pattern matches itself as a literal under \`Wildcard.match\`, so the resource patterns of the action's rules form a complete set of probes — a later broader rule overrides a probe exactly when it also covers every resource the probe covers.

Behavior change is limited to rulesets where narrow rules trail a catch-all deny for the same action; a trailing narrow \`ask\`/\`allow\` still keeps the tool visible (faithful to \`evaluate\`), while trailing narrow \`deny\` rules now hide it.

Note: this does **not** by itself remove \`shell\` from \`explore\` for the \`rm*: ask\` config above, since \`rm foo\` genuinely would prompt under those rules. That is a rule merge-order issue (global config appended after built-in agent rules) and will be addressed separately.

## Testing

- Added \`hides tools whose narrower trailing rules cannot get past deny\` in \`packages/core/test/tool-registry.test.ts\`
- \`bun test test/tool-registry.test.ts\` and \`bun test test/permission\` pass; \`bun typecheck\` clean in \`packages/core\`