### PR TITLE
fix: relax Bun version check in Nix pre-push

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -11,9 +11,13 @@ if (!expectedBunVersion) {
 }
 const expectedBunVersionRange = `^${expectedBunVersion}`;
 if (!semver.satisfies(process.versions.bun, expectedBunVersionRange)) {
-  throw new Error(`This script requires bun@${expectedBunVersionRange}, but you are using bun@${process.versions.bun}`);
-}
-if (process.versions.bun !== expectedBunVersion) {
+  const message = `This script requires bun@${expectedBunVersionRange}, but you are using bun@${process.versions.bun}`;
+  if (process.env.IN_NIX_SHELL) {
+    console.warn(`Warning: ${message}`);
+  } else {
+    throw new Error(message);
+  }
+} else if (process.versions.bun !== expectedBunVersion) {
   console.warn(`Warning: Bun version ${process.versions.bun} differs from expected ${expectedBunVersion}`);
 }
 '


### PR DESCRIPTION
### Issue for this PR

Closes #47332

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Allows the pre-push hook to continue with a warning when the Bun version mismatch occurs inside a Nix shell.

The Nix dev shell currently provides Bun 1.3.13 while the repository requires Bun 1.3.14. Bun 1.3.13 can still complete the pre-push typecheck successfully, so the version mismatch should not block pushes from the Nix development environment.

This is consistent with the existing Nix package behavior in #33166.

### How did you verify your code works?

Inside `nix develop` with Bun 1.3.13:

```
> bun --version
1.3.13
> ./.husky/pre-push
Warning: This script requires bun@^1.3.14, but you are using bun@1.3.13
...
Tasks:    30 successful, 30 total
```
Confirmed that the same mismatch still fails outside a Nix shell:

```
env -u IN_NIX_SHELL ./.husky/pre-push
> error: This script requires bun@^1.3.14, but you are using bun@1.3.13
```

Also confirmed that `git push` succeeds from the Nix development shell.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR