### PR TITLE
feat(opencode): discover vLLM models

### DIFF
--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -22,6 +22,7 @@ import { DigitalOceanAuthPlugin } from "./digitalocean"
 import { XaiAuthPlugin } from "./xai"
 import { CerebrasPlugin } from "./cerebras"
 import { SnowflakeCortexAuthPlugin } from "./snowflake-cortex"
+import { VllmPlugin } from "./vllm"
 import { Effect, Layer, Context } from "effect"
 import { EffectBridge } from "@/effect/bridge"
 import { InstanceState } from "@/effect/instance-state"
@@ -82,6 +83,7 @@ function internalPlugins(flags: RuntimeFlags.Info): PluginInstance[] {
     SnowflakeCortexAuthPlugin,
     XaiAuthPlugin,
     CerebrasPlugin,
+    VllmPlugin,
   ]
 }
 

--- a/packages/opencode/src/plugin/vllm.ts
+++ b/packages/opencode/src/plugin/vllm.ts
@@ -1,0 +1,89 @@
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import { Schema } from "effect"
+import { mergeDeep } from "remeda"
+
+const ID = "vllm"
+const DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1"
+const TTL = 30_000
+
+const response = Schema.Struct({
+  data: Schema.Array(
+    Schema.Struct({
+      id: Schema.String,
+      owned_by: Schema.optional(Schema.String),
+      max_model_len: Schema.optional(Schema.NullOr(Schema.Number)),
+    }),
+  ),
+})
+
+const decode = Schema.decodeUnknownSync(response)
+
+type Discovered = Record<string, { name: string; limit: { context: number; output: number }; interleaved: string }>
+
+// Keyed by endpoint so several instances sharing one server probe it once per TTL.
+const cache = new Map<string, { at: number; models: Promise<Discovered> }>()
+
+export function discover(baseURL: string, apiKey?: string) {
+  const key = `${baseURL}\n${apiKey ?? ""}`
+  const hit = cache.get(key)
+  if (hit && Date.now() - hit.at < TTL) return hit.models
+
+  const models = fetch(`${baseURL}/models`, {
+    headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+    signal: AbortSignal.timeout(3_000),
+  })
+    .then(async (res) => {
+      if (!res.ok) throw new Error(`Failed to fetch vLLM models: ${res.status}`)
+      return decode(await res.json())
+    })
+    .then(
+      (body): Discovered =>
+        Object.fromEntries(
+          body.data
+            // vLLM stamps its own model cards with owned_by "vllm"; skip anything else served on the same port.
+            .filter((item) => item.owned_by === ID && item.id.length > 0)
+            .map((item) => [
+              item.id,
+              {
+                name: item.id,
+                // vLLM reports the context window but no separate output cap; 0 keeps the generic default.
+                limit: { context: item.max_model_len ?? 0, output: 0 },
+                // vLLM reasoning parsers emit reasoning_content, and some chat templates (e.g. Kimi K2)
+                // reject assistant turns that come back without it. Harmless for models that never reason.
+                interleaved: "reasoning_content",
+              },
+            ]),
+        ),
+    )
+  cache.set(key, { at: Date.now(), models })
+  models.catch(() => cache.delete(key))
+  return models
+}
+
+export async function VllmPlugin(_input: PluginInput): Promise<Hooks> {
+  return {
+    config: async (cfg) => {
+      if (cfg.disabled_providers?.includes(ID)) return
+      if (cfg.enabled_providers && !cfg.enabled_providers.includes(ID)) return
+
+      const declared = cfg.provider?.[ID]
+      const baseURL = (declared?.options?.baseURL ?? process.env.VLLM_BASE_URL ?? DEFAULT_BASE_URL).replace(/\/+$/, "")
+      const apiKey = declared?.options?.apiKey ?? process.env.VLLM_API_KEY
+      const models = await discover(baseURL, apiKey).catch((): Discovered => ({}))
+      if (Object.keys(models).length === 0) return
+
+      cfg.provider = {
+        ...cfg.provider,
+        [ID]: {
+          ...declared,
+          npm: declared?.npm ?? "@ai-sdk/openai-compatible",
+          name: declared?.name ?? "vLLM",
+          env: declared?.env ?? ["VLLM_API_KEY"],
+          options: { ...declared?.options, baseURL },
+          // Discovered cards are defaults; anything declared in config wins.
+          models: mergeDeep(models, declared?.models ?? {}),
+        },
+      }
+    },
+  }
+}

--- a/packages/opencode/test/plugin/vllm.test.ts
+++ b/packages/opencode/test/plugin/vllm.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import type { Hooks, PluginInput } from "@opencode-ai/plugin"
+import { VllmPlugin } from "../../src/plugin/vllm"
+
+type Config = Parameters<NonNullable<Hooks["config"]>>[0]
+
+const env = new Map<string, string | undefined>()
+
+function setEnv(key: string, value: string | undefined) {
+  if (!env.has(key)) env.set(key, process.env[key])
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+}
+
+afterEach(() => {
+  for (const [key, value] of env) {
+    if (value === undefined) delete process.env[key]
+    else process.env[key] = value
+  }
+  env.clear()
+})
+
+function serve(handler: (request: Request) => Response) {
+  const requests: Array<{ path: string; authorization: string | null }> = []
+  const server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      requests.push({ path: new URL(request.url).pathname, authorization: request.headers.get("authorization") })
+      return handler(request)
+    },
+  })
+  return { server, requests, baseURL: `${server.url}v1`, [Symbol.dispose]: () => server.stop(true) }
+}
+
+const cards = Response.json({
+  object: "list",
+  data: [
+    { id: "Qwen/Qwen3-Coder-30B-A3B-Instruct", object: "model", owned_by: "vllm", max_model_len: 262_144 },
+    { id: "checkpoint_0001500", object: "model", owned_by: "vllm", max_model_len: null },
+    { id: "not-vllm", object: "model", owned_by: "openai", max_model_len: 8_192 },
+  ],
+})
+
+// The SDK config type lags the runtime schema (no `interleaved`), so build expectations from a helper.
+function card(id: string, context: number) {
+  return { name: id, limit: { context, output: 0 }, interleaved: "reasoning_content" }
+}
+
+async function run(cfg: Config) {
+  const hook = (await VllmPlugin({} as PluginInput)).config!
+  await hook(cfg)
+  return cfg
+}
+
+describe("VllmPlugin", () => {
+  test("discovers models from the configured base URL", async () => {
+    using fixture = serve(() => cards.clone())
+    const cfg = await run({ provider: { vllm: { options: { baseURL: `${fixture.baseURL}/` } } } })
+
+    expect(fixture.requests).toEqual([{ path: "/v1/models", authorization: null }])
+    expect(cfg.provider?.vllm).toEqual({
+      npm: "@ai-sdk/openai-compatible",
+      name: "vLLM",
+      env: ["VLLM_API_KEY"],
+      options: { baseURL: fixture.baseURL },
+      models: {
+        "Qwen/Qwen3-Coder-30B-A3B-Instruct": card("Qwen/Qwen3-Coder-30B-A3B-Instruct", 262_144),
+        checkpoint_0001500: card("checkpoint_0001500", 0),
+      },
+    })
+  })
+
+  test("reads the base URL and API key from the environment", async () => {
+    using fixture = serve(() => cards.clone())
+    setEnv("VLLM_BASE_URL", fixture.baseURL)
+    setEnv("VLLM_API_KEY", "secret")
+    const cfg = await run({})
+
+    expect(fixture.requests).toEqual([{ path: "/v1/models", authorization: "Bearer secret" }])
+    expect(cfg.provider?.vllm?.options).toEqual({ baseURL: fixture.baseURL })
+    expect(Object.keys(cfg.provider?.vllm?.models ?? {})).toEqual([
+      "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+      "checkpoint_0001500",
+    ])
+  })
+
+  test("keeps declared provider and model settings on top of discovery", async () => {
+    using fixture = serve(() => cards.clone())
+    const cfg = await run({
+      provider: {
+        vllm: {
+          name: "GPU box",
+          options: { baseURL: fixture.baseURL, apiKey: "token", timeout: 1000 },
+          models: {
+            checkpoint_0001500: {
+              name: "Checkpoint",
+              limit: { context: 131_072, output: 16_384 },
+              reasoning: true,
+            },
+          },
+        },
+      },
+    })
+
+    expect(fixture.requests[0].authorization).toBe("Bearer token")
+    expect(cfg.provider?.vllm?.name).toBe("GPU box")
+    expect(cfg.provider?.vllm?.options).toEqual({ baseURL: fixture.baseURL, apiKey: "token", timeout: 1000 })
+    expect(cfg.provider?.vllm?.models?.checkpoint_0001500).toEqual({
+      ...card("checkpoint_0001500", 0),
+      name: "Checkpoint",
+      limit: { context: 131_072, output: 16_384 },
+      reasoning: true,
+    })
+    expect(cfg.provider?.vllm?.models?.["Qwen/Qwen3-Coder-30B-A3B-Instruct"]?.limit).toEqual({
+      context: 262_144,
+      output: 0,
+    })
+  })
+
+  test("leaves config untouched when the server is unavailable", async () => {
+    using fixture = serve(() => new Response(null, { status: 503 }))
+    const declared = { options: { baseURL: fixture.baseURL }, models: { manual: { name: "Manual" } } }
+    const cfg = await run({ provider: { vllm: structuredClone(declared) } })
+
+    expect(cfg.provider?.vllm).toEqual(declared)
+  })
+
+  test("leaves config untouched when no vLLM model cards are served", async () => {
+    using fixture = serve(() => Response.json({ object: "list", data: [{ id: "other", owned_by: "openai" }] }))
+    const cfg = await run({ provider: { vllm: { options: { baseURL: fixture.baseURL } } } })
+
+    expect(cfg.provider?.vllm?.models).toBeUndefined()
+  })
+
+  test("skips discovery for a disabled provider", async () => {
+    using fixture = serve(() => cards.clone())
+    const cfg = await run({
+      disabled_providers: ["vllm"],
+      provider: { vllm: { options: { baseURL: fixture.baseURL } } },
+    })
+
+    expect(fixture.requests).toEqual([])
+    expect(cfg.provider?.vllm?.models).toBeUndefined()
+  })
+})

--- a/packages/opencode/test/provider/provider.test.ts
+++ b/packages/opencode/test/provider/provider.test.ts
@@ -287,6 +287,31 @@ it.instance(
   },
 )
 
+it.instance("discovers vLLM models from VLLM_BASE_URL", () =>
+  Effect.gen(function* () {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () =>
+        Response.json({
+          object: "list",
+          data: [
+            { id: "Qwen/Qwen3-Coder-30B-A3B-Instruct", object: "model", owned_by: "vllm", max_model_len: 262_144 },
+          ],
+        }),
+    })
+    yield* setProcessEnv("VLLM_BASE_URL", `${server.url}v1`)
+    const providers = yield* list
+    const provider = providers[ProviderV2.ID.make("vllm")]
+    expect(provider).toBeDefined()
+    expect(provider.name).toBe("vLLM")
+    expect(provider.options.baseURL).toBe(`${server.url}v1`)
+    const model = provider.models["Qwen/Qwen3-Coder-30B-A3B-Instruct"]
+    expect(model.api.npm).toBe("@ai-sdk/openai-compatible")
+    expect(model.limit.context).toBe(262_144)
+    expect(model.capabilities.toolcall).toBe(true)
+  }),
+)
+
 it.instance(
   "env variable takes precedence, config merges options",
   Effect.gen(function* () {

--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2418,6 +2418,41 @@ Some useful routing options:
 
 ---
 
+### vLLM
+
+OpenCode discovers models from a [vLLM](https://docs.vllm.ai) server automatically. By default it looks at `http://127.0.0.1:8000/v1`. Point it at another server with `VLLM_BASE_URL`:
+
+```bash
+VLLM_BASE_URL=http://my-gpu-box:8000/v1 opencode
+```
+
+Discovered models show up as `vllm/<served-model-name>` in `/models`, and the `max_model_len` reported by vLLM becomes the context limit. Tool calling is assumed to be available, so start vLLM with `--enable-auto-tool-choice` and a `--tool-call-parser` for your model.
+
+For an authenticated server or per-model overrides, configure the provider. Anything you declare here is merged on top of what discovery finds:
+
+```json title="opencode.json"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "vllm": {
+      "options": {
+        "baseURL": "http://my-gpu-box:8000/v1",
+        "apiKey": "{env:VLLM_API_KEY}"
+      },
+      "models": {
+        "Qwen/Qwen3-Coder-30B-A3B-Instruct": {
+          "limit": { "context": 131072, "output": 32768 }
+        }
+      }
+    }
+  }
+}
+```
+
+Omit `apiKey` when the server runs without `--api-key`. Discovered models send reasoning back as `reasoning_content` on follow-up turns, which models served with `--reasoning-parser` expect; set `"interleaved": false` on a model to turn that off. Only model cards with `owned_by: "vllm"` are discovered, and discovery is skipped when `vllm` is in `disabled_providers`.
+
+---
+
 ### xAI
 
 Two ways to authenticate: a SuperGrok subscription via device-code OAuth or a pay-as-you-go API key from the xAI console.


### PR DESCRIPTION
Closes #47344

Port of the v2 vLLM discovery (#43022, #43589) to `dev`: a built-in `vllm` provider plugin that reads `/v1/models` and injects the served models through the existing config-provider path.

- endpoint: `provider.vllm.options.baseURL` → `VLLM_BASE_URL` → `http://127.0.0.1:8000/v1`; optional `apiKey` / `VLLM_API_KEY`, keyless works
- `max_model_len` becomes `limit.context`; `interleaved: "reasoning_content"` by default so thinking models served with `--reasoning-parser` (Kimi K2 rejects assistant turns without it) work across turns
- only `owned_by: "vllm"` cards; anything declared in config wins over discovery; skipped for `disabled_providers`; results cached 30s, 3s timeout, config untouched when the server is down
- docs section under Providers

**Verification**

- `bun test test/plugin/vllm.test.ts test/provider/provider.test.ts` (new unit tests + a `Provider.list` integration test), `bun typecheck`, prettier
- Against a real vLLM server (Kimi-K2-style checkpoint, 512k ctx, no API key): `VLLM_BASE_URL=http://host:8000/v1 opencode models vllm` lists the served model with context 524288; `opencode run --model vllm/<id>` completed a multi-turn Read → Write tool-call session. Without the `reasoning_content` default the second turn failed with `Assistant message is missing a thinking field`.

Reproduce: start vLLM with `--enable-auto-tool-choice --tool-call-parser <parser>`, run `VLLM_BASE_URL=http://<host>:8000/v1 opencode`, pick `vllm/<served-model-name>` in `/models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
