### PR TITLE
feat(tui): expose plugin manager as /plugins slash command

### DIFF
--- a/packages/opencode/specs/tui-plugins.md
+++ b/packages/opencode/specs/tui-plugins.md
@@ -522,10 +522,11 @@ The plugin manager is exposed as a command with title `Plugins` and value `plugi
 
 - Keybind name is `plugin_manager`.
 - Default keybind is `none`.
+- Slash name is `/plugins`, with `/plugin` as an alias.
 - It lists both internal and external plugins.
 - It toggles based on `active`.
 - Its own row is disabled only inside the manager dialog.
-- It also exposes command `plugins.install` with title `Install plugin`.
+- It also exposes command `plugins.install` with title `Install plugin` and slash name `/plugin-install`.
 - Inside the Plugins dialog, key `shift+i` opens the install prompt.
 - Install prompt asks for npm package name.
 - Scope defaults to local, and `tab` toggles local/global.

--- a/packages/tui/src/feature-plugins/system/plugins.tsx
+++ b/packages/tui/src/feature-plugins/system/plugins.tsx
@@ -241,6 +241,8 @@ const tui: TuiPlugin = async (api) => {
       {
         name: "plugins.list",
         title: "Plugins",
+        slashName: "plugins",
+        slashAliases: ["plugin"],
         category: "System",
         namespace: "palette",
         run() {
@@ -250,6 +252,7 @@ const tui: TuiPlugin = async (api) => {
       {
         name: "plugins.install",
         title: "Install plugin",
+        slashName: "plugin-install",
         category: "System",
         namespace: "palette",
         run() {

--- a/packages/tui/test/feature-plugins/plugins-commands.test.ts
+++ b/packages/tui/test/feature-plugins/plugins-commands.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test"
+import PluginManager from "../../src/feature-plugins/system/plugins"
+import type { TuiPluginApi } from "@opencode-ai/plugin/tui"
+import { createTuiPluginApi } from "../fixture/tui-plugin"
+
+async function commands() {
+  const layers: { commands?: { name: string; slashName?: string; slashAliases?: string[] }[] }[] = []
+  await PluginManager.tui(
+    createTuiPluginApi({
+      keymap: {
+        registerLayer(layer: (typeof layers)[number]) {
+          layers.push(layer)
+          return () => {}
+        },
+      } as unknown as TuiPluginApi["keymap"],
+    }),
+    undefined,
+    {} as never,
+  )
+  return layers.flatMap((layer) => layer.commands ?? [])
+}
+
+describe("feature-plugins.plugin-manager", () => {
+  test("plugins.list is reachable as /plugins with a /plugin alias", async () => {
+    const list = (await commands()).find((command) => command.name === "plugins.list")
+
+    expect(list?.slashName).toBe("plugins")
+    expect(list?.slashAliases).toEqual(["plugin"])
+  })
+
+  test("plugins.install is reachable as /plugin-install", async () => {
+    const install = (await commands()).find((command) => command.name === "plugins.install")
+
+    expect(install?.slashName).toBe("plugin-install")
+    expect(install?.slashAliases).toBeUndefined()
+  })
+
+  test("every plugin manager command stays in the palette namespace", async () => {
+    const list = await commands()
+
+    expect(list.length).toBeGreaterThan(0)
+    expect(list.every((command) => "slashName" in command)).toBe(true)
+  })
+})

--- a/packages/web/src/content/docs/plugins.mdx
+++ b/packages/web/src/content/docs/plugins.mdx
@@ -64,6 +64,14 @@ Duplicate npm packages with the same name and version are loaded once. However, 
 
 ---
 
+### Manage plugins from the TUI
+
+Run `/plugins` (alias `/plugin`) to open the plugin manager. It lists both built-in and external plugins with their state, and `space` toggles a plugin on or off without editing your config.
+
+Run `/plugin-install` to install an npm plugin and add it to your config. `tab` switches between local and global scope.
+
+---
+
 ## Create a plugin
 
 A plugin is a **JavaScript/TypeScript module** that exports one or more plugin


### PR DESCRIPTION
### Issue for this PR

Closes #47345

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds slash names to the two plugin manager commands so the dialog is reachable by typing.

The plugin manager in `packages/tui/src/feature-plugins/system/plugins.tsx` already lists built-in and external plugins, toggles them with `space`, and installs npm plugins with local/global scope. But neither `plugins.list` nor `plugins.install` declared a `slashName`, and both keybinds default to `none` (`packages/tui/src/config/keybind.ts:226-227`). So the only way in was to open the palette and scroll, or configure a keybind by hand.

Every sibling dialog already has one: `/mcps`, `/agents`, `/models`, `/skills`, `/themes`, `/status`, `/variants`, `/workspaces`. Plugins were the only management dialog without.

- `plugins.list` -> `/plugins`, alias `/plugin`
- `plugins.install` -> `/plugin-install`

`/plugins` matches the existing plural convention. `/plugin` is the alias because that is the name Claude Code users reach for, and it is the specific ask in #23800 and #7716 (both closed into the marketplace megaissue #28696, but the UI they wanted already shipped, only the entry point was missing).

Why it works: `useCommandSlashes()` in `packages/tui/src/keymap.tsx:260-290` builds the slash list by reading `command.slashName` and `command.slashAliases` off every reachable `palette`-namespace command. These two commands were already `namespace: "palette"`, so declaring the fields is all that was needed. No new UI, no API change, no behavior change to the dialog, keybinds, or palette entries.

I checked for collisions across all `slashName`, `slashAliases`, and session-route `slash: { name }` values first. `plugins`, `plugin`, and `plugin-install` are all unused.

### How did you verify your code works?

Added `packages/tui/test/feature-plugins/plugins-commands.test.ts`, which invokes the real plugin's `tui()` with a recording keymap and asserts on the registered commands (no mocking of the plugin itself).

Confirmed the test actually catches the regression: with my `plugins.tsx` change stashed it goes 3 fail / 0 pass, and with it restored 3 pass / 0 fail.

- `cd packages/tui && bun test` -> 196 pass, 1 skip, 0 fail
- `cd packages/tui && bun typecheck` -> clean
- `cd packages/opencode && bun test test/cli/tui/plugin-toggle.test.ts test/cli/tui/plugin-install.test.ts test/config/tui.test.ts` -> 38 pass, 3 skip, 0 fail
- `prettier --check` and `oxlint` clean

Also updated `packages/opencode/specs/tui-plugins.md` to record the slash names, and added a short "Manage plugins from the TUI" section to the plugins doc, since the manager was not documented anywhere.

### Screenshots / recordings

No visual change. The dialogs are unchanged; this only adds a new way to invoke them. `/plugins` opens the same manager that `plugins.list` already opened from the palette.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
