### PR TITLE
docs(permissions): clarify write is not a permission key

### DIFF
--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -163,6 +163,12 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 - `external_directory` — triggered when a tool touches paths outside the project working directory
 - `doom_loop` — triggered when the same tool call repeats 3 times with identical input
 
+Any other key is matched as a wildcard pattern against the underlying tool name — this is how you gate an MCP or custom tool, for example `"mymcp_*": "deny"`. A key that matches no permission above and no tool name parses without error but is never consulted, so it silently does nothing — double-check the key against this list and your installed tools if a rule doesn't seem to take effect.
+
+:::caution
+A common mistake is writing a `"write": {...}` block, expecting it to gate file writes separately from edits. `write` is not a permission key — it parses cleanly but is never consulted. File writes are already covered by `edit`; use that instead.
+:::
+
 ---
 
 ## Defaults


### PR DESCRIPTION
### Issue for this PR

Closes #40150

### Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement

### What does this PR do?

`write:` blocks in `opencode.json` / agent frontmatter parse cleanly because the permission schema (`packages/core/src/v1/config/permission.ts`) has a catch-all `Schema.Record` rest element, but nothing ever consults them: `write.ts` asks under `permission: "edit"`, and there is no `permission: "write"` anywhere in `src`. An operator writing `"write": {"*.env": "deny"}` gets no error and no effect — the block is silently inert.

The issue thread converged on this being a documentation problem rather than a code one: `docs/permissions.mdx` already states `edit` covers `edit`, `write`, and `patch` — `write` was never meant to be a standalone key. Renaming what `write.ts` asks under would contradict that design (and there's a second call site, `permission/index.ts`'s `edits` array, that would need to move in lockstep to avoid a half-live fix). Introducing a general unknown-key diagnostic is tempting but riskier: any key that doesn't match a declared permission is legitimately used to gate MCP/custom tools by name (`"mymcp_*": "deny"`), so a blanket warning would need care to avoid false positives — a larger change than this specific, reported confusion warrants.

This PR instead documents the trap directly:
- A `:::caution` block calling out that `write` is not a permission key and file writes are already covered by `edit`.
- A sentence clarifying that unrecognized keys (in general) are matched as tool-name wildcards, and a key matching neither a declared permission nor a tool name silently does nothing.

### How did you verify your code works?

Docs-only change; verified against current `dev` that the described behavior is accurate:
- `packages/core/src/v1/config/permission.ts:19-33` — no `write` key declared, `Schema.Record` rest element present.
- `packages/opencode/src/tool/write.ts:55` — asks under `permission: "edit"`.
- `packages/opencode/src/permission/index.ts:205` — `const edits = ["edit", "write", "apply_patch"]`.

### Screenshots / recordings

Not applicable (docs text only).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR