### PR TITLE
feat(opencode): support managed OTLP exporter settings

### DIFF
--- a/packages/core/src/flag/flag.ts
+++ b/packages/core/src/flag/flag.ts
@@ -13,8 +13,12 @@ function enabledByExperimental(key: string) {
 }
 
 export const Flag = {
-  OTEL_EXPORTER_OTLP_ENDPOINT: process.env["OTEL_EXPORTER_OTLP_ENDPOINT"],
-  OTEL_EXPORTER_OTLP_HEADERS: process.env["OTEL_EXPORTER_OTLP_HEADERS"],
+  get OTEL_EXPORTER_OTLP_ENDPOINT() {
+    return process.env["OTEL_EXPORTER_OTLP_ENDPOINT"]
+  },
+  get OTEL_EXPORTER_OTLP_HEADERS() {
+    return process.env["OTEL_EXPORTER_OTLP_HEADERS"]
+  },
 
   OPENCODE_AUTO_HEAP_SNAPSHOT: truthy("OPENCODE_AUTO_HEAP_SNAPSHOT"),
   OPENCODE_GIT_BASH_PATH: process.env["OPENCODE_GIT_BASH_PATH"],

--- a/packages/core/src/observability/otlp.ts
+++ b/packages/core/src/observability/otlp.ts
@@ -4,10 +4,9 @@ import { Flag } from "../flag/flag"
 import { InstallationChannel, InstallationVersion } from "../installation/version"
 import { runID } from "./shared"
 
-const endpoint = Flag.OTEL_EXPORTER_OTLP_ENDPOINT
-
-const headers = Flag.OTEL_EXPORTER_OTLP_HEADERS
-  ? Flag.OTEL_EXPORTER_OTLP_HEADERS.split(",").reduce(
+const headers = () =>
+  Flag.OTEL_EXPORTER_OTLP_HEADERS
+    ? Flag.OTEL_EXPORTER_OTLP_HEADERS.split(",").reduce(
       (acc, entry) => {
         const [key, ...value] = entry.split("=")
         acc[key] = value.join("=")
@@ -15,7 +14,7 @@ const headers = Flag.OTEL_EXPORTER_OTLP_HEADERS
       },
       {} as Record<string, string>,
     )
-  : undefined
+    : undefined
 
 function resourceAttributes() {
   const value = process.env.OTEL_RESOURCE_ATTRIBUTES
@@ -48,11 +47,13 @@ export function resource(): { serviceName: string; serviceVersion: string; attri
 }
 
 export function loggers() {
+  const endpoint = Flag.OTEL_EXPORTER_OTLP_ENDPOINT
   if (!endpoint) return []
-  return [OtlpLogger.make({ url: `${endpoint}/v1/logs`, resource: resource(), headers })]
+  return [OtlpLogger.make({ url: `${endpoint}/v1/logs`, resource: resource(), headers: headers() })]
 }
 
 export async function tracingLayer() {
+  const endpoint = Flag.OTEL_EXPORTER_OTLP_ENDPOINT
   if (!endpoint) return Layer.empty
   const NodeSdk = await import("@effect/opentelemetry/NodeSdk")
   const OTLP = await import("@opentelemetry/exporter-trace-otlp-http")
@@ -70,7 +71,7 @@ export async function tracingLayer() {
     spanProcessor: new SdkBase.BatchSpanProcessor(
       new OTLP.OTLPTraceExporter({
         url: `${endpoint}/v1/traces`,
-        headers,
+        headers: headers(),
       }),
     ),
   }))

--- a/packages/core/src/v1/config/config.ts
+++ b/packages/core/src/v1/config/config.ts
@@ -166,6 +166,25 @@ export const Info = Schema.Struct({
       }),
     }),
   ),
+  telemetry: Schema.optional(
+    Schema.Struct({
+      otlp: Schema.optional(
+        Schema.Struct({
+          endpoint: Schema.optional(Schema.String).annotate({
+            description: "OTLP HTTP base endpoint for managed OpenCode logs and traces",
+          }),
+          headers: Schema.optional(Schema.String).annotate({
+            description: "Comma-separated OTLP exporter headers in key=value form",
+          }),
+          resourceAttributes: Schema.optional(Schema.String).annotate({
+            description: "Comma-separated OpenTelemetry resource attributes in key=value form",
+          }),
+        }),
+      ),
+    }),
+  ).annotate({
+    description: "Managed telemetry exporter settings",
+  }),
   experimental: Schema.optional(
     Schema.Struct({
       disable_paste_summary: Schema.optional(Schema.Boolean),

--- a/packages/opencode/src/config/managed.ts
+++ b/packages/opencode/src/config/managed.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs"
 import os from "os"
 import path from "path"
 import { Process } from "@/util/process"
+import { parse as parseJsonc } from "jsonc-parser"
 
 const MANAGED_PLIST_DOMAIN = "ai.opencode.managed"
 
@@ -66,4 +67,57 @@ export async function readManagedPreferences() {
   }
 
   return
+}
+
+type Telemetry = {
+  endpoint?: string
+  headers?: string
+  resourceAttributes?: string
+}
+
+const ENV = {
+  endpoint: "OTEL_EXPORTER_OTLP_ENDPOINT",
+  headers: "OTEL_EXPORTER_OTLP_HEADERS",
+  resourceAttributes: "OTEL_RESOURCE_ATTRIBUTES",
+} as const
+
+function telemetry(input: unknown): Telemetry | undefined {
+  if (!input || typeof input !== "object") return
+  const root = input as Record<string, unknown>
+  if (!root.telemetry || typeof root.telemetry !== "object") return
+  const value = (root.telemetry as Record<string, unknown>).otlp
+  if (!value || typeof value !== "object") return
+  const otlp = value as Record<string, unknown>
+  return {
+    endpoint: typeof otlp.endpoint === "string" ? otlp.endpoint : undefined,
+    headers: typeof otlp.headers === "string" ? otlp.headers : undefined,
+    resourceAttributes: typeof otlp.resourceAttributes === "string" ? otlp.resourceAttributes : undefined,
+  }
+}
+
+export async function readManagedTelemetry(): Promise<Telemetry | undefined> {
+  let result: Telemetry | undefined
+  const dir = managedConfigDir()
+  for (const name of ["opencode.json", "opencode.jsonc"]) {
+    const file = path.join(dir, name)
+    if (!existsSync(file)) continue
+    const value = telemetry(parseJsonc(await Bun.file(file).text()))
+    if (value) result = { ...result, ...value }
+  }
+  const managed = await readManagedPreferences()
+  if (!managed) return result
+  return { ...result, ...telemetry(JSON.parse(managed.text)) }
+}
+
+export function applyManagedTelemetry(value?: Telemetry) {
+  if (!value) return
+  for (const key of Object.keys(ENV) as Array<keyof typeof ENV>) {
+    const setting = value[key]
+    if (setting === undefined) continue
+    process.env[ENV[key]] = setting
+  }
+}
+
+export async function init() {
+  applyManagedTelemetry(await readManagedTelemetry())
 }

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -29,8 +29,11 @@ import { DbCommand } from "./cli/cmd/db"
 import { errorMessage } from "./util/error"
 import { PluginCommand } from "./cli/cmd/plug"
 import { Heap } from "./cli/heap"
+import { ConfigManaged } from "./config/managed"
 
 const args = hideBin(process.argv)
+
+await ConfigManaged.init()
 
 function show(out: string) {
   const text = out.trimStart()

--- a/packages/opencode/test/config/config.test.ts
+++ b/packages/opencode/test/config/config.test.ts
@@ -2232,3 +2232,66 @@ test("parseManagedPlist handles empty config", async () => {
   )
   expect(config.$schema).toBe("https://opencode.ai/config.json")
 })
+
+test("parseManagedPlist parses managed OTLP settings", async () => {
+  const config = ConfigParse.schema(
+    ConfigV1.Info,
+    ConfigParse.jsonc(
+      await ConfigManaged.parseManagedPlist(
+        JSON.stringify({
+          telemetry: {
+            otlp: {
+              endpoint: "https://otel.example.com",
+              headers: "Authorization=Bearer test",
+              resourceAttributes: "deployment.environment.name=managed",
+            },
+          },
+        }),
+      ),
+      "test:mobileconfig",
+    ),
+    "test:mobileconfig",
+  )
+  expect(config.telemetry?.otlp?.endpoint).toBe("https://otel.example.com")
+  expect(config.telemetry?.otlp?.headers).toBe("Authorization=Bearer test")
+  expect(config.telemetry?.otlp?.resourceAttributes).toBe("deployment.environment.name=managed")
+})
+
+test("managed OTLP settings override process environment", async () => {
+  await using tmp = await tmpdir()
+  const endpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+  const headers = process.env.OTEL_EXPORTER_OTLP_HEADERS
+  const attributes = process.env.OTEL_RESOURCE_ATTRIBUTES
+  const dir = process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR
+  try {
+    process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR = tmp.path
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "https://user.example.com"
+    process.env.OTEL_EXPORTER_OTLP_HEADERS = "Authorization=Bearer user"
+    process.env.OTEL_RESOURCE_ATTRIBUTES = "deployment.environment.name=user"
+    await Bun.write(
+      path.join(tmp.path, "opencode.json"),
+      JSON.stringify({
+        telemetry: {
+          otlp: {
+            endpoint: "https://managed-file.example.com",
+            headers: "Authorization=Bearer managed-file",
+            resourceAttributes: "deployment.environment.name=managed-file",
+          },
+        },
+      }),
+    )
+    ConfigManaged.applyManagedTelemetry(await ConfigManaged.readManagedTelemetry())
+    expect(process.env.OTEL_EXPORTER_OTLP_ENDPOINT).toBe("https://managed-file.example.com")
+    expect(process.env.OTEL_EXPORTER_OTLP_HEADERS).toBe("Authorization=Bearer managed-file")
+    expect(process.env.OTEL_RESOURCE_ATTRIBUTES).toBe("deployment.environment.name=managed-file")
+  } finally {
+    if (endpoint === undefined) delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT
+    else process.env.OTEL_EXPORTER_OTLP_ENDPOINT = endpoint
+    if (headers === undefined) delete process.env.OTEL_EXPORTER_OTLP_HEADERS
+    else process.env.OTEL_EXPORTER_OTLP_HEADERS = headers
+    if (attributes === undefined) delete process.env.OTEL_RESOURCE_ATTRIBUTES
+    else process.env.OTEL_RESOURCE_ATTRIBUTES = attributes
+    if (dir === undefined) delete process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR
+    else process.env.OPENCODE_TEST_MANAGED_CONFIG_DIR = dir
+  }
+})

--- a/packages/web/src/content/docs/config.mdx
+++ b/packages/web/src/content/docs/config.mdx
@@ -249,6 +249,25 @@ opencode debug config
 
 All managed preference keys appear in the resolved config and cannot be overridden by user or project configuration.
 
+Managed settings can also configure the OTLP HTTP exporter before OpenCode initializes observability:
+
+```json title="managed opencode.json"
+{
+  "telemetry": {
+    "otlp": {
+      "endpoint": "https://otel.example.com",
+      "headers": "Authorization=Bearer token",
+      "resourceAttributes": "deployment.environment.name=production"
+    }
+  },
+  "experimental": {
+    "openTelemetry": true
+  }
+}
+```
+
+The same `telemetry` dictionary can be placed directly in an `ai.opencode.managed` payload. As with every setting supplied by the profile, each OTLP value present in the mobileconfig has the highest precedence. Profile values override the system-managed file and `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, and `OTEL_RESOURCE_ATTRIBUTES` inherited from the process. Values omitted from the profile can fall back to the system-managed file or process environment. User and project configuration cannot set these exporter values.
+
 ---
 
 ## Schema


### PR DESCRIPTION
### Issue for this PR

Closes #47351

### Type of change

- [x] New feature
- [x] Documentation

### What does this PR do?

Adds managed-only OTLP exporter settings for endpoint-managed OpenCode deployments:

```json
{
  "telemetry": {
    "otlp": {
      "endpoint": "https://otel.example.com",
      "headers": "Authorization=Bearer token",
      "resourceAttributes": "deployment.environment.name=production"
    }
  }
}
```

OpenCode reads these values from the system-managed configuration directory and macOS `ai.opencode.managed` preferences before initializing observability.

Every value supplied by the macOS managed profile has the highest precedence. Profile values override the system-managed file and inherited `OTEL_*` environment variables. Values omitted from the profile may fall back to those lower-precedence sources.

User and project configuration cannot configure or redirect the managed OTLP exporter. Existing environment-only behavior remains unchanged when no managed OTLP settings are present.

### How did you verify your code works?

- `bun typecheck` in `packages/core`
- `bun typecheck` in `packages/opencode`
- `bun test test/effect/observability.test.ts` in `packages/core`
- `bun test test/config/config.test.ts` in `packages/opencode`
- `bun run build` in `packages/web`
- Full pre-push monorepo typecheck
- `git diff --check`

Tests cover managed OTLP parsing and managed settings overriding inherited process values.

### Screenshots / recordings

N/A, configuration-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes