### PR TITLE
fix(core): omit standalone signed-empty reasoning

### DIFF
--- a/packages/core/src/session/runner/to-llm-message.ts
+++ b/packages/core/src/session/runner/to-llm-message.ts
@@ -197,10 +197,17 @@ const assistant = (message: SessionMessage.Assistant, model: Model.Ref, provider
     )
     return result ? [call, result] : [call]
   })
+  const hasOutput = content.some((part) => {
+    if (part.type === "text" || part.type === "reasoning") return part.text !== ""
+    return true
+  })
   const meaningful = content.filter((part) => {
     if (part.type === "text") return part.text !== ""
     if (part.type !== "reasoning") return true
-    return part.text !== "" || (part.providerMetadata !== undefined && Object.keys(part.providerMetadata).length > 0)
+    return (
+      part.text !== "" ||
+      (hasOutput && part.providerMetadata !== undefined && Object.keys(part.providerMetadata).length > 0)
+    )
   })
   const results = message.content
     .filter((item): item is SessionMessage.AssistantTool => item.type === "tool" && item.executed !== true)

--- a/packages/core/test/session-runner-message.test.ts
+++ b/packages/core/test/session-runner-message.test.ts
@@ -68,18 +68,52 @@ describe("toLLMMessages", () => {
         assistant("empty-text", [SessionMessage.AssistantText.make({ type: "text", text: "" })]),
         assistant("empty-reasoning", [SessionMessage.AssistantReasoning.make({ type: "reasoning", text: "" })]),
         assistant("text", [SessionMessage.AssistantText.make({ type: "text", text: "Partial" })]),
-        assistant("reasoning", [
+        assistant("signed-reasoning", [
           SessionMessage.AssistantReasoning.make({
             type: "reasoning",
             text: "",
             state: { signature: "sig_1" },
           }),
         ]),
+        assistant("signed-reasoning-with-text", [
+          SessionMessage.AssistantReasoning.make({
+            type: "reasoning",
+            text: "",
+            state: { signature: "sig_2" },
+          }),
+          SessionMessage.AssistantText.make({ type: "text", text: "Visible" }),
+        ]),
+        assistant("signed-reasoning-with-tool", [
+          SessionMessage.AssistantReasoning.make({
+            type: "reasoning",
+            text: "",
+            state: { signature: "sig_3" },
+          }),
+          SessionMessage.AssistantTool.make({
+            type: "tool",
+            id: "read",
+            name: "read",
+            state: SessionMessage.ToolStateStreaming.make({ status: "streaming", input: '{"path":"README.md"}' }),
+            time: { created },
+          }),
+        ]),
       ],
       model,
     )
 
-    expect(messages.map((message) => message.id)).toEqual([id("text"), id("reasoning")])
+    expect(messages.map((message) => message.id)).toEqual([
+      id("text"),
+      id("signed-reasoning-with-text"),
+      id("signed-reasoning-with-tool"),
+    ])
+    expect(messages[1]?.content).toEqual([
+      { type: "reasoning", text: "", providerMetadata: { provider: { signature: "sig_2" } } },
+      { type: "text", text: "Visible", providerMetadata: undefined },
+    ])
+    expect(messages[2]?.content).toEqual([
+      { type: "reasoning", text: "", providerMetadata: { provider: { signature: "sig_3" } } },
+      { type: "tool-call", id: "read", name: "read", input: { path: "README.md" } },
+    ])
   })
 
   test("maps every top-level Session message type", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #46881

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

V2 keeps a reasoning message in model history even when it contains only a provider signature. These empty messages accumulate and get sent again on later requests.

Drop the standalone empty message, but keep its signature when the same message also contains text or a tool call. This changes history replay only. #45839 handles the separate legacy replay path.

### How did you verify your code works?

- `bun test test/session-runner-message.test.ts` in `packages/core`: 24 passed. Covers standalone signatures and signatures paired with text or a tool call.
- `bun typecheck` in `packages/core`: passed.
- The broader core suite has unrelated failures that also reproduce on clean `v2`; it is not fully green locally.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
