### PR TITLE
fix(core): clarify how to call search in Code Mode guidance

### DIFF
--- a/packages/core/src/codemode/instructions.ts
+++ b/packages/core/src/codemode/instructions.ts
@@ -12,7 +12,7 @@ ${hasMoreTools ? "The Code Mode catalog and `search` results are" : "This catalo
 
 ## Search
 
-Use \`search\` to discover exact paths and signatures for additional tools:
+Call \`search(...)\` to discover exact paths and signatures for additional tools:
 
 - ${searchSignature}` : ""}
 

--- a/packages/core/src/codemode/tool.ts
+++ b/packages/core/src/codemode/tool.ts
@@ -61,7 +61,7 @@ export type Inventory = {
 const description = [
   "Run JavaScript in a confined Code Mode runtime to orchestrate tool calls and compose their results.",
   "Imports, direct filesystem access, and timers are unavailable. Do not use `fetch`; all external access goes through `tools`.",
-  "Within `{ code }`, the only callable tools are those explicitly listed in the Code Mode catalog instructions or returned by `search`. Inside `{ code }`, ignore tools shown outside the Code Mode catalog. They are not available in the Code Mode runtime.",
+  "Within `{ code }`, the only callable tools are those explicitly listed in the Code Mode catalog instructions or returned by the `search` function. Inside `{ code }`, ignore tools shown outside the Code Mode catalog. They are not available in the Code Mode runtime.",
   'Call tools through `tools` using only exact paths and signatures from the catalog. Do not infer or normalize tool names; preserve bracket notation such as `tools.<namespace>["tool-name"](input)`.',
   "Prefer an explicit `return`; if omitted, the final top-level expression becomes the result.",
   "Await every call whose completion matters; pending calls are interrupted when execution ends. Run independent calls concurrently with `Promise.all`.",

--- a/packages/core/test/codemode/catalog.test.ts
+++ b/packages/core/test/codemode/catalog.test.ts
@@ -131,6 +131,7 @@ describe("CodeModeInstructions.render", () => {
     expect(partial).toContain("## Available tools")
     expect(partial).toContain("- orders (1 tool, none shown)")
     expect(partial).toContain("## Search")
+    expect(partial).toContain("Call `search(...)` to discover exact paths and signatures for additional tools:")
     expect(partial).toContain("The Code Mode tool catalog below is partial.")
     expect(partial).toContain(
       "The Code Mode catalog and `search` results are the complete set of tools available within Code Mode.",

--- a/packages/core/test/tool-execute.test.ts
+++ b/packages/core/test/tool-execute.test.ts
@@ -24,7 +24,7 @@ test("execute describes invariant Code Mode behavior", () => {
     [
       "Run JavaScript in a confined Code Mode runtime to orchestrate tool calls and compose their results.",
       "Imports, direct filesystem access, and timers are unavailable. Do not use `fetch`; all external access goes through `tools`.",
-      "Within `{ code }`, the only callable tools are those explicitly listed in the Code Mode catalog instructions or returned by `search`. Inside `{ code }`, ignore tools shown outside the Code Mode catalog. They are not available in the Code Mode runtime.",
+      "Within `{ code }`, the only callable tools are those explicitly listed in the Code Mode catalog instructions or returned by the `search` function. Inside `{ code }`, ignore tools shown outside the Code Mode catalog. They are not available in the Code Mode runtime.",
       'Call tools through `tools` using only exact paths and signatures from the catalog. Do not infer or normalize tool names; preserve bracket notation such as `tools.<namespace>["tool-name"](input)`.',
       "Prefer an explicit `return`; if omitted, the final top-level expression becomes the result.",
       "Await every call whose completion matters; pending calls are interrupted when execution ends. Run independent calls concurrently with `Promise.all`.",


### PR DESCRIPTION
## Summary

The model-facing Code Mode guidance told the model to use `search` to discover additional tools but never indicated how it is invoked. Every other callable in the catalog is namespaced under `tools.*`, so a model reading the guidance naturally guesses `tools.search(...)`, which does not exist — `search` is a standalone function in the execution scope.

This states the call form positively in both model-facing surfaces, without naming the anti-pattern (so a future `tools.search` fallback remains an option):

- **Catalog instructions** (`## Search` section): `Use \`search\`` → `Call \`search(...)\``
- **`execute` tool description**: `returned by \`search\`` → `returned by the \`search\` function`

No runtime behavior changes; prompt text only. Tests pinning the exact description strings are updated, and one assertion is added for the new `## Search` lead-in.

## Test plan

- [x] `bun test test/tool-execute.test.ts test/codemode/catalog.test.ts` from `packages/core` (23 pass)
- [x] `bun typecheck` from repo