### PR TITLE
feat(generate): accept provider request body

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -1153,7 +1153,11 @@ export interface ModelApi<E = never> {
   readonly default: ModelDefaultOperation<E>
 }
 
-export type GenerateTextInput = { readonly prompt: string; readonly model?: Model.Ref | undefined }
+export type GenerateTextInput = {
+  readonly prompt: string
+  readonly model?: Model.Ref | undefined
+  readonly body?: { readonly [x: string]: Schema.Json } | undefined
+}
 export type GenerateTextOutput = { readonly text: string }
 export type GenerateTextOperation<E = never> = (input: GenerateTextInput) => Effect.Effect<GenerateTextOutput, E>
 

--- a/packages/client/src/effect/generated/client.ts
+++ b/packages/client/src/effect/generated/client.ts
@@ -776,7 +776,7 @@ const adaptGroupModel = (raw: RawClient["server.model"]) => ({
 
 const EndpointGenerateText = (raw: RawClient["server.generate"]) => (input: GenerateTextInput) =>
   preserveEffect<GenerateTextOutput>()(
-    raw["generate.text"]({ payload: { prompt: input["prompt"], model: input["model"] } }).pipe(
+    raw["generate.text"]({ payload: { prompt: input["prompt"], model: input["model"], body: input["body"] } }).pipe(
       Effect.mapError(mapClientError),
       Effect.map((value) => value.data),
     ),

--- a/packages/client/src/promise/generated/client.ts
+++ b/packages/client/src/promise/generated/client.ts
@@ -1037,7 +1037,7 @@ export function make(options: ClientOptions) {
           {
             method: "POST",
             path: `/api/generate`,
-            body: { prompt: input["prompt"], model: input["model"] },
+            body: { prompt: input["prompt"], model: input["model"], body: input["body"] },
             successStatus: 200,
             declaredStatuses: [400, 503, 401],
             empty: false,

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -4332,11 +4332,18 @@ export type GenerateTextInput = {
   readonly prompt: {
     readonly prompt: string
     readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly body?: { readonly [x: string]: JsonValue } | null
   }["prompt"]
   readonly model?: {
     readonly prompt: string
     readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly body?: { readonly [x: string]: JsonValue } | null
   }["model"]
+  readonly body?: {
+    readonly prompt: string
+    readonly model?: { readonly id: string; readonly providerID: string; readonly variant?: string } | null
+    readonly body?: { readonly [x: string]: JsonValue } | null
+  }["body"]
 }
 
 export type GenerateTextOutput = GenerateTextResponse["data"]

--- a/packages/client/test/promise.test.ts
+++ b/packages/client/test/promise.test.ts
@@ -158,9 +158,9 @@ test("generate.text uses the locationless public contract", async () => {
     },
   })
 
-  expect(await client.generate.text({ prompt: "ping" })).toEqual({ text: "pong" })
+  expect(await client.generate.text({ prompt: "ping", body: { max_tokens: 321 } })).toEqual({ text: "pong" })
   expect(request?.url).toBe("http://localhost:3000/api/generate")
-  expect(await request?.json()).toEqual({ prompt: "ping" })
+  expect(await request?.json()).toEqual({ prompt: "ping", body: { max_tokens: 321 } })
 })
 
 test("websearch.query uses the public HTTP contract", async () => {

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -10,6 +10,7 @@ import { Model } from "./model.js"
 export interface TextInput {
   readonly prompt: string
   readonly model?: Model.Ref
+  readonly body?: Record<string, unknown>
 }
 
 export class ModelSelectionError extends Schema.TaggedError<ModelSelectionError>()("Generate.ModelSelectionError", {
@@ -57,15 +58,17 @@ export const layer = Layer.effect(
             ? `Model unavailable: ${input.model.providerID}/${input.model.id}`
             : "No model specified and no supported model is available",
         })
-      const response = yield* llm.generate(LLM.request({ model: resolved.model, prompt: input.prompt })).pipe(
-        Effect.mapError(
-          (error: AIError) =>
-            new UnavailableError({
-              message: error.message,
-              service: resolved.ref.providerID,
-            }),
-        ),
-      )
+      const response = yield* llm
+        .generate(LLM.request({ model: resolved.model, prompt: input.prompt, http: { body: input.body } }))
+        .pipe(
+          Effect.mapError(
+            (error: AIError) =>
+              new UnavailableError({
+                message: error.message,
+                service: resolved.ref.providerID,
+              }),
+          ),
+        )
       return response.text
     })
 

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "bun:test"
-import { LanguageModel } from "@opencode-ai/ai"
+import { LanguageModel, type LLMRequest } from "@opencode-ai/ai"
 import { OpenAIChat } from "@opencode-ai/ai/protocols"
 import { TestLLM } from "@opencode-ai/ai/testing"
 import { AISDK } from "@opencode-ai/core/aisdk"
@@ -65,7 +65,14 @@ const aisdk = Layer.mock(AISDK.Service, {
   },
   model: () => Effect.succeed(runtime),
 })
-const client = TestLLM.testLayer({ fallback: TestLLM.text("OK", "generate") })
+const requests: LLMRequest[] = []
+const client = TestLLM.testLayer({
+  transformRequest: (input) => {
+    requests.push(input)
+    return input
+  },
+  fallback: TestLLM.text("OK", "generate"),
+})
 
 const resolver = ModelResolver.layer.pipe(Layer.provide(Layer.mergeAll(catalog, integrations, npm, aisdk)))
 const it = testEffect(Generate.layer.pipe(Layer.provide(Layer.merge(resolver, client))))
@@ -74,12 +81,15 @@ const resolverIt = testEffect(resolver)
 it.effect("loads dynamic AI SDK models", () =>
   Effect.gen(function* () {
     const generate = yield* Generate.Service
+    requests.length = 0
     const result = yield* generate.text({
       prompt: "Return exactly OK",
       model: Ref.make({ providerID: selected.providerID, id: selected.id }),
+      body: { max_tokens: 321 },
     })
 
     expect(result).toBe("OK")
+    expect(requests[0]?.http?.body).toEqual({ max_tokens: 321 })
   }),
 )
 

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -4766,7 +4766,7 @@
             }
           }
         },
-        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified.",
+        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified. Optional provider-native body fields overlay the lowered request.",
         "summary": "Generate text",
         "requestBody": {
           "content": {
@@ -4781,6 +4781,16 @@
                     "anyOf": [
                       {
                         "$ref": "#/components/schemas/Model.Ref"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "anyOf": [
+                      {
+                        "type": "object"
                       },
                       {
                         "type": "null"

--- a/packages/protocol/src/groups/generate.ts
+++ b/packages/protocol/src/groups/generate.ts
@@ -9,6 +9,7 @@ export const GenerateGroup = HttpApiGroup.make("server.generate")
       payload: Schema.Struct({
         prompt: Schema.String,
         model: Model.Ref.pipe(Schema.optional),
+        body: Schema.optional(Schema.Record(Schema.String, Schema.Json)),
       }),
       success: Schema.Struct({
         data: Schema.Struct({ text: Schema.String }),
@@ -19,7 +20,7 @@ export const GenerateGroup = HttpApiGroup.make("server.generate")
         identifier: "v2.generate.text",
         summary: "Generate text",
         description:
-          "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified.",
+          "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified. Optional provider-native body fields overlay the lowered request.",
       }),
     ),
   )

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -4766,7 +4766,7 @@
             }
           }
         },
-        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified.",
+        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified. Optional provider-native body fields overlay the lowered request.",
         "summary": "Generate text",
         "requestBody": {
           "content": {
@@ -4781,6 +4781,16 @@
                     "anyOf": [
                       {
                         "$ref": "#/components/schemas/Model.Ref"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "anyOf": [
+                      {
+                        "type": "object"
                       },
                       {
                         "type": "null"

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -4766,7 +4766,7 @@
             }
           }
         },
-        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified.",
+        "description": "Run one stateless model generation using the server's base configuration and return the assistant text. Uses the base configuration's default model when none is specified. Optional provider-native body fields overlay the lowered request.",
         "summary": "Generate text",
         "requestBody": {
           "content": {
@@ -4781,6 +4781,16 @@
                     "anyOf": [
                       {
                         "$ref": "#/components/schemas/Model.Ref"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "body": {
+                    "anyOf": [
+                      {
+                        "type": "object"
                       },
                       {
                         "type": "null"

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -631,8 +631,11 @@ Generate text with a selected model without creating a session, invoking tools, 
 const review = await ctx.generate.text({
   model: { providerID: "anthropic", id: "claude-sonnet-4-6" },
   prompt: "Review this proposed action.",
+  body: { max_tokens: 2_000 },
 })
 ```
+
+`body` overlays provider-native options on the generated request.
 
 ### Permissions
 


### PR DESCRIPTION
### Issue for this PR

N/A — feature PR.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds an optional provider-native `body` to stateless `generate.text` calls. Plugin authors sometimes need per-request controls such as output token limits without creating a session. The body is applied through the existing raw request overlay after protocol lowering, avoiding a dedicated API field for every provider option.

### How did you verify your code works?

Added core generation and Promise client HTTP contract tests, then ran affected package typechecks and generated-file checks.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
