### PR TITLE
feat(tui): add manual update dialog

### DIFF
--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -1,16 +1,19 @@
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { CrossSpawnSpawner } from "@opencode-ai/util/cross-spawn-spawner"
 import { Global } from "@opencode-ai/util/global"
 import { run } from "@opencode-ai/tui"
 import { Commands } from "../commands"
 import { Runtime } from "../../framework/runtime"
 import { Config } from "../../config"
 import { Context, Effect, Fiber, FileSystem, Option, Queue } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { ServerConnection } from "../../services/server-connection"
 import { Updater } from "../../services/updater"
 import { UpdatePreflight } from "../../services/update-preflight"
 import { Npm } from "@opencode-ai/util/npm"
-import { OPENCODE_ARTIFACT, OPENCODE_CHANNEL, OPENCODE_VERSION } from "../../version"
+import { OPENCODE_ARTIFACT, OPENCODE_CHANNEL, OPENCODE_LOCAL, OPENCODE_VERSION } from "../../version"
 import { Env } from "../../env"
+import { selfCommand } from "../../util/process"
 
 export default Runtime.handler(Commands, (input) =>
   Effect.gen(function* () {
@@ -57,7 +60,7 @@ export default Runtime.handler(Commands, (input) =>
     const runFork = Effect.runForkWith(context)
     const runPromise = Effect.runPromiseWith(context)
     const service = server.service
-    yield* run({
+    return yield* run({
       app: {
         name: process.env.OPENCODE_CLIENT ?? OPENCODE_ARTIFACT,
         version: OPENCODE_VERSION,
@@ -92,6 +95,7 @@ export default Runtime.handler(Commands, (input) =>
             ),
             { signal },
           ),
+        check: () => runPromise(Fiber.join(update).pipe(Effect.flatMap(() => updater.checkManual()))),
         apply: (version) => runPromise(updater.apply(version)),
       },
       packages: {
@@ -111,5 +115,32 @@ export default Runtime.handler(Commands, (input) =>
         runFork(effect)
       },
     }).pipe(Effect.provide(LayerNode.compile(Global.node)))
-  }),
+  }).pipe(
+    Effect.scoped,
+    Effect.flatMap((restart) => {
+      if (!restart) return Effect.void
+      return Effect.gen(function* () {
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+        // Resolve the updated launcher, not the old binary in a package manager's cache.
+        const command = OPENCODE_LOCAL ? selfCommand() : [Commands.name]
+        const server = Option.getOrUndefined(input.server)
+        // Relaunch only after the old TUI and standalone server have shut down.
+        // Resume the current session without replaying the initial prompt.
+        const child = yield* spawner.spawn(
+          ChildProcess.make(
+            command[0],
+            [
+              ...command.slice(1),
+              ...(server !== undefined ? ["--server", server] : []),
+              ...(input.standalone ? ["--standalone"] : []),
+              ...(restart.sessionID ? ["--session", restart.sessionID] : []),
+              ...(input.auto || input.yolo || input.dangerouslySkipPermissions ? ["--auto"] : []),
+            ],
+            { stdin: "inherit", stdout: "inherit", stderr: "inherit" },
+          ),
+        )
+        process.exitCode = yield* child.exitCode
+      }).pipe(Effect.provide(LayerNode.compile(CrossSpawnSpawner.node)), Effect.scoped)
+    }),
+  ),
 )

--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -95,7 +95,7 @@ export default Runtime.handler(Commands, (input) =>
             ),
             { signal },
           ),
-        check: () => runPromise(Fiber.join(update).pipe(Effect.flatMap(() => updater.checkManual()))),
+        check: (signal) => runPromise(Fiber.join(update).pipe(Effect.flatMap(() => updater.checkManual())), { signal }),
         apply: (version) => runPromise(updater.apply(version)),
       },
       packages: {
@@ -136,7 +136,7 @@ export default Runtime.handler(Commands, (input) =>
               ...(restart.sessionID ? ["--session", restart.sessionID] : []),
               ...(input.auto || input.yolo || input.dangerouslySkipPermissions ? ["--auto"] : []),
             ],
-            { stdin: "inherit", stdout: "inherit", stderr: "inherit" },
+            { stdin: "inherit", stdout: "inherit", stderr: "inherit", detached: false },
           ),
         )
         process.exitCode = yield* child.exitCode

--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -47,7 +47,7 @@ export default Runtime.handler(Commands, (input) =>
       ),
     )
     const updater = yield* Updater.Service
-    const update = yield* updater.check().pipe(Effect.forkScoped)
+    const update = yield* updater.run().pipe(Effect.forkScoped)
     preflight.loading()
     const config = yield* Config.Service
     const npm = yield* Npm.Service
@@ -92,7 +92,7 @@ export default Runtime.handler(Commands, (input) =>
             ),
             { signal },
           ),
-        check: (signal) => runPromise(Fiber.join(update).pipe(Effect.flatMap(() => updater.checkManual())), { signal }),
+        check: (signal) => runPromise(Fiber.join(update).pipe(Effect.flatMap(() => updater.check())), { signal }),
         apply: (version) => runPromise(updater.apply(version)),
       },
       packages: {

--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -1,19 +1,16 @@
 import { LayerNode } from "@opencode-ai/util/effect/layer-node"
-import { CrossSpawnSpawner } from "@opencode-ai/util/cross-spawn-spawner"
 import { Global } from "@opencode-ai/util/global"
 import { run } from "@opencode-ai/tui"
 import { Commands } from "../commands"
 import { Runtime } from "../../framework/runtime"
 import { Config } from "../../config"
 import { Context, Effect, Fiber, FileSystem, Option, Queue } from "effect"
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { ServerConnection } from "../../services/server-connection"
 import { Updater } from "../../services/updater"
 import { UpdatePreflight } from "../../services/update-preflight"
 import { Npm } from "@opencode-ai/util/npm"
-import { OPENCODE_ARTIFACT, OPENCODE_CHANNEL, OPENCODE_LOCAL, OPENCODE_VERSION } from "../../version"
+import { OPENCODE_ARTIFACT, OPENCODE_CHANNEL, OPENCODE_VERSION } from "../../version"
 import { Env } from "../../env"
-import { selfCommand } from "../../util/process"
 
 export default Runtime.handler(Commands, (input) =>
   Effect.gen(function* () {
@@ -60,7 +57,7 @@ export default Runtime.handler(Commands, (input) =>
     const runFork = Effect.runForkWith(context)
     const runPromise = Effect.runPromiseWith(context)
     const service = server.service
-    return yield* run({
+    yield* run({
       app: {
         name: process.env.OPENCODE_CLIENT ?? OPENCODE_ARTIFACT,
         version: OPENCODE_VERSION,
@@ -115,32 +112,5 @@ export default Runtime.handler(Commands, (input) =>
         runFork(effect)
       },
     }).pipe(Effect.provide(LayerNode.compile(Global.node)))
-  }).pipe(
-    Effect.scoped,
-    Effect.flatMap((restart) => {
-      if (!restart) return Effect.void
-      return Effect.gen(function* () {
-        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
-        // Resolve the updated launcher, not the old binary in a package manager's cache.
-        const command = OPENCODE_LOCAL ? selfCommand() : [Commands.name]
-        const server = Option.getOrUndefined(input.server)
-        // Relaunch only after the old TUI and standalone server have shut down.
-        // Resume the current session without replaying the initial prompt.
-        const child = yield* spawner.spawn(
-          ChildProcess.make(
-            command[0],
-            [
-              ...command.slice(1),
-              ...(server !== undefined ? ["--server", server] : []),
-              ...(input.standalone ? ["--standalone"] : []),
-              ...(restart.sessionID ? ["--session", restart.sessionID] : []),
-              ...(input.auto || input.yolo || input.dangerouslySkipPermissions ? ["--auto"] : []),
-            ],
-            { stdin: "inherit", stdout: "inherit", stderr: "inherit", detached: false },
-          ),
-        )
-        process.exitCode = yield* child.exitCode
-      }).pipe(Effect.provide(LayerNode.compile(CrossSpawnSpawner.node)), Effect.scoped)
-    }),
-  ),
+  }),
 )

--- a/packages/cli/src/server-process.ts
+++ b/packages/cli/src/server-process.ts
@@ -167,7 +167,7 @@ const processEffect = Effect.fnUntraced(function* (options: Options) {
       yield* Updater.Service.pipe(
         Effect.flatMap((updater) =>
           Updater.pollUpdates({
-            check: updater.check().pipe(
+            check: updater.run().pipe(
               Effect.flatMap((result) => {
                 if (!result) return Effect.void
                 if (result.type === "available") return server.updateAvailable(result.version)

--- a/packages/cli/src/services/updater.ts
+++ b/packages/cli/src/services/updater.ts
@@ -9,12 +9,12 @@ import { action, parseReleaseVersion, type Policy } from "./updater-action"
 
 export const methods = ["curl", "npm", "pnpm", "bun", "yarn"] as const
 export type Method = (typeof methods)[number]
-export type CheckResult = { readonly type: "available" | "installed"; readonly version: string }
-export type ManualCheckResult = CheckResult | { readonly type: "unavailable"; readonly message: string }
+export type RunResult = { readonly type: "available" | "installed"; readonly version: string }
+export type CheckResult = RunResult | { readonly type: "unavailable"; readonly message: string }
 
 export interface Interface {
-  readonly check: () => Effect.Effect<CheckResult | undefined>
-  readonly checkManual: () => Effect.Effect<ManualCheckResult | undefined, Error>
+  readonly run: () => Effect.Effect<RunResult | undefined>
+  readonly check: () => Effect.Effect<CheckResult | undefined, Error>
   readonly apply: (version: string) => Effect.Effect<void, Error>
   readonly method: () => Effect.Effect<Method | undefined>
   readonly latest: () => Effect.Effect<string, Error>
@@ -78,7 +78,7 @@ const make = Effect.gen(function* () {
     return values.findLast((value) => value !== undefined) ?? "auto"
   })
 
-  const run = Effect.fnUntraced(function* (command: string[], timeout: Duration.Input = "10 seconds") {
+  const exec = Effect.fnUntraced(function* (command: string[], timeout: Duration.Input = "10 seconds") {
     return yield* appProcess
       .run(ChildProcess.make(command[0], command.slice(1)), {
         timeout,
@@ -113,7 +113,7 @@ const make = Effect.gen(function* () {
     ]
     const results = yield* Effect.forEach(
       checks,
-      (check) => run(check.command).pipe(Effect.map((result) => ({ check, result }))),
+      (check) => exec(check.command).pipe(Effect.map((result) => ({ check, result }))),
       { concurrency: "unbounded" },
     )
     return results.find((result) => result.result.stdout.includes(installedPackage))?.check.method
@@ -168,17 +168,20 @@ const make = Effect.gen(function* () {
           // Bun does not prune old versions from its shared package cache.
           yield* fs.makeDirectory(global.cache, { recursive: true })
           const cache = yield* fs.makeTempDirectoryScoped({ directory: global.cache, prefix: "update-" })
-          return yield* run(["bun", "install", "--global", "--trust", "--cache-dir", cache, target], "5 minutes")
+          return yield* exec(["bun", "install", "--global", "--trust", "--cache-dir", cache, target], "5 minutes")
         }
         if (method === "curl") {
           yield* fs.makeDirectory(global.cache, { recursive: true })
           const directory = yield* fs.makeTempDirectoryScoped({ directory: global.cache, prefix: "update-" })
           const installer = path.join(directory, "install")
-          const download = yield* run(["curl", "-fsSL", "-o", installer, "https://opencode.ai/v2/install"], "5 minutes")
+          const download = yield* exec(
+            ["curl", "-fsSL", "-o", installer, "https://opencode.ai/v2/install"],
+            "5 minutes",
+          )
           if (download.code !== 0) return download
-          return yield* run(["bash", installer, "--version", version, "--no-modify-path"], "5 minutes")
+          return yield* exec(["bash", installer, "--version", version, "--no-modify-path"], "5 minutes")
         }
-        return yield* run(commands[method], "5 minutes")
+        return yield* exec(commands[method], "5 minutes")
       }),
     ).pipe(Effect.mapError((cause) => new Error(`Failed to update with ${method}`, { cause })))
     if (result.code === 0) return
@@ -232,7 +235,7 @@ const make = Effect.gen(function* () {
     if (!(yield* install(version))) return yield* Effect.fail(new Error("Installation method not found"))
   })
 
-  const checkManual = Effect.fn("cli.updater.check-manual")(function* () {
+  const check = Effect.fn("cli.updater.check")(function* () {
     if (OPENCODE_LOCAL)
       return {
         type: "unavailable" as const,
@@ -250,7 +253,7 @@ const make = Effect.gen(function* () {
     return { type: "available" as const, version }
   })
 
-  const check = Effect.fn("cli.updater.check")(
+  const run = Effect.fn("cli.updater.run")(
     function* () {
       const result = yield* inspect()
       if (!result) return undefined
@@ -261,7 +264,7 @@ const make = Effect.gen(function* () {
     Effect.catch((error) => Effect.logWarning("update check failed", { error }).pipe(Effect.as(undefined))),
   )
 
-  return Service.of({ check, checkManual, apply, method, latest, upgrade })
+  return Service.of({ run, check, apply, method, latest, upgrade })
 })
 
 export const layer = Layer.effect(Service, make)

--- a/packages/cli/src/services/updater.ts
+++ b/packages/cli/src/services/updater.ts
@@ -121,12 +121,12 @@ const make = Effect.gen(function* () {
 
   const release = Effect.fnUntraced(function* () {
     const response = yield* Effect.tryPromise({
-      try: () =>
+      try: (signal) =>
         fetch(
           `https://update.opencode.ai/api/${encodeURIComponent(channel)}/${encodeURIComponent(OPENCODE_ARTIFACT)}/npm`,
           {
             headers: { "User-Agent": `opencode/${OPENCODE_VERSION}` },
-            signal: AbortSignal.timeout(10_000),
+            signal: AbortSignal.any([signal, AbortSignal.timeout(10_000)]),
           },
         ),
       catch: (cause) => new Error("Failed to check for updates", { cause }),

--- a/packages/cli/src/services/updater.ts
+++ b/packages/cli/src/services/updater.ts
@@ -10,9 +10,11 @@ import { action, parseReleaseVersion, type Policy } from "./updater-action"
 export const methods = ["curl", "npm", "pnpm", "bun", "yarn"] as const
 export type Method = (typeof methods)[number]
 export type CheckResult = { readonly type: "available" | "installed"; readonly version: string }
+export type ManualCheckResult = CheckResult | { readonly type: "unavailable"; readonly message: string }
 
 export interface Interface {
   readonly check: () => Effect.Effect<CheckResult | undefined>
+  readonly checkManual: () => Effect.Effect<ManualCheckResult | undefined, Error>
   readonly apply: (version: string) => Effect.Effect<void, Error>
   readonly method: () => Effect.Effect<Method | undefined>
   readonly latest: () => Effect.Effect<string, Error>
@@ -230,6 +232,24 @@ const make = Effect.gen(function* () {
     if (!(yield* install(version))) return yield* Effect.fail(new Error("Installation method not found"))
   })
 
+  const checkManual = Effect.fn("cli.updater.check-manual")(function* () {
+    if (OPENCODE_LOCAL)
+      return {
+        type: "unavailable" as const,
+        message: "This build runs from a source checkout. Use an installed OpenCode release to check for updates.",
+      }
+    const version = yield* latest()
+    if (!parseReleaseVersion(version)) return yield* Effect.fail(new Error(`Invalid version: ${version}`))
+    const current = yield* Ref.get(installedVersion)
+    if (action(current, version, "auto") === "none") {
+      // An earlier check may have installed the update while this client is still running.
+      return action(OPENCODE_VERSION, current, "auto") === "none"
+        ? undefined
+        : { type: "installed" as const, version: current }
+    }
+    return { type: "available" as const, version }
+  })
+
   const check = Effect.fn("cli.updater.check")(
     function* () {
       const result = yield* inspect()
@@ -241,7 +261,7 @@ const make = Effect.gen(function* () {
     Effect.catch((error) => Effect.logWarning("update check failed", { error }).pipe(Effect.as(undefined))),
   )
 
-  return Service.of({ check, apply, method, latest, upgrade })
+  return Service.of({ check, checkManual, apply, method, latest, upgrade })
 })
 
 export const layer = Layer.effect(Service, make)

--- a/packages/cli/test/fixture/upgrade.ts
+++ b/packages/cli/test/fixture/upgrade.ts
@@ -13,6 +13,7 @@ await Effect.runPromise(
   ).pipe(
     Effect.provideService(Updater.Service, {
       check: () => Effect.die("Manual upgrades must not check for automatic updates"),
+      checkManual: () => Effect.die("Manual upgrades must not check for TUI updates"),
       apply: () => Effect.die("Manual upgrades must not apply TUI updates"),
       method: () =>
         Effect.sync(() => {

--- a/packages/cli/test/fixture/upgrade.ts
+++ b/packages/cli/test/fixture/upgrade.ts
@@ -12,8 +12,8 @@ await Effect.runPromise(
     process.argv.slice(2),
   ).pipe(
     Effect.provideService(Updater.Service, {
-      check: () => Effect.die("Manual upgrades must not check for automatic updates"),
-      checkManual: () => Effect.die("Manual upgrades must not check for TUI updates"),
+      run: () => Effect.die("Manual upgrades must not check for automatic updates"),
+      check: () => Effect.die("Manual upgrades must not check for TUI updates"),
       apply: () => Effect.die("Manual upgrades must not apply TUI updates"),
       method: () =>
         Effect.sync(() => {

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -87,7 +87,7 @@ import open from "open"
 import { PromptRefProvider, usePromptRef } from "./context/prompt"
 import { Config, ConfigProvider, useConfig } from "./config"
 import { newSessionLocation } from "./config/new-session-location"
-import { UpdateNotificationProvider, type UpdateSource } from "./context/update-notification"
+import { UpdateNotificationProvider, useUpdateNotification, type UpdateSource } from "./context/update-notification"
 import { PluginProvider, usePlugin, type PackageSource } from "./plugin/context"
 import { localPluginDirectories } from "./plugin/discovery"
 import { PluginRoute, Slot } from "./plugin/render"
@@ -154,6 +154,7 @@ const appBindingCommands = [
   "provider.connect",
   "opencode.settings",
   "opencode.status",
+  "opencode.update",
   "server.pair",
   "service.restart",
   "opencode.debug",
@@ -225,7 +226,11 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
         restart: managed.restart,
       }
     : undefined
-  const exit = { epilogue: undefined as string | undefined, reason: undefined as unknown }
+  const exit = {
+    epilogue: undefined as string | undefined,
+    reason: undefined as unknown,
+    restart: undefined as { sessionID?: string } | undefined,
+  }
   const result = yield* Effect.scoped(
     Effect.gen(function* () {
       const options = {
@@ -396,6 +401,9 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                                                                         <AttentionProvider>
                                                                           <UpdateNotificationProvider
                                                                             updater={input.updater}
+                                                                            onRestart={(sessionID) => {
+                                                                              exit.restart = { sessionID }
+                                                                            }}
                                                                           >
                                                                             <PluginProvider
                                                                               packages={input.packages}
@@ -452,7 +460,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
         }
       })
       yield* shutdown.await
-      return { epilogue: exit.epilogue, reason: exit.reason }
+      return { epilogue: exit.epilogue, reason: exit.reason, restart: exit.restart }
     }),
   )
   yield* Effect.sync(() => {
@@ -460,6 +468,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
       process.stderr.write((cliErrorMessage(result.reason) ?? errorFormat(result.reason)) + "\n")
     if (result.epilogue) process.stdout.write(result.epilogue + "\n")
   })
+  return result.restart
 })
 
 function App(props: { pair?: DialogPairCredentials }) {
@@ -478,6 +487,7 @@ function App(props: { pair?: DialogPairCredentials }) {
   const event = useEvent()
   const client = useClient()
   const toast = useToast()
+  const updater = useUpdateNotification()
   const theme = useTheme()
   const { mode, supports, setMode, locked, lock, unlock } = useThemes()
   const data = useData()
@@ -938,6 +948,17 @@ function App(props: { pair?: DialogPairCredentials }) {
         },
         category: "System",
       },
+      ...(updater.open
+        ? [
+            {
+              name: "opencode.update",
+              title: "Update OpenCode",
+              slash: { name: "update" },
+              run: () => updater.open?.("manual"),
+              category: "System",
+            },
+          ]
+        : []),
       {
         name: "server.pair",
         title: "Pair device",

--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -226,11 +226,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
         restart: managed.restart,
       }
     : undefined
-  const exit = {
-    epilogue: undefined as string | undefined,
-    reason: undefined as unknown,
-    restart: undefined as { sessionID?: string } | undefined,
-  }
+  const exit = { epilogue: undefined as string | undefined, reason: undefined as unknown }
   const result = yield* Effect.scoped(
     Effect.gen(function* () {
       const options = {
@@ -401,9 +397,6 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
                                                                         <AttentionProvider>
                                                                           <UpdateNotificationProvider
                                                                             updater={input.updater}
-                                                                            onRestart={(sessionID) => {
-                                                                              exit.restart = { sessionID }
-                                                                            }}
                                                                           >
                                                                             <PluginProvider
                                                                               packages={input.packages}
@@ -460,7 +453,7 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
         }
       })
       yield* shutdown.await
-      return { epilogue: exit.epilogue, reason: exit.reason, restart: exit.restart }
+      return { epilogue: exit.epilogue, reason: exit.reason }
     }),
   )
   yield* Effect.sync(() => {
@@ -468,7 +461,6 @@ export const run = Effect.fn("Tui.run")(function* (input: TuiInput) {
       process.stderr.write((cliErrorMessage(result.reason) ?? errorFormat(result.reason)) + "\n")
     if (result.epilogue) process.stdout.write(result.epilogue + "\n")
   })
-  return result.restart
 })
 
 function App(props: { pair?: DialogPairCredentials }) {

--- a/packages/tui/src/component/dialog-update.tsx
+++ b/packages/tui/src/component/dialog-update.tsx
@@ -2,13 +2,12 @@ import { TextAttributes } from "@opentui/core"
 import { createEffect, createMemo, createResource, createSignal, For, Match, onCleanup, Show, Switch } from "solid-js"
 import { Keymap } from "../context/keymap"
 import { useTheme } from "../context/theme"
-import type { UpdateOrigin, UpdateState } from "../context/update-notification"
+import type { UpdateState } from "../context/update-notification"
 import { useDialog } from "../ui/dialog"
 import { errorMessage } from "../util/error"
 import { Spinner } from "./spinner"
 
 export function DialogUpdate(props: {
-  origin: UpdateOrigin
   check?: (signal: AbortSignal) => Promise<string | undefined>
   state: () => UpdateState | undefined
   install: () => Promise<void>
@@ -42,20 +41,13 @@ export function DialogUpdate(props: {
   const buttons = createMemo(() => {
     const type = state().type
     if (type === "installing") return []
-    if (type === "checking") return [{ label: "Cancel", run: () => dialog.clear() }]
     const confirm =
       type === "available"
         ? { label: "Update", run: props.install }
         : type === "installed"
           ? { label: "Restart", run: props.restart }
           : undefined
-    return [
-      {
-        label: type === "available" && props.origin === "notification" ? "Skip" : confirm ? "Cancel" : "close",
-        run: () => dialog.clear(),
-      },
-      ...(confirm ? [confirm] : []),
-    ]
+    return [{ label: "Skip", run: () => dialog.clear() }, ...(confirm ? [confirm] : [])]
   })
 
   createEffect(() => setActive(Math.max(0, buttons().length - 1)))

--- a/packages/tui/src/component/dialog-update.tsx
+++ b/packages/tui/src/component/dialog-update.tsx
@@ -2,12 +2,13 @@ import { TextAttributes } from "@opentui/core"
 import { createEffect, createMemo, createResource, createSignal, For, Match, onCleanup, Show, Switch } from "solid-js"
 import { Keymap } from "../context/keymap"
 import { useTheme } from "../context/theme"
-import type { UpdateState } from "../context/update-notification"
+import type { UpdateOrigin, UpdateState } from "../context/update-notification"
 import { useDialog } from "../ui/dialog"
 import { errorMessage } from "../util/error"
 import { Spinner } from "./spinner"
 
 export function DialogUpdate(props: {
+  origin: UpdateOrigin
   check?: (signal: AbortSignal) => Promise<string | undefined>
   state: () => UpdateState | undefined
   install: () => Promise<void>
@@ -48,7 +49,13 @@ export function DialogUpdate(props: {
         : type === "installed"
           ? { label: "Restart", run: props.restart }
           : undefined
-    return [{ label: confirm ? "Cancel" : "close", run: () => dialog.clear() }, ...(confirm ? [confirm] : [])]
+    return [
+      {
+        label: type === "available" && props.origin === "notification" ? "Skip" : confirm ? "Cancel" : "close",
+        run: () => dialog.clear(),
+      },
+      ...(confirm ? [confirm] : []),
+    ]
   })
 
   createEffect(() => setActive(Math.max(0, buttons().length - 1)))

--- a/packages/tui/src/component/dialog-update.tsx
+++ b/packages/tui/src/component/dialog-update.tsx
@@ -41,17 +41,14 @@ export function DialogUpdate(props: {
   const buttons = createMemo(() => {
     const type = state().type
     if (type === "installing") return []
-    if (type === "checking") return [{ label: "Cancel", padding: 1, run: () => dialog.clear() }]
+    if (type === "checking") return [{ label: "Cancel", run: () => dialog.clear() }]
     const confirm =
       type === "available"
         ? { label: "Update", run: props.install }
         : type === "installed"
           ? { label: "Restart", run: props.restart }
           : undefined
-    return [
-      { label: confirm ? "Cancel" : "close", padding: confirm ? 1 : 3, run: () => dialog.clear() },
-      ...(confirm ? [{ ...confirm, padding: 1 }] : []),
-    ]
+    return [{ label: confirm ? "Cancel" : "close", run: () => dialog.clear() }, ...(confirm ? [confirm] : [])]
   })
 
   createEffect(() => setActive(Math.max(0, buttons().length - 1)))
@@ -133,8 +130,8 @@ export function DialogUpdate(props: {
           <For each={buttons()}>
             {(button, index) => (
               <box
-                paddingLeft={button.padding}
-                paddingRight={button.padding}
+                paddingLeft={1}
+                paddingRight={1}
                 backgroundColor={active() === index() ? theme.background.action.primary.focused : undefined}
                 onMouseUp={() => void button.run()}
               >

--- a/packages/tui/src/component/dialog-update.tsx
+++ b/packages/tui/src/component/dialog-update.tsx
@@ -1,5 +1,5 @@
 import { TextAttributes } from "@opentui/core"
-import { createEffect, createMemo, createResource, createSignal, For, Match, Show, Switch } from "solid-js"
+import { createEffect, createMemo, createResource, createSignal, For, Match, onCleanup, Show, Switch } from "solid-js"
 import { Keymap } from "../context/keymap"
 import { useTheme } from "../context/theme"
 import type { UpdateState } from "../context/update-notification"
@@ -8,7 +8,7 @@ import { errorMessage } from "../util/error"
 import { Spinner } from "./spinner"
 
 export function DialogUpdate(props: {
-  check?: () => Promise<string | undefined>
+  check?: (signal: AbortSignal) => Promise<string | undefined>
   state: () => UpdateState | undefined
   install: () => Promise<void>
   restart: () => void
@@ -17,14 +17,16 @@ export function DialogUpdate(props: {
   const theme = useTheme("elevated")
   const [error, setError] = createSignal<string>()
   const [active, setActive] = createSignal(0)
+  const controller = new AbortController()
+  onCleanup(() => controller.abort())
 
   dialog.setCentered(true)
 
   const [check] = createResource(
     () => props.check,
     (check) =>
-      check().catch((error) => {
-        setError(errorMessage(error))
+      check(controller.signal).catch((error) => {
+        if (!controller.signal.aborted) setError(errorMessage(error))
         return undefined
       }),
   )

--- a/packages/tui/src/component/dialog-update.tsx
+++ b/packages/tui/src/component/dialog-update.tsx
@@ -1,0 +1,149 @@
+import { TextAttributes } from "@opentui/core"
+import { createEffect, createMemo, createResource, createSignal, For, Match, Show, Switch } from "solid-js"
+import { Keymap } from "../context/keymap"
+import { useTheme } from "../context/theme"
+import type { UpdateState } from "../context/update-notification"
+import { useDialog } from "../ui/dialog"
+import { errorMessage } from "../util/error"
+import { Spinner } from "./spinner"
+
+export function DialogUpdate(props: {
+  check?: () => Promise<string | undefined>
+  state: () => UpdateState | undefined
+  install: () => Promise<void>
+  restart: () => void
+}) {
+  const dialog = useDialog()
+  const theme = useTheme("elevated")
+  const [error, setError] = createSignal<string>()
+  const [active, setActive] = createSignal(0)
+
+  dialog.setCentered(true)
+
+  const [check] = createResource(
+    () => props.check,
+    (check) =>
+      check().catch((error) => {
+        setError(errorMessage(error))
+        return undefined
+      }),
+  )
+  const state = createMemo(() => {
+    if (check.loading) return { type: "checking" as const }
+    const unavailable = check()
+    if (unavailable) return { type: "unavailable" as const, message: unavailable }
+    const message = error()
+    if (message) return { type: "check-failed" as const, message }
+    return props.state() ?? { type: "current" as const }
+  })
+  const buttons = createMemo(() => {
+    const type = state().type
+    if (type === "installing") return []
+    if (type === "checking") return [{ label: "Cancel", padding: 1, run: () => dialog.clear() }]
+    const confirm =
+      type === "available"
+        ? { label: "Update", run: props.install }
+        : type === "installed"
+          ? { label: "Restart", run: props.restart }
+          : undefined
+    return [
+      { label: confirm ? "Cancel" : "close", padding: confirm ? 1 : 3, run: () => dialog.clear() },
+      ...(confirm ? [{ ...confirm, padding: 1 }] : []),
+    ]
+  })
+
+  createEffect(() => setActive(Math.max(0, buttons().length - 1)))
+
+  Keymap.createLayer(() => ({
+    mode: "modal",
+    commands: [
+      {
+        bind: "return",
+        title: "Confirm update action",
+        group: "Dialog",
+        run: () => void buttons()[active()]?.run(),
+      },
+      ...["left", "right", "tab", "shift+tab"].map((bind) => ({
+        bind,
+        title: bind === "left" || bind === "shift+tab" ? "Previous update action" : "Next update action",
+        group: "Dialog",
+        run: () => {
+          const count = buttons().length
+          if (count) setActive((value) => (value + 1) % count)
+        },
+      })),
+    ],
+  }))
+
+  return (
+    <box paddingLeft={2} paddingRight={2} gap={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text.default}>
+          {state().type === "available" || state().type === "installing" || state().type === "failed"
+            ? "Update available"
+            : "Update"}
+        </text>
+        <text fg={theme.text.subdued} onMouseUp={() => dialog.clear()}>
+          esc
+        </text>
+      </box>
+      <box paddingBottom={1}>
+        <Show when={state()} keyed>
+          {(current) => (
+            <Switch>
+              <Match when={current.type === "checking"}>
+                <Spinner shimmer={theme.text.default}>Checking for updates…</Spinner>
+              </Match>
+              <Match when={current.type === "available"}>
+                <text fg={theme.text.subdued}>
+                  An update is available. After installing, you'll be prompted to restart OpenCode.
+                </text>
+              </Match>
+              <Match when={current.type === "installing"}>
+                <Spinner shimmer={theme.text.default}>
+                  {current.type === "installing" ? `Installing OpenCode ${current.version}…` : ""}
+                </Spinner>
+              </Match>
+              <Match when={current.type === "installed"}>
+                <text fg={theme.text.subdued} wrapMode="word">
+                  Update successful! A restart is required. Any active sessions will be resumed automatically.
+                </text>
+              </Match>
+              <Match when={current.type === "current"}>
+                <text fg={theme.text.subdued}>OpenCode is already up to date.</text>
+              </Match>
+              <Match when={current.type === "unavailable"}>
+                <text fg={theme.text.subdued} wrapMode="word">
+                  {current.type === "unavailable" ? current.message : ""}
+                </text>
+              </Match>
+              <Match when={current.type === "failed" || current.type === "check-failed"}>
+                <text fg={theme.text.feedback.error.default}>
+                  {current.type === "failed" || current.type === "check-failed" ? current.message : ""}
+                </text>
+              </Match>
+            </Switch>
+          )}
+        </Show>
+      </box>
+      <Show when={buttons().length > 0}>
+        <box flexDirection="row" justifyContent="flex-end" paddingBottom={1}>
+          <For each={buttons()}>
+            {(button, index) => (
+              <box
+                paddingLeft={button.padding}
+                paddingRight={button.padding}
+                backgroundColor={active() === index() ? theme.background.action.primary.focused : undefined}
+                onMouseUp={() => void button.run()}
+              >
+                <text fg={active() === index() ? theme.text.action.primary.focused : theme.text.subdued}>
+                  {button.label}
+                </text>
+              </box>
+            )}
+          </For>
+        </box>
+      </Show>
+    </box>
+  )
+}

--- a/packages/tui/src/component/fade-in-text.tsx
+++ b/packages/tui/src/component/fade-in-text.tsx
@@ -1,14 +1,8 @@
-import {
-  OptimizedBuffer,
-  RGBA,
-  TargetChannel,
-  TextRenderable,
-  type RenderContext,
-  type TextOptions,
-} from "@opentui/core"
+import { RGBA, type OptimizedBuffer, type RenderContext, type TextOptions } from "@opentui/core"
 import { extend, type JSX } from "@opentui/solid"
 import { splitProps } from "solid-js"
 import { useConfig } from "../config"
+import { MaskedTextRenderable } from "./masked-text"
 import { coast, smootherstep } from "./tab-pulse"
 
 type FadeInTextOptions = TextOptions & {
@@ -20,19 +14,14 @@ type FadeInTextOptions = TextOptions & {
 
 const DURATION = 200
 const FEATHER = 8
-const TRANSPARENT = RGBA.fromValues(0, 0, 0, 0)
-const CONTINUATION = 0xc0000000 | 0
 const clamp = (value: number) => Math.max(0, Math.min(1, value))
 
-class FadeInTextRenderable extends TextRenderable {
+class FadeInTextRenderable extends MaskedTextRenderable {
   private _backdrop = RGBA.defaultBackground()
   private _enabled = true
   private _sweepOffset = 0
   private _sweepWidth: number | undefined
   private elapsed = 0
-  private scratch: OptimizedBuffer | undefined
-  private mask = new Float32Array(0)
-  private matrix = new Float32Array(16)
 
   constructor(ctx: RenderContext, options: FadeInTextOptions) {
     super(ctx, options)
@@ -77,47 +66,12 @@ class FadeInTextRenderable extends TextRenderable {
     if (!this._enabled || this.elapsed >= DURATION) return super.render(buffer, deltaTime)
     if (!this.visible || this.isDestroyed || !Number.isFinite(this.width) || this.width <= 0 || this.height <= 0) return
     this.elapsed = Math.min(DURATION, this.elapsed + deltaTime)
-    if (!this.scratch)
-      this.scratch = OptimizedBuffer.create(this.width, this.height, this._ctx.widthMethod, { respectAlpha: true })
-    if (this.scratch.width !== this.width || this.scratch.height !== this.height)
-      this.scratch.resize(this.width, this.height)
-
-    this.scratch.clear(TRANSPARENT)
-    this.scratch.drawTextBuffer(this.textBufferView, 0, 0)
-    const characters = this.scratch.buffers.char
-    let end = 0
-    for (let row = 0; row < this.height; row++) {
-      let column = this.width
-      while (
-        column > 0 &&
-        (characters[row * this.width + column - 1] === 32 || characters[row * this.width + column - 1] === 0)
-      )
-        column--
-      end = Math.max(end, column)
-    }
-    const progress = this.elapsed / DURATION
-    const front = -FEATHER + coast(progress) * ((this._sweepWidth ?? end) + FEATHER * 2)
-    if (this.mask.length !== this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
-    let strength = 1
-    for (let cell = 0; cell < characters.length; cell++) {
-      const column = cell % this.width
-      if ((characters[cell] & CONTINUATION) !== CONTINUATION)
-        strength = 1 - smootherstep(clamp((front - (this._sweepOffset + column)) / FEATHER))
-      this.mask[cell * 3] = column
-      this.mask[cell * 3 + 1] = Math.floor(cell / this.width)
-      this.mask[cell * 3 + 2] = strength
-    }
-    this.scratch.colorMatrix(this.matrix, this.mask, 1, TargetChannel.FG)
-    buffer.drawFrameBuffer(this.screenX, this.screenY, this.scratch)
-    this.markClean()
-    this._ctx.addToHitGrid(this.screenX, this.screenY, this.width, this.height, this.num)
+    this.renderMasked(buffer, 1, (end) => {
+      const progress = this.elapsed / DURATION
+      const front = -FEATHER + coast(progress) * ((this._sweepWidth ?? end) + FEATHER * 2)
+      return (column) => 1 - smootherstep(clamp((front - (this._sweepOffset + column)) / FEATHER))
+    })
     if (this.elapsed >= DURATION) this.live = false
-  }
-
-  override destroy() {
-    this.scratch?.destroy()
-    this.scratch = undefined
-    super.destroy()
   }
 }
 

--- a/packages/tui/src/component/masked-text.ts
+++ b/packages/tui/src/component/masked-text.ts
@@ -1,0 +1,56 @@
+import { OptimizedBuffer, RGBA, TargetChannel, TextRenderable } from "@opentui/core"
+
+const TRANSPARENT = RGBA.fromValues(0, 0, 0, 0)
+const CONTINUATION = 0xc0000000 | 0
+
+export class MaskedTextRenderable extends TextRenderable {
+  protected readonly matrix = new Float32Array(16)
+  private scratch: OptimizedBuffer | undefined
+  private mask = new Float32Array(0)
+
+  protected renderMasked(
+    buffer: OptimizedBuffer,
+    initialStrength: number,
+    shade: (width: number) => (column: number) => number,
+  ) {
+    if (!this.scratch)
+      this.scratch = OptimizedBuffer.create(this.width, this.height, this._ctx.widthMethod, { respectAlpha: true })
+    if (this.scratch.width !== this.width || this.scratch.height !== this.height)
+      this.scratch.resize(this.width, this.height)
+
+    this.scratch.clear(TRANSPARENT)
+    this.scratch.drawTextBuffer(this.textBufferView, 0, 0)
+    const characters = this.scratch.buffers.char
+    let end = 0
+    for (let row = 0; row < this.height; row++) {
+      let column = this.width
+      while (
+        column > 0 &&
+        (characters[row * this.width + column - 1] === 32 || characters[row * this.width + column - 1] === 0)
+      )
+        column--
+      end = Math.max(end, column)
+    }
+    const intensity = shade(end)
+    if (this.mask.length !== this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
+    let strength = initialStrength
+    for (let cell = 0; cell < characters.length; cell++) {
+      const column = cell % this.width
+      // Wide glyph continuation cells retain the head cell's intensity.
+      if ((characters[cell] & CONTINUATION) !== CONTINUATION) strength = intensity(column)
+      this.mask[cell * 3] = column
+      this.mask[cell * 3 + 1] = Math.floor(cell / this.width)
+      this.mask[cell * 3 + 2] = strength
+    }
+    this.scratch.colorMatrix(this.matrix, this.mask, 1, TargetChannel.FG)
+    buffer.drawFrameBuffer(this.screenX, this.screenY, this.scratch)
+    this.markClean()
+    this._ctx.addToHitGrid(this.screenX, this.screenY, this.width, this.height, this.num)
+  }
+
+  override destroy() {
+    this.scratch?.destroy()
+    this.scratch = undefined
+    super.destroy()
+  }
+}

--- a/packages/tui/src/component/shimmer-text.tsx
+++ b/packages/tui/src/component/shimmer-text.tsx
@@ -1,13 +1,7 @@
-import {
-  OptimizedBuffer,
-  RGBA,
-  TargetChannel,
-  TextRenderable,
-  type RenderContext,
-  type TextOptions,
-} from "@opentui/core"
+import { RGBA, type OptimizedBuffer, type RenderContext, type TextOptions } from "@opentui/core"
 import { extend, type JSX } from "@opentui/solid"
 import { splitProps } from "solid-js"
+import { MaskedTextRenderable } from "./masked-text"
 import { coast, intensityAt } from "./tab-pulse"
 
 type ShimmerTextOptions = TextOptions & {
@@ -15,15 +9,10 @@ type ShimmerTextOptions = TextOptions & {
 }
 
 const DURATION = 1200
-const TRANSPARENT = RGBA.fromValues(0, 0, 0, 0)
-const CONTINUATION = 0xc0000000 | 0
 
-class ShimmerTextRenderable extends TextRenderable {
+class ShimmerTextRenderable extends MaskedTextRenderable {
   private _shimmer = RGBA.defaultForeground()
   private elapsed = 0
-  private scratch: OptimizedBuffer | undefined
-  private mask = new Float32Array(0)
-  private matrix = new Float32Array(16)
 
   constructor(ctx: RenderContext, options: ShimmerTextOptions) {
     super(ctx, options)
@@ -47,44 +36,10 @@ class ShimmerTextRenderable extends TextRenderable {
   override render(buffer: OptimizedBuffer, deltaTime: number) {
     if (!this.visible || this.isDestroyed || !Number.isFinite(this.width) || this.width <= 0 || this.height <= 0) return
     this.elapsed = (this.elapsed + deltaTime) % DURATION
-    if (!this.scratch)
-      this.scratch = OptimizedBuffer.create(this.width, this.height, this._ctx.widthMethod, { respectAlpha: true })
-    if (this.scratch.width !== this.width || this.scratch.height !== this.height)
-      this.scratch.resize(this.width, this.height)
-
-    this.scratch.clear(TRANSPARENT)
-    this.scratch.drawTextBuffer(this.textBufferView, 0, 0)
-    const characters = this.scratch.buffers.char
-    let end = 0
-    for (let row = 0; row < this.height; row++) {
-      let column = this.width
-      while (
-        column > 0 &&
-        (characters[row * this.width + column - 1] === 32 || characters[row * this.width + column - 1] === 0)
-      )
-        column--
-      end = Math.max(end, column)
-    }
-    const front = -4 + coast(this.elapsed / DURATION) * (end + 22)
-    if (this.mask.length !== this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
-    let strength = 0
-    for (let cell = 0; cell < characters.length; cell++) {
-      const column = cell % this.width
-      if ((characters[cell] & CONTINUATION) !== CONTINUATION) strength = intensityAt(column, front, 4, 18)
-      this.mask[cell * 3] = column
-      this.mask[cell * 3 + 1] = Math.floor(cell / this.width)
-      this.mask[cell * 3 + 2] = strength
-    }
-    this.scratch.colorMatrix(this.matrix, this.mask, 1, TargetChannel.FG)
-    buffer.drawFrameBuffer(this.screenX, this.screenY, this.scratch)
-    this.markClean()
-    this._ctx.addToHitGrid(this.screenX, this.screenY, this.width, this.height, this.num)
-  }
-
-  override destroy() {
-    this.scratch?.destroy()
-    this.scratch = undefined
-    super.destroy()
+    this.renderMasked(buffer, 0, (end) => {
+      const front = -4 + coast(this.elapsed / DURATION) * (end + 22)
+      return (column) => intensityAt(column, front, 4, 18)
+    })
   }
 }
 

--- a/packages/tui/src/component/shimmer-text.tsx
+++ b/packages/tui/src/component/shimmer-text.tsx
@@ -1,0 +1,104 @@
+import {
+  OptimizedBuffer,
+  RGBA,
+  TargetChannel,
+  TextRenderable,
+  type RenderContext,
+  type TextOptions,
+} from "@opentui/core"
+import { extend, type JSX } from "@opentui/solid"
+import { splitProps } from "solid-js"
+import { coast, intensityAt } from "./tab-pulse"
+
+type ShimmerTextOptions = TextOptions & {
+  shimmer: RGBA
+}
+
+const DURATION = 1200
+const TRANSPARENT = RGBA.fromValues(0, 0, 0, 0)
+const CONTINUATION = 0xc0000000 | 0
+
+class ShimmerTextRenderable extends TextRenderable {
+  private _shimmer = RGBA.defaultForeground()
+  private elapsed = 0
+  private scratch: OptimizedBuffer | undefined
+  private mask = new Float32Array(0)
+  private matrix = new Float32Array(16)
+
+  constructor(ctx: RenderContext, options: ShimmerTextOptions) {
+    super(ctx, options)
+    this.matrix[3] = this._shimmer.r
+    this.matrix[7] = this._shimmer.g
+    this.matrix[11] = this._shimmer.b
+    this.matrix[15] = 1
+    if (options.shimmer) this.shimmer = options.shimmer
+    this.live = true
+  }
+
+  set shimmer(value: RGBA) {
+    if (value.equals(this._shimmer)) return
+    this._shimmer = value
+    this.matrix[3] = value.r
+    this.matrix[7] = value.g
+    this.matrix[11] = value.b
+    this.requestRender()
+  }
+
+  override render(buffer: OptimizedBuffer, deltaTime: number) {
+    if (!this.visible || this.isDestroyed || !Number.isFinite(this.width) || this.width <= 0 || this.height <= 0) return
+    this.elapsed = (this.elapsed + deltaTime) % DURATION
+    if (!this.scratch)
+      this.scratch = OptimizedBuffer.create(this.width, this.height, this._ctx.widthMethod, { respectAlpha: true })
+    if (this.scratch.width !== this.width || this.scratch.height !== this.height)
+      this.scratch.resize(this.width, this.height)
+
+    this.scratch.clear(TRANSPARENT)
+    this.scratch.drawTextBuffer(this.textBufferView, 0, 0)
+    const characters = this.scratch.buffers.char
+    let end = 0
+    for (let row = 0; row < this.height; row++) {
+      let column = this.width
+      while (
+        column > 0 &&
+        (characters[row * this.width + column - 1] === 32 || characters[row * this.width + column - 1] === 0)
+      )
+        column--
+      end = Math.max(end, column)
+    }
+    const front = -4 + coast(this.elapsed / DURATION) * (end + 22)
+    if (this.mask.length !== this.width * this.height * 3) this.mask = new Float32Array(this.width * this.height * 3)
+    let strength = 0
+    for (let cell = 0; cell < characters.length; cell++) {
+      const column = cell % this.width
+      if ((characters[cell] & CONTINUATION) !== CONTINUATION) strength = intensityAt(column, front, 4, 18)
+      this.mask[cell * 3] = column
+      this.mask[cell * 3 + 1] = Math.floor(cell / this.width)
+      this.mask[cell * 3 + 2] = strength
+    }
+    this.scratch.colorMatrix(this.matrix, this.mask, 1, TargetChannel.FG)
+    buffer.drawFrameBuffer(this.screenX, this.screenY, this.scratch)
+    this.markClean()
+    this._ctx.addToHitGrid(this.screenX, this.screenY, this.width, this.height, this.num)
+  }
+
+  override destroy() {
+    this.scratch?.destroy()
+    this.scratch = undefined
+    super.destroy()
+  }
+}
+
+extend({ shimmer_text: ShimmerTextRenderable })
+
+declare module "@opentui/solid" {
+  interface OpenTUIComponents {
+    shimmer_text: typeof ShimmerTextRenderable
+  }
+}
+
+type Props = Omit<JSX.IntrinsicElements["text"], "ref"> & { shimmer: RGBA }
+
+export function ShimmerText(props: Props) {
+  const [local, text] = splitProps(props, ["shimmer"])
+  return <shimmer_text {...text} shimmer={local.shimmer} />
+}

--- a/packages/tui/src/component/spinner.tsx
+++ b/packages/tui/src/component/spinner.tsx
@@ -1,30 +1,48 @@
-import { Show } from "solid-js"
+import { createEffect, createSignal, onCleanup, Show } from "solid-js"
 import { useTheme } from "../context/theme"
 import { useConfig } from "../config"
 import type { JSX } from "@opentui/solid"
 import type { RGBA } from "@opentui/core"
 import { registerOpencodeSpinner } from "./register-spinner"
 import { SPINNER_FRAMES } from "./spinner-frames"
+import { ShimmerText } from "./shimmer-text"
 
 export { SPINNER_FRAMES } from "./spinner-frames"
 
 registerOpencodeSpinner()
 
-export function Spinner(props: { children?: JSX.Element; color?: RGBA }) {
+export function Spinner(props: { children?: JSX.Element; color?: RGBA; shimmer?: RGBA }) {
   const theme = useTheme()
   const config = useConfig().data
   const color = () => props.color ?? theme.text.subdued
+  const [frame, setFrame] = createSignal(0)
+  createEffect(() => {
+    if (!(config.animations ?? true) || !props.shimmer) return
+    const timer = setInterval(() => setFrame((value) => (value + 1) % SPINNER_FRAMES.length), 80)
+    onCleanup(() => clearInterval(timer))
+  })
   return (
     <Show
       when={config.animations ?? true}
       fallback={<text fg={color()}>{props.children ? <>⋯ {props.children}</> : "⋯"}</text>}
     >
-      <box flexDirection="row" gap={1}>
-        <spinner frames={SPINNER_FRAMES} interval={80} color={color()} />
-        <Show when={props.children}>
-          <text fg={color()}>{props.children}</text>
-        </Show>
-      </box>
+      <Show
+        when={props.shimmer}
+        fallback={
+          <box flexDirection="row" gap={1}>
+            <spinner frames={SPINNER_FRAMES} interval={80} color={color()} />
+            <Show when={props.children}>
+              <text fg={color()}>{props.children}</text>
+            </Show>
+          </box>
+        }
+      >
+        {(shimmer) => (
+          <ShimmerText fg={color()} shimmer={shimmer()}>
+            {SPINNER_FRAMES[frame()]} {props.children}
+          </ShimmerText>
+        )}
+      </Show>
     </Show>
   )
 }

--- a/packages/tui/src/context/update-notification.tsx
+++ b/packages/tui/src/context/update-notification.tsx
@@ -10,7 +10,6 @@ import { DialogUpdate } from "../component/dialog-update"
 
 type ClientNotice = { readonly type: "available" | "installed"; readonly version: string }
 type Notice = ClientNotice & ({ readonly source: "client" } | { readonly source: "server"; readonly remote: boolean })
-export type UpdateOrigin = "manual" | "notification"
 export type UpdateState =
   | ClientNotice
   | { readonly type: "installing"; readonly version: string }
@@ -87,8 +86,10 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
       exit()
     }
 
-    const open = (origin: UpdateOrigin) => {
+    const open = (origin: "manual" | "notification") => {
       if (!props.updater) return
+      // Manual checks hide the current notice without marking the version as seen.
+      if (origin === "manual") setNotification(undefined)
       if (origin === "notification") {
         const current = notification()
         if (!current || (current.source === "server" && current.remote)) return
@@ -100,7 +101,6 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
       }
       dialog.replace(() => (
         <DialogUpdate
-          origin={origin}
           check={origin === "manual" ? check : undefined}
           state={state}
           install={install}

--- a/packages/tui/src/context/update-notification.tsx
+++ b/packages/tui/src/context/update-notification.tsx
@@ -5,88 +5,103 @@ import { useStorage } from "./storage"
 import { useEvent } from "./event"
 import { errorMessage } from "../util/error"
 import { useExit } from "./exit"
+import { useRoute } from "./route"
+import { useDialog } from "../ui/dialog"
+import { DialogUpdate } from "../component/dialog-update"
 
 type ClientNotice = { readonly type: "available" | "installed"; readonly version: string }
 type Notice = ClientNotice & ({ readonly source: "client" } | { readonly source: "server"; readonly remote: boolean })
-export type UpdateNotificationState =
-  | Notice
-  | { readonly source: "client"; readonly type: "installing"; readonly version: string }
-  | { readonly source: "client"; readonly type: "install-success"; readonly version: string }
-  | { readonly source: "client"; readonly type: "failed"; readonly version: string; readonly message: string }
+export type UpdateState =
+  | ClientNotice
+  | { readonly type: "installing"; readonly version: string }
+  | { readonly type: "failed"; readonly message: string }
 
 export type UpdateSource = {
   readonly remote: boolean
   readonly subscribe: (notify: (notice: ClientNotice) => void, signal: AbortSignal) => Promise<void>
+  readonly check: () => Promise<ClientNotice | { readonly type: "unavailable"; readonly message: string } | undefined>
   readonly apply: (version: string) => Promise<void>
 }
 
 export const { use: useUpdateNotification, provider: UpdateNotificationProvider } = createSimpleContext({
   name: "UpdateNotification",
-  init: (props: { updater?: UpdateSource }) => {
+  init: (props: { updater?: UpdateSource; onRestart?: (sessionID?: string) => void }) => {
     const event = useEvent()
     const exit = useExit()
+    const route = useRoute()
+    const dialog = useDialog()
     const log = useLog({ component: "update-notification" })
-    const [state, setState] = createSignal<UpdateNotificationState>()
+    const [state, setState] = createSignal<UpdateState>()
+    const [notification, setNotification] = createSignal<Notice>()
     const [notifications, markNotification] = useStorage().store<{ versions: string[] }>("update-notifications", {
       initial: { versions: [] },
     })
 
     const notify = (notice: Notice) => {
+      if (!props.updater) return
       if (
-        !props.updater ||
         notifications.versions.includes(`${notice.source}:${notice.version}`) ||
         (notice.source === "client" && notifications.versions.includes(notice.version))
       )
         return
-      setState((current) => {
+      setNotification((current) => {
         if (notice.source === "server" && current?.source === "client") return current
         return notice
       })
     }
 
-    const seen = (source: Notice["source"], version: string) =>
-      markNotification((draft) => {
-        draft.versions = [...draft.versions, `${source}:${version}`].slice(-100)
+    const dismiss = () => {
+      const current = notification()
+      if (!current) return
+      setNotification(undefined)
+      // Only interactions with the automatic notification update its history.
+      void markNotification((draft) => {
+        draft.versions = [...draft.versions, `${current.source}:${current.version}`].slice(-100)
       }).catch((error) => log.error("failed to persist update notification", { error }))
-
-    const skip = () => {
-      const current = state()
-      if (!current || current.type !== "available" || (current.source === "server" && current.remote)) return
-      setState(undefined)
-      void seen(current.source, current.version)
-    }
-
-    const close = () => {
-      const current = state()
-      if (!current || current.source !== "server") return
-      setState(undefined)
-      void seen(current.source, current.version)
     }
 
     const install = async () => {
       const updater = props.updater
       const current = state()
-      if (!updater || !current || current.type !== "available" || (current.source === "server" && current.remote))
-        return
-      setState({ source: "client", type: "installing", version: current.version })
-      void seen(current.source, current.version)
+      if (!updater || !current || current.type !== "available") return
+      setState({ type: "installing", version: current.version })
       await updater.apply(current.version).then(
-        () => setState({ source: "client", type: "install-success", version: current.version }),
-        (error) =>
-          setState({ source: "client", type: "failed", version: current.version, message: errorMessage(error) }),
+        () => setState({ type: "installed", version: current.version }),
+        (error) => setState({ type: "failed", message: errorMessage(error) }),
       )
+    }
+
+    const check = async () => {
+      const updater = props.updater
+      if (!updater || state()?.type === "installing") return
+      const result = await updater.check()
+      if (result?.type === "unavailable") return result.message
+      setState(result)
     }
 
     const restart = () => {
       const current = state()
-      if (!current || (current.type !== "installed" && current.type !== "install-success")) return
+      if (current?.type !== "installed") return
+      props.onRestart?.(route.data.type === "session" ? route.data.sessionID : undefined)
       exit()
     }
 
-    const later = () => {
-      const current = state()
-      if (!current || (current.type !== "installed" && current.type !== "install-success")) return
-      setState(undefined)
+    const open = (origin: "manual" | "notification") => {
+      if (!props.updater) return
+      if (origin === "notification") {
+        const current = notification()
+        if (!current || (current.source === "server" && current.remote)) return
+        if (state()?.type !== "installing") setState({ type: current.type, version: current.version })
+        dismiss()
+      }
+      dialog.replace(() => (
+        <DialogUpdate
+          check={origin === "manual" ? check : undefined}
+          state={state}
+          install={install}
+          restart={restart}
+        />
+      ))
     }
 
     onMount(() => {
@@ -122,6 +137,10 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
       ),
     )
 
-    return { state, skip, close, install, restart, later }
+    return {
+      notification,
+      dismiss,
+      open: props.updater ? open : undefined,
+    }
   },
 })

--- a/packages/tui/src/context/update-notification.tsx
+++ b/packages/tui/src/context/update-notification.tsx
@@ -10,6 +10,7 @@ import { DialogUpdate } from "../component/dialog-update"
 
 type ClientNotice = { readonly type: "available" | "installed"; readonly version: string }
 type Notice = ClientNotice & ({ readonly source: "client" } | { readonly source: "server"; readonly remote: boolean })
+export type UpdateOrigin = "manual" | "notification"
 export type UpdateState =
   | ClientNotice
   | { readonly type: "installing"; readonly version: string }
@@ -86,7 +87,7 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
       exit()
     }
 
-    const open = (origin: "manual" | "notification") => {
+    const open = (origin: UpdateOrigin) => {
       if (!props.updater) return
       if (origin === "notification") {
         const current = notification()
@@ -99,6 +100,7 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
       }
       dialog.replace(() => (
         <DialogUpdate
+          origin={origin}
           check={origin === "manual" ? check : undefined}
           state={state}
           install={install}

--- a/packages/tui/src/context/update-notification.tsx
+++ b/packages/tui/src/context/update-notification.tsx
@@ -19,7 +19,9 @@ export type UpdateState =
 export type UpdateSource = {
   readonly remote: boolean
   readonly subscribe: (notify: (notice: ClientNotice) => void, signal: AbortSignal) => Promise<void>
-  readonly check: () => Promise<ClientNotice | { readonly type: "unavailable"; readonly message: string } | undefined>
+  readonly check: (
+    signal: AbortSignal,
+  ) => Promise<ClientNotice | { readonly type: "unavailable"; readonly message: string } | undefined>
   readonly apply: (version: string) => Promise<void>
 }
 
@@ -71,10 +73,11 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
       )
     }
 
-    const check = async () => {
+    const check = async (signal: AbortSignal) => {
       const updater = props.updater
       if (!updater || state()?.type === "installing") return
-      const result = await updater.check()
+      const result = await updater.check(signal)
+      if (signal.aborted) return
       if (result?.type === "unavailable") return result.message
       setState(result)
     }
@@ -91,7 +94,10 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
       if (origin === "notification") {
         const current = notification()
         if (!current || (current.source === "server" && current.remote)) return
-        if (state()?.type !== "installing") setState({ type: current.type, version: current.version })
+        const active = state()
+        // The notification can predate an installation through /update.
+        if (active?.type !== "installing" && !(active?.type === "installed" && active.version === current.version))
+          setState({ type: current.type, version: current.version })
         dismiss()
       }
       dialog.replace(() => (

--- a/packages/tui/src/context/update-notification.tsx
+++ b/packages/tui/src/context/update-notification.tsx
@@ -5,7 +5,6 @@ import { useStorage } from "./storage"
 import { useEvent } from "./event"
 import { errorMessage } from "../util/error"
 import { useExit } from "./exit"
-import { useRoute } from "./route"
 import { useDialog } from "../ui/dialog"
 import { DialogUpdate } from "../component/dialog-update"
 
@@ -27,10 +26,9 @@ export type UpdateSource = {
 
 export const { use: useUpdateNotification, provider: UpdateNotificationProvider } = createSimpleContext({
   name: "UpdateNotification",
-  init: (props: { updater?: UpdateSource; onRestart?: (sessionID?: string) => void }) => {
+  init: (props: { updater?: UpdateSource }) => {
     const event = useEvent()
     const exit = useExit()
-    const route = useRoute()
     const dialog = useDialog()
     const log = useLog({ component: "update-notification" })
     const [state, setState] = createSignal<UpdateState>()
@@ -85,7 +83,6 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
     const restart = () => {
       const current = state()
       if (current?.type !== "installed") return
-      props.onRestart?.(route.data.type === "session" ? route.data.sessionID : undefined)
       exit()
     }
 

--- a/packages/tui/src/context/update-notification.tsx
+++ b/packages/tui/src/context/update-notification.tsx
@@ -88,20 +88,20 @@ export const { use: useUpdateNotification, provider: UpdateNotificationProvider 
 
     const open = (origin: "manual" | "notification") => {
       if (!props.updater) return
+      const current = notification()
+      const known = current && (current.source === "client" || !current.remote) ? current : undefined
+      if (origin === "notification" && !known) return
+      const active = state()
+      // The notification can predate an installation through /update.
+      if (known && active?.type !== "installing" && !(active?.type === "installed" && active.version === known.version))
+        setState({ type: known.type, version: known.version })
       // Manual checks hide the current notice without marking the version as seen.
       if (origin === "manual") setNotification(undefined)
-      if (origin === "notification") {
-        const current = notification()
-        if (!current || (current.source === "server" && current.remote)) return
-        const active = state()
-        // The notification can predate an installation through /update.
-        if (active?.type !== "installing" && !(active?.type === "installed" && active.version === current.version))
-          setState({ type: current.type, version: current.version })
-        dismiss()
-      }
+      if (origin === "notification") dismiss()
+      const status = state()?.type
       dialog.replace(() => (
         <DialogUpdate
-          check={origin === "manual" ? check : undefined}
+          check={status === undefined || status === "failed" ? check : undefined}
           state={state}
           install={install}
           restart={restart}

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -14,7 +14,6 @@ import { useTerminalDimensions } from "@opentui/solid"
 import { TextAttributes, type RGBA } from "@opentui/core"
 import { useTheme } from "../context/theme"
 import { useUpdateNotification } from "../context/update-notification"
-import { Spinner } from "../component/spinner"
 import { FadeInText } from "../component/fade-in-text"
 import { stringWidth } from "../util/string-width"
 
@@ -122,141 +121,60 @@ export function Home() {
 function UpdateNotification() {
   const update = useUpdateNotification()
   const theme = useTheme()
-  const action = theme.text.action.primary.selected
-  const [hovered, setHovered] = createSignal<"primary" | "skip" | "later" | "close">()
+  const remoteMessage = "A remote server cannot be updated from here. Updating it is recommended."
+  const [hovered, setHovered] = createSignal<"primary" | "close">()
   createEffect(() => {
-    update.state()
+    update.notification()
     setHovered(undefined)
   })
 
   return (
-    <Show when={update.state()} keyed>
+    <Show when={update.notification()} keyed>
       {(state) => (
         <box flexShrink={0} marginTop={4} alignItems="center">
           <Switch>
-            <Match when={state.type === "available" && (state.source === "client" || !state.remote)}>
-              <box alignItems="center">
-                <box
-                  alignItems="center"
-                  paddingLeft={1}
-                  paddingRight={1}
-                  backgroundColor={hovered() === "primary" ? theme.background.action.primary.hovered : undefined}
-                  onMouseOver={() => setHovered("primary")}
-                  onMouseOut={() => setHovered(undefined)}
-                  onMouseUp={() => void update.install()}
-                >
-                  <UpdateMessage
-                    title="Update available"
-                    description={`Version ${state.version} is available. Click to install`}
-                    backdrop={
-                      hovered() === "primary" ? theme.background.action.primary.hovered : theme.background.default
-                    }
-                  />
-                </box>
-                <box width="100%" alignItems="center" marginTop={1}>
-                  <FadeInText
-                    fg={theme.text.subdued}
-                    backdrop={hovered() === "skip" ? theme.background.action.primary.hovered : theme.background.default}
-                    sweepWidth={stringWidth(`Version ${state.version} is available. Click to install`)}
-                    sweepOffset={Math.floor(
-                      (stringWidth(`Version ${state.version} is available. Click to install`) -
-                        stringWidth("Skip this version")) /
-                        2,
-                    )}
-                    paddingLeft={1}
-                    paddingRight={1}
-                    bg={hovered() === "skip" ? theme.background.action.primary.hovered : undefined}
-                    onMouseOver={() => setHovered("skip")}
-                    onMouseOut={() => setHovered(undefined)}
-                    onMouseUp={update.skip}
-                  >
-                    Skip this version
-                  </FadeInText>
-                </box>
+            <Match when={state.source === "client" || !state.remote}>
+              <box
+                alignItems="center"
+                paddingLeft={1}
+                paddingRight={1}
+                backgroundColor={hovered() === "primary" ? theme.background.action.primary.hovered : undefined}
+                onMouseOver={() => setHovered("primary")}
+                onMouseOut={() => setHovered(undefined)}
+                onMouseUp={() => update.open?.("notification")}
+              >
+                <UpdateMessage
+                  title="Update available"
+                  description={`Version ${state.version} is available. Click for more details`}
+                  backdrop={
+                    hovered() === "primary" ? theme.background.action.primary.hovered : theme.background.default
+                  }
+                />
               </box>
             </Match>
             <Match when={state.type === "available" && state.source === "server" && state.remote}>
               <box alignItems="center">
                 <UpdateMessage
                   title="Server update available"
-                  description="A remote server cannot be updated from here. Updating it is recommended."
+                  description={remoteMessage}
                   backdrop={theme.background.default}
                 />
                 <FadeInText
                   fg={theme.text.subdued}
                   backdrop={hovered() === "close" ? theme.background.action.primary.hovered : theme.background.default}
-                  sweepWidth={stringWidth("A remote server cannot be updated from here. Updating it is recommended.")}
-                  sweepOffset={Math.floor(
-                    (stringWidth("A remote server cannot be updated from here. Updating it is recommended.") -
-                      stringWidth("Close")) /
-                      2,
-                  )}
+                  sweepWidth={stringWidth(remoteMessage)}
+                  sweepOffset={Math.floor((stringWidth(remoteMessage) - stringWidth("Close")) / 2)}
                   marginTop={1}
                   paddingLeft={1}
                   paddingRight={1}
                   bg={hovered() === "close" ? theme.background.action.primary.hovered : undefined}
                   onMouseOver={() => setHovered("close")}
                   onMouseOut={() => setHovered(undefined)}
-                  onMouseUp={update.close}
+                  onMouseUp={update.dismiss}
                 >
                   Close
                 </FadeInText>
               </box>
-            </Match>
-            <Match when={state.type === "installing"}>
-              <Spinner color={theme.text.subdued}>Installing update…</Spinner>
-            </Match>
-            <Match when={state.type === "install-success" || state.type === "installed"}>
-              <box alignItems="center">
-                <box
-                  alignItems="center"
-                  paddingLeft={1}
-                  paddingRight={1}
-                  backgroundColor={hovered() === "primary" ? theme.background.action.primary.hovered : undefined}
-                  onMouseOver={() => setHovered("primary")}
-                  onMouseOut={() => setHovered(undefined)}
-                  onMouseUp={update.restart}
-                >
-                  <UpdateMessage
-                    title="Update installed"
-                    description={
-                      state.type === "install-success"
-                        ? "Click to restart. Active sessions will\nautomatically resume after restart"
-                        : `Version ${state.version} has been installed. Click to restart`
-                    }
-                    animate={state.type === "installed"}
-                    backdrop={
-                      hovered() === "primary" ? theme.background.action.primary.hovered : theme.background.default
-                    }
-                  />
-                </box>
-                <box width="100%" alignItems="center" marginTop={1}>
-                  <FadeInText
-                    fg={theme.text.subdued}
-                    backdrop={
-                      hovered() === "later" ? theme.background.action.primary.hovered : theme.background.default
-                    }
-                    animate={state.type === "installed"}
-                    sweepWidth={stringWidth(`Version ${state.version} has been installed. Click to restart`)}
-                    sweepOffset={Math.floor(
-                      (stringWidth(`Version ${state.version} has been installed. Click to restart`) -
-                        stringWidth("Restart later")) /
-                        2,
-                    )}
-                    paddingLeft={1}
-                    paddingRight={1}
-                    bg={hovered() === "later" ? theme.background.action.primary.hovered : undefined}
-                    onMouseOver={() => setHovered("later")}
-                    onMouseOut={() => setHovered(undefined)}
-                    onMouseUp={update.later}
-                  >
-                    Restart later
-                  </FadeInText>
-                </box>
-              </box>
-            </Match>
-            <Match when={state.type === "failed"}>
-              <text fg={theme.text.feedback.error.default}>{state.type === "failed" ? state.message : ""}</text>
             </Match>
           </Switch>
         </box>
@@ -265,7 +183,7 @@ function UpdateNotification() {
   )
 }
 
-function UpdateMessage(props: { title: string; description: string; backdrop: RGBA; animate?: boolean }) {
+function UpdateMessage(props: { title: string; description: string; backdrop: RGBA }) {
   const theme = useTheme()
   const lines = props.description.split("\n")
   const width = Math.max(stringWidth(props.title), ...lines.map((line) => stringWidth(line)))
@@ -278,7 +196,6 @@ function UpdateMessage(props: { title: string; description: string; backdrop: RG
       wrapMode="none"
       fg={theme.text.default}
       backdrop={props.backdrop}
-      animate={props.animate}
     >
       <span style={{ fg: theme.text.action.primary.selected, attributes: TextAttributes.BOLD }}>
         {padding}

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -185,24 +185,20 @@ function UpdateNotification() {
 
 function UpdateMessage(props: { title: string; description: string; backdrop: RGBA }) {
   const theme = useTheme()
-  const lines = props.description.split("\n")
-  const width = Math.max(stringWidth(props.title), ...lines.map((line) => stringWidth(line)))
-  const padding = " ".repeat(Math.floor((width - stringWidth(props.title)) / 2))
-  const description = lines.map((line) => " ".repeat(Math.floor((width - stringWidth(line)) / 2)) + line).join("\n")
+  const titleWidth = stringWidth(props.title)
+  const descriptionWidth = stringWidth(props.description)
+  const width = Math.max(titleWidth, descriptionWidth)
   return (
-    <FadeInText
-      width={width}
-      height={lines.length + 1}
-      wrapMode="none"
-      fg={theme.text.default}
-      backdrop={props.backdrop}
-    >
+    <FadeInText width={width} height={2} wrapMode="none" fg={theme.text.default} backdrop={props.backdrop}>
       <span style={{ fg: theme.text.action.primary.selected, attributes: TextAttributes.BOLD }}>
-        {padding}
+        {" ".repeat(Math.floor((width - titleWidth) / 2))}
         {props.title}
       </span>
       {"\n"}
-      <span style={{ fg: theme.text.subdued }}>{description}</span>
+      <span style={{ fg: theme.text.subdued }}>
+        {" ".repeat(Math.floor((width - descriptionWidth) / 2))}
+        {props.description}
+      </span>
     </FadeInText>
   )
 }


### PR DESCRIPTION
## Summary

- Add `/update` and **Update OpenCode** in the command palette with a centered check, confirm, install, and restart dialog.
- Open known updates directly from the Home notification without checking again; keep only the local update entry point and the remote-server notice on Home.
- Keep manual update operations separate from automatic notification history, and reuse the existing release-channel lookup and installation methods.
- Exit normally after an update; the user reopens OpenCode, and the existing startup path handles managed-server version mismatches.
- Restore the previous dialog's shimmer styling, share its masked-text rendering with the existing fade animation, and remove temporary debug previews and obsolete inline Home update states.

## Review cleanup

- Preserve an already-installed version when opening a stale Home notification.
- Cancel in-flight checks when their dialog closes so late results cannot overwrite an installation.
- Remove the self-relaunch process wrapper and leave shutdown/startup handling unchanged.
- Remove duplicate success states, unused notification APIs, redundant Home wrappers, and obsolete multiline Home-message rendering.

## Validation

- Formatting and whitespace checks passed.
- No tests added or run, as requested.
- Three delegated reviews covered reuse, code quality, and efficiency. Findings were addressed; follow-up review found no remaining actionable issues.
