### PR TITLE
fix(tui): preview always-allow patterns without extra confirmation

### DIFF
--- a/packages/tui/src/routes/session/permission.tsx
+++ b/packages/tui/src/routes/session/permission.tsx
@@ -16,7 +16,7 @@ import { SimulationSemantics } from "../../simulation/semantics"
 import { PatchDiff } from "../../component/patch-diff"
 import { useToast } from "../../ui/toast"
 
-type PermissionStage = "permission" | "always" | "reject"
+type PermissionStage = "permission" | "reject"
 
 function EditBody(props: { file?: string; diff?: string; patch?: string }) {
   const theme = useTheme()
@@ -140,27 +140,6 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
 
   return (
     <Switch>
-      <Match when={store.stage === "always"}>
-        <SessionQuestion
-          title="Always allow"
-          semanticLabel={`Always allow ${props.request.action}`}
-          instance={props.request.id}
-          body={
-            <box paddingLeft={1} gap={1}>
-              <For each={permissionAlwaysLines(props.request)}>
-                {(line, index) => <text fg={index() === 0 ? theme.text.subdued : theme.text.default}>{line}</text>}
-              </For>
-            </box>
-          }
-          options={{ confirm: permissionOptionLabel("confirm"), cancel: permissionOptionLabel("cancel") }}
-          escapeKey="cancel"
-          onSelect={(option) => {
-            setStore("stage", "permission")
-            if (option === "cancel") return
-            reply("always")
-          }}
-        />
-      </Match>
       <Match when={store.stage === "reject"}>
         <RejectPrompt
           action={props.request.action}
@@ -185,7 +164,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
             },
             pathFormatter.format,
           )
-          const presentationBody =
+          const presentationBody = () =>
             props.request.action === "edit" ? (
               <EditBody file={current.file} diff={current.diff} patch={current.patch} />
             ) : props.request.action === "external_directory" ? (
@@ -240,7 +219,15 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               semanticLabel={permissionSemanticLabel(props.request.action, current.title)}
               instance={props.request.id}
               header={header()}
-              body={presentationBody}
+              body={(option) => (
+                <Show when={option === "always"} fallback={presentationBody()}>
+                  <box paddingLeft={1} gap={1}>
+                    <For each={permissionAlwaysLines(props.request)}>
+                      {(line, index) => <text fg={index() === 0 ? theme.text.subdued : theme.text.default}>{line}</text>}
+                    </For>
+                  </box>
+                </Show>
+              )}
               options={
                 props.request.save?.length
                   ? {
@@ -254,7 +241,7 @@ export function PermissionPrompt(props: { request: PermissionRequest; directory?
               fullscreen
               onSelect={(option) => {
                 if (option === "always") {
-                  setStore("stage", "always")
+                  reply("always")
                   return
                 }
                 if (option === "reject") {
@@ -423,7 +410,7 @@ export function SessionQuestion<const T extends Record<string, string>>(props: {
   group?: string
   choicesLabel?: string
   header?: JSX.Element
-  body: JSX.Element
+  body: JSX.Element | ((option: keyof T) => JSX.Element)
   options: T
   escapeKey?: keyof T
   fullscreen?: boolean
@@ -547,7 +534,7 @@ export function SessionQuestion<const T extends Record<string, string>>(props: {
             {props.header}
           </box>
         </Show>
-        {props.body}
+        {typeof props.body === "function" ? props.body(store.selected) : props.body}
       </box>
       <box
         flexDirection={narrow() ? "column" : "row"}


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Show saved permission patterns and project scope when Always allow is highlighted in the full-screen TUI. Enter submits immediately instead of opening another confirmation screen. Moving away restores operation details. Mini is unchanged.

### How did you verify your code works?

- TUI typecheck and repository pre-push typechecks passed.
- Nine existing permission checks passed.
- Four temporary render checks passed at 70 and 110 columns, covering explicit patterns, wildcard scope, restoring operation details, and single-Enter submission. Temporary tests were removed per repository guidance.

### Screenshots / recordings

Not captured; verified with the terminal render test harness.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR