### PR TITLE
fix(tui): clarify update notifications

### DIFF
--- a/packages/cli/src/services/updater.ts
+++ b/packages/cli/src/services/updater.ts
@@ -75,7 +75,7 @@ const make = Effect.gen(function* () {
         Effect.orElseSucceed(() => undefined),
       ),
     )
-    return values.findLast((value) => value !== undefined) ?? "auto"
+    return values.findLast((value) => value !== undefined) ?? "notify"
   })
 
   const exec = Effect.fnUntraced(function* (command: string[], timeout: Duration.Input = "10 seconds") {

--- a/packages/tui/src/routes/home.tsx
+++ b/packages/tui/src/routes/home.tsx
@@ -144,8 +144,8 @@ function UpdateNotification() {
                 onMouseUp={() => update.open?.("notification")}
               >
                 <UpdateMessage
-                  title="Update available"
-                  description={`Version ${state.version} is available. Click for more details`}
+                  title={state.type === "installed" ? "Update installed" : "Update available"}
+                  description={`Version ${state.version} is ${state.type === "installed" ? "installed" : "available"}. Click for more details`}
                   backdrop={
                     hovered() === "primary" ? theme.background.action.primary.hovered : theme.background.default
                   }

--- a/packages/www/src/docs/content/config.mdx
+++ b/packages/www/src/docs/content/config.mdx
@@ -131,7 +131,7 @@ agents.
 
 Control update checks from the global config. Set `update` to `"disable"` to
 skip them, `"notify"` to show available updates before installing them, or
-`"auto"` to install updates automatically. When omitted, `update` defaults to `"auto"`.
+`"auto"` to install updates automatically. When omitted, `update` defaults to `"notify"`.
 
 Automatic installation does not restart a running server. Restart it manually to activate the installed update.
 Project-level values are ignored.


### PR DESCRIPTION
## Summary
- distinguish installed updates from available updates on the home screen
- default the update policy to `notify` when unset
- update the V2 configuration documentation

## Testing
- `git diff --check`
- `bun test src/services/updater.test.ts` *(blocked: workspace dependency `@opencode-ai/util/global` is not linked in this worktree)*
- `bun typecheck` in `packages/tui` *(blocked by existing missing workspace modules and unrelated type errors)*