### PR TITLE
fix(app): widen new-session prompt beyond logo

### DIFF
--- a/packages/app/src/new-session/layout.ts
+++ b/packages/app/src/new-session/layout.ts
@@ -1,2 +1,2 @@
-/** Inline new-session content width — keep in sync with session composer `placement === "inline"`. */
-export const NEW_SESSION_CONTENT_WIDTH = "w-full max-w-[720px] px-0"
+/** Allows the prompt to extend 80px beyond each side of the 720px wordmark. */
+export const NEW_SESSION_CONTENT_WIDTH = "w-full max-w-[880px] px-0"

--- a/packages/app/src/new-session/view.tsx
+++ b/packages/app/src/new-session/view.tsx
@@ -61,7 +61,7 @@ export function NewSessionView(props: {
         />
         <div class="absolute inset-x-0 top-[25.375%] flex justify-center px-6">
           <div class={NEW_SESSION_CONTENT_WIDTH}>
-            <Wordmark class="h-auto w-full text-v2-background-bg-inverse" />
+            <Wordmark class="mx-auto h-auto w-full max-w-[720px] text-v2-background-bg-inverse" />
             <div class="mt-8 flex flex-col gap-8">
               <Composer model={props.composer} />
               <Show when={props.project.empty()}>


### PR DESCRIPTION
## Summary
- Widen the new-session prompt from 720px to 880px.
- Keep the OpenCode logo centered at a maximum width of 720px, so the prompt extends 80px beyond either side on wide windows.
- Preserve responsive sizing for smaller windows.

## Validation
- `bun typecheck` in `packages/app` passed.
- Full pre-push typechecks passed (33 tasks) with Bun 1.4.1.
- `git diff --check` passed.
- Visual verification not performed.