### PR TITLE
feat(app): add subtle new-session logo shimmer

### DIFF
--- a/packages/app/component-tests/new-session-wordmark.spec.ts
+++ b/packages/app/component-tests/new-session-wordmark.spec.ts
@@ -1,0 +1,86 @@
+import { expect, story } from "../../storybook/playwright/story"
+
+for (const theme of ["light", "dark"]) {
+  for (const direction of ["ltr", "rtl"]) {
+    story(`shimmers once over the visible wordmark (${theme}, ${direction})`, async ({ mount, page }, testInfo) => {
+      await page.emulateMedia({ reducedMotion: "no-preference" })
+      const component = await mount("app-new-session-wordmark--reveal", { globals: { theme, direction } })
+      const logo = component.locator('[data-component="new-session-wordmark"]')
+      const reveal = logo.locator('[data-slot="wordmark-reveal"]')
+      const shimmer = logo.locator(".wordmark-shimmer")
+      const base = logo.locator("svg").first()
+      await expect(base).toHaveCSS("opacity", theme === "dark" ? "0.5" : "0.6")
+      await expect(shimmer).toHaveCSS("animation-iteration-count", "1")
+      await expect(logo.locator("g[mask]")).toHaveCount(0)
+      await expect(shimmer).toHaveCSS("color", "rgb(255, 255, 255)")
+      await expect(shimmer).toHaveCSS("mix-blend-mode", "screen")
+      await expect(base.locator("g[fill]")).toHaveAttribute("fill", "currentColor")
+
+      await logo.evaluate((element) => {
+        element.getAnimations({ subtree: true }).forEach((animation) => {
+          animation.pause()
+          animation.currentTime = 0
+        })
+      })
+      await expect(reveal).toHaveCSS("opacity", "1")
+      await expect(reveal).toHaveCSS("animation-name", "none")
+      await expect(shimmer).toHaveCSS("mask-position", "100% 0px")
+
+      await logo.evaluate((element) => {
+        element.getAnimations({ subtree: true }).forEach((animation) => (animation.currentTime = 400))
+      })
+      await expect(shimmer).toHaveCSS("mask-position", "50% 0px")
+      await expect(shimmer).toHaveCSS("opacity", theme === "dark" ? "0.0672" : "0.45")
+      const swept = await logo.screenshot({ path: testInfo.outputPath("wordmark-shimmer.png") })
+
+      await logo.evaluate((element) => {
+        element.getAnimations({ subtree: true }).forEach((animation) => animation.finish())
+      })
+      await expect(reveal).toHaveCSS("opacity", "1")
+      await expect(shimmer).toHaveCSS("opacity", "0")
+      await expect(shimmer).toHaveCSS("mask-position", "0% 0px")
+      const settled = await logo.screenshot({ path: testInfo.outputPath("wordmark-settled.png") })
+      const brightness = await page.evaluate(
+        async (screenshots) => {
+          const pixels = await Promise.all(
+            screenshots.map(async (screenshot) => {
+              const image = new Image()
+              image.src = `data:image/png;base64,${screenshot}`
+              await image.decode()
+              const canvas = new OffscreenCanvas(image.width, image.height)
+              const context = canvas.getContext("2d")
+              if (!context) throw new Error("Cannot read screenshot pixels")
+              context.drawImage(image, 0, 0)
+              return context.getImageData(0, 0, image.width, image.height).data
+            }),
+          )
+          return {
+            min: pixels[0].reduce(
+              (min, value, index) => (index % 4 === 3 ? min : Math.min(min, value - pixels[1][index])),
+              0,
+            ),
+            max: pixels[0].reduce(
+              (max, value, index) => (index % 4 === 3 ? max : Math.max(max, value - pixels[1][index])),
+              0,
+            ),
+          }
+        },
+        [swept.toString("base64"), settled.toString("base64")],
+      )
+      expect(brightness.min).toBeGreaterThanOrEqual(0)
+      expect(brightness.max).toBeGreaterThanOrEqual(5)
+    })
+  }
+
+  story(`shows a static wordmark with reduced motion (${theme})`, async ({ mount, page }) => {
+    await page.emulateMedia({ reducedMotion: "reduce" })
+    await page.setViewportSize({ width: 360, height: 640 })
+    const component = await mount("app-new-session-wordmark--reveal", { globals: { theme } })
+    const logo = component.locator('[data-component="new-session-wordmark"]')
+    await expect(logo.locator("svg").first()).toHaveCSS("opacity", theme === "dark" ? "0.5" : "0.6")
+    await expect(logo.locator('[data-slot="wordmark-reveal"]')).toHaveCSS("opacity", "1")
+    await expect(logo.locator(".wordmark-shimmer")).toHaveCSS("opacity", "0")
+    expect(await logo.evaluate((element) => element.getAnimations({ subtree: true }).length)).toBe(0)
+    expect(await logo.evaluate((element) => element.getBoundingClientRect().right <= innerWidth)).toBe(true)
+  })
+}

--- a/packages/app/src/new-session/view.tsx
+++ b/packages/app/src/new-session/view.tsx
@@ -1,7 +1,6 @@
 import { useDialog } from "@opencode-ai/ui/context/dialog"
 import { Tooltip } from "@opencode-ai/ui/tooltip"
 import { Icon } from "@opencode-ai/ui/icon"
-import { Wordmark } from "@opencode-ai/ui/wordmark"
 import { Show, createMemo, createSignal } from "solid-js"
 import { Schema } from "effect"
 import createPresence from "solid-presence"
@@ -23,6 +22,7 @@ import { NEW_SESSION_CONTENT_WIDTH } from "@/new-session/layout"
 import { Persist, persisted } from "@/runtime/persistence/storage"
 import { Persistence } from "@/runtime/persistence/schema"
 import type { NewSessionWorkspaceController } from "./workspace/controller"
+import { NewSessionWordmark } from "./wordmark"
 
 const providerTipDismissalDuration = 30 * 24 * 60 * 60 * 1000
 
@@ -61,10 +61,7 @@ export function NewSessionView(props: {
         />
         <div class="absolute inset-x-0 top-[25.375%] flex justify-center px-6">
           <div class={NEW_SESSION_CONTENT_WIDTH}>
-            <Wordmark
-              fade={false}
-              class="mx-auto h-auto w-full max-w-[720px] text-v2-background-bg-inverse opacity-60 [[data-color-scheme=dark]_&]:opacity-50"
-            />
+            <NewSessionWordmark />
             <div class="mt-8 flex flex-col gap-8">
               <Composer model={props.composer} />
               <Show when={props.project.empty()}>

--- a/packages/app/src/new-session/view.tsx
+++ b/packages/app/src/new-session/view.tsx
@@ -61,7 +61,10 @@ export function NewSessionView(props: {
         />
         <div class="absolute inset-x-0 top-[25.375%] flex justify-center px-6">
           <div class={NEW_SESSION_CONTENT_WIDTH}>
-            <Wordmark class="mx-auto h-auto w-full max-w-[720px] text-v2-background-bg-inverse" />
+            <Wordmark
+              fade={false}
+              class="mx-auto h-auto w-full max-w-[720px] text-v2-background-bg-inverse opacity-60 [[data-color-scheme=dark]_&]:opacity-50"
+            />
             <div class="mt-8 flex flex-col gap-8">
               <Composer model={props.composer} />
               <Show when={props.project.empty()}>

--- a/packages/app/src/new-session/wordmark.css
+++ b/packages/app/src/new-session/wordmark.css
@@ -1,0 +1,43 @@
+[data-component="new-session-wordmark"] {
+  --wordmark-shimmer-opacity: 0.45;
+
+  .wordmark-shimmer {
+    /* Blend above the base logo's opacity so the sweep only adds light in either theme. */
+    color: white;
+    mix-blend-mode: screen;
+    opacity: 0;
+    mask-image: linear-gradient(to right, transparent 40%, black 50%, transparent 60%);
+    mask-size: 300% 100%;
+    mask-repeat: no-repeat;
+    animation: new-session-wordmark-shimmer 800ms linear both;
+  }
+}
+
+[data-color-scheme="dark"] [data-component="new-session-wordmark"] {
+  /* Preserve the previous dark highlight strength: 0.16 × 0.7 × 0.6. */
+  --wordmark-shimmer-opacity: 0.0672;
+}
+
+/* Oversizing the mask moves its highlight physically left to right, including in RTL. */
+@keyframes new-session-wordmark-shimmer {
+  0% {
+    mask-position: 100% 0;
+    opacity: 0;
+  }
+  20%,
+  80% {
+    opacity: var(--wordmark-shimmer-opacity);
+  }
+  100% {
+    mask-position: 0% 0;
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-component="new-session-wordmark"] {
+    .wordmark-shimmer {
+      animation: none;
+    }
+  }
+}

--- a/packages/app/src/new-session/wordmark.stories.tsx
+++ b/packages/app/src/new-session/wordmark.stories.tsx
@@ -1,0 +1,11 @@
+import { NewSessionWordmark } from "./wordmark"
+
+export default {
+  title: "App/New Session/Wordmark",
+  id: "app-new-session-wordmark",
+  component: NewSessionWordmark,
+}
+
+export const Reveal = {
+  render: () => <NewSessionWordmark />,
+}

--- a/packages/app/src/new-session/wordmark.tsx
+++ b/packages/app/src/new-session/wordmark.tsx
@@ -1,0 +1,17 @@
+import { Wordmark } from "@opencode-ai/ui/wordmark"
+import "./wordmark.css"
+
+export function NewSessionWordmark() {
+  return (
+    <div
+      data-component="new-session-wordmark"
+      aria-hidden="true"
+      class="pointer-events-none mx-auto w-full max-w-[720px] text-v2-background-bg-inverse"
+    >
+      <div data-slot="wordmark-reveal" class="relative">
+        <Wordmark fade={false} class="block h-auto w-full opacity-60 [[data-color-scheme=dark]_&]:opacity-50" />
+        <Wordmark fade={false} muted={false} class="wordmark-shimmer absolute inset-0 h-auto w-full" />
+      </div>
+    </div>
+  )
+}

--- a/packages/ui/src/typography/wordmark/wordmark.tsx
+++ b/packages/ui/src/typography/wordmark/wordmark.tsx
@@ -1,6 +1,6 @@
 import { createUniqueId, type ComponentProps } from "solid-js"
 
-export function Wordmark(props: Pick<ComponentProps<"svg">, "class"> & { fade?: boolean }) {
+export function Wordmark(props: Pick<ComponentProps<"svg">, "class"> & { fade?: boolean; muted?: boolean }) {
   const mask = createUniqueId()
   const maskGradient = createUniqueId()
 
@@ -11,49 +11,17 @@ export function Wordmark(props: Pick<ComponentProps<"svg">, "class"> & { fade?: 
       fill="none"
       classList={{ [props.class ?? ""]: !!props.class }}
     >
-      <g opacity="0.6" class="[[data-color-scheme=dark]_&]:opacity-100">
+      <g opacity={props.muted === false ? 1 : 0.6} class="[[data-color-scheme=dark]_&]:opacity-100">
         <g mask={props.fade === false ? undefined : `url(#${mask})`}>
-          <g opacity="0.16">
-            <path
-              opacity="0.7"
-              d="M55.3846 36.4286H18.4615V91.7143H55.3846V36.4286ZM73.8462 110.143H0V18H73.8462V110.143Z"
-              fill="currentColor"
-            />
-            <path
-              opacity="0.7"
-              d="M110.462 91.7143H147.385V36.4286H110.462V91.7143ZM165.846 110.143H110.462V128.571H92V18H165.846V110.143Z"
-              fill="currentColor"
-            />
-            <path
-              opacity="0.7"
-              d="M258.846 73.2857H203.462V91.7143H258.846V110.143H185V18H258.846V73.2857ZM203.462 54.8571H240.385V36.4286H203.462V54.8571Z"
-              fill="currentColor"
-            />
-            <path
-              opacity="0.7"
-              d="M332.385 36.4286H295.462V110.143H277V18H332.385V36.4286ZM350.846 110.143H332.385V36.4286H350.846V110.143Z"
-              fill="currentColor"
-            />
-            <path
-              opacity="0.7"
-              d="M442.846 36.4286H387.462V91.7143H442.846V110.143H369V18H442.846V36.4286Z"
-              fill="currentColor"
-            />
-            <path
-              opacity="0.7"
-              d="M517.385 36.4286H480.462V91.7143H517.385V36.4286ZM535.846 110.143H462V18H535.846V110.143Z"
-              fill="currentColor"
-            />
-            <path
-              opacity="0.7"
-              d="M609.385 36.8571H572.462V92.1429H609.385V36.8571ZM627.846 110.571H554V18.4286H609.385V0H627.846V110.571Z"
-              fill="currentColor"
-            />
-            <path
-              opacity="0.7"
-              d="M664.462 36.4286V54.8571H701.385V36.4286H664.462ZM719.846 73.2857H664.462V91.7143H719.846V110.143H646V18H719.846V73.2857Z"
-              fill="currentColor"
-            />
+          <g opacity={props.muted === false ? 1 : 0.16 * 0.7} fill="currentColor">
+            <path d="M55.3846 36.4286H18.4615V91.7143H55.3846V36.4286ZM73.8462 110.143H0V18H73.8462V110.143Z" />
+            <path d="M110.462 91.7143H147.385V36.4286H110.462V91.7143ZM165.846 110.143H110.462V128.571H92V18H165.846V110.143Z" />
+            <path d="M258.846 73.2857H203.462V91.7143H258.846V110.143H185V18H258.846V73.2857ZM203.462 54.8571H240.385V36.4286H203.462V54.8571Z" />
+            <path d="M332.385 36.4286H295.462V110.143H277V18H332.385V36.4286ZM350.846 110.143H332.385V36.4286H350.846V110.143Z" />
+            <path d="M442.846 36.4286H387.462V91.7143H442.846V110.143H369V18H442.846V36.4286Z" />
+            <path d="M517.385 36.4286H480.462V91.7143H517.385V36.4286ZM535.846 110.143H462V18H535.846V110.143Z" />
+            <path d="M609.385 36.8571H572.462V92.1429H609.385V36.8571ZM627.846 110.571H554V18.4286H609.385V0H627.846V110.571Z" />
+            <path d="M664.462 36.4286V54.8571H701.385V36.4286H664.462ZM719.846 73.2857H664.462V91.7143H719.846V110.143H646V18H719.846V73.2857Z" />
           </g>
         </g>
       </g>

--- a/packages/ui/src/typography/wordmark/wordmark.tsx
+++ b/packages/ui/src/typography/wordmark/wordmark.tsx
@@ -1,6 +1,6 @@
 import { createUniqueId, type ComponentProps } from "solid-js"
 
-export function Wordmark(props: Pick<ComponentProps<"svg">, "class">) {
+export function Wordmark(props: Pick<ComponentProps<"svg">, "class"> & { fade?: boolean }) {
   const mask = createUniqueId()
   const maskGradient = createUniqueId()
 
@@ -12,7 +12,7 @@ export function Wordmark(props: Pick<ComponentProps<"svg">, "class">) {
       classList={{ [props.class ?? ""]: !!props.class }}
     >
       <g opacity="0.6" class="[[data-color-scheme=dark]_&]:opacity-100">
-        <g mask={`url(#${mask})`}>
+        <g mask={props.fade === false ? undefined : `url(#${mask})`}>
           <g opacity="0.16">
             <path
               opacity="0.7"


### PR DESCRIPTION
## Summary
- Remove the new-session logo's static gradient mask, keeping a flat colour with additional transparency of 50% in dark mode and 40% in light mode.
- Add a one-time, 800ms left-to-right shimmer when the new-session screen mounts, with no fade-in.
- Use a light-only screen blend, with a stronger highlight in light mode and a subtle highlight in dark mode; retain the logo's resting transparency.
- Respect reduced motion by showing the static logo without a sweep.
- Add a component story and browser tests covering themes, LTR/RTL, narrow layouts, and reduced motion. Pixel comparisons verify that the shimmer visibly brightens without darkening pixels.

## Dependency
Builds on #47375 (wider new-session prompt). That PR is still open, so its width change is currently included in this branch's diff against `v2`.

## Validation
- `bun typecheck` passed in `packages/app` and `packages/ui`.
- All 6 new-session wordmark browser tests passed.
- Pre-push typechecks passed: 33 tasks (31 cached).
- Prettier checks and `git diff --check` passed.