### PR TITLE
fix: preserve Unicode in quoted Git paths

### DIFF
--- a/packages/app/src/context/file/path.test.ts
+++ b/packages/app/src/context/file/path.test.ts
@@ -55,6 +55,22 @@ describe("file path helpers", () => {
     expect(unquoteGitPath('"plain\\nname"')).toBe("plain\nname")
     expect(unquoteGitPath("a/b/c.ts")).toBe("a/b/c.ts")
   })
+
+  test.each([
+    ['"文件\\\".txt"', '文件".txt'],
+    ['"café\\t.txt"', "café\t.txt"],
+    ['"😀\\\".txt"', '😀".txt'],
+    ['"文\\303\\251😀\\t\\\".txt"', '文é😀\t".txt'],
+    ['"résumé\\\\文.txt"', "résumé\\文.txt"],
+  ])("preserves Unicode in quoted git path %s", (input, expected) => {
+    expect(unquoteGitPath(input)).toBe(expected)
+  })
+
+  test("normalizes quoted Unicode paths against workspace root", () => {
+    const path = createPathHelpers(() => "/repo")
+    expect(path.normalize('"/repo/文😀\\\".txt"')).toBe('文😀".txt')
+    expect(path.tab('"/repo/文😀\\\".txt"')).toBe("file://%E6%96%87%F0%9F%98%80%22.txt")
+  })
 })
 
 describe("encodeFilePath", () => {

--- a/packages/app/src/context/file/path.ts
+++ b/packages/app/src/context/file/path.ts
@@ -19,24 +19,25 @@ export function stripQueryAndHash(input: string) {
 export function unquoteGitPath(input: string) {
   if (!input.startsWith('"')) return input
   if (!input.endsWith('"')) return input
-  const body = input.slice(1, -1)
+  // Git mixes literal UTF-8 with escaped bytes when core.quotePath is false.
+  const body = new TextEncoder().encode(input.slice(1, -1))
   const bytes: number[] = []
 
   for (let i = 0; i < body.length; i++) {
-    const char = body[i]!
+    const char = String.fromCharCode(body[i])
     if (char !== "\\") {
       bytes.push(char.charCodeAt(0))
       continue
     }
 
-    const next = body[i + 1]
+    const next = i + 1 < body.length ? String.fromCharCode(body[i + 1]) : undefined
     if (!next) {
       bytes.push("\\".charCodeAt(0))
       continue
     }
 
     if (next >= "0" && next <= "7") {
-      const chunk = body.slice(i + 1, i + 4)
+      const chunk = String.fromCharCode(...body.subarray(i + 1, i + 4))
       const match = chunk.match(/^[0-7]{1,3}/)
       if (!match) {
         bytes.push(next.charCodeAt(0))

--- a/packages/opencode/src/session/summary.ts
+++ b/packages/opencode/src/session/summary.ts
@@ -10,24 +10,25 @@ import { Config } from "@/config/config"
 function unquoteGitPath(input: string) {
   if (!input.startsWith('"')) return input
   if (!input.endsWith('"')) return input
-  const body = input.slice(1, -1)
+  // Git mixes literal UTF-8 with escaped bytes when core.quotePath is false.
+  const body = new TextEncoder().encode(input.slice(1, -1))
   const bytes: number[] = []
 
   for (let i = 0; i < body.length; i++) {
-    const char = body[i]!
+    const char = String.fromCharCode(body[i])
     if (char !== "\\") {
       bytes.push(char.charCodeAt(0))
       continue
     }
 
-    const next = body[i + 1]
+    const next = i + 1 < body.length ? String.fromCharCode(body[i + 1]) : undefined
     if (!next) {
       bytes.push("\\".charCodeAt(0))
       continue
     }
 
     if (next >= "0" && next <= "7") {
-      const chunk = body.slice(i + 1, i + 4)
+      const chunk = String.fromCharCode(...body.subarray(i + 1, i + 4))
       const match = chunk.match(/^[0-7]{1,3}/)
       if (!match) {
         bytes.push(next.charCodeAt(0))

--- a/packages/opencode/test/server/session-diff-missing-patch.test.ts
+++ b/packages/opencode/test/server/session-diff-missing-patch.test.ts
@@ -66,7 +66,7 @@ describe("session diff with missing patch (#26574)", () => {
   )
 
   it.instance(
-    "GET /session/<id>/diff returns requested turn diffs",
+    "GET /session/<id>/diff returns requested turn diffs with quoted Unicode paths",
     () =>
       Effect.gen(function* () {
         const test = yield* TestInstance
@@ -80,7 +80,10 @@ describe("session diff with missing patch (#26574)", () => {
           agent: "build",
           model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("model") },
           summary: {
-            diffs: [{ file: "turn.ts", additions: 1, deletions: 0, status: "modified" }],
+            diffs: [
+              { file: "turn.ts", additions: 1, deletions: 0, status: "modified" },
+              { file: '"文\\303\\251😀\\t\\\".txt"', additions: 2, deletions: 1, status: "modified" },
+            ],
           },
         } satisfies SessionV1.User)
 
@@ -90,7 +93,10 @@ describe("session diff with missing patch (#26574)", () => {
         )
 
         expect(response.status).toBe(200)
-        expect(yield* response.json).toEqual([{ file: "turn.ts", additions: 1, deletions: 0, status: "modified" }])
+        expect(yield* response.json).toEqual([
+          { file: "turn.ts", additions: 1, deletions: 0, status: "modified" },
+          { file: '文é😀\t".txt', additions: 2, deletions: 1, status: "modified" },
+        ])
       }),
     { git: true, config: { formatter: false, lsp: false } },
   )


### PR DESCRIPTION
### Issue for this PR

Closes #47381

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

With `core.quotePath=false`, Git can mix literal Unicode and escapes in a quoted pathname. The app and legacy session-diff decoders currently truncate UTF-16 code units into bytes, corrupting names such as `中文".txt`.

Encode the complete quoted body as UTF-8 before interpreting the existing Git byte escapes. This preserves Unicode alongside octal and C-style escapes in both decoders.

Scope: pathname decoding only. A separate upstream snapshot lookup problem can still omit diff content for quoted paths; this PR does not fix that.

### How did you verify your code works?

On macOS 27.0 arm64 with Bun 1.3.14:

- `packages/app`: `bun test src/context/file/path.test.ts` — 47 pass; `bun run test:browser` — 41 pass.
- `packages/opencode`: `bun test test/server/session-diff-missing-patch.test.ts` — 2 pass.
- `bun typecheck` from each of those packages passed.
- Real Git roundtrips passed for seven filenames under both quotePath settings.
- Full app unit suite: 729 pass, 1 failure. Unchanged dev has the same `pa-PK` locale failure (expected `pa`, received `en`; 723 pass, 1 failure).

### Screenshots / recordings

Path-decoding logic only; no visual layout changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
