### PR TITLE
fix(opencode): allow bounded parent checks

### DIFF
--- a/packages/opencode/src/tool/shell/prompt.ts
+++ b/packages/opencode/src/tool/shell/prompt.ts
@@ -79,8 +79,10 @@ function bashCommandSection(chain: string, limits: Limits, defaultTimeoutMs: num
   return `Before executing the command, please follow these steps:
 
 1. Directory Verification:
-   - If the command will create new directories or files, first use \`ls\` to verify the parent directory exists and is the correct location
-   - For example, before running "mkdir foo/bar", first use \`ls foo\` to check that "foo" exists and is the intended parent directory
+   - If the command will create new directories or files, first verify the parent directory exists and is the correct location
+   - When only existence and type matter, use a bounded check such as \`test -d "foo"\` or \`stat "foo"\` instead of listing its contents
+   - Use \`ls "foo"\` only when child names are materially needed
+   - For example, before running \`mkdir "foo/bar"\`, first use \`test -d "foo"\` to check that \`foo\` exists and is a directory
 
 2. Command Execution:
    - Always quote file paths that contain spaces with double quotes (e.g., rm "path with spaces/file.txt")

--- a/packages/opencode/test/tool/shell-prompt.test.ts
+++ b/packages/opencode/test/tool/shell-prompt.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test"
+import { ShellPrompt } from "../../src/tool/shell/prompt"
+
+describe("tool.shell prompt", () => {
+  test("uses bounded parent directory verification for bash", () => {
+    const description = ShellPrompt.render("bash", "linux", { maxLines: 2000, maxBytes: 50_000 }, 120_000).description
+
+    expect(description).toContain('use a bounded check such as `test -d "foo"` or `stat "foo"`')
+    expect(description).toContain('Use `ls "foo"` only when child names are materially needed')
+    expect(description).not.toContain("first use `ls` to verify the parent directory")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #47380

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The Bash instructions used `ls` even when an agent only needed to confirm that a parent exists and is a directory. They now recommend a bounded `test -d` or `stat` check for that case and reserve `ls` for child discovery.

A focused prompt test keeps both parts of the contract explicit.

### How did you verify your code works?

- `bun test test/tool/shell-prompt.test.ts test/tool/shell.test.ts` (24 pass)
- `bun run lint packages/opencode/src/tool/shell/prompt.ts packages/opencode/test/tool/shell-prompt.test.ts`
- `bunx prettier --check packages/opencode/src/tool/shell/prompt.ts packages/opencode/test/tool/shell-prompt.test.ts`
- `bun typecheck` reaches an existing error in `test/provider/transform.test.ts:3885`; this branch does not modify that file

### Screenshots / recordings

Not applicable; this changes generated tool guidance.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
