### PR TITLE
fix(opencode): allow integer GPT versions in Codex model filter

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -297,7 +297,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               if (ALLOWED_MODELS.has(model.api.id)) return true
               if (DISALLOWED_MODELS.has(model.api.id)) return false
               if (model.api.id === "gpt-5.6") return false
-              const match = model.api.id.match(/^gpt-(\d+\.\d+)/)
+              const match = model.api.id.match(/^gpt-(\d+(?:\.\d+)?)/)
               return match ? parseFloat(match[1]) > 5.4 : false
             })
             .map(([modelID, model]) => [

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -326,6 +326,29 @@ describe("plugin.codex", () => {
     )
   })
 
+  test.each([
+    ["gpt-6-astra", true],
+    ["gpt-6", true],
+    ["gpt-6.0-astra", true],
+    ["gpt-7", true],
+    ["gpt-5", false],
+    ["gpt-4.1", false],
+    ["gpt-5.5-pro", false],
+    ["gpt-5.6", false],
+    ["not-a-gpt-model", false],
+  ])("filters OAuth model %s with integer or decimal versions", async (id, allowed) => {
+    const hooks = await CodexAuthPlugin({} as never)
+    const provider = {
+      models: {
+        [id]: { id, api: { id }, limit: {}, cost: {}, options: {} },
+      },
+    }
+
+    const models = await hooks.provider!.models!(provider as never, { auth: { type: "oauth" } } as never)
+
+    expect(Object.keys(models)).toEqual(allowed ? [id] : [])
+  })
+
   test("deduplicates concurrent Codex token refreshes", async () => {
     const refreshedAccess = createTestJwt({
       "https://api.openai.com/auth": { chatgpt_compute_residency: "eu" },


### PR DESCRIPTION
### Issue for this PR

No linked issue. `gpt-6-astra` is incorrectly hidden when using ChatGPT OAuth.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes the decimal portion of the GPT version optional in the Codex model filter. Previously, `gpt-6-astra` failed the regex and was removed from the model list. Integer versions now reach the existing version check; explicit exclusions and pro-mode filtering are unchanged. V2 is untouched.

Adds regression coverage for integer and decimal versions, older models, and existing exclusions.

### How did you verify your code works?

- Confirmed the new integer-version cases fail before the fix.
- `bun test test/plugin/codex.test.ts --timeout 30000`: 33 passed.
- `bun typecheck`: passed in `packages/opencode`.
- Prettier and `git diff --check`: passed.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR