### PR TITLE
fix(opencode): compare Codex GPT versions by major and minor

### DIFF
--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -297,7 +297,7 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               if (ALLOWED_MODELS.has(model.api.id)) return true
               if (DISALLOWED_MODELS.has(model.api.id)) return false
               if (model.api.id === "gpt-5.6") return false
-              const match = model.api.id.match(/^gpt-(\d+)(?:\.(\d+))?(?:-|$)/)
+              const match = model.api.id.match(/^gpt-(\d+)(?:\.(\d+))?/)
               if (!match) return false
               const major = Number(match[1])
               const minor = Number(match[2] ?? 0)

--- a/packages/opencode/src/plugin/openai/codex.ts
+++ b/packages/opencode/src/plugin/openai/codex.ts
@@ -297,8 +297,11 @@ export async function CodexAuthPlugin(input: PluginInput, options: CodexAuthPlug
               if (ALLOWED_MODELS.has(model.api.id)) return true
               if (DISALLOWED_MODELS.has(model.api.id)) return false
               if (model.api.id === "gpt-5.6") return false
-              const match = model.api.id.match(/^gpt-(\d+(?:\.\d+)?)/)
-              return match ? parseFloat(match[1]) > 5.4 : false
+              const match = model.api.id.match(/^gpt-(\d+)(?:\.(\d+))?(?:-|$)/)
+              if (!match) return false
+              const major = Number(match[1])
+              const minor = Number(match[2] ?? 0)
+              return major > 5 || (major === 5 && minor > 4)
             })
             .map(([modelID, model]) => [
               modelID,

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -331,12 +331,24 @@ describe("plugin.codex", () => {
     ["gpt-6", true],
     ["gpt-6.0-astra", true],
     ["gpt-7", true],
+    ["gpt-10", true],
+    ["gpt-5.5-astra", true],
+    ["gpt-5.9", true],
+    ["gpt-5.10", true],
+    ["gpt-5.10-astra", true],
+    ["gpt-5.40", true],
     ["gpt-5", false],
+    ["gpt-5.4-astra", false],
+    ["gpt-5.04-astra", false],
     ["gpt-4.1", false],
+    ["gpt-4.99", false],
     ["gpt-5.5-pro", false],
     ["gpt-5.6", false],
+    ["gpt-6garbage", false],
+    ["gpt-6.", false],
+    ["gpt-6.1.2", false],
     ["not-a-gpt-model", false],
-  ])("filters OAuth model %s with integer or decimal versions", async (id, allowed) => {
+  ])("filters OAuth model %s by GPT major and minor versions", async (id, allowed) => {
     const hooks = await CodexAuthPlugin({} as never)
     const provider = {
       models: {

--- a/packages/opencode/test/plugin/codex.test.ts
+++ b/packages/opencode/test/plugin/codex.test.ts
@@ -344,9 +344,9 @@ describe("plugin.codex", () => {
     ["gpt-4.99", false],
     ["gpt-5.5-pro", false],
     ["gpt-5.6", false],
-    ["gpt-6garbage", false],
-    ["gpt-6.", false],
-    ["gpt-6.1.2", false],
+    ["gpt-6garbage", true],
+    ["gpt-6.", true],
+    ["gpt-6.1.2", true],
     ["not-a-gpt-model", false],
   ])("filters OAuth model %s by GPT major and minor versions", async (id, allowed) => {
     const hooks = await CodexAuthPlugin({} as never)


### PR DESCRIPTION
### Issue for this PR

Follow-up to #47384.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Parses GPT major/minor versions separately and checks `major > 5 || (major === 5 && minor > 4)`. An omitted minor version is zero. This allows versions such as `5.10` that `parseFloat` incorrectly treated as `5.1`.

Only extracts the version prefix; it does not validate model suffixes. Existing explicit subscription allow/deny rules are unchanged. V2 is untouched.

### How did you verify your code works?

- Reproduced the multi-digit minor-version failures before the fix.
- Added coverage confirming suffixes do not cause newer models to be filtered out, including `gpt-6.`.
- `bun test test/plugin/codex.test.ts --timeout 30000`: 45 passed.
- `bun typecheck`: passed in `packages/opencode`.
- Prettier and `git diff --check`: passed.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR