### PR TITLE
fix(app): list OpenCode Go before Zen

### DIFF
--- a/packages/app/src/providers/catalog/order.test.ts
+++ b/packages/app/src/providers/catalog/order.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "bun:test"
+import { popularProviders } from "./order"
+
+test("lists OpenCode Go before Zen and other popular providers", () => {
+  expect(popularProviders.slice(0, 2)).toEqual(["opencode-go", "opencode"])
+})

--- a/packages/app/src/providers/catalog/order.ts
+++ b/packages/app/src/providers/catalog/order.ts
@@ -1,6 +1,6 @@
 export const popularProviders = [
-  "opencode",
   "opencode-go",
+  "opencode",
   "anthropic",
   "github-copilot",
   "openai",

--- a/packages/app/src/providers/connect/dialog.tsx
+++ b/packages/app/src/providers/connect/dialog.tsx
@@ -110,7 +110,7 @@ function ProviderPicker(props: { directory?: string; onSelect: (provider: string
     active: undefined as string | undefined,
     connecting: undefined as string | undefined,
   })
-  const featured = ["opencode", "opencode-go", "anthropic", "openai", "google", "openrouter", "vercel"]
+  const featured = ["opencode-go", "opencode", "anthropic", "openai", "google", "openrouter", "vercel"]
   const custom = () => ({ id: CUSTOM_ID, name: language.t("dialog.provider.custom.label") })
   const all = createMemo(() => {
     language.locale()

--- a/packages/app/src/providers/models/unpaid.tsx
+++ b/packages/app/src/providers/models/unpaid.tsx
@@ -13,7 +13,7 @@ import { useLanguage } from "@/runtime/i18n/language"
 import { ModelTooltip } from "./tooltip"
 
 type ModelState = ReturnType<typeof useLocal>["model"]
-const featuredProviders = ["opencode", "opencode-go", "openai", "anthropic", "google", "github-copilot"]
+const featuredProviders = ["opencode-go", "opencode", "openai", "anthropic", "google", "github-copilot"]
 const displayModelName = (name: string) => name.replace(/\s+(?:\(free\)|free)$/i, "")
 
 export const DialogSelectModelUnpaid: Component<{ model?: ModelState }> = (props) => {

--- a/packages/app/src/settings/providers/providers.tsx
+++ b/packages/app/src/settings/providers/providers.tsx
@@ -58,6 +58,7 @@ export const SettingsProviders: Component<{
         (provider) =>
           provider.id !== "opencode" || Object.values(provider.models).some((model) => model.cost.input > 0),
       )
+      .toSorted((a, b) => Number(b.id === "opencode-go") - Number(a.id === "opencode-go"))
   })
 
   const popular = createMemo(() => {

--- a/packages/storybook/.storybook/mocks/app/context/server-sdk.ts
+++ b/packages/storybook/.storybook/mocks/app/context/server-sdk.ts
@@ -1,6 +1,6 @@
 const providers = [
-  "opencode",
   "opencode-go",
+  "opencode",
   "anthropic",
   "openai",
   "google",

--- a/packages/storybook/.storybook/mocks/app/hooks/use-providers.ts
+++ b/packages/storybook/.storybook/mocks/app/hooks/use-providers.ts
@@ -15,8 +15,8 @@ const provider = {
 }
 
 const popular = [
-  { id: "opencode", name: "OpenCode Zen", models: {} },
   { id: "opencode-go", name: "OpenCode Go", models: {} },
+  { id: "opencode", name: "OpenCode Zen", models: {} },
   { id: "openai", name: "OpenAI", models: {} },
   provider,
   { id: "google", name: "Google", models: {} },


### PR DESCRIPTION
## Summary
- Put OpenCode Go before OpenCode Zen in the desktop/web provider connection picker and unpaid-model provider recommendations.
- Update the shared popular-provider order used by model selection, model management, and provider settings.
- Put Go first in connected-provider settings while preserving the remaining provider order.
- Align Storybook fixtures and add a regression test for the shared ordering.

This PR contains only the shared desktop/web UI changes. The terminal/CLI changes are in a separate, independent PR.

## Validation
- `packages/app`: `bun test src/providers/catalog/order.test.ts` — passed
- `packages/app`: `bun typecheck` — passed
- Repository pre-push typechecks — passed
- Captured the production provider picker in a browser with isolated sample data; Go appears above Zen.
