### PR TITLE
fix(tui): list OpenCode Go before Zen

### DIFF
--- a/packages/cli/src/commands/handlers/auth/login.ts
+++ b/packages/cli/src/commands/handlers/auth/login.ts
@@ -17,8 +17,8 @@ import {
 } from "./shared"
 
 const integrationPriority = new Map([
-  ["opencode", 0],
-  ["opencode-go", 1],
+  ["opencode-go", 0],
+  ["opencode", 1],
   ["openai", 2],
   ["github-copilot", 3],
   ["google", 4],

--- a/packages/cli/src/commands/handlers/auth/shared.ts
+++ b/packages/cli/src/commands/handlers/auth/shared.ts
@@ -18,7 +18,9 @@ export const loadIntegrations = Effect.fn("cli.auth.integrations")(function* (cl
   // The model endpoint is the existing public readiness boundary for the initial plugin generation.
   yield* request((signal) => client.model.default({ location }, { signal }))
   return yield* request((signal) => client.integration.list({ location }, { signal })).pipe(
-    Effect.map((response) => response.data),
+    Effect.map((response) =>
+      response.data.toSorted((a, b) => Number(b.id === "opencode-go") - Number(a.id === "opencode-go")),
+    ),
   )
 })
 

--- a/packages/cli/test/auth.test.ts
+++ b/packages/cli/test/auth.test.ts
@@ -68,6 +68,36 @@ describe("auth command", () => {
     expect(requests.indexOf("/api/model/default")).toBeLessThan(requests.indexOf("/api/integration"))
   })
 
+  test("lists OpenCode Go before Zen and preserves the remaining integration order", async () => {
+    using server = authServer((request, url) => {
+      if (url.pathname === "/api/integration") {
+        return Response.json(
+          located(
+            [
+              { id: "opencode", name: "OpenCode Zen" },
+              { id: "anthropic", name: "Anthropic" },
+              { id: "opencode-go", name: "OpenCode Go" },
+            ].map((integration) => ({
+              ...integration,
+              methods: [],
+              connections: [{ type: "env", name: "TEST_API_KEY" }],
+            })),
+          ),
+        )
+      }
+      return new Response("Not found", { status: 404 })
+    })
+
+    const result = await cli(["auth", "list", "--server", server.url.toString()])
+    expect({ exitCode: result.exitCode, stderr: result.stderr }).toEqual({ exitCode: 0, stderr: "" })
+    expect(
+      result.stdout
+        .trim()
+        .split("\n")
+        .map((line) => line.split(/\s{2,}/)[0]),
+    ).toEqual(["OpenCode Go", "OpenCode Zen", "Anthropic"])
+  })
+
   test("runs command authentication without interactive input", async () => {
     const requests: Array<{ method: string; path: string }> = []
     using server = authServer((request, url) => {

--- a/packages/tui/src/component/dialog-integration.tsx
+++ b/packages/tui/src/component/dialog-integration.tsx
@@ -27,8 +27,8 @@ import { useToast } from "../ui/toast"
 import { formLabel, formToggleMultiselect, formValidateValue, type FormAnswerField } from "../util/form"
 
 const INTEGRATION_PRIORITY: Record<string, number> = {
-  opencode: 0,
-  "opencode-go": 1,
+  "opencode-go": 0,
+  opencode: 1,
   openai: 2,
   "github-copilot": 3,
   anthropic: 4,

--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -192,7 +192,10 @@ export function sortModelOptions<
   },
 >(options: T[], grouped = true) {
   return options.toSorted((a, b) => {
-    const provider = grouped ? Number(a.providerID !== "opencode") - Number(b.providerID !== "opencode") : 0
+    const provider = grouped
+      ? Number(b.providerID === "opencode-go") - Number(a.providerID === "opencode-go") ||
+        Number(b.providerID === "opencode") - Number(a.providerID === "opencode")
+      : 0
     if (provider !== 0) return provider
 
     const name = grouped ? (a.providerName ?? "").localeCompare(b.providerName ?? "") : 0

--- a/packages/tui/test/cli/cmd/tui/integration-options.test.ts
+++ b/packages/tui/test/cli/cmd/tui/integration-options.test.ts
@@ -21,8 +21,10 @@ describe("integrationOptions", () => {
         integration({ id: "openai", name: "OpenAI" }),
         integration({ id: "custom-z", name: "Zebra" }),
         integration({ id: "anthropic", name: "Anthropic" }),
+        integration({ id: "opencode", name: "OpenCode Zen" }),
+        integration({ id: "opencode-go", name: "OpenCode Go" }),
       ]).map((item) => item.id),
-    ).toEqual(["openai", "anthropic", "mistral", "custom-z"])
+    ).toEqual(["opencode-go", "opencode", "openai", "anthropic", "mistral", "custom-z"])
   })
 
   test("keeps MCP integrations above popular integrations without relying on their IDs", () => {
@@ -31,8 +33,10 @@ describe("integrationOptions", () => {
         integration({ id: "openai", name: "OpenAI" }),
         integration({ id: "linear", name: "Linear", metadata: { source: "mcp" } }),
         integration({ id: "github", name: "GitHub", metadata: { source: "mcp" } }),
+        integration({ id: "opencode", name: "OpenCode Zen" }),
+        integration({ id: "opencode-go", name: "OpenCode Go" }),
       ]).map((item) => item.id),
-    ).toEqual(["github", "linear", "openai"])
+    ).toEqual(["github", "linear", "opencode-go", "opencode", "openai"])
   })
 })
 

--- a/packages/tui/test/cli/cmd/tui/model-options.test.ts
+++ b/packages/tui/test/cli/cmd/tui/model-options.test.ts
@@ -38,14 +38,28 @@ describe("sortModelOptions", () => {
     ])
   })
 
-  test("orders opencode models before other providers", () => {
+  test("orders OpenCode Go before Zen and other providers", () => {
     const sorted = sortModelOptions([
       { providerID: "openai", providerName: "OpenAI", releaseDate: 3, title: "GPT 5" },
-      { providerID: "opencode", providerName: "OpenCode", releaseDate: 1, title: "Claude Sonnet 4" },
+      { providerID: "opencode", providerName: "OpenCode Zen", releaseDate: 1, title: "Claude Sonnet 4" },
       { providerID: "anthropic", providerName: "Anthropic", releaseDate: 2, title: "Claude Opus 4" },
+      { providerID: "opencode-go", providerName: "OpenCode Go", releaseDate: 0, title: "Kimi K3" },
     ])
 
-    expect(sorted.map((model) => model.title)).toEqual(["Claude Sonnet 4", "Claude Opus 4", "GPT 5"])
+    expect(sorted.map((model) => model.title)).toEqual(["Kimi K3", "Claude Sonnet 4", "Claude Opus 4", "GPT 5"])
+  })
+
+  test("keeps ungrouped results free-first regardless of OpenCode provider", () => {
+    const sorted = sortModelOptions(
+      [
+        { providerID: "opencode-go", releaseDate: 3, title: "Go model" },
+        { providerID: "opencode", releaseDate: 1, title: "Free Zen model", footer: "Free" },
+        { providerID: "anthropic", releaseDate: 4, title: "Anthropic model" },
+      ],
+      false,
+    )
+
+    expect(sorted.map((model) => model.title)).toEqual(["Free Zen model", "Anthropic model", "Go model"])
   })
 
   test("orders provider groups by provider name and models by newest release", () => {


### PR DESCRIPTION
## Summary
- Put OpenCode Go before OpenCode Zen in the TUI integration picker and grouped model picker.
- Put Go first in CLI login, credential listing, and logout choices.
- Preserve MCP grouping, favorites, recents, ungrouped model ordering, and the remaining credential-list order.
- Add regression coverage for provider ordering and unchanged grouping behavior.

This PR contains only terminal/CLI changes. The desktop/web changes are in a separate, independent PR.

## Validation
- `packages/tui`: `bun test test/cli/cmd/tui/integration-options.test.ts test/cli/cmd/tui/model-options.test.ts` — 13 passed
- `packages/cli`: `bun test test/auth.test.ts` — 9 passed
- `bun typecheck` in `packages/tui` and `packages/cli` — passed
- Captured an isolated render of the production integration picker with sample provider data; Go appears above Zen.
