### PR TITLE
fix(app,enterprise): make custom-elements.d.ts a valid triple-slash reference

### DIFF
--- a/packages/app/src/custom-elements.d.ts
+++ b/packages/app/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />

--- a/packages/enterprise/src/custom-elements.d.ts
+++ b/packages/enterprise/src/custom-elements.d.ts
@@ -1,1 +1,1 @@
-../../ui/src/custom-elements.d.ts
+/// <reference path="../../ui/src/custom-elements.d.ts" />


### PR DESCRIPTION
Fixes custom-elements.d.ts to be a valid triple-slash reference.
Currently triggers TS1128 and breaks enterprise typecheck.

Baseline note: origin/dev@5cf9f517cf already fails typecheck in enterprise (TS1128 custom-elements.d.ts) and stats/app (4 errors), pre-existing, verified with --force scoped runs — this PR does not introduce them.

Verified: enterprise typecheck goes FAIL->PASS with this change.