### PR TITLE
fix(lsp): idle TTL timeout and LRU eviction policy

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -142,6 +142,35 @@ export async function create(input: {
   const diagnosticRegistrations = new Map<string, CapabilityRegistration>()
   const registrationListeners = new Set<() => void>()
   const diagnosticListeners = new Set<(input: { path: string; serverID: string }) => void>()
+  const MAX_FILES = 128
+
+  // vMK: LRU eviction via Map insertion order — re-add current file to tail
+  function pruneFiles(currentPath: string) {
+    const keys = Object.keys(files)
+    if (keys.length <= MAX_FILES) return
+    const toRemove = keys.length - MAX_FILES
+    let removed = 0
+    for (const key of keys) {
+      if (key === currentPath) continue
+      delete files[key]
+      // Notify server the file is closed so it doesn't hold stale state
+      connection.sendNotification("textDocument/didClose", {
+        textDocument: { uri: pathToFileURL(key).href },
+      }).catch(() => {})
+      pushDiagnostics.delete(key)
+      pullDiagnostics.delete(key)
+      published.delete(key)
+      removed++
+      if (removed >= toRemove) break
+    }
+    // Re-insert current file at tail (most recently used)
+    if (files[currentPath]) {
+      const entry = files[currentPath]
+      delete files[currentPath]
+      files[currentPath] = entry
+    }
+  }
+
   const mergedDiagnostics = (filePath: string) =>
     dedupeDiagnostics([...(pushDiagnostics.get(filePath) ?? []), ...(pullDiagnostics.get(filePath) ?? [])])
   const updatePushDiagnostics = (filePath: string, next: Diagnostic[]) => {
@@ -592,8 +621,9 @@ export async function create(input: {
                       text,
                     },
                   ]
-                : [{ text }],
+                 : [{ text }],
           })
+          pruneFiles(request.path)
           return next
         }
 
@@ -617,6 +647,7 @@ export async function create(input: {
           },
         })
         files[request.path] = { version: 0, text }
+        pruneFiles(request.path)
         return 0
       },
     },

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -8,7 +8,7 @@ import * as LSPServer from "./server"
 import { Config } from "@/config/config"
 import { Process } from "@/util/process"
 import { spawn as lspspawn } from "./launch"
-import { Effect, Layer, Context, Schema } from "effect"
+import { Duration, Effect, Layer, Context, Schema } from "effect"
 import { InstanceState } from "@/effect/instance-state"
 import { containsPath } from "@/project/instance-context"
 import { NonNegativeInt } from "@opencode-ai/core/schema"
@@ -109,8 +109,18 @@ const filterExperimentalServers = (servers: Record<string, LSPServer.Info>, flag
 
 type LocInput = { file: string; line: number; character: number }
 
+// vMK: wrapped client entry with last-used timestamp for idle eviction
+interface ClientEntry {
+  client: LSPClient.Info
+  lastUsed: number
+}
+
+// vMK: evict idle LSP clients after 30 min of inactivity
+const CLIENT_IDLE_TTL_MS = 30 * 60_000
+const CLIENT_IDLE_SCAN_INTERVAL_MS = 5 * 60_000
+
 interface State {
-  clients: LSPClient.Info[]
+  clients: ClientEntry[]
   servers: Record<string, LSPServer.Info>
   broken: Set<string>
   spawning: Map<string, Promise<LSPClient.Info | undefined>>
@@ -195,11 +205,28 @@ const layer = Layer.effect(
           spawning: new Map(),
         }
 
-        yield* Effect.addFinalizer(() =>
-          Effect.promise(async () => {
-            await Promise.all(s.clients.map((client) => client.shutdown()))
-          }),
-        )
+          yield* Effect.addFinalizer(() =>
+            Effect.promise(async () => {
+              await Promise.all(s.clients.map((entry) => entry.client.shutdown()))
+            }),
+          )
+
+          // vMK: background fiber to periodically evict idle LSP clients
+          yield* Effect.forkScoped(
+            Effect.gen(function* evictIdleClients() {
+              while (true) {
+                yield* Effect.sleep(Duration.millis(CLIENT_IDLE_SCAN_INTERVAL_MS))
+                const now = Date.now()
+                for (let i = s.clients.length - 1; i >= 0; i--) {
+                  const entry = s.clients[i]!
+                  if (now - entry.lastUsed > CLIENT_IDLE_TTL_MS) {
+                    entry.client.shutdown().catch(() => {})
+                    s.clients.splice(i, 1)
+                  }
+                }
+              }
+            }),
+          )
 
         return s
       }),
@@ -241,13 +268,14 @@ const layer = Layer.effect(
 
           if (!client) return undefined
 
-          const existing = s.clients.find((x) => x.root === root && x.serverID === server.id)
+          const existing = s.clients.find((x) => x.client.root === root && x.client.serverID === server.id)
           if (existing) {
+            existing.lastUsed = Date.now()
             await Process.stop(handle.process)
-            return existing
+            return existing.client
           }
 
-          s.clients.push(client)
+          s.clients.push({ client, lastUsed: Date.now() })
           return client
         }
 
@@ -258,9 +286,10 @@ const layer = Layer.effect(
           if (!root) continue
           if (s.broken.has(root + server.id)) continue
 
-          const match = s.clients.find((x) => x.root === root && x.serverID === server.id)
+          const match = s.clients.find((x) => x.client.root === root && x.client.serverID === server.id)
           if (match) {
-            result.push(match)
+            match.lastUsed = Date.now()
+            result.push(match.client)
             continue
           }
 
@@ -303,7 +332,7 @@ const layer = Layer.effect(
 
     const runAll = Effect.fnUntraced(function* <T>(fn: (client: LSPClient.Info) => Promise<T>) {
       const s = yield* InstanceState.get(state)
-      return yield* Effect.promise(() => Promise.all(s.clients.map((x) => fn(x))))
+      return yield* Effect.promise(() => Promise.all(s.clients.map((x) => fn(x.client))))
     })
 
     const init = Effect.fn("LSP.init")(function* () {
@@ -314,10 +343,12 @@ const layer = Layer.effect(
       const ctx = yield* InstanceState.context
       const s = yield* InstanceState.get(state)
       const result: Status[] = []
-      for (const client of s.clients) {
+      for (const entry of s.clients) {
+        const client = entry.client
+        const serverInfo = s.servers[client.serverID]
         result.push({
           id: client.serverID,
-          name: s.servers[client.serverID].id,
+          name: serverInfo?.id ?? client.serverID,
           root: path.relative(ctx.directory, client.root),
           status: "connected",
         })


### PR DESCRIPTION
Adds idle TTL timeout and LRU eviction policy for LSP clients.
Prevents unbounded growth and cleans up idle clients automatically.

Baseline note: origin/dev@5cf9f517cf already fails typecheck in enterprise (TS1128 custom-elements.d.ts) and stats/app (4 errors), pre-existing, verified with --force scoped runs — this PR does not introduce them.

Note: moderate drift (5 upstream refactors on these files), medium-high blast radius, needs careful review.