### PR TITLE
fix: preserve Unicode when truncating read lines

### DIFF
--- a/packages/core/src/tool/read-filesystem.ts
+++ b/packages/core/src/tool/read-filesystem.ts
@@ -248,7 +248,12 @@ export const read = Effect.fn("ReadTool.read")(function* (
           next = line
           return false
         }
-        const text = input.length > MAX_LINE_LENGTH ? input.slice(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : input
+        // Keep the UTF-16 limit without cutting a Unicode surrogate pair in half.
+        const end =
+          input.charCodeAt(MAX_LINE_LENGTH - 1) >= 0xd800 && input.charCodeAt(MAX_LINE_LENGTH - 1) <= 0xdbff
+            ? MAX_LINE_LENGTH - 1
+            : MAX_LINE_LENGTH
+        const text = input.length > MAX_LINE_LENGTH ? input.slice(0, end) + MAX_LINE_SUFFIX : input
         const size = Buffer.byteLength(text, "utf-8") + (lines.length > 0 ? 1 : 0)
         if (bytes + size > MAX_READ_BYTES) {
           next = line

--- a/packages/core/test/tool-read-filesystem.test.ts
+++ b/packages/core/test/tool-read-filesystem.test.ts
@@ -115,4 +115,67 @@ describe("ReadToolFileSystem", () => {
       )
     }),
   )
+
+  Array.of(
+    { name: "a surrogate pair at the truncation boundary", text: "a".repeat(1999) + "😀tail", head: "a".repeat(1999) },
+    {
+      name: "a complete surrogate pair within the limit",
+      text: "a".repeat(1998) + "😀tail",
+      head: "a".repeat(1998) + "😀",
+    },
+    { name: "ASCII at the truncation boundary", text: "a".repeat(2000) + "tail", head: "a".repeat(2000) },
+    { name: "BMP Unicode at the truncation boundary", text: "文".repeat(2000) + "tail", head: "文".repeat(2000) },
+  ).forEach((input) => {
+    it.live(`preserves valid Unicode when truncating ${input.name}`, () =>
+      Effect.gen(function* () {
+        const test = yield* fixture
+        const file = path.join(test.directory, "unicode.txt")
+        yield* test.files.writeFileString(file, input.text + "\nnext")
+
+        const result = yield* ReadToolFileSystem.read(test.fs, file, "unicode.txt", { limit: 1 })
+
+        expect(result).toMatchObject({
+          type: "text-page",
+          content: input.head + "... (line truncated to 2000 chars)",
+          truncated: true,
+          next: 2,
+        })
+        expect(result.content.isWellFormed()).toBe(true)
+        expect(Buffer.from(result.content).toString()).toBe(result.content)
+      }),
+    )
+  })
+
+  it.live("keeps exact-limit Unicode lines without a truncation marker", () =>
+    Effect.gen(function* () {
+      const test = yield* fixture
+      const file = path.join(test.directory, "exact.txt")
+      const content = "a".repeat(1998) + "😀"
+      yield* test.files.writeFileString(file, content + "\r\nnext")
+
+      const result = yield* ReadToolFileSystem.read(test.fs, file, "exact.txt", { limit: 1 })
+
+      expect(result).toMatchObject({ type: "text-page", content, truncated: true, next: 2 })
+      expect(result.content.isWellFormed()).toBe(true)
+    }),
+  )
+
+  it.live("preserves Unicode when a truncated line spans read chunks and ends at EOF", () =>
+    Effect.gen(function* () {
+      const test = yield* fixture
+      const file = path.join(test.directory, "chunks.txt")
+      // The first two bytes of the emoji fall in the first 64 KiB read.
+      yield* test.files.writeFileString(file, "p".repeat(63_534) + "\n" + "a".repeat(1999) + "😀tail")
+
+      const result = yield* ReadToolFileSystem.read(test.fs, file, "chunks.txt", { offset: 2, limit: 1 })
+
+      expect(result).toMatchObject({
+        type: "text-page",
+        content: "a".repeat(1999) + "... (line truncated to 2000 chars)",
+        offset: 2,
+        truncated: false,
+      })
+      expect(result.content.isWellFormed()).toBe(true)
+    }),
+  )
 })

--- a/packages/opencode/src/tool/read.ts
+++ b/packages/opencode/src/tool/read.ts
@@ -159,7 +159,12 @@ export const ReadTool = Tool.define<
               return
             }
 
-            const line = text.length > MAX_LINE_LENGTH ? text.substring(0, MAX_LINE_LENGTH) + MAX_LINE_SUFFIX : text
+            // Keep the UTF-16 limit without cutting a Unicode surrogate pair in half.
+            const end =
+              text.charCodeAt(MAX_LINE_LENGTH - 1) >= 0xd800 && text.charCodeAt(MAX_LINE_LENGTH - 1) <= 0xdbff
+                ? MAX_LINE_LENGTH - 1
+                : MAX_LINE_LENGTH
+            const line = text.length > MAX_LINE_LENGTH ? text.substring(0, end) + MAX_LINE_SUFFIX : text
             const size = Buffer.byteLength(line, "utf-8") + (raw.length > 0 ? 1 : 0)
             if (flags.bytes + size <= MAX_BYTES) {
               raw.push(line)

--- a/packages/opencode/test/tool/read.test.ts
+++ b/packages/opencode/test/tool/read.test.ts
@@ -482,6 +482,52 @@ describe("tool.read truncation", () => {
     }),
   )
 
+  Array.of(
+    { name: "a split emoji", text: "a".repeat(1999) + "😀tail", head: "a".repeat(1999) },
+    { name: "a complete emoji", text: "a".repeat(1998) + "😀tail", head: "a".repeat(1998) + "😀" },
+    { name: "ASCII", text: "a".repeat(2000) + "tail", head: "a".repeat(2000) },
+    { name: "BMP characters", text: "文".repeat(2000) + "tail", head: "文".repeat(2000) },
+  ).forEach((input) => {
+    it.instance(`preserves Unicode when truncating ${input.name} at EOF`, () =>
+      Effect.gen(function* () {
+        const test = yield* TestInstance
+        const filepath = path.join(test.directory, "unicode.txt")
+        yield* put(filepath, input.text)
+
+        const result = yield* run({ filePath: filepath })
+        const expected = input.head + "... (line truncated to 2000 chars)"
+
+        expect(result.output).toContain(`1: ${expected}\n\n(End of file - total 1 lines)`)
+        expect(result.output.isWellFormed()).toBe(true)
+        expect(Buffer.from(result.output).toString()).toBe(result.output)
+        expect(result.metadata.preview).toBe(expected)
+        expect(result.metadata.display).toMatchObject({ text: expected, lineStart: 1, lineEnd: 1 })
+        expect(yield* load(filepath)).toBe(input.text)
+      }),
+    )
+  })
+
+  it.instance("preserves exact-limit Unicode and pagination with CRLF", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const filepath = path.join(test.directory, "exact.txt")
+      const content = "a".repeat(1998) + "😀"
+      yield* put(filepath, content + "\r\nnext")
+
+      const result = yield* run({ filePath: filepath, limit: 1 })
+
+      expect(result.metadata.preview).toBe(content)
+      expect(result.metadata.display).toMatchObject({ text: content, lineStart: 1, lineEnd: 1, truncated: true })
+      expect(result.output).toContain("Use offset=2")
+      expect(result.output).not.toContain("line truncated")
+      expect(result.output.isWellFormed()).toBe(true)
+
+      const next = yield* run({ filePath: filepath, offset: 2, limit: 1 })
+      expect(next.metadata.preview).toBe("next")
+      expect(next.metadata.truncated).toBe(false)
+    }),
+  )
+
   it.live("image files set truncated to false", () =>
     Effect.gen(function* () {
       const dir = yield* tmpdirScoped()


### PR DESCRIPTION
### Issue for this PR

Closes #47399

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Prevent the legacy Read tool and paged Core reader from leaving half a Unicode surrogate pair when truncating a long line at 2,000 UTF-16 code units. If the retained prefix would end with a high surrogate, move the cut back one unit. Existing limits, truncation markers, and pagination behavior are preserved.

This fixes the returned text, including legacy previews and display metadata. It does not add grapheme-cluster truncation. Related #42356 fixed the same boundary problem in grep previews; this PR covers the separate Read paths.

### How did you verify your code works?

On macOS arm64 with Bun 1.3.14:

- `packages/opencode`: `bun test --timeout 30000 test/tool/read.test.ts` — 44 passed. The new split-emoji case failed before the legacy fix.
- `packages/core`: `bun test test/tool-read-filesystem.test.ts test/tool-read.test.ts test/tool-output-store.test.ts test/session-runner-tool-registry.test.ts` — 60 passed.
- `bun typecheck` passed in both packages; all 30 package typechecks also passed in the pre-push hook. Formatting and diff checks passed.

Tests cover split/intact emoji, ASCII/BMP controls, exact-limit CRLF, EOF, Core read-chunk boundaries, legacy output/preview/display, and continued pagination.

### Screenshots / recordings

Not applicable; text-processing fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
