### PR TITLE
fix(core): avoid full-output allocation for preview suffixes

### DIFF
--- a/packages/core/src/tool-output-store.ts
+++ b/packages/core/src/tool-output-store.ts
@@ -61,14 +61,22 @@ const takePrefix = (input: string, maximumBytes: number) => {
 
 const takeSuffix = (input: string, maximumBytes: number) => {
   let bytes = 0
-  const content: string[] = []
-  for (const char of Array.from(input).toReversed()) {
-    const size = Buffer.byteLength(char, "utf-8")
+  let start = input.length
+  while (start > 0) {
+    const last = input.charCodeAt(start - 1)
+    const paired =
+      last >= 0xdc00 &&
+      last <= 0xdfff &&
+      start > 1 &&
+      input.charCodeAt(start - 2) >= 0xd800 &&
+      input.charCodeAt(start - 2) <= 0xdbff
+    const previous = start - (paired ? 2 : 1)
+    const size = Buffer.byteLength(input.slice(previous, start), "utf-8")
     if (bytes + size > maximumBytes) break
-    content.unshift(char)
+    start = previous
     bytes += size
   }
-  return content.join("")
+  return input.slice(start)
 }
 
 const preview = (text: string, maxLines: number, maxBytes: number) => {

--- a/packages/core/test/tool-output-store.test.ts
+++ b/packages/core/test/tool-output-store.test.ts
@@ -16,7 +16,7 @@ const sessionID = SessionV2.ID.make("ses_tool_output_store")
 
 const withStore = <A, E, R>(
   body: (input: { root: string; store: ToolOutputStore.Interface; fs: FSUtil.Interface }) => Effect.Effect<A, E, R>,
-  config?: Config.Info,
+  config?: Config.Info | (() => Config.Info),
 ) =>
   Effect.acquireUseRelease(
     Effect.promise(() => tmpdir()),
@@ -26,7 +26,10 @@ const withStore = <A, E, R>(
         ? Layer.succeed(
             Config.Service,
             Config.Service.of({
-              entries: () => Effect.succeed([new Config.Document({ type: "document", info: config })]),
+              entries: () =>
+                Effect.sync(() => [
+                  new Config.Document({ type: "document", info: typeof config === "function" ? config() : config }),
+                ]),
             }),
           )
         : Layer.empty
@@ -82,6 +85,102 @@ describe("ToolOutputStore", () => {
       }),
     ),
   )
+
+  it.live("preserves exact UTF-8 suffixes across byte budget boundaries", () =>
+    Effect.forEach([512, 514, 516, 518], (maxBytes) =>
+      withStore(
+        ({ store }) =>
+          Effect.gen(function* () {
+            for (const [unit, width] of [
+              ["a", 1],
+              ["é", 2],
+              ["中", 3],
+              ["😀", 4],
+              ["\ud800", Buffer.byteLength("\ud800", "utf-8")],
+              ["\udc00", Buffer.byteLength("\udc00", "utf-8")],
+            ] as const) {
+              const result = yield* store.bound({
+                sessionID,
+                toolCallID: "call-utf8-suffix",
+                output: { structured: {}, content: [{ type: "text", text: unit.repeat(1_024) }] },
+              })
+              const marker = `... output truncated; full content saved to ${result.outputPaths[0]} ...`
+              const available = maxBytes - Buffer.byteLength(marker) - 4
+              const head = unit.repeat(Math.floor(Math.ceil(available / 2) / width))
+              const tail = unit.repeat(Math.floor(Math.floor(available / 2) / width))
+              expect(result.output.content).toEqual([{ type: "text", text: `${head}\n\n${marker}\n\n${tail}` }])
+              expect(Buffer.byteLength(`${head}\n\n${marker}\n\n${tail}`)).toBeLessThanOrEqual(maxBytes)
+            }
+          }),
+        new Config.Info({ tool_output: new ConfigToolOutput.Info({ max_bytes: maxBytes }) }),
+      ),
+    ),
+  )
+
+  it.live("keeps mixed-width suffixes in their original order", () =>
+    withStore(
+      ({ store, fs }) =>
+        Effect.gen(function* () {
+          const text = "a".repeat(1_024) + "é中😀Q"
+          const result = yield* store.bound({
+            sessionID,
+            toolCallID: "call-mixed-suffix",
+            output: { structured: {}, content: [{ type: "text", text }] },
+          })
+          const marker = `... output truncated; full content saved to ${result.outputPaths[0]} ...`
+          const available = 512 - Buffer.byteLength(marker) - 4
+          const head = "a".repeat(Math.ceil(available / 2))
+          const tail = "a".repeat(Math.floor(available / 2) - 10) + "é中😀Q"
+          expect(result.output.content).toEqual([{ type: "text", text: `${head}\n\n${marker}\n\n${tail}` }])
+          expect(yield* fs.readFileString(result.outputPaths[0])).toBe(text)
+        }),
+      new Config.Info({ tool_output: new ConfigToolOutput.Info({ max_bytes: 512 }) }),
+    ),
+  )
+
+  it.live("stops at the first suffix character that exceeds a tight byte budget", () => {
+    const limits = { maxBytes: 512 }
+    return withStore(
+      ({ store }) =>
+        Effect.gen(function* () {
+          const initial = yield* store.bound({
+            sessionID,
+            toolCallID: "call-marker-size",
+            output: { structured: {}, content: [{ type: "text", text: "a".repeat(1_024) }] },
+          })
+          const markerBytes = Buffer.byteLength(
+            `... output truncated; full content saved to ${initial.outputPaths[0]} ...`,
+          )
+          for (const [ending, budget, tail] of [
+            ["é", 1, ""],
+            ["é", 2, "é"],
+            ["😀", 3, ""],
+            ["😀", 4, "😀"],
+            ["😀a", 4, "a"],
+            ["😀a", 5, "😀a"],
+            ["\ud800", Buffer.byteLength("\ud800", "utf-8") - 1, ""],
+            ["\ud800", Buffer.byteLength("\ud800", "utf-8"), "\ud800"],
+            ["\udc00", Buffer.byteLength("\udc00", "utf-8") - 1, ""],
+            ["\udc00", Buffer.byteLength("\udc00", "utf-8"), "\udc00"],
+            ["\ud800\ud800\udc00", 4, "\ud800\udc00"],
+            ["\ud800\udc00\udc00", 3, "\udc00"],
+            ["\udc00\ud800", 3, "\ud800"],
+          ] as const) {
+            limits.maxBytes = markerBytes + 4 + budget * 2
+            const result = yield* store.bound({
+              sessionID,
+              toolCallID: "call-tight-suffix",
+              output: { structured: {}, content: [{ type: "text", text: "a".repeat(1_024) + ending }] },
+            })
+            const marker = `... output truncated; full content saved to ${result.outputPaths[0]} ...`
+            const text = "a".repeat(budget) + "\n\n" + marker + (tail ? "\n\n" + tail : "")
+            expect(result.output.content).toEqual([{ type: "text", text }])
+            expect(Buffer.byteLength(text)).toBeLessThanOrEqual(limits.maxBytes)
+          }
+        }),
+      () => new Config.Info({ tool_output: new ConfigToolOutput.Info({ max_bytes: limits.maxBytes }) }),
+    )
+  })
 
   it.live("preserves native media and structured metadata without applying a settlement media limit", () =>
     withStore(({ store }) =>


### PR DESCRIPTION
### Issue for this PR

Closes #47402

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Avoid building and reversing a full character array to retain a small tool-output suffix. Walk backward within the UTF-8 byte budget, then extract the retained suffix. Preserve character order, surrogate-pair handling, and the existing preview and retention behavior.

Related: #37968 included the same suffix optimization within broader structured-output changes against `v2`. It was closed without merging during automated cleanup. This PR targets only the suffix optimization and focused tests against `dev`.

### How did you verify your code works?

On macOS arm64 with Bun 1.3.14, from `packages/core`:

- `bun test test/tool-output-store.test.ts test/session-runner-tool-registry.test.ts`: 31 passed.
- `bun typecheck`: passed. The pre-push hook also passed all 30 package typechecks.
- Formatting, lint, and diff checks passed.

Real `ToolOutputStore.bound` measurements, including full retention writes, with two warmups and seven measured calls per case (median):

| Single-line input | Before | After |
| --- | ---: | ---: |
| 1 MiB ASCII | 65.01 ms | 8.30 ms |
| 1 MiB mixed Unicode | 19.20 ms | 7.05 ms |

Saved full content was verified; preview checksums matched after normalizing the generated file path. These are local service benchmarks, not whole-application speedups. Tests cover UTF-8 budgets, mixed character order, isolated surrogates, and adjacent surrogate sequences.

### Screenshots / recordings

Not applicable; internal text-processing optimization.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
