### PR TITLE
fix(core): compare Codex GPT versions by major and minor

### DIFF
--- a/packages/core/src/plugin/provider/openai.ts
+++ b/packages/core/src/plugin/provider/openai.ts
@@ -274,10 +274,12 @@ export const OpenAIPlugin = define({
             return
           }
           const apiID = draft.modelID ?? draft.id
-          const match = apiID.match(/^gpt-(\d+\.\d+)/)
+          const match = apiID.match(/^gpt-(\d+)(?:\.(\d+))?/)
+          const major = Number(match?.[1])
+          const minor = Number(match?.[2] ?? 0)
           if (
             !codexAllowed.has(apiID) &&
-            (codexDisallowed.has(apiID) || !match || Number.parseFloat(match[1]) <= 5.4)
+            (codexDisallowed.has(apiID) || !match || !(major > 5 || (major === 5 && minor > 4)))
           ) {
             draft.enabled = false
             return

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -115,6 +115,15 @@ describe("OpenAIPlugin", () => {
           model.limit = { context: 1_050_000, input: 922_000, output: 128_000 }
         })
         catalog.model.update(Provider.ID.openai, Model.ID.make("gpt-4.1"), () => {})
+        catalog.model.update(Provider.ID.openai, Model.ID.make("gpt-6-astra"), (model) => {
+          model.limit = { context: 1_050_000, input: 922_000, output: 128_000 }
+        })
+        catalog.model.update(Provider.ID.openai, Model.ID.make("gpt-5.10"), (model) => {
+          model.limit = { context: 1_050_000, input: 922_000, output: 128_000 }
+        })
+        catalog.model.update(Provider.ID.openai, Model.ID.make("gpt-5"), () => {})
+        catalog.model.update(Provider.ID.openai, Model.ID.make("gpt-5.04-astra"), () => {})
+        catalog.model.update(Provider.ID.openai, Model.ID.make("gpt-4.99"), () => {})
       })
       yield* credentials.create({
         integrationID: Integration.ID.make("openai"),
@@ -161,6 +170,11 @@ describe("OpenAIPlugin", () => {
       expect(gpt56.enabled).toBe(true)
       expect(gpt56.limit).toEqual({ context: 400_000, input: 272_000, output: 128_000 })
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-4.1"))).enabled).toBe(false)
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-6-astra"))).enabled).toBe(true)
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.10"))).enabled).toBe(true)
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5"))).enabled).toBe(false)
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.04-astra"))).enabled).toBe(false)
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-4.99"))).enabled).toBe(false)
     }),
   )
 


### PR DESCRIPTION
Ports the Codex OAuth model filter fixes from `dev` (#47384, #47385).

The filter matched `/^gpt-(\d+\.\d+)/` and `parseFloat`-ed the prefix, so:

- integer version ids like `gpt-6-astra` / `gpt-6` were not admitted at all
- `parseFloat` also misranked future versions (`gpt-5.10` → 5.1 < 5.4)

Now the match captures the major and minor separately and compares them numerically:

```ts
const match = apiID.match(/^gpt-(\d+)(?:\.(\d+))?/)
const major = Number(match?.[1])
const minor = Number(match?.[2] ?? 0)
// admitted when major > 5 || (major === 5 && minor > 4)
```

The explicit allowlist/disallowlist entries (`codexAllowed`, `codexDisallowed`, including `gpt-5.5-pro` and `gpt-5.6`) still take precedence, so older-model blacklisting behavior is unchanged.

Extends `provider-openai.test.ts` with `gpt-6-astra`, `gpt-5.10`, `gpt-5`, `gpt-5.04-astra`, and `gpt-4.99` cases mirroring the dev test suite.