### PR TITLE
fix(core): preserve literal command arguments

### DIFF
--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -206,7 +206,7 @@ function evaluateTemplate(
       if (position === last) return args.slice(argIndex).join(" ")
       return args[argIndex]
     })
-    const withArguments = expanded.replaceAll("$ARGUMENTS", input)
+    const withArguments = expanded.replaceAll("$ARGUMENTS", () => input)
     const text =
       placeholders.length === 0 && !template.includes("$ARGUMENTS") && input.trim()
         ? `${withArguments}\n\n${input}`.trim()

--- a/packages/core/test/config/command.test.ts
+++ b/packages/core/test/config/command.test.ts
@@ -71,6 +71,73 @@ const it = testEffect(
 const decode = Schema.decodeUnknownSync(Info)
 
 describe("ConfigCommandPlugin.Plugin", () => {
+  for (const item of [
+    ...["$&", "$$", "$`", "$'"].flatMap((input) => [
+      { template: "Explain $ARGUMENTS.", input, expected: `Explain ${input}.` },
+      { template: "Explain $1.", input: `"${input}"`, expected: `Explain ${input}.` },
+      { template: "Explain.", input, expected: `Explain.\n\n${input}` },
+    ]),
+    ...["abc", "", "alpha beta", '"alpha beta"', "$1", "$<name>"].map((input) => ({
+      template: "Explain $ARGUMENTS.",
+      input,
+      expected: `Explain ${input}.`,
+    })),
+    {
+      template: "First $1. Rest $2.",
+      input: '"alpha beta" gamma delta',
+      expected: "First alpha beta. Rest gamma delta.",
+    },
+    { template: "$ARGUMENTS / $ARGUMENTS", input: "$& $$", expected: "$& $$ / $& $$" },
+  ]) {
+    it.live(`interpolates ${JSON.stringify(item.template)} with literal input ${JSON.stringify(item.input)}`, () =>
+      Effect.gen(function* () {
+        const command = yield* Command.Service
+        const prompts: { text: string; delivery?: string }[] = []
+        yield* ConfigCommandPlugin.Plugin.effect(
+          host({
+            command: {
+              list: () => Effect.die(new Error("unused command.list")),
+              transform: command.transform,
+              reload: command.reload,
+            },
+            session: {
+              prompt: (input) =>
+                Effect.sync(() => {
+                  prompts.push({ text: input.text, delivery: input.delivery })
+                  return SessionInbox.User.make({
+                    id: SessionMessage.ID.make("msg_test"),
+                    sessionID: input.sessionID,
+                    timeCreated: DateTime.makeUnsafe(0),
+                    type: "user",
+                    payload: { text: input.text },
+                    delivery: input.delivery ?? "steer",
+                  })
+                }),
+            },
+          }),
+        ).pipe(
+          Effect.provide(
+            Config.testLayer([
+              new Document({
+                type: "document",
+                info: decode({ commands: { explain: { template: item.template } } }),
+              }),
+            ]),
+          ),
+        )
+        yield* command.execute({
+          name: "explain",
+          invocation: {
+            sessionID: Session.ID.make("ses_test"),
+            prompt: { text: item.input },
+            delivery: "queue",
+          },
+        })
+        expect(prompts).toEqual([{ text: item.expected, delivery: "queue" }])
+      }),
+    )
+  }
+
   it.live("loads inline and file-based commands in config order", () =>
     Effect.acquireDisposable(Effect.promise(() => tmpdir())).pipe(
       Effect.flatMap((tmp) =>


### PR DESCRIPTION
### Issue for this PR

Closes #47411

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

**Why:** With template `Explain $ARGUMENTS.`, passing `$&` submits `Explain $ARGUMENTS.` instead of `Explain $&.`. The replacement string interprets the argument as JavaScript replacement syntax.

**What changes:** Use a replacement callback so the complete argument string is inserted literally, including repeated placeholders.

**Scope:** Configured-command `$ARGUMENTS` interpolation. Positional parsing, no-placeholder appending, shell interpolation and delivery are unchanged.

### How did you verify your code works?

From `packages/core`:

```sh
bun run test test/config/command.test.ts test/config/command-subagent.test.ts test/command.test.ts test/plugin/command.test.ts
bun typecheck
```

Five new cases failed on the base. All 20 interpolation cases and all 38 relevant tests now pass. Tests invoke the real command plugin and dispatcher, capturing the resulting prompt. Formatting and production structural checks pass; existing test-file lint findings are unchanged.

Additional combined-tree checks passed full Core twice (5,267 passed, 41 skipped). An earlier run hit `pty > retains exited sessions until removed`; the timeout did not recur in paired clean-base/fixed reruns, but its cause remains unresolved.

### Screenshots / recordings

Not a UI change; tests assert the submitted prompt text and delivery.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
