### PR TITLE
fix(app): Path key normalization

### DIFF
--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -6,6 +6,7 @@ import { pathKey } from "@/utils/path-key"
 import { useServerHealth } from "@/utils/server-health"
 import { createServerSdkContext } from "./server-sdk"
 import { createServerSyncContext } from "./server-sync"
+import { enrichProject } from "./layout-helpers"
 import { getOwner } from "solid-js/web"
 import { QueryClient } from "@tanstack/solid-query"
 import type { ServerScope } from "@/utils/server-scope"
@@ -93,46 +94,6 @@ export const { use: useGlobal, provider: GlobalProvider } = createSimpleContext(
   },
 })
 
-function enrichProject({
-  project,
-  data,
-}: {
-  project: { worktree: string; expanded: boolean }
-  data: {
-    project: { id?: string; worktree: string; sandboxes?: string[] }[]
-    child: (directory: string, options?: { bootstrap: boolean }) => [Store<unknown>, SetStoreFunction<unknown>]
-  }
-}) {
-  const [childStore] = data.child(project.worktree, { bootstrap: false })
-  const child = childStore as Record<string, unknown>
-  const key = pathKey(project.worktree)
-  const byDirectory =
-    data.project.find((x) => pathKey(x.worktree) === key) ??
-    data.project.find((x) => x.sandboxes?.some((sandbox) => pathKey(sandbox) === key))
-  if (byDirectory) {
-    const base = { ...byDirectory, ...project }
-    const icon = child.icon
-    if (icon) {
-      return { ...base, icon: { ...base.icon, override: icon } }
-    }
-    return base
-  }
-  const projectID = child.project as string | undefined
-  const metadata = projectID
-    ? data.project.find((x) => x.id === projectID)
-    : data.project.find((x) => x.worktree === project.worktree)
-
-  // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
-  // Without this, different subdirectories of the same git repo would share the same
-  // icon from the database instead of using their individual overrides.
-  const base = { ...metadata, ...project }
-  const icon = child.icon
-  if (icon) {
-    return { ...base, icon: { ...base.icon, override: icon } }
-  }
-  return base
-}
-
 function createServerCtx(
   conn: ServerConnection.Any,
   scope: ServerScope,
@@ -150,14 +111,14 @@ function createServerCtx(
   const sdk = createServerSdkContext(conn, scope)
   const sync = createServerSyncContext(sdk)
 
-  const projectsList = createMemo(() => projects.list().map((project) => enrichProject({ project, data: sync })))
+  const projectsList = createMemo(() => projects.list().map((project) => enrichProject({ project, sync })))
   const recentlyClosedList = createMemo(() => {
     const known = new Set(sync.data.project.map((project) => pathKey(project.worktree)))
     return projects
       .recentlyClosed()
       .filter((worktree) => known.has(pathKey(worktree)))
       .slice(0, RECENTLY_CLOSED_DISPLAY_LIMIT)
-      .map((worktree) => enrichProject({ project: { worktree, expanded: false }, data: sync }))
+      .map((worktree) => enrichProject({ project: { worktree, expanded: false }, sync }))
   })
 
   const isLocal =

--- a/packages/app/src/context/global.tsx
+++ b/packages/app/src/context/global.tsx
@@ -93,6 +93,46 @@ export const { use: useGlobal, provider: GlobalProvider } = createSimpleContext(
   },
 })
 
+function enrichProject({
+  project,
+  data,
+}: {
+  project: { worktree: string; expanded: boolean }
+  data: {
+    project: { id?: string; worktree: string; sandboxes?: string[] }[]
+    child: (directory: string, options?: { bootstrap: boolean }) => [Store<unknown>, SetStoreFunction<unknown>]
+  }
+}) {
+  const [childStore] = data.child(project.worktree, { bootstrap: false })
+  const child = childStore as Record<string, unknown>
+  const key = pathKey(project.worktree)
+  const byDirectory =
+    data.project.find((x) => pathKey(x.worktree) === key) ??
+    data.project.find((x) => x.sandboxes?.some((sandbox) => pathKey(sandbox) === key))
+  if (byDirectory) {
+    const base = { ...byDirectory, ...project }
+    const icon = child.icon
+    if (icon) {
+      return { ...base, icon: { ...base.icon, override: icon } }
+    }
+    return base
+  }
+  const projectID = child.project as string | undefined
+  const metadata = projectID
+    ? data.project.find((x) => x.id === projectID)
+    : data.project.find((x) => x.worktree === project.worktree)
+
+  // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
+  // Without this, different subdirectories of the same git repo would share the same
+  // icon from the database instead of using their individual overrides.
+  const base = { ...metadata, ...project }
+  const icon = child.icon
+  if (icon) {
+    return { ...base, icon: { ...base.icon, override: icon } }
+  }
+  return base
+}
+
 function createServerCtx(
   conn: ServerConnection.Any,
   scope: ServerScope,
@@ -110,31 +150,14 @@ function createServerCtx(
   const sdk = createServerSdkContext(conn, scope)
   const sync = createServerSyncContext(sdk)
 
-  function enrich(project: { worktree: string; expanded: boolean }) {
-    const [childStore] = sync.child(project.worktree, { bootstrap: false })
-    const projectID = childStore.project
-    const metadata = projectID
-      ? sync.data.project.find((x) => x.id === projectID)
-      : sync.data.project.find((x) => x.worktree === project.worktree)
-
-    // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
-    // Without this, different subdirectories of the same git repo would share the same
-    // icon from the database instead of using their individual overrides.
-    const base = { ...metadata, ...project }
-    if (childStore.icon) {
-      return { ...base, icon: { ...base.icon, override: childStore.icon } }
-    }
-    return base
-  }
-
-  const projectsList = createMemo(() => projects.list().map(enrich))
+  const projectsList = createMemo(() => projects.list().map((project) => enrichProject({ project, data: sync })))
   const recentlyClosedList = createMemo(() => {
     const known = new Set(sync.data.project.map((project) => pathKey(project.worktree)))
     return projects
       .recentlyClosed()
       .filter((worktree) => known.has(pathKey(worktree)))
       .slice(0, RECENTLY_CLOSED_DISPLAY_LIMIT)
-      .map((worktree) => enrich({ worktree, expanded: false }))
+      .map((worktree) => enrichProject({ project: { worktree, expanded: false }, data: sync }))
   })
 
   const isLocal =

--- a/packages/app/src/context/layout-helpers.ts
+++ b/packages/app/src/context/layout-helpers.ts
@@ -1,4 +1,45 @@
 import type { Accessor } from "solid-js"
+import { pathKey } from "@/utils/path-key"
+import type { Project } from "@opencode-ai/sdk/v2"
+
+export type LocalProject = Partial<Project> & { worktree: string; expanded: boolean }
+
+export function enrichProject(input: {
+  project: { worktree: string; expanded: boolean }
+  sync: {
+    data: { project: Project[] }
+    child: (directory: string, options?: { bootstrap: boolean }) => [unknown, unknown]
+  }
+}): LocalProject {
+  const [childStore] = input.sync.child(input.project.worktree, { bootstrap: false })
+  const child = (childStore ?? {}) as Record<string, unknown>
+  const key = pathKey(input.project.worktree)
+  const byDirectory =
+    input.sync.data.project.find((x) => pathKey(x.worktree) === key) ??
+    input.sync.data.project.find((x) => x.sandboxes?.some((sandbox) => pathKey(sandbox) === key))
+  if (byDirectory) {
+    const base = { ...byDirectory, ...input.project }
+    const icon = child.icon as string | undefined
+    if (icon) {
+      return { ...base, icon: { ...base.icon, override: icon } }
+    }
+    return base
+  }
+  const projectID = child.project as string | undefined
+  const metadata = projectID
+    ? input.sync.data.project.find((x) => x.id === projectID)
+    : input.sync.data.project.find((x) => pathKey(x.worktree) === key)
+
+  // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
+  // Without this, different subdirectories of the same git repo would share the same
+  // icon from the database instead of using their individual overrides.
+  const base = { ...metadata, ...input.project }
+  const icon = child.icon as string | undefined
+  if (icon) {
+    return { ...base, icon: { ...base.icon, override: icon } }
+  }
+  return base
+}
 
 export function ensureSessionKey(key: string, touch: (key: string) => void, seed: (key: string) => void) {
   touch(key)

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys } from "./layout-helpers"
+import { createSessionKeyReader, enrichProject, ensureSessionKey, pruneSessionKeys } from "./layout-helpers"
+import { pathKey } from "@/utils/path-key"
+import type { Project } from "@opencode-ai/sdk/v2"
 
 describe("layout session-key helpers", () => {
   test("couples touch and scroll seed in order", () => {
@@ -136,5 +138,101 @@ describe("rootFor drive root guard", () => {
     const map = makeRoots([])
     expect(rootFor("C:/foo", map)).toBe("C:/foo")
     expect(rootFor("/tmp/test", map)).toBe("/tmp/test")
+  })
+})
+
+describe("enrichProject", () => {
+  const makeMockSync = (input?: {
+    projects?: Array<{ id?: string; worktree: string; sandboxes?: string[]; icon?: { override?: string } }>
+    childStores?: Record<string, { project?: string; icon?: string }>
+  }) => {
+    const projects = (input?.projects ?? []) as unknown as Project[]
+    const stores = input?.childStores ?? {}
+    return {
+      data: { project: projects },
+      // Include project API method stub to verify callers don't confuse sync.data.project with sync.project
+      project: {
+        loadSessions: () => Promise.resolve(),
+        meta: () => {},
+        icon: () => {},
+      },
+      child: (dir: string) => [stores[dir] ?? stores[pathKey(dir)] ?? {}, () => {}] as [unknown, unknown],
+    }
+  }
+
+  test("enriches project by matching worktree directory pathKey", () => {
+    const sync = makeMockSync({
+      projects: [{ id: "p1", worktree: "C:/projects/app", sandboxes: [] }],
+    })
+
+    const enriched = enrichProject({
+      project: { worktree: "C:\\projects\\app", expanded: true },
+      sync,
+    })
+
+    expect(enriched.id).toBe("p1")
+    expect(enriched.worktree).toBe("C:\\projects\\app")
+    expect(enriched.expanded).toBe(true)
+  })
+
+  test("enriches project by matching sandboxes", () => {
+    const sync = makeMockSync({
+      projects: [{ id: "p1", worktree: "C:/projects/main", sandboxes: ["C:/projects/branch-a"] }],
+    })
+
+    const enriched = enrichProject({
+      project: { worktree: "C:\\projects\\branch-a", expanded: false },
+      sync,
+    })
+
+    expect(enriched.id).toBe("p1")
+    expect(enriched.worktree).toBe("C:\\projects\\branch-a")
+  })
+
+  test("enriches project by childStore project ID when directory not found directly", () => {
+    const sync = makeMockSync({
+      projects: [{ id: "p1", worktree: "C:/projects/main", sandboxes: [] }],
+      childStores: {
+        "C:\\projects\\subdir": { project: "p1" },
+      },
+    })
+
+    const enriched = enrichProject({
+      project: { worktree: "C:\\projects\\subdir", expanded: false },
+      sync,
+    })
+
+    expect(enriched.id).toBe("p1")
+  })
+
+  test("preserves local icon override from childStore", () => {
+    const sync = makeMockSync({
+      projects: [{ id: "p1", worktree: "C:/projects/main", icon: { override: "default-icon" } }],
+      childStores: {
+        "C:/projects/main": { icon: "custom-icon" },
+      },
+    })
+
+    const enriched = enrichProject({
+      project: { worktree: "C:/projects/main", expanded: false },
+      sync,
+    })
+
+    expect(enriched.icon?.override).toBe("custom-icon")
+  })
+
+  test("does not crash when project is not found in sync.data.project", () => {
+    const sync = makeMockSync({
+      projects: [],
+    })
+
+    const enriched = enrichProject({
+      project: { worktree: "C:/projects/unknown", expanded: true },
+      sync,
+    })
+
+    expect(enriched.worktree).toBe("C:/projects/unknown")
+    expect(enriched.expanded).toBe(true)
+    expect(enriched.id).toBeUndefined()
   })
 })

--- a/packages/app/src/context/layout.test.ts
+++ b/packages/app/src/context/layout.test.ts
@@ -67,3 +67,74 @@ describe("pruneSessionKeys", () => {
     expect(drop).toEqual([])
   })
 })
+
+describe("rootFor drive root guard", () => {
+  // Simulates the roots() memo: sandbox -> worktree map keyed by pathKey
+  const makeRoots = (entries: { sandbox: string; worktree: string }[]) => {
+    const map = new Map<string, string>()
+    for (const { sandbox, worktree } of entries) {
+      map.set(pathKey(sandbox), worktree)
+    }
+    return map
+  }
+
+  const pathKey = (path: string) => {
+    const isWinPath = path[1] === ":" || path.startsWith("\\\\")
+    const value = isWinPath ? path.replaceAll("\\", "/") : path
+    const trimmed = value.replace(/\/+$/, "")
+    if (!trimmed && value.startsWith("/")) return "/"
+    const isDrive = trimmed.length === 2 && path[1] === ":" && /^[A-Za-z]$/.test(path[0])
+    if (isDrive) return `${trimmed}/`
+    return trimmed
+  }
+
+  const rootFor = (directory: string, map: Map<string, string>) => {
+    if (map.size === 0) return directory
+    const visited = new Set<string>()
+    const chain = [directory]
+    while (chain.length) {
+      const current = chain[chain.length - 1]
+      if (!current) return directory
+      if (current !== "/" && /^[a-z]:\//i.test(current) && pathKey(current).length <= 3) return directory
+      const next = map.get(pathKey(current))
+      if (!next) return current
+      const nextKey = pathKey(next)
+      if (visited.has(nextKey)) return directory
+      visited.add(nextKey)
+      chain.push(next)
+    }
+    return directory
+  }
+
+  test("returns drive root when sandbox resolves to drive root", () => {
+    const map = makeRoots([{ sandbox: "C:/foo", worktree: "C:/" }])
+    expect(rootFor("C:/", map)).toBe("C:/")
+    // Guard prevents traversal through drive roots, so C:/foo stays as-is
+    expect(rootFor("C:/foo", map)).toBe("C:/foo")
+  })
+
+  test("stops traversal when reaching a drive root from a deeper path", () => {
+    const map = makeRoots([
+      { sandbox: "C:/bar", worktree: "C:/foo" },
+      { sandbox: "C:/foo", worktree: "C:/" },
+    ])
+    expect(rootFor("C:/bar", map)).toBe("C:/bar")
+  })
+
+  test("normalizes drive roots regardless of slash style", () => {
+    const map = makeRoots([{ sandbox: "C:/foo", worktree: "C:/" }])
+    // C:\ normalizes to C:/ by pathKey, which is a drive root, so input stays as-is
+    expect(rootFor("C:\\", map)).toBe("C:\\")
+  })
+
+  test("does not prevent normal sandbox resolution for non-drive roots", () => {
+    const map = makeRoots([{ sandbox: "/home/user/repo", worktree: "/home/user/repo/main" }])
+    expect(rootFor("/home/user/repo", map)).toBe("/home/user/repo/main")
+  })
+
+  test("handles empty map by returning directory unchanged", () => {
+    const map = makeRoots([])
+    expect(rootFor("C:/foo", map)).toBe("C:/foo")
+    expect(rootFor("/tmp/test", map)).toBe("/tmp/test")
+  })
+})

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -127,6 +127,46 @@ const normalizeStoredSessionTabs = (key: string, tabs: SessionTabs) => {
   }
 }
 
+function enrichProject({
+  project,
+  data,
+}: {
+  project: { worktree: string; expanded: boolean }
+  data: {
+    project: { id?: string; worktree: string; sandboxes?: string[] }[]
+    child: (directory: string, options?: { bootstrap: boolean }) => [Store<unknown>, SetStoreFunction<unknown>]
+  }
+}) {
+  const [childStore] = data.child(project.worktree, { bootstrap: false })
+  const child = childStore as Record<string, unknown>
+  const key = pathKey(project.worktree)
+  const byDirectory =
+    data.project.find((x) => pathKey(x.worktree) === key) ??
+    data.project.find((x) => x.sandboxes?.some((sandbox) => pathKey(sandbox) === key))
+  if (byDirectory) {
+    const base = { ...byDirectory, ...project }
+    const icon = child.icon
+    if (icon) {
+      return { ...base, icon: { ...base.icon, override: icon } }
+    }
+    return base
+  }
+  const projectID = child.project as string | undefined
+  const metadata = projectID
+    ? data.project.find((x) => x.id === projectID)
+    : data.project.find((x) => x.worktree === project.worktree)
+
+  // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
+  // Without this, different subdirectories of the same git repo would share the same
+  // icon from the database instead of using their individual overrides.
+  const base = { ...metadata, ...project }
+  const icon = child.icon
+  if (icon) {
+    return { ...base, icon: { ...base.icon, override: icon } }
+  }
+  return base
+}
+
 export const currentRoute = (pathname: string, search: string): LayoutRoute => {
   const parts = pathname.split("/").filter(Boolean)
   if (parts.length === 0) return { type: "home" }
@@ -442,29 +482,19 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       return available[Math.floor(Math.random() * available.length)]
     }
 
-    function enrich(project: { worktree: string; expanded: boolean }) {
-      const [childStore] = serverSync().child(project.worktree, { bootstrap: false })
-      const projectID = childStore.project
-      const metadata = projectID
-        ? serverSync().data.project.find((x) => x.id === projectID)
-        : serverSync().data.project.find((x) => x.worktree === project.worktree)
+    const enriched = createMemo(() =>
+      server.projects.list().map((project) => enrichProject({ project, data: serverSync() })),
+    )
 
-      // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
-      // Without this, different subdirectories of the same git repo would share the same
-      // icon from the database instead of using their individual overrides.
-      const base = { ...metadata, ...project }
-      if (childStore.icon) {
-        return { ...base, icon: { ...base.icon, override: childStore.icon } }
-      }
-      return base
-    }
-
+    // Sandbox chain map keyed by pathKey so that drive roots (C:/) never resolve
+    // through subdirectories (C:/foo) and vice versa. Each sandbox maps to its
+    // parent worktree; the map must not contain drive roots as keys or values.
     const roots = createMemo(() => {
       const map = new Map<string, string>()
       for (const project of serverSync().data.project) {
         const sandboxes = project.sandboxes ?? []
         for (const sandbox of sandboxes) {
-          map.set(sandbox, project.worktree)
+          map.set(pathKey(sandbox), project.worktree)
         }
       }
       return map
@@ -481,11 +511,17 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
         const current = chain[chain.length - 1]
         if (!current) return directory
 
-        const next = map.get(current)
+        // Stop if we would traverse into a drive root (e.g. C:/) since that
+        // would cause a project on C:/foo to resolve back to C:/ and collide
+        // with a project actually rooted at C:/.
+        if (current !== "/" && /^[a-z]:\//i.test(current) && pathKey(current).length <= 3) return directory
+
+        const next = map.get(pathKey(current))
         if (!next) return current
 
-        if (visited.has(next)) return directory
-        visited.add(next)
+        const nextKey = pathKey(next)
+        if (visited.has(nextKey)) return directory
+        visited.add(nextKey)
         chain.push(next)
       }
 
@@ -494,18 +530,18 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
     createEffect(() => {
       const projects = server.projects.list()
-      const seen = new Set(projects.map((project) => project.worktree))
+      const seen = new Set(projects.map((project) => pathKey(project.worktree)))
 
       batch(() => {
         for (const project of projects) {
           const root = rootFor(project.worktree)
-          if (root === project.worktree) continue
+          if (pathKey(root) === pathKey(project.worktree)) continue
 
           server.projects.remove(project.worktree)
 
-          if (!seen.has(root)) {
+          if (!seen.has(pathKey(root))) {
             server.projects.open(root)
-            seen.add(root)
+            seen.add(pathKey(root))
           }
 
           if (project.expanded) server.projects.expand(root)
@@ -513,7 +549,9 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       })
     })
 
-    const enriched = createMemo(() => server.projects.list().map(enrich))
+    const enriched = createMemo(() =>
+      server.projects.list().map((project) => enrichProject({ project, data: serverSync() })),
+    )
     const list = createMemo(() => {
       const projects = enriched()
       return projects.map((project) => {
@@ -638,11 +676,12 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             .recentlyClosed()
             .filter((worktree) => known.has(pathKey(worktree)))
             .slice(0, RECENTLY_CLOSED_DISPLAY_LIMIT)
-            .map((worktree) => enrich({ worktree, expanded: false }))
+            .map((worktree) => enrichProject({ project: { worktree, expanded: false }, data: serverSync() }))
         }),
         open(directory: string) {
           const root = rootFor(directory)
-          if (server.projects.list().find((x) => x.worktree === root)) return
+          const rootKey = pathKey(root)
+          if (server.projects.list().find((x) => pathKey(x.worktree) === rootKey)) return
           void serverSync().project.loadSessions(root)
           server.projects.open(root)
         },

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -482,10 +482,6 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
       return available[Math.floor(Math.random() * available.length)]
     }
 
-    const enriched = createMemo(() =>
-      server.projects.list().map((project) => enrichProject({ project, data: serverSync() })),
-    )
-
     // Sandbox chain map keyed by pathKey so that drive roots (C:/) never resolve
     // through subdirectories (C:/foo) and vice versa. Each sandbox maps to its
     // parent worktree; the map must not contain drive roots as keys or values.
@@ -552,6 +548,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     const enriched = createMemo(() =>
       server.projects.list().map((project) => enrichProject({ project, data: serverSync() })),
     )
+
     const list = createMemo(() => {
       const projects = enriched()
       return projects.map((project) => {

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -17,7 +17,7 @@ import { createScrollPersistence, type SessionScroll } from "./layout-scroll"
 import { createPathHelpers } from "./file/path"
 import type { ProjectAvatarVariant } from "@opencode-ai/ui/v2/project-avatar-v2"
 import { migrateLegacySessionStateKeys, ServerScope, SessionStateKey } from "@/utils/server-scope"
-import { createSessionKeyReader, ensureSessionKey, pruneSessionKeys } from "./layout-helpers"
+import { createSessionKeyReader, enrichProject, ensureSessionKey, pruneSessionKeys } from "./layout-helpers"
 import { requireServerKey } from "@/utils/session-route"
 import { type DraftTab, useTabs } from "./tabs"
 import { closeSessionTab, openSessionTab, previewSessionTab, type SessionTabs } from "./layout-tabs"
@@ -125,46 +125,6 @@ const normalizeStoredSessionTabs = (key: string, tabs: SessionTabs) => {
     all: normalizeSessionTabList(path, tabs.all),
     active: tabs.active ? normalizeSessionTab(path, tabs.active) : tabs.active,
   }
-}
-
-function enrichProject({
-  project,
-  data,
-}: {
-  project: { worktree: string; expanded: boolean }
-  data: {
-    project: { id?: string; worktree: string; sandboxes?: string[] }[]
-    child: (directory: string, options?: { bootstrap: boolean }) => [Store<unknown>, SetStoreFunction<unknown>]
-  }
-}) {
-  const [childStore] = data.child(project.worktree, { bootstrap: false })
-  const child = childStore as Record<string, unknown>
-  const key = pathKey(project.worktree)
-  const byDirectory =
-    data.project.find((x) => pathKey(x.worktree) === key) ??
-    data.project.find((x) => x.sandboxes?.some((sandbox) => pathKey(sandbox) === key))
-  if (byDirectory) {
-    const base = { ...byDirectory, ...project }
-    const icon = child.icon
-    if (icon) {
-      return { ...base, icon: { ...base.icon, override: icon } }
-    }
-    return base
-  }
-  const projectID = child.project as string | undefined
-  const metadata = projectID
-    ? data.project.find((x) => x.id === projectID)
-    : data.project.find((x) => x.worktree === project.worktree)
-
-  // Preserve local icon override from per-workspace localStorage cache (childStore.icon).
-  // Without this, different subdirectories of the same git repo would share the same
-  // icon from the database instead of using their individual overrides.
-  const base = { ...metadata, ...project }
-  const icon = child.icon
-  if (icon) {
-    return { ...base, icon: { ...base.icon, override: icon } }
-  }
-  return base
 }
 
 export const currentRoute = (pathname: string, search: string): LayoutRoute => {
@@ -546,7 +506,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
     })
 
     const enriched = createMemo(() =>
-      server.projects.list().map((project) => enrichProject({ project, data: serverSync() })),
+      server.projects.list().map((project) => enrichProject({ project, sync: serverSync() })),
     )
 
     const list = createMemo(() => {
@@ -673,7 +633,7 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
             .recentlyClosed()
             .filter((worktree) => known.has(pathKey(worktree)))
             .slice(0, RECENTLY_CLOSED_DISPLAY_LIMIT)
-            .map((worktree) => enrichProject({ project: { worktree, expanded: false }, data: serverSync() }))
+            .map((worktree) => enrichProject({ project: { worktree, expanded: false }, sync: serverSync() }))
         }),
         open(directory: string) {
           const root = rootFor(directory)

--- a/packages/app/src/context/server.test.ts
+++ b/packages/app/src/context/server.test.ts
@@ -197,6 +197,142 @@ describe("createServerProjects", () => {
       dispose()
     })
   })
+
+  test("dedupes windows slash variants by normalized path", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("c:\\foo")
+      projects.open("c:/foo")
+      expect(projects.list()).toHaveLength(1)
+      expect(projects.list()[0]?.worktree).toBe("c:\\foo")
+      dispose()
+    })
+  })
+
+  test("dedupes drive-root variants (C:/ vs C:/foo)", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("c:\\")
+      projects.open("c:/")
+      expect(projects.list()).toHaveLength(1)
+      projects.close("c:/foo")
+      expect(projects.list()).toHaveLength(1)
+      expect(projects.list()[0]?.worktree).toBe("c:\\")
+      dispose()
+    })
+  })
+
+  test("removes windows projects via normalized path", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("c:\\foo")
+      projects.remove("c:/foo")
+      expect(projects.list()).toEqual([])
+      dispose()
+    })
+  })
+
+  test("keeps same-basename projects on different drives", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("c:\\foo")
+      projects.open("d:\\foo")
+      expect(projects.list()).toHaveLength(2)
+
+      projects.close("c:\\foo")
+      expect(projects.list().map((p) => p.worktree)).toEqual(["d:\\foo"])
+      expect(projects.recentlyClosed()).toEqual(["c:\\foo"])
+
+      projects.open("d:\\foo")
+      expect(projects.list().map((p) => p.worktree)).toEqual(["d:\\foo"])
+      dispose()
+    })
+  })
+
+  test("reopens slash variants without duplicating recently closed", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("c:\\foo")
+      projects.close("c:/foo")
+      expect(projects.recentlyClosed()).toEqual(["c:/foo"])
+
+      projects.open("c:/foo")
+      expect(projects.list()).toHaveLength(1)
+      expect(projects.recentlyClosed()).toEqual([])
+      dispose()
+    })
+  })
+
+  test("ignores remove for unknown directories", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("c:\\foo")
+      projects.remove("d:\\foo")
+      expect(projects.list()).toHaveLength(1)
+      expect(projects.recentlyClosed()).toEqual([])
+      dispose()
+    })
+  })
+
+  test("expands and collapses via normalized path", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("c:\\foo")
+      projects.collapse("c:/foo")
+      expect(projects.list()[0]?.expanded).toBe(false)
+
+      projects.expand("c:/foo")
+      expect(projects.list()[0]?.expanded).toBe(true)
+
+      projects.collapse("d:\\missing")
+      projects.expand("d:\\missing")
+      expect(projects.list()).toHaveLength(1)
+      dispose()
+    })
+  })
+
+  test("moves via normalized path and ignores bad moves", () => {
+    createRoot((dispose) => {
+      const [scope] = createSignal(ServerScope.local)
+      const [store, setStore] = createStore({ projects: {}, lastProject: {}, recentlyClosed: {} })
+      const projects = createServerProjects({ scope, store, setStore })
+
+      projects.open("c:\\a")
+      projects.open("d:\\b")
+      expect(projects.list().map((p) => p.worktree)).toEqual(["d:\\b", "c:\\a"])
+
+      projects.move("c:/a", 0)
+      expect(projects.list().map((p) => p.worktree)).toEqual(["c:\\a", "d:\\b"])
+
+      projects.move("c:\\a", 0)
+      expect(projects.list().map((p) => p.worktree)).toEqual(["c:\\a", "d:\\b"])
+
+      projects.move("c:\\missing", 0)
+      expect(projects.list().map((p) => p.worktree)).toEqual(["c:\\a", "d:\\b"])
+      dispose()
+    })
+  })
 })
 
 describe("migrateCanonicalLocalServerState", () => {

--- a/packages/app/src/context/server.tsx
+++ b/packages/app/src/context/server.tsx
@@ -54,13 +54,19 @@ export function migrateCanonicalLocalServerState(value: unknown, canonicalLocalS
   const next = { ...value }
   if (projects && Array.isArray(previousProjects)) {
     const local = Array.isArray(projects.local) ? projects.local : []
+    // Compare migrated worktrees against local ones using pathKey so that
+    // c:\foo and c:/foo are treated as the same project (deduped) while
+    // c:\foo and d:\foo remain distinct (different drives).
     const worktrees = new Set(
-      local.flatMap((project) => (isRecord(project) && typeof project.worktree === "string" ? [project.worktree] : [])),
+      local.flatMap((project) =>
+        isRecord(project) && typeof project.worktree === "string" ? [pathKey(project.worktree)] : [],
+      ),
     )
     const migrated = previousProjects.filter((project) => {
       if (!isRecord(project) || typeof project.worktree !== "string") return true
-      if (worktrees.has(project.worktree)) return false
-      worktrees.add(project.worktree)
+      const key = pathKey(project.worktree)
+      if (worktrees.has(key)) return false
+      worktrees.add(key)
       return true
     })
     const nextProjects: Record<string, unknown> = { ...projects, local: [...local, ...migrated] }
@@ -84,11 +90,15 @@ export function createServerProjects<T extends ServerProjectState>(input: {
   const setStore = input.setStore as unknown as SetStoreFunction<ServerProjectState>
   const current = () => input.store.projects[input.scope()] ?? []
   const currentClosed = () => input.store.recentlyClosed?.[input.scope()] ?? []
+  // Every comparison uses pathKey so that c:\foo and c:/foo are treated as the
+  // same project while c:\foo and d:\foo remain distinct. The stored worktree
+  // strings keep their original separators; only the lookup key is normalized.
   const remove = (directory: string) => {
+    const key = pathKey(directory)
     setStore(
       "projects",
       input.scope(),
-      current().filter((project) => project.worktree !== directory),
+      current().filter((project) => pathKey(project.worktree) !== key),
     )
   }
   return {
@@ -106,7 +116,7 @@ export function createServerProjects<T extends ServerProjectState>(input: {
           closed.filter((worktree) => pathKey(worktree) !== key),
         )
       }
-      if (current().some((project) => project.worktree === directory)) return
+      if (current().some((project) => pathKey(project.worktree) === key)) return
       setStore("projects", scope, [{ worktree: directory, expanded: true }, ...current()])
     },
     // User-initiated close: removes the project and records it in recently closed.
@@ -121,15 +131,18 @@ export function createServerProjects<T extends ServerProjectState>(input: {
       setStore("recentlyClosed", input.scope(), closed)
     },
     expand(directory: string) {
-      const index = current().findIndex((project) => project.worktree === directory)
+      const key = pathKey(directory)
+      const index = current().findIndex((project) => pathKey(project.worktree) === key)
       if (index !== -1) setStore("projects", input.scope(), index, "expanded", true)
     },
     collapse(directory: string) {
-      const index = current().findIndex((project) => project.worktree === directory)
+      const key = pathKey(directory)
+      const index = current().findIndex((project) => pathKey(project.worktree) === key)
       if (index !== -1) setStore("projects", input.scope(), index, "expanded", false)
     },
     move(directory: string, toIndex: number) {
-      const fromIndex = current().findIndex((project) => project.worktree === directory)
+      const key = pathKey(directory)
+      const fromIndex = current().findIndex((project) => pathKey(project.worktree) === key)
       if (fromIndex === -1 || fromIndex === toIndex) return
       const next = [...current()]
       const [item] = next.splice(fromIndex, 1)

--- a/packages/app/src/pages/home/home-controller.ts
+++ b/packages/app/src/pages/home/home-controller.ts
@@ -4,6 +4,7 @@ import { ServerConnection, useServer } from "@/context/server"
 import { useServerSync } from "@/context/server-sync"
 import { useTabs } from "@/context/tabs"
 import { toggleHomeProjectSelection } from "@/pages/layout/helpers"
+import { pathKey } from "@/utils/path-key"
 import { createEffect, createMemo } from "solid-js"
 
 export function createHomeController() {
@@ -27,13 +28,17 @@ export function createHomeController() {
     () => focusedServerCtx()?.projects.recentlyClosed() ?? layout.projects.recentlyClosed(),
   )
   const homedir = createMemo(() => focusedSync().data.path.home ?? "")
-  const selectedProject = createMemo(() => projects().find((project) => project.worktree === selection().directory))
-  const newSessionProject = createMemo(
-    () =>
-      selectedProject() ??
-      projects().find((project) => project.worktree === focusedServerCtx()?.projects.last()) ??
-      projects()[0],
-  )
+  const selectedProject = createMemo(() => {
+    const directory = selection().directory
+    if (!directory) return undefined
+    const key = pathKey(directory)
+    return projects().find((project) => pathKey(project.worktree) === key)
+  })
+  const newSessionProject = createMemo(() => {
+    const last = focusedServerCtx()?.projects.last()
+    const byLast = last ? projects().find((project) => pathKey(project.worktree) === pathKey(last)) : undefined
+    return selectedProject() ?? byLast ?? projects()[0]
+  })
 
   createEffect(() => {
     const list = global.servers.list()
@@ -81,7 +86,7 @@ export function createHomeController() {
           !global
             .ensureServerCtx(conn)
             .projects.list()
-            .some((project) => project.worktree === directory)
+            .some((project) => pathKey(project.worktree) === pathKey(directory))
         )
           return
         setSelection(toggleHomeProjectSelection(selection(), key, directory))
@@ -91,7 +96,8 @@ export function createHomeController() {
         if (!directory) return
         const ctx = global.ensureServerCtx(conn)
         directories.forEach((item) => {
-          if (ctx.projects.list().some((project) => project.worktree === item)) return
+          const itemKey = pathKey(item)
+          if (ctx.projects.list().some((project) => pathKey(project.worktree) === itemKey)) return
           const location = { directory: item }
           void ctx.sdk.api.file
             .list({ path: ".", location })

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -519,6 +519,9 @@ export default function LegacyLayout(props: ParentProps) {
 
     const projects = layout.projects.list()
 
+    // Dual-check: sandbox first (more specific match) then direct worktree
+    // then fallback to child-store project ID. The pathKey comparison ensures
+    // that c:\foo and c:/foo resolve to the same project while c:\foo and d:\foo stay distinct.
     const sandbox = projects.find((p) => p.sandboxes?.some((item) => pathKey(item) === key))
     if (sandbox) return sandbox
 
@@ -532,8 +535,9 @@ export default function LegacyLayout(props: ParentProps) {
     const meta = serverSync().data.project.find((p) => p.id === id)
     const root = meta?.worktree
     if (!root) return
+    if (pathKey(root) !== key && !meta?.sandboxes?.some((sandbox) => pathKey(sandbox) === key)) return
 
-    return projects.find((p) => p.worktree === root)
+    return projects.find((p) => pathKey(p.worktree) === pathKey(root))
   })
 
   const [autoselecting] = createResource(async () => {
@@ -548,7 +552,8 @@ export default function LegacyLayout(props: ParentProps) {
       if (!last) return
       await openProject(last, true)
     } else {
-      const next = list.find((project) => project.worktree === last) ?? list[0]
+      const matched = last ?? list.find((project) => pathKey(project.worktree) === pathKey(last))
+      const next = matched ?? list[0]
       if (!next) return
       await openProject(next.worktree, true)
     }
@@ -820,7 +825,7 @@ export default function LegacyLayout(props: ParentProps) {
     const current = currentProject()?.worktree
     const fallback = currentDir() ? projectRoot(currentDir()) : undefined
     const active = current ?? fallback
-    const index = active ? projects.findIndex((project) => project.worktree === active) : -1
+    const index = active ? projects.findIndex((project) => pathKey(project.worktree) === pathKey(active)) : -1
 
     const target =
       index === -1
@@ -1127,7 +1132,10 @@ export default function LegacyLayout(props: ParentProps) {
     if (!id) return directory
 
     const meta = serverSync().data.project.find((item) => item.id === id)
-    return meta?.worktree ?? directory
+    if (!meta) return directory
+    if (pathKey(meta.worktree) === key) return meta.worktree
+    if (meta.sandboxes?.some((sandbox) => pathKey(sandbox) === key)) return meta.worktree
+    return directory
   }
 
   function activeProjectRoot(directory: string) {
@@ -1163,8 +1171,9 @@ export default function LegacyLayout(props: ParentProps) {
   async function navigateToProject(directory: string | undefined) {
     if (!directory) return
     const root = projectRoot(directory)
+    const rootKey = pathKey(root)
     server.projects.touch(root)
-    const project = layout.projects.list().find((item) => item.worktree === root)
+    const project = layout.projects.list().find((item) => pathKey(item.worktree) === rootKey)
     let dirs = project
       ? effectiveWorkspaceOrder(root, [root, ...(project.sandboxes ?? [])], store.workspaceOrder[root])
       : [root]
@@ -1173,7 +1182,7 @@ export default function LegacyLayout(props: ParentProps) {
       return dirs.some((item) => pathKey(item) === pathKey(value))
     }
     const refreshDirs = async (target?: string) => {
-      if (!target || target === root || canOpen(target)) return canOpen(target)
+      if (!target || pathKey(target) === pathKey(root) || canOpen(target)) return canOpen(target)
       const listed = await Promise.resolve(
         project?.id ?? serverSDK().api.project.current({ location: { directory: root } }),
       )
@@ -1377,7 +1386,7 @@ export default function LegacyLayout(props: ParentProps) {
   }
 
   const deleteWorkspace = async (root: string, directory: string, leaveDeletedWorkspace = false) => {
-    if (directory === root) return
+    if (pathKey(directory) === pathKey(root)) return
 
     const current = currentDir()
     const currentKey = pathKey(current)
@@ -1411,12 +1420,14 @@ export default function LegacyLayout(props: ParentProps) {
     serverSync().set(
       "project",
       produce((draft) => {
-        const project = draft.find((item) => item.worktree === root)
+        const project = draft.find((item) => pathKey(item.worktree) === pathKey(root))
         if (!project) return
-        project.sandboxes = (project.sandboxes ?? []).filter((sandbox) => sandbox !== directory)
+        project.sandboxes = (project.sandboxes ?? []).filter((sandbox) => pathKey(sandbox) !== pathKey(directory))
       }),
     )
-    setStore("workspaceOrder", root, (order) => (order ?? []).filter((workspace) => workspace !== directory))
+    setStore("workspaceOrder", root, (order) =>
+      (order ?? []).filter((workspace) => pathKey(workspace) !== pathKey(directory)),
+    )
 
     layout.projects.close(directory)
     layout.projects.open(root)
@@ -1425,19 +1436,19 @@ export default function LegacyLayout(props: ParentProps) {
 
     const nextCurrent = currentDir()
     const nextKey = pathKey(nextCurrent)
-    const project = layout.projects.list().find((item) => item.worktree === root)
+    const project = layout.projects.list().find((item) => pathKey(item.worktree) === pathKey(root))
     const dirs = project
       ? effectiveWorkspaceOrder(root, [root, ...(project.sandboxes ?? [])], store.workspaceOrder[root])
       : [root]
     const valid = dirs.some((item) => pathKey(item) === nextKey)
 
-    if (params.dir && projectRoot(nextCurrent) === root && !valid) {
+    if (params.dir && pathKey(projectRoot(nextCurrent)) === pathKey(root) && !valid) {
       navigateWithSidebarReset(`/${base64Encode(root)}/session`)
     }
   }
 
   const resetWorkspace = async (root: string, directory: string) => {
-    if (directory === root) return
+    if (pathKey(directory) === pathKey(root)) return
     setBusy(directory, true)
 
     const progress = showToast({

--- a/packages/app/src/pages/layout.tsx
+++ b/packages/app/src/pages/layout.tsx
@@ -552,7 +552,7 @@ export default function LegacyLayout(props: ParentProps) {
       if (!last) return
       await openProject(last, true)
     } else {
-      const matched = last ?? list.find((project) => pathKey(project.worktree) === pathKey(last))
+      const matched = last ? list.find((project) => pathKey(project.worktree) === pathKey(last)) : undefined
       const next = matched ?? list[0]
       if (!next) return
       await openProject(next.worktree, true)

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -19,6 +19,7 @@ import {
   homeProjectDirectories,
   homeSessionServerStatus,
   latestRootSession,
+  projectForSession,
   sortedRootSessions,
   toggleHomeProjectSelection,
 } from "./helpers"
@@ -343,5 +344,50 @@ describe("layout workspace helpers", () => {
     expect(errorMessage({ data: { message: "boom" } }, "fallback")).toBe("boom")
     expect(errorMessage(new Error("broken"), "fallback")).toBe("broken")
     expect(errorMessage("unknown", "fallback")).toBe("fallback")
+  })
+
+  test("prefers session directory over shared project id", () => {
+    const projects = [
+      { id: "shared", worktree: "c:/foo" },
+      { id: "shared", worktree: "d:/foo" },
+    ]
+    const result = projectForSession(session({ id: "s1", directory: "c:\\foo", projectID: "shared" }), projects)
+    expect(result?.worktree).toBe("c:/foo")
+  })
+
+  test("matches session directory across windows slash variants", () => {
+    const projects = [{ id: "a", worktree: "c:\\foo" }]
+    const result = projectForSession(session({ id: "s1", directory: "c:/foo", projectID: "missing" }), projects)
+    expect(result?.worktree).toBe("c:\\foo")
+  })
+
+  test("falls back to project ID when session directory has no matching worktree", () => {
+    const projects = [
+      { id: "exact", worktree: "c:/exact-match" },
+      { id: "other", worktree: "d:/other" },
+    ]
+    const result = projectForSession(session({ id: "s1", directory: "no-match", projectID: "exact" }), projects)
+    expect(result?.worktree).toBe("c:/exact-match")
+  })
+
+  test("prioritizes sandbox match over project ID", () => {
+    const projects = [
+      { id: "id", worktree: "c:/root" },
+      { id: "sandbox-owner", worktree: "d:/other", sandboxes: ["c:/foo/sub"] },
+    ]
+    const result = projectForSession(session({ id: "s1", directory: "c:\\foo\\sub", projectID: "id" }), projects)
+    expect(result?.worktree).toBe("d:/other")
+  })
+
+  test("returns undefined when no match exists", () => {
+    const projects: Session["directory"][] = []
+    const result = projectForSession(session({ id: "s1", directory: "nowhere", projectID: "no-such-id" }), [])
+    expect(result).toBeUndefined()
+  })
+
+  test("handles undefined session projectID", () => {
+    const projects = [{ id: undefined, worktree: "c:/foo" }]
+    const result = projectForSession(session({ id: "s1", directory: "c:/foo" }), projects)
+    expect(result?.worktree).toBe("c:/foo")
   })
 })

--- a/packages/app/src/pages/layout/helpers.ts
+++ b/packages/app/src/pages/layout/helpers.ts
@@ -98,13 +98,13 @@ export function projectForSession<T extends { id?: string; worktree: string; san
   projects: T[],
   byID: Map<string, T> = new Map(projects.flatMap((project) => (project.id ? [[project.id, project] as const] : []))),
 ) {
-  const direct = byID.get(session.projectID)
-  if (direct) return direct
   const directory = pathKey(session.directory)
-  return projects.find(
+  const byDirectory = projects.find(
     (project) =>
       pathKey(project.worktree) === directory || project.sandboxes?.some((sandbox) => pathKey(sandbox) === directory),
   )
+  if (byDirectory) return byDirectory
+  return byID.get(session.projectID)
 }
 
 export const errorMessage = (err: unknown, fallback: string) => {

--- a/packages/app/src/utils/path-key.ts
+++ b/packages/app/src/utils/path-key.ts
@@ -1,3 +1,14 @@
+// Project identity key. Two worktrees are the same project only when their
+// pathKeys match: the full normalized path, never the basename. This keeps
+// same-name folders on different drives (c:/foo vs d:/foo) distinct while
+// collapsing slash and trailing-slash variants (c:\foo vs c:/foo/).
+//
+// Normalization:
+// - Windows drive and UNC paths have backslashes rewritten to forward slashes.
+// - Trailing slashes are trimmed, except POSIX "/" and drive roots ("C:/"),
+//   which keep one trailing slash so a root never collapses to "" or "C:".
+// - Case is preserved; case-insensitive drive matching lives with callers
+//   such as treePathWithin, not here.
 export type PathKey = string & { _brand: "PathKey" }
 
 const isDrive = (value: string) => {
@@ -15,6 +26,8 @@ const trimTrailingSlashes = (value: string) => {
 
 const isWindowsPath = (value: string) => value[1] === ":" || value.startsWith("\\\\")
 
+// Compare with `pathKey(a) === pathKey(b)`. The stored `worktree` string keeps
+// its original separators for display; only the comparison is normalized.
 export const pathKey = (path: string) => {
   const value = isWindowsPath(path) ? path.replaceAll("\\", "/") : path
   const trimmed = trimTrailingSlashes(value)


### PR DESCRIPTION
### Issue for this PR

Closes #40963

### Type of change

- [X] Bug fix

### What does this PR do?

When managing a list projects, ensures projects in the same path are identified as the same, and projects in different paths are identified as different. Fixes an issue where c:\foo and d:\foo were considered the same.

### How did you verify your code works?

Ran it locally
Ran the tests

### Checklist

- [X] I have tested my changes locally
- [X] I have not included unrelated changes in this PR
