### PR TITLE
feat(core): support provider OAuth client credentials

### DIFF
--- a/packages/ai/src/route/executor.ts
+++ b/packages/ai/src/route/executor.ts
@@ -257,7 +257,11 @@ export const layer: Layer.Layer<Service, never, HttpClient.HttpClient> = Layer.e
           http
             .execute(input)
             .pipe(Effect.mapError((cause) => (cause instanceof Error ? cause : new Error(String(cause))))),
-        ).pipe(Effect.mapError((error) => httpError({ error, request, operation: "request" })))
+        ).pipe(
+          Effect.mapError((error) =>
+            error instanceof AIError ? error : httpError({ error, request, operation: "request" }),
+          ),
+        )
         return yield* statusError(response)
       })
     return Service.of({

--- a/packages/ai/test/executor.test.ts
+++ b/packages/ai/test/executor.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect } from "bun:test"
 import { Deferred, Effect, Fiber, Ref, Stream } from "effect"
 import { Headers, HttpClientError, HttpClientRequest } from "effect/unstable/http"
-import { LLM, AIError, HttpContext, InvalidProviderOutputError, TransportError } from "../src/index.js"
+import {
+  LLM,
+  AIError,
+  AuthenticationError,
+  HttpContext,
+  InvalidProviderOutputError,
+  TransportError,
+} from "../src/index.js"
 import { LLMClient, RequestExecutor, WebSocketTransport, type WebSocketChannelExecutor } from "../src/route.js"
 import { route } from "../src/protocols/openai-chat.js"
 import { configure } from "../src/providers/openai.js"
@@ -29,6 +36,14 @@ const expectAIError = (error: unknown) => {
 const largeProviderMessage = `Upstream request failed: ${"validation failed; ".repeat(1_000)}`
 
 describe("RequestExecutor", () => {
+  it.effect("preserves authentication errors from HTTP middleware", () =>
+    Effect.gen(function* () {
+      const executor = yield* RequestExecutor.Service
+      const error = new AIError({ reason: new AuthenticationError({ message: "Token request failed" }) })
+      expect(yield* executor.execute(request, () => error).pipe(Effect.flip)).toBe(error)
+    }).pipe(Effect.provide(fixedResponse("unused", {}))),
+  )
+
   it.effect("preserves externally captured HTTP errors without inventing response context", () =>
     Effect.sync(() => {
       const cause = new Error("upstream request failed")

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -432,6 +432,17 @@ export type WebSearchResult = { url: string; title?: string; content?: string; t
 
 export type ConfigWorktree = { directory: string }
 
+export type ConfigProviderOAuth = {
+  grantType: "client_credentials"
+  tokenUrl: string
+  clientId: string
+  clientSecret: string
+  clientAuthMethod?: "client_secret_basic" | "client_secret_post"
+  scope?: string
+  audience?: string
+  resource?: string
+}
+
 export type ProviderRequest = {
   settings: ProviderSettings
   headers: { [x: string]: string }
@@ -2003,6 +2014,7 @@ export type ConfigEntry =
             name?: string
             env?: Array<string>
             package?: string
+            oauth?: ConfigProviderOAuth
             settings?: { [x: string]: JsonValue }
             headers?: { [x: string]: string }
             body?: { [x: string]: JsonValue }

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -42,6 +42,7 @@ export const layer = Layer.effect(
             "SessionRunnerModel.VariantUnavailableError",
             "SessionRunnerModel.UnsupportedPackageError",
             "SessionRunnerModel.UnresolvedProviderVariablesError",
+            "ModelResolver.UnsupportedOAuthPackageError",
           ],
           (error) => {
             const mapped: Error = input.model
@@ -57,15 +58,17 @@ export const layer = Layer.effect(
             ? `Model unavailable: ${input.model.providerID}/${input.model.id}`
             : "No model specified and no supported model is available",
         })
-      const response = yield* llm.generate(LLM.request({ model: resolved.model, prompt: input.prompt })).pipe(
-        Effect.mapError(
-          (error: AIError) =>
-            new UnavailableError({
-              message: error.message,
-              service: resolved.ref.providerID,
-            }),
-        ),
-      )
+      const response = yield* llm
+        .generate(LLM.request({ model: resolved.model, prompt: input.prompt }), { http: resolved.http })
+        .pipe(
+          Effect.mapError(
+            (error: AIError) =>
+              new UnavailableError({
+                message: error.message,
+                service: resolved.ref.providerID,
+              }),
+          ),
+        )
       return response.text
     })
 

--- a/packages/core/src/model-resolver.ts
+++ b/packages/core/src/model-resolver.ts
@@ -2,7 +2,7 @@ export * as ModelResolver from "./model-resolver.js"
 
 import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
 import { LanguageModel } from "@opencode-ai/ai"
-import { Auth } from "@opencode-ai/ai/route"
+import { Auth, type RequestExecutor } from "@opencode-ai/ai/route"
 import { Context, Effect, Layer, Schema, Struct } from "effect"
 import { AISDK } from "./aisdk.js"
 import { AISDKNative } from "./aisdk-native.js"
@@ -12,6 +12,7 @@ import { Integration } from "./integration.js"
 import { Capabilities, ID, Info, Ref, VariantID } from "./model.js"
 import { Npm } from "@opencode-ai/util/npm"
 import { Provider } from "./provider.js"
+import { ProviderOAuth } from "./provider-oauth.js"
 
 export class VariantUnavailableError extends Schema.TaggedError<VariantUnavailableError>()(
   "SessionRunnerModel.VariantUnavailableError",
@@ -52,13 +53,25 @@ export class UnresolvedProviderVariablesError extends Schema.TaggedError<Unresol
   }
 }
 
+export class UnsupportedOAuthPackageError extends Schema.TaggedError<UnsupportedOAuthPackageError>()(
+  "ModelResolver.UnsupportedOAuthPackageError",
+  { providerID: Provider.ID },
+) {
+  override get message() {
+    return `OAuth client credentials for ${this.providerID} require a native HTTP provider package`
+  }
+}
+
 export type Error =
   | VariantUnavailableError
   | UnsupportedPackageError
   | UnresolvedProviderVariablesError
   | Integration.AuthorizationError
+  | UnsupportedOAuthPackageError
 
 export interface Resolved {
+  /** Provider-owned authentication and recovery for outbound HTTP requests. */
+  readonly http?: RequestExecutor.HttpMiddleware
   /** Route-level model for provider requests; its id is the provider API model id, which may differ from the catalog id. */
   readonly model: LanguageModel
   /** Selected catalog identity. Durable records and displays must use this, never the API model id. */
@@ -268,26 +281,32 @@ export const layer = Layer.effect(
     const integrations = yield* Integration.Service
     const npm = yield* Npm.Service
     const aisdk = yield* AISDK.Service
+    const oauth = yield* ProviderOAuth.Service
     const load = Effect.fn("ModelResolver.resolveModel")(function* (selected: Info, variant?: VariantID) {
       const provider = yield* catalog.provider.get(selected.providerID)
-      const connection = yield* integrations.connection.active(
-        provider?.integrationID ?? Integration.ID.make(selected.providerID),
-      )
+      const http = yield* oauth.get(selected.providerID)
+      const connection = http
+        ? undefined
+        : yield* integrations.connection.active(provider?.integrationID ?? Integration.ID.make(selected.providerID))
       const credential = connection ? yield* integrations.connection.resolve(connection) : undefined
       const runtimeInfo = yield* withVariant(selected, variant)
       const model = yield* fromCatalogModel(runtimeInfo, credential, {
         loadPackage: (specifier) => Provider.loadPackage(specifier, npm),
         loadAISDK: (model) => aisdk.model(model),
       })
+      if (http && model.route.protocol === "ai-sdk")
+        return yield* new UnsupportedOAuthPackageError({ providerID: selected.providerID })
       const runtime =
-        provider?.activation === "enabled" &&
-        credential === undefined &&
-        !hasConfiguredAuth(runtimeInfo) &&
-        usesAPIKeyAuth(runtimeInfo.package)
+        http ||
+        (provider?.activation === "enabled" &&
+          credential === undefined &&
+          !hasConfiguredAuth(runtimeInfo) &&
+          usesAPIKeyAuth(runtimeInfo.package))
           ? LanguageModel.update(model, { route: model.route.with({ auth: Auth.none }) })
           : model
       return {
         model: runtime,
+        ...(http ? { http } : {}),
         ref: Ref.make({
           id: selected.id,
           providerID: selected.providerID,
@@ -361,5 +380,5 @@ function usesAPIKeyAuth(packageName: string | undefined) {
 export const node = makeLocationNode({
   service: Service,
   layer,
-  deps: [Catalog.node, Integration.node, Npm.node, AISDK.node],
+  deps: [Catalog.node, Integration.node, Npm.node, AISDK.node, ProviderOAuth.node],
 })

--- a/packages/core/src/provider-oauth.ts
+++ b/packages/core/src/provider-oauth.ts
@@ -1,0 +1,130 @@
+export * as ProviderOAuth from "./provider-oauth.js"
+
+import { isDeepStrictEqual } from "node:util"
+import { AIError, AuthenticationError } from "@opencode-ai/ai"
+import type { RequestExecutor } from "@opencode-ai/ai/route"
+import { ConfigProvider } from "@opencode-ai/schema/config/provider"
+import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { httpClient } from "@opencode-ai/util/effect/app-node-platform"
+import { Clock, Context, Effect, Layer, Redacted, Schema, Semaphore, Stream } from "effect"
+import { HttpClient, HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
+import { Config } from "./config.js"
+import { Provider } from "./provider.js"
+
+const Token = Schema.Struct({
+  access_token: Schema.NonEmptyString,
+  token_type: Schema.String.check(Schema.isPattern(/^bearer$/i)),
+  expires_in: Schema.Finite.check(Schema.isGreaterThan(0)).pipe(Schema.optionalKey),
+})
+
+export interface Interface {
+  readonly get: (providerID: Provider.ID) => Effect.Effect<RequestExecutor.HttpMiddleware | undefined>
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/ProviderOAuth") {}
+
+export const make = Effect.fn("ProviderOAuth.make")(function* (providerID: Provider.ID, config: ConfigProvider.OAuth) {
+  const http = yield* HttpClient.HttpClient
+  const lock = yield* Semaphore.make(1)
+  const state: { token?: { access: Redacted.Redacted; expires: number } } = {}
+  const failure = (message: string) =>
+    new AIError({ reason: new AuthenticationError({ message: `OAuth for ${providerID}: ${message}` }) })
+
+  const token = (rejected?: string) =>
+    lock.withPermit(
+      Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis
+        if (state.token && state.token.expires > now && Redacted.value(state.token.access) !== rejected)
+          return state.token.access
+        state.token = undefined
+        const request = HttpClientRequest.post(config.tokenUrl).pipe(
+          HttpClientRequest.acceptJson,
+          HttpClientRequest.bodyUrlParams({
+            grant_type: "client_credentials",
+            scope: config.scope,
+            audience: config.audience,
+            resource: config.resource,
+            ...(config.clientAuthMethod === "client_secret_post"
+              ? { client_id: config.clientId, client_secret: config.clientSecret }
+              : {}),
+          }),
+        )
+        const response = yield* http.execute(
+          config.clientAuthMethod === "client_secret_post"
+            ? request
+            : HttpClientRequest.basicAuth(request, formEncode(config.clientId), formEncode(config.clientSecret)),
+        )
+        if (response.status < 200 || response.status >= 300) {
+          yield* Stream.runDrain(response.stream).pipe(Effect.ignore)
+          return yield* failure(`token endpoint returned HTTP ${response.status}`)
+        }
+        const result = yield* HttpClientResponse.schemaBodyJson(Token)(response).pipe(
+          Effect.mapError(() => failure("token endpoint returned an invalid bearer token")),
+        )
+        const lifetime = (result.expires_in ?? 0) * 1000
+        state.token = {
+          access: Redacted.make(result.access_token),
+          expires: now + lifetime - Math.min(30_000, lifetime / 10),
+        }
+        return state.token.access
+      }).pipe(
+        Effect.timeout("10 seconds"),
+        // HTTP and schema errors can contain the client secret or token response.
+        Effect.mapError((error) => (error instanceof AIError ? error : failure("token request failed"))),
+      ),
+    )
+
+  const middleware: RequestExecutor.HttpMiddleware = (request, handler) =>
+    Effect.gen(function* () {
+      const access = yield* token()
+      const authenticated = request.pipe(
+        HttpClientRequest.removeHeader("api-key"),
+        HttpClientRequest.removeHeader("x-api-key"),
+        HttpClientRequest.removeHeader("x-goog-api-key"),
+        HttpClientRequest.bearerToken(access),
+      )
+      const response = yield* handler(authenticated)
+      const challenge = response.headers["www-authenticate"] ?? ""
+      if (
+        response.status !== 401 &&
+        !(response.status >= 400 && /\bBearer\b/i.test(challenge) && /\berror\s*=\s*"?invalid_token\b/i.test(challenge))
+      )
+        return response
+      yield* Stream.runDrain(response.stream).pipe(Effect.ignore)
+      const refreshed = yield* token(Redacted.value(access))
+      return yield* handler(HttpClientRequest.bearerToken(authenticated, refreshed))
+    })
+  return middleware
+})
+
+function formEncode(value: string) {
+  return new URLSearchParams({ value }).toString().slice("value=".length)
+}
+
+export const layer = Layer.effect(
+  Service,
+  Effect.gen(function* () {
+    const config = yield* Config.Service
+    const http = yield* HttpClient.HttpClient
+    const cache = new Map<Provider.ID, { config: ConfigProvider.OAuth; middleware: RequestExecutor.HttpMiddleware }>()
+    return Service.of({
+      get: Effect.fn("ProviderOAuth.get")(function* (providerID) {
+        const configured = (yield* config.entries())
+          .filter((entry) => entry.type === "document")
+          .map((entry) => entry.info.providers?.[providerID]?.oauth)
+          .findLast((oauth) => oauth !== undefined)
+        if (!configured) {
+          cache.delete(providerID)
+          return
+        }
+        const current = cache.get(providerID)
+        if (current && isDeepStrictEqual(current.config, configured)) return current.middleware
+        const middleware = yield* make(providerID, configured).pipe(Effect.provideService(HttpClient.HttpClient, http))
+        cache.set(providerID, { config: configured, middleware })
+        return middleware
+      }),
+    })
+  }),
+)
+
+export const node = makeLocationNode({ service: Service, layer, deps: [Config.node, httpClient] })

--- a/packages/core/src/session/model-request.ts
+++ b/packages/core/src/session/model-request.ts
@@ -355,7 +355,7 @@ export const layer = Layer.effect(
               Effect.orDie,
             )
           : false
-      const http = hasHttpHooks
+      const hookedHttp = hasHttpHooks
         ? httpMiddleware(hooks, {
             sessionID: session.id,
             agent: input.scope.agentID,
@@ -363,11 +363,14 @@ export const layer = Layer.effect(
             kind: input.kind,
           })
         : undefined
+      const providerHttp = resolved.http
+      const http: StreamOptions["http"] =
+        hookedHttp && providerHttp
+          ? (request, handler) => hookedHttp(request, (sent) => providerHttp(sent, handler))
+          : (providerHttp ?? hookedHttp)
       const options: StreamOptions = {
         ...(http ? { http } : {}),
-        ...(input.webSocket === "session" && webSocket && !hasHttpHooks
-          ? { webSocket: transport.bind(session.id) }
-          : {}),
+        ...(input.webSocket === "session" && webSocket && !http ? { webSocket: transport.bind(session.id) } : {}),
       }
       const executeTool: Prepared["executeTool"] = (input) =>
         tools

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -4,13 +4,16 @@ import { OpenAIChat } from "@opencode-ai/ai/protocols"
 import { TestLLM } from "@opencode-ai/ai/testing"
 import { AISDK } from "@opencode-ai/core/aisdk"
 import { Catalog } from "@opencode-ai/core/catalog"
+import { Config } from "@opencode-ai/core/config"
 import { Generate } from "@opencode-ai/core/generate"
 import { Integration } from "@opencode-ai/core/integration"
 import { ModelResolver } from "@opencode-ai/core/model-resolver"
 import { ID, Info, Ref } from "@opencode-ai/core/model"
 import { Provider } from "@opencode-ai/core/provider"
+import { ProviderOAuth } from "@opencode-ai/core/provider-oauth"
 import { Npm } from "@opencode-ai/util/npm"
 import { Effect, Layer } from "effect"
+import { FetchHttpClient } from "effect/unstable/http"
 import { testEffect } from "./lib/effect"
 
 const selected = Info.make({
@@ -67,7 +70,8 @@ const aisdk = Layer.mock(AISDK.Service, {
 })
 const client = TestLLM.testLayer({ fallback: TestLLM.text("OK", "generate") })
 
-const resolver = ModelResolver.layer.pipe(Layer.provide(Layer.mergeAll(catalog, integrations, npm, aisdk)))
+const oauth = ProviderOAuth.layer.pipe(Layer.provide(Layer.merge(Config.testLayer(), FetchHttpClient.layer)))
+const resolver = ModelResolver.layer.pipe(Layer.provide(Layer.mergeAll(catalog, integrations, npm, aisdk, oauth)))
 const it = testEffect(Generate.layer.pipe(Layer.provide(Layer.merge(resolver, client))))
 const resolverIt = testEffect(resolver)
 

--- a/packages/core/test/model-resolver.test.ts
+++ b/packages/core/test/model-resolver.test.ts
@@ -3,11 +3,13 @@ import { LLM, LanguageModel, Message } from "@opencode-ai/ai"
 import { OpenAIChat } from "@opencode-ai/ai/protocols"
 import { compileRequest } from "@opencode-ai/ai/route/client"
 import { ConfigProvider, Effect, Layer } from "effect"
-import { Headers } from "effect/unstable/http"
+import { FetchHttpClient, Headers } from "effect/unstable/http"
+import { Config } from "@opencode-ai/core/config"
 import { Credential } from "@opencode-ai/core/credential"
 import { Integration } from "@opencode-ai/core/integration"
 import { Compatibility, ID, Info, VariantID } from "@opencode-ai/core/model"
 import { Provider } from "@opencode-ai/core/provider"
+import { ProviderOAuth } from "@opencode-ai/core/provider-oauth"
 import { ModelResolver } from "@opencode-ai/core/model-resolver"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { AISDK } from "@opencode-ai/core/aisdk"
@@ -358,7 +360,8 @@ describe("ModelResolver", () => {
       },
       model: () => Effect.die("unused"),
     })
-    const layer = ModelResolver.layer.pipe(Layer.provide(Layer.mergeAll(catalog, integrations, npm, aisdk)))
+    const oauth = ProviderOAuth.layer.pipe(Layer.provide(Layer.merge(Config.testLayer(), FetchHttpClient.layer)))
+    const layer = ModelResolver.layer.pipe(Layer.provide(Layer.mergeAll(catalog, integrations, npm, aisdk, oauth)))
 
     return withConfigEnv({}, () =>
       Effect.gen(function* () {

--- a/packages/core/test/provider-oauth.test.ts
+++ b/packages/core/test/provider-oauth.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect } from "bun:test"
+import { AIError } from "@opencode-ai/ai"
+import type { RequestExecutor } from "@opencode-ai/ai/route"
+import { Config } from "@opencode-ai/core/config"
+import { Provider } from "@opencode-ai/core/provider"
+import { ProviderOAuth } from "@opencode-ai/core/provider-oauth"
+import { Document, Info } from "@opencode-ai/schema/config"
+import { ConfigProvider } from "@opencode-ai/schema/config/provider"
+import { Effect, Fiber, Layer, Schema } from "effect"
+import { FetchHttpClient, HttpClient, HttpClientRequest } from "effect/unstable/http"
+import { testEffect } from "./lib/effect"
+
+const it = testEffect(Layer.merge(Config.testLayer(), FetchHttpClient.layer))
+const providerID = Provider.ID.make("corporate")
+const credentials = {
+  grantType: "client_credentials",
+  clientId: "client :+é",
+  clientSecret: "secret &+é",
+} as const
+
+const serve = Effect.fn(function* (fetch: (request: Request) => Response | Promise<Response>) {
+  const server = yield* Effect.acquireRelease(
+    Effect.sync(() => Bun.serve({ hostname: "127.0.0.1", port: 0, fetch })),
+    (server) => Effect.promise(() => server.stop(true)),
+  )
+  const http = yield* HttpClient.HttpClient
+  return {
+    tokenUrl: new URL("/token", server.url).href,
+    call: (middleware: RequestExecutor.HttpMiddleware) =>
+      middleware(
+        HttpClientRequest.post(new URL("/chat", server.url).href).pipe(
+          HttpClientRequest.bodyText('{"prompt":"hello"}', "application/json"),
+          HttpClientRequest.setHeaders({ "x-tenant": "example", "x-api-key": "old-key" }),
+        ),
+        http.execute,
+      ).pipe(Effect.flatMap((response) => response.text)),
+  }
+})
+
+describe("ProviderOAuth", () => {
+  for (const clientAuthMethod of ["client_secret_basic", "client_secret_post"] as const) {
+    it.live(`exchanges ${clientAuthMethod} credentials and shares cached tokens`, () =>
+      Effect.gen(function* () {
+        const requests: Array<{ path: string; auth: string | null; body: string; type: string | null }> = []
+        const server = yield* serve(async (request) => {
+          const path = new URL(request.url).pathname
+          requests.push({
+            path,
+            auth: request.headers.get("authorization"),
+            body: await request.text(),
+            type: request.headers.get("content-type"),
+          })
+          if (path === "/token") return Response.json({ access_token: "token", token_type: "Bearer", expires_in: 3600 })
+          expect(request.headers.get("x-api-key")).toBeNull()
+          expect(request.headers.get("x-tenant")).toBe("example")
+          return new Response("ok")
+        })
+        const middleware = yield* ProviderOAuth.make(providerID, {
+          ...credentials,
+          tokenUrl: server.tokenUrl,
+          clientAuthMethod,
+          scope: "llm.invoke other",
+          audience: "gateway",
+          resource: "https://gateway.example.com",
+        })
+        expect(requests).toEqual([])
+        expect(
+          yield* Effect.all(
+            Array.from({ length: 8 }, () => server.call(middleware)),
+            { concurrency: 8 },
+          ),
+        ).toEqual(Array(8).fill("ok"))
+        const tokens = requests.filter((request) => request.path === "/token")
+        expect(tokens).toHaveLength(1)
+        expect(tokens[0]?.type).toBe("application/x-www-form-urlencoded")
+        expect(Object.fromEntries(new URLSearchParams(tokens[0]?.body))).toEqual({
+          grant_type: "client_credentials",
+          scope: "llm.invoke other",
+          audience: "gateway",
+          resource: "https://gateway.example.com",
+          ...(clientAuthMethod === "client_secret_post"
+            ? { client_id: credentials.clientId, client_secret: credentials.clientSecret }
+            : {}),
+        })
+        expect(tokens[0]?.auth).toBe(
+          clientAuthMethod === "client_secret_basic"
+            ? `Basic ${btoa("client+%3A%2B%C3%A9:secret+%26%2B%C3%A9")}`
+            : null,
+        )
+        expect(requests.filter((request) => request.path === "/chat")).toEqual(
+          Array(8).fill({ path: "/chat", auth: "Bearer token", body: '{"prompt":"hello"}', type: "application/json" }),
+        )
+      }),
+    )
+  }
+
+  for (const test of [
+    { status: 401, challenge: "", retry: true },
+    { status: 403, challenge: 'Bearer error="invalid_token"', retry: true },
+    { status: 403, challenge: 'Bearer error="insufficient_scope"', retry: false },
+    { status: 500, challenge: "", retry: false },
+  ]) {
+    it.live(`bounds retries for HTTP ${test.status} ${test.challenge}`, () =>
+      Effect.gen(function* () {
+        const tokens: string[] = []
+        const calls: Array<{ auth: string | null; body: string }> = []
+        const server = yield* serve(async (request) => {
+          if (new URL(request.url).pathname === "/token") {
+            tokens.push(`token-${tokens.length + 1}`)
+            return Response.json({ access_token: tokens.at(-1), token_type: "bearer", expires_in: 3600 })
+          }
+          calls.push({ auth: request.headers.get("authorization"), body: await request.text() })
+          return new Response("rejected", { status: test.status, headers: { "www-authenticate": test.challenge } })
+        })
+        const middleware = yield* ProviderOAuth.make(providerID, { ...credentials, tokenUrl: server.tokenUrl })
+        expect(yield* server.call(middleware)).toBe("rejected")
+        expect(tokens).toHaveLength(test.retry ? 2 : 1)
+        expect(calls).toEqual(tokens.map((token) => ({ auth: `Bearer ${token}`, body: '{"prompt":"hello"}' })))
+      }),
+    )
+  }
+
+  it.live("shares renewal after concurrent rejections and returns the successful response", () =>
+    Effect.gen(function* () {
+      const tokens: string[] = []
+      const server = yield* serve((request) => {
+        if (new URL(request.url).pathname === "/token") {
+          tokens.push(`token-${tokens.length + 1}`)
+          return Response.json({ access_token: tokens.at(-1), token_type: "Bearer", expires_in: 3600 })
+        }
+        return request.headers.get("authorization") === "Bearer token-1"
+          ? new Response("expired", { status: 401 })
+          : new Response("ok")
+      })
+      const middleware = yield* ProviderOAuth.make(providerID, { ...credentials, tokenUrl: server.tokenUrl })
+      expect(
+        yield* Effect.all(
+          Array.from({ length: 8 }, () => server.call(middleware)),
+          { concurrency: 8 },
+        ),
+      ).toEqual(Array(8).fill("ok"))
+      expect(tokens).toHaveLength(2)
+    }),
+  )
+
+  it.live("renews expired tokens and does not cache tokens without expires_in", () =>
+    Effect.gen(function* () {
+      const tokens: string[] = []
+      const server = yield* serve((request) => {
+        if (new URL(request.url).pathname !== "/token") return new Response("ok")
+        tokens.push("token")
+        return Response.json({
+          access_token: "token",
+          token_type: "Bearer",
+          ...(tokens.length === 1 ? { expires_in: 0.1 } : {}),
+        })
+      })
+      const middleware = yield* ProviderOAuth.make(providerID, { ...credentials, tokenUrl: server.tokenUrl })
+      yield* server.call(middleware)
+      yield* Effect.sleep("150 millis")
+      yield* server.call(middleware)
+      yield* server.call(middleware)
+      expect(tokens).toHaveLength(3)
+    }),
+  )
+
+  for (const response of [
+    { status: 400, body: '{"error":"invalid_client","secret":"do-not-leak"}' },
+    { status: 200, body: "do-not-leak" },
+    { status: 200, body: '{"access_token":"do-not-leak","token_type":"MAC"}' },
+    { status: 200, body: '{"access_token":"","token_type":"Bearer"}' },
+    { status: 200, body: '{"access_token":"do-not-leak","token_type":"Bearer","expires_in":-1}' },
+  ]) {
+    it.live(`rejects invalid token responses without exposing credentials: ${response.body}`, () =>
+      Effect.gen(function* () {
+        const paths: string[] = []
+        const server = yield* serve((request) => {
+          paths.push(new URL(request.url).pathname)
+          return new Response(response.body, { status: response.status })
+        })
+        const middleware = yield* ProviderOAuth.make(providerID, { ...credentials, tokenUrl: server.tokenUrl })
+        const error = yield* server.call(middleware).pipe(Effect.flip)
+        expect(error).toBeInstanceOf(AIError)
+        expect(error).toMatchObject({ reason: { _tag: "Authentication" } })
+        expect(String(error)).not.toContain("do-not-leak")
+        expect(JSON.stringify(error)).not.toContain(credentials.clientSecret)
+        expect(paths).toEqual(["/token"])
+      }),
+    )
+  }
+
+  it.live("cancels token acquisition and allows the next request to acquire a token", () =>
+    Effect.gen(function* () {
+      const started = Promise.withResolvers<void>()
+      const tokens: string[] = []
+      const server = yield* serve((request) => {
+        if (new URL(request.url).pathname !== "/token") return new Response("ok")
+        tokens.push("token")
+        if (tokens.length === 1) {
+          started.resolve()
+          return new Promise<Response>(() => {})
+        }
+        return Response.json({ access_token: "token", token_type: "Bearer", expires_in: 3600 })
+      })
+      const middleware = yield* ProviderOAuth.make(providerID, { ...credentials, tokenUrl: server.tokenUrl })
+      const pending = yield* server.call(middleware).pipe(Effect.forkScoped)
+      yield* Effect.promise(() => started.promise)
+      yield* Fiber.interrupt(pending)
+      expect(yield* server.call(middleware)).toBe("ok")
+      expect(tokens).toHaveLength(2)
+    }),
+  )
+
+  it.live("isolates providers and replaces cached auth when configuration changes", () =>
+    Effect.gen(function* () {
+      const secrets: Array<string | null> = []
+      const server = yield* serve(async (request) => {
+        if (new URL(request.url).pathname !== "/token") return new Response("ok")
+        secrets.push(new URLSearchParams(await request.text()).get("client_secret"))
+        return Response.json({ access_token: `token-${secrets.length}`, token_type: "Bearer", expires_in: 3600 })
+      })
+      const config = yield* Config.Test
+      const oauth = { ...credentials, tokenUrl: server.tokenUrl, clientAuthMethod: "client_secret_post" } as const
+      const document = (providers: Info["providers"]) =>
+        new Document({ type: "document", info: Info.make({ providers }) })
+      yield* config.setEntries([document({ corporate: { oauth }, other: { oauth } })])
+      const service = yield* ProviderOAuth.Service.pipe(Effect.provide(ProviderOAuth.layer))
+      const first = yield* service.get(providerID)
+      if (!first) throw new Error("Expected configured OAuth")
+      yield* server.call(first)
+      expect(yield* service.get(providerID)).toBe(first)
+      const other = yield* service.get(Provider.ID.make("other"))
+      if (!other) throw new Error("Expected second provider OAuth")
+      yield* server.call(other)
+      yield* config.setEntries([
+        document({ corporate: { oauth } }),
+        document({ corporate: { oauth: { ...oauth, clientSecret: "rotated" } } }),
+      ])
+      const updated = yield* service.get(providerID)
+      if (!updated) throw new Error("Expected updated OAuth")
+      expect(updated).not.toBe(first)
+      yield* server.call(updated)
+      yield* config.setEntries([])
+      expect(yield* service.get(providerID)).toBeUndefined()
+      expect(secrets).toEqual([credentials.clientSecret, credentials.clientSecret, "rotated"])
+    }),
+  )
+
+  it.effect("validates the configuration and omits absent optional fields", () =>
+    Effect.sync(() => {
+      const decode = Schema.decodeUnknownSync(ConfigProvider.OAuth)
+      const encode = Schema.encodeSync(ConfigProvider.OAuth)
+      const oauth = { ...credentials, tokenUrl: "https://auth.example.com/token" }
+      expect(encode(decode(oauth))).toEqual(oauth)
+      expect(() => decode({ ...oauth, clientSecret: "" })).toThrow()
+      expect(() => decode({ ...oauth, grantType: "authorization_code" })).toThrow()
+      expect(() => decode({ ...oauth, clientAuthMethod: "none" })).toThrow()
+    }),
+  )
+})

--- a/packages/core/test/session-model-request-hooks.test.ts
+++ b/packages/core/test/session-model-request-hooks.test.ts
@@ -1,17 +1,31 @@
 import { describe, expect } from "bun:test"
 import { OpenAIChat } from "@opencode-ai/ai/protocols"
+import { LLMClient } from "@opencode-ai/ai"
+import { RequestExecutor } from "@opencode-ai/ai/route"
 import { Agent } from "@opencode-ai/schema/agent"
+import { Document, Info } from "@opencode-ai/schema/config"
 import { Money } from "@opencode-ai/schema/money"
 import { Session } from "@opencode-ai/schema/session"
 import type { SessionRequestKind } from "@opencode-ai/plugin/effect/session"
 import { Location } from "@opencode-ai/core/location"
+import { Catalog } from "@opencode-ai/core/catalog"
+import { Config } from "@opencode-ai/core/config"
+import { ConfigProviderPlugin } from "@opencode-ai/core/config/plugin/provider"
+import { Credential } from "@opencode-ai/core/credential"
+import { Generate } from "@opencode-ai/core/generate"
+import { Integration } from "@opencode-ai/core/integration"
+import { ModelResolver } from "@opencode-ai/core/model-resolver"
+import { Plugin } from "@opencode-ai/core/plugin"
+import { PluginHost } from "@opencode-ai/core/plugin/host"
+import { CoherePlugin } from "@opencode-ai/core/plugin/provider/cohere"
 import { PluginHooks } from "@opencode-ai/core/plugin/hooks"
+import { ProviderOAuth } from "@opencode-ai/core/provider-oauth"
 import { Project } from "@opencode-ai/core/project"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { SessionModelRequest } from "@opencode-ai/core/session/model-request"
 import { SessionModelTransport } from "@opencode-ai/core/session/model-transport"
 import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
-import { DateTime, Effect } from "effect"
+import { ConfigProvider, DateTime, Effect, Schema } from "effect"
 import { HttpClientRequest, HttpClientResponse } from "effect/unstable/http"
 import { testEffect } from "./lib/effect"
 import { PluginTestLayer } from "./plugin/fixture"
@@ -40,6 +54,151 @@ const transport = SessionModelTransport.Service.of({
 })
 
 describe("SessionModelRequest HTTP hooks", () => {
+  it.live("uses configured OAuth for all request kinds without persisting tokens", () =>
+    Effect.gen(function* () {
+      const tokens: string[] = []
+      const calls: Array<{ auth: string | null; key: string | null; hook: string | null; body: string }> = []
+      const server = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          Bun.serve({
+            hostname: "127.0.0.1",
+            port: 0,
+            async fetch(request) {
+              if (new URL(request.url).pathname === "/token") {
+                tokens.push(`token-${tokens.length + 1}`)
+                return Response.json({ access_token: tokens.at(-1), token_type: "Bearer", expires_in: 3600 })
+              }
+              calls.push({
+                auth: request.headers.get("authorization"),
+                key: request.headers.get("x-api-key"),
+                hook: request.headers.get("x-hook"),
+                body: await request.text(),
+              })
+              if (request.headers.get("authorization") === "Bearer token-1")
+                return new Response("expired", { status: 401 })
+              return new Response(
+                [
+                  'data: {"id":"test","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n\n',
+                  'data: {"id":"test","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+                  "data: [DONE]\n\n",
+                ].join(""),
+                { headers: { "content-type": "text/event-stream" } },
+              )
+            },
+          }),
+        ),
+        (server) => Effect.promise(() => server.stop(true)),
+      )
+      const entries = [
+        new Document({
+          type: "document",
+          info: Schema.decodeUnknownSync(Info)({
+            providers: {
+              corporate: {
+                package: "@opencode-ai/ai/providers/openai-compatible",
+                settings: { baseURL: new URL("/v1", server.url).href, apiKey: "old-configured-key" },
+                headers: { Authorization: "Bearer old-header", "X-API-Key": "old-header-key" },
+                oauth: {
+                  grantType: "client_credentials",
+                  tokenUrl: new URL("/token", server.url).href,
+                  clientId: "client",
+                  clientSecret: "private-client-secret",
+                },
+                models: { chat: {} },
+              },
+            },
+          }),
+        }),
+      ]
+      yield* Effect.gen(function* () {
+        const plugins = yield* Plugin.Service
+        const host = yield* PluginHost.make(plugins)
+        yield* ConfigProviderPlugin.Plugin.effect(host)
+        const catalog = yield* Catalog.Service
+        const selected = (yield* catalog.model.available()).find((model) => model.providerID === "corporate")
+        if (!selected) throw new Error("Expected configured model")
+        expect(JSON.stringify(yield* catalog.provider.all())).not.toContain("private-client-secret")
+        expect(JSON.stringify(selected)).not.toContain("private-client-secret")
+        const credentials = yield* Credential.Service
+        const saved = yield* credentials.create({
+          integrationID: Integration.ID.make(selected.providerID),
+          value: Credential.Key.make({ type: "key", key: "saved-key" }),
+        })
+        const resolver = yield* ModelResolver.Service.pipe(Effect.provide(ModelResolver.layer))
+        const resolved = yield* resolver.resolveModel(selected)
+        expect(tokens).toEqual([])
+        const requests = yield* SessionModelRequest.Service.pipe(Effect.provide(SessionModelRequest.layer))
+        const unhooked = yield* requests.prepare({
+          kind: "primary",
+          scope: {
+            session,
+            agentID: Agent.ID.make("build"),
+            model: { ...resolved, capabilities: { ...resolved.capabilities, responsesWebsockets: true } },
+          },
+          transcript: { system: [], messages: [] },
+          webSocket: "session",
+        })
+        expect(unhooked.options.http).toBe(resolved.http)
+        expect(unhooked.options.webSocket).toBeUndefined()
+        const hooks = yield* PluginHooks.Service
+        const seen: SessionRequestKind[] = []
+        yield* hooks.register("session", "http.request", (event) =>
+          Effect.sync(() => event.request.headers.set("x-hook", "present")),
+        )
+        yield* hooks.register("session", "http.response", (event) =>
+          Effect.sync(() => {
+            seen.push(event.kind)
+          }),
+        )
+        const llm = yield* LLMClient.Service.pipe(
+          Effect.provide(LLMClient.layer),
+          Effect.provide(RequestExecutor.layer),
+        )
+        for (const kind of KINDS) {
+          const prepared = yield* requests.prepare({
+            kind,
+            scope: {
+              session,
+              agentID: Agent.ID.make("build"),
+              model: { ...resolved, capabilities: { ...resolved.capabilities, responsesWebsockets: true } },
+            },
+            transcript: { system: [], messages: [] },
+            webSocket: "session",
+          })
+          expect(prepared.options.webSocket).toBeUndefined()
+          expect((yield* llm.generate(prepared.request, prepared.options)).text).toBe("ok")
+        }
+        const generate = yield* Generate.Service.pipe(
+          Effect.provide(Generate.layer),
+          Effect.provideService(ModelResolver.Service, resolver),
+          Effect.provideService(LLMClient.Service, llm),
+        )
+        expect(yield* generate.text({ model: resolved.ref, prompt: "hello" })).toBe("ok")
+        expect(tokens).toHaveLength(2)
+        expect(calls).toHaveLength(6)
+        expect(calls[0]?.body).toBe(calls[1]?.body)
+        expect(calls.every((call) => call.key === null && !call.body.includes("private-client-secret"))).toBe(true)
+        expect(calls.slice(1).every((call) => call.auth === "Bearer token-2")).toBe(true)
+        expect(calls.slice(0, 5).every((call) => call.hook === "present")).toBe(true)
+        expect(seen).toEqual([...KINDS])
+        expect(yield* credentials.list(Integration.ID.make(selected.providerID))).toEqual([saved])
+
+        yield* CoherePlugin.effect(host)
+        expect(
+          yield* resolver.resolveModel({ ...selected, package: "aisdk:@ai-sdk/cohere" }).pipe(Effect.flip),
+        ).toBeInstanceOf(ModelResolver.UnsupportedOAuthPackageError)
+      }).pipe(
+        Effect.provide(ProviderOAuth.layer),
+        Effect.provide(Config.testLayer(entries)),
+        Effect.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromEnv({ env: { OPENCODE_EXPERIMENTAL_CORPORATE_RESPONSES_WEBSOCKET: "true" } }),
+          ),
+        ),
+      )
+    }).pipe(Effect.provideService(SessionModelTransport.Service, transport)),
+  )
+
   it.effect("tags every Session request kind on http.request and http.response", () =>
     Effect.gen(function* () {
       const hooks = yield* PluginHooks.Service

--- a/packages/protocol/openapi.json
+++ b/packages/protocol/openapi.json
@@ -14483,6 +14483,42 @@
         "required": ["package"],
         "additionalProperties": false
       },
+      "Config.Provider.OAuth": {
+        "type": "object",
+        "properties": {
+          "grantType": {
+            "type": "string",
+            "enum": ["client_credentials"]
+          },
+          "tokenUrl": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientSecret": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientAuthMethod": {
+            "type": "string",
+            "enum": ["client_secret_basic", "client_secret_post"]
+          },
+          "scope": {
+            "type": "string"
+          },
+          "audience": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          }
+        },
+        "required": ["grantType", "tokenUrl", "clientId", "clientSecret"],
+        "additionalProperties": false
+      },
       "Config.ProviderEncoded": {
         "type": "object",
         "properties": {
@@ -14500,6 +14536,9 @@
           },
           "package": {
             "type": "string"
+          },
+          "oauth": {
+            "$ref": "#/components/schemas/Config.Provider.OAuth"
           },
           "settings": {
             "type": "object"

--- a/packages/schema/src/config/provider.ts
+++ b/packages/schema/src/config/provider.ts
@@ -57,11 +57,24 @@ class Model extends Schema.Class<Model>("Config.Model")({
   limit: Limit.pipe(optional),
 }) {}
 
+export interface OAuth extends Schema.Schema.Type<typeof OAuth> {}
+export const OAuth = Schema.Struct({
+  grantType: Schema.Literal("client_credentials"),
+  tokenUrl: Schema.NonEmptyString,
+  clientId: Schema.NonEmptyString,
+  clientSecret: Schema.NonEmptyString,
+  clientAuthMethod: Schema.Literals(["client_secret_basic", "client_secret_post"]).pipe(optional),
+  scope: Schema.String.pipe(optional),
+  audience: Schema.String.pipe(optional),
+  resource: Schema.String.pipe(optional),
+}).annotate({ identifier: "Config.Provider.OAuth" })
+
 export class Info extends Schema.Class<Info>("Config.Provider")({
   canonical: Provider.ID.pipe(optional),
   name: Schema.String.pipe(optional),
   env: Schema.String.pipe(Schema.Array, optional),
   package: Schema.String.pipe(optional),
+  oauth: OAuth.pipe(optional),
   ...Overlays,
   models: Schema.Record(Schema.String, Model).pipe(optional),
 }) {}

--- a/packages/www/openapi.json
+++ b/packages/www/openapi.json
@@ -14483,6 +14483,42 @@
         "required": ["package"],
         "additionalProperties": false
       },
+      "Config.Provider.OAuth": {
+        "type": "object",
+        "properties": {
+          "grantType": {
+            "type": "string",
+            "enum": ["client_credentials"]
+          },
+          "tokenUrl": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientSecret": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientAuthMethod": {
+            "type": "string",
+            "enum": ["client_secret_basic", "client_secret_post"]
+          },
+          "scope": {
+            "type": "string"
+          },
+          "audience": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          }
+        },
+        "required": ["grantType", "tokenUrl", "clientId", "clientSecret"],
+        "additionalProperties": false
+      },
       "Config.ProviderEncoded": {
         "type": "object",
         "properties": {
@@ -14500,6 +14536,9 @@
           },
           "package": {
             "type": "string"
+          },
+          "oauth": {
+            "$ref": "#/components/schemas/Config.Provider.OAuth"
           },
           "settings": {
             "type": "object"

--- a/packages/www/public/openapi.json
+++ b/packages/www/public/openapi.json
@@ -14483,6 +14483,42 @@
         "required": ["package"],
         "additionalProperties": false
       },
+      "Config.Provider.OAuth": {
+        "type": "object",
+        "properties": {
+          "grantType": {
+            "type": "string",
+            "enum": ["client_credentials"]
+          },
+          "tokenUrl": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientSecret": {
+            "type": "string",
+            "minLength": 1
+          },
+          "clientAuthMethod": {
+            "type": "string",
+            "enum": ["client_secret_basic", "client_secret_post"]
+          },
+          "scope": {
+            "type": "string"
+          },
+          "audience": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          }
+        },
+        "required": ["grantType", "tokenUrl", "clientId", "clientSecret"],
+        "additionalProperties": false
+      },
       "Config.ProviderEncoded": {
         "type": "object",
         "properties": {
@@ -14500,6 +14536,9 @@
           },
           "package": {
             "type": "string"
+          },
+          "oauth": {
+            "$ref": "#/components/schemas/Config.Provider.OAuth"
           },
           "settings": {
             "type": "object"

--- a/packages/www/src/docs/content/providers.mdx
+++ b/packages/www/src/docs/content/providers.mdx
@@ -34,9 +34,44 @@ The `providers` object is keyed by provider ID. Each provider accepts these fiel
 | `env`      | Ordered environment variable names that provide a connection.   |
 | `package`  | Runtime provider package.                                       |
 | `settings` | JSON settings passed to the runtime package, such as `baseURL`. |
+| `oauth`    | Non-interactive OAuth client credentials for a gateway.         |
 | `headers`  | String-valued HTTP headers added to requests.                   |
 | `body`     | JSON fields merged into request bodies.                         |
 | `models`   | Models to add or override, keyed by catalog model ID.           |
+
+## OAuth client credentials
+
+For an enterprise gateway that uses OAuth 2.0 client credentials, add `oauth` to the provider. No `/connect`, browser,
+or refresh token is required. Keep secrets in environment variables available to the OpenCode server.
+
+```jsonc title="opencode.jsonc"
+{
+  "$schema": "https://opencode.ai/config.json",
+  "providers": {
+    "corporate": {
+      "package": "@opencode-ai/ai/providers/openai-compatible",
+      "settings": { "baseURL": "https://gateway.example.com/v1" },
+      "oauth": {
+        "grantType": "client_credentials",
+        "tokenUrl": "https://auth.example.com/oauth2/token",
+        "clientId": "{env:LLM_CLIENT_ID}",
+        "clientSecret": "{env:LLM_CLIENT_SECRET}",
+        "clientAuthMethod": "client_secret_basic",
+        "scope": "llm.invoke",
+      },
+      "models": { "corporate-model": {} },
+    },
+  },
+}
+```
+
+- `clientAuthMethod` defaults to `client_secret_basic`. Use `client_secret_post` to send the credentials in the form body.
+- `scope`, `audience`, and `resource` are optional token-request parameters.
+- Tokens stay in memory and are renewed shortly before `expires_in`. A token without an expiry is not reused across requests.
+- A `401` or an HTTP error with a Bearer `invalid_token` challenge triggers one token renewal and retry.
+- OAuth replaces saved connection credentials and API-key authentication for this provider. Other providers are unchanged.
+- This mode uses native HTTP provider packages. WebSockets are disabled; packages that require the fallback AI SDK runtime are not supported.
+- A higher-priority `oauth` block replaces the whole block. Changing it discards the previous cached token on the next model resolution.
 
 ## Azure OpenAI and Microsoft Foundry
 


### PR DESCRIPTION
Refs #24084

- Add opt-in OAuth `client_credentials` authentication for configured providers, with Basic or POST client authentication.
- Cache tokens only in memory, renew on expiry, and retry once after `401` or a Bearer `invalid_token` challenge. No browser, `/connect`, or refresh token.
- Keep this first version on native HTTP providers. WebSockets are disabled for these providers; the fallback AI SDK runtime is rejected explicitly. Existing interactive login is unchanged.

```jsonc
{
  "providers": {
    "corporate": {
      "package": "@opencode-ai/ai/providers/openai-compatible",
      "settings": { "baseURL": "https://gateway.example.com/v1" },
      "oauth": {
        "grantType": "client_credentials",
        "tokenUrl": "https://auth.example.com/oauth2/token",
        "clientId": "{env:LLM_CLIENT_ID}",
        "clientSecret": "{env:LLM_CLIENT_SECRET}",
        "scope": "llm.invoke"
      },
      "models": { "corporate-model": {} }
    }
  }
}
```