### PR TITLE
fix(core): bound npm installs with a configurable timeout

### DIFF
--- a/packages/core/src/npm.ts
+++ b/packages/core/src/npm.ts
@@ -42,6 +42,15 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Np
 
 const illegal = process.platform === "win32" ? new Set(["<", ">", ":", '"', "|", "?", "*"]) : undefined
 
+// Matches npm's own fetch-timeout default so a slow registry fails like npm
+// itself would instead of hanging the awaiting session path forever.
+const DEFAULT_INSTALL_TIMEOUT = 300_000
+
+const installTimeout = () => {
+  const configured = Number(process.env.OPENCODE_NPM_INSTALL_TIMEOUT)
+  return Number.isFinite(configured) && configured > 0 ? configured : DEFAULT_INSTALL_TIMEOUT
+}
+
 export function sanitize(pkg: string) {
   if (!illegal) return pkg
   return Array.from(pkg, (char) => (illegal.has(char) || char.charCodeAt(0) < 32 ? "_" : char)).join("")
@@ -105,7 +114,19 @@ const layer = Layer.effect(
               add,
               dir: input.dir,
             }),
-        }) as Effect.Effect<ArboristTree, InstallFailedError>
+        }).pipe(
+          Effect.timeout(installTimeout()),
+          Effect.catchTag("TimeoutError", () =>
+            new InstallFailedError({
+              add,
+              dir: input.dir,
+              cause: new Error(`npm install timed out after ${installTimeout()}ms`),
+            }),
+          ),
+          Effect.tapError((error) =>
+            Effect.logError("npm install failed", { add, dir: input.dir, error: error.message }),
+          ),
+        ) as Effect.Effect<ArboristTree, InstallFailedError>
       }).pipe(
         Effect.withSpan("Npm.reify", {
           attributes: input,

--- a/packages/core/test/npm.test.ts
+++ b/packages/core/test/npm.test.ts
@@ -55,6 +55,31 @@ describe("Npm.add", () => {
 
     expect(entry.entrypoint).toBeDefined()
   })
+
+  test("fails with InstallFailedError when the registry never responds within the timeout", async () => {
+    await using tmp = await tmpdir()
+    const server = Bun.serve({ port: 0, fetch: () => new Promise(() => {}) })
+    const spec = "never-resolves-package@1.0.0"
+    process.env.npm_config_registry = `http://127.0.0.1:${server.port}/`
+    process.env.OPENCODE_NPM_INSTALL_TIMEOUT = "1000"
+    try {
+      const error = await Effect.gen(function* () {
+        const npm = yield* Npm.Service
+        return yield* npm.add(spec)
+      }).pipe(
+        Effect.flip,
+        Effect.scoped,
+        Effect.provide(npmLayer(path.join(tmp.path, "cache"))),
+        Effect.runPromise,
+      )
+
+      expect(error).toBeInstanceOf(Npm.InstallFailedError)
+    } finally {
+      delete process.env.npm_config_registry
+      delete process.env.OPENCODE_NPM_INSTALL_TIMEOUT
+      server.stop()
+    }
+  })
 })
 
 describe("Npm.install", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #31463

Related: #41934, #44684, #27971, #47212. Port of #41936 (v2) to the v1 line.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`Npm.reify()` awaits arborist's `reify()` with no bound. During instance bootstrap, `plugin.init()` runs it ahead of every service and ahead of any request being answered — and the HTTP listener is already bound by then, so from outside the server looks healthy while it waits. With a cold cache and a slow or wedged registry that wait runs to npm's own retry ceiling; I measured 181–370 s across ~60 headless `serve` runs before the first request got an answer.

This adds `OPENCODE_NPM_INSTALL_TIMEOUT` (default `300000` ms, matching npm's `fetch-timeout` so a slow registry fails the way npm itself would). A timeout surfaces as the existing `InstallFailedError` with cause `npm install timed out after <n>ms` and is logged, instead of hanging the session path.

Semantics are the same as #41936; only the syntax is adapted to `packages/core/src/npm.ts`'s Effect pipeline, and no new error class is needed because `dev` already has the one that PR introduces. The timeout abandons the fiber but does not cancel arborist's promise, same as the `Promise.race` in the original.

### How did you verify your code works?

- New test: a local registry that never responds, `OPENCODE_NPM_INSTALL_TIMEOUT=1000` → `Npm.add()` fails with `InstallFailedError` within the bound.
- Set the default to `1` ms: the existing tests that do a real `reify()` fail with the timeout error. Restored it: back to green. So the bound fires on genuine installs, not only the mocked case.
- `packages/core`: 1098/1098, `tsgo --noEmit` clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

Co-authored with @Robin1987China, who wrote the original.
