### PR TITLE
fix(tui): rename /variants slash to /reasoning, keep variants alias

### DIFF
--- a/packages/tui/src/app.tsx
+++ b/packages/tui/src/app.tsx
@@ -714,7 +714,8 @@ function App(props: { onSnapshot?: () => Promise<string[]>; pluginHost: TuiPlugi
         title: "Switch model variant",
         category: "Agent",
         hidden: local.model.variant.list().length === 0,
-        slashName: "variants",
+        slashName: "reasoning",
+        slashAliases: ["variants"],
         run: () => {
           if (local.model.variant.list().length === 0) {
             return toast.show({


### PR DESCRIPTION
### Issue for this PR

Closes #47432

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Makes /reasoning the slash name for the model-variant picker (variant.list in packages/tui/src/app.tsx) and keeps /variants as an alias. Variants are reasoning-effort levels, so /reasoning says what the picker does. Same slashAliases pattern as sessions, exit, models. Titles, keybinds, and variant logic untouched.

### How did you verify your code works?

tsgo --noEmit on packages/tui is clean, oxlint on app.tsx reports 0 errors, and the tui keymap tests pass (2 pass). keymap.tsx builds slash entries from slashName plus slashAliases, so both triggers dispatch to variant.list.

### Screenshots / recordings

N/A — same dialog, only the slash trigger changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR