### PR TITLE
feat(ai): resolve Bedrock credentials through the AWS default chain

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       "name": "@opencode-ai/ai",
       "version": "1.17.20",
       "dependencies": {
+        "@aws-sdk/credential-providers": "3.1057.0",
         "@opencode-ai/schema": "workspace:*",
         "@smithy/eventstream-codec": "4.2.14",
         "@smithy/util-utf8": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "packageManager": "bun@1.4.1",
   "scripts": {
-    "dev": "bun run --cwd packages/cli --conditions=browser src/index.ts",
+    "dev": "bun run --cwd packages/cli src/index.ts",
     "dev:live": "sh -c 'OPENCODE_TUI_CHANNEL=dev OPENCODE_PASSWORD=\"$(opencode2 service get password)\" exec bun run dev \"$@\" --server \"$(opencode2 service status)\"' --",
     "dev:desktop": "bun --cwd packages/desktop dev",
     "dev:web": "bun --cwd packages/app dev",

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -28,6 +28,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
+    "@aws-sdk/credential-providers": "3.1057.0",
     "@smithy/eventstream-codec": "4.2.14",
     "@smithy/util-utf8": "4.2.2",
     "@opencode-ai/schema": "workspace:*",

--- a/packages/ai/src/protocols/utils/bedrock-auth.ts
+++ b/packages/ai/src/protocols/utils/bedrock-auth.ts
@@ -16,11 +16,7 @@ export interface Credentials {
   readonly sessionToken?: string
 }
 
-/**
- * Static credentials or an effect resolved before every request. Effect sources
- * own caching and refresh, which is how STS, SSO, and instance credentials stay
- * valid across a long-lived model.
- */
+/** Static credentials or an effect resolved before every request. */
 export type CredentialSource = Credentials | Effect.Effect<Credentials, AIError>
 
 export interface DefaultChainOptions {
@@ -32,21 +28,16 @@ export interface DefaultChainOptions {
 /**
  * Resolve credentials through the AWS default provider chain: environment
  * variables, shared config and SSO caches, web identity tokens, process
- * credentials, and container or instance metadata. The chain is created once
- * per model and memoizes credentials internally, refreshing them before expiry.
+ * credentials, and container or instance metadata. A fresh chain runs on every
+ * request so credentials rotated on disk without an expiration (for example
+ * shared-config keys rewritten by a corporate SSO tool) are always re-read;
+ * the SDK's own memoization would otherwise pin them for the process lifetime.
  */
-export const defaultChain = (options: DefaultChainOptions): Effect.Effect<Credentials, AIError> => {
-  let chain: Promise<() => Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }>> | undefined
-  const load = () => {
-    if (chain) return chain
-    chain = import("@aws-sdk/credential-providers").then(({ fromNodeProviderChain }) =>
-      fromNodeProviderChain(options.profile === undefined ? {} : { profile: options.profile }),
-    )
-    return chain
-  }
-  return Effect.tryPromise({
+export const defaultChain = (options: DefaultChainOptions): Effect.Effect<Credentials, AIError> =>
+  Effect.tryPromise({
     try: async () => {
-      const identity = await (await load())()
+      const { fromNodeProviderChain } = await import("@aws-sdk/credential-providers")
+      const identity = await fromNodeProviderChain(options.profile === undefined ? {} : { profile: options.profile })()
       return {
         region: options.region,
         accessKeyId: identity.accessKeyId,
@@ -62,7 +53,6 @@ export const defaultChain = (options: DefaultChainOptions): Effect.Effect<Creden
         }),
       }),
   })
-}
 
 const signRequest = (input: {
   readonly url: string

--- a/packages/ai/src/protocols/utils/bedrock-auth.ts
+++ b/packages/ai/src/protocols/utils/bedrock-auth.ts
@@ -2,19 +2,66 @@ import { AwsV4Signer } from "aws4fetch"
 import { Effect } from "effect"
 import { Headers } from "effect/unstable/http"
 import { Auth, type AuthInput } from "../../route/auth.js"
+import { AIError, AuthenticationError } from "../../schema/index.js"
 import { ProviderShared } from "../shared.js"
 
 /**
  * AWS credentials for SigV4 signing. Bedrock also supports Bearer API key auth,
- * which provider facades configure as route auth instead of SigV4. STS-vended
- * credentials should be refreshed by the consumer (rebuild the model) before
- * they expire; the route does not refresh.
+ * which provider facades configure as route auth instead of SigV4.
  */
 export interface Credentials {
   readonly region: string
   readonly accessKeyId: string
   readonly secretAccessKey: string
   readonly sessionToken?: string
+}
+
+/**
+ * Static credentials or an effect resolved before every request. Effect sources
+ * own caching and refresh, which is how STS, SSO, and instance credentials stay
+ * valid across a long-lived model.
+ */
+export type CredentialSource = Credentials | Effect.Effect<Credentials, AIError>
+
+export interface DefaultChainOptions {
+  readonly region: string
+  /** Shared config profile passed to the AWS default chain. */
+  readonly profile?: string
+}
+
+/**
+ * Resolve credentials through the AWS default provider chain: environment
+ * variables, shared config and SSO caches, web identity tokens, process
+ * credentials, and container or instance metadata. The chain is created once
+ * per model and memoizes credentials internally, refreshing them before expiry.
+ */
+export const defaultChain = (options: DefaultChainOptions): Effect.Effect<Credentials, AIError> => {
+  let chain: Promise<() => Promise<{ accessKeyId: string; secretAccessKey: string; sessionToken?: string }>> | undefined
+  const load = () => {
+    if (chain) return chain
+    chain = import("@aws-sdk/credential-providers").then(({ fromNodeProviderChain }) =>
+      fromNodeProviderChain(options.profile === undefined ? {} : { profile: options.profile }),
+    )
+    return chain
+  }
+  return Effect.tryPromise({
+    try: async () => {
+      const identity = await (await load())()
+      return {
+        region: options.region,
+        accessKeyId: identity.accessKeyId,
+        secretAccessKey: identity.secretAccessKey,
+        ...(identity.sessionToken === undefined ? {} : { sessionToken: identity.sessionToken }),
+      }
+    },
+    catch: (error) =>
+      new AIError({
+        reason: new AuthenticationError({
+          message: `AWS default credential chain failed: ${ProviderShared.errorText(error)}`,
+          cause: error,
+        }),
+      }),
+  })
 }
 
 const signRequest = (input: {
@@ -48,16 +95,17 @@ const signRequest = (input: {
 
 /** Sign the exact JSON bytes with SigV4 using credentials configured on the route. */
 export const sigV4 = (
-  credentials: Credentials | undefined,
+  source: CredentialSource | undefined,
   options: { readonly service?: string; readonly name?: string } = {},
 ) =>
   Auth.custom((input: AuthInput) => {
     return Effect.gen(function* () {
-      if (!credentials) {
+      if (!source) {
         return yield* ProviderShared.invalidRequest(
           `${options.name ?? "Bedrock Converse"} requires either route bearer auth or AWS credentials configured on the route`,
         )
       }
+      const credentials = Effect.isEffect(source) ? yield* source : source
       const headersForSigning = Headers.set(input.headers, "content-type", "application/json")
       const signed = yield* signRequest({
         url: input.url,
@@ -73,5 +121,36 @@ export const sigV4 = (
 
 /** Bedrock route auth defaults to SigV4 and expects credentials from route configuration. */
 export const auth = sigV4(undefined)
+
+export const resolveRegion = (input: {
+  readonly region?: string
+  readonly credentials?: { readonly region: string }
+}) =>
+  input.region ?? input.credentials?.region ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? "us-east-1"
+
+export interface ResolveAuthInput {
+  readonly apiKey?: string
+  readonly credentials?: Credentials
+  readonly profile?: string
+}
+
+export interface ResolveAuthOptions {
+  readonly service?: string
+  readonly name?: string
+  /** `sigv4` ignores an ambient `AWS_BEARER_TOKEN_BEDROCK`; `bearer` is validated by the caller. */
+  readonly mode?: "bearer" | "sigv4"
+}
+
+/**
+ * Bearer wins over SigV4 and explicit static credentials win over the default
+ * chain, matching the AWS SDK's own precedence for `AWS_BEARER_TOKEN_BEDROCK`.
+ * The region is applied to the SigV4 scope so it always matches the endpoint host.
+ */
+export const resolveAuth = (input: ResolveAuthInput, region: string, options: ResolveAuthOptions = {}) => {
+  const apiKey = options.mode === "sigv4" ? undefined : (input.apiKey ?? process.env.AWS_BEARER_TOKEN_BEDROCK)
+  if (apiKey !== undefined) return Auth.bearer(apiKey)
+  if (input.credentials !== undefined) return sigV4({ ...input.credentials, region }, options)
+  return sigV4(defaultChain({ region, profile: input.profile }), options)
+}
 
 export * as BedrockAuth from "./bedrock-auth.js"

--- a/packages/ai/src/providers/amazon-bedrock-mantle.ts
+++ b/packages/ai/src/providers/amazon-bedrock-mantle.ts
@@ -11,6 +11,8 @@ export const id = ProviderID.make("amazon-bedrock")
 export type Config = RouteDefaultsInput & {
   /** Bedrock API key. Falls back to `AWS_BEARER_TOKEN_BEDROCK`; bearer auth takes precedence over SigV4. */
   readonly apiKey?: string
+  /** `sigv4` ignores `apiKey` fallbacks from the environment; `bearer` requires a token. */
+  readonly auth?: "bearer" | "sigv4"
   readonly baseURL?: string
   /** Static SigV4 credentials. When omitted the AWS default credential chain resolves them per request. */
   readonly credentials?: Credentials
@@ -50,26 +52,38 @@ const chatRoute = OpenAIChat.route.with({
 
 export const routes = [responsesRoute, chatRoute]
 
-const configuredRoute = <Body, Prepared>(
-  route: Route<Body, Prepared>,
-  input: Config,
-  mode?: BedrockAuth.ResolveAuthOptions["mode"],
-) => {
+const configuredRoute = <Body, Prepared>(route: Route<Body, Prepared>, input: Config) => {
   const region = BedrockAuth.resolveRegion(input)
   return route.with({
     endpoint: { baseURL: input.baseURL ?? `https://bedrock-mantle.${region}.api.aws/v1` },
-    auth: BedrockAuth.resolveAuth(input, region, { service: "bedrock-mantle", name: "Bedrock Mantle", mode }),
+    auth: BedrockAuth.resolveAuth(input, region, {
+      service: "bedrock-mantle",
+      name: "Bedrock Mantle",
+      mode: input.auth,
+    }),
   })
 }
 
 const defaults = (input: Config) => {
-  const { apiKey: _, baseURL: _baseURL, credentials: _credentials, profile: _profile, region: _region, ...rest } = input
+  const {
+    apiKey: _,
+    auth: _auth,
+    baseURL: _baseURL,
+    credentials: _credentials,
+    profile: _profile,
+    region: _region,
+    ...rest
+  } = input
   return rest
 }
 
-const build = (input: Config, mode?: BedrockAuth.ResolveAuthOptions["mode"]) => {
-  const configuredResponsesRoute = configuredRoute(responsesRoute, input, mode)
-  const configuredChatRoute = configuredRoute(chatRoute, input, mode)
+export const configure = (input: Config = {}) => {
+  if (input.auth === "bearer" && input.apiKey === undefined && process.env.AWS_BEARER_TOKEN_BEDROCK === undefined)
+    throw new Error("Amazon Bedrock Mantle bearer auth requires apiKey")
+  if (input.auth === "sigv4" && input.apiKey !== undefined)
+    throw new Error("Amazon Bedrock Mantle SigV4 auth does not accept apiKey")
+  const configuredResponsesRoute = configuredRoute(responsesRoute, input)
+  const configuredChatRoute = configuredRoute(chatRoute, input)
   const modelDefaults = defaults(input)
   const responses = (modelID: string | ModelID) =>
     configuredResponsesRoute
@@ -89,30 +103,21 @@ const build = (input: Config, mode?: BedrockAuth.ResolveAuthOptions["mode"]) => 
   }
 }
 
-export const configure = (input: Config = {}) => build(input)
-
 export const provider = configure()
 
-const fromSettings = (settings: Settings) => {
-  if (settings.auth === "bearer" && settings.apiKey === undefined && process.env.AWS_BEARER_TOKEN_BEDROCK === undefined)
-    throw new Error("Amazon Bedrock Mantle bearer auth requires apiKey")
-  if (settings.auth === "sigv4" && settings.apiKey !== undefined)
-    throw new Error("Amazon Bedrock Mantle SigV4 auth does not accept apiKey")
-  return build(
-    {
-      apiKey: settings.apiKey,
-      baseURL: settings.baseURL,
-      credentials: settings.credentials,
-      generation: settings.topP === undefined ? undefined : { topP: settings.topP },
-      headers: settings.headers === undefined ? undefined : { ...settings.headers },
-      http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-      profile: settings.profile,
-      providerOptions: settings.providerOptions,
-      region: settings.region,
-    },
-    settings.auth,
-  )
-}
+const fromSettings = (settings: Settings) =>
+  configure({
+    apiKey: settings.apiKey,
+    auth: settings.auth,
+    baseURL: settings.baseURL,
+    credentials: settings.credentials,
+    generation: settings.topP === undefined ? undefined : { topP: settings.topP },
+    headers: settings.headers === undefined ? undefined : { ...settings.headers },
+    http: settings.body === undefined ? undefined : { body: { ...settings.body } },
+    profile: settings.profile,
+    providerOptions: settings.providerOptions,
+    region: settings.region,
+  })
 
 export const chatModel: ProviderPackage.Definition<Settings, OpenAIProviderOptionsInput>["model"] = (
   modelID,

--- a/packages/ai/src/providers/amazon-bedrock-mantle.ts
+++ b/packages/ai/src/providers/amazon-bedrock-mantle.ts
@@ -1,4 +1,3 @@
-import { Auth } from "../route/auth.js"
 import { Route, type RouteDefaultsInput } from "../route/client.js"
 import type { ProviderPackage } from "../provider-package.js"
 import { OpenAIChat } from "../protocols/openai-chat.js"
@@ -10,9 +9,13 @@ import { withOpenAIOptions, type OpenAIProviderOptionsInput } from "./openai-opt
 export const id = ProviderID.make("amazon-bedrock")
 
 export type Config = RouteDefaultsInput & {
+  /** Bedrock API key. Falls back to `AWS_BEARER_TOKEN_BEDROCK`; bearer auth takes precedence over SigV4. */
   readonly apiKey?: string
   readonly baseURL?: string
+  /** Static SigV4 credentials. When omitted the AWS default credential chain resolves them per request. */
   readonly credentials?: Credentials
+  /** Shared config profile for the default credential chain. */
+  readonly profile?: string
   readonly region?: string
   readonly providerOptions?: OpenAIProviderOptionsInput
 }
@@ -22,6 +25,7 @@ export interface Settings extends ProviderPackage.Settings {
   readonly auth?: "bearer" | "sigv4"
   readonly baseURL?: string
   readonly credentials?: Credentials
+  readonly profile?: string
   readonly region?: string
   readonly topP?: number
   readonly providerOptions?: OpenAIProviderOptionsInput
@@ -46,26 +50,26 @@ const chatRoute = OpenAIChat.route.with({
 
 export const routes = [responsesRoute, chatRoute]
 
-const configuredRoute = <Body, Prepared>(route: Route<Body, Prepared>, input: Config) => {
-  const region = input.region ?? input.credentials?.region ?? "us-east-1"
-  const credentials = input.credentials === undefined ? undefined : { ...input.credentials, region }
+const configuredRoute = <Body, Prepared>(
+  route: Route<Body, Prepared>,
+  input: Config,
+  mode?: BedrockAuth.ResolveAuthOptions["mode"],
+) => {
+  const region = BedrockAuth.resolveRegion(input)
   return route.with({
     endpoint: { baseURL: input.baseURL ?? `https://bedrock-mantle.${region}.api.aws/v1` },
-    auth:
-      input.apiKey === undefined
-        ? BedrockAuth.sigV4(credentials, { service: "bedrock-mantle", name: "Bedrock Mantle" })
-        : Auth.bearer(input.apiKey),
+    auth: BedrockAuth.resolveAuth(input, region, { service: "bedrock-mantle", name: "Bedrock Mantle", mode }),
   })
 }
 
 const defaults = (input: Config) => {
-  const { apiKey: _, baseURL: _baseURL, credentials: _credentials, region: _region, ...rest } = input
+  const { apiKey: _, baseURL: _baseURL, credentials: _credentials, profile: _profile, region: _region, ...rest } = input
   return rest
 }
 
-export const configure = (input: Config = {}) => {
-  const configuredResponsesRoute = configuredRoute(responsesRoute, input)
-  const configuredChatRoute = configuredRoute(chatRoute, input)
+const build = (input: Config, mode?: BedrockAuth.ResolveAuthOptions["mode"]) => {
+  const configuredResponsesRoute = configuredRoute(responsesRoute, input, mode)
+  const configuredChatRoute = configuredRoute(chatRoute, input, mode)
   const modelDefaults = defaults(input)
   const responses = (modelID: string | ModelID) =>
     configuredResponsesRoute
@@ -85,31 +89,37 @@ export const configure = (input: Config = {}) => {
   }
 }
 
+export const configure = (input: Config = {}) => build(input)
+
 export const provider = configure()
 
-const config = (settings: Settings): Config => {
-  if (settings.auth === "bearer" && settings.apiKey === undefined)
+const fromSettings = (settings: Settings) => {
+  if (settings.auth === "bearer" && settings.apiKey === undefined && process.env.AWS_BEARER_TOKEN_BEDROCK === undefined)
     throw new Error("Amazon Bedrock Mantle bearer auth requires apiKey")
   if (settings.auth === "sigv4" && settings.apiKey !== undefined)
     throw new Error("Amazon Bedrock Mantle SigV4 auth does not accept apiKey")
-  return {
-    apiKey: settings.auth === "sigv4" ? undefined : settings.apiKey,
-    baseURL: settings.baseURL,
-    credentials: settings.credentials,
-    generation: settings.topP === undefined ? undefined : { topP: settings.topP },
-    headers: settings.headers === undefined ? undefined : { ...settings.headers },
-    http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    providerOptions: settings.providerOptions,
-    region: settings.region,
-  }
+  return build(
+    {
+      apiKey: settings.apiKey,
+      baseURL: settings.baseURL,
+      credentials: settings.credentials,
+      generation: settings.topP === undefined ? undefined : { topP: settings.topP },
+      headers: settings.headers === undefined ? undefined : { ...settings.headers },
+      http: settings.body === undefined ? undefined : { body: { ...settings.body } },
+      profile: settings.profile,
+      providerOptions: settings.providerOptions,
+      region: settings.region,
+    },
+    settings.auth,
+  )
 }
 
 export const chatModel: ProviderPackage.Definition<Settings, OpenAIProviderOptionsInput>["model"] = (
   modelID,
   settings,
-) => configure(config(settings)).chat(modelID)
+) => fromSettings(settings).chat(modelID)
 export const responsesModel: ProviderPackage.Definition<Settings, OpenAIProviderOptionsInput>["model"] = (
   modelID,
   settings,
-) => configure(config(settings)).responses(modelID)
+) => fromSettings(settings).responses(modelID)
 export const model = responsesModel

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -10,6 +10,8 @@ export const id = ProviderID.make("amazon-bedrock")
 export type Config = RouteDefaultsInput & {
   /** Bedrock API key. Falls back to `AWS_BEARER_TOKEN_BEDROCK`; bearer auth takes precedence over SigV4. */
   readonly apiKey?: string
+  /** `sigv4` ignores `apiKey` fallbacks from the environment; `bearer` requires a token. */
+  readonly auth?: "bearer" | "sigv4"
   readonly headers?: Record<string, string>
   /** Static SigV4 credentials. When omitted the AWS default credential chain resolves them per request. */
   readonly credentials?: BedrockCredentials
@@ -34,15 +36,18 @@ export const routes = [BedrockConverse.route]
 
 const bedrockBaseURL = (region: string) => `https://bedrock-runtime.${region}.amazonaws.com`
 
-const configuredRoute = (input: Config, mode?: BedrockAuth.ResolveAuthOptions["mode"]) => {
-  const { apiKey, credentials, profile, region, baseURL, ...rest } = input
+const configuredRoute = (input: Config) => {
+  const { apiKey, auth, credentials, profile, region, baseURL, ...rest } = input
+  if (auth === "bearer" && apiKey === undefined && process.env.AWS_BEARER_TOKEN_BEDROCK === undefined)
+    throw new Error("Amazon Bedrock bearer auth requires apiKey")
+  if (auth === "sigv4" && apiKey !== undefined) throw new Error("Amazon Bedrock SigV4 auth does not accept apiKey")
   const resolvedRegion = BedrockAuth.resolveRegion(input)
   return BedrockConverse.route.with({
     ...rest,
     provider: id,
     providerMetadataKey: "bedrock",
     endpoint: { baseURL: baseURL ?? bedrockBaseURL(resolvedRegion) },
-    auth: BedrockAuth.resolveAuth({ apiKey, credentials, profile }, resolvedRegion, { mode }),
+    auth: BedrockAuth.resolveAuth({ apiKey, credentials, profile }, resolvedRegion, { mode: auth }),
   })
 }
 
@@ -56,22 +61,15 @@ export const configure = (input: Config = {}) => {
 }
 
 export const provider = configure()
-export const model: ProviderPackage.Definition<Settings>["model"] = (modelID, settings) => {
-  if (settings.auth === "bearer" && settings.apiKey === undefined && process.env.AWS_BEARER_TOKEN_BEDROCK === undefined)
-    throw new Error("Amazon Bedrock bearer auth requires apiKey")
-  if (settings.auth === "sigv4" && settings.apiKey !== undefined)
-    throw new Error("Amazon Bedrock SigV4 auth does not accept apiKey")
-  return configuredRoute(
-    {
-      apiKey: settings.apiKey,
-      baseURL: settings.baseURL,
-      credentials: settings.credentials,
-      generation: settings.topP === undefined ? undefined : { topP: settings.topP },
-      headers: settings.headers === undefined ? undefined : { ...settings.headers },
-      http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-      profile: settings.profile,
-      region: settings.region,
-    },
-    settings.auth,
-  ).model({ id: modelID })
-}
+export const model: ProviderPackage.Definition<Settings>["model"] = (modelID, settings) =>
+  configure({
+    apiKey: settings.apiKey,
+    auth: settings.auth,
+    baseURL: settings.baseURL,
+    credentials: settings.credentials,
+    generation: settings.topP === undefined ? undefined : { topP: settings.topP },
+    headers: settings.headers === undefined ? undefined : { ...settings.headers },
+    http: settings.body === undefined ? undefined : { body: { ...settings.body } },
+    profile: settings.profile,
+    region: settings.region,
+  }).model(modelID)

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -1,17 +1,21 @@
 import type { RouteDefaultsInput } from "../route/client.js"
-import { Auth } from "../route/auth.js"
 import type { ProviderPackage } from "../provider-package.js"
 import { ProviderID, type ModelID } from "../schema/index.js"
 import * as BedrockConverse from "../protocols/bedrock-converse.js"
 import type { BedrockCredentials } from "../protocols/bedrock-converse.js"
+import { BedrockAuth } from "../protocols/utils/bedrock-auth.js"
 
 export const id = ProviderID.make("amazon-bedrock")
 
 export type Config = RouteDefaultsInput & {
+  /** Bedrock API key. Falls back to `AWS_BEARER_TOKEN_BEDROCK`; bearer auth takes precedence over SigV4. */
   readonly apiKey?: string
   readonly headers?: Record<string, string>
+  /** Static SigV4 credentials. When omitted the AWS default credential chain resolves them per request. */
   readonly credentials?: BedrockCredentials
-  /** AWS region. Defaults to `us-east-1` when neither this nor `credentials.region` is set. */
+  /** Shared config profile for the default credential chain. */
+  readonly profile?: string
+  /** AWS region. Falls back to `credentials.region`, `AWS_REGION`, `AWS_DEFAULT_REGION`, then `us-east-1`. */
   readonly region?: string
   /** Override the computed `https://bedrock-runtime.<region>.amazonaws.com` URL. */
   readonly baseURL?: string
@@ -22,6 +26,7 @@ export interface Settings extends ProviderPackage.Settings {
   readonly auth?: "bearer" | "sigv4"
   readonly baseURL?: string
   readonly credentials?: BedrockCredentials
+  readonly profile?: string
   readonly region?: string
   readonly topP?: number
 }
@@ -29,15 +34,15 @@ export const routes = [BedrockConverse.route]
 
 const bedrockBaseURL = (region: string) => `https://bedrock-runtime.${region}.amazonaws.com`
 
-const configuredRoute = (input: Config) => {
-  const { apiKey, credentials, region, baseURL, ...rest } = input
-  const resolvedRegion = region ?? credentials?.region ?? "us-east-1"
+const configuredRoute = (input: Config, mode?: BedrockAuth.ResolveAuthOptions["mode"]) => {
+  const { apiKey, credentials, profile, region, baseURL, ...rest } = input
+  const resolvedRegion = BedrockAuth.resolveRegion(input)
   return BedrockConverse.route.with({
     ...rest,
     provider: id,
     providerMetadataKey: "bedrock",
     endpoint: { baseURL: baseURL ?? bedrockBaseURL(resolvedRegion) },
-    auth: apiKey === undefined ? BedrockConverse.sigV4Auth(credentials) : Auth.bearer(apiKey),
+    auth: BedrockAuth.resolveAuth({ apiKey, credentials, profile }, resolvedRegion, { mode }),
   })
 }
 
@@ -52,17 +57,21 @@ export const configure = (input: Config = {}) => {
 
 export const provider = configure()
 export const model: ProviderPackage.Definition<Settings>["model"] = (modelID, settings) => {
-  if (settings.auth === "bearer" && settings.apiKey === undefined)
+  if (settings.auth === "bearer" && settings.apiKey === undefined && process.env.AWS_BEARER_TOKEN_BEDROCK === undefined)
     throw new Error("Amazon Bedrock bearer auth requires apiKey")
   if (settings.auth === "sigv4" && settings.apiKey !== undefined)
     throw new Error("Amazon Bedrock SigV4 auth does not accept apiKey")
-  return configure({
-    apiKey: settings.auth === "sigv4" ? undefined : settings.apiKey,
-    baseURL: settings.baseURL,
-    credentials: settings.credentials,
-    generation: settings.topP === undefined ? undefined : { topP: settings.topP },
-    headers: settings.headers === undefined ? undefined : { ...settings.headers },
-    http: settings.body === undefined ? undefined : { body: { ...settings.body } },
-    region: settings.region,
-  }).model(modelID)
+  return configuredRoute(
+    {
+      apiKey: settings.apiKey,
+      baseURL: settings.baseURL,
+      credentials: settings.credentials,
+      generation: settings.topP === undefined ? undefined : { topP: settings.topP },
+      headers: settings.headers === undefined ? undefined : { ...settings.headers },
+      http: settings.body === undefined ? undefined : { body: { ...settings.body } },
+      profile: settings.profile,
+      region: settings.region,
+    },
+    settings.auth,
+  ).model({ id: modelID })
 }

--- a/packages/ai/test/lib/env.ts
+++ b/packages/ai/test/lib/env.ts
@@ -1,0 +1,30 @@
+import { Effect } from "effect"
+
+/**
+ * Run an effect with `process.env` overrides, restoring the previous values
+ * afterwards. Use for code that reads `process.env` directly, such as AWS SDK
+ * credential providers, where Effect `ConfigProvider` layers do not apply.
+ * `undefined` removes a variable for the duration of the effect.
+ */
+export const withProcessEnv =
+  (env: Record<string, string | undefined>) =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => {
+        const previous = Object.fromEntries(Object.keys(env).map((name) => [name, process.env[name]]))
+        apply(env)
+        return previous
+      }),
+      () => effect,
+      (previous) => Effect.sync(() => apply(previous)),
+    )
+
+const apply = (env: Record<string, string | undefined>) => {
+  for (const [name, value] of Object.entries(env)) {
+    if (value === undefined) {
+      delete process.env[name]
+      continue
+    }
+    process.env[name] = value
+  }
+}

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -1404,6 +1404,27 @@ describe("Bedrock Converse route", () => {
     ),
   )
 
+  it.effect("re-resolves rotated chain credentials on the next request without rebuilding the model", () =>
+    Effect.gen(function* () {
+      const chained = AmazonBedrock.configure({ baseURL: "https://bedrock-runtime.test", region: "us-west-2" }).model(
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      )
+      const first = yield* captureHeaders(chained)
+      const second = yield* captureHeaders(chained).pipe(
+        withProcessEnv({ AWS_ACCESS_KEY_ID: "AKIAROTATEDEXAMPLE", AWS_SECRET_ACCESS_KEY: "rotated-secret" }),
+      )
+
+      expect(first.get("authorization")).toContain("Credential=AKIACHAINEXAMPLE/")
+      expect(second.get("authorization")).toContain("Credential=AKIAROTATEDEXAMPLE/")
+    }).pipe(
+      withProcessEnv({
+        ...noAmbientAWS,
+        AWS_ACCESS_KEY_ID: "AKIACHAINEXAMPLE",
+        AWS_SECRET_ACCESS_KEY: "chain-secret",
+      }),
+    ),
+  )
+
   it.effect("prefers AWS_BEARER_TOKEN_BEDROCK over the credential chain", () =>
     Effect.gen(function* () {
       const bearer = AmazonBedrock.configure({ baseURL: "https://bedrock-runtime.test" }).model(

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -1443,16 +1443,22 @@ describe("Bedrock Converse route", () => {
     ),
   )
 
-  it.effect("explicit sigv4 settings ignore an ambient bearer token", () =>
+  it.effect("auth: sigv4 ignores an ambient bearer token from configure and settings", () =>
     Effect.gen(function* () {
-      const signed = AmazonBedrock.model("anthropic.claude-3-5-sonnet-20240620-v1:0", {
+      const configured = AmazonBedrock.configure({ auth: "sigv4", baseURL: "https://bedrock-runtime.test" }).model(
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      )
+      const fromSettings = AmazonBedrock.model("anthropic.claude-3-5-sonnet-20240620-v1:0", {
         auth: "sigv4",
         baseURL: "https://bedrock-runtime.test",
       })
-      const headers = yield* captureHeaders(signed)
 
-      expect(headers.get("authorization")).toContain("Credential=AKIACHAINEXAMPLE/")
-      expect(headers.get("authorization")).toContain("/ap-southeast-2/bedrock/aws4_request")
+      for (const target of [configured, fromSettings]) {
+        const headers = yield* captureHeaders(target)
+        expect(headers.get("authorization")).toContain("Credential=AKIACHAINEXAMPLE/")
+        expect(headers.get("authorization")).toContain("/ap-southeast-2/bedrock/aws4_request")
+      }
+      expect(() => AmazonBedrock.configure({ auth: "sigv4", apiKey: "k" })).toThrow("does not accept apiKey")
     }).pipe(
       withProcessEnv({
         ...noAmbientAWS,

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -2,9 +2,11 @@ import { EventStreamCodec } from "@smithy/eventstream-codec"
 import { fromUtf8, toUtf8 } from "@smithy/util-utf8"
 import { describe, expect } from "bun:test"
 import { Effect, Encoding, Ref, Stream } from "effect"
+import { HttpClientRequest } from "effect/unstable/http"
 import {
   CacheHint,
   GenerationOptions,
+  type LanguageModel,
   LLM,
   LLMEvent,
   LLMRequest,
@@ -18,7 +20,8 @@ import { compileRequest } from "../../src/route/client.js"
 import { AmazonBedrock } from "../../src/providers.js"
 import * as BedrockConverse from "../../src/protocols/bedrock-converse.js"
 import { it } from "../lib/effect.js"
-import { fixedResponse } from "../lib/http.js"
+import { withProcessEnv } from "../lib/env.js"
+import { dynamicResponse, fixedResponse } from "../lib/http.js"
 import {
   eventSummary,
   expectWeatherToolLoop,
@@ -94,6 +97,41 @@ const fixedByteChunks = (...chunks: ReadonlyArray<Uint8Array>) =>
     }),
     { headers: { "content-type": "application/vnd.amazon.eventstream" } },
   )
+
+// Clears every input the AWS default chain reads so tests do not pick up the
+// developer's profiles, SSO cache, or instance metadata.
+const noAmbientAWS = {
+  AWS_ACCESS_KEY_ID: undefined,
+  AWS_SECRET_ACCESS_KEY: undefined,
+  AWS_SESSION_TOKEN: undefined,
+  AWS_BEARER_TOKEN_BEDROCK: undefined,
+  AWS_PROFILE: undefined,
+  AWS_REGION: undefined,
+  AWS_DEFAULT_REGION: undefined,
+  AWS_WEB_IDENTITY_TOKEN_FILE: undefined,
+  AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: undefined,
+  AWS_CONTAINER_CREDENTIALS_FULL_URI: undefined,
+  AWS_EC2_METADATA_DISABLED: "true",
+}
+
+const captureHeaders = (target: LanguageModel) =>
+  Effect.gen(function* () {
+    const seen: Array<Headers> = []
+    yield* LLMClient.generate(LLMRequest.update(baseRequest, { model: target })).pipe(
+      Effect.provide(
+        dynamicResponse((input) =>
+          Effect.gen(function* () {
+            const request = yield* HttpClientRequest.toWeb(input.request)
+            seen.push(request.headers)
+            return input.respond(eventStreamBody(["messageStop", { stopReason: "end_turn" }]), {
+              headers: { "content-type": "application/vnd.amazon.eventstream" },
+            })
+          }),
+        ),
+      ),
+    )
+    return seen[0]!
+  })
 
 const model = AmazonBedrock.configure({
   baseURL: "https://bedrock-runtime.test",
@@ -1311,35 +1349,110 @@ describe("Bedrock Converse route", () => {
     }),
   )
 
-  it.effect("rejects requests with no auth path", () =>
+  it.effect("fails with an authentication error when the default chain cannot resolve credentials", () =>
     Effect.gen(function* () {
       const unsignedModel = AmazonBedrock.configure({
         baseURL: "https://bedrock-runtime.test",
+        profile: "opencode-test-missing-profile",
       }).model("anthropic.claude-3-5-sonnet-20240620-v1:0")
       const error = yield* LLMClient.generate(LLMRequest.update(baseRequest, { model: unsignedModel })).pipe(
         Effect.provide(fixedBytes(eventStreamBody(["messageStop", { stopReason: "end_turn" }]))),
         Effect.flip,
       )
 
-      expect(error.message).toContain("Bedrock Converse requires either route bearer auth or AWS credentials")
-    }),
+      expect(error.reason._tag).toBe("Authentication")
+      expect(error.message).toContain("AWS default credential chain failed")
+    }).pipe(withProcessEnv(noAmbientAWS)),
   )
 
-  it.effect("signs requests with SigV4 when AWS credentials are provided (deterministic plumbing check)", () =>
+  it.effect("signs with static credentials using the configured region for the SigV4 scope", () =>
     Effect.gen(function* () {
       const signed = AmazonBedrock.configure({
         baseURL: "https://bedrock-runtime.test",
+        region: "eu-west-1",
         credentials: {
           region: "us-east-1",
           accessKeyId: "AKIAIOSFODNN7EXAMPLE",
           secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
         },
       }).model("anthropic.claude-3-5-sonnet-20240620-v1:0")
-      const prepared = yield* compileRequest(LLMRequest.update(baseRequest, { model: signed }))
+      const headers = yield* captureHeaders(signed)
 
-      expect(prepared.route).toBe("bedrock-converse")
-      expect(prepared.model).toBe(signed)
-    }),
+      expect(headers.get("authorization")).toContain("Credential=AKIAIOSFODNN7EXAMPLE/")
+      expect(headers.get("authorization")).toContain("/eu-west-1/bedrock/aws4_request")
+      expect(headers.get("x-amz-security-token")).toBeNull()
+    }).pipe(withProcessEnv(noAmbientAWS)),
+  )
+
+  it.effect("resolves SigV4 credentials through the AWS default chain on every request", () =>
+    Effect.gen(function* () {
+      const chained = AmazonBedrock.configure({ baseURL: "https://bedrock-runtime.test", region: "us-west-2" }).model(
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      )
+      const headers = yield* captureHeaders(chained)
+
+      expect(headers.get("authorization")).toContain("Credential=AKIACHAINEXAMPLE/")
+      expect(headers.get("authorization")).toContain("/us-west-2/bedrock/aws4_request")
+      expect(headers.get("x-amz-security-token")).toBe("chain-session-token")
+    }).pipe(
+      withProcessEnv({
+        ...noAmbientAWS,
+        AWS_ACCESS_KEY_ID: "AKIACHAINEXAMPLE",
+        AWS_SECRET_ACCESS_KEY: "chain-secret",
+        AWS_SESSION_TOKEN: "chain-session-token",
+      }),
+    ),
+  )
+
+  it.effect("prefers AWS_BEARER_TOKEN_BEDROCK over the credential chain", () =>
+    Effect.gen(function* () {
+      const bearer = AmazonBedrock.configure({ baseURL: "https://bedrock-runtime.test" }).model(
+        "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      )
+      const headers = yield* captureHeaders(bearer)
+
+      expect(headers.get("authorization")).toBe("Bearer env-bearer-token")
+    }).pipe(
+      withProcessEnv({
+        ...noAmbientAWS,
+        AWS_BEARER_TOKEN_BEDROCK: "env-bearer-token",
+        AWS_ACCESS_KEY_ID: "AKIACHAINEXAMPLE",
+        AWS_SECRET_ACCESS_KEY: "chain-secret",
+      }),
+    ),
+  )
+
+  it.effect("explicit sigv4 settings ignore an ambient bearer token", () =>
+    Effect.gen(function* () {
+      const signed = AmazonBedrock.model("anthropic.claude-3-5-sonnet-20240620-v1:0", {
+        auth: "sigv4",
+        baseURL: "https://bedrock-runtime.test",
+      })
+      const headers = yield* captureHeaders(signed)
+
+      expect(headers.get("authorization")).toContain("Credential=AKIACHAINEXAMPLE/")
+      expect(headers.get("authorization")).toContain("/ap-southeast-2/bedrock/aws4_request")
+    }).pipe(
+      withProcessEnv({
+        ...noAmbientAWS,
+        AWS_BEARER_TOKEN_BEDROCK: "env-bearer-token",
+        AWS_REGION: "ap-southeast-2",
+        AWS_ACCESS_KEY_ID: "AKIACHAINEXAMPLE",
+        AWS_SECRET_ACCESS_KEY: "chain-secret",
+      }),
+    ),
+  )
+
+  it.effect("derives the endpoint region from AWS_REGION then AWS_DEFAULT_REGION", () =>
+    Effect.gen(function* () {
+      const fromRegion = AmazonBedrock.configure({ apiKey: "k" }).model("anthropic.claude-3-5-sonnet-20240620-v1:0")
+      expect(fromRegion.route.endpoint.baseURL).toBe("https://bedrock-runtime.eu-central-1.amazonaws.com")
+
+      const fromDefault = yield* Effect.sync(() =>
+        AmazonBedrock.configure({ apiKey: "k" }).model("anthropic.claude-3-5-sonnet-20240620-v1:0"),
+      ).pipe(withProcessEnv({ AWS_REGION: undefined }))
+      expect(fromDefault.route.endpoint.baseURL).toBe("https://bedrock-runtime.us-gov-west-1.amazonaws.com")
+    }).pipe(withProcessEnv({ ...noAmbientAWS, AWS_REGION: "eu-central-1", AWS_DEFAULT_REGION: "us-gov-west-1" })),
   )
 
   it.effect("emits cachePoint markers after system, user-text, and assistant-text with cache hints", () =>

--- a/packages/ai/test/provider/bedrock-mantle.test.ts
+++ b/packages/ai/test/provider/bedrock-mantle.test.ts
@@ -7,6 +7,7 @@ import { model } from "../../src/providers/amazon-bedrock/mantle.js"
 import { OpenAIResponses } from "../../src/protocols/openai-responses.js"
 import { compileRequest, LLMClient } from "../../src/route/client.js"
 import { it } from "../lib/effect.js"
+import { withProcessEnv } from "../lib/env.js"
 import { dynamicResponse, fixedResponse } from "../lib/http.js"
 import { sseEvents } from "../lib/sse.js"
 import { recordedTests } from "../recorded-test.js"
@@ -80,6 +81,36 @@ describe("Amazon Bedrock Mantle provider", () => {
       expect(seen[0]?.url).toBe("https://bedrock-mantle.us-west-1.api.aws/v1/responses")
       expect(seen[0]?.authorization).toContain("/us-west-1/bedrock-mantle/aws4_request")
     }),
+  )
+
+  it.effect("signs with the Mantle service using default-chain credentials", () =>
+    Effect.gen(function* () {
+      const seen: Array<string | undefined> = []
+      const model = AmazonBedrockMantle.configure({ region: "us-west-1" }).responses("openai.gpt-oss-120b")
+      yield* LLMClient.generate(LLM.request({ model, prompt: "Hi" })).pipe(
+        Effect.provide(
+          dynamicResponse((input) =>
+            Effect.gen(function* () {
+              const request = yield* HttpClientRequest.toWeb(input.request)
+              seen.push(request.headers.get("authorization") ?? undefined)
+              return input.respond("", { headers: { "content-type": "text/event-stream" } })
+            }),
+          ),
+        ),
+        Effect.flip,
+      )
+
+      expect(seen[0]).toContain("Credential=AKIACHAINEXAMPLE/")
+      expect(seen[0]).toContain("/us-west-1/bedrock-mantle/aws4_request")
+    }).pipe(
+      withProcessEnv({
+        AWS_BEARER_TOKEN_BEDROCK: undefined,
+        AWS_PROFILE: undefined,
+        AWS_ACCESS_KEY_ID: "AKIACHAINEXAMPLE",
+        AWS_SECRET_ACCESS_KEY: "chain-secret",
+        AWS_SESSION_TOKEN: undefined,
+      }),
+    ),
   )
 
   it.effect("supports bearer authentication and custom base URLs", () =>


### PR DESCRIPTION
## Problem

The native Bedrock routes in `packages/ai` only accepted a static `{ accessKeyId, secretAccessKey, sessionToken }` struct or a bearer `apiKey`. Nothing read `AWS_PROFILE`, `~/.aws` shared config, the SSO cache, web identity tokens, or instance/container metadata, and STS-vended credentials could not refresh because they were captured once at `configure()`. V1 delegated all of this to the AI SDK's `credentialProvider`; V2 dropped the AI SDK for Bedrock but never replaced that layer.

## Changes

- `BedrockAuth.sigV4` accepts a `CredentialSource` (static or `Effect<Credentials>`) resolved before every request.
- `BedrockAuth.defaultChain({ region, profile? })` lazily imports `@aws-sdk/credential-providers` and runs a fresh `fromNodeProviderChain` on every request. The SDK memoizes credentials that carry no `expiration` for the life of the provider, which pinned shared-config keys rotated on disk by SSO tooling (#30940); a per-request chain always re-reads them. Mirrors the Vertex ADC pattern in `google-vertex-shared.ts`.
- `BedrockAuth.resolveAuth` centralizes precedence for Converse and Mantle: `apiKey ?? AWS_BEARER_TOKEN_BEDROCK` (bearer) → explicit static credentials → default chain. `auth: "sigv4"` in settings ignores an ambient bearer token.
- `BedrockAuth.resolveRegion`: `region ?? credentials.region ?? AWS_REGION ?? AWS_DEFAULT_REGION ?? us-east-1`, applied to both the endpoint host and the SigV4 scope (Converse previously let them diverge).
- `Settings`/`Config` gain `profile`; `auth: "bearer" | "sigv4"` moves onto `Config` so programmatic callers can also opt out of the ambient bearer token. `model(id, settings)` is now just `configure(settings).model(id)`.
- Root `dev` script drops `--conditions=browser`: it resolves `@smithy/core/config` to a browser build that stubs node-only exports and breaks the credential chain (`parseKnownFiles is not a function`). The release build already uses node conditions.
- `@aws-sdk/credential-providers` added to `packages/ai`.

Chain failures surface as `AIError` with an `Authentication` reason.

## Tests

- Chain failure → `Authentication` error (uses a missing profile with IMDS disabled so it is deterministic on any machine).
- Chain success via `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` for Converse and Mantle, asserting the SigV4 credential scope and `x-amz-security-token`.
- Rotated credentials are picked up on the next request against the same model instance.
- `AWS_BEARER_TOKEN_BEDROCK` precedence, `auth: "sigv4"` ignoring it, region env fallbacks, and static credentials taking the configured region for the scope.
- New `test/lib/env.ts` helper scopes `process.env` overrides (needed because the AWS SDK reads `process.env` directly).

## Follow-up (separate PR, `packages/core`)

Wire discovery into `AmazonBedrockPlugin`: narrow the models.dev env method to `AWS_BEARER_TOKEN_BEDROCK` so `AWS_ACCESS_KEY_ID` stops being sent as a bearer token, flip `activation` to `enabled` when chain-style env is present, forward `profile` through `mapBedrockSettings`, and delete the dead AI SDK hooks plus the `@ai-sdk/amazon-bedrock` dependency.