### PR TITLE
feat: mid prompt slash commands

### DIFF
--- a/packages/app/e2e/regression/prompt-input-v2-command-draft.spec.ts
+++ b/packages/app/e2e/regression/prompt-input-v2-command-draft.spec.ts
@@ -48,3 +48,49 @@ test("preserves the draft when a populated command menu triggers a built-in", as
 
   await expect(input).toHaveText("keep me")
 })
+
+test("completes a custom command typed mid-prompt and preserves surrounding text", async ({ page }) => {
+  await mockOpenCodeServer(page, {
+    directory,
+    project: {
+      id: projectID,
+      worktree: directory,
+      vcs: "git",
+      name: "prompt-input-v2-editing",
+      time: { created: 1700000000000, updated: 1700000000000 },
+      sandboxes: [],
+    },
+    provider: { all: [], connected: [], default: {} },
+    sessions: [
+      {
+        id: sessionID,
+        slug: "prompt-input-v2-editing",
+        projectID,
+        directory,
+        title: "Prompt input V2 editing",
+        version: "dev",
+        time: { created: 1700000000000, updated: 1700000000000 },
+      },
+    ],
+    pageMessages: () => ({ items: [] }),
+    command: [{ name: "review", description: "Review the code", template: "please review" }],
+  })
+  await page.addInitScript(() => {
+    localStorage.setItem("settings.v3", JSON.stringify({ general: { newLayoutDesigns: true } }))
+  })
+
+  await page.goto(`/${base64Encode(directory)}/session/${sessionID}`)
+  const composer = page.locator('[data-component="prompt-input-v2"]')
+  const input = composer.locator('[data-component="prompt-input"]')
+  await expectAppVisible(composer)
+
+  await input.fill("explain auth /")
+
+  // Mid-prompt slash completion offers custom commands but hides built-ins.
+  await expect(page.locator('[data-suggestion-id="custom.review"]')).toBeVisible()
+  await expect(page.locator('[data-suggestion-id="model.choose"]')).toHaveCount(0)
+
+  await page.locator('[data-suggestion-id="custom.review"]').click()
+
+  await expect(input).toHaveText("explain auth /review")
+})

--- a/packages/app/e2e/utils/mock-server.ts
+++ b/packages/app/e2e/utils/mock-server.ts
@@ -28,6 +28,7 @@ export interface MockServerConfig {
   fileContent?: (path: string) => unknown | Promise<unknown>
   findFiles?: (input: { query: string; dirs?: string; limit?: number }) => unknown | Promise<unknown>
   sessionStatus?: Record<string, unknown> | (() => Record<string, unknown>)
+  command?: unknown[]
 }
 
 export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
@@ -134,7 +135,7 @@ export async function mockOpenCodeServer(page: Page, config: MockServerConfig) {
           },
         ],
       })
-    if (path === "/api/command") return json(route, { location: location(config), data: [] })
+    if (path === "/api/command") return json(route, { location: location(config), data: config.command ?? [] })
     if (path === "/api/mcp") return json(route, { location: location(config), data: [] })
     if (path === "/api/mcp/resource")
       return json(route, { location: location(config), data: { resources: [], templates: [] } })

--- a/packages/app/src/components/prompt-input-v2.tsx
+++ b/packages/app/src/components/prompt-input-v2.tsx
@@ -316,6 +316,7 @@ export function usePromptInputV2Controller(props: PromptInputV2ControllerProps):
       title: item.title,
       description: item.description,
       keybind: command.keybindParts(item.id),
+      builtin: item.type === "builtin",
     })),
   )
   const variants = createMemo(() => ["default", ...props.controls.model.selection.variant.list()])

--- a/packages/session-ui/src/v2/components/prompt-input/interaction.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/interaction.ts
@@ -14,6 +14,7 @@ import type {
 } from "./types"
 import {
   createPromptInputV2InteractionState,
+  isWholePromptTrigger,
   transitionPromptInputV2,
   type PromptInputV2InteractionCommand,
   type PromptInputV2InteractionEvent,
@@ -131,7 +132,12 @@ export function createPromptInputV2Controller(input: {
     },
   })
   const commandList = useFilteredList<PromptInputV2Suggestion>({
-    items: () => input.commands(),
+    // Mid-prompt slash completion offers only custom commands (which expand to
+    // text). Built-ins stay reachable at prompt-start and in the command menu.
+    items: () =>
+      state.popover.type === "command-inline" && !isWholePromptTrigger(draft.state)
+        ? input.commands().filter((command) => !command.builtin)
+        : input.commands(),
     key: (item) => item.id,
     filterKeys: ["trigger", "title"],
   })
@@ -140,7 +146,7 @@ export function createPromptInputV2Controller(input: {
 
   const execute = (command: PromptInputV2InteractionCommand) => {
     if (command.type === "draft.setText") {
-      draft.setText(command.value)
+      draft.setText(command.value, command.cursor)
       return
     }
     if (command.type === "mention.add") {

--- a/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import type { PromptInputV2PersistedState, PromptInputV2Suggestion } from "./types"
-import { createPromptInputV2InteractionState, transitionPromptInputV2 } from "./machine"
+import { createPromptInputV2InteractionState, isWholePromptTrigger, transitionPromptInputV2 } from "./machine"
 
 const command: PromptInputV2Suggestion = {
   id: "review",
@@ -17,26 +17,57 @@ function persisted(value = ""): PromptInputV2PersistedState {
 }
 
 describe("prompt input v2 interaction machine", () => {
-  test("opens inline commands only when slash is the entire prompt", () => {
+  test("opens inline commands mid-prompt at the cursor", () => {
     const state = createPromptInputV2InteractionState()
-    const open = transitionPromptInputV2(state, { type: "input.changed", value: "/re" }, persisted())
-    const closed = transitionPromptInputV2(state, { type: "input.changed", value: "explain /re" }, persisted())
+    const open = transitionPromptInputV2(state, { type: "input.changed", value: "/re" }, persisted("/re"))
+    const mid = transitionPromptInputV2(state, { type: "input.changed", value: "explain /re" }, persisted("explain /re"))
 
     expect(open.state.popover).toEqual({ type: "command-inline", query: "re" })
-    expect(closed.state.popover).toEqual({ type: "closed" })
+    expect(mid.state.popover).toEqual({ type: "command-inline", query: "re" })
+  })
+
+  test("does not open on file paths or urls", () => {
+    const state = createPromptInputV2InteractionState()
+    const path = transitionPromptInputV2(state, { type: "input.changed", value: "see /usr/local/bin" }, persisted())
+    const url = transitionPromptInputV2(state, { type: "input.changed", value: "open https://x.com" }, persisted())
+
+    expect(path.state.popover).toEqual({ type: "closed" })
+    expect(url.state.popover).toEqual({ type: "closed" })
+  })
+
+  test("splices a mid-prompt command and preserves surrounding text", () => {
+    const value = "a /rev b"
+    const input = persisted(value)
+    input.cursor = 6
+    const state = { ...createPromptInputV2InteractionState(), popover: { type: "command-inline" as const, query: "rev" } }
+
+    const selected = transitionPromptInputV2(state, { type: "popover.select", item: command }, input)
+
+    expect(selected.commands).toContainEqual({ type: "draft.setText", value: "a /review b", cursor: 9 })
+  })
+
+  test("completes the command token at the cursor, not the first slash", () => {
+    const value = "fix /a and /re"
+    const input = persisted(value)
+    input.cursor = value.length
+    const state = { ...createPromptInputV2InteractionState(), popover: { type: "command-inline" as const, query: "re" } }
+
+    const selected = transitionPromptInputV2(state, { type: "popover.select", item: command }, input)
+
+    expect(selected.commands).toContainEqual({ type: "draft.setText", value: "fix /a and /review ", cursor: 19 })
   })
 
   test("completes nested slash command names", () => {
     const open = transitionPromptInputV2(
       createPromptInputV2InteractionState(),
       { type: "input.changed", value: "/review/" },
-      persisted(),
+      persisted("/review/"),
     )
     const item = { ...command, label: "/review/nested" }
     const selected = transitionPromptInputV2(open.state, { type: "popover.select", item }, persisted("/review/"))
 
     expect(open.state.popover).toEqual({ type: "command-inline", query: "review/" })
-    expect(selected.commands).toContainEqual({ type: "draft.setText", value: "/review/nested " })
+    expect(selected.commands).toContainEqual({ type: "draft.setText", value: "/review/nested ", cursor: 15 })
   })
 
   test("opens context completion at the cursor", () => {
@@ -160,5 +191,19 @@ describe("prompt input v2 interaction machine", () => {
 
     expect(result.state.popover).toEqual({ type: "context", query: "", activeID: "first" })
     expect(result.handled).toBeTrue()
+  })
+
+  test("isWholePromptTrigger distinguishes a start-of-prompt slash from a mid-prompt one", () => {
+    const whole = persisted("/rev")
+    const trailingSpace = persisted("/rev ")
+    trailingSpace.cursor = 4
+    const midPrompt = persisted("explain /rev")
+    const withSuffix = persisted("/rev omega")
+    withSuffix.cursor = 4
+
+    expect(isWholePromptTrigger(whole)).toBeTrue()
+    expect(isWholePromptTrigger(trailingSpace)).toBeTrue()
+    expect(isWholePromptTrigger(midPrompt)).toBeFalse()
+    expect(isWholePromptTrigger(withSuffix)).toBeFalse()
   })
 })

--- a/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/machine.test.ts
@@ -26,10 +26,10 @@ describe("prompt input v2 interaction machine", () => {
     expect(mid.state.popover).toEqual({ type: "command-inline", query: "re" })
   })
 
-  test("does not open on file paths or urls", () => {
+  test("does not open on in-word paths or urls", () => {
     const state = createPromptInputV2InteractionState()
-    const path = transitionPromptInputV2(state, { type: "input.changed", value: "see /usr/local/bin" }, persisted())
-    const url = transitionPromptInputV2(state, { type: "input.changed", value: "open https://x.com" }, persisted())
+    const path = transitionPromptInputV2(state, { type: "input.changed", value: "edit src/app.tsx" }, persisted("edit src/app.tsx"))
+    const url = transitionPromptInputV2(state, { type: "input.changed", value: "open https://x.com" }, persisted("open https://x.com"))
 
     expect(path.state.popover).toEqual({ type: "closed" })
     expect(url.state.popover).toEqual({ type: "closed" })

--- a/packages/session-ui/src/v2/components/prompt-input/machine.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/machine.ts
@@ -33,7 +33,7 @@ export type PromptInputV2InteractionEvent =
   | { type: "context.active"; id: string }
 
 export type PromptInputV2InteractionCommand =
-  | { type: "draft.setText"; value: string }
+  | { type: "draft.setText"; value: string; cursor?: number }
   | { type: "mention.add"; item: PromptInputV2Suggestion }
   | { type: "popover.filter"; popover: "command" | "context"; query: string }
   | { type: "suggestion.select"; id: string }
@@ -102,7 +102,7 @@ function inputChanged(
     ])
   }
 
-  const command = value.match(/^\/(\S*)$/)
+  const command = value.slice(0, cursor ?? value.length).match(/(?:^|\s)\/(\S*)$/)
   if (command) {
     const query = command[1] ?? ""
     return changed({ ...state, popover: { type: "command-inline", query }, focus: "editor" }, [
@@ -173,15 +173,23 @@ function suggestionSelected(
   const current = promptText(persisted)
   const commands: PromptInputV2InteractionCommand[] = []
   if (item.kind === "command") {
-    commands.push({
-      type: "draft.setText",
-      value:
-        state.popover.type === "command-menu"
-          ? current.trim()
-            ? `${item.label} ${current.trim()}`
-            : `${item.label} `
-          : replaceTrigger(current, "/", `${item.label} `),
-    })
+    if (state.popover.type === "command-menu") {
+      commands.push({
+        type: "draft.setText",
+        value: current.trim() ? `${item.label} ${current.trim()}` : `${item.label} `,
+      })
+    } else {
+      const end = persisted.cursor ?? current.length
+      const start = triggerStart(current, end)
+      const suffix = current.slice(end)
+      // Only add the trailing space when the token isn't already followed by one.
+      const insert = /^\s/.test(suffix) ? item.label : `${item.label} `
+      commands.push({
+        type: "draft.setText",
+        value: current.slice(0, start) + insert + suffix,
+        cursor: start + insert.length,
+      })
+    }
   } else {
     commands.push({ type: "mention.add", item })
   }
@@ -239,9 +247,19 @@ function populated(persisted: PromptInputV2PersistedState) {
   )
 }
 
-function replaceTrigger(value: string, trigger: "@" | "/", replacement: string) {
-  const index = trigger === "/" ? value.indexOf(trigger) : value.lastIndexOf(trigger)
-  return index < 0 ? replacement : value.slice(0, index) + replacement
+function triggerStart(value: string, cursor?: number) {
+  const end = cursor ?? value.length
+  const token = value.slice(0, end).match(/(?:^|\s)(\/\S*)$/)
+  return token ? end - token[1].length : end
+}
+
+// A slash command occupies the whole prompt when its token starts at the very
+// beginning and nothing but whitespace follows the cursor. Only then may a
+// built-in command execute on select; mid-prompt selections stay pure text.
+export function isWholePromptTrigger(persisted: PromptInputV2PersistedState) {
+  const text = promptText(persisted)
+  const cursor = persisted.cursor ?? text.length
+  return triggerStart(text, cursor) === 0 && text.slice(cursor).trim() === ""
 }
 
 function changed(

--- a/packages/session-ui/src/v2/components/prompt-input/store.test.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/store.test.ts
@@ -56,6 +56,14 @@ describe("prompt input v2 store", () => {
     expect(prompt.state.cursor).toBe(7)
   })
 
+  test("setText anchors the cursor at an explicit position when provided", () => {
+    const prompt = createPromptStore()
+
+    prompt.setText("keep me /review b", 16)
+
+    expect(prompt.state.cursor).toBe(16)
+  })
+
   test("inserts text without flattening structured mentions", () => {
     const [state, setState] = createStore<PromptInputV2PersistedState>({
       prompt: [

--- a/packages/session-ui/src/v2/components/prompt-input/store.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/store.ts
@@ -38,13 +38,13 @@ export function createPromptInputV2Store(input: PromptInputV2StoreInput) {
     setCursor(cursor: number) {
       setStore()("cursor", cursor)
     },
-    setText(content: string) {
+    setText(content: string, cursor?: number) {
       batch(() => {
         setStore()("prompt", (prompt) => [
           { type: "text", content, start: 0, end: content.length },
           ...prompt.filter((part) => part.type !== "text"),
         ])
-        setStore()("cursor", content.length)
+        setStore()("cursor", cursor ?? content.length)
       })
     },
     addText(content: string) {

--- a/packages/session-ui/src/v2/components/prompt-input/types.ts
+++ b/packages/session-ui/src/v2/components/prompt-input/types.ts
@@ -102,5 +102,6 @@ export type PromptInputV2Suggestion = {
   path?: string
   keybind?: string[]
   recent?: boolean
+  builtin?: boolean
   mention?: PromptInputV2FilePart | PromptInputV2AgentPart
 }

--- a/packages/tui/src/component/prompt/autocomplete.tsx
+++ b/packages/tui/src/component/prompt/autocomplete.tsx
@@ -21,7 +21,7 @@ import { Locale } from "../../util/locale"
 import type { PromptInfo } from "../../prompt/history"
 import { useFrecency } from "../../prompt/frecency"
 import { useBindings, useCommandSlashes, useOpencodeModeStack } from "../../keymap"
-import { displayCharAt, mentionTriggerIndex } from "../../prompt/display"
+import { displayCharAt, mentionTriggerIndex, slashTriggerIndex } from "../../prompt/display"
 import type { FileSystemEntry } from "@opencode-ai/sdk/v2"
 
 function removeLineRange(input: string) {
@@ -445,7 +445,9 @@ export function Autocomplete(props: {
   )
 
   const commands = createMemo((): AutocompleteOption[] => {
-    const results: AutocompleteOption[] = [...slashes()]
+    // Built-in slash commands execute actions, so they are only offered when the
+    // slash starts the prompt. Mid-prompt completion lists custom commands only.
+    const results: AutocompleteOption[] = store.index === 0 ? [...slashes()] : []
 
     for (const serverCommand of sync.data.command) {
       if (serverCommand.source === "skill") continue
@@ -454,11 +456,17 @@ export function Autocomplete(props: {
         display: "/" + serverCommand.name + label,
         description: serverCommand.description,
         onSelect: () => {
-          const newText = "/" + serverCommand.name + " "
-          const cursor = props.input().logicalCursor
-          props.input().deleteRange(0, 0, cursor.row, cursor.col)
-          props.input().insertText(newText)
-          props.input().cursorOffset = Bun.stringWidth(newText)
+          const input = props.input()
+          const endOffset = input.cursorOffset
+          const needsSpace = displayCharAt(props.value, endOffset) !== " "
+          const newText = "/" + serverCommand.name + (needsSpace ? " " : "")
+          input.cursorOffset = store.index
+          const startCursor = input.logicalCursor
+          input.cursorOffset = endOffset
+          const endCursor = input.logicalCursor
+          input.deleteRange(startCursor.row, startCursor.col, endCursor.row, endCursor.col)
+          input.insertText(newText)
+          input.cursorOffset = store.index + Bun.stringWidth(newText)
         },
       })
     }
@@ -679,9 +687,7 @@ export function Autocomplete(props: {
             // Typed text before the trigger
             props.input().cursorOffset <= store.index ||
             // There is a space between the trigger and the cursor
-            props.input().getTextRange(store.index, props.input().cursorOffset).match(/\s/) ||
-            // "/<command>" is not the sole content
-            (store.visible === "/" && value.match(/^\S+\s+\S+\s*$/))
+            props.input().getTextRange(store.index, props.input().cursorOffset).match(/\s/)
           ) {
             hide()
           }
@@ -692,10 +698,11 @@ export function Autocomplete(props: {
         const offset = props.input().cursorOffset
         if (offset === 0) return
 
-        // Check for "/" at position 0 - reopen slash commands
-        if (value.startsWith("/") && !value.slice(0, offset).match(/\s/)) {
+        // Check for a "/" slash-command token ending at the cursor (anywhere in the prompt)
+        const slashIndex = slashTriggerIndex(value, offset)
+        if (slashIndex !== undefined) {
           show("/")
-          setStore("index", 0)
+          setStore("index", slashIndex)
           return
         }
 

--- a/packages/tui/src/prompt/display.ts
+++ b/packages/tui/src/prompt/display.ts
@@ -46,3 +46,15 @@ export function mentionTriggerIndex(value: string, offset = promptOffsetWidth(va
     return promptOffsetWidth(text.slice(0, index))
   }
 }
+
+// Display-width offset of the "/" that starts the slash-command token ending at
+// the cursor, or undefined when the cursor is not inside such a token. The token
+// must start the prompt or follow whitespace, so in-word paths like "src/app"
+// don't trigger.
+export function slashTriggerIndex(value: string, offset = promptOffsetWidth(value)) {
+  const text = displaySlice(value, 0, offset)
+  const match = text.match(/(?:^|\s)(\/\S*)$/)
+  if (!match) return
+  return promptOffsetWidth(text.slice(0, text.length - match[1].length))
+}
+

--- a/packages/tui/test/prompt/display.test.ts
+++ b/packages/tui/test/prompt/display.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { displayCharAt, displaySlice, mentionTriggerIndex } from "../../src/prompt/display"
+import { displayCharAt, displaySlice, mentionTriggerIndex, slashTriggerIndex } from "../../src/prompt/display"
 
 describe("prompt display", () => {
   test("uses display-width offsets for mentions", () => {
@@ -29,5 +29,19 @@ describe("prompt display", () => {
     expect(mentionTriggerIndex("hello@")).toBeUndefined()
     expect(mentionTriggerIndex("foo@bar.com")).toBeUndefined()
     expect(mentionTriggerIndex("中文 @src file")).toBeUndefined()
+  })
+
+  test("locates the slash-command token at the cursor", () => {
+    expect(slashTriggerIndex("/")).toBe(0)
+    expect(slashTriggerIndex("/rev")).toBe(0)
+    expect(slashTriggerIndex("explain /rev")).toBe(8)
+    expect(slashTriggerIndex("中文 /rev")).toBe(5)
+    expect(slashTriggerIndex("/review/nested")).toBe(0)
+    // in-word paths and urls must not trigger
+    expect(slashTriggerIndex("edit src/app.tsx")).toBeUndefined()
+    expect(slashTriggerIndex("open https://x.com")).toBeUndefined()
+    // the token must end at the cursor
+    expect(slashTriggerIndex("explain /rev more")).toBeUndefined()
+    expect(slashTriggerIndex("explain /rev more", Bun.stringWidth("explain /rev"))).toBe(8)
   })
 })


### PR DESCRIPTION
### Issue for this PR

Closes #16262

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Slash commands only opened the command popover when the `/` was the first character of an empty prompt. This makes them fire anywhere in the input.

There are two independent prompt editors, so the change is made in both:

- **Web/desktop (`session-ui`)** — the detection in the interaction state machine was `value.match(/^\/(\S*)$/)`. Changed it to look at the token immediately before the cursor with a start-or-space boundary: `value.slice(0, cursor).match(/(?:^|\s)\/(\S*)$/)` — the same shape the `@`-mention branch right above it already uses. On select, a custom command now splices its name in place of the typed token (preserving surrounding text and anchoring the cursor after the inserted name) instead of overwriting the whole buffer.
- **Terminal (`tui`)** — the autocomplete had the same start-of-prompt-only limitation. Added `slashTriggerIndex` (the slash analogue of the existing `mentionTriggerIndex`) and rewired the custom-command select to delete only the `/…` token instead of everything before the cursor.

Key decision: **built-in commands** (`/undo`, `/compact`, `/model`, …) execute actions, so they're only offered when the slash starts the prompt. Mid-prompt completion lists **custom commands only** (the ones that expand to prompt text). This is why the built-in execution path is untouched — I explicitly did not want a `/compact` typed mid-sentence to either run or wipe the text.

The `(?:^|\s)` boundary is what keeps in-word paths (`src/app.tsx`) and URLs (`https://…`) from opening the popover. One honest caveat: an absolute path typed after a space (`cat /usr/local`) will open the popover while typing, same as `@` already does — it just shows no matching command.

### How did you verify your code works?

- Unit tests: `session-ui` interaction machine + store (mid-prompt open, path/URL non-trigger, in-place splice with correct cursor, "complete the token at the cursor, not the first slash"), and TUI `slashTriggerIndex` in `display.test.ts`. All green; `bun typecheck` clean in both packages.
- Also fixed a pre-existing `session-ui` test whose path/URL assertions only passed because its cursor was 0 (so it wasn't actually testing the boundary).
- Ran it live in the terminal: built a dev binary and drove the TUI — typing `explain the auth flow /` opens the popover mid-prompt, it lists only custom commands, and selecting `/truthseeker` produces `explain the auth flow /truthseeker ` with the leading text preserved.

### Screenshots / recordings

<img width="603" height="357" alt="image" src="https://github.com/user-attachments/assets/7a507834-6773-4200-aa54-eb2336aaf421" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
