### PR TITLE
chore(core): remove stray agent artifact file

### DIFF
--- a/packages/core/src/effect/dfdf
+++ b/packages/core/src/effect/dfdf
@@ -1,1 +1,0 @@
-File to save in: ~/.local/share/opencode/worktree/012780/location-layer-tiers/packages/core/src/effect/


### PR DESCRIPTION
### Issue for this PR

Closes #47451

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Deletes `packages/core/src/effect/dfdf`, a stray file whose only content is a single instruction line (`File to save in: ~/.local/share/opencode/worktree/...`). It has no extension, contains no code, and nothing references it.

### How did you verify your code works?

Searched the repo for any imports or references to the file — none. `bun typecheck` passes in `packages/core`.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
