### PR TITLE
fix(lsp): catch rejected diagnostic requests

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -398,13 +398,18 @@ export async function create(input: {
       }
 
       for (const request of requests) {
-        request.then((result) => {
-          results.push(result)
-          pending -= 1
-          const merged = mergeResults(filePath, results)
-          finish(merged)
-          if (pending === 0) finish(merged, true)
-        })
+        request
+          .then((result) => {
+            results.push(result)
+            pending -= 1
+            const merged = mergeResults(filePath, results)
+            finish(merged)
+            if (pending === 0) finish(merged, true)
+          })
+          .catch(() => {
+            pending -= 1
+            if (pending === 0) finish(mergeResults(filePath, results), true)
+          })
       }
     })
   }


### PR DESCRIPTION
### Issue for this PR

Closes #47452

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`requestDiagnostics` in `packages/opencode/src/lsp/client.ts` only attached a fulfillment handler to each diagnostic request promise. If one of those promises rejected, `pending` never reached 0 and the returned promise could hang forever, plus the rejection was unhandled.

This adds a `.catch` that decrements `pending` and force-finishes once all requests have settled, treating the failed request as contributing no results — same shape as the success path.

### How did you verify your code works?

`bun typecheck` passes in `packages/opencode`. Also traced the only caller (`requestDocumentDiagnostics`) and confirmed a rejected request now resolves the aggregate promise with the results that did succeed instead of hanging.

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
