### PR TITLE
fix(opencode): surface unavailable configured models

### DIFF
--- a/packages/opencode/src/cli/error.ts
+++ b/packages/opencode/src/cli/error.ts
@@ -75,6 +75,17 @@ export function FormatError(input: unknown): string | undefined {
     return `Failed to initialize provider "${stringField(providerInit, "providerID")}". Check credentials and configuration.`
   }
 
+  const notFound = configData(input, "NotFoundError")
+  if (notFound) {
+    const message = stringField(notFound, "message") ?? "Resource not found"
+    if (!message.startsWith("Model not found:")) return message
+    return [
+      message,
+      `Try: \`opencode models\` to list available models`,
+      `Or check your config (opencode.json) provider/model names`,
+    ].join("\n")
+  }
+
   // ConfigJsonError: { path: string, message?: string }
   const configJson = configData(input, "ConfigJsonError")
   if (configJson) {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session-errors.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session-errors.ts
@@ -1,5 +1,6 @@
 import type { NotFoundError as StorageNotFoundError } from "@/storage/storage"
 import type { Session } from "@/session/session"
+import { ModelNotFoundError } from "@/provider/provider"
 import { Effect } from "effect"
 import * as ApiError from "../errors"
 
@@ -17,5 +18,11 @@ export function mapBusy<A, R>(self: Effect.Effect<A, Session.BusyError, R>) {
         }),
       ),
     ),
+  )
+}
+
+export function mapModelNotFound<A, E, R>(self: Effect.Effect<A, E | ModelNotFoundError, R>) {
+  return self.pipe(
+    Effect.catchIf(ModelNotFoundError.isInstance, (error) => Effect.fail(ApiError.notFound(error.message))),
   )
 }

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/session.ts
@@ -36,7 +36,7 @@ import {
   SummarizePayload,
   UpdatePayload,
 } from "../groups/session"
-import { PermissionNotFoundError } from "../errors"
+import { ApiNotFoundError, PermissionNotFoundError } from "../errors"
 import * as SessionError from "./session-errors"
 
 const tryParseJson = (text: string) =>
@@ -302,7 +302,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
           ...ctx.payload,
           sessionID: ctx.params.sessionID,
         })
-        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+        .pipe(
+          SessionError.mapModelNotFound,
+          Effect.mapError((error) => (error instanceof ApiNotFoundError ? error : new HttpApiError.BadRequest({}))),
+        )
       return HttpServerResponse.stream(Stream.make(JSON.stringify(message)).pipe(Stream.encodeText), {
         contentType: "application/json",
       })
@@ -333,9 +336,10 @@ export const sessionHandlers = HttpApiBuilder.group(InstanceHttpApi, "session", 
       payload: typeof CommandPayload.Type
     }) {
       yield* requireSession(ctx.params.sessionID)
-      return yield* promptSvc
-        .command({ ...ctx.payload, sessionID: ctx.params.sessionID })
-        .pipe(Effect.mapError(() => new HttpApiError.BadRequest({})))
+      return yield* promptSvc.command({ ...ctx.payload, sessionID: ctx.params.sessionID }).pipe(
+        SessionError.mapModelNotFound,
+        Effect.mapError((error) => (error instanceof ApiNotFoundError ? error : new HttpApiError.BadRequest({}))),
+      )
     })
 
     const shell = Effect.fn("SessionHttpApi.shell")(function* (ctx: {

--- a/packages/opencode/src/session/prompt.ts
+++ b/packages/opencode/src/session/prompt.ts
@@ -101,10 +101,12 @@ function isOrphanedInterruptedTool(part: SessionV1.ToolPart) {
 
 export interface Interface {
   readonly cancel: (sessionID: SessionID) => Effect.Effect<void>
-  readonly prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
+  readonly prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error | Provider.ModelNotFoundError>
   readonly loop: (input: LoopInput) => Effect.Effect<SessionV1.WithParts>
   readonly shell: (input: ShellInput) => Effect.Effect<SessionV1.WithParts, Session.BusyError>
-  readonly command: (input: CommandInput) => Effect.Effect<SessionV1.WithParts, Image.Error>
+  readonly command: (
+    input: CommandInput,
+  ) => Effect.Effect<SessionV1.WithParts, Image.Error | Provider.ModelNotFoundError>
   readonly resolvePromptParts: (template: string) => Effect.Effect<PromptInput["parts"]>
 }
 
@@ -645,12 +647,16 @@ const layer = Layer.effect(
 
       const model = input.model ?? ag.model ?? (yield* currentModel(input.sessionID))
       const same = ag.model && model.providerID === ag.model.providerID && model.modelID === ag.model.modelID
+      // Executing prompts resolve before persistence so unavailable configured models remain typed request errors.
+      // Admit-only prompts keep accepting messages without requiring the selected provider to be online.
       const full =
-        !input.variant && ag.variant && same
-          ? yield* provider
-              .getModel(model.providerID, model.modelID)
-              .pipe(Effect.catchIf(Provider.ModelNotFoundError.isInstance, () => Effect.succeed(undefined)))
-          : undefined
+        input.noReply !== true
+          ? yield* provider.getModel(model.providerID, model.modelID)
+          : !input.variant && ag.variant && same
+            ? yield* provider
+                .getModel(model.providerID, model.modelID)
+                .pipe(Effect.catchIf(Provider.ModelNotFoundError.isInstance, () => Effect.succeed(undefined)))
+            : undefined
       const variant = input.variant ?? (ag.variant && full?.variants?.[ag.variant] ? ag.variant : undefined)
 
       const info: SessionV1.User = {
@@ -1049,7 +1055,9 @@ const layer = Layer.effect(
       return { info, parts }
     }, Effect.scoped)
 
-    const prompt: (input: PromptInput) => Effect.Effect<SessionV1.WithParts, Image.Error> = Effect.fn(
+    const prompt: (
+      input: PromptInput,
+    ) => Effect.Effect<SessionV1.WithParts, Image.Error | Provider.ModelNotFoundError> = Effect.fn(
       "SessionPrompt.prompt",
     )(function* (input: PromptInput) {
       const session = yield* sessions.get(input.sessionID).pipe(Effect.orDie)
@@ -1418,7 +1426,7 @@ const layer = Layer.effect(
         return yield* currentModel(input.sessionID)
       })
 
-      yield* getModel(taskModel.providerID, taskModel.modelID, input.sessionID)
+      yield* provider.getModel(taskModel.providerID, taskModel.modelID)
 
       const agent = agentName ? yield* agents.get(agentName) : yield* agents.defaultInfo()
       if (!agent) {

--- a/packages/opencode/test/cli/error.test.ts
+++ b/packages/opencode/test/cli/error.test.ts
@@ -89,6 +89,18 @@ describe("cli.error", () => {
     expect(FormatError({ _tag: "ProviderInitError", ...data })).toBe(expected)
   })
 
+  test("formats model not found API errors with recovery guidance", () => {
+    const data = { message: "Model not found: opencode/x-preview-f-free." }
+    const expected = [
+      data.message,
+      "Try: `opencode models` to list available models",
+      "Or check your config (opencode.json) provider/model names",
+    ].join("\n")
+
+    expect(FormatError({ name: "NotFoundError", data })).toBe(expected)
+    expect(FormatError({ _tag: "NotFoundError", ...data })).toBe(expected)
+  })
+
   test("formats cancelled UI errors as empty output", () => {
     expect(FormatError(new UI.CancelledError())).toBe("")
   })

--- a/packages/opencode/test/cli/run/run-process.test.ts
+++ b/packages/opencode/test/cli/run/run-process.test.ts
@@ -7,6 +7,7 @@ import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { reply } from "../../lib/llm-server"
 import { cliIt } from "../../lib/cli-process"
+import { testProviderConfig } from "../../lib/test-provider"
 
 describe("opencode run (non-interactive subprocess)", () => {
   // Happy path: prompt completes, output reaches stdout, process exits 0.
@@ -77,6 +78,27 @@ describe("opencode run (non-interactive subprocess)", () => {
         })
         expect(result.exitCode).not.toBe(0)
         expect(result.durationMs).toBeLessThan(15_000)
+      }),
+    30_000,
+  )
+
+  cliIt.concurrent(
+    "reports an actionable error when the configured model is unavailable",
+    ({ llm, opencode }) =>
+      Effect.gen(function* () {
+        const result = yield* opencode.spawn(["run", "say hi"], {
+          env: {
+            OPENCODE_CONFIG_CONTENT: JSON.stringify({
+              ...testProviderConfig(llm.url),
+              model: "test/deprecated-model",
+            }),
+          },
+        })
+
+        expect(result.exitCode).not.toBe(0)
+        expect(result.stderr).toContain("Model not found: test/deprecated-model")
+        expect(result.stderr).toContain("opencode models")
+        expect(result.stderr).not.toContain("Unexpected server error")
       }),
     30_000,
   )

--- a/packages/opencode/test/session/prompt.test.ts
+++ b/packages/opencode/test/session/prompt.test.ts
@@ -2383,6 +2383,25 @@ noLLMServer.instance(
 
 // Agent / command resolution errors
 
+noLLMServer.instance("unavailable models fail before the user message is persisted", () =>
+  Effect.gen(function* () {
+    const prompt = yield* SessionPrompt.Service
+    const sessions = yield* Session.Service
+    const session = yield* sessions.create({})
+    const error = yield* prompt
+      .prompt({
+        sessionID: session.id,
+        agent: "build",
+        model: { providerID: ProviderV2.ID.make("test"), modelID: ModelV2.ID.make("missing-model") },
+        parts: [{ type: "text", text: "hello" }],
+      })
+      .pipe(Effect.flip)
+
+    expect(ProviderSvc.ModelNotFoundError.isInstance(error)).toBe(true)
+    expect(yield* sessions.messages({ sessionID: session.id })).toEqual([])
+  }),
+)
+
 noLLMServer.instance(
   "unknown agent throws typed error",
   () =>


### PR DESCRIPTION
### Issue for this PR

Closes #46760

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a configured model is no longer in the provider catalog, opencode run currently turns the lookup failure into an opaque HTTP 500. This resolves the selected model before persisting the prompt, maps the model lookup failure to the existing typed 404 response, and prints the model ID plus opencode models recovery guidance. It does not silently select a fallback model. Admit-only prompts keep their existing behavior.

### How did you verify your code works?

Added a subprocess regression test with an unavailable configured model and verified that it exits nonzero, names the model, suggests opencode models, and does not print Unexpected server error. Also added session persistence and CLI formatter coverage.

Ran from packages/opencode:

- bun typecheck
- bun test test/cli/error.test.ts
- bun test test/cli/run/run-process.test.ts
- targeted tests in test/session/prompt.test.ts

### Screenshots / recordings

Not applicable; this is a non-interactive CLI error-path change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR