### PR TITLE
fix(webfetch): bound the timeout parameter

### DIFF
--- a/packages/opencode/src/tool/webfetch.ts
+++ b/packages/opencode/src/tool/webfetch.ts
@@ -10,6 +10,8 @@ const MAX_RESPONSE_SIZE = 5 * 1024 * 1024 // 5MB
 const DEFAULT_TIMEOUT = 30 * 1000 // 30 seconds
 const MAX_TIMEOUT = 120 * 1000 // 2 minutes
 
+const Timeout = Schema.Number.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(MAX_TIMEOUT / 1000))
+
 export const Parameters = Schema.Struct({
   url: Schema.String.annotate({ description: "The URL to fetch content from" }),
   format: Schema.Literals(["text", "markdown", "html"])
@@ -18,7 +20,9 @@ export const Parameters = Schema.Struct({
       default: "markdown",
     })
     .pipe(Schema.withDecodingDefault(Effect.succeed("markdown" as const))),
-  timeout: Schema.optional(Schema.Number).annotate({ description: "Optional timeout in seconds (max 120)" }),
+  timeout: Schema.optional(Timeout).annotate({
+    description: `Optional timeout in seconds (maximum: ${MAX_TIMEOUT / 1000})`,
+  }),
 })
 
 export const WebFetchTool = Tool.define(

--- a/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
+++ b/packages/opencode/test/tool/__snapshots__/parameters.test.ts.snap
@@ -388,7 +388,9 @@ exports[`tool parameters JSON Schema (wire shape) webfetch 1`] = `
       "type": "string",
     },
     "timeout": {
-      "description": "Optional timeout in seconds (max 120)",
+      "description": "Optional timeout in seconds (maximum: 120)",
+      "exclusiveMinimum": 0,
+      "maximum": 120,
       "type": "number",
     },
     "url": {


### PR DESCRIPTION
### Issue for this PR

Closes #47459

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Split out of #45235 on review feedback, so the body-timeout fix there stays reviewable on its own. This is only the input validation.

`timeout` was `Schema.optional(Schema.Number)` with no bounds. `Math.min((params.timeout ?? 30) * 1000, MAX_TIMEOUT)` clamps the ceiling but nothing clamps the floor, so `timeout: 0` produced a 0 ms deadline that aborted the request immediately, and a negative value produced a negative duration.

The description already claimed "max 120", but that bound existed only in the silent `Math.min` clamp — it was not in the JSON Schema the model receives, so the model had no way to know the limit or to be told when it exceeded one.

This applies the same check the v2 tool already uses in `packages/core/src/tool/webfetch.ts`:

```ts
const Timeout = Schema.Number.check(Schema.isGreaterThan(0), Schema.isLessThanOrEqualTo(MAX_TIMEOUT_SECONDS))
```

I kept the existing `Math.min(...)` clamp rather than removing it as now-redundant — anything constructing `Parameters` directly still gets the old ceiling behaviour, and it costs nothing.

### How did you verify your code works?

The parameters snapshot pins the webfetch wire shape, so this change is visible there and the snapshot is regenerated in this PR. Before:

```
 57 pass, 1 fail
(fail) tool parameters > JSON Schema (wire shape) > webfetch
```

After regenerating, `bun test test/tool/parameters.test.ts` (bun 1.4.0) gives **58 pass, 16 snapshots, 0 fail**, and the snapshot diff is exactly the intended three lines:

```diff
     "timeout": {
-      "description": "Optional timeout in seconds (max 120)",
+      "description": "Optional timeout in seconds (maximum: 120)",
+      "exclusiveMinimum": 0,
+      "maximum": 120,
       "type": "number",
     },
```

That diff is the point of the change: the bound is now something the model is told about in the schema rather than a clamp applied behind its back.

`bun test test/tool/webfetch.test.ts` also passes (5 pass, 0 fail) on this branch.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
