### PR TITLE
fix(desktop): restore user PATH after Explorer overflow

### DIFF
--- a/packages/desktop/src/main/lifecycle/environment.ts
+++ b/packages/desktop/src/main/lifecycle/environment.ts
@@ -7,7 +7,7 @@ import contextMenu from "electron-context-menu"
 import { Effect, FileSystem, Path } from "effect"
 import { CHANNEL } from "../constants"
 import { DesktopPaths } from "../paths"
-import { getUserShell, loadShellEnv } from "../service/shell-env"
+import { getUserShell, loadShellEnv, loadWindowsPath } from "../service/shell-env"
 import { cleanupStoreFiles } from "../storage/cleanup"
 import { registerRendererProtocol, setDockIcon } from "../windows"
 
@@ -58,8 +58,8 @@ export const prepareApplicationEnvironment = Effect.gen(function* () {
 })
 
 export const preferApplicationEnvironment = Effect.gen(function* () {
-  const shell = process.platform === "win32" ? null : getUserShell()
-  const shellEnv = shell ? yield* loadShellEnv(shell) : null
+  const shellEnv: Record<string, string> | null =
+    process.platform === "win32" ? yield* loadWindowsPath() : yield* loadShellEnv(getUserShell())
   yield* Effect.sync(() => {
     if (!shellEnv?.XDG_STATE_HOME) delete process.env.XDG_STATE_HOME
     Object.assign(process.env, {

--- a/packages/desktop/src/main/service/shell-env.test.ts
+++ b/packages/desktop/src/main/service/shell-env.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test"
 import * as NodePath from "@effect/platform-node/NodePath"
 import { Effect } from "effect"
 
-import { isNushell, parseShellEnv, resolveUserShell } from "./shell-env"
+import { isNushell, parseShellEnv, repairWindowsPath, resolveUserShell } from "./shell-env"
 
 describe("shell env", () => {
   test("parseShellEnv supports null-delimited pairs", () => {
@@ -32,5 +32,32 @@ describe("shell env", () => {
     expect(check("/opt/homebrew/bin/nu")).toBe(true)
     expect(check("C:\\Program Files\\nu.exe")).toBe(true)
     expect(check("/bin/zsh")).toBe(false)
+  })
+
+  test.each([4094, 4095, 4096, 16000])("repairs only the long machine-only Windows PATH (%i characters)", (length) => {
+    const machine = "C:\\Windows\\System32"
+    const user = "C:\\Tools;".repeat(2000).slice(0, length - machine.length - 1)
+    expect(repairWindowsPath(machine, machine, user)).toBe(length < 4095 ? undefined : `${machine};${user}`)
+  })
+
+  test("preserves complete and customized Windows paths", () => {
+    const machine = "C:\\Windows\\System32"
+    const user = "C:\\Tools;".repeat(500)
+    expect(repairWindowsPath(`${machine};${user}`, machine, user)).toBeUndefined()
+    expect(repairWindowsPath(`C:\\venv\\Scripts;${machine}`, machine, user)).toBeUndefined()
+    expect(repairWindowsPath("C:\\custom", machine, user)).toBeUndefined()
+  })
+
+  test("handles Windows path casing, separators, and Unicode", () => {
+    const machine = "C:\\Windows\\System32;"
+    const user = "C:\\Users\\使用者\\工具;".repeat(300)
+    expect(repairWindowsPath(machine.toLowerCase(), machine, user)).toBe(machine + user)
+    expect(parseShellEnv(Buffer.from(`machine=${machine}\0user=${user}`))).toEqual({ machine, user })
+  })
+
+  test("leaves missing Windows path values unchanged", () => {
+    expect(repairWindowsPath(undefined, "C:\\Windows", "C:\\Tools")).toBeUndefined()
+    expect(repairWindowsPath("C:\\Windows", undefined, "C:\\Tools")).toBeUndefined()
+    expect(repairWindowsPath("C:\\Windows", "C:\\Windows", undefined)).toBeUndefined()
   })
 })

--- a/packages/desktop/src/main/service/shell-env.ts
+++ b/packages/desktop/src/main/service/shell-env.ts
@@ -29,6 +29,35 @@ export function parseShellEnv(out: Buffer) {
   return env
 }
 
+export const loadWindowsPath = Effect.fn("ShellEnv.windowsPath")(function* () {
+  const path = yield* Path.Path
+  const out = spawnSync(
+    path.join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+    [
+      "-NoLogo",
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      `[Console]::OutputEncoding = [Text.UTF8Encoding]::new($false); [Console]::Write('machine=' + [Environment]::GetEnvironmentVariable('Path', 'Machine') + [char]0 + 'user=' + [Environment]::GetEnvironmentVariable('Path', 'User'))`,
+    ],
+    { stdio: ["ignore", "pipe", "ignore"], timeout: TIMEOUT, windowsHide: true },
+  )
+  if (out.error || out.status !== 0) {
+    yield* Effect.logWarning("[server] Failed to read Windows PATH; keeping inherited environment")
+    return null
+  }
+  const env = parseShellEnv(out.stdout)
+  const value = repairWindowsPath(process.env.PATH, env.machine, env.user)
+  return value ? { PATH: value } : null
+})
+
+export function repairWindowsPath(current: string | undefined, machine: string | undefined, user: string | undefined) {
+  if (!machine || !user || current?.toLowerCase() !== machine.toLowerCase()) return
+  const value = machine + (machine.endsWith(";") ? "" : ";") + user
+  // Explorer's 4 KB environment rebuild drops the user PATH entirely. Leave custom launch environments alone.
+  if (value.length >= 4095) return value
+}
+
 const probe = Effect.fn("ShellEnv.probe")(function* (shell: string, mode: "-il" | "-l") {
   const out = spawnSync(shell, [mode, "-c", "env -0"], {
     stdio: ["ignore", "pipe", "ignore"],


### PR DESCRIPTION
- Restore the user `PATH` when Windows Explorer drops it at the 4 KB boundary.
- Repair only the inherited machine-only case at desktop startup; preserve custom paths and never edit the registry.

PowerShell startup with the reproduced environment, before and after the desktop repair helper:

| Before | After |
| --- | --- |
| ![Oh My Posh missing from PATH](https://github.com/user-attachments/assets/2a91d8df-b89a-4d77-b2ab-ac89fa6e1b36) | ![Oh My Posh loads with the repaired PATH](https://github.com/user-attachments/assets/0357721d-780a-4c96-b25e-df4187aebe97) |
