### PR TITLE
fix(app): make PWA icons usable for installation

### DIFF
--- a/packages/app/manifest.json
+++ b/packages/app/manifest.json
@@ -9,13 +9,13 @@
       "src": "/web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "any maskable"
     },
     {
       "src": "/web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "maskable"
+      "purpose": "any maskable"
     }
   ],
   "theme_color": "#080808",

--- a/packages/app/vite.icons.test.ts
+++ b/packages/app/vite.icons.test.ts
@@ -59,7 +59,8 @@ test.each(["dev", "beta", "prod"])("serves %s app icons", async (channel) => {
 async function check(channel: string, read: (path: string) => Promise<Uint8Array>) {
   const html = new TextDecoder().decode(await read("/index.html"))
   const actual: typeof manifest = JSON.parse(new TextDecoder().decode(await read("/site.webmanifest")))
-  expect(actual.icons.every((icon) => icon.purpose === "maskable")).toBe(true)
+  expect(actual.icons.every((icon) => icon.purpose.split(" ").includes("any"))).toBe(true)
+  expect(actual.icons.every((icon) => icon.purpose.split(" ").includes("maskable"))).toBe(true)
   expect(actual).toEqual({
     ...manifest,
     icons: manifest.icons.map((icon) => ({ ...icon, src: `/icons/${channel}${icon.src}` })),


### PR DESCRIPTION
<!-- pi-pr:start -->
### Issue for this PR

Closes #47466

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Mark the 192px and 512px PWA icons as `any maskable`. Chromium's installability check requires an `any`-purpose icon; the current maskable-only manifest fails with `manifest-missing-suitable-icon` and `no-acceptable-icon`.

Keep maskable support and verify both purposes in the existing build/dev-server tests for each channel.

### How did you verify your code works?

- `bun test ./vite.icons.test.ts` in `packages/app`: 7 failures before the fix, 7 passes after.
- `bun typecheck` in `packages/app`, changed-file Prettier/Oxlint, and diff checks pass.
- An isolated Chromium manifest override removed both installability errors.
- Full app suites and a real Android installation have not been run.

### Screenshots / recordings

No visual UI change; the diagnostics above cover manifest installability.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
<!-- pi-pr:end -->
