### PR TITLE
fix(cli): serve empty embedded web assets

### DIFF
--- a/packages/cli/src/services/web-ui.ts
+++ b/packages/cli/src/services/web-ui.ts
@@ -30,7 +30,7 @@ function serveUI(request: HttpServerRequest.HttpServerRequest, url: URL, assets:
     return Effect.succeed(HttpServerResponse.empty({ status: 404, headers: { "cache-control": "no-store" } }))
   const name = assets[key] !== undefined ? key : "index.html"
   const file = assets[name]
-  if (!file) return Effect.succeed(HttpServerResponse.empty({ status: 404 }))
+  if (file === undefined) return Effect.succeed(HttpServerResponse.empty({ status: 404 }))
   if (request.method !== "GET" && request.method !== "HEAD")
     return Effect.succeed(HttpServerResponse.empty({ status: 405 }))
   const html = name === "index.html"

--- a/packages/cli/test/web-ui.test.ts
+++ b/packages/cli/test/web-ui.test.ts
@@ -20,6 +20,7 @@ describe("web UI", () => {
     const assets = {
       "index.html": await Bun.file(index).text(),
       "_assets/app.js": await Bun.file(asset).text(),
+      "_assets/empty.js": "",
       "sw.js": "service worker",
       "registerSW.js": "registration",
       "font.woff2": new Uint8Array([0, 1, 2, 255]),
@@ -66,6 +67,16 @@ describe("web UI", () => {
           expect(yield* Effect.promise(() => script.text())).toBe("console.log('embedded')")
           expect(script.headers.get("content-type")).toContain("javascript")
           expect(script.headers.get("cache-control")).toBe("public, max-age=31536000, immutable")
+
+          yield* Effect.forEach(["GET", "HEAD"], (method) =>
+            Effect.gen(function* () {
+              const empty = yield* Effect.promise(() => fetch(`${origin}/_assets/empty.js`, { method }))
+              expect(empty.status).toBe(200)
+              expect(empty.headers.get("content-type")).toContain("javascript")
+              expect(empty.headers.get("cache-control")).toBe("public, max-age=31536000, immutable")
+              expect(yield* Effect.promise(() => empty.text())).toBe("")
+            }),
+          )
 
           const worker = yield* Effect.promise(() => fetch(`${origin}/sw.js`))
           expect(worker.headers.get("cache-control")).toBe("no-cache")


### PR DESCRIPTION
<!-- pi-pr:start -->
### Issue for this PR

Closes #47467

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Check for `undefined` instead of falsiness when serving an embedded asset. An empty JavaScript file is present but falsy, so the current handler returns 404. This makes Workbox reject the entire service worker installation when that file is precached.

Add regression coverage for GET and HEAD of an empty JS asset, including status, MIME type, cache headers, and body. Existing missing-asset/API and SPA-fallback assertions stay in place.

### How did you verify your code works?

- `bun test ./test/web-ui.test.ts` in `packages/cli`: new assertion fails with 404 before the fix, then passes (34 assertions).
- `bun typecheck` in `packages/cli`, changed-file Prettier/Oxlint, and diff checks pass.
- Full CLI suites, a release-binary build, and post-fix browser worker installation have not been run.

### Screenshots / recordings

Not applicable; HTTP asset-serving change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
<!-- pi-pr:end -->
