### PR TITLE
fix(stats): close the model usage box without a cursor escape

### DIFF
--- a/packages/opencode/src/cli/cmd/stats.ts
+++ b/packages/opencode/src/cli/cmd/stats.ts
@@ -337,7 +337,8 @@ export function displayStats(stats: SessionStats, toolLimit?: number, modelLimit
     console.log("│                      MODEL USAGE                       │")
     console.log("├────────────────────────────────────────────────────────┤")
 
-    for (const [model, usage] of modelsToDisplay) {
+    for (const [index, [model, usage]] of modelsToDisplay.entries()) {
+      if (index > 0) console.log("├────────────────────────────────────────────────────────┤")
       console.log(`│ ${model.padEnd(54)} │`)
       console.log(renderRow("  Messages", usage.messages.toLocaleString()))
       console.log(renderRow("  Input Tokens", formatNumber(usage.tokens.input)))
@@ -345,10 +346,7 @@ export function displayStats(stats: SessionStats, toolLimit?: number, modelLimit
       console.log(renderRow("  Cache Read", formatNumber(usage.tokens.cache.read)))
       console.log(renderRow("  Cache Write", formatNumber(usage.tokens.cache.write)))
       console.log(renderRow("  Cost", `$${usage.cost.toFixed(4)}`))
-      console.log("├────────────────────────────────────────────────────────┤")
     }
-    // Remove last separator and add bottom border
-    process.stdout.write("\x1B[1A") // Move up one line
     console.log("└────────────────────────────────────────────────────────┘")
   }
   console.log()


### PR DESCRIPTION
### Issue for this PR

Closes #47471

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode stats` closed its MODEL USAGE box by printing a separator after every model and then erasing the last one with a cursor-up escape:

```ts
console.log("├──…──┤")     // after every entry
}
// Remove last separator and add bottom border
process.stdout.write("\x1B[1A") // Move up one line
console.log("└──…──┘")
```

`\x1B[1A` only erases anything on a terminal, and it was written unconditionally — there is no `isTTY` check anywhere in the file. So the moment stdout is not a terminal, the escape lands in the output as literal bytes and the separator it was meant to overwrite survives.

That covers every non-interactive use of the command: `opencode stats > stats.txt`, `opencode stats | less`, or capturing it from a script or CI job.

The fix prints the separator *before* each entry except the first, so the last thing in the loop is a data row and the bottom border follows naturally. No escape, no erasing, and the boxes above (OVERVIEW, COST & TOKENS) are untouched since they have fixed row counts and never needed the trick.

### How did you verify your code works?

I extracted the exact print sequence from both versions and piped it through `cat -v`:

```
# before, piped
│ modelA                                                 │
├────────────────────────────────────────────────────────┤
│ modelB                                                 │
├────────────────────────────────────────────────────────┤     <- never erased
^[[1A└────────────────────────────────────────────────────────┘  <- literal ESC[1A

# after, piped
│ modelA                                                 │
├────────────────────────────────────────────────────────┤
│ modelB                                                 │
└────────────────────────────────────────────────────────┘
```

On a terminal the two produce the same visible result: previously the cursor moved up and overwrote the trailing separator with the bottom border; now that separator is simply never printed. The number of separators is the same in both cases — `n - 1` for `n` models — so the box is identical.

`packages/opencode/src/cli/cmd/stats.ts` parses clean under `bun build --no-bundle` (bun 1.4.0). There are no existing tests for this command to extend, and the change is print-order only.

While reading this file I also noticed `formatNumber` renders 999,950–999,999 as `"1000.0K"` instead of `"1.0M"`, which affects the four token rows. That is a separate defect in a different function, so I left it out of this PR rather than mixing the two.

### Screenshots / recordings

Terminal rendering is unchanged; the diff above is the piped output, which is where the bug is visible.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
