### PR TITLE
fix(core): send x-opencode-session header on session runner requests

### DIFF
--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -208,6 +208,7 @@ const layer = Layer.effect(
           headers: {
             "x-session-affinity": session.id,
             "X-Session-Id": session.id,
+            "x-opencode-session": session.id,
             ...(session.parentID ? { "x-parent-session-id": session.parentID } : {}),
           },
         },

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -1105,10 +1105,12 @@ describe("SessionRunnerLLM", () => {
         {
           "x-session-affinity": sessionID,
           "X-Session-Id": sessionID,
+          "x-opencode-session": sessionID,
         },
         {
           "x-session-affinity": sessionID,
           "X-Session-Id": sessionID,
+          "x-opencode-session": sessionID,
         },
       ])
       expect(userTexts(requests[0])[0]).toContain("## Objective")
@@ -2530,6 +2532,7 @@ describe("SessionRunnerLLM", () => {
       expect(requests[0]?.http?.headers).toEqual({
         "x-session-affinity": sessionID,
         "X-Session-Id": sessionID,
+        "x-opencode-session": sessionID,
       })
     }),
   )


### PR DESCRIPTION
### Issue for this PR

Closes #47438

### Type of change

- [x] Bug fix

### What does this PR do?

Requests made by the V2 session runner only carried `x-session-affinity` and `X-Session-Id`. #44752 fixed the header set on the request path in `packages/opencode/src/session/llm/request.ts`, but the runner builds its own headers in `packages/core/src/session/runner/llm.ts` and never got the `x-opencode-session` header, so those requests reach opencode providers with only the transport's default user agent (Node fetch) and no session identifier. That matches the provider report in the issue.

This adds `x-opencode-session` alongside the existing correlation headers in the runner, so both request paths now identify the session the same way.

### How did you verify your code works?

Added `x-opencode-session` to the existing "adds session correlation headers to model requests" test in `packages/core/test/session-runner.test.ts` and confirmed it fails against the current runner with exactly that key missing from the received headers, then passes after the one-line fix. The full `packages/core` suite passes: 1091 pass, 7 skip (the one `Npm.add` failure in the full run is an unrelated 5s timeout that passes in isolation).

### Screenshots / recordings

N/A

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
