### PR TITLE
docs: add Standard Compute provider setup

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2308,6 +2308,32 @@ The model catalog is provided automatically. A minimal `opencode.json` is all th
 
 ---
 
+### Standard Compute
+
+[Standard Compute](https://standardcompute.com/) provides a model gateway with a fixed monthly price and an included compute budget.
+
+1. Create an account and copy your API key from the [Standard Compute dashboard](https://standardcompute.com/dashboard).
+
+2. Run `/connect` and search for **Standard Compute**, then enter your API key.
+
+   ```txt
+   /connect
+   ```
+
+3. Run `/models` and select **Standard Compute**.
+
+   ```txt
+   /models
+   ```
+
+The full model identifier is `standardcompute/standardcompute`. Configure routing and model selection in the Standard Compute dashboard. See the [available models](https://standardcompute.com/models) and [plan budgets](https://standardcompute.com/pricing).
+
+:::note
+Requests consume your included compute budget and stop when it is exhausted. A fixed monthly price does not mean unlimited usage.
+:::
+
+---
+
 ### Together AI
 
 1. Head over to the [Together AI console](https://api.together.ai), create an account, and click **Add Key**.


### PR DESCRIPTION
### Issue for this PR

Closes #47475

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the `/connect` and `/models` setup steps for Standard Compute, already present in models.dev, plus dashboard links and a note on the included monthly budget. No provider code changes.

Disclosure: I operate Standard Compute; AI assisted this contribution.

### How did you verify your code works?

`opencode models standardcompute` on v1.18.18 lists `standardcompute/standardcompute`. The full updated provider document compiles with MDX 3.1.1. No live inference or full Astro build was run.

### Screenshots / recordings

Not applicable: provider documentation only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
