### PR TITLE
feat(skill): expand shell directives in skill content

### DIFF
--- a/packages/opencode/src/tool/skill.ts
+++ b/packages/opencode/src/tool/skill.ts
@@ -1,7 +1,11 @@
 import path from "path"
 import { Effect, Schema } from "effect"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
+import { Shell } from "@opencode-ai/core/shell"
 import { Skill } from "../skill"
+import { Config } from "@/config/config"
+import { ConfigMarkdown } from "@/config/markdown"
+import { Process } from "@/util/process"
 import * as Tool from "./tool"
 import DESCRIPTION from "./skill.txt"
 
@@ -14,6 +18,7 @@ export const SkillTool = Tool.define(
   Effect.gen(function* () {
     const skill = yield* Skill.Service
     const ripgrep = yield* Ripgrep.Service
+    const config = yield* Config.Service
 
     return {
       description: DESCRIPTION,
@@ -32,6 +37,19 @@ export const SkillTool = Tool.define(
           })
 
           const dir = path.dirname(info.location)
+          const shellMatches = ConfigMarkdown.shell(info.content)
+          const rendered = yield* Effect.gen(function* () {
+            if (shellMatches.length === 0) return info.content.trim()
+            const cfg = yield* config.get()
+            const sh = Shell.preferred(cfg.shell)
+            const results = yield* Effect.promise(() =>
+              Promise.all(
+                shellMatches.map(async ([, cmd]) => (await Process.text([cmd], { cwd: dir, shell: sh, nothrow: true })).text),
+              ),
+            )
+            let index = 0
+            return info.content.replace(ConfigMarkdown.SHELL_REGEX, () => results[index++] ?? "").trim()
+          })
           const base = dir
           const files = yield* ripgrep.find({
             cwd: dir,
@@ -48,7 +66,7 @@ export const SkillTool = Tool.define(
               `<skill_content name="${info.name}">`,
               `# Skill: ${info.name}`,
               "",
-              info.content.trim(),
+              rendered,
               "",
               `Base directory for this skill: ${base}`,
               "Relative paths in this skill (e.g., scripts/, reference/) are relative to this base directory.",

--- a/packages/opencode/src/tool/skill.txt
+++ b/packages/opencode/src/tool/skill.txt
@@ -2,4 +2,6 @@ Load a specialized skill when the task at hand matches one of the skills listed 
 
 Use this tool to inject the skill's instructions and resources into current conversation. The output may contain detailed workflow guidance as well as references to scripts, files, etc in the same directory as the skill.
 
+When a skill contains `!`command`` directives, they are expanded at load time by executing each command in the skill directory and replacing the directive with stdout.
+
 The skill name must match one of the skills listed in your system prompt.

--- a/packages/opencode/test/tool/skill.test.ts
+++ b/packages/opencode/test/tool/skill.test.ts
@@ -2,10 +2,9 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { Ripgrep } from "@opencode-ai/core/ripgrep"
-import { Cause, Effect, Exit, Layer } from "effect"
+import { Cause, Effect, Exit } from "effect"
 import { afterEach, describe, expect } from "bun:test"
 import path from "path"
-import type { Permission } from "../../src/permission"
 import type { Tool } from "@/tool/tool"
 import { SkillTool } from "../../src/tool/skill"
 import { ToolRegistry } from "@/tool/registry"
@@ -129,6 +128,103 @@ Use this skill.
         expect(error).toBeInstanceOf(Error)
         if (error instanceof Error) expect(error.message).toContain('Skill "missing-skill" not found.')
       }
+    }),
+  )
+
+  it.instance("execute expands shell directives in skill content", () =>
+    Effect.gen(function* () {
+      const dir = (yield* TestInstance).directory
+      const skill = path.join(dir, ".opencode", "skill", "shell-skill")
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(skill, "SKILL.md"),
+          `---
+name: shell-skill
+description: Skill with shell expansion.
+---
+
+# Shell Skill
+
+Output: !\`printf expanded-ok\`
+`,
+        ),
+      )
+
+      const home = process.env.OPENCODE_TEST_HOME
+      process.env.OPENCODE_TEST_HOME = dir
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          process.env.OPENCODE_TEST_HOME = home
+        }),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const agent = { name: "build", mode: "primary" as const, permission: [], options: {} }
+      const tool = (yield* registry.tools({
+        providerID: "opencode" as any,
+        modelID: "gpt-5" as any,
+        agent,
+      })).find((tool) => tool.id === SkillTool.id)
+      if (!tool) throw new Error("Skill tool not found")
+
+      const result = yield* tool.execute(
+        { name: "shell-skill" },
+        {
+          ...baseCtx,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain("Output: expanded-ok")
+      expect(result.output).not.toContain("!`printf expanded-ok`")
+    }),
+  )
+
+  it.instance("execute runs shell directives from the skill directory", () =>
+    Effect.gen(function* () {
+      const dir = (yield* TestInstance).directory
+      const skill = path.join(dir, ".opencode", "skill", "shell-cwd")
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(skill, "SKILL.md"),
+          `---
+name: shell-cwd
+description: Skill that inspects current directory.
+---
+
+# Shell Cwd
+
+Current directory: !\`pwd\`
+`,
+        ),
+      )
+
+      const home = process.env.OPENCODE_TEST_HOME
+      process.env.OPENCODE_TEST_HOME = dir
+      yield* Effect.addFinalizer(() =>
+        Effect.sync(() => {
+          process.env.OPENCODE_TEST_HOME = home
+        }),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const agent = { name: "build", mode: "primary" as const, permission: [], options: {} }
+      const tool = (yield* registry.tools({
+        providerID: "opencode" as any,
+        modelID: "gpt-5" as any,
+        agent,
+      })).find((tool) => tool.id === SkillTool.id)
+      if (!tool) throw new Error("Skill tool not found")
+
+      const result = yield* tool.execute(
+        { name: "shell-cwd" },
+        {
+          ...baseCtx,
+          ask: () => Effect.void,
+        },
+      )
+
+      expect(result.output).toContain(`Current directory: ${skill}`)
     }),
   )
 })

--- a/packages/web/src/content/docs/skills.mdx
+++ b/packages/web/src/content/docs/skills.mdx
@@ -100,6 +100,27 @@ Ask clarifying questions if the target versioning scheme is unclear.
 
 ---
 
+## Inject dynamic context
+
+Skills support inline shell directives with Claude-compatible syntax:
+
+```markdown
+Branch: !`git branch --show-current`
+Recent commits:
+!`git log --oneline -5`
+```
+
+When a skill is loaded via the `skill` tool:
+
+- Each `!`command`` is executed
+- The directive is replaced with the command stdout
+- Commands run from the skill directory (`.../<skill-name>/`)
+- Command failures are included as command output (non-throwing behavior)
+
+Use this for short, deterministic context snapshots. Avoid long-running or interactive commands.
+
+---
+
 ## Recognize tool description
 
 OpenCode lists available skills in the `skill` tool description.


### PR DESCRIPTION
### Issue for this PR

Closes #10892

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `!`command`` expansion when loading skill content in the `skill` tool. Reuses the existing shell execution path (preferred shell + `Process.text` with `nothrow`), executes commands from the skill directory, and documents behavior.

### How did you verify your code works?

- `bun test test/tool/skill.test.ts test/skill/skill.test.ts` from `packages/opencode`
- `bun typecheck` from `packages/opencode`
- `bun run build` from `packages/web`

### Screenshots / recordings

N/A (non-UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR