### PR TITLE
feat(instruction): expand shell directives in instruction files

### DIFF
--- a/packages/opencode/src/session/instruction.ts
+++ b/packages/opencode/src/session/instruction.ts
@@ -11,6 +11,9 @@ import { Flag } from "@opencode-ai/core/flag/flag"
 import { FSUtil } from "@opencode-ai/core/fs-util"
 import { withTransientReadRetry } from "@/util/effect-http-client"
 import { Global } from "@opencode-ai/core/global"
+import { Shell } from "@opencode-ai/core/shell"
+import { ConfigMarkdown } from "@/config/markdown"
+import { Process } from "@/util/process"
 import type { MessageV2 } from "./message-v2"
 import type { MessageID } from "./schema"
 
@@ -89,7 +92,18 @@ const layer: Layer.Layer<
     })
 
     const read = Effect.fnUntraced(function* (filepath: string) {
-      return yield* fs.readFileString(filepath).pipe(Effect.catch(() => Effect.succeed("")))
+      const content = yield* fs.readFileString(filepath).pipe(Effect.catch(() => Effect.succeed("")))
+      const shellMatches = ConfigMarkdown.shell(content)
+      if (shellMatches.length === 0) return content
+      const config = yield* cfg.get()
+      const sh = Shell.preferred(config.shell)
+      const results = yield* Effect.promise(() =>
+        Promise.all(
+          shellMatches.map(async ([, cmd]) => (await Process.text([cmd], { cwd: path.dirname(filepath), shell: sh, nothrow: true })).text),
+        ),
+      )
+      let index = 0
+      return content.replace(ConfigMarkdown.SHELL_REGEX, () => results[index++] ?? "")
     })
 
     const fetch = Effect.fnUntraced(function* (url: string) {

--- a/packages/opencode/test/session/instruction.test.ts
+++ b/packages/opencode/test/session/instruction.test.ts
@@ -143,6 +143,47 @@ describe("Instruction.resolve", () => {
     ),
   )
 
+  it.live("expands shell directives in nearby AGENTS.md content", () =>
+    withFiles(
+      {
+        "subdir/AGENTS.md": "# Subdir Instructions\n\nOutput: !`printf expanded-ok`\n",
+        "subdir/nested/file.ts": "const x = 1",
+      },
+      (dir) =>
+        Effect.gen(function* () {
+          const svc = yield* Instruction.Service
+          const results = yield* svc.resolve(
+            [],
+            path.join(dir, "subdir", "nested", "file.ts"),
+            MessageID.make("msg_message-test-shell-1"),
+          )
+          expect(results).toHaveLength(1)
+          expect(results[0].content).toContain("Output: expanded-ok")
+          expect(results[0].content).not.toContain("!`printf expanded-ok`")
+        }),
+    ),
+  )
+
+  it.live("runs nearby AGENTS.md shell directives from the instruction file directory", () =>
+    withFiles(
+      {
+        "subdir/AGENTS.md": "# Subdir Instructions\n\nCurrent directory: !`pwd`\n",
+        "subdir/nested/file.ts": "const x = 1",
+      },
+      (dir) =>
+        Effect.gen(function* () {
+          const svc = yield* Instruction.Service
+          const results = yield* svc.resolve(
+            [],
+            path.join(dir, "subdir", "nested", "file.ts"),
+            MessageID.make("msg_message-test-shell-2"),
+          )
+          expect(results).toHaveLength(1)
+          expect(results[0].content).toContain(`Current directory: ${path.join(dir, "subdir")}`)
+        }),
+    ),
+  )
+
   it.live("doesn't reload AGENTS.md when reading it directly", () =>
     withFiles({ "subdir/AGENTS.md": "# Subdir Instructions", "subdir/nested/file.ts": "const x = 1" }, (dir) =>
       Effect.gen(function* () {

--- a/packages/web/src/content/docs/rules.mdx
+++ b/packages/web/src/content/docs/rules.mdx
@@ -132,6 +132,25 @@ All instruction files are combined with your `AGENTS.md` files.
 
 ---
 
+## Dynamic context in instruction files
+
+Instruction files support inline shell directives with `!`command`` syntax.
+
+```markdown
+Current branch: !`git branch --show-current`
+```
+
+When instruction files are loaded:
+
+- Each `!`command`` is executed
+- The directive is replaced with command stdout
+- Commands run from the instruction file's directory
+- Failures are returned as command output (non-throwing behavior)
+
+Use short, deterministic commands. Avoid interactive or long-running commands.
+
+---
+
 ## Referencing External Files
 
 While opencode doesn't automatically parse file references in `AGENTS.md`, you can achieve similar functionality in two ways:


### PR DESCRIPTION
### Issue for this PR

Closes #10892

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds `!`command`` expansion for instruction files (for example `AGENTS.md` and configured instruction files). Commands use the configured shell, run from each instruction file's directory, and replace directives with stdout.

### How did you verify your code works?

- `bun test test/session/instruction.test.ts`
- `bun test test/tool/skill.test.ts`
- `bun typecheck` (from `packages/opencode`)
- `bun run build` (from `packages/web`)

### Screenshots / recordings

N/A (non-UI change).

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR