### PR TITLE
docs(providers): document attachment/modalities model capabilities for custom models

### DIFF
--- a/packages/web/src/content/docs/providers.mdx
+++ b/packages/web/src/content/docs/providers.mdx
@@ -2668,6 +2668,41 @@ Configuration details:
 
 The `limit` fields allow OpenCode to understand how much context you have left. Standard providers pull these from models.dev automatically.
 
+###### Model capabilities
+
+Custom models also accept capability flags that tell OpenCode what the model supports:
+
+```json title="opencode.json" {12-15}
+{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "myprovider": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "My AI Provider Display Name",
+      "options": {
+        "baseURL": "https://api.myprovider.com/v1"
+      },
+      "models": {
+        "my-model-name": {
+          "name": "My Model Display Name",
+          "attachment": true,
+          "modalities": {
+            "input": ["text", "image"]
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- **attachment**: Whether the model can process file attachments such as images. Defaults to `false` for custom models.
+- **modalities.input**: The input types the model accepts (`text`, `image`, `audio`, `video`, `pdf`).
+
+:::warning
+If a custom model can see images but `attachment` is not set to `true`, pasted or attached images are replaced with a plain text placeholder (for example `[Attached image/png: file.png]`) before the request is sent. The model never receives the image and no warning is shown, which is easy to mistake for a provider problem. Set `attachment: true` (and `modalities.input`) on custom models that accept images.
+:::
+
 ---
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Documents the per-model capability options `attachment` and `modalities.input` for custom provider models in the providers guide, with a warning about the silent-placeholder behavior when `attachment` is not set.

Closes half of #47480 (the docs half).

## Context

Custom models default to `attachment: false`. When images are pasted or attached in a session on such a model, the media part is silently replaced by a plain text placeholder (`[Attached image/png: file.png]`) before the request is sent — the model never receives the image and nothing warns the user. This is especially confusing when the model behind the endpoint actually supports vision: the model typically "explains" that it cannot see images, and users conclude their provider is broken.

I hit exactly this against an OpenAI-compatible gateway with Gemini-class (vision) heads, and the only way to discover the flag was inspecting the bundled model loader. Documenting it prevents the trap.

## Changes

- New **Model capabilities** subsection under *Custom provider* in `packages/web/src/content/docs/providers.mdx`:
  - example config with `attachment: true` and `modalities.input`
  - explanation of both keys
  - a `:::warning` callout describing the silent placeholder substitution default

English page only — translations can follow their usual flow.

## Verification

- Field names verified against the model loader (`attachment: cfg.attachment ?? false`, `input.image: cfg.modalities?.input?.includes("image") ?? ...`) on 1.18.25 CLI and the desktop app server (1.18.29).
- Behavior verified end-to-end against an OpenAI-compatible gateway: with `attachment: true` (+ `modalities.input`) the model transcribes pasted screenshots natively; without it the stored part is the text placeholder.

Happy to extend this with the TUI warning proposed in the issue if maintainers want it server-side or client-side — pointers welcome.
