### PR TITLE
fix(acp): sync edited file content to the client

### DIFF
--- a/packages/opencode/src/acp/event.ts
+++ b/packages/opencode/src/acp/event.ts
@@ -9,6 +9,7 @@ import type {
   ToolPart,
 } from "@opencode-ai/sdk/v2"
 import { Effect } from "effect"
+import { exists, readText } from "@/util/filesystem"
 import { ACPSession } from "./session"
 import { ACPPermission } from "./permission"
 import { partsToContentChunks, type ReplayPart } from "./content"
@@ -29,6 +30,7 @@ type GlobalEventEnvelope = {
 type GlobalEventStream = {
   stream: AsyncIterable<GlobalEventEnvelope>
 }
+type FileEditedEvent = Extract<Event, { type: "file.edited" }>
 
 export function start(input: { sdk: OpencodeClient; connection: Connection; session: ACPSession.Interface }) {
   const subscription = new Subscription(input)
@@ -45,6 +47,8 @@ export class Subscription {
   private readonly permission: ACPPermission.Handler
   private connected = false
   private started = false
+  // file.edited has no session ID, so infer it from the most recent tool call, since edits happen during tool execution.
+  private activeSessionId: string | undefined
 
   constructor(
     private readonly input: {
@@ -102,6 +106,8 @@ export class Subscription {
         return this.handlePartUpdated(event)
       case "message.part.delta":
         return this.handlePartDelta(event)
+      case "file.edited":
+        return this.handleFileEdited(event)
     }
   }
 
@@ -207,6 +213,7 @@ export class Subscription {
       }),
     )
     if (part.type === "tool") {
+      this.activeSessionId = session.id
       await this.handleToolPart(session.id, part, session.cwd)
     }
   }
@@ -256,6 +263,18 @@ export class Subscription {
         },
       })
     }
+  }
+
+  private async handleFileEdited(event: FileEditedEvent) {
+    const sessionId = this.activeSessionId
+    const connection = this.input.connection
+    if (!sessionId || !connection.writeTextFile) return
+
+    const path = event.properties.file
+    if (!path || !(await exists(path))) return
+
+    const content = await readText(path)
+    await connection.writeTextFile({ sessionId, path, content })
   }
 
   private async fetchPartMetadata(sessionId: string, cwd: string, messageId: string, partId: string) {

--- a/packages/opencode/test/acp/event.test.ts
+++ b/packages/opencode/test/acp/event.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test"
+import { rm } from "fs/promises"
+import { tmpdir } from "os"
+import { join } from "path"
 import type { AgentSideConnection } from "@agentclientprotocol/sdk"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import type { Event, Message, OpencodeClient, Part, SessionMessageResponse, ToolPart } from "@opencode-ai/sdk/v2"
@@ -9,6 +12,7 @@ import { Directory } from "@/acp/directory"
 import { ACPSession } from "@/acp/session"
 
 type SessionUpdateParams = Parameters<AgentSideConnection["sessionUpdate"]>[0]
+type WriteTextFileParams = Parameters<AgentSideConnection["writeTextFile"]>[0]
 type ToolSessionUpdateParams = SessionUpdateParams & {
   update: Extract<SessionUpdateParams["update"], { sessionUpdate: "tool_call" | "tool_call_update" }>
 }
@@ -80,6 +84,7 @@ function createEventStream() {
 
 function createHarness(messages: Record<string, SessionMessageResponse> = {}) {
   const updates: SessionUpdateParams[] = []
+  const writeTextFileCalls: WriteTextFileParams[] = []
   const calls = {
     eventSubscribe: 0,
     message: 0,
@@ -106,11 +111,15 @@ function createHarness(messages: Record<string, SessionMessageResponse> = {}) {
       updates.push(params)
       return Promise.resolve()
     },
-  } satisfies Pick<AgentSideConnection, "sessionUpdate">
+    writeTextFile: (params: WriteTextFileParams) => {
+      writeTextFileCalls.push(params)
+      return Promise.resolve({})
+    },
+  } satisfies Pick<AgentSideConnection, "sessionUpdate" | "writeTextFile">
   const session = makeSessionService()
   const subscription = new ACPEvent.Subscription({ sdk, connection, session })
 
-  return { calls, connection, events, sdk, session, subscription, updates }
+  return { calls, connection, events, sdk, session, subscription, updates, writeTextFileCalls }
 }
 
 function textDelta(sessionID: string, messageID: string, partID: string, delta: string): Event {
@@ -164,6 +173,14 @@ function toolUpdated(part: ToolPart): Event {
       time: Date.now(),
       part,
     },
+  }
+}
+
+function fileEdited(file: string): Event {
+  return {
+    id: `evt_file_edited_${file}`,
+    type: "file.edited",
+    properties: { file },
   }
 }
 
@@ -747,5 +764,38 @@ describe("acp event routing", () => {
         { type: "content", content: { type: "image", mimeType: "image/png", data: image } },
       ],
     ])
+  })
+
+  it("syncs the edited file content to the client during a tool call", async () => {
+    const harness = createHarness()
+    await Effect.runPromise(harness.session.create({ id: "ses_edit", cwd: "/workspace" }))
+
+    const filepath = join(tmpdir(), `opencode-acp-file-edited-${process.pid}-${Date.now()}.txt`)
+    await Bun.write(filepath, "edited content")
+
+    try {
+      await harness.subscription.handle(toolUpdated(runningTool("ses_edit", "call_edit")))
+      await harness.subscription.handle(fileEdited(filepath))
+
+      expect(harness.writeTextFileCalls).toEqual([{ sessionId: "ses_edit", path: filepath, content: "edited content" }])
+    } finally {
+      await rm(filepath, { force: true })
+    }
+  })
+
+  it("does not sync file edits when no tool call is active", async () => {
+    const harness = createHarness()
+    await Effect.runPromise(harness.session.create({ id: "ses_idle", cwd: "/workspace" }))
+
+    const filepath = join(tmpdir(), `opencode-acp-file-edited-idle-${process.pid}-${Date.now()}.txt`)
+    await Bun.write(filepath, "content")
+
+    try {
+      await harness.subscription.handle(fileEdited(filepath))
+
+      expect(harness.writeTextFileCalls).toEqual([])
+    } finally {
+      await rm(filepath, { force: true })
+    }
   })
 })


### PR DESCRIPTION
Fixes #47484

## Problem

When opencode edits a file through ACP, the change does not appear in the editor's review list (e.g. Zed's Review panel with Keep/Reject). The file is modified on disk, but the client is never told about the final content, so there is nothing to review.

## Cause

Clients such as Zed build their review list from `fs/write_text_file` requests sent by the agent. opencode's ACP adapter only sends the *proposed* content during the permission-approval flow (`ACPPermission.writeProposedEdit`), and never sends the *written* content after the edit completes. When edits are auto-allowed (the common default), no `write_text_file` reaches the client, so the change is never recorded.

## Solution

In the ACP event subscription, handle `file.edited` events — published by the write / edit / apply_patch tools after a successful write — and send the new file content to the client via `connection.writeTextFile`. The session is inferred from the most recent tool call, since `file.edited` carries no session ID and edits always happen during tool execution.

This is confined to the ACP adapter layer: translating opencode's internal events into ACP protocol messages is exactly the adapter's responsibility. No changes to the tools or the edit flow itself.

## Testing

Added two unit tests in `packages/opencode/test/acp/event.test.ts`:
- syncs the edited file content to the client during a tool call
- does not sync file edits when no tool call is active (guards against spurious writes from unrelated `file.edited` events)

Verified end-to-end in Zed: edited files now appear in the Review list with Keep/Reject controls.
