### PR TITLE
fix(opencode): run live metadata updates from plugin tools

### DIFF
--- a/packages/opencode/src/tool/registry.ts
+++ b/packages/opencode/src/tool/registry.ts
@@ -148,6 +148,12 @@ const layer = Layer.effect(
                 const pluginCtx: PluginToolContext = {
                   ...toolCtx,
                   ask: (req) => bridge.promise(toolCtx.ask(req)),
+                  // `metadata` is void in the plugin API but Effect-backed on the
+                  // host, so spreading it would hand plugins an Effect nobody runs
+                  // and silently drop every live update (#37877).
+                  metadata: (input) => {
+                    bridge.fork(toolCtx.metadata(input))
+                  },
                   directory: ctx.directory,
                   worktree: ctx.worktree,
                 }

--- a/packages/opencode/test/tool/registry.test.ts
+++ b/packages/opencode/test/tool/registry.test.ts
@@ -7,7 +7,7 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { ToolRegistry } from "@/tool/registry"
 import { Tool } from "@/tool/tool"
 import { disposeAllInstances, TestInstance } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
+import { pollWithTimeout, testEffect } from "../lib/effect"
 import { TestConfig } from "../fixture/config"
 import { Config } from "@/config/config"
 import { Plugin } from "@/plugin"
@@ -459,6 +459,61 @@ describe("tool.registry", () => {
       expect(result.attachments).toEqual([
         { type: "file", mime: "image/png", filename: "picture.png", url: "data:image/png;base64,AAAA" },
       ])
+    }),
+  )
+
+  // Regression for #37877: the public plugin API declares `metadata()` as a
+  // plain `void` call, but the host implementation returns an Effect, so it only
+  // reaches the running tool part if the registry runs it.
+  it.instance("publishes metadata from a still-running custom tool", () =>
+    Effect.gen(function* () {
+      const test = yield* TestInstance
+      const customTools = path.join(test.directory, ".opencode", "tools")
+      const pluginTool = pathToFileURL(path.resolve(import.meta.dir, "../../../plugin/src/tool.ts")).href
+      yield* Effect.promise(() => fs.mkdir(customTools, { recursive: true }))
+      yield* Effect.promise(() =>
+        Bun.write(
+          path.join(customTools, "progress.ts"),
+          [
+            `import { tool } from ${JSON.stringify(pluginTool)}`,
+            "export default tool({",
+            "  description: 'progress tool',",
+            "  args: {},",
+            "  execute: async (_args, context) => {",
+            "    context.metadata({ title: 'Working', metadata: { phase: 'running' } })",
+            "    return 'done'",
+            "  },",
+            "})",
+            "",
+          ].join("\n"),
+        ),
+      )
+
+      const registry = yield* ToolRegistry.Service
+      const loaded = (yield* registry.all()).find((tool) => tool.id === "progress")
+      if (!loaded) throw new Error("custom progress tool was not loaded")
+      const agents = yield* Agent.Service
+      const updates: { title?: string; metadata?: Record<string, unknown> }[] = []
+      const result = yield* loaded.execute({}, {
+        sessionID: SessionID.make("ses_test"),
+        messageID: MessageID.make("msg_test"),
+        agent: (yield* agents.defaultInfo()).name,
+        abort: new AbortController().signal,
+        messages: [],
+        metadata: (input) =>
+          Effect.sync(() => {
+            updates.push(input)
+          }),
+        ask: () => Effect.void,
+      } satisfies Tool.Context)
+
+      expect(result.output).toBe("done")
+      expect(
+        yield* pollWithTimeout(
+          Effect.sync(() => updates.at(0)),
+          "running custom tool never published metadata",
+        ),
+      ).toEqual({ title: "Working", metadata: { phase: "running" } })
     }),
   )
 


### PR DESCRIPTION
### Issue for this PR

Closes #50313

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`ToolContext.metadata()` is a plain `void` call in the plugin API, but the host
context returns an Effect. `fromPlugin()` bridges `ask()` and spreads the rest,
so a plugin calling `context.metadata()` builds an Effect that nobody runs and
the update is dropped. Metadata only shows up once the tool returns it in its
final result, which is too late for anything that wants to report progress, or
publish a child session id while it is still working.

This bridges `metadata()` the same way `ask()` is bridged. It is forked rather
than awaited because the public signature is synchronous while the host update
is not.

### How did you verify your code works?

Added a regression test in `packages/opencode/test/tool/registry.test.ts` that
loads a real custom tool calling `context.metadata()` mid-execution and asserts
the host callback receives the update before the tool returns. It fails on `dev`
and passes with the fix.

- `bun test test/tool/registry.test.ts` in `packages/opencode`: 16 pass
- same, with the `registry.ts` change reverted: 1 fail, so the test covers the bug
- `bun test test/tool/`: 342 pass
- `bun typecheck` in `packages/opencode`: clean

### Screenshots / recordings

Not applicable, this is a server-side plugin bridge.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
