### PR TITLE
fix(session): cap images per request and classify image-count limit as overflow

### DIFF
--- a/packages/llm/src/provider-error.ts
+++ b/packages/llm/src/provider-error.ts
@@ -29,6 +29,9 @@ const patterns = [
   /model_context_window_exceeded/i,
   /too many tokens/i,
   /token limit exceeded/i,
+  /request contains \d+ images/i,
+  /exceeding the maximum of \d+ .* allowed/i,
+  /too many images/i,
 ]
 
 const exclusions = [/^(throttling error|service unavailable):/i, /rate limit/i, /too many requests/i]

--- a/packages/llm/test/provider-error.test.ts
+++ b/packages/llm/test/provider-error.test.ts
@@ -18,6 +18,16 @@ describe("provider error classification", () => {
     expect(messages.every(isContextOverflow)).toBe(true)
   })
 
+  test("classifies provider image count limit as context overflow", () => {
+    const messages = [
+      "Error from provider (Console Go): Upstream request failed: [invalid_request_error] request contains 51 images, exceeding the maximum of 50 allowed per request",
+      "request contains 60 images, exceeding the maximum of 50 allowed per request",
+      "Too many images in request",
+    ]
+
+    expect(messages.every(isContextOverflow)).toBe(true)
+  })
+
   test("does not classify rate limits as context overflow", () => {
     const messages = [
       "Throttling error: Too many tokens, please wait before trying again.",

--- a/packages/opencode/src/session/message-v2.ts
+++ b/packages/opencode/src/session/message-v2.ts
@@ -46,6 +46,15 @@ interface FetchDecompressionError extends Error {
 export const SYNTHETIC_ATTACHMENT_PROMPT = "Attached media from tool result:"
 export { isMedia }
 
+/**
+ * Maximum number of media attachments (images, PDFs) sent in a single model
+ * request. Providers enforce count limits (e.g. Console Go rejects requests
+ * with more than 50 images). Oldest media beyond this budget is replaced with
+ * a text placeholder so long sessions degrade gracefully instead of bricking
+ * with an unrecoverable 400 error. See https://github.com/anomalyco/opencode/issues/47487
+ */
+export const MAX_MODEL_IMAGES = 40
+
 function truncateToolOutput(text: string, maxChars?: number) {
   if (!maxChars || text.length <= maxChars) return text
   const omitted = text.length - maxChars
@@ -192,6 +201,38 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
     return { type: "json", value: output as never }
   }
 
+  // Enforce a client-side image budget so providers with count limits
+  // (e.g. 50 images max) never receive an unrecoverable request.
+  // Oldest media beyond MAX_MODEL_IMAGES is replaced with a text placeholder.
+  let mediaToOmit = 0
+  if (!options?.stripMedia) {
+    let totalMedia = 0
+    for (const msg of input) {
+      for (const part of msg.parts) {
+        if (
+          msg.info.role === "user" &&
+          part.type === "file" &&
+          part.mime !== "text/plain" &&
+          part.mime !== "application/x-directory" &&
+          isMedia(part.mime)
+        ) {
+          totalMedia++
+        }
+        if (
+          msg.info.role === "assistant" &&
+          part.type === "tool" &&
+          part.state.status === "completed" &&
+          !part.state.time.compacted
+        ) {
+          for (const attachment of part.state.attachments ?? []) {
+            if (isMedia(attachment.mime)) totalMedia++
+          }
+        }
+      }
+    }
+    mediaToOmit = Math.max(0, totalMedia - MAX_MODEL_IMAGES)
+  }
+
   for (const msg of input) {
     if (msg.parts.length === 0) continue
 
@@ -214,6 +255,12 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
             userMessage.parts.push({
               type: "text",
               text: `[Attached ${part.mime}: ${part.filename ?? "file"}]`,
+            })
+          } else if (isMedia(part.mime) && mediaToOmit > 0) {
+            mediaToOmit--
+            userMessage.parts.push({
+              type: "text",
+              text: `[Attached ${part.mime}: ${part.filename ?? "file"} - omitted to stay under provider image limit]`,
             })
           } else {
             userMessage.parts.push({
@@ -295,22 +342,40 @@ export const toModelMessagesEffect = Effect.fnUntraced(function* (
               : truncateToolOutput(part.state.output, options?.toolOutputMaxChars)
             const attachments = part.state.time.compacted || options?.stripMedia ? [] : (part.state.attachments ?? [])
 
+            // Drop oldest media beyond the budget, keeping newest images.
+            // Messages are processed oldest-first so the first mediaToOmit
+            // entries encountered are the oldest.
+            const omittedPlaceholders: string[] = []
+            const budgetedAttachments = []
+            for (const attachment of attachments) {
+              if (isMedia(attachment.mime) && mediaToOmit > 0) {
+                mediaToOmit--
+                omittedPlaceholders.push(
+                  `[Attached ${attachment.mime}: ${attachment.filename ?? "file"} - omitted to stay under provider image limit]`,
+                )
+              } else {
+                budgetedAttachments.push(attachment)
+              }
+            }
+            const textWithBudget =
+              omittedPlaceholders.length > 0 ? [outputText, ...omittedPlaceholders].join("\n") : outputText
+
             // For providers that don't support media in tool results, extract media files
             // (images, PDFs) to be sent as a separate user message
-            const mediaAttachments = attachments.filter((a) => isMedia(a.mime))
+            const mediaAttachments = budgetedAttachments.filter((a) => isMedia(a.mime))
             const extractedMedia = mediaAttachments.filter((a) => !supportsMediaInToolResult(a))
             if (extractedMedia.length > 0) {
               media.push(...extractedMedia)
             }
-            const finalAttachments = attachments.filter((a) => !isMedia(a.mime) || supportsMediaInToolResult(a))
+            const finalAttachments = budgetedAttachments.filter((a) => !isMedia(a.mime) || supportsMediaInToolResult(a))
 
             const output =
               finalAttachments.length > 0
                 ? {
-                    text: outputText,
+                    text: textWithBudget,
                     attachments: finalAttachments,
                   }
-                : outputText
+                : textWithBudget
 
             assistantMessage.parts.push({
               type: ("tool-" + part.tool) as `tool-${string}`,

--- a/packages/opencode/test/session/message-v2.test.ts
+++ b/packages/opencode/test/session/message-v2.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { APICallError } from "ai"
-import { MessageV2 } from "../../src/session/message-v2"
+import { MessageV2, MAX_MODEL_IMAGES } from "../../src/session/message-v2"
 import { ProviderTransform } from "@/provider/transform"
 import type { Provider } from "@/provider/provider"
 
@@ -409,6 +409,58 @@ describe("session.message-v2.toModelMessage", () => {
         ],
       },
     ])
+  })
+
+  test("caps images at MAX_MODEL_IMAGES, omitting oldest with placeholder", async () => {
+    const total = MAX_MODEL_IMAGES + 5
+    const userID = "m-user-cap"
+    const assistantID = "m-assistant-cap"
+    const attachments = Array.from({ length: total }, (_, i) => ({
+      ...basePart(assistantID, `file-cap-${i}`),
+      type: "file",
+      mime: "image/png",
+      filename: `shot-${i}.png`,
+      url: `data:image/png;base64,Zm9v${i}`,
+    }))
+    const input: SessionV1.WithParts[] = [
+      {
+        info: userInfo(userID),
+        parts: [
+          {
+            ...basePart(userID, "u1-cap"),
+            type: "text",
+            text: "check screenshots",
+          },
+        ] as SessionV1.Part[],
+      },
+      {
+        info: assistantInfo(assistantID, userID),
+        parts: [
+          {
+            ...basePart(assistantID, "a1-cap"),
+            type: "tool",
+            callID: "call-cap-1",
+            tool: "read",
+            state: {
+              status: "completed",
+              input: { filePath: "/tmp/shot.png" },
+              output: "screenshots read",
+              title: "Read",
+              metadata: {},
+              time: { start: 0, end: 1 },
+              attachments,
+            },
+          },
+        ] as SessionV1.Part[],
+      },
+    ]
+
+    const result = await MessageV2.toModelMessages(input, model)
+    const dump = JSON.stringify(result)
+    // Oldest 5 omitted as text, newest MAX kept as media
+    expect(dump).toInclude("[Attached image/png: shot-0.png - omitted")
+    const mediaCount = (dump.match(/"media"/g) ?? []).length
+    expect(mediaCount).toBe(MAX_MODEL_IMAGES)
   })
 
   test("preserves jpeg tool-result media for anthropic models", async () => {
@@ -1452,6 +1504,7 @@ describe("session.message-v2.fromError", () => {
       "Please reduce the length of the messages or completion",
       "400 status code (no body)",
       "413 status code (no body)",
+      "Error from provider (Console Go): Upstream request failed: [invalid_request_error] request contains 51 images, exceeding the maximum of 50 allowed per request",
     ]
 
     cases.forEach((message) => {


### PR DESCRIPTION
### Issue for this PR

Closes #47487

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

An agent that reads screenshots in a loop can accumulate 50+ image attachments in session history. The provider (Console Go in my case) then rejects every request with `request contains 51 images, exceeding the maximum of 50 allowed per request`, and the session is bricked because the images stay in history on every retry.

Two changes:

1. `packages/llm/src/provider-error.ts`: treat image-count rejections as context overflow (`request contains N images`, `exceeding the maximum of M allowed`, `too many images`), so the session triggers auto-compaction instead of surfacing a dead APIError.

2. `packages/opencode/src/session/message-v2.ts`: cap outgoing media at `MAX_MODEL_IMAGES = 40` in `toModelMessagesEffect`. Media is processed oldest-first, so the oldest attachments beyond the budget become a text placeholder and the newest 40 images are still sent. This covers user file parts and tool attachments, and skips already-compacted parts. The cap lives in the same function that already shapes media for providers, so no caller changes were needed.

Why this works: the classification fix gives the existing overflow recovery a chance to run, and the cap guarantees the request stays under the provider count limit even when compaction keeps a long tail verbatim.

### How did you verify your code works?

New tests plus existing suites (bun 1.3.14):

- `bun test test/provider-error.test.ts` in `packages/llm`: 3 pass, including the exact 51-image message.
- `bun test test/session/message-v2.test.ts` in `packages/opencode`: 40 pass, including a new capping test (45 attachments in, 40 media out, oldest replaced with placeholder) and the 51-image string added to the overflow cases.
- `bun test test/session/compaction.test.ts test/provider/error.test.ts`: 56 pass, 1 skip.
- `bun test test/tool/read.test.ts`: 39 pass.
- `bun test test/session/processor-effect.test.ts`: 17 pass.
- `tsgo --noEmit` clean in both `packages/llm` and `packages/opencode`; `oxlint` 0 errors; `prettier --check` clean on touched files.

### Screenshots / recordings

<img width="1470" height="439" alt="image" src="https://github.com/user-attachments/assets/64c9aca5-76c5-48d3-b7ff-897daf214866" />

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR