### PR TITLE
fix(console): inject enterprise sales inbox secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
           PLANETSCALE_SERVICE_TOKEN_NAME: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_NAME }}
           PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
           STRIPE_SECRET_KEY: ${{ github.ref_name == 'production' && secrets.STRIPE_SECRET_KEY_PROD || secrets.STRIPE_SECRET_KEY_DEV }}
+          SST_SECRET_ENTERPRISE_SALES_INBOX_EMAIL: ${{ secrets.ENTERPRISE_SALES_INBOX_EMAIL }}
           HONEYCOMB_API_KEY: ${{ secrets.HONEYCOMB_API_KEY }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}


### PR DESCRIPTION
## Why

The enterprise form reaches Salesforce but its Chatwoot email is not delivered. The production Console links an SST secret, but the deploy workflow does not provide the protected environment value.

## What

Pass the production environment's `ENTERPRISE_SALES_INBOX_EMAIL` secret to SST using its supported `SST_SECRET_` environment override. The secret value remains hidden from source and logs.

Salesforce, EmailOctopus, form content, and the prospect `Reply-To` are unchanged.

## Verification

- production and dev GitHub environments contain `ENTERPRISE_SALES_INBOX_EMAIL`
- repository pre-push hook: 30 package typechecks passed
- `git diff --check`

After deployment, submit one controlled enterprise form and confirm the resulting conversation appears in Chatwoot inbox `133751`.
