### PR TITLE
fix(lsp): attach language servers to extensionless files

### DIFF
--- a/packages/opencode/src/lsp/client.ts
+++ b/packages/opencode/src/lsp/client.ts
@@ -3,7 +3,7 @@ import { pathToFileURL, fileURLToPath } from "url"
 import { createMessageConnection, StreamMessageReader, StreamMessageWriter } from "vscode-jsonrpc/node"
 import type { Diagnostic as VSCodeDiagnostic } from "vscode-languageserver-types"
 import { Process } from "@/util/process"
-import { LANGUAGE_EXTENSIONS } from "./language"
+import { languageId } from "./language"
 import { Effect, Schema } from "effect"
 import type * as LSPServer from "./server"
 import { withTimeout } from "../util/timeout"
@@ -556,8 +556,7 @@ export async function create(input: {
           path.isAbsolute(request.path) ? request.path : path.resolve(input.directory, request.path),
         )
         const text = await Filesystem.readText(request.path)
-        const extension = path.extname(request.path)
-        const languageId = LANGUAGE_EXTENSIONS[extension] ?? "plaintext"
+        const language = languageId(request.path)
 
         const document = files[request.path]
         if (document !== undefined) {
@@ -611,7 +610,7 @@ export async function create(input: {
         await connection.sendNotification("textDocument/didOpen", {
           textDocument: {
             uri: pathToFileURL(request.path).href,
-            languageId,
+            languageId: language,
             version: 0,
             text,
           },

--- a/packages/opencode/src/lsp/language.ts
+++ b/packages/opencode/src/lsp/language.ts
@@ -1,3 +1,5 @@
+import path from "path"
+
 export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".abap": "abap",
   ".bat": "bat",
@@ -23,6 +25,7 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".patch": "diff",
   ".dart": "dart",
   ".dockerfile": "dockerfile",
+  Dockerfile: "dockerfile",
   ".ex": "elixir",
   ".exs": "elixir",
   ".erl": "erlang",
@@ -119,3 +122,9 @@ export const LANGUAGE_EXTENSIONS: Record<string, string> = {
   ".typ": "typst",
   ".typc": "typst",
 } as const
+
+// Resolve a file to its LSP languageId. Files with no extension (Dockerfile, ...) fall back to the
+// basename so they still map to a language instead of "plaintext".
+export function languageId(file: string): string {
+  return LANGUAGE_EXTENSIONS[path.extname(file) || path.basename(file)] ?? "plaintext"
+}

--- a/packages/opencode/src/lsp/lsp.ts
+++ b/packages/opencode/src/lsp/lsp.ts
@@ -210,7 +210,7 @@ const layer = Layer.effect(
       if (!containsPath(file, ctx)) return [] as LSPClient.Info[]
       const s = yield* InstanceState.get(state)
       const clients = yield* Effect.promise(async () => {
-        const extension = path.parse(file).ext || file
+        const extension = path.parse(file).ext || path.basename(file)
         const result: LSPClient.Info[] = []
         let updated = 0
 
@@ -329,7 +329,7 @@ const layer = Layer.effect(
       const ctx = yield* InstanceState.context
       const s = yield* InstanceState.get(state)
       return yield* Effect.promise(async () => {
-        const extension = path.parse(file).ext || file
+        const extension = path.parse(file).ext || path.basename(file)
         for (const server of Object.values(s.servers)) {
           if (server.extensions.length && !server.extensions.includes(extension)) continue
           const root = await server.root(file, ctx)

--- a/packages/opencode/test/lsp/language.test.ts
+++ b/packages/opencode/test/lsp/language.test.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "bun:test"
+import { languageId } from "@/lsp/language"
+
+test("languageId resolves known extensions", () => {
+  expect(languageId("foo.ts")).toBe("typescript")
+  expect(languageId("/proj/src/app.py")).toBe("python")
+})
+
+test("languageId resolves extensionless files by basename", () => {
+  // Regression for #33372 / #27604: a file literally named "Dockerfile" has no extension,
+  // so extname() is empty and it used to resolve to "plaintext".
+  expect(languageId("Dockerfile")).toBe("dockerfile")
+  expect(languageId("/proj/Dockerfile")).toBe("dockerfile")
+})
+
+test("languageId falls back to plaintext for unknown files", () => {
+  expect(languageId("notes.unknownext")).toBe("plaintext")
+  expect(languageId("randomfile")).toBe("plaintext")
+})


### PR DESCRIPTION
### Issue for this PR

Closes #33372

### Type of change

- [x] Bug fix

### What does this PR do?

Replaces #37741, which was closed by the automated cleanup (created >1 month ago, <2 reactions) rather than by a fix. Rebased on current `dev` and re-verified — the bug is unchanged.

Files with no extension (`Dockerfile`, `Makefile`, `wscript`) never get LSP support, for two reasons:

1. **The server never matches.** `lsp/lsp.ts` uses `path.parse(file).ext || file`, so for an extensionless file the match key becomes the whole path. The bundled `dockerfile` server already declares `extensions: [".dockerfile", "Dockerfile"]` in `lsp/server.ts`, but that `"Dockerfile"` entry can never match under the current matcher — the intent is already in the codebase, it just doesn't work. Fixed by falling back to the basename.
2. **The languageId is wrong.** `lsp/client.ts` resolves it from `path.extname` only, which is empty for these files, so the server receives `languageId: "plaintext"` and won't analyze them. Added a `languageId()` helper that falls back to the basename, plus the missing `Dockerfile` mapping.

The overlapping PR #33690 (matcher only) was closed by its own author in favour of this one, since the matcher fix alone still leaves the file as `plaintext`.

### How did you verify your code works?

`test/lsp/language.test.ts` covers `languageId()`: known extensions, extensionless files (`Dockerfile`, with and without a directory), and the `plaintext` fallback. 3/3 pass and `bun typecheck` is clean on current `dev`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
