### PR TITLE
fix(session): retry HTTP 408 request timeouts

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -88,10 +88,12 @@ export function retryable(error: Err, provider: string) {
   if (SessionV1.APIError.isInstance(error)) {
     const status = error.data.statusCode
     // 5xx errors are transient server failures and should always be retried,
-    // even when the provider SDK doesn't explicitly mark them as retryable.
+    // even when the provider SDK doesn't explicitly mark them as retryable. 408 is the one 4xx
+    // that is transient in the same way: the request timed out before completing, so it is safe
+    // to send again.
     if (
       !error.data.isRetryable &&
-      !(status !== undefined && status >= 500) &&
+      !(status !== undefined && (status === 408 || status >= 500)) &&
       !matchesRetryableMessage(error.data.message) &&
       !matchesRetryableMessage(error.data.responseBody)
     )

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -309,6 +309,26 @@ describe("session.retry.retryable", () => {
     expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "Service unavailable" })
   })
 
+  test("retries 408 request timeout errors", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "stream error: stream disconnected before completion",
+        isRetryable: false,
+        statusCode: 408,
+        responseBody: JSON.stringify({
+          type: "error",
+          sequence_number: 0,
+          code: "request_timeout",
+          message: "stream error: stream disconnected before completion",
+        }),
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({
+      message: "stream error: stream disconnected before completion",
+    })
+  })
+
   test("does not retry 4xx errors when isRetryable is false", () => {
     const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
       new SessionV1.APIError({


### PR DESCRIPTION
### Issue for this PR

Closes #47525

### Type of change

- [x] Bug fix

### What does this PR do?

Replaces #39413, which was closed by the automated cleanup rather than by a fix. Rebased onto the reworked `retry.ts` (message patterns, jitter, max retries) and re-verified against current `dev`.

`retryable()` only bypasses the provider SDK's `isRetryable` flag for `status >= 500`, so an HTTP 408 that the SDK didn't mark retryable ends the turn and the user has to resend the prompt by hand. This shows up with OpenAI-compatible proxies that normalise an aborted upstream stream into `408 request_timeout`.

Note on the newer `RETRYABLE_MESSAGE_PATTERNS`: they don't cover this case. The timeout pattern requires a literal space (`request timeout`), while the payload in #39221 carries `request_timeout` with an underscore. I checked the reported `message` and `responseBody` against the current pattern list and both return `false`, so a 408 still falls through today.

408 Request Timeout is the one 4xx that is transient in the same way a 5xx is — the request never completed, so sending it again is the defined behaviour for that status. It takes exactly the same path as 5xx: same classification, same backoff, same `retry-after` handling. Other 4xx statuses are unchanged.

#39221 was closed as addressed by #39391, which fixed 408/409 in `packages/ai` (the v2 path). This targets the v1 `packages/opencode/src/session` path, which is still wired in through `session/processor.ts` and still classifies these as non-retryable. Happy to close this if that path is being retired.

### How did you verify your code works?

`retries 408 request timeout errors` in `test/session/retry.test.ts`, built from the payload in the issue. Ran the whole suite — 61/61 pass, including `does not retry 4xx errors when isRetryable is false` (status 400), so 4xx isn't loosened generally. `bun typecheck` clean.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
