### PR TITLE
fix(core): fail content-filtered and outputless length settlements

### DIFF
--- a/packages/core/src/session/generate.ts
+++ b/packages/core/src/session/generate.ts
@@ -1,6 +1,6 @@
 export * as SessionGenerate from "./generate.js"
 
-import { LLMClient, Message, type AIError } from "@opencode-ai/ai"
+import { AIError, ContentPolicyError, InvalidProviderOutputError, LLMClient, Message } from "@opencode-ai/ai"
 import { Effect } from "effect"
 import { Database } from "../database/database.js"
 import { Instance } from "../instance/service.js"
@@ -56,6 +56,16 @@ export const generate = Effect.fn("SessionGenerate.generate")(function* (input: 
     })
     const response = yield* llm.generate(prepared.request, prepared.options)
     yield* Effect.logInfo("session generation usage diagnostic", { usage: response.usage })
+    if (response.finishReason.normalized === "content-filter")
+      return yield* new AIError({
+        reason: new ContentPolicyError({ message: "Provider blocked the response" }),
+      })
+    if (response.finishReason.normalized === "length" && !response.text && response.toolCalls.length === 0)
+      return yield* new AIError({
+        reason: new InvalidProviderOutputError({
+          message: "The model reached its output limit before producing text or a tool call",
+        }),
+      })
     return response.text
   }).pipe(instances.provide(input.session))
 })

--- a/packages/core/src/session/runner/publish-llm-event.ts
+++ b/packages/core/src/session/runner/publish-llm-event.ts
@@ -28,7 +28,7 @@ const asRecord = (value: unknown): Record<string, unknown> =>
 
 /** Immutable fold of the durable facts a step's writer has recorded so far. */
 export interface StepRecord {
-  /** The model produced visible output this attempt, which bars transparent retries and overflow recovery. */
+  /** The model produced durable output this attempt, which bars transparent retries and overflow recovery. */
   readonly outputStarted: boolean
   readonly providerFailed: boolean
   /** The step's recorded assistant failure, if any. */
@@ -92,6 +92,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
   let stepStarted = false
   let providerFailed = false
   let outputStarted = false
+  let usefulOutput = false
   let stepFailure: SessionError.Error | undefined
   let stepSettlement: StepRecord["finish"]
 
@@ -395,9 +396,11 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         })
         return
       case "text-delta":
+        if (event.text.length > 0) usefulOutput = true
         yield* text.append(event.id, event.text, providerState(event.providerMetadata))
         return
       case "text-end":
+        if (event.text && event.text.length > 0) usefulOutput = true
         yield* text.end(event.id, providerState(event.providerMetadata), event.text)
         return
       case "reasoning-start":
@@ -438,6 +441,7 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         return
       case "tool-call": {
         outputStarted = true
+        usefulOutput = true
         const tool = tools.get(event.id) ?? (yield* startToolInput(event))
         if (toolInput.has(event.id)) yield* endToolInput(event)
         if (tool.name !== event.name)
@@ -525,6 +529,14 @@ export const createLLMEventPublisher = (bus: Pick<Bus.Interface, "publish">, inp
         if (event.reason.normalized === "content-filter") {
           providerFailed = true
           yield* failAssistant({ type: "provider.content-filter", message: "Provider blocked the response" })
+          return
+        }
+        if (event.reason.normalized === "length" && !usefulOutput) {
+          providerFailed = true
+          yield* failAssistant({
+            type: "provider.invalid-output",
+            message: "The model reached its output limit before producing text or a tool call",
+          })
           return
         }
         return

--- a/packages/core/test/session-generate.test.ts
+++ b/packages/core/test/session-generate.test.ts
@@ -56,18 +56,40 @@ const client = Layer.mock(LLMClient.Service)({
     Effect.sync(() => {
       requests.push(request)
       options.push(requestOptions)
-      const response = LLMResponse.fromEvents([
-        LLMEvent.stepStart({ index: 0 }),
-        LLMEvent.textStart({ id: "generate" }),
-        LLMEvent.textDelta({ id: "generate", text: "Transient answer" }),
-        LLMEvent.textEnd({ id: "generate" }),
-        LLMEvent.stepFinish({
-          index: 0,
-          reason: { normalized: "stop" },
-          usage: { inputTokens: 100, outputTokens: 10 },
-        }),
-        LLMEvent.finish({ reason: { normalized: "stop" } }),
-      ])
+      const prompt = request.messages
+        .at(-1)
+        ?.content.flatMap((part) => (part.type === "text" ? [part.text] : []))
+        .join("")
+      const events = (() => {
+        if (prompt === "Filtered privately")
+          return [
+            LLMEvent.stepStart({ index: 0 }),
+            LLMEvent.stepFinish({ index: 0, reason: { normalized: "content-filter", raw: "content_filtered" } }),
+            LLMEvent.finish({ reason: { normalized: "content-filter", raw: "content_filtered" } }),
+          ]
+        if (prompt === "Reason privately")
+          return [
+            LLMEvent.stepStart({ index: 0 }),
+            LLMEvent.reasoningStart({ id: "generate-reasoning" }),
+            LLMEvent.reasoningDelta({ id: "generate-reasoning", text: "Thinking without an answer" }),
+            LLMEvent.reasoningEnd({ id: "generate-reasoning" }),
+            LLMEvent.stepFinish({ index: 0, reason: { normalized: "length", raw: "max_tokens" } }),
+            LLMEvent.finish({ reason: { normalized: "length", raw: "max_tokens" } }),
+          ]
+        return [
+          LLMEvent.stepStart({ index: 0 }),
+          LLMEvent.textStart({ id: "generate" }),
+          LLMEvent.textDelta({ id: "generate", text: "Transient answer" }),
+          LLMEvent.textEnd({ id: "generate" }),
+          LLMEvent.stepFinish({
+            index: 0,
+            reason: { normalized: "stop" },
+            usage: { inputTokens: 100, outputTokens: 10 },
+          }),
+          LLMEvent.finish({ reason: { normalized: "stop" } }),
+        ]
+      })()
+      const response = LLMResponse.fromEvents(events)
       if (!response) throw new Error("Incomplete generate response")
       return response
     }),
@@ -339,6 +361,43 @@ it.effect(
       expect(requests[0]?.tools).toMatchObject([{ name: "lookup", description: "Lookup" }])
       expect(requests[0]?.toolChoice).toBeUndefined()
       expect(options[0]?.webSocket).toBeUndefined()
+      expect(yield* durableState(db, sessionID)).toEqual(before)
+    }),
+  { timeout: 15_000 },
+)
+
+it.effect(
+  "fails transient generation when the provider filters or exhausts output before answering",
+  () =>
+    Effect.gen(function* () {
+      requests.length = 0
+      options.length = 0
+      instruction = "Initial context"
+      const { db, bus, instructions, session, instances } = yield* setup
+      yield* InstructionState.prepare(db, bus, instructions, sessionID)
+      const before = yield* durableState(db, sessionID)
+
+      for (const failure of [
+        {
+          prompt: "Filtered privately",
+          reason: { _tag: "ContentPolicy", message: "Provider blocked the response" },
+        },
+        {
+          prompt: "Reason privately",
+          reason: {
+            _tag: "InvalidProviderOutput",
+            message: "The model reached its output limit before producing text or a tool call",
+          },
+        },
+      ]) {
+        const error = yield* SessionGenerate.generate({ session, prompt: failure.prompt }).pipe(
+          Effect.provideService(Instance.Service, instances),
+          Effect.flip,
+        )
+        expect(error).toMatchObject({ _tag: "AI.Error", reason: failure.reason })
+      }
+
+      expect(requests).toHaveLength(2)
       expect(yield* durableState(db, sessionID)).toEqual(before)
     }),
   { timeout: 15_000 },

--- a/packages/core/test/session-runner-tool-events.test.ts
+++ b/packages/core/test/session-runner-tool-events.test.ts
@@ -625,3 +625,62 @@ test("content-filter finish preserves partial streamed text and never ends the s
     error: { type: "provider.content-filter" },
   })
 })
+
+test("reasoning-only length finish retains evidence and fails step closeout", async () => {
+  const { published, publisher } = capture()
+  await Effect.runPromise(
+    Effect.forEach(
+      [
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.reasoningStart({ id: "reasoning" }),
+        LLMEvent.reasoningDelta({ id: "reasoning", text: "Thinking without an answer" }),
+        LLMEvent.reasoningEnd({ id: "reasoning" }),
+        LLMEvent.stepFinish({ index: 0, reason: { normalized: "length", raw: "max_tokens" } }),
+      ],
+      (event) => publisher.publish(event),
+      { discard: true },
+    ),
+  )
+
+  expect(publisher.record()).toMatchObject({
+    outputStarted: true,
+    providerFailed: true,
+    failure: {
+      type: "provider.invalid-output",
+      message: "The model reached its output limit before producing text or a tool call",
+    },
+    finish: { finish: "length", rawFinish: "max_tokens" },
+  })
+  await Effect.runPromise(publisher.publishStepFailure())
+  expect(published.find((event) => event.type === "session.reasoning.ended.1")?.data).toMatchObject({
+    text: "Thinking without an answer",
+  })
+  expect(published.find((event) => event.type === "session.step.failed.1")?.data).toMatchObject({
+    rawFinish: "max_tokens",
+    error: { type: "provider.invalid-output" },
+  })
+})
+
+test("length finish remains successful after partial text", async () => {
+  const { publisher } = capture()
+  await Effect.runPromise(
+    Effect.forEach(
+      [
+        LLMEvent.stepStart({ index: 0 }),
+        LLMEvent.textStart({ id: "text" }),
+        LLMEvent.textDelta({ id: "text", text: "Partial answer" }),
+        LLMEvent.textEnd({ id: "text" }),
+        LLMEvent.stepFinish({ index: 0, reason: { normalized: "length", raw: "max_tokens" } }),
+      ],
+      (event) => publisher.publish(event),
+      { discard: true },
+    ),
+  )
+
+  expect(publisher.record()).toMatchObject({
+    outputStarted: true,
+    providerFailed: false,
+    finish: { finish: "length", rawFinish: "max_tokens" },
+  })
+  expect(publisher.record().failure).toBeUndefined()
+})


### PR DESCRIPTION
### Issue for this PR

Closes #46596
Related: #40146

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two settlement paths recorded provider failures as success:

1. `SessionGenerate.generate` (backing `POST /api/session/:id/generate`) returned `response.text` regardless of the finish reason. A stream finishing `content_filtered`, or `max_tokens` with no text and no tool call, produced `{"data":{"text":""}}` with HTTP 200.
2. In the runner, `publish-llm-event.ts` failed the assistant step on `content-filter`, but a step finishing `length` with reasoning-only output (no text, no tool call) settled as `succeeded`. The user saw an empty assistant message recorded as a successful turn. On Bedrock with adaptive thinking this is the common failure mode when the output budget is spent on reasoning.

Changes:

- `generate.ts`: raise `AIError(ContentPolicyError)` on `content-filter` and `AIError(InvalidProviderOutputError)` on `length` with empty text and no tool calls, instead of returning empty text.
- `publish-llm-event.ts`: track `usefulOutput` (any non-empty text delta/end or a tool call) separately from `outputStarted`. On `finish-step` with `length` and no useful output, fail the assistant with `provider.invalid-output`. Reasoning parts and `rawFinish` are still recorded, so the truncated reasoning remains available for diagnosis. Truncated responses that did produce partial text or a tool call keep settling as before, so no valid output is lost.

This is a re-submission of #46602, rebased on current `v2` (the original was auto-closed by the compliance bot because the checklist section was missing). `generate-node.ts` was folded into `generate.ts` upstream in #46639, and #46937 removed the `stepStreamed`/`stepFailed` flags; the change is adapted to both.

### How did you verify your code works?

- `packages/core/test/session-generate.test.ts`: new case "fails transient generation when the provider filters or exhausts output before answering" covering both `content-filter` and reasoning-only `length`, asserting the typed `AIError` reason and that durable session state is untouched.
- `packages/core/test/session-runner-tool-events.test.ts`: new case asserting a reasoning-only `length` step settles as `provider.invalid-output` while keeping the reasoning part, and that `length` with partial text still succeeds.
- `bun run test test/session-generate.test.ts test/session-runner-tool-events.test.ts` in `packages/core`: 29 pass, 0 fail.
- `bun typecheck` across the monorepo (33 packages) clean.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
