### PR TITLE
feat(core): support Astra async tools and live steering

### DIFF
--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -47,7 +47,9 @@ Plain-text prompts sent with `delivery: "steer"` are persisted before `response.
 
 One update is in flight per response. Additional updates, attachments, skills, moves, and compaction use the existing step-boundary inbox path. A rejected steer remains in canonical history; disconnect recovery rebuilds from that history rather than assuming connection-local steering survived. Changes to the request settings during handoff also require a full-context recovery.
 
-Monitoring blocks are classified by `misalignment_policy_violation`, stop pending local work, and are not automatically retried. Fixture and local-server tests cover the transport and runner; these tests do not establish availability on a particular API account or ChatGPT plan.
+Monitoring blocks are classified by `misalignment_policy_violation`, stop pending local work, and are not automatically retried. Fixture and local-server tests cover the transport and runner. Live ChatGPT OAuth checks also covered ordinary replies, async shell execution, accepted steering with automatic continuation, and delivery of deferred tool results after steering. Availability still depends on the account and plan.
+
+Steering acceptance does not guarantee immediate interruption: the server may finish the current response before starting its automatic successor. The Astra system prompt tells the model to end its response when it needs a pending async result, allowing the runner to deliver that result instead of waiting inside generation.
 
 API references: [async tool calling](https://developers.openai.com/api/docs/guides/async-tool-calling), [mid-turn steering](https://developers.openai.com/api/docs/guides/steering), [monitoring stops](https://developers.openai.com/api/docs/guides/safety-checks/misalignment-monitoring).
 

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -29,6 +29,28 @@ await Effect.runPromise(program.pipe(Effect.provide(llmLayer)))
 
 Run `LLMClient.stream(request)` instead of `generate` when you want incremental `LLMEvent`s. The event stream is provider-neutral — same shape across OpenAI Chat, OpenAI Responses, Anthropic Messages, Gemini, Bedrock Converse, and any OpenAI-compatible deployment.
 
+## GPT-6 Astra sessions
+
+Select `openai/gpt-6-astra` with either the existing OpenAI API-key integration or ChatGPT login. Astra uses Responses, defaults to `low` reasoning, and retains encrypted reasoning for continuation. Tool calling through Chat Completions and unsupported sampling/logprob options fail locally.
+
+OpenCode sessions enable Responses WebSockets for Astra by default. Set `OPENCODE_EXPERIMENTAL_OPENAI_RESPONSES_WEBSOCKET=false` to use HTTP; failed WebSocket upgrades also retain the existing HTTP fallback.
+
+Local functions run with `async: true`, except the synchronous question tool. They start when complete call items arrive, so the model can continue generating while tools run. The existing permission checks, cancellation, result truncation, and durable tool events still apply. Results settle at the step boundary and retain their original `call_id`; this does not introduce detached jobs that survive the session runner.
+
+Low-level callers opt in by naming functions in `providerOptions.asyncTools`, including functions inside namespaces:
+
+```ts
+LLM.request({ model: OpenAI.responses("gpt-6-astra"), prompt, tools, providerOptions: { asyncTools: ["lookup"] } })
+```
+
+Plain-text prompts sent with `delivery: "steer"` are persisted before `response.steer` is sent on the active connection. An automatic continuation is consumed as the next physical attempt without another `response.create`. When the server needs a tool result, the next explicit request supplies it without repeating accepted steering. Async results completed during an automatic continuation are delivered in the following request.
+
+One update is in flight per response. Additional updates, attachments, skills, moves, and compaction use the existing step-boundary inbox path. A rejected steer remains in canonical history; disconnect recovery rebuilds from that history rather than assuming connection-local steering survived. Changes to the request settings during handoff also require a full-context recovery.
+
+Monitoring blocks are classified by `misalignment_policy_violation`, stop pending local work, and are not automatically retried. Fixture and local-server tests cover the transport and runner; these tests do not establish availability on a particular API account or ChatGPT plan.
+
+API references: [async tool calling](https://developers.openai.com/api/docs/guides/async-tool-calling), [mid-turn steering](https://developers.openai.com/api/docs/guides/steering), [monitoring stops](https://developers.openai.com/api/docs/guides/safety-checks/misalignment-monitoring).
+
 ## Image generation
 
 Use `Image.generate` with an image model for direct asset generation:

--- a/packages/ai/src/protocols/open-responses-channel.ts
+++ b/packages/ai/src/protocols/open-responses-channel.ts
@@ -163,6 +163,10 @@ export const transport = <Body>(options: Options): Transport<Body, Prepared, str
                     request: create.request,
                     message: create.message,
                     base,
+                    steering:
+                      options.id === "openai-responses" &&
+                      typeof create.request.model === "string" &&
+                      /^gpt-6-astra(?:-|$)/.test(create.request.model),
                   }),
                 }
               })

--- a/packages/ai/src/protocols/open-responses-continuation.ts
+++ b/packages/ai/src/protocols/open-responses-continuation.ts
@@ -299,7 +299,8 @@ export const driver = (input: DriverInput): WebSocketChannelDriver => {
               request,
               pendingInput,
               // Completion can re-encrypt reasoning. Callers replay the item already emitted by output_item.done.
-              output: event.response?.output
+              // ChatGPT may send output: [] at completion after streaming all items separately.
+              output: event.response?.output?.length
                 ? event.response.output.map((item) =>
                     item.type === "reasoning" && item.id !== undefined
                       ? (output.find((done) => done.type === item.type && done.id === item.id) ?? item)

--- a/packages/ai/src/protocols/open-responses-continuation.ts
+++ b/packages/ai/src/protocols/open-responses-continuation.ts
@@ -7,12 +7,21 @@ import { OpenResponses } from "./open-responses.js"
 const PROTOCOL = "open-responses.websocket.v1"
 const VERSION = 1
 const decodeEvent = Schema.decodeUnknownEffect(OpenResponses.protocol.stream.event)
+const decodeSteer = Schema.decodeUnknownEffect(
+  Schema.Struct({
+    id: Schema.NonEmptyString,
+    previous_response_id: Schema.NonEmptyString,
+  }),
+)
 
 interface CheckpointValue {
   readonly version: typeof VERSION
   readonly responseID: string
   readonly request: Readonly<Record<string, unknown>>
   readonly output: ReadonlyArray<unknown>
+  readonly steer?: string
+  readonly automatic?: boolean
+  readonly pendingInput?: ReadonlyArray<unknown>
 }
 
 export interface DriverInput {
@@ -21,6 +30,7 @@ export interface DriverInput {
   readonly request: Readonly<Record<string, unknown>>
   readonly message: string
   readonly base: WebSocketChannelDriver
+  readonly steering?: boolean
 }
 
 const checkpointValue = (checkpoint: ChannelCheckpoint | undefined): CheckpointValue | undefined => {
@@ -34,6 +44,9 @@ const checkpointValue = (checkpoint: ChannelCheckpoint | undefined): CheckpointV
     responseID: checkpoint.value.responseID,
     request: checkpoint.value.request,
     output: checkpoint.value.output,
+    steer: typeof checkpoint.value.steer === "string" ? checkpoint.value.steer : undefined,
+    automatic: checkpoint.value.automatic === true,
+    pendingInput: Array.isArray(checkpoint.value.pendingInput) ? checkpoint.value.pendingInput : undefined,
   }
 }
 
@@ -96,7 +109,7 @@ const incremental = (
   if (!Array.isArray(input) || !Array.isArray(previousInput)) return undefined
   if (canonical(invariant(request)) !== canonical(invariant(checkpoint.request))) return undefined
   const baseline = [...previousInput, ...checkpoint.output]
-  if (input.length <= baseline.length) return undefined
+  if (input.length < baseline.length) return undefined
   if (!baseline.every((item, index) => canonical(comparable(item)) === canonical(comparable(input[index]))))
     return undefined
   return input.slice(baseline.length)
@@ -128,15 +141,93 @@ const rejected = (
 export const driver = (input: DriverInput): WebSocketChannelDriver => {
   const { previous_response_id: _previousResponseID, ...request } = input.request
   let output: OpenResponses.StreamItem[] = []
+  let responseID: string | undefined
+  let steer: string | undefined
+  let accepted = false
+  let steerID: string | undefined
+  let terminal: Extract<ChannelObservation, { type: "completed" | "incomplete" }> | undefined
+  let pendingInput: ReadonlyArray<unknown> | undefined
+  const handoff = (automatic: boolean, continuation?: string): ChannelObservation => {
+    if (!terminal?.checkpoint) throw new Error("Steering continuation requires a response checkpoint")
+    const previous = checkpointValue(terminal.checkpoint)!
+    return {
+      ...terminal,
+      continuation,
+      checkpoint: { protocol: PROTOCOL, value: { ...previous, steer, automatic } satisfies CheckpointValue },
+    }
+  }
   return {
+    steer: input.steering
+      ? (text) =>
+          Effect.sync(() => {
+            // ponytail: one in-flight update per response; additional inbox entries deliver at the next boundary.
+            if (!responseID || terminal || steer !== undefined || !text.trim()) return undefined
+            steer = text
+            return ProviderShared.encodeJson({ type: "response.steer", previous_response_id: responseID, input: text })
+          })
+      : undefined,
     create: (checkpoint) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         output = []
         const previous = checkpointValue(checkpoint)
         const delta = previous ? incremental(request, previous) : undefined
-        if (!previous || !delta) return { message: ProviderShared.encodeJson(request), mode: "full" as const }
+        if (previous?.automatic && !delta)
+          return yield* new AIError({
+            reason: new TransportError({
+              message: "The conversation changed before its automatic steering continuation could be consumed",
+              transport: "websocket",
+              operation: "request",
+              recovery: "rotate-and-retry-full",
+            }),
+          })
+        if (
+          !previous ||
+          !delta ||
+          (delta.length === 0 && !previous.pendingInput?.length && previous.steer === undefined)
+        )
+          return { message: ProviderShared.encodeJson(request), mode: "full" as const }
+        const steerIndex =
+          previous.steer === undefined
+            ? -1
+            : delta.findIndex(
+                (item) =>
+                  ProviderShared.isRecord(item) &&
+                  item.role === "user" &&
+                  Array.isArray(item.content) &&
+                  item.content.length === 1 &&
+                  ProviderShared.isRecord(item.content[0]) &&
+                  item.content[0].type === "input_text" &&
+                  item.content[0].text === previous.steer,
+              )
+        if (previous.steer !== undefined && steerIndex === -1)
+          return yield* new AIError({
+            reason: new TransportError({
+              message: "Accepted steering is missing from the canonical conversation",
+              transport: "websocket",
+              operation: "request",
+              recovery: "rotate-and-retry-full",
+            }),
+          })
+        const remaining = delta.filter((_, index) => index !== steerIndex)
+        if (previous.automatic) {
+          if (remaining.some((item) => !ProviderShared.isRecord(item) || item.type !== "function_call_output"))
+            return yield* new AIError({
+              reason: new TransportError({
+                message: "New input requires a fresh request after steering",
+                transport: "websocket",
+                operation: "request",
+                recovery: "rotate-and-retry-full",
+              }),
+            })
+          pendingInput = [...(previous.pendingInput ?? []), ...remaining]
+          return { message: "", mode: "automatic" as const }
+        }
         return {
-          message: ProviderShared.encodeJson({ ...request, input: delta, previous_response_id: previous.responseID }),
+          message: ProviderShared.encodeJson({
+            ...request,
+            input: [...(previous.pendingInput ?? []), ...remaining],
+            previous_response_id: previous.responseID,
+          }),
           mode: "incremental" as const,
         }
       }),
@@ -147,6 +238,39 @@ export const driver = (input: DriverInput): WebSocketChannelDriver => {
             ProviderShared.eventError(input.id, `Invalid ${input.name} WebSocket event`, frame, cause),
           ),
         )
+        if (input.steering && event.type.startsWith("response.steer.")) {
+          const identity = yield* decodeSteer(event.steer).pipe(
+            Effect.mapError((cause) =>
+              ProviderShared.eventError(input.id, "Invalid steering acknowledgment", frame, cause),
+            ),
+          )
+          if (
+            steer === undefined ||
+            identity.previous_response_id !== responseID ||
+            (steerID !== undefined && identity.id !== steerID)
+          )
+            return yield* ProviderShared.eventError(
+              input.id,
+              "Steering acknowledgment does not match the active update",
+              frame,
+            )
+          steerID = identity.id
+        }
+        if (input.steering && event.type === "response.steer.accepted") {
+          accepted = true
+          return { type: "ignore" }
+        }
+        if (input.steering && event.type === "response.steer.failed") {
+          steer = undefined
+          steerID = undefined
+          accepted = false
+          return terminal ?? { type: "ignore" }
+        }
+        if (input.steering && terminal && accepted) {
+          if (event.type === "response.steer.pending") return handoff(false)
+          if (event.type === "response.created") return handoff(true, frame)
+        }
+        if (event.type === "response.created") responseID = event.response?.id
         const observation = yield* input.base.observe(create, frame)
         if (event.type === "response.output_item.done" && event.item) output.push(event.item)
         if (observation.type === "provider-failure") {
@@ -154,23 +278,26 @@ export const driver = (input: DriverInput): WebSocketChannelDriver => {
           if (rejection === "previous_response_not_found") return rejected(observation, "retry-full")
           if (rejection === "websocket_connection_limit_reached") return rejected(observation, "rotate-and-retry-full")
         }
-        if (observation.type !== "completed") return observation
+        if (observation.type !== "completed" && !(observation.type === "incomplete" && steer !== undefined))
+          return observation
         // A trigger installs a different context window. Clear the append baseline, retaining the socket.
         if (
           Array.isArray(request.input) &&
           request.input.some((item) => ProviderShared.isRecord(item) && item.type === "compaction_trigger")
         )
           return observation
-        const responseID = event.response?.id
-        if (!responseID || responseID.trim().length === 0) return observation
-        return {
+        const finishedID = event.response?.id
+        if (!finishedID || finishedID.trim().length === 0) return observation
+        const completed = {
           ...observation,
           checkpoint: {
             protocol: PROTOCOL,
+            pendingInput: pendingInput !== undefined && pendingInput.length > 0,
             value: {
               version: VERSION,
-              responseID,
+              responseID: finishedID,
               request,
+              pendingInput,
               // Completion can re-encrypt reasoning. Callers replay the item already emitted by output_item.done.
               output: event.response?.output
                 ? event.response.output.map((item) =>
@@ -182,6 +309,9 @@ export const driver = (input: DriverInput): WebSocketChannelDriver => {
             } satisfies CheckpointValue,
           },
         }
+        terminal = completed
+        if (steer !== undefined) return { type: "ignore" }
+        return completed
       }),
   }
 }

--- a/packages/ai/src/protocols/open-responses.ts
+++ b/packages/ai/src/protocols/open-responses.ts
@@ -186,6 +186,7 @@ export const InputItem = Schema.Union([
   OpenResponsesReasoningItem,
   Schema.Struct({
     type: Schema.tag("function_call"),
+    async: Schema.optional(Schema.Boolean),
     id: Schema.optionalKey(Schema.String),
     call_id: Schema.String,
     name: Schema.String,
@@ -487,6 +488,7 @@ const lowerToolCall = (part: ToolCallPart, providerMetadataKey: string): OpenRes
   const id = itemID(part.providerMetadata, providerMetadataKey)
   return {
     type: "function_call",
+    ...(part.providerMetadata?.[providerMetadataKey]?.async === true ? { async: true } : {}),
     ...(id === undefined ? {} : { id }),
     call_id: part.id,
     name: part.name,
@@ -871,6 +873,7 @@ const mapFinishReason = (event: Event, hasFunctionCall: boolean): FinishReason =
   }
   if (reason === "max_output_tokens") return "length"
   if (reason === "content_filter") return "content-filter"
+  if (reason === "steered") return hasFunctionCall ? "tool-calls" : "stop"
   return hasFunctionCall ? "tool-calls" : "unknown"
 }
 
@@ -1092,7 +1095,7 @@ const onOutputItemAdded = (state: ParserState, event: NormalizedEvent): StepResu
   }
   if (item.type !== "function_call" || !item.call_id) return [state, NO_EVENTS]
   if (state.tools[item.id] !== undefined) return [state, NO_EVENTS]
-  const metadata = providerMetadata(state, { itemId: item.id })
+  const metadata = providerMetadata(state, { itemId: item.id, ...(item.async === true ? { async: true } : {}) })
   const events: LLMEvent[] = []
   const lifecycle = Lifecycle.stepStart(state.lifecycle, events)
   return [
@@ -1230,10 +1233,14 @@ const onOutputItemDone = Effect.fn("OpenResponses.onOutputItemDone")(function* (
 
   if (item.type === "function_call") {
     if (!item.call_id || !item.name) return [state, NO_EVENTS] satisfies StepResult
-    const metadata = providerMetadata(state, { itemId: item.id })
+    const metadata = providerMetadata(state, {
+      ...state.tools[item.id]?.providerMetadata?.[state.providerMetadataKey],
+      itemId: item.id,
+      ...(item.async === undefined ? {} : { async: item.async }),
+    })
     const registered = state.tools[item.id] !== undefined
     const tools = registered
-      ? state.tools
+      ? ToolStream.start(state.tools, item.id, { ...state.tools[item.id]!, providerMetadata: metadata })
       : ToolStream.start(state.tools, item.id, {
           id: item.call_id,
           name: item.name,

--- a/packages/ai/src/protocols/openai-chat.ts
+++ b/packages/ai/src/protocols/openai-chat.ts
@@ -727,6 +727,8 @@ export const fromRequest = Effect.fn("OpenAIChat.fromRequest")(function* (
   request: LLMRequest,
   options: LoweringOptions = {},
 ) {
+  if (/^gpt-6-astra(?:-|$)/.test(request.model.id) && request.tools.length > 0)
+    return yield* ProviderShared.invalidRequest("GPT-6 Astra tool calling requires the Responses API")
   // `fromRequest` returns the provider body only. Endpoint, auth, framing,
   // validation, and HTTP execution are composed by `Route.make`.
   const reasoningField = request.model.compatibility?.reasoningField

--- a/packages/ai/src/protocols/openai-responses.ts
+++ b/packages/ai/src/protocols/openai-responses.ts
@@ -80,11 +80,11 @@ const OpenAIResponsesNamespace = Schema.Struct({
   type: Schema.tag("namespace"),
   name: Schema.String,
   description: Schema.String,
-  tools: Schema.Array(OpenResponses.Tool),
+  tools: Schema.Array(Schema.Struct({ ...OpenResponses.Tool.fields, async: Schema.optional(Schema.Boolean) })),
 })
 
 const OpenAIResponsesTools = Schema.Union([
-  OpenResponses.Tool,
+  Schema.Struct({ ...OpenResponses.Tool.fields, async: Schema.optional(Schema.Boolean) }),
   OpenAIResponsesNamespace,
   OpenAIResponsesImageGenerationTool,
 ])
@@ -186,11 +186,17 @@ const lowerToolChoice = (toolChoice: NonNullable<LLMRequest["toolChoice"]>, tool
 const decodeBody = ProviderShared.validateWith(Schema.decodeUnknownEffect(OpenAIResponsesBody))
 
 const fromRequest = Effect.fn("OpenAIResponses.fromRequest")(function* (request: LLMRequest) {
+  const asyncTools = yield* ProviderShared.validateWith(
+    Schema.decodeUnknownEffect(Schema.UndefinedOr(Schema.Array(Schema.String))),
+  )(request.providerOptions?.asyncTools)
+  const astra = request.model.id === "gpt-6-astra" || request.model.id.startsWith("gpt-6-astra-")
+  if (asyncTools?.length && !astra)
+    return yield* ProviderShared.invalidRequest("Async tool calling requires GPT-6 Astra")
   const management = yield* ProviderShared.validateWith(
     Schema.decodeUnknownEffect(Schema.UndefinedOr(ContextManagement)),
   )(request.providerOptions?.contextManagement)
   const toolSchemaCompatibility = request.model.compatibility?.toolSchema
-  return yield* decodeBody({
+  const body = yield* decodeBody({
     ...(yield* OpenResponses.lowerConversation(request, adapter)),
     ...OpenResponses.lowerGeneration(request),
     context_management: management?.map((edit) => ({ type: edit.type, compact_threshold: edit.compactThreshold })),
@@ -202,6 +208,30 @@ const fromRequest = Effect.fn("OpenAIResponses.fromRequest")(function* (request:
       OpenResponses.allowedToolChoice(request) ??
       (request.toolChoice ? yield* lowerToolChoice(request.toolChoice, request.tools) : undefined),
   })
+  if (astra && (body.reasoning?.effort === "none" || body.reasoning?.effort === "minimal"))
+    return yield* ProviderShared.invalidRequest("GPT-6 Astra requires reasoning effort low or higher")
+  if (
+    astra &&
+    (body.temperature !== undefined ||
+      body.top_p !== undefined ||
+      body.top_logprobs !== undefined ||
+      body.include?.includes("message.output_text.logprobs"))
+  )
+    return yield* ProviderShared.invalidRequest("GPT-6 Astra does not support temperature, top_p, or logprobs")
+  if (asyncTools?.length) {
+    const enabled = new Set(asyncTools)
+    return {
+      ...body,
+      tools: body.tools?.map((tool) =>
+        tool.type === "namespace"
+          ? { ...tool, tools: tool.tools.map((leaf) => ({ ...leaf, async: enabled.has(leaf.name) || undefined })) }
+          : tool.type === "function"
+            ? { ...tool, async: enabled.has(tool.name) || undefined }
+            : tool,
+      ),
+    }
+  }
+  return body
 })
 
 const checkpointBody = {

--- a/packages/ai/src/protocols/utils/open-responses-options.ts
+++ b/packages/ai/src/protocols/utils/open-responses-options.ts
@@ -1,7 +1,7 @@
 import { Option, Schema } from "effect"
 import type { LLMRequest } from "../../schema/index.js"
 
-export const ReasoningEfforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max"] as const
+export const ReasoningEfforts = ["none", "minimal", "low", "medium", "high", "xhigh", "max", "ultra"] as const
 export type ReasoningEffort = (typeof ReasoningEfforts)[number] | (string & {})
 export const ReasoningEffort = Schema.declare<ReasoningEffort>(
   (value): value is ReasoningEffort => typeof value === "string",

--- a/packages/ai/src/provider-error.ts
+++ b/packages/ai/src/provider-error.ts
@@ -110,6 +110,8 @@ export function classifyProviderFailure(input: ProviderFailure): AIError["reason
   const text = [input.message, body].filter((value) => value.length > 0).join("\n")
   const clientScoped = input.status === undefined || (input.status >= 400 && input.status < 500)
 
+  if (codes.includes("misalignment_policy_violation")) return new ContentPolicyError(details)
+
   if (
     clientScoped &&
     (codes.includes("context_length_exceeded") ||

--- a/packages/ai/src/providers/openai-options.ts
+++ b/packages/ai/src/providers/openai-options.ts
@@ -6,6 +6,8 @@ import type { ContextManagement } from "../protocols/openai-responses.js"
 export type { OpenAIResponseIncludable, OpenAIServiceTier } from "../protocols/utils/openai-options.js"
 
 export type OpenAIOptionsInput = Omit<Options, "serviceTier"> & {
+  /** Local functions the model may leave running while it continues its response. */
+  readonly asyncTools?: ReadonlyArray<string>
   /** Advanced in-band compaction. The caller owns checkpoint persistence and recovery. */
   readonly contextManagement?: ContextManagement
   readonly serviceTier?: OpenAIServiceTier
@@ -58,7 +60,17 @@ export const openAIDefaultOptions = (
   modelID: string,
   options: { readonly textVerbosity?: boolean } = {},
 ): ProviderOptions | undefined =>
-  mergeProviderOptions(openAIProviderOptions({ store: false }), gpt5DefaultOptions(modelID, options))
+  mergeProviderOptions(
+    openAIProviderOptions({ store: false }),
+    modelID === "gpt-6-astra" || modelID.startsWith("gpt-6-astra-")
+      ? openAIProviderOptions({
+          reasoningEffort: "low",
+          reasoningSummary: "auto",
+          include: ["reasoning.encrypted_content"],
+          textVerbosity: options.textVerbosity ? "low" : undefined,
+        })
+      : gpt5DefaultOptions(modelID, options),
+  )
 
 export const withOpenAIOptions = <Options extends { readonly providerOptions?: OpenAIProviderOptionsInput }>(
   modelID: string,

--- a/packages/ai/src/route/transport/websocket-channel.ts
+++ b/packages/ai/src/route/transport/websocket-channel.ts
@@ -30,17 +30,30 @@ export interface WebSocketChannelExchange {
 export interface WebSocketChannelDriver {
   readonly create: (checkpoint: ChannelCheckpoint | undefined) => Effect.Effect<ChannelCreate, AIError>
   readonly observe: (create: ChannelCreate, frame: string) => Effect.Effect<ChannelObservation, AIError>
+  /** Undefined when this response cannot accept a user update. */
+  readonly steer?: (text: string) => Effect.Effect<string | undefined, AIError>
 }
 
 export interface ChannelCreate {
   readonly message: string
-  readonly mode: "full" | "incremental"
+  readonly mode: "full" | "incremental" | "automatic"
 }
 
 export type ChannelObservation =
+  | { readonly type: "ignore" }
   | { readonly type: "frame"; readonly frame: string }
-  | { readonly type: "completed"; readonly frame: string; readonly checkpoint?: ChannelCheckpoint }
-  | { readonly type: "incomplete"; readonly frame: string }
+  | {
+      readonly type: "completed"
+      readonly frame: string
+      readonly checkpoint?: ChannelCheckpoint
+      readonly continuation?: string
+    }
+  | {
+      readonly type: "incomplete"
+      readonly frame: string
+      readonly checkpoint?: ChannelCheckpoint
+      readonly continuation?: string
+    }
   | { readonly type: "provider-failure"; readonly error: AIError }
   | { readonly type: "rejected"; readonly error: AIError; readonly recovery: "retry-full" }
   | { readonly type: "rejected"; readonly error: AIError; readonly recovery: "rotate-and-retry-full" }
@@ -48,4 +61,6 @@ export type ChannelObservation =
 export interface ChannelCheckpoint {
   readonly protocol: string
   readonly value: unknown
+  /** Input deferred while a server-created response was already running. */
+  readonly pendingInput?: boolean
 }

--- a/packages/ai/src/route/transport/websocket.ts
+++ b/packages/ai/src/route/transport/websocket.ts
@@ -346,12 +346,14 @@ export const messageText = (message: string | Uint8Array, decoder: TextDecoder) 
   typeof message === "string" ? message : decoder.decode(message)
 
 const observationFrame = (observation: ChannelObservation) => {
+  if (observation.type === "ignore") return Effect.die("Ignored channel event reached the parser")
   if (observation.type === "frame" || observation.type === "completed" || observation.type === "incomplete")
     return Effect.succeed(observation.frame)
   return Effect.fail(observation.error)
 }
 
-const observationTerminal = (observation: ChannelObservation) => observation.type !== "frame"
+const observationTerminal = (observation: ChannelObservation) =>
+  observation.type !== "frame" && observation.type !== "ignore"
 
 export const makeDirect = (connector: WebSocketConnector): WebSocketChannelExecutor => ({
   execute: (exchange) =>
@@ -422,6 +424,7 @@ export const makeDirect = (connector: WebSocketConnector): WebSocketChannelExecu
             ),
           ),
           Stream.takeUntil(observationTerminal),
+          Stream.filter((observation) => observation.type !== "ignore"),
           Stream.mapEffect(observationFrame),
           Stream.mapError(
             (error) =>

--- a/packages/ai/test/provider-error.test.ts
+++ b/packages/ai/test/provider-error.test.ts
@@ -3,6 +3,14 @@ import { isContextOverflow } from "../src/index.js"
 import { classifyProviderFailure } from "../src/provider-error.js"
 
 describe("provider error classification", () => {
+  test("recognizes misalignment stops by code with and without an HTTP status", () => {
+    for (const status of [undefined, 403]) {
+      const body = JSON.stringify({ error: { code: "misalignment_policy_violation", message: "Review required" } })
+      const reason = classifyProviderFailure({ status, message: "Review required", rawBody: body })
+      expect(reason._tag).toBe("ContentPolicy")
+      expect(reason.body).toBe(body)
+    }
+  })
   test("classifies provider token limit messages as context overflow", () => {
     const messages = [
       "tokens in request more than max tokens allowed",

--- a/packages/ai/test/provider/openai-responses.test.ts
+++ b/packages/ai/test/provider/openai-responses.test.ts
@@ -109,6 +109,63 @@ const expectToolOutput = (body: OpenAIResponses.OpenAIResponsesBody): OpenAITool
 }
 
 describe("OpenAI Responses route", () => {
+  it.effect("prepares Astra async functions while keeping question tools synchronous", () =>
+    Effect.gen(function* () {
+      const astra = OpenAI.configure({ apiKey: "test" }).responses("gpt-6-astra")
+      const tools = [
+        ToolNamespace.make({
+          name: "tools",
+          tools: [
+            ToolDefinition.make({ name: "lookup", description: "Lookup", inputSchema: {} }),
+            ToolDefinition.make({ name: "question", description: "Ask", inputSchema: {} }),
+          ],
+        }),
+      ]
+      const prepared = yield* compileRequest(
+        LLM.request({ model: astra, prompt: "Start", tools, providerOptions: { asyncTools: ["lookup"] } }),
+      )
+      expect(prepared.body.reasoning).toEqual({ effort: "low", summary: "auto" })
+      expect(prepared.body.tools).toMatchObject([
+        {
+          type: "namespace",
+          tools: [
+            { type: "function", name: "lookup", async: true },
+            { type: "function", name: "question", async: undefined },
+          ],
+        },
+      ])
+      const incompatible = yield* compileRequest(
+        LLM.request({ model, prompt: "Start", tools, providerOptions: { asyncTools: ["lookup"] } }),
+      ).pipe(Effect.flip)
+      expect(incompatible.reason._tag).toBe("InvalidRequest")
+    }),
+  )
+
+  it.effect("rejects unsupported Astra parameters before sending a request", () =>
+    Effect.gen(function* () {
+      const astra = OpenAI.configure({ apiKey: "test" }).responses("gpt-6-astra")
+      for (const overrides of [
+        { providerOptions: { reasoningEffort: "none" } },
+        { providerOptions: { reasoningEffort: "minimal" } },
+        { generation: { temperature: 0 } },
+        { providerOptions: { include: ["message.output_text.logprobs"] } },
+      ]) {
+        const error = yield* compileRequest(LLM.request({ model: astra, prompt: "Start", ...overrides })).pipe(
+          Effect.flip,
+        )
+        expect(error.reason._tag).toBe("InvalidRequest")
+      }
+      const error = yield* compileRequest(
+        LLM.request({
+          model: OpenAI.configure({ apiKey: "test" }).chat("gpt-6-astra"),
+          prompt: "Start",
+          tools: [{ name: "lookup", description: "Lookup", inputSchema: {} }],
+        }),
+      ).pipe(Effect.flip)
+      expect(error.message).toContain("Responses API")
+    }),
+  )
+
   it.effect("prepares OpenAI Responses target", () =>
     Effect.gen(function* () {
       const prepared = yield* compileRequest(request)

--- a/packages/core/src/plugin/system-prompt/gpt-astra.txt
+++ b/packages/core/src/plugin/system-prompt/gpt-astra.txt
@@ -4,6 +4,7 @@ You are an AI agent powered by OpenCode, a coding agent harness. Help the user a
 - Responses are rendered as GitHub-flavored Markdown.
 - `<system-reminder>` blocks are harness instructions, not user-authored content. Read and follow them.
 - Prefer parallelizing independent tool calls.
+- Tools marked async can run while you continue independent work. Their results arrive in a later request after your current response ends. When you need a pending result, end your response; the harness waits for the tools and resumes you with their outputs. Do not keep reasoning or polling to wait for an async result, and never invent it.
 - Do not use a skill based solely on keywords, superficial relevance, or its availability. Avoid re-reading skills already available in the conversation unless needed.
 ${OPENCODE_TOOL_GUIDANCE}
 

--- a/packages/core/src/session/model-request.ts
+++ b/packages/core/src/session/model-request.ts
@@ -342,7 +342,16 @@ export const layer = Layer.effect(
           tools: Array.from(hooked, ([name, tool]) => ({ ...tool, name })),
           toolChoice: input.toolChoice,
           generation: Object.keys(context.generation).length === 0 ? undefined : context.generation,
-          providerOptions: Object.keys(context.providerOptions).length === 0 ? undefined : context.providerOptions,
+          providerOptions:
+            model.route.id === "openai-responses" && /^gpt-6-astra(?:-|$)/.test(model.id)
+              ? {
+                  asyncTools: Array.from(hooked.keys()).filter((name) => name !== "question"),
+                  ...model.route.defaults?.providerOptions,
+                  ...context.providerOptions,
+                }
+              : Object.keys(context.providerOptions).length === 0
+                ? undefined
+                : context.providerOptions,
         }),
       )
       const hasHttpHooks =
@@ -351,7 +360,7 @@ export const layer = Layer.effect(
       const webSocket =
         resolved.capabilities.responsesWebsockets === true
           ? yield* Config.boolean(responsesWebSocketFlag(resolved.ref.providerID)).pipe(
-              Config.withDefault(false),
+              Config.withDefault(model.route.id === "openai-responses" && /^gpt-6-astra(?:-|$)/.test(model.id)),
               Effect.orDie,
             )
           : false

--- a/packages/core/src/session/model-transport.ts
+++ b/packages/core/src/session/model-transport.ts
@@ -9,6 +9,7 @@ import {
   type WebSocketChannelExecutor,
   type WebSocketConnection,
   type WebSocketConnector,
+  type WebSocketChannelDriver,
 } from "@opencode-ai/ai/route"
 import { AIError, AIErrorReason, TransportError, type TransportOperation } from "@opencode-ai/ai"
 import { Hash } from "@opencode-ai/util/hash"
@@ -31,6 +32,7 @@ const metric = (event: string, attributes: Record<string, string> = {}) =>
 interface Active {
   readonly queue: Queue.Queue<string, AIError>
   delivery: "send-attempted" | "provider-observed" | "terminal"
+  driver: WebSocketChannelDriver
 }
 
 interface Channel {
@@ -42,6 +44,7 @@ interface Channel {
   checkpoint?: ChannelCheckpoint
   pending?: { readonly token: object; readonly checkpoint: ChannelCheckpoint }
   reader?: Fiber.Fiber<unknown, unknown>
+  continuation?: string
 }
 
 interface State {
@@ -55,6 +58,8 @@ export interface Interface {
   readonly bind: (sessionID: SessionSchema.ID) => WebSocketChannelExecutor
   readonly close: (sessionID: SessionSchema.ID) => Effect.Effect<void>
   readonly closeAll: Effect.Effect<void>
+  readonly steer: (sessionID: SessionSchema.ID, text: string, admit: Effect.Effect<void>) => Effect.Effect<boolean>
+  readonly hasPendingInput: (sessionID: SessionSchema.ID) => boolean
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionModelTransport") {}
@@ -92,12 +97,14 @@ const affinity = (exchange: WebSocketChannelExchange) =>
   `${exchange.connect.url}:${Hash.sha256(JSON.stringify(Object.entries(exchange.connect.headers).sort(([a], [b]) => a.localeCompare(b))))}`
 
 const observationFrame = (observation: ChannelObservation) => {
+  if (observation.type === "ignore") return Effect.die("Ignored channel event reached the parser")
   if (observation.type === "frame" || observation.type === "completed" || observation.type === "incomplete")
     return Effect.succeed(observation.frame)
   return Effect.fail(observation.error)
 }
 
-const observationTerminal = (observation: ChannelObservation) => observation.type !== "frame"
+const observationTerminal = (observation: ChannelObservation) =>
+  observation.type !== "frame" && observation.type !== "ignore"
 
 export const makeLayer = (connector: WebSocketConnector) =>
   Layer.effect(
@@ -316,12 +323,21 @@ export const makeLayer = (connector: WebSocketConnector) =>
           Effect.onInterrupt(() => closeChannel(owner, channel)),
         )
         if (create.mode === "full") channel.checkpoint = undefined
-        const active: Active = {
-          queue: yield* Queue.bounded<string, AIError>(INBOUND_CAPACITY),
-          delivery: "send-attempted",
-        }
+        const carried = channel.continuation
+        const active: Active =
+          create.mode === "automatic" && channel.active
+            ? channel.active
+            : {
+                queue: yield* Queue.bounded<string, AIError>(INBOUND_CAPACITY),
+                delivery: "send-attempted",
+                driver: exchange.driver,
+              }
+        active.driver = exchange.driver
         channel.active = active
-        const sent = yield* channel.connection.sendText(create.message).pipe(
+        channel.continuation = undefined
+        const sent = yield* (
+          create.mode === "automatic" ? Effect.void : channel.connection.sendText(create.message)
+        ).pipe(
           Effect.withSpan("SessionModelTransport.send"),
           Effect.onInterrupt(() => closeChannel(owner, channel)),
           Effect.result,
@@ -348,7 +364,11 @@ export const makeLayer = (connector: WebSocketConnector) =>
 
         let terminal: ChannelObservation | undefined
         const token = {}
-        const frames = Stream.fromQueue(active.queue).pipe(
+        // Pull one frame at a time: a chunk may also contain the automatic successor.
+        const inbound = Stream.fromEffectRepeat(Queue.take(active.queue))
+        const frames = (
+          create.mode === "automatic" && carried ? Stream.concat(Stream.succeed(carried), inbound) : inbound
+        ).pipe(
           Stream.timeoutOrElse({
             duration: IDLE_TIMEOUT,
             orElse: () =>
@@ -368,15 +388,22 @@ export const makeLayer = (connector: WebSocketConnector) =>
               if (!observationTerminal(observation)) return
               terminal = observation
               active.delivery = "terminal"
-              const staged = observation.type === "completed" ? observation.checkpoint : undefined
+              const staged =
+                observation.type === "completed" || observation.type === "incomplete"
+                  ? observation.checkpoint
+                  : undefined
               if (staged) channel.pending = { token, checkpoint: staged }
-              if (observation.type !== "completed" || !staged) channel.checkpoint = undefined
+              if (!staged) channel.checkpoint = undefined
+              if (observation.type === "completed" || observation.type === "incomplete")
+                channel.continuation = observation.continuation
             }),
           ),
           Stream.takeUntil(observationTerminal),
+          Stream.filter((observation) => observation.type !== "ignore"),
           Stream.mapEffect(observationFrame),
           Stream.ensuring(
             Effect.gen(function* () {
+              if (channel.continuation) return
               if (channel.active === active) channel.active = undefined
               const pending = yield* Queue.size(active.queue)
               yield* Queue.shutdown(active.queue)
@@ -481,8 +508,38 @@ export const makeLayer = (connector: WebSocketConnector) =>
         )
       })
 
+      const steer = Effect.fn("SessionModelTransport.steer")(function* (
+        sessionID: SessionSchema.ID,
+        text: string,
+        admit: Effect.Effect<void>,
+      ) {
+        const owner = states.get(sessionID)
+        const channel = owner?.channel
+        const active = channel?.active
+        if (!owner || !channel || channel.closing || !active?.driver.steer) return false
+        return yield* Effect.uninterruptibleMask((restore) =>
+          Effect.gen(function* () {
+            const message = yield* active.driver.steer!(text).pipe(Effect.orElseSucceed(() => undefined))
+            if (!message) return false
+            // Persist before sending: a disconnect must never lose the user's update.
+            yield* admit
+            yield* restore(channel.connection.sendText(message)).pipe(
+              Effect.catch((error) => poison(owner, channel, error)),
+              Effect.onInterrupt(() => closeChannel(owner, channel)),
+            )
+            return true
+          }),
+        )
+      })
+
       yield* Effect.addFinalizer(() => closeAll)
-      return Service.of({ bind, close, closeAll })
+      return Service.of({
+        bind,
+        close,
+        closeAll,
+        steer,
+        hasPendingInput: (sessionID) => states.get(sessionID)?.channel?.checkpoint?.pendingInput === true,
+      })
     }),
   )
 

--- a/packages/core/src/session/runner/llm.ts
+++ b/packages/core/src/session/runner/llm.ts
@@ -175,7 +175,9 @@ const layer = Layer.effect(
       while (true) {
         const next = yield* advanceToStep()
         if (next._tag !== "Ready") return next
-        continuing = yield* runStep(next.context, step)
+        continuing = yield* runStep(next.context, step, () => {
+          step = 0
+        })
         step++
         force = false
         entering = false
@@ -190,7 +192,11 @@ const layer = Layer.effect(
     })
 
     /** Owns logical Step policy; each attempt owns its streaming, tools, and durable settlement. */
-    const runStep = Effect.fn("SessionRunner.runStep")(function* (first: SessionContext.Loaded, step: number) {
+    const runStep = Effect.fn("SessionRunner.runStep")(function* (
+      first: SessionContext.Loaded,
+      step: number,
+      onSteer: () => void,
+    ) {
       const sessionID = first.session.id
       let assistantMessageID = SessionMessage.ID.create()
       const retry = yield* SessionRunnerRetry.make(bus, sessionID)
@@ -248,6 +254,7 @@ const layer = Layer.effect(
               retry: proposed,
             }),
           recoverContinuation,
+          onSteer,
           recoverOverflow: Effect.suspend(() =>
             recoverOverflow && compaction.enabled()
               ? compaction.compact(compactionInput).pipe(Effect.map((result) => result.status === "completed"))

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -27,6 +27,7 @@ export interface Decision {
 }
 
 export function isRetryable(error: AIError) {
+  if (error.reason._tag === "ContentPolicy") return false
   const override = error.reason.http?.headers["x-should-retry"]
   if (override === "true") return true
   if (override === "false") return false
@@ -45,7 +46,6 @@ export function isRetryable(error: AIError) {
       return true
     case "Authentication":
     case "QuotaExceeded":
-    case "ContentPolicy":
     case "InvalidRequest":
     case "UnsupportedOperation":
     case "NoRoute":

--- a/packages/core/src/session/runner/step.ts
+++ b/packages/core/src/session/runner/step.ts
@@ -22,6 +22,9 @@ import { StepFailedError } from "../error.js"
 import { SessionEvent } from "../event.js"
 import { SessionMessage } from "../message.js"
 import { SessionModelRequest } from "../model-request.js"
+import { SessionModelTransport } from "../model-transport.js"
+import { SessionInbox } from "../inbox.js"
+import { Database } from "../../database/database.js"
 import { SessionSchema } from "../schema.js"
 import { toSessionError } from "../to-session-error.js"
 import { SessionUsage } from "../usage.js"
@@ -55,6 +58,7 @@ interface Input {
   readonly recoverContinuation: boolean
   /** The runner owns compaction policy; the attempt invokes it only before durable output. */
   readonly recoverOverflow: Effect.Effect<boolean>
+  readonly onSteer?: () => void
 }
 
 const TOOLS_INTERRUPTED = { type: "aborted", message: "Tool execution interrupted" } as const
@@ -67,6 +71,8 @@ export const make = Effect.gen(function* () {
   const llm = yield* LLMClient.Service
   const snapshots = yield* Snapshot.Service
   const toolOutput = yield* ToolOutput.Service
+  const transport = yield* SessionModelTransport.Service
+  const db = (yield* Database.Service).db
 
   const attempt = Effect.fn("SessionStep.attempt")(function* (input: Input) {
     const startSnapshot = yield* snapshots.capture()
@@ -78,6 +84,44 @@ export const make = Effect.gen(function* () {
       providerMetadataKey: input.model.model.route.providerMetadataKey ?? input.model.model.provider,
       snapshot: startSnapshot,
     })
+    let steered = false
+    const steer = input.prepared.options.webSocket
+      ? SessionInbox.serialized(
+          input.sessionID,
+          Effect.gen(function* () {
+            const pending = yield* SessionInbox.nextPromotable(db, input.sessionID, "steer")
+            // Attachments and controls require normal context preparation at a step boundary.
+            if (
+              pending?.type !== "user" ||
+              pending.payload.files?.length ||
+              pending.payload.agents?.length ||
+              pending.payload.skills?.length
+            )
+              return
+            yield* transport.steer(
+              input.sessionID,
+              pending.payload.text,
+              publisher.startAssistant().pipe(
+                Effect.andThen(
+                  bus.publish(SessionEvent.InboxDelivered, { sessionID: input.sessionID, inboxID: pending.id }),
+                ),
+                Effect.tap(() =>
+                  Effect.sync(() => {
+                    steered = true
+                    input.onSteer?.()
+                  }),
+                ),
+                Effect.asVoid,
+              ),
+            )
+          }),
+        )
+      : Effect.void
+    const steering = yield* bus.subscribe([SessionEvent.InboxEnqueued, SessionEvent.InboxDeliveryChanged]).pipe(
+      Stream.filter((event) => event.data.sessionID === input.sessionID),
+      Stream.runForEach(() => steer),
+      Effect.forkScoped({ startImmediately: true }),
+    )
     const toolRuns: Array<{
       readonly call: ToolCall
       readonly fiber: Fiber.Fiber<void, Permission.DeclinedError | QuestionTool.CancelledError>
@@ -112,6 +156,7 @@ export const make = Effect.gen(function* () {
             return
           }
           yield* publisher.publish(event)
+          if (event.type === "step-start") yield* steer
           if (event.type !== "tool-call" || event.providerExecuted) return
           toolRuns.push({
             call: event,
@@ -134,10 +179,12 @@ export const make = Effect.gen(function* () {
     return yield* Effect.uninterruptibleMask((restore) =>
       Effect.gen(function* () {
         const stream = yield* restore(providerStream).pipe(Effect.exit)
+        yield* Fiber.interrupt(steering)
         const streamFailure = Option.getOrUndefined(Exit.findErrorOption(stream))
         const streamInterrupted = Exit.hasInterrupts(stream)
         if (!overflowFailure && publisher.hasStarted()) yield* publisher.streamed()
-        if (streamInterrupted) yield* interruptTools
+        if (streamInterrupted || (streamFailure instanceof AIError && streamFailure.reason._tag === "ContentPolicy"))
+          yield* interruptTools
         const joined = yield* restore(Fiber.awaitAll(toolRuns.map((run) => run.fiber))).pipe(Effect.exit)
         if (Exit.isFailure(joined)) yield* interruptTools
         const tools = classifyToolExits(joined, toolRuns)
@@ -170,7 +217,7 @@ export const make = Effect.gen(function* () {
         )
           return Outcome.RecoverFull()
         const retry =
-          llmFailure && llmError && !isContextOverflowFailure(llmFailure)
+          llmFailure && llmError && llmFailure.reason._tag !== "ContentPolicy" && !isContextOverflowFailure(llmFailure)
             ? yield* restore(
                 input.retry(
                   llmFailure,
@@ -256,7 +303,10 @@ export const make = Effect.gen(function* () {
         if (tools.interrupted && Exit.isFailure(joined)) return yield* Effect.failCause(joined.cause)
         if (record.failure) return yield* new StepFailedError({ error: record.failure })
         return Outcome.Completed({
-          needsContinuation: input.prepared.request.toolChoice?.type !== "none" && record.needsContinuation,
+          needsContinuation:
+            steered ||
+            transport.hasPendingInput(input.sessionID) ||
+            (input.prepared.request.toolChoice?.type !== "none" && record.needsContinuation),
         })
       }),
     )

--- a/packages/core/test/plugin/provider-openai.test.ts
+++ b/packages/core/test/plugin/provider-openai.test.ts
@@ -173,7 +173,9 @@ describe("OpenAIPlugin", () => {
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-6-astra"))).enabled).toBe(true)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.10"))).enabled).toBe(true)
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5"))).enabled).toBe(false)
-      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.04-astra"))).enabled).toBe(false)
+      expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-5.04-astra"))).enabled).toBe(
+        false,
+      )
       expect(required(yield* catalog.model.get(Provider.ID.openai, Model.ID.make("gpt-4.99"))).enabled).toBe(false)
     }),
   )
@@ -226,6 +228,8 @@ describe("OpenAIPlugin", () => {
         bind: () => executor,
         close: () => Effect.void,
         closeAll: Effect.void,
+        steer: () => Effect.succeed(false),
+        hasPendingInput: () => false,
       })
       const sessionID = Session.ID.make("ses_websocket_hooks")
       const agentID = Agent.ID.make("build")

--- a/packages/core/test/session-astra-transport.test.ts
+++ b/packages/core/test/session-astra-transport.test.ts
@@ -1,0 +1,210 @@
+import { expect, test } from "bun:test"
+import { AIError, LLM, LLMRequest, LLMResponse, Message, TransportError } from "@opencode-ai/ai"
+import { configure } from "@opencode-ai/ai/providers/openai"
+import { LLMClient, RequestExecutor, type WebSocketConnector } from "@opencode-ai/ai/route"
+import { SessionModelTransport } from "../src/session/model-transport"
+import { Session } from "@opencode-ai/schema/session"
+import { Cause, Effect, Layer, Queue, Stream } from "effect"
+
+const sessionID = Session.ID.make("ses_astra")
+const item = (id: string, text: string) => ({
+  type: "message",
+  id,
+  role: "assistant",
+  content: [{ type: "output_text", text }],
+})
+const call = { type: "function_call", id: "fc_1", call_id: "call_1", name: "lookup", arguments: "{}", async: true }
+const result = Message.tool({ id: "call_1", name: "lookup", result: "42", resultType: "text" })
+
+for (const mode of ["automatic", "completed", "pending", "failed", "disconnect", "async"] as const) {
+  test(
+    `Astra steering: ${mode}`,
+    () =>
+      Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const frames = yield* Queue.unbounded<string | Uint8Array, AIError>()
+            const sent: Array<Record<string, unknown>> = []
+            let admitted = false
+            let opens = 0
+            const send = (event: unknown) => Queue.offerUnsafe(frames, JSON.stringify(event))
+            const finish = (id: string, text: string) => {
+              const output = item(`msg_${id}`, text)
+              send({ type: "response.created", response: { id } })
+              send({ type: "response.output_item.done", item: output })
+              send({
+                type: "response.completed",
+                response: { id, output: [output], usage: { input_tokens: 10, output_tokens: 2 } },
+              })
+            }
+            const connector: WebSocketConnector = {
+              open: () =>
+                Effect.sync(() => {
+                  opens++
+                  return {
+                    messages: Stream.fromQueue(frames),
+                    close: Effect.void,
+                    sendText: (message) =>
+                      Effect.sync(() => {
+                        const body = JSON.parse(message)
+                        sent.push(body)
+                        if (sent.length === 1) {
+                          send({ type: "response.created", response: { id: "resp_1" } })
+                          send({ type: "response.output_item.added", item: item("msg_first", "") })
+                          send({ type: "response.output_text.delta", item_id: "msg_first", delta: "Working" })
+                          return
+                        }
+                        if (body.type === "response.steer") {
+                          expect(admitted).toBe(true)
+                          expect(body).toEqual({
+                            type: "response.steer",
+                            previous_response_id: "resp_1",
+                            input: "Be brief",
+                          })
+                          if (mode === "disconnect") {
+                            Queue.failCauseUnsafe(
+                              frames,
+                              Cause.fail(
+                                new AIError({
+                                  reason: new TransportError({
+                                    message: "Disconnected",
+                                    operation: "read",
+                                    transport: "websocket",
+                                  }),
+                                }),
+                              ),
+                            )
+                            return
+                          }
+                          const steer = { id: "steer_1", previous_response_id: "resp_1", input: "Be brief" }
+                          send({
+                            type: mode === "failed" ? "response.steer.failed" : "response.steer.accepted",
+                            steer,
+                            ...(mode === "failed"
+                              ? { error: { code: "steering_not_supported", message: "Unsupported" } }
+                              : {}),
+                          })
+                          const output = [item("msg_first", "Working")]
+                          send({ type: "response.output_item.done", item: output[0] })
+                          if (mode === "async") send({ type: "response.output_item.added", item: call })
+                          if (mode === "pending" || mode === "async") {
+                            const { async: _, ...done } = call
+                            send({ type: "response.output_item.done", item: done })
+                          }
+                          send({
+                            type:
+                              mode === "completed" || mode === "failed" || mode === "pending"
+                                ? "response.completed"
+                                : "response.incomplete",
+                            response: {
+                              id: "resp_1",
+                              output: mode === "pending" || mode === "async" ? [...output, call] : output,
+                              ...(mode === "automatic" || mode === "async"
+                                ? { incomplete_details: { reason: "steered" } }
+                                : {}),
+                              usage: { input_tokens: 8, output_tokens: 1 },
+                            },
+                          })
+                          if (mode === "pending") {
+                            send({
+                              type: "response.steer.pending",
+                              steer,
+                              reason: "waiting_for_required_input",
+                              required_input: [{ type: "function_call_output", call_id: "call_1", name: "lookup" }],
+                            })
+                            return
+                          }
+                          if (mode !== "failed") finish("resp_2", "Brief")
+                          return
+                        }
+                        finish(mode === "async" ? "resp_3" : "resp_2", "Done")
+                      }),
+                  }
+                }),
+            }
+            const runtime = Layer.mergeAll(
+              SessionModelTransport.makeLayer(connector),
+              LLMClient.layer.pipe(
+                Layer.provide(
+                  Layer.succeed(
+                    RequestExecutor.Service,
+                    RequestExecutor.Service.of({ execute: () => Effect.die("Unexpected HTTP request") }),
+                  ),
+                ),
+              ),
+            )
+            yield* Effect.gen(function* () {
+              const transport = yield* SessionModelTransport.Service
+              const options = { webSocket: transport.bind(sessionID) }
+              const request = LLM.request({
+                model: configure({ apiKey: "test" }).responses("gpt-6-astra"),
+                prompt: "Start",
+              })
+              const first = yield* LLMClient.stream(request, options).pipe(
+                Stream.tap((event) =>
+                  event.type === "text-delta"
+                    ? transport.steer(
+                        sessionID,
+                        "Be brief",
+                        Effect.sync(() => {
+                          admitted = true
+                        }),
+                      )
+                    : Effect.void,
+                ),
+                Stream.runCollect,
+                Effect.result,
+              )
+              expect(admitted).toBe(true)
+              if (mode === "disconnect") {
+                expect(first._tag).toBe("Failure")
+                return
+              }
+              if (first._tag === "Failure") return yield* Effect.fail(first.failure)
+              const response = LLMResponse.fromEvents(first.success)!
+              expect(response.text).toBe("Working")
+              expect(response.usage?.outputTokens).toBe(1)
+              const messages = [
+                ...request.messages,
+                response.message,
+                ...(mode === "pending" || mode === "async" ? [result] : []),
+                Message.user("Be brief"),
+              ]
+              const second = yield* LLMClient.generate(LLMRequest.update(request, { messages }), options)
+              expect(second.text).toBe(mode === "failed" || mode === "pending" ? "Done" : "Brief")
+              expect(second.usage?.outputTokens).toBe(2)
+              expect(opens).toBe(1)
+              if (mode === "pending") {
+                expect(sent[2]).toMatchObject({
+                  type: "response.create",
+                  previous_response_id: "resp_1",
+                  input: [{ type: "function_call_output", call_id: "call_1", output: "42" }],
+                })
+              } else if (mode === "failed") {
+                expect(sent[2]).toMatchObject({
+                  input: [{ role: "user", content: [{ type: "input_text", text: "Be brief" }] }],
+                })
+              } else {
+                expect(sent).toHaveLength(2)
+              }
+              if (mode === "async") {
+                expect(response.toolCalls).toHaveLength(1)
+                expect(response.toolCalls[0].providerMetadata?.openai?.async).toBe(true)
+                expect(transport.hasPendingInput(sessionID)).toBe(true)
+                yield* LLMClient.generate(
+                  LLMRequest.update(request, { messages: [...messages, second.message] }),
+                  options,
+                )
+                expect(sent[2]).toMatchObject({
+                  previous_response_id: "resp_2",
+                  input: [{ type: "function_call_output", call_id: "call_1", output: "42" }],
+                })
+                expect(transport.hasPendingInput(sessionID)).toBe(false)
+              }
+            }).pipe(Effect.provide(runtime))
+          }),
+        ),
+      ),
+    5000,
+  )
+}

--- a/packages/core/test/session-astra-transport.test.ts
+++ b/packages/core/test/session-astra-transport.test.ts
@@ -98,7 +98,12 @@ for (const mode of ["automatic", "completed", "pending", "failed", "disconnect",
                                 : "response.incomplete",
                             response: {
                               id: "resp_1",
-                              output: mode === "pending" || mode === "async" ? [...output, call] : output,
+                              output:
+                                mode === "pending" || mode === "async"
+                                  ? [...output, call]
+                                  : mode === "completed"
+                                    ? []
+                                    : output,
                               ...(mode === "automatic" || mode === "async"
                                 ? { incomplete_details: { reason: "steered" } }
                                 : {}),

--- a/packages/core/test/session-error.test.ts
+++ b/packages/core/test/session-error.test.ts
@@ -239,5 +239,15 @@ describe("toSessionError", () => {
         llm(new InvalidRequestError({ message: "retry", http: http({ "x-should-retry": "true" }) })),
       ),
     ).toBeTrue()
+    expect(
+      SessionRunnerRetry.isRetryable(
+        llm(
+          new ContentPolicyError({
+            message: "Review required",
+            http: http({ "x-should-retry": "true" }),
+          }),
+        ),
+      ),
+    ).toBeFalse()
   })
 })

--- a/packages/core/test/session-model-request-hooks.test.ts
+++ b/packages/core/test/session-model-request-hooks.test.ts
@@ -37,6 +37,8 @@ const transport = SessionModelTransport.Service.of({
   bind: () => ({ execute: () => Effect.die("unused WebSocket execution") }),
   close: () => Effect.void,
   closeAll: Effect.void,
+  steer: () => Effect.succeed(false),
+  hasPendingInput: () => false,
 })
 
 describe("SessionModelRequest HTTP hooks", () => {

--- a/packages/core/test/session-remove.test.ts
+++ b/packages/core/test/session-remove.test.ts
@@ -32,6 +32,8 @@ const transport = Layer.effect(
       bind: () => ({ execute: () => Effect.die("Unexpected WebSocket execution") }),
       close: (sessionID) => Effect.sync(() => closed.push(sessionID)),
       closeAll: Effect.void,
+      steer: () => Effect.succeed(false),
+      hasPendingInput: () => false,
     })
   }),
 )

--- a/packages/core/test/session-runner.test.ts
+++ b/packages/core/test/session-runner.test.ts
@@ -11,6 +11,7 @@ import {
   TransportError,
   InvalidProviderOutputError,
   InvalidRequestError,
+  ContentPolicyError,
   RateLimitError,
   UnknownProviderError,
 } from "@opencode-ai/ai"
@@ -193,12 +194,14 @@ test("does not apply an ineligible tier without base pricing", () => {
 })
 
 const makeRunnerState = () => {
+  const steer: SessionModelTransport.Interface["steer"] = () => Effect.succeed(false)
   let toolBarrier: ToolBarrier | undefined
   const releaseTools = (barrier: ToolBarrier) =>
     Effect.sync(() => {
       if (toolBarrier === barrier) toolBarrier = undefined
     }).pipe(Effect.andThen(Deferred.succeed(barrier.release, undefined)), Effect.asVoid)
   return {
+    steer,
     currentModel: model,
     modelResolveHook: Effect.void,
     systemBaseline: "Initial context",
@@ -269,6 +272,8 @@ const layer = Layer.unwrap(
         bind: () => ({ execute: () => Effect.die("Unexpected WebSocket execution") }),
         close: (sessionID) => Effect.sync(() => state.closedTransports.push(sessionID)),
         closeAll: Effect.void,
+        steer: (sessionID, text, admit) => state.steer(sessionID, text, admit),
+        hasPendingInput: () => false,
       }),
     )
     const echo = Layer.effectDiscard(
@@ -315,7 +320,12 @@ const layer = Layer.unwrap(
           Effect.map(() => {
             const selected = session.model?.id === "replacement" ? replacementModel : state.currentModel
             return SessionRunnerModel.resolved(selected, {
-              capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+              capabilities: {
+                tools: true,
+                input: ["text", "image"],
+                output: ["text"],
+                responsesWebsockets: selected.route.id === "openai-responses" && selected.id === "gpt-6-astra",
+              },
               cost: [],
               limit: modelLimits.get(String(selected.id)) ?? defaultModelLimit,
               variant: session.model?.variant,
@@ -3587,6 +3597,67 @@ describe("SessionRunnerLLM", () => {
     expect(s.requests).toHaveLength(2)
     expect(userTexts(s.requests[0])).toEqual(["Interrupt current work"])
     expect(userTexts(s.requests[1])).toEqual(["Interrupt current work", "Run after interrupt"])
+  })
+
+  scenario("durably delivers live Astra steering once and resets the step allowance", function* (s) {
+    s.currentModel = LanguageModel.make({ id: "gpt-6-astra", provider: "fake", route: OpenAIResponses.route })
+    const agents = yield* Agent.Service
+    yield* agents.transform((editor) =>
+      editor.update(Agent.ID.make("build"), (agent) => {
+        agent.steps = 2
+      }),
+    )
+    const delivered = yield* Deferred.make<void>()
+    s.steer = (_sessionID, text, admit) =>
+      Effect.gen(function* () {
+        expect(text).toBe("Be brief")
+        yield* admit
+        expect(yield* SessionInbox.has(s.db, sessionID, "steer")).toBe(false)
+        yield* Deferred.succeed(delivered, undefined)
+        return true
+      })
+    yield* s.admit("Start")
+    yield* s.llm.push(TestLLM.text("Working", "text-working"), TestLLM.text("Brief", "text-brief"))
+    const paused = yield* s.resumePaused
+    yield* s.admit("Be brief")
+    yield* Deferred.await(delivered)
+    yield* paused.finish
+    expect(s.requests).toHaveLength(2)
+    expect(s.requests[1].toolChoice).toBeUndefined()
+    expect(userTexts(s.requests[1])).toEqual(["Start", "Be brief"])
+    expect(s.requests[0].providerOptions?.asyncTools).toContain("echo")
+    expect((yield* s.context).map((message) => message.type)).toEqual(["user", "assistant", "user", "assistant"])
+    expect((yield* recordedEventTypes(sessionID)).filter((type) => type === "session.inbox.delivered.1")).toHaveLength(
+      2,
+    )
+  })
+
+  scenario("stops pending tools without retrying a monitoring block", function* (s) {
+    const tools = yield* s.blockTools()
+    yield* s.llm.push(
+      Stream.concat(
+        Stream.make(LLMEvent.toolCall({ id: "call-blocked", name: "echo", input: { text: "pending" } })),
+        Stream.fromEffect(tools.started).pipe(
+          Stream.flatMap(() =>
+            Stream.fail(
+              new AIError({
+                reason: new ContentPolicyError({ message: "misalignment_policy_violation: Review required" }),
+              }),
+            ),
+          ),
+        ),
+      ),
+    )
+    yield* s.admit("Start")
+    const exit = yield* s.resume.pipe(Effect.exit)
+    expect(exit._tag).toBe("Failure")
+    expect(s.requests).toHaveLength(1)
+    expect(yield* recordedEventTypes(sessionID)).not.toContain("session.retry.scheduled.1")
+    expect(
+      (yield* s.context).some(
+        (message) => message.type === "assistant" && message.error?.type === "provider.content-filter",
+      ),
+    ).toBe(true)
   })
 
   scenario("preserves durable steering input for a later resume after interruption", function* (s) {

--- a/packages/core/test/session-step.test.ts
+++ b/packages/core/test/session-step.test.ts
@@ -12,6 +12,7 @@ import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath, RelativePath } from "@opencode-ai/core/schema"
 import { Session } from "@opencode-ai/core/session"
 import { SessionMessage } from "@opencode-ai/core/session/message"
+import { SessionModelTransport } from "@opencode-ai/core/session/model-transport"
 import { SessionProjector } from "@opencode-ai/core/session/projector"
 import { SessionRunnerModel } from "@opencode-ai/core/session/runner/model"
 import { SessionStep } from "@opencode-ai/core/session/runner/step"
@@ -26,9 +27,10 @@ import { testEffect } from "./lib/effect"
 
 const it = testEffect(
   Layer.merge(
-    AppNodeBuilder.build(LayerNode.group([Database.node, Bus.node, SessionProjector.node, ToolOutput.node]), [
-      Bus.node.replace(Bus.configured({ persist: true })),
-    ]),
+    AppNodeBuilder.build(
+      LayerNode.group([Database.node, Bus.node, SessionProjector.node, ToolOutput.node, SessionModelTransport.node]),
+      [Bus.node.replace(Bus.configured({ persist: true }))],
+    ),
     TestLLM.testLayer(),
   ),
 )


### PR DESCRIPTION
### Issue for this PR

Closes #47550

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Adds Astra Responses async function calls and live plain-text steering to v2's existing session runner. Inbox updates are persisted before sending; automatic successor responses reuse the socket without an extra create, and pending tool results keep their call IDs. Rejected steering and disconnects retain canonical history.

Also supplies Astra defaults and parameter validation, and stops pending tools without retrying monitoring blocks. No new dependencies or public endpoints. The README documents limits: one steering update per response, tools joined at step boundaries, and full recovery when request settings change.

### How did you verify your code works?

AI and core typechecks pass, as do all 33 pre-push typecheck tasks. AI suite: 1006 pass, 28 skip; affected core tests: 265 pass. Local-server tests were rerun outside the restricted sandbox. Six transport scenarios cover automatic/completed/pending/failed/disconnected steering and deferred async output; runner tests cover durable delivery and monitoring cancellation. CLI `bun dev --help` passes.

Live ChatGPT OAuth checks on 2026-09-06 passed: exact text reply, an async shell call, accepted steering with automatic continuation and no duplicate response.create, and steering during a running tool with deferred output delivered before the final answer. These checks caught and fixed empty terminal output losing the replay checkpoint, and missing guidance to yield for pending async results. The API-key path has not been tested live.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
