### PR TITLE
fix(tui): keep sessions visible after project identity changes

### DIFF
--- a/packages/client/src/solid/data.ts
+++ b/packages/client/src/solid/data.ts
@@ -716,6 +716,19 @@ export function createData(config: CreateDataInput) {
           setStore("session", "info", sessionID, "projectID", adopted.projectID)
           setStore("session", "info", sessionID, "subpath", adopted.subpath)
         }
+        for (const [key, location] of Object.entries(store.location)) {
+          const info = location.info
+          if (
+            !info ||
+            !Worktree.adopt(
+              { projectID: info.project.id, directory: info.project.directory, workspaceID: info.workspaceID },
+              event.data,
+            )
+          )
+            continue
+          sync.invalidate(`location:${key}`)
+          refresh(() => result.location.syncInfo(info))
+        }
         return
       }
       case "session.inbox.delivered": {

--- a/packages/client/test/solid-data.test.ts
+++ b/packages/client/test/solid-data.test.ts
@@ -312,6 +312,75 @@ test("adopts cached directory-project sessions when their repository is resolved
   }
 })
 
+test("refreshes cached location identities when their repository is resolved", async () => {
+  const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
+  const requests: string[] = []
+  const identity = { id: "directory-root" }
+  const api = OpenCode.make({
+    baseUrl: "http://opencode.local",
+    fetch: async (input, init) => {
+      const request = input instanceof Request ? input : new Request(input, init)
+      const url = new URL(request.url)
+      if (url.pathname !== "/api/location") throw new Error(`Unexpected request: ${request.url}`)
+      const directory = url.searchParams.get("location[directory]") ?? "/repo"
+      const workspaceID = url.searchParams.get("location[workspace]") ?? undefined
+      requests.push(`${workspaceID ?? ""}:${directory}`)
+      return Response.json({
+        directory,
+        workspaceID,
+        project: {
+          id: directory === "/repo-other" ? "other" : workspaceID ? "directory-root" : identity.id,
+          directory: directory === "/repo-other" ? directory : "/repo",
+          canonical: directory === "/repo-other" ? directory : "/repo",
+        },
+      })
+    },
+  })
+  const setup = createRoot((dispose) => ({
+    data: createData({
+      api: () => api,
+      directory: "/repo",
+      event: {
+        on: () => () => {},
+        listen(handler) {
+          listeners.add(handler)
+          return () => listeners.delete(handler)
+        },
+      },
+    }),
+    dispose,
+  }))
+
+  try {
+    for (const location of [
+      { directory: "/repo" },
+      { directory: "/repo/app" },
+      { directory: "/repo-other" },
+      { directory: "/repo", workspaceID: "remote" },
+    ]) {
+      await setup.data.location.syncInfo(location)
+    }
+    requests.length = 0
+    identity.id = "global"
+    const resolved: OpenCodeEvent = {
+      id: "evt_unborn_repository",
+      created: 1,
+      type: "worktree.resolved",
+      durable: { aggregateID: "global", seq: 0, version: 1 },
+      data: { projectID: "global", directory: "/repo", previous: "global", adopted: ["directory-root"] },
+    }
+    listeners.forEach((listener) => listener({ name: resolved.type, details: resolved }))
+
+    await wait(() => setup.data.location.info()?.project.id === "global")
+    expect(setup.data.location.info({ directory: "/repo/app" })?.project.id).toBe("global")
+    expect(setup.data.location.info({ directory: "/repo-other" })?.project.id).toBe("other")
+    expect(setup.data.location.info({ directory: "/repo", workspaceID: "remote" })?.project.id).toBe("directory-root")
+    expect(requests.sort()).toEqual([":/repo", ":/repo/app"])
+  } finally {
+    setup.dispose()
+  }
+})
+
 test("refreshes global credential events across every loaded location and workspace", async () => {
   const listeners = new Set<Parameters<CreateDataInput["event"]["listen"]>[0]>()
   const requests: URL[] = []

--- a/packages/core/src/location.ts
+++ b/packages/core/src/location.ts
@@ -16,6 +16,19 @@ export class Service extends Context.Service<Service, Interface>()("@opencode/Lo
 
 export const node = LayerNode.unbound(Service, tags.values.location)
 
+// Location services retain their boot snapshot. Read metadata must follow project
+// adoption after git init, the first commit, or adding a remote in that directory.
+export const current = Effect.gen(function* () {
+  const location = yield* Service
+  const project = yield* Project.Service
+  const resolved = yield* project.resolve(location.directory)
+  return new Info({
+    directory: location.directory,
+    workspaceID: location.workspaceID,
+    project: { id: resolved.id, directory: resolved.directory, canonical: resolved.canonical },
+  })
+})
+
 const layer = (ref: Ref, options?: { readonly discovery?: boolean }) =>
   Layer.effect(
     Service,

--- a/packages/server/src/handlers/location.ts
+++ b/packages/server/src/handlers/location.ts
@@ -1,18 +1,7 @@
 import { Location } from "@opencode-ai/core/location"
-import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { Api } from "../api"
 
 export const LocationHandler = HttpApiBuilder.group(Api, "server.location", (handlers) =>
-  handlers.handle(
-    "location.get",
-    Effect.fn(function* () {
-      const location = yield* Location.Service
-      return new Location.Info({
-        directory: location.directory,
-        workspaceID: location.workspaceID,
-        project: location.project,
-      })
-    }),
-  ),
+  handlers.handle("location.get", () => Location.current),
 )

--- a/packages/server/src/handlers/project.ts
+++ b/packages/server/src/handlers/project.ts
@@ -21,13 +21,5 @@ export const ProjectHandler = HttpApiBuilder.group(Api, "server.project", (handl
         ),
       ),
     )
-    .handle("project.current", () =>
-      Location.Service.use((location) =>
-        Effect.succeed({
-          id: location.project.id,
-          directory: location.project.directory,
-          canonical: location.project.canonical,
-        }),
-      ),
-    ),
+    .handle("project.current", () => Location.current.pipe(Effect.map((location) => location.project))),
 )

--- a/packages/server/src/location.ts
+++ b/packages/server/src/location.ts
@@ -17,13 +17,8 @@ export class LocationMiddleware extends HttpApiMiddleware.Service<LocationMiddle
 
 export function response<A, E, R>(data: Effect.Effect<A, E, R>) {
   return Effect.gen(function* () {
-    const location = yield* Location.Service
     return {
-      location: new Location.Info({
-        directory: location.directory,
-        workspaceID: location.workspaceID,
-        project: location.project,
-      }),
+      location: yield* Location.current,
       data: yield* data,
     }
   })

--- a/packages/server/test/location.test.ts
+++ b/packages/server/test/location.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+import { $ } from "bun"
+import { expect } from "bun:test"
+import { Effect } from "effect"
+import { OpenCode } from "@opencode-ai/client"
+import { tmpdir } from "../../core/test/fixture/tmpdir"
+import { it } from "../../core/test/lib/effect"
+import { startServer } from "./fixture/server"
+
+it.live(
+  "keeps directory session discovery consistent when a cached location becomes a repository",
+  () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireDisposable(Effect.promise(() => tmpdir("opencode-location-identity-")))
+      const directory = path.join(tmp.path, "project")
+      const nested = path.join(directory, "app")
+      yield* Effect.promise(() => fs.mkdir(nested, { recursive: true }))
+      const server = yield* startServer(path.join(tmp.path, "config"))
+      const api = OpenCode.make({ baseUrl: server.base, headers: server.headers })
+
+      yield* Effect.promise(async () => {
+        const root = await api.session.create({ location: { directory }, title: "Before git" })
+        const child = await api.session.create({ location: { directory: nested }, title: "Nested before git" })
+        const before = await api.location.get({ location: { directory } })
+        await api.location.get({ location: { directory: nested } })
+        expect(before.project.id).toBe(root.projectID)
+
+        await $`git init -q`.cwd(directory)
+        // Session creation resolves the repository independently of the cached Location graph.
+        const after = await api.session.create({ location: { directory }, title: "After git" })
+        expect(after.projectID).toBe("global")
+
+        for (const remote of [false, true]) {
+          if (remote) await $`git remote add origin git@github.com:example/location-identity.git`.cwd(directory)
+          for (const current of [directory, nested]) {
+            const location = await api.location.get({ location: { directory: current } })
+            expect(location.project.id === "global").toBe(!remote)
+            expect(location.project.directory).toBe(directory)
+            expect(await api.project.current({ location: { directory: current } })).toEqual(location.project)
+            expect((await api.agent.list({ location: { directory: current } })).location).toEqual(location)
+            const sessions = await api.session.list({
+              ...(location.project.id === "global"
+                ? { directory: current }
+                : { project: location.project.id, subpath: path.relative(directory, current) }),
+              parentID: null,
+            })
+            expect(sessions.data.map((session) => session.id).sort()).toEqual(
+              (current === directory ? [root.id, after.id] : [child.id]).sort(),
+            )
+          }
+        }
+      })
+    }),
+  30_000,
+)

--- a/packages/tui/src/component/dialog-session-list.tsx
+++ b/packages/tui/src/component/dialog-session-list.tsx
@@ -56,6 +56,7 @@ export function DialogSessionList() {
       query: search().trim(),
       allProjects: allProjects(),
       location: pickerLocation(),
+      projectID: data.location.info(pickerLocation())?.project.id,
     }),
     async ({ query, allProjects, location }) => {
       try {

--- a/packages/tui/test/cli/tui/dialog-session-list.test.tsx
+++ b/packages/tui/test/cli/tui/dialog-session-list.test.tsx
@@ -23,14 +23,15 @@ import { emptyThemeSource, tmpdir } from "../../fixture/fixture"
 import { TestTuiContexts } from "../../fixture/tui-environment"
 import { createTuiResolvedConfig } from "../../fixture/tui-runtime"
 
-test("scopes sessions to the active session location", async () => {
+test("scopes sessions to the active location and follows its project identity while open", async () => {
   const active = "/tmp/opencode/project-b"
   const events = createEventStream()
+  const identity = { project: "proj_b" }
   const requestedProjects: string[] = []
   const calls = createFetch((url) => {
     if (url.pathname === "/api/location") {
       const directory = url.searchParams.get("location[directory]") ?? process.cwd()
-      const project = directory === active ? "proj_b" : "proj_a"
+      const project = directory === active ? identity.project : "proj_a"
       return json({ directory, project: { id: project, directory, canonical: directory } })
     }
     if (url.pathname !== "/api/session") return undefined
@@ -42,13 +43,18 @@ test("scopes sessions to the active session location", async () => {
     return json({
       data: [
         {
-          id: project === "proj_b" ? "ses_b" : "ses_a",
+          id: project === "proj_a" ? "ses_a" : "ses_b",
           projectID: project,
           cost: 0,
           tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
           time: { created: 1, updated: 2 },
-          title: project === "proj_b" ? "Project B session" : "Project A session",
-          location: { directory: project === "proj_b" ? active : process.cwd() },
+          title:
+            project === "proj_b_identified"
+              ? "Identified project session"
+              : project === "proj_b"
+                ? "Project B session"
+                : "Project A session",
+          location: { directory: project === "proj_a" ? process.cwd() : active },
         },
       ],
       cursor: {},
@@ -122,6 +128,18 @@ test("scopes sessions to the active session location", async () => {
     const frame = await app.waitForFrame((value) => value.includes("Project B session"))
     expect(frame).not.toContain("Project A session")
     expect(requestedProjects.at(-1)).toBe("proj_b")
+
+    identity.project = "proj_b_identified"
+    events.emit({
+      id: "evt_project_identified",
+      created: 4,
+      type: "worktree.resolved",
+      durable: { aggregateID: identity.project, seq: 0, version: 1 },
+      data: { projectID: identity.project, directory: active, previous: "proj_b" },
+    })
+    const updated = await app.waitForFrame((value) => value.includes("Identified project session"))
+    expect(updated).not.toContain("Project A session")
+    expect(requestedProjects.at(-1)).toBe(identity.project)
   } finally {
     app.renderer.destroy()
     await storage.flush()


### PR DESCRIPTION
### Issue for this PR

Found while investigating sessions disappearing from the directory-scoped picker after creating a separate plugin repository. No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Opening a plain directory, creating a session, then running `git init` can change the session's project identity while the cached Location still reports its original identity. The picker searches the old project ID and returns no sessions.

Resolve current project metadata for server responses, refresh affected client locations on `worktree.resolved`, and rerun an open session picker when its project ID changes. Regression coverage includes empty Git repositories, adding a remote, nested directories, and an already-open picker.

### How did you verify your code works?

- Typechecks passed in Core, Server, Client, and TUI.
- Focused Core, Server, Client, and TUI tests passed. The new server and client regressions failed before the fix.
- Full TUI suite: 1,288 passed, 4 skipped, 7 failed. All seven passed on targeted reruns: isolated config for plugin tests, a longer timeout for shell-output tests, and a retry for the watcher test.

### Screenshots / recordings

Verified in the real TUI with the directory-scoped picker left open across `git init`: it refreshed automatically and displayed sessions created both before and after initialization. A screenshot was captured locally during verification.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR