### PR TITLE
fix(opencode): sanitize MCP tool schemas for Anthropic root combinators

### DIFF
--- a/packages/opencode/src/provider/transform.ts
+++ b/packages/opencode/src/provider/transform.ts
@@ -1559,6 +1559,47 @@ function sanitizeOpenAISchema(value: unknown): unknown {
   return result
 }
 
+// Anthropic's tool input_schema rejects root-level anyOf/oneOf/allOf (it only
+// allows them nested inside a property). MCP servers commonly emit these to
+// express "exactly one of" or to split constraints into multiple branches, so
+// fold them into the root object schema instead of forwarding them verbatim
+// and taking the whole tool down with a 400. Only the root is affected; nested
+// content is returned untouched. `allOf` is an intersection, so its members'
+// properties/required are merged in; `anyOf`/`oneOf` express exclusive
+// alternatives Anthropic can't represent, so they're dropped to avoid both the
+// 400 and over-constraining the root object.
+function sanitizeAnthropicSchema(value: unknown): unknown {
+  if (!isPlainObject(value)) return value
+
+  const result: JsonRecord = { ...value }
+  const ownProperties = isPlainObject(value.properties) ? (value.properties as JsonRecord) : {}
+  const mergedProperties = { ...ownProperties }
+
+  if (Array.isArray(value.allOf)) {
+    delete result.allOf
+    for (const member of value.allOf) {
+      if (!isPlainObject(member)) continue
+      if (isPlainObject(member.properties)) {
+        Object.assign(mergedProperties, member.properties)
+      }
+      if (Array.isArray(member.required)) {
+        const required = new Set(Array.isArray(result.required) ? (result.required as string[]) : [])
+        for (const name of member.required) {
+          if (typeof name === "string") required.add(name)
+        }
+        result.required = Array.from(required)
+      }
+    }
+    result.properties = mergedProperties
+  }
+
+  for (const key of ["anyOf", "oneOf"] as const) {
+    if (key in value) delete result[key]
+  }
+
+  return result
+}
+
 export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 {
   /*
   if (["openai", "azure"].includes(providerID)) {
@@ -1581,6 +1622,16 @@ export function schema(model: Provider.Model, schema: JSONSchema7): JSONSchema7 
   if (model.api.npm === "@ai-sdk/openai" || model.api.npm === "@ai-sdk/azure") {
     schema = sanitizeOpenAISchema(schema) as JSONSchema7
     // Codex also applies lossy compaction above 4 KB; defer that until OpenCode needs the same schema budget.
+  }
+
+  // Anthropic (and GitHub Copilot proxying Claude models) rejects root-level
+  // anyOf/oneOf/allOf in a tool input_schema. Fold them into the root object.
+  const isAnthropicFamily =
+    model.api.npm === "@ai-sdk/anthropic" ||
+    model.api.npm === "@ai-sdk/google-vertex/anthropic" ||
+    (model.api.npm === "@ai-sdk/github-copilot" && model.id?.toLowerCase().includes("claude"))
+  if (isAnthropicFamily) {
+    schema = sanitizeAnthropicSchema(schema) as JSONSchema7
   }
 
   if (model.providerID === "moonshotai" || model.api.id.toLowerCase().includes("kimi")) {

--- a/packages/opencode/test/provider/transform.test.ts
+++ b/packages/opencode/test/provider/transform.test.ts
@@ -2001,6 +2001,82 @@ describe("ProviderTransform.schema - openai supported schema subset", () => {
   })
 })
 
+describe("ProviderTransform.schema - anthropic root combinators", () => {
+  const anthropicModel = {
+    providerID: "anthropic",
+    id: "claude-sonnet-4",
+    api: {
+      id: "claude-sonnet-4",
+      npm: "@ai-sdk/anthropic",
+    },
+  } as any
+
+  test.each([
+    ["anthropic", "claude-sonnet-4", "@ai-sdk/anthropic"],
+    ["github-copilot", "github-copilot/claude-haiku-4.5", "@ai-sdk/github-copilot"],
+    ["google", "claude-sonnet-4", "@ai-sdk/google-vertex/anthropic"],
+  ])("flattens root-level %s combinators for %s", (_label, id, npm) => {
+    const result = ProviderTransform.schema(
+      {
+        providerID: npm.split("/")[0],
+        id,
+        api: { id, npm },
+      } as any,
+      {
+        type: "object",
+        properties: { a: { type: "string" }, b: { type: "string" } },
+        anyOf: [{ required: ["a"] }, { required: ["b"] }],
+        oneOf: [{ required: ["a"] }, { required: ["b"] }],
+        allOf: [{ properties: { c: { type: "number" } } }],
+        required: [],
+      } as any,
+    ) as any
+
+    expect(result.anyOf).toBeUndefined()
+    expect(result.oneOf).toBeUndefined()
+    expect(result.allOf).toBeUndefined()
+    // Content from folded branches survives in the root object.
+    expect(result.properties.c).toEqual({ type: "number" })
+    expect(result.properties.a).toEqual({ type: "string" })
+  })
+
+  test("keeps nested combinators inside properties", () => {
+    const result = ProviderTransform.schema(anthropicModel, {
+      type: "object",
+      properties: {
+        value: {
+          type: "string",
+          anyOf: [{ type: "string" }, { type: "null" }],
+        },
+      },
+    } as any) as any
+
+    expect(result.properties.value.anyOf).toEqual([{ type: "string" }, { type: "null" }])
+  })
+
+  test("preserves sibling keywords and non-combinator content", () => {
+    const result = ProviderTransform.schema(anthropicModel, {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          pattern: "^https://",
+        },
+      },
+    } as any) as any
+
+    expect(result).toEqual({
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          pattern: "^https://",
+        },
+      },
+    })
+  })
+})
+
 describe("ProviderTransform.schema - moonshot $ref siblings", () => {
   const moonshotModel = {
     providerID: "moonshotai",


### PR DESCRIPTION
### Issue for this PR

Closes #47543

### Type of change

- [x] Bug fix

### What does this PR do?

Anthropic rejects a tool `input_schema` that uses `anyOf`/`oneOf`/`allOf` at the **root level**; these combinators are only accepted nested inside `properties`. MCP servers commonly emit "exactly one of these fields" patterns as root-level combinators, which then fail Anthropic validation with a 400 and take the whole tool down.

This adds a targeted `sanitizeAnthropicSchema` alongside the existing OpenAI sanitizer (#32489). It folds root-level combinators into the root object schema:
- `allOf` (an intersection): member `properties` are merged and `required` are unioned into the root.
- `anyOf`/`oneOf` (exclusive alternatives Anthropic can't represent): dropped so the root object stays valid without being over-constrained.
- Everything else — including nested combinators inside `properties` — is preserved verbatim.

The Anthropic family is detected by the AI SDK adapter (`@ai-sdk/anthropic`, `@ai-sdk/google-vertex/anthropic`) plus GitHub Copilot only when it proxies a Claude model (Copilot also proxies GPT models, which must stay on the OpenAI path).

### How did you verify your code works?

Added a focused test suite in `packages/opencode/test/provider/transform.test.ts`:
- Root-level `anyOf`/`oneOf`/`allOf` are removed.
- `allOf` branch content (`properties.c`) survives merged into the root.
- Nested combinators inside `properties` survive unchanged.
- Sibling keywords (`pattern`, etc.) and non-combinator content are preserved.

### Checklist

- [x] I tested my changes locally
- [x] I did not include unrelated changes in this PR