### PR TITLE
fix(desktop): keep server CORS headers so preflights cache

### DIFF
--- a/packages/desktop/src/main/windows/headers.test.ts
+++ b/packages/desktop/src/main/windows/headers.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import { addRendererHeaders, documentPolicyHeader, jsCallStacksDocumentPolicy, upsertHeader } from "./headers"
+
+describe("renderer response headers", () => {
+  test("keeps the server's exact allow-headers list so Chromium can reuse the cached preflight", () => {
+    const headers = {
+      "access-control-allow-origin": ["oc://renderer"],
+      "access-control-allow-headers": ["authorization"],
+      "access-control-max-age": ["86400"],
+    }
+    addRendererHeaders(headers, { document: false })
+    expect(headers).toEqual({
+      "access-control-allow-origin": ["*"],
+      "access-control-allow-headers": ["authorization"],
+      "access-control-max-age": ["86400"],
+    })
+  })
+
+  test("fills CORS headers for servers that send none, naming authorization explicitly", () => {
+    const headers: Record<string, string[]> = { "content-type": ["application/json"] }
+    addRendererHeaders(headers, { document: false })
+    expect(headers["Access-Control-Allow-Origin"]).toEqual(["*"])
+    expect(headers["Access-Control-Allow-Headers"]).toEqual(["*, authorization"])
+    expect(headers["Access-Control-Max-Age"]).toEqual(["7200"])
+  })
+
+  test("adds the crash-report document policy only to renderer documents", () => {
+    const document = {}
+    addRendererHeaders(document, { document: true })
+    expect(Reflect.get(document, documentPolicyHeader)).toEqual([jsCallStacksDocumentPolicy])
+    const asset = {}
+    addRendererHeaders(asset, { document: false })
+    expect(Object.keys(asset)).not.toContain(documentPolicyHeader)
+  })
+
+  test("upsert replaces a header regardless of key casing", () => {
+    const headers = { "X-Test": ["a"] }
+    upsertHeader(headers, "x-test", ["b"])
+    expect(headers).toEqual({ "X-Test": ["b"] })
+  })
+})

--- a/packages/desktop/src/main/windows/headers.ts
+++ b/packages/desktop/src/main/windows/headers.ts
@@ -1,0 +1,29 @@
+export const documentPolicyHeader = "Document-Policy"
+export const jsCallStacksDocumentPolicy = "include-js-call-stacks-in-crash-reports"
+
+// The renderer lives at oc://renderer, so every server it talks to is cross-origin. Servers that
+// send no CORS headers get permissive ones here so the renderer can still reach them.
+//
+// A server's own `Access-Control-Allow-Headers` is kept as-is. Chromium reuses a cached preflight
+// only when that header names `authorization` explicitly (`*` never covers it), so overwriting the
+// server's exact list with `*` forced a fresh OPTIONS round trip in front of every API call.
+export function addRendererHeaders(headers: object, options: { document: boolean }) {
+  upsertHeader(headers, "Access-Control-Allow-Origin", ["*"])
+  if (!hasHeader(headers, "Access-Control-Allow-Headers")) {
+    upsertHeader(headers, "Access-Control-Allow-Headers", ["*, authorization"])
+  }
+  if (!hasHeader(headers, "Access-Control-Max-Age")) {
+    // Chromium caps preflight cache lifetime at two hours; without the header it caches for 5s.
+    upsertHeader(headers, "Access-Control-Max-Age", ["7200"])
+  }
+  if (options.document) upsertHeader(headers, documentPolicyHeader, [jsCallStacksDocumentPolicy])
+}
+
+export function hasHeader(headers: object, key: string) {
+  return Object.keys(headers).some((header) => header.toLowerCase() === key.toLowerCase())
+}
+
+export function upsertHeader(headers: object, key: string, value: string | string[]) {
+  const current = Object.keys(headers).find((header) => header.toLowerCase() === key.toLowerCase())
+  Reflect.set(headers, current ?? key, value)
+}

--- a/packages/desktop/src/main/windows/protocol.ts
+++ b/packages/desktop/src/main/windows/protocol.ts
@@ -4,11 +4,10 @@ import { pathToFileURL } from "node:url"
 import { Effect, Path } from "effect"
 import { scoped } from "../native/logging"
 import { DesktopPaths } from "../paths"
+import { documentPolicyHeader, jsCallStacksDocumentPolicy } from "./headers"
 
 const rendererProtocol = "oc"
 const rendererHost = "renderer"
-const documentPolicyHeader = "Document-Policy"
-const jsCallStacksDocumentPolicy = "include-js-call-stacks-in-crash-reports"
 
 protocol.registerSchemesAsPrivileged([
   {
@@ -83,17 +82,6 @@ export function isRendererUrl(value?: string, html = false) {
   const devUrl = process.env.ELECTRON_RENDERER_URL
   if (!devUrl || !URL.canParse(devUrl)) return false
   return url.origin === new URL(devUrl).origin
-}
-
-export function addRendererHeaders(value: string, headers: object) {
-  upsertHeader(headers, "Access-Control-Allow-Origin", ["*"])
-  upsertHeader(headers, "Access-Control-Allow-Headers", ["*"])
-  if (isRendererUrl(value, true)) upsertHeader(headers, documentPolicyHeader, [jsCallStacksDocumentPolicy])
-}
-
-export function upsertHeader(headers: object, key: string, value: string | string[]) {
-  const current = Object.keys(headers).find((header) => header.toLowerCase() === key.toLowerCase())
-  Reflect.set(headers, current ?? key, value)
 }
 
 function addDocumentPolicy(response: Response, file: string) {

--- a/packages/desktop/src/main/windows/security.ts
+++ b/packages/desktop/src/main/windows/security.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow } from "electron"
-import { addRendererHeaders, isRendererUrl, upsertHeader } from "./protocol"
+import { addRendererHeaders } from "./headers"
+import { isRendererUrl } from "./protocol"
 
 const rendererPermissions = new Set(["clipboard-sanitized-write", "notifications"])
 
@@ -30,13 +31,9 @@ export function wireNavigationPolicy(win: BrowserWindow, openExternalURL: (url: 
 }
 
 export function wireRendererHeaders(win: BrowserWindow) {
-  win.webContents.session.webRequest.onBeforeSendHeaders((details, callback) => {
-    upsertHeader(details.requestHeaders, "Access-Control-Allow-Origin", ["*"])
-    callback({ requestHeaders: details.requestHeaders })
-  })
   win.webContents.session.webRequest.onHeadersReceived((details, callback) => {
     const responseHeaders = details.responseHeaders ?? {}
-    addRendererHeaders(details.url, responseHeaders)
+    addRendererHeaders(responseHeaders, { document: isRendererUrl(details.url, true) })
     callback({ responseHeaders })
   })
 }


### PR DESCRIPTION
Every Desktop API call was preceded by a fresh CORS preflight. In a 310 s netlog from a Desktop debug export, 1519 requests to the local server were **759 real calls + 759 `OPTIONS`**, and Chromium's preflight cache logged `hit-and-fail` 591 times and `hit-and-pass` never. Those preflights spent 20.9 s on the critical path (mean 27.5 ms each, 79 over 50 ms) and doubled the server's request load during every session-tab mount.

## Why the cache never hit

```mermaid
sequenceDiagram
  participant R as renderer (oc://renderer)
  participant M as main: onHeadersReceived
  participant C as Chromium CORS
  participant S as server
  R->>S: OPTIONS /api/…  (Access-Control-Request-Headers: authorization)
  S-->>M: access-control-allow-headers: authorization<br/>access-control-max-age: 86400
  M-->>C: access-control-allow-headers: *   ← overwritten
  Note over C: cache entry stored as "*"
  R->>C: GET /api/… (Authorization: Basic …)
  Note over C: PreflightCache always checks with<br/>NonWildcardRequestHeadersSupport(true):<br/>"*" does not cover Authorization → hit-and-fail → erase
  C->>S: OPTIONS again …
```

`wireRendererHeaders` ran `addRendererHeaders` on **every** response and it did `upsertHeader(headers, "Access-Control-Allow-Headers", ["*"])`. Per the Fetch spec `*` never matches `Authorization`, and Chromium's `PreflightCache::CheckIfRequestCanSkipPreflight` validates cached entries strictly, so the entry was discarded on every lookup while the fresh preflight (checked leniently) kept passing and re-caching `*`.

## Change

`packages/desktop/src/main/windows/headers.ts` (pure, testable; no `electron` import):

```ts
export function addRendererHeaders(headers: object, options: { document: boolean }) {
  upsertHeader(headers, "Access-Control-Allow-Origin", ["*"])
  if (!hasHeader(headers, "Access-Control-Allow-Headers")) {
    upsertHeader(headers, "Access-Control-Allow-Headers", ["*, authorization"])
  }
  if (!hasHeader(headers, "Access-Control-Max-Age")) {
    upsertHeader(headers, "Access-Control-Max-Age", ["7200"])
  }
  if (options.document) upsertHeader(headers, documentPolicyHeader, [jsCallStacksDocumentPolicy])
}
```

- A server's own `Access-Control-Allow-Headers` is kept. The OpenCode server echoes the requested header list with `max-age: 86400`, so Chromium now caches each (origin, URL, method) preflight for its 2 h cap.
- Servers that send no CORS headers (the reason #23633 added this hook) still get permissive values, but the fallback names `authorization` explicitly so those cache too, and gets a `Max-Age` (Chromium's default without one is 5 s).
- Removed the `onBeforeSendHeaders` listener that added `Access-Control-Allow-Origin: *` to *request* headers. It is a response header, so it did nothing, but a blocking listener costs a main-process round trip per request.

Expected effect on the trace above: ~759 preflights → one per distinct URL, and the client's 4-slot request queue (#47441) stops spending half its slots on `OPTIONS`.
