### PR TITLE
fix(app): keep slow git reads from filling the request queue

### DIFF
--- a/packages/app/src/runtime/server/request-queue.test.ts
+++ b/packages/app/src/runtime/server/request-queue.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test"
-import { createRequestQueue } from "./request-queue"
+import { createRequestQueue, isSlowRequest } from "./request-queue"
 
-function setup(input?: { limit?: number; stallMs?: number; headersTimeoutMs?: number }) {
+function setup(input?: { limit?: number; slowLimit?: number; stallMs?: number; headersTimeoutMs?: number }) {
   const pending: Array<{ url: string; signal: AbortSignal; resolve: () => void }> = []
   const logs: Array<{ message: string; data: Record<string, unknown> }> = []
   let clock = 0
   const queue = createRequestQueue({
     limit: input?.limit ?? 2,
+    slowLimit: input?.slowLimit,
     stallMs: input?.stallMs,
     headersTimeoutMs: input?.headersTimeoutMs,
     now: () => clock,
@@ -38,6 +39,36 @@ describe("createRequestQueue", () => {
     input.pending.forEach((item) => item.resolve())
     await Promise.all(responses)
     expect(input.queue.inflight()).toBe(0)
+  })
+
+  test("slow endpoints hold at most their share of slots so small reads go first", async () => {
+    const input = setup({ limit: 4, slowLimit: 2 })
+    const paths = ["/api/vcs?location[directory]=%2Fa", "/api/vcs/diff?location[directory]=%2Fa", "/api/worktree", "/api/session/ses_1"]
+    const responses = paths.map((path) => input.queue.fetch(`http://server${path}`))
+    await input.settle()
+    const started = () => input.pending.map((item) => new URL(item.url).pathname)
+    // Two slow requests fill the slow share; the worktree read waits while the session read jumps ahead.
+    expect(started()).toEqual(["/api/vcs", "/api/vcs/diff", "/api/session/ses_1"])
+    expect(input.queue.inflight()).toBe(3)
+    expect(input.queue.queued()).toBe(1)
+    // A fast request finishing does not free a slow slot.
+    input.pending[2]!.resolve()
+    await input.settle()
+    expect(started()).toEqual(["/api/vcs", "/api/vcs/diff", "/api/session/ses_1"])
+    input.pending[0]!.resolve()
+    await input.settle()
+    expect(started()).toEqual(["/api/vcs", "/api/vcs/diff", "/api/session/ses_1", "/api/worktree"])
+    input.pending.forEach((item) => item.resolve())
+    await Promise.all(responses)
+    expect(input.queue.inflight()).toBe(0)
+  })
+
+  test("classifies git and worktree endpoints as slow", () => {
+    expect(isSlowRequest("/api/vcs")).toBe(true)
+    expect(isSlowRequest("/api/vcs/branches")).toBe(true)
+    expect(isSlowRequest("/api/worktree")).toBe(true)
+    expect(isSlowRequest("/api/vcsx")).toBe(false)
+    expect(isSlowRequest("/api/session")).toBe(false)
   })
 
   test("never counts the event stream against the budget", async () => {

--- a/packages/app/src/runtime/server/request-queue.ts
+++ b/packages/app/src/runtime/server/request-queue.ts
@@ -1,9 +1,14 @@
-type Entry = { method: string; url: string; at: number }
+type Entry = { method: string; url: string; at: number; slow: boolean }
 
 // Chromium allows six connections per origin. The event stream holds one for the life of the
 // connection and health probes use their own fetch, so the app's API calls stay below that or
 // a burst stalls probes and user actions inside the browser where nothing can observe it.
 export const requestQueueLimit = 4
+
+// Endpoints that shell out to git or walk the filesystem take seconds on a large repository. They
+// may hold at most this many slots, so a session mount's small reads never queue behind them.
+export const requestQueueSlowLimit = 2
+export const slowRequestPaths = ["/api/vcs", "/api/worktree"]
 
 // A mount legitimately fires a dozen requests at once; only a request that has waited this long
 // for a slot indicates the server is not keeping up.
@@ -14,15 +19,21 @@ export const requestStallMs = 2_000
 // instead of wedging every later API call; the body may still stream for as long as it needs.
 export const requestHeadersTimeoutMs = 60_000
 
+export function isSlowRequest(pathname: string) {
+  return slowRequestPaths.some((path) => pathname === path || pathname.startsWith(`${path}/`))
+}
+
 export function createRequestQueue(input: {
   fetch: typeof globalThis.fetch
   limit?: number
+  slowLimit?: number
   stallMs?: number
   headersTimeoutMs?: number
   log?: (message: string, data: Record<string, unknown>) => void
   now?: () => number
 }) {
   const limit = input.limit ?? requestQueueLimit
+  const slowLimit = input.slowLimit ?? requestQueueSlowLimit
   const stallMs = input.stallMs ?? requestStallMs
   const headersTimeoutMs = input.headersTimeoutMs ?? requestHeadersTimeoutMs
   // Call the browser fetch unbound; `input.fetch(...)` would make `this` the options object.
@@ -50,9 +61,17 @@ export function createRequestQueue(input: {
     }
     watcher = setTimeout(watch, stallMs)
   }
+  const canStart = (entry: Entry) => {
+    if (inflight.size >= limit) return false
+    if (!entry.slow) return true
+    return [...inflight].filter((item) => item.slow).length < slowLimit
+  }
+  // FIFO, except a slow request waits its turn behind faster ones while the slow slots are full.
   const release = (entry: Entry) => {
     inflight.delete(entry)
-    waiting.shift()?.start()
+    const index = waiting.findIndex((item) => canStart(item.entry))
+    if (index === -1) return
+    waiting.splice(index, 1)[0]?.start()
   }
   const acquire = (entry: Entry) =>
     new Promise<void>((resolve) => {
@@ -61,7 +80,7 @@ export function createRequestQueue(input: {
         inflight.add(entry)
         resolve()
       }
-      if (inflight.size < limit) return start()
+      if (canStart(entry)) return start()
       waiting.push({ entry, start })
       watcher ??= setTimeout(watch, stallMs)
     })
@@ -69,9 +88,10 @@ export function createRequestQueue(input: {
   const fetch: typeof globalThis.fetch = Object.assign(
     async (resource: RequestInfo | URL, init?: RequestInit) => {
       const request = new Request(resource, init)
+      const pathname = new URL(request.url).pathname
       // The event stream is long-lived; never count it against the request budget.
-      if (new URL(request.url).pathname === "/api/event") return base(request)
-      const entry = { method: request.method, url: request.url, at: now() }
+      if (pathname === "/api/event") return base(request)
+      const entry = { method: request.method, url: request.url, at: now(), slow: isSlowRequest(pathname) }
       await acquire(entry)
       if (request.signal.aborted) {
         release(entry)


### PR DESCRIPTION
The request queue from #47441 is a plain FIFO with 4 slots. A Desktop netlog shows what sits in those slots during a session-tab mount:

| Endpoint | Server time |
|---|---|
| `GET /api/vcs` | p50 **1789 ms**, max 2468 ms |
| `GET /api/worktree` | p50 461 ms, max 2243 ms |
| `GET /api/session/:id`, `/message`, `/permission`, `/form`, catalogs | p50 2–25 ms |

A mount fires ~21 requests; two of them run `git` and can hold slots for over two seconds each. With several tabs mounting or a reconnect re-syncing directories, git reads take all 4 slots and the reads that actually paint the session sit behind them — which is exactly what `server thrashing detected` was logging (`inflight: [GET /api/worktree…, GET /api/worktree…]`, `queued: [GET /api/health]`).

```mermaid
flowchart LR
  subgraph before [Before: FIFO x4]
    B[vcs · vcs · worktree · worktree] --> Q[queued: session, messages, permissions…]
  end
  subgraph after [After: slow share = 2 of 4]
    A1[vcs · vcs] --- A2[session · messages · …]
    A3[worktree · worktree] -.waits for a slow slot.-> A1
  end
```

## Change — `packages/app/src/runtime/server/request-queue.ts`

- `slowRequestPaths = ["/api/vcs", "/api/worktree"]` (prefix match, so `/api/vcs/diff`, `/api/vcs/branches` included); `requestQueueSlowLimit = 2`.
- Slow requests may hold at most 2 of the 4 slots. Order stays FIFO otherwise: a slow request only yields its turn while the slow share is full, so nothing starves and fast reads never change order among themselves.
- The wait list is scanned for the first *eligible* entry on each release instead of popping the head.

```ts
const canStart = (entry: Entry) => {
  if (inflight.size >= limit) return false
  if (!entry.slow) return true
  return [...inflight].filter((item) => item.slow).length < slowLimit
}
const release = (entry: Entry) => {
  inflight.delete(entry)
  const index = waiting.findIndex((item) => canStart(item.entry))
  if (index === -1) return
  waiting.splice(index, 1)[0]?.start()
}
```

Total concurrency is unchanged (4 + the event stream), so the Chromium per-origin limit reasoning in #47441 still holds.
