### PR TITLE
fix(app): pace directory re-sync after reconnect

### DIFF
--- a/packages/app/src/runtime/server/server-sync/connection.test.ts
+++ b/packages/app/src/runtime/server/server-sync/connection.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test"
 import { createRoot, createSignal } from "solid-js"
-import { createConnectionSync } from "./connection"
+import { createConnectionSync, reconnectOrder } from "./connection"
 
 test("invalidates disconnected data and synchronizes after the handshake", () => {
   const calls: string[] = []
@@ -18,4 +18,10 @@ test("invalidates disconnected data and synchronizes after the handshake", () =>
     return dispose
   })
   dispose()
+})
+
+test("held directories refresh before the rest, otherwise keeping their order", () => {
+  const held = new Set(["/b", "/d"])
+  expect(reconnectOrder(["/a", "/b", "/c", "/d"], (directory) => held.has(directory))).toEqual(["/b", "/d", "/a", "/c"])
+  expect(reconnectOrder(["/a", "/c"], (directory) => held.has(directory))).toEqual(["/a", "/c"])
 })

--- a/packages/app/src/runtime/server/server-sync/connection.ts
+++ b/packages/app/src/runtime/server/server-sync/connection.ts
@@ -20,3 +20,8 @@ export function createConnectionSync(input: {
 
   return { handleEvent }
 }
+
+// Directories a mounted view holds refresh first; the rest keep their existing order behind them.
+export function reconnectOrder(directories: string[], held: (directory: string) => boolean) {
+  return [...directories.filter(held), ...directories.filter((directory) => !held(directory))]
+}

--- a/packages/app/src/runtime/server/sync.tsx
+++ b/packages/app/src/runtime/server/sync.tsx
@@ -17,7 +17,7 @@ import type { ServerScope } from "@/runtime/server/scope"
 import { persisted } from "@/runtime/persistence/storage"
 import type { ServerApi } from "@/runtime/server/api"
 import { toggleMcp } from "./global-sync/mcp"
-import { createConnectionSync } from "./server-sync/connection"
+import { createConnectionSync, reconnectOrder } from "./server-sync/connection"
 import { usePlatform } from "@/runtime/platform/platform"
 import type { Data } from "@opencode-ai/client/solid"
 import { createWorktreeInventory, withWorktreeInventory } from "@/workspaces/inventory"
@@ -162,12 +162,11 @@ export function createServerSyncContextInner(serverSDK: ServerSDK, data: Data) {
     },
     connected: (info) => {
       if (bootstrap.data !== undefined && !bootstrap.isFetching) void bootstrap.refetch()
-      Object.keys(children.children)
-        .filter(children.active)
-        .forEach((directory) => {
-          queue.push(directory)
-          void data.location.sync({ directory }).catch(() => undefined)
-        })
+      // The refresh queue re-syncs two directories at a time, held ones first. Syncing every active
+      // directory here as well sent the whole catalog fan-out for all of them at once.
+      reconnectOrder(Object.keys(children.children).filter(children.active), children.pinned).forEach(
+        (directory) => queue.push(directory),
+      )
     },
   })
 


### PR DESCRIPTION
When the event stream reconnects, `sync.tsx` did two things for every active directory: `queue.push(directory)` (the refresh queue, which re-bootstraps two directories at a time) **and** an immediate `data.location.sync({ directory })`. The second call bypassed the pacing, so a reconnect with ~20 directories open sent ~20 × 13 catalog reads to the server in the same tick. In the Desktop netlog that is the ~500-request burst at 12:43:33 right after the sidecar restarted, followed by `server thrashing detected`.

```mermaid
flowchart LR
  subgraph before [Before]
    C1[server.connected] --> P1[queue.push × N]
    C1 --> S1["location.sync × N (unpaced, same tick)"]
  end
  subgraph after [After]
    C2[server.connected] --> O[held directories first, then the rest] --> P2[queue.push × N → 2 at a time]
  end
```

## Change

- `packages/app/src/runtime/server/sync.tsx`: reconnect only pushes into the refresh queue. `bootstrapInstance` already runs `data.location.sync` for each directory it processes, so nothing is skipped — it is just paced.
- Directories a mounted view currently holds (`children.pinned`) are pushed first, so the tab the user is looking at repopulates before background ones.

```ts
connected: (info) => {
  if (bootstrap.data !== undefined && !bootstrap.isFetching) void bootstrap.refetch()
  reconnectOrder(Object.keys(children.children).filter(children.active), children.pinned).forEach(
    (directory) => queue.push(directory),
  )
},
```

- `reconnectOrder` lives in `server-sync/connection.ts`: held directories first, otherwise original order.
