### PR TITLE
fix(app): time out requests the server never answers

### DIFF
--- a/packages/app/src/runtime/server/request-queue.test.ts
+++ b/packages/app/src/runtime/server/request-queue.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, test } from "bun:test"
 import { createRequestQueue } from "./request-queue"
 
-function setup(input?: { limit?: number; stallMs?: number }) {
-  const pending: Array<{ url: string; resolve: () => void }> = []
+function setup(input?: { limit?: number; stallMs?: number; headersTimeoutMs?: number }) {
+  const pending: Array<{ url: string; signal: AbortSignal; resolve: () => void }> = []
   const logs: Array<{ message: string; data: Record<string, unknown> }> = []
   let clock = 0
   const queue = createRequestQueue({
     limit: input?.limit ?? 2,
     stallMs: input?.stallMs,
+    headersTimeoutMs: input?.headersTimeoutMs,
     now: () => clock,
     log: (message, data) => logs.push({ message, data }),
     fetch: Object.assign(
       (resource: RequestInfo | URL) =>
-        new Promise<Response>((resolve) => {
-          pending.push({ url: new Request(resource).url, resolve: () => resolve(new Response("ok")) })
+        new Promise<Response>((resolve, reject) => {
+          const request = new Request(resource)
+          request.signal.addEventListener("abort", () => reject(request.signal.reason), { once: true })
+          pending.push({ url: request.url, signal: request.signal, resolve: () => resolve(new Response("ok")) })
         }),
       { preconnect() {} },
     ),
@@ -56,6 +59,34 @@ describe("createRequestQueue", () => {
     input.pending[0]!.resolve()
     await expect(aborted).rejects.toBeInstanceOf(DOMException)
     expect(input.pending.map((item) => new URL(item.url).pathname)).toEqual(["/api/first"])
+    expect(input.queue.inflight()).toBe(0)
+  })
+
+  test("a request the server never answers times out and frees its slot", async () => {
+    const input = setup({ limit: 1, headersTimeoutMs: 10 })
+    const dead = input.queue.fetch("http://server/api/dead")
+    const next = input.queue.fetch("http://server/api/next")
+    await input.settle()
+    expect(input.queue.queued()).toBe(1)
+    const error = await dead.catch((cause: unknown) => cause)
+    expect(error).toBeInstanceOf(DOMException)
+    expect((error as DOMException).name).toBe("TimeoutError")
+    await input.settle()
+    expect(input.pending.map((item) => new URL(item.url).pathname)).toEqual(["/api/dead", "/api/next"])
+    input.pending[1]!.resolve()
+    await expect(next).resolves.toBeInstanceOf(Response)
+    expect(input.queue.inflight()).toBe(0)
+  })
+
+  test("caller aborts still reach the underlying request", async () => {
+    const input = setup({ limit: 1 })
+    const controller = new AbortController()
+    const request = input.queue.fetch("http://server/api/slow", { signal: controller.signal })
+    await input.settle()
+    expect(input.pending[0]!.signal.aborted).toBe(false)
+    controller.abort()
+    expect(input.pending[0]!.signal.aborted).toBe(true)
+    await expect(request).rejects.toBeInstanceOf(DOMException)
     expect(input.queue.inflight()).toBe(0)
   })
 

--- a/packages/app/src/runtime/server/request-queue.ts
+++ b/packages/app/src/runtime/server/request-queue.ts
@@ -9,15 +9,22 @@ export const requestQueueLimit = 4
 // for a slot indicates the server is not keeping up.
 export const requestStallMs = 2_000
 
+// A socket that dies while the device sleeps can leave fetch waiting for response headers until the
+// OS gives up on TCP retransmits, which takes minutes. Bound that so a dead request frees its slot
+// instead of wedging every later API call; the body may still stream for as long as it needs.
+export const requestHeadersTimeoutMs = 60_000
+
 export function createRequestQueue(input: {
   fetch: typeof globalThis.fetch
   limit?: number
   stallMs?: number
+  headersTimeoutMs?: number
   log?: (message: string, data: Record<string, unknown>) => void
   now?: () => number
 }) {
   const limit = input.limit ?? requestQueueLimit
   const stallMs = input.stallMs ?? requestStallMs
+  const headersTimeoutMs = input.headersTimeoutMs ?? requestHeadersTimeoutMs
   // Call the browser fetch unbound; `input.fetch(...)` would make `this` the options object.
   const base = input.fetch
   const now = input.now ?? Date.now
@@ -70,7 +77,16 @@ export function createRequestQueue(input: {
         release(entry)
         throw request.signal.reason ?? new DOMException("The operation was aborted.", "AbortError")
       }
-      return base(request).finally(() => release(entry))
+      const controller = new AbortController()
+      request.signal.addEventListener("abort", () => controller.abort(request.signal.reason), { once: true })
+      const timer = setTimeout(
+        () => controller.abort(new DOMException("Timed out waiting for the server to respond", "TimeoutError")),
+        headersTimeoutMs,
+      )
+      return base(new Request(request, { signal: controller.signal })).finally(() => {
+        clearTimeout(timer)
+        release(entry)
+      })
     },
     // Bun's fetch type carries preconnect; the browser never calls it.
     { preconnect: () => {} },


### PR DESCRIPTION
A socket that dies while a phone sleeps can leave `fetch` waiting for response headers until the OS gives up on TCP retransmits, which is minutes on Android and Linux. The request queue allows four in-flight requests per server, so a few of those dead requests wedge every later API call, and the only symptom is a `server thrashing detected` console warning.

- Each queued request now gets a 60 s headers deadline. If no response arrives by then the request is aborted with a `TimeoutError` and its slot is released.
- The deadline covers headers only; once the response arrives the body may stream for as long as it needs.
- Caller `AbortSignal`s still propagate to the underlying request.
- `/api/event` keeps its existing bypass; the event stream has its own idle watchdog.

```ts
const controller = new AbortController()
request.signal.addEventListener("abort", () => controller.abort(request.signal.reason), { once: true })
const timer = setTimeout(
  () => controller.abort(new DOMException("Timed out waiting for the server to respond", "TimeoutError")),
  headersTimeoutMs,
)
return base(new Request(request, { signal: controller.signal })).finally(() => {
  clearTimeout(timer)
  release(entry)
})
```

Touches the same file as #47564; the conflict is confined to the test `setup` helper and the `fetch` body.
