### PR TITLE
feat(app): pulse the status dot while the event stream reconnects

### DIFF
--- a/packages/app/src/shell/status/indicator.test.ts
+++ b/packages/app/src/shell/status/indicator.test.ts
@@ -21,6 +21,19 @@ describe("serverStatusDotClass", () => {
     expect(serverStatusDotClass({ ready: true, serverHealth: false, issue: true })).toBe("bg-icon-critical-base")
   })
 
+  test("pulses the neutral dot while the event stream is reconnecting", () => {
+    expect(serverStatusDotClass({ ready: true, serverHealth: true, issue: false, connecting: true })).toBe(
+      "bg-border-weak-base animate-pulse",
+    )
+    expect(serverStatusDotClass({ ready: false, serverHealth: undefined, issue: false, connecting: true })).toBe(
+      "bg-border-weak-base animate-pulse",
+    )
+    // A server that is known to be down stays critical rather than looking like a routine reconnect.
+    expect(serverStatusDotClass({ ready: true, serverHealth: false, issue: false, connecting: true })).toBe(
+      "bg-icon-critical-base",
+    )
+  })
+
   test("stays neutral before status is ready", () => {
     expect(serverStatusDotClass({ ready: false, serverHealth: true, issue: false })).toBe("bg-border-weak-base")
     expect(serverStatusDotClass({ ready: false, serverHealth: undefined, issue: false })).toBe("bg-border-weak-base")

--- a/packages/app/src/shell/status/indicator.ts
+++ b/packages/app/src/shell/status/indicator.ts
@@ -20,8 +20,12 @@ export function serverStatusDotClass(input: {
   serverHealth: boolean | undefined
   attention?: boolean
   issue: boolean
+  connecting?: boolean
 }) {
   if (input.serverHealth === false) return "bg-icon-critical-base"
+  // The event stream is (re)connecting: keep the neutral dot but let it breathe so a stale
+  // session is visibly waiting on the server rather than silently frozen.
+  if (input.connecting) return "bg-border-weak-base animate-pulse"
   if (!input.ready || input.serverHealth === undefined) return "bg-border-weak-base"
   if (input.attention) return "bg-v2-background-bg-accent"
   if (input.issue) return "bg-icon-warning-base"

--- a/packages/app/src/shell/status/status-popover.tsx
+++ b/packages/app/src/shell/status/status-popover.tsx
@@ -42,6 +42,7 @@ export function StatusPopover() {
     serverHealth: serverHealth(),
     attention: attention(),
     issue: issue(),
+    connecting: server.ctx.sdk.connection.status() !== "connected",
     sidebar: sidebar(),
     placement: sidebar() ? "top-start" : "bottom-end",
     shift: sidebar() ? 0 : -168,
@@ -63,6 +64,7 @@ type StatusPopoverState = {
   serverHealth: boolean | undefined
   attention: boolean
   issue: boolean
+  connecting: boolean
   sidebar: boolean
   placement: "top-start" | "bottom-end"
   shift: number


### PR DESCRIPTION
While the event stream is connecting or reconnecting, nothing in the UI shows it. With the stall detection in #47571 a phone that wakes from sleep now reconnects and resyncs on its own, but for that second or two the page looks frozen with a green dot.

- The existing server status dot keeps its neutral colour while `connection.status() !== "connected"` and gains `animate-pulse`, so it visibly breathes while waiting on the server.
- A server that is known to be down stays critical red; the pulse never masks a real outage.
- Health-only states (`ready`, `attention`, `issue`) are unchanged once the stream is connected.

Both clips: stream healthy → event stream cut for ~5 s (server still answering `/api/health`) → stream restored.

**Before** — the dot stays solid green while the stream is dead:

https://github.com/user-attachments/assets/336bf2a6-8a58-4a2d-b264-a92e46ba2de2

**After** — the dot turns neutral and pulses until the stream reconnects:

https://github.com/user-attachments/assets/b9603782-fbdc-420d-9e6e-cad1fc129dd2

```ts
if (input.serverHealth === false) return "bg-icon-critical-base"
if (input.connecting) return "bg-border-weak-base animate-pulse"
```
