### PR TITLE
docs: add oh-my-agentmemory to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [oh-my-agentmemory](https://github.com/dev-hann/oh-my-agentmemory)                                 | Forces opencode agents to actually write to agentmemory - per-turn policy directives, slot bootstrap, bilingual intent keywords, auto-lessons |
 
 ---
 


### PR DESCRIPTION
Adds oh-my-agentmemory to the Plugins table in the ecosystem docs.

oh-my-agentmemory is a companion plugin to agentmemory (rohitg00/agentmemory) focused on the write side: it re-injects a memory policy directive into the system prompt every turn via experimental.chat.system.transform, bootstraps empty pinned slots on session start, catches bilingual intent keywords (EN/KR), auto-saves lessons from error-signal file edits, and suggests crystallizing finished work. Installs from npm with one line in opencode.json.

Repo: https://github.com/dev-hann/oh-my-agentmemory
npm: https://www.npmjs.com/package/oh-my-agentmemory