### PR TITLE
fix(app): accept uppercase deep-link schemes

### DIFF
--- a/packages/app/src/pages/layout/deep-links.ts
+++ b/packages/app/src/pages/layout/deep-links.ts
@@ -1,10 +1,11 @@
 export const deepLinkEvent = "opencode:deep-link"
 
 const parseUrl = (input: string) => {
-  if (!input.startsWith("opencode://")) return
   if (typeof URL.canParse === "function" && !URL.canParse(input)) return
   try {
-    return new URL(input)
+    const url = new URL(input)
+    if (url.protocol.toLowerCase() !== "opencode:") return
+    return url
   } catch {
     return
   }

--- a/packages/app/src/pages/layout/helpers.test.ts
+++ b/packages/app/src/pages/layout/helpers.test.ts
@@ -43,6 +43,13 @@ describe("layout deep links", () => {
     expect(parseDeepLink("opencode://open-project?directory=/tmp/demo")).toBe("/tmp/demo")
   })
 
+  test("accepts case-insensitive deep-link schemes", () => {
+    expect(parseDeepLink("OPENCODE://open-project?directory=/tmp/demo")).toBe("/tmp/demo")
+    expect(parseNewSessionDeepLink("OpenCode://new-session?directory=/tmp/demo")).toEqual({
+      directory: "/tmp/demo",
+    })
+  })
+
   test("ignores non-project deep links", () => {
     expect(parseDeepLink("opencode://other?directory=/tmp/demo")).toBeUndefined()
     expect(parseDeepLink("https://example.com")).toBeUndefined()


### PR DESCRIPTION
### Issue for this PR

Closes #47581

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The deep-link parser rejected uppercase and mixed-case `opencode` schemes through a raw case-sensitive prefix check, even though URI schemes are case-insensitive. This change parses the URL first and validates its normalized protocol, preserving rejection of non-OpenCode URLs. Regression coverage includes both open-project and new-session links.

### How did you verify your code works?

From `packages/app` at reduced process priority:

- `bun test src/pages/layout/helpers.test.ts` — 28 tests passed
- `bun typecheck` — passed

### Screenshots / recordings

Not applicable. This changes deep-link parsing logic without changing the rendered UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR