### PR TITLE
fix(opencode): decode uppercase base64 markers

### DIFF
--- a/packages/opencode/src/util/data-url.ts
+++ b/packages/opencode/src/util/data-url.ts
@@ -4,6 +4,8 @@ export function decodeDataUrl(url: string) {
 
   const head = url.slice(0, idx)
   const body = url.slice(idx + 1)
-  if (head.includes(";base64")) return Buffer.from(body, "base64").toString("utf8")
+  if (head.split(";").some((part) => part.toLowerCase() === "base64")) {
+    return Buffer.from(body, "base64").toString("utf8")
+  }
   return decodeURIComponent(body)
 }

--- a/packages/opencode/test/util/data-url.test.ts
+++ b/packages/opencode/test/util/data-url.test.ts
@@ -8,6 +8,10 @@ describe("decodeDataUrl", () => {
     expect(decodeDataUrl(url)).toBe(body)
   })
 
+  test("decodes case-insensitive base64 markers", () => {
+    expect(decodeDataUrl("data:text/plain;BASE64,SGVsbG8=")).toBe("Hello")
+  })
+
   test("decodes plain data URLs", () => {
     expect(decodeDataUrl("data:text/plain,hello%20world")).toBe("hello world")
   })


### PR DESCRIPTION
### Issue for this PR

Closes #47583

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The text data-URL decoder only recognized the lowercase substring `;base64`, so uppercase markers exposed the encoded payload as text. This change checks semicolon-delimited metadata for an exact `base64` token case-insensitively, matching the Fetch data-URL processor and avoiding prefix matches such as `base64x`. A regression test covers the uppercase marker.

### How did you verify your code works?

From `packages/opencode` at reduced process priority:

- `bun test --timeout 30000 test/util/data-url.test.ts` — 3 tests passed
- `bun typecheck` — started but stopped locally after several minutes to avoid resource contention; no diagnostic was emitted before cancellation

### Screenshots / recordings

Not applicable. This changes data-URL decoding logic without changing the rendered UI.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR