### PR TITLE
fix(desktop): add sidecar credentials from the main process

### DIFF
--- a/packages/desktop/src/main/ipc-handlers/app.ts
+++ b/packages/desktop/src/main/ipc-handlers/app.ts
@@ -14,6 +14,7 @@ import { ApplicationLifecycle } from "../lifecycle"
 import { finishFirstLaunchOnboarding, isFirstLaunchOnboardingPending } from "../lifecycle/onboarding"
 import { BackgroundService } from "../service/background-service"
 import { DesktopCli } from "../service/desktop-cli"
+import { SidecarCredentials } from "../service/sidecar-credentials"
 import { getDefaultServerUrl, setDefaultServerUrl } from "../service/server-settings"
 import { Updater } from "../updater"
 import { getLastFocusedWindow, setBackgroundColor } from "../windows"
@@ -29,8 +30,8 @@ export const appHandlers = AppRpcs.toLayer(
     const logging = yield* DesktopLogging.Service
     const runFork = Effect.runForkWith(yield* Effect.context())
     return AppRpcs.of({
-      AppAwaitInitialization: () => background.connection,
-      AppReconnectService: () => background.reconnect,
+      AppAwaitInitialization: () => background.connection.pipe(Effect.map(SidecarCredentials.ready)),
+      AppReconnectService: () => background.reconnect.pipe(Effect.map(SidecarCredentials.ready)),
       AppConsumeInitialDeepLinks: () => Effect.sync(lifecycle.consumeInitialDeepLinks),
       AppGetDefaultServerUrl: () => Effect.sync(getDefaultServerUrl),
       AppSetDefaultServerUrl: ({ url }) => Effect.sync(() => setDefaultServerUrl(url)),

--- a/packages/desktop/src/main/service/background-service-state.ts
+++ b/packages/desktop/src/main/service/background-service-state.ts
@@ -1,14 +1,14 @@
 export * as BackgroundServiceState from "./background-service-state"
 
 import { Effect, Exit, Ref } from "effect"
-import type { ServerReadyData } from "../../shared/ipc-contract"
+import type { SidecarCredentials } from "./sidecar-credentials"
 
 export const make = Effect.fn("BackgroundServiceState.make")(function* (options: {
-  readonly initial: Effect.Effect<ServerReadyData, unknown>
-  readonly reconnect: Effect.Effect<ServerReadyData>
+  readonly initial: Effect.Effect<SidecarCredentials.Data, unknown>
+  readonly reconnect: Effect.Effect<SidecarCredentials.Data>
 }) {
   // Every Exit is an Effect, so the latest resolution replays directly for each consumer.
-  const current = yield* Ref.make<Exit.Exit<ServerReadyData, unknown>>(yield* options.initial.pipe(Effect.exit))
+  const current = yield* Ref.make<Exit.Exit<SidecarCredentials.Data, unknown>>(yield* options.initial.pipe(Effect.exit))
   return {
     connection: Ref.get(current).pipe(Effect.flatten, Effect.orDie),
     reconnect: options.reconnect.pipe(Effect.tap((next) => Ref.set(current, Exit.succeed(next)))),

--- a/packages/desktop/src/main/service/background-service.ts
+++ b/packages/desktop/src/main/service/background-service.ts
@@ -1,6 +1,5 @@
 import { app } from "electron"
 import { Context, Effect, FileSystem, Layer, Path } from "effect"
-import type { ServerReadyData } from "../../shared/ipc-contract"
 import { BackgroundServiceState } from "./background-service-state"
 import { cleanStages, DesktopCli } from "./desktop-cli"
 import { SidecarCredentials } from "./sidecar-credentials"
@@ -8,8 +7,8 @@ import { SidecarCredentials } from "./sidecar-credentials"
 export * as BackgroundService from "./background-service"
 
 export interface Interface {
-  readonly connection: Effect.Effect<ServerReadyData>
-  readonly reconnect: Effect.Effect<ServerReadyData>
+  readonly connection: Effect.Effect<SidecarCredentials.Data>
+  readonly reconnect: Effect.Effect<SidecarCredentials.Data>
 }
 
 export class Service extends Context.Service<Service, Interface>()("opencode/desktop/BackgroundService") {}
@@ -57,7 +56,7 @@ const connect = Effect.fn("BackgroundService.connect")(function* (mode: "initial
     ...endpoint(url.origin),
   })
   if (mode === "initial" && isolated && cli.binary) yield* cleanStages(cli.binary).pipe(Effect.orDie)
-  const ready = { url: url.origin, password: service.auth.password } satisfies ServerReadyData
+  const ready = { url: url.origin, password: service.auth.password } satisfies SidecarCredentials.Data
   SidecarCredentials.set(ready)
   return ready
 })

--- a/packages/desktop/src/main/service/background-service.ts
+++ b/packages/desktop/src/main/service/background-service.ts
@@ -3,6 +3,7 @@ import { Context, Effect, FileSystem, Layer, Path } from "effect"
 import type { ServerReadyData } from "../../shared/ipc-contract"
 import { BackgroundServiceState } from "./background-service-state"
 import { cleanStages, DesktopCli } from "./desktop-cli"
+import { SidecarCredentials } from "./sidecar-credentials"
 
 export * as BackgroundService from "./background-service"
 
@@ -56,10 +57,9 @@ const connect = Effect.fn("BackgroundService.connect")(function* (mode: "initial
     ...endpoint(url.origin),
   })
   if (mode === "initial" && isolated && cli.binary) yield* cleanStages(cli.binary).pipe(Effect.orDie)
-  return {
-    url: url.origin,
-    password: service.auth.password,
-  } satisfies ServerReadyData
+  const ready = { url: url.origin, password: service.auth.password } satisfies ServerReadyData
+  SidecarCredentials.set(ready)
+  return ready
 })
 
 function endpoint(url: string | undefined) {

--- a/packages/desktop/src/main/service/sidecar-credentials.test.ts
+++ b/packages/desktop/src/main/service/sidecar-credentials.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test"
-import { authorization } from "./sidecar-credentials"
+import { authorization, ready } from "./sidecar-credentials"
 
 const sidecar = { url: "http://127.0.0.1:4096", password: "secret" }
 const expected = `Basic ${Buffer.from("opencode:secret").toString("base64")}`
@@ -10,6 +10,10 @@ describe("sidecar authorization", () => {
     expect(authorization(sidecar, "http://127.0.0.1:4097/api/session")).toBeUndefined()
     expect(authorization(sidecar, "http://localhost:4096/api/session")).toBeUndefined()
     expect(authorization(sidecar, "https://127.0.0.1:4096/api/session")).toBeUndefined()
+  })
+
+  test("hands the renderer the origin only", () => {
+    expect(ready(sidecar)).toEqual({ url: sidecar.url })
   })
 
   test("adds nothing before the sidecar is known or when it has no password", () => {

--- a/packages/desktop/src/main/service/sidecar-credentials.test.ts
+++ b/packages/desktop/src/main/service/sidecar-credentials.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test"
+import { authorization } from "./sidecar-credentials"
+
+const sidecar = { url: "http://127.0.0.1:4096", password: "secret" }
+const expected = `Basic ${Buffer.from("opencode:secret").toString("base64")}`
+
+describe("sidecar authorization", () => {
+  test("adds the Basic credential only for the sidecar origin", () => {
+    expect(authorization(sidecar, "http://127.0.0.1:4096/api/session?limit=1")).toBe(expected)
+    expect(authorization(sidecar, "http://127.0.0.1:4097/api/session")).toBeUndefined()
+    expect(authorization(sidecar, "http://localhost:4096/api/session")).toBeUndefined()
+    expect(authorization(sidecar, "https://127.0.0.1:4096/api/session")).toBeUndefined()
+  })
+
+  test("adds nothing before the sidecar is known or when it has no password", () => {
+    expect(authorization(undefined, "http://127.0.0.1:4096/api/session")).toBeUndefined()
+    expect(authorization({ url: sidecar.url, password: null }, "http://127.0.0.1:4096/api/session")).toBeUndefined()
+    expect(authorization(sidecar, "not a url")).toBeUndefined()
+  })
+})

--- a/packages/desktop/src/main/service/sidecar-credentials.ts
+++ b/packages/desktop/src/main/service/sidecar-credentials.ts
@@ -2,12 +2,14 @@ export * as SidecarCredentials from "./sidecar-credentials"
 
 import type { ServerReadyData } from "../../shared/ipc-contract"
 
+export type Data = ServerReadyData & { password: string | null }
+
 // The renderer talks to the sidecar without an Authorization header; the main process adds it from
 // here so GET requests stay CORS-simple and skip the preflight round trip. Both the initial connection
 // and every reconnect publish the current endpoint.
-let current: ServerReadyData | undefined
+let current: Data | undefined
 
-export function set(data: ServerReadyData) {
+export function set(data: Data) {
   current = data
 }
 
@@ -15,8 +17,13 @@ export function get() {
   return current
 }
 
+/** What the renderer learns about the sidecar: its origin, never its credential. */
+export function ready(data: Data): ServerReadyData {
+  return { url: data.url }
+}
+
 /** The Basic credential for a request to the sidecar origin, or undefined for any other URL. */
-export function authorization(sidecar: ServerReadyData | undefined, url: string) {
+export function authorization(sidecar: Data | undefined, url: string) {
   if (!sidecar?.password || !URL.canParse(url)) return
   if (new URL(url).origin !== sidecar.url) return
   return `Basic ${Buffer.from(`opencode:${sidecar.password}`).toString("base64")}`

--- a/packages/desktop/src/main/service/sidecar-credentials.ts
+++ b/packages/desktop/src/main/service/sidecar-credentials.ts
@@ -1,0 +1,23 @@
+export * as SidecarCredentials from "./sidecar-credentials"
+
+import type { ServerReadyData } from "../../shared/ipc-contract"
+
+// The renderer talks to the sidecar without an Authorization header; the main process adds it from
+// here so GET requests stay CORS-simple and skip the preflight round trip. Both the initial connection
+// and every reconnect publish the current endpoint.
+let current: ServerReadyData | undefined
+
+export function set(data: ServerReadyData) {
+  current = data
+}
+
+export function get() {
+  return current
+}
+
+/** The Basic credential for a request to the sidecar origin, or undefined for any other URL. */
+export function authorization(sidecar: ServerReadyData | undefined, url: string) {
+  if (!sidecar?.password || !URL.canParse(url)) return
+  if (new URL(url).origin !== sidecar.url) return
+  return `Basic ${Buffer.from(`opencode:${sidecar.password}`).toString("base64")}`
+}

--- a/packages/desktop/src/main/windows/security.ts
+++ b/packages/desktop/src/main/windows/security.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow } from "electron"
-import { addRendererHeaders } from "./headers"
+import { SidecarCredentials } from "../service/sidecar-credentials"
+import { addRendererHeaders, hasHeader, upsertHeader } from "./headers"
 import { isRendererUrl } from "./protocol"
 
 const rendererPermissions = new Set(["clipboard-sanitized-write", "notifications"])
@@ -31,6 +32,19 @@ export function wireNavigationPolicy(win: BrowserWindow, openExternalURL: (url: 
 }
 
 export function wireRendererHeaders(win: BrowserWindow) {
+  // The renderer sends sidecar requests without credentials, so its GETs are CORS-simple and need no
+  // preflight. Electron applies these listeners in Chromium's extraHeaders mode, after the CORS
+  // decision, so adding Authorization here does not reintroduce one.
+  win.webContents.session.webRequest.onBeforeSendHeaders(
+    { urls: ["http://127.0.0.1/*", "http://localhost/*"] },
+    (details, callback) => {
+      const authorization = SidecarCredentials.authorization(SidecarCredentials.get(), details.url)
+      if (authorization && !hasHeader(details.requestHeaders, "Authorization")) {
+        upsertHeader(details.requestHeaders, "Authorization", authorization)
+      }
+      callback({ requestHeaders: details.requestHeaders })
+    },
+  )
   win.webContents.session.webRequest.onHeadersReceived((details, callback) => {
     const responseHeaders = details.responseHeaders ?? {}
     addRendererHeaders(responseHeaders, { document: isRendererUrl(details.url, true) })

--- a/packages/desktop/src/main/windows/security.ts
+++ b/packages/desktop/src/main/windows/security.ts
@@ -35,10 +35,16 @@ export function wireRendererHeaders(win: BrowserWindow) {
   // The renderer sends sidecar requests without credentials, so its GETs are CORS-simple and need no
   // preflight. Electron applies these listeners in Chromium's extraHeaders mode, after the CORS
   // decision, so adding Authorization here does not reintroduce one.
+  //
+  // Only the renderer's own top-level frame is credentialed. Other content in this session (web views,
+  // embedded pages) can reach the same loopback origin and must not inherit its access. Requests with
+  // no frame, such as from a service worker, are not credentialed either; the renderer registers none.
   win.webContents.session.webRequest.onBeforeSendHeaders(
     { urls: ["http://127.0.0.1/*", "http://localhost/*"] },
     (details, callback) => {
-      const authorization = SidecarCredentials.authorization(SidecarCredentials.get(), details.url)
+      const frame = details.frame
+      const renderer = !!frame && frame.parent === null && isRendererUrl(frame.url)
+      const authorization = renderer && SidecarCredentials.authorization(SidecarCredentials.get(), details.url)
       if (authorization && !hasHeader(details.requestHeaders, "Authorization")) {
         upsertHeader(details.requestHeaders, "Authorization", authorization)
       }

--- a/packages/desktop/src/renderer/migration-status.tsx
+++ b/packages/desktop/src/renderer/migration-status.tsx
@@ -49,12 +49,8 @@ export function MigrationStatus(props: { server: ServerReadyData }) {
     await wait(1_000, abort.signal)
     if (abort.signal.aborted) return
 
-    const client = OpenCode.make({
-      baseUrl: props.server.url,
-      headers: props.server.password
-        ? { Authorization: `Basic ${btoa(`opencode:${props.server.password}`)}` }
-        : undefined,
-    })
+    // The main process credentials sidecar requests; see `wireRendererHeaders`.
+    const client = OpenCode.make({ baseUrl: props.server.url })
 
     void (async () => {
       while (true) {

--- a/packages/desktop/src/renderer/startup/initialization.test.ts
+++ b/packages/desktop/src/renderer/startup/initialization.test.ts
@@ -27,7 +27,7 @@ describe("desktop renderer initialization", () => {
   })
 
   test("returns initialized sidecar data", () => {
-    const sidecar = { url: "http://127.0.0.1:1234", password: "secret" }
+    const sidecar = { url: "http://127.0.0.1:1234" }
 
     expect(initializationData(Object.assign(() => sidecar, { error: undefined }))).toBe(sidecar)
   })
@@ -47,7 +47,7 @@ describe("desktop renderer initialization", () => {
   })
 
   test("refreshes the managed sidecar endpoint", async () => {
-    const sidecar = { url: "http://127.0.0.1:4321", password: "next" }
+    const sidecar = { url: "http://127.0.0.1:4321" }
     const updates: (typeof sidecar)[] = []
     const resolve = createSidecarResolver({
       api: { reconnectService: async () => sidecar },
@@ -55,12 +55,12 @@ describe("desktop renderer initialization", () => {
       update: (next) => updates.push(next),
     })
 
-    expect(await resolve(new AbortController().signal)).toEqual({ url: sidecar.url })
+    expect(await resolve(new AbortController().signal)).toEqual(sidecar)
     expect(updates).toEqual([sidecar])
   })
 
   test("keeps the current sidecar when reconnection resolves the same endpoint", async () => {
-    const sidecar = { url: "http://127.0.0.1:4321", password: "same" }
+    const sidecar = { url: "http://127.0.0.1:4321" }
     const updates: (typeof sidecar)[] = []
     const resolve = createSidecarResolver({
       api: { reconnectService: async () => ({ ...sidecar }) },
@@ -68,12 +68,12 @@ describe("desktop renderer initialization", () => {
       update: (next) => updates.push(next),
     })
 
-    expect(await resolve(new AbortController().signal)).toEqual({ url: sidecar.url })
+    expect(await resolve(new AbortController().signal)).toEqual(sidecar)
     expect(updates).toEqual([])
   })
 
   test("does not publish a sidecar resolved after cancellation", async () => {
-    const sidecar = { url: "http://127.0.0.1:4321", password: "next" }
+    const sidecar = { url: "http://127.0.0.1:4321" }
     const pending = Promise.withResolvers<typeof sidecar>()
     const updates: (typeof sidecar)[] = []
     const resolve = createSidecarResolver({

--- a/packages/desktop/src/renderer/startup/initialization.test.ts
+++ b/packages/desktop/src/renderer/startup/initialization.test.ts
@@ -55,7 +55,7 @@ describe("desktop renderer initialization", () => {
       update: (next) => updates.push(next),
     })
 
-    expect(await resolve(new AbortController().signal)).toEqual(sidecar)
+    expect(await resolve(new AbortController().signal)).toEqual({ url: sidecar.url })
     expect(updates).toEqual([sidecar])
   })
 
@@ -68,7 +68,7 @@ describe("desktop renderer initialization", () => {
       update: (next) => updates.push(next),
     })
 
-    expect(await resolve(new AbortController().signal)).toEqual(sidecar)
+    expect(await resolve(new AbortController().signal)).toEqual({ url: sidecar.url })
     expect(updates).toEqual([])
   })
 

--- a/packages/desktop/src/renderer/startup/initialization.ts
+++ b/packages/desktop/src/renderer/startup/initialization.ts
@@ -7,8 +7,8 @@ export function initializationData<A>(state: (() => A | undefined) & { error: un
   return state()
 }
 
-// No password: the main process adds Authorization to sidecar requests (`wireRendererHeaders`), so
-// the renderer's GETs carry only CORS-safelisted headers and skip the preflight round trip.
+// The main process adds Authorization to sidecar requests (`wireRendererHeaders`); the renderer never
+// holds the password, and its GETs carry only CORS-safelisted headers so they skip the preflight.
 export function sidecarHttp(data: SidecarData) {
   return { url: data.url }
 }
@@ -28,7 +28,7 @@ export function createSidecarResolver(input: {
 }
 
 function sameSidecar(current: SidecarData | undefined, next: SidecarData) {
-  return current?.url === next.url && current.password === next.password
+  return current?.url === next.url
 }
 
 function markLocalServerStartup(error: unknown) {

--- a/packages/desktop/src/renderer/startup/initialization.ts
+++ b/packages/desktop/src/renderer/startup/initialization.ts
@@ -7,11 +7,10 @@ export function initializationData<A>(state: (() => A | undefined) & { error: un
   return state()
 }
 
+// No password: the main process adds Authorization to sidecar requests (`wireRendererHeaders`), so
+// the renderer's GETs carry only CORS-safelisted headers and skip the preflight round trip.
 export function sidecarHttp(data: SidecarData) {
-  return {
-    url: data.url,
-    password: data.password ?? undefined,
-  }
+  return { url: data.url }
 }
 
 export function createSidecarResolver(input: {

--- a/packages/desktop/src/shared/ipc-contract.ts
+++ b/packages/desktop/src/shared/ipc-contract.ts
@@ -1,6 +1,6 @@
+// The sidecar password never crosses into the renderer; the main process adds it to sidecar requests.
 export type ServerReadyData = {
   url: string
-  password: string | null
 }
 
 export type TitlebarTheme = {

--- a/packages/desktop/src/shared/ipc-rpc/app.ts
+++ b/packages/desktop/src/shared/ipc-rpc/app.ts
@@ -3,7 +3,6 @@ import { Rpc, RpcGroup } from "effect/unstable/rpc"
 
 const ServerReadyData = Schema.Struct({
   url: Schema.String,
-  password: Schema.NullOr(Schema.String),
 })
 
 export const AppAwaitInitialization = Rpc.make("AppAwaitInitialization", { success: ServerReadyData })


### PR DESCRIPTION
Follow-up to #47560. That PR made Desktop's CORS preflights cacheable; this one removes them from GET requests to the local sidecar entirely, and moves the sidecar credential out of the renderer.

The renderer at `oc://renderer` is cross-origin to `http://127.0.0.1:<port>`, and the only thing that made its GETs non-simple was the `Authorization` header. Per the Fetch spec a request with just CORS-safelisted headers needs no preflight, so if the renderer stops sending credentials and the main process adds them, every GET becomes one round trip instead of two. POSTs with a JSON body still preflight, but those are cached after #47560.

```mermaid
sequenceDiagram
  participant R as renderer (oc://renderer, top frame)
  participant N as Chromium network service
  participant M as main: onBeforeSendHeaders
  participant S as sidecar
  R->>N: GET /api/session/… (no Authorization)
  Note over N: CORS: safelisted headers only → no preflight
  N->>M: extraHeaders hook (details.frame = renderer top frame)
  M-->>N: + Authorization: Basic …
  N->>S: GET /api/session/…
```

Electron registers `webRequest` listeners in Chromium's `extraHeaders` mode, which runs after the CORS decision; header changes made there do not trigger a preflight (the documented behaviour extensions rely on to add credentials).

## Changes — `packages/desktop`

**Credential stays in main.** `ServerReadyData` over IPC is now `{ url }` only; the password never reaches the renderer. `SidecarCredentials` (`main/service/sidecar-credentials.ts`) holds `{ url, password }`, is published on the initial connection and every reconnect, and `ready()` is what the IPC handlers return.

**Injection is scoped to the renderer's own top-level frame.** Anything else in the session (web views, embedded pages, sub-frames, frame-less requests such as a service worker) can reach the same loopback origin and gets nothing — the same rule `allowRendererPermissions` already applies to permission requests. Fails closed when `details.frame` is null.

```ts
win.webContents.session.webRequest.onBeforeSendHeaders(
  { urls: ["http://127.0.0.1/*", "http://localhost/*"] },
  (details, callback) => {
    const frame = details.frame
    const renderer = !!frame && frame.parent === null && isRendererUrl(frame.url)
    const authorization = renderer && SidecarCredentials.authorization(SidecarCredentials.get(), details.url)
    if (authorization && !hasHeader(details.requestHeaders, "Authorization")) {
      upsertHeader(details.requestHeaders, "Authorization", authorization)
    }
    callback({ requestHeaders: details.requestHeaders })
  },
)
```

- `authorization(sidecar, url)` matches the request **origin exactly** against the sidecar origin; remote servers (WSL, Tailscale, manual) keep sending credentials from the renderer as before.
- Renderer: `sidecarHttp` passes only the URL into the app's `ServerConnection`, `createSidecarResolver` compares URLs, and the migration-status client no longer builds a header. The app package is untouched: a connection without a password already means "send no Authorization".

## Against the Electron security checklist

- Least privilege: the secret lives in one process, the one that already had it.
- #5/#17 spirit — privileged behaviour gated on the requesting frame's origin, validated with a URL parser, deny by default.
- Cross-origin redirects: Chromium strips `Authorization` itself, and the listener re-checks the origin on every leg.
- Not applicable yet: `session.webRequest.setHeaderRules()` (declarative, no main-process hop) lands in a newer Electron than 42; worth switching to when Electron is bumped.
- Pre-existing and out of scope: the desktop renderer defines no Content-Security-Policy (#7).

The web app / PWA is unaffected by this PR; it never had the desktop preflight-cache bug and keeps building its own header.
