### PR TITLE
fix(console): handle OAuth callback errors gracefully

### DIFF
--- a/packages/console/app/src/i18n/en.ts
+++ b/packages/console/app/src/i18n/en.ts
@@ -48,6 +48,7 @@ export const dict = {
   "user.logout": "Logout",
 
   "auth.callback.error.codeMissing": "No authorization code found.",
+  "auth.callback.error.oauth": "OAuth authorization failed.",
 
   "workspace.select": "Select workspace",
   "workspace.createNew": "+ Create New Workspace",

--- a/packages/console/app/src/lib/oauth-callback.ts
+++ b/packages/console/app/src/lib/oauth-callback.ts
@@ -1,0 +1,19 @@
+import type { Dict } from "~/i18n"
+
+export type OAuthCallbackOutcome =
+  | { type: "success" }
+  | { type: "denied" }
+  | { type: "error"; message: string }
+
+export function resolveOAuthCallback(searchParams: URLSearchParams, dict: Dict): OAuthCallbackOutcome {
+  const error = searchParams.get("error")
+  if (error === "access_denied") return { type: "denied" }
+  if (error) {
+    const detail = searchParams.get("error_description") ?? error
+    return { type: "error", message: `${dict["auth.callback.error.oauth"]} ${detail}` }
+  }
+  if (!searchParams.get("code")) {
+    return { type: "error", message: dict["auth.callback.error.codeMissing"] }
+  }
+  return { type: "success" }
+}

--- a/packages/console/app/src/routes/auth/[...callback].ts
+++ b/packages/console/app/src/routes/auth/[...callback].ts
@@ -4,15 +4,24 @@ import { AuthClient } from "~/context/auth"
 import { useAuthSession } from "~/context/auth"
 import { i18n } from "~/i18n"
 import { localeFromRequest, route } from "~/lib/language"
+import { resolveOAuthCallback } from "~/lib/oauth-callback"
 
 export async function GET(input: APIEvent) {
   const url = new URL(input.request.url)
   const locale = localeFromRequest(input.request)
   const dict = i18n(locale)
 
+  const outcome = resolveOAuthCallback(url.searchParams, dict)
+  if (outcome.type === "denied") {
+    const next = url.pathname === "/auth/callback" ? "/auth" : url.pathname.replace("/auth/callback", "")
+    return redirect(route(locale, next))
+  }
+  if (outcome.type === "error") {
+    return new Response(JSON.stringify({ error: outcome.message }), { status: 400 })
+  }
+
   try {
-    const code = url.searchParams.get("code")
-    if (!code) throw new Error(dict["auth.callback.error.codeMissing"])
+    const code = url.searchParams.get("code") ?? ""
     const result = await AuthClient.exchange(code, `${url.origin}${url.pathname}`)
     if (result.err) throw new Error(result.err.message)
     const decoded = AuthClient.decode(result.tokens.access, {} as any)
@@ -38,7 +47,6 @@ export async function GET(input: APIEvent) {
     return new Response(
       JSON.stringify({
         error: e.message,
-        cause: Object.fromEntries(url.searchParams.entries()),
       }),
       { status: 500 },
     )

--- a/packages/console/app/test/oauth-callback.test.ts
+++ b/packages/console/app/test/oauth-callback.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test"
+import { resolveOAuthCallback } from "../src/lib/oauth-callback"
+import { dict as en } from "../src/i18n/en"
+
+const params = (query: string) => new URLSearchParams(query)
+
+describe("resolveOAuthCallback", () => {
+  test("returns success when a code is present", () => {
+    expect(resolveOAuthCallback(params("code=abc123&state=x"), en)).toEqual({ type: "success" })
+  })
+
+  test("treats access_denied as a user cancellation", () => {
+    const outcome = resolveOAuthCallback(params("error=access_denied&error_description=The user denied"), en)
+    expect(outcome).toEqual({ type: "denied" })
+  })
+
+  test("returns an error message when the code is missing", () => {
+    const outcome = resolveOAuthCallback(params("state=x"), en)
+    expect(outcome).toEqual({ type: "error", message: en["auth.callback.error.codeMissing"] })
+  })
+
+  test("surfaces the error description for other OAuth errors", () => {
+    const outcome = resolveOAuthCallback(
+      params("error=invalid_request&error_description=Missing scope"),
+      en,
+    )
+    expect(outcome).toEqual({ type: "error", message: `${en["auth.callback.error.oauth"]} Missing scope` })
+  })
+
+  test("falls back to the error code when no description is provided", () => {
+    const outcome = resolveOAuthCallback(params("error=server_error"), en)
+    expect(outcome).toEqual({ type: "error", message: `${en["auth.callback.error.oauth"]} server_error` })
+  })
+
+  test("does not include raw query parameters in the error message", () => {
+    const outcome = resolveOAuthCallback(params("error=server_error&code=secret"), en)
+    expect(outcome.type).toBe("error")
+    if (outcome.type === "error") expect(outcome.message).not.toContain("secret")
+  })
+})


### PR DESCRIPTION
### Issue for this PR
Closes #47590
Closes #40232
Closes #39414

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

When a user cancels sign-in (or something fails on the auth server), the provider redirects back to `/auth/callback` with an `error` param instead of a `code`. The callback only looked for `code`, so it threw "No authorization code found" and returned a 500 that also echoed the full callback query params (which can include sensitive OAuth values like authorization codes).

This PR makes the callback check `error` / `error_description` before requiring `code`:
- `access_denied` is treated as a normal user cancel and redirects back to the auth page.
- Other OAuth errors return a clean 400 with the actual error message instead of the misleading 500.
- Removed the `cause` field that echoed the callback query params in the error response.
- Valid `code` flow is unchanged.

### How did you verify your code works?

Added unit tests covering success, `access_denied`, missing code, and other OAuth errors. All pass locally with `bun test`.

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR