### PR TITLE
docs: add opencode-memory-pro to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -32,6 +32,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-shell-strategy](https://github.com/JRedeker/opencode-shell-strategy)                     | Instructions for non-interactive shell commands - prevents hangs from TTY-dependent operations     |
 | [opencode-wakatime](https://github.com/angristan/opencode-wakatime)                                | Track OpenCode usage with Wakatime                                                                 |
 | [opencode-md-table-formatter](https://github.com/franlol/opencode-md-table-formatter/tree/main)    | Clean up markdown tables produced by LLMs                                                          |
+| [opencode-memory-pro](https://github.com/tman204-50/opencode-memory-pro)                          | Persistent long-term memory across sessions with LanceDB, offline entity graph, and LLM summarization |
 | [opencode-morph-fast-apply](https://github.com/JRedeker/opencode-morph-fast-apply)                 | 10x faster code editing with Morph Fast Apply API and lazy edit markers                            |
 | [opencode-morph-plugin](https://github.com/morphllm/opencode-morph-plugin)                         | Fast Apply editing, WarpGrep codebase search, and context compaction via Morph                     |
 | [oh-my-opencode](https://github.com/code-yeongyu/oh-my-opencode)                                   | Background agents, pre-built LSP/AST/MCP tools, curated agents, Claude Code compatible             |


### PR DESCRIPTION
### Issue for this PR

Closes # (no issue — documentation listing)

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds **opencode-memory-pro** to the plugins table on the OpenCode ecosystem docs page (`packages/web/src/content/docs/ecosystem.mdx`).

The plugin is a published npm OpenCode memory plugin (LanceDB-backed persistent memory with hybrid vector+BM25 retrieval, offline entity graph, LLM capture/summarization, lifecycle tools, and retention). It is listed on the ecosystem page today, which is the primary discovery channel for OpenCode plugins, but the plugin is currently missing from it.

The change is a single table row, alphabetically placed between `opencode-md-table-formatter` and `opencode-morph-fast-apply`, matching the existing column alignment.

### How did you verify your code works?

- Confirmed the new row renders correctly in the existing markdown table (matched column alignment).
- Verified the package is published and installable via `opencode plugin opencode-memory-pro` (npm, Node >= 22).
- This is a documentation-only change; no runtime code was touched.

### Screenshots / recordings

_If this is a UI change, please include a screenshot or recording._ (n/a — docs table change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR