### PR TITLE
fix(tui): dynamically expand DialogModel size based on terminal width

### DIFF
--- a/packages/tui/src/component/dialog-model.tsx
+++ b/packages/tui/src/component/dialog-model.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createSignal } from "solid-js"
+import { createEffect, createMemo, createSignal } from "solid-js"
 import { useLocal } from "../context/local"
 import { map, pipe, flatMap, entries, filter, sortBy, take } from "remeda"
 import { DialogSelect } from "../ui/dialog-select"
@@ -8,12 +8,24 @@ import { DialogVariant } from "./dialog-variant"
 import * as fuzzysort from "fuzzysort"
 import { useConnected } from "./use-connected"
 import { useSync } from "../context/sync"
+import { useTerminalDimensions } from "@opentui/solid"
+
+export function getDialogModelSize(width: number): "xlarge" | "large" | "medium" {
+  if (width >= 128) return "xlarge"
+  if (width >= 96) return "large"
+  return "medium"
+}
 
 export function DialogModel(props: { providerID?: string }) {
   const local = useLocal()
   const sync = useSync()
   const dialog = useDialog()
+  const dimensions = useTerminalDimensions()
   const [query, setQuery] = createSignal("")
+
+  createEffect(() => {
+    dialog.setSize(getDialogModelSize(dimensions().width))
+  })
 
   const connected = useConnected()
   const providers = createDialogProviderOptions()

--- a/packages/tui/test/component/dialog-model.test.ts
+++ b/packages/tui/test/component/dialog-model.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+import { getDialogModelSize } from "../../src/component/dialog-model"
+
+describe("dialog model sizing", () => {
+  test("returns xlarge for terminals with width >= 128", () => {
+    expect(getDialogModelSize(128)).toBe("xlarge")
+    expect(getDialogModelSize(160)).toBe("xlarge")
+    expect(getDialogModelSize(200)).toBe("xlarge")
+  })
+
+  test("returns large for terminals with width >= 96 and < 128", () => {
+    expect(getDialogModelSize(96)).toBe("large")
+    expect(getDialogModelSize(100)).toBe("large")
+    expect(getDialogModelSize(127)).toBe("large")
+  })
+
+  test("returns medium for terminals with width < 96", () => {
+    expect(getDialogModelSize(95)).toBe("medium")
+    expect(getDialogModelSize(80)).toBe("medium")
+    expect(getDialogModelSize(60)).toBe("medium")
+  })
+})


### PR DESCRIPTION
### Issue for this PR

Closes #47600

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

In the TUI, `DialogModel` currently defaults to `size: "medium"` (60 columns) because it does not set its size. On wide terminals, this causes the model name to be heavily truncated whenever the provider footer takes up 35+ columns.

This PR adds responsive sizing via `useTerminalDimensions()` and `createEffect()`, matching the sizing behavior in `packages/tui/src/feature-plugins/system/plugins.tsx`:
- `xlarge` (116 columns) when terminal width >= 128
- `large` (88 columns) when terminal width >= 96
- `medium` (60 columns) as baseline

### How did you verify your code works?

Verified in TUI with terminal widths of 80, 100, 140, and 180 columns. The dialog expands dynamically and preserves the full visibility of model names and provider footers without truncation.

### Screenshots / recordings

Before: model names truncated to ~16 chars.
After: dialog dynamically uses large/xlarge width when terminal allows, showing full model identifiers and footers.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR