### PR TITLE
refactor(opencode): optimize levenshtein and bound edit locks

### DIFF
--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -33,11 +33,19 @@ function convertToLineEnding(text: string, ending: "\n" | "\r\n"): string {
 }
 
 const locks = new Map<string, Semaphore.Semaphore>()
+const MAX_LOCKS = 512
 
 function lock(filePath: string) {
   const resolvedFilePath = FSUtil.resolve(filePath)
   const hit = locks.get(resolvedFilePath)
   if (hit) return hit
+
+  // Evict oldest entry when the map reaches its cap to prevent unbounded growth
+  // in long-running sessions that edit many distinct files.
+  if (locks.size >= MAX_LOCKS) {
+    const oldest = locks.keys().next().value
+    if (oldest) locks.delete(oldest)
+  }
 
   const next = Semaphore.makeUnsafe(1)
   locks.set(resolvedFilePath, next)
@@ -221,24 +229,36 @@ const SINGLE_CANDIDATE_SIMILARITY_THRESHOLD = 0.65
 const MULTIPLE_CANDIDATES_SIMILARITY_THRESHOLD = 0.65
 
 /**
- * Levenshtein distance algorithm implementation
+ * Levenshtein distance using two-row optimization.
+ * Memory: O(min(n, m)) instead of the full O(n × m) matrix.
+ * Called per-line in BlockAnchorReplacer, so allocation pressure matters.
  */
-function levenshtein(a: string, b: string): number {
-  // Handle empty strings
-  if (a === "" || b === "") {
-    return Math.max(a.length, b.length)
+export function levenshtein(a: string, b: string): number {
+  if (a === "" || b === "") return Math.max(a.length, b.length)
+
+  // Work along the shorter string to minimise the row allocation.
+  if (a.length < b.length) {
+    const tmp = a
+    a = b
+    b = tmp
   }
-  const matrix = Array.from({ length: a.length + 1 }, (_, i) =>
-    Array.from({ length: b.length + 1 }, (_, j) => (i === 0 ? j : j === 0 ? i : 0)),
-  )
+
+  const bLen = b.length
+  let prev = Array.from({ length: bLen + 1 }, (_, j) => j)
+  let curr = new Array<number>(bLen + 1)
 
   for (let i = 1; i <= a.length; i++) {
-    for (let j = 1; j <= b.length; j++) {
+    curr[0] = i
+    for (let j = 1; j <= bLen; j++) {
       const cost = a[i - 1] === b[j - 1] ? 0 : 1
-      matrix[i][j] = Math.min(matrix[i - 1][j] + 1, matrix[i][j - 1] + 1, matrix[i - 1][j - 1] + cost)
+      curr[j] = Math.min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
     }
+    const swap = prev
+    prev = curr
+    curr = swap
   }
-  return matrix[a.length][b.length]
+
+  return prev[bLen]
 }
 
 export const SimpleReplacer: Replacer = function* (_content, find) {

--- a/packages/opencode/src/tool/edit.ts
+++ b/packages/opencode/src/tool/edit.ts
@@ -245,7 +245,7 @@ export function levenshtein(a: string, b: string): number {
 
   const bLen = b.length
   let prev = Array.from({ length: bLen + 1 }, (_, j) => j)
-  let curr = new Array<number>(bLen + 1)
+  let curr = Array.from<number>({ length: bLen + 1 })
 
   for (let i = 1; i <= a.length; i++) {
     curr[0] = i

--- a/packages/opencode/test/tool/edit-pure.test.ts
+++ b/packages/opencode/test/tool/edit-pure.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, test } from "bun:test"
+import {
+  levenshtein,
+  replace,
+  trimDiff,
+  SimpleReplacer,
+  LineTrimmedReplacer,
+  BlockAnchorReplacer,
+  WhitespaceNormalizedReplacer,
+  IndentationFlexibleReplacer,
+  EscapeNormalizedReplacer,
+  TrimmedBoundaryReplacer,
+  ContextAwareReplacer,
+  MultiOccurrenceReplacer,
+} from "../../src/tool/edit"
+
+function collect(replacer: (content: string, find: string) => Generator<string>, content: string, find: string) {
+  return Array.from(replacer(content, find))
+}
+
+describe("levenshtein", () => {
+  test("identical strings have distance 0", () => {
+    expect(levenshtein("abc", "abc")).toBe(0)
+  })
+
+  test("empty vs non-empty returns length", () => {
+    expect(levenshtein("", "abc")).toBe(3)
+    expect(levenshtein("abc", "")).toBe(3)
+  })
+
+  test("both empty returns 0", () => {
+    expect(levenshtein("", "")).toBe(0)
+  })
+
+  test("single character difference", () => {
+    expect(levenshtein("a", "b")).toBe(1)
+  })
+
+  test("insertion", () => {
+    expect(levenshtein("abc", "abcd")).toBe(1)
+  })
+
+  test("deletion", () => {
+    expect(levenshtein("abcd", "abc")).toBe(1)
+  })
+
+  test("substitution", () => {
+    expect(levenshtein("kitten", "sitten")).toBe(1)
+  })
+
+  test("classic kitten-sitting example", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(3)
+  })
+
+  test("completely different strings", () => {
+    expect(levenshtein("abc", "xyz")).toBe(3)
+  })
+
+  test("is symmetric", () => {
+    expect(levenshtein("foo", "bar")).toBe(levenshtein("bar", "foo"))
+    expect(levenshtein("kitten", "sitting")).toBe(levenshtein("sitting", "kitten"))
+  })
+
+  test("handles strings of very different lengths", () => {
+    expect(levenshtein("a", "abcdef")).toBe(5)
+    expect(levenshtein("abcdef", "a")).toBe(5)
+  })
+})
+
+describe("replace", () => {
+  test("exact match replacement", () => {
+    expect(replace("hello world", "hello", "goodbye")).toBe("goodbye world")
+  })
+
+  test("throws when oldString not found", () => {
+    expect(() => replace("hello world", "missing", "replacement")).toThrow("Could not find oldString")
+  })
+
+  test("throws when oldString equals newString", () => {
+    expect(() => replace("hello", "hello", "hello")).toThrow("identical")
+  })
+
+  test("throws when oldString is empty", () => {
+    expect(() => replace("hello", "", "new")).toThrow("oldString cannot be empty")
+  })
+
+  test("replaces first occurrence when multiple exist without replaceAll", () => {
+    // Multiple exact matches without replaceAll should fail (unique match required)
+    expect(() => replace("foo bar foo", "foo", "baz")).toThrow()
+  })
+
+  test("replaces all occurrences with replaceAll", () => {
+    expect(replace("foo bar foo baz foo", "foo", "qux", true)).toBe("qux bar qux baz qux")
+  })
+
+  test("handles multiline content", () => {
+    expect(replace("line1\nline2\nline3", "line2", "new line")).toBe("line1\nnew line\nline3")
+  })
+
+  test("falls through to fuzzy replacers on whitespace differences", () => {
+    const content = "  hello  world  \n  foo  bar  "
+    // LineTrimmedReplacer or WhitespaceNormalizedReplacer should handle trimmed match
+    expect(replace(content, "hello  world", "goodbye world")).toBe("  goodbye world  \n  foo  bar  ")
+  })
+})
+
+describe("trimDiff", () => {
+  test("removes common leading whitespace from diff lines", () => {
+    const diff = [
+      "--- a/file.ts",
+      "+++ b/file.ts",
+      "@@ -1,3 +1,3 @@",
+      "     unchanged",
+      "-    old line",
+      "+    new line",
+      "     unchanged",
+    ].join("\n")
+
+    const result = trimDiff(diff)
+    expect(result).not.toContain("     unchanged")
+    // Should have reduced indentation
+    expect(result).toContain("-old line")
+    expect(result).toContain("+new line")
+  })
+
+  test("returns diff unchanged when no common whitespace", () => {
+    const diff = ["--- a/file.ts", "+++ b/file.ts", "@@ -1 +1 @@", "-old", "+new"].join("\n")
+    expect(trimDiff(diff)).toBe(diff)
+  })
+
+  test("returns diff unchanged when no content lines", () => {
+    const diff = "--- a/file\n+++ b/file\n"
+    expect(trimDiff(diff)).toBe(diff)
+  })
+})
+
+describe("SimpleReplacer", () => {
+  test("yields the exact find string", () => {
+    expect(collect(SimpleReplacer, "any content", "find")).toEqual(["find"])
+  })
+})
+
+describe("LineTrimmedReplacer", () => {
+  test("matches lines ignoring leading/trailing whitespace", () => {
+    const content = "  hello world  \n  foo bar  "
+    const matches = collect(LineTrimmedReplacer, content, "hello world")
+    expect(matches.length).toBe(1)
+    expect(matches[0]).toBe("  hello world  ")
+  })
+
+  test("matches multi-line blocks with trimmed lines", () => {
+    const content = "  line1  \n  line2  \n  line3  "
+    const matches = collect(LineTrimmedReplacer, content, "line1\nline2")
+    expect(matches.length).toBe(1)
+  })
+
+  test("returns empty when no trimmed match", () => {
+    expect(collect(LineTrimmedReplacer, "hello world", "not here")).toEqual([])
+  })
+})
+
+describe("BlockAnchorReplacer", () => {
+  test("requires at least 3 lines", () => {
+    expect(collect(BlockAnchorReplacer, "a\nb", "a\nb")).toEqual([])
+  })
+
+  test("matches block with same first and last lines", () => {
+    const content = "function foo() {\n  const x = 1\n  return x\n}"
+    const find = "function foo() {\n  const x = 1\n  return x\n}"
+    const matches = collect(BlockAnchorReplacer, content, find)
+    expect(matches.length).toBe(1)
+  })
+
+  test("rejects blocks with unrelated middle content", () => {
+    const content = "function foo() {\n  deleteEverything()\n}"
+    const find = "function foo() {\n  const x = 1\n}"
+    const matches = collect(BlockAnchorReplacer, content, find)
+    expect(matches).toEqual([])
+  })
+})
+
+describe("WhitespaceNormalizedReplacer", () => {
+  test("matches with different internal whitespace", () => {
+    const content = "hello   world   here"
+    const matches = collect(WhitespaceNormalizedReplacer, content, "hello world here")
+    expect(matches.length).toBeGreaterThan(0)
+  })
+
+  test("returns empty for no match", () => {
+    expect(collect(WhitespaceNormalizedReplacer, "hello world", "not here")).toEqual([])
+  })
+})
+
+describe("IndentationFlexibleReplacer", () => {
+  test("matches blocks with different indentation levels", () => {
+    const content = "    line1\n    line2"
+    const matches = collect(IndentationFlexibleReplacer, content, "  line1\n  line2")
+    expect(matches.length).toBe(1)
+    expect(matches[0]).toBe("    line1\n    line2")
+  })
+
+  test("returns empty for content mismatch", () => {
+    expect(collect(IndentationFlexibleReplacer, "  foo", "  bar")).toEqual([])
+  })
+})
+
+describe("EscapeNormalizedReplacer", () => {
+  test("matches unescaped version in content", () => {
+    const content = 'line with "quotes"'
+    const matches = collect(EscapeNormalizedReplacer, content, 'line with \\"quotes\\"')
+    expect(matches.length).toBeGreaterThan(0)
+  })
+})
+
+describe("TrimmedBoundaryReplacer", () => {
+  test("matches trimmed version of find in content", () => {
+    const content = "hello world"
+    const matches = collect(TrimmedBoundaryReplacer, content, "  hello world  ")
+    // Yields both a direct substring match and a block-level trimmed match
+    expect(matches.length).toBe(2)
+    expect(matches[0]).toBe("hello world")
+    expect(matches[1]).toBe("hello world")
+  })
+
+  test("skips when find is already trimmed", () => {
+    expect(collect(TrimmedBoundaryReplacer, "hello", "hello")).toEqual([])
+  })
+})
+
+describe("ContextAwareReplacer", () => {
+  test("requires at least 3 lines", () => {
+    expect(collect(ContextAwareReplacer, "a\nb", "a\nb")).toEqual([])
+  })
+
+  test("matches context-anchored blocks", () => {
+    const content = "start\n  middle\nend\nother"
+    const find = "start\n  middle\nend"
+    const matches = collect(ContextAwareReplacer, content, find)
+    expect(matches.length).toBe(1)
+    expect(matches[0]).toBe("start\n  middle\nend")
+  })
+})
+
+describe("MultiOccurrenceReplacer", () => {
+  test("yields all exact occurrences", () => {
+    const matches = collect(MultiOccurrenceReplacer, "foo bar foo baz foo", "foo")
+    expect(matches.length).toBe(3)
+    expect(matches).toEqual(["foo", "foo", "foo"])
+  })
+
+  test("returns empty for no match", () => {
+    expect(collect(MultiOccurrenceReplacer, "hello", "xyz")).toEqual([])
+  })
+})


### PR DESCRIPTION
 ### Issue for this PR

Closes #47604


### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Optimizes `levenshtein()` in `src/tool/edit.ts` by replacing the full (n+1)×(m+1) matrix allocation with a two-row swap technique, reducing memory usage from O(n×m) to O(min(n,m)). `BlockAnchorReplacer` calls `levenshtein()` per-line during fuzzy edit matching, so this reduces garbage collection pressure on large files.

Additionally, sets an upper bound of 512 entries with oldest-first eviction on the per-file `locks` Map in `src/tool/edit.ts` to prevent unbounded memory growth during long-running sessions.

Also adds comprehensive unit tests covering pure functions in `src/tool/edit.ts` (`levenshtein`, `replace`, `trimDiff`, and all replacer generators).

### How did you verify your code works?

- Added and ran 40 unit tests in `packages/opencode/test/tool/edit-pure.test.ts` (all pass)
- Ran existing integration tests in `packages/opencode/test/tool/edit.test.ts` (all 29 pass)
- Ran `bun typecheck` across all monorepo packages (clean, 0 errors)
- Verified `bun run check:generated` in `packages/client` (clean)

### Screenshots / recordings

N/A (backend performance improvement, no UI changes)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
