### PR TITLE
/claim #47610: Retry provider-busy messages (e.g. "no eligible device") to avoid headless session wedge

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -38,6 +38,11 @@ const RETRYABLE_MESSAGE_PATTERNS = [
   /^timeout$|\b(?:request|response|connection|network|stream|read) (?:timeout|timed out|time out)\b/i,
   /try your request again|retry your request|resource exhausted|resource_exhausted/i,
   /\btry again (?:later|in\b)|\b(?:currently|temporarily) at capacity\b/i,
+  // Additional patterns to catch provider-busy messages from self-hosted or gateway
+  // deployments that don't include numeric status codes in their short failure messages.
+  /no eligible device/i,
+  /no available device(s)?/i,
+  /model (?:temporarily )?unavailable/i,
 ]
 
 function cap(ms: number) {


### PR DESCRIPTION
Executive summary:

- Treat provider-busy/fill-errors reported as plain text (e.g. "no eligible device", "model temporarily unavailable", "no available device") as retryable by SessionRetry.
- This leverages the existing retry Schedule (honors Retry-After, exponential backoff, attempt budget) so transient 503s no longer kill in-flight turns in headless/ACP runs.
- Minimal, localized change: updated retry message patterns in packages/opencode/src/session/retry.ts.

Details:

The repo already implements a durable retry Schedule for provider attempts, but some self-hosted or gateway deployments return provider-busy failures with short textual messages that were not matched by the retry classifier. Those turns would be treated as terminal errors and leave headless agent sessions idle/wedged.

This PR adds a few additional regex patterns to SessionRetry.MATCH patterns to detect common provider-busy phrases ("no eligible device", "no available device(s)?", and "model temporarily unavailable"). Once matched, the existing retry policy will schedule backoff retries (respecting Retry-After headers, bounded exponential backoff, and RETRY_MAX_RETRIES).

Files changed:
- packages/opencode/src/session/retry.ts — add additional retryable message patterns for provider-busy text.

Verification guidance:

- Reproduce the original scenario: run a headless/ACP session against a provider that returns an immediate 503 and the body/message "no eligible device" when busy. Previously the turn would fail immediately and wedge the session; with this change the turn will enter retry status and the system will attempt retries until Retry-After or the retry budget is exhausted.
- The change is purely pattern matching and relies on the existing retry policy (which already honors Retry-After and exponential backoff).

Notes & follow-ups:

- This is a targeted fix to broaden the retry classifier. If you want a configurable list of retryable message patterns for operators, we can expose that in config in a follow-up.

Closes #47610


Closes #47610