### PR TITLE
fix(ci): compute the bun cache key once so restore and save match

### DIFF
--- a/.github/actions/setup-bun/action.yml
+++ b/.github/actions/setup-bun/action.yml
@@ -35,17 +35,19 @@ runs:
         bun-version-file: ${{ !steps.bun-url.outputs.url && 'package.json' || '' }}
         bun-download-url: ${{ steps.bun-url.outputs.url }}
 
-    - name: Get cache directory
+    - name: Get cache directory and key
       id: cache
       shell: bash
-      run: echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "dir=$(bun pm cache)" >> "$GITHUB_OUTPUT"
+        echo "key=${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}" >> "$GITHUB_OUTPUT"
 
     - name: Restore Bun dependencies
       id: bun-cache
       uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        key: ${{ steps.cache.outputs.key }}
         restore-keys: |
           ${{ runner.os }}-bun-
 
@@ -70,4 +72,4 @@ runs:
       uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ steps.cache.outputs.dir }}
-        key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+        key: ${{ steps.cache.outputs.key }}


### PR DESCRIPTION
### Issue for this PR

Closes #47617

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`setup-bun` evaluates `hashFiles('**/bun.lock')` twice: once in `actions/cache/restore` (before `bun install`) and once in `actions/cache/save` (after). After install the glob also matches `bun.lock` files inside `node_modules` (currently two, from `ghostty-web`), so the save key is different from the restore key and exact cache hits never happen. See the issue for logs and the recomputed hashes.

This computes the key once in the existing "Get cache directory" step and reuses the output in both cache steps. The `**/bun.lock` glob is kept on purpose: `publish-vscode.yml` also installs `sdks/vscode`, which has its own lockfile.

### How did you verify your code works?

- Recomputed `hashFiles` locally before and after `bun install` on a fresh clone of `dev`; the after-install hash equals the key the save step tries to write in the CI logs (`b26debf2…`), the before-install hash does not.
- Ran the modified action YAML through a parser; the key output is set before both cache steps read it.

### Screenshots / recordings

N/A, CI config only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
