### PR TITLE
docs: add voice-mcp to ecosystem listing

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,6 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
+| [@yuvarjbhado/voice-mcp](https://github.com/YuvrajSinghBhadoria2/opencode-voice-mcp)              | Voice input via MCP — local Whisper transcription, 100% offline                                  |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — documentation-only.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds the community voice-input MCP server (opencode-voice-mcp by @YuvrajSinghBhadoria2) to the Ecosystem page's Plugins table. The page explicitly invites community projects with "Submit a PR" (packages/web/src/content/docs/ecosystem.mdx), and this entry follows the exact table format of the existing ~40 listings. It only documents an existing third-party server — no core behavior, no docs navigation changes.

Note: opencode#41413 discusses whether voice input should become a core feature. This PR is independent of that decision and only adds the ecosystem listing where community integrations live today.

### How did you verify your code works?

- Confirmed the added row matches the table format of the existing entries (same columns, same Markdown link syntax).
- Validated the table structure renders correctly in Markdown.

### Screenshots / recordings

N/A — documentation-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR