### PR TITLE
fix(core): interrupt sessions before inactivity eviction

### DIFF
--- a/packages/client/src/effect/api/api.ts
+++ b/packages/client/src/effect/api/api.ts
@@ -605,7 +605,10 @@ export type SessionLogOutput =
           readonly type: "session.execution.interrupted"
           readonly durable: { readonly aggregateID: string; readonly seq: Event.Seq; readonly version: Event.Version }
           readonly location?: Location.Ref | undefined
-          readonly data: { readonly sessionID: Session.ID; readonly reason: "user" | "shutdown" | "superseded" }
+          readonly data: {
+            readonly sessionID: Session.ID
+            readonly reason: "user" | "shutdown" | "superseded" | "inactivity"
+          }
         }
       | {
           readonly id: Event.ID

--- a/packages/client/src/promise/generated/types.ts
+++ b/packages/client/src/promise/generated/types.ts
@@ -710,7 +710,7 @@ export type SessionExecutionInterrupted = {
   type: "session.execution.interrupted"
   durable: { aggregateID: string; seq: number; version: 1 }
   location?: LocationRef
-  data: { sessionID: string; reason: "user" | "shutdown" | "superseded" }
+  data: { sessionID: string; reason: "user" | "shutdown" | "superseded" | "inactivity" }
 }
 
 export type SessionInstructionsUpdated = {

--- a/packages/core/src/location-activity.ts
+++ b/packages/core/src/location-activity.ts
@@ -24,7 +24,7 @@ export function layer(options: { readonly timeToLive?: Duration.Input; readonly 
       const sessions = yield* SessionStore.Service
       const timeToLive = Duration.toMillis(options.timeToLive ?? "60 minutes")
       const entries = new Map<string, { readonly ref: Location.Ref; expiresAt: number }>()
-      const key = (ref: Location.Ref) => `${ref.directory}\0${ref.workspaceID ?? ""}`
+      const key = (ref: Location.Ref) => `${LocationServiceMap.canonical(ref).directory}\0${ref.workspaceID ?? ""}`
       const touch = (ref: Location.Ref) =>
         Effect.sync(() => {
           entries.set(key(ref), { ref, expiresAt: clock.currentTimeMillisUnsafe() + timeToLive })
@@ -60,10 +60,14 @@ export function layer(options: { readonly timeToLive?: Duration.Input; readonly 
               )
               // Invalidation only detaches the cache entry; borrowers retain the old
               // graph. Stop its executions and settle tool cleanup before detaching it.
-              yield* Effect.forEach(owners, (session) => execution.interrupt(session.id, { reason: "inactivity" }), {
-                discard: true,
-              })
-              yield* Effect.forEach(owners, (session) => execution.awaitIdle(session.id), { discard: true })
+              yield* Effect.forEach(
+                owners,
+                (session) => execution.interrupt(session.id, { reason: "inactivity", awaitSettlement: true }),
+                {
+                  discard: true,
+                  concurrency: "unbounded",
+                },
+              )
               const remaining = yield* Effect.forEach(yield* execution.active, (sessionID) => sessions.get(sessionID))
               // New work admitted during cleanup may now own the cached graph.
               if (remaining.some((session) => session && key(session.location) === key(entry.ref))) {

--- a/packages/core/src/location-activity.ts
+++ b/packages/core/src/location-activity.ts
@@ -5,6 +5,8 @@ import { Bus } from "./bus.js"
 import { Location } from "./location.js"
 import { LocationServiceMap } from "./location-service-map.js"
 import { SessionEvent } from "./session/event.js"
+import { SessionExecution } from "./session/execution.js"
+import { SessionStore } from "./session/store.js"
 import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
 
 const isSessionEvent = Schema.is(SessionEvent.Durable)
@@ -18,6 +20,8 @@ export function layer(options: { readonly timeToLive?: Duration.Input; readonly 
       const clock = yield* Clock.Clock
       const bus = yield* Bus.Service
       const locations = yield* LocationServiceMap.Service
+      const execution = yield* SessionExecution.Service
+      const sessions = yield* SessionStore.Service
       const timeToLive = Duration.toMillis(options.timeToLive ?? "60 minutes")
       const entries = new Map<string, { readonly ref: Location.Ref; expiresAt: number }>()
       const key = (ref: Location.Ref) => `${ref.directory}\0${ref.workspaceID ?? ""}`
@@ -39,26 +43,40 @@ export function layer(options: { readonly timeToLive?: Duration.Input; readonly 
         yield* Effect.sleep(options.sweepInterval ?? "1 minute")
         const refs = Array.from(yield* RcMap.keys(locations.rcMap))
         const cached = new Set(refs.map(key))
-        yield* Effect.forEach(
-          refs,
-          (ref) => (entries.has(key(ref)) ? Effect.void : touch(ref)),
-          { discard: true },
-        )
+        yield* Effect.forEach(refs, (ref) => (entries.has(key(ref)) ? Effect.void : touch(ref)), { discard: true })
         for (const id of entries.keys()) {
           if (!cached.has(id)) entries.delete(id)
         }
         const now = clock.currentTimeMillisUnsafe()
         const expired = Array.from(entries.values()).filter((entry) => entry.expiresAt <= now)
+        if (expired.length === 0) return
+        const active = yield* Effect.forEach(yield* execution.active, (sessionID) => sessions.get(sessionID))
         yield* Effect.forEach(
           expired,
-          (entry) => {
-            entries.delete(key(entry.ref))
-            return Effect.logInfo("location services evicted", {
-              directory: entry.ref.directory,
-              workspaceID: entry.ref.workspaceID,
-            }).pipe(Effect.andThen(locations.invalidate(entry.ref)))
-          },
-          { discard: true },
+          (entry) =>
+            Effect.gen(function* () {
+              const owners = active.flatMap((session) =>
+                session && key(session.location) === key(entry.ref) ? [session] : [],
+              )
+              // Invalidation only detaches the cache entry; borrowers retain the old
+              // graph. Stop its executions and settle tool cleanup before detaching it.
+              yield* Effect.forEach(owners, (session) => execution.interrupt(session.id, { reason: "inactivity" }), {
+                discard: true,
+              })
+              yield* Effect.forEach(owners, (session) => execution.awaitIdle(session.id), { discard: true })
+              const remaining = yield* Effect.forEach(yield* execution.active, (sessionID) => sessions.get(sessionID))
+              // New work admitted during cleanup may now own the cached graph.
+              if (remaining.some((session) => session && key(session.location) === key(entry.ref))) {
+                yield* touch(entry.ref)
+                return
+              }
+              entries.delete(key(entry.ref))
+              yield* Effect.logInfo("location services evicted", {
+                directory: entry.ref.directory,
+                workspaceID: entry.ref.workspaceID,
+              }).pipe(Effect.andThen(locations.invalidate(entry.ref)))
+            }),
+          { discard: true, concurrency: "unbounded" },
         )
       }).pipe(Effect.forever, Effect.forkScoped)
 
@@ -70,5 +88,5 @@ export function layer(options: { readonly timeToLive?: Duration.Input; readonly 
 export const node = makeGlobalNode({
   service: Service,
   layer: layer(),
-  deps: [Bus.node, LocationServiceMap.node],
+  deps: [Bus.node, LocationServiceMap.node, SessionExecution.node, SessionStore.node],
 })

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -28,11 +28,16 @@ export interface Interface {
    * Interrupt active work owned by this process. Idle interruption is a no-op. Resolves once
    * the interruption is accepted; cleanup settles asynchronously in the execution fiber.
    * Returns whether an active execution was interrupted. Compose with `awaitIdle` when
-   * settlement matters.
+   * settlement matters. `awaitSettlement` waits only for the interrupted execution,
+   * rather than fresh work admitted during its cleanup.
    */
   readonly interrupt: (
     sessionID: SessionSchema.ID,
-    options?: { readonly continue?: boolean; readonly reason?: "user" | "inactivity" },
+    options?: {
+      readonly continue?: boolean
+      readonly reason?: "user" | "inactivity"
+      readonly awaitSettlement?: boolean
+    },
   ) => Effect.Effect<boolean>
   /** Resolves once this process owns no active execution for the Session. Returns immediately when idle and never starts work. */
   readonly awaitIdle: (sessionID: SessionSchema.ID) => Effect.Effect<void>
@@ -149,7 +154,7 @@ export const layer = Layer.effect(
       isActive: coordinator.isActive,
       interrupt: (sessionID, options) =>
         Effect.gen(function* () {
-          const interrupted = yield* coordinator.interrupt(sessionID, options?.reason ?? "user")
+          const interrupted = yield* coordinator.interrupt(sessionID, options?.reason ?? "user", options)
           if (!options?.continue) return interrupted
           // Resume steering input and between-turn control work from the interrupted
           // intent. Queued next-turn prompts stay parked: a steer-scoped drain never

--- a/packages/core/src/session/execution.ts
+++ b/packages/core/src/session/execution.ts
@@ -30,7 +30,10 @@ export interface Interface {
    * Returns whether an active execution was interrupted. Compose with `awaitIdle` when
    * settlement matters.
    */
-  readonly interrupt: (sessionID: SessionSchema.ID, options?: { readonly continue?: boolean }) => Effect.Effect<boolean>
+  readonly interrupt: (
+    sessionID: SessionSchema.ID,
+    options?: { readonly continue?: boolean; readonly reason?: "user" | "inactivity" },
+  ) => Effect.Effect<boolean>
   /** Resolves once this process owns no active execution for the Session. Returns immediately when idle and never starts work. */
   readonly awaitIdle: (sessionID: SessionSchema.ID) => Effect.Effect<void>
 }
@@ -38,7 +41,7 @@ export interface Interface {
 /** Routes execution from a Session ID to its selected instance's runner. */
 export class Service extends Context.Service<Service, Interface>()("@opencode/SessionExecution") {}
 
-type InterruptReason = "user" | "shutdown"
+type InterruptReason = "user" | "shutdown" | "inactivity"
 
 export function terminal(exit: Exit.Exit<void, SessionRunner.RunError>, reason?: InterruptReason) {
   if (Exit.isSuccess(exit)) return { type: "succeeded" as const }
@@ -120,9 +123,8 @@ export const layer = Layer.effect(
               return
             }
             if (outcome.type === "interrupted") {
-              // A user cancel releases the claim: the turn must not resurrect at the next
-              // boot. Shutdown interruption keeps it for restart continuity.
-              if (outcome.reason === "user") yield* jobs.cancel(sessionID)
+              // Deliberate stops release the claim; shutdown keeps it for restart continuity.
+              if (outcome.reason !== "shutdown") yield* jobs.cancel(sessionID)
               yield* bus.publish(
                 SessionEvent.Execution.Interrupted,
                 { sessionID, reason: outcome.reason },
@@ -147,7 +149,7 @@ export const layer = Layer.effect(
       isActive: coordinator.isActive,
       interrupt: (sessionID, options) =>
         Effect.gen(function* () {
-          const interrupted = yield* coordinator.interrupt(sessionID, "user")
+          const interrupted = yield* coordinator.interrupt(sessionID, options?.reason ?? "user")
           if (!options?.continue) return interrupted
           // Resume steering input and between-turn control work from the interrupted
           // intent. Queued next-turn prompts stay parked: a steer-scoped drain never

--- a/packages/core/src/session/run-coordinator.ts
+++ b/packages/core/src/session/run-coordinator.ts
@@ -17,9 +17,14 @@ export interface Coordinator<Key, E, Reason = never> {
    * Stops the active execution and clears its doorbell. No-op when idle. Resolves once the
    * interruption is accepted, not when cleanup settles: the execution fiber finishes its
    * finalizers and settled hook on its own time. Returns whether an active execution was
-   * interrupted. Compose with `awaitIdle` for settlement.
+   * interrupted. `awaitSettlement` waits for this execution's cleanup and settled hook,
+   * without following fresh work admitted during cleanup. `awaitIdle` follows successors too.
    */
-  readonly interrupt: (key: Key, reason?: Reason) => Effect.Effect<boolean>
+  readonly interrupt: (
+    key: Key,
+    reason?: Reason,
+    options?: { readonly awaitSettlement?: boolean },
+  ) => Effect.Effect<boolean>
   /** Resolves once no execution is active for the key. Returns immediately when already idle and never starts work. */
   readonly awaitIdle: (key: Key) => Effect.Effect<void>
 }
@@ -170,5 +175,22 @@ export const make = <Key, E, Reason = never>(options: {
         return Deferred.await(execution.done).pipe(Effect.ignoreCause, Effect.andThen(awaitIdle(key)))
       })
 
-    return { active: Effect.sync(() => new Set(executions.keys())), isActive, run, wake, interrupt, awaitIdle }
+    return {
+      active: Effect.sync(() => new Set(executions.keys())),
+      isActive,
+      run,
+      wake,
+      interrupt: (key, reason, options) =>
+        Effect.suspend(() => {
+          const execution = executions.get(key)
+          return interrupt(key, reason).pipe(
+            Effect.tap(() =>
+              options?.awaitSettlement && execution
+                ? Deferred.await(execution.done).pipe(Effect.ignoreCause)
+                : Effect.void,
+            ),
+          )
+        }),
+      awaitIdle,
+    }
   })

--- a/packages/core/test/location-activity.test.ts
+++ b/packages/core/test/location-activity.test.ts
@@ -28,7 +28,7 @@ const locations = Layer.effect(
   LocationServiceMap.Service,
   Effect.gen(function* () {
     const bus = yield* Bus.Service
-    return yield* LayerMap.make(
+    const map = yield* LayerMap.make(
       (ref: Location.Ref) =>
         // The fixture only exercises these three Location services.
         // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
@@ -68,6 +68,13 @@ const locations = Layer.effect(
         ) as unknown as Layer.Layer<LocationServices>,
       { idleTimeToLive: Duration.infinity },
     )
+    return {
+      ...map,
+      get: (ref: Location.Ref) => map.get(LocationServiceMap.canonical(ref)),
+      contextEffect: (ref: Location.Ref) => map.contextEffect(LocationServiceMap.canonical(ref)),
+      contextEffectOption: (ref: Location.Ref) => map.contextEffectOption(LocationServiceMap.canonical(ref)),
+      invalidate: (ref: Location.Ref) => map.invalidate(LocationServiceMap.canonical(ref)),
+    }
   }),
 )
 
@@ -94,13 +101,15 @@ const it = testEffect(
 )
 
 describe("LocationActivity eviction", () => {
-  for (const [count, newWork] of [
-    [1, false],
-    [2, false],
-    [1, true],
+  for (const [count, admission] of [
+    [1, "none"],
+    [2, "none"],
+    [1, "other"],
+    [1, "same"],
   ] as const) {
+    const newWork = admission !== "none"
     it.effect(
-      `interrupts ${count} waiting executions before eviction${newWork ? "; preserves new work during cleanup" : ""}`,
+      `interrupts ${count} waiting executions before eviction (${admission} session admitted during cleanup)`,
       () =>
         Effect.gen(function* () {
           const db = (yield* Database.Service).db
@@ -111,7 +120,7 @@ describe("LocationActivity eviction", () => {
           const sessionIDs = Array.from({ length: count }, (_, index) =>
             Session.ID.make(`ses_waiting_question_${index}`),
           )
-          const newcomer = Session.ID.make("ses_new_question")
+          const newcomer = admission === "same" ? sessionIDs[0] : Session.ID.make("ses_new_question")
           const ref = LocationServiceMap.canonical({ directory: AbsolutePath.make("/project") })
           const idle = Location.Ref.make({ directory: ref.directory, workspaceID: Workspace.ID.make("wrk_idle") })
           yield* db
@@ -122,7 +131,7 @@ describe("LocationActivity eviction", () => {
           yield* db
             .insert(SessionTable)
             .values(
-              [...sessionIDs, newcomer].map((sessionID) => ({
+              Array.from(new Set([...sessionIDs, newcomer]), (sessionID) => ({
                 id: sessionID,
                 project_id: Project.ID.global,
                 slug: "question",
@@ -175,9 +184,10 @@ describe("LocationActivity eviction", () => {
 
           if (newWork) {
             yield* execution.wake(newcomer)
-            yield* Deferred.await(newCreated)
+            if (admission === "other") yield* Deferred.await(newCreated)
           }
           yield* TestClock.adjust("5 minutes")
+          if (newWork) yield* Deferred.await(newCreated)
           const results = yield* Effect.forEach(running, Fiber.join)
           expect(results.every((exit) => exit._tag === "Failure")).toBe(true)
           expect(Array.from(yield* execution.active)).toEqual(newWork ? [newcomer] : [])
@@ -188,6 +198,16 @@ describe("LocationActivity eviction", () => {
           expect(Array.from(yield* RcMap.keys(map.rcMap))).toEqual(newWork ? [ref] : [])
           if (newWork) {
             expect(yield* forms.list({ sessionID: newcomer })).toEqual([pending[count]])
+            if (admission === "same") {
+              const later = LocationServiceMap.canonical({ directory: AbsolutePath.make("/later") })
+              yield* Location.Service.pipe(Effect.provide(map.get(later)), Effect.scoped)
+              yield* TestClock.adjust("30 minutes")
+              // Keep fresh work active while a different graph reaches its own deadline.
+              yield* bus.publish(SessionEvent.Execution.Started, { sessionID: newcomer }, { location: ref })
+              yield* TestClock.adjust("32 minutes")
+              expect(Array.from(yield* execution.active)).toEqual([newcomer])
+              expect(Array.from(yield* RcMap.keys(map.rcMap))).toEqual([ref])
+            }
             yield* execution.interrupt(newcomer)
             yield* TestClock.adjust("5 minutes")
             yield* execution.awaitIdle(newcomer)

--- a/packages/core/test/location-activity.test.ts
+++ b/packages/core/test/location-activity.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect } from "bun:test"
+import { Context, Deferred, Duration, Effect, Fiber, Layer, LayerMap, RcMap, Schema } from "effect"
+import { TestClock } from "effect/testing"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/util/effect/layer-node"
+import { makeGlobalNode } from "@opencode-ai/util/effect/app-node"
+import { Bus } from "@opencode-ai/core/bus"
+import { Database } from "@opencode-ai/core/database/database"
+import { Form } from "@opencode-ai/core/form"
+import { Location } from "@opencode-ai/core/location"
+import { LocationActivity } from "@opencode-ai/core/location-activity"
+import { LocationServiceMap, type LocationServices } from "@opencode-ai/core/location-services"
+import { Project } from "@opencode-ai/core/project"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
+import { AbsolutePath } from "@opencode-ai/core/schema"
+import { Session } from "@opencode-ai/core/session"
+import { SessionExecution } from "@opencode-ai/core/session/execution"
+import { SessionEvent } from "@opencode-ai/core/session/event"
+import { SessionRunner } from "@opencode-ai/core/session/runner/index"
+import { SessionTable } from "@opencode-ai/core/session/sql"
+import { SessionStore } from "@opencode-ai/core/session/store"
+import { Workspace } from "@opencode-ai/core/workspace"
+import { testEffect } from "./lib/effect"
+
+// Keep real execution ownership, location caching, forms, and eviction. The fixture
+// runner waits on a form instead of making a model request before asking a question.
+const locations = Layer.effect(
+  LocationServiceMap.Service,
+  Effect.gen(function* () {
+    const bus = yield* Bus.Service
+    return yield* LayerMap.make(
+      (ref: Location.Ref) =>
+        // The fixture only exercises these three Location services.
+        // oxlint-disable-next-line typescript-eslint/no-unsafe-type-assertion
+        Layer.merge(
+          Layer.succeed(
+            Location.Service,
+            Location.Service.of({
+              directory: ref.directory,
+              workspaceID: ref.workspaceID,
+              project: { id: Project.ID.global, directory: ref.directory, canonical: ref.directory },
+            }),
+          ),
+          Layer.effect(
+            SessionRunner.Service,
+            Effect.gen(function* () {
+              const forms = yield* Form.Service
+              return SessionRunner.Service.of({
+                drain: ({ sessionID }) =>
+                  forms
+                    .ask({
+                      sessionID,
+                      title: "Questions",
+                      fields: [{ key: "runtime", type: "string" }],
+                    })
+                    .pipe(
+                      Effect.orDie,
+                      Effect.as(SessionRunner.DrainResult.Complete()),
+                      Effect.onInterrupt(() => Effect.sleep("5 minutes")),
+                    ),
+              })
+            }),
+          ),
+        ).pipe(
+          Layer.provideMerge(Form.layer),
+          Layer.provide(Layer.succeed(Bus.Service, bus)),
+          Layer.fresh,
+        ) as unknown as Layer.Layer<LocationServices>,
+      { idleTimeToLive: Duration.infinity },
+    )
+  }),
+)
+
+const it = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([
+      Database.node,
+      Bus.node,
+      SessionStore.node,
+      LocationServiceMap.node,
+      SessionExecution.node,
+      LocationActivity.node,
+    ]),
+    [
+      LocationServiceMap.node.replace(
+        makeGlobalNode({
+          service: LocationServiceMap.Service,
+          layer: locations,
+          deps: [Bus.node],
+        }),
+      ),
+    ],
+  ),
+)
+
+describe("LocationActivity eviction", () => {
+  for (const [count, newWork] of [
+    [1, false],
+    [2, false],
+    [1, true],
+  ] as const) {
+    it.effect(
+      `interrupts ${count} waiting executions before eviction${newWork ? "; preserves new work during cleanup" : ""}`,
+      () =>
+        Effect.gen(function* () {
+          const db = (yield* Database.Service).db
+          const bus = yield* Bus.Service
+          const map = yield* LocationServiceMap.Service
+          const execution = yield* SessionExecution.Service
+          const store = yield* SessionStore.Service
+          const sessionIDs = Array.from({ length: count }, (_, index) =>
+            Session.ID.make(`ses_waiting_question_${index}`),
+          )
+          const newcomer = Session.ID.make("ses_new_question")
+          const ref = LocationServiceMap.canonical({ directory: AbsolutePath.make("/project") })
+          const idle = Location.Ref.make({ directory: ref.directory, workspaceID: Workspace.ID.make("wrk_idle") })
+          yield* db
+            .insert(ProjectTable)
+            .values({ id: Project.ID.global, worktree: ref.directory, sandboxes: [] })
+            .run()
+            .pipe(Effect.orDie)
+          yield* db
+            .insert(SessionTable)
+            .values(
+              [...sessionIDs, newcomer].map((sessionID) => ({
+                id: sessionID,
+                project_id: Project.ID.global,
+                slug: "question",
+                directory: ref.directory,
+                title: "Waiting question",
+                version: "test",
+              })),
+            )
+            .run()
+            .pipe(Effect.orDie)
+
+          const created = yield* Deferred.make<void>()
+          const newCreated = yield* Deferred.make<void>()
+          const pending: Form.Info[] = []
+          const interrupted: SessionEvent.Execution.Interrupted["data"][] = []
+          const unsubscribe = yield* bus.listen((event) =>
+            Effect.gen(function* () {
+              if (event.type === SessionEvent.Execution.Interrupted.type) {
+                interrupted.push(Schema.decodeUnknownSync(SessionEvent.Execution.Interrupted.data)(event.data))
+              }
+              if (event.type !== Form.Event.Created.type) return
+              pending.push(Schema.decodeUnknownSync(Form.Event.Created.data)(event.data).form)
+              if (pending.length === count) yield* Deferred.succeed(created, undefined)
+              if (pending.length > count) yield* Deferred.succeed(newCreated, undefined)
+            }),
+          )
+          yield* Effect.addFinalizer(() => unsubscribe)
+          const running = yield* Effect.forEach(sessionIDs, (sessionID) =>
+            execution.resume(sessionID).pipe(Effect.exit, Effect.forkScoped),
+          )
+          yield* Effect.addFinalizer(() =>
+            Effect.forEach([...sessionIDs, newcomer], (sessionID) => execution.interrupt(sessionID)).pipe(
+              Effect.andThen(TestClock.adjust("5 minutes")),
+            ),
+          )
+          yield* Deferred.await(created)
+          const context = yield* map.contextEffect(ref).pipe(Effect.scoped)
+          const forms = Context.get(context, Form.Service)
+          expect((yield* store.listSuspended()).toSorted()).toEqual(sessionIDs.toSorted())
+          yield* Location.Service.pipe(Effect.provide(map.get(idle)), Effect.scoped)
+
+          // Human input produces no durable activity while the question is pending.
+          yield* TestClock.adjust("1 minute")
+          yield* TestClock.adjust("62 minutes")
+          // Interruption has cancelled each question, but slow cleanup still owns the graph.
+          expect(Array.from(yield* execution.active).toSorted()).toEqual(sessionIDs.toSorted())
+          expect(Array.from(yield* RcMap.keys(map.rcMap))).toEqual([ref])
+          expect(yield* forms.list()).toEqual([])
+          for (const form of pending) expect(yield* forms.state(form.id)).toEqual({ status: "cancelled" })
+
+          if (newWork) {
+            yield* execution.wake(newcomer)
+            yield* Deferred.await(newCreated)
+          }
+          yield* TestClock.adjust("5 minutes")
+          const results = yield* Effect.forEach(running, Fiber.join)
+          expect(results.every((exit) => exit._tag === "Failure")).toBe(true)
+          expect(Array.from(yield* execution.active)).toEqual(newWork ? [newcomer] : [])
+          expect(yield* store.listSuspended()).toEqual(newWork ? [newcomer] : [])
+          expect(interrupted.toSorted((a, b) => a.sessionID.localeCompare(b.sessionID))).toEqual(
+            sessionIDs.map((sessionID) => ({ sessionID, reason: "inactivity" })),
+          )
+          expect(Array.from(yield* RcMap.keys(map.rcMap))).toEqual(newWork ? [ref] : [])
+          if (newWork) {
+            expect(yield* forms.list({ sessionID: newcomer })).toEqual([pending[count]])
+            yield* execution.interrupt(newcomer)
+            yield* TestClock.adjust("5 minutes")
+            yield* execution.awaitIdle(newcomer)
+            yield* TestClock.adjust("62 minutes")
+            expect(yield* store.listSuspended()).toEqual([])
+            expect(Array.from(yield* RcMap.keys(map.rcMap))).toEqual([])
+          }
+        }),
+    )
+  }
+})

--- a/packages/schema/src/session-event.ts
+++ b/packages/schema/src/session-event.ts
@@ -233,7 +233,7 @@ export namespace Execution {
   export const Interrupted = Event.durable({
     type: "session.execution.interrupted",
     ...options,
-    schema: { ...Base, reason: Schema.Literals(["user", "shutdown", "superseded"]) },
+    schema: { ...Base, reason: Schema.Literals(["user", "shutdown", "superseded", "inactivity"]) },
   })
   export type Interrupted = typeof Interrupted.Type
 }


### PR DESCRIPTION
## Why

A session waiting for a question can outlive the location's 60-minute inactivity deadline. Eviction removes the service graph from the cache while its execution still holds the old graph. Answering the question then reaches a replacement `Form.Service`: the question disappears, but the original tool keeps waiting and the session never settles.

## What Changes

**Before:** inactivity eviction detaches a running execution from the services used by subsequent client requests.

**After:** inactivity eviction interrupts every active session at that location, waits for tool cleanup and terminal execution settlement, then invalidates the cached graph. The question is cancelled and the TUI shows **interrupted**.

The execution records `reason: "inactivity"` and releases its recovery claim, so a server restart does not resume deliberately expired work. The wait covers the selected execution's settlement, not fresh work admitted during its cleanup. If new work starts in the same or another session, the sweep defers eviction and future sweeps continue. Location comparisons use the cache's canonical path representation, including on Windows.

```mermaid
sequenceDiagram
    participant Activity as LocationActivity
    participant Execution as SessionExecution
    participant Tool as Running tools
    participant Cache as LocationServiceMap
    Activity->>Execution: interrupt(location's sessions, inactivity, awaitSettlement)
    Execution->>Tool: interrupt
    Tool-->>Execution: cleanup complete
    Execution->>Execution: publish terminal, release recovery claim
    Execution-->>Activity: selected executions settled
    Activity->>Execution: check for new active sessions
    Activity->>Cache: invalidate if location has no active sessions
```

## Demo

https://github.com/user-attachments/assets/d78ddce0-15d6-42f6-9844-7a29ab7285cd

Matched OpenCode Drive 2.1.0 recording: **before** `b2cecc6350`, **after** `34f77d5877`. Both run the real TUI and question tool with an identical simulated model response, 95×30 viewport, and Enter press after expiry. Both temporarily accelerate the existing 60-minute TTL to 5 seconds and the 1-minute sweep to 1 second. Production timings are unchanged. The 10-second comparison shows the initial question, automatic interruption on the right, and the orphaned spinner on the left after Enter.

## Scope

Owns inactivity-eviction ordering through the existing process-local execution coordinator, plus the durable interruption reason and regenerated client types. Supersedes the active-location retention policy proposed in #47626.

## Verification

```sh
# packages/core
bun run test test/location-activity.test.ts test/location-layer.test.ts test/session-execution.test.ts test/session-run-coordinator.test.ts test/form.test.ts test/permission.test.ts
bun run test test/location-activity.test.ts
bun typecheck

# packages/server
bun typecheck

# packages/client
bun run generate

# repo root
bunx oxlint packages/core/src/location-activity.ts packages/core/src/session/execution.ts packages/core/src/session/run-coordinator.ts packages/core/test/location-activity.test.ts
opencode-drive check .drive-output/eviction-demo.ts
```

- All 204 focused tests passed. The original three eviction regressions fail on the base revision. A fourth regression fails with the chain-wide `awaitIdle` implementation and passes with the selected-execution settlement wait.
- Regressions use real execution ownership, forms, cache eviction, and recovery claims. They cover one or two active sessions, delayed cleanup, an independently idle workspace at the same directory, and same-session or different-session work admitted during cleanup. The same-session case also proves a later-expiring graph is still evicted while the successor execution is active.
- Core and Server typechecks passed; the required pre-push typecheck completed all 33 package tasks successfully. Lint reports no warnings or errors.
- Drive asserts that the base tool remains running, the fixed tool settles, the fixed session outcome is interrupted, and no pending question remains.
