### PR TITLE
fix(llm): accept uppercase data URL schemes in media validation

### DIFF
--- a/packages/llm/src/protocols/shared.ts
+++ b/packages/llm/src/protocols/shared.ts
@@ -163,6 +163,7 @@ export const MAX_MEDIA_ENCODED_BYTES = 28 * 1024 * 1024
 export const MAX_MEDIA_DECODED_BYTES = 20 * 1024 * 1024
 
 const base64Pattern = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/
+const dataUrlPattern = /^data:([^;,]+);base64,([A-Za-z0-9+/]*={0,2})$/si
 
 export interface ValidatedMedia {
   readonly mime: string
@@ -184,8 +185,8 @@ export const validateMedia = Effect.fn("ProviderShared.validateMedia")(function*
     if (part.data.byteLength > MAX_MEDIA_DECODED_BYTES)
       return yield* invalidRequest(`${route} media exceeds the ${MAX_MEDIA_DECODED_BYTES} byte decoded limit`)
     base64 = Buffer.from(part.data).toString("base64")
-  } else if (part.data.startsWith("data:")) {
-    const match = /^data:([^;,]+);base64,([A-Za-z0-9+/]*={0,2})$/s.exec(part.data)
+  } else if (dataUrlPattern.test(part.data)) {
+    const match = dataUrlPattern.exec(part.data)
     if (!match) return yield* invalidRequest(`${route} media data URL must contain valid base64`)
     if (match[1]!.toLowerCase() !== mime)
       return yield* invalidRequest(`${route} media type ${part.mediaType} does not match data URL type ${match[1]}`)

--- a/packages/llm/test/provider/openai-chat.test.ts
+++ b/packages/llm/test/provider/openai-chat.test.ts
@@ -462,6 +462,33 @@ describe("OpenAI Chat route", () => {
     }),
   )
 
+  it.effect("normalizes uppercase data URL schemes without double prefixing", () =>
+    Effect.gen(function* () {
+      const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(
+        LLM.request({
+          id: "req_media_upper",
+          model,
+          messages: [
+            Message.user([
+              { type: "media", mediaType: "image/png", data: "DATA:image/png;base64,AAECAw==" },
+              { type: "media", mediaType: "image/png", data: "Data:image/png;base64,AAECAw==" },
+            ]),
+          ],
+        }),
+      )
+
+      expect(prepared.body.messages).toEqual([
+        {
+          role: "user",
+          content: [
+            { type: "image_url", image_url: { url: "data:image/png;base64,AAECAw==" } },
+            { type: "image_url", image_url: { url: "data:image/png;base64,AAECAw==" } },
+          ],
+        },
+      ])
+    }),
+  )
+
   it.effect("lowers reasoning-only assistant history", () =>
     Effect.gen(function* () {
       const prepared = yield* LLMClient.prepare<OpenAIChat.OpenAIChatBody>(


### PR DESCRIPTION
### Issue for this PR

Closes #47538

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`validateMedia` detected existing data URLs with a case-sensitive `startsWith("data:")`, so an uppercase `DATA:` scheme was treated as raw base64 and the rebuilt data URL got a second prefix (`data:image/png;base64,DATA:image/png;base64,...`). The detection and parse pattern are now case-insensitive for the scheme, matching RFC 3986 section 3.1. The emitted data URL is unchanged for all valid inputs.

### How did you verify your code works?

From `packages/llm`:

- `bun test --timeout 30000 test/provider/openai-chat.test.ts` — 28 pass, including a new regression test that feeds `DATA:` and `Data:` URLs and asserts the single correct `data:image/png;base64,AAECAw==` URL
- `bun test --timeout 30000 test/provider/anthropic-messages.test.ts test/provider/gemini.test.ts test/provider/openai-responses.test.ts test/provider/bedrock-converse.test.ts` — 129 pass (all other `validateMedia` callers)
- `bun run typecheck` — clean

### Screenshots / recordings

Not applicable. No rendered UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR