### PR TITLE
fix(core): recover project identity from project_directory when git i…

### DIFF
--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -109,7 +109,11 @@ const layer = Layer.effect(
 
     const resolve = Effect.fn("Project.resolve")(function* (input: AbsolutePath) {
       const repo = yield* git.repo.discover(input)
-      if (!repo) return { id: ID.global, directory: AbsolutePath.make(path.parse(input).root), vcs: undefined }
+      if (!repo) {
+        const known = yield* projectDirectories.find(input)
+        if (known) return { id: known.projectID, directory: known.directory, vcs: undefined }
+        return { id: ID.global, directory: AbsolutePath.make(path.parse(input).root), vcs: undefined }
+      }
 
       const previous = yield* cached(repo.commonDirectory)
       const id = (yield* remote(repo)) ?? previous ?? (yield* root(repo))

--- a/packages/core/src/project/directories.ts
+++ b/packages/core/src/project/directories.ts
@@ -1,12 +1,12 @@
 export * as ProjectDirectories from "./directories"
 
-import { and, asc, desc, eq, isNotNull, isNull, ne, or } from "drizzle-orm"
+import { and, asc, desc, eq, isNotNull, isNull, ne, or, sql } from "drizzle-orm"
 import { Context, Effect, Layer, Schema } from "effect"
 import { Database } from "../database/database"
 import { makeGlobalNode } from "../effect/app-node"
 import { AbsolutePath, optional } from "../schema"
 import { ProjectSchema } from "./schema"
-import { ProjectDirectoryTable } from "./sql"
+import { ProjectDirectoryTable, ProjectTable } from "./sql"
 import type { EffectDrizzleSqlite } from "@opencode-ai/effect-drizzle-sqlite"
 
 export interface Directory {
@@ -53,6 +53,12 @@ export interface Interface {
   readonly contains: (input: { projectID: ProjectSchema.ID; directory: AbsolutePath }) => Effect.Effect<boolean>
   readonly create: (input: CreateInput, tx?: Transaction) => Effect.Effect<boolean>
   readonly remove: (input: RemoveInput, tx?: Transaction) => Effect.Effect<boolean>
+  /**
+   * Reverse lookup: given an opened directory, find the project that claimed it (or an
+   * ancestor of it) when the git repository no longer exists. Returns the deepest claim;
+   * falls back to the project table for databases predating project_directory rows.
+   */
+  readonly find: (directory: AbsolutePath) => Effect.Effect<{ projectID: ProjectSchema.ID; directory: AbsolutePath } | undefined>
 }
 
 export class Service extends Context.Service<Service, Interface>()("@opencode/ProjectDirectories") {}
@@ -145,12 +151,57 @@ const layer = Layer.effect(
       return row ? { directory: row.directory, strategy: row.strategy ?? undefined } : undefined
     })
 
+    const find = Effect.fn("ProjectDirectories.find")(function* (directory: AbsolutePath) {
+      // Stored rows are slash-normalized on Windows; the input keeps native separators.
+      const path = process.platform === "win32" ? directory.replaceAll("\\", "/") : directory
+      const rows = yield* db
+        .select({
+          projectID: ProjectDirectoryTable.project_id,
+          directory: ProjectDirectoryTable.directory,
+          created: ProjectDirectoryTable.time_created,
+        })
+        .from(ProjectDirectoryTable)
+        .where(
+          and(
+            ne(ProjectDirectoryTable.project_id, ProjectSchema.ID.global),
+            sql`(${ProjectDirectoryTable.directory} = ${path} or ${path} like ${ProjectDirectoryTable.directory} || '/%')`,
+          ),
+        )
+        .all()
+        .pipe(Effect.orDie)
+      const match = rows.reduce((best, row) => {
+        if (!best) return row
+        if (row.directory.length !== best.directory.length)
+          return row.directory.length > best.directory.length ? row : best
+        return row.created > best.created ? row : best
+      }, undefined as { projectID: ProjectSchema.ID; directory: AbsolutePath; created: number } | undefined)
+      if (match) return { projectID: match.projectID, directory: match.directory }
+
+      // Databases predating the project_directory table only have the project worktree.
+      const legacy = yield* db
+        .select({
+          projectID: ProjectTable.id,
+          directory: ProjectTable.worktree,
+          updated: ProjectTable.time_updated,
+        })
+        .from(ProjectTable)
+        .where(and(eq(ProjectTable.worktree, directory), ne(ProjectTable.id, ProjectSchema.ID.global)))
+        .all()
+        .pipe(Effect.orDie)
+      const matchLegacy = legacy.reduce((best, row) => {
+        if (!best) return row
+        return row.updated > best.updated ? row : best
+      }, undefined as { projectID: ProjectSchema.ID; directory: AbsolutePath; updated: number } | undefined)
+      return matchLegacy ? { projectID: matchLegacy.projectID, directory: matchLegacy.directory } : undefined
+    })
+
     return Service.of({
       list,
       get,
       contains,
       create,
       remove,
+      find,
     })
   }),
 )

--- a/packages/core/test/project.test.ts
+++ b/packages/core/test/project.test.ts
@@ -2,15 +2,20 @@ import { describe, expect } from "bun:test"
 import { $ } from "bun"
 import fs from "fs/promises"
 import path from "path"
+import { eq } from "drizzle-orm"
 import { Effect, Schema } from "effect"
+import { Database } from "@opencode-ai/core/database/database"
 import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { ProjectV2 } from "@opencode-ai/core/project"
+import { ProjectDirectories } from "@opencode-ai/core/project/directories"
+import { ProjectTable } from "@opencode-ai/core/project/sql"
 import { AbsolutePath } from "@opencode-ai/core/schema"
 import { Hash } from "@opencode-ai/core/util/hash"
 import { tmpdir } from "./fixture/tmpdir"
 import { testEffect } from "./lib/effect"
 
-const it = testEffect(AppNodeBuilder.build(ProjectV2.node))
+const it = testEffect(AppNodeBuilder.build(LayerNode.group([Database.node, ProjectDirectories.node, ProjectV2.node])))
 
 function remoteID(remote: string) {
   return ProjectV2.ID.make(Hash.fast(`git-remote:${remote}`))
@@ -36,6 +41,21 @@ async function initRepo(dir: string, opts?: { commit?: boolean; remote?: string 
 
 async function rootCommit(dir: string) {
   return (await $`git rev-list --max-parents=0 HEAD`.cwd(dir).text()).trim()
+}
+
+function seedProject(id: ProjectV2.ID, worktree: string) {
+  return Database.Service.use(({ db }) =>
+    db
+      .insert(ProjectTable)
+      .values({ id, worktree: abs(worktree), sandboxes: [], time_created: 1, time_updated: 1 })
+      .onConflictDoNothing()
+      .run()
+      .pipe(Effect.orDie),
+  )
+}
+
+function unseedProject(id: ProjectV2.ID) {
+  return Database.Service.use(({ db }) => db.delete(ProjectTable).where(eq(ProjectTable.id, id)).run().pipe(Effect.orDie))
 }
 
 describe("ProjectV2.resolve", () => {
@@ -216,6 +236,93 @@ describe("ProjectV2.resolve", () => {
       expect(result.previous).toBe(ProjectV2.ID.make("old-id"))
       expect(result.id).toBe(remoteID("github.com/owner/repo"))
       expect(result.vcs?.type).toBe("git")
+    }),
+  )
+})
+
+describe("ProjectV2.resolve with the git repository removed", () => {
+  it.live("recovers the project from a project_directory row", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const id = ProjectV2.ID.make(`recover-root-${Date.now()}`)
+      yield* Effect.addFinalizer(() => unseedProject(id))
+      yield* seedProject(id, tmp.path)
+      const directories = yield* ProjectDirectories.Service
+      yield* directories.create({ projectID: id, directory: abs(tmp.path) })
+      const project = yield* ProjectV2.Service
+
+      const result = yield* project.resolve(abs(tmp.path))
+
+      expect(result.id).toBe(id)
+      expect(result.directory).toBe(abs(tmp.path))
+      expect(result.previous).toBeUndefined()
+      expect(result.vcs).toBeUndefined()
+    }),
+  )
+
+  it.live("recovers the project when opened in a subdirectory", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const id = ProjectV2.ID.make(`recover-sub-${Date.now()}`)
+      yield* Effect.addFinalizer(() => unseedProject(id))
+      yield* seedProject(id, tmp.path)
+      const directories = yield* ProjectDirectories.Service
+      yield* directories.create({ projectID: id, directory: abs(tmp.path) })
+      const project = yield* ProjectV2.Service
+
+      const result = yield* project.resolve(abs(path.join(tmp.path, "packages", "core")))
+
+      expect(result.id).toBe(id)
+      expect(result.directory).toBe(abs(tmp.path))
+      expect(result.vcs).toBeUndefined()
+    }),
+  )
+
+  it.live("prefers the deepest recovered project", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const outer = ProjectV2.ID.make(`recover-outer-${Date.now()}`)
+      const inner = ProjectV2.ID.make(`recover-inner-${Date.now()}`)
+      yield* Effect.addFinalizer(() => unseedProject(outer))
+      yield* Effect.addFinalizer(() => unseedProject(inner))
+      yield* seedProject(outer, tmp.path)
+      yield* seedProject(inner, path.join(tmp.path, "inner"))
+      const directories = yield* ProjectDirectories.Service
+      yield* directories.create({ projectID: outer, directory: abs(tmp.path) })
+      yield* directories.create({ projectID: inner, directory: abs(path.join(tmp.path, "inner")) })
+      const project = yield* ProjectV2.Service
+
+      const result = yield* project.resolve(abs(path.join(tmp.path, "inner", "sub")))
+
+      expect(result.id).toBe(inner)
+      expect(result.directory).toBe(abs(path.join(tmp.path, "inner")))
+    }),
+  )
+
+  it.live("recovers the project from the project table when no directory rows exist", () =>
+    Effect.gen(function* () {
+      const tmp = yield* Effect.acquireRelease(
+        Effect.promise(() => tmpdir()),
+        (tmp) => Effect.promise(() => tmp[Symbol.asyncDispose]()),
+      )
+      const id = ProjectV2.ID.make(`recover-legacy-${Date.now()}`)
+      yield* Effect.addFinalizer(() => unseedProject(id))
+      yield* seedProject(id, tmp.path)
+      const project = yield* ProjectV2.Service
+
+      const result = yield* project.resolve(abs(tmp.path))
+
+      expect(result.id).toBe(id)
+      expect(result.directory).toBe(abs(tmp.path))
     }),
   )
 })


### PR DESCRIPTION
### Issue for this PR

Closes #47652

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After `rm -rf .git` on a project directory, sessions bound to the project directory disappear from the `/sessions` list. `ProjectV2.resolve` collapses a no-repo directory to the `global` project, and the old git `project_id` is never recovered, so `listByProject` (which filters by current project id) hides the old sessions.

I added `ProjectDirectories.find(directory)`: it looks up the `project_directory` table for the same directory or an ancestor of it and returns the deepest match (by latest `time_created`), with a fallback to a `project.worktree` exact match for DBs from before that table existed. The no-repo branch of `resolve` now returns that project id + directory instead of `global`.

Why it works: the recovered id passes the `project_id` filter in `listByProject`, and the recovered directory becomes the worktree, so the TUI's relative-path filter computes to empty and is skipped. `fromDirectory` also re-tags sessions that were mistagged `global` while the repo root was open, so those are fixed on next open.

This also mitigates #42230 (stale git detection after in-place `git init`): identity is recovered from `project_directory` instead of new sessions being tagged `global`. I did not touch the git-discovery logic, so that root cause remains.

### How did you verify your code works?

- **New unit tests** in `packages/core/test/project.test.ts`: exact directory, subdirectory, deepest-of-nested, and legacy worktree fallback. Core suite passes.
- **Manual reproduction:** 
1. Create a test repo:
```bash
mkdir -p ~/opencode-repro && cd ~/opencode-repro
git init -q && echo x > f.txt && git add . && git commit -qm init
```
2. Test:
```bash
cd <YOUR_PULLED_FORK_DIR>/packages/opencode
bun run build -- --single --skip-embed-web-ui 2>&1
husky
cd ~/opencode-repro
<YOUR_PULLED_FORK_DIR>/packages/opencode/dist/opencode-darwin-arm64/bin/opencode
```

3. Send a trivial prompt to create a session, verify it exists in the `/sessions` list, quit OpenCode.

4. Remove the local git repo:
```bash
rm -rf ~/opencode-repro/.git
<YOUR__PULLED_FORK_DIR>/packages/opencode/dist/opencode-darwin-arm64/bin/opencode
```

5. Run `/sessions` again and verify the session still shows up in the list.

### Screenshots / recordings

n/a (TUI, verified locally)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR