### PR TITLE
fix(core): follow resource_metadata from the MCP OAuth challenge

### DIFF
--- a/packages/core/src/mcp/oauth.ts
+++ b/packages/core/src/mcp/oauth.ts
@@ -1,8 +1,14 @@
 export * as McpOAuth from "./oauth.js"
 
-import { auth, parseErrorResponse, type OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
+import {
+  auth,
+  extractWWWAuthenticateParams,
+  parseErrorResponse,
+  type OAuthClientProvider,
+} from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
 import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js"
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js"
 import { Cause, Deferred, Effect } from "effect"
 import { Credential } from "@opencode-ai/schema/credential"
 import { ConfigMCP } from "@opencode-ai/schema/config/mcp"
@@ -277,8 +283,37 @@ export const authorize = (input: {
       return toCredential({ methodID: input.methodID, serverUrl: input.config.url, tokens, client })
     })
 
+    // RFC 9728 §5.1: the 401 challenge names the exact protected-resource metadata URL (path and query
+    // included). Without it the SDK derives well-known URLs from the origin and, when those 404, treats
+    // the resource host itself as the authorization server. Transport-driven connects read the
+    // challenge inside the SDK; this interactive flow has to probe for it. Uses the global fetch so
+    // the expected 401 is not logged as a rejected authentication.
+    const challenge = yield* Effect.tryPromise(async () => {
+      const response = await fetch(input.config.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          ...input.config.headers,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: LATEST_PROTOCOL_VERSION,
+            capabilities: {},
+            clientInfo: { name: "opencode", version: "unknown" },
+          },
+        }),
+      })
+      await response.body?.cancel()
+      return extractWWWAuthenticateParams(response)
+    }).pipe(Effect.orElseSucceed(() => ({}) as ReturnType<typeof extractWWWAuthenticateParams>))
+    const discovery = { resourceMetadataUrl: challenge.resourceMetadataUrl, scope: oauth?.scope ?? challenge.scope }
+
     yield* Effect.tryPromise({
-      try: () => auth(oauthProvider, { serverUrl: input.config.url, scope: oauth?.scope, fetchFn }),
+      try: () => auth(oauthProvider, { serverUrl: input.config.url, ...discovery, fetchFn }),
       catch: (error) => (error instanceof Error ? error : new Error(String(error))),
     })
 
@@ -296,7 +331,7 @@ export const authorize = (input: {
               auth(oauthProvider, {
                 serverUrl: input.config.url,
                 authorizationCode: value,
-                scope: oauth?.scope,
+                ...discovery,
                 fetchFn,
               }),
             catch: (error) => (error instanceof Error ? error : new Error(String(error))),

--- a/packages/core/test/mcp-oauth.test.ts
+++ b/packages/core/test/mcp-oauth.test.ts
@@ -149,6 +149,72 @@ describe("MCP OAuth", () => {
     ])
   })
 
+  test("follows the resource_metadata URL from the WWW-Authenticate challenge", async () => {
+    const issuer = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url)
+        if (url.pathname !== "/.well-known/oauth-authorization-server") return new Response(null, { status: 404 })
+        return Response.json({
+          issuer: url.origin,
+          authorization_endpoint: `${url.origin}/authorize`,
+          token_endpoint: `${url.origin}/token`,
+          response_types_supported: ["code"],
+          code_challenge_methods_supported: ["S256"],
+        })
+      },
+    })
+    const metadataRequests: string[] = []
+    // Bedrock AgentCore shape: metadata lives under the resource path with a query string, the domain
+    // root well-known 404s, and the authorization server is a different host.
+    const resource = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url)
+        const metadata = `${url.origin}/runtimes/example/invocations/.well-known/oauth-protected-resource?qualifier=dev`
+        if (request.method === "POST" && url.pathname === "/runtimes/example/invocations")
+          return new Response(null, {
+            status: 401,
+            headers: { "WWW-Authenticate": `Bearer resource_metadata="${metadata}", scope="mcp:read"` },
+          })
+        if (url.href === metadata) {
+          metadataRequests.push(url.href)
+          return Response.json({
+            resource: `${url.origin}/runtimes/example/invocations`,
+            authorization_servers: [issuer.url.origin],
+          })
+        }
+        return new Response(null, { status: 404 })
+      },
+    })
+
+    try {
+      const authorization = await Effect.runPromise(
+        Effect.scoped(
+          McpOAuth.authorize({
+            name: "agentcore",
+            config: new ConfigMCP.Remote({
+              type: "remote",
+              url: `${resource.url.origin}/runtimes/example/invocations?qualifier=dev`,
+              oauth: { client_id: "client" },
+            }),
+            methodID: Integration.MethodID.make("oauth"),
+          }),
+        ),
+      )
+      const url = new URL(authorization.url)
+      expect(url.origin).toBe(issuer.url.origin)
+      expect(url.pathname).toBe("/authorize")
+      expect(url.searchParams.get("scope")).toBe("mcp:read")
+      expect(metadataRequests).toEqual([
+        `${resource.url.origin}/runtimes/example/invocations/.well-known/oauth-protected-resource?qualifier=dev`,
+      ])
+    } finally {
+      resource.stop(true)
+      issuer.stop(true)
+    }
+  })
+
   test("generates a loopback redirect URL when none is configured", async () => {
     expect(await authorize()).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/)
   })


### PR DESCRIPTION
### Issue for this PR

Closes #44790

### Type of change

- [x] Bug fix

### What does this PR do?

`authorize()` in `packages/core/src/mcp/oauth.ts` calls the SDK `auth()` with only `serverUrl` and `scope`, so the SDK derives the RFC 9728 well-known URL from the origin. When a server only announces its metadata in the 401 `WWW-Authenticate` header at a path-shaped URL (AWS Bedrock AgentCore puts the runtime ARN in the path and a `?qualifier=` query on the metadata URL), both derived lookups 404 and the SDK falls back to using the resource host as the authorization server. The browser then opens `https://<resource-host>/authorize`, which does not exist.

This probes the endpoint once with an `initialize` request, reads the challenge with the SDK's `extractWWWAuthenticateParams`, and passes `resourceMetadataUrl` and the challenge `scope` (config `scope` still wins) to both `auth()` calls: discovery and the code exchange. The provider has no discovery cache, so the second call needs the URL explicitly or it would rediscover from the origin. The probe is best-effort: if it throws or there is no challenge, behavior is unchanged. It uses the global `fetch` rather than `loggedFetch` so the expected 401 is not logged as a rejected authentication.

Transport-driven connects already get this from the SDK's own 401 handling; `authorize()` was the one path that skipped it.

Same fix as #44808, which predates the `fetchFn` change on `v2` and no longer applies cleanly. Happy to close this one if that PR gets rebased instead.

### How did you verify your code works?

- New test in `packages/core/test/mcp-oauth.test.ts`: resource server returns a 401 pointing at a path+query metadata URL, root well-known 404s, and the metadata names a separate issuer server. Asserts the authorization URL is on the issuer origin, the challenge scope is used, and the exact metadata URL was fetched.
- With the fix stashed the test fails on the origin assertion (authorization URL lands on the resource host); with the fix, `bun test test/mcp-oauth.test.ts` passes 7/7.
- `GOMAXPROCS=1 bun typecheck` and `bun x prettier --check` on both files are clean.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
