### PR TITLE
fix(ai): restrict Bedrock cache checkpoints to Claude

### DIFF
--- a/packages/ai/src/protocols/bedrock-converse.ts
+++ b/packages/ai/src/protocols/bedrock-converse.ts
@@ -235,7 +235,7 @@ const lowerTools = (
   const result: BedrockTool[] = []
   for (const tool of tools) {
     result.push(lowerToolSpec(tool, ToolSchemaProjection.modelCompatibility(tool.inputSchema, compatibility)))
-    const cachePoint = BedrockCache.block(breakpoints, tool.cache, "tools")
+    const cachePoint = BedrockCache.block(breakpoints, tool.cache)
     if (cachePoint) result.push(cachePoint)
   }
   return result
@@ -426,7 +426,7 @@ const fromRequest = Effect.fn("BedrockConverse.fromRequest")(function* (request:
   const toolChoice = request.toolChoice ? yield* lowerToolChoice(request.toolChoice) : undefined
   const flattened = ProviderShared.flattenToolRequest(request)
   const generation = request.generation
-  // Supported models share a 4-breakpoint cap. Spend the budget in
+  // Bedrock-Claude shares Anthropic's 4-breakpoint cap. Spend the budget in
   // tools → system → messages order to favour the highest-impact prefixes.
   const breakpoints = BedrockCache.breakpoints(request.model.id)
   const toolConfig = (() => {

--- a/packages/ai/src/protocols/bedrock-converse.ts
+++ b/packages/ai/src/protocols/bedrock-converse.ts
@@ -235,7 +235,7 @@ const lowerTools = (
   const result: BedrockTool[] = []
   for (const tool of tools) {
     result.push(lowerToolSpec(tool, ToolSchemaProjection.modelCompatibility(tool.inputSchema, compatibility)))
-    const cachePoint = BedrockCache.block(breakpoints, tool.cache)
+    const cachePoint = BedrockCache.block(breakpoints, tool.cache, "tools")
     if (cachePoint) result.push(cachePoint)
   }
   return result
@@ -415,10 +415,7 @@ const lowerMessages = Effect.fn("BedrockConverse.lowerMessages")(function* (
 
 // System prompts share the cache-point convention: emit the text block, then
 // optionally a positional `cachePoint` marker.
-const lowerSystem = (
-  breakpoints: BedrockCache.Breakpoints,
-  system: ReadonlyArray<LLMRequest["system"][number]>,
-) => {
+const lowerSystem = (breakpoints: BedrockCache.Breakpoints, system: ReadonlyArray<LLMRequest["system"][number]>) => {
   const content = system
     .filter((part) => part.text.length > 0)
     .flatMap((part) => textWithCache(breakpoints, part.text, part.cache))
@@ -429,9 +426,9 @@ const fromRequest = Effect.fn("BedrockConverse.fromRequest")(function* (request:
   const toolChoice = request.toolChoice ? yield* lowerToolChoice(request.toolChoice) : undefined
   const flattened = ProviderShared.flattenToolRequest(request)
   const generation = request.generation
-  // Bedrock-Claude shares Anthropic's 4-breakpoint cap. Spend the budget in
+  // Supported models share a 4-breakpoint cap. Spend the budget in
   // tools → system → messages order to favour the highest-impact prefixes.
-  const breakpoints = BedrockCache.breakpoints()
+  const breakpoints = BedrockCache.breakpoints(request.model.id)
   const toolConfig = (() => {
     if (flattened.tools.length === 0) return undefined
     return {

--- a/packages/ai/src/protocols/utils/bedrock-cache.ts
+++ b/packages/ai/src/protocols/utils/bedrock-cache.ts
@@ -13,8 +13,7 @@ export const CachePointBlock = Schema.Struct({
 })
 export type CachePointBlock = Schema.Schema.Type<typeof CachePointBlock>
 
-// Converse cache support is model-specific, including the allowed fields and TTL.
-// Bedrock's model cards also list older Claude models and Nova's system/messages-only support.
+// These legacy Claude releases support explicit caching, but only for five minutes.
 const CLAUDE_5M = new Set([
   "anthropic.claude-3-5-sonnet-20241022-v2:0",
   "anthropic.claude-3-5-haiku-20241022-v1:0",
@@ -22,29 +21,6 @@ const CLAUDE_5M = new Set([
   "anthropic.claude-sonnet-4-20250514-v1:0",
   "anthropic.claude-opus-4-20250514-v1:0",
   "anthropic.claude-opus-4-1-20250805-v1:0",
-])
-const CLAUDE_1H = new Set([
-  "anthropic.claude-haiku-4-5-20251001-v1:0",
-  "anthropic.claude-sonnet-4-5-20250929-v1:0",
-  "anthropic.claude-sonnet-4-6",
-  "anthropic.claude-sonnet-5",
-  "anthropic.claude-opus-4-5-20251101-v1:0",
-  "anthropic.claude-opus-4-6-v1",
-  "anthropic.claude-opus-4-7",
-  "anthropic.claude-opus-4-8",
-  "anthropic.claude-opus-5",
-  "anthropic.claude-mythos-preview",
-  "anthropic.claude-mythos-5",
-  "anthropic.claude-mythos-5-1",
-  "anthropic.claude-fable-5",
-  "anthropic.claude-fable-5-1",
-])
-const NOVA = new Set([
-  "amazon.nova-micro-v1:0",
-  "amazon.nova-lite-v1:0",
-  "amazon.nova-pro-v1:0",
-  "amazon.nova-premier-v1:0",
-  "amazon.nova-2-lite-v1:0",
 ])
 
 // Callers share the four-breakpoint budget across system, messages, and tools.
@@ -56,12 +32,14 @@ export const breakpoints = (modelID: string) => {
   const id = modelID
     .replace(/^arn:[^:]+:bedrock:[^:]*:[^:]*:(?:foundation-model|inference-profile)\//, "")
     .replace(/^(?:[a-z]{2}|apac|global)\./, "")
-  const claude = CLAUDE_5M.has(id) || CLAUDE_1H.has(id)
+  const short = CLAUDE_5M.has(id)
   return {
     ...newBreakpoints(BEDROCK_BREAKPOINT_CAP),
-    supported: claude || NOVA.has(id),
-    tools: claude,
-    ttl1h: CLAUDE_1H.has(id),
+    // Assume modern Claude releases retain caching support; older generations need an explicit exception.
+    // Other model families use implicit caching where available.
+    supported:
+      id.startsWith("anthropic.claude-") && (short || !/^anthropic\.claude-(?:instant|v[12]|3)(?:[-:]|$)/.test(id)),
+    ttl1h: !short,
   }
 }
 export type Breakpoints = ReturnType<typeof breakpoints>
@@ -69,12 +47,8 @@ export type Breakpoints = ReturnType<typeof breakpoints>
 const DEFAULT_5M: CachePointBlock = { cachePoint: { type: "default" } }
 const DEFAULT_1H: CachePointBlock = { cachePoint: { type: "default", ttl: "1h" } }
 
-export const block = (
-  breakpoints: Breakpoints,
-  cache: CacheHint | undefined,
-  section: "tools" | "content" = "content",
-): CachePointBlock | undefined => {
-  if (!breakpoints.supported || (section === "tools" && !breakpoints.tools)) return undefined
+export const block = (breakpoints: Breakpoints, cache: CacheHint | undefined): CachePointBlock | undefined => {
+  if (!breakpoints.supported) return undefined
   if (cache?.type !== "ephemeral" && cache?.type !== "persistent") return undefined
   if (breakpoints.remaining <= 0) {
     breakpoints.dropped += 1

--- a/packages/ai/src/protocols/utils/bedrock-cache.ts
+++ b/packages/ai/src/protocols/utils/bedrock-cache.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect"
 import type { CacheHint } from "../../schema/index.js"
-import { newBreakpoints, ttlBucket, type Breakpoints } from "./cache.js"
+import { newBreakpoints, ttlBucket } from "./cache.js"
 
 // Bedrock cache markers are positional: emit a `cachePoint` block immediately
 // after the content the caller wants treated as a cacheable prefix. Bedrock
@@ -13,24 +13,75 @@ export const CachePointBlock = Schema.Struct({
 })
 export type CachePointBlock = Schema.Schema.Type<typeof CachePointBlock>
 
-// Callers pass a shared counter through every `block()` call site so the
-// four-breakpoint budget is respected across `system`, `messages`, and `tools`.
+// Converse cache support is model-specific, including the allowed fields and TTL.
+// Bedrock's model cards also list older Claude models and Nova's system/messages-only support.
+const CLAUDE_5M = new Set([
+  "anthropic.claude-3-5-sonnet-20241022-v2:0",
+  "anthropic.claude-3-5-haiku-20241022-v1:0",
+  "anthropic.claude-3-7-sonnet-20250219-v1:0",
+  "anthropic.claude-sonnet-4-20250514-v1:0",
+  "anthropic.claude-opus-4-20250514-v1:0",
+  "anthropic.claude-opus-4-1-20250805-v1:0",
+])
+const CLAUDE_1H = new Set([
+  "anthropic.claude-haiku-4-5-20251001-v1:0",
+  "anthropic.claude-sonnet-4-5-20250929-v1:0",
+  "anthropic.claude-sonnet-4-6",
+  "anthropic.claude-sonnet-5",
+  "anthropic.claude-opus-4-5-20251101-v1:0",
+  "anthropic.claude-opus-4-6-v1",
+  "anthropic.claude-opus-4-7",
+  "anthropic.claude-opus-4-8",
+  "anthropic.claude-opus-5",
+  "anthropic.claude-mythos-preview",
+  "anthropic.claude-mythos-5",
+  "anthropic.claude-mythos-5-1",
+  "anthropic.claude-fable-5",
+  "anthropic.claude-fable-5-1",
+])
+const NOVA = new Set([
+  "amazon.nova-micro-v1:0",
+  "amazon.nova-lite-v1:0",
+  "amazon.nova-pro-v1:0",
+  "amazon.nova-premier-v1:0",
+  "amazon.nova-2-lite-v1:0",
+])
+
+// Callers share the four-breakpoint budget across system, messages, and tools.
 export const BEDROCK_BREAKPOINT_CAP = 4
 
-export type { Breakpoints } from "./cache.js"
-export const breakpoints = () => newBreakpoints(BEDROCK_BREAKPOINT_CAP)
+export const breakpoints = (modelID: string) => {
+  // Foundation-model and system inference-profile ARNs carry the model ID.
+  // Opaque application profiles cannot establish explicit caching support.
+  const id = modelID
+    .replace(/^arn:[^:]+:bedrock:[^:]*:[^:]*:(?:foundation-model|inference-profile)\//, "")
+    .replace(/^(?:[a-z]{2}|apac|global)\./, "")
+  const claude = CLAUDE_5M.has(id) || CLAUDE_1H.has(id)
+  return {
+    ...newBreakpoints(BEDROCK_BREAKPOINT_CAP),
+    supported: claude || NOVA.has(id),
+    tools: claude,
+    ttl1h: CLAUDE_1H.has(id),
+  }
+}
+export type Breakpoints = ReturnType<typeof breakpoints>
 
 const DEFAULT_5M: CachePointBlock = { cachePoint: { type: "default" } }
 const DEFAULT_1H: CachePointBlock = { cachePoint: { type: "default", ttl: "1h" } }
 
-export const block = (breakpoints: Breakpoints, cache: CacheHint | undefined): CachePointBlock | undefined => {
+export const block = (
+  breakpoints: Breakpoints,
+  cache: CacheHint | undefined,
+  section: "tools" | "content" = "content",
+): CachePointBlock | undefined => {
+  if (!breakpoints.supported || (section === "tools" && !breakpoints.tools)) return undefined
   if (cache?.type !== "ephemeral" && cache?.type !== "persistent") return undefined
   if (breakpoints.remaining <= 0) {
     breakpoints.dropped += 1
     return undefined
   }
   breakpoints.remaining -= 1
-  return ttlBucket(cache.ttlSeconds) === "1h" ? DEFAULT_1H : DEFAULT_5M
+  return breakpoints.ttl1h && ttlBucket(cache.ttlSeconds) === "1h" ? DEFAULT_1H : DEFAULT_5M
 }
 
 export * as BedrockCache from "./bedrock-cache.js"

--- a/packages/ai/src/protocols/utils/bedrock-cache.ts
+++ b/packages/ai/src/protocols/utils/bedrock-cache.ts
@@ -13,32 +13,29 @@ export const CachePointBlock = Schema.Struct({
 })
 export type CachePointBlock = Schema.Schema.Type<typeof CachePointBlock>
 
+const LEGACY_CLAUDE = ["anthropic.claude-instant", "anthropic.claude-v1", "anthropic.claude-v2", "anthropic.claude-3-"]
+
 // These legacy Claude releases support explicit caching, but only for five minutes.
-const CLAUDE_5M = new Set([
+const CLAUDE_5M = [
   "anthropic.claude-3-5-sonnet-20241022-v2:0",
   "anthropic.claude-3-5-haiku-20241022-v1:0",
   "anthropic.claude-3-7-sonnet-20250219-v1:0",
   "anthropic.claude-sonnet-4-20250514-v1:0",
   "anthropic.claude-opus-4-20250514-v1:0",
   "anthropic.claude-opus-4-1-20250805-v1:0",
-])
+]
 
 // Callers share the four-breakpoint budget across system, messages, and tools.
 export const BEDROCK_BREAKPOINT_CAP = 4
 
 export const breakpoints = (modelID: string) => {
-  // Foundation-model and system inference-profile ARNs carry the model ID.
-  // Opaque application profiles cannot establish explicit caching support.
-  const id = modelID
-    .replace(/^arn:[^:]+:bedrock:[^:]*:[^:]*:(?:foundation-model|inference-profile)\//, "")
-    .replace(/^(?:[a-z]{2}|apac|global)\./, "")
-  const short = CLAUDE_5M.has(id)
+  // Substring matching also handles regional prefixes and model-bearing ARNs.
+  const short = CLAUDE_5M.some((id) => modelID.includes(id))
   return {
     ...newBreakpoints(BEDROCK_BREAKPOINT_CAP),
     // Assume modern Claude releases retain caching support; older generations need an explicit exception.
     // Other model families use implicit caching where available.
-    supported:
-      id.startsWith("anthropic.claude-") && (short || !/^anthropic\.claude-(?:instant|v[12]|3)(?:[-:]|$)/.test(id)),
+    supported: modelID.includes("anthropic.claude-") && (short || !LEGACY_CLAUDE.some((id) => modelID.includes(id))),
     ttl1h: !short,
   }
 }

--- a/packages/ai/test/provider/bedrock-converse-cache.test.ts
+++ b/packages/ai/test/provider/bedrock-converse-cache.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { CacheHint, LLM, Message, ToolCallPart } from "../../src/index.js"
+import { AmazonBedrock, AmazonBedrockMantle } from "../../src/providers.js"
+import { compileRequest } from "../../src/route/client.js"
+import { it } from "../lib/effect.js"
+
+const bedrock = AmazonBedrock.configure({ apiKey: "fixture" })
+
+describe("Bedrock Converse model-specific cache support", () => {
+  for (const id of [
+    "deepseek.r1-v1:0",
+    "meta.llama3-3-70b-instruct-v1:0",
+    "mistral.mistral-large-2402-v1:0",
+    "qwen.qwen3-coder-480b-a35b-v1:0",
+    "openai.gpt-oss-120b-1:0",
+    "cohere.command-r-v1:0",
+    "anthropic.claude-v2:1",
+    "anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "amazon.nova-unknown-v1:0",
+    "custom-model",
+    "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
+  ]) {
+    for (const policy of [undefined, "auto", "none", { tools: true, system: true, messages: { tail: 3 } }] as const) {
+      it.effect(`omits unsupported checkpoints for ${id} (${JSON.stringify(policy)})`, () =>
+        Effect.gen(function* () {
+          // Exercise both automatic placement and manual hints at every lowering site.
+          const cache = policy === "none" ? new CacheHint({ type: "ephemeral", ttlSeconds: 3600 }) : undefined
+          const prepared = yield* compileRequest(
+            LLM.request({
+              model: bedrock.model(id),
+              cache: policy,
+              system: [{ type: "text", text: "System prefix", cache }],
+              tools: [{ name: "lookup", description: "Lookup", inputSchema: { type: "object" }, cache }],
+              messages: [
+                Message.user([{ type: "text", text: "Question", cache }]),
+                Message.system([{ type: "text", text: "Update", cache }]),
+                Message.assistant([
+                  { type: "text", text: "Answer", cache },
+                  { type: "reasoning", text: "Unsigned reasoning", cache },
+                  ToolCallPart.make({ id: "call_1", name: "lookup", input: {} }),
+                ]),
+                Message.tool({ id: "call_1", name: "lookup", result: "Result", cache }),
+              ],
+            }),
+          )
+
+          expect(JSON.stringify(prepared.body)).not.toContain("cachePoint")
+          expect(prepared.body).toMatchObject({
+            modelId: id,
+            system: [{ text: "System prefix" }],
+            toolConfig: { tools: [{ toolSpec: { name: "lookup" } }] },
+            messages: [
+              { role: "user", content: [{ text: "Question" }, { text: "<system-update>\nUpdate\n</system-update>" }] },
+              {
+                role: "assistant",
+                content: [{ text: "Answer" }, { text: "Unsigned reasoning" }, { toolUse: { name: "lookup" } }],
+              },
+              { role: "user", content: [{ toolResult: { content: [{ json: "Result" }] } }] },
+            ],
+          })
+        }),
+      )
+    }
+  }
+
+  for (const [id, ttl] of [
+    ["anthropic.claude-3-5-sonnet-20241022-v2:0", undefined],
+    ["us.anthropic.claude-3-5-haiku-20241022-v1:0", undefined],
+    ["eu.anthropic.claude-3-7-sonnet-20250219-v1:0", undefined],
+    ["apac.anthropic.claude-sonnet-4-20250514-v1:0", undefined],
+    ["anthropic.claude-opus-4-1-20250805-v1:0", undefined],
+    ["anthropic.claude-sonnet-4-5-20250929-v1:0", "1h"],
+    ["us.anthropic.claude-haiku-4-5-20251001-v1:0", "1h"],
+    ["global.anthropic.claude-opus-4-6-v1", "1h"],
+    ["anthropic.claude-opus-4-8", "1h"],
+    ["anthropic.claude-sonnet-5", "1h"],
+    ["anthropic.claude-fable-5-1", "1h"],
+    ["arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6", "1h"],
+    ["arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6", "1h"],
+  ] as const) {
+    it.effect(`preserves supported Claude checkpoints and TTL for ${id}`, () =>
+      Effect.gen(function* () {
+        const prepared = yield* compileRequest(
+          LLM.request({
+            model: bedrock.model(id),
+            system: [
+              { type: "text", text: "Agent" },
+              { type: "text", text: "Project" },
+            ],
+            tools: [{ name: "lookup", description: "Lookup", inputSchema: { type: "object" } }],
+            prompt: "Question",
+            cache: { tools: true, system: true, messages: { tail: 1 }, ttlSeconds: 3600 },
+          }),
+        )
+        const marker = { cachePoint: ttl === undefined ? { type: "default" } : { type: "default", ttl } }
+
+        expect(prepared.body).toMatchObject({
+          modelId: id,
+          toolConfig: { tools: [{ toolSpec: { name: "lookup" } }, marker] },
+          system: [{ text: "Agent" }, marker, { text: "Project" }, marker],
+          messages: [{ role: "user", content: [{ text: "Question" }, marker] }],
+        })
+      }),
+    )
+  }
+
+  for (const id of [
+    "amazon.nova-micro-v1:0",
+    "us.amazon.nova-lite-v1:0",
+    "eu.amazon.nova-pro-v1:0",
+    "amazon.nova-premier-v1:0",
+    "jp.amazon.nova-2-lite-v1:0",
+    "global.amazon.nova-2-lite-v1:0",
+  ]) {
+    it.effect(`limits Nova checkpoints to system/messages with the default TTL for ${id}`, () =>
+      Effect.gen(function* () {
+        const prepared = yield* compileRequest(
+          LLM.request({
+            model: bedrock.model(id),
+            system: "System prefix",
+            tools: [{ name: "lookup", description: "Lookup", inputSchema: { type: "object" } }],
+            prompt: "Question",
+            cache: { tools: true, system: true, messages: { tail: 1 }, ttlSeconds: 3600 },
+          }),
+        )
+
+        expect(prepared.body).toMatchObject({
+          toolConfig: { tools: [{ toolSpec: { name: "lookup" } }] },
+          system: [{ text: "System prefix" }, { cachePoint: { type: "default" } }],
+          messages: [{ role: "user", content: [{ text: "Question" }, { cachePoint: { type: "default" } }] }],
+        })
+      }),
+    )
+  }
+
+  it.effect("unsupported Nova tool checkpoints do not consume the message checkpoint budget", () =>
+    Effect.gen(function* () {
+      const cache = new CacheHint({ type: "ephemeral", ttlSeconds: 3600 })
+      const prepared = yield* compileRequest(
+        LLM.request({
+          model: bedrock.model("amazon.nova-lite-v1:0"),
+          cache: "none",
+          tools: ["one", "two", "three", "four"].map((name) => ({
+            name,
+            description: name,
+            inputSchema: { type: "object" },
+            cache,
+          })),
+          system: [{ type: "text", text: "System prefix", cache }],
+          messages: [
+            Message.user("Question"),
+            Message.assistant([ToolCallPart.make({ id: "call_1", name: "one", input: {} })]),
+            Message.tool({ id: "call_1", name: "one", result: "Result", cache }),
+          ],
+        }),
+      )
+
+      expect(JSON.stringify(prepared.body.toolConfig)).not.toContain("cachePoint")
+      expect(prepared.body.system).toEqual([{ text: "System prefix" }, { cachePoint: { type: "default" } }])
+      expect(prepared.body.messages.at(-1)).toMatchObject({
+        role: "user",
+        content: [{ toolResult: { toolUseId: "call_1" } }, { cachePoint: { type: "default" } }],
+      })
+    }),
+  )
+
+  for (const api of ["chat", "responses"] as const) {
+    it.effect(`Mantle ${api} does not emit Converse checkpoints`, () =>
+      Effect.gen(function* () {
+        const prepared = yield* compileRequest(
+          LLM.request({
+            model: AmazonBedrockMantle.configure({ apiKey: "fixture" })[api]("openai.gpt-oss-120b"),
+            system: "System prefix",
+            prompt: "Question",
+          }),
+        )
+        expect(JSON.stringify(prepared.body)).not.toContain("cachePoint")
+      }),
+    )
+  }
+})

--- a/packages/ai/test/provider/bedrock-converse-cache.test.ts
+++ b/packages/ai/test/provider/bedrock-converse-cache.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect } from "bun:test"
 import { Effect } from "effect"
 import { CacheHint, LLM, Message, ToolCallPart } from "../../src/index.js"
-import { AmazonBedrock, AmazonBedrockMantle } from "../../src/providers.js"
+import { AmazonBedrock } from "../../src/providers.js"
 import { compileRequest } from "../../src/route/client.js"
 import { it } from "../lib/effect.js"
 
 const bedrock = AmazonBedrock.configure({ apiKey: "fixture" })
 
-describe("Bedrock Converse model-specific cache support", () => {
+describe("Bedrock Converse cache policy", () => {
   for (const id of [
     "deepseek.r1-v1:0",
     "meta.llama3-3-70b-instruct-v1:0",
@@ -15,15 +15,21 @@ describe("Bedrock Converse model-specific cache support", () => {
     "qwen.qwen3-coder-480b-a35b-v1:0",
     "openai.gpt-oss-120b-1:0",
     "cohere.command-r-v1:0",
+    "anthropic.claude-instant-v1",
+    "anthropic.claude-v1",
+    "anthropic.claude-v2",
     "anthropic.claude-v2:1",
     "anthropic.claude-3-haiku-20240307-v1:0",
+    "anthropic.claude-3-sonnet-20240229-v1:0",
+    "anthropic.claude-3-opus-20240229-v1:0",
     "anthropic.claude-3-5-sonnet-20240620-v1:0",
-    "amazon.nova-unknown-v1:0",
+    "amazon.nova-lite-v1:0",
+    "global.amazon.nova-2-lite-v1:0",
     "custom-model",
     "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/abc123",
   ]) {
     for (const policy of [undefined, "auto", "none", { tools: true, system: true, messages: { tail: 3 } }] as const) {
-      it.effect(`omits unsupported checkpoints for ${id} (${JSON.stringify(policy)})`, () =>
+      it.effect(`omits checkpoints for ${id} (${JSON.stringify(policy)})`, () =>
         Effect.gen(function* () {
           // Exercise both automatic placement and manual hints at every lowering site.
           const cache = policy === "none" ? new CacheHint({ type: "ephemeral", ttlSeconds: 3600 }) : undefined
@@ -70,114 +76,44 @@ describe("Bedrock Converse model-specific cache support", () => {
     ["us.anthropic.claude-3-5-haiku-20241022-v1:0", undefined],
     ["eu.anthropic.claude-3-7-sonnet-20250219-v1:0", undefined],
     ["apac.anthropic.claude-sonnet-4-20250514-v1:0", undefined],
+    ["anthropic.claude-opus-4-20250514-v1:0", undefined],
     ["anthropic.claude-opus-4-1-20250805-v1:0", undefined],
     ["anthropic.claude-sonnet-4-5-20250929-v1:0", "1h"],
-    ["us.anthropic.claude-haiku-4-5-20251001-v1:0", "1h"],
-    ["global.anthropic.claude-opus-4-6-v1", "1h"],
-    ["anthropic.claude-opus-4-8", "1h"],
-    ["anthropic.claude-sonnet-5", "1h"],
-    ["anthropic.claude-fable-5-1", "1h"],
+    ["global.anthropic.claude-sonnet-99", "1h"],
+    ["anthropic.claude-new-family-99", "1h"],
     ["arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-sonnet-4-6", "1h"],
     ["arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-6", "1h"],
   ] as const) {
-    it.effect(`preserves supported Claude checkpoints and TTL for ${id}`, () =>
-      Effect.gen(function* () {
-        const prepared = yield* compileRequest(
-          LLM.request({
-            model: bedrock.model(id),
-            system: [
-              { type: "text", text: "Agent" },
-              { type: "text", text: "Project" },
-            ],
-            tools: [{ name: "lookup", description: "Lookup", inputSchema: { type: "object" } }],
-            prompt: "Question",
-            cache: { tools: true, system: true, messages: { tail: 1 }, ttlSeconds: 3600 },
-          }),
-        )
-        const marker = { cachePoint: ttl === undefined ? { type: "default" } : { type: "default", ttl } }
+    for (const ttlSeconds of [undefined, 3600]) {
+      it.effect(`preserves Claude checkpoints for ${id} (TTL: ${ttlSeconds ?? "default"})`, () =>
+        Effect.gen(function* () {
+          const prepared = yield* compileRequest(
+            LLM.request({
+              model: bedrock.model(id),
+              system: [
+                { type: "text", text: "Agent" },
+                { type: "text", text: "Project" },
+              ],
+              tools: [{ name: "lookup", description: "Lookup", inputSchema: { type: "object" } }],
+              prompt: "Question",
+              cache:
+                ttlSeconds === undefined ? undefined : { tools: true, system: true, messages: { tail: 1 }, ttlSeconds },
+            }),
+          )
+          const marker = {
+            cachePoint: ttlSeconds === undefined || ttl === undefined ? { type: "default" } : { type: "default", ttl },
+          }
 
-        expect(prepared.body).toMatchObject({
-          modelId: id,
-          toolConfig: { tools: [{ toolSpec: { name: "lookup" } }, marker] },
-          system: [{ text: "Agent" }, marker, { text: "Project" }, marker],
-          messages: [{ role: "user", content: [{ text: "Question" }, marker] }],
-        })
-      }),
-    )
-  }
-
-  for (const id of [
-    "amazon.nova-micro-v1:0",
-    "us.amazon.nova-lite-v1:0",
-    "eu.amazon.nova-pro-v1:0",
-    "amazon.nova-premier-v1:0",
-    "jp.amazon.nova-2-lite-v1:0",
-    "global.amazon.nova-2-lite-v1:0",
-  ]) {
-    it.effect(`limits Nova checkpoints to system/messages with the default TTL for ${id}`, () =>
-      Effect.gen(function* () {
-        const prepared = yield* compileRequest(
-          LLM.request({
-            model: bedrock.model(id),
-            system: "System prefix",
-            tools: [{ name: "lookup", description: "Lookup", inputSchema: { type: "object" } }],
-            prompt: "Question",
-            cache: { tools: true, system: true, messages: { tail: 1 }, ttlSeconds: 3600 },
-          }),
-        )
-
-        expect(prepared.body).toMatchObject({
-          toolConfig: { tools: [{ toolSpec: { name: "lookup" } }] },
-          system: [{ text: "System prefix" }, { cachePoint: { type: "default" } }],
-          messages: [{ role: "user", content: [{ text: "Question" }, { cachePoint: { type: "default" } }] }],
-        })
-      }),
-    )
-  }
-
-  it.effect("unsupported Nova tool checkpoints do not consume the message checkpoint budget", () =>
-    Effect.gen(function* () {
-      const cache = new CacheHint({ type: "ephemeral", ttlSeconds: 3600 })
-      const prepared = yield* compileRequest(
-        LLM.request({
-          model: bedrock.model("amazon.nova-lite-v1:0"),
-          cache: "none",
-          tools: ["one", "two", "three", "four"].map((name) => ({
-            name,
-            description: name,
-            inputSchema: { type: "object" },
-            cache,
-          })),
-          system: [{ type: "text", text: "System prefix", cache }],
-          messages: [
-            Message.user("Question"),
-            Message.assistant([ToolCallPart.make({ id: "call_1", name: "one", input: {} })]),
-            Message.tool({ id: "call_1", name: "one", result: "Result", cache }),
-          ],
+          expect(prepared.body).toMatchObject({
+            modelId: id,
+            toolConfig: { tools: [{ toolSpec: { name: "lookup" } }, marker] },
+            system: [{ text: "Agent" }, marker, { text: "Project" }, marker],
+            messages: [{ role: "user", content: [{ text: "Question" }, marker] }],
+          })
+          if (ttlSeconds === undefined || ttl === undefined)
+            expect(JSON.stringify(prepared.body)).not.toContain('"ttl"')
         }),
       )
-
-      expect(JSON.stringify(prepared.body.toolConfig)).not.toContain("cachePoint")
-      expect(prepared.body.system).toEqual([{ text: "System prefix" }, { cachePoint: { type: "default" } }])
-      expect(prepared.body.messages.at(-1)).toMatchObject({
-        role: "user",
-        content: [{ toolResult: { toolUseId: "call_1" } }, { cachePoint: { type: "default" } }],
-      })
-    }),
-  )
-
-  for (const api of ["chat", "responses"] as const) {
-    it.effect(`Mantle ${api} does not emit Converse checkpoints`, () =>
-      Effect.gen(function* () {
-        const prepared = yield* compileRequest(
-          LLM.request({
-            model: AmazonBedrockMantle.configure({ apiKey: "fixture" })[api]("openai.gpt-oss-120b"),
-            system: "System prefix",
-            prompt: "Question",
-          }),
-        )
-        expect(JSON.stringify(prepared.body)).not.toContain("cachePoint")
-      }),
-    )
+    }
   }
 })

--- a/packages/ai/test/provider/bedrock-converse.test.ts
+++ b/packages/ai/test/provider/bedrock-converse.test.ts
@@ -136,7 +136,7 @@ const captureHeaders = (target: LanguageModel) =>
 const model = AmazonBedrock.configure({
   baseURL: "https://bedrock-runtime.test",
   apiKey: "test-bearer",
-}).model("anthropic.claude-3-5-sonnet-20240620-v1:0")
+}).model("anthropic.claude-sonnet-4-5-20250929-v1:0")
 
 const baseRequest = LLM.request({
   id: "req_1",
@@ -155,7 +155,7 @@ describe("Bedrock Converse route", () => {
       const prepared = yield* compileRequest(baseRequest)
 
       expect(prepared.body).toEqual({
-        modelId: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+        modelId: "anthropic.claude-sonnet-4-5-20250929-v1:0",
         system: [{ text: "You are concise." }],
         messages: [{ role: "user", content: [{ text: "Say hello." }] }],
         inferenceConfig: { maxTokens: 64, temperature: 0 },


### PR DESCRIPTION
### Issue for this PR

No linked issue.

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Converse requests currently emit explicit cache checkpoints for every model when automatic caching is enabled. Models without checkpoint support can reject those requests.

- Limit automatic and manual checkpoints to Claude, with a five-minute default. Nova and other model families use implicit caching where available.
- Recognize new Claude releases by family instead of listing release IDs. Hardcode only legacy support and five-minute-only exceptions; modern models accept one hour when requested.
- Handle regional/global prefixes and model-bearing ARNs. Opaque profiles omit checkpoints because their underlying model is unknown.

### How did you verify your code works?

- 194 tests passed across the cache policy, Converse, cache defaults and legacy exceptions, recorded cache write/read, and Mantle suites. Coverage includes unlisted future Claude generations and family names.
- `bun typecheck` passed in `packages/ai`.
- Formatting and diff checks passed. Lint reported no errors and seven existing warnings.

### Screenshots / recordings

Not applicable.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
