### PR TITLE
docs: add opencode-kevin to ecosystem

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -55,7 +55,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-jfrog-plugin](https://github.com/jfrog/opencode-jfrog-plugin)                            | JFrog Plugin for seamless integration of Opencode users to JFrog platform                          |
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
-
+| [opencode-kevin](https://github.com/jmtrin/opencode-kevin)                                         | Local-first memory plugin that learns, recalls, and curates knowledge from coding sessions         |
 ---
 
 ## Projects

--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -56,6 +56,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [opencode-goal-plugin](https://github.com/willytop8/OpenCode-goal-plugin)                          | Session-scoped `/goal` workflow that keeps objectives in context and auto-continues until complete |
 | [opencode-tavily](https://github.com/tavily-ai/opencode-tavily)                                    | Web search, extraction, crawling, and deep research via the Tavily CLI                             |
 | [opencode-kevin](https://github.com/jmtrin/opencode-kevin)                                         | Local-first memory plugin that learns, recalls, and curates knowledge from coding sessions         |
+
 ---
 
 ## Projects


### PR DESCRIPTION
### Issue for this PR

Closes #47667

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds `opencode-kevin` to the OpenCode Ecosystem under Plugins.

Kevin is a local-first memory plugin for OpenCode that learns from coding sessions, recalls relevant knowledge, and curates durable project guidance.

This PR only updates ecosystem documentation and adds a community-project disclaimer to the Kevin README.

### How did you verify your code works?

Verified that the ecosystem entry points to the correct repository and that the documentation and installation instructions are available.

### Screenshots / recordings

N/A, docs only.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
