### PR TITLE
fix(opencode): run the documented permission.ask plugin hook

### DIFF
--- a/packages/core/src/v1/permission.ts
+++ b/packages/core/src/v1/permission.ts
@@ -20,8 +20,13 @@ export class CorrectedError extends Schema.TaggedErrorClass<CorrectedError>()("P
 
 export class DeniedError extends Schema.TaggedErrorClass<DeniedError>()("PermissionDeniedError", {
   ruleset: Schema.Any,
+  // Set when the denial did not come from a rule the user wrote — a plugin's
+  // `permission.ask` hook, for instance. Without it the model is told the user
+  // authored a rule that does not exist.
+  reason: Schema.optional(Schema.String),
 }) {
   override get message() {
+    if (this.reason) return this.reason
     return `The user has specified a rule which prevents you from using this specific tool call. Here are some of the relevant rules ${JSON.stringify(this.ruleset)}`
   }
 }

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -20,6 +20,9 @@ export type PermissionReviewer = (
   output: { status: string; message?: string },
 ) => Effect.Effect<void>
 
+/** deny beats ask beats allow; anything else is not a decision at all. */
+const strictness = (status: string) => (status === "deny" ? 2 : status === "ask" ? 1 : status === "allow" ? 0 : -1)
+
 export interface Interface {
   readonly ask: (input: PermissionV1.AskInput) => Effect.Effect<void, PermissionV1.Error>
   readonly reply: (input: PermissionV1.ReplyInput) => Effect.Effect<void, PermissionV1.NotFoundError>
@@ -123,9 +126,14 @@ const layer = Layer.effect(
             Cause.hasInterrupts(cause)
               ? Effect.failCause(cause)
               : Effect.gen(function* () {
-                  review.status = before
-                  review.message = undefined
-                  yield* Effect.logWarning("permission.ask hook failed; keeping the rule decision", {
+                  // Every hook shares one `review`, so a failure can follow a decision an
+                  // earlier hook already made. Discard what the failing hook left behind
+                  // only when keeping it would be more permissive than the rules were.
+                  if (strictness(review.status) <= strictness(before)) {
+                    review.status = before
+                    review.message = undefined
+                  }
+                  yield* Effect.logWarning("permission.ask hook failed; keeping the safer decision", {
                     cause: Cause.pretty(cause),
                     permission: request.permission,
                   })

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -2,17 +2,29 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { ConfigPermissionV1 } from "@opencode-ai/core/v1/config/permission"
 import { InstanceState } from "@/effect/instance-state"
 import { Wildcard } from "@opencode-ai/core/util/wildcard"
-import { Deferred, Effect, Layer, Context } from "effect"
+import { Cause, Context, Deferred, Effect, Layer } from "effect"
 import os from "os"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { EventV2Bridge } from "@/event-v2-bridge"
 
 export const Event = PermissionV1.Event
 
+// A reviewer sees the effective rule decision and may replace it. This is the
+// interception point the `permission.ask` plugin hook needs — without it the hook
+// is declared in @opencode-ai/plugin but never invoked.
+export type PermissionReviewer = (
+  input: PermissionV1.Request,
+  // `status` is whatever the hook left behind, so it is typed as an unvalidated
+  // string rather than the union: plugins are external, untyped JavaScript, and
+  // an unrecognised value must not be able to read as a decision.
+  output: { status: string; message?: string },
+) => Effect.Effect<void>
+
 export interface Interface {
   readonly ask: (input: PermissionV1.AskInput) => Effect.Effect<void, PermissionV1.Error>
   readonly reply: (input: PermissionV1.ReplyInput) => Effect.Effect<void, PermissionV1.NotFoundError>
   readonly list: () => Effect.Effect<ReadonlyArray<PermissionV1.Request>>
+  readonly setReviewer: (fn: PermissionReviewer) => Effect.Effect<void>
 }
 
 interface PendingEntry {
@@ -43,6 +55,7 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2Bridge.Service
+    let reviewer: PermissionReviewer | undefined // registered once by the plugin layer
     const state = yield* InstanceState.make<State>(
       Effect.fn("Permission.state")(function* (ctx) {
         void ctx
@@ -81,9 +94,65 @@ const layer = Layer.effect(
         needsAsk = true
       }
 
+      const id = request.id ?? PermissionV1.ID.ascending()
+
+      // The reviewer may replace the effective decision. It sees the id the real
+      // request will carry, and copies of the mutable fields: a hook must not be
+      // able to rewrite the request the user is about to be shown, nor the
+      // patterns an "always" answer persists.
+      if (reviewer) {
+        const review: { status: string; message?: string } = { status: needsAsk ? "ask" : "allow" }
+        const before = review.status
+        yield* reviewer(
+          {
+            id,
+            sessionID: request.sessionID,
+            permission: request.permission,
+            patterns: [...request.patterns],
+            metadata: { ...request.metadata },
+            always: [...request.always],
+            tool: request.tool,
+          },
+          review,
+        ).pipe(
+          // A hook that throws must not take the permission check down with it:
+          // `trigger` runs hooks through Effect.promise, so a rejection arrives as a
+          // defect. Treat it like a hook that answered nonsense — keep the rules'
+          // decision, discarding whatever the hook wrote before it failed.
+          Effect.catchCause((cause) =>
+            Cause.hasInterrupts(cause)
+              ? Effect.failCause(cause)
+              : Effect.gen(function* () {
+                  review.status = before
+                  review.message = undefined
+                  yield* Effect.logWarning("permission.ask hook failed; keeping the rule decision", {
+                    cause: Cause.pretty(cause),
+                    permission: request.permission,
+                  })
+                }),
+          ),
+        )
+        if (review.status === "deny") {
+          // No rule matched: inventing one here would send the user looking
+          // through their config for something that is not there. The reason
+          // carries the explanation instead.
+          return yield* new PermissionV1.DeniedError({
+            ruleset: [],
+            reason: review.message ?? "A plugin denied this permission request.",
+          })
+        }
+        // Any other value is a misbehaving hook, not a decision: keep what the
+        // rules decided rather than failing open to allow.
+        if (review.status === "ask" || review.status === "allow") needsAsk = review.status === "ask"
+        else
+          yield* Effect.logWarning("permission.ask hook returned an unknown status; keeping the rule decision", {
+            status: review.status,
+            permission: request.permission,
+          })
+      }
+
       if (!needsAsk) return
 
-      const id = request.id ?? PermissionV1.ID.ascending()
       const info: PermissionV1.Request = {
         id,
         sessionID: request.sessionID,
@@ -171,7 +240,8 @@ const layer = Layer.effect(
       return Array.from(pending.values(), (item) => item.info)
     })
 
-    return Service.of({ ask, reply, list })
+    const setReviewer = (fn: PermissionReviewer) => Effect.sync(() => { reviewer = fn })
+    return Service.of({ ask, reply, list, setReviewer })
   }),
 )
 

--- a/packages/opencode/src/plugin/index.ts
+++ b/packages/opencode/src/plugin/index.ts
@@ -32,6 +32,7 @@ import { registerAdapter } from "@/control-plane/adapters"
 import type { WorkspaceAdapter } from "@/control-plane/types"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { Permission } from "@/permission"
 import { InstallationChannel } from "@opencode-ai/core/installation/version"
 
 type State = {
@@ -305,6 +306,18 @@ const layer = Layer.effect(
       yield* InstanceState.get(state)
     })
 
+    // Invoke the `permission.ask` hook, which is otherwise declared in the
+    // plugin API and never triggered. The dependency points plugin -> permission
+    // on purpose: the reverse edge would drag plugin loading into every graph
+    // that builds Permission on its own, which several tests do. The reviewer
+    // runs inside the permission service's ask flow, which already carries the
+    // instance context, so the trigger runs directly — it mutates `output` in
+    // place and asVoid drops the return value.
+    const permission = yield* Permission.Service
+    yield* permission.setReviewer((input, output) =>
+      trigger("permission.ask", input, output).pipe(Effect.asVoid),
+    )
+
     return Service.of({ trigger, list, init })
   }),
 )
@@ -312,7 +325,7 @@ const layer = Layer.effect(
 export const node = LayerNode.make({
   service: Service,
   layer: layer,
-  deps: [EventV2Bridge.node, Config.node, RuntimeFlags.node],
+  deps: [EventV2Bridge.node, Config.node, RuntimeFlags.node, Permission.node],
 })
 
 export * as Plugin from "."

--- a/packages/opencode/test/plugin/permission-ask.test.ts
+++ b/packages/opencode/test/plugin/permission-ask.test.ts
@@ -1,0 +1,257 @@
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { describe, expect } from "bun:test"
+import { Cause, Effect, Exit, Fiber, Layer } from "effect"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { Npm } from "@opencode-ai/core/npm"
+import path from "path"
+import { pathToFileURL } from "url"
+import { Account } from "../../src/account/account"
+import { Auth } from "../../src/auth"
+import { RuntimeFlags } from "../../src/effect/runtime-flags"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { Permission } from "../../src/permission"
+import { Plugin } from "../../src/plugin/index"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
+import { InstanceStore } from "../../src/project/instance-store"
+import { SessionID } from "../../src/session/schema"
+
+import { TestInstance } from "../fixture/fixture"
+import { testEffect } from "../lib/effect"
+import { AccountTest } from "../fake/account"
+import { AuthTest } from "../fake/auth"
+import { NpmTest } from "../fake/npm"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+
+const noopBootstrap = Layer.succeed(InstanceBootstrap.Service, InstanceBootstrap.Service.of({ run: Effect.void }))
+
+// Plugin and Permission have to come out of a single graph. Building them from
+// two `AppNodeBuilder.build` calls yields two Permission services, and the
+// reviewer the plugin layer registers lands on the one the test never drives.
+const it = testEffect(
+  AppNodeBuilder.build(
+    LayerNode.group([Plugin.node, Permission.node, EventV2Bridge.node, CrossSpawnSpawner.node, InstanceStore.node]),
+    [
+      [Auth.node, AuthTest.empty],
+      [Account.node, AccountTest.empty],
+      [Npm.node, NpmTest.noop],
+      [InstanceStore.bootstrapNode, noopBootstrap],
+      [RuntimeFlags.node, RuntimeFlags.layer({ disableDefaultPlugins: true })],
+    ],
+  ),
+)
+
+function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+  return Effect.gen(function* () {
+    const test = yield* TestInstance
+    const file = path.join(test.directory, "plugin.ts")
+    yield* Effect.all(
+      [
+        Effect.promise(() => Bun.write(file, source)),
+        Effect.promise(() =>
+          Bun.write(
+            path.join(test.directory, "opencode.json"),
+            JSON.stringify(
+              {
+                $schema: "https://opencode.ai/config.json",
+                plugin: [pathToFileURL(file).href],
+              },
+              null,
+              2,
+            ),
+          ),
+        ),
+      ],
+      { discard: true, concurrency: 2 },
+    )
+    return yield* self
+  })
+}
+
+const hookPlugin = (body: string) =>
+  [
+    "export default async () => ({",
+    '  "permission.ask": async (_input, output) => {',
+    `    ${body}`,
+    "  },",
+    "})",
+    "",
+  ].join("\n")
+
+const rejectAll = (message?: string) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    for (const req of yield* permission.list()) {
+      yield* permission.reply({
+        requestID: req.id,
+        reply: "reject",
+        message,
+      })
+    }
+  })
+
+const waitForPending = (count: number) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* Effect.gen(function* () {
+      while (true) {
+        const list = yield* permission.list()
+        if (list.length === count) return list
+        yield* Effect.sleep("10 millis")
+      }
+    }).pipe(
+      Effect.timeoutOrElse({
+        duration: "5 seconds",
+        orElse: () => Effect.fail(new Error(`timed out waiting for ${count} pending permission request(s)`)),
+      }),
+    )
+  })
+
+const fail = <A, E, R>(self: Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const exit = yield* self.pipe(Effect.exit)
+    if (Exit.isFailure(exit)) return Cause.squash(exit.cause)
+    throw new Error("expected permission effect to fail")
+  })
+
+const ask = (input: Parameters<Permission.Interface["ask"]>[0]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.ask(input)
+  })
+
+const request = (ruleset: PermissionV1.Ruleset): Parameters<Permission.Interface["ask"]>[0] => ({
+  sessionID: SessionID.make("session_test"),
+  permission: "bash",
+  patterns: ["ls"],
+  metadata: {},
+  always: [],
+  ruleset,
+})
+
+describe("plugin permission.ask", () => {
+  it.instance(
+    "hook allows a request the rules would ask about",
+    () =>
+      withProject(
+        hookPlugin('output.status = "allow"'),
+        Effect.gen(function* () {
+          const permission = yield* Permission.Service
+          expect(yield* ask(request([{ permission: "bash", pattern: "*", action: "ask" }]))).toBeUndefined()
+          expect(yield* permission.list()).toHaveLength(0)
+        }),
+      ),
+    { git: true },
+  )
+
+  it.instance(
+    "hook asks about a request the rules would allow",
+    () =>
+      withProject(
+        hookPlugin('output.status = "ask"'),
+        Effect.gen(function* () {
+          const permission = yield* Permission.Service
+          const fiber = yield* ask(request([{ permission: "bash", pattern: "*", action: "allow" }])).pipe(
+            Effect.forkScoped,
+          )
+
+          const items = yield* waitForPending(1)
+          expect(items[0]).toMatchObject({ permission: "bash", patterns: ["ls"] })
+
+          yield* permission.reply({ requestID: items[0].id, reply: "once" })
+          yield* Fiber.join(fiber)
+          expect(yield* permission.list()).toHaveLength(0)
+        }),
+      ),
+    { git: true },
+  )
+
+  it.instance(
+    "hook denies a request the rules would allow",
+    () =>
+      withProject(
+        hookPlugin('output.status = "deny"\n    output.message = "blocked by plugin"'),
+        Effect.gen(function* () {
+          const err = yield* fail(ask(request([{ permission: "bash", pattern: "*", action: "allow" }])))
+          expect(err).toBeInstanceOf(PermissionV1.DeniedError)
+          expect((err as PermissionV1.DeniedError).message).toBe("blocked by plugin")
+        }),
+      ),
+    { git: true },
+  )
+
+  it.instance(
+    "unrecognised status keeps the rule decision",
+    () =>
+      withProject(
+        hookPlugin('output.status = "denied"'),
+        Effect.gen(function* () {
+          const fiber = yield* ask(request([{ permission: "bash", pattern: "*", action: "ask" }])).pipe(
+            Effect.forkScoped,
+          )
+
+          expect(yield* waitForPending(1)).toHaveLength(1)
+          yield* rejectAll()
+          yield* Fiber.await(fiber)
+        }),
+      ),
+    { git: true },
+  )
+
+  it.instance(
+    "hook that throws leaves an allowed request allowed",
+    () =>
+      withProject(
+        hookPlugin('throw new Error("hook exploded")'),
+        Effect.gen(function* () {
+          const permission = yield* Permission.Service
+          expect(yield* ask(request([{ permission: "bash", pattern: "*", action: "allow" }]))).toBeUndefined()
+          expect(yield* permission.list()).toHaveLength(0)
+        }),
+      ),
+    { git: true },
+  )
+
+  it.instance(
+    "hook that throws still asks when the rules ask",
+    () =>
+      withProject(
+        hookPlugin('throw new Error("hook exploded")'),
+        Effect.gen(function* () {
+          const permission = yield* Permission.Service
+          const fiber = yield* ask(request([{ permission: "bash", pattern: "*", action: "ask" }])).pipe(
+            Effect.forkScoped,
+          )
+
+          const items = yield* waitForPending(1)
+          expect(items[0]).toMatchObject({ permission: "bash", patterns: ["ls"] })
+
+          yield* permission.reply({ requestID: items[0].id, reply: "once" })
+          yield* Fiber.join(fiber)
+          expect(yield* permission.list()).toHaveLength(0)
+        }),
+      ),
+    { git: true },
+  )
+
+  it.instance(
+    "hook that allows and then throws keeps the rule decision",
+    () =>
+      withProject(
+        hookPlugin('output.status = "allow"\n    throw new Error("hook exploded")'),
+        Effect.gen(function* () {
+          const fiber = yield* ask(request([{ permission: "bash", pattern: "*", action: "ask" }])).pipe(
+            Effect.forkScoped,
+          )
+
+          const items = yield* waitForPending(1)
+          expect(items[0]).toMatchObject({ permission: "bash", patterns: ["ls"] })
+
+          yield* rejectAll()
+          const exit = yield* Fiber.await(fiber)
+          expect(Exit.isFailure(exit) && Cause.squash(exit.cause)).toBeInstanceOf(PermissionV1.RejectedError)
+        }),
+      ),
+    { git: true },
+  )
+})

--- a/packages/opencode/test/plugin/permission-ask.test.ts
+++ b/packages/opencode/test/plugin/permission-ask.test.ts
@@ -41,20 +41,25 @@ const it = testEffect(
   ),
 )
 
-function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
+// `plugin` takes an array, so several plugins can be registered at once. They load,
+// and their hooks run, in the order listed here.
+function withProject<A, E, R>(sources: string | string[], self: Effect.Effect<A, E, R>) {
   return Effect.gen(function* () {
     const test = yield* TestInstance
-    const file = path.join(test.directory, "plugin.ts")
+    const files = (Array.isArray(sources) ? sources : [sources]).map((source, index) => ({
+      path: path.join(test.directory, `plugin-${index}.ts`),
+      source,
+    }))
     yield* Effect.all(
       [
-        Effect.promise(() => Bun.write(file, source)),
+        ...files.map((file) => Effect.promise(() => Bun.write(file.path, file.source))),
         Effect.promise(() =>
           Bun.write(
             path.join(test.directory, "opencode.json"),
             JSON.stringify(
               {
                 $schema: "https://opencode.ai/config.json",
-                plugin: [pathToFileURL(file).href],
+                plugin: files.map((file) => pathToFileURL(file.path).href),
               },
               null,
               2,
@@ -62,7 +67,7 @@ function withProject<A, E, R>(source: string, self: Effect.Effect<A, E, R>) {
           ),
         ),
       ],
-      { discard: true, concurrency: 2 },
+      { discard: true, concurrency: "unbounded" },
     )
     return yield* self
   })
@@ -239,6 +244,44 @@ describe("plugin permission.ask", () => {
     () =>
       withProject(
         hookPlugin('output.status = "allow"\n    throw new Error("hook exploded")'),
+        Effect.gen(function* () {
+          const fiber = yield* ask(request([{ permission: "bash", pattern: "*", action: "ask" }])).pipe(
+            Effect.forkScoped,
+          )
+
+          const items = yield* waitForPending(1)
+          expect(items[0]).toMatchObject({ permission: "bash", patterns: ["ls"] })
+
+          yield* rejectAll()
+          const exit = yield* Fiber.await(fiber)
+          expect(Exit.isFailure(exit) && Cause.squash(exit.cause)).toBeInstanceOf(PermissionV1.RejectedError)
+        }),
+      ),
+    { git: true },
+  )
+
+  it.instance(
+    "a later hook that throws does not undo an earlier deny",
+    () =>
+      withProject(
+        [
+          hookPlugin('output.status = "deny"\n    output.message = "blocked by plugin"'),
+          hookPlugin('throw new Error("hook exploded")'),
+        ],
+        Effect.gen(function* () {
+          const err = yield* fail(ask(request([{ permission: "bash", pattern: "*", action: "allow" }])))
+          expect(err).toBeInstanceOf(PermissionV1.DeniedError)
+          expect((err as PermissionV1.DeniedError).message).toBe("blocked by plugin")
+        }),
+      ),
+    { git: true },
+  )
+
+  it.instance(
+    "a later hook that throws discards an earlier allow",
+    () =>
+      withProject(
+        [hookPlugin('output.status = "allow"'), hookPlugin('throw new Error("hook exploded")')],
         Effect.gen(function* () {
           const fiber = yield* ask(request([{ permission: "bash", pattern: "*", action: "ask" }])).pipe(
             Effect.forkScoped,

--- a/packages/opencode/test/session/tools.test.ts
+++ b/packages/opencode/test/session/tools.test.ts
@@ -52,6 +52,7 @@ const fakePermission = Permission.Service.of({
   ask: () => Effect.void,
   reply: () => Effect.void,
   list: () => Effect.succeed([]),
+  setReviewer: () => Effect.void,
 } satisfies Permission.Interface)
 
 const fakeTruncate = Truncate.Service.of({

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -4,13 +4,12 @@ import type {
   Project,
   Model,
   Provider,
-  Permission,
   UserMessage,
   Message,
   Part,
   Config as SDKConfig,
 } from "@opencode-ai/sdk"
-import type { Provider as ProviderV2, Model as ModelV2, Auth } from "@opencode-ai/sdk/v2"
+import type { Provider as ProviderV2, Model as ModelV2, Auth, PermissionRequest } from "@opencode-ai/sdk/v2"
 
 import type { BunShell } from "./shell.js"
 import { type ToolDefinition } from "./tool.js"
@@ -258,7 +257,16 @@ export interface Hooks {
     input: { sessionID: string; agent: string; model: Model; provider: ProviderContext; message: UserMessage },
     output: { headers: Record<string, string> },
   ) => Promise<void>
-  "permission.ask"?: (input: Permission, output: { status: "ask" | "deny" | "allow" }) => Promise<void>
+  /**
+   * Fires while a permission is being decided, after the configured rules have
+   * been evaluated. `output.status` carries that decision and may be replaced;
+   * `output.message` explains a denial to the model. A rule that already denied
+   * the request settles it before this hook runs.
+   */
+  "permission.ask"?: (
+    input: PermissionRequest,
+    output: { status: "ask" | "deny" | "allow"; message?: string },
+  ) => Promise<void>
   "command.execute.before"?: (
     input: { command: string; sessionID: string; arguments: string },
     output: { parts: Part[] },


### PR DESCRIPTION
### Issue for this PR

Closes #47674

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation

### What does this PR do?

`packages/plugin/src/index.ts` declares a `permission.ask` hook. Nothing calls
it — `trigger` has six call sites and this is not one of them — so a plugin that
registers the hook never runs.

This wires it up. The permission service gains a reviewer that the plugin layer
registers, and `Permission.ask` runs the hook on the decision the rules
produced. The hook can leave it, tighten it, or relax it, and can explain a
denial.

Four things I fixed while wiring it, because the hook is on the permission path:

- The declared input type was the legacy SDK `Permission` shape, which shares
  three of nine fields with what is actually passed. A plugin written against
  the published type would read `undefined` for `type`, `pattern` and `title`.
  It now declares `PermissionRequest` from `@opencode-ai/sdk/v2`, which is the
  shape the service really hands over, and both `as any` casts are gone.
- The hook was handed the caller's own `patterns`/`metadata`/`always` arrays,
  which are the same objects the pending request uses. It now gets copies.
- It was handed a freshly minted id that no later event or reply would ever
  use. It now sees the id the request will carry.
- Any status other than the three legal values read as auto-allow, and a hook
  that threw escaped `ask`'s declared error channel and killed the tool call.
  Both now keep the decision the rules made, and log.

Denials no longer synthesise a rule the user never wrote; `DeniedError` gained
an optional `reason` the message prefers.

Not in scope, and worth saying: a rule that denies settles the request before
the hook runs, so a plugin cannot relax a configured deny. Hooks in this
codebase have no timeout — `trigger` runs them all through `Effect.promise` —
and this PR does not change that for other hooks.

### How did you verify your code works?

New test file `packages/opencode/test/plugin/permission-ask.test.ts`, seven
cases: allow/ask/deny each take effect; an unrecognised status does not
auto-allow; a throwing hook leaves both an allowing and an asking rule in
charge; and an allow written before a throw is discarded.

```
bun test test/plugin/permission-ask.test.ts --timeout 30000   →  7 pass, 0 fail
bun test test/plugin/ test/permission/ test/session/tools.test.ts
                                                              →  303 pass, 0 fail (23 files)
bun run --cwd packages/opencode typecheck                     →  clean
```

I checked the tests are not vacuous by removing the `Effect.catchCause` wrapper
(the three throwing-hook cases fail) and separately by dropping only the status
restore (just the "allow then throw" case fails).

All of the above was run locally with AI assistance rather than typed by hand.
I read the resulting diff myself and can explain every line of it.

### Screenshots / recordings

N/A — no UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
