### PR TITLE
fix(app): stop the bootstrap queries from being refetched right after they load

### DIFF
--- a/packages/app/src/context/global-sync/bootstrap.test.ts
+++ b/packages/app/src/context/global-sync/bootstrap.test.ts
@@ -236,6 +236,31 @@ describe("query keys", () => {
     expect([...loadProvidersQuery(remote, null, api).queryKey]).toEqual(["https://debian.example", null, "providers"])
   })
 
+  test("maps both spellings of a Windows directory onto one entry", () => {
+    const client = {} as Parameters<typeof loadPathQuery>[2]
+    const api = {} as CatalogApi
+    const agents = {} as Parameters<typeof loadAgentsQuery>[2]
+
+    // Consumers reach these queries through `PathKey`, which normalises backslashes to slashes,
+    // while the bootstrap passes the raw directory. Unnormalised, the same directory lands under
+    // two cache entries and every consumer refetches what the bootstrap already loaded.
+    const backslash = "C:\\repo\\app"
+    const slash = "C:/repo/app"
+
+    expect([...loadPathQuery(ServerScope.local, backslash, client).queryKey]).toEqual([
+      ...loadPathQuery(ServerScope.local, slash, client).queryKey,
+    ])
+    expect([...loadProvidersQuery(ServerScope.local, backslash, api).queryKey]).toEqual([
+      ...loadProvidersQuery(ServerScope.local, slash, api).queryKey,
+    ])
+    expect([...loadAgentsQuery(ServerScope.local, backslash, agents).queryKey]).toEqual([
+      ...loadAgentsQuery(ServerScope.local, slash, agents).queryKey,
+    ])
+    expect([...loadReferencesQuery(ServerScope.local, backslash, {} as never).queryKey]).toEqual([
+      ...loadReferencesQuery(ServerScope.local, slash, {} as never).queryKey,
+    ])
+  })
+
   test("loads the current provider and model catalog", async () => {
     const calls: unknown[] = []
     const api = {

--- a/packages/app/src/context/global-sync/bootstrap.ts
+++ b/packages/app/src/context/global-sync/bootstrap.ts
@@ -24,6 +24,7 @@ import type {
   SessionApi,
 } from "@opencode-ai/client/promise"
 import { showToast } from "@/utils/toast"
+import { pathKey } from "@/utils/path-key"
 import { getFilename } from "@opencode-ai/core/util/path"
 import { retry } from "@opencode-ai/core/util/retry"
 import { batch } from "solid-js"
@@ -105,9 +106,22 @@ function showErrors(input: {
   })
 }
 
+// The bootstrap queries are requested by several consumers at once during startup — the global
+// bootstrap, the per-project bootstrap, the child store and the composer controls. Without a
+// staleTime every entry counts as stale the moment it is written, so each of those consumers
+// issues its own request for data that was just fetched.
+const BOOTSTRAP_STALE_TIME = 30_000
+
+// Consumers reach these queries through `PathKey`, which normalises backslashes to slashes,
+// while the bootstrap passes the raw directory it was handed. Without normalising here the same
+// directory lands under two cache entries on Windows, so every consumer refetches what the
+// bootstrap already loaded.
+const directoryKeyPart = (directory: string | null) => (directory === null ? null : pathKey(directory))
+
 export const loadGlobalConfigQuery = (scope: ServerScope, sdk: OpencodeClient, protocol?: Promise<ServerProtocol>) =>
   queryOptions({
     queryKey: [scope, "config"],
+    staleTime: BOOTSTRAP_STALE_TIME,
     queryFn: async () => {
       if ((await protocol) !== "v1") return {}
       return retry(() => sdk.global.config.get().then((x) => x.data!))
@@ -127,6 +141,7 @@ type VcsApi = ServerApi["vcs"]
 export const loadProjectsQuery = (scope: ServerScope, api: ProjectApi) =>
   queryOptions({
     queryKey: [scope, "project"],
+    staleTime: BOOTSTRAP_STALE_TIME,
     queryFn: () =>
       retry(() =>
         api.list().then((projects) => {
@@ -226,7 +241,8 @@ export const loadProvidersQuery = (
   protocol?: Promise<ServerProtocol>,
 ) =>
   queryOptions({
-    queryKey: [scope, directory, "providers"],
+    queryKey: [scope, directoryKeyPart(directory), "providers"],
+    staleTime: BOOTSTRAP_STALE_TIME,
     queryFn: () =>
       retry(async () => {
         if ((await protocol) === "v1" && legacy) {
@@ -263,7 +279,8 @@ export const loadAgentsQuery = (
   protocol?: Promise<ServerProtocol>,
 ) =>
   queryOptions({
-    queryKey: [scope, directory, "agents"],
+    queryKey: [scope, directoryKeyPart(directory), "agents"],
+    staleTime: BOOTSTRAP_STALE_TIME,
     queryFn: () =>
       retry(async () => {
         if ((await protocol) === "v1" && legacy) return normalizeAgentList((await legacy.app.agents()).data ?? [])
@@ -302,7 +319,8 @@ export const loadPathQuery = (
   protocol?: Promise<ServerProtocol>,
 ) =>
   queryOptions<Path>({
-    queryKey: [scope, directory, "path"],
+    queryKey: [scope, directoryKeyPart(directory), "path"],
+    staleTime: BOOTSTRAP_STALE_TIME,
     queryFn: async () => {
       if ((await protocol) !== "v1")
         return { state: "", config: "", worktree: "", directory: directory ?? "", home: "" }
@@ -318,7 +336,8 @@ export const loadReferencesQuery = (
   protocol?: Promise<ServerProtocol>,
 ) =>
   queryOptions<ReferenceInfo[]>({
-    queryKey: [scope, directory, "references"] as const,
+    queryKey: [scope, directoryKeyPart(directory), "references"] as const,
+    staleTime: BOOTSTRAP_STALE_TIME,
     queryFn: () =>
       retry(async () => {
         if ((await protocol) === "v1" && legacy) return (await legacy.v2.reference.list()).data?.data ?? []


### PR DESCRIPTION
### Issue for this PR

Closes #47681

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Two independent causes in `bootstrap.ts`, same effect: the app refetches data the bootstrap just
loaded.

**staleTime.** None of the bootstrap queries set one, so every entry is stale the moment it is
written and each consumer that mounts afterwards issues its own request. `BOOTSTRAP_STALE_TIME`
(30s) is applied to `config`, `project`, `providers`, `agents`, `path` and `references`. Thirty
seconds covers the startup burst without holding data past the point where a reload would matter;
all six are invalidated explicitly on the events that change them, so the window does not decide
freshness, only whether the same startup asks twice.

**Query key.** The directory-scoped keys were built from the raw directory the bootstrap was
handed, while consumers reach the same queries through the `PathKey` facade in `server-sync.tsx`,
which normalises backslashes to slashes. `bootstrapInstance` already computes `directoryKey()` for
its own bookkeeping but passes the raw path into `bootstrapDirectory`, so on Windows `C:\repo\app`
and `C:/repo/app` are two entries for one directory and the consumer side never hits what the
bootstrap loaded. `directoryKeyPart` puts the key through the same `pathKey` normalisation the
consumers use. Non-Windows paths are unchanged by `pathKey`, so this is a no-op there.

### How did you verify your code works?

New regression test in `packages/app/src/context/global-sync/bootstrap.test.ts`: both spellings of a
Windows directory map onto the same query key for `path`, `providers`, `agents` and `references`.
Verified it fails on unmodified `dev` — the two spellings produce different keys — and passes with
the change.

- `bun test --conditions=solid --preload ./happydom.ts src/context/global-sync/bootstrap.test.ts` in
  `packages/app`: 11 pass, 0 fail
- `tsgo -b` in `packages/app`: clean
- `prettier --check` on both changed files: clean
- `oxlint` on the changed file: 5 warnings, all present on `dev` before this change

The test file is additive against `dev`; no existing expectation was changed.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
