### PR TITLE
fix(app): drop every reference to a session once it is deleted

### DIFF
--- a/packages/app/src/app.tsx
+++ b/packages/app/src/app.tsx
@@ -28,6 +28,7 @@ import {
   createRenderEffect,
   createResource,
   createSignal,
+  catchError,
   ErrorBoundary,
   For,
   type JSX,
@@ -154,7 +155,14 @@ function LegacyTargetSessionRedirect() {
   )
 
   createEffect(() => {
-    const directory = current()?.session.directory
+    // `current()` throws when the session cannot be resolved. During render the enclosing
+    // SessionRouteErrorBoundary catches that and shows the scoped "not found" page; from inside
+    // an effect the throw bypasses it and reaches the global boundary, which replaces the whole
+    // window with "something went wrong" - for a chat that was merely deleted.
+    const directory = catchError(
+      () => current()?.session.directory,
+      () => undefined,
+    )
     if (!directory) return
     navigate(legacySessionHref(directory, params.id), { replace: true })
   })

--- a/packages/app/src/context/layout.tsx
+++ b/packages/app/src/context/layout.tsx
@@ -3,6 +3,7 @@ import { batch, createEffect, createMemo, onCleanup, onMount, type Accessor } fr
 import { useLocation } from "@solidjs/router"
 import { createSimpleContext } from "@opencode-ai/ui/context"
 import { makeEventListener } from "@solid-primitives/event-listener"
+import { readSessionTabsRemovedDetail, SESSION_TABS_REMOVED_EVENT } from "@/components/titlebar-session-events"
 import { useServerSync } from "./server-sync"
 import { useServerSDK } from "./server-sdk"
 import { RECENTLY_CLOSED_DISPLAY_LIMIT, ServerConnection, useServer } from "./server"
@@ -427,6 +428,17 @@ export const { use: useLayout, provider: LayoutProvider } = createSimpleContext(
 
       makeEventListener(window, "pagehide", flush)
       makeEventListener(document, "visibilitychange", handleVisibility)
+
+      // A deleted session must not leave anything pointing at it. The handoff carries a session
+      // id across a layout switch and is persisted; without this it survived the deletion and
+      // every later start tried to restore a session that no longer exists.
+      makeEventListener(window, SESSION_TABS_REMOVED_EVENT, (event) => {
+        const detail = readSessionTabsRemovedDetail(event)
+        const pending = store.handoff?.tabs
+        if (!detail || !pending) return
+        if (!detail.sessionIDs.includes(pending.id)) return
+        setStore("handoff", "tabs", undefined)
+      })
 
       onCleanup(() => {
         scroll.dispose()

--- a/packages/app/src/context/tabs.test.ts
+++ b/packages/app/src/context/tabs.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { createRoot, getOwner, onCleanup } from "solid-js"
 import { createTabMemory } from "./tab-memory"
 import { nextTabAfterClose, pushClosedTab, removeClosedTabs, takeClosedTab, type ClosedTab } from "./closed-tabs"
+import { recentKeyPointsAtSession, tabHref, tabKey } from "./tabs"
 import type { SessionTab, Tab } from "./tabs"
 import { migrateTabs } from "./tab-migration"
 import type { ServerConnection } from "./server"
@@ -26,6 +27,35 @@ describe("tab migration", () => {
   test("replaces invalid top-level persisted data", () => {
     expect(migrateTabs(null, server)).toEqual([])
     expect(migrateTabs({}, server)).toEqual([])
+  })
+})
+
+describe("session tab removal", () => {
+  test("addresses a session tab without a directory", () => {
+    // The href is built from server and session id alone. Requiring a directory alongside it
+    // meant the current tab was never recognised on `/server/:serverKey/session/:id`, where no
+    // directory exists - the deleted session then stayed in the address bar.
+    expect(tabHref(sessionTab("a"))).toBe(tabHref({ type: "session", server, sessionId: "a" }))
+    expect(tabHref(sessionTab("a"))).toContain("/session/a")
+  })
+
+  test("spots a recent pointer aimed at a deleted session", () => {
+    const key = tabKey(sessionTab("a"))
+
+    expect(recentKeyPointsAtSession(key, ["a"])).toBe(true)
+    expect(recentKeyPointsAtSession(key, ["b", "a"])).toBe(true)
+    expect(recentKeyPointsAtSession(key, ["b"])).toBe(false)
+  })
+
+  test("leaves pointers it cannot read alone", () => {
+    expect(recentKeyPointsAtSession(undefined, ["a"])).toBe(false)
+    expect(recentKeyPointsAtSession("", ["a"])).toBe(false)
+    expect(recentKeyPointsAtSession("draft:d1", ["a"])).toBe(false)
+    expect(recentKeyPointsAtSession(tabKey(sessionTab("a")), [])).toBe(false)
+  })
+
+  test("does not mistake a session whose id merely ends the same way", () => {
+    expect(recentKeyPointsAtSession(tabKey(sessionTab("ses_abc")), ["abc"])).toBe(false)
   })
 })
 

--- a/packages/app/src/context/tabs.tsx
+++ b/packages/app/src/context/tabs.tsx
@@ -46,6 +46,20 @@ export const tabHref = (tab: Tab) =>
 
 export const tabKey = (tab: Tab) => (tab.type === "draft" ? `draft:${tab.draftID}` : `${tab.server}\n${tabHref(tab)}`)
 
+/**
+ * Does the recent-tab pointer aim at one of these sessions?
+ *
+ * The caller's `removed` list only covers sessions that still had an open tab. This pointer is
+ * persisted on its own and outlives the tab, so it has to be matched against the deleted ids
+ * directly - otherwise it keeps aiming at a session that is gone and the next start restores it.
+ */
+export function recentKeyPointsAtSession(recentKey: string | undefined, sessionIDs: string[]) {
+  if (!recentKey) return false
+  // The key ends in the tab href, so matching the tail is enough - and it avoids splitting on the
+  // separator, which the server key itself can contain.
+  return sessionIDs.some((sessionID) => recentKey.endsWith(`/session/${sessionID}`))
+}
+
 export function sessionHasOpenTab(tabs: Tab[], server: ServerConnection.Key, session: Session) {
   return tabs.some((tab) => tab.type === "session" && tab.server === server && tab.sessionId === session.id)
 }
@@ -307,8 +321,13 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
           setStore(
             produce((tabs) => {
               const sessionIDs = new Set(input.sessionIDs)
+              // `params.dir` only exists on the legacy `/:dir/session/:id` route. On
+              // `/server/:serverKey/session/:id` there is no directory, so requiring one left
+              // `currentHref` undefined, `removedCurrent` false and the follow-up navigation
+              // below unreached - the deleted session stayed in the address bar and the view
+              // kept trying to load it. `tabHref` builds from server and session id alone.
               const currentHref =
-                targetServer === server.key && params.dir && params.id
+                targetServer === server.key && params.id
                   ? tabHref({
                       type: "session",
                       server: targetServer,
@@ -342,7 +361,8 @@ export const { use: useTabs, provider: TabsProvider } = createSimpleContext({
               else navigate("/")
             }),
           )
-          if (recent.key && removed.includes(recent.key)) setRecentKey(undefined)
+          if (recentKeyPointsAtSession(recent.key, input.sessionIDs) || (recent.key && removed.includes(recent.key)))
+            setRecentKey(undefined)
         })
         for (const key of removed) memory.remove(key)
         for (const key of removed) removeInfo(key)

--- a/packages/app/src/pages/session.tsx
+++ b/packages/app/src/pages/session.tsx
@@ -10,6 +10,7 @@ import {
   Show,
   Match,
   Switch,
+  catchError,
   createMemo,
   createEffect,
   createComputed,
@@ -256,7 +257,14 @@ function ResolvedTargetSessionRoute() {
   const targetDirectory = () => directory()!
 
   createEffect(() => {
-    const session = current()
+    // `current()` throws when the session cannot be resolved. During render the enclosing
+    // SessionRouteErrorBoundary catches that and shows the scoped "not found" page; from inside
+    // an effect the throw bypasses it and reaches the global boundary, which replaces the whole
+    // window with "something went wrong" - for a chat that was merely deleted.
+    const session = catchError(
+      () => current(),
+      () => undefined,
+    )
     if (!session) return
     tabs.addSessionTab({
       server: serverKey(),


### PR DESCRIPTION
### Issue for this PR

Closes #47683

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Three references to a deleted session outlived it, all for the same reason, so they are fixed
together.

**Address bar.** The current-tab check in `removeSessions` required `params.dir`, which only the
legacy `/:dir/session/:id` route provides. On `/server/:serverKey/session/:id` there is no
directory, so `currentHref` stayed undefined, `removedCurrent` stayed false and the navigation to
the next tab never ran. `tabHref` builds the href from server and session id alone, so the
directory was never needed for this comparison — dropping it is the whole fix.

**Recent-tab pointer.** It was only cleared when the removed session still had an open tab, because
the check matched against the list of removed tab keys. The pointer is persisted on its own and
outlives the tab, so it is now matched against the deleted session ids directly, through the
extracted `recentKeyPointsAtSession`. That function matches the tail of the key rather than
splitting on the separator, because the server key can contain the separator itself.

**Persisted handoff.** It carries a session id across a layout switch and nothing cleared it on
deletion, so later starts restored a session that was gone. A listener on the existing
`SESSION_TABS_REMOVED_EVENT` drops it when its target is among the removed ids.

**Error path.** The two effects that read `current()` now go through `catchError`. Solid's
`ErrorBoundary` only catches throws during render; a throw from inside an effect passes the scoped
`SessionRouteErrorBoundary` — which would show the "not found" page — and reaches the global
boundary, replacing the whole window with "something went wrong". This is the same contract, not a
new behavior: the scoped page still handles the render path.

`recentKeyPointsAtSession` is extracted from the inline check so it can be tested without a router
or context. Writing that test caught a bug in my first version: it split the key on the separator
and read the second field, but the server key contains that separator, so the pointer was never
recognised.

### How did you verify your code works?

New tests in `packages/app/src/context/tabs.test.ts`, additive — no existing expectation changed:
the recent pointer is recognised for a deleted id and for one among several; it is not recognised
for an unrelated id, for an empty or missing key, for a draft key, or for an empty removal list;
and a session whose id merely ends with the same characters is not matched. A separate test pins
that the session href needs no directory.

- `bun test --conditions=solid --preload ./happydom.ts src/context/tabs.test.ts` in `packages/app`:
  16 pass, 0 fail
- `tsgo -b` in `packages/app`: clean
- `prettier --check` on all five changed files: clean
- `oxlint` on the changed files: 11 warnings, all present on `dev` before this change

What the tests do not cover: the `params.dir` condition and the handoff listener are not exercised
by a regression test — both need the router and the persisted layout store. The `params.dir` change
rests on the route shape, which the href test pins, and I reproduced the original behavior by
deleting an open session on `/server/:serverKey/session/:id`.

### Screenshots / recordings

Not a UI change — no visual difference, only which references survive a deletion.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
