### PR TITLE
fix(session): stop retrying when the provider reports an exhausted budget

### DIFF
--- a/packages/opencode/src/session/retry.ts
+++ b/packages/opencode/src/session/retry.ts
@@ -13,6 +13,11 @@ export type RetryReason = "free_tier_limit" | "account_rate_limit" | (string & {
 
 export type Retryable = {
   message: string
+  /**
+   * The provider reported an exhausted budget rather than momentary pressure. Such a limit does
+   * not recover inside a retry window, so waiting only burns time and hides the real error.
+   */
+  terminal?: boolean
   action?: {
     reason: RetryReason
     provider: string
@@ -29,6 +34,17 @@ export const RETRY_JITTER_FACTOR = 0.25
 export const RETRY_MAX_DELAY_NO_HEADERS = 30_000 // 30 seconds
 export const RETRY_MAX_DELAY = 2_147_483_647 // max 32-bit signed integer for setTimeout
 export const RETRY_MAX_RETRIES = 5
+
+// Providers signal an exhausted budget structurally before they say it in prose. These are
+// documented, stable identifiers - not message text, which varies per provider and locale.
+const TERMINAL_STATUS_CODES = new Set([402])
+const TERMINAL_ERROR_CODES = new Set([
+  // openai
+  "insufficient_quota",
+  "billing_hard_limit_reached",
+  "billing_not_active",
+  "account_deactivated",
+])
 
 const RETRYABLE_MESSAGE_PATTERNS = [
   /429|500|502|503|504|524/i,
@@ -142,16 +158,47 @@ export function retryable(error: Err, provider: string) {
         },
       }
     }
+    if (terminalStatus(status) || terminalBody(error.data.responseBody))
+      return { message: error.data.message, terminal: true }
     return { message: error.data.message.includes("Overloaded") ? "Provider is overloaded" : error.data.message }
   }
 
   const message = isRecord(error.data) ? error.data.message : undefined
   if (typeof message !== "string") return undefined
   const lower = message.toLowerCase()
+  if (terminalBody(message)) return { message, terminal: true }
   if (lower.includes("too_many_requests")) return { message: "Too Many Requests" }
   if (lower.includes("exhausted") || lower.includes("unavailable")) return { message: "Provider is overloaded" }
   if (matchesRetryableMessage(message)) return { message }
   return undefined
+}
+
+function terminalStatus(status: number | undefined) {
+  return status !== undefined && TERMINAL_STATUS_CODES.has(status)
+}
+
+// Terminal only on an explicit provider signal: a documented error code, or a google QuotaFailure
+// whose quota id names a per-day window. A per-minute quota stays retryable.
+function terminalBody(value: unknown) {
+  const body = parseJSON(value)
+  if (!isRecord(body)) return false
+  const error = isRecord(body.error) ? body.error : undefined
+  for (const code of [error?.type, error?.code, body.code, body.type]) {
+    if (typeof code === "string" && TERMINAL_ERROR_CODES.has(code.toLowerCase())) return true
+  }
+  const details = (isRecord(body.error) ? body.error.details : undefined) ?? body.details
+  if (!Array.isArray(details)) return false
+  for (const detail of details) {
+    if (!isRecord(detail)) continue
+    const violations = detail.violations
+    if (!Array.isArray(violations)) continue
+    for (const violation of violations) {
+      if (!isRecord(violation)) continue
+      const quota = violation.quotaId ?? violation.quotaMetric
+      if (typeof quota === "string" && /PerDay/i.test(quota)) return true
+    }
+  }
+  return false
 }
 
 function matchesRetryableMessage(value: unknown) {
@@ -194,12 +241,15 @@ export function policy(opts: {
       return Effect.gen(function* () {
         const wait = delay(meta.attempt, SessionV1.APIError.isInstance(error) ? error : undefined)
         const now = yield* Clock.currentTimeMillis
+        // The status is published first so the UI reports the limit exactly as it does today,
+        // then the schedule ends and the error reaches the caller instead of a pending retry.
         yield* opts.set({
           attempt: meta.attempt,
           message: retry.message,
           action: retry.action,
-          next: now + wait,
+          next: retry.terminal ? now : now + wait,
         })
+        if (retry.terminal) return yield* Cause.done(meta.attempt)
         return [meta.attempt, Duration.millis(wait)] as [number, Duration.Duration]
       })
     }),

--- a/packages/opencode/test/session/retry.test.ts
+++ b/packages/opencode/test/session/retry.test.ts
@@ -425,6 +425,83 @@ describe("session.retry.retryable", () => {
       "Usage limit reached. It will reset in 15 minutes. To continue using this model now, enable usage from your available balance",
     )
   })
+
+  test("treats payment-required responses as terminal", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({ message: "boom", isRetryable: true, statusCode: 402 }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "boom", terminal: true })
+  })
+
+  test("treats structured quota codes as terminal", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "You exceeded your current quota",
+        isRetryable: true,
+        statusCode: 429,
+        responseBody: JSON.stringify({ error: { type: "insufficient_quota", code: "insufficient_quota" } }),
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({
+      message: "You exceeded your current quota",
+      terminal: true,
+    })
+  })
+
+  test("treats per-day quota violations as terminal", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "Resource has been exhausted",
+        isRetryable: true,
+        statusCode: 429,
+        responseBody: JSON.stringify({
+          error: {
+            code: 429,
+            status: "RESOURCE_EXHAUSTED",
+            details: [
+              {
+                "@type": "type.googleapis.com/google.rpc.QuotaFailure",
+                violations: [{ quotaId: "GenerateRequestsPerDayPerProjectPerModel" }],
+              },
+            ],
+          },
+        }),
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({
+      message: "Resource has been exhausted",
+      terminal: true,
+    })
+  })
+
+  test("keeps per-minute quota violations retryable", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({
+        message: "Resource has been exhausted",
+        isRetryable: true,
+        statusCode: 429,
+        responseBody: JSON.stringify({
+          error: {
+            status: "RESOURCE_EXHAUSTED",
+            details: [{ violations: [{ quotaId: "GenerateRequestsPerMinutePerProject" }] }],
+          },
+        }),
+      }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "Resource has been exhausted" })
+  })
+
+  test("keeps plain rate limits retryable", () => {
+    const error = Schema.decodeUnknownSync(SessionV1.APIError.Schema)(
+      new SessionV1.APIError({ message: "rate limit exceeded", isRetryable: true, statusCode: 429 }).toObject(),
+    )
+
+    expect(SessionRetry.retryable(error, retryProvider)).toEqual({ message: "rate limit exceeded" })
+  })
 })
 
 describe("session.message-v2.fromError", () => {


### PR DESCRIPTION
### Issue for this PR

Closes #47685

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`retryable()` decides whether a provider error is worth another attempt by looking at prose — the
message and the response body run through `RETRYABLE_MESSAGE_PATTERNS`, plus two zen-specific
markers. A provider that reports an exhausted budget without a recognisable phrase, and without
asking for a long `retry-after`, falls through as an ordinary retryable error. The session then
spends all five attempts on a limit that resets on a billing or daily window.

This classifies the documented structural signals instead of the wording:

- HTTP 402,
- the OpenAI billing error codes (`insufficient_quota`, `billing_hard_limit_reached`,
  `billing_not_active`, `account_deactivated`), read from `error.type`/`error.code` or the
  top-level `code`/`type`,
- a google `QuotaFailure` whose `quotaId`/`quotaMetric` names a per-day window.

These are stable identifiers rather than message text, which varies per provider and locale.

A terminal result ends the schedule, but only after the retry status has been published, so the UI
reports the limit exactly as it does today and the error then reaches the caller instead of a
pending attempt. Per-minute quotas, plain 429s, 5xx and everything else keep their current retry
behavior — the new checks run after the existing classification and only add a `terminal` flag.

**Relation to the other open PRs in this area,** since they overlap in this file: #47339 stops on
the `free_tier_limit` and `account_rate_limit` reasons, which are derived from zen markers in the
body; #47641 stops when the requested wait exceeds a ceiling. This PR covers the case neither
reaches — a structural budget signal with a short or absent `retry-after` and no zen marker. All
three compose; none of them subsumes another.

### How did you verify your code works?

Five new tests in `packages/opencode/test/session/retry.test.ts`, additive — no existing
expectation was changed:

- HTTP 402 is terminal,
- a structured `insufficient_quota` body is terminal,
- a google per-day `QuotaFailure` is terminal,
- a per-minute `QuotaFailure` stays retryable,
- a plain 429 without structural markers stays retryable.

Verified the three terminal cases fail on unmodified `dev` and pass with the change.

- `bun test test/session/retry.test.ts` in `packages/opencode`: 65 pass, 0 fail
- `tsgo --noEmit` in `packages/opencode`: clean
- `prettier --check` on both changed files: clean
- `oxlint` on the changed file: 2 warnings, the same two present on `dev` before this change

Not verified: an exhausted account against a live provider. The classification is driven by the
documented response shapes, and the tests use those shapes verbatim.

### Screenshots / recordings

Not a UI change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
