### PR TITLE
docs: add opencode-brl-cost to ecosystem plugins

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -47,6 +47,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [micode](https://github.com/vtemian/micode)                                                        | Structured Brainstorm → Plan → Implement workflow with session continuity                          |
 | [octto](https://github.com/vtemian/octto)                                                          | Interactive browser UI for AI brainstorming with multi-question forms                              |
 | [opencode-background-agents](https://github.com/kdcokenny/opencode-background-agents)              | Claude Code-style background agents with async delegation and context persistence                  |
+| [opencode-brl-cost](https://github.com/br4zz4/opencode-brl-cost)                                  | Track AI session costs in Brazilian Reais (R$) with day/week/month totals and month-end projection |
 | [opencode-notify](https://github.com/kdcokenny/opencode-notify)                                    | Native OS notifications for OpenCode – know when tasks complete                                    |
 | [opencode-workspace](https://github.com/kdcokenny/opencode-workspace)                              | Bundled multi-agent orchestration harness – 16 components, one install                             |
 | [opencode-worktree](https://github.com/kdcokenny/opencode-worktree)                                | Zero-friction git worktrees for OpenCode                                                           |


### PR DESCRIPTION
### Issue for this PR

N/A

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [opencode-brl-cost](https://github.com/br4zz4/opencode-brl-cost) to the community plugins table in `packages/web/src/content/docs/ecosystem.mdx`.

The plugin tracks AI session costs in Brazilian Reais (R$), showing day/week/month totals, a month-end projection based on the daily average of completed days, and an OpenRouter balance display. Listing it in the ecosystem table makes it discoverable for users who want cost tracking in BRL.

Project links:
- GitHub: https://github.com/br4zz4/opencode-brl-cost
- npm: https://www.npmjs.com/package/opencode-brl-cost

### How did you verify your code works?

- Confirmed the docs entry was added to the `Plugins` table in `packages/web/src/content/docs/ecosystem.mdx`
- Verified the link target and description text match the plugin's published GitHub repo and npm package
- Confirmed this PR only adds the new ecosystem entry with no unrelated changes

### Screenshots / recordings

N/A (docs-only change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR