### PR TITLE
fix(desktop): emit preload as .cjs so it loads under --no-sandbox

### DIFF
--- a/packages/desktop/electron.vite.config.ts
+++ b/packages/desktop/electron.vite.config.ts
@@ -78,7 +78,10 @@ const require = __cjs_mod__.createRequire(import.meta.url);
         input: { index: "src/preload/index.ts" },
         output: {
           format: "cjs",
-          entryFileNames: "[name].js",
+          // The package is "type": "module". Under --no-sandbox Electron loads the preload
+          // through Node's module loader, which treats a .js file as ESM and fails on
+          // require("electron"). The sandboxed path ignores the extension.
+          entryFileNames: "[name].cjs",
         },
       },
     },

--- a/packages/desktop/src/main/paths.ts
+++ b/packages/desktop/src/main/paths.ts
@@ -13,7 +13,7 @@ export const resolve = Effect.gen(function* () {
   const root = path.dirname(yield* path.fromFileUrl(new URL(import.meta.url)))
   return {
     developmentResourcesRoot: path.join(root, "../../resources"),
-    preloadPath: path.join(root, "../preload/index.js"),
+    preloadPath: path.join(root, "../preload/index.cjs"),
     rendererRoot: path.join(root, "../renderer"),
   } satisfies Resolved
 }).pipe(Effect.orDie)


### PR DESCRIPTION
- `packages/desktop/package.json` is `"type": "module"`, but the preload is built as CommonJS and was emitted as `out/preload/index.js`.
- With the sandbox on (our default) Electron evaluates the preload as a plain script, so the extension never mattered.
- With `--no-sandbox`, Electron loads non-`.mjs` preloads through Node's CJS loader ([`lib/renderer/init.ts`](https://github.com/electron/electron/blob/main/lib/renderer/init.ts) → `Module._load`). Node sees `.js` + `"type": "module"`, treats it as ESM, and the preload dies on its first line:

  ```
  ReferenceError: require is not defined in ES module scope, you can use import instead
  ```

  `contextBridge` never runs, the renderer never signals ready, `ready-to-show` never fires, and the window stays hidden.
- `.cjs` forces CommonJS regardless of the package `type`, so the same file works in both modes. This is also electron-vite's own default for a CJS preload in an ESM package; the `.js` override dates from #23523.

```mermaid
flowchart LR
  A[BrowserWindow preload] --> B{--no-sandbox?}
  B -- no --> C[Sandboxed renderer<br/>plain script + polyfilled require]
  B -- yes --> D[Module._load]
  D --> E{index.js<br/>type: module}
  D --> F[index.cjs]
  E -- ESM --> G[ReferenceError: require<br/>window never shown]
  F -- CJS --> H[contextBridge exposed]
  C --> H
```

Reproduced with Electron 42's Node (`ELECTRON_RUN_AS_NODE=1`) requiring the built preload from a CJS parent:

| File | Result |
| --- | --- |
| `out/preload/index.js` (before) | `require is not defined in ES module scope` |
| `out/preload/index.cjs` (after) | loads as CJS |

Reported in #46691 (the crash itself is the install-dir ACL fixed in #46696; this only removes the hidden-window failure when users fall back to `--no-sandbox`). No change to the default sandboxed path.
