### PR TITLE
chore: stop trusting tree-sitter install scripts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1036,12 +1036,9 @@
     },
   },
   "trustedDependencies": [
-    "esbuild",
-    "tree-sitter-powershell",
-    "protobufjs",
     "electron",
-    "web-tree-sitter",
-    "tree-sitter-bash",
+    "esbuild",
+    "protobufjs",
   ],
   "patchedDependencies": {
     "@pierre/trees@1.0.0-beta.4": "patches/@pierre%2Ftrees@1.0.0-beta.4.patch",

--- a/package.json
+++ b/package.json
@@ -146,10 +146,6 @@
     "esbuild",
     "node-pty",
     "protobufjs",
-    "tree-sitter",
-    "tree-sitter-bash",
-    "tree-sitter-powershell",
-    "web-tree-sitter",
     "electron"
   ],
   "overrides": {


### PR DESCRIPTION
`trustedDependencies` still lists `tree-sitter`, `tree-sitter-bash`, `tree-sitter-powershell`, and `web-tree-sitter`. Those entries date from #1546 (Aug 2025), when the V1 bash tool loaded the **native** `tree-sitter` binding. V2 only loads the shipped `.wasm`:

```ts
// packages/core/src/shell/parser-wasm.bun.ts
import bash from "tree-sitter-bash/tree-sitter-bash.wasm" with { type: "file" }
import powershell from "tree-sitter-powershell/tree-sitter-powershell.wasm" with { type: "file" }
```

What the four entries do today:

| package | install script | effect |
|---|---|---|
| `tree-sitter` | — | not installed; dead entry |
| `web-tree-sitter` | none | dead entry |
| `tree-sitter-bash` | `node-gyp-build` | ships `prebuilds/` for all platforms, no-op |
| `tree-sitter-powershell` | `node-gyp-build` | **no `prebuilds/`** → node-gyp + Python + MSBuild + `cl.exe` on every fresh install |

Measured on Windows: the `tree-sitter-powershell` build alone is **23 s** of a fresh `bun install`, producing a `build/Release/*.node` that nothing loads. Dropping the trust entries skips it; the `.wasm` files are in the tarballs regardless.

`bun.lock` regenerated. `packages/core/test/shell-scan/scan.test.ts` passes against the wasm parsers with no native build present.
