### PR TITLE
fix(cli): pass --model through to the TUI entry

### DIFF
--- a/packages/cli/src/commands/commands.ts
+++ b/packages/cli/src/commands/commands.ts
@@ -55,6 +55,11 @@ const Root = Spec.make(typeof OPENCODE_CLI_NAME === "string" ? OPENCODE_CLI_NAME
       Flag.optional,
     ),
     prompt: Flag.string("prompt").pipe(Flag.withDescription("Prompt to use"), Flag.optional),
+    model: Flag.string("model").pipe(
+      Flag.withAlias("m"),
+      Flag.withDescription("Model to use in the format provider/model#variant"),
+      Flag.optional,
+    ),
   },
   commands: [
     Spec.make("upgrade", {

--- a/packages/cli/src/commands/handlers/default.ts
+++ b/packages/cli/src/commands/handlers/default.ts
@@ -76,6 +76,7 @@ export default Runtime.handler(Commands, (input) =>
         continue: input.continue,
         sessionID: Option.getOrUndefined(input.session),
         prompt: Option.getOrUndefined(input.prompt),
+        model: Option.getOrUndefined(input.model),
         auto: input.auto || input.yolo || input.dangerouslySkipPermissions,
       },
       config: {


### PR DESCRIPTION
### Issue for this PR

Fixes #47172

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

`opencode --model <id> --prompt ...` accepted the flag on the root command but dropped it before the TUI started, so the session silently ran on the configured default model — the requested id was never mentioned or validated. The `run` path already resolves and validates the same flag.

- Define `--model` (with `-m` alias) on the root command params
- Pass it through to the TUI args, where the existing `args.model` handling parses it and selects the model, warning on malformed values — matching the `run` path

### How did you verify your code works?

- `--help` on the root entry now lists `--model, -m`
- `bun typecheck` in `packages/cli` and `packages/tui`
- `bun test` in `packages/cli` (259 passing) and `packages/tui` (2 pre-existing timeouts in dialog-shell-output tests reproduce on a clean baseline, unrelated)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR