### PR TITLE
feat(plugin): register template commands

### DIFF
--- a/packages/core/src/command/template.ts
+++ b/packages/core/src/command/template.ts
@@ -1,0 +1,182 @@
+export * as CommandTemplate from "./template.js"
+
+import type { CommandTemplateDefinition } from "@opencode-ai/plugin/effect/command"
+import type { Context as PluginContext } from "@opencode-ai/plugin/effect/plugin"
+import { Model } from "@opencode-ai/schema/model"
+import { Provider } from "@opencode-ai/schema/provider"
+import { makeLocationNode } from "@opencode-ai/util/effect/app-node"
+import { AppProcess } from "@opencode-ai/util/process"
+import { Context, Effect, Layer } from "effect"
+import { ChildProcess } from "effect/unstable/process"
+import { Agent } from "../agent.js"
+import { Command } from "../command.js"
+import { Job } from "../job.js"
+import { Location } from "../location.js"
+import { Session } from "../session.js"
+import { SubagentJob } from "../session/subagent-job.js"
+import { ShellSelect } from "../shell/select.js"
+
+export interface Interface {
+  readonly definition: (command: CommandTemplateDefinition) => Command.Definition
+}
+
+export class Service extends Context.Service<Service, Interface>()("@opencode/CommandTemplate") {}
+
+export const make = Effect.fn("CommandTemplate.make")(function* (
+  api?: Pick<PluginContext, "agent" | "session">,
+) {
+  const location = yield* Location.Service
+  const processes = yield* AppProcess.Service
+  const shell = yield* ShellSelect.Service
+  const sessions = yield* Session.Service
+  const agents = yield* Agent.Service
+  const subagents = yield* SubagentJob.make
+
+  return Service.of({
+    definition: (command): Command.Definition => ({
+      name: command.name,
+      description: command.description,
+      execute: (input) =>
+        Effect.gen(function* () {
+          const agent = command.agent === undefined ? undefined : Agent.ID.make(command.agent)
+          const commandAgent =
+            agent === undefined
+              ? undefined
+              : api === undefined
+                ? yield* agents.get(agent)
+                : (yield* api.agent.get({ agentID: agent })).data
+          if (agent !== undefined && commandAgent === undefined)
+            return yield* Effect.fail(new Error(`Agent not found: ${agent}`))
+          const model =
+            command.model === undefined
+              ? commandAgent?.model
+              : {
+                  id: Model.ID.make(command.model.model),
+                  providerID: Provider.ID.make(command.model.providerID),
+                  ...(command.model.variant === undefined
+                    ? {}
+                    : { variant: Model.VariantID.make(command.model.variant) }),
+                }
+          const text = yield* evaluate(command.template, input.prompt.text, { location, processes, shell })
+          if (command.subagent ?? commandAgent?.mode === "subagent") {
+            const parent = yield* sessions.get(input.sessionID)
+            const selected = yield* agents.select(agent ?? parent.agent)
+            const child = yield* sessions.create({
+              parentID: parent.id,
+              title: command.description ?? command.name,
+              agent: selected.id,
+              model: model ?? selected.info?.model ?? parent.model,
+            })
+            yield* sessions.prompt({
+              ...input.prompt,
+              sessionID: child.id,
+              text: ["You are a subagent spawned by another session.", text].join("\n"),
+              resume: false,
+            })
+            const recovery = {
+              kind: "subagent" as const,
+              parentSessionID: parent.id,
+              childSessionID: child.id,
+              agent: selected.id,
+              description: command.description ?? command.name,
+            }
+            yield* subagents.start(recovery)
+            yield* subagents.background(recovery)
+            return
+          }
+          if (agent !== undefined) {
+            const session = yield* (api?.session.get({ sessionID: input.sessionID }) ?? sessions.get(input.sessionID))
+            if (session.agent !== agent)
+              yield* (api?.session.switchAgent({ sessionID: input.sessionID, agent }) ??
+                sessions.switchAgent({ sessionID: input.sessionID, agent }))
+          }
+          if (model !== undefined)
+            yield* (api?.session.switchModel({ sessionID: input.sessionID, model }) ??
+              sessions.switchModel({ sessionID: input.sessionID, model }))
+          yield* (api?.session.prompt({
+            ...input.prompt,
+            sessionID: input.sessionID,
+            text,
+            delivery: input.delivery,
+          }) ??
+            sessions.prompt({
+              ...input.prompt,
+              sessionID: input.sessionID,
+              text,
+              delivery: input.delivery,
+            }))
+        }).pipe(Effect.asVoid),
+    }),
+  })
+})
+
+export const layer = Layer.effect(Service, make())
+
+export const node = makeLocationNode({
+  service: Service,
+  layer,
+  deps: [Location.node, AppProcess.node, ShellSelect.node, Session.node, Agent.node, Job.node],
+})
+
+function evaluate(
+  template: string,
+  input: string,
+  services: {
+    readonly location: Location.Info
+    readonly processes: AppProcess.Interface
+    readonly shell: ShellSelect.Interface
+  },
+) {
+  return Effect.gen(function* () {
+    const args = parseArguments(input)
+    const placeholders = template.match(placeholderRegex) ?? []
+    const last = Math.max(0, ...placeholders.map((item) => Number(item.slice(1))))
+    const expanded = template.replaceAll(placeholderRegex, (_, index) => {
+      const position = Number(index)
+      const argIndex = position - 1
+      if (argIndex >= args.length) return ""
+      if (position === last) return args.slice(argIndex).join(" ")
+      return args[argIndex]
+    })
+    const withArguments = expanded.replaceAll("$ARGUMENTS", input)
+    const text =
+      placeholders.length === 0 && !template.includes("$ARGUMENTS") && input.trim()
+        ? `${withArguments}\n\n${input}`.trim()
+        : withArguments.trim()
+    const matches = Array.from(text.matchAll(shellRegex))
+    if (matches.length === 0) return text
+    const executable = yield* services.shell.resolve({ priority: "config" })
+    const outputs = yield* Effect.forEach(
+      matches,
+      (match) => {
+        const source = match[1] ?? ""
+        return services.processes
+          .run(
+            ChildProcess.make(executable, ShellSelect.args(executable, source), {
+              cwd: services.location.directory,
+              stdin: "ignore",
+            }),
+            { combineOutput: true },
+          )
+          .pipe(
+            Effect.map((result) => (result.output ?? Buffer.concat([result.stdout, result.stderr])).toString("utf8")),
+            Effect.mapError(
+              (error) => new Error(`Shell interpolation failed for ${JSON.stringify(source)}: ${error.message}`),
+            ),
+          )
+      },
+      { concurrency: 2 },
+    )
+    const iterator = outputs[Symbol.iterator]()
+    return text.replace(shellRegex, () => iterator.next().value ?? "")
+  })
+}
+
+function parseArguments(input: string) {
+  return (input.match(argsRegex) ?? []).map((arg) => arg.replace(quoteTrimRegex, ""))
+}
+
+const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi
+const placeholderRegex = /\$(\d+)/g
+const quoteTrimRegex = /^["']|["']$/g
+const shellRegex = /!`([^`]+)`/g

--- a/packages/core/src/config/plugin/command.ts
+++ b/packages/core/src/config/plugin/command.ts
@@ -3,19 +3,11 @@ export * as ConfigCommandPlugin from "./command.js"
 import { define } from "@opencode-ai/plugin/effect/plugin"
 import { Info, type Entry } from "@opencode-ai/schema/config"
 import { ConfigCommand } from "@opencode-ai/schema/config/command"
-import { Model } from "@opencode-ai/schema/model"
-import { Provider } from "@opencode-ai/schema/provider"
-import { AppProcess } from "@opencode-ai/util/process"
+import { FSUtil } from "@opencode-ai/util/fs-util"
 import path from "path"
 import { Effect, Option, PubSub, Schema, Stream } from "effect"
-import { ChildProcess } from "effect/unstable/process"
-import { Agent } from "../../agent.js"
+import { CommandTemplate } from "../../command/template.js"
 import { Config } from "../../config.js"
-import { Location } from "../../location.js"
-import { Session } from "../../session.js"
-import { SubagentJob } from "../../session/subagent-job.js"
-import { ShellSelect } from "../../shell/select.js"
-import { FSUtil } from "@opencode-ai/util/fs-util"
 import { ConfigMarkdown } from "../markdown.js"
 
 const decodeCommand = Schema.decodeUnknownOption(ConfigCommand.Info)
@@ -31,12 +23,7 @@ export const Plugin = define({
       const commands = yield* loadDirectory(fs, entry.path)
       return [{ commands: Object.fromEntries(commands.map((command) => [command.name, command.info])) }]
     })
-    const location = yield* Location.Service
-    const processes = yield* AppProcess.Service
-    const shell = yield* ShellSelect.Service
-    const sessions = yield* Session.Service
-    const agents = yield* Agent.Service
-    const subagents = yield* SubagentJob.make
+    const commandTemplate = yield* CommandTemplate.make(ctx)
     const load = Effect.fn("ConfigCommandPlugin.load")(function* () {
       return yield* Effect.forEach(yield* config.entries(), loadEntry).pipe(Effect.map((documents) => documents.flat()))
     })
@@ -72,68 +59,16 @@ export const Plugin = define({
     yield* ctx.command.transform((editor) => {
       for (const document of loaded.documents) {
         for (const [name, command] of Object.entries(document.commands ?? {})) {
-          const subagent = command.subagent ?? command.subtask
-          editor.add({
-            name,
-            description: command.description,
-            execute: (input) =>
-              Effect.gen(function* () {
-                const agent = command.agent === undefined ? undefined : Agent.ID.make(command.agent)
-                const commandAgent = agent === undefined ? undefined : (yield* ctx.agent.get({ agentID: agent })).data
-                const model =
-                  command.model === undefined
-                    ? commandAgent?.model
-                    : {
-                        id: Model.ID.make(command.model.model),
-                        providerID: Provider.ID.make(command.model.providerID),
-                        ...(command.model.variant === undefined
-                          ? {}
-                          : { variant: Model.VariantID.make(command.model.variant) }),
-                      }
-                const text = yield* evaluateTemplate(command.template, input.prompt.text, {
-                  location,
-                  processes,
-                  shell,
-                })
-                if (subagent ?? commandAgent?.mode === "subagent") {
-                  const parent = yield* sessions.get(input.sessionID)
-                  const selected = yield* agents.select(agent ?? parent.agent)
-                  const child = yield* sessions.create({
-                    parentID: parent.id,
-                    title: command.description ?? name,
-                    agent: selected.id,
-                    model: model ?? selected.info?.model ?? parent.model,
-                  })
-                  yield* sessions.prompt({
-                    ...input.prompt,
-                    sessionID: child.id,
-                    text: ["You are a subagent spawned by another session.", text].join("\n"),
-                    resume: false,
-                  })
-                  const recovery = {
-                    kind: "subagent" as const,
-                    parentSessionID: parent.id,
-                    childSessionID: child.id,
-                    agent: selected.id,
-                    description: command.description ?? name,
-                  }
-                  yield* subagents.start(recovery)
-                  yield* subagents.background(recovery)
-                  return
-                }
-                if (agent !== undefined) {
-                  const session = yield* ctx.session.get({ sessionID: input.sessionID })
-                  if (session.agent !== agent) yield* ctx.session.switchAgent({ sessionID: input.sessionID, agent })
-                }
-                if (model !== undefined) yield* ctx.session.switchModel({ sessionID: input.sessionID, model })
-                yield* ctx.session.prompt({
-                  ...input.prompt,
-                  sessionID: input.sessionID,
-                  text,
-                  delivery: input.delivery,
-                })
-              }).pipe(Effect.asVoid),
-          })
+          editor.add(
+            commandTemplate.definition({
+              name,
+              description: command.description,
+              template: command.template,
+              agent: command.agent,
+              model: command.model,
+              subagent: command.subagent ?? command.subtask,
+            }),
+          )
         }
       }
     })
@@ -185,66 +120,3 @@ function decode(directory: string, filepath: string, content: string) {
     info,
   }
 }
-
-function evaluateTemplate(
-  template: string,
-  input: string,
-  services: {
-    readonly location: Location.Info
-    readonly processes: AppProcess.Interface
-    readonly shell: ShellSelect.Interface
-  },
-) {
-  return Effect.gen(function* () {
-    const args = parseArguments(input)
-    const placeholders = template.match(placeholderRegex) ?? []
-    const last = Math.max(0, ...placeholders.map((item) => Number(item.slice(1))))
-    const expanded = template.replaceAll(placeholderRegex, (_, index) => {
-      const position = Number(index)
-      const argIndex = position - 1
-      if (argIndex >= args.length) return ""
-      if (position === last) return args.slice(argIndex).join(" ")
-      return args[argIndex]
-    })
-    const withArguments = expanded.replaceAll("$ARGUMENTS", input)
-    const text =
-      placeholders.length === 0 && !template.includes("$ARGUMENTS") && input.trim()
-        ? `${withArguments}\n\n${input}`.trim()
-        : withArguments.trim()
-    const matches = Array.from(text.matchAll(shellRegex))
-    if (matches.length === 0) return text
-    const shell = yield* services.shell.resolve({ priority: "config" })
-    const outputs = yield* Effect.forEach(
-      matches,
-      (match) => {
-        const source = match[1] ?? ""
-        return services.processes
-          .run(
-            ChildProcess.make(shell, ShellSelect.args(shell, source), {
-              cwd: services.location.directory,
-              stdin: "ignore",
-            }),
-            { combineOutput: true },
-          )
-          .pipe(
-            Effect.map((result) => (result.output ?? Buffer.concat([result.stdout, result.stderr])).toString("utf8")),
-            Effect.mapError(
-              (error) => new Error(`Shell interpolation failed for ${JSON.stringify(source)}: ${error.message}`),
-            ),
-          )
-      },
-      { concurrency: 2 },
-    )
-    const iterator = outputs[Symbol.iterator]()
-    return text.replace(shellRegex, () => iterator.next().value ?? "")
-  })
-}
-
-function parseArguments(input: string) {
-  return (input.match(argsRegex) ?? []).map((arg) => arg.replace(quoteTrimRegex, ""))
-}
-
-const argsRegex = /(?:\[Image\s+\d+\]|"[^"]*"|'[^']*'|[^\s"']+)/gi
-const placeholderRegex = /\$(\d+)/g
-const quoteTrimRegex = /^["']|["']$/g
-const shellRegex = /!`([^`]+)`/g

--- a/packages/core/src/plugin/host.ts
+++ b/packages/core/src/plugin/host.ts
@@ -11,6 +11,7 @@ import { Agent } from "../agent.js"
 import { AISDK } from "../aisdk.js"
 import { Catalog } from "../catalog.js"
 import { Command } from "../command.js"
+import { CommandTemplate } from "../command/template.js"
 import { Credential } from "../credential.js"
 import { Bus } from "../bus.js"
 import { Integration } from "../integration.js"
@@ -53,6 +54,7 @@ export const make = Effect.fn("PluginHost.make")(function* (
   const aisdk = yield* AISDK.Service
   const catalog = yield* Catalog.Service
   const commands = yield* Command.Service
+  const commandTemplate = yield* CommandTemplate.Service
   const bus = yield* Bus.Service
   const integration = yield* Integration.Service
   const kv = yield* KV.Service
@@ -243,7 +245,13 @@ export const make = Effect.fn("PluginHost.make")(function* (
     command: {
       list: () => response(commands.list()),
       reload: commands.reload,
-      transform: commands.transform,
+      transform: (callback) =>
+        commands.transform((editor) => {
+          callback({
+            add: (definition) =>
+              editor.add("execute" in definition ? definition : commandTemplate.definition(definition)),
+          })
+        }),
     },
     event: {
       subscribe: () =>
@@ -554,6 +562,7 @@ export const requirements = LayerNode.group([
   Permission.node,
   PluginHooks.node,
   Session.node,
+  CommandTemplate.node,
   PersistentPty.node,
   LocationServiceMap.node,
 ])

--- a/packages/core/test/plugin.test.ts
+++ b/packages/core/test/plugin.test.ts
@@ -134,6 +134,49 @@ it.effect("unloading a plugin removes its commands and runs cleanup", () =>
   }),
 )
 
+it.effect("registers declarative commands from Effect and Promise plugins", () =>
+  Effect.gen(function* () {
+    const plugins = yield* Plugin.Service
+    const commands = yield* Command.Service
+    const promise = fromPromise({
+      id: "promise-command",
+      async setup(ctx) {
+        await ctx.command.transform((editor) =>
+          editor.add({
+            name: "promise-review",
+            description: "Promise review",
+            template: "Review $ARGUMENTS",
+            subagent: true,
+          }),
+        )
+      },
+    })
+    yield* plugins.activate([
+      {
+        id: "effect-command",
+        revision: "1",
+        effect: (ctx) =>
+          ctx.command
+            .transform((editor) =>
+              editor.add({
+                name: "effect-review",
+                description: "Effect review",
+                template: "Review $ARGUMENTS",
+                agent: "build",
+              }),
+            )
+            .pipe(Effect.asVoid),
+      },
+      { ...promise, revision: "1" },
+    ])
+
+    expect(yield* commands.list()).toEqual([
+      Command.Info.make({ name: "effect-review", description: "Effect review" }),
+      Command.Info.make({ name: "promise-review", description: "Promise review" }),
+    ])
+  }),
+)
+
 it.effect("reports a failed plugin without blocking a healthy plugin", () =>
   Effect.gen(function* () {
     const plugins = yield* Plugin.Service

--- a/packages/core/test/plugin/fixture.ts
+++ b/packages/core/test/plugin/fixture.ts
@@ -2,6 +2,7 @@ import { Agent } from "@opencode-ai/core/agent"
 import { AISDK } from "@opencode-ai/core/aisdk"
 import { Catalog } from "@opencode-ai/core/catalog"
 import { Command } from "@opencode-ai/core/command"
+import { CommandTemplate } from "@opencode-ai/core/command/template"
 import { Config } from "@opencode-ai/core/config"
 import { Credential } from "@opencode-ai/core/credential"
 import { LayerNodePlatform } from "@opencode-ai/util/effect/app-node-platform"
@@ -79,6 +80,7 @@ export const PluginTestLayer = AppNodeBuilder.build(
     AISDK.node,
     Catalog.node,
     Command.node,
+    CommandTemplate.node,
     Integration.node,
     KV.node,
     Mcp.node,

--- a/packages/plugin/src/effect/command.ts
+++ b/packages/plugin/src/effect/command.ts
@@ -1,4 +1,5 @@
 import type { CommandApi } from "@opencode-ai/client/effect/api"
+import type { ConfigCommand } from "@opencode-ai/schema/config/command"
 import type { PromptInput } from "@opencode-ai/schema/prompt-input"
 import type { Session } from "@opencode-ai/schema/session"
 import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
@@ -11,11 +12,22 @@ export interface CommandInvocation {
   readonly delivery: SessionInbox.Delivery
 }
 
-export interface CommandDefinition {
+export interface CommandCallbackDefinition {
   readonly name: string
   readonly description?: string
   readonly execute: (input: CommandInvocation) => Effect.Effect<void, unknown>
 }
+
+export interface CommandTemplateDefinition {
+  readonly name: string
+  readonly description?: string
+  readonly template: string
+  readonly agent?: string
+  readonly model?: ConfigCommand.Info["model"]
+  readonly subagent?: boolean
+}
+
+export type CommandDefinition = CommandCallbackDefinition | CommandTemplateDefinition
 
 export interface CommandEditor {
   add(definition: CommandDefinition): void

--- a/packages/plugin/src/promise/adapter.ts
+++ b/packages/plugin/src/promise/adapter.ts
@@ -315,12 +315,14 @@ export function fromPromise(plugin: Plugin) {
               register(
                 host.command.transform((editor) =>
                   callback({
-                    add: (definition) =>
+                    add: (definition) => {
+                      if (!("execute" in definition)) return editor.add(definition)
                       editor.add({
                         ...definition,
                         execute: (input) =>
                           Effect.tryPromise({ try: () => definition.execute(input), catch: (cause) => cause }),
-                      }),
+                      })
+                    },
                   }),
                 ),
               ),

--- a/packages/plugin/src/promise/command.ts
+++ b/packages/plugin/src/promise/command.ts
@@ -1,4 +1,5 @@
 import type { CommandApi } from "@opencode-ai/client/promise/api"
+import type { ConfigCommand } from "@opencode-ai/schema/config/command"
 import type { PromptInput } from "@opencode-ai/schema/prompt-input"
 import type { Session } from "@opencode-ai/schema/session"
 import type { SessionInbox } from "@opencode-ai/schema/session-inbox"
@@ -10,11 +11,22 @@ export interface CommandInvocation {
   readonly delivery: SessionInbox.Delivery
 }
 
-export interface CommandDefinition {
+export interface CommandCallbackDefinition {
   readonly name: string
   readonly description?: string
   readonly execute: (input: CommandInvocation) => Promise<void>
 }
+
+export interface CommandTemplateDefinition {
+  readonly name: string
+  readonly description?: string
+  readonly template: string
+  readonly agent?: string
+  readonly model?: ConfigCommand.Info["model"]
+  readonly subagent?: boolean
+}
+
+export type CommandDefinition = CommandCallbackDefinition | CommandTemplateDefinition
 
 export interface CommandEditor {
   add(definition: CommandDefinition): void

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -366,8 +366,10 @@ effect: (ctx) =>
   }),
 ```
 
+#### Template commands
+
 The command transform is add-only. Template commands use the configured-command argument expansion, agent and model
-selection, and optional subagent execution. Use an `execute` callback instead when the command needs custom behavior.
+selection, and optional subagent execution.
 
 ```ts
 effect: (ctx) =>
@@ -383,6 +385,32 @@ effect: (ctx) =>
       })
     })
     yield* command.reload()
+  }),
+```
+
+#### Callback commands
+
+Use an `execute` callback instead when the command needs custom behavior. It receives the session, prompt attachments,
+and delivery mode.
+
+```ts
+effect: (ctx) =>
+  Effect.gen(function* () {
+    const command = ctx.command
+    const session = ctx.session
+    yield* command.transform((editor) => {
+      editor.add({
+        name: "security-review-custom",
+        description: "Review changes with custom behavior",
+        execute: (input) =>
+          session.prompt({
+            ...input.prompt,
+            sessionID: input.sessionID,
+            text: `Review these changes for security issues.\n\n${input.prompt.text}`,
+            delivery: input.delivery,
+          }).pipe(Effect.asVoid),
+      })
+    })
   }),
 ```
 

--- a/packages/www/src/docs/content/build/plugins/effect.mdx
+++ b/packages/www/src/docs/content/build/plugins/effect.mdx
@@ -366,24 +366,20 @@ effect: (ctx) =>
   }),
 ```
 
-The current command transform is add-only. An executor receives the session, prompt attachments, and delivery mode.
+The command transform is add-only. Template commands use the configured-command argument expansion, agent and model
+selection, and optional subagent execution. Use an `execute` callback instead when the command needs custom behavior.
 
 ```ts
 effect: (ctx) =>
   Effect.gen(function* () {
     const command = ctx.command
-    const session = ctx.session
     yield* command.transform((editor) => {
       editor.add({
         name: "security-review",
         description: "Review changes for security issues",
-        execute: (input) =>
-          session.prompt({
-            ...input.prompt,
-            sessionID: input.sessionID,
-            text: `Review these changes for security issues.\n\n${input.prompt.text}`,
-            delivery: input.delivery,
-          }).pipe(Effect.asVoid),
+        template: "Review these changes for security issues.\n\n$ARGUMENTS",
+        agent: "reviewer",
+        subagent: true,
       })
     })
     yield* command.reload()
@@ -400,11 +396,22 @@ interface CommandInvocation {
   readonly delivery: SessionInbox.Delivery
 }
 
-interface CommandDefinition {
+interface CommandCallbackDefinition {
   readonly name: string
   readonly description?: string
   readonly execute: (input: CommandInvocation) => Effect.Effect<void, unknown>
 }
+
+interface CommandTemplateDefinition {
+  readonly name: string
+  readonly description?: string
+  readonly template: string
+  readonly agent?: string
+  readonly model?: { readonly providerID: string; readonly model: string; readonly variant?: string }
+  readonly subagent?: boolean
+}
+
+type CommandDefinition = CommandCallbackDefinition | CommandTemplateDefinition
 
 interface CommandEditor {
   add(definition: CommandDefinition): void

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -345,24 +345,24 @@ Read the commands available at a location.
 const commands = await ctx.command.list()
 ```
 
-Register commands with a transform. The executor receives the session, prompt attachments, and requested delivery mode.
+Register a prompt command with the same fields used by configured commands. OpenCode expands `$ARGUMENTS`, positional
+arguments such as `$1`, and shell substitutions before submitting the prompt. Setting `subagent` runs it in a child
+session.
 
 ```ts
 await ctx.command.transform((editor) => {
   editor.add({
     name: "security-review",
     description: "Review changes for security issues",
-    execute: async ({ sessionID, prompt, delivery }) => {
-      await ctx.session.prompt({
-        ...prompt,
-        sessionID,
-        text: `Review these changes for security issues.\n\n${prompt.text}`,
-        delivery,
-      })
-    },
+    template: "Review these changes for security issues.\n\n$ARGUMENTS",
+    agent: "reviewer",
+    subagent: true,
   })
 })
 ```
+
+Use `execute` instead of `template` when the command needs custom behavior. The callback receives the session, prompt
+attachments, and requested delivery mode.
 
 Reload commands after external state used by a transform changes.
 
@@ -386,11 +386,22 @@ interface CommandEditor {
   add(definition: CommandDefinition): void
 }
 
-interface CommandDefinition {
+interface CommandCallbackDefinition {
   name: string
   description?: string
   execute(input: CommandInvocation): Promise<void>
 }
+
+interface CommandTemplateDefinition {
+  name: string
+  description?: string
+  template: string
+  agent?: string
+  model?: { providerID: string; model: string; variant?: string }
+  subagent?: boolean
+}
+
+type CommandDefinition = CommandCallbackDefinition | CommandTemplateDefinition
 
 interface CommandInvocation {
   sessionID: string

--- a/packages/www/src/docs/content/build/plugins/index.mdx
+++ b/packages/www/src/docs/content/build/plugins/index.mdx
@@ -345,6 +345,8 @@ Read the commands available at a location.
 const commands = await ctx.command.list()
 ```
 
+#### Template commands
+
 Register a prompt command with the same fields used by configured commands. OpenCode expands `$ARGUMENTS`, positional
 arguments such as `$1`, and shell substitutions before submitting the prompt. Setting `subagent` runs it in a child
 session.
@@ -361,8 +363,27 @@ await ctx.command.transform((editor) => {
 })
 ```
 
+#### Callback commands
+
 Use `execute` instead of `template` when the command needs custom behavior. The callback receives the session, prompt
 attachments, and requested delivery mode.
+
+```ts
+await ctx.command.transform((editor) => {
+  editor.add({
+    name: "security-review-custom",
+    description: "Review changes with custom behavior",
+    execute: async ({ sessionID, prompt, delivery }) => {
+      await ctx.session.prompt({
+        ...prompt,
+        sessionID,
+        text: `Review these changes for security issues.\n\n${prompt.text}`,
+        delivery,
+      })
+    },
+  })
+})
+```
 
 Reload commands after external state used by a transform changes.
 


### PR DESCRIPTION
### Issue for this PR

N/A. Feature PR.

### Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Allows Promise and Effect plugins to register declarative commands using `template`, `agent`, `model`, and `subagent`.

These commands use the same argument expansion, shell interpolation, model selection, and subagent execution as configured commands. Existing custom `execute` callbacks remain supported.

### How did you verify your code works?

- Ran Core typecheck
- Ran plugin typecheck
- Ran focused config-command and plugin tests: 27 passed
- Ran lint on changed TypeScript files: 0 errors

### Screenshots / recordings

Not applicable. No UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR