### PR TITLE
docs: add octl to ecosystem projects

### DIFF
--- a/packages/web/src/content/docs/ecosystem.mdx
+++ b/packages/web/src/content/docs/ecosystem.mdx
@@ -73,6 +73,7 @@ You can also check out [awesome-opencode](https://github.com/awesome-opencode/aw
 | [OpenWork](https://github.com/different-ai/openwork)                                       | An open-source alternative to Claude Cowork, powered by OpenCode |
 | [ocx](https://github.com/kdcokenny/ocx)                                                    | OpenCode extension manager with portable, isolated profiles.     |
 | [CodeNomad](https://github.com/NeuralNomadsAI/CodeNomad)                                   | Desktop, Web, Mobile and Remote Client App for OpenCode          |
+| [octl](https://github.com/tomasWade/octl)                                                  | Terminal TUI + daemon for managing local opencode sessions       |
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

N/A — docs addition, no linked issue.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [x] Documentation

### What does this PR do?

Adds [octl](https://github.com/tomasWade/octl) to the ecosystem projects table in `ecosystem.mdx` (one line). octl is a terminal TUI + daemon for managing local opencode sessions: real-time status across all projects, an embedded sidebar panel with one-click tmux jump, favorites and usage stats. Fully offline; SQLite is only ever opened read-only.

### How did you verify your code works?

Ran the docs site locally and confirmed the table renders correctly; verified the repo link resolves.

### Screenshots / recordings

N/A — one-line table addition.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
