### PR TITLE
fix(desktop): surface default path opening errors

### DIFF
--- a/packages/desktop/src/main/ipc.ts
+++ b/packages/desktop/src/main/ipc.ts
@@ -1,4 +1,3 @@
-import { execFile } from "node:child_process"
 import { stat } from "node:fs/promises"
 import { basename, join } from "node:path"
 import { app, BrowserWindow, clipboard, dialog, ipcMain, shell } from "electron"
@@ -24,6 +23,7 @@ import type { UpdaterController } from "./updater-controller"
 import { createUpdaterSubscriptions } from "./updater-subscriptions"
 import { createDesktopDraftStore } from "./draft-store"
 import { nativeT } from "./native-translations"
+import { openPath } from "./open-path"
 
 const pickerFilters = (ext?: string[]) => {
   if (!ext || ext.length === 0) return undefined
@@ -216,14 +216,9 @@ export function registerIpcHandlers(deps: Deps) {
     openLocalFileURL(url)
   })
 
-  ipcMain.handle("open-path", async (_event: IpcMainInvokeEvent, path: string, app?: string) => {
-    if (!app) return shell.openPath(path)
-    await new Promise<void>((resolve, reject) => {
-      const [cmd, args] =
-        process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)
-      execFile(cmd, args, (err) => (err ? reject(err) : resolve()))
-    })
-  })
+  ipcMain.handle("open-path", (_event: IpcMainInvokeEvent, path: string, app?: string) =>
+    openPath(path, app, (path) => shell.openPath(path)),
+  )
 
   ipcMain.handle("reveal-path", async (_event: IpcMainInvokeEvent, path: string) => {
     const exists = await stat(path).then(

--- a/packages/desktop/src/main/open-path.test.ts
+++ b/packages/desktop/src/main/open-path.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test"
+import { openPath } from "./open-path"
+
+describe("openPath", () => {
+  test("resolves without a value when the default application opens the path", async () => {
+    const paths: string[] = []
+    await expect(
+      openPath("/project", undefined, async (path) => {
+        paths.push(path)
+        return ""
+      }),
+    ).resolves.toBeUndefined()
+    expect(paths).toEqual(["/project"])
+  })
+
+  test("rejects when Electron resolves with an error message", async () => {
+    await expect(openPath("/missing/project", undefined, async () => "Failed to open path")).rejects.toThrow(
+      "Failed to open path",
+    )
+  })
+
+  test("preserves rejected errors from the default application", async () => {
+    const error = new Error("Application unavailable")
+    await expect(
+      openPath("/project", undefined, async () => {
+        throw error
+      }),
+    ).rejects.toBe(error)
+  })
+})

--- a/packages/desktop/src/main/open-path.ts
+++ b/packages/desktop/src/main/open-path.ts
@@ -1,0 +1,15 @@
+import { execFile } from "node:child_process"
+
+export async function openPath(path: string, app: string | undefined, openDefault: (path: string) => Promise<string>) {
+  if (!app) {
+    // Electron resolves with an error string instead of rejecting when opening fails.
+    const error = await openDefault(path)
+    if (error) throw new Error(error)
+    return
+  }
+  await new Promise<void>((resolve, reject) => {
+    const [cmd, args] =
+      process.platform === "darwin" ? (["open", ["-a", app, path]] as const) : ([app, [path]] as const)
+    execFile(cmd, args, (err) => (err ? reject(err) : resolve()))
+  })
+}


### PR DESCRIPTION
### Issue for this PR

Closes #47722

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reject non-empty errors returned by Electron's `shell.openPath()` so a failed file-manager launch reaches the existing request-error toast. Extract the IPC operation into a testable function; explicit application launching keeps its existing behavior.

### How did you verify your code works?

- `bun test src/main/open-path.test.ts`: 3 passing tests for success, resolved error strings, and rejected errors. The error-string regression failed before the fix.
- `bun typecheck` in `packages/desktop`: passes.
- Prettier and `git diff --check`: pass.
- Broader desktop run: 63 tests passed; WSL tests were blocked by the missing Electron binary. The download retry stalled.

### Screenshots / recordings

Not captured. This changes IPC error propagation and reuses the existing toast. Full desktop UI verification has not been performed.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
