### PR TITLE
fix(app): keep new session open while the worktree list loads

### DIFF
--- a/packages/app/src/new-session/workspace/controller.ts
+++ b/packages/app/src/new-session/workspace/controller.ts
@@ -75,13 +75,14 @@ export function createNewSessionWorkspaceController(input: {
       if (event.type === "worktree.updated") void worktreeActions.refetch()
     }),
   )
+  // `latest` only skips Suspense once the resource has resolved at least once. Before that it
+  // behaves like a plain read, which holds the transition that opens the New Session tab until
+  // the worktree list returns.
+  const worktreesLoaded = () => worktrees.state === "ready" || worktrees.state === "refreshing"
   const worktreeItems = createMemo(() => {
     const project = currentProject()
     if (!project) return []
-    // `latest` only skips Suspense once the resource has resolved at least once. Before that it
-    // behaves like a plain read, which holds the transition that opens the New Session tab until
-    // the worktree list returns. Fall back to the project inventory until then.
-    if (worktrees.state !== "ready" && worktrees.state !== "refreshing") return project.worktrees
+    if (!worktreesLoaded()) return project.worktrees
     const loaded = worktrees.latest
     return loaded?.projectID === project.id ? loaded.items : project.worktrees
   })
@@ -114,10 +115,11 @@ export function createNewSessionWorkspaceController(input: {
     const project = currentProject()
     const worktree = input.selectedWorktree()
     if (!project || !worktree) return
-    return isWorkspaceSelection(project, worktree) ||
-      worktreeDirectories().some((item) => sameDirectory(item, worktree))
-      ? worktree
-      : undefined
+    if (isWorkspaceSelection(project, worktree)) return worktree
+    // A saved choice may only exist in the server inventory. Keep it until the list can confirm it,
+    // otherwise the selector falls back to Local while loading and a submit would target the wrong directory.
+    if (!worktreesLoaded()) return worktree
+    return worktreeDirectories().some((item) => sameDirectory(item, worktree)) ? worktree : undefined
   })
   const fallback = createMemo(() => {
     const project = currentProject()
@@ -180,12 +182,10 @@ export function createNewSessionWorkspaceController(input: {
       workspace: createMemo(() => {
         const project = currentProject()
         const current = value()
-        return (
-          current === "create" ||
-          (!!project &&
-            (isWorkspaceDirectory(project, current) ||
-              worktreeDirectories().some((item) => sameDirectory(item, current))))
-        )
+        if (current === "create") return true
+        if (current === "main" || !project) return false
+        if (isWorkspaceDirectory(project, current) || !worktreesLoaded()) return true
+        return worktreeDirectories().some((item) => sameDirectory(item, current))
       }),
       reset: () => {
         input.setSelectedWorktree(undefined)

--- a/packages/app/src/new-session/workspace/controller.ts
+++ b/packages/app/src/new-session/workspace/controller.ts
@@ -78,6 +78,10 @@ export function createNewSessionWorkspaceController(input: {
   const worktreeItems = createMemo(() => {
     const project = currentProject()
     if (!project) return []
+    // `latest` only skips Suspense once the resource has resolved at least once. Before that it
+    // behaves like a plain read, which holds the transition that opens the New Session tab until
+    // the worktree list returns. Fall back to the project inventory until then.
+    if (worktrees.state !== "ready" && worktrees.state !== "refreshing") return project.worktrees
     const loaded = worktrees.latest
     return loaded?.projectID === project.id ? loaded.items : project.worktrees
   })
@@ -140,12 +144,19 @@ export function createNewSessionWorkspaceController(input: {
         .catch(() => ({ directory, search, data: [] })),
   )
   createEffect(() => {
-    void Promise.all([data.location.syncInfo({ directory: sdk().directory }), data.project.sync()]).catch(
-      () => undefined,
-    )
-    const project = currentProject()
-    const directories = project ? [project.worktree, ...worktreeDirectories()] : [sdk().directory]
-    directories.forEach((directory) => void data.location.vcs.sync({ directory }).catch(() => undefined))
+    void Promise.all([
+      data.location.syncInfo({ directory: sdk().directory }),
+      data.project.sync(),
+      data.location.vcs.sync({ directory: sdk().directory }),
+    ]).catch(() => undefined)
+  })
+  // Only the selected worktree feeds the branch label. Syncing every worktree in the inventory boots
+  // each one on the server, which then emits `agent.updated` and makes the client run the full
+  // catalog fan-out for every directory.
+  createEffect(() => {
+    const selection = value()
+    if (selection === "main" || selection === "create") return
+    void data.location.vcs.sync({ directory: selection }).catch(() => undefined)
   })
   const branch = createMemo(() =>
     resolveNewSessionBranch({


### PR DESCRIPTION
Follow-up to #47310.

- Clicking **New session** looked dead until `GET /api/worktree` returned. Going Home then revealed the tab, and clicking the tab hung the same way.
- Opening New Session also fired `GET /api/vcs` for every worktree in the inventory. Each one booted that location on the server, which emitted `agent.updated`, which made the client run the full catalog fan-out (`provider`, `agent`, `command`, `skill`, `mcp`, …) for every worktree.

```mermaid
sequenceDiagram
    participant U as User
    participant T as tabs.tsx (startTransition)
    participant C as workspace/controller.ts
    participant S as Server
    U->>T: New session
    T->>C: mount route
    C->>S: GET /api/worktree
    Note over C: worktrees.latest read before first resolve<br/>registers with Suspense + transition
    T-->>U: tab + navigation held until response
    C->>S: GET /api/vcs ×N (every worktree)
    S-->>C: location booted ×N → agent.updated ×N
    C->>S: catalog fan-out ×N
```

### `worktrees.latest` suspends until the first value

`latest` only skips Suspense after the resource has resolved once. Before that it is a plain read, so the transition that adds the draft tab and navigates waits for the response.

```ts
// packages/app/src/new-session/workspace/controller.ts
if (worktrees.state !== "ready" && worktrees.state !== "refreshing") return project.worktrees
const loaded = worktrees.latest
```

### Keep a saved inventory-only worktree while the list loads

`selected()` only accepted a saved worktree that was in `sandboxes` or the loaded list. With the fallback above, an inventory-only worktree resolved to `undefined` until the response landed, so the selector showed Local and a submit in that window would target the wrong directory.

```ts
if (isWorkspaceSelection(project, worktree)) return worktree
if (!worktreesLoaded()) return worktree
return worktreeDirectories().some((item) => sameDirectory(item, worktree)) ? worktree : undefined
```

### Sync vcs for the directories the page reads

The branch label only reads `vcs.info` for `sdk().directory` and the selected worktree.

```ts
createEffect(() => {
  const selection = value()
  if (selection === "main" || selection === "create") return
  void data.location.vcs.sync({ directory: selection }).catch(() => undefined)
})
```
