### PR TITLE
fix(desktop): brand macOS dev app as OpenCode Dev

### DIFF
--- a/packages/desktop/scripts/dev-electron.ts
+++ b/packages/desktop/scripts/dev-electron.ts
@@ -1,0 +1,35 @@
+import { $ } from "bun"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export async function prepareDevElectron() {
+  const electron = dirname(fileURLToPath(import.meta.resolve("electron/package.json")))
+  const icon = Bun.file(join(import.meta.dirname, "../icons/dev/icon.icns"))
+  const hash = new Bun.CryptoHasher("sha256")
+    .update(electron)
+    .update(process.arch)
+    .update(await Bun.file(join(electron, "package.json")).text())
+    .update(await icon.arrayBuffer())
+    .update(await Bun.file(import.meta.filename).text())
+    .digest("hex")
+    .slice(0, 16)
+  const root = join(import.meta.dirname, "../node_modules/.cache/opencode-dev", hash)
+  const bundle = join(root, "OpenCode Dev.app")
+  // Electron uses the executable's name to distinguish development from packaged apps.
+  const executable = join(bundle, "Contents/MacOS/Electron")
+  if (await Bun.file(join(root, "ready")).exists()) return executable
+
+  // macOS reads the Dock and app-switcher identity from the bundle, even after app.setName().
+  await $`mkdir -p ${root}`
+  await $`ditto ${join(electron, "dist/Electron.app")} ${bundle}`
+  const plist = join(bundle, "Contents/Info.plist")
+  for (const key of ["CFBundleName", "CFBundleDisplayName"]) {
+    await $`plutil -replace ${key} -string ${"OpenCode Dev"} ${plist}`
+  }
+  await $`plutil -replace CFBundleIdentifier -string ai.opencode.desktop.dev ${plist}`
+  await Bun.write(join(bundle, "Contents/Resources/electron.icns"), icon)
+  // Changing the bundle resources invalidates Electron's signature.
+  await $`codesign --force --deep --sign - ${bundle}`
+  await Bun.write(join(root, "ready"), "")
+  return executable
+}

--- a/packages/desktop/scripts/dev.ts
+++ b/packages/desktop/scripts/dev.ts
@@ -1,6 +1,7 @@
 import { $ } from "bun"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { prepareDevElectron } from "./dev-electron"
 import { downloadCliToResources, windowsify } from "./utils"
 
 type ServerSource = { type: "build" } | { type: "download"; version: string }
@@ -23,6 +24,7 @@ async function prepareDesktop() {
     $`bun run install-electron`,
     $`bun ./scripts/copy-icons.ts ${process.env.OPENCODE_CHANNEL ?? "dev"}`,
   ])
+  if (process.platform === "darwin") process.env.ELECTRON_EXEC_PATH = await prepareDevElectron()
 }
 
 function selectOptions(): DevOptions {


### PR DESCRIPTION
## Summary

Make `bun dev:desktop` appear as **OpenCode Dev** with the existing dev icon in the macOS Dock and app switcher.

- Prepare a cached copy of Electron's macOS app bundle with the dev display name, bundle identifier, and icon, then ad-hoc sign it.
- Launch that bundle through electron-vite's `ELECTRON_EXEC_PATH` override.
- Keep the executable named `Electron` so `app.isPackaged` remains `false` and development behavior is preserved.
- Key the cache by Electron installation, architecture, icon, and preparation script. Run this preparation only on macOS.

## Validation

Validated the same two-file change in the original development worktree before copying it to this dedicated branch:

- `bun typecheck` from `packages/desktop`.
- Prettier checks for both changed scripts and `git diff --check`.
- Launched the prepared bundle with an isolated Electron smoke fixture. macOS `NSRunningApplication` reported `OpenCode Dev` and `ai.opencode.desktop.dev`; Electron reported `app.isPackaged === false`.
- Confirmed the bundled icon is byte-identical to `icons/dev/icon.icns`.
- `codesign --verify --deep --strict` passed for the prepared bundle.

Windows and Linux were not runtime-tested. Their launch paths bypass the macOS preparation.

Screenshot limitation: this change affects native macOS application identity rather than a renderer route, so browser screenshots cannot capture the affected Dock/app-switcher UI. Native identity and icon checks are recorded above.
