### PR TITLE
fix(opencode): decide auto permission approval on the server

### DIFF
--- a/packages/core/src/v1/permission.ts
+++ b/packages/core/src/v1/permission.ts
@@ -2,7 +2,7 @@ export * as PermissionV1 from "./permission"
 
 import { Schema } from "effect"
 export * from "@opencode-ai/schema/permission-v1"
-import { ID } from "@opencode-ai/schema/permission-v1"
+import { AutoLeaseID, ID } from "@opencode-ai/schema/permission-v1"
 
 export class RejectedError extends Schema.TaggedErrorClass<RejectedError>()("PermissionRejectedError", {}) {
   override get message() {
@@ -29,5 +29,12 @@ export class DeniedError extends Schema.TaggedErrorClass<DeniedError>()("Permiss
 export class NotFoundError extends Schema.TaggedErrorClass<NotFoundError>()("Permission.NotFoundError", {
   requestID: ID,
 }) {}
+
+// Raised when renewing a lease that was already released or has expired. The
+// owner must acquire a new one instead of assuming auto mode is still active.
+export class AutoLeaseNotFoundError extends Schema.TaggedErrorClass<AutoLeaseNotFoundError>()(
+  "Permission.AutoLeaseNotFoundError",
+  { leaseID: AutoLeaseID },
+) {}
 
 export type Error = DeniedError | RejectedError | CorrectedError

--- a/packages/opencode/src/cli/cmd/run.ts
+++ b/packages/opencode/src/cli/cmd/run.ts
@@ -21,6 +21,7 @@ import { Effect } from "effect"
 import { UI } from "../ui"
 import { effectCmd } from "../effect-cmd"
 import { EOL } from "os"
+import { defer } from "@/util/defer"
 import { Filesystem } from "@/util/filesystem"
 import { createOpencodeClient, type OpencodeClient, type ToolPart } from "@opencode-ai/sdk/v2"
 import { FormatError, FormatUnknownError } from "../error"
@@ -803,6 +804,9 @@ export const RunCommand = effectCmd({
               if (!sessions.has(permission.sessionID)) continue
 
               if (auto) {
+                // A server holding our lease resolved this without asking, so
+                // reaching here means it predates the lease endpoint.
+                if (lease) continue
                 await client.permission.reply({
                   requestID: permission.id,
                   reply: "once",
@@ -824,6 +828,32 @@ export const RunCommand = effectCmd({
         }
         const cwd = args.attach ? (directory ?? sess.directory ?? (await current(sdk))) : (directory ?? root)
         const client = args.attach ? attachSDK(cwd) : sdk
+
+        // Auto mode belongs to the server so `permission.asked` keeps meaning "a
+        // human must answer". The lease covers this session and the subagent
+        // sessions it spawns, so an attached long-running server keeps asking for
+        // everything else. It also lapses on its own, so killing this process
+        // cannot leave that server in auto mode. Servers predating the endpoint
+        // return no lease and `loop` keeps replying client-side.
+        const lease = auto
+          ? await client.permission
+              .autoAcquire({ scope: { type: "session", sessionID } })
+              .then((result) => result.data)
+              .catch(() => undefined)
+          : undefined
+        const renewal = lease
+          ? setInterval(
+              () => void client.permission.autoRenew({ leaseID: lease.id }).catch(() => {}),
+              Math.max(1000, Math.floor(lease.ttl / 3)),
+            )
+          : undefined
+        renewal?.unref?.()
+        // Released on scope exit rather than left to lapse, so an attached server
+        // stops auto-approving as soon as this run finishes.
+        await using _auto = defer(async () => {
+          if (renewal) clearInterval(renewal)
+          if (lease) await client.permission.autoRelease({ leaseID: lease.id }).catch(() => {})
+        })
 
         // Validate agent if specified
         const agent = await pickAgent(client)

--- a/packages/opencode/src/permission/index.ts
+++ b/packages/opencode/src/permission/index.ts
@@ -2,10 +2,12 @@ import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { ConfigPermissionV1 } from "@opencode-ai/core/v1/config/permission"
 import { InstanceState } from "@/effect/instance-state"
 import { Wildcard } from "@opencode-ai/core/util/wildcard"
-import { Deferred, Effect, Layer, Context } from "effect"
+import { Clock, Deferred, Effect, Layer, Context } from "effect"
 import os from "os"
 import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { EventV2Bridge } from "@/event-v2-bridge"
+import { Session } from "@/session/session"
+import type { SessionID } from "@/session/schema"
 
 export const Event = PermissionV1.Event
 
@@ -13,6 +15,12 @@ export interface Interface {
   readonly ask: (input: PermissionV1.AskInput) => Effect.Effect<void, PermissionV1.Error>
   readonly reply: (input: PermissionV1.ReplyInput) => Effect.Effect<void, PermissionV1.NotFoundError>
   readonly list: () => Effect.Effect<ReadonlyArray<PermissionV1.Request>>
+  readonly autoList: () => Effect.Effect<ReadonlyArray<PermissionV1.AutoLease>>
+  readonly autoAcquire: (input: PermissionV1.AutoAcquireBody) => Effect.Effect<PermissionV1.AutoLease>
+  readonly autoRenew: (
+    leaseID: PermissionV1.AutoLeaseID,
+  ) => Effect.Effect<PermissionV1.AutoLease, PermissionV1.AutoLeaseNotFoundError>
+  readonly autoRelease: (leaseID: PermissionV1.AutoLeaseID) => Effect.Effect<boolean>
 }
 
 interface PendingEntry {
@@ -23,6 +31,7 @@ interface PendingEntry {
 interface State {
   pending: Map<PermissionV1.ID, PendingEntry>
   approved: PermissionV1.Rule[]
+  leases: Map<PermissionV1.AutoLeaseID, PermissionV1.AutoLease>
 }
 
 export function evaluate(permission: string, pattern: string, ...rulesets: PermissionV1.Ruleset[]): PermissionV1.Rule {
@@ -43,12 +52,14 @@ const layer = Layer.effect(
   Service,
   Effect.gen(function* () {
     const events = yield* EventV2Bridge.Service
+    const sessions = yield* Session.Service
     const state = yield* InstanceState.make<State>(
       Effect.fn("Permission.state")(function* (ctx) {
         void ctx
-        const state = {
+        const state: State = {
           pending: new Map<PermissionV1.ID, PendingEntry>(),
           approved: [],
+          leases: new Map<PermissionV1.AutoLeaseID, PermissionV1.AutoLease>(),
         }
 
         yield* Effect.addFinalizer(() =>
@@ -65,12 +76,12 @@ const layer = Layer.effect(
     )
 
     const ask = Effect.fn("Permission.ask")(function* (input: PermissionV1.AskInput) {
-      const { approved, pending } = yield* InstanceState.get(state)
+      const current = yield* InstanceState.get(state)
       const { ruleset, ...request } = input
       let needsAsk = false
 
       for (const pattern of request.patterns) {
-        const rule = evaluate(request.permission, pattern, ruleset, approved)
+        const rule = evaluate(request.permission, pattern, ruleset, current.approved)
         yield* Effect.logInfo("evaluated", { permission: request.permission, pattern, action: rule })
         if (rule.action === "deny") {
           return yield* new PermissionV1.DeniedError({
@@ -82,6 +93,16 @@ const layer = Layer.effect(
       }
 
       if (!needsAsk) return
+
+      // Every pattern has been evaluated, so an explicit `deny` has already won.
+      // Only now may an auto lease turn the remaining `ask` outcomes into an
+      // approval, and it resolves the request without publishing
+      // `permission.asked` or `permission.replied` — integrations depend on
+      // those events meaning a human was involved.
+      if (yield* leased(current, request.sessionID)) {
+        yield* Effect.logInfo("auto approved", { permission: request.permission, patterns: request.patterns })
+        return
+      }
 
       const id = request.id ?? PermissionV1.ID.ascending()
       const info: PermissionV1.Request = {
@@ -96,12 +117,12 @@ const layer = Layer.effect(
       yield* Effect.logInfo("asking", { id, permission: info.permission, patterns: info.patterns })
 
       const deferred = yield* Deferred.make<void, PermissionV1.RejectedError | PermissionV1.CorrectedError>()
-      pending.set(id, { info, deferred })
+      current.pending.set(id, { info, deferred })
       yield* events.publish(Event.Asked, info)
       return yield* Effect.ensuring(
         Deferred.await(deferred),
         Effect.sync(() => {
-          pending.delete(id)
+          current.pending.delete(id)
         }),
       )
     })
@@ -171,7 +192,84 @@ const layer = Layer.effect(
       return Array.from(pending.values(), (item) => item.info)
     })
 
-    return Service.of({ ask, reply, list })
+    // Drops leases whose owner stopped renewing. Expiry is evaluated lazily on
+    // every read instead of from a timer fiber, so a lease that outlives its
+    // owner can never cover a request even if nothing else touches the map.
+    const activeLeases = Effect.fn("Permission.activeLeases")(function* (current: State) {
+      const now = yield* Clock.currentTimeMillis
+      for (const [id, lease] of current.leases) {
+        if (lease.expires > now) continue
+        current.leases.delete(id)
+        yield* Effect.logInfo("auto lease expired", { leaseID: id })
+      }
+      return current.leases
+    })
+
+    // A session-scoped lease covers the session it names plus every session
+    // descended from it, so subagents spawned by `opencode run --auto` are
+    // covered while sessions belonging to other clients are not.
+    const leased = Effect.fn("Permission.leased")(function* (current: State, sessionID: SessionID) {
+      const leases = yield* activeLeases(current)
+      if (leases.size === 0) return false
+
+      const roots = new Set<SessionID>()
+      for (const lease of leases.values()) {
+        if (lease.scope.type === "instance") return true
+        roots.add(lease.scope.sessionID)
+      }
+
+      let cursor: SessionID | undefined = sessionID
+      while (cursor) {
+        if (roots.has(cursor)) return true
+        const info: Session.Info | undefined = yield* sessions
+          .get(cursor)
+          .pipe(Effect.catchTag("NotFoundError", () => Effect.succeed(undefined)))
+        cursor = info?.parentID
+      }
+      return false
+    })
+
+    const autoList = Effect.fn("Permission.autoList")(function* () {
+      return Array.from((yield* activeLeases(yield* InstanceState.get(state))).values())
+    })
+
+    const autoAcquire = Effect.fn("Permission.autoAcquire")(function* (input: PermissionV1.AutoAcquireBody) {
+      // Requests already pending are deliberately left alone: they were raised
+      // while a human was still expected to answer, and some other client may be
+      // showing that prompt right now.
+      const leases = yield* activeLeases(yield* InstanceState.get(state))
+      const ttl = Math.min(
+        Math.max(input.ttl ?? PermissionV1.AUTO_LEASE_TTL_DEFAULT, PermissionV1.AUTO_LEASE_TTL_MIN),
+        PermissionV1.AUTO_LEASE_TTL_MAX,
+      )
+      const lease: PermissionV1.AutoLease = {
+        id: PermissionV1.AutoLeaseID.ascending(),
+        scope: input.scope,
+        ttl,
+        expires: (yield* Clock.currentTimeMillis) + ttl,
+      }
+      leases.set(lease.id, lease)
+      yield* Effect.logInfo("auto lease acquired", { leaseID: lease.id, scope: lease.scope, ttl })
+      return lease
+    })
+
+    const autoRenew = Effect.fn("Permission.autoRenew")(function* (leaseID: PermissionV1.AutoLeaseID) {
+      const leases = yield* activeLeases(yield* InstanceState.get(state))
+      const existing = leases.get(leaseID)
+      if (!existing) return yield* new PermissionV1.AutoLeaseNotFoundError({ leaseID })
+      const renewed = { ...existing, expires: (yield* Clock.currentTimeMillis) + existing.ttl }
+      leases.set(leaseID, renewed)
+      return renewed
+    })
+
+    const autoRelease = Effect.fn("Permission.autoRelease")(function* (leaseID: PermissionV1.AutoLeaseID) {
+      const leases = yield* activeLeases(yield* InstanceState.get(state))
+      const removed = leases.delete(leaseID)
+      if (removed) yield* Effect.logInfo("auto lease released", { leaseID })
+      return removed
+    })
+
+    return Service.of({ ask, reply, list, autoList, autoAcquire, autoRenew, autoRelease })
   }),
 )
 
@@ -218,6 +316,6 @@ export function visibleTools<T>(tools: Record<string, T>, ruleset: PermissionV1.
   return Object.fromEntries(Object.entries(tools).filter(([name]) => !hidden.has(name)))
 }
 
-export const node = LayerNode.make({ service: Service, layer: layer, deps: [EventV2Bridge.node] })
+export const node = LayerNode.make({ service: Service, layer: layer, deps: [EventV2Bridge.node, Session.node] })
 
 export * as Permission from "."

--- a/packages/opencode/src/server/routes/instance/httpapi/errors.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/errors.ts
@@ -140,6 +140,15 @@ export class PermissionNotFoundError extends Schema.TaggedErrorClass<PermissionN
   { httpApiStatus: 404 },
 ) {}
 
+export class PermissionAutoLeaseNotFoundError extends Schema.TaggedErrorClass<PermissionAutoLeaseNotFoundError>()(
+  "PermissionAutoLeaseNotFoundError",
+  {
+    leaseID: Schema.String,
+    message: Schema.String,
+  },
+  { httpApiStatus: 404 },
+) {}
+
 export class McpServerNotFoundError extends Schema.TaggedErrorClass<McpServerNotFoundError>()(
   "McpServerNotFoundError",
   {

--- a/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/groups/permission.ts
@@ -2,7 +2,7 @@ import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { Permission } from "@/permission"
 import { Schema } from "effect"
 import { HttpApi, HttpApiEndpoint, HttpApiError, HttpApiGroup, OpenApi } from "effect/unstable/httpapi"
-import { PermissionNotFoundError } from "../errors"
+import { PermissionAutoLeaseNotFoundError, PermissionNotFoundError } from "../errors"
 import { Authorization } from "../middleware/authorization"
 import { InstanceContextMiddleware } from "../middleware/instance-context"
 import { WorkspaceRoutingMiddleware, WorkspaceRoutingQuery } from "../middleware/workspace-routing"
@@ -12,6 +12,10 @@ const root = "/permission"
 const ReplyPayload = Schema.Struct({
   reply: PermissionV1.Reply,
   message: Schema.optional(Schema.String),
+})
+const AutoAcquirePayload = Schema.Struct({
+  scope: PermissionV1.AutoScope,
+  ttl: PermissionV1.AutoAcquireBody.fields.ttl,
 })
 
 export const PermissionApi = HttpApi.make("permission")
@@ -26,6 +30,51 @@ export const PermissionApi = HttpApi.make("permission")
             identifier: "permission.list",
             summary: "List pending permissions",
             description: "Get all pending permission requests across all sessions.",
+          }),
+        ),
+        HttpApiEndpoint.get("autoList", `${root}/auto`, {
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Array(PermissionV1.AutoLease), "Active auto-approve leases"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "permission.autoList",
+            summary: "List auto-approve leases",
+            description: "List the auto-approve leases that have not expired or been released.",
+          }),
+        ),
+        HttpApiEndpoint.post("autoAcquire", `${root}/auto`, {
+          query: WorkspaceRoutingQuery,
+          payload: AutoAcquirePayload,
+          success: described(PermissionV1.AutoLease, "Acquired lease"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "permission.autoAcquire",
+            summary: "Acquire an auto-approve lease",
+            description:
+              "Auto-approve requests in scope that would otherwise ask, without publishing permission.asked. Explicit deny rules still apply, requests already pending are unaffected, and the lease expires unless renewed within its ttl.",
+          }),
+        ),
+        HttpApiEndpoint.post("autoRenew", `${root}/auto/:leaseID/renew`, {
+          params: { leaseID: PermissionV1.AutoLeaseID },
+          query: WorkspaceRoutingQuery,
+          success: described(PermissionV1.AutoLease, "Renewed lease"),
+          error: PermissionAutoLeaseNotFoundError,
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "permission.autoRenew",
+            summary: "Renew an auto-approve lease",
+            description: "Extend a lease by its ttl. Fails once the lease has expired or been released.",
+          }),
+        ),
+        HttpApiEndpoint.delete("autoRelease", `${root}/auto/:leaseID`, {
+          params: { leaseID: PermissionV1.AutoLeaseID },
+          query: WorkspaceRoutingQuery,
+          success: described(Schema.Boolean, "Lease released"),
+        }).annotateMerge(
+          OpenApi.annotations({
+            identifier: "permission.autoRelease",
+            summary: "Release an auto-approve lease",
+            description: "Release a lease immediately instead of waiting for it to expire.",
           }),
         ),
         HttpApiEndpoint.post("reply", `${root}/:requestID/reply`, {

--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/permission.ts
@@ -3,7 +3,7 @@ import { Permission } from "@/permission"
 import { Effect } from "effect"
 import { HttpApiBuilder } from "effect/unstable/httpapi"
 import { InstanceHttpApi } from "../api"
-import { PermissionNotFoundError } from "../errors"
+import { PermissionAutoLeaseNotFoundError, PermissionNotFoundError } from "../errors"
 
 export const permissionHandlers = HttpApiBuilder.group(InstanceHttpApi, "permission", (handlers) =>
   Effect.gen(function* () {
@@ -36,6 +36,43 @@ export const permissionHandlers = HttpApiBuilder.group(InstanceHttpApi, "permiss
       return true
     })
 
-    return handlers.handle("list", list).handle("reply", reply)
+    const autoList = Effect.fn("PermissionHttpApi.autoList")(function* () {
+      return yield* svc.autoList()
+    })
+
+    const autoAcquire = Effect.fn("PermissionHttpApi.autoAcquire")(function* (ctx: {
+      payload: PermissionV1.AutoAcquireBody
+    }) {
+      return yield* svc.autoAcquire(ctx.payload)
+    })
+
+    const autoRenew = Effect.fn("PermissionHttpApi.autoRenew")(function* (ctx: {
+      params: { leaseID: PermissionV1.AutoLeaseID }
+    }) {
+      return yield* svc.autoRenew(ctx.params.leaseID).pipe(
+        Effect.catchTag("Permission.AutoLeaseNotFoundError", (error) =>
+          Effect.fail(
+            new PermissionAutoLeaseNotFoundError({
+              leaseID: String(error.leaseID),
+              message: `Permission auto lease not found: ${error.leaseID}`,
+            }),
+          ),
+        ),
+      )
+    })
+
+    const autoRelease = Effect.fn("PermissionHttpApi.autoRelease")(function* (ctx: {
+      params: { leaseID: PermissionV1.AutoLeaseID }
+    }) {
+      return yield* svc.autoRelease(ctx.params.leaseID)
+    })
+
+    return handlers
+      .handle("list", list)
+      .handle("autoList", autoList)
+      .handle("autoAcquire", autoAcquire)
+      .handle("autoRenew", autoRenew)
+      .handle("autoRelease", autoRelease)
+      .handle("reply", reply)
   }),
 )

--- a/packages/opencode/test/cli/run/auto-attach.test.ts
+++ b/packages/opencode/test/cli/run/auto-attach.test.ts
@@ -1,0 +1,97 @@
+// End-to-end coverage for `opencode run --attach ... --auto` against a
+// long-running server. See opencode#47545: the point of moving auto approval
+// into the server is that `permission.asked` keeps meaning "a human must
+// respond", and that one run invocation cannot put a shared server into auto
+// mode for everyone else or leave it that way after it exits.
+import { describe, expect } from "bun:test"
+import { Effect } from "effect"
+import { reply } from "../../lib/llm-server"
+import { cliIt } from "../../lib/cli-process"
+
+type Lease = { id: string; scope: { type: string; sessionID?: string }; ttl: number }
+
+function leases(url: string, directory: string) {
+  return Effect.promise(
+    async () =>
+      (await (
+        await fetch(new URL("/permission/auto", url), { headers: { "x-opencode-directory": directory } })
+      ).json()) as Lease[],
+  )
+}
+
+// Collects every event the server publishes for the lifetime of the scope, the
+// way an external integration such as Warp or Orca would consume them.
+function watchEvents(url: string, directory: string) {
+  return Effect.gen(function* () {
+    const seen: Array<{ type: string; properties: Record<string, unknown> }> = []
+    const controller = new AbortController()
+    yield* Effect.acquireRelease(
+      Effect.promise(async () => {
+        const response = await fetch(new URL("/event", url), {
+          headers: { "x-opencode-directory": directory },
+          signal: controller.signal,
+        })
+        const reader = response.body!.pipeThrough(new TextDecoderStream()).getReader()
+        void (async () => {
+          while (true) {
+            const chunk = await reader.read()
+            if (chunk.done) return
+            for (const line of chunk.value.split("\n")) {
+              if (!line.startsWith("data: ")) continue
+              seen.push(JSON.parse(line.slice(6)))
+            }
+          }
+        })().catch(() => {})
+      }),
+      () => Effect.sync(() => controller.abort()),
+    )
+    return seen
+  })
+}
+
+describe("opencode run --attach --auto", () => {
+  cliIt.live(
+    "auto-approves only its own session and gives the lease back when it exits",
+    ({ llm, opencode, home }) =>
+      Effect.gen(function* () {
+        const server = yield* opencode.serve()
+        const events = yield* watchEvents(server.url, home)
+
+        // The tool sleeps so the lease is observable while the run is running.
+        yield* llm.push(reply().tool("bash", { command: "sleep 2", description: "Sleep briefly" }))
+        yield* llm.text("finished")
+
+        const handle = yield* opencode.startRun("use a tool", {
+          extraArgs: ["--attach", server.url, "--auto"],
+        })
+
+        const held = yield* Effect.gen(function* () {
+          while (true) {
+            const current = yield* leases(server.url, home)
+            if (current.length > 0) return current
+            yield* Effect.sleep("100 millis")
+          }
+        }).pipe(
+          Effect.timeoutOrElse({
+            duration: "30 seconds",
+            orElse: () => Effect.fail(new Error("run --auto never acquired a lease")),
+          }),
+        )
+
+        // Scoped to the run's own session, so unrelated sessions on this
+        // server keep asking.
+        expect(held).toHaveLength(1)
+        expect(held[0]!.scope.type).toBe("session")
+        expect(held[0]!.scope.sessionID).toStartWith("ses_")
+
+        const result = yield* handle.result
+        opencode.expectExit(result, 0)
+        expect(result.stdout).toContain("finished")
+
+        // Nothing a human had to answer, and no leftover authority.
+        expect(events.filter((event) => event.type === "permission.asked")).toEqual([])
+        expect(yield* leases(server.url, home)).toEqual([])
+      }),
+    120_000,
+  )
+})

--- a/packages/opencode/test/permission/auto-lease.test.ts
+++ b/packages/opencode/test/permission/auto-lease.test.ts
@@ -1,0 +1,418 @@
+import { expect } from "bun:test"
+import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
+import { AppNodeBuilder } from "@opencode-ai/core/effect/app-node-builder"
+import { LayerNode } from "@opencode-ai/core/effect/layer-node"
+import { Database } from "@opencode-ai/core/database/database"
+import { FSUtil } from "@opencode-ai/core/fs-util"
+import { SessionProjector } from "@opencode-ai/core/session/projector"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { Cause, Effect, Exit, Fiber } from "effect"
+import { EventV2Bridge } from "../../src/event-v2-bridge"
+import { Permission } from "../../src/permission"
+import { InstanceBootstrap } from "../../src/project/bootstrap"
+import { InstanceStore } from "../../src/project/instance-store"
+import { Project } from "../../src/project/project"
+import { Vcs } from "../../src/project/vcs"
+import { Session } from "../../src/session/session"
+import { SessionID } from "../../src/session/schema"
+import { testEffect } from "../lib/effect"
+
+// Session lineage decides what a session scoped lease covers, so these tests
+// run against real sessions and therefore need the fully bootstrapped instance.
+const env = AppNodeBuilder.build(
+  LayerNode.group([
+    Permission.node,
+    Session.node,
+    SessionProjector.node,
+    Project.node,
+    Vcs.node,
+    Database.node,
+    EventV2Bridge.node,
+    FSUtil.node,
+    CrossSpawnSpawner.node,
+    InstanceStore.node,
+  ]),
+  [[InstanceStore.bootstrapNode, InstanceBootstrap.node]],
+)
+const it = testEffect(env)
+
+// Bootstrapping a real instance is slow on a cold cache and a few of these
+// tests deliberately wait out a lease expiry.
+const TIMEOUT = 20_000
+
+// The whole point of the lease is that covered requests never reach an
+// integration, so every test that claims "auto approved" also proves no
+// `permission.asked` was published for it.
+const recordAsked = Effect.gen(function* () {
+  const events = yield* EventV2Bridge.Service
+  const asked: string[] = []
+  const unsubscribe = yield* events.listen((event) =>
+    Effect.sync(() => {
+      if (event.type !== "permission.asked") return
+      asked.push((event.data as PermissionV1.Request).sessionID)
+    }),
+  )
+  yield* Effect.addFinalizer(() => unsubscribe)
+  return asked
+})
+
+const ask = (sessionID: SessionID, ruleset: PermissionV1.Ruleset = [], patterns = ["ls"]) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    return yield* permission.ask({
+      sessionID,
+      permission: "bash",
+      patterns,
+      metadata: {},
+      always: [],
+      ruleset,
+    })
+  })
+
+const waitForPending = (count: number) =>
+  Effect.gen(function* () {
+    const permission = yield* Permission.Service
+    while (true) {
+      const list = yield* permission.list()
+      if (list.length === count) return list
+      yield* Effect.sleep("10 millis")
+    }
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: "2 seconds",
+      orElse: () => Effect.fail(new Error(`timed out waiting for ${count} pending permission request(s)`)),
+    }),
+  )
+
+// Rejecting one request also rejects the rest of its session, so ignore the
+// misses this leaves behind.
+const rejectAll = Effect.gen(function* () {
+  const permission = yield* Permission.Service
+  for (const request of yield* permission.list()) {
+    yield* Effect.ignore(permission.reply({ requestID: request.id, reply: "reject" }))
+  }
+})
+
+const fail = <A, E, R>(self: Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const exit = yield* self.pipe(Effect.exit)
+    if (Exit.isFailure(exit)) return Cause.squash(exit.cause)
+    throw new Error("expected permission effect to fail")
+  })
+
+it.instance(
+  "auto lease resolves a covered request without publishing permission.asked",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const asked = yield* recordAsked
+
+      yield* permission.autoAcquire({ scope: { type: "instance" } })
+      yield* ask(SessionID.make("session_covered"))
+
+      expect(asked).toEqual([])
+      expect(yield* permission.list()).toEqual([])
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "requests still ask when no lease is held",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const asked = yield* recordAsked
+
+      const fiber = yield* ask(SessionID.make("session_uncovered")).pipe(Effect.forkScoped)
+      yield* waitForPending(1)
+
+      expect(asked).toEqual(["session_uncovered"])
+      yield* rejectAll
+      yield* Fiber.await(fiber)
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "explicit deny still wins while a lease is held",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      yield* permission.autoAcquire({ scope: { type: "instance" } })
+
+      const denied = yield* fail(
+        ask(SessionID.make("session_denied"), [{ permission: "bash", pattern: "*", action: "deny" }]),
+      )
+      expect(denied).toBeInstanceOf(PermissionV1.DeniedError)
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "a single denied pattern fails the request even when the rest are covered",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const asked = yield* recordAsked
+      yield* permission.autoAcquire({ scope: { type: "instance" } })
+
+      const denied = yield* fail(
+        ask(
+          SessionID.make("session_mixed"),
+          [
+            { permission: "bash", pattern: "*", action: "ask" },
+            { permission: "bash", pattern: "rm *", action: "deny" },
+          ],
+          ["ls", "rm -rf /"],
+        ),
+      )
+      expect(denied).toBeInstanceOf(PermissionV1.DeniedError)
+      expect(asked).toEqual([])
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "acquiring a lease leaves requests that were already pending alone",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const fiber = yield* ask(SessionID.make("session_pending")).pipe(Effect.forkScoped)
+      const [pending] = yield* waitForPending(1)
+
+      yield* permission.autoAcquire({ scope: { type: "instance" } })
+      yield* Effect.sleep("50 millis")
+
+      expect(yield* permission.list()).toHaveLength(1)
+
+      yield* permission.reply({ requestID: pending.id, reply: "once" })
+      yield* Fiber.await(fiber)
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "releasing a lease restores interactive behaviour",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const lease = yield* permission.autoAcquire({ scope: { type: "instance" } })
+      expect(yield* permission.autoList()).toEqual([lease])
+
+      yield* ask(SessionID.make("session_released"))
+      expect(yield* permission.autoRelease(lease.id)).toBe(true)
+      expect(yield* permission.autoList()).toEqual([])
+      expect(yield* permission.autoRelease(lease.id)).toBe(false)
+
+      const fiber = yield* ask(SessionID.make("session_released")).pipe(Effect.forkScoped)
+      yield* waitForPending(1)
+      yield* rejectAll
+      yield* Fiber.await(fiber)
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+// Stopping renewal is what a crashed or SIGKILLed owner looks like to the
+// server: nothing is released, the lease simply stops being renewed.
+it.instance(
+  "a lease whose owner stops renewing expires and stops covering requests",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const lease = yield* permission.autoAcquire({
+        scope: { type: "instance" },
+        ttl: PermissionV1.AUTO_LEASE_TTL_MIN,
+      })
+      expect(lease.ttl).toBe(PermissionV1.AUTO_LEASE_TTL_MIN)
+
+      yield* Effect.sleep(PermissionV1.AUTO_LEASE_TTL_MIN + 200)
+
+      expect(yield* permission.autoList()).toEqual([])
+      expect(yield* fail(permission.autoRenew(lease.id))).toBeInstanceOf(PermissionV1.AutoLeaseNotFoundError)
+
+      const fiber = yield* ask(SessionID.make("session_expired")).pipe(Effect.forkScoped)
+      yield* waitForPending(1)
+      yield* rejectAll
+      yield* Fiber.await(fiber)
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "renewing keeps a lease covering requests past its original expiry",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const asked = yield* recordAsked
+      const lease = yield* permission.autoAcquire({
+        scope: { type: "instance" },
+        ttl: PermissionV1.AUTO_LEASE_TTL_MIN,
+      })
+
+      yield* Effect.sleep(PermissionV1.AUTO_LEASE_TTL_MIN - 300)
+      const renewed = yield* permission.autoRenew(lease.id)
+      expect(renewed.expires).toBeGreaterThan(lease.expires)
+
+      yield* Effect.sleep(400)
+      yield* ask(SessionID.make("session_renewed"))
+      expect(asked).toEqual([])
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "ttl is clamped to the range the server is willing to honour",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const tooShort = yield* permission.autoAcquire({ scope: { type: "instance" }, ttl: 1 })
+      const tooLong = yield* permission.autoAcquire({
+        scope: { type: "instance" },
+        ttl: PermissionV1.AUTO_LEASE_TTL_MAX * 10,
+      })
+      const unset = yield* permission.autoAcquire({ scope: { type: "instance" } })
+
+      expect(tooShort.ttl).toBe(PermissionV1.AUTO_LEASE_TTL_MIN)
+      expect(tooLong.ttl).toBe(PermissionV1.AUTO_LEASE_TTL_MAX)
+      expect(unset.ttl).toBe(PermissionV1.AUTO_LEASE_TTL_DEFAULT)
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "a session scoped lease covers descendant sessions but nothing else",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const sessions = yield* Session.Service
+      const root = yield* sessions.create({ title: "run" })
+      const child = yield* sessions.create({ parentID: root.id, title: "subagent" })
+      const grandchild = yield* sessions.create({ parentID: child.id, title: "nested subagent" })
+      const unrelated = yield* sessions.create({ title: "someone else" })
+      const asked = yield* recordAsked
+
+      yield* permission.autoAcquire({ scope: { type: "session", sessionID: root.id } })
+
+      yield* ask(root.id)
+      yield* ask(child.id)
+      yield* ask(grandchild.id)
+      expect(asked).toEqual([])
+
+      const fiber = yield* ask(unrelated.id).pipe(Effect.forkScoped)
+      yield* waitForPending(1)
+      expect(asked).toEqual([unrelated.id])
+
+      yield* rejectAll
+      yield* Fiber.await(fiber)
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+// `opencode run --attach --auto` against a shared server, and a second client
+// working on that server at the same time.
+it.instance(
+  "two clients keep separate auto authority",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const sessions = yield* Session.Service
+      const a = yield* sessions.create({ title: "client a" })
+      const b = yield* sessions.create({ title: "client b" })
+      const asked = yield* recordAsked
+
+      // Client B is mid-prompt before client A turns auto on.
+      const pendingB = yield* ask(b.id).pipe(Effect.forkScoped)
+      yield* waitForPending(1)
+      expect(asked).toEqual([b.id])
+
+      const lease = yield* permission.autoAcquire({ scope: { type: "session", sessionID: a.id } })
+
+      // B's visible prompt is untouched, A's new work is approved silently.
+      yield* Effect.sleep("50 millis")
+      expect(yield* permission.list()).toHaveLength(1)
+      yield* ask(a.id)
+      expect(asked).toEqual([b.id])
+
+      // B keeps asking for new work too.
+      const secondB = yield* ask(b.id).pipe(Effect.forkScoped)
+      yield* waitForPending(2)
+      expect(asked).toEqual([b.id, b.id])
+
+      // Client A exits: its authority goes with it and A asks again.
+      yield* permission.autoRelease(lease.id)
+      const afterA = yield* ask(a.id).pipe(Effect.forkScoped)
+      yield* waitForPending(3)
+      expect(asked).toEqual([b.id, b.id, a.id])
+
+      yield* rejectAll
+      yield* Fiber.await(pendingB)
+      yield* Fiber.await(secondB)
+      yield* Fiber.await(afterA)
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "an instance scoped lease covers every session in the instance",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const sessions = yield* Session.Service
+      const first = yield* sessions.create({ title: "first" })
+      const second = yield* sessions.create({ title: "second" })
+      const asked = yield* recordAsked
+
+      yield* permission.autoAcquire({ scope: { type: "instance" } })
+      yield* ask(first.id)
+      yield* ask(second.id)
+
+      expect(asked).toEqual([])
+    }),
+  { git: true },
+  TIMEOUT,
+)
+
+it.instance(
+  "leases do not resolve a doom_loop request that a deny rule forbids",
+  () =>
+    Effect.gen(function* () {
+      const permission = yield* Permission.Service
+      const asked = yield* recordAsked
+      yield* permission.autoAcquire({ scope: { type: "instance" } })
+
+      yield* permission.ask({
+        sessionID: SessionID.make("session_doom"),
+        permission: "doom_loop",
+        patterns: ["*"],
+        metadata: {},
+        always: [],
+        ruleset: [],
+      })
+      expect(asked).toEqual([])
+
+      const denied = yield* fail(
+        permission.ask({
+          sessionID: SessionID.make("session_doom"),
+          permission: "doom_loop",
+          patterns: ["*"],
+          metadata: {},
+          always: [],
+          ruleset: [{ permission: "doom_loop", pattern: "*", action: "deny" }],
+        }),
+      )
+      expect(denied).toBeInstanceOf(PermissionV1.DeniedError)
+    }),
+  { git: true },
+  TIMEOUT,
+)

--- a/packages/opencode/test/server/httpapi-permission-auto.test.ts
+++ b/packages/opencode/test/server/httpapi-permission-auto.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
+import { Server } from "../../src/server/server"
+import { resetDatabase } from "../fixture/db"
+import { disposeAllInstances, tmpdir } from "../fixture/fixture"
+
+function app() {
+  return Server.Default().app
+}
+
+afterEach(async () => {
+  await disposeAllInstances()
+  await resetDatabase()
+})
+
+describe("permission auto lease HttpApi", () => {
+  test("acquires, lists, renews and releases a lease", async () => {
+    await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+    const headers = { "x-opencode-directory": tmp.path }
+    const jsonHeaders = { ...headers, "content-type": "application/json" }
+
+    const empty = await app().request("/permission/auto", { headers })
+    expect(empty.status).toBe(200)
+    expect(await empty.json()).toEqual([])
+
+    const acquired = await app().request("/permission/auto", {
+      method: "POST",
+      headers: jsonHeaders,
+      body: JSON.stringify({ scope: { type: "instance" } }),
+    })
+    expect(acquired.status).toBe(200)
+    const lease = await acquired.json()
+    expect(lease.id).toStartWith("pal_")
+    expect(lease).toMatchObject({ scope: { type: "instance" }, ttl: PermissionV1.AUTO_LEASE_TTL_DEFAULT })
+
+    const listed = await app().request("/permission/auto", { headers })
+    expect(await listed.json()).toEqual([lease])
+
+    const renewed = await app().request(`/permission/auto/${lease.id}/renew`, { method: "POST", headers })
+    expect(renewed.status).toBe(200)
+    expect((await renewed.json()).expires).toBeGreaterThanOrEqual(lease.expires)
+
+    const released = await app().request(`/permission/auto/${lease.id}`, { method: "DELETE", headers })
+    expect(released.status).toBe(200)
+    expect(await released.json()).toBe(true)
+    expect(await (await app().request("/permission/auto", { headers })).json()).toEqual([])
+
+    const missing = await app().request(`/permission/auto/${lease.id}/renew`, { method: "POST", headers })
+    expect(missing.status).toBe(404)
+    expect(await missing.json()).toEqual({
+      _tag: "PermissionAutoLeaseNotFoundError",
+      leaseID: lease.id,
+      message: `Permission auto lease not found: ${lease.id}`,
+    })
+  })
+
+  test("accepts a session scope and clamps the requested ttl", async () => {
+    await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+    const created = await app().request("/session", {
+      method: "POST",
+      headers: { "x-opencode-directory": tmp.path, "content-type": "application/json" },
+      body: JSON.stringify({ title: "run" }),
+    })
+    expect(created.status).toBe(200)
+    const session = await created.json()
+
+    const acquired = await app().request("/permission/auto", {
+      method: "POST",
+      headers: { "x-opencode-directory": tmp.path, "content-type": "application/json" },
+      body: JSON.stringify({ scope: { type: "session", sessionID: session.id }, ttl: 1 }),
+    })
+    expect(acquired.status).toBe(200)
+    expect(await acquired.json()).toMatchObject({
+      scope: { type: "session", sessionID: session.id },
+      ttl: PermissionV1.AUTO_LEASE_TTL_MIN,
+    })
+  })
+
+  test("rejects a scope it does not understand", async () => {
+    await using tmp = await tmpdir({ git: true, config: { formatter: false, lsp: false } })
+    const response = await app().request("/permission/auto", {
+      method: "POST",
+      headers: { "x-opencode-directory": tmp.path, "content-type": "application/json" },
+      body: JSON.stringify({ scope: { type: "everything" } }),
+    })
+    expect(response.status).toBe(400)
+  })
+})

--- a/packages/opencode/test/session/tools.test.ts
+++ b/packages/opencode/test/session/tools.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "bun:test"
 import { ModelV2 } from "@opencode-ai/core/model"
 import { ProviderV2 } from "@opencode-ai/core/provider"
+import { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { SessionV1 } from "@opencode-ai/core/v1/session"
 import { Agent } from "@/agent/agent"
 import { MCP } from "@/mcp"
@@ -52,6 +53,11 @@ const fakePermission = Permission.Service.of({
   ask: () => Effect.void,
   reply: () => Effect.void,
   list: () => Effect.succeed([]),
+  autoList: () => Effect.succeed([]),
+  autoAcquire: (input) =>
+    Effect.succeed({ id: PermissionV1.AutoLeaseID.ascending(), scope: input.scope, ttl: 0, expires: 0 }),
+  autoRenew: (leaseID) => Effect.fail(new PermissionV1.AutoLeaseNotFoundError({ leaseID })),
+  autoRelease: () => Effect.succeed(false),
 } satisfies Permission.Interface)
 
 const fakeTruncate = Truncate.Service.of({

--- a/packages/schema/src/v1/permission.ts
+++ b/packages/schema/src/v1/permission.ts
@@ -4,7 +4,7 @@ import { Schema } from "effect"
 import { define, inventory } from "../event"
 import { ascending } from "../identifier"
 import { Project } from "../project"
-import { statics } from "../schema"
+import { NonNegativeInt, PositiveInt, statics } from "../schema"
 import { SessionID } from "../session-id"
 
 export const ID = Schema.String.check(Schema.isStartsWith("per")).pipe(
@@ -57,6 +57,47 @@ export const ReplyInput = Schema.Struct({ requestID: ID, ...ReplyBody.fields }).
   identifier: "PermissionReplyInput",
 })
 export type ReplyInput = typeof ReplyInput.Type
+
+// Auto mode is an ephemeral lease rather than a rule or a server-wide flag. A
+// lease turns requests that would resolve to `ask` into `allow` *before*
+// `permission.asked` is published, so that event keeps meaning "a human has to
+// respond". Explicit `deny` rules are evaluated first and are never affected.
+export const AutoLeaseID = Schema.String.check(Schema.isStartsWith("pal")).pipe(
+  Schema.brand("PermissionAutoLeaseID"),
+  statics((schema) => ({ ascending: (id?: string) => schema.make(id ?? "pal_" + ascending()) })),
+)
+export type AutoLeaseID = typeof AutoLeaseID.Type
+
+// `instance` matches what the TUI does today: everything in the connected
+// directory. `session` covers one session plus every session descended from it,
+// which is what a single `opencode run --auto` invocation owns.
+export const AutoScope = Schema.Union([
+  Schema.Struct({ type: Schema.Literal("instance") }),
+  Schema.Struct({ type: Schema.Literal("session"), sessionID: SessionID }),
+]).annotate({ identifier: "PermissionAutoScope" })
+export type AutoScope = typeof AutoScope.Type
+
+// A lease only survives while its owner keeps renewing it, so a client that
+// crashes, is SIGKILLed, or loses the network cannot leave auto mode on.
+export const AUTO_LEASE_TTL_DEFAULT = 30_000
+export const AUTO_LEASE_TTL_MIN = 1_000
+export const AUTO_LEASE_TTL_MAX = 300_000
+
+export const AutoLease = Schema.Struct({
+  id: AutoLeaseID,
+  scope: AutoScope,
+  // Milliseconds the lease survives without a renewal, and the wall clock time
+  // it lapses at. Owners should renew well inside `ttl`.
+  ttl: NonNegativeInt,
+  expires: NonNegativeInt,
+}).annotate({ identifier: "PermissionAutoLease" })
+export type AutoLease = typeof AutoLease.Type
+
+export const AutoAcquireBody = Schema.Struct({
+  scope: AutoScope,
+  ttl: Schema.optional(PositiveInt),
+}).annotate({ identifier: "PermissionAutoAcquireBody" })
+export type AutoAcquireBody = typeof AutoAcquireBody.Type
 
 const Asked = define({ type: "permission.asked", schema: Request.fields })
 const Replied = define({

--- a/packages/sdk/js/src/v2/gen/sdk.gen.ts
+++ b/packages/sdk/js/src/v2/gen/sdk.gen.ts
@@ -121,6 +121,15 @@ import type {
   PartUpdateResponses,
   PathGetErrors,
   PathGetResponses,
+  PermissionAutoAcquireErrors,
+  PermissionAutoAcquireResponses,
+  PermissionAutoListErrors,
+  PermissionAutoListResponses,
+  PermissionAutoReleaseErrors,
+  PermissionAutoReleaseResponses,
+  PermissionAutoRenewErrors,
+  PermissionAutoRenewResponses,
+  PermissionAutoScope,
   PermissionListErrors,
   PermissionListResponses,
   PermissionReplyErrors,
@@ -3108,6 +3117,149 @@ export class Permission extends HeyApiClient {
     )
     return (options?.client ?? this.client).get<PermissionListResponses, PermissionListErrors, ThrowOnError>({
       url: "/permission",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * List auto-approve leases
+   *
+   * List the auto-approve leases that have not expired or been released.
+   */
+  public autoList<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).get<PermissionAutoListResponses, PermissionAutoListErrors, ThrowOnError>({
+      url: "/permission/auto",
+      ...options,
+      ...params,
+    })
+  }
+
+  /**
+   * Acquire an auto-approve lease
+   *
+   * Auto-approve requests in scope that would otherwise ask, without publishing permission.asked. Explicit deny rules still apply, requests already pending are unaffected, and the lease expires unless renewed within its ttl.
+   */
+  public autoAcquire<ThrowOnError extends boolean = false>(
+    parameters?: {
+      directory?: string
+      workspace?: string
+      scope?: PermissionAutoScope
+      ttl?: number
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+            { in: "body", key: "scope" },
+            { in: "body", key: "ttl" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<
+      PermissionAutoAcquireResponses,
+      PermissionAutoAcquireErrors,
+      ThrowOnError
+    >({
+      url: "/permission/auto",
+      ...options,
+      ...params,
+      headers: {
+        "Content-Type": "application/json",
+        ...options?.headers,
+        ...params.headers,
+      },
+    })
+  }
+
+  /**
+   * Renew an auto-approve lease
+   *
+   * Extend a lease by its ttl. Fails once the lease has expired or been released.
+   */
+  public autoRenew<ThrowOnError extends boolean = false>(
+    parameters: {
+      leaseID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "leaseID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).post<PermissionAutoRenewResponses, PermissionAutoRenewErrors, ThrowOnError>(
+      {
+        url: "/permission/auto/{leaseID}/renew",
+        ...options,
+        ...params,
+      },
+    )
+  }
+
+  /**
+   * Release an auto-approve lease
+   *
+   * Release a lease immediately instead of waiting for it to expire.
+   */
+  public autoRelease<ThrowOnError extends boolean = false>(
+    parameters: {
+      leaseID: string
+      directory?: string
+      workspace?: string
+    },
+    options?: Options<never, ThrowOnError>,
+  ) {
+    const params = buildClientParams(
+      [parameters],
+      [
+        {
+          args: [
+            { in: "path", key: "leaseID" },
+            { in: "query", key: "directory" },
+            { in: "query", key: "workspace" },
+          ],
+        },
+      ],
+    )
+    return (options?.client ?? this.client).delete<
+      PermissionAutoReleaseResponses,
+      PermissionAutoReleaseErrors,
+      ThrowOnError
+    >({
+      url: "/permission/auto/{leaseID}",
       ...options,
       ...params,
     })

--- a/packages/sdk/js/src/v2/gen/types.gen.ts
+++ b/packages/sdk/js/src/v2/gen/types.gen.ts
@@ -2483,6 +2483,28 @@ export type PermissionRequest = {
   }
 }
 
+export type PermissionAutoScope =
+  | {
+      type: "instance"
+    }
+  | {
+      type: "session"
+      sessionID: string
+    }
+
+export type PermissionAutoLease = {
+  id: string
+  scope: PermissionAutoScope
+  ttl: number
+  expires: number
+}
+
+export type PermissionAutoLeaseNotFoundError = {
+  _tag: "PermissionAutoLeaseNotFoundError"
+  leaseID: string
+  message: string
+}
+
 export type PermissionNotFoundError = {
   _tag: "PermissionNotFoundError"
   requestID: string
@@ -9263,6 +9285,129 @@ export type PermissionListResponses = {
 }
 
 export type PermissionListResponse = PermissionListResponses[keyof PermissionListResponses]
+
+export type PermissionAutoListData = {
+  body?: never
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/permission/auto"
+}
+
+export type PermissionAutoListErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionAutoListError = PermissionAutoListErrors[keyof PermissionAutoListErrors]
+
+export type PermissionAutoListResponses = {
+  /**
+   * Active auto-approve leases
+   */
+  200: Array<PermissionAutoLease>
+}
+
+export type PermissionAutoListResponse = PermissionAutoListResponses[keyof PermissionAutoListResponses]
+
+export type PermissionAutoAcquireData = {
+  body?: {
+    scope: PermissionAutoScope
+    ttl?: number
+  }
+  path?: never
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/permission/auto"
+}
+
+export type PermissionAutoAcquireErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionAutoAcquireError = PermissionAutoAcquireErrors[keyof PermissionAutoAcquireErrors]
+
+export type PermissionAutoAcquireResponses = {
+  /**
+   * Acquired lease
+   */
+  200: PermissionAutoLease
+}
+
+export type PermissionAutoAcquireResponse = PermissionAutoAcquireResponses[keyof PermissionAutoAcquireResponses]
+
+export type PermissionAutoRenewData = {
+  body?: never
+  path: {
+    leaseID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/permission/auto/{leaseID}/renew"
+}
+
+export type PermissionAutoRenewErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+  /**
+   * PermissionAutoLeaseNotFoundError
+   */
+  404: PermissionAutoLeaseNotFoundError
+}
+
+export type PermissionAutoRenewError = PermissionAutoRenewErrors[keyof PermissionAutoRenewErrors]
+
+export type PermissionAutoRenewResponses = {
+  /**
+   * Renewed lease
+   */
+  200: PermissionAutoLease
+}
+
+export type PermissionAutoRenewResponse = PermissionAutoRenewResponses[keyof PermissionAutoRenewResponses]
+
+export type PermissionAutoReleaseData = {
+  body?: never
+  path: {
+    leaseID: string
+  }
+  query?: {
+    directory?: string
+    workspace?: string
+  }
+  url: "/permission/auto/{leaseID}"
+}
+
+export type PermissionAutoReleaseErrors = {
+  /**
+   * Bad request
+   */
+  400: BadRequestError
+}
+
+export type PermissionAutoReleaseError = PermissionAutoReleaseErrors[keyof PermissionAutoReleaseErrors]
+
+export type PermissionAutoReleaseResponses = {
+  /**
+   * Lease released
+   */
+  200: boolean
+}
+
+export type PermissionAutoReleaseResponse = PermissionAutoReleaseResponses[keyof PermissionAutoReleaseResponses]
 
 export type PermissionReplyData = {
   body?: {

--- a/packages/sdk/openapi.json
+++ b/packages/sdk/openapi.json
@@ -4867,6 +4867,273 @@
         ]
       }
     },
+    "/permission/auto": {
+      "get": {
+        "tags": ["permission"],
+        "operationId": "permission.autoList",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Active auto-approve leases",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PermissionAutoLease"
+                  },
+                  "description": "Active auto-approve leases"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "List the auto-approve leases that have not expired or been released.",
+        "summary": "List auto-approve leases",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.autoList({\n  ...\n})"
+          }
+        ]
+      },
+      "post": {
+        "tags": ["permission"],
+        "operationId": "permission.autoAcquire",
+        "parameters": [
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Acquired lease",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionAutoLease"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Auto-approve requests in scope that would otherwise ask, without publishing permission.asked. Explicit deny rules still apply, requests already pending are unaffected, and the lease expires unless renewed within its ttl.",
+        "summary": "Acquire an auto-approve lease",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "scope": {
+                    "$ref": "#/components/schemas/PermissionAutoScope"
+                  },
+                  "ttl": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  }
+                },
+                "required": ["scope"],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.autoAcquire({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/permission/auto/{leaseID}/renew": {
+      "post": {
+        "tags": ["permission"],
+        "operationId": "permission.autoRenew",
+        "parameters": [
+          {
+            "name": "leaseID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^pal"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Renewed lease",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionAutoLease"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "PermissionAutoLeaseNotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionAutoLeaseNotFoundError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Extend a lease by its ttl. Fails once the lease has expired or been released.",
+        "summary": "Renew an auto-approve lease",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.autoRenew({\n  ...\n})"
+          }
+        ]
+      }
+    },
+    "/permission/auto/{leaseID}": {
+      "delete": {
+        "tags": ["permission"],
+        "operationId": "permission.autoRelease",
+        "parameters": [
+          {
+            "name": "leaseID",
+            "in": "path",
+            "schema": {
+              "type": "string",
+              "pattern": "^pal"
+            },
+            "required": true
+          },
+          {
+            "name": "directory",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "workspace",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Lease released",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean",
+                  "description": "Lease released"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequestError"
+                }
+              }
+            }
+          }
+        },
+        "description": "Release a lease immediately instead of waiting for it to expire.",
+        "summary": "Release an auto-approve lease",
+        "x-codeSamples": [
+          {
+            "lang": "js",
+            "source": "import { createOpencodeClient } from \"@opencode-ai/sdk\n\nconst client = createOpencodeClient()\nawait client.permission.autoRelease({\n  ...\n})"
+          }
+        ]
+      }
+    },
     "/permission/{requestID}/reply": {
       "post": {
         "tags": ["permission"],
@@ -22891,6 +23158,75 @@
           }
         },
         "required": ["id", "sessionID", "permission", "patterns", "metadata", "always"],
+        "additionalProperties": false
+      },
+      "PermissionAutoScope": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["instance"]
+              }
+            },
+            "required": ["type"],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["session"]
+              },
+              "sessionID": {
+                "type": "string",
+                "pattern": "^ses"
+              }
+            },
+            "required": ["type", "sessionID"],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "PermissionAutoLease": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^pal"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/PermissionAutoScope"
+          },
+          "ttl": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "expires": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": ["id", "scope", "ttl", "expires"],
+        "additionalProperties": false
+      },
+      "PermissionAutoLeaseNotFoundError": {
+        "type": "object",
+        "properties": {
+          "_tag": {
+            "type": "string",
+            "enum": ["PermissionAutoLeaseNotFoundError"]
+          },
+          "leaseID": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": ["_tag", "leaseID", "message"],
         "additionalProperties": false
       },
       "PermissionNotFoundError": {

--- a/packages/tui/src/context/permission.tsx
+++ b/packages/tui/src/context/permission.tsx
@@ -1,6 +1,8 @@
+import { onCleanup, onMount } from "solid-js"
 import { createStore } from "solid-js/store"
 import { useArgs } from "./args"
 import { createSimpleContext } from "./helper"
+import { useSDK } from "./sdk"
 
 export type PermissionMode = "auto" | "normal"
 
@@ -8,18 +10,87 @@ export const { use: usePermission, provider: PermissionProvider } = createSimple
   name: "Permission",
   init: () => {
     const args = useArgs()
-    const [store, setStore] = createStore<{ mode: PermissionMode }>({
+    const sdk = useSDK()
+    // `managed` means the server holds a lease for us and resolves auto-approved
+    // requests without publishing `permission.asked`. Servers predating the
+    // lease endpoint leave it false and `sync.tsx` keeps replying client-side.
+    const [store, setStore] = createStore<{ mode: PermissionMode; managed: boolean }>({
       mode: args.auto ? "auto" : "normal",
+      managed: false,
     })
+
+    // The lease covers this instance, matching what client-side auto mode has
+    // always done for a connected TUI. It has to be renewed to stay alive, so a
+    // crashed or killed TUI cannot leave an attached server auto-approving.
+    let lease: { id: string; ttl: number } | undefined
+    let renewal: ReturnType<typeof setInterval> | undefined
+
+    function stopRenewal() {
+      if (!renewal) return
+      clearInterval(renewal)
+      renewal = undefined
+    }
+
+    async function acquire() {
+      const result = await sdk.client.permission
+        .autoAcquire({ scope: { type: "instance" } })
+        .then((response) => response.data)
+        .catch(() => undefined)
+      if (!result) return setStore("managed", false)
+      lease = result
+      setStore("managed", true)
+      stopRenewal()
+      renewal = setInterval(() => void renew(), Math.max(1000, Math.floor(result.ttl / 3)))
+    }
+
+    async function renew() {
+      const held = lease
+      if (!held) return
+      const result = await sdk.client.permission
+        .autoRenew({ leaseID: held.id })
+        .then((response) => response.data)
+        .catch(() => undefined)
+      if (result || lease !== held) return
+      // The server dropped the lease — the instance was disposed or the renewal
+      // was too late. Take a fresh one so the indicator keeps telling the truth.
+      lease = undefined
+      await acquire()
+    }
+
+    async function release() {
+      const held = lease
+      lease = undefined
+      stopRenewal()
+      setStore("managed", false)
+      if (!held) return
+      await sdk.client.permission.autoRelease({ leaseID: held.id }).catch(() => {})
+    }
+
+    function apply(mode: PermissionMode) {
+      setStore("mode", mode)
+      void (mode === "auto" ? acquire() : release())
+    }
+
+    onMount(() => {
+      if (store.mode === "auto") void acquire()
+    })
+
+    onCleanup(() => {
+      void release()
+    })
+
     return {
       get mode() {
         return store.mode
       },
+      get managed() {
+        return store.managed
+      },
       set(mode: PermissionMode) {
-        setStore("mode", mode)
+        apply(mode)
       },
       toggle() {
-        setStore("mode", (mode) => (mode === "auto" ? "normal" : "auto"))
+        apply(store.mode === "auto" ? "normal" : "auto")
       },
     }
   },

--- a/packages/tui/src/context/sync.tsx
+++ b/packages/tui/src/context/sync.tsx
@@ -195,7 +195,10 @@ export const {
 
         case "permission.asked": {
           const request = event.properties
-          if (permission.mode === "auto") {
+          // A server holding our lease never publishes this event for a request
+          // it auto-approved, so replying here is only needed against servers
+          // predating the lease endpoint.
+          if (permission.mode === "auto" && !permission.managed) {
             void sdk.client.permission.reply({
               requestID: request.id,
               reply: "once",

--- a/packages/tui/test/cli/cmd/tui/permission-auto.test.tsx
+++ b/packages/tui/test/cli/cmd/tui/permission-auto.test.tsx
@@ -1,0 +1,200 @@
+/** @jsxImportSource @opentui/solid */
+import { testRender } from "@opentui/solid"
+import type { GlobalEvent } from "@opencode-ai/sdk/v2"
+import { expect, test } from "bun:test"
+import { onMount } from "solid-js"
+import { ArgsProvider } from "../../../../src/context/args"
+import { ExitProvider } from "../../../../src/context/exit"
+import { KVProvider } from "../../../../src/context/kv"
+import { PermissionProvider, usePermission } from "../../../../src/context/permission"
+import { ProjectProvider } from "../../../../src/context/project"
+import { SDKProvider } from "../../../../src/context/sdk"
+import { SyncProvider, useSync } from "../../../../src/context/sync"
+import { TestTuiContexts } from "../../../fixture/tui-environment"
+import { createEventSource, createFetch, directory, json } from "../../../fixture/tui-sdk"
+import { wait } from "./sync-fixture"
+
+type Call = { method: string; path: string }
+
+// Stands in for the instance server. `leases: false` reproduces a server
+// predating /permission/auto, which the TUI must still drive client-side.
+function createLeaseServer(input?: { leases?: boolean }) {
+  const calls: Call[] = []
+  const replied: string[] = []
+  const held = new Set<string>()
+  let next = 0
+
+  const handler = async (url: URL, request: Request) => {
+    if (!url.pathname.startsWith("/permission")) return undefined
+    calls.push({ method: request.method, path: url.pathname })
+
+    if (url.pathname.endsWith("/reply")) {
+      replied.push(url.pathname.split("/")[2]!)
+      return json(true)
+    }
+    if (input?.leases === false) return json({ message: "not found" }, { status: 404 })
+    if (url.pathname === "/permission/auto" && request.method === "POST") {
+      const id = `pal_test${(next += 1)}`
+      held.add(id)
+      return json({ id, scope: { type: "instance" }, ttl: 30000, expires: Date.now() + 30000 })
+    }
+
+    const id = url.pathname.split("/")[3]!
+    if (request.method === "DELETE") return json(held.delete(id))
+    if (!held.has(id)) return json({ message: "not found" }, { status: 404 })
+    return json({ id, scope: { type: "instance" }, ttl: 30000, expires: Date.now() + 30000 })
+  }
+
+  return { handler, calls, replied, held }
+}
+
+async function mount(input?: { auto?: boolean; leases?: boolean }) {
+  const server = createLeaseServer(input)
+  const events = createEventSource()
+  // `createFetch` only passes the URL through, but a lease API needs the method
+  // and the request, so intercept before handing over to the shared fixture.
+  const base = createFetch()
+  const fetch = (async (resource: RequestInfo | URL, init?: RequestInit) => {
+    const request = new Request(resource as RequestInfo, init)
+    return (await server.handler(new URL(request.url), request)) ?? base.fetch(resource, init)
+  }) as typeof globalThis.fetch
+
+  let permission!: ReturnType<typeof usePermission>
+  let sync!: ReturnType<typeof useSync>
+  let done!: () => void
+  const ready = new Promise<void>((resolve) => {
+    done = resolve
+  })
+
+  function Probe() {
+    const permissionCtx = usePermission()
+    const syncCtx = useSync()
+    onMount(() => {
+      permission = permissionCtx
+      sync = syncCtx
+      done()
+    })
+    return <box />
+  }
+
+  const app = await testRender(() => (
+    <TestTuiContexts>
+      <ArgsProvider auto={input?.auto}>
+        <KVProvider>
+          <SDKProvider url="http://test" directory={directory} fetch={fetch} events={events.source}>
+            <PermissionProvider>
+              <ProjectProvider>
+                <ExitProvider exit={() => {}}>
+                  <SyncProvider>
+                    <Probe />
+                  </SyncProvider>
+                </ExitProvider>
+              </ProjectProvider>
+            </PermissionProvider>
+          </SDKProvider>
+        </KVProvider>
+      </ArgsProvider>
+    </TestTuiContexts>
+  ))
+
+  await ready
+  await wait(() => sync.status === "complete")
+  return {
+    app,
+    calls: server.calls,
+    replied: server.replied,
+    held: server.held,
+    emit: events.emit,
+    get permission() {
+      return permission
+    },
+  }
+}
+
+function askedEvent(requestID: string): GlobalEvent {
+  return {
+    directory,
+    project: "proj_test",
+    payload: {
+      id: "evt_asked",
+      type: "permission.asked",
+      properties: {
+        id: requestID,
+        sessionID: "ses_test",
+        permission: "bash",
+        patterns: ["ls"],
+        metadata: {},
+        always: [],
+      },
+    },
+  }
+}
+
+test("--auto takes a lease instead of replying to permissions itself", async () => {
+  const harness = await mount({ auto: true })
+  try {
+    await wait(() => harness.permission.managed)
+    expect(harness.permission.mode).toBe("auto")
+    expect(harness.calls).toContainEqual({ method: "POST", path: "/permission/auto" })
+    expect(harness.held.size).toBe(1)
+
+    // A managed server only publishes this when a human really is needed, so
+    // the TUI must surface it rather than approving it behind their back.
+    harness.emit(askedEvent("per_managed"))
+    await Bun.sleep(50)
+    expect(harness.replied).toEqual([])
+  } finally {
+    harness.app.renderer.destroy()
+  }
+})
+
+// Regression for opencode#47545: an older server never suppresses
+// permission.asked, so the TUI has to keep replying itself.
+test("keeps replying client-side when the server has no lease route", async () => {
+  const harness = await mount({ auto: true, leases: false })
+  try {
+    await wait(() => harness.calls.some((call) => call.path === "/permission/auto"))
+    expect(harness.permission.mode).toBe("auto")
+    expect(harness.permission.managed).toBe(false)
+
+    harness.emit(askedEvent("per_legacy"))
+    await wait(() => harness.replied.length === 1)
+    expect(harness.replied).toEqual(["per_legacy"])
+  } finally {
+    harness.app.renderer.destroy()
+  }
+})
+
+test("toggling auto mode acquires and releases the lease", async () => {
+  const harness = await mount()
+  try {
+    expect(harness.permission.mode).toBe("normal")
+    expect(harness.held.size).toBe(0)
+
+    harness.permission.toggle()
+    await wait(() => harness.permission.managed)
+    expect(harness.permission.mode).toBe("auto")
+    expect(harness.held.size).toBe(1)
+
+    harness.permission.toggle()
+    await wait(() => harness.held.size === 0)
+    expect(harness.permission.mode).toBe("normal")
+    expect(harness.permission.managed).toBe(false)
+
+    // Back in normal mode the TUI shows the prompt instead of answering it.
+    harness.emit(askedEvent("per_normal"))
+    await Bun.sleep(50)
+    expect(harness.replied).toEqual([])
+  } finally {
+    harness.app.renderer.destroy()
+  }
+})
+
+test("leaving the TUI releases the lease", async () => {
+  const harness = await mount({ auto: true })
+  await wait(() => harness.permission.managed)
+  expect(harness.held.size).toBe(1)
+
+  harness.app.renderer.destroy()
+  await wait(() => harness.held.size === 0)
+})

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -37,6 +37,15 @@ Explicit `"deny"` rules are still enforced. Auto mode only changes requests that
 
 In the TUI, open the command palette and select **Enable auto-approve permissions** or **Disable auto-approve permissions** to change modes. When auto mode is active, the prompt displays a muted `auto` indicator next to the current agent.
 
+Auto mode is applied by the server before it announces anything, so a request it approves never produces a `permission.asked` event. Integrations that watch the event stream can therefore treat `permission.asked` as meaning a person has to respond.
+
+The client that turns auto mode on holds it as a short-lived lease that it keeps renewing, and it only covers what that client owns:
+
+- The TUI covers the instance it is connected to, matching the sessions it can see.
+- `opencode run --auto` covers only the session that run created and the subagent sessions it spawns, so `opencode run --attach ... --auto` never auto-approves anyone else's work on a shared server.
+
+Because the lease has to be renewed, a client that exits, crashes, or is killed loses its auto mode within seconds instead of leaving the server approving on its own. Requests that were already waiting for an answer when auto mode was turned on stay pending — auto mode only applies to requests raised after it.
+
 ---
 
 ## Configuration


### PR DESCRIPTION
### Issue for this PR

Closes #47545

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Moves Auto permission handling server-side so auto-approved requests are resolved before `permission.asked` is emitted.

Auto is represented as a renewable client lease. Deny rules still take precedence, and leases expire if the client disappears.

TUI Auto applies to all sessions on the connected server, matching its current behavior. `run --auto` only applies to that run and its child sessions.

This PR is draft mainly to confirm whether TUI Auto should continue applying to all sessions, or only the current session.

### How did you verify your code works?

Added tests for lease behavior, Auto scope, deny precedence, and `permission.asked` suppression. `bun typecheck` passes.

### Screenshots / recordings

*Not a UI change.*

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
