### PR TITLE
fix(app): ignore stale file tree requests after reset

### DIFF
--- a/packages/app/src/context/file/tree-store.test.ts
+++ b/packages/app/src/context/file/tree-store.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test"
+import type { FileNode } from "@opencode-ai/sdk/v2"
+import { createFileTreeStore } from "./tree-store"
+
+function setup() {
+  const scope = { directory: "/first" }
+  const requests: ReturnType<typeof Promise.withResolvers<FileNode[]>>[] = []
+  const errors: string[] = []
+  const tree = createFileTreeStore({
+    scope: () => scope.directory,
+    normalizeDir: (path) => path,
+    list: () => {
+      const request = Promise.withResolvers<FileNode[]>()
+      requests.push(request)
+      return request.promise
+    },
+    onError: (message) => errors.push(message),
+  })
+  return { tree, scope, requests, errors }
+}
+
+function file(path: string): FileNode {
+  return { path, name: path, absolute: `/first/${path}`, type: "file", ignored: false }
+}
+
+describe("file tree request ownership", () => {
+  test("old project completion preserves the new project's pending request", async () => {
+    const state = setup()
+    const old = state.tree.listDir("")
+    state.scope.directory = "/second"
+    state.tree.reset()
+    const current = state.tree.listDir("")
+    state.requests[0].resolve([])
+    await old
+
+    expect(state.tree.listDir("")).toBe(current)
+    expect(state.requests).toHaveLength(2)
+    state.requests[1].resolve([])
+    await current
+  })
+
+  test("a response from before reset cannot overwrite the same project's new tree", async () => {
+    const state = setup()
+    const old = state.tree.listDir("")
+    state.tree.reset()
+    const current = state.tree.listDir("")
+    state.requests[1].resolve([file("new.txt")])
+    await current
+    state.requests[0].resolve([file("old.txt")])
+    await old
+
+    expect(state.tree.children("").map((node) => node.path)).toEqual(["new.txt"])
+    expect(state.tree.node("old.txt")).toBeUndefined()
+  })
+
+  test("an error from before reset cannot clear loading or report a stale failure", async () => {
+    const state = setup()
+    const old = state.tree.listDir("")
+    state.tree.reset()
+    const current = state.tree.listDir("")
+    state.requests[0].reject(new Error("old failure"))
+    await old
+
+    expect(state.tree.dirState("")?.loading).toBe(true)
+    expect(state.tree.dirState("")?.error).toBeUndefined()
+    expect(state.errors).toEqual([])
+    expect(state.tree.listDir("")).toBe(current)
+    state.requests[1].resolve([])
+    await current
+  })
+
+  test("current failures are reported and can be retried", async () => {
+    const state = setup()
+    const failed = state.tree.listDir("")
+    state.requests[0].reject(new Error("current failure"))
+    await failed
+    expect(state.errors).toEqual(["current failure"])
+    expect(state.tree.dirState("")?.loading).toBe(false)
+
+    const retry = state.tree.listDir("")
+    state.requests[1].resolve([file("new.txt")])
+    await retry
+    expect(state.tree.isLoaded("")).toBe(true)
+    expect(state.tree.dirState("")?.error).toBeUndefined()
+    expect(state.tree.children("").map((node) => node.path)).toEqual(["new.txt"])
+  })
+})

--- a/packages/app/src/context/file/tree-store.ts
+++ b/packages/app/src/context/file/tree-store.ts
@@ -63,7 +63,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
     const promise = options
       .list(dir)
       .then((nodes) => {
-        if (options.scope() !== directory) return
+        if (options.scope() !== directory || inflight.get(dir) !== promise) return
         const prevChildren = tree.dir[dir]?.children ?? []
         const nextChildren = nodes.map((node) => node.path)
         const nextSet = new Set(nextChildren)
@@ -108,7 +108,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
         )
       })
       .catch((e) => {
-        if (options.scope() !== directory) return
+        if (options.scope() !== directory || inflight.get(dir) !== promise) return
         setTree(
           "dir",
           dir,
@@ -120,7 +120,7 @@ export function createFileTreeStore(options: TreeStoreOptions) {
         options.onError(e.message)
       })
       .finally(() => {
-        inflight.delete(dir)
+        if (inflight.get(dir) === promise) inflight.delete(dir)
       })
 
     inflight.set(dir, promise)


### PR DESCRIPTION
### Issue for this PR

Closes #47741

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

After a file-tree reset, an old listing could delete a newer pending request, overwrite its file list, or report a stale error. Check that each promise still owns its in-flight entry before applying results, errors, or cleanup.

The production change is three guards in `tree-store.ts`; there are no API or layout changes.

### How did you verify your code works?

- Added four deterministic tests against the real tree store with deferred list responses. Three regression cases failed before the fix; all four now pass.
- File-tree and cache tests: 15 pass across four files (`bun test --conditions=solid src/context/file/tree-store.test.ts src/context/file-content-eviction-accounting.test.ts src/components/file-tree.test.ts src/components/file-tree-v2-model.test.ts`, from `packages/app`).
- `bun typecheck` in `packages/app`, Prettier, and `git diff --check` pass.

### Screenshots / recordings

No layout change. Verified the request race at the store boundary; no desktop UI recording was captured.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
