### PR TITLE
perf(server): reuse provider catalog responses within instance lifecycle

### DIFF
--- a/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
+++ b/packages/opencode/src/server/routes/instance/httpapi/handlers/provider.ts
@@ -3,6 +3,7 @@ import { Config } from "@/config/config"
 import { ModelsDev } from "@opencode-ai/core/models-dev"
 import { Provider } from "@/provider/provider"
 import { Auth } from "@/auth"
+import { InstanceState } from "@/effect/instance-state"
 
 import { mapValues } from "remeda"
 import { Effect, Schema } from "effect"
@@ -38,27 +39,37 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
     const provider = yield* Provider.Service
     const svc = yield* ProviderAuth.Service
     const authStore = yield* Auth.Service
+    const state = yield* InstanceState.make(() =>
+      Effect.sync(() => new WeakMap<object, { authorization: string; response: HttpServerResponse.HttpServerResponse }>()),
+    )
 
     const list = Effect.fn("ProviderHttpApi.list")(function* () {
       const config = yield* cfg.get()
       const all = yield* ModelsDev.Service.use((s) => s.get())
+      const connected = yield* provider.list()
+      const credentials = yield* authStore.all().pipe(Effect.orDie)
+      const authorization = Object.keys(credentials).sort().join("\0")
+      // Config changes dispose the instance; a catalog refresh replaces `all`.
+      const cache = yield* InstanceState.get(state)
+      const cached = cache.get(all)
+      if (cached?.authorization === authorization) return cached.response
       const disabled = new Set(config.disabled_providers ?? [])
       const enabled = config.enabled_providers ? new Set(config.enabled_providers) : undefined
       const filtered: Record<string, (typeof all)[string]> = {}
       for (const [key, value] of Object.entries(all)) {
         if ((enabled ? enabled.has(key) : true) && !disabled.has(key)) filtered[key] = value
       }
-      const connected = yield* provider.list()
-      const credentials = yield* authStore.all().pipe(Effect.orDie)
       const providers = Object.assign(
         mapValues(filtered, (item) => Provider.fromModelsDevProvider(item)),
         connected,
       )
-      return {
+      const response = HttpServerResponse.jsonUnsafe({
         all: Object.values(providers).map(Provider.toPublicInfo),
         default: Provider.defaultModelIDs(providers),
         connected: Object.keys(providers).filter((id) => id in connected || credentials[id]),
-      }
+      })
+      cache.set(all, { authorization, response })
+      return response
     })
 
     const auth = Effect.fn("ProviderHttpApi.auth")(function* () {
@@ -108,7 +119,7 @@ export const providerHandlers = HttpApiBuilder.group(InstanceHttpApi, "provider"
     })
 
     return handlers
-      .handle("list", list)
+      .handleRaw("list", list)
       .handle("auth", auth)
       .handleRaw("authorize", authorizeRaw)
       .handle("callback", callback)

--- a/packages/opencode/test/server/httpapi-listen.test.ts
+++ b/packages/opencode/test/server/httpapi-listen.test.ts
@@ -4,6 +4,8 @@ import path from "node:path"
 import { pathToFileURL } from "node:url"
 import { Flag } from "@opencode-ai/core/flag/flag"
 import { Server } from "../../src/server/server"
+import { Provider } from "../../src/provider/provider"
+import { Schema } from "effect"
 import { PtyPaths } from "../../src/server/routes/instance/httpapi/groups/pty"
 import { withTimeout } from "../../src/util/timeout"
 import { resetDatabase } from "../fixture/db"
@@ -17,6 +19,39 @@ const original = {
 }
 const auth = { username: "opencode", password: "listen-secret" }
 const testPty = process.platform === "win32" ? test.skip : test
+
+test("provider catalog revalidates after configuration changes", async () => {
+  await using dir = await tmpdir({ config: { snapshot: false, formatter: false, lsp: false } })
+  const listener = await startListener()
+  const headers = {
+    authorization: authorization(),
+    "x-opencode-directory": dir.path,
+    "content-type": "application/json",
+  }
+  const url = new URL("/provider", listener.url)
+  try {
+    const first = await fetch(url, { headers })
+    expect(first.status).toBe(200)
+    const body = await first.text()
+    const catalog = Schema.decodeUnknownSync(Provider.ListResult)(JSON.parse(body))
+    expect(catalog.all.length).toBeGreaterThan(0)
+    const repeated = await fetch(url, { headers })
+    expect(repeated.status).toBe(200)
+    expect(await repeated.text()).toBe(body)
+    const disabled = catalog.all[0].id
+    await Bun.write(path.join(dir.path, "opencode.json"), JSON.stringify({ disabled_providers: [disabled] }))
+    const changed = await fetch(new URL("/instance/dispose", listener.url), { method: "POST", headers })
+    expect(changed.status).toBe(200)
+    await changed.text()
+    const refreshed = await fetch(url, { headers })
+    expect(refreshed.status).toBe(200)
+    const next = Schema.decodeUnknownSync(Provider.ListResult)(await refreshed.json())
+    expect(next.all.length).toBe(catalog.all.length - 1)
+    expect(next.all.some((provider) => provider.id === disabled)).toBe(false)
+  } finally {
+    await stop(listener, "provider catalog listener did not stop")
+  }
+}, 30000)
 
 afterEach(async () => {
   Flag.OPENCODE_SERVER_PASSWORD = original.OPENCODE_SERVER_PASSWORD


### PR DESCRIPTION
### What does this PR do?

Avoid rebuilding and re-encoding the full provider catalog on every GET /provider. Reuse the encoded response inside the existing instance lifecycle, keyed by the ModelsDev catalog identity and connected credential IDs. Configuration disposal, catalog refresh, and provider connections invalidate it naturally. No timers or new cache service.

### How did you verify your code works?

- Real HTTP regression test: repeated responses match, editing configuration plus disposing the instance removes the disabled provider.
- Provider/listener tests: 17 passed (one existing skipped test).
- All 30 workspace typecheck tasks passed.
- Backported to v1.17.15 and tested on a small Linux server: a 5.7 MB catalog response previously took seconds; settled warm requests measured 35–61 ms. Cold startup remains separate.

AI-assisted implementation and testing.

### Checklist
- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR