### PR TITLE
refactor(core): remove legacy Console variant normalization

### DIFF
--- a/packages/core/src/plugin/provider/opencode.ts
+++ b/packages/core/src/plugin/provider/opencode.ts
@@ -163,11 +163,7 @@ export const OpencodePlugin = define<HttpClient.HttpClient | Bus.Service | Scope
                 existing.settings = Provider.mergeOverlay(existing.settings, withoutCredentials(variant.settings))
               if (variant.headers !== undefined)
                 existing.headers = Provider.mergeHeaders(existing.headers, variant.headers)
-              if (variant.body !== undefined)
-                existing.body = Provider.mergeOverlay(
-                  existing.body,
-                  variantBody(variant.body, model.package ?? item.package ?? source?.provider.package),
-                )
+              if (variant.body !== undefined) existing.body = Provider.mergeOverlay(existing.body, variant.body)
             }
             if (config.cost !== undefined)
               model.cost = (Array.isArray(config.cost) ? config.cost : [config.cost]).map((cost) => ({
@@ -234,18 +230,6 @@ function fetchProviders(http: HttpClient.HttpClient, value: Credential.Value) {
         )
       }),
     )
-}
-
-function variantBody(body: Readonly<Record<string, unknown>>, packageName: string | undefined) {
-  if (packageName !== Provider.aisdk("@ai-sdk/openai")) return body
-  const { reasoningEffort, reasoningSummary, ...native } = body
-  const reasoning = {
-    ...(typeof reasoningEffort === "string" ? { effort: reasoningEffort } : {}),
-    ...(typeof reasoningSummary === "string" ? { summary: reasoningSummary } : {}),
-  }
-  if (Object.keys(reasoning).length === 0) return body
-  // Existing Console variants stored SDK options here before V2 consumed raw bodies.
-  return Provider.mergeOverlay({ reasoning }, native)
 }
 
 function withoutCredentials<Value>(body: Readonly<Record<string, Value>> | undefined) {

--- a/packages/core/test/plugin/provider-opencode.test.ts
+++ b/packages/core/test/plugin/provider-opencode.test.ts
@@ -380,40 +380,23 @@ describe("OpencodePlugin", () => {
     ),
   )
 
-  it.live("normalizes legacy Console OpenAI variant bodies without changing native bodies", () =>
+  it.live("preserves native Console OpenAI variant bodies in inference requests", () =>
     Effect.acquireUseRelease(
       Effect.sync(() => {
         const variants = [
           {
-            id: "legacy",
-            body: { reasoningEffort: "high", reasoningSummary: "auto" },
-            expected: { reasoning: { effort: "high", summary: "auto" } },
-          },
-          {
             id: "effort-only",
-            body: { reasoningEffort: "low" },
-            expected: { reasoning: { effort: "low" } },
+            body: { reasoning: { effort: "low" } },
           },
           {
             id: "summary-only",
-            body: { reasoningSummary: "detailed" },
-            expected: { reasoning: { summary: "detailed" } },
+            body: { reasoning: { summary: "detailed" } },
           },
           {
             id: "native",
             body: { reasoning: { effort: "high", summary: "auto" } },
-            expected: { reasoning: { effort: "high", summary: "auto" } },
           },
-          {
-            id: "mixed",
-            body: {
-              reasoningEffort: "low",
-              reasoningSummary: "auto",
-              reasoning: { effort: "high", summary: "detailed" },
-            },
-            expected: { reasoning: { effort: "high", summary: "detailed" } },
-          },
-          { id: "plain", body: {}, expected: {} },
+          { id: "plain", body: {} },
         ]
         const models = {
           astra: {
@@ -481,7 +464,7 @@ describe("OpencodePlugin", () => {
             Effect.gen(function* () {
               const projected = required(model.variants.find((item) => item.id === variant.id))
               expect(projected.body).toEqual({
-                ...variant.expected,
+                ...variant.body,
                 include: ["reasoning.encrypted_content"],
                 metadata: { custom: "unchanged" },
               })
@@ -495,7 +478,7 @@ describe("OpencodePlugin", () => {
               const request = required(requests.at(-1))
               expect(request.variant).toBe(variant.id)
               expect(request.body).toMatchObject({
-                ...variant.expected,
+                ...variant.body,
                 model: "api-astra",
                 include: ["reasoning.encrypted_content"],
                 metadata: { custom: "unchanged" },
@@ -508,9 +491,8 @@ describe("OpencodePlugin", () => {
           const compatible = required(yield* catalog.model.get(Provider.ID.make("compatible"), Model.ID.make("astra")))
           const override = required(yield* catalog.model.get(Provider.ID.make("remote"), Model.ID.make("override")))
           for (const model of [compatible, override]) {
-            expect(model.variants.find((variant) => variant.id === "legacy")?.body).toEqual({
-              reasoningEffort: "high",
-              reasoningSummary: "auto",
+            expect(model.variants.find((variant) => variant.id === "native")?.body).toEqual({
+              reasoning: { effort: "high", summary: "auto" },
               include: ["reasoning.encrypted_content"],
               metadata: { custom: "unchanged" },
             })


### PR DESCRIPTION
### Issue for this PR

Follow-up to #46586 after the production variant-data migration.

### Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Remove the OpenAI reasoning-field compatibility shim. Merge Console variant bodies directly; retain native, partial, and plain-body HTTP request coverage.

### How did you verify your code works?

- Production audit: 30 migrated variants; zero of 44 OpenAI connections retain legacy reasoning fields.
- Shim-free source server fetched production Console config and completed production inference with native high/auto reasoning, preserved include, and no legacy fields. Used an enabled model with the migrated variant copied into its local config projection because the original custom aliases are unavailable upstream. Response: `NATIVE_VARIANT_OK`.
- Core and repository pre-push typechecks passed. Formatting and lint checks passed; automated tests left to CI.

### Screenshots / recordings

N/A.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR