### PR TITLE
fix: add Android/Termux support to postinstall.mjs

### DIFF
--- a/packages/opencode/script/postinstall.mjs
+++ b/packages/opencode/script/postinstall.mjs
@@ -15,6 +15,7 @@ const platformMap = {
   darwin: "darwin",
   linux: "linux",
   win32: "windows",
+  android: "linux",
 }
 const archMap = {
   x64: "x64",
@@ -80,6 +81,7 @@ function isMusl() {
   if (platform !== "linux") return false
 
   try {
+    if (os.platform() === "android") return true
     if (fs.existsSync("/etc/alpine-release")) return true
   } catch {
     // Ignore filesystem probes that are blocked by the host.


### PR DESCRIPTION


Adds Android/Termux support to the v2 CLI's `postinstall.mjs`.

## Changes

1. **Platform map** (line 14): add `android: "linux"` so `os.platform()` resolves correctly on Termux
2. **isMusl()** (line 82): return `true` on Android — Termux uses bionic but we use the musl binary + Alpine musl loader via `patchelf`

## Why

The v2 npm install (`npm install -g @opencode-ai/cli@beta --force`) fails on Termux with:
```
Error: OpenCode does not provide a binary for android-arm64
```

This is because `os.platform()` returns `android` on Termux, which isn't in the platform map. The musl binary already exists and works — just needs the platform detection fix.

## Testing

Tested on Termux (Android aarch64) with:
```sh
npm install -g @opencode-ai/cli@beta --force
opencode2 --version
# opencode2 v0.0.0-beta-19228
```

Fixes #47612
Fixes #36081