### PR TITLE
fix(server): strip connection-nominated proxy headers

### DIFF
--- a/packages/opencode/src/server/proxy-util.ts
+++ b/packages/opencode/src/server/proxy-util.ts
@@ -10,8 +10,14 @@ const hop = new Set([
   "upgrade",
   "host",
 ])
+const fieldName = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
 
 function sanitize(out: Headers) {
+  const connection = out.get("connection")
+  for (const key of connection?.split(",") ?? []) {
+    const name = key.trim()
+    if (fieldName.test(name)) out.delete(name)
+  }
   for (const key of hop) out.delete(key)
   out.delete("accept-encoding")
   out.delete("x-opencode-directory")

--- a/packages/opencode/test/server/proxy-util.test.ts
+++ b/packages/opencode/test/server/proxy-util.test.ts
@@ -65,6 +65,21 @@ describe("ProxyUtil", () => {
       expect(result.get("content-type")).toBe("application/json")
     })
 
+    test("strips headers named by the connection header", () => {
+      const req = new Request("http://localhost", {
+        headers: {
+          connection: "x-hop, invalid name, x-second",
+          "x-hop": "remove",
+          "x-second": "remove",
+          "x-end-to-end": "keep",
+        },
+      })
+      const result = ProxyUtil.headers(req)
+      expect(result.get("x-hop")).toBeNull()
+      expect(result.get("x-second")).toBeNull()
+      expect(result.get("x-end-to-end")).toBe("keep")
+    })
+
     test("strips opencode-specific headers", () => {
       const req = new Request("http://localhost", {
         headers: {


### PR DESCRIPTION
### Issue for this PR

Closes #47770

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Reads the incoming `Connection` options before sanitizing proxy headers and removes the corresponding fields as required by RFC 9110. Invalid connection options are ignored instead of being passed to `Headers.delete()`.

### How did you verify your code works?

- `bun test test/server/proxy-util.test.ts` (14 passed)
- `bun typecheck` in `packages/opencode`
- pre-push monorepo typecheck (30 packages passed)

### Screenshots / recordings

N/A (no UI change)

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR