### PR TITLE
fix(app): restore the review panel landmark label

### DIFF
--- a/packages/app/src/runtime/i18n/en.ts
+++ b/packages/app/src/runtime/i18n/en.ts
@@ -671,7 +671,7 @@ export const dict = {
   "session.tab.add": "Add tab",
   "session.tab.context": "Context",
   "session.tab.unknown": "Unknown Session",
-  "session.panel.reviewAndFiles": "Review, files, and browser",
+  "session.panel.reviewAndFiles": "Review and files",
   "session.error.notFound": "This session cannot be found",
   "session.error.notFound.description": "This tab points to a session that no longer exists on this server.",
   "session.error.notFound.closeTab": "Close Tab",


### PR DESCRIPTION
#44838 renamed the English source of `session.panel.reviewAndFiles` to "Review, files, and browser". #47164 landed on `v2` in the meantime with `command-registration.spec.ts` locating the panel by its original landmark name, so `e2e (linux)` fails on `v2` at `8a1a6b8fb4`.

The rename was not needed: the browser tab is opt-in and every translation still says "Review and files". This restores the English text; the key is unchanged.

`command-registration.spec.ts` passes locally against this change (both tests).
