### PR TITLE
feat(desktop): use base menu selection styling

### DIFF
--- a/packages/ui/src/forms/select/select.css
+++ b/packages/ui/src/forms/select/select.css
@@ -260,20 +260,19 @@
   --menu-v2-fg-muted: var(--v2-text-text-faint);
   --menu-v2-fg-subtle: var(--v2-text-text-muted);
   --menu-v2-icon: var(--v2-icon-icon-base);
-  --menu-v2-accent: var(--v2-text-text-accent);
   --menu-v2-badge-bg: var(--v2-background-bg-layer-02);
   --menu-v2-badge-border: var(--v2-border-border-base);
   --menu-v2-hover: var(--v2-overlay-simple-overlay-hover);
 }
 
-/* Listbox uses data-selected; menu item CSS uses data-checked — mirror accent */
+/* Listbox uses data-selected; menu item CSS uses data-checked — mirror selection styling */
 [data-slot="select-v2-listbox"] [data-component="menu-v2-item"][data-selected] [data-slot="menu-v2-item-content"] {
-  font-weight: 530;
-  color: var(--menu-v2-accent);
+  font-weight: 440;
+  color: var(--menu-v2-fg);
 }
 
 [data-slot="select-v2-listbox"] [data-component="menu-v2-item"][data-selected] [data-slot="menu-v2-item-indicator"] {
-  color: var(--menu-v2-accent);
+  color: var(--menu-v2-icon);
 }
 
 [data-slot="select-v2-listbox"]

--- a/packages/ui/src/navigation/menu/menu.css
+++ b/packages/ui/src/navigation/menu/menu.css
@@ -40,7 +40,6 @@
   --menu-v2-fg-muted: var(--v2-text-text-faint);
   --menu-v2-fg-subtle: var(--v2-text-text-muted);
   --menu-v2-icon: var(--v2-icon-icon-base);
-  --menu-v2-accent: var(--v2-text-text-accent);
   --menu-v2-badge-bg: var(--v2-background-bg-layer-02);
   --menu-v2-badge-border: var(--v2-border-border-base);
   --menu-v2-hover: var(--v2-overlay-simple-overlay-hover);
@@ -146,12 +145,12 @@
   }
 
   &[data-checked] [data-slot="menu-v2-item-content"] {
-    font-weight: 530;
-    color: var(--menu-v2-accent);
+    font-weight: 440;
+    color: var(--menu-v2-fg);
   }
 
   &[data-checked] [data-slot="menu-v2-item-indicator"] {
-    color: var(--menu-v2-accent);
+    color: var(--menu-v2-icon);
   }
 
   &[data-disabled] {

--- a/packages/ui/src/navigation/menu/menu.stories.tsx
+++ b/packages/ui/src/navigation/menu/menu.stories.tsx
@@ -13,12 +13,12 @@ Composable menu primitive built on Kobalte's \`DropdownMenu\` and \`ContextMenu\
 - \`Menu.Context\` namespace mirrors the same shape for right-click menus.
 - \`appearance\`: \`compact\` (default) or \`standard\`.
 - \`Menu.Item\` — supports a freeform \`children\` slot (avatar, icon, text — whatever) plus \`shortcut\` and \`badge\` props.
-- \`Menu.CheckboxItem\` / \`Menu.RadioItem\` — same item shape; auto-render a check indicator that turns blue when selected.
+- \`Menu.CheckboxItem\` / \`Menu.RadioItem\` — same item shape; auto-render a check indicator when selected.
 - \`Menu.Sub\` / \`Menu.SubTrigger\` / \`Menu.SubContent\` — nested submenus; \`SubTrigger\` auto-renders the trailing chevron.
 
 ### Behavior
 - Items expose Kobalte's data attributes — \`data-highlighted\`, \`data-checked\`, \`data-disabled\`.
-- Blue selected state is reserved for \`CheckboxItem\` / \`RadioItem\` (the rest just highlight on hover).
+- Selected state is reserved for \`CheckboxItem\` / \`RadioItem\` (the rest just highlight on hover).
 - Chevron is only rendered on \`SubTrigger\`.
 `
 


### PR DESCRIPTION
### Issue for this PR

N/A — design update.

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Updates selected menu and select items to keep their regular base text styling instead of switching to strong accent text. Selection indicators now use the base icon color token as well.

This keeps selection visible through the checkmark while preserving the normal label hierarchy.

### How did you verify your code works?

- Ran `bun typecheck` in `packages/ui`.
- Ran the UI test suite: 54 tests passed.
- Passed the repository pre-push typecheck across 34 packages.
- Verified the selected state in the `UI/Select` Storybook fixture.

### Screenshots / recordings

| Before | After |
| --- | --- |
| ![Selected item using strong blue accent text and icon](https://github.com/user-attachments/assets/bbe6c112-0290-456b-bc40-4fa5766fbd6e) | ![Selected item using regular base text and base icon color](https://github.com/user-attachments/assets/b66559b0-4ea2-4846-af86-e405bd23e32c) |

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
