### PR TITLE
chore: bump gitlab-ai-provider to 6.15.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -341,7 +341,7 @@
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "3.1.0",
-        "gitlab-ai-provider": "6.14.0",
+        "gitlab-ai-provider": "6.15.0",
         "glob": "13.0.5",
         "google-auth-library": "10.5.0",
         "gray-matter": "4.0.3",
@@ -634,7 +634,7 @@
         "drizzle-orm": "catalog:",
         "effect": "catalog:",
         "fuzzysort": "3.1.0",
-        "gitlab-ai-provider": "6.14.0",
+        "gitlab-ai-provider": "6.15.0",
         "glob": "13.0.5",
         "google-auth-library": "10.5.0",
         "gray-matter": "4.0.3",
@@ -3846,7 +3846,7 @@
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
-    "gitlab-ai-provider": ["gitlab-ai-provider@6.14.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "openai": "^6.16.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=3.0.0", "@ai-sdk/provider-utils": ">=4.0.0" } }, "sha512-qTkmFhcHXH0tjQN6i5D2lz9OpmYN0lwJdmFIXlsmy6IiYVV2dmsqMemlDNjpE5M8gdSC+61n4mByPzVsyBu0lg=="],
+    "gitlab-ai-provider": ["gitlab-ai-provider@6.15.0", "", { "dependencies": { "@anthropic-ai/sdk": "^0.71.0", "@anycable/core": "^0.9.2", "graphql-request": "^6.1.0", "isomorphic-ws": "^5.0.0", "openai": "^6.16.0", "socket.io-client": "^4.8.1", "vscode-jsonrpc": "^8.2.1", "zod": "^3.25.76" }, "peerDependencies": { "@ai-sdk/provider": ">=3.0.0", "@ai-sdk/provider-utils": ">=4.0.0" } }, "sha512-hHJsb4WP+WPTMtMC0gZcTi0wreMvR6WdEPeUPRHNlyW7yX0HuFG7v1oZ/ethbF6y/FG3/7NcirNgjZLjNneW7g=="],
 
     "glob": ["glob@13.0.5", "", { "dependencies": { "minimatch": "^10.2.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-BzXxZg24Ibra1pbQ/zE7Kys4Ua1ks7Bn6pKLkVPZ9FZe4JQS6/Q7ef3LG1H+k7lUf5l4T3PLSyYyYJVYUvfgTw=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,7 +108,7 @@
     "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "3.1.0",
-    "gitlab-ai-provider": "6.14.0",
+    "gitlab-ai-provider": "6.15.0",
     "glob": "13.0.5",
     "google-auth-library": "10.5.0",
     "gray-matter": "4.0.3",

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -120,7 +120,7 @@
     "drizzle-orm": "catalog:",
     "effect": "catalog:",
     "fuzzysort": "3.1.0",
-    "gitlab-ai-provider": "6.14.0",
+    "gitlab-ai-provider": "6.15.0",
     "glob": "13.0.5",
     "google-auth-library": "10.5.0",
     "gray-matter": "4.0.3",


### PR DESCRIPTION
### Issue for this PR

Closes #47791

### Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Bumps the pinned `gitlab-ai-provider` dependency from 6.14.0 to 6.15.0 in `packages/core` and `packages/opencode` (plus the resulting `bun.lock` update).

6.15.0 adds a mapping for GitLab Duo's newly published GPT-6 Astra model: `duo-chat-gpt-6-astra` -> OpenAI `gpt-6-astra`, routed through the Responses API. Without the bump the model is absent from the provider's `MODEL_MAPPINGS`, so it never appears in the model picker even though GitLab's API already serves it.

No opencode-side code was needed — GitLab model resolution is entirely driven by the provider package's mapping table combined with the models.dev metadata entry (anomalyco/models.dev#6499). This is a version bump only.

### How did you verify your code works?

After `bun install`, confirmed the workspace resolves the published package (not a leftover `file:` link) and that it contains the new model:

```
$ grep '"version"' packages/core/node_modules/gitlab-ai-provider/package.json
  "version": "6.15.0",
$ grep -c "gpt-6-astra" packages/core/node_modules/gitlab-ai-provider/dist/index.js
1
```

The model is listed by the CLI:

```
$ bun run --cwd packages/opencode src/index.ts models | grep gpt-6-astra
gitlab/duo-chat-gpt-6-astra
```

And a live round-trip against the GitLab Duo endpoint returns a real completion:

```
$ bun run --cwd packages/opencode src/index.ts run "Reply with exactly: astra-ok" \
    --model gitlab/duo-chat-gpt-6-astra
> plan · duo-chat-gpt-6-astra
astra-ok
```

(Run with `OPENCODE_MODELS_PATH` pointed at a locally built models.dev JSON containing the pending `duo-chat-gpt-6-astra` entry, since that PR is not merged yet.)

### Screenshots / recordings

_Not a UI change._

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR