### PR TITLE
fix(session): detect periodic tool-call cycles

### DIFF
--- a/packages/opencode/src/session/doom-loop.ts
+++ b/packages/opencode/src/session/doom-loop.ts
@@ -1,0 +1,36 @@
+export const MAX_PERIOD = 10
+
+export interface Detector {
+  readonly check: (tool: string, input: Record<string, unknown>) => boolean
+}
+
+export function create(): Detector {
+  const capacity = 2 * MAX_PERIOD + 1
+  const signatures = Array.from({ length: capacity }, () => "")
+  const streaks = Array.from({ length: MAX_PERIOD + 1 }, () => 0)
+  let next = 0
+  let size = 0
+
+  function latest(offset: number) {
+    return signatures[(next - 1 - offset + capacity) % capacity]
+  }
+
+  return {
+    check(tool, input) {
+      signatures[next] = JSON.stringify([tool, input])
+      next = (next + 1) % capacity
+      size = Math.min(size + 1, capacity)
+
+      let detected = false
+      for (let period = 1; period <= MAX_PERIOD; period++) {
+        const same = size > 2 * period && latest(0) === latest(period) && latest(0) === latest(2 * period)
+        // A streak of p matching triples proves three equal length-p suffix blocks.
+        streaks[period] = same ? Math.min(streaks[period] + 1, period) : 0
+        if (streaks[period] === period) detected = true
+      }
+      return detected
+    },
+  }
+}
+
+export * as DoomLoop from "./doom-loop"

--- a/packages/opencode/src/session/processor.ts
+++ b/packages/opencode/src/session/processor.ts
@@ -12,6 +12,7 @@ import { Snapshot } from "@/snapshot"
 import { Session } from "./session"
 import { LLM } from "./llm"
 import { MessageV2 } from "./message-v2"
+import { DoomLoop } from "./doom-loop"
 import { isOverflow } from "./overflow"
 import { PartID } from "./schema"
 import type { SessionID } from "./schema"
@@ -23,10 +24,8 @@ import { Question } from "@/question"
 import { errorMessage } from "@/util/error"
 import { isRecord } from "@/util/record"
 import { EventV2Bridge } from "@/event-v2-bridge"
-import { Database } from "@opencode-ai/core/database/database"
 import { Usage, type LLMEvent } from "@opencode-ai/llm"
 
-const DOOM_LOOP_THRESHOLD = 3
 export type Result = "compact" | "stop" | "continue"
 
 export interface Handle {
@@ -62,10 +61,13 @@ type ToolCall = {
   messageID: SessionV1.ToolPart["messageID"]
   sessionID: SessionV1.ToolPart["sessionID"]
   done: Deferred.Deferred<void>
+  // Overlapping updates replace the record, but must share the same admission state.
+  readonly admission: { counted: boolean }
 }
 
 interface ProcessorContext extends Input {
   toolcalls: Record<string, ToolCall>
+  doomLoop: DoomLoop.Detector
   shouldBreak: boolean
   snapshot: string | undefined
   blocked: boolean
@@ -93,7 +95,6 @@ const layer = Layer.effect(
     const status = yield* SessionStatus.Service
     const image = yield* Image.Service
     const events = yield* EventV2Bridge.Service
-    const database = yield* Database.Service
 
     const create = Effect.fn("SessionProcessor.create")(function* (input: Input) {
       // Pre-capture snapshot before the LLM stream starts. The AI SDK
@@ -105,6 +106,7 @@ const layer = Layer.effect(
         sessionID: input.sessionID,
         model: input.model,
         toolcalls: {},
+        doomLoop: DoomLoop.create(),
         shouldBreak: false,
         snapshot: initialSnapshot,
         blocked: false,
@@ -245,6 +247,7 @@ const layer = Layer.effect(
         } satisfies SessionV1.ToolPart)
         ctx.toolcalls[input.id] = {
           done: yield* Deferred.make<void>(),
+          admission: { counted: false },
           partID: part.id,
           messageID: part.messageID,
           sessionID: part.sessionID,
@@ -334,7 +337,7 @@ const layer = Layer.effect(
             }
             yield* ensureToolCall(value)
             const input = isRecord(value.input) ? value.input : { value: value.input }
-            yield* updateToolCall(value.id, (match) => ({
+            const part = yield* updateToolCall(value.id, (match) => ({
               ...match,
               tool: value.name,
               state:
@@ -350,23 +353,11 @@ const layer = Layer.effect(
                 : value.providerMetadata,
             }))
 
-            const parts = yield* MessageV2.parts(ctx.assistantMessage.id).pipe(
-              Effect.provideService(Database.Service, database),
-            )
-            const recentParts = parts.slice(-DOOM_LOOP_THRESHOLD)
-
-            if (
-              recentParts.length !== DOOM_LOOP_THRESHOLD ||
-              !recentParts.every(
-                (part) =>
-                  part.type === "tool" &&
-                  part.tool === value.name &&
-                  part.state.status !== "pending" &&
-                  JSON.stringify(part.state.input) === JSON.stringify(input),
-              )
-            ) {
-              return
-            }
+            // Metadata may start execution before normalized delivery; persisted status is not an admission flag.
+            const call = ctx.toolcalls[value.id]
+            if (!part || !call || call.admission.counted) return
+            call.admission.counted = true
+            if (!ctx.doomLoop.check(value.name, input)) return
 
             const agent = yield* agents.get(ctx.assistantMessage.agent)
             yield* permission.ask({
@@ -725,7 +716,6 @@ export const node = LayerNode.make({
     SessionStatus.node,
     Image.node,
     EventV2Bridge.node,
-    Database.node,
   ],
 })
 

--- a/packages/opencode/test/session/doom-loop.test.ts
+++ b/packages/opencode/test/session/doom-loop.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test"
+import { DoomLoop } from "../../src/session/doom-loop"
+
+type Call = { tool: string; input: Record<string, unknown> }
+
+function pattern(period: number): Call[] {
+  return Array.from({ length: period }, (_, index) => ({ tool: "lookup", input: { query: index } }))
+}
+
+function repeat(calls: readonly Call[], count: number) {
+  return Array.from({ length: count }, () => calls).flat()
+}
+
+function results(calls: readonly Call[]) {
+  const detector = DoomLoop.create()
+  return calls.map((call) => detector.check(call.tool, call.input))
+}
+
+function oracle(calls: readonly Call[]) {
+  const signatures = calls.map((call) => JSON.stringify([call.tool, call.input]))
+  for (let period = 1; period <= DoomLoop.MAX_PERIOD; period++) {
+    if (signatures.length < 3 * period) continue
+    const blocks = [3, 2, 1].map((offset) =>
+      signatures.slice(signatures.length - offset * period, signatures.length - (offset - 1) * period),
+    )
+    if (
+      JSON.stringify(blocks[0]) === JSON.stringify(blocks[1]) &&
+      JSON.stringify(blocks[1]) === JSON.stringify(blocks[2])
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
+describe("doom-loop detector", () => {
+  test.each(Array.from({ length: DoomLoop.MAX_PERIOD }, (_, index) => index + 1))(
+    "detects period %i only when the third block completes",
+    (period) => {
+      const detected = results(repeat(pattern(period), 3))
+      expect(detected.slice(0, -1).every((value) => !value)).toBe(true)
+      expect(detected.at(-1)).toBe(true)
+    },
+  )
+
+  test("does not detect only two repetitions", () => {
+    expect(results(repeat(pattern(DoomLoop.MAX_PERIOD), 2)).every((value) => !value)).toBe(true)
+  })
+
+  test("does not detect a fundamental period above the bound", () => {
+    expect(results(repeat(pattern(DoomLoop.MAX_PERIOD + 1), 4)).every((value) => !value)).toBe(true)
+  })
+
+  test("does not detect when the third block changes an input", () => {
+    const calls = repeat(pattern(3), 3)
+    calls[8] = { tool: "lookup", input: { query: "changed" } }
+    expect(results(calls).every((value) => !value)).toBe(true)
+  })
+
+  test("does not detect when the third block changes a tool name", () => {
+    const calls = repeat(pattern(3), 3)
+    calls[8] = { ...calls[8], tool: "search" }
+    expect(results(calls).every((value) => !value)).toBe(true)
+  })
+
+  test("keeps detecting a continuing cycle", () => {
+    const detected = results(repeat(pattern(3), 5))
+    expect(detected.slice(0, 8).every((value) => !value)).toBe(true)
+    expect(detected.slice(8).every(Boolean)).toBe(true)
+  })
+
+  test("detects the smaller fundamental period", () => {
+    expect(results(repeat(repeat(pattern(2), 2), 3)).findIndex(Boolean)).toBe(5)
+  })
+
+  test("preserves JSON.stringify key-order semantics", () => {
+    expect(
+      results([
+        { tool: "lookup", input: { a: 1, b: 2 } },
+        { tool: "lookup", input: { b: 2, a: 1 } },
+        { tool: "lookup", input: { a: 1, b: 2 } },
+      ]),
+    ).toEqual([false, false, false])
+  })
+
+  test("does not retain mutable input objects", () => {
+    const detector = DoomLoop.create()
+    const input = { query: "a" }
+    expect(detector.check("lookup", input)).toBe(false)
+    input.query = "b"
+    expect(detector.check("lookup", input)).toBe(false)
+    expect(detector.check("lookup", input)).toBe(false)
+    expect(detector.check("lookup", input)).toBe(true)
+  })
+
+  test("keeps separate detector instances isolated", () => {
+    const first = DoomLoop.create()
+    const second = DoomLoop.create()
+    expect(first.check("lookup", {})).toBe(false)
+    expect(first.check("lookup", {})).toBe(false)
+    expect(second.check("lookup", {})).toBe(false)
+    expect(first.check("lookup", {})).toBe(true)
+  })
+
+  test("detects a maximum-period suffix after many ring wraps", () => {
+    const noise = Array.from({ length: 10_000 }, (_, index) => ({ tool: "noise", input: { index } }))
+    const detected = results([...noise, ...repeat(pattern(DoomLoop.MAX_PERIOD), 3)])
+    expect(detected.slice(0, -1).every((value) => !value)).toBe(true)
+    expect(detected.at(-1)).toBe(true)
+  })
+
+  test("matches an independent suffix-block oracle for every short binary sequence", () => {
+    const alphabet = pattern(2)
+    for (let length = 1; length <= 10; length++) {
+      for (let mask = 0; mask < 1 << length; mask++) {
+        const detector = DoomLoop.create()
+        const calls: Call[] = []
+        for (let index = 0; index < length; index++) {
+          const call = alphabet[(mask >> index) & 1]
+          calls.push(call)
+          expect(detector.check(call.tool, call.input)).toBe(oracle(calls))
+        }
+      }
+    }
+  })
+
+  test("matches the oracle across ring wraps, near misses, and changing periods", () => {
+    const calls = Array.from({ length: DoomLoop.MAX_PERIOD + 1 }, (_, index) => [
+      ...repeat(pattern(index + 1), 4),
+      { tool: "noise", input: { index } },
+      ...repeat(pattern(index + 1), 2),
+      { tool: "changed", input: { index } },
+    ]).flat()
+    const detector = DoomLoop.create()
+    calls.forEach((call, index) => {
+      expect(detector.check(call.tool, call.input)).toBe(oracle(calls.slice(0, index + 1)))
+    })
+  })
+})

--- a/packages/opencode/test/session/processor-effect.test.ts
+++ b/packages/opencode/test/session/processor-effect.test.ts
@@ -1,15 +1,17 @@
 import { SessionV1 } from "@opencode-ai/core/v1/session"
+import type { PermissionV1 } from "@opencode-ai/core/v1/permission"
 import { Database } from "@opencode-ai/core/database/database"
 import { LayerNode } from "@opencode-ai/core/effect/layer-node"
 import { EventV2Bridge } from "@/event-v2-bridge"
 import { expect } from "bun:test"
 import { tool } from "ai"
-import { Cause, Effect, Exit, Fiber, Layer, Stream } from "effect"
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Stream } from "effect"
 import path from "path"
 import z from "zod"
 import type { Agent } from "../../src/agent/agent"
 import { Provider } from "@/provider/provider"
 
+import { Permission } from "@/permission"
 import { Session } from "@/session/session"
 import { LLM } from "../../src/session/llm"
 import { MessageV2 } from "../../src/session/message-v2"
@@ -19,7 +21,7 @@ import { SessionStatus } from "../../src/session/status"
 import { SessionSummary } from "../../src/session/summary"
 import { CrossSpawnSpawner } from "@opencode-ai/core/cross-spawn-spawner"
 import { provideTmpdirInstance, provideTmpdirServer } from "../fixture/fixture"
-import { testEffect } from "../lib/effect"
+import { awaitWithTimeout, testEffect } from "../lib/effect"
 import { raw, reply, TestLLMServer } from "../lib/llm-server"
 import { RuntimeFlags } from "@/effect/runtime-flags"
 import { ProviderV2 } from "@opencode-ai/core/provider"
@@ -167,6 +169,7 @@ const assistant = Effect.fn("TestSession.assistant")(function* (
 
 const root = LayerNode.group([
   SessionProcessor.node,
+  Permission.node,
   Session.node,
   SessionProjector.node,
   Provider.node,
@@ -1116,6 +1119,392 @@ itProviderError.live("session.processor effect tests fail provider-executed erro
     { config: cfg },
   ),
 )
+
+const periodicCalls = [
+  { id: "call-a1", name: "lookup", input: { query: "a" } },
+  { id: "call-b1", name: "search", input: { query: "b" } },
+  { id: "call-a2", name: "lookup", input: { query: "a" } },
+  { id: "call-b2", name: "search", input: { query: "b" } },
+  { id: "call-a3", name: "lookup", input: { query: "a" } },
+  { id: "call-b3", name: "search", input: { query: "b" } },
+]
+
+type DoomLoopFixture = {
+  name: string
+  calls: typeof periodicCalls
+  delivery?: "duplicate" | "out-of-order"
+  history?: boolean
+  metadata?: boolean | "overlap"
+  action?: "allow" | "deny"
+  reply?: "once" | "reject"
+}
+
+const doomLoopFixtures: DoomLoopFixture[] = [
+  {
+    name: "session.processor asks doom_loop permission after three period-2 repetitions",
+    calls: periodicCalls,
+  },
+  {
+    name: "session.processor preserves period-1 doom_loop ask behavior",
+    calls: [
+      { id: "call-a1", name: "lookup", input: { query: "a" } },
+      { id: "call-a2", name: "lookup", input: { query: "a" } },
+      { id: "call-a3", name: "lookup", input: { query: "a" } },
+    ],
+  },
+  {
+    name: "session.processor doom_loop counts repeated active IDs once and preserves part mapping",
+    calls: periodicCalls,
+    delivery: "duplicate",
+    reply: "once",
+  },
+  {
+    name: "session.processor doom_loop does not seed a new detector from stored tool parts",
+    calls: [periodicCalls[0]],
+    history: true,
+  },
+  {
+    name: "session.processor doom_loop counts call order despite out-of-order results and concurrent completion",
+    calls: periodicCalls,
+    delivery: "out-of-order",
+    reply: "reject",
+  },
+  {
+    name: "session.processor doom_loop allows period-2 continuation",
+    calls: periodicCalls,
+    action: "allow",
+  },
+  {
+    name: "session.processor doom_loop denies period-2 calls with clean termination",
+    calls: periodicCalls,
+    action: "deny",
+  },
+  {
+    name: "session.processor doom_loop rejects period-2 calls with clean termination",
+    calls: periodicCalls,
+    reply: "reject",
+  },
+  ...([undefined, "deny"] as const).map((action) => ({
+    name: `session.processor doom_loop ${action ?? "asks"} after metadata starts calls before normalized delivery`,
+    calls: periodicCalls.filter((call) => call.name === "lookup"),
+    metadata: true,
+    action,
+  })),
+  {
+    name: "session.processor doom_loop counts metadata-prestarted active duplicates once and eventually asks",
+    calls: periodicCalls.filter((call) => call.name === "lookup"),
+    metadata: true,
+    delivery: "duplicate",
+  },
+  {
+    name: "session.processor doom_loop metadata overlap asks only on the third unique normalized call",
+    calls: periodicCalls.filter((call) => call.name === "lookup"),
+    metadata: "overlap",
+    delivery: "duplicate",
+  },
+  ...(["allow", "deny"] as const).map((action) => ({
+    name: `session.processor doom_loop preserves period-1 ${action} behavior`,
+    calls: periodicCalls.filter((call) => call.name === "lookup"),
+    action,
+  })),
+]
+
+for (const fixture of doomLoopFixtures) {
+  const overlap =
+    fixture.metadata === "overlap"
+      ? {
+          armed: true,
+          normalized: false,
+          committed: Deferred.makeUnsafe<void>(),
+          release: Deferred.makeUnsafe<void>(),
+          admitted: Deferred.makeUnsafe<void>(),
+          joined: Deferred.makeUnsafe<void>(),
+        }
+      : undefined
+  const metadata = fixture.metadata
+    ? (overlap ? fixture.calls.slice(0, 1) : fixture.calls).map((call) => ({
+        call,
+        ready: Deferred.makeUnsafe<void>(),
+        resume: Deferred.makeUnsafe<void>(),
+      }))
+    : []
+  const result = (call: (typeof periodicCalls)[number]) =>
+    LLMEvent.toolResult({
+      id: call.id,
+      name: call.name,
+      result: { type: "json", value: { title: call.name, output: `done:${call.id}`, metadata: {} } },
+    })
+  const llm = Layer.mock(LLM.Service, {
+    stream: () =>
+      Stream.fromIterable([
+        // No step boundary between stored history and the current call: the old DB suffix would match.
+        ...(fixture.history ? [] : [LLMEvent.stepStart({ index: 0 })]),
+        ...(fixture.delivery === "out-of-order"
+          ? [
+              ...fixture.calls.slice(0, -1).map((call) => LLMEvent.toolCall(call)),
+              ...[1, 3, 0, 4, 2].map((index) => result(fixture.calls[index])),
+              LLMEvent.toolCall(fixture.calls[5]),
+              result(fixture.calls[5]),
+            ]
+          : fixture.calls.flatMap((call) => [
+              LLMEvent.toolInputStart({ id: call.id, name: call.name }),
+              LLMEvent.toolInputEnd({ id: call.id, name: call.name }),
+              LLMEvent.toolCall(call),
+              ...(fixture.delivery === "duplicate" ? [LLMEvent.toolCall(call), LLMEvent.toolCall(call)] : []),
+              result(call),
+            ])),
+        LLMEvent.stepFinish({ index: 0, reason: "tool-calls" }),
+        LLMEvent.finish({ reason: "tool-calls" }),
+      ]).pipe(
+        Stream.rechunk(1),
+        Stream.mapEffect((event) => {
+          if (overlap && event.type === "tool-call" && event.id === fixture.calls[0].id) {
+            if (!overlap.normalized) {
+              overlap.normalized = true
+              return Effect.succeed(event)
+            }
+            // rechunk(1): this pull proves the first normalized handler returned, not just that its write committed.
+            return Deferred.succeed(overlap.admitted, undefined).pipe(
+              Effect.andThen(Deferred.await(overlap.joined)),
+              Effect.as(event),
+            )
+          }
+          const next = event.type === "tool-input-end" ? metadata.find((item) => item.call.id === event.id) : undefined
+          if (!next) return Effect.succeed(event)
+          // Input-start was consumed; overlap admits after commit while the older callback is still suspended.
+          return Deferred.succeed(next.ready, undefined).pipe(
+            Effect.andThen(Deferred.await(overlap?.committed ?? next.resume)),
+            Effect.as(event),
+          )
+        }),
+      ),
+  })
+  const itDoomLoop = testEffect(LayerNode.compile(root, [...replacements, [LLM.node, llm]]))
+
+  itDoomLoop.live(fixture.name, () =>
+    provideTmpdirInstance(
+      (dir) =>
+        Effect.gen(function* () {
+          const { processors, session, provider } = yield* boot()
+          const events = yield* EventV2Bridge.Service
+          const database = yield* Database.Service
+          const chat = yield* session.create({})
+          const parent = yield* user(chat.id, "repeated tool calls")
+          const msg = yield* assistant(chat.id, parent.id, path.resolve(dir))
+          const mdl = yield* provider.getModel(ref.providerID, ref.modelID)
+          const permission = yield* Permission.Service
+          const last = fixture.calls[fixture.calls.length - 1]
+          const history = fixture.history
+            ? [0, 1].map((index) => ({
+                id: PartID.ascending(),
+                messageID: msg.id,
+                sessionID: chat.id,
+                type: "tool" as const,
+                tool: last.name,
+                callID: `stored-${index}`,
+                state: {
+                  status: "completed" as const,
+                  input: last.input,
+                  title: last.name,
+                  output: "stored",
+                  metadata: {},
+                  time: { start: 1, end: 2 },
+                },
+              }))
+            : []
+          yield* Effect.forEach(history, (part) => session.updatePart(part))
+
+          const asked = yield* Deferred.make<PermissionV1.Request>()
+          const suffix = yield* Deferred.make<SessionV1.Part[]>()
+          const completed = yield* Deferred.make<void>()
+          const requests: PermissionV1.Request[] = []
+          const pending = new Map<string, PartID>()
+          const settlements: string[] = []
+          const off = yield* events.listen((event) => {
+            if (event.type === MessageV2.Event.PartUpdated.type) {
+              const { part } = event.data as typeof MessageV2.Event.PartUpdated.data.Type
+              if (part.sessionID !== chat.id || part.type !== "tool") return Effect.void
+              if (part.state.status === "pending") pending.set(part.callID, part.id)
+              if (overlap?.armed && part.callID === fixture.calls[0].id && part.state.status === "running") {
+                // Disarm before yielding: normalized writes must pass while this older metadata write is held.
+                overlap.armed = false
+                return Deferred.succeed(overlap.committed, undefined).pipe(
+                  Effect.andThen(Deferred.await(overlap.release)),
+                )
+              }
+              if (fixture.history && part.state.status === "running") {
+                return Effect.gen(function* () {
+                  // Capture the unfiltered persisted suffix at admission, exactly where the old predicate read it.
+                  yield* Deferred.succeed(suffix, (yield* MessageV2.parts(msg.id)).slice(-3))
+                }).pipe(Effect.provideService(Database.Service, database))
+              }
+              if (part.state.status !== "completed") return Effect.void
+              settlements.push(part.callID)
+              if (part.callID === last.id) return Deferred.succeed(completed, undefined).pipe(Effect.asVoid)
+              return Effect.void
+            }
+            if (event.type !== Permission.Event.Asked.type) return Effect.void
+            const request = event.data as PermissionV1.Request
+            if (request.sessionID !== chat.id) return Effect.void
+            requests.push(request)
+            return Deferred.succeed(asked, request).pipe(Effect.asVoid)
+          })
+          yield* Effect.addFinalizer(() => off)
+
+          const handle = yield* processors.create({ assistantMessage: msg, sessionID: chat.id, model: mdl })
+          const worker = yield* Effect.forEach(metadata, (item) =>
+            Effect.gen(function* () {
+              yield* Deferred.await(item.ready)
+              const part = yield* handle.updateToolCall(item.call.id, (match) => {
+                expect(match.state.status).toBe("pending")
+                // Mirror session/tools.ts metadata(): execution can start before normalized stream consumption.
+                return {
+                  ...match,
+                  state: {
+                    title: "metadata progress",
+                    metadata: { progress: true },
+                    status: "running",
+                    input: item.call.input,
+                    time: { start: Date.now() },
+                  },
+                }
+              })
+              expect(part?.state.status).toBe("running")
+              yield* Deferred.succeed(item.resume, undefined)
+            }),
+          ).pipe(Effect.forkScoped)
+          // Keep the processor alive for assertions; scope exit interrupts any pending permission, even on failure.
+          const fiber = yield* handle
+            .process({
+              user: parent,
+              sessionID: chat.id,
+              model: mdl,
+              agent: agent(),
+              system: [],
+              messages: [{ role: "user", content: "repeated tool calls" }],
+              tools: {},
+            })
+            .pipe(Effect.forkScoped)
+          if (overlap) {
+            expect(
+              yield* awaitWithTimeout(
+                Effect.raceFirst(
+                  Deferred.await(overlap.admitted).pipe(Effect.as("admitted")),
+                  Fiber.join(fiber).pipe(Effect.as("completed")),
+                ),
+                "first normalized call did not return while metadata was suspended",
+              ),
+            ).toBe("admitted")
+            yield* Deferred.succeed(overlap.release, undefined)
+            yield* awaitWithTimeout(Fiber.join(worker), "overlapping metadata callback did not finish")
+            // Join the stale record installation before delivering any active duplicate.
+            yield* Deferred.succeed(overlap.joined, undefined)
+          }
+          // An absent ask produces a completion result, not a timeout waiting for an event that never arrives.
+          const outcome = yield* awaitWithTimeout(
+            Effect.raceFirst(
+              Deferred.await(asked).pipe(Effect.map((request) => ({ type: "permission" as const, request }))),
+              Fiber.join(fiber).pipe(Effect.map((result) => ({ type: "completed" as const, result }))),
+            ),
+            "processor neither asked permission nor finished",
+          )
+
+          if (fixture.history) {
+            expect(
+              yield* awaitWithTimeout(Deferred.await(suffix), "current call did not publish a running part"),
+            ).toMatchObject([
+              ...history,
+              { callID: last.id, type: "tool", tool: last.name, state: { status: "running", input: last.input } },
+            ])
+          }
+          const parts = yield* MessageV2.parts(msg.id)
+          const tools = parts.filter(
+            (part): part is SessionV1.ToolPart => part.type === "tool" && !part.callID.startsWith("stored-"),
+          )
+          expect(tools).toHaveLength(fixture.calls.length)
+          expect(fixture.calls.map((call) => pending.get(call.id))).toEqual(tools.map((part) => part.id))
+          expect(tools.slice(0, -1)).toMatchObject(
+            fixture.calls.slice(0, -1).map((call) => ({
+              callID: call.id,
+              tool: call.name,
+              state: { status: "completed", input: call.input },
+            })),
+          )
+          if (!fixture.history && !fixture.action) {
+            expect(outcome).toMatchObject({
+              type: "permission",
+              request: {
+                sessionID: chat.id,
+                permission: "doom_loop",
+                patterns: [last.name],
+                metadata: { tool: last.name, input: last.input },
+                always: [last.name],
+              },
+            })
+            expect(tools[tools.length - 1]).toMatchObject({
+              callID: last.id,
+              tool: last.name,
+              state: { status: "running", input: last.input },
+            })
+            if (outcome.type !== "permission") throw new Error("expected doom_loop permission")
+            if (fixture.delivery === "out-of-order") {
+              expect(settlements).toEqual([1, 3, 0, 4, 2].map((index) => fixture.calls[index].id))
+              // A tool can finish while the serialized stream is blocked in Permission.ask.
+              const worker = yield* handle
+                .completeToolCall(last.id, {
+                  title: last.name,
+                  output: `done:${last.id}`,
+                  metadata: { concurrent: true },
+                })
+                .pipe(Effect.forkScoped)
+              yield* awaitWithTimeout(Deferred.await(completed), "concurrent tool did not publish completion")
+              yield* awaitWithTimeout(Fiber.join(worker), "concurrent tool did not settle")
+            }
+            yield* permission.reply({ requestID: outcome.request.id, reply: fixture.reply ?? "once" })
+          }
+
+          yield* awaitWithTimeout(Fiber.join(worker), "metadata callbacks did not finish")
+          const value = yield* awaitWithTimeout(Fiber.join(fiber), "processor did not finish after permission decision")
+          const stopped = fixture.action === "deny" || fixture.reply === "reject"
+          expect(value).toBe(stopped ? "stop" : "continue")
+          expect(Boolean(handle.message.error)).toBe(stopped)
+          expect(requests).toHaveLength(fixture.history || fixture.action ? 0 : 1)
+          expect(yield* permission.list()).toEqual([])
+          const stored = (yield* MessageV2.parts(msg.id)).filter(
+            (part): part is SessionV1.ToolPart => part.type === "tool",
+          )
+          expect(stored).toHaveLength(history.length + fixture.calls.length)
+          expect(stored.slice(0, history.length)).toEqual(history)
+          expect(stored.slice(history.length)).toMatchObject(
+            fixture.calls.map((call) => ({
+              id: pending.get(call.id),
+              callID: call.id,
+              tool: call.name,
+              state: {
+                input: call.input,
+                ...(stopped && call.id === last.id && fixture.delivery !== "out-of-order"
+                  ? { status: "error", error: "Tool execution aborted", metadata: { interrupted: true } }
+                  : { status: "completed", output: `done:${call.id}` }),
+              },
+            })),
+          )
+          if (fixture.delivery === "out-of-order") {
+            expect(stored[stored.length - 1].state).toMatchObject({ metadata: { concurrent: true } })
+            expect(settlements).toEqual([1, 3, 0, 4, 2, 5].map((index) => fixture.calls[index].id))
+          }
+          for (const call of fixture.calls) {
+            expect(yield* handle.updateToolCall(call.id, (part) => part)).toBeUndefined()
+          }
+        }).pipe(Effect.scoped),
+      {
+        config: {
+          ...cfg,
+          ...(fixture.action ? { permission: { doom_loop: fixture.action } } : {}),
+        },
+      },
+    ),
+  )
+}
 
 itFragmentFailure.live("session.processor effect tests retain partial legacy parts without v2 events", () =>
   provideTmpdirInstance(

--- a/packages/web/src/content/docs/permissions.mdx
+++ b/packages/web/src/content/docs/permissions.mdx
@@ -161,7 +161,7 @@ OpenCode permissions are keyed by tool name, plus a couple of safety guards:
 - `webfetch` — fetching a URL (matches the URL)
 - `websearch` — web search (matches the query)
 - `external_directory` — triggered when a tool touches paths outside the project working directory
-- `doom_loop` — triggered when the same tool call repeats 3 times with identical input
+- `doom_loop` — triggered when a sequence of 1–10 tool calls repeats 3 consecutive times with identical tool names and inputs within one processor
 
 ---
 


### PR DESCRIPTION
### Issue for this PR

Closes #47759

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

The current guard catches `A,A,A` but misses cycles such as `A,B,A,B,A,B`. This change detects three consecutive repetitions of an ordered tool-call block of length 1–10 within one processor, using the existing `doom_loop` permission flow.

Related approaches:

- #46272 adds a stop after ten consecutive identical calls. This PR also detects multi-call cycles and preserves permission-based continuation rather than adding an unconditional stop.
- #32089 counts matching tool/input occurrences across uncompacted history. That can also catch alternating calls, but does not require repeated blocks. This PR checks an ordered suffix without scanning persisted history.

Key properties:

- Bounded detector history: 21 signature slots and capped per-period counters. Consecutive matching triples establish equality of all three blocks; retained bytes still depend on input size.
- Each active call contributes once, including when metadata starts execution early or concurrent updates replace its record. A shared admission cell prevents stale updates from resetting this state.
- Existing JSON input comparison and permission payloads are preserved; no provider, public schema, or dependency changes.

### How did you verify your code works?

Validated the exact contribution in a fresh frozen-lockfile installation with Bun 1.3.14:

```sh
bun test --cwd packages/opencode --timeout 30000 test/session test/permission test/provider/transform.test.ts
bun run --cwd packages/opencode typecheck
bun run typecheck
```

Results: **1,116 passed, 0 failed, 7 skipped, 1 todo**; package typecheck passed; workspace typecheck **30/30 passed with no cache hits**. Tests cover an independent suffix-block oracle, exact trigger boundaries, duplicate delivery, metadata races, history isolation, and permission outcomes. The periodic-cycle and metadata regressions were demonstrated failing before their corresponding fixes.

### Screenshots / recordings

Not applicable; no UI changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
