### PR TITLE
fix(core): retry transient provider compaction failures

### DIFF
--- a/packages/core/src/session/compaction.ts
+++ b/packages/core/src/session/compaction.ts
@@ -475,19 +475,29 @@ export const layer = Layer.effect(
         return yield* reject(
           "Provider compaction requires the endpoint in provider/model settings, not a model.request rewrite",
         )
+      const transient = SessionRunnerRetry.transient(yield* SessionRunnerRetry.policy(context.session.id), {
+        agent: Agent.ID.make("compaction"),
+        model: context.model.ref,
+        hook: prepared.retry,
+      })
       yield* started(input, "")
       return yield* Effect.uninterruptibleMask((restore) =>
         Effect.gen(function* () {
-          // One native physical attempt; only a known automatic overflow permits local recovery.
+          // Transient provider failures retry like any other request; only a known automatic overflow permits
+          // local recovery, and nothing is installed until the provider returns a checkpoint.
           const result = yield* restore(
             Effect.gen(function* () {
               if (LLMClient.canCompact(request, { mechanism: "trigger" })) {
                 const retained = retainUsers(yield* original(context.session.id), context.model, state.get().tokens)
-                const result = yield* llm.compact(request, { ...prepared.options, mechanism: "trigger" })
+                const result = yield* llm
+                  .compact(request, { ...prepared.options, mechanism: "trigger" })
+                  .pipe(transient)
                 return { replacement: [...retained, Message.assistant(result.checkpoint)], usage: result.usage }
               }
               if (LLMClient.canCompact(request))
-                return yield* llm.compact(request, { mechanism: "endpoint", http: prepared.options.http })
+                return yield* llm
+                  .compact(request, { mechanism: "endpoint", http: prepared.options.http })
+                  .pipe(transient)
               // Model resolution admits provider policies only for routes with a compaction operation.
               return yield* Effect.die(
                 new Error(`${request.model.provider}/${request.model.route.id} has no compaction operation`),
@@ -562,8 +572,12 @@ export const layer = Layer.effect(
           ),
         ),
       ])
-      const retry = yield* SessionRunnerRetry.policy(context.session.id)
       // Both requests share the retry allowance; rejected output never enters the reminder request.
+      const transient = SessionRunnerRetry.transient(yield* SessionRunnerRetry.policy(context.session.id), {
+        agent: Agent.ID.make("compaction"),
+        model: context.model.ref,
+        hook: prepared.retry,
+      })
       for (const request of [
         prepared.request,
         LLMRequest.update(prepared.request, {
@@ -624,23 +638,7 @@ export const layer = Layer.effect(
             }
             return Effect.void
           }),
-          Effect.retry({
-            while: (cause) =>
-              Effect.gen(function* () {
-                if (isContextOverflowFailure(cause)) return false
-                const decision = yield* retry({
-                  cause,
-                  error: toSessionError(cause),
-                  agent: Agent.ID.make("compaction"),
-                  model: context.model.ref,
-                  hook: prepared.retry,
-                  retry: SessionRunnerRetry.isRetryable(cause),
-                })
-                if (!decision.retry) return false
-                yield* Effect.sleep(decision.delay)
-                return true
-              }),
-          }),
+          transient,
           Effect.catchTag("AI.Error", (error) =>
             Effect.sync(() => {
               failure = toSessionError(error)

--- a/packages/core/src/session/runner/retry.ts
+++ b/packages/core/src/session/runner/retry.ts
@@ -1,6 +1,6 @@
 export * as SessionRunnerRetry from "./retry.js"
 
-import { AIError } from "@opencode-ai/ai"
+import { AIError, isContextOverflowFailure } from "@opencode-ai/ai"
 import { Agent } from "@opencode-ai/schema/agent"
 import { Model } from "@opencode-ai/schema/model"
 import { SessionError } from "@opencode-ai/schema/session-error"
@@ -10,6 +10,7 @@ import type { PluginHooks } from "../../plugin/hooks.js"
 import { SessionEvent } from "../event.js"
 import { SessionMessage } from "../message.js"
 import { SessionSchema } from "../schema.js"
+import { toSessionError } from "../to-session-error.js"
 
 interface Input {
   readonly cause: AIError
@@ -105,6 +106,24 @@ export const policy = (sessionID: SessionSchema.ID) =>
         return { retry: true as const, attempt, delay: normalized }
       })
   })
+
+/**
+ * Retries one auxiliary request's transient failures under a shared `policy` allowance, letting the
+ * session retry hook adjust each decision. Context overflow is never transient: callers recover it.
+ */
+export const transient =
+  (decide: Effect.Success<ReturnType<typeof policy>>, input: Pick<Input, "agent" | "model" | "hook">) =>
+  <A, R>(effect: Effect.Effect<A, AIError, R>) =>
+    Effect.retry(effect, {
+      while: (cause) =>
+        Effect.gen(function* () {
+          if (isContextOverflowFailure(cause)) return false
+          const decision = yield* decide({ ...input, cause, error: toSessionError(cause), retry: isRetryable(cause) })
+          if (!decision.retry) return false
+          yield* Effect.sleep(decision.delay)
+          return true
+        }),
+    })
 
 export const make = (bus: Bus.Interface, sessionID: SessionSchema.ID) =>
   Effect.gen(function* () {

--- a/packages/core/test/session-native-compaction.test.ts
+++ b/packages/core/test/session-native-compaction.test.ts
@@ -54,7 +54,7 @@ const setup = Effect.fnUntraced(function* (endpoint = false) {
   const hooks = yield* PluginHooks.Service
   const blocked = Deferred.makeUnsafe<void>()
   const hanging = Promise.withResolvers<Response>()
-  const state = { failure: false, hang: false, overflow: false, localFailure: false, calls: 0 }
+  const state = { failure: false, flaky: false, hang: false, overflow: false, localFailure: false, calls: 0 }
   const bodies: Record<string, unknown>[] = []
   const headers: Headers[] = []
   const server = yield* Effect.acquireRelease(
@@ -74,11 +74,15 @@ const setup = Effect.fnUntraced(function* (endpoint = false) {
             Deferred.doneUnsafe(blocked, Effect.void)
             return hanging.promise
           }
-          if (state.failure)
+          // Persistent failures opt out of retries so the schedule's backoff stays out of these tests.
+          if (state.failure || state.flaky) {
+            const retry = state.flaky
+            state.flaky = false
             return Response.json(
               { error: { message: "fixture rate limit", type: "rate_limit_error" } },
-              { status: 429 },
+              { status: 429, headers: retry ? {} : { "x-should-retry": "false" } },
             )
+          }
           const trigger = JSON.stringify(bodies.at(-1)).includes("compaction_trigger")
           if (state.overflow && (trigger || state.localFailure))
             return Response.json(
@@ -304,12 +308,36 @@ it.live(
       expect(yield* fixture.compact).toMatchObject({ status: "failed", error: { type: "provider.rate-limit" } })
       expect(fixture.state.calls).toBe(4)
       expect(yield* fixture.checkpoint).toEqual(second)
+      fixture.state.failure = false
       fixture.state.hang = true
       const pending = yield* fixture.compact.pipe(Effect.forkScoped)
       yield* Deferred.await(fixture.blocked)
       yield* Fiber.interrupt(pending)
       expect(fixture.state.calls).toBe(5)
       expect(yield* fixture.checkpoint).toEqual(second)
+      // A transient provider failure retries under the shared session policy and its plugin hook.
+      fixture.state.hang = false
+      const retries: PluginHooks.Domains["session"]["retry"][] = []
+      yield* fixture.hooks.register("session", "retry", (event) =>
+        Effect.sync(() => {
+          retries.push(event)
+          event.decision = { retry: true, delay: 0 }
+        }),
+      )
+      fixture.state.flaky = true
+      expect(yield* fixture.compact).toEqual({ status: "completed" })
+      expect(fixture.state.calls).toBe(7)
+      expect(retries).toMatchObject([
+        {
+          agent: "compaction",
+          attempt: 2,
+          error: { type: "provider.rate-limit" },
+          decision: { retry: true, delay: 0 },
+        },
+      ])
+      expect(
+        SessionProviderContext.decode(yield* fixture.checkpoint).filter((message) => message.role === "user"),
+      ).toHaveLength(3)
     }),
   15000,
 )

--- a/packages/www/src/docs/content/compaction.mdx
+++ b/packages/www/src/docs/content/compaction.mdx
@@ -106,7 +106,9 @@ provider policy. An individual model's policy replaces the entire provider polic
   usage anchor. Encrypted checkpoint bytes are not a meaningful token count.
 - OpenAI Responses uses a streamed compaction trigger when the route supports it.
   Endpoint-only routes use their standalone compaction endpoint. Deployment/model
-  support can vary; native operations make one attempt without generic retries.
+  support can vary. Transient provider failures retry under the same session retry
+  policy and plugin hook as other requests; nothing is installed until a checkpoint
+  is returned.
 - A known automatic context overflow uses local recovery over the durable original
   history, re-expanding native checkpoints. This applies both to ordinary model
   calls and native compaction rejection. If local recovery fails, the prior


### PR DESCRIPTION
## Summary
- Provider compaction made exactly one `llm.compact` attempt, so a transient 429/5xx/transport failure on the trigger call failed the compaction and, for automatic compaction, the step. Local compaction already retried these through `SessionRunnerRetry.policy` and the `session.retry` plugin hook (#47159, #45999).
- Lift that retry predicate into `SessionRunnerRetry.transient(policy, { agent, model, hook })` and use it for both local summary attempts and the provider trigger/endpoint calls. Retrying is safe: nothing is installed until the provider returns a checkpoint, and context overflow is excluded so the existing local-recovery path still handles it.
- Provider compaction now honors the same backoff, `retry-after`, `x-should-retry`, and plugin `retry` hook as every other session request. Docs updated.

Follow-up to #47322–#47324.

## Validation
- `session-native-compaction.test.ts`: a 429 answered once retries under a `retry` hook (`delay: 0`, `attempt: 2`, `agent: "compaction"`) and installs the checkpoint on the second call; persistent failures opt out via `x-should-retry: false` and still surface `provider.rate-limit` after one call; cancellation/overflow behavior unchanged.
- Core suite via `bun run test`: 5,243 passed, 35 skipped; core typecheck clean.
