### PR TITLE
fix(core): merge model.request.headers into SDK options in prepareOptions()

### DIFF
--- a/packages/core/src/aisdk.ts
+++ b/packages/core/src/aisdk.ts
@@ -78,6 +78,9 @@ function prepareOptions(model: ModelV2.Info, pkg: string) {
     ...model.request.body,
   }
   if (model.api.type === "aisdk" && model.api.url) options.baseURL = model.api.url
+  if (model.request.headers && Object.keys(model.request.headers).length > 0) {
+    options.headers = { ...options.headers, ...model.request.headers }
+  }
 
   const customFetch = options.fetch
   const chunkTimeout = options.chunkTimeout


### PR DESCRIPTION
Closes #36619

## Problem

Custom provider headers configured via `provider.options.headers` / `provider.models.<model>.headers` are correctly lowered into `model.request.headers`, but `prepareOptions()` in `packages/core/src/aisdk.ts` never merges them into the options object passed to the SDK factory. As a result the configured headers never reach the actual HTTP request.

## Fix

Add a 3-line merge of `model.request.headers` into `options.headers`, matching the existing pattern used for `settings` and `body`. This mirrors the previously proposed fix in #36579 / #36620 but is rebased against the current `dev` branch.

## Verification

- Same minimal patch previously verified in #36579/#36620.
- Not run locally in this environment because `bun` is unavailable; the change is a pure options-object merge and covered by existing AISDK plugin tests.