### PR TITLE
test(mcp): preserve detailed tool errors

### DIFF
--- a/packages/opencode/test/mcp/catalog.test.ts
+++ b/packages/opencode/test/mcp/catalog.test.ts
@@ -48,6 +48,18 @@ describe("McpCatalog.convertTool", () => {
       content: [{ type: "text", text: JSON.stringify(structuredContent) }],
     })
   })
+
+  test("preserves MCP error text when isError is true", async () => {
+    const converted = McpCatalog.convertTool(
+      mcpTool(),
+      clientReturning({
+        isError: true,
+        content: [{ type: "text", text: "invalid id: path separators are not allowed" }],
+      }),
+    )
+
+    await expect(converted.execute?.({}, options)).rejects.toThrow("invalid id: path separators are not allowed")
+  })
 })
 
 test("preserves output schema validation across paginated tool discovery", async () => {


### PR DESCRIPTION
### Issue for this PR

Closes #47740

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

This PR adds a regression test for MCP tool results with `isError: true`. It verifies that the detailed text in `content[].text` is preserved in the thrown error message. The production conversion path already preserves this text; the test prevents a future regression and covers the behavior reported in #47740.

### How did you verify your code works?

- `bun test test/mcp/catalog.test.ts` — 4 tests passed
- `bunx prettier --check packages/opencode/test/mcp/catalog.test.ts` — passed
- OpenCode pre-push typecheck — 30/30 packages passed
- `git diff --check` — passed

### Screenshots / recordings

Not applicable; this is a test-only change.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

