### PR TITLE
feat(core): bind MCP OAuth refresh tokens to their issuing authorization server

### DIFF
--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -292,8 +292,7 @@ export const layer = (options?: Options) =>
         // Tracks the refresh token this provider last presented, so invalidate can tell whether the SDK
         // rejected the currently-stored credential or a snapshot another connection has already rotated past.
         let presented = found.value.refresh
-        // Authorization server the SDK discovered for this connection; compared against the issuer recorded at
-        // login before a refresh token is presented.
+        const bound = McpOAuth.issuerFromCredential(found.value)
         let issuer: string | undefined
         const readOAuthCredential = async () => {
           const stored = await run(credentials.get(credentialID))
@@ -301,8 +300,10 @@ export const layer = (options?: Options) =>
         }
         return McpOAuth.provider({
           ...base,
-          onDiscovery: (discovery) => {
+          onDiscovery: async (discovery) => {
             issuer = discovery.authorizationServerMetadata?.issuer
+            if (bound && issuer && bound !== issuer)
+              await run(Effect.logWarning("mcp oauth issuer changed", { ...fields, expected: bound, actual: issuer }))
           },
           // Drop a credential the SDK rejected so the next connect cleanly reports needs_auth — but only if it is
           // still the stored one. Rotating servers hand out a fresh refresh token per use, so a concurrent
@@ -338,17 +339,7 @@ export const layer = (options?: Options) =>
               const oauth = await readOAuthCredential()
               if (!oauth) return undefined
               presented = oauth.refresh
-              const tokens = McpOAuth.toTokens(oauth, issuer)
-              if (oauth.refresh && !tokens.refresh_token)
-                await run(
-                  Effect.logWarning("mcp oauth refresh withheld", {
-                    ...fields,
-                    reason: "issuer_changed",
-                    expected: McpOAuth.issuerFromCredential(oauth),
-                    actual: issuer,
-                  }),
-                )
-              return tokens
+              return McpOAuth.toTokens(oauth, issuer)
             },
             saveTokens: async (tokens) => {
               const previous = await readOAuthCredential()
@@ -357,8 +348,7 @@ export const layer = (options?: Options) =>
                 serverUrl: remote.url,
                 tokens,
                 client: previous ? McpOAuth.clientFromCredential(previous) : undefined,
-                // Keep the issuer bound at login; credentials from before issuer tracking adopt the current one.
-                issuer: (previous ? McpOAuth.issuerFromCredential(previous) : undefined) ?? issuer,
+                issuer: (previous && McpOAuth.issuerFromCredential(previous)) || issuer,
               })
               presented = value.refresh
               await run(

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -292,12 +292,18 @@ export const layer = (options?: Options) =>
         // Tracks the refresh token this provider last presented, so invalidate can tell whether the SDK
         // rejected the currently-stored credential or a snapshot another connection has already rotated past.
         let presented = found.value.refresh
+        // Authorization server the SDK discovered for this connection; compared against the issuer recorded at
+        // login before a refresh token is presented.
+        let issuer: string | undefined
         const readOAuthCredential = async () => {
           const stored = await run(credentials.get(credentialID))
           return stored?.value.type === "oauth" ? stored.value : undefined
         }
         return McpOAuth.provider({
           ...base,
+          onDiscovery: (discovery) => {
+            issuer = discovery.authorizationServerMetadata?.issuer
+          },
           // Drop a credential the SDK rejected so the next connect cleanly reports needs_auth — but only if it is
           // still the stored one. Rotating servers hand out a fresh refresh token per use, so a concurrent
           // connection may have already replaced ours; deleting then would discard the newer valid credential and
@@ -332,7 +338,17 @@ export const layer = (options?: Options) =>
               const oauth = await readOAuthCredential()
               if (!oauth) return undefined
               presented = oauth.refresh
-              return McpOAuth.toTokens(oauth)
+              const tokens = McpOAuth.toTokens(oauth, issuer)
+              if (oauth.refresh && !tokens.refresh_token)
+                await run(
+                  Effect.logWarning("mcp oauth refresh withheld", {
+                    ...fields,
+                    reason: "issuer_changed",
+                    expected: McpOAuth.issuerFromCredential(oauth),
+                    actual: issuer,
+                  }),
+                )
+              return tokens
             },
             saveTokens: async (tokens) => {
               const previous = await readOAuthCredential()
@@ -341,6 +357,8 @@ export const layer = (options?: Options) =>
                 serverUrl: remote.url,
                 tokens,
                 client: previous ? McpOAuth.clientFromCredential(previous) : undefined,
+                // Keep the issuer bound at login; credentials from before issuer tracking adopt the current one.
+                issuer: (previous ? McpOAuth.issuerFromCredential(previous) : undefined) ?? issuer,
               })
               presented = value.refresh
               await run(

--- a/packages/core/src/mcp/oauth.ts
+++ b/packages/core/src/mcp/oauth.ts
@@ -96,7 +96,7 @@ export interface Options {
   readonly clientMetadataUrl?: string
   /** Pre-fetched authorization server discovery so the SDK does not repeat it. */
   readonly discovery?: OAuthServerInfo
-  /** Receives the authorization server the SDK discovered for this connection, before it refreshes or authorizes. */
+  /** Receives the SDK's discovery result before it refreshes or authorizes. */
   readonly onDiscovery?: (discovery: OAuthDiscoveryState) => void | Promise<void>
   /** Invoked by the SDK to drop credentials it has determined are invalid (e.g. a rejected refresh token). */
   readonly invalidate?: (scope: "all" | "client" | "tokens" | "verifier" | "discovery") => void | Promise<void>
@@ -173,7 +173,7 @@ export const memoryStore = (): Store => {
 export const clientFromCredential = (credential: Credential.OAuth) =>
   credential.metadata?.client as OAuthClientInformationMixed | undefined
 
-/** Reads the authorization server issuer recorded when the credential was obtained, if any. */
+/** Reads the authorization server issuer recorded when the credential was obtained. */
 export const issuerFromCredential = (credential: Credential.OAuth) => {
   const issuer = credential.metadata?.issuer
   return typeof issuer === "string" ? issuer : undefined
@@ -204,22 +204,18 @@ export const toCredential = (input: {
   })
 
 /**
- * Reconstructs SDK tokens from a stored credential so the connect-time provider can present them.
- *
- * A refresh token must only go back to the authorization server that issued it. When `issuer` names the server
- * discovery currently points at and it differs from the one recorded at login, the refresh token is withheld:
- * the SDK then re-authorizes instead of handing the token to a server that never issued it. The access token is
- * still returned so an unexpired session keeps working. A CIMD client_id is valid at any authorization server,
- * so a changed issuer is the only signal that the MCP server's auth has moved.
+ * Reconstructs SDK tokens from a stored credential so the connect-time provider can present them. The refresh
+ * token is withheld when `issuer` differs from the one recorded at login, so the SDK re-authorizes instead of
+ * sending it to an authorization server that did not issue it.
  */
 export const toTokens = (credential: Credential.OAuth, issuer?: string): OAuthTokens => {
   const metadata = credential.metadata ?? {}
   const bound = issuerFromCredential(credential)
-  const moved = bound !== undefined && issuer !== undefined && bound !== issuer
+  const refresh = credential.refresh && (!bound || !issuer || bound === issuer)
   return {
     access_token: credential.access,
     token_type: typeof metadata.tokenType === "string" ? metadata.tokenType : "Bearer",
-    ...(credential.refresh && !moved ? { refresh_token: credential.refresh } : {}),
+    ...(refresh ? { refresh_token: credential.refresh } : {}),
     ...(credential.expires ? { expires_in: Math.max(0, Math.floor((credential.expires - Date.now()) / 1000)) } : {}),
     ...(typeof metadata.scope === "string" ? { scope: metadata.scope } : {}),
   }

--- a/packages/core/src/mcp/oauth.ts
+++ b/packages/core/src/mcp/oauth.ts
@@ -5,6 +5,7 @@ import {
   discoverOAuthServerInfo,
   parseErrorResponse,
   type OAuthClientProvider,
+  type OAuthDiscoveryState,
   type OAuthServerInfo,
 } from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
@@ -95,6 +96,8 @@ export interface Options {
   readonly clientMetadataUrl?: string
   /** Pre-fetched authorization server discovery so the SDK does not repeat it. */
   readonly discovery?: OAuthServerInfo
+  /** Receives the authorization server the SDK discovered for this connection, before it refreshes or authorizes. */
+  readonly onDiscovery?: (discovery: OAuthDiscoveryState) => void | Promise<void>
   /** Invoked by the SDK to drop credentials it has determined are invalid (e.g. a rejected refresh token). */
   readonly invalidate?: (scope: "all" | "client" | "tokens" | "verifier" | "discovery") => void | Promise<void>
   /** Receives the authorization URL so the caller can open a browser and capture the eventual code. */
@@ -113,6 +116,7 @@ export const provider = (options: Options): OAuthClientProvider => {
     redirectUrl: options.redirectUrl,
     ...(options.clientMetadataUrl ? { clientMetadataUrl: options.clientMetadataUrl } : {}),
     ...(options.discovery ? { discoveryState: () => options.discovery } : {}),
+    ...(options.onDiscovery ? { saveDiscoveryState: options.onDiscovery } : {}),
     clientMetadata: {
       redirect_uris: [options.redirectUrl],
       client_name: "opencode",
@@ -169,12 +173,19 @@ export const memoryStore = (): Store => {
 export const clientFromCredential = (credential: Credential.OAuth) =>
   credential.metadata?.client as OAuthClientInformationMixed | undefined
 
-/** Folds SDK tokens (plus DCR client info and the server URL) into a storable credential. */
+/** Reads the authorization server issuer recorded when the credential was obtained, if any. */
+export const issuerFromCredential = (credential: Credential.OAuth) => {
+  const issuer = credential.metadata?.issuer
+  return typeof issuer === "string" ? issuer : undefined
+}
+
+/** Folds SDK tokens (plus client info, issuer, and the server URL) into a storable credential. */
 export const toCredential = (input: {
   readonly methodID: Integration.MethodID
   readonly serverUrl: string
   readonly tokens: OAuthTokens
   readonly client: OAuthClientInformationMixed | undefined
+  readonly issuer?: string
 }) =>
   Credential.OAuth.make({
     type: "oauth",
@@ -188,16 +199,27 @@ export const toCredential = (input: {
       tokenType: input.tokens.token_type,
       ...(input.tokens.scope ? { scope: input.tokens.scope } : {}),
       ...(input.client ? { client: input.client } : {}),
+      ...(input.issuer ? { issuer: input.issuer } : {}),
     },
   })
 
-/** Reconstructs SDK tokens from a stored credential so the connect-time provider can present them. */
-export const toTokens = (credential: Credential.OAuth): OAuthTokens => {
+/**
+ * Reconstructs SDK tokens from a stored credential so the connect-time provider can present them.
+ *
+ * A refresh token must only go back to the authorization server that issued it. When `issuer` names the server
+ * discovery currently points at and it differs from the one recorded at login, the refresh token is withheld:
+ * the SDK then re-authorizes instead of handing the token to a server that never issued it. The access token is
+ * still returned so an unexpired session keeps working. A CIMD client_id is valid at any authorization server,
+ * so a changed issuer is the only signal that the MCP server's auth has moved.
+ */
+export const toTokens = (credential: Credential.OAuth, issuer?: string): OAuthTokens => {
   const metadata = credential.metadata ?? {}
+  const bound = issuerFromCredential(credential)
+  const moved = bound !== undefined && issuer !== undefined && bound !== issuer
   return {
     access_token: credential.access,
     token_type: typeof metadata.tokenType === "string" ? metadata.tokenType : "Bearer",
-    ...(credential.refresh ? { refresh_token: credential.refresh } : {}),
+    ...(credential.refresh && !moved ? { refresh_token: credential.refresh } : {}),
     ...(credential.expires ? { expires_in: Math.max(0, Math.floor((credential.expires - Date.now()) / 1000)) } : {}),
     ...(typeof metadata.scope === "string" ? { scope: metadata.scope } : {}),
   }
@@ -312,7 +334,13 @@ export const authorize = (input: {
         hasRefreshToken: Boolean(tokens.refresh_token),
         expiresIn: tokens.expires_in,
       })
-      return toCredential({ methodID: input.methodID, serverUrl: input.config.url, tokens, client })
+      return toCredential({
+        methodID: input.methodID,
+        serverUrl: input.config.url,
+        tokens,
+        client,
+        issuer: discovery.authorizationServerMetadata?.issuer,
+      })
     })
 
     yield* Effect.tryPromise({

--- a/packages/core/test/mcp-oauth.test.ts
+++ b/packages/core/test/mcp-oauth.test.ts
@@ -118,6 +118,53 @@ describe("MCP OAuth", () => {
     expect(tokenRequests[0]?.get("refresh_token")).toBe("refresh")
   })
 
+  test("withholds the refresh token when the authorization server issuer changed", async () => {
+    const tokenRequests: unknown[] = []
+    const server = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url)
+        if (url.pathname === "/.well-known/oauth-authorization-server")
+          return Response.json({
+            issuer: "https://other.example.com",
+            authorization_endpoint: `${url.origin}/authorize`,
+            token_endpoint: `${url.origin}/token`,
+            response_types_supported: ["code"],
+          })
+        if (request.method === "POST" && url.pathname === "/token") {
+          tokenRequests.push(await request.text())
+          return Response.json({ access_token: "next", token_type: "Bearer" })
+        }
+        return new Response(null, { status: 404 })
+      },
+    })
+    const credential = Credential.OAuth.make({
+      type: "oauth",
+      methodID: Integration.MethodID.make("oauth"),
+      access: "expired",
+      refresh: "refresh",
+      expires: Date.now() - 1000,
+      metadata: { serverUrl: server.url.href, tokenType: "Bearer", issuer: server.url.origin },
+    })
+    let issuer: string | undefined
+    const store = McpOAuth.memoryStore()
+    const oauthProvider = McpOAuth.provider({
+      redirectUrl: "http://127.0.0.1/callback",
+      client: { id: "client" },
+      onDiscovery: (discovery) => {
+        issuer = discovery.authorizationServerMetadata?.issuer
+      },
+      onRedirect: () => undefined,
+      store: { ...store, tokens: async () => McpOAuth.toTokens(credential, issuer) },
+    })
+
+    const result = await auth(oauthProvider, { serverUrl: server.url.href }).finally(() => server.stop(true))
+
+    expect(result).toBe("REDIRECT")
+    expect(tokenRequests).toHaveLength(0)
+    expect(McpOAuth.toTokens(credential, server.url.origin).refresh_token).toBe("refresh")
+  })
+
   test("shares concurrent refreshes for the same token", async () => {
     let requests = 0
     const pending = Promise.withResolvers<void>()
@@ -228,6 +275,7 @@ describe("MCP OAuth", () => {
       expect(registrations).toHaveLength(0)
       expect(tokenRequests[0]?.get("client_id")).toBe(McpOAuth.CLIENT_METADATA_URL)
       expect(McpOAuth.clientFromCredential(credential)).toEqual({ client_id: McpOAuth.CLIENT_METADATA_URL })
+      expect(McpOAuth.issuerFromCredential(credential)).toBe(server.url.origin)
     })
 
     test("registers dynamically when the server does not accept public clients", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #47743. Records the authorization server's `issuer` when an MCP OAuth credential is obtained, and refuses to present the stored refresh token if a later connection discovers a different issuer for the same MCP server. Mirrors Codex's `validate_refresh_token_issuer` (`codex-rs/rmcp-client/src/oauth/issuer_binding.rs`).

## Why

A refresh token must only go back to the server that issued it. With Dynamic Client Registration this was implicitly enforced: the `client_id` was minted by one specific authorization server, so if the MCP server switched auth providers the old id was simply unknown and refresh failed. A CIMD `client_id` is a public URL that is valid at *any* authorization server. If an MCP server's `/.well-known/oauth-protected-resource` starts pointing somewhere else, nothing in the current flow stops us from sending the refresh token to the new (possibly hostile) server. Storing the issuer at login and checking it before refresh closes that.

## Behavior

- `McpOAuth.authorize` stores `metadata.issuer` on the credential from the discovery it already performs.
- The connect-time provider records the issuer the SDK discovers (via the SDK's `saveDiscoveryState` hook) and passes it to `toTokens`. If the stored issuer is set and differs, `refresh_token` is omitted from what the SDK sees, so the SDK skips refresh and falls through to re-authorization → `UnauthorizedError` → `needs_auth`. The access token is still presented, so an unexpired session keeps working until it lapses. A warning is logged with expected/actual issuer.
- Credentials from before this change have no stored issuer, so they are never blocked; the first successful refresh adopts the current issuer.
- Nothing is cached beyond the live connection; discovery still runs as before.

## Changes

- `packages/core/src/mcp/oauth.ts` — `issuerFromCredential`, `issuer` on `toCredential`, issuer-aware `toTokens`, `onDiscovery` provider option
- `packages/core/src/mcp/index.ts` — connect-time provider records the discovered issuer, withholds refresh on mismatch, carries the issuer forward on refresh
- `packages/core/test/mcp-oauth.test.ts` — login stores the issuer; refresh is withheld and no `/token` request is made when discovery names a different issuer

## Test plan

- [x] `bun test test/mcp-oauth.test.ts` in `packages/core` (10 pass)
- [x] `bun typecheck` in `packages/core`